### PR TITLE
Create legacy_match_list.lua

### DIFF
--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -98,7 +98,7 @@ function LegacyMatchList.convertMatchMaps(frame)
 	return LegacyMatchList.toEncodedJson(args)
 end
 
---THIS FUNCTION IS STILL NOT PROPERLY TESTED
+--THIS FUNCTION IS NOT READY FOR USAGE
 function LegacyMatchList.convertSwissMatchMaps(frame)
 	local args = getArgs(frame)
 	local details = json.parseIfString(args.details or '{}')

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -3,7 +3,6 @@ local LegacyMatchList = {}
 local getArgs = require('Module:Arguments').getArgs
 local json = require('Module:Json')
 local Logic = require('Module:Logic')
-local Variables = require('Module:Variables')
 local Table = require('Module:Table')
 local MatchSubobjects = require('Module:Match/Subobjects')
 local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -136,6 +136,8 @@ end
 function LegacyMatchList.convertSwissMatchMaps(frame)
 	local args = getArgs(frame)
 
+error('SwissMatchMaps conversion is not yet supported')
+
 	return LegacyMatchList.toEncodedJson(args)
 end
 

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -226,6 +226,13 @@ function LegacyMatchList.processMaps(args, details)
 	return args, details
 end
 
+function LegacyMatchList.getMapScoreFromGoals(goals)
+	if Logic.isEmpty(goals) then return nil end
+
+	local indexedGoals = mw.text.split(goals, ',')
+	return #indexedGoals
+end
+
 function LegacyMatchList.handleLiteralsForOpponents(args)
 	for opponentIndex = 1, 2 do
 		local opponent = args['opponent' .. opponentIndex]

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -1,0 +1,180 @@
+local LegacyMatchList = {}
+
+local getArgs = require('Module:Arguments').getArgs
+local json = require('Module:Json')
+local processMatch = require('Module:Brkts/WikiSpecific').processMatch
+local Logic = require('Module:Logic')
+local Variables = require('Module:Variables')
+local Table = require('Module:Table')
+local String = require('Module:StringUtils')
+local MatchSubobjects = require('Module:Match/Subobjects')
+local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }
+local MatchGroup
+
+
+function LegacyMatchList.convertMatchList(frame)
+	local args = getArgs(frame)
+
+	--switch matches (and headers) to the correct parameters for the new system
+	for index = 1, 64 do
+		if not Logic.isEmpty(args['match' .. index]) then
+			args['M' .. index] = args['match' .. index]
+			args['match' .. index] = nil
+			--header adjusting
+			local header = Variables.varDefault('M' .. index .. 'header', '')
+			if header ~= '' then
+				args['M' .. index .. 'header'] = header
+				Variables.varDefine('M' .. index .. 'header', '')
+			end
+		else
+			break
+		end
+	end
+
+	--switch hide to collapsed param
+	if string.lower(args.hide or '') == 'false' then
+		args.collapsed = 'false'
+	else
+		args.collapsed = 'true'
+	end
+
+	--title adjusting
+	if (not args.title) and args[1] then
+		args.title = args[1]
+	end
+	args[1] = nil
+
+	--pass the adjusted arguments to the MatchGroup
+	return require('Module:MatchGroup').luaMatchlist(frame, args)
+end
+
+function LegacyMatchList.convertMatchMaps(frame)
+	local args = getArgs(frame)
+	local details = json.parseIfString(args.details or '{}')
+
+	--process opponents
+	for index = 1, 2 do
+		local template = args['team' .. index]
+		if (not template) or template == '&nbsp;' then
+			template = 'tbd'
+		else
+			template = string.lower(template)
+		end
+		local score
+		if args.walkover then
+			if tonumber(walkover) == index then
+				score = 'W'
+			elseif Table.includes(ALLOWED_STATUSES, args['games' .. index]) then
+				score = args['games' .. index]
+			else
+				score = 'L'
+			end
+		else
+			score = args['games' .. index] or '-1'
+			if tonumber(score) == -1 then
+				score = Variables.varDefault('team' .. index .. 'wins', '0')
+			end
+		end
+
+		if template ~= 'tbd' then
+			args['opponent' .. index] = MatchSubobjects.luaGetOpponent(frame, {
+					type = 'team',
+					template = template,
+					score = score,
+				})
+		end
+		args['opponent' .. index .. 'literal'] = args['team' .. index .. 'literal']
+
+		--empty all the stuff we set into this opponent
+		args['team' .. index .. 'literal'] = nil
+		args['games' .. index] = nil
+		args['team' .. index] = nil
+		args.walkover = nil
+	end
+
+	--process maps
+	for index = 1, 15 do
+		if details['map' .. index] then
+			args['map' .. index] = MatchSubobjects.luaGetMap(frame, {
+				map = detail['map' .. index],
+				winner = detail['map' .. index .. 'win'],
+				score1 = detail['map' .. index .. 't1score'],
+				score2 = detail['map' .. index .. 't2score'],
+				ot = detail['ot' .. index],
+				otlength = detail['otlength' .. index],
+				vod = detail['vodgame' .. index],
+				comment = detail['map' .. index .. 'comment'],
+				})
+			--atm we ignore the old mapXtYgoals parameters, because
+			--1) according to Lukasz they are not used nor disaplayed anymore anyways
+			--2) they are pretty hard to convert, due tot the new system wanting goal times
+			--tied to the participants and that info isn't available for the old stuff
+
+			--empty all the stuff we set into this map
+			detail['map' .. index] = nil
+			detail['map' .. index .. 'win'] = nil
+			detail['map' .. index .. 't1score'] = nil
+			detail['map' .. index .. 't2score'] = nil
+			detail['ot' .. index] = nil
+			detail['otlength' .. index] = nil
+			detail['vodgame' .. index] = nil
+			detail['map' .. index .. 'comment'] = nil
+		else
+			break
+		end
+	end
+
+	--process other stuff from details
+	for key, value in pairs(details) do
+		if Logic.isEmpty(args[key]) then
+			args[key] = value
+		end
+	end
+	args.details = nil
+
+	return LegacyMatchList.toEncodedJson(args)
+end
+
+--follows later, is used for solo matches
+function LegacyMatchList.convertSwissMatchMaps(frame)
+	local args = getArgs(frame)
+	
+	
+	
+	return LegacyMatchList.toEncodedJson(args)
+end
+
+--the following function is basically copied from Module:Match
+--it is adjusted a bit to fit the conversion
+function LegacyMatchList.toEncodedJson(args)
+	-- handle tbd and literals for opponents
+	for opponentIndex = 1, 2 do
+		local opponent = args['opponent' .. opponentIndex]
+		if Logic.isEmpty(opponent) then
+			args['opponent' .. opponentIndex] = {
+				['type'] = 'literal', template = 'tbd', name = args['opponent' .. opponentIndex .. 'literal']
+			}
+		end
+	end
+
+	-- handle literals for qualifiers
+	local bracketdata = json.parse(args.bracketdata or '{}')
+	bracketdata.qualwinLiteral = args.qualwinliteral
+	bracketdata.qualloseLiteral = args.qualloseliteral
+	args.bracketdata = json.stringify(bracketdata)
+
+	-- parse maps
+	for mapIndex = 1, 15 do
+		local map = args['map' .. mapIndex]
+		if type(map) == 'string' then
+			map = json.parse(map)
+			args['map' .. mapIndex] = map
+		else
+			break
+		end
+	end
+
+	return json.stringify(args)
+end
+
+return LegacyMatchList

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -8,13 +8,15 @@ local Table = require('Module:Table')
 local MatchSubobjects = require('Module:Match/Subobjects')
 local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }
 
