### PR TITLE
Add option to disable ID duplicate check (stacked)

### DIFF
--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -39,7 +39,7 @@ function p.luaMatchlist(frame, args, matchBuilder)
 	bracketid = p.getBracketIdPrefix() .. bracketid
 
 	-- check if the bracket is a duplicate
-	if storeInLPDB and args.noDuplicateCheck then
+	if storeInLPDB == false and Logic.readBool(args.noDuplicateCheck) then
 		p._checkBracketDuplicate(bracketid)
 	end
 
@@ -153,7 +153,7 @@ function p.luaBracket(frame, args, matchBuilder)
 	bracketid = p.getBracketIdPrefix() .. bracketid
 
 	-- check if the bracket is a duplicate
-	if storeInLPDB and args.noDuplicateCheck then
+	if storeInLPDB == false and Logic.readBool(args.noDuplicateCheck) then
 		p._checkBracketDuplicate(bracketid)
 	end
 

--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -39,7 +39,9 @@ function p.luaMatchlist(frame, args, matchBuilder)
 	bracketid = p.getBracketIdPrefix() .. bracketid
 
 	-- check if the bracket is a duplicate
-	p._checkBracketDuplicate(bracketid)
+	if storeInLPDB and args.noDuplicateCheck then
+		p._checkBracketDuplicate(bracketid)
+	end
 
 	local storedData = {}
 	local currentMatchInWikicode = "M1"
@@ -151,7 +153,9 @@ function p.luaBracket(frame, args, matchBuilder)
 	bracketid = p.getBracketIdPrefix() .. bracketid
 
 	-- check if the bracket is a duplicate
-	p._checkBracketDuplicate(bracketid)
+	if storeInLPDB and args.noDuplicateCheck then
+		p._checkBracketDuplicate(bracketid)
+	end
 
 	-- get bracket data from template
 	local bracketData = p._getBracketData(templateid, bracketid)


### PR DESCRIPTION
Add option to disable ID duplicate check if storage is also disabled

Use-Case:
Legacy Bracket that gets transcluded, for which storage is disabled (only on the page that gets transcluded) the double ID check will still add the double ID category to the page that gets transcluded.