### PR TITLE
Support for multiple opponents in brackets, and conversion to use structural data types

### DIFF
--- a/match2/commons/match_group_display_bracket.lua
+++ b/match2/commons/match_group_display_bracket.lua
@@ -134,7 +134,7 @@ end
 
 BracketDisplay.types.Layout = TypeUtil.struct({
     height = 'number',
-    lowerMarginTop = 'number',
+    lowerNodeMarginTop = 'number',
     matchHeight = 'number',
     matchMarginTop = 'number',
     mid = 'number',
@@ -190,15 +190,15 @@ function BracketDisplay.computeBracketLayout(matchesById, config)
         local matchHeight = #match.opponents * config.opponentHeight
 
         -- Compute offset with lower nodes
-        local matchTop = BracketDisplay.alignMatchWithLowerNodes(match, lowerLayouts, heightSums)
+        local matchTop = BracketDisplay.alignMatchWithLowerNodes(match, lowerLayouts, heightSums, config.opponentHeight)
         -- Vertical space between lower rounds and top of bracket node body
-        local lowerMarginTop = matchTop < 0 and -matchTop or 0
+        local lowerNodeMarginTop = matchTop < 0 and -matchTop or 0
         -- Vertical space between match and top of bracket node body
         local matchMarginTop = 0 < matchTop and matchTop or 0
 
         -- Ensure matchMarginTop is at least config.matchMargin
         if matchMarginTop < config.matchMargin then
-            lowerMarginTop = lowerMarginTop + config.matchMargin - matchMarginTop
+            lowerNodeMarginTop = lowerNodeMarginTop + config.matchMargin - matchMarginTop
             matchMarginTop = config.matchMargin
         end
 
@@ -209,13 +209,13 @@ function BracketDisplay.computeBracketLayout(matchesById, config)
         -- place match and qualifier rounds.
         local height = headerFullHeight 
             + math.max(
-                lowerMarginTop + heightSums[#heightSums], 
+                lowerNodeMarginTop + heightSums[#heightSums], 
                 matchMarginTop + matchHeight + config.matchMargin
             )
         
         return {
             height = height,
-            lowerMarginTop = lowerMarginTop,
+            lowerNodeMarginTop = lowerNodeMarginTop,
             matchHeight = matchHeight,
             matchMarginTop = matchMarginTop,
             mid = mid,
@@ -243,7 +243,8 @@ function BracketDisplay.computeBracketLayout(matchesById, config)
 end
 
 -- Computes the vertical offset of a match with its lower round matches
-function BracketDisplay.alignMatchWithLowerNodes(match, lowerLayouts, heightSums)
+function BracketDisplay.alignMatchWithLowerNodes(match, lowerLayouts, heightSums, opponentHeight)
+    local matchHeight = #match.opponents * opponentHeight
 
     -- Show a connector line without joints if there is a single lower round 
     -- match advancing an opponent that is placed near the middle of this match.
@@ -264,7 +265,7 @@ function BracketDisplay.alignMatchWithLowerNodes(match, lowerLayouts, heightSums
         -- of the opponent it connects into.
         local opponentIx = match.bracketData.lowerMatches[1].opponentIx
         return lowerLayouts[1].mid 
-            - ((opponentIx - 1) + 0.5) * config.opponentHeight
+            - ((opponentIx - 1) + 0.5) * opponentHeight
 
     elseif 0 < #lowerLayouts then 
         if #lowerLayouts % 2 == 0 then
@@ -397,7 +398,7 @@ function BracketDisplay.NodeBody(props)
     local lowerNode
     if 0 < #match.bracketData.lowerMatches then
         lowerNode = html.create('div'):addClass('brkts-round-lower')
-            :css('margin-top', layout.lowerMarginTop .. 'px')
+            :css('margin-top', layout.lowerNodeMarginTop .. 'px')
         for _, lowerMatch in ipairs(match.bracketData.lowerMatches) do
             local childProps = Table.merge(props, {matchId = lowerMatch.matchId})
             lowerNode
@@ -625,7 +626,7 @@ function BracketDisplay.NodeLowerConnectors(props)
     -- Draw connectors between lower round matches and this match
     for ix, x in ipairs(lowerMatches) do
         local lowerLayout = lowerLayouts[ix]
-        local leftTop = layout.lowerMarginTop + heightSums[ix] + lowerLayout.mid
+        local leftTop = layout.lowerNodeMarginTop + heightSums[ix] + lowerLayout.mid
         local rightTop = layout.matchMarginTop + ((x.opponentIx - 1) + 0.5) * config.opponentHeight
         local jointLeft = (config.roundHorizontalMargin - 2) * jointIxs[x.opponentIx] / (jointCount + 1)
 

--- a/match2/commons/match_group_display_helper.lua
+++ b/match2/commons/match_group_display_helper.lua
@@ -1,9 +1,13 @@
+--
+-- @author QuadratClown for Liquipedia
+--
+
 local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
-local Json = require('Module:Json')
+local Json = require("Module:Json")
 local LuaUtils = require('Module:LuaUtils')
 local Table = require('Module:Table')
-local utils = require('Module:LuaUtils')
+local utils = require("Module:LuaUtils")
 
 local DisplayHelper = {}
 
@@ -12,17 +16,18 @@ local DisplayHelper = {}
 -- expect flattened input
 -- a '_' (underscore) shows a key originates from a nested table
 -- e.g. { key1 = { key2 = val } } becomes { key1_key2 = val }
+-- Deprecated
 function DisplayHelper.flattenArgs(args, prefix)
     local out = {}
-    prefix = prefix or ''
+    prefix = prefix or ""
     for key, val in pairs(args) do
         if tonumber(key) ~= nil then
-            if utils.string.endsWith(prefix, 's_') then
+            if utils.string.endsWith(prefix, "s_") then
                 prefix = prefix:sub(1, prefix:len() - 2)
             end
         end
-        if type(val) == 'table' then
-            local newArgs = DisplayHelper.flattenArgs(val, prefix .. key .. '_')
+        if type(val) == "table" then
+            local newArgs = DisplayHelper.flattenArgs(val, prefix .. key .. "_")
             for newKey, newVal in pairs(newArgs) do
                 out[newKey] = newVal
             end
@@ -35,17 +40,18 @@ end
 
 -- returns matches that match the given bracketid from var or LPDB
 -- tries to get from var first, otherwise uses LPDB
+-- Deprecated
 function DisplayHelper.getMatches(bracketid)
-    local varData = utils.mw.varGet('match2bracket_' .. bracketid)
+    local varData = utils.mw.varGet("match2bracket_" .. bracketid)
     if varData ~= nil then
         return Json.parse(varData)
     else
         local res =
             mw.ext.LiquipediaDB.lpdb(
-            'match2',
+            "match2",
             {
-                conditions = '([[namespace::0]] or [[namespace::>0]]) AND [[match2bracketid::' .. bracketid .. ']]',
-                order = 'match2id ASC',
+                conditions = "([[namespace::0]] or [[namespace::>0]]) AND [[match2bracketid::" .. bracketid .. "]]",
+                order = "match2id ASC",
                 limit = 5000
             }
         )
@@ -54,15 +60,17 @@ function DisplayHelper.getMatches(bracketid)
 end
 
 -- @returns the key used for highlighting the same opponents while hovering
+-- Deprecated
 function DisplayHelper.getOpponentHighlightKey(opponent)
     return string.lower(
-        (opponent.name or '') ..
-        (opponent.template or '') ..
-        (opponent.type == 'team' and '' or Json.stringify(opponent.match2players))
+        (opponent.name or "") ..
+        (opponent.template or "") ..
+        (opponent.type == "team" and "" or Json.stringify(opponent.match2players))
     )
 end
 
 -- @returns the type of a MatchGroup
+-- Deprecated
 function DisplayHelper.getMatchGroupType(bracketid)
     local varData = utils.mw.varGet('match2bracket_' .. bracketid)
     if varData ~= nil then
@@ -92,7 +100,10 @@ function DisplayHelper.opponentIsHighlightable(opponent)
     end
 end
 
--- Builds a hash of the opponent that is used to visually highlight their progress in the bracket. 
+--[[
+Builds a hash of the opponent that is used to visually highlight their progress 
+in the bracket. 
+]]
 function DisplayHelper.makeOpponentHighlightKey2(opponent)
     if opponent.type == 'literal' then
         return opponent.name and string.lower(opponent.name) or ''
@@ -130,15 +141,26 @@ function DisplayHelper.expandHeader(header)
 end
 
 --[[
-Determines whether a MatchSummary popup shall be enabled for a match.
+Determines whether a match summary popup shall be enabled for a match.
 
-This is the default policy for Bracket and Matchlist. The matchHasDetails 
-property can be used to specifiy a different policy.
+This is the default policy for Bracket and Matchlist. Wikis may specify a 
+different policy by setting props.matchHasDetails in the Bracket and Matchlist 
+components.
 ]]
 function DisplayHelper.defaultMatchHasDetails(match)
     return match.dateIsExact or 0 < #match.games
 end
 
+--[[
+Display component showing the detailed summary of a match. The component will 
+appear as a popup from the Matchlist and Bracket components. This is a 
+container component, so it takes in the match ID and bracket ID as inputs, 
+which it uses to fetch the match data from LPDB and page variables.
+
+This is the default implementation. Specific wikis may override this by passing 
+in a different props.MatchSummaryContainer in the Bracket and Matchlist 
+components.
+]]
 DisplayHelper.DefaultMatchSummaryContainer = function(props)
     local DevFlags = require('Module:DevFlags')
     local MatchSummaryModule = DevFlags.matchGroupDev and LuaUtils.lua.requireIfExists('Module:MatchSummary/dev')
@@ -158,6 +180,10 @@ DisplayHelper.DefaultMatchSummaryContainer = function(props)
     end
 end
 
+--[[
+Retrieves the wiki specific global bracket config specified in 
+MediaWiki:BracketConfig.
+]]
 DisplayHelper.getGlobalConfig = FnUtil.memoize(function()
     local defaultConfig = {
         headerHeight = 25,

--- a/match2/commons/match_group_display_helper.lua
+++ b/match2/commons/match_group_display_helper.lua
@@ -1,13 +1,9 @@
---
--- @author QuadratClown for Liquipedia
---
-
 local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
-local Json = require("Module:Json")
+local Json = require('Module:Json')
 local LuaUtils = require('Module:LuaUtils')
 local Table = require('Module:Table')
-local utils = require("Module:LuaUtils")
+local utils = require('Module:LuaUtils')
 
 local DisplayHelper = {}
 
@@ -19,15 +15,15 @@ local DisplayHelper = {}
 -- Deprecated
 function DisplayHelper.flattenArgs(args, prefix)
     local out = {}
-    prefix = prefix or ""
+    prefix = prefix or ''
     for key, val in pairs(args) do
         if tonumber(key) ~= nil then
-            if utils.string.endsWith(prefix, "s_") then
+            if utils.string.endsWith(prefix, 's_') then
                 prefix = prefix:sub(1, prefix:len() - 2)
             end
         end
-        if type(val) == "table" then
-            local newArgs = DisplayHelper.flattenArgs(val, prefix .. key .. "_")
+        if type(val) == 'table' then
+            local newArgs = DisplayHelper.flattenArgs(val, prefix .. key .. '_')
             for newKey, newVal in pairs(newArgs) do
                 out[newKey] = newVal
             end
@@ -42,16 +38,16 @@ end
 -- tries to get from var first, otherwise uses LPDB
 -- Deprecated
 function DisplayHelper.getMatches(bracketid)
-    local varData = utils.mw.varGet("match2bracket_" .. bracketid)
+    local varData = utils.mw.varGet('match2bracket_' .. bracketid)
     if varData ~= nil then
         return Json.parse(varData)
     else
         local res =
             mw.ext.LiquipediaDB.lpdb(
-            "match2",
+            'match2',
             {
-                conditions = "([[namespace::0]] or [[namespace::>0]]) AND [[match2bracketid::" .. bracketid .. "]]",
-                order = "match2id ASC",
+                conditions = '([[namespace::0]] or [[namespace::>0]]) AND [[match2bracketid::' .. bracketid .. ']]',
+                order = 'match2id ASC',
                 limit = 5000
             }
         )
@@ -63,9 +59,9 @@ end
 -- Deprecated
 function DisplayHelper.getOpponentHighlightKey(opponent)
     return string.lower(
-        (opponent.name or "") ..
-        (opponent.template or "") ..
-        (opponent.type == "team" and "" or Json.stringify(opponent.match2players))
+        (opponent.name or '') ..
+        (opponent.template or '') ..
+        (opponent.type == 'team' and '' or Json.stringify(opponent.match2players))
     )
 end
 

--- a/match2/commons/match_group_display_matchlist.lua
+++ b/match2/commons/match_group_display_matchlist.lua
@@ -1,217 +1,291 @@
-local Matchlist = {}
+local Class = require('Module:Class')
+local DisplayHelper = require('Module:MatchGroup/Display/Helper')
+local DisplayUtil = require('Module:DisplayUtil')
+local Json = require('Module:Json')
+local LuaUtils = require('Module:LuaUtils')
+local MatchGroupUtil = require('Module:MatchGroup/Util')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
 
-local DisplayHelper = require("Module:MatchGroup/Display/Helper")
-local OpponentDisplay = require("Module:OpponentDisplay")
-local MatchSummary = require("Module:MatchSummary")
-local Json = require("Module:Json")
-local HasDetails = require("Module:Brkts/WikiSpecific").matchHasDetails
-
-local getArgs = require("Module:Arguments").getArgs
-local utils = require("Module:LuaUtils")
 local html = mw.html
 
-local _frame
+local Matchlist = {propTypes = {}, types = {}}
 
-function Matchlist.get(frame)
-	local args = getArgs(frame)
-
-	local bracketid = args[1];
-
-	local matches = _getMatches(bracketid)
-
-	return Matchlist.luaGet(frame, args, matches)
+-- Called by MatchGroup/Display
+function Matchlist.luaGet(_, args)
+    return Matchlist.MatchlistContainer({
+        bracketId = args[1],
+        config = Matchlist.configFromArgs(args),
+    })
 end
 
--- draw the table
-function Matchlist.luaGet(frame, args, matches)
-	_frame = frame
-
-	if not matches then
-		local bracketid = args[1]
-		matches = _getMatches(bracketid)
-	end
-
-	--set main div, with customizable width and with attachable option (to e.g. grouptables)
-	local main = html.create("div"):addClass("brkts-main"):cssText(args.attached == 'true' and 'padding-left:0px;padding-right:0px' or '')
-	local width = string.gsub(args.width or 300, 'px', '')
-	width = (tonumber(width) or 300) .. 'px'
-
-	--determine class for the tableWrapper (collaps options)
-	local main_class = 'brkts-matchlist wikitable wikitable-bordered matchlist'
-	if args.nocollapse ~= 'true' then
-		main_class = main_class .. ' collapsible'
-		if args.collapsed == 'true' then
-			main_class = main_class .. ' collapsed'
-		end
-	end
-
-	--set tableWrapper with attachable option (to e.g. grouptables) and with collaps options
-	local tableWrapper = html.create("table")
-		:addClass(main_class)
-		:cssText(args.attached == 'true' and 'margin-bottom:-1px;margin-top:-2px' or '')
-		:css("width", width)
-	tableWrapper:node(tableBody)
-
-	-- add matches
-	for index, match in ipairs(matches) do
-		local bracketdata = match.match2bracketdata or {}
-		if type(bracketdata) == "string" then
-			bracketdata = Json.parse(bracketdata)
-		end
-		match.extradata = Json.stringify(match.extradata or {})
-
-		-- add title
-		if index == 1 then
-			local temp = _drawTitle(bracketdata.title or "Match List")
-			if not utils.misc.isEmpty(bracketdata.header) then
-				temp:tag('tr'):node(_drawHeader(bracketdata.header))
-			end
-			tableWrapper:node(temp)
-		end
-
-		-- add header
-		if index ~= 1 and not utils.misc.isEmpty(bracketdata.header) then
-			tableWrapper:node(_drawHeader(bracketdata.header))
-		end
-	
-		tableWrapper:node(_drawMatch(match))
-	end
-
-	return main:node(tableWrapper)
+Matchlist.configFromArgs = function(args)
+    return {
+        attached = LuaUtils.misc.readBool(args.attached),
+        collapsed = LuaUtils.misc.readBool(args.collapsed),
+        collapsible = not LuaUtils.misc.readBool(args.nocollapse),
+        width = tonumber(string.gsub(args.width or '', 'px', ''), nil),
+    }
 end
 
--- draw table row containing the table title
-function _drawTitle(title)
-	return html.create("th")
-		:addClass("brkts-matchlist-title")
-		:attr("colspan", "5")
-		:node(html.create("center")
-			:wikitext(title)
-		)
+Matchlist.types.MatchlistConfig = TypeUtil.struct({
+    MatchSummaryContainer = 'function',
+    Opponent = 'function',
+    Score = 'function',
+    attached = 'boolean',
+    collapsed = 'boolean',
+    collapsible = 'boolean',
+    matchHasDetails = 'function',
+    width = 'number',
+})
+Matchlist.types.MatchlistConfigOptions = TypeUtil.struct(
+    Table.mapValues(Matchlist.types.MatchlistConfig.struct, TypeUtil.optional)
+)
+
+--[[
+Display component for a tournament matchlist. The matchlist is specified by ID. 
+The component fetches the match data from LPDB or page variables.
+]]
+Matchlist.propTypes.MatchlistContainer = {
+    bracketId = 'string',
+    config = TypeUtil.optional(Matchlist.types.MatchlistConfigOptions),
+}
+function Matchlist.MatchlistContainer(props)
+    DisplayUtil.assertPropTypes(props, Matchlist.propTypes.MatchlistContainer)
+    return Matchlist.Matchlist({
+        config = props.config,
+        matches = MatchGroupUtil.fetchMatches(props.bracketId),
+    })
 end
 
--- draw table row containing match from match data
-function _drawMatch(match)
-	local winner = tonumber(match.winner)
-	if match.resulttype == 'draw' then
-		winner = 0
-	end
-	local default_opponent = {
-		name = "",
-		template = ""
-	}
+--[[
+Display component for a tournament matchlist. Match data is specified in the 
+input.
+]] 
+Matchlist.propTypes.Matchlist = {
+    config = TypeUtil.optional(Matchlist.types.MatchlistConfigOptions),
+    matches = TypeUtil.array(MatchGroupUtil.types.Match),
+}
+function Matchlist.Matchlist(props)
+    DisplayUtil.assertPropTypes(props, Matchlist.propTypes.Matchlist)
 
-	local opponent1data = match.match2opponents[1] or default_opponent
-	local opponent2data = match.match2opponents[2] or default_opponent
-	local opponent1key = DisplayHelper.getOpponentHighlightKey(opponent1data)
-	local opponent2key = DisplayHelper.getOpponentHighlightKey(opponent2data)
+    local propsConfig = props.config or {}
+    local config = {
+        MatchSummaryContainer = propsConfig.MatchSummaryContainer or DisplayHelper.DefaultMatchSummaryContainer,
+        Opponent = propsConfig.Opponent or Matchlist.DefaultOpponent,
+        Score = propsConfig.Score or Matchlist.DefaultScore,
+        attached = propsConfig.attached or false,
+        collapsed = propsConfig.collapsed or false,
+        collapsible = LuaUtils.misc.emptyOr(propsConfig.collapsible, true),
+        matchHasDetails = propsConfig.matchHasDetails or DisplayHelper.defaultMatchHasDetails,
+        width = propsConfig.width or 300,
+    }
 
-	local tbd1 =
-		match.opponent1template == 'tbd' or match.opponent1 == 'TBD' or
-		utils.string.startsWith(opponent1data.type, 'literal')
-	local tbd2 =
-		match.opponent2template == 'tbd' or match.opponent2 == 'TBD' or
-		utils.string.startsWith(opponent2data.type, 'literal')
+    local tableNode = html.create('table')
+        :addClass('brkts-matchlist wikitable wikitable-bordered matchlist')
+        :addClass(config.collapsible and 'collapsible' or nil)
+        :addClass(config.collapsed and 'collapsed' or nil)
+        :cssText(config.attached and 'margin-bottom:-1px;margin-top:-2px' or nil)
+        :css('width', config.width .. 'px')
+    
+    for index, match in ipairs(props.matches) do
+        local titleNode = index == 1
+            and Matchlist.Title({title = match.bracketData.title or 'Match List'})
+            or nil
 
-	local hasDetails = HasDetails(match)
-
-	return html.create("tr")
-		:addClass("brtks-matchlist-row brkts-match-popup-wrapper")
-		:css("cursor", "pointer")
-		:node(html.create("td")
-			:addClass("brkts-matchlist-slot brkts-opponent-hover" .. (tonumber(match.winner) == 1 and " brkts-matchlist-slot-winner" or tonumber(match.winner) == 0 and " brkts-matchlist-slot-bold bg-draw" or ""))
-			:attr("aria-label", not tbd1 and opponent1key or nil)
-			:attr("width", "40%")
-			:attr("align", "right")
-			:node(OpponentDisplay.luaGet(_frame, _addDisplayType(_flattenArgs(opponent1data), "matchlist-left")))
-		)
-		:node(html.create("td")
-			:addClass("brkts-matchlist-slot brkts-opponent-hover" .. ((tonumber(match.winner) == 1 or tonumber(match.winner) == 0) and " brkts-matchlist-slot-bold" or ""))
-			:attr("aria-label", not tbd1 and opponent1key or nil)
-			:attr("width", "10.8%")
-			:attr("align", "center")
-			:node(OpponentDisplay.luaGet(_frame, _addDisplayType(_flattenArgs(opponent1data), "matchlist-left-score")))
-		)
-		:node(
-			not hasDetails and "" or
-			html.create("td")
-				:addClass("brkts-match-info brkts-empty-td")
-				:node(
-					html.create("div")
-						:addClass("brkts-match-info-icon")
-				)
-				:node(
-					html.create("div")
-						:addClass("brkts-match-info-popup")
-						:node(MatchSummary.luaGet(_frame, _flattenArgs(match)))
-						:css("display", "none")
-				)
-			)
-		:node(html.create("td")
-			:addClass("brkts-matchlist-slot brkts-opponent-hover" .. ((tonumber(match.winner) == 2 or tonumber(match.winner) == 0) and " brkts-matchlist-slot-bold" or ""))
-			:attr("aria-label", not tbd2 and opponent2key or nil)
-			:attr("width", "10.8%")
-			:attr("align", "center")
-			:node(OpponentDisplay.luaGet(_frame, _addDisplayType(_flattenArgs(opponent2data), "matchlist-right-score")))
-		)
-		:node(html.create("td")
-			:addClass("brkts-matchlist-slot brkts-opponent-hover" .. (tonumber(match.winner) == 2 and " brkts-matchlist-slot-winner" or tonumber(match.winner) == 0 and " brkts-matchlist-slot-bold bg-draw" or ""))
-			:attr("aria-label", not tbd2 and opponent2key or nil)
-			:attr("width", "40%")
-			:attr("align", "left")
-			:node(OpponentDisplay.luaGet(_frame, _addDisplayType(_flattenArgs(opponent2data), "matchlist-right")))
-		)
+        local headerNode = match.bracketData.header
+            and Matchlist.Header({header = match.bracketData.header})
+            or nil
+        
+        local matchNode = Matchlist.Match({
+            MatchSummaryContainer = config.MatchSummaryContainer,
+            Opponent = config.Opponent,
+            Score = config.Score,
+            match = match, 
+            matchHasDetails = config.matchHasDetails
+        })
+        
+        tableNode
+            :node(titleNode)
+            :node(headerNode)
+            :node(matchNode)
+    end
+    
+    return html.create('div'):addClass('brkts-main')
+        :cssText(config.attached and 'padding-left:0px;padding-right:0px' or nil)
+        :node(tableNode)
 end
 
-function _drawHeader(header)
-	return html.create("th")
-		:addClass("brkts-matchlist-header")
-		:attr("colspan", "5")
-		:node(html.create("center")
-			:wikitext(header)
-		)
+--[[
+Display component for a match in a matchlist. Consists of two opponents, two 
+scores, and a icon for the match summary popup.
+]]
+Matchlist.propTypes.Match = {
+    MatchSummaryContainer = 'function',
+    Opponent = 'function',
+    Score = 'function',
+    match = MatchGroupUtil.types.Match,
+    matchHasDetails = 'function',
+}
+function Matchlist.Match(props)
+    DisplayUtil.assertPropTypes(props, Matchlist.propTypes.Match)
+    local match = props.match
+    
+    local renderOpponent = function(opponentIx)
+        local opponent = match.opponents[opponentIx] or MatchGroupUtil.createOpponent({})
+
+        local canHighlight = DisplayHelper.opponentIsHighlightable(opponent)
+        local opponentNode = props.Opponent({
+            opponent = opponent,
+            side = opponentIx == 1 and 'left' or 'right',
+        })
+        return html.create('td')
+            :addClass('brkts-matchlist-slot')
+            :addClass(canHighlight and 'brkts-opponent-hover' or nil)
+            :addClass(match.winner == opponentIx and 'brkts-matchlist-slot-winner' or nil)
+            :addClass(match.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
+            :attr('aria-label', canHighlight and DisplayHelper.makeOpponentHighlightKey2(opponent) or nil)
+            :attr('width', '40%')
+            :attr('align', opponentIx == 1 and 'right' or 'left')
+            :node(opponentNode)
+    end
+
+    local renderScore = function(opponentIx)
+        local opponent = match.opponents[opponentIx] or MatchGroupUtil.createOpponent({})
+
+        local canHighlight = DisplayHelper.opponentIsHighlightable(opponent)
+        local scoreNode = props.Score({
+            opponent = opponent,
+            side = opponentIx == 1 and 'left' or 'right',
+        })
+        return html.create('td')
+            :addClass('brkts-matchlist-slot')
+            :addClass(canHighlight and 'brkts-opponent-hover' or nil)
+            :addClass((match.winner == opponentIx or match.resultType == 'draw') and 'brkts-matchlist-slot-bold' or nil)
+            :attr('aria-label', canHighlight and DisplayHelper.makeOpponentHighlightKey2(opponent) or nil)
+            :attr('width', '10.8%')
+            :attr('align', 'center')
+            :node(scoreNode)
+    end
+
+    local matchInfo
+    if props.matchHasDetails(match) then
+        local matchSummaryNode = DisplayUtil.TryPureComponent(props.MatchSummaryContainer, {
+            bracketId = props.match.matchId:match('^(.*)_'), -- everything up to the final '_'
+            matchId = props.match.matchId,
+        })
+
+        local matchSummaryPopupNode = html.create('div')
+            :addClass('brkts-match-info-popup')
+            :css('max-height', '80vh')
+            :css('overflow', 'auto')
+            :css('display', 'none')
+            :node(matchSummaryNode)
+
+        matchInfo = html.create('td')
+            :addClass('brkts-match-info brkts-empty-td')
+            :node(
+                html.create('div')
+                    :addClass('brkts-match-info-icon')
+            )
+            :node(matchSummaryPopupNode)
+    end
+
+    return html.create('tr')
+        :addClass('brtks-matchlist-row brkts-match-popup-wrapper')
+        :css('cursor', 'pointer')
+        :node(renderOpponent(1))
+        :node(renderScore(1))
+        :node(matchInfo)
+        :node(renderScore(2))
+        :node(renderOpponent(2))
 end
 
--- get matches from LPDB or from a var
-function _getMatches(bracketid)
-	local varData = utils.mw.varGet("match2bracket_" .. bracketid)
-	if varData ~= nil then
-		return Json.parse(varData)
-	else
-		local res = mw.ext.LiquipediaDB.lpdb("match2", {
-				conditions = "([[namespace::0]] or [[namespace::>0]]) AND [[match2bracketid::" .. bracketid .. "]]",
-				order = "match2id ASC"
-			})
-		
-		return res
-	end
+--[[
+Display component for a title in a matchlist.
+]]
+Matchlist.propTypes.Title = {
+    title = 'string',
+}
+function Matchlist.Title(props)
+    DisplayUtil.assertPropTypes(props, Matchlist.propTypes.Title)
+    return html.create('th')
+        :addClass('brkts-matchlist-title')
+        :attr('colspan', '5')
+        :node(
+            html.create('center')
+                :wikitext(props.title)
+        )
 end
 
-function _flattenArgs(args, prefix)
-	local out = {}
-	prefix = prefix or ""
-	for key, val in pairs(args) do
-		if tonumber(key) ~= nil then
-			key = tonumber(key)
-			if utils.string.endsWith(prefix, "s_") then
-				prefix = prefix:sub(1, prefix:len() - 2)
-			end
-		end
-		if type(val) == "table" then
-			local newArgs = _flattenArgs(val, prefix .. key .. "_")
-			for newKey, newVal in pairs(newArgs) do
-				out[newKey] = newVal
-			end
-		else
-			out[prefix .. key] = tostring(val)
-		end	
-	end
-	return out
+--[[
+Display component for a header in a matchlist.
+]]
+Matchlist.propTypes.Header = {
+    header = 'string',
+}
+function Matchlist.Header(props)
+    DisplayUtil.assertPropTypes(props, Matchlist.propTypes.Header)
+    return html.create('th')
+        :addClass('brkts-matchlist-header')
+        :attr('colspan', '5')
+        :node(
+            html.create('center')
+                :wikitext(props.header)
+        )
 end
 
-function _addDisplayType(args, displayType)
-	args.displaytype = displayType
-	return args
+--[[
+Display component for an opponent in a matchlist. 
+
+This is the default implementation. Specific wikis may override this by passing 
+in a different props.Opponent in the Matchlist component.
+]]
+function Matchlist.DefaultOpponent(props)
+    local opponent = props.opponent
+
+    --temp fix so that opponent extradata is available if data is inherited from storage vars
+    opponent._rawRecord.extradata = Json.parseIfString(opponent._rawRecord.extradata) or {}
+    for _, playerRecord in ipairs(opponent._rawRecord.match2players) do
+        playerRecord.extradata = Json.parseIfString(playerRecord.extradata) or {}
+    end
+    
+    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and LuaUtils.lua.requireIfExists('Module:OpponentDisplay/dev')
+        or LuaUtils.lua.requireIfExists('Module:OpponentDisplay')
+        or {}
+    return OpponentDisplay.luaGet(
+        mw.getCurrentFrame(),
+        Table.mergeInto(DisplayHelper.flattenArgs(opponent._rawRecord), {
+            displaytype = props.side == 'left' and 'matchlist-left' or 'matchlist-right',
+        })
+    )
 end
 
-return Matchlist
+
+--[[
+Display component for the score of an opponent in a matchlist. 
+
+This is the default implementation. Specific wikis may override this by passing 
+in a different props.Score in the Matchlist component.
+]]
+function Matchlist.DefaultScore(props)
+    local opponent = props.opponent
+
+    --temp fix so that opponent extradata is available if data is inherited from storage vars
+    opponent._rawRecord.extradata = Json.parseIfString(opponent._rawRecord.extradata) or {}
+    for _, playerRecord in ipairs(opponent._rawRecord.match2players) do
+        playerRecord.extradata = Json.parseIfString(playerRecord.extradata) or {}
+    end
+    
+    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and LuaUtils.lua.requireIfExists('Module:OpponentDisplay/dev')
+        or LuaUtils.lua.requireIfExists('Module:OpponentDisplay')
+        or {}
+    return OpponentDisplay.luaGet(
+        mw.getCurrentFrame(),
+        Table.mergeInto(DisplayHelper.flattenArgs(opponent._rawRecord), {
+            displaytype = props.side == 'left' and 'matchlist-left-score' or 'matchlist-right-score',
+        })
+    )
+end
+
+return Class.export(Matchlist)

--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -1,0 +1,305 @@
+local Array = require('Module:Array')
+local FnUtil = require('Module:FnUtil')
+local Json = require('Module:Json')
+local LuaUtils = require('Module:LuaUtils')
+local String = require('Module:String')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+
+local nilIfEmpty = String.nilIfEmpty
+
+--[[ 
+Non-display utility functions for brackets, matchlists, matches, opponents, 
+games, and etc in the new bracket framework. 
+
+Display related functions go in Module:MatchGroup/Display/Helper. 
+]]
+local MatchGroupUtil = {types = {}}
+
+
+MatchGroupUtil.types.LowerMatch = TypeUtil.struct({
+    matchId = 'string',
+    opponentIx = 'number',
+})
+MatchGroupUtil.types.BracketBracketData = TypeUtil.struct({
+    bracketResetMatchId = 'string?',
+    bracketSection = 'string',
+    header = 'string?',
+    lowerMatches = TypeUtil.array(MatchGroupUtil.types.LowerMatch),
+    qualLose = 'boolean?',
+    qualLoseLiteral = 'string?',
+    qualSkip = 'number?',
+    qualWin = 'boolean?',
+    qualWinLiteral = 'string?',
+    skipRound = 'number?',
+    thirdPlaceMatchId = 'string?',
+    title = 'string?',
+    type = TypeUtil.literal('bracket'),
+})
+MatchGroupUtil.types.MatchlistBracketData = TypeUtil.struct({
+    header = 'string?',
+    title = 'string?',
+    type = TypeUtil.literal('matchlist'),
+})
+MatchGroupUtil.types.BracketData = TypeUtil.union(
+    MatchGroupUtil.types.MatchlistBracketData,
+    MatchGroupUtil.types.BracketBracketData
+)
+
+MatchGroupUtil.types.Player = TypeUtil.struct({
+    displayName = 'string?',
+    flag = 'string?',
+    pageName = 'string?',
+})
+
+MatchGroupUtil.types.Opponent = TypeUtil.struct({
+    icon = 'string?',
+    name = 'string?',
+    placement = 'number?',
+    placement2 = 'number?',
+    players = TypeUtil.array(MatchGroupUtil.types.Player),
+    score = 'number?',
+    score2 = 'number?',
+    status = 'string?',
+    status2 = 'string?',
+    template = 'string?',
+    type = 'string',
+})
+
+MatchGroupUtil.types.ResultType = TypeUtil.literalUnion('default', 'draw', 'np')
+MatchGroupUtil.types.Walkover = TypeUtil.literalUnion('L', 'FF', 'DQ')
+MatchGroupUtil.types.Game = TypeUtil.struct({
+    comment = 'string?',
+    header = 'string?',
+    length = 'number?',
+    map = 'string?',
+    mode = 'string?',
+    participants = 'table',
+    resultType = TypeUtil.optional(MatchGroupUtil.types.ResultType),
+    subgroup = 'number?',
+    vod = 'string?',
+    walkover = TypeUtil.optional(MatchGroupUtil.types.Walkover),
+    winner = 'number?',
+})
+
+MatchGroupUtil.types.Match = TypeUtil.struct({
+    bracketData = MatchGroupUtil.types.BracketData,
+    comment = 'string?',
+    date = 'string',
+    dateIsExact = 'boolean',
+    finished = 'boolean',
+    games = TypeUtil.array(MatchGroupUtil.types.Game),
+    links = 'table',
+    matchId = 'string?',
+    mode = 'string',
+    opponents = TypeUtil.array(MatchGroupUtil.types.Opponent),
+    resultType = 'string?',
+    stream = 'table',
+    type = 'string?',
+    vod = 'string?',
+    walkover = 'string?',
+    winner = 'number?',
+})
+
+--[[
+Fetches all matches in a matchlist or bracket. Tries to read from page 
+variables before fetching from LPDB. Returns a list of records 
+ordered lexicographically by matchId.
+]]
+function MatchGroupUtil.fetchMatchRecords(bracketId)
+    local varData = LuaUtils.mw.varGet("match2bracket_" .. bracketId)
+    if varData then
+        return Json.parse(varData)
+    else
+        return mw.ext.LiquipediaDB.lpdb(
+            "match2",
+            {
+                conditions = "([[namespace::0]] or [[namespace::>0]]) AND [[match2bracketid::" .. bracketId .. "]]",
+                order = "match2id ASC",
+                limit = 5000,
+            }
+        )
+    end
+end
+
+--[[
+Fetches all matches in a matchlist or bracket. Returns a list of structurally 
+typed matches lexicographically ordered by matchId.
+]]
+MatchGroupUtil.fetchMatches = FnUtil.memoize(function(bracketId)
+    return Array.map(
+        MatchGroupUtil.fetchMatchRecords(bracketId), 
+        require('Module:Brkts/WikiSpecific').matchFromRecord
+    )
+end)
+
+-- Returns a table whose entries are (matchId, match)
+MatchGroupUtil.fetchMatchesTable = FnUtil.memoize(function(bracketId)
+    local matches = MatchGroupUtil.fetchMatches(bracketId)
+    local matchesById = {}
+    for _, match in pairs(matches) do
+        matchesById[match.matchId] = match
+    end
+    return matchesById
+end)
+
+--[[
+Converts a match record to a structurally typed table with the appropriate data 
+types for field values. The match record is either a match created in the store 
+bracket codepath (WikiSpecific.processMatch), or a record fetched from LPDB 
+(MatchGroupUtil.fetchMatchRecords). The returned match struct is used in 
+various display components (Bracket, MatchSummary, etc)
+
+This is the implementation used on wikis by default. Wikis may specify a 
+different conversion by setting WikiSpecific.matchFromRecord. Refer
+to the starcraft2 wiki as an example.
+]]
+function MatchGroupUtil.matchFromRecord(record)
+    local extradata = Json.parseIfString(record.extradata) or {}
+    local opponents = Array.map(record.match2opponents, MatchGroupUtil.opponentFromRecord)
+
+    return {
+        _rawRecord = record, --deprecated
+        bracketData = MatchGroupUtil.bracketDataFromRecord(Json.parseIfString(record.match2bracketdata), #opponents),
+        comment = nilIfEmpty(extradata.comment),
+        extradata = extradata,
+        date = record.date,
+        dateIsExact = LuaUtils.misc.readBool(record.dateexact),
+        finished = LuaUtils.misc.readBool(record.finished),
+        games = Array.map(record.match2games, MatchGroupUtil.gameFromRecord),
+        links = Json.parseIfString(record.links) or {},
+        matchId = record.match2id,
+        mode = record.mode,
+        opponents = opponents,
+        resultType = nilIfEmpty(record.resulttype),
+        stream = Json.parseIfString(record.stream) or {},
+        type = nilIfEmpty(record.type),
+        vod = nilIfEmpty(record.vod),
+        walkover = nilIfEmpty(record.walkover),
+        winner = tonumber(record.winner),
+    }
+end
+
+function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
+    if data.type == 'bracket' then
+        local lowerMatches = {}
+        local midIx = math.ceil(opponentCount / 2)
+        if nilIfEmpty(data.toupper) then
+            table.insert(lowerMatches, {
+                matchId = data.toupper, 
+                opponentIx = midIx,
+            })
+        end
+        if nilIfEmpty(data.tolower) then
+            table.insert(lowerMatches, {
+                matchId = data.tolower, 
+                opponentIx = math.min(midIx + 1, opponentCount),
+            })
+        end
+
+        return {
+            bracketResetMatchId = nilIfEmpty(data.bracketreset),
+            bracketSection = data.bracketsection,
+            header = nilIfEmpty(data.header),
+            lowerMatches = lowerMatches,
+            qualLose = LuaUtils.misc.readBool(data.quallose),
+            qualLoseLiteral = nilIfEmpty(data.qualLoseLiteral),
+            qualSkip = tonumber(data.qualskip) or data.qualskip == 'true' and 1 or 0,
+            qualWin = LuaUtils.misc.readBool(data.qualwin),
+            qualWinLiteral = nilIfEmpty(data.qualWinLiteral),
+            skipRound = tonumber(data.skipround) or data.skipround == 'true' and 1 or 0,
+            thirdPlaceMatchId = nilIfEmpty(data.thirdplace),
+            type = 'bracket',
+        }
+    else
+        return {
+            header = nilIfEmpty(data.header),
+            title = nilIfEmpty(data.title),
+            type = 'matchlist',
+        }
+    end
+end
+
+function MatchGroupUtil.opponentFromRecord(record)
+    local extradata = Json.parseIfString(record.extradata) or {}
+    return {
+        _rawRecord = record, --deprecated
+        extradata = extradata,
+        icon = nilIfEmpty(record.icon),
+        name = nilIfEmpty(record.name),
+        placement = tonumber(record.placement),
+        players = Array.map(record.match2players, MatchGroupUtil.playerFromRecord),
+        score = tonumber(record.score),
+        status = record.status,
+        template = nilIfEmpty(record.template),
+        type = nilIfEmpty(record.type) or 'literal',
+    }
+end
+
+function MatchGroupUtil.createOpponent(args)
+    return {
+        _rawRecord = args, --deprecated
+        extradata = args.extradata or {},
+        icon = args.icon,
+        name = args.name,
+        placement = args.placement,
+        players = args.players or {},
+        score = args.score,
+        status = args.status,
+        template = args.template,
+        type = args.type or 'literal',
+    }
+end
+
+function MatchGroupUtil.playerFromRecord(record)
+    local extradata = Json.parseIfString(record.extradata) or {}
+    return {
+        displayName = record.displayname,
+        extradata = extradata,
+        flag = nilIfEmpty(record.flag),
+        pageName = record.name,
+    }
+end
+
+function MatchGroupUtil.gameFromRecord(record)
+    local extradata = Json.parseIfString(record.extradata) or {}
+    return {
+        comment = nilIfEmpty(extradata.comment),
+        extradata = extradata,
+        header = nilIfEmpty(extradata.header),
+        length = tonumber(record.length),
+        map = nilIfEmpty(record.map),
+        mode = nilIfEmpty(record.mode),
+        participants = Json.parseIfString(record.participants) or {},
+        resultType = nilIfEmpty(record.resulttype),
+        subgroup = tonumber(record.subgroup),
+        vod = nilIfEmpty(record.vod),
+        walkover = nilIfEmpty(record.walkover),
+        winner = tonumber(record.winner),
+    }
+end
+
+-- Merges a grand finals match with results of its bracket reset match.
+function MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
+    local mergedMatch = Table.merge(match, {
+        opponents = {},
+        games = Table.copy(match.games),
+    })
+
+    for ix, opponent in ipairs(match.opponents) do
+        local resetOpponent = bracketResetMatch.opponents[ix]
+        mergedMatch.opponents[ix] = Table.merge(opponent, {
+            score2 = resetOpponent.score,
+            status2 = resetOpponent.status,
+            placement2 = resetOpponent.placement,
+        })
+    end
+
+    for _, game in ipairs(bracketResetMatch.games) do
+        table.insert(mergedMatch.games, game)
+    end
+
+    return mergedMatch
+end
+
+return MatchGroupUtil

--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -16,7 +16,6 @@ Display related functions go in Module:MatchGroup/Display/Helper.
 ]]
 local MatchGroupUtil = {types = {}}
 
-
 MatchGroupUtil.types.LowerMatch = TypeUtil.struct({
     matchId = 'string',
     opponentIx = 'number',

--- a/match2/wikis/valorant/match_summary.lua
+++ b/match2/wikis/valorant/match_summary.lua
@@ -1,13 +1,15 @@
-local MatchSummary = require('Module:MatchSummary/Base')
-local Json = require('Module:Json')
+---
+-- @author Vogan for Liquipedia
+--
+
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
-local Template = require('Module:Template')
+local Countdown = require('Module:Countdown')
 local LuaUtils = require("Module:LuaUtils")
+local MatchGroupUtil = require('Module:MatchGroup/Util')
+local MatchSummary = require('Module:MatchSummary/Base')
 local Table = require('Module:Table')
-
-local config = LuaUtils.lua.moduleExists("Module:Match/Config") and require("Module:Match/Config") or {}
-local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
+local Template = require('Module:Template')
 
 local Agents = Class.new(
     function(self)
@@ -99,11 +101,11 @@ function Score:setSecondRoundScore(side, score)
 end
 
 function Score:_getSideColor(side)
-	if side == 'atk' then
-		return '#c04845'
-	elseif side == 'def' then
-		return '#46b09c'
-	end
+    if side == 'atk' then
+        return '#c04845'
+    elseif side == 'def' then
+        return '#46b09c'
+    end
 end
 
 function Score:create()
@@ -113,25 +115,26 @@ end
 
 local CustomMatchSummary = {}
 
--- Suboptimal to have this be global, but alas
-local vods = {}
+function CustomMatchSummary.getByMatchId(args)
+    local match = MatchGroupUtil.fetchMatchesTable(args.bracketId)[args.matchId]
+    local frame = mw.getCurrentFrame()
 
-function CustomMatchSummary.get(frame)
-    return CustomMatchSummary.luaGet(frame, require('Module:Arguments').getArgs(frame))
-end
-
-function CustomMatchSummary.luaGet(frame, args)
     local matchSummary = MatchSummary:init('480px')
-    matchSummary:header(CustomMatchSummary._createHeader(frame, args))
-                :body(CustomMatchSummary._createBody(frame, args))
+    matchSummary:header(CustomMatchSummary._createHeader(frame, match))
+                :body(CustomMatchSummary._createBody(frame, match))
 
-  	local matchExtradata = Json.parse(args.extradata or "{}")
-
-    if not LuaUtils.misc.isEmpty(matchExtradata.comment) then
-        matchSummary:comment(MatchSummary.Comment():content(matchExtradata.comment))
+    if match.comment then
+        matchSummary:comment(MatchSummary.Comment():content(match.comment))
     end
 
-    if Table.size(vods) > 0 then
+    local vods = {}
+    for index, game in ipairs(match.games) do
+        if game.vod then
+            vods[index] = game.vod
+        end
+    end
+
+    if not Table.isEmpty(vods) then
         local footer = MatchSummary.Footer()
 
         for index, vod in pairs(vods) do
@@ -148,68 +151,56 @@ function CustomMatchSummary.luaGet(frame, args)
     return matchSummary:create()
 end
 
-function CustomMatchSummary._createHeader(frame, args)
+function CustomMatchSummary._createHeader(frame, match)
     local header = MatchSummary.Header()
-    header  :left(CustomMatchSummary._createLeftOpponent(frame, args))
-            :right(CustomMatchSummary._createRightOpponent(frame, args))
+    header  :left(CustomMatchSummary._createLeftOpponent(frame, match.opponents[1]))
+            :right(CustomMatchSummary._createRightOpponent(frame, match.opponents[2]))
 
     return header
 end
 
-function CustomMatchSummary._createBody(frame, args)
+function CustomMatchSummary._createBody(frame, match)
     local body = MatchSummary.Body()
 
     local streamElement = mw.html.create('center')
-    streamElement   :wikitext(CustomMatchSummary._createStreamCountdown(frame, args))
+    streamElement   :wikitext(CustomMatchSummary._createStreamCountdown(frame, match))
                     :css('display', 'block')
                     :css('margin', 'auto')
     body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(streamElement))
 
     local matchPageElement = mw.html.create('center')
-    matchPageElement   :wikitext('[[Match:ID_' .. args['match2id'] .. '|Match Page]]')
+    matchPageElement   :wikitext('[[Match:ID_' .. match.matchId .. '|Match Page]]')
                     :css('display', 'block')
                     :css('margin', 'auto')
     body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(matchPageElement))
 
-  	for index = 1, MAX_NUM_MAPS do
-		local game = "match2game" .. index .. '_'
-		local map = args[game .. "map"]
-		if not LuaUtils.misc.isEmpty(map) then
-            body:addRow(CustomMatchSummary._createMap(frame, args, game, map))
-        end
-
-        local vod = args[game .. "vod"]
-        if not LuaUtils.misc.isEmpty(vod) then
-            vods[index] = vod
+    for _, game in ipairs(match.games) do
+        if game.map then
+            body:addRow(CustomMatchSummary._createMap(frame, game))
         end
     end
 
     return body
 end
 
-function CustomMatchSummary._createMap(frame, args, game, map)
+function CustomMatchSummary._createMap(frame, game)
     local row = MatchSummary.Row()
 
-    local winner = args[game .. "winner"]
-    local extradata, err = Json.parse(args[game .. "extradata"])
-    local participants = args[game .. 'participants']
     local team1Agents, team2Agents
 
-    if participants ~= nil then
-        participants = Json.parse(participants)
-
+    if not Table.isEmpty(game.participants) then
         team1Agents = Agents():setLeft()
         team2Agents = Agents():setRight()
 
         for player = 1, 5 do
-            local playerStats = participants['1_' .. player]
+            local playerStats = game.participants['1_' .. player]
             if playerStats ~= nil then
                 team1Agents:add(frame, playerStats['agent'])
             end
         end
 
         for player = 1, 5 do
-            local playerStats = participants['2_' .. player]
+            local playerStats = game.participants['2_' .. player]
             if playerStats ~= nil then
                 team2Agents:add(frame, playerStats['agent'])
             end
@@ -219,12 +210,13 @@ function CustomMatchSummary._createMap(frame, args, game, map)
 
     local score1, score2
 
-    if extradata ~= nil then
+    local extradata = game.extradata
+    if not Table.isEmpty(extradata) then
         score1 = Score():setLeft()
         score2 = Score():setRight()
 
-        score1:setMapScore(args[game .. 'score1'])
-        score2:setMapScore(args[game .. 'score2'])
+        score1:setMapScore(game.opponents[1].score)
+        score2:setMapScore(game.opponents[2].score)
 
         score1:setFirstRoundScore(extradata.op1startside, extradata.half1score1)
         score1:setSecondRoundScore(
@@ -235,7 +227,7 @@ function CustomMatchSummary._createMap(frame, args, game, map)
         score2:setSecondRoundScore(extradata.op1startside, extradata.half2score2)
     end
 
-    row:addElement(CustomMatchSummary._createCheckMark(tonumber(winner) == 1))
+    row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))
     if team1Agents ~= nil then
         row:addElement(team1Agents:create())
     end
@@ -243,11 +235,11 @@ function CustomMatchSummary._createMap(frame, args, game, map)
 
     local centerNode = mw.html.create('div')
     centerNode  :addClass('brkts-popup-spaced')
-                :wikitext('[[' .. map .. ']]')
+                :wikitext('[[' .. game.map .. ']]')
                 :css('width', '100px')
                 :css('text-align', 'center')
 
-    if args[game .. 'resulttype'] == 'np' then
+    if game.resultType == 'np' then
         centerNode:addClass('brkts-popup-spaced-map-skip')
     end
 
@@ -257,12 +249,12 @@ function CustomMatchSummary._createMap(frame, args, game, map)
     if team2Agents ~= nil then
         row:addElement(team2Agents:create())
     end
-    row:addElement(CustomMatchSummary._createCheckMark(tonumber(winner) == 2))
+    row:addElement(CustomMatchSummary._createCheckMark(game.winner == 2))
 
-    if not LuaUtils.misc.isEmpty(extradata.comment) then
+    if not LuaUtils.misc.isEmpty(game.comment) then
         row:addElement(MatchSummary.Break():create())
         local comment = mw.html.create('div')
-        comment :wikitext(extradata.comment)
+        comment :wikitext(game.comment)
                 :css('margin', 'auto')
         row:addElement(comment)
     end
@@ -272,10 +264,10 @@ function CustomMatchSummary._createMap(frame, args, game, map)
 end
 
 function CustomMatchSummary._getOppositeSide(side)
-	if side == 'atk' then
-		return 'def'
-	end
-	return 'atk'
+    if side == 'atk' then
+        return 'def'
+    end
+    return 'atk'
 end
 
 function CustomMatchSummary._createCheckMark(isWinner)
@@ -291,52 +283,53 @@ function CustomMatchSummary._createCheckMark(isWinner)
     return container
 end
 
-function CustomMatchSummary._createStreamCountdown(frame, args)
-  	local stream = Json.parse(args.stream or "{}")
-  	stream.date = mw.getContentLanguage():formatDate('r', args.date)
-	stream.finished = LuaUtils.misc.readBool(args.finished) and "true" or ""
+function CustomMatchSummary._createStreamCountdown(frame, match)
+    local stream = Table.merge(match.stream, {
+        date = mw.getContentLanguage():formatDate('r', match.date),
+        finished = match.finished and 'true' or nil,
+    })
 
-    return Template.safeExpand(frame, 'countdown', stream)
+    return Countdown._create(stream)
 end
 
-function CustomMatchSummary._createLeftOpponent(frame, args)
+function CustomMatchSummary._createLeftOpponent(frame, opponent)
     local container = mw.html.create('div')
     container   :addClass('brkts-popup-header-left')
                 :css('justify-content', 'flex-end')
                 :css('display', 'flex')
                 :css('width', '45%')
 
-    local prefix = 'match2opponent1_'
-    local opponent = CustomMatchSummary._renderOpponent(
-        prefix .. 'type',
+    local opponentNode = CustomMatchSummary._renderOpponent(
+        opponent.type,
         function()
-            return Template.safeExpand(frame, 'Team2Short', { args[prefix .. 'template'] or 'TBD' })
+            return Template.safeExpand(frame, 'Team2Short', { opponent.template or 'TBD' })
         end,
         function()
-            return Template.safeExpand(frame, 'Player2', { args[prefix .. 'match2player1_name'], flag = args[prefix .. 'match2player1_flag'] })
+            local player = opponent.players[1]
+            return Template.safeExpand(frame, 'Player2', { player.name, flag = player.flag })
         end
     )
 
-    container:node(opponent)
+    container:node(opponentNode)
     return container
 end
 
-function CustomMatchSummary._createRightOpponent(frame, args)
+function CustomMatchSummary._createRightOpponent(frame, opponent)
     local container = mw.html.create('div')
     container:addClass('brkts-popup-header-right')
 
-    local prefix = 'match2opponent2_'
-    local opponent = CustomMatchSummary._renderOpponent(
-        prefix .. 'type',
+    local opponentNode = CustomMatchSummary._renderOpponent(
+        opponent.type,
         function()
-            return Template.safeExpand(frame, 'TeamShort', { args[prefix .. 'template'] or 'TBD' })
+            return Template.safeExpand(frame, 'TeamShort', { opponent.template or 'TBD' })
         end,
         function()
-            return Template.safeExpand(frame, 'Player', { args[prefix .. 'match2player1_name'], flag = args[prefix .. 'match2player1_flag'] })
+            local player = opponent.players[1]
+            return Template.safeExpand(frame, 'Player', { player.name, flag = player.flag })
         end
     )
 
-    container:node(opponent)
+    container:node(opponentNode)
     return container
 end
 

--- a/match2/wikis/valorant/match_summary.lua
+++ b/match2/wikis/valorant/match_summary.lua
@@ -1,7 +1,3 @@
----
--- @author Vogan for Liquipedia
---
-
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')


### PR DESCRIPTION
Changes:
- Support for multiple opponents in brackets
- Use structural data types, so all the to number, nilIfEmpty, readBool, Json.parse etc type conversions are done before the render pipeline for brackets and matchlists
- Greatly simplify layout computation for brackets, and minor visual bug fixes
- Simplify Bracket-OpponentDisplay interface by removing 3 nested divs
- Simplify Bracket-MatchSummary and Matchlist-MatchSummary interface by removing args flattening and unflattening, and 1 nested div
- Add documentation to Bracket and Matchlist
- Wiki specific customizations to Bracket and Matchlist components no longer go through Brkts/WikiSpecific - they are now passed as props to Bracket and Matchlist. See https://liquipedia.net/commons/Module:MatchGroup/Display/Bracket/Starcraft as an example