+local _MAX_NUMBER_OF_MATCHES = 64
+local _MAX_NUMBER_OF_MAPS = 15
+
 function LegacyMatchList.convertMatchList(frame)
 	local args = getArgs(frame)
 
 	--switch matches (and headers) to the correct parameters for the new system
-	for index = 1, 64 do
+	for index = 1, _MAX_NUMBER_OF_MATCHES do
 		if not Logic.isEmpty(args['match' .. index]) then
-			--parse match
 			local match = json.parse(args['match' .. index])
 			--header adjusting
 			args['M' .. index .. 'header'] = match.header
@@ -169,7 +171,7 @@ function LegacyMatchList.copyDetailsToArgs(args, details)
 end
 
 function LegacyMatchList.processMaps(args, details)
-	for index = 1, 15 do
+	for index = 1, _MAX_NUMBER_OF_MAPS do
 		if details['map' .. index] then
 			args['map' .. index] = MatchSubobjects.luaGetMap(nil, {
 				map = details['map' .. index],
@@ -182,7 +184,7 @@ function LegacyMatchList.processMaps(args, details)
 				comment = details['map' .. index .. 'comment'],
 				})
 			--atm we ignore the old mapXtYgoals parameters, because
-			--1) according to Lukasz they are not used nor disaplayed anymore anyways
+			--1) according to Lukasz they are not used nor displayed anymore anyways
 			--2) they are pretty hard to convert, due to the new system wanting goal times
 			--tied to the participants and that info isn't available for the old stuff
 
