### PR TITLE
Commons based match2 Modules specific for SC/SC2

### DIFF
--- a/match2/commons/starcraft_starcraft2/README.txt
+++ b/match2/commons/starcraft_starcraft2/README.txt
@@ -1,0 +1,5 @@
+This Directory contains Mdules that are located on Commons but SC/SC2 specific.
+
+The reason for them to be on commons is that both the SC and the SC2 wiki use them.
+
+At the moment the Module for FFA MatchSummary is still missing, because that Module is still a Work in Progress to the first stable version.

--- a/match2/commons/starcraft_starcraft2/README.txt
+++ b/match2/commons/starcraft_starcraft2/README.txt
@@ -1,4 +1,4 @@
-This Directory contains Mdules that are located on Commons but SC/SC2 specific.
+This Directory contains Modules that are located on Commons but are SC/SC2 specific.
 
 The reason for them to be on commons is that both the SC and the SC2 wiki use them.
 

--- a/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
@@ -1,0 +1,140 @@
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local TypeUtil = require('Module:TypeUtil')
+
+--[[
+Utility module for working with starcraft and starcraft2 specific external
+media links of matches. This includes the preview, lrthread, vodN, interviewN,
+recap, and review params of both matches and games.
+]]
+
+local StarcraftMatchExternalLinks = {propTypes = {}}
+
+-- List of supported external link parameters, in display order
+StarcraftMatchExternalLinks.paramTypes = {
+	'preview',
+	'lrthread',
+	'vod',
+	'vodgame',
+	'interview',
+	'recap',
+	'review',
+}
+
+StarcraftMatchExternalLinks.paramTypeIndexes = {}
+for index, paramType in ipairs(StarcraftMatchExternalLinks.paramTypes) do
+	StarcraftMatchExternalLinks.paramTypeIndexes[paramType] = index
+end
+
+--[[
+Renders a single external link.
+
+props.type: 'vod', 'preview', 'lrthread', or one of the allowed values in MatchExternalLinks.paramTypes
+props.number: A number used to visually distinguish between multiple vods. Only number 1-9 have unique icons.
+props.url:
+]]
+StarcraftMatchExternalLinks.propTypes.ExternalLink = {
+	number = 'number?',
+	type = 'string',
+	url = 'string',
+}
+
+function StarcraftMatchExternalLinks.ExternalLink(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchExternalLinks.propTypes.ExternalLink)
+
+	if props.type == 'preview' then
+		return '[[File:Preview_Icon32.png|link=' .. props.url .. '|alt=preview|16px|Preview]] '
+	end
+
+	if props.type == 'lrthread' then
+		return '[[File:LiveReport32.png|link=' .. props.url .. '|alt=lrthread|16px|Live Report Thread]] '
+	end
+
+	if props.type == 'vod' then
+		if props.number and 1 <= props.number and props.number <= 9 then
+			return '[[File:VOD Icon' .. props.number .. '.png|16px|link=' .. props.url .. '|Watch Game ' .. props.number .. ']] '
+		else
+			return '[[File:VOD Icon.png|link=' .. props.url .. '|16px|Watch VOD]] '
+		end
+	end
+
+	if props.type == 'interview' then
+		return '[[File:Int_Icon.png|link=' .. props.url .. '|16px|Interview]] '
+	end
+
+	if props.type == 'recap' then
+		return '[[File:Reviews32.png|link=' .. props.url .. '|16px|Recap]] '
+	end
+	if props.type == 'review' then
+		return '[[File:Reviews32.png|link=' .. props.url .. '|16px|Review]] '
+	end
+
+	error('Unsupported prop type ' .. tostring(props.type))
+end
+
+--[[
+Extracts match media link relevant args from a generic args array, and
+returns an array of link propss that can be rendered via
+StarcraftMatchExternalLinks.MatchExternalLinks.
+]]
+function StarcraftMatchExternalLinks.extractFromArgs(args)
+	local links = {}
+	for paramName, url in pairs(args) do
+		local type, number = tostring(paramName):match('^(%a+)(%d*)$')
+		if StarcraftMatchExternalLinks.paramTypeIndexes[type] and url ~= '' then
+			table.insert(links, {
+				type = type,
+				number = tonumber(number),
+				url = url,
+			})
+		end
+	end
+
+	return links
+end
+
+function StarcraftMatchExternalLinks.extractFromMatch(match)
+	local links = StarcraftMatchExternalLinks.extractFromArgs(match.links)
+
+	if match.vod then
+		table.insert(links, {type = 'vod', url = match.vod})
+	end
+	for gameIx, game in ipairs(match.games) do
+		if game.vod then
+			table.insert(links, {type = 'vod', number = gameIx, url = game.vod})
+		end
+	end
+
+	return links
+end
+
+StarcraftMatchExternalLinks.propTypes.MatchExternalLinks = {
+	links = TypeUtil.array(TypeUtil.struct(StarcraftMatchExternalLinks.propTypes.ExternalLink)),
+}
+
+function StarcraftMatchExternalLinks.MatchExternalLinks(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchExternalLinks.propTypes.MatchExternalLinks)
+	local links = Array.sortBy(props.links, function(link)
+		return {
+			StarcraftMatchExternalLinks.paramTypeIndexes[link.type],
+			-- Unnumbered vods appear before numbered ones
+			link.number or -1,
+		}
+	end)
+
+	local list = mw.html.create('span')
+	for _, link in ipairs(links) do
+		list:node(StarcraftMatchExternalLinks.ExternalLink(link))
+	end
+	return list
+end
+
+-- Called by Template:MatchExternalLink
+function StarcraftMatchExternalLinks.TemplateMatchExternalLink(frame)
+	local args = require('Module:Arguments').getArgs(frame)
+	args.number = tonumber(args.number)
+	return StarcraftMatchExternalLinks.ExternalLink(args)
+end
+
+return Class.export(StarcraftMatchExternalLinks)

--- a/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -1,0 +1,140 @@
+local BracketDisplay = require('Module:MatchGroup/Display/Bracket')
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local Lua = require('Module:Lua')
+local MatchGroupUtil = require('Module:MatchGroup/Util')
+local OpponentDisplay = require('Module:OpponentDisplay')
+local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
+local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft')
+local Table = require('Module:Table')
+
+local RaceColor = Lua.loadDataIfExists('Module:RaceColorClass') or {}
+
+local html = mw.html
+
+local StarcraftBracketDisplay = {propTypes = {}}
+
+function StarcraftBracketDisplay.luaGet(_, args)
+	return StarcraftBracketDisplay.BracketContainer({
+		bracketId = args[1],
+		config = BracketDisplay.configFromArgs(args),
+	})
+end
+
+function StarcraftBracketDisplay.BracketContainer(props)
+	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.BracketContainer)
+	return StarcraftBracketDisplay.Bracket({
+		config = props.config,
+		matchesById = MatchGroupUtil.fetchMatchesTable(props.bracketId),
+	})
+end
+
+function StarcraftBracketDisplay.Bracket(props)
+	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.Bracket)
+	return BracketDisplay.Bracket({
+		matchesById = props.matchesById,
+		config = Table.merge(props.config, {
+			MatchSummaryContainer = require('Module:MatchSummary/Starcraft').MatchSummaryContainer,
+			OpponentEntry = StarcraftBracketDisplay.OpponentEntry,
+			matchHasDetails = StarcraftMatchGroupUtil.matchHasDetails,
+			opponentHeight = StarcraftBracketDisplay.computeBracketOpponentHeight(props.matchesById),
+		})
+	})
+end
+
+local defaultOpponentHeights = {
+	solo = 17 + 6,
+	duo = 2 * 17 + 6 + 4,
+	trio = 3 * 17 + 6,
+	quad = 4 * 17 + 6,
+	team = 17 + 6,
+	literal = 17 + 6,
+}
+function StarcraftBracketDisplay.computeBracketOpponentHeight(matchesById)
+	local maxHeight = 10
+	for _, match in pairs(matchesById) do
+		for _, opponent in ipairs(match.opponents) do
+			maxHeight = math.max(maxHeight, defaultOpponentHeights[opponent.type] or 0)
+		end
+	end
+	return maxHeight
+end
+
+function StarcraftBracketDisplay.OpponentEntry(props)
+	local opponent = props.opponent
+
+	local showRaceBackground = opponent.type == 'solo'
+		or opponent.type == 'duo' and opponent.isArchon
+
+	-- Temporary workaround for lpdb bug misplacing players in match2opponent
+	if #opponent.players == 0 then
+		showRaceBackground = false
+	end
+
+	local leftNode = html.create('div'):addClass('brkts-opponent-entry-left')
+		:addClass(showRaceBackground and RaceColor[opponent.players[1].race] or nil)
+
+	if opponent.type == 'team' then
+		local bracketNode = StarcraftOpponentDisplay.BlockTeamContainer({
+			overflow = 'ellipsis',
+			showLink = false,
+			style = 'bracket',
+			team = opponent.team,
+			template = opponent.template,
+		})
+		local shortNode = StarcraftOpponentDisplay.BlockTeamContainer({
+			overflow = 'hidden',
+			showLink = false,
+			style = 'short',
+			team = opponent.team,
+			template = opponent.template,
+		})
+		leftNode
+			:node(bracketNode:addClass('hidden-xs'))
+			:node(shortNode:addClass('visible-xs'))
+	else
+		local blockOpponentNode = StarcraftOpponentDisplay.BlockOpponent({
+			opponent = opponent,
+			overflow = 'ellipsis',
+			playerClass = 'starcraft-bracket-block-player',
+			showLink = false,
+			showRace = not showRaceBackground,
+		})
+		leftNode:node(blockOpponentNode)
+	end
+
+	local scoreNode
+	if props.displayType == 'bracket' then
+		scoreNode = OpponentDisplay.BracketScore({
+			isWinner = opponent.placement == 1,
+			scoreText = StarcraftOpponentDisplay.InlineScore(opponent),
+		})
+	end
+
+	local score2Node
+	if opponent.score2 and props.displayType == 'bracket' then
+		score2Node = OpponentDisplay.BracketScore({
+			isWinner = opponent.placement2 == 1,
+			scoreText = OpponentDisplay.InlineScore2(opponent),
+		})
+	end
+
+	local contestNode
+	if opponent.extradata.contest and props.displayType == 'bracket' then
+		contestNode = OpponentDisplay.BracketScore({
+			scoreText = opponent.extradata.contest,
+		})
+	end
+
+	local isWinner = (opponent.placement2 or opponent.placement or 0) == 1
+		or opponent.extradata.advances == 'true'
+
+	return html.create('div'):addClass('brkts-opponent-entry')
+		:addClass(isWinner and 'brkts-opponent-win' or nil)
+		:node(leftNode)
+		:node(scoreNode)
+		:node(score2Node)
+		:node(contestNode)
+end
+
+return Class.export(StarcraftBracketDisplay)

--- a/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -1,0 +1,66 @@
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local MatchGroupUtil = require('Module:MatchGroup/Util')
+local MatchlistDisplay = require('Module:MatchGroup/Display/Matchlist')
+local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
+local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft')
+local Table = require('Module:Table')
+
+local html = mw.html
+
+local StarcraftMatchlistDisplay = {}
+
+function StarcraftMatchlistDisplay.luaGet(_, args)
+	return StarcraftMatchlistDisplay.MatchlistContainer({
+		bracketId = args[1],
+		config = MatchlistDisplay.configFromArgs(args),
+	})
+end
+
+function StarcraftMatchlistDisplay.MatchlistContainer(props)
+	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.MatchlistContainer)
+	return StarcraftMatchlistDisplay.Matchlist({
+		config = props.config,
+		matches = MatchGroupUtil.fetchMatches(props.bracketId),
+	})
+end
+
+function StarcraftMatchlistDisplay.Matchlist(props)
+	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Matchlist)
+	return MatchlistDisplay.Matchlist({
+		config = Table.merge(props.config, {
+			MatchSummaryContainer = require('Module:MatchSummary/Starcraft').MatchSummaryContainer,
+			Opponent = StarcraftMatchlistDisplay.Opponent,
+			Score = StarcraftMatchlistDisplay.Score,
+			matchHasDetails = StarcraftMatchGroupUtil.matchHasDetails,
+		}),
+		matches = props.matches,
+	})
+end
+
+function StarcraftMatchlistDisplay.Opponent(props)
+	local contentNode = StarcraftOpponentDisplay.BlockOpponent({
+		flip = props.side == 'left',
+		opponent = props.opponent,
+		overflow = 'ellipsis',
+		showFlag = false,
+		showLink = false,
+		teamStyle = 'short',
+	})
+		:css('width', props.width - 2 * 5 .. 'px')
+	return html.create('td')
+		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
+		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
+		:node(contentNode)
+end
+
+function StarcraftMatchlistDisplay.Score(props)
+	local contentNode = html.create('div'):addClass('brkts-matchlist-score')
+		:node(StarcraftOpponentDisplay.InlineScore(props.opponent))
+		:css('width', props.width - 2 * 5 .. 'px')
+	return html.create('td')
+		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-bold' or nil)
+		:node(contentNode)
+end
+
+return Class.export(StarcraftMatchlistDisplay)

