### PR TITLE
3 minor bugfixes for R6

### DIFF
--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -64,10 +64,10 @@ function p.storeGames(match, match2)
 			local team2 = {}
 			if extradata.t1firstside[1] == "atk" then
 				team1 = {"atk", extradata.t1halfs.atk, extradata.t1halfs.def}
-				team2 = {"def", extradata.t2halfs.def, extradata.t2halfs.atk}
+				team2 = {"def", extradata.t2halfs.atk, extradata.t2halfs.def}
 			elseif extradata.t1firstside[1] == "def" then
 				team2 = {"atk", extradata.t2halfs.atk, extradata.t2halfs.def}
-				team1 = {"def", extradata.t1halfs.def, extradata.t1halfs.atk}
+				team1 = {"def", extradata.t1halfs.atk, extradata.t1halfs.def}
 			end
 			if extradata.t1firstside.ot == "atk" then
 				table.insert(team1, "atk")
@@ -129,7 +129,7 @@ function p.convertParameters(match2)
 		match.extradata.mvp = match.extradata.mvp .. ";" .. mvp.points
 	end
 
-	match.extradata.bestofx = match2.bestof
+	match.extradata.bestofx = tostring(match2.bestof)
 
 	local veto = json.parse(extradata.mapveto)
 	if veto then

--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -497,11 +497,11 @@ function CustomMatchSummary._createMap(game)
 		local oppositeSideOvertime = CustomMatchSummary._getOppositeSide(firstSideOvertime)
 
 		if not Logic.isEmpty(firstSideOvertime) then
-			team1Score:setFirstOvertimeRoundScore(firstSideOvertime, team1Halfs['ot'..firstSide], true)
-			team1Score:setSecondOvertimeRoundScore(oppositeSideOvertime, team1Halfs['ot'..oppositeSide], true)
+			team1Score:setFirstOvertimeRoundScore(firstSideOvertime, team1Halfs['ot'..firstSideOvertime], true)
+			team1Score:setSecondOvertimeRoundScore(oppositeSideOvertime, team1Halfs['ot'..oppositeSideOvertime], true)
 
-			team2Score:setFirstOvertimeRoundScore(oppositeSideOvertime, team2Halfs['ot'..oppositeSide], false)
-			team2Score:setSecondOvertimeRoundScore(firstSideOvertime, team2Halfs['ot'..firstSide], false)
+			team2Score:setFirstOvertimeRoundScore(oppositeSideOvertime, team2Halfs['ot'..oppositeSideOvertime], false)
+			team2Score:setSecondOvertimeRoundScore(firstSideOvertime, team2Halfs['ot'..firstSideOvertime], false)
 		else
 			team1Score:addEmptyOvertime()
 			team2Score:addEmptyOvertime()


### PR DESCRIPTION
* Match2 to Match1 -> usage of extradata.bestofx is expected a string and not a number (it's template based and not module so it matter). Convert to bestof to a string before saving
* Match2 to Match1 -> Order of map halves in Match1 is always atk,def,otatk,otdef. Fixed it
* MatchSummary could display wrong for OT, it took some of the data from RT instead of OT.