### PR TITLE
Handle links being given to `_exists`

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -376,7 +376,15 @@ function League:_cleanDate(date)
 end
 
 function League:_exists(page)
-	return mw.title.new(page).exists
+	local existingPage = mw.title.new(page)
+
+	-- In some cases we might have gotten an external link,
+	-- which will mean `existingPage` will equal nil
+	if existingPage == nil then
+		return false
+	end
+
+	return existingPage.exists
 end
 
 function League:_isUnknownDate(date)


### PR DESCRIPTION
If we are given the following param:

```
|organizer=[https://www.dell.com/en-us/gaming/alienware Alienware]
```

We would error since `mw.title.new` will return `nil`. Handle those cases.