### PR TITLE
Add SC2 based match2 Modules

### DIFF
--- a/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -1,0 +1,43 @@
+local FnUtil = require('Module:FnUtil')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local WikiSpecific = Table.copy(require('Module:Brkts/WikiSpecific/Base'))
+
+WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
+	local InputModule = require('Module:DevFlags').matchGroupDev
+		and Lua.requireIfExists('Module:MatchGroup/Input/StarCraft/dev')
+		or require('Module:MatchGroup/Input/StarCraft')
+	return InputModule.processMatch
+end)
+
+-- useless functions that should be present for some default checks
+-- would get called from Module:Match/Subobjects if we wouldn't circumvent that module completly
+function WikiSpecific.processMap(frame, map)
+	return map
+end
+
+function WikiSpecific.processOpponent(frame, opponent)
+	return opponent
+end
+
+WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
+	return require('Module:MatchGroup/Util/Starcraft').matchFromRecord
+end)
+
+function WikiSpecific.getMatchGroupModule(matchGroupType)
+	local DevFlags = require('Module:DevFlags')
+	if matchGroupType == 'matchlist' then
+		return DevFlags.matchGroupDev
+			and Lua.requireIfExists('Module:MatchGroup/Display/Matchlist/Starcraft/dev')
+			or require('Module:MatchGroup/Display/Matchlist/Starcraft')
+	else -- matchGroupType == 'bracket'
+		return DevFlags.matchGroupDev
+			and Lua.requireIfExists('Module:MatchGroup/Display/Bracket/Starcraft/dev')
+			or require('Module:MatchGroup/Display/Bracket/Starcraft')
+	end
+end
+
+WikiSpecific.defaultIcon = 'StarCraft 2 Default logo.png'
+
+return WikiSpecific

--- a/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -11,16 +11,6 @@ WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
 	return InputModule.processMatch
 end)
 
--- useless functions that should be present for some default checks
--- would get called from Module:Match/Subobjects if we wouldn't circumvent that module completly
-function WikiSpecific.processMap(frame, map)
-	return map
-end
-
-function WikiSpecific.processOpponent(frame, opponent)
-	return opponent
-end
-
 WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 	return require('Module:MatchGroup/Util/Starcraft').matchFromRecord
 end)
@@ -38,6 +28,17 @@ function WikiSpecific.getMatchGroupModule(matchGroupType)
 	end
 end
 
+--Default Logo for Teams without Team Template
 WikiSpecific.defaultIcon = 'StarCraft 2 Default logo.png'
+
+-- useless functions that should be present for some default checks
+-- would get called from Module:Match/Subobjects if we wouldn't circumvent that module completly
+function WikiSpecific.processMap(frame, map)
+	return map
+end
+
+function WikiSpecific.processOpponent(frame, opponent)
+	return opponent
+end
 
 return WikiSpecific

