### PR TITLE
Add function `getAllArgsForBase` to `Module:Infobox/Basic`

### DIFF
--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -1,6 +1,9 @@
 local Class = require('Module:Class')
 local Infobox = require('Module:Infobox')
+local String = require('Module:StringUtils')
 local getArgs = require('Module:Arguments').getArgs
+
+local _LARGE_NUMBER = 99
 
 local BasicInfobox = Class.new(
 	function(self, frame)
@@ -32,7 +35,7 @@ function BasicInfobox:createBottomContent(infobox)
 end
 
 --- Allows for using this for customCells
-function Skill:getMultiArgsForType(args, argType)
+function BasicInfobox:getMultiArgsForType(args, argType)
 	local typeArgs = {}
 	if String.isEmpty(args[argType]) then
 		return typeArgs
@@ -57,7 +60,7 @@ function Skill:getMultiArgsForType(args, argType)
 end
 
 --- Allows for using this for customCells
-function Skill:getMultiArgsForTypeNoLink(args, argType)
+function BasicInfobox:getMultiArgsForTypeNoLink(args, argType)
 	local typeArgs = {}
 	if String.isEmpty(args[argType]) then
 		return typeArgs

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -1,9 +1,8 @@
 local Class = require('Module:Class')
 local Infobox = require('Module:Infobox')
 local String = require('Module:StringUtils')
+local Logic = require('Module:Logic')
 local getArgs = require('Module:Arguments').getArgs
-
-local _LARGE_NUMBER = 99
 
 local BasicInfobox = Class.new(
 	function(self, frame)
@@ -35,48 +34,34 @@ function BasicInfobox:createBottomContent(infobox)
 end
 
 --- Allows for using this for customCells
-function BasicInfobox:getMultiArgsForType(args, argType)
-	local typeArgs = {}
-	if String.isEmpty(args[argType]) then
-		return typeArgs
+function BasicInfobox:getAllArgsForBase(args, base, options)
+	local foundArgs = {}
+	if String.isEmpty(args[base]) then
+		return foundArgs
 	end
 
-	local argType1 = (args[argType .. 'link'] or args[argType])
-		.. '|' .. args[argType]
+	local makeLink = Logic.readBool(options.makeLink)
 
-	table.insert(typeArgs, '[[' .. argType1 .. ']]')
+	local base1 = args[base]
+	if makeLink then
+		base1 = '[[' .. (args[base .. 'link'] or base1)
+			.. '|' .. base1 .. ']]'
+	end
 
-	for index = 2, _LARGE_NUMBER do
-		if String.isEmpty(args[argType .. index]) then
-			break
-		else
-			local indexedArgType = (args[argType .. index .. 'link'] or args[argType .. index])
-				.. '|' .. args[argType .. index]
-			table.insert(typeArgs, '[[' .. indexedArgType .. ']]')
+	table.insert(foundArgs, base1)
+	local index = 2
+
+	while not String.isEmpty(args[argType .. index]) do
+		local indexedbase = args[base .. index]
+		if makeLink then
+			indexedbase = '[[' .. (args[base .. index .. 'link'] or indexedbase)
+				.. '|' .. indexedbase .. ']]'
 		end
+		table.insert(foundArgs, indexedbase)
+		index = index + 1
 	end
 
-	return typeArgs
-end
-
---- Allows for using this for customCells
-function BasicInfobox:getMultiArgsForTypeNoLink(args, argType)
-	local typeArgs = {}
-	if String.isEmpty(args[argType]) then
-		return typeArgs
-	end
-
-	table.insert(typeArgs, args[argType])
-
-	for index = 2, _LARGE_NUMBER do
-		if String.isEmpty(args[argType .. index]) then
-			break
-		else
-			table.insert(typeArgs, args[argType .. index])
-		end
-	end
-
-	return typeArgs
+	return foundArgs
 end
 
 return BasicInfobox

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -31,4 +31,49 @@ function BasicInfobox:createBottomContent(infobox)
     return nil
 end
 
+--- Allows for using this for customCells
+function Skill:getMultiArgsForType(args, argType)
+	local typeArgs = {}
+	if String.isEmpty(args[argType]) then
+		return typeArgs
+	end
+
+	local argType1 = (args[argType .. 'link'] or args[argType])
+		.. '|' .. args[argType]
+
+	table.insert(typeArgs, '[[' .. argType1 .. ']]')
+
+	for index = 2, _LARGE_NUMBER do
+		if String.isEmpty(args[argType .. index]) then
+			break
+		else
+			local indexedArgType = (args[argType .. index .. 'link'] or args[argType .. index])
+				.. '|' .. args[argType .. index]
+			table.insert(typeArgs, '[[' .. indexedArgType .. ']]')
+		end
+	end
+
+	return typeArgs
+end
+
+--- Allows for using this for customCells
+function Skill:getMultiArgsForTypeNoLink(args, argType)
+	local typeArgs = {}
+	if String.isEmpty(args[argType]) then
+		return typeArgs
+	end
+
+	table.insert(typeArgs, args[argType])
+
+	for index = 2, _LARGE_NUMBER do
+		if String.isEmpty(args[argType .. index]) then
+			break
+		else
+			table.insert(typeArgs, args[argType .. index])
+		end
+	end
+
+	return typeArgs
+end
+
 return BasicInfobox

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -42,13 +42,13 @@ function BasicInfobox:getAllArgsForBase(args, base, options)
 
 	local makeLink = Logic.readBool(options.makeLink)
 
-	local base1 = args[base]
+	local baseArg = args[base]
 	if makeLink then
-		base1 = '[[' .. (args[base .. 'link'] or base1)
-			.. '|' .. base1 .. ']]'
+		baseArg = '[[' .. (args[base .. 'link'] or baseArg)
+			.. '|' .. baseArg .. ']]'
 	end
 
-	table.insert(foundArgs, base1)
+	table.insert(foundArgs, baseArg)
 	local index = 2
 
 	while not String.isEmpty(args[base .. index]) do

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -1,6 +1,6 @@
 local Class = require('Module:Class')
 local Infobox = require('Module:Infobox')
-local String = require('Module:StringUtils')
+local String = require('Module:String')
 local Logic = require('Module:Logic')
 local getArgs = require('Module:Arguments').getArgs
 

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -51,7 +51,7 @@ function BasicInfobox:getAllArgsForBase(args, base, options)
 	table.insert(foundArgs, base1)
 	local index = 2
 
-	while not String.isEmpty(args[argType .. index]) do
+	while not String.isEmpty(args[base .. index]) do
 		local indexedbase = args[base .. index]
 		if makeLink then
 			indexedbase = '[[' .. (args[base .. index .. 'link'] or indexedbase)


### PR DESCRIPTION
we need this function in several infoboxes, so we could just call them from here

* function `getAllArgsForBase` allows it to retrieve a set of customizable Links or args for a certain baseArg from args

intended usage is for use in unpack inside fcell

example code:
```
	infobox:fcell(Cell:new('Caster(s)'):options({}):content(
		unpack(self:getAllArgsForBase(args, 'caster', {makeLink = true}))):make())
```
result:
![Screenshot 2021-08-21 19 42 15](https://user-images.githubusercontent.com/75081997/130330569-61fb40f1-de45-4c10-acd3-96aa76393702.png)

needs updating the /doc too
