### PR TITLE
add exception for matcherino

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -198,7 +198,11 @@ end
 --remove appended numbers
 --needed because the link icons require e.g. 'esl' instead of 'esl2'
 function Infobox.getIconString(key)
-	return string.gsub(key, '%d$', '')
+    if key == 'matcherinolink' then
+        key = 'matcherino'
+    end
+
+    return string.gsub(key, '%d$', '')
 end
 
 function Infobox:centeredCell(content)

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -7,6 +7,10 @@ end
 
 local Infobox = Class.new()
 
+local _ICON_KEYS_TO_RENAME = {
+    matcherinolink = 'matcherino'
+}
+
 --- Inits the Infobox instance
 function Infobox:create(frame, gameName)
     self.frame = frame
@@ -198,9 +202,8 @@ end
 --remove appended numbers
 --needed because the link icons require e.g. 'esl' instead of 'esl2'
 function Infobox.getIconString(key)
-    if key == 'matcherinolink' then
-        key = 'matcherino'
-    end
+    key = string.gsub(key, '%d$', '')
+    key = _ICON_KEYS_TO_RENAME[key] or key
 
     return string.gsub(key, '%d$', '')
 end


### PR DESCRIPTION
Matcherino is used on tournament pages.
Sadly it has 2 different link formats, but we use the same icon for it, hence we need this exception here.