--- a/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -1,0 +1,152 @@
+local p = {}
+
+local Lua = require("Module:Lua")
+local Logic = require("Module:Logic")
+local String = require("Module:StringUtils")
+local config = Lua.moduleExists("Module:Match/Config") and require("Module:Match/Config") or {}
+
+local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
+
+local roundData
+function p.get(templateid, bracketType)
+	local LowerHeader = {}
+	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateid)
+
+	assert(type(matches) == "table")
+	local bracketData = {}
+	roundData = roundData or {}
+	local lastround = 0
+	for _, match in ipairs(matches) do
+		bracketData, lastround, LowerHeader = p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+	end
+
+	-- add reference for map mappings
+	bracketData["$$map"] = {
+		["$notEmpty$"] = "map$1$",
+		map = "map$1$",
+		winner = "map$1$win",
+		race1 = "map$1$p1race",
+		race2 = "map$1$p2race"
+	}
+
+	for n=1,lastround do
+		bracketData["R" .. n .. "M1header"] = "R" .. n
+		if LowerHeader[n] then
+			bracketData["R" .. n .. "M" .. LowerHeader[n] .. "header"] = "L" .. n
+		end
+	end
+
+	return bracketData
+end
+
+local lastRound
+function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+	local id = String.split(match.match2id, "_")[2] or match.match2id
+	id = id:gsub("0*([1-9])", "%1"):gsub("%-", "")
+	local bd = match.match2bracketdata
+
+	local roundNum
+	local round
+	local reset = false
+	if id == "RxMTP" then
+		round = lastRound
+	elseif id == "RxMBR" then
+		round = lastRound
+		round.G = round.G - 2
+		round.W = round.W - 2
+		round.D = round.D - 2
+		reset = true
+	else
+		roundNum = id:match("R%d*"):gsub("R", "")
+		roundNum = tonumber(roundNum)
+		round = roundData[roundNum] or { R = roundNum, G = 0, D = 1, W = 1 }
+	end
+	round.G = round.G + 1
+
+	if string.match(bd.header or '', '^!l') then
+		LowerHeader[roundNum] = round.G
+	end
+
+	-- opponents
+	local opponent1
+	local finished1
+	if Logic.isEmpty(bd.toupper) and not reset then
+		-- RxDx
+		opponent1 = {
+		["type"] = "type",
+		["1"] = "R" .. round.R .. "D" .. round.D,
+		flag = "R" .. round.R .. "D" .. round.D .. "flag",
+		race = "R" .. round.R .. "D" .. round.D .. "race",
+		score = "R" .. round.R .. "D" .. round.D .. "score",
+		win = "R" .. round.R .. "D" .. round.D .. "win"
+		}
+		finished1 = "R" .. round.R .. "D" .. round.D .. "win"
+		round.D = round.D + 1
+	else
+		-- RxWx
+		opponent1 = {
+		["type"] = "type",
+		["1"] = "R" .. round.R .. "W" .. round.W,
+		flag = "R" .. round.R .. "W" .. round.W .. "flag",
+		race = "R" .. round.R .. "W" .. round.W .. "race",
+		score = "R" .. round.R .. "W" .. round.W .. "score" .. (reset and "2" or ""),
+		win = "R" .. round.R .. "W" .. round.W .. "win"
+		}
+		finished1 = "R" .. round.R .. "W" .. round.W .. "win"
+		round.W = round.W + 1
+	end
+
+	local opponent2
+	local finished2
+	if Logic.isEmpty(bd.tolower) and not reset then
+		-- RxDx
+		opponent2 = {
+		["type"] = "type",
+		["1"] = "R" .. round.R .. "D" .. round.D,
+		flag = "R" .. round.R .. "D" .. round.D .. "flag",
+		race = "R" .. round.R .. "D" .. round.D .. "race",
+		score = "R" .. round.R .. "D" .. round.D .. "score",
+		win = "R" .. round.R .. "D" .. round.D .. "win"
+		}
+		finished2 = "R" .. round.R .. "D" .. round.D .. "win"
+		round.D = round.D + 1
+	else
+		-- RxWx
+		opponent2 = {
+		["type"] = "type",
+		["1"] = "R" .. round.R .. "W" .. round.W,
+		flag = "R" .. round.R .. "W" .. round.W .. "flag",
+		race = "R" .. round.R .. "W" .. round.W .. "race",
+		score = "R" .. round.R .. "W" .. round.W .. "score" .. (reset and "2" or ""),
+		win = "R" .. round.R .. "W" .. round.W .. "win"
+		}
+		finished2 = "R" .. round.R .. "W" .. round.W .. "win"
+		round.W = round.W + 1
+	end
+
+	opponent1["$notEmpty$"] = opponent1["1"]
+	opponent2["$notEmpty$"] = opponent2["1"]
+
+	match = {
+		opponent1 = opponent1,
+		opponent2 = opponent2,
+		finished = finished1 .. "|" .. finished2,
+		-- reference to variables that shall be flattened
+		["$flatten$"] = { "R" .. round.R .. "G" .. round.G .. "details" }
+	}
+
+	for mapIndex = 1, MAX_NUM_MAPS do
+		match["map" .. mapIndex] = {
+			["$ref$"] = "map",
+			["$1$"] = mapIndex
+		}
+	end
+
+	bracketData[id] = match
+	lastRound = round
+	roundData[round.R] = round
+
+	return bracketData, round.R, LowerHeader
+end
+
+return p

