### PR TITLE
Add Catch for "bye"

### DIFF
--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -62,9 +62,14 @@ function p.processOpponent(frame, opponent)
 
 	-- process opponent
 	if not Logic.isEmpty(opponent.template) then
-		local name, icon = opponentFunctions.getTeamNameAndIcon(opponent.template)
-		opponent.name = opponent.name or name or opponentFunctions.getTeamName(opponent.template)
-		opponent.icon = opponent.icon or icon or opponentFunctions.getIconName(opponent.template)
+		if string.lower(opponent.template) == 'bye' then
+			opponent.name = 'BYE'
+			opponent.type = 'literal'
+		else
+			local name, icon = opponentFunctions.getTeamNameAndIcon(opponent.template)
+			opponent.name = opponent.name or name or opponentFunctions.getTeamName(opponent.template)
+			opponent.icon = opponent.icon or icon or opponentFunctions.getIconName(opponent.template)
+		end
 	end
 
 	--fix for legacy conversion


### PR DESCRIPTION
Convert Team Opponents with Template "bye" to Literal Opponents
Avoids the "No team template exists for name bye" stuff

__Before__
![Screenshot 2021-07-23 11 45 41](https://user-images.githubusercontent.com/75081997/126765219-26ab614f-fc53-48d0-b274-60c6a68fa66f.png)

__After__
![Screenshot 2021-07-23 11 46 06](https://user-images.githubusercontent.com/75081997/126765243-4d8bda48-d34d-458f-a0b3-55a991fd54fc.png)
