### PR TITLE
Add icon retrieval for storage during match processing

### DIFF
--- a/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -668,6 +668,7 @@ end
 
 function StarCraftMatchGroupInput.getTeamNameIcon(template)
 	local team
+	local icon
 	if template ~= nil and TeamTemplates._teamexists(template) then
 		team = mw.ext.TeamTemplate.raw(template)
 		icon = team.image

--- a/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -669,13 +669,15 @@ end
 function StarCraftMatchGroupInput.getTeamNameIcon(template)
 	local team
 	if template ~= nil and TeamTemplates._teamexists(template) then
-		team = TeamTemplates._team(template)
-		team = team:gsub('%&', '')
-		team = String.split(team, 'link=')[2]
-		team = String.split(team, ']]')[1]
+		team = mw.ext.TeamTemplate.raw(template)
+		icon = team.image
+		if icon == '' then
+			icon = team.legacyimage
+		end
+		team = team.page
 	end
 
-	return team
+	return team, icon
 end
 
 function StarCraftMatchGroupInput.ProcessTeamOpponentInput(opp, date)


### PR DESCRIPTION
Changes to `Module:MatchGroup/Input/StarCraft` on Commons:
* Add Icon retrieval so it can be stored in match2opponent
* Improve retrieval of Team link/page for storage in the `name` field in match2opponent