### PR TITLE
change icon and name retrieval

### DIFF
--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -58,8 +58,8 @@ function p.processOpponent(frame, opponent)
 	-- process opponent
 	if not Logic.isEmpty(opponent.template) then
 		local name, icon = opponentFunctions.getTeamNameAndIcon(opponent.template)
-		opponent.name = opponent.name or name
-		opponent.icon = opponent.icon or icon
+		opponent.name = opponent.name or name or opponentFunctions.getTeamName(opponent.template)
+		opponent.icon = opponent.icon or icon or opponentFunctions.getIconName(opponent.template)
 	end
 
 	--fix for legacy conversion
@@ -419,6 +419,33 @@ function opponentFunctions.getTeamNameAndIcon(template)
 	end
 
 	return team, icon
+end
+
+--the following 2 functions are a fallback
+--they are only useful if the team template doesn't exist
+--in the teram template extension
+function opponentFunctions.getTeamName(template)
+	if template ~= nil then
+		local team = Template.expandTemplate(_frame, "Team", { template })
+		team = team:gsub("%&", "")
+		team = String.split(team, "link=")[2]
+		team = String.split(team, "]]")[1]
+		return team
+	else
+		return nil
+	end
+end
+
+function opponentFunctions.getIconName(template)
+	if template ~= nil then
+		local icon = Template.expandTemplate(_frame, "Team", { template })
+		icon = icon:gsub("%&", "")
+		icon = String.split(icon, "File:")[2]
+		icon = String.split(icon, "|")[1]
+		return icon
+	else
+		return nil
+	end
 end
 
 --needed for legacy conversion to work for solo brackets

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -7,7 +7,6 @@ local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local json = require("Module:Json")
 local getIconName = require("Module:IconName").luaGet
-local _frame
 
 local ALLOWED_STATUSES = { "W", "FF", "DQ", "L" }
 local MAX_NUM_OPPONENTS = 2
@@ -21,7 +20,6 @@ local opponentFunctions = {}
 
 -- called from Module:MatchGroup
 function p.processMatch(frame, match)
-	_frame = frame
 	if type(match) == "string" then
 		match = json.parse(match)
 	end
@@ -38,7 +36,6 @@ end
 
 -- called from Module:Match/Subobjects
 function p.processMap(frame, map)
-	_frame = frame
 	if type(map) == "string" then
 		map = json.parse(map)
 	end
@@ -54,7 +51,6 @@ end
 
 -- called from Module:Match/Subobjects
 function p.processOpponent(frame, opponent)
-	_frame = frame
 	if type(opponent) == "string" then
 		opponent = json.parse(opponent)
 	end
@@ -91,7 +87,6 @@ end
 
 -- called from Module:Match/Subobjects
 function p.processPlayer(frame, player)
-	_frame = frame
 	if type(player) == "string" then
 		player = json.parse(player)
 	end

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -5,7 +5,6 @@ local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
-local Template = require('Module:Template')
 local json = require("Module:Json")
 local getIconName = require("Module:IconName").luaGet
 local _frame
@@ -62,7 +61,7 @@ function p.processOpponent(frame, opponent)
 
 	-- process opponent
 	if not Logic.isEmpty(opponent.template) then
-		local name, icon = opponentFunctions.getTeamNameAndIcon(template)
+		local name, icon = opponentFunctions.getTeamNameAndIcon(opponent.template)
 		opponent.name = opponent.name or name
 		opponent.icon = opponent.icon or icon
 	end

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -62,8 +62,9 @@ function p.processOpponent(frame, opponent)
 
 	-- process opponent
 	if not Logic.isEmpty(opponent.template) then
-		opponent.name = opponent.name or opponentFunctions.getTeamName(opponent.template)
-		opponent.icon = opponent.icon or opponentFunctions.getIconName(opponent.template)
+		local name, icon = opponentFunctions.getTeamNameAndIcon(template)
+		opponent.name = opponent.name or name
+		opponent.icon = opponent.icon or icon
 	end
 
 	--fix for legacy conversion
@@ -408,28 +409,22 @@ end
 --
 -- opponent related functions
 --
-function opponentFunctions.getTeamName(template)
-	if template ~= nil then
-		local team = Template.expandTemplate(_frame, "Team", { template })
-		team = team:gsub("%&", "")
-		team = String.split(team, "link=")[2]
-		team = String.split(team, "]]")[1]
-		return team
-	else
-		return nil
-	end
-end
+function opponentFunctions.getTeamNameAndIcon(template)
+	local team
+	local icon
+	template = (template or ''):lower():gsub('_', ' ')
+	if template ~= '' and template ~= 'noteam' and
+		mw.ext.TeamTemplate.teamexists(template) then
 
-function opponentFunctions.getIconName(template)
-	if template ~= nil then
-		local icon = Template.expandTemplate(_frame, "Team", { template })
-		icon = icon:gsub("%&", "")
-		icon = String.split(icon, "File:")[2]
-		icon = String.split(icon, "|")[1]
-		return icon
-	else
-		return nil
+		team = mw.ext.TeamTemplate.raw(template)
+		icon = team.image
+		if icon == '' then
+			icon = team.legacyimage
+		end
+		team = team.page
 	end
+
+	return team, icon
 end
 
 --needed for legacy conversion to work for solo brackets

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -5,8 +5,10 @@ local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
+local Template = require('Module:Template')
 local json = require("Module:Json")
 local getIconName = require("Module:IconName").luaGet
+local _frame
 
 local ALLOWED_STATUSES = { "W", "FF", "DQ", "L" }
 local MAX_NUM_OPPONENTS = 2
@@ -20,6 +22,7 @@ local opponentFunctions = {}
 
 -- called from Module:MatchGroup
 function p.processMatch(frame, match)
+	_frame = frame
 	if type(match) == "string" then
 		match = json.parse(match)
 	end
@@ -36,6 +39,7 @@ end
 
 -- called from Module:Match/Subobjects
 function p.processMap(frame, map)
+	_frame = frame
 	if type(map) == "string" then
 		map = json.parse(map)
 	end
@@ -51,6 +55,7 @@ end
 
 -- called from Module:Match/Subobjects
 function p.processOpponent(frame, opponent)
+	_frame = frame
 	if type(opponent) == "string" then
 		opponent = json.parse(opponent)
 	end
@@ -87,6 +92,7 @@ end
 
 -- called from Module:Match/Subobjects
 function p.processPlayer(frame, player)
+	_frame = frame
 	if type(player) == "string" then
 		player = json.parse(player)
 	end


### PR DESCRIPTION
change icon and name retrieval to use `mw.ext.TeamTemplate.raw`

but keep the old functions, so that in case the team template exists the old way, but not in the extension it will still be recognized