### PR TITLE
Fix bracket reset match display issues

### DIFF
--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -186,9 +186,23 @@ function MatchGroupUtil.fetchMatches(bracketId)
 	return MatchGroupUtil.fetchMatchGroup(bracketId).matches
 end
 
--- Returns a table whose entries are (matchId, match)
-function MatchGroupUtil.fetchMatchesTable(bracketId)
-	return MatchGroupUtil.fetchMatchGroup(bracketId).matchesById
+--[[
+Returns a match struct for use in a bracket display or match summary popup. The
+bracket display and match summary popup expects that the finals match also
+include results from the bracket reset match.
+]]
+function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId)
+	local bracket = MatchGroupUtil.fetchMatchGroup(bracketId)
+	local match = bracket.matchesById[matchId]
+
+	local bracketResetMatch = match
+		and match.bracketData.bracketResetMatchId
+		and bracket.matchesById[match.bracketData.bracketResetMatchId]
+	if bracketResetMatch then
+		return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
+	else
+		return match
+	end
 end
 
 --[[

--- a/match2/commons/opponent_display.lua
+++ b/match2/commons/opponent_display.lua
@@ -83,7 +83,7 @@ function OpponentDisplay.BracketOpponentEntry:addScores(opponent)
 
 	if (opponent.placement2 or opponent.placement or 0) == 1
 		or opponent.advances then
-		self.root:addClass('brkts-opponent-win')
+		self.content:addClass('brkts-opponent-win')
 	end
 end
 

--- a/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -71,8 +71,12 @@ function StarcraftBracketDisplay.OpponentEntry(props)
 		showRaceBackground = false
 	end
 
+	local isWinner = (opponent.placement2 or opponent.placement or 0) == 1
+		or opponent.advances
+
 	local leftNode = html.create('div'):addClass('brkts-opponent-entry-left')
 		:addClass(showRaceBackground and RaceColor[opponent.players[1].race] or nil)
+		:addClass(isWinner and 'brkts-opponent-win' or nil)
 
 	if opponent.type == 'team' then
 		local bracketNode = StarcraftOpponentDisplay.BlockTeamContainer({
@@ -126,11 +130,7 @@ function StarcraftBracketDisplay.OpponentEntry(props)
 		})
 	end
 
-	local isWinner = (opponent.placement2 or opponent.placement or 0) == 1
-		or opponent.advances
-
 	return html.create('div'):addClass('brkts-opponent-entry')
-		:addClass(isWinner and 'brkts-opponent-win' or nil)
 		:node(leftNode)
 		:node(scoreNode)
 		:node(score2Node)

--- a/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -26,7 +26,7 @@ StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
 }
 
 function StarcraftMatchSummary.MatchSummaryContainer(props)
-	local match = MatchGroupUtil.fetchMatchesTable(props.bracketId)[props.matchId]
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
 	local MatchSummary = match.isFFA
 		and require('Module:MatchSummary/FFA/Starcraft').FFAMatchSummary
 		or StarcraftMatchSummary.MatchSummary

--- a/match2/wikis/rocketleague/match_summary.lua
+++ b/match2/wikis/rocketleague/match_summary.lua
@@ -9,7 +9,7 @@ local htmlCreate = mw.html.create
 local p = {}
 
 function p.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchesTable(args.bracketId)[args.matchId]
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
 
 	local wrapper = htmlCreate("div")
 		:addClass("brkts-popup")

--- a/match2/wikis/valorant/match_summary.lua
+++ b/match2/wikis/valorant/match_summary.lua
@@ -112,7 +112,7 @@ end
 local CustomMatchSummary = {}
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchesTable(args.bracketId)[args.matchId]
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
 	local frame = mw.getCurrentFrame()
 
 	local matchSummary = MatchSummary:init('480px')


### PR DESCRIPTION
Fixes a few issues:
- Match summary was missing additional rows for games in the bracket reset match. 
- The scores in a finals match with bracket reset match weren't bolded properly.

Before
![Screenshot 2021-06-29 085918](https://user-images.githubusercontent.com/85348434/123903593-d5dc4f00-d923-11eb-9f13-11240175794a.jpg)

After
![image](https://user-images.githubusercontent.com/85348434/123903545-bf35f800-d923-11eb-86e6-f023b255bad9.png)

