### PR TITLE
Add functions `matchMappingFromCustom` and `matchResetMappingFromCustom`

### DIFF
--- a/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -197,7 +197,7 @@ end
 --this is for custom mappings for 3rd place matches
 --it switches score2 into the place of score
 --and sets flatten to nil
-function p.match3rdMappingFromCustom(mapping)
+function p.matchResetMappingFromCustom(mapping)
 	local mapping3rd = mw.clone(mapping)
 	mapping3rd.opponent1.score = mapping.opponent1.score .. '2'
 	mapping3rd.opponent2.score = mapping.opponent2.score .. '2'

--- a/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -142,6 +142,12 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 	return bracketData, round.R, LowerHeader
 end
 
+--[[
+custom mappings are used to overwrite the default mappings
+in the cases where the default mappings do not fit the
+parameter format of the old bracket
+]]--
+
 --this can be used for custom mappings too
 function p.addMaps(match)
 	for mapIndex = 1, MAX_NUM_MAPS do

--- a/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -194,7 +194,7 @@ function p.matchMappingFromCustom(data)
 	return mapping
 end
 
---this is for custom mappings for 3rd place matches
+--this is for custom mappings for Reset finals matches
 --it switches score2 into the place of score
 --and sets flatten to nil
 function p.matchResetMappingFromCustom(mapping)

--- a/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -194,4 +194,15 @@ function p.matchMappingFromCustom(data)
 	return mapping
 end
 
+--this is for custom mappings for 3rd place matches
+--it switches score2 into the place of score
+--and sets flatten to nil
+function p.match3rdMappingFromCustom(mapping)
+	local mapping3rd = mw.clone(mapping)
+	mapping3rd.opponent1.score = mapping.opponent1.score .. '2'
+	mapping3rd.opponent2.score = mapping.opponent2.score .. '2'
+	mapping3rd['$flatten$'] = nil
+	return mapping3rd
+end
+
 return p

--- a/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -153,5 +153,45 @@ function p.addMaps(match)
 	return match
 end
 
-return p
+--this is for custom mappings
+function p.matchMappingFromCustom(data)
+	--[[
+	data has the form {
+		opp1,
+		opp2,
+		details,
+		match,
+		header
+	}
+	]]--
+	local mapping = {
+		['$flatten$'] = { data.details },
+		['finished'] = data.opp1 .. 'win|' .. data.opp2 .. 'win',
+		['opponent1'] = {
+			['$notEmpty$'] = data.opp1,
+			['1'] = data.opp1,
+			['flag'] = data.opp1 .. 'flag',
+			['race'] = data.opp1 .. 'race',
+			['score'] = data.opp1 .. 'score',
+			['type'] = 'type',
+			['win'] = data.opp1 .. 'win',
+			},
+		['opponent2'] = {
+			['$notEmpty$'] = data.opp2,
+			['1'] = data.opp2,
+			['flag'] = data.opp2 .. 'flag',
+			['race'] = data.opp2 .. 'race',
+			['score'] = data.opp2 .. 'score',
+			['type'] = 'type',
+			['win'] = data.opp2 .. 'win',
+			},
+	}
+	if match and header then
+		mapping[match .. 'header'] = header
+	end
+	mapping = p.addMaps(mapping)
 
+	return mapping
+end
+
+return p

--- a/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -186,8 +186,8 @@ function p.matchMappingFromCustom(data)
 			['win'] = data.opp2 .. 'win',
 			},
 	}
-	if match and header then
-		mapping[match .. 'header'] = header
+	if data.match and data.header then
+		mapping[data.match .. 'header'] = data.header
 	end
 	mapping = p.addMaps(mapping)
 


### PR DESCRIPTION
### __Function `matchMappingFromCustom` is used to create custom mappings the easier way.__

With this change for a match that has to be set in a custom way we only need to call
```
	customMapping.R3M1 = DefaultMapping.matchMappingFromCustom({
			opp1 = 'R3W9',
			opp2 = 'R3W10',
			details = 'R3G5details',
			match = 'R3M1',
			header = 'L3',
		})
```

instead of setting

```
	customMapping.R3M1 = {
		['$flatten$'] = { 'R3G5details' },
		['finished'] = 'R3W9win|R3W10win',
		['opponent1'] = {
			['$notEmpty$'] = 'R3W9',
			['1'] = 'R3W9',
			['flag'] = 'R3W9flag',
			['race'] = 'R3W9race',
			['score'] = 'R3W9score',
			['type'] = 'type',
			['win'] = 'R3W9win',
			},
		['opponent2'] = {
			['$notEmpty$'] = 'R3W10',
			['1'] = 'R3W10',
			['flag'] = 'R3W10flag',
			['race'] = 'R3W10race',
			['score'] = 'R3W10score',
			['type'] = 'type',
			['win'] = 'R3W10win',
			},
		['R3M1header'] = 'L3'
	}
	customMapping.R3M1= DefaultMapping.addMaps(customMapping.R3M1)
```

If no header is needed `match` and `header` can be set as nil (or omitted).

### __Function `matchResetMappingFromCustom` is used to create custom mappings for Bracket Reset the easier way.__

This function is used to copy the mapping from a match into a new mapping, switch score to score2 and nil flatten.



Example use case: https://liquipedia.net/starcraft2/Module:MatchGroup/Legacy/Bracket/32U16L8DSL4DSL2DSL1D

