### PR TITLE
Add DisplayHelper.MapAndStatus

### DIFF
--- a/match2/commons/match_group_display_helper.lua
+++ b/match2/commons/match_group_display_helper.lua
@@ -99,12 +99,12 @@ function DisplayHelper.MatchCountdownBlock(match)
 end
 
 --[[
-Displays the map name and link, and the status of the match if it had an 
+Displays the map name and link, and the status of the match if it had an
 unusual status.
 ]]
 function DisplayHelper.MapAndStatus(game)
-	local mapText = game.map 
-		and '[[' .. game.map .. ']]' 
+	local mapText = game.map
+		and '[[' .. game.map .. ']]'
 		or 'Unknown'
 	if game.resultType == 'np' or game.resultType == 'default' then
 		mapText = '<s>' .. mapText .. '</s>'

--- a/match2/commons/match_group_display_helper.lua
+++ b/match2/commons/match_group_display_helper.lua
@@ -98,6 +98,28 @@ function DisplayHelper.MatchCountdownBlock(match)
 		:node(require('Module:Countdown')._create(stream))
 end
 
+function DisplayHelper.MapAndStatus(game)
+	local mapText = game.map and ('[[' .. game.map .. ']]') or 'Unknown'
+	if game.resultType == 'np' or game.resultType == 'default' then
+		mapText = '<s>' .. mapText .. '</s>'
+	end
+
+	local statusText = nil
+	if game.resultType == 'default' then
+		if game.walkover == 'L' then
+			statusText = '&nbsp;<i>(w/o)</i>'
+		elseif game.walkover == 'FF' then
+			statusText = '&nbsp;<i>(ff)</i>'
+		elseif game.walkover == 'DQ' then
+			statusText = '&nbsp;<i>(dq)</i>'
+		else
+			statusText = '&nbsp;<i>(def.)</i>'
+		end
+	end
+
+	return mapText .. (statusText or '')
+end
+
 --[[
 Display component showing the detailed summary of a match. The component will
 appear as a popup from the Matchlist and Bracket components. This is a

--- a/match2/commons/match_group_display_helper.lua
+++ b/match2/commons/match_group_display_helper.lua
@@ -98,8 +98,14 @@ function DisplayHelper.MatchCountdownBlock(match)
 		:node(require('Module:Countdown')._create(stream))
 end
 
+--[[
+Displays the map name and link, and the status of the match if it had an 
+unusual status.
+]]
 function DisplayHelper.MapAndStatus(game)
-	local mapText = game.map and ('[[' .. game.map .. ']]') or 'Unknown'
+	local mapText = game.map 
+		and '[[' .. game.map .. ']]' 
+		or 'Unknown'
 	if game.resultType == 'np' or game.resultType == 'default' then
 		mapText = '<s>' .. mapText .. '</s>'
 	end
@@ -107,17 +113,17 @@ function DisplayHelper.MapAndStatus(game)
 	local statusText = nil
 	if game.resultType == 'default' then
 		if game.walkover == 'L' then
-			statusText = '&nbsp;<i>(w/o)</i>'
+			statusText = '<i>(w/o)</i>'
 		elseif game.walkover == 'FF' then
-			statusText = '&nbsp;<i>(ff)</i>'
+			statusText = '<i>(ff)</i>'
 		elseif game.walkover == 'DQ' then
-			statusText = '&nbsp;<i>(dq)</i>'
+			statusText = '<i>(dq)</i>'
 		else
-			statusText = '&nbsp;<i>(def.)</i>'
+			statusText = '<i>(def.)</i>'
 		end
 	end
 
-	return mapText .. (statusText or '')
+	return mapText .. (statusText and '&nbsp;' .. statusText or '')
 end
 
 --[[


### PR DESCRIPTION
Displays the map name and link of game, and the status of the match if it had an unusual status.

- Used by FFAMatchSummary and Starcraft's MatchSummary. 
- Should be applicable to other MatchSummarys as well.