### PR TITLE
Add UserSpace workarounds (stacked)

### DIFF
--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -11,7 +11,7 @@ local Variables = require("Module:Variables")
 local String = require("Module:StringUtils")
 
 local _IS_USERSPACE = false
-local _NAMESPACE_USER_NUMBER = 2
+local _NAMESPACE_USER = 2
 local _type
 local _args
 
@@ -23,7 +23,7 @@ function Legacy.get(frame)
 	if storage == '' or storage == nil then
 		storage = Variables.varDefault('disable_SMW_storage') == 'true' and 'false' or nil
 	end
-	if (storage or '') ~= 'true' and nameSpaceNumber == _NAMESPACE_USER_NUMBER then
+	if (storage or '') ~= 'true' and nameSpaceNumber == _NAMESPACE_USER then
 		storage = 'false'
 		_IS_USERSPACE = true
 	end

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -11,7 +11,7 @@ local Variables = require("Module:Variables")
 local String = require("Module:StringUtils")
 
 local _IS_USERSPACE = false
-local _USERSPACE_NUMBER = 2
+local _NAMESPACE_USER_NUMBER = 2
 local _type
 local _args
 
@@ -23,7 +23,7 @@ function Legacy.get(frame)
 	if storage == '' or storage == nil then
 		storage = Variables.varDefault('disable_SMW_storage') == 'true' and 'false' or nil
 	end
-	if (storage or '') ~= 'true' and nameSpaceNumber == _USERSPACE_NUMBER then
+	if (storage or '') ~= 'true' and nameSpaceNumber == _NAMESPACE_USER_NUMBER then
 		storage = 'false'
 		_IS_USERSPACE = true
 	end

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -7,6 +7,7 @@ local getDefaultMapping = require("Module:MatchGroup/Legacy/Default").get
 local Logic = require("Module:Logic")
 local Lua = require("Module:Lua")
 local Table = require("Module:Table")
+local Variables = require("Module:Variables")
 local String = require("Module:StringUtils")
 
 local _type
@@ -40,6 +41,12 @@ function Legacy.get(frame)
 	local newArgs = Legacy._convert(mapping)
 	newArgs.id = bracketid
 	newArgs["1"] = templateid
+
+	local storage = _args.store
+	if storage == '' or storage == nil then
+		storage = Variables.varDefault('disable_SMW_storage') == 'true' and 'false'
+	end
+	newArgs.store = storage
 
 	return MatchGroup.luaBracket(frame, newArgs)
 end

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -55,6 +55,7 @@ function Legacy.get(frame)
 	newArgs["1"] = templateid
 
 	newArgs.store = storage
+	newArgs.noDuplicateCheck = _args.noDuplicateCheck
 
 	return MatchGroup.luaBracket(frame, newArgs)
 end

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -11,6 +11,7 @@ local Variables = require("Module:Variables")
 local String = require("Module:StringUtils")
 
 local _IS_USERSPACE = false
+local _USERSPACE_NUMBER = 2
 local _type
 local _args
 
@@ -22,7 +23,7 @@ function Legacy.get(frame)
 	if storage == '' or storage == nil then
 		storage = Variables.varDefault('disable_SMW_storage') == 'true' and 'false' or nil
 	end
-	if (storage or '') ~= 'true' and nameSpaceNumber == 2 then
+	if (storage or '') ~= 'true' and nameSpaceNumber == _USERSPACE_NUMBER then
 		storage = 'false'
 		_IS_USERSPACE = true
 	end

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -10,7 +10,7 @@ local Table = require("Module:Table")
 local Variables = require("Module:Variables")
 local String = require("Module:StringUtils")
 
-local ISUSERSPACE = false
+local _IS_USERSPACE = false
 local _type
 local _args
 
@@ -24,7 +24,7 @@ function Legacy.get(frame)
 	end
 	if (storage or '') ~= 'true' and nameSpaceNumber == 2 then
 		storage = 'false'
-		ISUSERSPACE = true
+		_IS_USERSPACE = true
 	end
 
 	local bracketid = _args["id"]
@@ -149,7 +149,7 @@ function Legacy._convertSingle(realKey, val, match, mapping, flattened)
 				end)
 		end
 
-		if ISUSERSPACE then
+		if _IS_USERSPACE then
 			--the following could be used to allow empty matches in the conversion
 			if String.startsWith(realKey, "opponent") and
 				Logic.isEmpty(_args[val["$notEmpty$"]] or flattened[val["$notEmpty$"]]) then

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -102,7 +102,7 @@ function Legacy._convert(mapping)
 			-- do actual conversion
 			local nested = {}
 			for key, val in pairs(flattened) do
-				if not String.startsWith(key, "map") then
+				if not String.startsWith(tostring(key), "map") then
 					nested[key] = val
 				end
 			end

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -151,8 +151,9 @@ function Legacy._convertSingle(realKey, val, match, mapping, flattened)
 
 		if ISUSERSPACE then
 			--the following could be used to allow empty matches in the conversion
-			if String.startsWith(realKey, "opponent") and Logic.isEmpty(_args[val["$notEmpty$"]] or flattened[val["$notEmpty$"]]) then
-				_args[val["$notEmpty$"]] = '&nbsp;'
+			if String.startsWith(realKey, "opponent") and
+				Logic.isEmpty(_args[val["$notEmpty$"]] or flattened[val["$notEmpty$"]]) then
+					_args[val["$notEmpty$"]] = '&nbsp;'
 			end
 		end
 


### PR DESCRIPTION
* Disable storage by default in UserSpace
* Allow blank entries in Brackets in UserSpace IF storage is not enabled manually

Reason:
Brackets in UserSpace often are incomplete and wrongly used.
Due to that the Conversion on UserSpace throws several errors.