### PR TITLE
Allow manual overwrite for mobile match width

### DIFF
--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -263,6 +263,7 @@ function p.luaBracket(frame, args, matchBuilder)
 			hideRoundTitles = args.hideRoundTitles,
 			matchHeight = args.matchHeight,
 			matchWidth = args.matchWidth,
+			matchWidthMobile = args.matchWidthMobile,
 			opponentHeight = args.opponentHeight,
 			qualifiedHeader = args.qualifiedHeader,
 		}))


### PR DESCRIPTION
Allow manual overwrite for mobile match width in brackets.
The Display Modules already have the functionality, the param just needs to be passed to them.