--- a/match2/wikis/starcraft2/match_legacy.lua
+++ b/match2/wikis/starcraft2/match_legacy.lua
@@ -1,0 +1,228 @@
+--[[ToDo:
+* Remove temp smw support (after lpdb api is available)
+]]--
+
+local p = {}
+
+local json = require("Module:Json")
+local String = require("Module:StringUtils")
+local Table = require("Module:Table")
+
+local MODES = { ["solo"] = "1v1", ["team"] = "team" }
+
+function p.storeMatch(match2)
+	local match, do_store = p.convertParameters(match2)
+
+	if do_store then
+		match.games = p.storeGames(match, match2)
+
+		if (match2.match2opponents[1] or {}).type == 'team' then
+			p.storeTeamMatchSMW(match, match2)
+		elseif (match2.match2opponents[1] or {}).type == 'solo' then
+			p.storeSoloMatchSMW(match, match2)
+		else
+			mw.logObject((match2.match2opponents[1] or {}).type)
+		end
+
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	else
+		return ''
+	end
+end
+
+function p.storeGames(match, match2)
+	local games = ""
+	for gameIndex, game in ipairs(match2.match2games or {}) do
+		game.extradata = json.parseIfString(game.extradata or '{}') or game.extradata
+
+		if game.mode == "1v1" and game.extradata.isSubMatch == 'false' then
+			game.opponent1 = game.extradata.opponent1
+			game.opponent2 = game.extradata.opponent2
+			game.date = match.date
+			local scores = json.parseIfString(game.scores or '{}') or {}
+			game.opponent1score = scores[1] or 0
+			game.opponent2score = scores[2] or 0
+
+			-- participants holds additional playerdata per match, e.g. the faction (=race)
+			-- participants is stored as opponentID_playerID, so e.g. for opponent2, player1 it is "2_1"
+			local playerdata = json.parseIfString(game.participants or '{}') or game.participants
+			for key, item in pairs(playerdata) do
+				local k = mw.text.split(key or '', '_')
+				local l = tonumber(k[2])
+				k = tonumber(k[1])
+				game.extradata['opponent' .. k .. 'race'] = item.faction
+				local opp = match2.match2opponents[k] or {}
+				local pl = opp.match2players or {}
+				game['opponent' .. k .. 'flag'] = (pl[l] or {}).flag
+				game.extradata['opponent' .. k .. 'name'] = (pl[l] or {}).displayname
+			end
+			game.extradata.gamenumber = gameIndex
+
+			game.extradata = json.stringify(game.extradata)
+			local res = mw.ext.LiquipediaDB.lpdb_game(
+				"legacygame_" .. match2.match2id .. gameIndex,
+				game
+			)
+
+			p.storeSoloMapSMW(game, gameIndex, match.tournament or '', match2.match2id)
+
+			games = games .. res
+		end
+	end
+	return games
+end
+
+function p.convertParameters(match2)
+	local do_store = true
+	local match = Table.deepCopy(match2)
+	for key, _ in pairs(match) do
+		if String.startsWith(key, "match2") then
+			match[key] = nil
+		end
+	end
+
+	match.staticid = match2.match2id
+	match.extradata = json.parseIfString(match.extradata) or {}
+	local opponent1 = match2.match2opponents[1] or {}
+	local opponent1match2players = opponent1.match2players or {}
+	local opponent2 = match2.match2opponents[2] or {}
+	local opponent2match2players = opponent2.match2players or {}
+
+	if opponent1.type == opponent2.type then
+		match.mode = MODES[opponent1.type]
+
+		if opponent1.type == "solo" then
+			local player = opponent1match2players[1] or {}
+			match.opponent1 = player.name
+			match.opponent1score = (tonumber(opponent1.score or 0) or 0) >= 0 and opponent1.score or 0
+			match.opponent1flag = player.flag
+			match.extradata.opponent1name = player.displayname
+			player.extradata = json.parseIfString(player.extradata or '{}') or player.extradata
+			match.extradata.opponent1race = player.extradata.faction
+			player = opponent2match2players[1] or {}
+			match.opponent2 = player.name
+			match.opponent2score = (tonumber(opponent2.score or 0) or 0) >= 0 and opponent2.score or 0
+			match.opponent2flag = player.flag
+			match.extradata.opponent2name = player.displayname
+			player.extradata = json.parseIfString(player.extradata or '{}') or player.extradata
+			match.extradata.opponent2race = player.extradata.faction
+		elseif opponent1.type == "team" then
+			match.opponent1 = (opponent1.name or '') ~= '' and opponent1.name or 'TBD'
+			match.opponent1score = (tonumber(opponent1.score or 0) or 0) >= 0 and opponent1.score or 0
+			match.opponent2 = (opponent2.name or '') ~= '' and opponent2.name or 'TBD'
+			match.opponent2score = (tonumber(opponent2.score or 0) or 0) >= 0 and opponent2.score or 0
+			match.mode = 'team'
+		else
+			return nil, false
+		end
+
+		if match.resulttype == 'default' then
+			match.resulttype = string.upper(match.walkover or '')
+			match.walkover = match.winner
+		end
+		match.extradata.bestof = match.bestof
+		match.extradata = json.stringify(match.extradata)
+	else
+		do_store = false
+		match = nil
+	end
+
+	return match, do_store
+end
+
+function p.storeTeamMatchSMW(match, match2)
+	local streams = match.stream or {}
+	if type(streams) == 'string' then streams = json.parse(streams) end
+	local extradata = match.extradata or {}
+	if type(extradata) == 'string' then extradata = json.parse(extradata) end
+	mw.smw.subobject({
+		'legacymatch_' .. match2.match2id,
+		'has match vod=' .. (match.vod or ''),
+		'has team left page=' .. (match.opponent1 or ''),
+		'has team right page=' .. (match.opponent2 or ''),
+		'has team left=' .. string.lower(match2.match2opponents[1].template or ''),
+		'has team right=' .. string.lower(match2.match2opponents[2].template or ''),
+		--apparently needed for sorting ...
+		'has player left page=' .. (match.opponent1 or ''),
+		'has player right page=' .. (match.opponent2 or ''),
+		'has match date=' .. (match.date or ''),
+		'has tournament=' .. (match.tournament or ''),
+		'has tournament tier=' .. (match.liquipediatier or ''),
+		'is finished=' .. (match.finished == '1' and 'true' or ''),
+		'has winner=' .. (match.winner or ''),
+		'has winning team page=' ..
+			(match.winner == '1' and match.opponent1 or match.winner == '2' and match.opponent2 or ''),
+		'has losing team page=' ..
+			(match.winner == '2' and match.opponent1 or match.winner == '1' and match.opponent2 or ''),
+		'has team left score=' .. (match2.match2opponents[1].score or ''),
+		'has team right score=' .. (match2.match2opponents[2].score or ''),
+		'has exact time=' .. (match.dateexact == '1' and 'true' or ''),
+		'has match stream=' .. (streams.stream or ''),
+		'has match twitch=' .. (streams.twitch or ''),
+		'has match twitch2=' .. (streams.twitch2 or ''),
+		'has match trovo=' .. (streams.trovo or ''),
+		'has match afreeca=' .. (streams.afreeca or ''),
+		'has match afreecatv=' .. (streams.afreecatv or ''),
+		'has match dailymotion=' .. (streams.dailymotion or ''),
+		'has match douyu=' .. (streams.douyu or ''),
+		'has match smashcast=' .. (streams.smashcast or ''),
+		'has match youtube=' .. (streams.youtube or ''),
+		'has best of=' .. (extradata.bestof or ''),
+	})
+end
+
+function p.storeSoloMatchSMW(match, match2)
+	local streams = match.stream or {}
+	if type(streams) == 'string' then streams = json.parse(streams) end
+	local extradata = match.extradata or {}
+	if type(extradata) == 'string' then extradata = json.parse(extradata) end
+	mw.smw.subobject({
+		'legacymatch_' .. match2.match2id,
+		'has match vod=' .. (match.vod or ''),
+		'has player left=' .. extradata.opponent1name,
+		'has player right=' .. extradata.opponent2name,
+		'has player left page=' .. (match.opponent1 or ''),
+		'has player right page=' .. (match.opponent2 or ''),
+		'has player left flag=' .. match.opponent1flag,
+		'has player right flag=' .. match.opponent2flag,
+		'has player left race=' .. extradata.opponent1race,
+		'has player right race=' .. extradata.opponent2race,
+		'has match date=' .. (match.date or ''),
+		'has tournament=' .. (match.tournament or ''),
+		'has tournament tier=' .. (match.liquipediatier or ''),
+		'is finished=' .. (match.finished == '1' and 'true' or ''),
+		'has winner=' .. (match.winner or ''),
+		'has player left score=' .. (match2.match2opponents[1].score or ''),
+		'has player right score=' .. (match2.match2opponents[2].score or ''),
+		'has exact time=' .. (match.dateexact == '1' and 'true' or ''),
+		'has match stream=' .. (streams.stream or ''),
+		'has match twitch=' .. (streams.twitch or ''),
+		'has match twitch2=' .. (streams.twitch2 or ''),
+		'has match trovo=' .. (streams.trovo or ''),
+		'has match afreeca=' .. (streams.afreeca or ''),
+		'has match afreecatv=' .. (streams.afreecatv or ''),
+		'has match dailymotion=' .. (streams.dailymotion or ''),
+		'has match douyu=' .. (streams.douyu or ''),
+		'has match smashcast=' .. (streams.smashcast or ''),
+		'has match youtube=' .. (streams.youtube or ''),
+		'has best of=' .. (extradata.bestof or ''),
+	})
+end
+
+function p.storeSoloMapSMW(game, gameIndex, tournament, id)
+	game.extradata = json.parseIfString(game.extradata or '{}') or game.extradata
+	local object = 'Map ' .. game.opponent1 .. ' vs ' .. game.opponent2 .. ' at ' ..
+		(game.date or '') .. 'in Match TBD Map ' .. gameIndex .. ' on ' .. (game.map or '')
+	mw.smw.subobject({
+		'legacymatch_' .. id .. object,
+		'has winning race=' .. game.extradata.winnerrace,
+		'has losing race=' .. game.extradata.loserrace,
+		'has tournament=' .. tournament,
+		'is played on=' .. game.map,
+	})
+end
+
+return p


### PR DESCRIPTION
Add the sc2 specific Modules that are located on the SC2 wiki.
* https://liquipedia.net/starcraft2/Module:Brkts/WikiSpecific
* https://liquipedia.net/starcraft2/Module:Match/Legacy
* https://liquipedia.net/starcraft2/Module:MatchGroup/Legacy/Default

All other Modules are set up on commons due to SC and SC2 using them together. `Module:Brkts/WikiSpecific` is mostly a hull for a shared SC/SC2 Module on commons that handles the Input Processing.