### PR TITLE
Handle valid locations which are not countries

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -265,9 +265,14 @@ function League:_createLocation(details)
 			content = '[[Category:Unrecognised Country|' .. details.country .. ']]'
 	else
 		local countryName = Localisation.getCountryName(details.country)
+		local displayText = details.location or countryName
+		if displayText == '' then
+			displayText = details.country
+		end
+
 		content = Flags._Flag(details.country) .. '&nbsp;' ..
 			'[[:Category:' .. nationality .. ' Tournaments|' ..
-			(details.location or countryName) .. ']]' ..
+			displayText .. ']]' ..
 			'[[Category:' .. nationality .. ' Tournaments]]'
 	end
 
@@ -279,9 +284,15 @@ function League:_createLocation(details)
 			content = content .. '[[Category:Unrecognised Country|' .. details.country2 .. ']]'
 		else
 			local countryName2 = Localisation.getCountryName(details.country2)
+
+			local displayText = details.location2 or countryName2
+			if displayText == '' then
+				displayText = details.country2
+			end
+
 			content = content .. Flags._Flag(details.country2) .. '&nbsp;' ..
 				'[[:Category:' .. nationality2 .. ' Tournaments|' ..
-				(details.location2 or countryName2) .. ']]' ..
+				displayText .. ']]' ..
 				'[[Category:' .. nationality2 .. ' Tournaments]]'
 		end
 	end


### PR DESCRIPTION
On many wikis, when a tournament's location is online, the region is put as location, like so:

```
|country=Oceania
```

This breaks our location display:

![image](https://user-images.githubusercontent.com/5138348/130615023-b604f117-2a62-4607-b2e5-2ee94448270f.png)

This PR makes sure those locations are handled

![image](https://user-images.githubusercontent.com/5138348/130615068-feaffd84-989f-4116-b3dd-c033db574d78.png)
