### PR TITLE
Convert PlayerDisplay to use Module:Flags

### DIFF
--- a/match2/commons/player_display.lua
+++ b/match2/commons/player_display.lua
@@ -84,12 +84,7 @@ function PlayerDisplay.InlinePlayer(props)
 		:wikitext(text)
 end
 
--- Note: require('Module:Flag')[flag] automatically includes a span with class="flag"
-function PlayerDisplay.Flag(flag)
-	flag = flag:lower()
-	local text = require('Module:Flag')[flag]
-		or mw.getCurrentFrame():expandTemplate{ title = 'Flag/' .. flag }
-	return DisplayUtil.removeLinkFromWikiLink(text)
-end
+-- Note: require('Module:Flags')_FlagNoLink automatically includes a span with class="flag"
+PlayerDisplay.Flag = require('Module:Flags')._FlagNoLink
 
 return Class.export(PlayerDisplay)


### PR DESCRIPTION
`Module:Flags` already has the ability to display flags with link, and with support of both country codes and country names. Use that instead.