### PR TITLE
Add Prefix text to the MVP output

### DIFF
--- a/match2/wikis/rainbow_six/match_summary.lua
+++ b/match2/wikis/rainbow_six/match_summary.lua
@@ -317,11 +317,7 @@ end
 
 function MVP:create()
 	local span = mw.html.create('span')
-	if #self.players > 1 then
-		span:wikitext('MVPs: ')
-	else
-		span:wikitext('MVP: ')
-	end
+	span:wikitext(#self.players > 1 and 'MVPs: ' or 'MVP: ')
 	for index, player in ipairs(self.players) do
 		if index > 1 then
 			span:wikitext(', ')


### PR DESCRIPTION
In match summary popup, changed MVP Display from -> to:
`Foo` -> `MVP: Foo` 
`Foo, Bar` -> `MVPs: Foo, Bar`
Changed way is the same as BracketMatchSummary displays MVPs.