### PR TITLE
Create infobox_scene.lua

### DIFF
--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -35,12 +35,12 @@ function Scene:createInfobox(frame)
             :cell('Region', Scene:createRegion(args))
             :fcell(Cell:new('National team'):options({makeLink = true}):content(args.nationalteam):make())
             :fcell(Cell:new('Events'):options({makeLink = true}):content(
-                                                                                    args.event or args.event1,
-                                                                                    args.event2,
-                                                                                    args.event3,
-                                                                                    args.event4,
-                                                                                    args.event5
-                                                                                ):make())
+                                                                            args.event or args.event1,
+                                                                            args.event2,
+                                                                            args.event3,
+                                                                            args.event4,
+                                                                            args.event5
+                                                                        ):make())
             :cell('Size', args.size)
     Scene:addCustomCells(infobox, args)
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -34,13 +34,16 @@ function Scene:createInfobox(frame)
             :header('Scene Information', true)
             :cell('Region', Scene:createRegion(args))
             :fcell(Cell:new('National team'):options({makeLink = true}):content(args.nationalteam):make())
-            :fcell(Cell:new('Events'):options({makeLink = true}):content(
-                                                                            args.event or args.event1,
-                                                                            args.event2,
-                                                                            args.event3,
-                                                                            args.event4,
-                                                                            args.event5
-                                                                        ):make())
+            :fcell(Cell :new('Events')
+                        :options({makeLink = true})
+                        :content(
+                            args.event or args.event1,
+                            args.event2,
+                            args.event3,
+                            args.event4,
+                            args.event5
+                        ):make()
+            )
             :cell('Size', args.size)
     Scene:addCustomCells(infobox, args)
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -61,7 +61,7 @@ function Scene:nameDisplay(args)
     if not name then
         local localised = Localisation(country)
         local flag = Flags._Flag(country)
-        name = flag .. '&nbsp;' .. localised .. (args.gamenamedisplay or '') .. 'scene'
+        name = flag .. '&nbsp;' .. localised .. ((' ' .. args.gamenamedisplay) or '') .. ' scene'
     end
 
     Variables.varDefine('country', country)

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -1,8 +1,9 @@
 local Class = require('Module:Class')
+local Cell = require('Module:Infobox/Cell')
 local Infobox = require('Module:Infobox')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
-local Localisation = require('Module:Localisation').getLocalisation
+local Localisation = require('Module:Localisation')
 local Flags = require('Module:Flags')
 local Links = require('Module:Links')
 
@@ -32,8 +33,7 @@ function Scene:createInfobox(frame)
             :centeredCell(args.caption)
             :header('Scene Information', true)
             :cell('Region', Scene:createRegion(args))
-            :cell('National team', (args.nationalteam ~= nil) and ('[[' .. args.nationalteam .. ']]') or nil)
-            :cell('Key people', args['key people'])
+            :fcell(Cell:new('National team'):options({makeLink = true}):content(args.nationalteam):make())
             :cell('Events', args.events)
             :cell('Size', args.size)
     Scene:addCustomCells(infobox, args)
@@ -59,7 +59,7 @@ function Scene:nameDisplay(args)
     local name = args.name
     local country = Flags._CountryName(args.country or args.scene)
     if not name then
-        local localised = Localisation(country)
+        local localised = Localisation.getLocalisation(country)
         local flag = Flags._Flag(country)
         name = flag .. '&nbsp;' .. localised .. ((' ' .. args.gamenamedisplay) or '') .. ' scene'
     end

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -34,7 +34,13 @@ function Scene:createInfobox(frame)
             :header('Scene Information', true)
             :cell('Region', Scene:createRegion(args))
             :fcell(Cell:new('National team'):options({makeLink = true}):content(args.nationalteam):make())