--- a/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -1,0 +1,1094 @@
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local TeamTemplates = require('Module:TeamTemplates')
+local Variables = require('Module:Variables')
+local config = Lua.loadDataIfExists('Module:Match/Config') or {}
+local json = require('Module:Json')
+local cleanFlag = require('Module:Flags')._CountryName
+local FFA
+local defaultIcon
+
+local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
+local FACTIONS = mw.loadData('Module:Races')
+local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }
+local ALLOWED_STATUSES2 = { ['W'] = 'W', ['FF'] = 'FF', ['L'] = 'L', ['DQ'] = 'DQ', ['-'] = 'L' }
+local MAX_NUM_OPPONENTS = 2
+local MAX_NUM_PLAYERS = 30
+local MAX_NUM_VODGAMES = 9
+local MODES2 = {
+	['solo'] = '1',
+	['duo'] = '2',
+	['trio'] = '3',
+	['quad'] = '4',
+	['team'] = 'team',
+	['literal'] = 'literal',
+	}
+
+--[[
+Module for converting input args of match group objects into LPDB records. This
+module is specific to the StarCraft and StarCraft2 wikis.
+]]
+local StarCraftMatchGroupInput = {}
+
+-- called from Module:MatchGroup
+function StarCraftMatchGroupInput.processMatch(_, match)
+	if type(match) == 'string' then
+		match = json.parse(match)
+	end
+
+	-- process match
+	match = StarCraftMatchGroupInput.getDateStuff(match)
+	match = StarCraftMatchGroupInput.getTournamentVars(match)
+	if match.ffa == 'true' then
+		if not FFA then
+			FFA = require('Module:DevFlags').matchGroupDev
+				and Lua.requireIfExists('Module:MatchGroup/Input/StarCraft/FFA/dev')
+				or require('Module:MatchGroup/Input/StarCraft/FFA')
+		end
+		match = FFA.adjustData(match)
+	else
+		match = StarCraftMatchGroupInput.adjustData(match)
+	end
+	match = StarCraftMatchGroupInput.checkFinished(match)
+	match = StarCraftMatchGroupInput.getVodStuff(match)
+	match = StarCraftMatchGroupInput.getLinks(match)
+	match = StarCraftMatchGroupInput.getExtraData(match)
+
+	return match
+end
+
+function StarCraftMatchGroupInput.getDateStuff(match)
+	local lang = mw.getContentLanguage()
+	match.lang = lang
+	-- parse date string with abbr
+	if not Logic.isEmpty(match.date) then
+		local matchString = match.date or ''
+		local timezone = String.split(
+			String.split(matchString, 'data%-tz%=\"')[2] or '',
+			'\"')[1] or String.split(
+			String.split(matchString, 'data%-tz%=\'')[2] or '',
+			'\'')[1] or ''
+		local matchDate = String.explode(matchString, '<', 0):gsub('-', '')
+		match.date = matchDate .. timezone
+		match.dateexact = match.dateexact == 'true' or String.contains(match.date, '%+') or String.contains(match.date, '%-')
+		match.date = lang:formatDate('c', match.date)
+		Variables.varDefine('matchDate', match.date)
+	else
+		local DateVar = (Variables.varDefault('matchDate', Variables.varDefault('tournament_date', '') or '') or '')
+		local missingDates = Variables.varDefault('num_missing_dates', 0) or 0
+		match.date = lang:formatDate('c', DateVar .. ' + ' .. missingDates .. ' second')
+		match.dateexact = false
+		Variables.varDefine('num_missing_dates', Variables.varDefault('num_missing_dates', 0) + 1)
+	end
+
+	return match
+end
+
+function StarCraftMatchGroupInput.checkFinished(match)
+	local lang = match.lang
+	if Logic.readBool(match.finished) or (not Logic.isEmpty(match.winner)) then
+		match.finished = true
+	else
+		local currentUnixTime = os.time(os.date('!*t'))
+		local matchUnixTime = tonumber(lang:formatDate('U', match.date))
+		local threshold = match.dateexact and 30800 or 86400
+		if matchUnixTime + threshold < currentUnixTime then
+			match.finished = true
+		end
+	end
+
+	match.lang = nil
+
+	return match
+end
+
+function StarCraftMatchGroupInput.getTournamentVars(match)
+	match.noQuery = Variables.varDefault('disable_SMW_storage', 'false')
+	match.cancelled = Logic.emptyOr(match.cancelled, Variables.varDefault('cancelled tournament', 'false'))
+	match['type'] = Logic.emptyOr(match['type'], Variables.varDefault('tournament_type'))
+	match.tournament = Logic.emptyOr(match.tournament, Variables.varDefault('tournament_name'))
+	match.tickername = Logic.emptyOr(match.tickername, Variables.varDefault('tournament_ticker_name'))
+	match.shortname = Logic.emptyOr(match.shortname, Variables.varDefault('tournament_shortname'))
+	match.series = Logic.emptyOr(match.series, Variables.varDefault('tournament_series'))
+	match.icon = Logic.emptyOr(match.icon, Variables.varDefault('tournament_icon'))
+	match.liquipediatier = Logic.emptyOr(match.liquipediatier, Variables.varDefault('tournament_tier'))
+	match.liquipediatiertype = Logic.emptyOr(match.liquipediatiertype, Variables.varDefault('tournament_tiertype'))
+	match.game = Logic.emptyOr(match.game, Variables.varDefault('tournament_game'))
+	match.headtohead = Logic.emptyOr(match.headtohead, Variables.varDefault('headtohead'))
+	Variables.varDefine('headtohead', match.headtohead)
+	match.featured = Logic.emptyOr(match.featured, Variables.varDefault('featured'))
+	match.bestof = Logic.emptyOr(match.bestof, Variables.varDefault('bestof'))
+	Variables.varDefine('bestof', match.bestof)
+	return match
+end
+
+function StarCraftMatchGroupInput.getVodStuff(match)
+	match.stream = match.stream or {}
+	match.stream = json.stringify({
+		stream = Logic.emptyOr(match.stream, Variables.varDefault('stream')),
+		twitch = Logic.emptyOr(match.twitch, Variables.varDefault('twitch')),
+		twitch2 = Logic.emptyOr(match.twitch2, Variables.varDefault('twitch2')),
+		afreeca = Logic.emptyOr(match.afreeca, Variables.varDefault('afreeca')),
+		afreecatv = Logic.emptyOr(match.afreecatv, Variables.varDefault('afreecatv')),
+		dailymotion = Logic.emptyOr(match.dailymotion, Variables.varDefault('dailymotion')),
+		douyu = Logic.emptyOr(match.douyu, Variables.varDefault('douyu')),
+		smashcast = Logic.emptyOr(match.smashcast, Variables.varDefault('smashcast')),
+		youtube = Logic.emptyOr(match.youtube, Variables.varDefault('youtube')),
+		trovo = Logic.emptyOr(match.trovo, Variables.varDefault('trovo'))
+	})
+	match.vod = Logic.emptyOr(match.vod)
+
+	return match
+end
+
+function StarCraftMatchGroupInput.getLinks(match)
+	match.links = json.stringify({
+		preview = match.preview,
+		preview2 = match.preview2,
+		interview = match.interview,
+		interview2 = match.interview2,
+		review = match.review,
+		recap = match.recap,
+		lrthread = match.lrthread,
+	})
+	return match
+end
+
+function StarCraftMatchGroupInput.getExtraData(match)
+	match.extradata = json.stringify({
+		noQuery = match.noQuery,
+		matchsection = Variables.varDefault('matchsection'),
+		comment = match.comment,
+		featured = match.featured,
+		veto1by = (match.vetoplayer1 or '') ~= '' and match.vetoplayer1 or match.vetoopponent1,
+		veto1 = match.veto1,
+		veto2by = (match.vetoplayer2 or '') ~= '' and match.vetoplayer2 or match.vetoopponent2,
+		veto2 = match.veto2,
+		veto3by = (match.vetoplayer3 or '') ~= '' and match.vetoplayer3 or match.vetoopponent3,
+		veto3 = match.veto3,
+		veto4by = (match.vetoplayer4 or '') ~= '' and match.vetoplayer4 or match.vetoopponent4,
+		veto4 = match.veto4,
+		veto5by = (match.vetoplayer5 or '') ~= '' and match.vetoplayer5 or match.vetoopponent5,
+		veto5 = match.veto5,
+		veto6by = (match.vetoplayer6 or '') ~= '' and match.vetoplayer6 or match.vetoopponent6,
+		veto6 = match.veto6,
+		contestname = (match.contestname or '') ~= '' and (match.contestname .. ' Bracket Contest') or nil,
+		subGroup1header = StarCraftMatchGroupInput.getSubGroupHeader(1, match),
+		subGroup2header = StarCraftMatchGroupInput.getSubGroupHeader(2, match),
+		subGroup3header = StarCraftMatchGroupInput.getSubGroupHeader(3, match),
+		subGroup4header = StarCraftMatchGroupInput.getSubGroupHeader(4, match),
+		subGroup5header = StarCraftMatchGroupInput.getSubGroupHeader(5, match),
+		subGroup6header = StarCraftMatchGroupInput.getSubGroupHeader(6, match),
+		subGroup7header = StarCraftMatchGroupInput.getSubGroupHeader(7, match),
+		subGroup8header = StarCraftMatchGroupInput.getSubGroupHeader(8, match),
+		subGroup9header = StarCraftMatchGroupInput.getSubGroupHeader(9, match),
+		headtohead = match.headtohead,
+		ffa = match.ffa == 'true' and 'true' or 'false',
+		noscore = match.noscore
+	})
+	return match
+end
+
+function StarCraftMatchGroupInput.getSubGroupHeader(index, match)
+	local out = match['subGroup' .. index .. 'header'] or ''
+	if out == '' then
+		out = match['subgroup' .. index .. 'header'] or ''
+		if out == '' then
+			out = match['submatch' .. index .. 'header'] or ''
+			if out == '' then
+				return nil
+			end
+		end
+	end
+	return out
+end
+
+function StarCraftMatchGroupInput.adjustData(match)
+	--parse opponents + set base sumscores + determine match mode
+	match.mode = ''
+	match = StarCraftMatchGroupInput.OpponentInput(match)
+
+	--main processing done here
+	local subgroup = 0
+	for i = 1, MAX_NUM_MAPS do
+		if match['map' .. i] then
+			--parse the stringified map arguments to be a table again
+			match['map' .. i] = json.parseIfString(match['map' .. i])
+		else
+			break
+		end
+		if (match['map' .. i].winner or '') ~= '' or (match['map' .. i].map or '') ~= '' then
+			match, subgroup = StarCraftMatchGroupInput.MapInput(match, i, subgroup)
+		else
+			match['map' .. i] = nil
+			break
+		end
+	end
+
+	--apply vodgames
+	for index = 1, MAX_NUM_VODGAMES do
+		local vodgame = match['vodgame' .. index]
+		if (not Logic.isEmpty(vodgame)) and (not Logic.isEmpty(match['map' .. index])) then
+			match['map' .. index].vod = match['map' .. index].vod or vodgame
+		end
+	end
+
+	if string.find(match.mode, 'team') then
+		match = StarCraftMatchGroupInput.SubMatchStructure(match)
+	else
+		for i = 1, MAX_NUM_MAPS do
+			if match['map' .. i] then
+				--stringify maps if not team match (for team matches it is done via the above function)
+				match['map' .. i].participants = json.stringify(match['map' .. i].participants)
+				match['map' .. i] = json.stringify(match['map' .. i])
+			else
+				break
+			end
+		end
+	end
+
+	match = StarCraftMatchGroupInput.MatchWinnerProcessing(match)
+
+	--Bracket Contest Handling
+	if match.contest and tostring(match.contest.finished) == '1' then
+		match = StarCraftMatchGroupInput.processContest(match)
+	end
+
+	return match
+end
+
+--[[
+
+Misc. MatchInput functions
+--> Winner, Walkover, Placement, Resulttype, Status
+--> Sub-Match Structure
+
+]]--
+function StarCraftMatchGroupInput.MatchWinnerProcessing(match)
+	local bestof = tonumber(match.bestof or 99) or 99
+	local walkover = match.walkover or ''
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		if not Logic.isEmpty(match['opponent' .. opponentIndex]) then
+			--determine opponent scores, status and placement
+			--determine MATCH winner, resulttype and walkover
+			--the following ignores the possibility of > 2 opponents
+			if walkover ~= '' then
+				if Logic.isNumeric(walkover) then
+					walkover = tonumber(walkover)
+					if walkover == opponentIndex then
+						match.winner = opponentIndex
+						match.walkover = 'L'
+						match['opponent' .. opponentIndex].status = 'W'
+					elseif walkover == 0 then
+						match.winner = 0
+						match.walkover = 'L'
+						match['opponent' .. opponentIndex].status = 'L'
+					else
+						local upper = string.upper(match['opponent' .. opponentIndex].score or '')
+						match['opponent' .. opponentIndex].status = ALLOWED_STATUSES2[upper] or 'L'
+					end
+				elseif Table.includes(ALLOWED_STATUSES, string.upper(walkover)) then
+					if tonumber(match.winner or 0) == opponentIndex then
+						match['opponent' .. opponentIndex].status = 'W'
+					else
+						match['opponent' .. opponentIndex].status = ALLOWED_STATUSES2[string.upper(walkover)] or 'L'
+					end
+				else
+					local upper = string.upper(match['opponent' .. opponentIndex].score or '')
+					match['opponent' .. opponentIndex].status = ALLOWED_STATUSES2[upper] or 'L'
+					match.walkover = 'L'
+				end
+				match['opponent' .. opponentIndex].score = -1
+				match.finished = 'true'
+				match.resulttype = 'default'
+			elseif Logic.readBool(match.cancelled) then
+				match.resulttype = 'np'
+				match.finished = 'true'
+				match['opponent' .. opponentIndex].score = -1
+			elseif ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score or '')] then
+				if string.upper(match['opponent' .. opponentIndex].score) == 'W' then
+					match.winner = opponentIndex
+					match.resulttype = 'default'
+					match.finished = 'true'
+					match['opponent' .. opponentIndex].score = -1
+					match['opponent' .. opponentIndex].status = 'W'
+				else
+					match.resulttype = 'default'
+					match.finished = 'true'
+					match.walkover = ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score)]
+					local upper = string.upper(match['opponent' .. opponentIndex].score)
+					match['opponent' .. opponentIndex].status = ALLOWED_STATUSES2[upper]
+					match['opponent' .. opponentIndex].score = -1
+				end
+			else
+				match['opponent' .. opponentIndex].status = 'S'
+				match['opponent' .. opponentIndex].score = tonumber(match['opponent' .. opponentIndex].score or '') or
+					tonumber(match['opponent' .. opponentIndex].sumscore) or -1
+
+				if match['opponent' .. opponentIndex].score > bestof / 2 then
+					match.finished = 'true'
+					match.winner = tonumber(match.winner or '') or opponentIndex
+				elseif match.winner == 'draw' or tonumber(match.winner) == 0 or
+						(match.opponent1 == bestof / 2 and match.opponent1 == match.opponent2) then
+					match.finished = 'true'
+					match.winner = 0
+					match.resulttype = 'draw'
+				end
+			end
+			if tostring(match.winner) == tostring(opponentIndex) or
+					match.resulttype == 'draw' or
+					match['opponent' .. opponentIndex].score == bestof / 2 then
+				match['opponent' .. opponentIndex].placement = 1
+			else
+				match['opponent' .. opponentIndex].placement = 2
+			end
+
+			--stringify player data
+			for key, _ in ipairs(match['opponent' .. opponentIndex].match2players) do
+				match['opponent' .. opponentIndex].match2players[key].extradata =
+					json.stringify(match['opponent' .. opponentIndex].match2players[key].extradata)
+			end
+			match['opponent' .. opponentIndex].match2players = json.stringify(match['opponent' .. opponentIndex].match2players)
+
+			--stringify opponent extradata
+			match['opponent' .. opponentIndex].extradata = json.stringify(match['opponent' .. opponentIndex].extradata)
+
+			--stringify opponents
+			match['opponent' .. opponentIndex] = json.stringify(match['opponent' .. opponentIndex])
+		else
+			break
+		end
+	end
+
+	return match
+end
+
+function StarCraftMatchGroupInput.SubMatchStructure(match)
+	local SubMatches = {}
+	local j = 0
+
+	for i = 1, MAX_NUM_MAPS do
+		if not Logic.isEmpty(match['map' .. i]) then
+			j = i
+			local participants = match['map' .. i].participants or {}
+			local opp = {}
+
+			if match['map' .. i].mode == '1v1' then
+				for key, item in pairs(participants) do
+					local temp = String.split(key, '_')
+					opp[temp[1]] = item.player
+				end
+			end
+
+			local k = match['map' .. i].subgroup
+			--create a new sub-match if necessary
+			SubMatches[k] = SubMatches[k] or {
+				date = match['map' .. i].date,
+				game = match['map' .. i].game,
+				liquipediatier = match['map' .. i].liquipediatier,
+				liquipediatiertype = match['map' .. i].liquipediatiertype,
+				participants = json.stringify(participants),
+				mode = match['map' .. i].mode,
+				resulttype = 'submatch',
+				subgroup = k,
+				extradata = json.stringify({
+					header = (match['subGroup' .. k .. 'header'] or '') ~= '' and match['subGroup' .. k .. 'header'] or
+						(match['subgroup' .. k .. 'header'] or '') ~= '' and match['subgroup' .. k .. 'header'] or
+						match['submatch' .. k .. 'header'],
+					noQuery = match.noQuery,
+					matchsection = Variables.varDefault('matchsection'),
+					featured = match.featured,
+					isSubMatch = 'true',
+					opponent1 = opp['1'],
+					opponent2 = opp['2']
+				}),
+				['type'] = match['type'],
+				scores = { 0, 0 },
+				winner = 0
+			}
+			--adjust sub-match scores
+			if tonumber(match['map' .. i].winner) == 1 then
+				SubMatches[k].scores[1] = SubMatches[k].scores[1] + 1
+			elseif tonumber(match['map' .. i].winner) == 1 then
+				SubMatches[k].scores[2] = SubMatches[k].scores[2] + 1
+			end
+			--stringify map
+			match['map' .. i].participants = json.stringify(match['map' .. i].participants)
+			match['map' .. i] = json.stringify(match['map' .. i])
+		else
+			break
+		end
+	end
+
+	for k, sub in ipairs(SubMatches) do
+		--get winner
+		if sub.scores[1] > sub.scores[2] then
+			sub.winner = 1
+		elseif sub.scores[2] > sub.scores[1] then
+			sub.winner = 2
+		end
+
+		match['map' .. (j + k)] = sub
+	end
+
+	return match
+end
+
+--[[
+
+OpponentInput functions
+
+]]--
+function StarCraftMatchGroupInput.OpponentInput(match)
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		if not Logic.isEmpty(match['opponent' .. opponentIndex]) then
+			--parse the stringified opponent arguments to be a table again
+			match['opponent' .. opponentIndex] = json.parseIfString(match['opponent' .. opponentIndex])
+
+			--fix legacy winner
+			if (match['opponent' .. opponentIndex].win or '') ~= '' then
+				if (match.winner or '') == '' then
+					match.winner = tostring(opponentIndex)
+				else
+					match.winner = '0'
+				end
+				match['opponent' .. opponentIndex].win = nil
+			end
+
+			--opponent processing (first part)
+			--sort out extradata
+			match['opponent' .. opponentIndex].extradata = {
+				advantage = match['opponent' .. opponentIndex].advantage,
+				score2 = match['opponent' .. opponentIndex].score2,
+				isarchon = match['opponent' .. opponentIndex].isarchon
+			}
+
+			--process input depending on type
+			if match['opponent' .. opponentIndex]['type'] == 'solo' then
+				match['opponent' .. opponentIndex] =
+					StarCraftMatchGroupInput.ProcessSoloOpponentInput(match['opponent' .. opponentIndex])
+			elseif match['opponent' .. opponentIndex]['type'] == 'duo' then
+				match['opponent' .. opponentIndex] =
+					StarCraftMatchGroupInput.ProcessDuoOpponentInput(match['opponent' .. opponentIndex])
+			elseif match['opponent' .. opponentIndex]['type'] == 'trio' then
+				match['opponent' .. opponentIndex] =
+					StarCraftMatchGroupInput.ProcessOpponentInput(match['opponent' .. opponentIndex], 3)
+			elseif match['opponent' .. opponentIndex]['type'] == 'quad' then
+				match['opponent' .. opponentIndex] =
+					StarCraftMatchGroupInput.ProcessOpponentInput(match['opponent' .. opponentIndex], 4)
+			elseif match['opponent' .. opponentIndex]['type'] == 'team' then
+				match['opponent' .. opponentIndex] =
+					StarCraftMatchGroupInput.ProcessTeamOpponentInput(match['opponent' .. opponentIndex], match.date)
+			elseif match['opponent' .. opponentIndex]['type'] == 'literal' then
+				match['opponent' .. opponentIndex] =
+					StarCraftMatchGroupInput.ProcessLiteralOpponentInput(match['opponent' .. opponentIndex])
+			else
+				error('Unsupported Opponent Type')
+			end
+
+			--mark match as noQuery if it contains BYE/TBD/TBA/'' or Literal opponents
+			local pltemp = string.lower(match['opponent' .. opponentIndex].name or '')
+			if pltemp == '' or pltemp == 'tbd' or pltemp == 'tba' or pltemp == 'bye' or
+					match['opponent' .. opponentIndex]['type'] == 'literal' then
+				match.noQuery = 'true'
+			end
+
+			--set initial opponent sumscore
+			match['opponent' .. opponentIndex].sumscore =
+				tonumber(match['opponent' .. opponentIndex].extradata.advantage or '') or ''
+
+			local mode = MODES2[match['opponent' .. opponentIndex]['type']]
+			if mode == '2' and match['opponent' .. opponentIndex].extradata.isarchon == 'true' then
+				mode = 'Archon'
+			end
+
+			match.mode = match.mode .. (opponentIndex ~= 1 and '_' or '') .. mode
+		else
+			break
+		end
+	end
+
+	return match
+end
+
+function StarCraftMatchGroupInput.ProcessSoloOpponentInput(opp)
+	local name = (opp.name or '') ~= '' and opp.name or (opp.p1 or '') ~= '' and opp.p1
+		or (opp[1] or '') ~= '' and opp[1] or ''
+	local link = mw.ext.TeamLiquidIntegration.resolve_redirect((opp.link or '') ~= '' and opp.link
+		or Variables.varDefault(name .. '_page') or name)
+	local race = (opp.race or '') ~= '' and opp.race or Variables.varDefault(name .. '_race') or ''
+	local players = {}
+	local flag = (opp.flag or '') ~= '' and opp.flag or Variables.varDefault(name .. '_flag')
+	players[1] = {
+		displayname = name,
+		name = link,
+		flag = cleanFlag(flag),
+		extradata = { faction = FACTIONS[string.lower(race)] or 'u' }
+	}
+
+	local opp2 = {
+		type = opp['type'],
+		name = link,
+		score = opp.score,
+		extradata = opp.extradata,
+		match2players = players
+	}
+
+	return opp2
+end
+
+function StarCraftMatchGroupInput.ProcessDuoOpponentInput(opp)
+	opp.p1 = (opp.p1 or '') and opp.p1 or ''
+	opp.p2 = (opp.p2 or '') and opp.p2 or ''
+	opp.link1 = mw.ext.TeamLiquidIntegration.resolve_redirect((opp.p1link or '') ~= ''
+		and opp.p1link or Variables.varDefault(opp.p1 .. '_page') or opp.p1)
+	opp.link2 = mw.ext.TeamLiquidIntegration.resolve_redirect((opp.p2link or '') ~= ''
+		and opp.p2link or Variables.varDefault(opp.p2 .. '_page') or opp.p2)
+	if opp.extradata.isarchon == 'true' then
+		opp.p1race = FACTIONS[string.lower(opp.race or '')] or 'u'
+		opp.p2race = opp.p1race
+	else
+		opp.p1race = FACTIONS[string.lower((opp.p1race or '') ~= '' and
+			opp.p1race or Variables.varDefault(opp.p1 .. '_race') or '')] or 'u'
+		opp.p2race = FACTIONS[string.lower((opp.p2race or '') ~= '' and
+			opp.p2race or Variables.varDefault(opp.p2 .. '_race') or '')] or 'u'
+	end
+
+	local players = {}
+	for i = 1, 2 do
+		local flag = (opp['p' .. i .. 'flag'] or '') ~= '' and opp['p' .. i .. 'flag'] or
+			Variables.varDefault(opp['p' .. i] .. '_flag')
+		players[i] = {
+			displayname = opp['p' .. i],
+			name = opp['link' .. i],
+			flag = cleanFlag(flag),
+			extradata = { faction = FACTIONS[string.lower(opp['p' .. i .. 'race'])] or 'u' }
+		}
+	end
+	local name = opp.link1 .. ' / ' .. opp.link2
+
+	local opp2 = {
+		type = opp['type'],
+		name = name,
+		score = opp.score,
+		extradata = opp.extradata,
+		match2players = players
+	}
+
+	return opp2
+end
+
+function StarCraftMatchGroupInput.ProcessOpponentInput(opp, playernumber)
+	local name = ''
+
+	local players = {}
+	for i = 1, playernumber do
+		local Pname = (opp['p' .. i] or '') ~= '' and opp['p' .. i] or ''
+		local link = mw.ext.TeamLiquidIntegration.resolve_redirect((opp['p' .. i .. 'link'] or '') ~= ''
+			and opp['p' .. i .. 'link'] or Variables.varDefault(Pname .. '_page') or Pname)
+		local race = (opp['p' .. i .. 'race'] or '') ~= '' and opp['p' .. i .. 'race'] or
+			Variables.varDefault(Pname .. '_race') or ''
+
+		name = name .. (i ~= 1 and ' / ' or '') .. link
+		local flag = (opp['p' .. i .. 'flag'] or '') ~= '' and opp['p' .. i .. 'flag'] or
+				Variables.varDefault((opp['p' .. i] or '') .. '_flag')
+
+		players[i] = {
+			displayname = Pname,
+			name = link,
+			flag = cleanFlag(flag),
+			extradata = { faction = FACTIONS[string.lower(race)] or 'u' }
+		}
+	end
+
+	local opp2 = {
+		type = opp['type'],
+		name = name,
+		score = opp.score,
+		extradata = opp.extradata,
+		match2players = players
+	}
+
+	return opp2
+end
+
+function StarCraftMatchGroupInput.ProcessLiteralOpponentInput(opp)
+	return {
+		type = opp['type'],
+		name = opp[1],
+		score = opp.score,
+		extradata = opp.extradata,
+		match2players = {}
+	}
+end
+
+function StarCraftMatchGroupInput.getPlayersLegacy(playerData)
+	local players = {}
+	playerData = json.parseIfString(playerData) or {}
+	for playerIndex = 1, MAX_NUM_PLAYERS do
+		local name = mw.ext.TeamLiquidIntegration.resolve_redirect((playerData['p' .. playerIndex .. 'link'] or '') ~= ''
+			and playerData['p' .. playerIndex .. 'link'] or playerData['p' .. playerIndex] or '')
+		if name ~= '' then
+			players[playerIndex] = {
+				name = name,
+				displayname = playerData['p' .. playerIndex],
+				flag = cleanFlag(playerData['p' .. playerIndex .. 'flag']),
+				extradata = {
+					faction = playerData['p' .. playerIndex .. 'race'],
+					position = playerIndex
+				}
+			}
+		else
+			break
+		end
+	end
+	return players
+end
+
+function StarCraftMatchGroupInput.getPlayers(teamName)
+	local players = {}
+	for playerIndex = 1, MAX_NUM_PLAYERS do
+		local name = Variables.varDefault(teamName .. '_p' .. playerIndex)
+		if not Logic.isEmpty(name) then
+			local flag = Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
+			players[playerIndex] = {
+				name = name,
+				displayname = Variables.varDefault(teamName .. '_p' .. playerIndex .. 'display'),
+				flag = cleanFlag(flag),
+				extradata = { faction = Variables.varDefault(teamName .. '_p' .. playerIndex .. 'race') }
+			}
+		else
+			break
+		end
+	end
+	return players
+end
+
+function StarCraftMatchGroupInput.getTeamNameIcon(template)
+	local team
+	if template ~= nil and TeamTemplates._teamexists(template) then
+		team = TeamTemplates._team(template)
+		team = team:gsub('%&', '')
+		team = String.split(team, 'link=')[2]
+		team = String.split(team, ']]')[1]
+	end
+
+	return team
+end
+
+function StarCraftMatchGroupInput.ProcessTeamOpponentInput(opp, date)
+	local customTeam = Logic.readBool(opp.default) or Logic.readBool(opp.defaulticon) or Logic.readBool(opp.custom)
+	local name
+	local icon
+
+	if customTeam then
+		if not defaultIcon then
+			defaultIcon = require('Module:Brkts/WikiSpecific').defaultIcon
+		end
+		opp.template = 'default'
+		icon = defaultIcon
+		name = (opp.link or '') ~= '' and opp.link or (opp.name or '') ~= '' and opp.name or opp[1] or ''
+		opp.extradata = opp.extradata or {}
+		opp.extradata.display = (opp.name or '') ~= '' and opp.name or opp[1] or ''
+		opp.extradata.short = (opp.short or '') ~= '' and opp.short or (opp.name or '') ~= '' and opp.name or opp[1] or ''
+		opp.extradata.bracket = (opp.bracket or '') ~= '' and opp.bracket
+			or (opp.name or '') ~= '' and opp.name or opp[1] or ''
+	else
+		opp.template = string.lower((opp.template or '') ~= '' and opp.template or opp[1] or '')
+		opp.template = StarCraftMatchGroupInput.getTeamTemplate(opp.template, date)
+		name, icon = StarCraftMatchGroupInput.getTeamNameIcon(opp.template)
+	end
+	name = mw.ext.TeamLiquidIntegration.resolve_redirect(name or '')
+	local players = StarCraftMatchGroupInput.getPlayers(name)
+	if Logic.isEmpty(players) then
+		players = StarCraftMatchGroupInput.getPlayersLegacy(opp.players)
+	end
+
+	return {
+		icon = icon,
+		template = opp.template,
+		['type'] = opp['type'],
+		name = name,
+		score = opp.score,
+		extradata = opp.extradata,
+		match2players = players
+	}
+end
+
+function StarCraftMatchGroupInput.getTeamTemplate(input, date)
+	local historicals = mw.ext.TeamTemplate.raw_historical(input)
+	if type(historicals) ~= 'table' then
+		return input
+	end
+
+	local temp = {}
+	local k = 0
+
+	for key, item in pairs(historicals) do
+		k = k + 1
+		temp[k] = { date = string.gsub(key, '-', ''), template = item }
+	end
+
+	table.sort(temp, StarCraftMatchGroupInput.TeamTemplateSortCat)
+	temp[k+1] = { date = '39999999', template = '' }
+
+	for i = 1, k do
+		if date >= temp[i].date and date < temp[i+1].date then
+			return temp[i].template
+		end
+	end
+end
+
+function StarCraftMatchGroupInput.TeamTemplateSortCat(a,b)
+	return a.date < b.date
+end
+
+--[[
+
+MapInput functions
+
+]]--
+function StarCraftMatchGroupInput.MapInput(match, i, subgroup)
+	--redirect maps
+	if match['map' .. i].map ~= 'TBD' then
+		match['map' .. i].map = mw.ext.TeamLiquidIntegration.resolve_redirect(match['map' .. i].map or '')
+	end
+
+	--set initial extradata for maps
+	match['map' .. i].extradata = {
+		comment = match['map' .. i].comment or '',
+		header = match['map' .. i].header or '',
+		noQuery = match.noQuery,
+		isSubMatch = 'false'
+	}
+
+	--inherit stuff from match data
+	match['map' .. i]['type'] = match['type']
+	match['map' .. i].liquipediatier = match.liquipediatier
+	match['map' .. i].liquipediatiertype = match.liquipediatiertype
+	match['map' .. i].game = match.game
+	match['map' .. i].date = match.date
+
+	--determine score, resulttype, walkover and winner
+	match['map' .. i] = StarCraftMatchGroupInput.MapWinnerProcessing(match['map' .. i])
+
+	--get participants data for the map + get map mode + winnerrace and loserrace
+	--(w/l race stuff only for 1v1 maps)
+	match['map' .. i] = StarCraftMatchGroupInput.ProcessPlayerMapData(match['map' .. i], match, 2)
+
+	--set sumscore to 0 if it isn't a number
+	if match.opponent1.sumscore == '' then
+		match.opponent1.sumscore = 0
+	end
+	if match.opponent2.sumscore == '' then
+		match.opponent2.sumscore = 0
+	end
+
+	--adjust sumscore for winner opponent
+	if (tonumber(match['map' .. i].winner or 0) or 0) > 0 then
+		match['opponent' .. match['map' .. i].winner].sumscore =
+			match['opponent' .. match['map' .. i].winner].sumscore + 1
+	end
+
+	--handle subgroup stuff if team match
+	if string.find(match.mode, 'team') then
+		match['map' .. i].subgroup = tonumber(match['map' .. i].subgroup or '')
+		if match['map' .. i].subgroup then
+			subgroup = match['map' .. i].subgroup
+		else
+			subgroup = subgroup + 1
+			match['map' .. i].subgroup = subgroup
+		end
+	end
+
+	return match, subgroup
+end
+
+function StarCraftMatchGroupInput.MapWinnerProcessing(map)
+	map.scores = {}
+	local manual_scores = false
+	local indexedScores = {}
+	for scoreIndex = 1, MAX_NUM_OPPONENTS do
+		-- read scores
+		local score = map['score' .. scoreIndex]
+		local obj = {}
+		if not Logic.isEmpty(score) then
+			manual_scores = true
+			score = ALLOWED_STATUSES2[score] or score
+			if Logic.isNumeric(score) then
+				obj.status = 'S'
+				obj.score = score
+			elseif Table.includes(ALLOWED_STATUSES, score) then
+				obj.status = score
+				obj.score = -1
+			end
+			table.insert(map.scores, score)
+			indexedScores[scoreIndex] = obj
+		else
+			break
+		end
+	end
+
+	if manual_scores then
+		for scoreIndex, _ in Table.iter.spairs(indexedScores, StarCraftMatchGroupInput.placementSortFunction) do
+			if not tonumber(map.winner or '') then
+				map.winner = scoreIndex
+			else
+				break
+			end
+		end
+	else
+		if (map.walkover or '') ~= '' then
+			if map.walkover == '1' then
+				map.winner = '1'
+			elseif map.walkover == '2' then
+				map.winner = '2'
+			elseif map.walkover == '0' then
+				map.winner = '0'
+			end
+			map.walkover = Table.includes(ALLOWED_STATUSES, map.walkover) and map.walkover or 'L'
+			map.scores = { -1, -1 }
+			map.resulttype = 'default'
+		elseif map.winner == 'skip' then
+			map.scores = { 0, 0 }
+			map.scores = { -1, -1 }
+			map.resulttype = 'np'
+		elseif map.winner == '1' then
+			map.scores = { 1, 0 }
+		elseif map.winner == '2' then
+			map.scores = { 0, 1 }
+		elseif map.winner == '0' or map.winner == 'draw' then
+			map.scores = { 0.5, 0.5 }
+			map.resulttype = 'draw'
+		end
+	end
+	return map
+end
+
+function StarCraftMatchGroupInput.ProcessPlayerMapData(map, match, OppNumber)
+	local participants = {}
+	local map_mode = ''
+	local raceOP = {}
+	local PL = {}
+
+	for i = 1, OppNumber do
+		local number = 0
+		if match['opponent' .. i]['type'] == 'team' then
+			local players = match['opponent' .. i].match2players
+			if players == {} then
+				break
+			end
+
+			local tbds = 0
+
+			local PlayerData = {}
+			for j = 1, 4 do
+				if not Logic.isEmpty(map['t' .. i .. 'p' .. j]) then
+					if map['t' .. i .. 'p' .. j] ~= 'TBD' and map['t' .. i .. 'p' .. j] ~= 'TBA' then
+						map['t' .. i .. 'p' .. j] = mw.ext.TeamLiquidIntegration.resolve_redirect(map['t' .. i .. 'p' .. j])
+
+						if map['opponent' .. i .. 'archon'] == 'true' then
+							PlayerData[map['t' .. i .. 'p' .. j]] = {
+								faction = FACTIONS[string.lower((map['t' .. i .. 'race'] or '') ~= '' and map['t' .. i .. 'race'] or
+									(map['opponent' .. i .. 'race'] or '') ~= '' and map['opponent' .. i .. 'race'] or
+									(map['t' .. i .. 'p' .. j .. 'race'] or '') ~= '' and map['t' .. i .. 'p' .. j .. 'race']
+									or 'u')] or 'u',
+								position = j
+							}
+						else
+							PlayerData[map['t' .. i .. 'p' .. j]] = {
+								faction = FACTIONS[string.lower((map['t' .. i .. 'p' .. j .. 'race'] or '') ~= '' and
+									map['t' .. i .. 'p' .. j .. 'race'] or 'u')] or 'u',
+								position = j
+							}
+						end
+					else
+						tbds = tbds + 1
+					end
+				else
+					break
+				end
+			end
+
+			for key, item in pairs(players) do
+				if item and PlayerData[item.name] then
+					number = number + 1
+					local faction = (PlayerData[item.name].faction ~= 'u') and PlayerData[item.name].faction or
+						item.extradata.faction or 'u'
+					raceOP[i] = faction
+					PL[i] = item.name
+					participants[i .. '_' .. key] = {
+						faction = faction,
+						player = item.name,
+						position = PlayerData[item.name].position,
+						flag = cleanFlag(item.flag),
+					}
+				end
+			end
+
+			local num = #players
+
+			for r = 1, tbds do
+				number = number + 1
+				participants[i .. '_' .. (num + r)] = {
+						faction = 'u',
+						player = 'TBD'
+					}
+			end
+
+			if number == 2 and map['opponent' .. i .. 'archon'] == 'true' then
+				number = 'Archon'
+			elseif number == 2 and map['opponent' .. i .. 'duoSpecial'] == 'true' then
+				number = '2S'
+			elseif number == 4 and map['opponent' .. i .. 'quadSpecial'] == 'true' then
+				number = '4S'
+			end
+		elseif match['opponent' .. i]['type'] == 'literal' then
+			number = 'Literal'
+		elseif match['opponent' .. i]['type'] == 'duo' and match['opponent' .. i].extradata.isarchon == 'true' then
+			number = 'Archon'
+			local players = match['opponent' .. i].match2players
+			if players == {} then
+				break
+			else
+				local faction = string.lower((map['opponent' .. i .. 'race'] or '') ~= '' and map['opponent' .. i .. 'race'] or
+					(map['race' .. i] or '') ~= '' and map['race' .. i] or players[1].extradata.faction or 'u')
+				participants[i .. '_1'] = {
+					faction = FACTIONS[faction] or 'u',
+					player = players[1].name
+				}
+				raceOP[i] = participants[i .. '_1'].faction
+				PL[i] = players[1].name
+
+				participants[i .. '_2'] = {
+					faction = FACTIONS[faction] or 'u',
+					player = players[2].name
+				}
+			end
+		else
+			number = tonumber(MODES2[match['opponent' .. i]['type']])
+			local players = match['opponent' .. i].match2players
+			if players == {} then
+				break
+			else
+				local faction = string.lower((map['t' .. i .. 'p1race'] or '') ~= '' and map['t' .. i .. 'p1race'] or
+					(map['race' .. i] or '') ~= '' and map['race' .. i] or 'u')
+				participants[i .. '_1'] = {
+					faction = FACTIONS[faction] or players[1].extradata.faction or 'u',
+					player = players[1].name
+				}
+				raceOP[i] = participants[i .. '_1'].faction
+				PL[i] = players[1].name
+				for j = 2, number do
+					faction = string.lower((map['t' .. i .. 'p' .. j .. 'race'] or '') ~= '' and
+						map['t' .. i .. 'p' .. j .. 'race'] or 'u')
+					participants[i .. '_' .. j] = {
+						faction = FACTIONS[faction] or players[j].extradata.faction or 'u',
+						player = players[j].name
+					}
+				end
+			end
+		end
+		map_mode = map_mode .. (i ~= 1 and 'v' or '') .. number
+
+		if map_mode == '1v1' and OppNumber == 2 then
+			if tonumber(map.winner or 0) == 1 then
+				map.extradata.winnerrace = raceOP[1]
+				map.extradata.loserrace = raceOP[2]
+			elseif tonumber(map.winner or 0) == 2 then
+				map.extradata.winnerrace = raceOP[2]
+				map.extradata.loserrace = raceOP[1]
+			end
+			map.extradata.opponent1 = PL[1]
+			map.extradata.opponent2 = PL[2]
+		end
+	end
+
+	map.mode = map_mode
+
+	map.participants = participants
+	map.extradata = json.stringify(map.extradata)
+	return map
+end
+
+-- function to sort out winner/placements
+function StarCraftMatchGroupInput.placementSortFunction(table, key1, key2)
+	local op1 = table[key1]
+	local op2 = table[key2]
+	local op1norm = op1.status == 'S'
+	local op2norm = op2.status == 'S'
+	if op1norm then
+		if op2norm then
+			return tonumber(op1.score) > tonumber(op2.score)
+		else return true end
+	else
+		if op2norm then return false
+		elseif op1.status == 'W' then return true
+		elseif op1.status == 'DQ' then return false
+		elseif op1.status == 'FF' then return false
+		elseif op1.status == 'L' then return false
+		elseif op2.status == 'W' then return false
+		elseif op2.status == 'DQ' then return true
+		elseif op2.status == 'FF' then return true
+		elseif op2.status == 'L' then return true
+		else return true end
+	end
+end
+
+--[[
+
+Bracket Contests function
+
+]]--
+function StarCraftMatchGroupInput.processContest(match)
+	local points = tonumber(Variables.varDefault('contestPoints', 0)) or 0
+	local score1 = {}
+	local score2 = {}
+	local Rscore1 = {}
+	local Rscore2 = {}
+	for opponentIndex = 1, 2 do
+		match['opponent' .. opponentIndex] = json.parseIfString(match['opponent' .. opponentIndex])
+		match['opponent' .. opponentIndex].extradata = json.parseIfString(match['opponent' .. opponentIndex].extradata)
+		local Opp = match['opponent' .. opponentIndex]
+		local ResultOpp = match.contest.opponents[opponentIndex]
+		ResultOpp.extradata = ResultOpp.extradata or {}
+		if ResultOpp.name ~= Opp.name then
+			break
+		end
+		score1[opponentIndex] = tonumber(Opp.score or 0) or 0
+		score2[opponentIndex] = tonumber(Opp.extradata.score2 or 0) or 0
+		Rscore1[opponentIndex] = tonumber(ResultOpp.score or 0) or 0
+		Rscore2[opponentIndex] = tonumber(ResultOpp.extradata.score2 or 0) or 0
+
+		if score1[opponentIndex] == Rscore1[opponentIndex] and score2[opponentIndex] == Rscore2[opponentIndex] then
+			match['opponent' .. opponentIndex].extradata.contest =
+				'<i class="fa fa-check forest-green-text" aria-hidden="true"></i>'
+		else
+			match['opponent' .. opponentIndex].extradata.contest = '&nbsp;'
+		end
+	end
+
+	if match.opponent1.extradata.contest ~= '&nbsp;' and match.opponent1.extradata.contest ~= '&nbsp;' then
+		points = points + match.contest.points.score
+	elseif score1[1] - score1[2] + Rscore1[2] - Rscore1[1] == 0 and
+			score2[1] - score2[2] + Rscore2[2] - Rscore2[1] == 0 then
+		points = points + match.contest.points.diff
+	elseif tostring(match.winner) == tostring(match.contest.winner) then
+		points = points + match.contest.points.win
+	end
+
+	for opponentIndex = 1, 2 do
+		match['opponent' .. opponentIndex].extradata = json.stringify(match['opponent' .. opponentIndex].extradata)
+		match['opponent' .. opponentIndex] = json.stringify(match['opponent' .. opponentIndex])
+	end
+
+	match.contest = nil
+
+	Variables.varDefine('contestPoints', points)
+
+	return match
+end
+
+return StarCraftMatchGroupInput

