### PR TITLE
add option to change the size of infoboxImage

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -36,13 +36,20 @@ function Infobox:name(name)
     return self
 end
 
-function Infobox:image(fileName, default)
+function Infobox:image(fileName, default, size)
     if (fileName == nil or fileName == '') and (default == nil or default == '') then
         return self
     end
 
     local infoboxImage = mw.html.create('div'):addClass('infobox-image')
-    local fullFileName = '[[File:' .. (fileName or default) .. '|center|600px]]'
+    size = tonumber(size or '')
+    if size then
+        size = size .. 'px' 
+        infoboxImage:addClass('infobox-fixed-size-image')
+    else
+        size = '600px'
+    end
+    local fullFileName = '[[File:' .. (fileName or default) .. '|center|' .. size .. ']]'
     infoboxImage:wikitext(self.frame:preprocess('{{#metaimage:' .. (fileName or '') .. '}}') .. fullFileName)
     self.content:node(mw.html.create('div'):node(infoboxImage))
     return self

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -44,7 +44,7 @@ function Infobox:image(fileName, default, size)
     local infoboxImage = mw.html.create('div'):addClass('infobox-image')
     size = tonumber(size or '')
     if size then
-        size = size .. 'px' 
+        size = size .. 'px'
         infoboxImage:addClass('infobox-fixed-size-image')
     else
         size = '600px'


### PR DESCRIPTION
needed for some infoboxes on sc2 (e.g. ability, spell)

![Screenshot 2021-08-21 19 52 48](https://user-images.githubusercontent.com/75081997/130330846-b2b16829-8b9c-4504-8d8e-c2c73c555650.png)

needs updating the /doc too