### PR TITLE
Change TBD from template to hardcoded stuff

### DIFF
--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -7,6 +7,8 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
+local TBD_DISPLAY = '<abbr title="To Be Decided">TBD</abbr>'
+
 local nilIfEmpty = String.nilIfEmpty
 
 --[[
@@ -323,6 +325,14 @@ end
 Fetches information about a team via mw.ext.TeamTemplate.
 ]]
 function MatchGroupUtil.fetchTeam(template)
+	if string.lower(template) == 'tbd' then
+		return {
+			bracketName = TBD_DISPLAY,
+			displayName = TBD_DISPLAY,
+			pageName = 'TBD',
+			shortName = TBD_DISPLAY,
+		}
+	end
 	local rawTeam = mw.ext.TeamTemplate.raw(template)
 	if not rawTeam then
 		return nil

--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -325,6 +325,7 @@ end
 Fetches information about a team via mw.ext.TeamTemplate.
 ]]
 function MatchGroupUtil.fetchTeam(template)
+	--exception for TBD opponents
 	if string.lower(template) == 'tbd' then
 		return {
 			bracketName = TBD_DISPLAY,


### PR DESCRIPTION
Reason: when retrieving stuff from the TBD team template it returns `{{Abbr|TBD|To Be Decided}}` which will just be displayed like that.
Changing the team template would cause other issues (like the the displays linking to the `TBD` page everywhere it is used).
This change solves the bad display without creating the (red) links everywhere else.

__Before:__
![Screenshot 2021-07-21 17 49 33](https://user-images.githubusercontent.com/75081997/126519862-f9e46b10-5b2b-4649-af66-4cfb511c8d18.png)

__After:__
![Screenshot 2021-07-21 17 51 42](https://user-images.githubusercontent.com/75081997/126519853-c697f0ab-9eef-497b-a6e6-78aba39138db.png)

