### PR TITLE
Adjust processing to allow score2 & score3

### DIFF
--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -72,6 +72,20 @@ function p.processOpponent(frame, opponent)
 		opponent = opponentFunctions.getSoloFromLegacy(opponent)
 	end
 
+	--score2 & score3 support for every match
+	local score2 = tonumber(opponent.score2 or '')
+	local score3 = tonumber(opponent.score3 or '')
+	if score2 then
+		opponent.extradata = json.stringify({
+			score2 = score2,
+			score3 = score3,
+			set1win = Logic.readBool(opponent.set1win),
+			set2win = Logic.readBool(opponent.set2win),
+			set3win = Logic.readBool(opponent.set3win),
+			additionalScores = true
+		})
+	end
+
 	return opponent
 end
 
@@ -94,7 +108,13 @@ function p._placementSortFunction(table, key1, key2)
 	local op2norm = op2.status == "S"
 	if op1norm then
 		if op2norm then
-			return tonumber(op1.score) > tonumber(op2.score)
+			local op1setwins = p._getSetWins(op1)
+			local op2setwins = p._getSetWins(op2)
+			if op1setwins + op2setwins > 0 then
+				return op1setwins > op2setwins
+			else
+				return tonumber(op1.score) > tonumber(op2.score)
+			end
 		else return true end
 	else
 		if op2norm then return false
@@ -104,6 +124,15 @@ function p._placementSortFunction(table, key1, key2)
 		elseif op2.status == "DQ" then return true
 		else return true end
 	end
+end
+
+function p._getSetWins(opp)
+	local extradata = json.parseIfString(opp.extradata or '{}')
+	local set1win = extradata.set1win and 1 or 0
+	local set2win = extradata.set2win and 1 or 0
+	local set3win = extradata.set3win and 1 or 0
+	local sum = set1win + set2win + set3win
+	return sum
 end
 
 --
@@ -276,7 +305,8 @@ function matchFunctions.getVodStuff(match)
 	map.extradata = json.stringify({
 		ot = map.ot,
 		otlength = map.otlength,
-		comment = map.comment
+		comment = map.comment,
+		header = map.header,
 	})
 	return map
 	end

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -203,9 +203,9 @@ function matchFunctions.getVodStuff(match)
 		end
 	end
 	return match
-	end
+end
 
-	function matchFunctions.getExtraData(match)
+function matchFunctions.getExtraData(match)
 	local opponent1 = match.opponent1 or {}
 	local opponent2 = match.opponent2 or {}
 	match.extradata = json.stringify({
@@ -219,9 +219,9 @@ function matchFunctions.getVodStuff(match)
 		isconverted = 0
 	})
 	return match
-	end
+end
 
-	function matchFunctions.getOpponents(args)
+function matchFunctions.getOpponents(args)
 	-- read opponents and ignore empty ones
 	local opponents = {}
 	local isScoreSet = false
@@ -280,9 +280,9 @@ function matchFunctions.getVodStuff(match)
 		end
 	end
 	return args
-	end
+end
 
-	function matchFunctions.getPlayers(match, opponentIndex, teamName)
+function matchFunctions.getPlayers(match, opponentIndex, teamName)
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = match["opponent" .. opponentIndex .. "_p" .. playerIndex] or {}
@@ -296,12 +296,12 @@ function matchFunctions.getVodStuff(match)
 		end
 	end
 	return match
-	end
+end
 
-	--
-	-- map related functions
-	--
-	function mapFunctions.getExtraData(map)
+--
+-- map related functions
+--
+function mapFunctions.getExtraData(map)
 	map.extradata = json.stringify({
 		ot = map.ot,
 		otlength = map.otlength,
@@ -309,9 +309,9 @@ function matchFunctions.getVodStuff(match)
 		header = map.header,
 	})
 	return map
-	end
+end
 
-	function mapFunctions.getScoresAndWinner(map)
+function mapFunctions.getScoresAndWinner(map)
 	map.scores = {}
 	local indexedScores = {}
 	for scoreIndex = 1, MAX_NUM_OPPONENTS do
@@ -395,12 +395,12 @@ function matchFunctions.getVodStuff(match)
 
 	map.participants = participants
 	return map
-	end
+end
 
-	--
-	-- opponent related functions
-	--
-	function opponentFunctions.getTeamName(template)
+--
+-- opponent related functions
+--
+function opponentFunctions.getTeamName(template)
 	if template ~= nil then
 		local team = Template.expandTemplate(_frame, "Team", { template })
 		team = team:gsub("%&", "")


### PR DESCRIPTION
* Adjust RL Input processing (via `Module:Brkts/WikiSpecific`) to allow score2 & score3
* Allow Headers for maps (also needed for the 3set match stuff)

Display adjustments will follow in later PRs

Example where it will be used: https://liquipedia.net/rocketleague/Rocket_League_Championship_Series/Season_X/Championships/Europe#Results

functionality in combination with #106 