### PR TITLE
Various R6 fixes

### DIFF
--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -297,6 +297,7 @@ function matchFunctions.getDateStuff(match)
 	else
 		match.date = lang:formatDate('c', _EPOCH_TIME)
 		match.dateexact = false
+		match.nodate = true
 	end
 	return match
 end
@@ -450,7 +451,7 @@ function matchFunctions.getOpponents(match)
 	end
 
 	-- see if match should actually be finished if score is set
-	if isScoreSet and not Logic.readBool(match.finished) then
+	if isScoreSet and not Logic.readBool(match.finished) and not match.nodate then
 		local currentUnixTime = os.time(os.date('!*t'))
 		local lang = mw.getContentLanguage()
 		local matchUnixTime = tonumber(lang:formatDate('U', match.date))

--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -294,10 +294,10 @@ function matchFunctions.getDateStuff(match)
 		local matchDate = String.explode(matchString, '<', 0):gsub('-', '')
 		match.date = matchDate .. timezone
 		match.dateexact = String.contains(match.date, '%+') or String.contains(match.date, '%-')
+		match.hasDate = true
 	else
 		match.date = lang:formatDate('c', _EPOCH_TIME)
 		match.dateexact = false
-		match.nodate = true
 	end
 	return match
 end
@@ -451,7 +451,7 @@ function matchFunctions.getOpponents(match)
 	end
 
 	-- see if match should actually be finished if score is set
-	if isScoreSet and not Logic.readBool(match.finished) and not match.nodate then
+	if isScoreSet and not Logic.readBool(match.finished) and match.hasDate then
 		local currentUnixTime = os.time(os.date('!*t'))
 		local lang = mw.getContentLanguage()
 		local matchUnixTime = tonumber(lang:formatDate('U', match.date))

--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -257,7 +257,7 @@ function matchFunctions.getScoreFromMapWinners(match)
 		end
 	else -- For best of >1, disply the map wins
 		for i = 1, MAX_NUM_MAPS do
-			if match['map'..i] and match['map'..i].winner then
+			if match['map'..i] then
 				local winner = tonumber(match['map'..i].winner)
 				foundScores = true
 				-- Only two opponents in R6

--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -524,7 +524,7 @@ function mapFunctions.getScoresAndWinner(map)
 	for scoreIndex = 1, MAX_NUM_OPPONENTS do
 		-- read scores
 		local score = map['score' .. scoreIndex]
-		if map['t'.. scoreIndex ..'atk'] then
+		if map['t'.. scoreIndex ..'atk'] or map['t'.. scoreIndex ..'def'] then
 			score =   (tonumber(map['t'.. scoreIndex ..'atk']) or 0)
 					+ (tonumber(map['t'.. scoreIndex ..'def']) or 0)
 					+ (tonumber(map['t'.. scoreIndex ..'otatk']) or 0)

--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -2,6 +2,7 @@ local p = {}
 
 local json = require("Module:Json")
 local Logic = require("Module:Logic")
+local DisplayHelper = require("Module:MatchGroup/Display/Helper")
 local String = require("Module:StringUtils")
 local Table = require("Module:Table")
 local Variables = require("Module:Variables")
@@ -136,6 +137,18 @@ function p.convertParameters(match2)
 	end
 
 	match.extradata.bestofx = tostring(match2.bestof)
+	local bracketData = json.parse(match2.match2bracketdata)
+	if type(bracketData) == "table" and bracketData.type == "bracket" and bracketData.header then
+		local headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
+		if not headerName or headerName == "" then
+			headerName = Variables.varDefault("match_legacy_header_name")
+		else
+			Variables.varDefine("match_legacy_header_name", headerName)
+		end
+		if headerName and headerName ~= "" then
+			match.header = headerName
+		end
+	end
 
 	local veto = json.parse(extradata.mapveto)
 	if veto then

--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -117,6 +117,12 @@ function p.convertParameters(match2)
 		end
 	end
 
+	if match.walkover == "ff" or match.walkover == "dq" then
+		match.walkover = match.winner
+	elseif match.walkover == "l" then
+		match.walkover = nil
+	end
+
 	match.staticid = match2.match2id
 
 	-- Handle extradata fields

