### PR TITLE
Starcraft: Clear values when extracting from extradata

### DIFF
--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -174,7 +174,7 @@ different conversion by setting WikiSpecific.matchFromRecord. Refer
 to the starcraft2 wiki as an example.
 ]]
 function MatchGroupUtil.matchFromRecord(record)
-	local extradata = Json.parseIfString(record.extradata) or {}
+	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	local opponents = Array.map(record.match2opponents, MatchGroupUtil.opponentFromRecord)
 
 	return {
@@ -239,7 +239,7 @@ function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
 end
 
 function MatchGroupUtil.opponentFromRecord(record)
-	local extradata = Json.parseIfString(record.extradata) or {}
+	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	return {
 		extradata = extradata,
 		icon = nilIfEmpty(record.icon),
@@ -268,7 +268,7 @@ function MatchGroupUtil.createOpponent(args)
 end
 
 function MatchGroupUtil.playerFromRecord(record)
-	local extradata = Json.parseIfString(record.extradata) or {}
+	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	return {
 		displayName = record.displayname,
 		extradata = extradata,
@@ -278,7 +278,7 @@ function MatchGroupUtil.playerFromRecord(record)
 end
 
 function MatchGroupUtil.gameFromRecord(record)
-	local extradata = Json.parseIfString(record.extradata) or {}
+	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	return {
 		comment = nilIfEmpty(Table.extract(extradata, 'comment')),
 		date = record.date,
@@ -345,6 +345,17 @@ function MatchGroupUtil.fetchTeam(template)
 		pageName = rawTeam.page,
 		shortName = rawTeam.shortname,
 	}
+end
+
+--[[
+Parse extradata as a JSON string if read from page variables. Otherwise create
+a copy if fetched from lpdb. The returned extradata table can then be mutated
+without altering the source.
+]]
+function MatchGroupUtil.parseOrCopyExtradata(recordExtradata)
+	return type(recordExtradata) == 'string' and Json.parse(recordExtradata)
+		or type(recordExtradata) == 'table' and Table.copy(recordExtradata)
+		or {}
 end
 
 return MatchGroupUtil

--- a/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -78,23 +78,23 @@ function StarcraftMatchGroupUtil.matchFromRecord(record)
 
 		-- Extract submatch headers from extradata
 		for _, submatch in pairs(match.submatches) do
-			submatch.header = match.extradata['subGroup' .. submatch.subgroup .. 'header']
+			submatch.header = Table.extract(match.extradata, 'subGroup' .. submatch.subgroup .. 'header')
 		end
 	end
 
 	-- Add vetoes
 	match.vetoes = {}
 	for vetoIx = 1, math.huge do
-		local map = match.extradata['veto' .. vetoIx]
-		local by = tonumber(match.extradata['veto' .. vetoIx .. 'by'])
+		local map = Table.extract(match.extradata, 'veto' .. vetoIx)
+		local by = tonumber(Table.extract(match.extradata, 'veto' .. vetoIx .. 'by'))
 		if not map then break end
 
 		table.insert(match.vetoes, {map = map, by = by})
 	end
 
 	-- Misc
-	match.headToHead = Logic.readBool(match.extradata.headtohead) -- TODO move this out of match
-	match.isFFA = Logic.readBool(match.extradata.ffa)
+	match.headToHead = Logic.readBool(Table.extract(match.extradata, 'headtohead'))
+	match.isFFA = Logic.readBool(Table.extract(match.extradata, 'ffa'))
 
 	return match
 end
@@ -104,22 +104,22 @@ function StarcraftMatchGroupUtil.populateOpponents(match)
 	local opponents = match.opponents
 
 	for _, opponent in ipairs(opponents) do
-		opponent.isArchon = Logic.readBool(opponent.extradata.isarchon)
-		opponent.score2 = tonumber(opponent.extradata.score2)
-		opponent.status2 = opponent.extradata.score2 and 'S' or nil
-		opponent.placement2 = tonumber(opponent.extradata.placement2)
+		opponent.isArchon = Logic.readBool(Table.extract(opponent.extradata, 'isarchon'))
+		opponent.score2 = tonumber(Table.extract(opponent.extradata, 'score2'))
+		opponent.status2 = opponent.score2 and 'S' or nil
+		opponent.placement2 = tonumber(Table.extract(opponent.extradata, 'placement2'))
 
 		for _, player in ipairs(opponent.players) do
-			player.race = player.extradata.faction or 'u'
+			player.race = Table.extract(player.extradata, 'faction') or 'u'
 			player.mainRace = player.race
 		end
 
 		if opponent.template == 'default' then
 			opponent.team = {
-				bracketName = opponent.extradata.bracket,
-				displayName = opponent.extradata.display,
+				bracketName = Table.extract(opponent.extradata, 'bracket'),
+				displayName = Table.extract(opponent.extradata, 'display'),
 				pageName = opponent.name,
-				shortName = opponent.extradata.short,
+				shortName = Table.extract(opponent.extradata, 'short'),
 			}
 		end
 	end


### PR DESCRIPTION
When populating match2 structural types from extradata, remove those values in extradata. Makes things easier to read when dumping match2 objects to logs.