--- a/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -1,0 +1,529 @@
+local FFA = {}
+
+local json = require('Module:Json')
+local Variables = require('Module:Variables')
+local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
+local Table = require('Module:Table')
+local config = Lua.moduleExists('Module:Match/Config') and mw.loadData('Module:Match/Config') or {}
+local WikiSpecific = require('Module:DevFlags').matchGroupDev
+		and Lua.requireIfExists('Module:MatchGroup/Input/StarCraft/dev')
+		or require('Module:MatchGroup/Input/StarCraft')
+
+local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
+local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }
+local ALLOWED_STATUSES2 = { ['W'] = 'W', ['FF'] = 'FF', ['L'] = 'L', ['DQ'] = 'DQ', ['-'] = 'L' }
+local MAX_NUM_OPPONENTS = 8
+local MAX_NUM_VODGAMES = 9
+local MODES2 = {
+	['solo'] = '1',
+	['duo'] = '2',
+	['trio'] = '3',
+	['quad'] = '4',
+	['team'] = 'team',
+	['literal'] = 'literal'
+	}
+
+function FFA.adjustData(match)
+	local OppNumber = 0
+	local noscore = match.noscore == 'true' or match.noscore == '1' or match.nopoints == 'true' or match.nopoints == '1'
+	match.noscore = noscore
+	--parse opponents + determine match mode + set initial stuff
+	match.mode = ''
+	match, OppNumber = FFA.OpponentInput(match, OppNumber, noscore)
+
+	--indicate it is an FFA match
+	match.mode = match.mode .. '_ffa'
+
+	--main processing done here
+	local subgroup = 0
+	for i = 1, MAX_NUM_MAPS do
+		if match['map' .. i] then
+			--parse the stringified map arguments to be a table again
+			match['map' .. i] = json.parseIfString(match['map' .. i])
+		else
+			break
+		end
+		if 	((match['map' .. i].opponent1placement or '') ~= '' or (match['map' .. i].placement1 or '') ~= '' or
+				(match['map' .. i].points1 or '') ~= '' or (match['map' .. i].opponent1points or '') ~= '' or
+				(match['map' .. i].score1 or '') ~= '' or (match['map' .. i].opponent1score or '') ~= '' or
+				(match['map' .. i].map or '') ~= '') then
+			match, subgroup = FFA.MapInput(match, i, subgroup, noscore, OppNumber)
+		else
+			match['map' .. i] = nil
+			break
+		end
+	end
+
+	--apply vodgames
+	for index = 1, MAX_NUM_VODGAMES do
+		local vodgame = match['vodgame' .. index]
+		if (not Logic.isEmpty(vodgame)) and (not Logic.isEmpty(match['map' .. index])) then
+			match['map' .. index].vod = match['map' .. index].vod or vodgame
+		end
+	end
+
+	for i = 1, MAX_NUM_MAPS do
+		if match['map' .. i] then
+			--stringify maps
+			match['map' .. i].participants = json.stringify(match['map' .. i].participants)
+			match['map' .. i] = json.stringify(match['map' .. i])
+		else
+			break
+		end
+	end
+
+	match = FFA.MatchWinnerProcessing(match, OppNumber, noscore)
+
+	for opponentIndex = 1, OppNumber do
+		--stringify player data
+		for key, item in ipairs(match['opponent' .. opponentIndex].match2players) do
+			match['opponent' .. opponentIndex].match2players[key].extradata = json.stringify(item.extradata)
+		end
+		match['opponent' .. opponentIndex].match2players = json.stringify(match['opponent' .. opponentIndex].match2players)
+		--stringify opponent extradata
+		match['opponent' .. opponentIndex].extradata = json.stringify(match['opponent' .. opponentIndex].extradata)
+		--stringify opponents
+		match['opponent' .. opponentIndex] = json.stringify(match['opponent' .. opponentIndex])
+	end
+
+	--Bracket Contest Handling
+	if match.contest and tostring(match.contest.finished) == '1' then
+		match = FFA.processContest(match, OppNumber)
+	end
+
+	return match
+end
+
+-- function to sort out placements
+function FFA.placementSortFunction(table, key1, key2)
+	local op1 = table[key1]
+	local op2 = table[key2]
+	return tonumber(op1) > tonumber(op2)
+end
+
+--[[
+
+Match Winner, Walkover, Placement, Resulttype, Status functions
+
+]]--
+function FFA.MatchWinnerProcessing(match, OppNumber, noscore)
+	local bestof = tonumber(match.firstto or '') or tonumber(match.bestof or '') or 9999
+	match.bestof = bestof
+	local walkover = match.walkover or ''
+	local IndScore = {}
+	for opponentIndex = 1, OppNumber do
+		--determine opponent scores, status
+		--determine MATCH winner, resulttype and walkover
+		if walkover ~= '' then
+			if Logic.isNumeric(walkover) then
+				walkover = tonumber(walkover)
+				if walkover == opponentIndex then
+					match.winner = opponentIndex
+					match.walkover = 'L'
+					match['opponent' .. opponentIndex].status = 'W'
+					IndScore[opponentIndex] = 9999
+				elseif walkover == 0 then
+					match.winner = 0
+					match.walkover = 'L'
+					match['opponent' .. opponentIndex].status = 'L'
+					IndScore[opponentIndex] = -1
+				else
+					match['opponent' .. opponentIndex].status =
+						ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score or '')] or 'L'
+					IndScore[opponentIndex] = -1
+				end
+			elseif Table.includes(ALLOWED_STATUSES, string.upper(walkover)) then
+				if tonumber(match.winner or 0) == opponentIndex then
+					IndScore[opponentIndex] = 9999
+					match['opponent' .. opponentIndex].status = 'W'
+				else
+					IndScore[opponentIndex] = -1
+					match['opponent' .. opponentIndex].status = ALLOWED_STATUSES2[string.upper(walkover)] or 'L'
+				end
+			else
+				match['opponent' .. opponentIndex].status =
+					ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score or '')] or 'L'
+				match.walkover = 'L'
+				if ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score or '')] == 'W' then
+					IndScore[opponentIndex] = 9999
+				else
+					IndScore[opponentIndex] = -1
+				end
+			end
+			match['opponent' .. opponentIndex].score = -1
+			match.finished = 'true'
+			match.resulttype = 'default'
+		elseif Logic.readBool(match.cancelled) then
+			match.resulttype = 'np'
+			match.finished = 'true'
+			match['opponent' .. opponentIndex].score = -1
+			IndScore[opponentIndex] = -1
+		elseif ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score or '')] then
+			if string.upper(match['opponent' .. opponentIndex].score) == 'W' then
+				match.winner = opponentIndex
+				match.resulttype = 'default'
+				match.finished = 'true'
+				match['opponent' .. opponentIndex].score = -1
+				match['opponent' .. opponentIndex].status = 'W'
+				IndScore[opponentIndex] = 9999
+			else
+				match.resulttype = 'default'
+				match.finished = 'true'
+				match.walkover = ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score)]
+				match['opponent' .. opponentIndex].status =
+					ALLOWED_STATUSES2[string.upper(match['opponent' .. opponentIndex].score)]
+				match['opponent' .. opponentIndex].score = -1
+				IndScore[opponentIndex] = -1
+			end
+		else
+			match['opponent' .. opponentIndex].status = 'S'
+			match['opponent' .. opponentIndex].score = tonumber(match['opponent' .. opponentIndex].score or '') or
+				tonumber(match['opponent' .. opponentIndex].sumscore) or -1
+			IndScore[opponentIndex] = match['opponent' .. opponentIndex].score
+		end
+	end
+
+	match = FFA.MatchPlacements(match, OppNumber, noscore, IndScore)
+
+	return match
+end
+
+--determine placements and winner (if not already set)
+function FFA.MatchPlacements(match, OppNumber, noscore, IndScore)
+	local counter = 0
+	local temp = {}
+	match.finished = (match.finished or '') ~= '' and match.finished ~= 'false' and match.finished ~= '0' and 'true' or nil
+
+	if not noscore then
+		for scoreIndex, score in Table.iter.spairs(IndScore, FFA.placementSortFunction) do
+			counter = counter + 1
+			if counter == 1 and (match.winner or '') == '' then
+				if match.finished or score >= match.bestof then
+					match.winner = scoreIndex
+					match.finished = 'true'
+					match['opponent' .. scoreIndex].placement = tonumber(match['opponent' .. scoreIndex].placement or '') or counter
+					match['opponent' .. scoreIndex].extradata.advances = true
+					temp.place = counter
+					temp.score = IndScore[scoreIndex]
+				else
+					break
+				end
+			elseif match.finished then
+				if temp.score == score then
+					match['opponent' .. scoreIndex].placement = tonumber(match['opponent' .. scoreIndex].placement or '') or temp.place
+				else
+					match['opponent' .. scoreIndex].placement = tonumber(match['opponent' .. scoreIndex].placement or '') or counter
+					temp.place = counter
+					temp.score = IndScore[scoreIndex]
+				end
+			else
+				break
+			end
+		end
+	elseif tonumber(match.winner or '') then
+		for oppIndex = 1, OppNumber do
+			match['opponent' .. oppIndex].placement = tonumber(match['opponent' .. oppIndex].placement or '') or 99
+			if match['opponent' .. oppIndex].placement == 99 and tonumber(match.winner) == oppIndex then
+				match['opponent' .. oppIndex].placement = 1
+			end
+		end
+	else
+		for oppIndex = 1, OppNumber do
+			match['opponent' .. oppIndex].placement = tonumber(match['opponent' .. oppIndex].placement or '') or 99
+			if match['opponent' .. oppIndex].placement == 1 then
+				match.winner = oppIndex
+			end
+		end
+	end
+
+	return match
+end
+
+--[[
+
+OpponentInput functions
+
+]]--
+function FFA.OpponentInput(match, OppNumber, noscore)
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		if not Logic.isEmpty(match['opponent' .. opponentIndex]) then
+			OppNumber = opponentIndex
+			--parse the stringified opponent arguments to be a table again
+			match['opponent' .. opponentIndex] = json.parseIfString(match['opponent' .. opponentIndex])
+
+			local advances = match['opponent' .. opponentIndex].advance or ''
+			if advances == '' then
+				advances = match['opponent' .. opponentIndex].win or ''
+				if advances == '' then
+					advances = match['opponent' .. opponentIndex].advances or ''
+				end
+			end
+			advances = advances ~= 'false' and advances ~= '' and advances ~= '0' and 'true'
+
+			--opponent processing (first part)
+			--sort out extradata
+			match['opponent' .. opponentIndex].extradata = {
+				advantage = match['opponent' .. opponentIndex].advantage,
+				score2 = match['opponent' .. opponentIndex].score2,
+				isarchon = match['opponent' .. opponentIndex].isarchon,
+				advances = advances,
+				noscore = noscore
+			}
+
+			--set initial opponent sumscore
+			match['opponent' .. opponentIndex].sumscore =
+				tonumber(match['opponent' .. opponentIndex].extradata.advantage or '') or ''
+
+			local temp_place = match['opponent' .. opponentIndex].placement
+			--process input depending on type
+			if match['opponent' .. opponentIndex]['type'] == 'solo' then
+				match['opponent' .. opponentIndex] =
+					WikiSpecific.ProcessSoloOpponentInput(match['opponent' .. opponentIndex])
+			elseif match['opponent' .. opponentIndex]['type'] == 'duo' then
+				match['opponent' .. opponentIndex] =
+					WikiSpecific.ProcessDuoOpponentInput(match['opponent' .. opponentIndex])
+			elseif match['opponent' .. opponentIndex]['type'] == 'trio' then
+				match['opponent' .. opponentIndex] =
+					WikiSpecific.ProcessOpponentInput(match['opponent' .. opponentIndex], 3)
+			elseif match['opponent' .. opponentIndex]['type'] == 'quad' then
+				match['opponent' .. opponentIndex] =
+					WikiSpecific.ProcessOpponentInput(match['opponent' .. opponentIndex], 4)
+			elseif match['opponent' .. opponentIndex]['type'] == 'team' then
+				match['opponent' .. opponentIndex] =
+					WikiSpecific.ProcessTeamOpponentInput(match['opponent' .. opponentIndex], match.date)
+			elseif match['opponent' .. opponentIndex]['type'] == 'literal' then
+				match['opponent' .. opponentIndex] =
+					WikiSpecific.ProcessLiteralOpponentInput(match['opponent' .. opponentIndex])
+			else
+				error('Unsupported Opponent Type')
+			end
+
+			match['opponent' .. opponentIndex].placement = temp_place
+
+			--mark match as noQuery if it contains BYE/TBD/TBA/'' or Literal opponents
+			local pltemp = string.lower(match['opponent' .. opponentIndex].name or '')
+			if pltemp == '' or pltemp == 'tbd' or pltemp == 'tba' or pltemp == 'bye' or
+					match['opponent' .. opponentIndex]['type'] == 'literal' then
+				match.noQuery = 'true'
+			end
+
+			local mode = MODES2[match['opponent' .. opponentIndex]['type']]
+			if mode == '2' and match['opponent' .. opponentIndex].extradata.isarchon == 'true' then
+				mode = 'Archon'
+			end
+
+			match.mode = match.mode .. (opponentIndex ~= 1 and '_' or '') .. mode
+		else
+			break
+		end
+	end
+
+	return match, OppNumber
+end
+
+--[[
+
+MapInput functions
+
+]]--
+function FFA.MapInput(match, i, subgroup, noscore, OppNumber)
+	--redirect maps
+	if match['map' .. i].map ~= 'TBD' then
+		match['map' .. i].map = mw.ext.TeamLiquidIntegration.resolve_redirect(match['map' .. i].map or '')
+	end
+
+	--set initial extradata for maps
+	match['map' .. i].extradata = {
+		comment = match['map' .. i].comment or '',
+		header = match['map' .. i].header or '',
+		noQuery = match.noQuery,
+		isSubMatch = 'false'
+	}
+
+	--inherit stuff from match data
+	match['map' .. i]['type'] = match['type']
+	match['map' .. i].liquipediatier = match.liquipediatier
+	match['map' .. i].liquipediatiertype = match.liquipediatiertype
+	match['map' .. i].game = match.game
+	match['map' .. i].date = match.date
+
+	--get participants data for the map + get map mode
+	match['map' .. i] = WikiSpecific.ProcessPlayerMapData(match['map' .. i], match, OppNumber)
+
+	--determine scores, resulttype, walkover and winner
+	match['map' .. i] = FFA.MapScoreProcessing(match['map' .. i], OppNumber, noscore)
+
+	--adjust sumscores if scores/points are used
+	if not noscore then
+		for j = 1, OppNumber do
+			--set sumscore to 0 if it isn't a number
+			if (match['opponent' .. j].sumscore or '') == '' then
+				match['opponent' .. j].sumscore = 0
+			end
+			match['opponent' .. j].sumscore = match['opponent' .. j].sumscore + (tonumber(match['map' .. i].scores[j] or 0) or 0)
+		end
+	end
+
+	--subgroup handling
+	subgroup = tonumber(match['map' .. i].subgroup or '') or subgroup + 1
+
+	return match, subgroup
+end
+
+
+function FFA.MapScoreProcessing(map, OppNumber, noscore)
+	map.extradata = json.parseIfString(map.extradata)
+	map.scores = {}
+	local indexedScores = {}
+	local hasScoreSet = false
+	--read scores
+	if not noscore then
+		for scoreIndex = 1, OppNumber do
+			local score =	(map['score' .. scoreIndex] or '') ~= '' and map['score' .. scoreIndex] or
+							(map['points' .. scoreIndex] or '') ~= '' and map['points' .. scoreIndex] or
+							(map['opponent' .. scoreIndex .. 'points'] or '') ~= '' and map['opponent' .. scoreIndex .. 'points'] or
+							(map['opponent' .. scoreIndex .. 'score'] or '') ~= '' and map['opponent' .. scoreIndex .. 'score'] or ''
+			score = ALLOWED_STATUSES2[score] or tonumber(score) or 0
+			indexedScores[scoreIndex] = score
+			if not Logic.isNumeric(score) then
+				map.resulttype = 'default'
+				if (map.walkover or '') == '' or map.walkover == 'L' then
+					if score == 'DQ' then
+						map.walkover = 'DQ'
+					elseif score == 'FF' then
+						map.walkover = 'FF'
+					else
+						map.walkover = 'L'
+					end
+				end
+				if score == 'W' then
+					indexedScores[scoreIndex] = 9999
+				else
+					indexedScores[scoreIndex] = -1
+				end
+			end
+
+			--check if any score is not 0, i.e. a score has been actually entered
+			if score ~= 0 then
+				hasScoreSet = true
+			end
+
+			map.scores[scoreIndex] = score
+		end
+
+		--determine map winner and placements from scores if not set manually
+		if hasScoreSet then
+			local counter = 0
+			local temp = {}
+			for scoreIndex, score in Table.iter.spairs(indexedScores, FFA.placementSortFunction) do
+				counter = counter + 1
+				if counter == 1 and (map.winner or '') == '' then
+					map.winner = scoreIndex
+					map.extradata['placement' .. scoreIndex] = tonumber(map['placement' .. scoreIndex] or '') or
+						tonumber(map['opponent' .. scoreIndex .. 'placement'] or '') or counter
+					temp.place = counter
+					temp.score = indexedScores[scoreIndex]
+				elseif temp.score == score then
+					map.extradata['placement' .. scoreIndex] = tonumber(map['placement' .. scoreIndex] or '') or
+						tonumber(map['opponent' .. scoreIndex .. 'placement'] or '') or temp.place
+				else
+					map.extradata['placement' .. scoreIndex] = tonumber(map['placement' .. scoreIndex] or '') or
+						tonumber(map['opponent' .. scoreIndex .. 'placement'] or '') or counter
+					temp.place = counter
+					temp.score = indexedScores[scoreIndex]
+				end
+			end
+		end
+	elseif tonumber(map.winner or '') then
+		for oppIndex = 1, OppNumber do
+			map.extradata['placement' .. oppIndex] = tonumber(map['placement' .. oppIndex] or '') or
+				tonumber(map['opponent' .. oppIndex .. 'placement'] or '') or 99
+			if map.extradata['placement' .. oppIndex] == 99 and tonumber(map.winner) == oppIndex then
+				map.extradata['placement' .. oppIndex] = 1
+			end
+		end
+	else
+		for oppIndex = 1, OppNumber do
+			map.extradata['placement' .. oppIndex] = tonumber(map['placement' .. oppIndex] or '') or
+				tonumber(map['opponent' .. oppIndex .. 'placement'] or '') or 99
+			if map.extradata['placement' .. oppIndex] == 1 then
+				map.winner = oppIndex
+			end
+		end
+	end
+
+	map.extradata = json.stringify(map.extradata)
+
+	return map
+end
+
+
+
+
+
+
+--[[
+
+Bracket Contests function
+
+]]--
+function FFA.processContest(match, OppNumber)
+	local points = tonumber(Variables.varDefault('contestPoints', 0)) or 0
+	local score1 = {}
+	local score2 = {}
+	local Rscore1 = {}
+	local Rscore2 = {}
+	for opponentIndex = 1, OppNumber do
+		match['opponent' .. opponentIndex] = json.parseIfString(match['opponent' .. opponentIndex])
+		match['opponent' .. opponentIndex].extradata = json.parseIfString(match['opponent' .. opponentIndex].extradata)
+		local Opp = match['opponent' .. opponentIndex]
+		local ResultOpp = match.contest.opponents[opponentIndex]
+		ResultOpp.extradata = ResultOpp.extradata or {}
+		if ResultOpp.name ~= Opp.name then
+			break
+		end
+		score1[opponentIndex] = tonumber(Opp.score or 0) or 0
+		score2[opponentIndex] = tonumber(Opp.extradata.score2 or 0) or 0
+		Rscore1[opponentIndex] = tonumber(ResultOpp.score or 0) or 0
+		Rscore2[opponentIndex] = tonumber(ResultOpp.extradata.score2 or 0) or 0
+
+		if score1[opponentIndex] == Rscore1[opponentIndex] and score2[opponentIndex] == Rscore2[opponentIndex] then
+			match['opponent' .. opponentIndex].extradata.contest =
+				'<i class="fa fa-check forest-green-text" aria-hidden="true"></i>'
+		else
+			match['opponent' .. opponentIndex].extradata.contest = '&nbsp;'
+		end
+	end
+
+	if match.opponent1.extradata.contest ~= '&nbsp;' and match.opponent1.extradata.contest ~= '&nbsp;' then
+		points = points + match.contest.points.score
+	else
+		local diff = score1[1] - Rscore1[1]
+		local hasSameDiff = true
+		for i = 2, OppNumber do
+			if score1[i] - Rscore1[i] - diff ~= 0 then
+				hasSameDiff = false
+				break
+			end
+		end
+		if hasSameDiff then
+			points = points + match.contest.points.diff
+		elseif tostring(match.winner) == tostring(match.contest.winner) then
+			points = points + match.contest.points.win
+		end
+	end
+
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		match['opponent' .. opponentIndex].extradata = json.stringify(match['opponent' .. opponentIndex].extradata)
+		match['opponent' .. opponentIndex] = json.stringify(match['opponent' .. opponentIndex])
+	end
+
+	match.contest = nil
+
+	Variables.varDefine('contestPoints', points)
+
+	return match
+end
+
+return FFA

