### PR TITLE
Improve Matchlist width calculation

### DIFF
--- a/match2/commons/display_util.lua
+++ b/match2/commons/display_util.lua
@@ -72,7 +72,7 @@ function DisplayUtil.applyOverflowStyles(node, mode)
 		:css('overflow', (mode == 'ellipsis' or mode == 'hidden') and 'hidden' or nil)
 		:css('overflow-wrap', mode == 'wrap' and 'break-word' or nil)
 		:css('text-overflow', mode == 'ellipsis' and 'ellipsis' or nil)
-		:css('white-space', (mode == 'ellipsis' or mode == 'hidden') and 'pre' or 'unset')
+		:css('white-space', (mode == 'ellipsis' or mode == 'hidden') and 'pre' or 'normal')
 end
 
 -- Whether a value is a mediawiki html node.


### PR DESCRIPTION
In Matchlist component
- Prevent score width from getting too narrow
- Force overflow on headers and titles in matchlist
- For testing: https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Wide_Load