@@ -222,7 +224,7 @@ function LegacyMatchList.toEncodedJson(args)
 	args.bracketdata = json.stringify(bracketdata)
 
 	-- parse maps
-	for mapIndex = 1, 15 do
+	for mapIndex = 1, _MAX_NUMBER_OF_MAPS do
 		local map = args['map' .. mapIndex]
 		if type(map) == 'string' then
 			map = json.parse(map)

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -14,14 +14,15 @@ function LegacyMatchList.convertMatchList(frame)
 	--switch matches (and headers) to the correct parameters for the new system
 	for index = 1, 64 do
 		if not Logic.isEmpty(args['match' .. index]) then
-			args['M' .. index] = args['match' .. index]
-			args['match' .. index] = nil
+			--parse match
+			local match = json.parse(args['match' .. index])
 			--header adjusting
-			local header = Variables.varDefault('M' .. index .. 'header', '')
-			if header ~= '' then
-				args['M' .. index .. 'header'] = header
-				Variables.varDefine('M' .. index .. 'header', '')
-			end
+			args['M' .. index .. 'header'] = match.header
+			match.header = nil
+			--stringify match again and asign new key
+			args['M' .. index] = json.stringify(match)
+			--kick old key
+			args['match' .. index] = nil
 		else
 			break
 		end
@@ -87,9 +88,6 @@ function LegacyMatchList.convertMatchMaps(frame)
 		args['team' .. index] = nil
 		args.walkover = nil
 	end
-
-	--pass header to MatchList conversion
-	Variables.varDefine('M' .. index .. 'header', args.header or '')
 
 	--process maps
 	for index = 1, 15 do

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -62,7 +62,7 @@ function LegacyMatchList.convertMatchMaps(frame)
 		end
 		local score
 		if args.walkover then
-			if tonumber(walkover) == index then
+			if tonumber(args.walkover) == index then
 				score = 'W'
 			elseif Table.includes(ALLOWED_STATUSES, args['games' .. index]) then
 				score = args['games' .. index]
@@ -96,14 +96,14 @@ function LegacyMatchList.convertMatchMaps(frame)
 	for index = 1, 15 do
 		if details['map' .. index] then
 			args['map' .. index] = MatchSubobjects.luaGetMap(frame, {
-				map = detail['map' .. index],
-				winner = detail['map' .. index .. 'win'],
-				score1 = detail['map' .. index .. 't1score'],
-				score2 = detail['map' .. index .. 't2score'],
-				ot = detail['ot' .. index],
-				otlength = detail['otlength' .. index],
-				vod = detail['vodgame' .. index],
-				comment = detail['map' .. index .. 'comment'],
+				map = details['map' .. index],
+				winner = details['map' .. index .. 'win'],
+				score1 = details['map' .. index .. 't1score'],
+				score2 = details['map' .. index .. 't2score'],
+				ot = details['ot' .. index],
+				otlength = details['otlength' .. index],
+				vod = details['vodgame' .. index],
+				comment = details['map' .. index .. 'comment'],
 				})
 			--atm we ignore the old mapXtYgoals parameters, because
 			--1) according to Lukasz they are not used nor disaplayed anymore anyways
@@ -111,14 +111,14 @@ function LegacyMatchList.convertMatchMaps(frame)
 			--tied to the participants and that info isn't available for the old stuff
 
 			--empty all the stuff we set into this map
-			detail['map' .. index] = nil
-			detail['map' .. index .. 'win'] = nil
-			detail['map' .. index .. 't1score'] = nil
-			detail['map' .. index .. 't2score'] = nil
-			detail['ot' .. index] = nil
-			detail['otlength' .. index] = nil
-			detail['vodgame' .. index] = nil
-			detail['map' .. index .. 'comment'] = nil
+			details['map' .. index] = nil
+			details['map' .. index .. 'win'] = nil
+			details['map' .. index .. 't1score'] = nil
+			details['map' .. index .. 't2score'] = nil
+			details['ot' .. index] = nil
+			details['otlength' .. index] = nil
+			details['vodgame' .. index] = nil
+			details['map' .. index .. 'comment'] = nil
 		else
 			break
 		end
@@ -138,9 +138,7 @@ end
 --follows later, is used for solo matches
 function LegacyMatchList.convertSwissMatchMaps(frame)
 	local args = getArgs(frame)
-	
-	
-	
+
 	return LegacyMatchList.toEncodedJson(args)
 end
 

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -98,7 +98,7 @@ function LegacyMatchList.convertMatchMaps(frame)
 	--process other stuff from details
 	args = LegacyMatchList.copyDetailsToArgs(args, details)
 
