### PR TITLE
Add Support for Legacy usage of `|pXteam=`

### DIFF
--- a/match2/wikis/rocketleague/match_summary.lua
+++ b/match2/wikis/rocketleague/match_summary.lua
@@ -6,6 +6,8 @@ local Template = require('Module:Template')
 
 local htmlCreate = mw.html.create
 
+local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
+
 local p = {}
 
 function p.getByMatchId(args)
@@ -32,7 +34,7 @@ function p.getByMatchId(args)
 			local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
 			local display = teamExists
 				and mw.ext.TeamTemplate.teamicon(opponent.template, match.date)
-				or mw.ext.TeamTemplate.teamicon('tbd')
+				or _TBD_ICON
 			return mw.html.create('div'):wikitext(display)
 				:addClass('brkts-popup-header-opponent-solo-team')
 		else

--- a/match2/wikis/rocketleague/match_summary.lua
+++ b/match2/wikis/rocketleague/match_summary.lua
@@ -25,7 +25,7 @@ function p.getByMatchId(args)
 				and 'brkts-popup-header-opponent'
 				or 'brkts-popup-header-opponent-solo-with-team')
 	end
-	
+
 	local function renderSoloOpponentTeam(opponentIndex)
 		local opponent = match.opponents[opponentIndex]
 		if opponent.type == 'solo' then

--- a/match2/wikis/rocketleague/match_summary.lua
+++ b/match2/wikis/rocketleague/match_summary.lua
@@ -44,8 +44,10 @@ function p.getByMatchId(args)
 
 	-- header
 	local header = htmlCreate('div'):addClass('brkts-popup-header-dev')
-		:node(tostring(renderSoloOpponentTeam(1)) .. tostring(renderOpponent(1)))
-		:node(tostring(renderOpponent(2)) .. tostring(renderSoloOpponentTeam(2)))
+		:node(renderSoloOpponentTeam(1) or '')
+		:node(renderOpponent(1))
+		:node(renderOpponent(2))
+		:node(renderSoloOpponentTeam(2) or '')
 	wrapper:node(header):node(p._breakNode())
 
 	-- body

--- a/match2/wikis/rocketleague/match_summary.lua
+++ b/match2/wikis/rocketleague/match_summary.lua
@@ -29,16 +29,12 @@ function p.getByMatchId(args)
 	local function renderSoloOpponentTeam(opponentIndex)
 		local opponent = match.opponents[opponentIndex]
 		if opponent.type == 'solo' then
-			local hasTeam1Display = match.opponents[1].template or ''
-			local hasTeam2Display = match.opponents[2].template or ''
-			if (hasTeam1Display ~= '') or (hasTeam2Display ~= '') then
-				local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
-				local display = teamExists
-					and mw.ext.TeamTemplate.teamicon(opponent.template, match.date)
-					or mw.ext.TeamTemplate.teamicon('tbd')
-				return mw.html.create('div'):wikitext(display)
-					:addClass('brkts-popup-header-opponent-solo-team')
-			end
+			local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
+			local display = teamExists
+				and mw.ext.TeamTemplate.teamicon(opponent.template, match.date)
+				or mw.ext.TeamTemplate.teamicon('tbd')
+			return mw.html.create('div'):wikitext(display)
+				:addClass('brkts-popup-header-opponent-solo-team')
 		end
 	end
 

--- a/match2/wikis/rocketleague/match_summary.lua
+++ b/match2/wikis/rocketleague/match_summary.lua
@@ -35,15 +35,17 @@ function p.getByMatchId(args)
 				or mw.ext.TeamTemplate.teamicon('tbd')
 			return mw.html.create('div'):wikitext(display)
 				:addClass('brkts-popup-header-opponent-solo-team')
+		else
+			return ''
 		end
 	end
 
 	-- header
 	local header = htmlCreate('div'):addClass('brkts-popup-header-dev')
-		:node(renderSoloOpponentTeam(1) or '')
+		:node(renderSoloOpponentTeam(1))
 		:node(renderOpponent(1))
 		:node(renderOpponent(2))
-		:node(renderSoloOpponentTeam(2) or '')
+		:node(renderSoloOpponentTeam(2))
 	wrapper:node(header):node(p._breakNode())
 
 	-- body

--- a/match2/wikis/rocketleague/match_summary.lua
+++ b/match2/wikis/rocketleague/match_summary.lua
@@ -21,13 +21,31 @@ function p.getByMatchId(args)
 			overflow = 'wrap',
 			teamStyle = 'short',
 		})
-			:addClass('brkts-popup-header-opponent')
+			:addClass(match.opponents[opponentIndex].type ~= 'solo'
+				and 'brkts-popup-header-opponent'
+				or 'brkts-popup-header-opponent-solo-with-team')
+	end
+	
+	local function renderSoloOpponentTeam(opponentIndex)
+		local opponent = match.opponents[opponentIndex]
+		if opponent.type == 'solo' then
+			local hasTeam1Display = match.opponents[1].template or ''
+			local hasTeam2Display = match.opponents[2].template or ''
+			if (hasTeam1Display ~= '') or (hasTeam2Display ~= '') then
+				local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
+				local display = teamExists
+					and mw.ext.TeamTemplate.teamicon(opponent.template, match.date)
+					or mw.ext.TeamTemplate.teamicon('tbd')
+				return mw.html.create('div'):wikitext(display)
+					:addClass('brkts-popup-header-opponent-solo-team')
+			end
+		end
 	end
 
 	-- header
 	local header = htmlCreate('div'):addClass('brkts-popup-header-dev')
-		:node(renderOpponent(1))
-		:node(renderOpponent(2))
+		:node(tostring(renderSoloOpponentTeam(1)) .. tostring(renderOpponent(1)))
+		:node(tostring(renderOpponent(2)) .. tostring(renderSoloOpponentTeam(2)))
 	wrapper:node(header):node(p._breakNode())
 
 	-- body


### PR DESCRIPTION
Add Support for Legacy usage of `|pXteam=` in https://liquipedia.net/rocketleague/Template:SwissMatchMaps

![Screenshot 2021-08-01 19 32 23](https://user-images.githubusercontent.com/75081997/127780185-825343a6-4750-4b33-9d98-dc8645f53dbb.png)
