### PR TITLE
Add BracketTemplateDisplay

### DIFF
--- a/components/match2/commons/match_group_display_bracket_template.lua
+++ b/components/match2/commons/match_group_display_bracket_template.lua
@@ -1,0 +1,46 @@
+local Arguments = require('Module:Arguments')
+local BracketDisplay = require('Module:MatchGroup/Display/Bracket')
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local MatchGroupUtil = require('Module:MatchGroup/Util')
+local Table = require('Module:Table')
+
+local BracketTemplateDisplay = {propTypes = {}}
+
+--[[
+Display component showing an empty tournament bracket with no opponents. Used
+by Template:BracketDocumentation.
+]]
+
+--Entry point called from Template:BracketDocumentation
+function BracketTemplateDisplay.TemplateBracketTemplate(frame)
+	local args = Arguments.getArgs(frame)
+	return BracketTemplateDisplay.BracketContainer({
+		bracketId = args.bracketId,
+	})
+end
+
+function BracketTemplateDisplay.BracketContainer(props)
+	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.BracketContainer)
+	return BracketTemplateDisplay.Bracket({
+		config = props.config,
+		bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId),
+	})
+end
+
+function BracketTemplateDisplay.Bracket(props)
+	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.Bracket)
+	return BracketDisplay.Bracket({
+		bracket = props.bracket,
+		config = Table.merge(props.config, {
+			OpponentEntry = BracketTemplateDisplay.OpponentEntry,
+			matchHasDetails = function() return false end,
+		})
+	})
+end
+
+function BracketTemplateDisplay.OpponentEntry(props)
+	return mw.html.create('div'):addClass('brkts-opponent-entry')
+end
+
+return Class.export(BracketTemplateDisplay)

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -18,7 +18,7 @@ end
 -- Whether to allow highlighting an opponent via mouseover
 function DisplayHelper.opponentIsHighlightable(opponent)
 	if opponent.type == 'literal' then
-		return opponent.name and opponent.name ~= 'TBD' or false
+		return opponent.name and opponent.name ~= '' and opponent.name ~= 'TBD' or false
 	elseif opponent.type == 'team' then
 		return opponent.template and opponent.template ~= 'tbd' or false
 	else


### PR DESCRIPTION
Used by bracket template pages on commons to show a blank bracket. This was previously rendered in php. 

Example https://liquipedia.net/commons/Template:Bracket/8-1Q-2L1D-1Q