-	return LegacyMatchList.toEncodedJson(args)
+	return LegacyMatchList.matchToEncodedJson(args)
 end
 
 --THIS FUNCTION IS NOT READY FOR USAGE
@@ -156,7 +156,7 @@ function LegacyMatchList.convertSwissMatchMaps(frame)
 	--process other stuff from details
 	args = LegacyMatchList.copyDetailsToArgs(args, details)
 
-	return LegacyMatchList.toEncodedJson(args)
+	return LegacyMatchList.matchToEncodedJson(args)
 end
 
 --functions shared between convertMatchMaps and convertSwissMatchMaps
@@ -204,10 +204,8 @@ function LegacyMatchList.processMaps(args, details)
 	return args, details
 end
 
---the following function is basically copied from Module:Match
---it is adjusted a bit to fit the conversion
-function LegacyMatchList.toEncodedJson(args)
-	-- handle tbd and literals for opponents
+function LegacyMatchList.matchToEncodedJson(args)
+	--handle literals for opponents
 	for opponentIndex = 1, 2 do
 		local opponent = args['opponent' .. opponentIndex]
 		if Logic.isEmpty(opponent) then
@@ -217,13 +215,7 @@ function LegacyMatchList.toEncodedJson(args)
 		end
 	end
 
-	-- handle literals for qualifiers
-	local bracketdata = json.parse(args.bracketdata or '{}')
-	bracketdata.qualwinLiteral = args.qualwinliteral
-	bracketdata.qualloseLiteral = args.qualloseliteral
-	args.bracketdata = json.stringify(bracketdata)
-
-	-- parse maps
+	--parse maps
 	for mapIndex = 1, _MAX_NUMBER_OF_MAPS do
 		local map = args['map' .. mapIndex]
 		if type(map) == 'string' then

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -88,6 +88,9 @@ function LegacyMatchList.convertMatchMaps(frame)
 		args.walkover = nil
 	end
 
+	--pass header to MatchList conversion
+	Variables.varDefine('M' .. index .. 'header', args.header or '')
+
 	--process maps
 	for index = 1, 15 do
 		if details['map' .. index] then

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -34,6 +34,7 @@ function LegacyMatchList.convertMatchList(frame)
 	else
 		args.collapsed = 'true'
 	end
+	args.hide = nil
 
 	--title adjusting
 	if (not args.title) and args[1] then

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -92,42 +92,14 @@ function LegacyMatchList.convertMatchMaps(frame)
 	--process maps
 	for index = 1, 15 do
 		if details['map' .. index] then
-			args['map' .. index] = MatchSubobjects.luaGetMap(frame, {
-				map = details['map' .. index],
-				winner = details['map' .. index .. 'win'],
-				score1 = details['map' .. index .. 't1score'],
-				score2 = details['map' .. index .. 't2score'],
-				ot = details['ot' .. index],
-				otlength = details['otlength' .. index],
-				vod = details['vodgame' .. index],
-				comment = details['map' .. index .. 'comment'],
-				})
-			--atm we ignore the old mapXtYgoals parameters, because
-			--1) according to Lukasz they are not used nor disaplayed anymore anyways
-			--2) they are pretty hard to convert, due tot the new system wanting goal times
-			--tied to the participants and that info isn't available for the old stuff
-
-			--empty all the stuff we set into this map
-			details['map' .. index] = nil
-			details['map' .. index .. 'win'] = nil
-			details['map' .. index .. 't1score'] = nil
-			details['map' .. index .. 't2score'] = nil
-			details['ot' .. index] = nil
-			details['otlength' .. index] = nil
-			details['vodgame' .. index] = nil
-			details['map' .. index .. 'comment'] = nil
+			args['map' .. index], details = LegacyMatchList.processMap(details, index)
 		else
 			break
 		end
 	end
 
 	--process other stuff from details
-	for key, value in pairs(details) do
-		if Logic.isEmpty(args[key]) then
-			args[key] = value
-		end
-	end
-	args.details = nil
+	args = LegacyMatchList.copyDetailsToArgs(args, details)
 
 	return LegacyMatchList.toEncodedJson(args)
 end
@@ -139,6 +111,45 @@ function LegacyMatchList.convertSwissMatchMaps(frame)
 error('SwissMatchMaps conversion is not yet supported')
 
 	return LegacyMatchList.toEncodedJson(args)
