### PR TITLE
add optional function to define vars (stacked)

### DIFF
--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -132,7 +132,7 @@ function Series:addCustomCells(infobox, args)
 end
 
 --- Allows for overriding this functionality
-function Series:setTournamentVars(args)
+function Series:addCustomVariables(args)
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -57,6 +57,8 @@ function Series:createInfobox(frame)
 
     if Namespace.isMain() then
 
+        Series:setTournamentVars(args)
+
         local lpdbData = {
             name = self.name,
             image = args.image,
@@ -127,6 +129,10 @@ end
 --- Allows for overriding this functionality
 function Series:addCustomCells(infobox, args)
     return infobox
+end
+
+--- Allows for overriding this functionality
+function Series:setTournamentVars(args)
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -56,7 +56,6 @@ function Series:createInfobox(frame)
             :links(links)
 
     if Namespace.isMain() then
-
         Series:addCustomVariables(args)
 
         local lpdbData = {

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -57,7 +57,7 @@ function Series:createInfobox(frame)
 
     if Namespace.isMain() then
 
-        Series:setTournamentVars(args)
+        Series:addCustomVariables(args)
 
         local lpdbData = {
             name = self.name,


### PR DESCRIPTION
add optional function to define tournament vars for infobox series
(needed for e.g. external cup lists)

**alternate option:** call this from `addCustomCells` in the Custom module