--- a/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -1,0 +1,301 @@
+local Array = require('Module:Array')
+local Logic = require('Module:Logic')
+local MatchGroupUtil = require('Module:MatchGroup/Util')
+local String = require('Module:String')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+
+--[[
+Utility functions for match group related things specific to the starcraft and starcraft2 wikis.
+]]
+local StarcraftMatchGroupUtil = {}
+
+StarcraftMatchGroupUtil.types = {}
+
+StarcraftMatchGroupUtil.types.Race = TypeUtil.literalUnion('p', 't', 'z', 'r', 'u')
+StarcraftMatchGroupUtil.types.Player = TypeUtil.extendStruct(MatchGroupUtil.types.Player, {
+	mainRace = StarcraftMatchGroupUtil.types.Race,
+	position = 'number?',
+	race = StarcraftMatchGroupUtil.types.Race,
+})
+StarcraftMatchGroupUtil.types.Opponent = TypeUtil.extendStruct(MatchGroupUtil.types.Opponent, {
+	players = TypeUtil.array(StarcraftMatchGroupUtil.types.Player),
+	isArchon = 'boolean',
+	team = TypeUtil.optional(MatchGroupUtil.types.Team),
+})
+StarcraftMatchGroupUtil.types.GameOpponent = TypeUtil.struct({
+	players = TypeUtil.array(StarcraftMatchGroupUtil.types.Player),
+	isArchon = 'boolean',
+	isSpecialArchon = 'boolean',
+})
+StarcraftMatchGroupUtil.types.Game = TypeUtil.extendStruct(MatchGroupUtil.types.Game, {
+	opponents = TypeUtil.array(StarcraftMatchGroupUtil.types.Opponent),
+})
+StarcraftMatchGroupUtil.types.MatchVeto = TypeUtil.struct({
+	by = 'number',
+	map = 'string',
+})
+StarcraftMatchGroupUtil.types.Submatch = TypeUtil.struct({
+	games = TypeUtil.array(StarcraftMatchGroupUtil.types.Game),
+	mode = 'string',
+	opponents = TypeUtil.array(StarcraftMatchGroupUtil.types.Opponent),
+	resultType = TypeUtil.optional(MatchGroupUtil.types.ResultType),
+	scores = TypeUtil.table('number', 'number'),
+	subgroup = 'number',
+	walkover = TypeUtil.optional(MatchGroupUtil.types.Walkover),
+	winner = 'number?',
+})
+StarcraftMatchGroupUtil.types.Match = TypeUtil.extendStruct(MatchGroupUtil.types.Match, {
+	games = TypeUtil.array(StarcraftMatchGroupUtil.types.Game),
+	headToHead = 'boolean',
+	isFFA = 'boolean',
+	opponentMode = TypeUtil.literalUnion('uniform', 'team'),
+	opponents = TypeUtil.array(StarcraftMatchGroupUtil.types.Opponent),
+	vetoes = TypeUtil.array(StarcraftMatchGroupUtil.types.MatchVeto),
+})
+
+
+function StarcraftMatchGroupUtil.matchFromRecord(record)
+	local match = MatchGroupUtil.matchFromRecord(record)
+
+	-- Add additional fields to opponents
+	StarcraftMatchGroupUtil.populateOpponents(match)
+
+	-- Remove submatches from match.games because submatches will be computed later (even when fetching from lpdb)
+	match.games = Array.filter(match.games, function(game) return game.resultType ~= 'submatch' end)
+
+	-- Compute game.opponents by looking up game.participants in match.opponents
+	for _, game in ipairs(match.games) do
+		game.opponents = StarcraftMatchGroupUtil.computeGameOpponents(game, match.opponents)
+	end
+
+	-- Determine whether the match is a team match with different players each game
+	match.opponentMode = match.mode:match('team') and 'team' or 'uniform'
+
+	if match.opponentMode == 'team' then
+		-- Compute submatches
+		match.submatches = StarcraftMatchGroupUtil.groupBySubmatch(match.games)
+
+		-- Extract submatch headers from extradata
+		for _, submatch in pairs(match.submatches) do
+			submatch.header = match.extradata['subGroup' .. submatch.subgroup .. 'header']
+		end
+	end
+
+	-- Add vetoes
+	match.vetoes = {}
+	for vetoIx = 1, math.huge do
+		local map = match.extradata['veto' .. vetoIx]
+		local by = tonumber(match.extradata['veto' .. vetoIx .. 'by'])
+		if not map then break end
+
+		table.insert(match.vetoes, {map = map, by = by})
+	end
+
+	-- Misc
+	match.headToHead = Logic.readBool(match.extradata.headtohead) -- TODO move this out of match
+	match.isFFA = Logic.readBool(match.extradata.ffa)
+
+	return match
+end
+
+-- Move additional fields from extradata to struct
+function StarcraftMatchGroupUtil.populateOpponents(match)
+	local opponents = match.opponents
+
+	for _, opponent in ipairs(opponents) do
+		opponent.isArchon = Logic.readBool(opponent.extradata.isarchon)
+		opponent.score2 = tonumber(opponent.extradata.score2)
+		opponent.status2 = opponent.extradata.score2 and 'S' or nil
+		opponent.placement2 = tonumber(opponent.extradata.placement2)
+
+		for _, player in ipairs(opponent.players) do
+			player.race = player.extradata.faction or 'u'
+			player.mainRace = player.race
+		end
+
+		if opponent.template == 'default' then
+			opponent.team = {
+				bracketName = opponent.extradata.bracket,
+				displayName = opponent.extradata.display,
+				pageName = opponent.name,
+				shortName = opponent.extradata.short,
+			}
+		end
+	end
+
+	if opponents[1] and opponents[2] and opponents[1].score2 and opponents[2].score2 then
+		local d = opponents[1].score2 - opponents[2].score2
+		opponents[1].placement2 = d > 0 and 1 or 2
+		opponents[2].placement2 = d < 0 and 1 or 2
+	end
+end
+
+-- Computes game.opponents by looking up matchOpponents.players on each
+-- participant.
+function StarcraftMatchGroupUtil.computeGameOpponents(game, matchOpponents)
+	local opponents = {}
+	for key, participant in pairs(game.participants) do
+		local opponentIx, matchPlayerIx = key:match('(%d+)_(%d+)')
+		opponentIx = tonumber(opponentIx)
+		matchPlayerIx = tonumber(matchPlayerIx)
+
+		local matchPlayer = matchOpponents[opponentIx].players[matchPlayerIx]
+		local player = matchPlayer
+			and Table.merge(matchPlayer, {
+				mainRace = matchPlayer.race,
+				matchPlayerIx = matchPlayerIx,
+				race = participant.faction,
+				position = tonumber(participant.position),
+			})
+			or {
+				displayName = 'TBD',
+				mainRace = 'u',
+				matchPlayerIx = matchPlayerIx,
+				race = 'u',
+			}
+
+		if not opponents[opponentIx] then
+			opponents[opponentIx] = {
+				-- TODO add FFA support
+				isArchon = opponentIx == 1 and game.mode:match('^Archon') ~= nil
+					or opponentIx == 2 and game.mode:match('Archon$') ~= nil,
+				isSpecialArchon = opponentIx == 1 and game.mode:match('^%dS') ~= nil
+					or opponentIx == 2 and game.mode:match('%dS$') ~= nil,
+				players = {},
+			}
+		end
+		table.insert(opponents[opponentIx].players, player)
+	end
+
+	for _, opponent in pairs(opponents) do
+		if opponent.isSpecialArchon then
+			-- Team melee: Sort players by the order they were inputted
+			table.sort(opponent.players, function(a, b)
+				return a.position < b.position
+			end)
+		else
+			-- Sort players by the order they appear in the match opponent players list
+			table.sort(opponent.players, function(a, b)
+				return a.matchPlayerIx < b.matchPlayerIx
+			end)
+		end
+	end
+
+	return opponents
+end
+
+-- Group games on the subgroup field to form submatches
+function StarcraftMatchGroupUtil.groupBySubmatch(matchGames)
+	-- Group games on adjacent subgroups
+	local previousSubgroup = nil
+	local currentGames = nil
+	local submatchGames = {}
+	for _, game in ipairs(matchGames) do
+		if previousSubgroup == nil or previousSubgroup ~= game.subgroup then
+			currentGames = {}
+			table.insert(submatchGames, currentGames)
+			previousSubgroup = game.subgroup
+		end
+		table.insert(currentGames, game)
+	end
+
+	-- Construct submatch objects on grouped games
+	return Array.map(submatchGames, StarcraftMatchGroupUtil.constructSubmatch)
+end
+
+--Constructs a submatch object whose properties are aggregated from that of its games.
+function StarcraftMatchGroupUtil.constructSubmatch(games)
+	local opponents = Table.deepCopy(games[1].opponents)
+
+	-- If the same race was played in all games, display that instead of the
+	-- player's main race.
+	for opponentIx, opponent in pairs(opponents) do
+		-- Aggregate races among games for each player
+		local playerRaces = {}
+		for _, game in pairs(games) do
+			for playerIx, player in pairs(game.opponents[opponentIx].players) do
+				if not playerRaces[playerIx] then
+					playerRaces[playerIx] = {}
+				end
+				playerRaces[playerIx][player.race] = true
+			end
+		end
+
+		for playerIx, player in pairs(opponent.players) do
+			player.race = Table.uniqueKey(playerRaces[playerIx])
+				or player.mainRace
+		end
+	end
+
+	-- Sum up scores
+	local scores = {}
+	for opponentIx, _ in pairs(opponents) do
+		scores[opponentIx] = 0
+	end
+	for _, game in pairs(games) do
+		if game.winner then
+			scores[game.winner] = (scores[game.winner] or 0) + 1
+		end
+	end
+
+	-- Compute winner if all games have been played, skipped, or defaulted
+	local allPlayed = Array.all(games, function(game)
+		return game.winner ~= nil or game.resultType ~= nil
+	end)
+
+	local resultType = nil
+	local winner = nil
+	if allPlayed then
+		local diff = (scores[1] or 0) - (scores[2] or 0)
+		if diff < 0 then
+			winner = 2
+		elseif diff == 0 then
+			resultType = 'draw'
+		else
+			winner = 1
+		end
+	end
+
+	-- Set resultType and walkover if every game is a walkover
+	local walkovers = {}
+	local resultTypes = {}
+	for _, game in pairs(games) do
+		resultTypes[game.resultType or ''] = true
+		walkovers[game.walkover or ''] = true
+	end
+	local walkover
+	local uniqueResult = Table.uniqueKey(resultTypes)
+	if uniqueResult == 'default' then
+		resultType = 'default'
+		walkover = String.nilIfEmpty(Table.uniqueKey(walkovers)) or 'L'
+	elseif uniqueResult == 'np' then
+		resultType = 'np'
+	end
+
+	return {
+		games = games,
+		mode = games[1].mode,
+		opponents = opponents,
+		resultType = resultType,
+		scores = scores,
+		subgroup = games[1].subgroup,
+		walkover = walkover,
+		winner = winner,
+	}
+end
+
+-- Determine if a match has details that should be displayed via popup
+StarcraftMatchGroupUtil.matchHasDetails = function(match)
+	return match.dateIsExact
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.vetoes
+		or Array.any(match.games, function(game)
+			return game.map and game.map ~= 'TBD'
+				or game.winner
+		end)
+end
+
+return StarcraftMatchGroupUtil

