### PR TITLE
Support `mapXtYgoals` STORAGE for Legacy reasons

### DIFF
--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -326,6 +326,9 @@ function mapFunctions.getExtraData(map)
 		otlength = map.otlength,
 		comment = map.comment,
 		header = map.header,
+		--the following is used to store "mapXtYgoals" from LegacyMatchLists
+		t1goals = map.t1goals,
+		t2goals = map.t2goals,
 	})
 	return map
 end

--- a/match2/wikis/rocketleague/match_group_legacy_default.lua
+++ b/match2/wikis/rocketleague/match_group_legacy_default.lua
@@ -26,7 +26,9 @@ function p.get(templateid, bracketType)
 		map = "map$1$",
 		score1 = "map$1$t1score",
 		score2 = "map$1$t2score",
-		winner = "map$1$win"
+		winner = "map$1$win",
+		t1goals = "map$1$t1goals",
+		t2goals = "map$1$t2goals",
 	}
 
 	for n = 1, lastRound do


### PR DESCRIPTION
Adjust
* `Module:Brkts/WikiSpecific`
* `Module:MatchGroup/Legacy/Default`
to enable legacy STORAGE of `mapXtYgoals`

Display to be done later (if we want it)