### PR TITLE
add OPTION to disable lpdb storage

### DIFF
--- a/match2/commons/match.lua
+++ b/match2/commons/match.lua
@@ -50,8 +50,8 @@ function p.toEncodedJson(frame)
 	return json.stringify(globalArgs)
 end
 
-function p.store(args, storeInLPDB)
-	storeInLpdb = storeInLPDB
+function p.store(args, shouldStoreInLpdb)
+	storeInLpdb = shouldStoreInLpdb
 	local matchid = args["matchid"] or -1
 	local bracketid = args["bracketid"] or -1
 	local staticid = bracketid .. "_" .. matchid

--- a/match2/commons/match.lua
+++ b/match2/commons/match.lua
@@ -122,7 +122,7 @@ function p._storePlayers(args, staticid, opponentIndex, storeInLPDB)
 				staticid .. "_m2o_" .. opponentIndex .. "_m2p_" .. playerIndex, player
 			)
 		else
-			res = playerIndex --maybe wrong, have to test
+			res = playerIndex
 		end
 
 		-- append player to string to allow setting the match2opponentid later
@@ -165,7 +165,7 @@ function p._storeOpponents(args, staticid, opponentPlayers, storeInLPDB)
 		if storeInLPDB then
 			res = mw.ext.LiquipediaDB.lpdb_match2opponent(staticid .. "_m2o_" .. opponentIndex, opponent, storeInLPDB)
 		else
-			res = opponentIndex --maybe wrong, have to test
+			res = opponentIndex
 		end
 
 		-- recover raw players

--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -127,7 +127,6 @@ function p.bracket(frame)
 end
 
 function p.luaBracket(frame, args, matchBuilder)
-	local contest
 	local templateid = args["1"]
 	local bracketid = args["id"]
 	if templateid == nil or templateid == "" then
@@ -181,11 +180,6 @@ function p.luaBracket(frame, args, matchBuilder)
 		if match ~= nil then
 			if type(match) == "string" then
 				match = json.parse(match)
-			end
-
-			if contest then
-				match.contest = contest[matchid]
-				match.contestname = args.contestname
 			end
 
 			p._validateMatchBracketData(matchid, bd)

--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -3,7 +3,7 @@ local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Variables = require('Module:Variables')
-local String = require('Module:String')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
@@ -176,7 +176,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		opponents = opponents,
 		resultType = nilIfEmpty(record.resulttype),
 		stream = Json.parseIfString(record.stream) or {},
-		type = nilIfEmpty(record.type),
+		type = nilIfEmpty(record.type) or 'literal',
 		vod = nilIfEmpty(record.vod),
 		walkover = nilIfEmpty(record.walkover),
 		winner = tonumber(record.winner),


### PR DESCRIPTION
### Changes to Module:MatchGroup/Base and Module:Match to add an **_OPTION_** to disable the storage in LPDB
-> As now the Brackets/Matchlists are rendered via the Vars instead of the LPDB calls if displayed on the same page as the input happens we now can give an option to disable the LPDB storage.
-> Storage is still the default

### Also rename "errorCat" to "category" in Module:MatchGroup/Base
-> we might want to use it for other categories too (e.g. if we should add support for Bracket Contests), so giving it a slightly less specific name seems to be better

### Small fix in Module:MatchGroup/Util