--- a/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -1,0 +1,417 @@
+local Array = require('Module:Array')
+local DisplayHelper = require('Module:MatchGroup/Display/Helper')
+local DisplayUtil = require('Module:DisplayUtil')
+local Lua = require('Module:Lua')
+local MatchGroupUtil = require('Module:MatchGroup/Util')
+local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
+local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
+local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft')
+
+local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
+	getTinyIcon = function() end,
+}
+
+local html = mw.html
+
+--[[
+Display component for the match summary used by the starcraft and stacraft2
+wikis. Shows details of a StarCraft match, including opponents, maps,
+submatches, and external media links.
+]]
+local StarcraftMatchSummary = {propTypes = {}}
+
+StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
+	bracketId = 'string',
+	matchId = 'string',
+}
+
+function StarcraftMatchSummary.MatchSummaryContainer(props)
+	local match = MatchGroupUtil.fetchMatchesTable(props.bracketId)[props.matchId]
+	local MatchSummary = match.isFFA
+		and require('Module:MatchSummary/FFA/Starcraft').FFAMatchSummary
+		or StarcraftMatchSummary.MatchSummary
+	return MatchSummary({match = match})
+end
+
+StarcraftMatchSummary.propTypes.MatchSummary = {
+	match = StarcraftMatchGroupUtil.types.Match,
+}
+
+function StarcraftMatchSummary.MatchSummary(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.MatchSummary)
+	local match = props.match
+
+	-- Compute offraces
+	if match.opponentMode == 'uniform' then
+		for _, game in pairs(match.games) do
+			StarcraftMatchSummary.computeGameOffraces(game)
+		end
+	else
+		for _, submatch in pairs(match.submatches) do
+			StarcraftMatchSummary.computeSubmatchOffraces(submatch)
+		end
+	end
+
+	return html.create('div')
+		:addClass('brkts-popup')
+		:addClass('brkts-popup-sc')
+		:addClass(match.opponentMode == 'uniform' and 'brkts-popup-sc-uniform-match' or 'brkts-popup-sc-team-match')
+		:node(StarcraftMatchSummary.Header({match = match}))
+		:node(StarcraftMatchSummary.Body({match = match}))
+		:node(StarcraftMatchSummary.Footer({match = match, showHeadToHead = match.headToHead}))
+end
+
+StarcraftMatchSummary.propTypes.Header = {
+	match = StarcraftMatchGroupUtil.types.Match,
+}
+
+function StarcraftMatchSummary.Header(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.Header)
+	local match = props.match
+
+	local renderOpponent = function(opponentIx)
+		local opponent = match.opponents[opponentIx]
+		return StarcraftOpponentDisplay.BlockOpponent({
+			flip = opponentIx == 1,
+			opponent = opponent,
+			overflow = 'wrap',
+			showFlag = false,
+			showLink = opponent.type == 'team',
+		})
+			:addClass('brkts-popup-header-opponent')
+	end
+
+	local header = html.create('div'):addClass('brkts-popup-header-dev')
+		:node(renderOpponent(1))
+		:node(renderOpponent(2))
+
+	return header
+end
+
+StarcraftMatchSummary.propTypes.Body = {
+	match = StarcraftMatchGroupUtil.types.Match,
+}
+
+function StarcraftMatchSummary.Body(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.Body)
+	local match = props.match
+
+	local body = html.create('div')
+		:addClass('brkts-popup-body')
+		:addClass('brkts-popup-sc-body')
+
+	-- Stream, date, and countdown
+	if match.dateIsExact then
+		local countdownNode = DisplayHelper.MatchCountdownBlock(match)
+			:addClass('brkts-popup-body-element')
+			:addClass('brkts-popup-countdown')
+		body:node(countdownNode)
+	end
+
+	if match.opponentMode == 'uniform' then
+		for _, game in ipairs(match.games) do
+			if game.map or game.winner then
+				body:node(StarcraftMatchSummary.Game(game):addClass('brkts-popup-body-element'))
+			end
+		end
+	else -- match.opponentMode == 'team'
+
+		-- Show the submatch score if any submatch consists of more than one game
+		local showScore = Array.any(match.submatches, function(submatch) return 1 < #submatch.games end)
+
+		for _, submatch in ipairs(match.submatches) do
+			body:node(
+				StarcraftMatchSummary.TeamSubmatch({submatch = submatch, showScore = showScore})
+					:addClass('brkts-popup-body-element')
+			)
+		end
+	end
+
+	-- Vetoes
+	for ix, veto in ipairs(match.vetoes) do
+		local vetoNode = StarcraftMatchSummary.Veto(veto)
+		if ix == 1 then
+			vetoNode = html.create('div')
+				:node(StarcraftMatchSummary.GameHeader({header = 'Vetoes'}))
+				:node(vetoNode)
+		end
+		body:node(vetoNode:addClass('brkts-popup-body-element'))
+	end
+
+	-- Match comment
+	if match.comment then
+		body:node(
+			html.create('div'):addClass('brkts-popup-sc-game-comment')
+				:node(match.comment)
+		)
+	end
+
+	return body
+end
+
+function StarcraftMatchSummary.Game(game)
+	DisplayUtil.assertPropTypes(game, StarcraftMatchGroupUtil.types.Game.struct)
+
+	local centerNode = html.create('div'):addClass('brkts-popup-sc-game-center')
+		:wikitext(DisplayHelper.MapAndStatus(game))
+
+	local winnerIcon = function(opponentIx)
+		return game.resultType == 'draw' and StarcraftMatchSummary.ColoredIcon('YellowLine')
+			or game.winner == opponentIx and StarcraftMatchSummary.ColoredIcon('GreenCheck')
+			or StarcraftMatchSummary.ColoredIcon('NoCheck')
+	end
+
+	local showOffraceIcons = game.offraces ~= nil and (game.offraces[1] ~= nil or game.offraces[2] ~= nil)
+	local offraceIcons = function(opponentIx)
+		local offraces = game.offraces ~= nil and game.offraces[opponentIx] or nil
+		local opponent = game.opponents ~= nil and game.opponents[opponentIx] or nil
+
+		if offraces and opponent then
+			if opponent.isArchon then
+				return StarcraftMatchSummary.OffraceIcons({offraces[1]})
+			else
+				return StarcraftMatchSummary.OffraceIcons(offraces)
+			end
+		elseif showOffraceIcons then
+			return StarcraftMatchSummary.OffraceIcons({})
+		else
+			return nil
+		end
+	end
+
+	local bodyNode = html.create('div')
+		:addClass('brkts-popup-sc-game-body')
+		:node(winnerIcon(1))
+		:node(offraceIcons(1))
+		:node(centerNode)
+		:node(offraceIcons(2))
+		:node(winnerIcon(2))
+
+	local commentNode
+	if game.comment then
+		commentNode = html.create('div')
+			:addClass('brkts-popup-sc-game-comment')
+			:wikitext(game.comment)
+	end
+
+	local gameNode = html.create('div')
+		:addClass('brkts-popup-sc-game')
+		:node(game.header and StarcraftMatchSummary.GameHeader({header = game.header}) or nil)
+		:node(bodyNode)
+		:node(commentNode)
+
+	return gameNode
+end
+
+StarcraftMatchSummary.propTypes.TeamSubmatch = {
+	showScore = 'boolean',
+	submatch = StarcraftMatchGroupUtil.types.Submatch,
+}
+
+function StarcraftMatchSummary.TeamSubmatch(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.TeamSubmatch)
+	local submatch = props.submatch
+
+	local centerNode = html.create('div')
+		:addClass('brkts-popup-sc-submatch-center')
+	for _, game in ipairs(submatch.games) do
+		if game.map or game.winner then
+			centerNode:node(StarcraftMatchSummary.Game(game))
+		end
+	end
+
+	local renderOpponent = function(opponentIx)
+		local opponent = submatch.opponents[opponentIx]
+		local node = opponent
+			and StarcraftOpponentDisplay.BlockOpponent({
+				opponent = opponent,
+				flip = opponentIx == 1,
+			})
+			or html.create('div'):wikitext('&nbsp;')
+		return node:addClass('brkts-popup-sc-submatch-opponent')
+	end
+
+	-- Render scores
+	local renderScore = function(opponentIx)
+		local isWinner = opponentIx == submatch.winner
+		local text
+		if submatch.resultType == 'default' then
+			text = isWinner and 'W' or submatch.walkover
+		else
+			local score = submatch.scores[opponentIx]
+			text = score and tostring(score) or ''
+		end
+		return html.create('div')
+			:addClass('brkts-popup-sc-submatch-score')
+			:wikitext(text)
+	end
+
+	local renderSide = function(opponentIx)
+		local sideNode = html.create('div')
+			:addClass('brkts-popup-sc-submatch-side')
+			:addClass(opponentIx == 1 and 'brkts-popup-left' or 'brkts-popup-right')
+			:addClass(opponentIx == submatch.winner and 'bg-win' or nil)
+			:addClass(submatch.resultType == 'draw' and 'bg-draw' or nil)
+			:node(opponentIx == 1 and renderOpponent(1) or nil)
+			:node(props.showScore and renderScore(opponentIx) or nil)
+			:node(opponentIx == 2 and renderOpponent(2) or nil)
+
+		return sideNode
+	end
+
+	local bodyNode = html.create('div')
+		:addClass('brkts-popup-sc-submatch-body')
+		:addClass(props.showScore and 'brkts-popup-sc-submatch-has-score' or nil)
+		:node(renderSide(1))
+		:node(centerNode)
+		:node(renderSide(2))
+
+	local headerNode
+	if submatch.header then
+		headerNode = html.create('div')
+			:addClass('brkts-popup-sc-submatch-header')
+			:wikitext(submatch.header)
+	end
+
+	local submatchNode = html.create('div')
+		:addClass('brkts-popup-sc-submatch')
+		:node(headerNode)
+		:node(bodyNode)
+
+	return submatchNode
+end
+
+StarcraftMatchSummary.propTypes.GameHeader = {
+	header = 'string',
+}
+
+function StarcraftMatchSummary.GameHeader(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.GameHeader)
+	return html.create('div')
+		:addClass('brkts-popup-sc-game-header')
+		:wikitext(props.header)
+end
+
+function StarcraftMatchSummary.Veto(veto)
+	DisplayUtil.assertPropTypes(veto, StarcraftMatchGroupUtil.types.MatchVeto.struct)
+
+	local centerNode = html.create('div'):addClass('brkts-popup-sc-veto-center')
+		:node('[[' .. veto.map .. ']]')
+
+	local statusIcon = function(opponentIx)
+		return opponentIx == veto.by
+			and StarcraftMatchSummary.ColoredIcon('RedCross')
+			or StarcraftMatchSummary.ColoredIcon('NoCheck')
+	end
+
+	return html.create('div')
+		:addClass('brkts-popup-sc-veto-body')
+		:node(statusIcon(1))
+		:node(centerNode)
+		:node(statusIcon(2))
+end
+
+StarcraftMatchSummary.propTypes.Footer = {
+	match = StarcraftMatchGroupUtil.types.Match,
+	showHeadToHead = 'boolean',
+}
+
+function StarcraftMatchSummary.Footer(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.Footer)
+	local match = props.match
+
+	local links = StarcraftMatchExternalLinks.extractFromMatch(match)
+
+	local headToHeadNode
+	if props.showHeadToHead
+		and match.mode == '1_1'
+		and match.opponents[1].players[1]
+		and match.opponents[1].players[1].pageName
+		and match.opponents[2].players[1]
+		and match.opponents[2].players[1].pageName
+	then
+		local link = tostring(mw.uri.fullUrl('Special:RunQuery/Match_history'))
+			.. '?pfRunQueryFormName=Match+history&Head_to_head_query%5Bplayer%5D='
+			.. match.opponents[1].players[1].pageName
+			.. '&Head_to_head_query%5Bopponent%5D='
+			.. match.opponents[2].players[1].pageName
+			.. '&wpRunQuery=Run+query'
+		headToHeadNode = '[[File:Match Info Stats.png|link=' .. link .. '|16px|Head-to-head statistics]]'
+	end
+
+	local hasFooter = (0 < #links) or headToHeadNode
+	if hasFooter then
+		local linksNode = StarcraftMatchExternalLinks.MatchExternalLinks({links = links})
+			:node(headToHeadNode)
+			:addClass('brkts-popup-sc-footer-links')
+		return html.create('div')
+			:addClass('brkts-popup-footer')
+			:addClass('brkts-popup-sc-footer')
+			:node(linksNode)
+	else
+		return nil
+	end
+end
+
+function StarcraftMatchSummary.ColoredIcon(icon)
+	if icon == 'GreenCheck' then
+		return '<i class="fa fa-check forest-green-text" style="width: 14px; text-align: center" ></i>'
+	elseif icon == 'YellowLine' then
+		return '<i class="fas fa-minus bright-sun-text" style="width: 14px; text-align: center" ></i>'
+	elseif icon == 'YellowQuestionMark' then
+		return '[[File:YellowQuestionMark.png|14x14px|link=]]'
+	elseif icon == 'RedCross' then
+		return '<i class="fas fa-times cinnabar-text" style="width: 14px; text-align: center" ></i>'
+	elseif icon == 'NoCheck' then
+		return '[[File:NoCheck.png|link=]]'
+	else
+		return nil
+	end
+end
+
+-- Renders off-races as Nx2 grid of tiny icons
+function StarcraftMatchSummary.OffraceIcons(races)
+	local racesNode = html.create('div')
+		:addClass('brkts-popup-sc-game-offrace-icons')
+	for _, race in ipairs(races) do
+		racesNode:node(RaceIcon.getTinyIcon({race}))
+	end
+
+	return racesNode
+end
+
+-- Populate game.offraces if the played races differ from the players' main races
+function StarcraftMatchSummary.computeGameOffraces(game)
+	game.offraces = {}
+	for opponentIx, opponent in pairs(game.opponents) do
+		local gameRaces = {}
+		for _, player in ipairs(opponent.players) do
+			table.insert(gameRaces, player.race)
+			if player.race ~= player.mainRace then
+				game.offraces[opponentIx] = gameRaces
+			end
+		end
+	end
+	return game
+end
+
+-- Populate game.offraces if the played races differ from the races listed in
+-- the submatch
+function StarcraftMatchSummary.computeSubmatchOffraces(submatch)
+	for _, game in pairs(submatch.games) do
+		game.offraces = {}
+		for opponentIx, gameOpponent in pairs(game.opponents) do
+			local gameRaces = {}
+			for playerIx, gamePlayer in ipairs(gameOpponent.players) do
+				local submatchPlayer = submatch.opponents[opponentIx].players[playerIx]
+				table.insert(gameRaces, gamePlayer.race)
+				if gamePlayer.race ~= submatchPlayer.race then
+					game.offraces[opponentIx] = gameRaces
+				end
+			end
+		end
+	end
+	return submatch
+end
+
+return StarcraftMatchSummary

--- a/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -1,0 +1,249 @@
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local Lua = require('Module:Lua')
+local OpponentDisplay = require('Module:OpponentDisplay')
+local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
+local StarcraftPlayerDisplay = require('Module:Player/Display/Starcraft')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+
+local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
+	getBigIcon = function() end,
+}
+
+local html = mw.html
+
+--[[
+Display components for opponents used by the starcraft and starcraft 2 wikis
+]]
+local StarcraftOpponentDisplay = {propTypes = {}, types={}}
+
+StarcraftOpponentDisplay.propTypes.InlineOpponent = {
+	flip = 'boolean?',
+	opponent = StarcraftMatchGroupUtil.types.GameOpponent,
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showRace = 'boolean?',
+	teamStyle = TypeUtil.optional(OpponentDisplay.types.TeamStyle),
+}
+
+--[[
+Displays an opponent as an inline element. Useful for describing opponents in
+prose.
+]]
+function StarcraftOpponentDisplay.InlineOpponent(props)
+	DisplayUtil.assertPropTypes(props, StarcraftOpponentDisplay.propTypes.InlineOpponent)
+	local opponent = props.opponent
+
+	if opponent.type == 'team' then
+		return StarcraftOpponentDisplay.InlineTeamContainer({
+			flip = props.flip,
+			showLink = props.showLink,
+			style = props.teamStyle,
+			team = opponent.team,
+			template = opponent.template or 'tbd',
+		})
+	elseif opponent.type == 'literal' then
+		return OpponentDisplay.InlineOpponent(props)
+	else -- opponent.type == 'solo' 'duo' 'trio' 'quad'
+		return StarcraftOpponentDisplay.PlayerInlineOpponent(props)
+	end
+end
+
+StarcraftOpponentDisplay.propTypes.BlockOpponent = {
+	flip = 'boolean?',
+	opponent = StarcraftMatchGroupUtil.types.GameOpponent,
+	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showRace = 'boolean?',
+	teamStyle = TypeUtil.optional(OpponentDisplay.types.TeamStyle),
+	playerClass = 'string?',
+}
+
+--[[
+Displays an opponent as a block element. The width of the component is
+determined by its layout context, and not of the opponent.
+]]
+function StarcraftOpponentDisplay.BlockOpponent(props)
+	DisplayUtil.assertPropTypes(props, StarcraftOpponentDisplay.propTypes.BlockOpponent)
+	local opponent = props.opponent
+
+	if opponent.type == 'team' then
+		return StarcraftOpponentDisplay.BlockTeamContainer({
+			flip = props.flip,
+			overflow = props.overflow,
+			showLink = props.showLink,
+			style = props.teamStyle,
+			team = opponent.team,
+			template = opponent.template or 'tbd',
+		})
+	elseif opponent.type == 'literal' then
+		return OpponentDisplay.BlockOpponent(props)
+	else -- opponent.type == 'solo' 'duo' 'trio' 'quad'
+		return StarcraftOpponentDisplay.PlayerBlockOpponent(props)
+	end
+end
+
+function StarcraftOpponentDisplay.InlineTeamContainer(props)
+	return props.template == 'default'
+		and OpponentDisplay.InlineTeam(props)
+		or OpponentDisplay.InlineTeamContainer(props)
+end
+
+function StarcraftOpponentDisplay.BlockTeamContainer(props)
+	return props.template == 'default'
+		and OpponentDisplay.BlockTeam(Table.merge(props, {
+			icon = mw.ext.TeamTemplate.teamicon('default'),
+		}))
+		or OpponentDisplay.BlockTeamContainer(props)
+end
+
+--[[
+Displays a player opponent (solo, duo, trio, or quad) as an inline element.
+]]
+function StarcraftOpponentDisplay.PlayerInlineOpponent(props)
+	local showRace = props.showRace ~= false
+	local opponent = props.opponent
+
+	local playerTexts = Array.map(opponent.players, function(player)
+		local node = StarcraftPlayerDisplay.InlinePlayer({
+			flip = props.flip,
+			player = player,
+			showFlag = props.showFlag,
+			showLink = props.showLink,
+			showRace = showRace and not opponent.isArchon,
+		})
+		return tostring(node)
+	end)
+	if props.flip then
+		playerTexts = Array.reverse(playerTexts)
+	end
+
+	local playersNode = opponent.isArchon
+		and '(' .. table.concat(playerTexts, ', ') .. ')'
+		or table.concat(playerTexts, ' / ')
+
+	local archonRaceNode
+	if showRace and opponent.isArchon then
+		archonRaceNode = StarcraftPlayerDisplay.Race(opponent.players[1].race)
+	end
+
+	return html.create('span')
+		:node(not props.flip and archonRaceNode or nil)
+		:node(playersNode)
+		:node(props.flip and archonRaceNode or nil)
+end
+
+--[[
+Displays a player opponent (solo, duo, trio, or quad) as a block element.
+]]
+function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
+	local opponent = props.opponent
+	local showRace = props.showRace ~= false
+
+	local playerNodes = Array.map(opponent.players, function(player)
+		return StarcraftPlayerDisplay.BlockPlayer({
+			flip = props.flip,
+			overflow = props.overflow,
+			player = player,
+			showFlag = props.showFlag,
+			showLink = props.showLink,
+			showRace = showRace and not opponent.isArchon and not opponent.isSpecialArchon,
+		})
+			:addClass(props.playerClass)
+	end)
+
+	if #opponent.players == 1 then
+		return playerNodes[1]
+
+	elseif showRace and opponent.isArchon then
+		local raceIcon = DisplayUtil.removeLinkFromWikiLink(
+			RaceIcon.getBigIcon({opponent.players[1].race})
+		)
+		return StarcraftOpponentDisplay.BlockArchon({
+			flip = props.flip,
+			playerNodes = playerNodes,
+			raceNode = html.create('div'):wikitext(raceIcon),
+		})
+
+	elseif showRace and opponent.isSpecialArchon then
+		local archonsNode = html.create('div')
+			:addClass('starcraft-special-archon-block-opponent')
+		for archonIx = 1, #opponent.players / 2 do
+			local primaryRace = opponent.players[2 * archonIx - 1].race
+			local secondaryRace = opponent.players[2 * archonIx].race
+			local primaryIcon = DisplayUtil.removeLinkFromWikiLink(
+				RaceIcon.getBigIcon({primaryRace})
+			)
+			local secondaryIcon
+			if primaryRace ~= secondaryRace then
+				secondaryIcon = html.create('div')
+					:css('position', 'absolute')
+					:css('right', '1px')
+					:css('bottom', '1px')
+					:node(StarcraftPlayerDisplay.Race(secondaryRace))
+			end
+			local raceNode = html.create('div')
+				:css('position', 'relative')
+				:node(primaryIcon)
+				:node(secondaryIcon)
+
+			local archonNode = StarcraftOpponentDisplay.BlockArchon({
+				flip = props.flip,
+				playerNodes = Array.sub(playerNodes, 2 * archonIx - 1, 2 * archonIx),
+				raceNode = raceNode,
+			})
+			archonsNode:node(archonNode)
+		end
+		return archonsNode
+
+	else
+		local playersNode = html.create('div')
+		for _, playerNode in ipairs(playerNodes) do
+			playersNode:node(playerNode)
+		end
+		return playersNode
+	end
+end
+
+StarcraftOpponentDisplay.propTypes.BlockArchon = {
+	flip = 'boolean?',
+	playerNodes = 'array',
+	raceNode = 'any',
+}
+
+function StarcraftOpponentDisplay.BlockArchon(props)
+	props.raceNode:addClass('starcraft-block-archon-race')
+
+	local playersNode = html.create('div'):addClass('starcraft-block-archon-players')
+	for _, node in ipairs(props.playerNodes) do
+		playersNode:node(node)
+	end
+
+	return html.create('div'):addClass('starcraft-block-archon')
+		:addClass(props.flip and 'flipped' or nil)
+		:node(props.raceNode)
+		:node(playersNode)
+end
+
+local CheckMark = '<i class="fa fa-check forest-green-text" aria-hidden="true"></i>'
+
+function StarcraftOpponentDisplay.InlineScore(opponent)
+	if opponent.status == 'S' then
+		local advantage = tonumber(opponent.extradata.advantage) or 0
+		if advantage > 0 then
+			local title = 'Advantage of ' .. advantage .. ' game' .. (advantage > 1 and 's' or '')
+			return '<abbr title="' .. title .. '">' .. opponent.score .. '</abbr>'
+		end
+	elseif opponent.extradata.noscore == 'true' then
+		return opponent.extradata.advances =='true'
+			and CheckMark
+			or ''
+	end
+
+	return OpponentDisplay.InlineScore(opponent)
+end
+
+return Class.export(StarcraftOpponentDisplay)

--- a/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -1,0 +1,225 @@
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local PlayerDisplay = require('Module:Player/Display')
+local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
+local StarcraftPlayerUtil = require('Module:Player/Util/Starcraft')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+
+local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
+	getSmallIcon = function() end,
+}
+
+local html = mw.html
+
+--[[
+Display components for players used in the starcraft and starcraft2 wikis.
+]]
+local StarcraftPlayerDisplay = {propTypes = {}}
+
+StarcraftPlayerDisplay.propTypes.BlockPlayer = {
+	flip = 'boolean?',
+	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
+	player = StarcraftMatchGroupUtil.types.Player,
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showRace = 'boolean?',
+}
+
+--[[
+Displays a player as a block element. The width of the component is
+determined by its layout context, and not by the player name.
+]]
+function StarcraftPlayerDisplay.BlockPlayer(props)
+	DisplayUtil.assertPropTypes(props, StarcraftPlayerDisplay.propTypes.BlockPlayer)
+	local player = props.player
+
+	local nameNode = html.create('span'):addClass('name')
+		:wikitext(props.showLink ~= false and player.pageName
+			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
+			or player.displayName
+		)
+	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
+
+	local flagNode
+	if props.showFlag ~= false and player.flag then
+		flagNode = PlayerDisplay.Flag(player.flag)
+	end
+
+	local raceNode
+	if props.showRace ~= false and player.race ~= 'u' then
+		raceNode = html.create('span'):addClass('race')
+			:wikitext(StarcraftPlayerDisplay.Race(player.race))
+	end
+
+	return html.create('div'):addClass('block-player starcraft-block-player')
+		:addClass(props.flip and 'flipped' or nil)
+		:node(flagNode)
+		:node(raceNode)
+		:node(nameNode)
+end
+
+-- Called from Template:Player and Template:Player2
+function StarcraftPlayerDisplay.TemplatePlayer()
+	local args = require('Module:Arguments').getArgs(mw.getCurrentFrame())
+
+	local pageName
+	local displayName
+	if not args.noclean then
+		pageName, displayName = StarcraftPlayerUtil.extractFromLink(args[1])
+		if args.link == 'true' then
+			pageName = displayName
+		elseif args.link then
+			pageName = args.link
+		end
+	else
+		pageName = args.link
+		displayName = args[1]
+	end
+
+	local player = {
+		displayName = displayName,
+		flag = String.nilIfEmpty(args.flag),
+		pageName = pageName,
+		race = String.nilIfEmpty(args.race) or 'u',
+	}
+
+	if not args.novar then
+		StarcraftPlayerUtil.saveToPageVars(player)
+	end
+
+	local hiddenSort = args.hs
+		and StarcraftPlayerUtil.hiddenSort(player.displayName, player.flag, player.race, args.hs)
+		or ''
+	return hiddenSort .. StarcraftPlayerDisplay.InlinePlayer({
+		dq = Logic.readBool(args.dq),
+		flip = Logic.readBool(args.flip),
+		player = player,
+		showRace = (args.showRace or 'true') == 'true',
+	})
+end
+
+-- Called from Template:InlinePlayer
+function StarcraftPlayerDisplay.TemplateInlinePlayer()
+	local args = require('Module:Arguments').getArgs(mw.getCurrentFrame())
+
+	local player = {
+		displayName = args[1],
+		flag = args.flag,
+		pageName = args.link,
+		race = StarcraftPlayerUtil.readRace(args.race),
+	}
+	return StarcraftPlayerDisplay.InlinePlayerContainer({
+		date = args.date,
+		dontSave = Logic.readBool(args.novar),
+		dq = Logic.readBool(args.dq),
+		flip = Logic.readBool(args.flip),
+		player = player,
+		showFlag = Logic.emptyOr(Logic.readBool(args.showFlag), true),
+		showLink = Logic.emptyOr(Logic.readBool(args.showLink), true),
+		showRace = Logic.emptyOr(Logic.readBool(args.showRace), true),
+	})
+end
+
+StarcraftPlayerDisplay.propTypes.InlinePlayerContainer = {
+	date = 'string?',
+	dontSave = 'boolean?',
+	dq = 'boolean?',
+	flip = 'boolean?',
+	player = 'table',
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showRace = 'boolean?',
+}
+
+--[[
+Displays a player as an inline element. Useful for referencing players in
+prose. This container will automatically look up the pageName, race, and flag
+of the player from page variables or LPDB, and save the results to page
+variables.
+]]
+function StarcraftPlayerDisplay.InlinePlayerContainer(props)
+	DisplayUtil.assertPropTypes(props, StarcraftPlayerDisplay.propTypes.InlinePlayerContainer)
+
+	return StarcraftPlayerDisplay.InlinePlayer(
+		Table.merge(props, {
+			player = StarcraftPlayerUtil.syncPlayer(props.player, props.date, props.dontSave),
+		})
+	)
+end
+
+--[[
+Displays a player as an inline element. Useful for referencing players in
+prose.
+]]
+StarcraftPlayerDisplay.propTypes.InlinePlayer = {
+	dq = 'boolean?',
+	flip = 'boolean?',
+	player = StarcraftMatchGroupUtil.types.Player,
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showRace = 'boolean?',
+}
+function StarcraftPlayerDisplay.InlinePlayer(props)
+	DisplayUtil.assertPropTypes(props, StarcraftPlayerDisplay.propTypes.InlinePlayer)
+	local player = props.player
+
+	local flag = props.showFlag ~= false and player.flag
+		and PlayerDisplay.Flag(player.flag)
+		or nil
+
+	local race = props.showRace ~= false and player.race ~= 'u'
+		and StarcraftPlayerDisplay.Race(player.race)
+		or nil
+
+	local nameAndLink = props.showLink ~= false and player.pageName
+		and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
+		or player.displayName
+	if props.dq then
+		nameAndLink = '<s>' .. nameAndLink .. '</s>'
+	end
+
+	local text
+	if props.flip then
+		text = nameAndLink
+			.. (race and '&nbsp;' .. race or '')
+			.. (flag and '&nbsp;' .. flag or '')
+	else
+		text = (flag and flag .. '&nbsp;' or '')
+			.. (race and race .. '&nbsp;' or '')
+			.. nameAndLink
+	end
+
+	return html.create('span'):addClass('starcraft-inline-player')
+		:addClass(props.flip and 'flipped' or nil)
+		:css('white-space', 'pre')
+		:wikitext(text)
+end
+
+function StarcraftPlayerDisplay.hiddenSort(name, flag, race, field)
+	local text
+	if field == 'race' then
+		text = race
+	elseif field == 'name' then
+		text = name
+	elseif field == 'flag' then
+		text = flag
+	else
+		text = field
+	end
+
+	return html.create('span')
+		:css('display', 'none')
+		:wikitext(text)
+end
+
+function StarcraftPlayerDisplay.Race(race)
+	return DisplayUtil.removeLinkFromWikiLink(
+		RaceIcon.getSmallIcon({race})
+	)
+end
+
+return Class.export(StarcraftPlayerDisplay)

