### PR TITLE
Make use of new boolean input functions in Module:Logic

### DIFF
--- a/match2/commons/match_group_display_bracket.lua
+++ b/match2/commons/match_group_display_bracket.lua
@@ -27,7 +27,7 @@ function BracketDisplay.configFromArgs(args)
 	return {
 		headerHeight = tonumber(args.headerHeight),
 		headerMargin = tonumber(args.headerMargin),
-		hideRoundTitles = Logic.readBool(args.hideRoundTitles),
+		hideRoundTitles = Logic.readBoolOrNil(args.hideRoundTitles),
 		lineWidth = tonumber(args.lineWidth),
 		matchMargin = tonumber(args.matchMargin),
 		matchWidth = tonumber(args.matchWidth),

--- a/match2/commons/match_group_display_matchlist.lua
+++ b/match2/commons/match_group_display_matchlist.lua
@@ -21,9 +21,9 @@ end
 
 MatchlistDisplay.configFromArgs = function(args)
 	return {
-		attached = Logic.readBool(args.attached),
-		collapsed = Logic.readBool(args.collapsed),
-		collapsible = not Logic.readBool(args.nocollapse),
+		attached = Logic.readBoolOrNil(args.attached),
+		collapsed = Logic.readBoolOrNil(args.collapsed),
+		collapsible = not Logic.readBoolOrNil(args.nocollapse),
 		width = tonumber(string.gsub(args.width or '', 'px', ''), nil),
 	}
 end
@@ -78,7 +78,7 @@ function MatchlistDisplay.Matchlist(props)
 		Score = propsConfig.Score or MatchlistDisplay.Score,
 		attached = propsConfig.attached or false,
 		collapsed = propsConfig.collapsed or false,
-		collapsible = Logic.emptyOr(propsConfig.collapsible, true),
+		collapsible = Logic.nilOr(propsConfig.collapsible, true),
 		matchHasDetails = propsConfig.matchHasDetails or DisplayHelper.defaultMatchHasDetails,
 		width = propsConfig.width or 300,
 	}

--- a/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -95,8 +95,8 @@ function StarcraftPlayerDisplay.TemplatePlayer()
 		and StarcraftPlayerUtil.hiddenSort(player.displayName, player.flag, player.race, args.hs)
 		or ''
 	return hiddenSort .. StarcraftPlayerDisplay.InlinePlayer({
-		dq = Logic.readBool(args.dq),
-		flip = Logic.readBool(args.flip),
+		dq = Logic.readBoolOrNil(args.dq),
+		flip = Logic.readBoolOrNil(args.flip),
 		player = player,
 		showRace = (args.showRace or 'true') == 'true',
 	})
@@ -114,13 +114,13 @@ function StarcraftPlayerDisplay.TemplateInlinePlayer()
 	}
 	return StarcraftPlayerDisplay.InlinePlayerContainer({
 		date = args.date,
-		dontSave = Logic.readBool(args.novar),
-		dq = Logic.readBool(args.dq),
-		flip = Logic.readBool(args.flip),
+		dontSave = Logic.readBoolOrNil(args.novar),
+		dq = Logic.readBoolOrNil(args.dq),
+		flip = Logic.readBoolOrNil(args.flip),
 		player = player,
-		showFlag = Logic.emptyOr(Logic.readBool(args.showFlag), true),
-		showLink = Logic.emptyOr(Logic.readBool(args.showLink), true),
-		showRace = Logic.emptyOr(Logic.readBool(args.showRace), true),
+		showFlag = Logic.readBoolOrNil(args.showFlag),
+		showLink = Logic.readBoolOrNil(args.showLink),
+		showRace = Logic.readBoolOrNil(args.showRace),
 	})
 end
 


### PR DESCRIPTION
I added several new functions `Module:Logic` that allow more fine grained control over boolean input processing

- ~~`Logic.readTrue`~~ - Same as `Logic.readBool`. Returns true on `true, 'true', 1, '1'`, else false.
- ~~`Logic.readFalse`~~ - Returns false on `false, 'false', 0, '0'`, else true.
- `Logic.readBoolOrNil` - Same as `readTrue` and `readFalse` except that it returns `nil` if it's not one of the 8 values above.
- `Logic.nilOr` - Returns the first non-nil arg. For example `nilOr(nil, false, '', 3)` returns `false`. Used when the `or` operator doesn't cut it - in that example `nil or false or '' or 3` is `''` instead of `false`.

This pr converts match2 code to use those functions where applicable.