### PR TITLE
[3/7] Convert Matchlist to use new OpponentDisplay components

### DIFF
--- a/match2/commons/match_group_display_helper.lua
+++ b/match2/commons/match_group_display_helper.lua
@@ -66,6 +66,13 @@ function DisplayHelper.makeOpponentHighlightKey2(opponent)
 	end
 end
 
+function DisplayHelper.addOpponentHighlight(node, opponent)
+	local canHighlight = DisplayHelper.opponentIsHighlightable(opponent)
+	return node
+		:addClass(canHighlight and 'brkts-opponent-hover' or nil)
+		:attr('aria-label', canHighlight and DisplayHelper.makeOpponentHighlightKey2(opponent) or nil)
+end
+
 -- Expands a header code by making a RPC call.
 function DisplayHelper.expandHeaderCode(headerCode)
 	headerCode = headerCode:gsub('$', '!')

--- a/match2/commons/match_group_display_matchlist.lua
+++ b/match2/commons/match_group_display_matchlist.lua
@@ -1,10 +1,9 @@
 local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
-local Json = require('Module:Json')
 local Logic = require('Module:Logic')
-local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
+local OpponentDisplay = require('Module:OpponentDisplay')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
@@ -135,7 +134,6 @@ function MatchlistDisplay.Match(props)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Match)
 	local match = props.match
 
-	local padding = 5
 	local opponentWidth = math.floor(0.4 * props.width) - 1
 	local scoreWidth = 0.5 * (props.width - 5 - 2 * opponentWidth)
 
@@ -148,7 +146,6 @@ function MatchlistDisplay.Match(props)
 			side = opponentIx == 1 and 'left' or 'right',
 			width = opponentWidth,
 		})
-			:css('width', opponentWidth - 2 * padding .. 'px')
 		return DisplayHelper.addOpponentHighlight(opponentNode, opponent)
 	end
 
@@ -161,7 +158,6 @@ function MatchlistDisplay.Match(props)
 			side = opponentIx == 1 and 'left' or 'right',
 			width = scoreWidth,
 		})
-			:css('width', scoreWidth - 2 * padding .. 'px')
 		return DisplayHelper.addOpponentHighlight(scoreNode, opponent)
 	end
 
@@ -255,7 +251,7 @@ function MatchlistDisplay.Opponent(props)
 		showLink = false,
 		teamStyle = 'short',
 	})
-		:css('width', props.width - 2 * padding .. 'px')
+		:css('width', props.width - 2 * 5 .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
 		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
@@ -272,7 +268,7 @@ component.
 function MatchlistDisplay.Score(props)
 	local contentNode = html.create('div'):addClass('brkts-matchlist-score')
 		:node(OpponentDisplay.InlineScore(props.opponent))
-		:css('width', props.width - 2 * padding .. 'px')
+		:css('width', props.width - 2 * 5 .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-bold' or nil)
 		:node(contentNode)

--- a/match2/commons/match_group_display_matchlist.lua
+++ b/match2/commons/match_group_display_matchlist.lua
@@ -134,6 +134,8 @@ function MatchlistDisplay.Match(props)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Match)
 	local match = props.match
 
+	-- Compute widths of the 2 opponent and 2 score columns. The small offsets
+	-- are due to border splitting from table-layout: auto.
 	local opponentWidth = math.floor(0.4 * props.width) - 1
 	local scoreWidth = 0.5 * (props.width - 5 - 2 * opponentWidth)
 

--- a/match2/commons/opponent_display.lua
+++ b/match2/commons/opponent_display.lua
@@ -124,10 +124,6 @@ function p.luaGet(frame, args)
 		bracket:addScores(score1, score2, args.placement, args.placement2)
 		return bracket.root
 
-	elseif String.startsWith(displayType, "matchlist") then
-
-		return p._createMatchListOpponent(frame, displayType, args.template, p._getScore(args))
-
 	else
 		local opponent = BaseOpponentDisplay()
 		local score1, score2 = p._getScore(args)
@@ -149,17 +145,6 @@ function p._getTeam(frame, template)
 	return team
 end
 
-function p._getTeamMatchList(frame, template, side)
-	local teamExists = mw.ext.TeamTemplate.teamexists(template)
-	if side == "left" then
-		return teamExists
-			and mw.ext.TeamTemplate.team2short(template)
-			or Template.safeExpand(frame, "Team2Short", { template })
-	elseif side == "right" then
-		return teamExists and mw.ext.TeamTemplate.teamshort(template) or Template.safeExpand(frame, "TeamShort", { template })
-	end
-end
-
 function p._getScore(args)
 	local score = ""
 	if args.status == "S" then
@@ -179,32 +164,6 @@ function p._getScore(args)
 		score2 = ""
 	end
 	return score, score2
-end
-
-function p._createMatchListOpponent(frame, displayType, name, score)
-	if displayType == 'matchlist-left' then
-		if String.isEmpty(name) then
-			return ''
-		end
-
-		local team = p._getTeamMatchList(frame, name, 'left')
-		return mw.html.create('div')
-			:addClass('brkts-matchlist-opponent-template-container')
-			:css('display', 'inline')
-			:node(team)
-	elseif displayType == 'matchlist-right' then
-		if String.isEmpty(name) then
-			return ''
-		end
-
-		local team = p._getTeamMatchList(frame, name, 'right')
-		return mw.html.create('div')
-			:addClass('brkts-matchlist-opponent-template-container')
-			:css('display', 'inline')
-			:node(team)
-	elseif displayType == 'matchlist-left-score' or displayType == 'matchlist-right-score' then
-		return score
-	end
 end
 
 --local Class = require('Module:Class')


### PR DESCRIPTION
- Change the Matchlist -> OpponentDisplay call to use structural types instead of flattened args
- Default Opponent and Score components are provided in Matchlist module. To override, pass in different components in Matchlist props. See `starcraft2` wiki as an example: https://liquipedia.net/commons/Module:MatchGroup/Display/Matchlist/Starcraft/dev
- Fix layout issues in Matchlist due to long player or team names https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Wide_Load
Before
![image](https://user-images.githubusercontent.com/85348434/122833295-92d60800-d2a1-11eb-9a5f-1a8721bec9fc.png)
After
![image](https://user-images.githubusercontent.com/85348434/122833243-7b971a80-d2a1-11eb-81ec-8eb4ff275c80.png)
