### PR TITLE
Fixed the height of the teamarea in the matchsummary popup. 

### DIFF
--- a/match2/wikis/rainbow_six/match_summary.lua
+++ b/match2/wikis/rainbow_six/match_summary.lua
@@ -339,7 +339,9 @@ function CustomMatchSummary.getByMatchId(args)
 	mw.logObject(match)
 	local frame = mw.getCurrentFrame()
 
-	local matchSummary = MatchSummary():init('330px')
+	local matchSummary = MatchSummary():init()
+	matchSummary.root:css('flex-wrap', 'unset') -- temporary workaround to fix height, taken from RL
+
 	matchSummary:header(CustomMatchSummary._createHeader(match))
 				:body(CustomMatchSummary._createBody(match))
 


### PR DESCRIPTION
Fix taken from Rocket League wiki 
Also removed the width param, since 330px is default in the css