### PR TITLE
Add Option to use unnamed params for matches in matchlists

### DIFF
--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -85,7 +85,8 @@ function p.luaMatchlist(frame, args, matchBuilder)
 		bd["type"] = "matchlist"
 		bd["next"] = hasNextMatch and nextMatchId or nil
 		bd["title"] = matchIndex == 1 and args["title"] or nil
-		local header = args[currentMatchInWikicode .. "header"] or args["header" .. currentMatchInWikicode] or args[currentMatchInWikicode .. "header"]
+		local header = args[currentMatchInWikicode .. "header"] or 
+			args["header" .. currentMatchInWikicode] or args[currentMatchInWikicode .. "header"]
 		if header ~= nil and header ~= "" then
 			bd["header"] = header
 		end

--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -85,7 +85,7 @@ function p.luaMatchlist(frame, args, matchBuilder)
 		bd["type"] = "matchlist"
 		bd["next"] = hasNextMatch and nextMatchId or nil
 		bd["title"] = matchIndex == 1 and args["title"] or nil
-		local header = args[currentMatchInWikicode .. "header"] or 
+		local header = args[currentMatchInWikicode .. "header"] or
 			args["header" .. currentMatchInWikicode] or args[currentMatchInWikicode .. "header"]
 		if header ~= nil and header ~= "" then
 			bd["header"] = header

--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -68,7 +68,7 @@ function p.luaMatchlist(frame, args, matchBuilder)
 
 		local nextMatchIndex = matchIndex + 1
 		local nextMatchInWikicode = "M" .. nextMatchIndex
-		nextMatch = args[nextMatchInWikicode]
+		nextMatch = args[nextMatchInWikicode] or args[nextMatchIndex]
 		local hasNextMatch = nextMatch ~= nil
 		local nextMatchId = bracketid .. "_" .. string.format("%04d", nextMatchIndex)
 
@@ -85,7 +85,7 @@ function p.luaMatchlist(frame, args, matchBuilder)
 		bd["type"] = "matchlist"
 		bd["next"] = hasNextMatch and nextMatchId or nil
 		bd["title"] = matchIndex == 1 and args["title"] or nil
-		local header = args[currentMatchInWikicode .. "header"]
+		local header = args[currentMatchInWikicode .. "header"] or args["header" .. currentMatchInWikicode] or args[currentMatchInWikicode .. "header"]
 		if header ~= nil and header ~= "" then
 			bd["header"] = header
 		end


### PR DESCRIPTION
Following the discussion in the bracket-update channel these changes would make iMarbot and Rathoz happy.
--> https://discord.com/channels/93055209017729024/756217678493909143/862030161729290267

In Matchlists it enables that matches are entered into unnamed params.

Plus adding aliases for the Match headers in Matchlists to be better in line (naming wise) if the unnamed params are used.

I think this might get used by quite some wikis, so it seems to be better to enable it directly in the base version instead of letting most wikis overwrite it.

(Just a suggestion, no problem if not wanted^^)

Example:
The following code snippets will do the same after this change

```
{{MatchList|id=...
|{{Match|...}}
|{{Match|...}}
|{{Match|...}}
}}

---------------

{{MatchList|id=...
|M1={{Match|...}}
|M2={{Match|...}}
|M3={{Match|...}}
}}