### PR TITLE
More matchlist widths fine tuning

### DIFF
--- a/match2/commons/match_group_display_matchlist.lua
+++ b/match2/commons/match_group_display_matchlist.lua
@@ -148,8 +148,8 @@ function MatchlistDisplay.Match(props)
 	-- Compute widths of the 2 opponent and 2 score columns. The small offsets
 	-- are due to border splitting from table-layout: auto.
 	local minScoreWidth = 30
-	local scoreWidth = math.max(minScoreWidth, math.floor(0.1 * props.width) - 1)
-	local opponentWidth = 0.5 * (props.width - 5 - 2 * scoreWidth)
+	local scoreWidth = math.max(minScoreWidth, math.floor(0.1 * props.width))
+	local opponentWidth = 0.5 * (props.width - 2 - 2 * scoreWidth)
 
 	local renderOpponent = function(opponentIx)
 		local opponent = match.opponents[opponentIx] or MatchGroupUtil.createOpponent({})
@@ -219,7 +219,7 @@ Display component for a title in a matchlist.
 function MatchlistDisplay.Title(props)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Title)
 	local titleNode = html.create('div')
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding .. 'px')
+		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 2 .. 'px')
 		:wikitext(props.title)
 
 	local thNode = html.create('th')
@@ -240,7 +240,7 @@ function MatchlistDisplay.Header(props)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Header)
 
 	local headerNode = html.create('div')
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding .. 'px')
+		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 2 .. 'px')
 		:wikitext(props.header)
 
 	local thNode = html.create('th')
@@ -257,7 +257,8 @@ Display component for an opponent in a matchlist.
 
 This is the default implementation used by the Matchlist component. Specific
 wikis may override this by passing a different props.Opponent to the Matchlist
-component.
+component. Custom implementations should ensure that the rendered width is
+exactly props.width.
 ]]
 function MatchlistDisplay.Opponent(props)
 	local contentNode = OpponentDisplay.BlockOpponent({
@@ -267,7 +268,7 @@ function MatchlistDisplay.Opponent(props)
 		showLink = false,
 		teamStyle = 'short',
 	})
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding .. 'px')
+		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
 		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
@@ -279,12 +280,13 @@ Display component for the score of an opponent in a matchlist.
 
 This is the default implementation used by the Matchlist component. Specific
 wikis may override this by passing a different props.Score to the Matchlist
-component.
+component. Custom implementations should ensure that the rendered width is
+exactly props.width.
 ]]
 function MatchlistDisplay.Score(props)
 	local contentNode = html.create('div'):addClass('brkts-matchlist-score')
 		:node(OpponentDisplay.InlineScore(props.opponent))
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding .. 'px')
+		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-bold' or nil)
 		:node(contentNode)

--- a/match2/commons/match_group_display_matchlist.lua
+++ b/match2/commons/match_group_display_matchlist.lua
@@ -149,7 +149,8 @@ function MatchlistDisplay.Match(props)
 	-- are due to border splitting from table-layout: auto.
 	local minScoreWidth = 30
 	local scoreWidth = math.max(minScoreWidth, math.floor(0.1 * props.width))
-	local opponentWidth = 0.5 * (props.width - 2 - 2 * scoreWidth)
+	-- width of both opponent fields is total width -2 (border widths) - width of the score fields
+	local opponentWidth = 0.5 * (props.width - 2 - (2 * scoreWidth))
 
 	local renderOpponent = function(opponentIx)
 		local opponent = match.opponents[opponentIx] or MatchGroupUtil.createOpponent({})
@@ -219,7 +220,7 @@ Display component for a title in a matchlist.
 function MatchlistDisplay.Title(props)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Title)
 	local titleNode = html.create('div')
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 2 .. 'px')
+		:css('width', (props.width - (2 * MatchlistDisplay.cellPadding) - 2) .. 'px')
 		:wikitext(props.title)
 
 	local thNode = html.create('th')
@@ -240,7 +241,7 @@ function MatchlistDisplay.Header(props)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Header)
 
 	local headerNode = html.create('div')
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 2 .. 'px')
+		:css('width', (props.width - (2 * MatchlistDisplay.cellPadding) - 2) .. 'px')
 		:wikitext(props.header)
 
 	local thNode = html.create('th')
@@ -268,7 +269,7 @@ function MatchlistDisplay.Opponent(props)
 		showLink = false,
 		teamStyle = 'short',
 	})
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
+		:css('width', (props.width - (2 * MatchlistDisplay.cellPadding) - 1) .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
 		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
@@ -286,7 +287,7 @@ exactly props.width.
 function MatchlistDisplay.Score(props)
 	local contentNode = html.create('div'):addClass('brkts-matchlist-score')
 		:node(OpponentDisplay.InlineScore(props.opponent))
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
+		:css('width', (props.width - (2 * MatchlistDisplay.cellPadding) - 1) .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-bold' or nil)
 		:node(contentNode)

--- a/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -47,7 +47,7 @@ function StarcraftMatchlistDisplay.Opponent(props)
 		showLink = false,
 		teamStyle = 'short',
 	})
-		:css('width', props.width - 2 * 5 .. 'px')
+		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
 		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
@@ -57,7 +57,7 @@ end
 function StarcraftMatchlistDisplay.Score(props)
 	local contentNode = html.create('div'):addClass('brkts-matchlist-score')
 		:node(StarcraftOpponentDisplay.InlineScore(props.opponent))
-		:css('width', props.width - 2 * 5 .. 'px')
+		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
 	return html.create('td')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-bold' or nil)
 		:node(contentNode)


### PR DESCRIPTION
Makes it so that a matchlist with `|width=300px` actually shows up as 300px wide. I don't know why the `-1` and `-2`s are needed but empirically they seem to work. Probably something to do with the `table-layout: auto` being used.

Before
![image](https://user-images.githubusercontent.com/85348434/123945959-8a419980-d953-11eb-8d47-49d2bb605a37.png)

After
![image](https://user-images.githubusercontent.com/85348434/123946607-41d6ab80-d954-11eb-8783-6b9e5faea238.png)
