### PR TITLE
add alternative arg keys

### DIFF
--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -34,8 +34,8 @@ function Company:createInfobox(frame)
             :centeredCell(args.caption)
             :header('Company Information', true)
             :fcell(Cell:new('Parent company'):options({makeLink = true}):content(args.parent, args.parent2):make())
-            :cell('Founded', args.foundeddate)
-            :cell('Defunct', args.defunctdate)
+            :cell('Founded', args.foundeddate or agrs.founded)
+            :cell('Defunct', args.defunctdate or args.disbanded)
             :cell('Location', Company:_createLocation(frame, args.location))
             :cell('Headquarters', args.headquarters)
             :cell('Employees', args.employees)
@@ -59,8 +59,8 @@ function Company:createInfobox(frame)
         location = args.location,
         headquarterslocation = args.headquarters,
         parentcompany = args.parent,
-        foundeddate = ReferenceCleaner.clean(args.foundeddate),
-        defunctdate = ReferenceCleaner.clean(args.defunctdate),
+        foundeddate = ReferenceCleaner.clean(args.foundeddate or agrs.founded),
+        defunctdate = ReferenceCleaner.clean(args.defunctdate or args.disbanded),
         numberofemployees = ReferenceCleaner.cleanNumber(args.employees),
         links = mw.ext.LiquipediaDB.lpdb_create_json({
             discord = Links.makeFullLink('discord', args.discord),

--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -34,7 +34,7 @@ function Company:createInfobox(frame)
             :centeredCell(args.caption)
             :header('Company Information', true)
             :fcell(Cell:new('Parent company'):options({makeLink = true}):content(args.parent, args.parent2):make())
-            :cell('Founded', args.foundeddate or agrs.founded)
+            :cell('Founded', args.foundeddate or args.founded)
             :cell('Defunct', args.defunctdate or args.disbanded)
             :cell('Location', Company:_createLocation(frame, args.location))
             :cell('Headquarters', args.headquarters)
@@ -59,7 +59,7 @@ function Company:createInfobox(frame)
         location = args.location,
         headquarterslocation = args.headquarters,
         parentcompany = args.parent,
-        foundeddate = ReferenceCleaner.clean(args.foundeddate or agrs.founded),
+        foundeddate = ReferenceCleaner.clean(args.foundeddate or args.founded),
         defunctdate = ReferenceCleaner.clean(args.defunctdate or args.disbanded),
         numberofemployees = ReferenceCleaner.cleanNumber(args.employees),
         links = mw.ext.LiquipediaDB.lpdb_create_json({


### PR DESCRIPTION
add alternative arg keys for
* `foundeddate` --> allow `founded`
* `defunctdate` --> allow `disbanded`

i think those are used on several wikis (they certainly are on sc2)

if you do not want it let me know so i can bot switch it instead on sc2 (<100 pages in total so not much work)