### PR TITLE
[ffa 1/5] Add more fields for match to match relations (`bracketData.advanceSpots`, `MatchGroup` struct)

### DIFF
--- a/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -25,19 +25,19 @@ function StarcraftBracketDisplay.BracketContainer(props)
 	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.BracketContainer)
 	return StarcraftBracketDisplay.Bracket({
 		config = props.config,
-		matchesById = MatchGroupUtil.fetchMatchesTable(props.bracketId),
+		bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId),
 	})
 end
 
 function StarcraftBracketDisplay.Bracket(props)
 	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.Bracket)
 	return BracketDisplay.Bracket({
-		matchesById = props.matchesById,
+		bracket = props.bracket,
 		config = Table.merge(props.config, {
 			MatchSummaryContainer = require('Module:MatchSummary/Starcraft').MatchSummaryContainer,
 			OpponentEntry = StarcraftBracketDisplay.OpponentEntry,
 			matchHasDetails = StarcraftMatchGroupUtil.matchHasDetails,
-			opponentHeight = StarcraftBracketDisplay.computeBracketOpponentHeight(props.matchesById),
+			opponentHeight = StarcraftBracketDisplay.computeBracketOpponentHeight(props.bracket.matchesById),
 		})
 	})
 end

--- a/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -173,7 +173,7 @@ function FFA.getExtraData(match)
 
 	--add the pbg stuff
 	for key, item in pairs(match.pbg) do
-		extradata[key] = item
+		extradata['pbg' .. key] = item
 	end
 	match.pbg = nil
 


### PR DESCRIPTION
- Move `upperMatchIds`, `headMatchIds` computation out of `BracketDisplay` because the FFA display module will also make use of it. Ideally this would also be stored in lpdb (and fetched instead of computed). I'm leaving that for the future.
- Added a `MatchGroup` structural type to hold the new fields.
- Added field `match.bracketData.advanceSpots`: an array that maps placements to advancement colors (`up`, `stayup`, etc). It is roughly the match2 equivalent of the `pbg=` params used in standings tables, as it encodes which placements advance, and is populated before the match starts. It encompasses info stored under `qualWin, qualLose, upperMatchIds, winnerto, loserto`, and generalizes them to multiple opponents.
