### PR TITLE
Disable storage in user space as default for Legacy (stacked)

### DIFF
--- a/match2/commons/match_group_legacy.lua
+++ b/match2/commons/match_group_legacy.lua
@@ -31,7 +31,8 @@ function p.get(frame)
 			and 'false' or nil
 	end
 
-	if nameSpaceNumber == _NAMESPACE_USER then
+	if (storage or '') ~= 'true' and nameSpaceNumber == _NAMESPACE_USER then
+		storage = 'false'
 		_IS_USERSPACE = true
 	end
 


### PR DESCRIPTION
Disable storage in user space as default for Legacy
Overwrite via `|store=true` would still be possible.