### PR TITLE
fix `BasicInfobox:createBottomContent`

### DIFF
--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -28,7 +28,7 @@ end
 
 --- Allows for overriding this functionality
 function BasicInfobox:createBottomContent(infobox)
-    return infobox
+    return nil
 end
 
 return BasicInfobox


### PR DESCRIPTION
fix `BasicInfobox:createBottomContent` so we can use self on the call