### PR TITLE
Improve randomness of ID generator + enable `args` passing

### DIFF
--- a/match2/commons/get_match_group_copy_paste.lua
+++ b/match2/commons/get_match_group_copy_paste.lua
@@ -10,8 +10,6 @@ local Lua = require("Module:Lua")
 local BracketAlias = Lua.moduleExists("Module:BracketAlias") and mw.loadData('Module:BracketAlias') or {}
 local WikiSpecific = require("Module:GetMatchGroupCopyPaste/wiki")
 
-local args
-
 function copyPaste.generateID()
 	--initiate the rnd generator
 	math.randomseed(os.time())

--- a/match2/commons/get_match_group_copy_paste.lua
+++ b/match2/commons/get_match_group_copy_paste.lua
@@ -13,7 +13,6 @@ local WikiSpecific = require("Module:GetMatchGroupCopyPaste/wiki")
 function copyPaste.generateID()
 	--initiate the rnd generator
 	math.randomseed(os.time())
-	math.random(); math.random(); math.random()
 	return copyPaste._generateID()
 end
 

--- a/match2/commons/get_match_group_copy_paste.lua
+++ b/match2/commons/get_match_group_copy_paste.lua
@@ -92,7 +92,7 @@ function copyPaste._getHeader(headerCode, customHeader, match)
 	return header
 end
 
-function copyPaste.bracket(frame)
+function copyPaste.bracket(frame, args)
 	if not args then
 		args = getArgs(frame)
 	end
@@ -142,7 +142,7 @@ function copyPaste.bracket(frame)
 	return out .. '\n}}</pre>'
 end
 
-function copyPaste.matchlist(frame)
+function copyPaste.matchlist(frame, args)
 	if not args then
 		args = getArgs(frame)
 	end

--- a/match2/commons/get_match_group_copy_paste.lua
+++ b/match2/commons/get_match_group_copy_paste.lua
@@ -12,6 +12,13 @@ local WikiSpecific = require("Module:GetMatchGroupCopyPaste/wiki")
 
 local args
 
+function copyPaste.generateID()
+	--initiate the rnd generator
+	math.randomseed(os.time())
+	math.random(); math.random(); math.random()
+	return copyPaste._generateID()
+end
+
 function copyPaste._generateID()
 	local id = ''
 
@@ -101,7 +108,7 @@ function copyPaste.bracket(frame)
 	local templateid = BracketAlias[string.lower(args.id)] or args.id
 
 	local out = '<pre class="selectall" width=50%>' ..
-		WikiSpecific.getStart(templateid, copyPaste._generateID(), 'bracket', args)
+		WikiSpecific.getStart(templateid, copyPaste.generateID(), 'bracket', args)
 
 	local bracketData = copyPaste._getBracketData(templateid)
 
@@ -148,7 +155,7 @@ function copyPaste.matchlist(frame)
 	local mode = WikiSpecific.getMode(args.mode)
 
 	local out = '<pre class="selectall" width=50%>' ..
-		WikiSpecific.getStart(nil, copyPaste._generateID(), 'matchlist', args)
+		WikiSpecific.getStart(nil, copyPaste.generateID(), 'matchlist', args)
 
 	for index = 1, matches do
 		if customHeader then


### PR DESCRIPTION
* Improve randomness of ID generator due to seeding the Random Number Generator by time and throwing the first 3 random values away.
* Enable `args` to be passed to matchlist and bracket functions.