### PR TITLE
Rewrite matchlist using css grid

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -6,8 +6,6 @@ local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft')
 local Table = require('Module:Table')
 
-local html = mw.html
-
 local StarcraftMatchlistDisplay = {}
 
 function StarcraftMatchlistDisplay.luaGet(_, args)
@@ -47,18 +45,19 @@ function StarcraftMatchlistDisplay.Opponent(props)
 		showLink = false,
 		teamStyle = 'short',
 	})
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
-	return html.create('td')
+		:addClass('brkts-matchlist-cell-content')
+	return mw.html.create('div')
+		:addClass('brkts-matchlist-cell brkts-matchlist-opponent')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
 		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
 		:node(contentNode)
 end
 
 function StarcraftMatchlistDisplay.Score(props)
-	local contentNode = html.create('div'):addClass('brkts-matchlist-score')
+	local contentNode = mw.html.create('div'):addClass('brkts-matchlist-cell-content')
 		:node(StarcraftOpponentDisplay.InlineScore(props.opponent))
-		:css('width', props.width - 2 * MatchlistDisplay.cellPadding - 1 .. 'px')
-	return html.create('td')
+	return mw.html.create('div')
+		:addClass('brkts-matchlist-cell brkts-matchlist-score')
 		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-bold' or nil)
 		:node(contentNode)
 end


### PR DESCRIPTION
This rewrites matchlist to use css grid instead of table. It fixes a bunch of issues that are a result of wiki not supporting `table-layout: fixed`.

Fixes mouseover z-index interaction with green backgrounds on adjacent cells
![image](https://user-images.githubusercontent.com/85348434/130189701-b77e925b-fc3f-4d85-b020-429688f7a8f0.png)
Before:
![image](https://user-images.githubusercontent.com/85348434/130191554-e3b949ad-fc16-422b-83b9-76a761738dca.png)
After:
![image](https://user-images.githubusercontent.com/85348434/130191603-f0aad00d-07cf-4982-a363-ba506f1cce5b.png)

Fixes mobile width calculation
Before
![image](https://user-images.githubusercontent.com/85348434/130192874-71b2efff-9c0f-4cc5-90da-a303fe536633.png)
After
![image](https://user-images.githubusercontent.com/85348434/130192904-548d99b5-f4cf-4d86-8e99-1749261e446a.png)


Fixes simultaneous popup active and opponent hover effects
Before
![image](https://user-images.githubusercontent.com/85348434/130192159-b771cda9-6866-436a-be9f-707c301478c0.png)
After
![image](https://user-images.githubusercontent.com/85348434/130192216-4e2661cf-4564-480c-8abe-4ad370bfd0b6.png)
