### PR TITLE
Add SC2 Custom Version of Module:MatchGroup/Legacy

### DIFF
--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -30,13 +30,15 @@ function p.get(frame)
 		error("argument 'templateOld' is empty")
 	end
 
-	local mapping = p.getMapping(templateid, oldTemplateid)
+	if Logic.isEmpty(_args.type) then
+		error("argument 'type' is empty")
+	end
 
-	local newArgs = p.convert(mapping)
+	local mapping = p._getMapping(templateid, oldTemplateid)
+
+	local newArgs = p._convert(mapping)
 	newArgs.id = bracketid
 	newArgs["1"] = templateid
-
---mw.logObject(newArgs)
 
 	return MatchGroup.luaBracket(frame, newArgs)
 end
@@ -54,7 +56,11 @@ function p.getTemplate(frame)
 		error("argument 'templateOld' is empty")
 	end
 
-	local mapping = p.getMapping(templateid)
+	if Logic.isEmpty(_args.type) then
+		error("argument 'type' is empty")
+	end
+
+	local mapping = p._getMapping(templateid)
 
 	local out = json.stringify(mapping, true)
 		:gsub("\"([^\n:\"]-)\":", "%1 = ")
@@ -71,7 +77,7 @@ function p.getTemplate(frame)
 		"|Link to mapping]]" .. "<pre class=\"selectall\">" .. out  .. "</pre>"
 end
 
-function p.convert(mapping)
+function p._convert(mapping)
 	local newArgs = {}
 	for source, target in pairs(mapping) do
 		-- nested tables
@@ -158,7 +164,7 @@ function p._convertSingle(realKey, val, match, mapping, flattened)
 	return match
 end
 
-function p.getMapping(templateid, oldTemplateid)
+function p._getMapping(templateid, oldTemplateid)
 	if Lua.moduleExists("Module:MatchGroup/Legacy/" .. templateid) then
 		mw.log("Module:MatchGroup/Legacy/" .. templateid .. "exists")
 		return (require("Module:MatchGroup/Legacy/" .. templateid)[oldTemplateid] or function() return nil end)()

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -30,7 +30,8 @@ function p.get(frame)
 		error("argument 'templateOld' is empty")
 	end
 
-	if Logic.isEmpty(_args.type) then
+	_type = _args.type
+	if Logic.isEmpty(_type) then
 		error("argument 'type' is empty")
 	end
 
@@ -56,7 +57,8 @@ function p.getTemplate(frame)
 		error("argument 'templateOld' is empty")
 	end
 
-	if Logic.isEmpty(_args.type) then
+	_type = _args.type
+	if Logic.isEmpty(_type) then
 		error("argument 'type' is empty")
 	end
 

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -9,7 +9,7 @@ local Lua = require("Module:Lua")
 local Table = require("Module:Table")
 local String = require("Module:StringUtils")
 