--- a/match2/commons/starcraft_starcraft2/player_util_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/player_util_starcraft.lua
@@ -1,0 +1,175 @@
+local FnUtil = require('Module:FnUtil')
+local Localisation = require('Module:Localisation')
+local String = require('Module:String')
+local Table = require('Module:Table')
+
+local nilIfEmpty = String.nilIfEmpty
+
+local StarcraftPlayerUtil = {}
+
+local allowedRaces = {
+	['p'] = 'p',
+	['protoss'] = 'p',
+	['t'] = 't',
+	['terran'] = 't',
+	['z'] = 'z',
+	['zerg'] = 'z',
+	['r'] = 'r',
+	['random'] = 'r',
+	['pt'] = 'p',
+	['pz'] = 'p',
+	['tz'] = 't',
+	['tp'] = 't',
+	['zt'] = 'z',
+	['zp'] = 'z'
+	}
+
+-- Reduces a race down to a single character, either 'p', 't', 'z', or 'r', or nil if it can't be done.
+function StarcraftPlayerUtil.readRace(race)
+	if type(race) == 'string' then
+		return allowedRaces[race:lower()] or nil
+	end
+end
+
+--[===[
+Splits a wiki link of a player into a pageName and displayName.
+
+For example:
+extractFromLink('[[Dream (Korean Terran player)|Dream]]')
+-- returns 'Dream (Korean Terran player)', 'Dream'
+--]===]
+function StarcraftPlayerUtil.extractFromLink(name)
+	name = mw.text.trim(
+		name:gsub('%b{}', '')
+			:gsub('%b<>', '')
+			:gsub('%b[]', '')
+	)
+
+	local pageName, displayName = unpack(mw.text.split(name, '|', true))
+	if displayName and displayName ~= '' then
+		return pageName, displayName
+	end
+	return nil, name
+end
+
+-- Asks LPDB for the race and flag of a player.
+function StarcraftPlayerUtil.fetchRaceAndFlag(pageName, date)
+	local resolvedPage = mw.ext.TeamLiquidIntegration.resolve_redirect(pageName)
+
+	local rows = mw.ext.LiquipediaDB.lpdb('player', {
+		conditions = '[[pagename::' .. string.gsub(resolvedPage, ' ', '_') .. ']]',
+		query = 'nationality, extradata',
+	})
+
+	local row = rows[1]
+	if type(row) == 'table' then
+		local historicalRace
+		if row.extradata.racehistorical == 'true' then
+			historicalRace = StarcraftPlayerUtil.fetchHistoricalRace(resolvedPage, date)
+		end
+
+		return {
+			flag = row.nationality,
+			race = historicalRace or StarcraftPlayerUtil.readRace(row.extradata.race),
+		}
+	end
+end
+
+-- Asks LPDB for the main race of a player on a specified date.
+function StarcraftPlayerUtil.fetchHistoricalRace(resolvedPage, date)
+	local conditions = '[[pagename::' .. string.gsub(resolvedPage, ' ', '_') .. ']] ' ..
+		'AND [[type::playerrace]] AND [[extradata_startdate::<' .. date .. ']] ' ..
+		'AND [[extradata_enddate::>' .. date .. ']]'
+	local rows = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = conditions,
+		query = 'information',
+	})
+
+	local row = rows[1]
+	if type(row) == 'table' then
+		return StarcraftPlayerUtil.readRace(row.information)
+	end
+end
+
+-- Asks LPDB for the team a player belonged to on a particular date. Returns a team template or nil.
+function StarcraftPlayerUtil.fetchTeam(pageName, date)
+	local resolvedPage = mw.ext.TeamLiquidIntegration.resolve_redirect(pageName)
+
+	local conditions = '[[pagename::' .. string.gsub(resolvedPage, ' ', '_') .. ']] AND [[type::teamhistory]] AND ' ..
+		'([[extradata_joindate::<' .. date .. ']] OR [[extradata_joindate::' .. date .. ']]) AND ' ..
+		'[[extradata_joindate::>]] AND [[extradata_leavedate::>' .. date .. ']]'
+	local rows = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = conditions,
+		query = 'information',
+	})
+
+	local row = rows[1]
+	if type(row) == 'table' then
+		return nilIfEmpty(row.information)
+	end
+end
+
+--[[
+Fills in the flag, race, and pageName of a player if they are missing. Uses
+data previously stored in page variables, and failing that, queries LPDB. The
+results are saved to page variables for future use.
+
+Retrieves the flag and race of a player from first the arguments, then page variables, and finally lpdb.
+The returned race is a single character string, either 'p' 't' 'z' or 'r', or nil if unspecified.
+
+player.displayName
+player.pageName
+player.race: Either 'p' 't' 'z' 'r' or 'u'. Will look up if nil.
+player.flag: A flag code like 'nl'. Will look up if nil.
+date: Needed if the player used a different race in the past.
+]]
+function StarcraftPlayerUtil.syncPlayer(player_, date_, dontSave)
+	local player = Table.copy(player_)
+
+	if not player.pageName then
+		player.pageName = nilIfEmpty(mw.ext.VariablesLua.var(player.displayName .. '_page'))
+			or player.displayName
+	end
+
+	local lpdbPlayer = FnUtil.memoize(function()
+		local date = date_
+			or nilIfEmpty(mw.ext.VariablesLua.var('formatted_tournament_edate'))
+			or os.date('%F')
+		return StarcraftPlayerUtil.fetchRaceAndFlag(player.pageName, date)
+	end)
+
+	if not player.flag then
+		player.flag = nilIfEmpty(mw.ext.VariablesLua.var(player.displayName .. '_flag'))
+			or lpdbPlayer() and lpdbPlayer().flag
+	end
+
+	if not player.race then
+		player.race = nilIfEmpty(mw.ext.VariablesLua.var(player.displayName .. '_race'))
+			or lpdbPlayer() and lpdbPlayer().race
+			or 'u'
+	end
+
+	if not dontSave then
+		StarcraftPlayerUtil.saveToPageVars(player)
+	end
+
+	return player
+end
+
+--[[
+Saves the pageName, flag, and race of a player to page variables, so that
+editors do not have to duplicate the same info later on.
+]]
+function StarcraftPlayerUtil.saveToPageVars(player)
+	if player.pageName then
+		mw.ext.VariablesLua.vardefine(player.displayName .. '_page', player.pageName)
+	end
+	if player.flag then
+		mw.ext.VariablesLua.vardefine(player.displayName .. '_flag', Localisation.getCountryName{player.flag, 'false'})
+	end
+	if player.race then
+		mw.ext.VariablesLua.vardefine(player.displayName .. '_race', player.race)
+	end
+end
+
+return StarcraftPlayerUtil


