### PR TITLE
Fix DE reset conversion (stacked)

### DIFF
--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -59,6 +59,12 @@ function Legacy.get(frame)
 	newArgs.store = storage
 	newArgs.noDuplicateCheck = _args.noDuplicateCheck
 
+	local storage = _args.store
+	if storage == '' or storage == nil then
+		storage = Variables.varDefault('disable_SMW_storage') == 'true' and 'false'
+	end
+	newArgs.store = storage
+
 	return MatchGroup.luaBracket(frame, newArgs)
 end
 

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -59,10 +59,6 @@ function Legacy.get(frame)
 	newArgs.store = storage
 	newArgs.noDuplicateCheck = _args.noDuplicateCheck
 
-	local storage = _args.store
-	if storage == '' or storage == nil then
-		storage = Variables.varDefault('disable_SMW_storage') == 'true' and 'false'
-	end
 	newArgs.store = storage
 
 	return MatchGroup.luaBracket(frame, newArgs)

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -132,7 +132,16 @@ function Legacy._convert(mapping)
 			end
 
 			if not Logic.isEmpty(nested) then
-				newArgs[source] = nested
+				if source == 'RxMBR' then
+					--for 3rd place match only add the data if the according scores are set
+					local score1 = json.parseIfString(nested.opponent1 or {}).score or ''
+					local score2 = json.parseIfString(nested.opponent1 or {}).score or ''
+					if score1 ~= '' or score2 ~= '' then
+						newArgs[source] = nested
+					end
+				else
+					newArgs[source] = nested
+				end
 			end
 		-- regular args
 		else

--- a/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/match2/wikis/starcraft2/match_group_legacy.lua
@@ -60,6 +60,7 @@ function Legacy.get(frame)
 	newArgs.noDuplicateCheck = _args.noDuplicateCheck
 
 	newArgs.store = storage
+	newArgs.noDuplicateCheck = _args.noDuplicateCheck
 
 	return MatchGroup.luaBracket(frame, newArgs)
 end


### PR DESCRIPTION
Fix DE reset conversion
this enforces that the Finals macth only displays score2 if there actually is a score set for one of the opponents

__Before:__
![Screenshot 2021-07-15 17 20 21](https://user-images.githubusercontent.com/75081997/125813986-2cea2f98-591e-40fa-9e64-b556629557d3.png)

__After:__
![Screenshot 2021-07-15 17 20 37](https://user-images.githubusercontent.com/75081997/125814009-1d4c0fbe-bff1-4e7c-a45f-791bea5ddaf1.png)
