### PR TITLE
Add option for unfinished maps (OPTION 2)

### DIFF
--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -352,7 +352,7 @@ function mapFunctions.getScoresAndWinner(map)
 		end
 	end
 	local finished = Logic.readBool(map.finished or true) or
-		not Logic.readBool(unfinished)
+		not Logic.readBool(map.unfinished)
 	if not finished then
 		-- luacheck: push ignore
 		for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -365,9 +365,11 @@ function mapFunctions.getScoresAndWinner(map)
 end
 
 function mapFunctions.getWinner(indexedScores)
+	-- luacheck: push ignore
 	for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do
 		return scoreIndex
 	end
+	-- luacheck: pop
 end
 
 function mapFunctions.getTournamentVars(map)

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -351,8 +351,12 @@ function mapFunctions.getScoresAndWinner(map)
 			break
 		end
 	end
-	local finished = Logic.readBool(map.finished or true) or
-		not Logic.readBool(map.unfinished)
+	local finished = map.finished
+	if not Logic.isEmpty(finished) then
+		finished = Logic.readBool(map.finished)
+	else
+		finished = not Logic.readBool(map.unfinished)
+	end
 	if not finished then
 		-- luacheck: push ignore
 		for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -351,22 +351,23 @@ function mapFunctions.getScoresAndWinner(map)
 			break
 		end
 	end
-	local finished = map.finished
-	if not Logic.isEmpty(finished) then
-		finished = Logic.readBool(map.finished)
+	local isFinished = map.finished
+	if not Logic.isEmpty(isFinished) then
+		isFinished = Logic.readBool(isFinished)
 	else
-		finished = not Logic.readBool(map.unfinished)
+		isFinished = not Logic.readBool(map.unfinished)
 	end
-	if finished then
-		-- luacheck: push ignore
-		for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do
-			map.winner = scoreIndex
-			break
-		end
-		-- luacheck: pop
+	if isFinished then
+		map.winner = mapFunctions.getWinner(indexedScores)
 	end
 
 	return map
+end
+
+function mapFunctions.getWinner(indexedScores)
+	for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do
+		return scoreIndex
+	end
 end
 
 function mapFunctions.getTournamentVars(map)

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -376,13 +376,7 @@ function mapFunctions.mapWinnerSortFunction(op1, op2)
 	local op2norm = op2.status == "S"
 	if op1norm then
 		if op2norm then
-			local op1setwins = p._getSetWins(op1)
-			local op2setwins = p._getSetWins(op2)
-			if op1setwins + op2setwins > 0 then
-				return op1setwins > op2setwins
-			else
-				return tonumber(op1.score) > tonumber(op2.score)
-			end
+			return tonumber(op1.score) > tonumber(op2.score)
 		else return true end
 	else
 		if op2norm then return false

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -357,7 +357,7 @@ function mapFunctions.getScoresAndWinner(map)
 	else
 		finished = not Logic.readBool(map.unfinished)
 	end
-	if not finished then
+	if finished then
 		-- luacheck: push ignore
 		for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do
 			map.winner = scoreIndex

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -351,17 +351,21 @@ function mapFunctions.getScoresAndWinner(map)
 			break
 		end
 	end
-	-- luacheck: push ignore
-	for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do
-		map.winner = scoreIndex
-		break
+	local finished = Logic.readBool(map.finished or true) or
+		not Logic.readBool(unfinished)
+	if not finished then
+		-- luacheck: push ignore
+		for scoreIndex, _ in Table.iter.spairs(indexedScores, p._placementSortFunction) do
+			map.winner = scoreIndex
+			break
+		end
+		-- luacheck: pop
 	end
-	-- luacheck: pop
 
 	return map
-	end
+end
 
-	function mapFunctions.getTournamentVars(map)
+function mapFunctions.getTournamentVars(map)
 	map.mode = Logic.emptyOr(map.mode, Variables.varDefault("tournament_mode", "3v3"))
 	map.type = Logic.emptyOr(map.type, Variables.varDefault("tournament_type"))
 	map.tournament = Logic.emptyOr(map.tournament, Variables.varDefault("tournament_name"))
@@ -371,9 +375,9 @@ function mapFunctions.getScoresAndWinner(map)
 	map.icon = Logic.emptyOr(map.icon, Variables.varDefault("tournament_icon"))
 	map.liquipediatier = Logic.emptyOr(map.liquipediatier, Variables.varDefault("tournament_tier"))
 	return map
-	end
+end
 
-	function mapFunctions.getParticipantsData(map)
+function mapFunctions.getParticipantsData(map)
 	local participants = map.participants or {}
 	if type(participants) == "string" then
 		participants = json.parse(participants)


### PR DESCRIPTION
Add option for unfinished maps (OPTION 2)

* Maps can be set as not yet finished via `|finished=false` or `|unfinished=true` in the map template call

PR #131 has an alternative way how we can achieve it

__Advantages to #131 __
* Better performance
* all map functions directly used in map processing and not having to move some to match processing