### PR TITLE
Default to enddate when no startdate is given

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -206,7 +206,7 @@ function League:_setLpdbData(args)
 			organizer4 = args.organizer4,
 			organizer5 = args.organizer5,
 		}),
-		startdate = Variables.varDefault('tournament_startdate', Variables.varDefault('tournament_enddate', '1970-01-01')),
+		startdate = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', '1970-01-01'),
 		enddate = Variables.varDefault('tournament_enddate', '1970-01-01'),
 		sortdate = Variables.varDefault('tournament_enddate', '1970-01-01'),
 		location = Locale.formatLocation({city = args.city or args.location, country = args.country}),

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -206,7 +206,7 @@ function League:_setLpdbData(args)
 			organizer4 = args.organizer4,
 			organizer5 = args.organizer5,
 		}),
-		startdate = Variables.varDefault('tournament_startdate', '1970-01-01'),
+		startdate = Variables.varDefault('tournament_startdate', Variables.varDefault('tournament_enddate', '1970-01-01')),
 		enddate = Variables.varDefault('tournament_enddate', '1970-01-01'),
 		sortdate = Variables.varDefault('tournament_enddate', '1970-01-01'),
 		location = Locale.formatLocation({city = args.city or args.location, country = args.country}),


### PR DESCRIPTION
If a tournament is single date, i.e. happens on a single day, we have no startdate. In that case default to the enddate for LPDB