### PR TITLE
Fix Legacy Conversion error (stacked 1st)

### DIFF
--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -102,7 +102,7 @@ function Legacy._convert(mapping)
 			-- do actual conversion
 			local nested = {}
 			for key, val in pairs(flattened) do
-				if not String.startsWith(key, "map") then
+				if not String.startsWith(tostring(key), "map") then
 					nested[key] = val
 				end
 			end


### PR DESCRIPTION
Sometimes that key is a number so using String functions on it throws errors. Converting it to a string first solves that.