### PR TITLE
Simplify and fix chronology code

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -92,14 +92,14 @@ function Infobox:chronology(links)
         return self
     end
 
-    local content = mw.html.create('div')
-    content:node(self:_createChronologyRow(links['previous'], links['next']))
+    self.chronologyContent = mw.html.create('div')
+    self.chronologyContent:node(self:_createChronologyRow(links['previous'], links['next']))
 
     local index = 2
     local previous = links['previous' .. index]
     local next = links['next' .. index]
     while (previous ~= nil or next ~= nil) do
-        content:node(self:_createChronologyRow(previous, next))
+        self.chronologyContent:node(self:_createChronologyRow(previous, next))
 
         previous = links['previous' .. index]
         next = links['next' .. index]
@@ -224,6 +224,10 @@ end
 --- Returns completed infobox
 function Infobox:build()
     self.root:node(self.content)
+
+    if self.chronologyContent ~= nil then
+        self.root:node(self.chronologyContent)
+    end
 
     if self.bottomContent ~= nil then
         self.root:node(self.bottomContent)

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -92,14 +92,14 @@ function Infobox:chronology(links)
         return self
     end
 
-    self.chronologyContent = mw.html.create('div')
-    self:_createChronologyRow(links['previous'], links['next'])
+    local content = mw.html.create('div')
+    content:node(self:_createChronologyRow(links['previous'], links['next']))
 
     local index = 2
     local previous = links['previous' .. index]
     local next = links['next' .. index]
     while (previous ~= nil or next ~= nil) do
-        self:_createChronologyRow(previous, next)
+        content:node(self:_createChronologyRow(previous, next))
 
         previous = links['previous' .. index]
         next = links['next' .. index]
@@ -150,8 +150,7 @@ function Infobox:_createChronologyRow(previous, next)
         node:node(nextWrapper)
     end
 
-    self.chronology:node(node)
-    return self
+    return node
 end
 
 function Infobox:_createInfoboxButtons()


### PR DESCRIPTION
Fixes a bug where we tried to add a node to `self.chronology`, as opposed to `self.chronologyContent`. We don't even need that class var set though, so simplify the code while we're at it.