### PR TITLE
[ffa 3/5] Add FFA fields to various structs

### DIFF
--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -62,6 +62,8 @@ MatchGroupUtil.types.Player = TypeUtil.struct({
 })
 
 MatchGroupUtil.types.Opponent = TypeUtil.struct({
+	advanceBg = 'string?',
+	advances = 'boolean?',
 	icon = 'string?',
 	name = 'string?',
 	placement = 'number?',
@@ -283,6 +285,8 @@ end
 function MatchGroupUtil.opponentFromRecord(record)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	return {
+		advanceBg = nilIfEmpty(Table.extract(extradata, 'bg')),
+		advances = Logic.readBoolOrNil(Table.extract(extradata, 'advances')),
 		extradata = extradata,
 		icon = nilIfEmpty(record.icon),
 		name = nilIfEmpty(record.name),

--- a/match2/commons/opponent_display.lua
+++ b/match2/commons/opponent_display.lua
@@ -67,7 +67,7 @@ end
 
 function OpponentDisplay.BracketOpponentEntry:addScores(opponent)
 	local score1Node = OpponentDisplay.BracketScore({
-		isWinner = opponent.placement == 1,
+		isWinner = opponent.placement == 1 or opponent.advances,
 		scoreText = OpponentDisplay.InlineScore(opponent),
 	})
 	self.root:node(score1Node)
@@ -82,7 +82,7 @@ function OpponentDisplay.BracketOpponentEntry:addScores(opponent)
 	self.root:node(score2Node)
 
 	if (opponent.placement2 or opponent.placement or 0) == 1
-		or opponent.extradata.advances == 'true' then
+		or opponent.advances then
 		self.root:addClass('brkts-opponent-win')
 	end
 end

--- a/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -106,7 +106,7 @@ function StarcraftBracketDisplay.OpponentEntry(props)
 	local scoreNode
 	if props.displayType == 'bracket' then
 		scoreNode = OpponentDisplay.BracketScore({
-			isWinner = opponent.placement == 1,
+			isWinner = opponent.placement == 1 or opponent.advances,
 			scoreText = StarcraftOpponentDisplay.InlineScore(opponent),
 		})
 	end
@@ -127,7 +127,7 @@ function StarcraftBracketDisplay.OpponentEntry(props)
 	end
 
 	local isWinner = (opponent.placement2 or opponent.placement or 0) == 1
-		or opponent.extradata.advances == 'true'
+		or opponent.advances
 
 	return html.create('div'):addClass('brkts-opponent-entry')
 		:addClass(isWinner and 'brkts-opponent-win' or nil)

--- a/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -1,6 +1,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local OpponentDisplay = require('Module:OpponentDisplay')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
@@ -228,7 +229,7 @@ function StarcraftOpponentDisplay.BlockArchon(props)
 		:node(playersNode)
 end
 
-local CheckMark = '<i class="fa fa-check forest-green-text" aria-hidden="true"></i>'
+StarcraftOpponentDisplay.CheckMark = '<i class="fa fa-check forest-green-text" aria-hidden="true"></i>'
 
 function StarcraftOpponentDisplay.InlineScore(opponent)
 	if opponent.status == 'S' then
@@ -237,9 +238,11 @@ function StarcraftOpponentDisplay.InlineScore(opponent)
 			local title = 'Advantage of ' .. advantage .. ' game' .. (advantage > 1 and 's' or '')
 			return '<abbr title="' .. title .. '">' .. opponent.score .. '</abbr>'
 		end
-	elseif opponent.extradata.noscore == 'true' then
-		return opponent.extradata.advances =='true'
-			and CheckMark
+	end
+
+	if Logic.readBool(opponent.extradata.noscore) then
+		return (opponent.placement == 1 or opponent.advances)
+			and StarcraftOpponentDisplay.CheckMark
 			or ''
 	end
 


### PR DESCRIPTION
- Added fields to structural types: `Match.noScore`, `Opponent.advances`, `GameOpponent.placement` `GameOpponent.score` 
- See https://liquipedia.net/starcraft2/Liquipedia:Brackets/FFA for a description of what they do
- Added `showplacement` to `match.extradata`, which overrides whether the match-level placement column (to the left of the opponent column) appears in the FFA match summary.
- Added `advancecount` to `match.extradata`, which overrides the number of opponents that advance from a match. See https://liquipedia.net/starcraft/Liquipedia:BracketUpdate/Tests/Artosis for an example.
- The fields are added to the starcraft namespace. Will move them to general namespace once we have more experience with ffa related things.