### PR TITLE
Fix h2h link

### DIFF
--- a/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -336,6 +336,7 @@ function StarcraftMatchSummary.Footer(props)
 			.. '&Head_to_head_query%5Bopponent%5D='
 			.. match.opponents[2].players[1].pageName
 			.. '&wpRunQuery=Run+query'
+		link = string.gsub(link, ' ', '_')
 		headToHeadNode = '[[File:Match Info Stats.png|link=' .. link .. '|16px|Head-to-head statistics]]'
 	end
 


### PR DESCRIPTION
Fix h2h link for players that have spaces in their name

__Before:__
![Screenshot 2021-07-15 14 46 34](https://user-images.githubusercontent.com/75081997/125791054-edaf31b2-392f-4c35-9865-180f7a8ed23c.png)

__After:__
![Screenshot 2021-07-15 14 52 03](https://user-images.githubusercontent.com/75081997/125791259-c49db144-c79a-4351-aee7-e8a155039962.png)