+end
+
+--functions shared between convertMatchMaps and convertSwissMatchMaps
+function LegacyMatchList.copyDetailsToArgs(args, details)
+	for key, value in pairs(details) do
+		if Logic.isEmpty(args[key]) then
+			args[key] = value
+		end
+	end
+	args.details = nil
+	return args
+end
+
+function LegacyMatchList.processMap(details, index)
+	local map = MatchSubobjects.luaGetMap(frame, {
+		map = details['map' .. index],
+		winner = details['map' .. index .. 'win'],
+		score1 = details['map' .. index .. 't1score'],
+		score2 = details['map' .. index .. 't2score'],
+		ot = details['ot' .. index],
+		otlength = details['otlength' .. index],
+		vod = details['vodgame' .. index],
+		comment = details['map' .. index .. 'comment'],
+		})
+	--atm we ignore the old mapXtYgoals parameters, because
+	--1) according to Lukasz they are not used nor disaplayed anymore anyways
+	--2) they are pretty hard to convert, due tot the new system wanting goal times
+	--tied to the participants and that info isn't available for the old stuff
+
+	--empty all the stuff we set into this map
+	details['map' .. index] = nil
+	details['map' .. index .. 'win'] = nil
+	details['map' .. index .. 't1score'] = nil
+	details['map' .. index .. 't2score'] = nil
+	details['ot' .. index] = nil
+	details['otlength' .. index] = nil
+	details['vodgame' .. index] = nil
+	details['map' .. index .. 'comment'] = nil
+	return map, details
 end
 
 --the following function is basically copied from Module:Match

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -2,15 +2,11 @@ local LegacyMatchList = {}
 
 local getArgs = require('Module:Arguments').getArgs
 local json = require('Module:Json')
-local processMatch = require('Module:Brkts/WikiSpecific').processMatch
 local Logic = require('Module:Logic')
 local Variables = require('Module:Variables')
 local Table = require('Module:Table')
-local String = require('Module:StringUtils')
 local MatchSubobjects = require('Module:Match/Subobjects')
 local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }
-local MatchGroup
-
 
 function LegacyMatchList.convertMatchList(frame)
 	local args = getArgs(frame)

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -125,7 +125,7 @@ function LegacyMatchList.copyDetailsToArgs(args, details)
 end
 
 function LegacyMatchList.processMap(details, index)
-	local map = MatchSubobjects.luaGetMap(frame, {
+	local map = MatchSubobjects.luaGetMap(nil, {
 		map = details['map' .. index],
 		winner = details['map' .. index .. 'win'],
 		score1 = details['map' .. index .. 't1score'],

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -106,6 +106,7 @@ function LegacyMatchList.convertSwissMatchMaps(frame)
 	--process opponents
 	for index = 1, 2 do
 		local player = args['player' .. index] or args['team' .. index] or 'TBD'
+		local playerLink = args['player' .. index .. 'link'] or player
 
 		local score
 		if args.walkover then
@@ -123,7 +124,7 @@ function LegacyMatchList.convertSwissMatchMaps(frame)
 			args['opponent' .. index] = MatchSubobjects.luaGetOpponent(frame, {
 					type = 'solo',
 					match2players = '[' .. json.stringify({
-						name = player,
+						name = playerLink,
 						displayname = player,
 						flag = args['p' .. index .. 'flag'],
 					}) .. ']',

--- a/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/match2/wikis/rocketleague/legacy_match_list.lua
@@ -137,7 +137,7 @@ function LegacyMatchList.processMap(details, index)
 		})
 	--atm we ignore the old mapXtYgoals parameters, because
 	--1) according to Lukasz they are not used nor disaplayed anymore anyways
-	--2) they are pretty hard to convert, due tot the new system wanting goal times
+	--2) they are pretty hard to convert, due to the new system wanting goal times
 	--tied to the participants and that info isn't available for the old stuff
 
 	--empty all the stuff we set into this map


### PR DESCRIPTION
**__Module for Legacy Conversion of MatchLists__**

* function `convertMatchList` switches Global MatchList params so they fit the new system
* function `convertMatchMaps` switches parameters from matches so they fit the new system
** it also calls the map and opponent processing with constructed objects (from the matchMaps args and the details from BracketMatchSummary)
* function `toEncodedJson` is basically a coppy of the same function in `Module:Match`, just adjusted so it can handle the input of the converted params
* function `convertSwissMatchMaps` does the same as function `convertMatchMaps`, just for the SwissMatchMaps (aka solo matches)
** this function most likely needs further changes (after adjusting some stuff for it in `Module:Brkts/WikiSpecific` and `Module:MatchSummary` --> `pXteam` and `teamXstanding` params processing and display)

test page: https://liquipedia.net/rocketleague/User:Hjpalpha/temp