### PR TITLE
Customize third place header

### DIFF
--- a/match2/commons/match_group_display_bracket.lua
+++ b/match2/commons/match_group_display_bracket.lua
@@ -439,7 +439,7 @@ function BracketDisplay.NodeBody(props)
 	local thirdPlaceMatchNode
 	if thirdPlaceMatch then
 		thirdPlaceHeaderNode = BracketDisplay.MatchHeader({
-			header = '!tp',
+			header = thirdPlaceMatch.bracketData.header or '!tp',
 			height = config.headerHeight,
 		})
 			:css('margin-top', 20 + config.headerMargin .. 'px')


### PR DESCRIPTION
Uses the third place header specified via `RxMTPheader=` if it's set