### PR TITLE
Adjust Legacy resulttype storage

### DIFF
--- a/match2/wikis/starcraft2/match_legacy.lua
+++ b/match2/wikis/starcraft2/match_legacy.lua
@@ -119,6 +119,9 @@ function p.convertParameters(match2)
 
 		if match.resulttype == 'default' then
 			match.resulttype = string.upper(match.walkover or '')
+			if match.resulttype == 'L' then
+				match.resulttype = 'unk'
+			end
 			match.walkover = match.winner
 		end
 		match.extradata.bestof = match.bestof

--- a/match2/wikis/starcraft2/match_legacy.lua
+++ b/match2/wikis/starcraft2/match_legacy.lua
@@ -7,6 +7,7 @@ local p = {}
 local json = require("Module:Json")
 local String = require("Module:StringUtils")
 local Table = require("Module:Table")
+local _UNKNOWNREASON_DEFAULT_LOSS = 'L'
 
 local MODES = { ["solo"] = "1v1", ["team"] = "team" }
 
@@ -119,7 +120,8 @@ function p.convertParameters(match2)
 
 		if match.resulttype == 'default' then
 			match.resulttype = string.upper(match.walkover or '')
-			if match.resulttype == 'L' then
+			if match.resulttype == _UNKNOWNREASON_DEFAULT_LOSS then
+				--needs to be converted because in match1 storage it was marked this way
 				match.resulttype = 'unk'
 			end
 			match.walkover = match.winner


### PR DESCRIPTION
Change "L" walkovers to be "unk" resulttype in the match(1) storage.

Reason:
some "old" Modules want this value instead of the "L" one.
e.g. https://liquipedia.net/commons/Module:Player_matches_table