### PR TITLE
Add option to not display a default header

### DIFF
--- a/match2/commons/match_group_display_bracket.lua
+++ b/match2/commons/match_group_display_bracket.lua
@@ -11,6 +11,7 @@ local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
 local html = mw.html
+local _NON_BREAKING_SPACE = '&nbsp;'
 
 local BracketDisplay = {propTypes = {}, types = {}}
 
@@ -332,6 +333,10 @@ function BracketDisplay.MatchHeader(props)
 	local options = DisplayHelper.expandHeader(props.header)
 
 	local headerNode = html.create('div'):addClass('brkts-header brkts-header-div')
+		:addClass(--do not display the header if it is "&nbsp;"
+			options[1] == _NON_BREAKING_SPACE
+			and 'brkts-header-nodisplay' or ''
+		)
 		:css('height', props.height .. 'px')
 		:css('line-height', props.height - 11 .. 'px')
 		:wikitext(options[1])


### PR DESCRIPTION
Add Option to "not" display a header that by default is set via entering `&nbsp;` manually into it.
The header is still there but the background color is inherited and it has no border.

new css class for this:

```
.brkts-header-nodisplay {
	border: none;
	background-color: inherit;
}
```

Result:
![Screenshot 2021-07-26 14 41 51](https://user-images.githubusercontent.com/75081997/126990498-cead44a1-e39f-45d9-9dd1-f15e5620c5cb.png)