-            :cell('Events', args.events)
+            :fcell(Cell:new('Events'):options({makeLink = true}):content(
+                                                                                    args.event or args.event1,
+                                                                                    args.event2,
+                                                                                    args.event3,
+                                                                                    args.event4,
+                                                                                    args.event5
+                                                                                ):make())
             :cell('Size', args.size)
     Scene:addCustomCells(infobox, args)
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -26,7 +26,7 @@ function Scene:createInfobox(frame)
     end
 
     local infobox = Infobox:create(frame, args.game)
-    local nameDisplay = Scene:nameDisplay(args)
+    local nameDisplay = Scene:createNameDisplay(args)
 
     infobox :name(nameDisplay)
             :image(args.image)
@@ -55,7 +55,7 @@ function Scene:createInfobox(frame)
 end
 
 --- Allows for overriding this functionality
-function Scene:nameDisplay(args)
+function Scene:createNameDisplay(args)
     local name = args.name
     local country = Flags._CountryName(args.country or args.scene)
     if not name then

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -1,0 +1,97 @@
+local Class = require('Module:Class')
+local Infobox = require('Module:Infobox')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+local Localisation = require('Module:Localisation').getLocalisation
+local Flags = require('Module:Flags')
+local Links = require('Module:Links')
+
+local getArgs = require('Module:Arguments').getArgs
+
+local Scene = Class.new()
+
+function Scene.run(frame)
+    return Scene:createInfobox(frame)
+end
+
+function Scene:createInfobox(frame)
+    local args = getArgs(frame)
+    self.frame = frame
+    self.pagename = mw.title.getCurrentTitle().text
+    self.name = args.country or args.scene or self.pagename
+
+    if args.game == nil then
+        return error('Please provide a game!')
+    end
+
+    local infobox = Infobox:create(frame, args.game)
+    local nameDisplay = Scene:nameDisplay(args)
+
+    infobox :name(nameDisplay)
+            :image(args.image)
+            :centeredCell(args.caption)
+            :header('Scene Information', true)
+            :cell('Region', Scene:createRegion(args))
+            :cell('National team', (args.nationalteam ~= nil) and ('[[' .. args.nationalteam .. ']]') or nil)
+            :cell('Key people', args['key people'])
+            :cell('Events', args.events)
+            :cell('Size', args.size)
+    Scene:addCustomCells(infobox, args)
+
+    local links = Links.transform(args)
+    local achievements = Scene:getAchievements(infobox, args)
+
+    infobox :header('Links', not Table.isEmpty(links))
+            :links(links)
+            :header('Achievements', achievements)
+            :centeredCell(achievements)
+            :centeredCell(args.footnotes)
+    Scene:addCustomContent(infobox, args)
+    infobox:bottom(Scene.createBottomContent(infobox))
+
+    infobox:categories('Scene')
+
+    return infobox:build()
+end
+
+--- Allows for overriding this functionality
+function Scene:nameDisplay(args)
+    local name = args.name
+    local country = Flags._CountryName(args.country or args.scene)
+    if not name then
+        local localised = Localisation(country)
+        local flag = Flags._Flag(country)
+        name = flag .. '&nbsp;' .. localised .. (args.gamenamedisplay or '') .. 'scene'
+    end
+
+    Variables.varDefine('country', country)
+
+    return name
+end
+
+--- Allows for overriding this functionality
+function Scene:addCustomContent(infobox, args)
+    return infobox
+end
+
+--- Allows for overriding this functionality
+function Scene:getAchievements(infobox, args)
+    return args.achievements
+end
+
+--- Allows for overriding this functionality
+function Scene:addCustomCells(infobox, args)
+    return infobox
+end
+
+--- Allows for overriding this functionality
+function Scene:createBottomContent(infobox)
+    return infobox
+end
+
+--- Allows for overriding this functionality
+function Scene:createRegion(args)
+    return args.region
+end
+
+return Scene


### PR DESCRIPTION
Infobox scene is used for scene pages on SC2.
Example: https://liquipedia.net/starcraft2/British_SC2_Scene
![Screenshot 2021-08-18 13 08 11](https://user-images.githubusercontent.com/75081997/129888006-7a6bc98a-0c99-48ab-b773-f406fe5ebd3b.png)

