### PR TITLE
Use legacy liquipediatiertype for RL

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -177,7 +177,7 @@ end
 
 function RLLeague:addToLpdb(lpdbData, args)
 	if not String.isEmpty(args.liquipediatiertype) then
-		lpdbData['liquipediatier'] = args.liquipediatiertype or args.liquipediatier
+		lpdbData['liquipediatier'] = args.liquipediatiertype
 	end
 
 	lpdbData['game'] = 'rocket league'

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -176,6 +176,10 @@ function RLLeague:defineCustomPageVariables(args)
 end
 
 function RLLeague:addToLpdb(lpdbData, args)
+	if not String.isEmpty(args.liquipediatiertype) then
+		lpdbData['liquipediatier'] = args.liquipediatiertype or args.liquipediatier
+	end
+
 	lpdbData['game'] = 'rocket league'
 	lpdbData['patch'] = args.patch
 	lpdbData['participantsnumber'] = args.team_number


### PR DESCRIPTION
Rocket League still uses a legacy implementation of `liquipediatiertype`, so we need to support that for now.