### PR TITLE
Create prizepool calculation for tournaments

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -128,8 +128,6 @@ function League:createInfobox(frame)
         self:_setLpdbData(args)
     end
 
-    self:_definePageVariables(args)
-
     return infobox:build()
 end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -128,6 +128,8 @@ function League:createInfobox(frame)
         self:_setLpdbData(args)
     end
 
+    self:_definePageVariables(args)
+
     return infobox:build()
 end
 

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -1,6 +1,7 @@
 local League = require('Module:Infobox/League')
 local Cell = require('Module:Infobox/Cell')
 local String = require('Module:String')
+local Template = require('Module:Template')
 
 local RLLeague = {}
 
@@ -23,9 +24,39 @@ function RLLeague:createTier(args)
 end
 
 function RLLeague:createPrizepool(args)
+	local cell = Cell:new('Prize pool'):options({})
+	if String.isEmpty(args.prizepool) and
+		String.isEmpty(args.prizepoolusd) then
+			return cell:content()
+	end
+
+	local content
+	local prizepool = args.prizepool
+	local prizepoolInUsd = args.prizepoolusd
+	local localCurrency = args.localcurrency
+
+	if String.isEmpty(prizepool) then
+		content = '$' .. prizepoolInUsd .. ' ' .. Template.expand(mw.getCurrentFrame(), 'Abbr/USD')
+	else
+		if not String.isEmpty(localCurrency) then
+			content = Template.expand(
+				mw.getCurrentFrame(),
+				'Local currency',
+				{localCurrency:lower(), prizepool = prizepool}
+			)
+		else
+			content = prizepool
+		end
+
+		if not String.isEmpty(prizepoolInUsd) then
+			content = content .. '<br>(≃ $' .. prizepoolInUsd .. ' ' ..
+				Template.expand(mw.getCurrentFrame(), 'Abbr/USD') .. ')'
+		end
+	end
+
 	return Cell	:new('Prize pool')
 				:options({})
-				:content('0')
+				:content(content)
 end
 
 function RLLeague:addCustomContent(infobox, args)

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -2,6 +2,7 @@ local League = require('Module:Infobox/League')
 local Cell = require('Module:Infobox/Cell')
 local String = require('Module:String')
 local Template = require('Module:Template')
+local Variables = require('Module:Variables')
 
 local RLLeague = {}
 
@@ -53,6 +54,8 @@ function RLLeague:createPrizepool(args)
 				Template.expand(mw.getCurrentFrame(), 'Abbr/USD') .. ')'
 		end
 	end
+
+	Variables.varDefine('tournament_prizepoolusd', prizepoolInUsd)
 
 	return Cell	:new('Prize pool')
 				:options({})

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -57,9 +57,7 @@ function RLLeague:createPrizepool(args)
 
 	Variables.varDefine('tournament_prizepoolusd', prizepoolInUsd)
 
-	return Cell	:new('Prize pool')
-				:options({})
-				:content(content)
+	return cell:content(content)
 end
 
 function RLLeague:addCustomContent(infobox, args)

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -37,10 +37,10 @@ function RLLeague:createPrizepool(args)
 	local localCurrency = args.localcurrency
 
 	if String.isEmpty(prizepool) then
-		content = '$' .. prizepoolInUsd .. ' ' .. Template.expand(mw.getCurrentFrame(), 'Abbr/USD')
+		content = '$' .. prizepoolInUsd .. ' ' .. Template.safeExpand(mw.getCurrentFrame(), 'Abbr/USD')
 	else
 		if not String.isEmpty(localCurrency) then
-			content = Template.expand(
+			content = Template.safeExpand(
 				mw.getCurrentFrame(),
 				'Local currency',
 				{localCurrency:lower(), prizepool = prizepool}
@@ -51,7 +51,7 @@ function RLLeague:createPrizepool(args)
 
 		if not String.isEmpty(prizepoolInUsd) then
 			content = content .. '<br>(≃ $' .. prizepoolInUsd .. ' ' ..
-				Template.expand(mw.getCurrentFrame(), 'Abbr/USD') .. ')'
+				Template.safeExpand(mw.getCurrentFrame(), 'Abbr/USD') .. ')'
 		end
 	end
 


### PR DESCRIPTION
Stacks on #206 

Creates Rocket League's prize pool calculation. Would be better to use the automated conversion for this but the current one doesn't use it, so this PR simply converts the current template code to lua