### PR TITLE
Add custom bracket & matchlist functions

### DIFF
--- a/match2/commons/match_group_display.lua
+++ b/match2/commons/match_group_display.lua
@@ -1,19 +1,72 @@
 local MatchGroupDisplay = {}
+local MatchGroupUtil
+local getArgs = require('Module:Arguments').getArgs
 
 function MatchGroupDisplay.bracket(frame)
-	local args = require('Module:Arguments').getArgs(frame)
+	local args = getArgs(frame)
 	return MatchGroupDisplay.luaBracket(frame, args)
 end
 
-function MatchGroupDisplay.luaBracket(frame, args)
+function MatchGroupDisplay.customBracket(frame, args, matches)
+	if not args then
+		args = getArgs(frame)
+	end
+
+	if not matches or #matches == 0 then
+		args[1] = args.id or args[1] or ''
+		matches = MatchGroupDisplay._getMatches(args[1])
+	end
+
+	if args.title ~= '' and args.title ~= nil then
+		matches[1].bracketData.title = args.title
+	end
+
+	for index, match in ipairs(matches) do
+		local round, matchInRound = MatchGroupDisplay._getMatchIndexFromMatchId(match.matchId, args[1])
+
+		if round and matchInRound then
+			local matchId = 'R' .. round .. 'M' .. matchInRound
+			if args[matchId .. 'header'] ~= '' and args[matchId .. 'header'] ~= nil then
+				matches[index].bracketData.header = args[matchId .. 'header']
+			end
+		end
+	end
+
+	return MatchGroupDisplay.luaBracket(frame, args, matches)
+end
+
+function MatchGroupDisplay.luaBracket(frame, args, matches)
 	mw.log("drawing from lua")
 	local BracketDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('bracket')
-	return BracketDisplay.luaGet(frame, args)
+	return BracketDisplay.luaGet(frame, args, matches)
 end
 
 function MatchGroupDisplay.matchlist(frame)
-	local args = require('Module:Arguments').getArgs(frame)
+	local args = getArgs(frame)
 	return MatchGroupDisplay.luaMatchlist(frame, args)
+end
+
+function MatchGroupDisplay.customMatchlist(frame, args, matches)
+	if not args then
+		args = getArgs(frame)
+	end
+
+	if not matches or #matches == 0 then
+		args[1] = args.id or args[1] or ''
+		matches = MatchGroupDisplay._getMatches(args[1])
+	end
+
+	if args.title ~= '' and args.title ~= nil then
+		matches[1].bracketData.title = args.title
+	end
+
+	for index, _ in ipairs(matches) do
+		if args['M' .. index .. 'header'] ~= '' and args['M' .. index .. 'header'] ~= nil then
+			matches[index].bracketData.header = args['M' .. index .. 'header']
+		end
+	end
+
+	return MatchGroupDisplay.luaMatchlist(frame, args, matches)
 end
 
 function MatchGroupDisplay.luaMatchlist(frame, args, matches)
@@ -23,24 +76,39 @@ end
 
 -- display MatchGroup (Bracket/MatchList) from ID
 function MatchGroupDisplay.Display(frame)
-	local args = require('Module:Arguments').getArgs(frame)
+	local args = getArgs(frame)
 	args[1] = args.id or args[1] or ''
 	local bracketId = args[1]
 
-	local MatchGroupUtil = require('Module:MatchGroup/Util')
-	local matches = MatchGroupUtil.fetchMatches(bracketId)
-	if #matches == 0 then
-		error('No Data found for bracketId=' .. bracketId)
-	end
+	local matches = MatchGroupDisplay._getMatches(bracketId)
+
 	local matchGroupType = matches[1].bracketData.type
 
 	local MatchGroupModule = require('Module:Brkts/WikiSpecific').getMatchGroupModule(matchGroupType)
-	return MatchGroupModule.luaGet(frame, args)
+	return MatchGroupModule.luaGet(frame, args, matches)
 end
 
 function MatchGroupDisplay.DisplayDev(frame)
 	require('Module:DevFlags').matchGroupDev = true
 	return MatchGroupDisplay.Display(frame)
+end
+
+--Helper functions for custom Bracket/Matchlist options
+function MatchGroupDisplay._getMatches(id)
+	if not MatchGroupUtil then
+		MatchGroupUtil = require('Module:MatchGroup/Util')
+	end
+	local matches = MatchGroupUtil.fetchMatches(id)
+	if #matches == 0 then
+		error('No data found for bracketId=' .. id)
+	end
+	return matches
+end
+
+function MatchGroupDisplay._getMatchIndexFromMatchId(matchId, bracketId)
+	matchId = string.gsub(matchId, bracketId .. '_', '')
+	local round, matchInRound = string.match(matchId, '^R(%d+)%-M(%d+)$')
+	return tonumber(round or ''), tonumber(matchInRound or '')
 end
 
 return MatchGroupDisplay


### PR DESCRIPTION
RE of #22 
(was closed during the PR mess some weeks ago, unknown if auto-closed or intentional, no hard feelings if rejected^^)

* __function "customMatchlist":__
** If matches are passed to it it uses those matches, else it fetches matches from a given bracketID
** Allows to add custom title and matchheaders for the matchlist (overwrite the title/headers set in the queried data)

* __function "customBracket":__
** If matches are passed to it it uses those matches, else it fetches matches from a given bracketID
** Allows to add custom title and matchheaders for the bracket (overwrite the title/headers set in the queried data)

These functions can be useful if one wants to display a bracket/matchlist on a different page, but wants to change headers/titles.