--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -64,26 +64,26 @@ function p.storeGames(match, match2)
 			local team1 = {}
 			local team2 = {}
 			if extradata.t1firstside[1] == "atk" then
-				team1 = {"atk", extradata.t1halfs.atk, extradata.t1halfs.def}
-				team2 = {"def", extradata.t2halfs.atk, extradata.t2halfs.def}
+				team1 = {"atk", extradata.t1halfs.atk or 0, extradata.t1halfs.def or 0}
+				team2 = {"def", extradata.t2halfs.atk or 0, extradata.t2halfs.def or 0}
 			elseif extradata.t1firstside[1] == "def" then
-				team2 = {"atk", extradata.t2halfs.atk, extradata.t2halfs.def}
-				team1 = {"def", extradata.t1halfs.atk, extradata.t1halfs.def}
+				team2 = {"atk", extradata.t2halfs.atk or 0, extradata.t2halfs.def or 0}
+				team1 = {"def", extradata.t1halfs.atk or 0, extradata.t1halfs.def or 0}
 			end
 			if extradata.t1firstside.ot == "atk" then
 				table.insert(team1, "atk")
-				table.insert(team1, extradata.t1halfs.otatk)
-				table.insert(team1, extradata.t1halfs.otdef)
+				table.insert(team1, extradata.t1halfs.otatk or 0)
+				table.insert(team1, extradata.t1halfs.otdef or 0)
 				table.insert(team2, "def")
-				table.insert(team2, extradata.t2halfs.otatk)
-				table.insert(team2, extradata.t2halfs.otdef)
+				table.insert(team2, extradata.t2halfs.otatk or 0)
+				table.insert(team2, extradata.t2halfs.otdef or 0)
 			elseif extradata.t1firstside.ot == "def" then
 				table.insert(team2, "atk")
-				table.insert(team2, extradata.t2halfs.otatk)
-				table.insert(team2, extradata.t2halfs.otdef)
+				table.insert(team2, extradata.t2halfs.otatk or 0)
+				table.insert(team2, extradata.t2halfs.otdef or 0)
 				table.insert(team1, "def")
-				table.insert(team1, extradata.t1halfs.otatk)
-				table.insert(team1, extradata.t1halfs.otdef)
+				table.insert(team1, extradata.t1halfs.otatk or 0)
+				table.insert(team1, extradata.t1halfs.otdef or 0)
 			end
 			game.extradata.opponent1scores = table.concat(team1, ", ")
 			game.extradata.opponent2scores = table.concat(team2, ", ")

--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -414,7 +414,7 @@ function CustomMatchSummary._createBody(match)
 				:css('text-align', 'center')
 				-- Workaround for .brkts-popup-body-element > * selector
 				:css('display', 'block')
-				:wikitext(mw.getContentLanguage():formatDate('F d, Y'))
+				:wikitext(mw.getContentLanguage():formatDate('F d, Y', match.date))
 		))
 	end
 

--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -348,7 +348,9 @@ function CustomMatchSummary.getByMatchId(args)
 				:body(CustomMatchSummary._createBody(match))
 
 	if match.comment then
-		matchSummary:comment(MatchSummary.Comment():content(match.comment))
+		local comment = MatchSummary.Comment():content(match.comment)
+		comment.root:css('display', 'block'):css('text-align', 'center')
+		matchSummary:comment(comment)
 	end
 
 	local vods = {}


### PR DESCRIPTION
- Changed MatchSummary comment to use block display. It fixes issues in the previous iterations, `<span>comment</span> `didn't linebreak correctly & none-block-display solution looks really bad if there's a link or reference in the comment.
- Forgot to add the date parameter to the formatDate call, fixed
- Changed the Match2->Match1 mapping when it comes to how the R6 match1 handles walkovers
- Added the match1.header field in the Match2->Match1 mapping
- Fixed case where if only defense and not attack (live updating) score has been entered, it would ignore the entered defense score
- Modules calling Match1 expects atk/def to have 0's instead of blank
- Fixed issue where games without a date, would be automatically marked as finished, because more then one day has passed since 1970.