-local _type = 'solo'
+local _type
 local _args
 
 function p.get(frame)

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -1,0 +1,171 @@
+local p = {}
+
+local getArgs = require("Module:Arguments").getArgs
+local json = require("Module:Json")
+local MatchGroup = require("Module:MatchGroup")
+local getDefaultMapping = require("Module:MatchGroup/Legacy/Default").get
+local Logic = require("Module:Logic")
+local Lua = require("Module:Lua")
+local Table = require("Module:Table")
+local String = require("Module:StringUtils")
+
+local _type = 'solo'
+local _args
+
+function p.get(frame)
+	_args = getArgs(frame)
+
+	local bracketid = _args["id"]
+	if Logic.isEmpty(bracketid) then
+		error("argument 'id' is empty")
+	end
+
+	local templateid = _args["template"]
+	if Logic.isEmpty(templateid) then
+		error("argument 'template' is empty")
+	end
+
+	local oldTemplateid = _args["templateOld"]
+	if Logic.isEmpty(oldTemplateid) then
+		error("argument 'templateOld' is empty")
+	end
+
+	local mapping = p.getMapping(templateid, oldTemplateid)
+
+	local newArgs = p.convert(mapping)
+	newArgs.id = bracketid
+	newArgs["1"] = templateid
+
+--mw.logObject(newArgs)
+
+	return MatchGroup.luaBracket(frame, newArgs)
+end
+
+function p.getTemplate(frame)
+	_args = getArgs(frame)
+
+	local templateid = _args["template"]
+	if Logic.isEmpty(templateid) then
+		error("argument 'template' is empty")
+	end
+
+	local oldTemplateid = _args["templateOld"]
+	if Logic.isEmpty(oldTemplateid) then
+		error("argument 'templateOld' is empty")
+	end
+
+	local mapping = p.getMapping(templateid)
+
+	local out = json.stringify(mapping, true)
+		:gsub("\"([^\n:\"]-)\":", "%1 = ")
+		:gsub("type =", "[\"type\"] =")
+		:gsub(" = %[(.-)%]", " = { %1 }")
+	out = "-- Custom mapping for '" .. templateid .. "' from '" .. oldTemplateid .. "'\n"
+		.. "local p = {}\n\n"
+		.. "p[\"" .. oldTemplateid .. "\"] = function() "
+		.. "return " .. out .. "\n"
+		.. "end\n\n"
+		.. "return p"
+
+	return "[[Module:MatchGroup/Legacy/" .. templateid ..
+		"|Link to mapping]]" .. "<pre class=\"selectall\">" .. out  .. "</pre>"
+end
+
+function p.convert(mapping)
+	local newArgs = {}
+	for source, target in pairs(mapping) do
+		-- nested tables
+		if type(target) == "table" then
+			-- flatten nested tables like RxGx
+			local flatten = target["$flatten$"] or {}
+			local flattened = {}
+			for _, flattensource in ipairs(flatten) do
+				local toFlatten = _args[flattensource] or {}
+				if type(toFlatten) == "string" then
+					toFlatten = json.parse(toFlatten)
+				end
+				for key, val in pairs(toFlatten) do
+					flattened[key] = val
+				end
+			end
+
+			target["$flatten$"] = nil
+
+			-- do actual conversion
+			local nested = {}
+			for key, val in pairs(flattened) do
+				if not String.startsWith(key, "map") then
+					nested[key] = val
+				end
+			end
+			for realKey, val in pairs(target) do
+				nested = p._convertSingle(realKey, val, nested, mapping, flattened)
+			end
+
+			if not Logic.isEmpty(nested) then
+				newArgs[source] = nested
+			end
+		-- regular args
+		else
+			newArgs = p._convertSingle(source, target, newArgs, mapping)
+		end
+	end
+	return newArgs
+end
+
+function p._convertSingle(realKey, val, match, mapping, flattened)
+	flattened = flattened or _args
+	local NoSkip = not String.startsWith(realKey, "$$")
+	if NoSkip and type(val) == "table" then
+		-- references
+		if val["$ref$"] ~= nil then
+			local subst = val["$1$"] or ""
+			val = Table.deepCopy(mapping["$$" .. val["$ref$"]])
+			Table.iter.forEachPair(val, function(k,v)
+					if type(v) == "string" then
+						val[k] = v:gsub("%$1%$",subst)
+					end
+				end)
+		end
+
+		if val["$notEmpty$"] == nil or not Logic.isEmpty(_args[val["$notEmpty$"]] or flattened[val["$notEmpty$"]]) then
+			local nestedArgs = {}
+			for innerKey, innerVal in pairs(val) do
+				nestedArgs[innerKey] = _args[innerVal] or flattened[innerVal]
+			end
+			if String.startsWith(realKey, "opponent") then
+				match[realKey] = json.stringify(nestedArgs)
+			elseif String.startsWith(realKey, "map") then
+				match[realKey] = nestedArgs
+			else
+				match[realKey] = nestedArgs
+			end
+		end
+	elseif NoSkip then
+		local options = String.split(val, "|")
+		if Table.size(options) > 1 then
+			for _, option in ipairs(options) do
+				local set = _args[option] or flattened[option]
+				if Logic.readBool(set) then
+					match[realKey] = true
+					break
+				end
+			end
+		else
+			match[realKey] = _args[val] or flattened[val]
+		end
+	end
+	return match
+end
+
+function p.getMapping(templateid, oldTemplateid)
+	if Lua.moduleExists("Module:MatchGroup/Legacy/" .. templateid) then
+		mw.log("Module:MatchGroup/Legacy/" .. templateid .. "exists")
+		return (require("Module:MatchGroup/Legacy/" .. templateid)[oldTemplateid] or function() return nil end)()
+			or getDefaultMapping(templateid, _type)
+	else
+		return getDefaultMapping(templateid, _type)
+	end
+end
+
+return p


### PR DESCRIPTION
Was forgotten in yesterdays PR (#34)

Custom Version of the common based Module:MatchGroup/Legacy
* Skips some stuff not needed for SC2 (getOpponent and getMap calls - those do nothing on SC/SC2)
* Additional handling of headers