### PR DESCRIPTION
Add the SC/SC2 specific Modules that are located on the Commons wiki. (Both wikis share those, hence on Commons.)
* https://liquipedia.net/commons/Module:MatchExternalLinks/Starcraft (live)
* https://liquipedia.net/commons/Module:MatchGroup/Display/Bracket/Starcraft
* https://liquipedia.net/commons/Module:MatchGroup/Display/Matchlist/Starcraft
* https://liquipedia.net/commons/Module:MatchGroup/Input/StarCraft (live)
* https://liquipedia.net/commons/Module:MatchGroup/Input/StarCraft/FFA (live)
* https://liquipedia.net/commons/Module:MatchGroup/Util/Starcraft (live)
* https://liquipedia.net/commons/Module:MatchSummary/Starcraft
* https://liquipedia.net/commons/Module:OpponentDisplay/Starcraft
* https://liquipedia.net/commons/Module:Player/Display/Starcraft
* https://liquipedia.net/commons/Module:Player/Util/Starcraft

Currently the FFA MatchSummary Module will not be added as it still is a Work in Progress until first stable Version.

The BracketContest Stuff in the Input Modules is still wip.

Modules with `(live)` behind them are already used atm, the other ones are to be used with the switch to the "dev" Version that is already merged in this repo but still have to be put live on the wikis.