### PR TITLE
Minor improvements to PlayerDisplay

### DIFF
--- a/match2/commons/player_display.lua
+++ b/match2/commons/player_display.lua
@@ -80,7 +80,6 @@ function PlayerDisplay.InlinePlayer(props)
 
 	return mw.html.create('span'):addClass('inline-player')
 		:addClass(props.flip and 'flipped' or nil)
-		:css('white-space', 'pre')
 		:wikitext(text)
 end
 

--- a/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -62,8 +62,8 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 end
 
 -- Called from Template:Player and Template:Player2
-function StarcraftPlayerDisplay.TemplatePlayer()
-	local args = require('Module:Arguments').getArgs(mw.getCurrentFrame())
+function StarcraftPlayerDisplay.TemplatePlayer(frame)
+	local args = require('Module:Arguments').getArgs(frame)
 
 	local pageName
 	local displayName
@@ -90,20 +90,21 @@ function StarcraftPlayerDisplay.TemplatePlayer()
 		StarcraftPlayerUtil.saveToPageVars(player)
 	end
 
-	local hiddenSort = args.hs
-		and StarcraftPlayerUtil.hiddenSort(player.displayName, player.flag, player.race, args.hs)
+	local hiddenSortNode = args.hs
+		and StarcraftPlayerUtil.HiddenSort(player.displayName, player.flag, player.race, args.hs)
 		or ''
-	return hiddenSort .. StarcraftPlayerDisplay.InlinePlayer({
+	local playerNode = StarcraftPlayerDisplay.InlinePlayer({
 		dq = Logic.readBoolOrNil(args.dq),
 		flip = Logic.readBoolOrNil(args.flip),
 		player = player,
 		showRace = (args.showRace or 'true') == 'true',
 	})
+	return tostring(hiddenSortNode) .. tostring(playerNode)
 end
 
 -- Called from Template:InlinePlayer
-function StarcraftPlayerDisplay.TemplateInlinePlayer()
-	local args = require('Module:Arguments').getArgs(mw.getCurrentFrame())
+function StarcraftPlayerDisplay.TemplateInlinePlayer(frame)
+	local args = require('Module:Arguments').getArgs(frame)
 
 	local player = {
 		displayName = args[1],
@@ -191,11 +192,10 @@ function StarcraftPlayerDisplay.InlinePlayer(props)
 
 	return html.create('span'):addClass('starcraft-inline-player')
 		:addClass(props.flip and 'flipped' or nil)
-		:css('white-space', 'pre')
 		:wikitext(text)
 end
 
-function StarcraftPlayerDisplay.hiddenSort(name, flag, race, field)
+function StarcraftPlayerDisplay.HiddenSort(name, flag, race, field)
 	local text
 	if field == 'race' then
 		text = race

--- a/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -6,7 +6,6 @@ local PlayerDisplay = require('Module:Player/Display')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local StarcraftPlayerUtil = require('Module:Player/Util/Starcraft')
 local String = require('Module:StringUtils')
-local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
@@ -143,12 +142,9 @@ variables.
 ]]
 function StarcraftPlayerDisplay.InlinePlayerContainer(props)
 	DisplayUtil.assertPropTypes(props, StarcraftPlayerDisplay.propTypes.InlinePlayerContainer)
+	StarcraftPlayerUtil.syncPlayer(props.player, props.date, props.dontSave)
 
-	return StarcraftPlayerDisplay.InlinePlayer(
-		Table.merge(props, {
-			player = StarcraftPlayerUtil.syncPlayer(props.player, props.date, props.dontSave),
-		})
-	)
+	return StarcraftPlayerDisplay.InlinePlayer(props)
 end
 
 --[[


### PR DESCRIPTION
- Remove white-space pre from InlinePlayer. It's not needed because InlinePlayer already sets `&nbsp;` between race and flag and player name. If the player name has a space, then it's long enough to deserve line breaks anyway.
- For `TemplatePlayer` in `starcraft/starcraft2`: Read the frame object from args instead of `mw.getCurrentFrame()` so it can be used as a drop in replacement for `require('Module:Player').player`. Example: https://liquipedia.net/starcraft2/index.php?title=Module:Portal_tournaments&action=edit