### PR TITLE
Create infobox_basic.lua

### DIFF
--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -18,11 +18,6 @@ local BasicInfobox = Class.new(
 )
 
 --- Allows for overriding this functionality
-function BasicInfobox:getDisplayName(args)
-	return args.name
-end
-
---- Allows for overriding this functionality
 function BasicInfobox:addCustomCells(infobox, args)
     return infobox
 end
@@ -35,16 +30,6 @@ end
 --- Allows for overriding this functionality
 function BasicInfobox:createBottomContent(infobox)
     return infobox
-end
-
---- Allows for overriding this functionality
-function BasicInfobox:addBaseDisplay(infobox, informationType, args)
-	infobox:name(BasicInfobox:getDisplayName(args))
-	infobox:image(args.image, args.defaultImage)
-	infobox:centeredCell(args.caption)
-	infobox:header(informationType .. ' Information', true)
-
-	return infobox
 end
 
 return BasicInfobox

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -1,0 +1,50 @@
+local Class = require('Module:Class')
+local Infobox = require('Module:Infobox')
+local getArgs = require('Module:Arguments').getArgs
+
+local BasicInfobox = Class.new(
+	function(self, frame)
+		local args = getArgs(frame)
+		self.frame = frame
+		self.pagename = mw.title.getCurrentTitle().title
+		self.name = args.name or self.pagename
+
+		if args.wiki == nil then
+			return error('Please provide a wiki!')
+		end
+
+		self.infobox = Infobox:create(frame, args.wiki)
+	end
+)
+
+--- Allows for overriding this functionality
+function BasicInfobox:getDisplayName(args)
+	return args.name
+end
+
+--- Allows for overriding this functionality
+function BasicInfobox:addCustomCells(infobox, args)
+    return infobox
+end
+
+--- Allows for overriding this functionality
+function BasicInfobox:addCustomContent(infobox, args)
+    return infobox
+end
+
+--- Allows for overriding this functionality
+function BasicInfobox:createBottomContent(infobox)
+    return infobox
+end
+
+--- Allows for overriding this functionality
+function BasicInfobox:addBaseSetup(infobox, informationType, args)
+	infobox:name(BasicInfobox:getDisplayName(args))
+	infobox:image(args.image, args.defaultImage)
+	infobox:centeredCell(args.caption)
+	infobox:header(informationType .. ' Information', true)
+
+	return infobox
+end
+
+return BasicInfobox

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -38,7 +38,7 @@ function BasicInfobox:createBottomContent(infobox)
 end
 
 --- Allows for overriding this functionality
-function BasicInfobox:addBaseSetup(infobox, informationType, args)
+function BasicInfobox:addBaseDisplay(infobox, informationType, args)
 	infobox:name(BasicInfobox:getDisplayName(args))
 	infobox:image(args.image, args.defaultImage)
 	infobox:centeredCell(args.caption)


### PR DESCRIPTION
Basic functions for most infoboxes
(reduces code for infoboxes about ~33 lines)

```lua
local BasicInfobox = require('Module:Infobox/Basic')
local Class = require('Module:Class')
local Cell = require('Module:Infobox/Cell')
local Namespace = require('Module:Namespace')
local getArgs = require('Module:Arguments').getArgs

local Map = Class.new(BasicInfobox)

function Map.run(frame)
	local map = Map(frame)
	local args = getArgs(frame)
	local infobox = map.infobox
	infobox:name(Map:getNameDisplay(args))
	infobox:image(args.image, args.defaultImage)
	infobox:centeredCell(args.caption)
	infobox:header('Map Information', true)
	infobox:fcell(Cell:new('Creator'):options({makeLink = true}):content(
		args.creator or args['created-by']):make())
	Map:addCustomCells(infobox, args)
	infobox:bottom(Map.createBottomContent(infobox))

	if Namespace.isMain() then
		infobox:categories('Maps')
		Map:_setLpdbData(args)
	end

	return infobox:build()
end

--- Allows for overriding this functionality
function Map:getNameDisplay(args)
	return args.name
end

--- Allows for overriding this functionality
function Map:addToLpdb(lpdbData, args)
	return lpdbData
end

function Map:_setLpdbData(args)
	local lpdbData = {
		name = self.name,
		type = 'map',
		image = args.image,
	}

	lpdbData = self:addToLpdb(lpdbData, args)
	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
	mw.ext.LiquipediaDB.lpdb_datapoint('map_TEST_' .. lpdbData.name, lpdbData)
end

return Map
``` 

from #214 