### PR TITLE
Better customization options for matchHasDetails

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -9,6 +9,7 @@ local Math = require('Module:Math')
 local OpponentDisplay = require('Module:OpponentDisplay')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
+local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
 
 local html = mw.html
 local _NON_BREAKING_SPACE = '&nbsp;'
@@ -97,7 +98,7 @@ function BracketDisplay.Bracket(props)
 		headerMargin = propsConfig.headerMargin or defaultConfig.headerMargin,
 		hideRoundTitles = propsConfig.hideRoundTitles or false,
 		lineWidth = propsConfig.lineWidth or defaultConfig.lineWidth,
-		matchHasDetails = propsConfig.matchHasDetails or DisplayHelper.defaultMatchHasDetails,
+		matchHasDetails = propsConfig.matchHasDetails or matchHasDetailsWikiSpecific or DisplayHelper.defaultMatchHasDetails,
 		matchMargin = propsConfig.matchMargin or math.floor(defaultConfig.opponentHeight / 4),
 		matchWidth = propsConfig.matchWidth or defaultConfig.matchWidth,
 		matchWidthMobile = propsConfig.matchWidthMobile or defaultConfig.matchWidthMobile,

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -6,6 +6,7 @@ local MatchGroupUtil = require('Module:MatchGroup/Util')
 local OpponentDisplay = require('Module:OpponentDisplay')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
+local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
 
 local html = mw.html
 
@@ -84,7 +85,7 @@ function MatchlistDisplay.Matchlist(props)
 		attached = propsConfig.attached or false,
 		collapsed = propsConfig.collapsed or false,
 		collapsible = Logic.nilOr(propsConfig.collapsible, true),
-		matchHasDetails = propsConfig.matchHasDetails or DisplayHelper.defaultMatchHasDetails,
+		matchHasDetails = propsConfig.matchHasDetails or matchHasDetailsWikiSpecific or DisplayHelper.defaultMatchHasDetails,
 		width = propsConfig.width or 300,
 	}
 	local tableNode = html.create('table')

--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -15,6 +15,7 @@ local MAX_NUM_MAPS = 9
 local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
 
 local _EPOCH_TIME = '1970-01-01 00:00:00'
+local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 
 -- containers for process helper functions
 local matchFunctions = {}
@@ -582,6 +583,18 @@ function opponentFunctions.getTeamNameAndIcon(template, date)
 	end
 
 	return team, icon, template
+end
+
+--
+-- Override functons
+--
+function p.matchHasDetails(match)
+	return match.dateIsExact
+		or match.date ~= _EPOCH_TIME_EXTENDED
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.games
 end
 
 return p


### PR DESCRIPTION
Added support for a function in brkts/wikispecific to overrule the default matchHasDetails.
This is instead of requiring the overrule to be in a custom MatchGroup/Display/Bracket AND MatchGroup/Display/Matchlist which most wikis likely won't need. 

matchHasDetails determine's if the popout with match details is available or not.

Brkts/wikispecific was choosen after discussion with hjp, due to other similiar functions already exists in brkts/wikispecific, such as getMatchGroupModule
