### PR TITLE
Attach chronology cell to content, not root

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -230,11 +230,11 @@ end
 
 --- Returns completed infobox
 function Infobox:build()
-    self.root:node(self.content)
-
     if self.chronologyContent ~= nil then
-        self.root:node(self.chronologyContent)
+        self.content:node(self.chronologyContent)
     end
+
+    self.root:node(self.content)
 
     if self.bottomContent ~= nil then
         self.root:node(self.bottomContent)


### PR DESCRIPTION
Fixes an issue where chronology was being set to the root HTML, as opposed to the infobox specific HTML. See the screenshot for visual example.

![image](https://user-images.githubusercontent.com/5138348/129534978-6bbb0bc6-7902-4114-b550-461549f19f8a.png)
