### PR TITLE
Show `&zwsp;` for empty block-style opponents

### DIFF
--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -16,6 +16,8 @@ local Table = require('Module:Table')
 local Template = require('Module:Template')
 local TypeUtil = require('Module:TypeUtil')
 
+local zeroWidthSpace = '&#8203;'
+
 local OpponentDisplay = {propTypes = {}, types = {}}
 
 OpponentDisplay.types.TeamStyle = TypeUtil.literalUnion('standard', 'short', 'bracket')
@@ -234,7 +236,7 @@ function OpponentDisplay.InlineTeam(props)
 		template = 'default',
 	}))
 		:gsub('DefaultPage', props.team.pageName)
-		:gsub('DefaultName', props.team.displayName)
+		:gsub('DefaultName', Logic.emptyOr(props.team.displayName, zeroWidthSpace))
 		:gsub('DefaultShort', props.team.shortName)
 		:gsub('DefaultBracket', props.team.bracketName)
 end
@@ -317,7 +319,7 @@ function OpponentDisplay.BlockLiteral(props)
 	return DisplayUtil.applyOverflowStyles(mw.html.create('div'), props.overflow or 'wrap')
 		:addClass('brkts-opponent-block-literal')
 		:addClass(props.flip and 'flipped' or nil)
-		:node(Logic.emptyOr(props.name, '&nbsp;'))
+		:node(Logic.emptyOr(props.name, zeroWidthSpace))
 end
 
 --[[

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local TypeUtil = require('Module:TypeUtil')
 
@@ -32,10 +33,11 @@ function PlayerDisplay.BlockPlayer(props)
 	DisplayUtil.assertPropTypes(props, PlayerDisplay.propTypes.BlockPlayer)
 	local player = props.player
 
+	local zeroWidthSpace = '&#8203;'
 	local nameNode = mw.html.create('span'):addClass('name')
 		:wikitext(props.showLink ~= false and player.pageName
 			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
-			or player.displayName
+			or Logic.emptyOr(player.displayName, zeroWidthSpace)
 		)
 	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
 

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -44,10 +44,11 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 	DisplayUtil.assertPropTypes(props, StarcraftPlayerDisplay.propTypes.BlockPlayer)
 	local player = props.player
 
+	local zeroWidthSpace = '&#8203;'
 	local nameNode = html.create('span'):addClass('name')
 		:wikitext(props.showLink ~= false and player.pageName
 			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
-			or Logic.emptyOr(player.displayName, '&nbsp;')
+			or Logic.emptyOr(player.displayName, zeroWidthSpace)
 		)
 	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
 


### PR DESCRIPTION
Applies to block-style components for players, teams, and literals. 

Before
![image](https://user-images.githubusercontent.com/85348434/123987347-f59f6180-d97b-11eb-9a4e-7a2c78d6f517.png)
![image](https://user-images.githubusercontent.com/85348434/123988037-85451000-d97c-11eb-91b2-b2fbd311dac7.png)

After
![image](https://user-images.githubusercontent.com/85348434/123987293-e91b0900-d97b-11eb-8a5f-9f18fe884d40.png)
![image](https://user-images.githubusercontent.com/85348434/123987770-50d15400-d97c-11eb-83a6-5a10e7781fa8.png)
