### PR TITLE
copy from live

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -15,7 +15,7 @@ local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
 
 local DisplayHelper = {}
-local _NONBREAKING_SPACE
+local _NONBREAKING_SPACE = '&nbsp;'
 
 function DisplayHelper.opponentIsTBD(opponent)
 	return opponent.type == 'literal'

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -15,6 +15,7 @@ local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
 
 local DisplayHelper = {}
+local _NONBREAKING_SPACE
 
 function DisplayHelper.opponentIsTBD(opponent)
 	return opponent.type == 'literal'
@@ -122,13 +123,13 @@ function DisplayHelper.MapAndStatus(game)
 	local statusText = nil
 	if game.resultType == 'default' then
 		if game.walkover == 'L' then
-			statusText = '&nbsp;<i>(w/o)</i>'
+			statusText = _NONBREAKING_SPACE .. '<i>(w/o)</i>'
 		elseif game.walkover == 'FF' then
-			statusText = '&nbsp;<i>(ff)</i>'
+			statusText = _NONBREAKING_SPACE .. '<i>(ff)</i>'
 		elseif game.walkover == 'DQ' then
-			statusText = '&nbsp;<i>(dq)</i>'
+			statusText = _NONBREAKING_SPACE .. '<i>(dq)</i>'
 		else
-			statusText = '&nbsp;<i>(def.)</i>'
+			statusText = _NONBREAKING_SPACE .. '<i>(def.)</i>'
 		end
 	end
 

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=starcraft2
+-- wiki=commons
 -- page=Module:MatchGroup/Display/Helper
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -101,6 +101,7 @@ function DisplayHelper.MatchCountdownBlock(match)
 		finished = match.finished and 'true' or nil,
 	})
 	return mw.html.create('div'):addClass('match-countdown-block')
+		:css('text-align', 'center')
 		-- Workaround for .brkts-popup-body-element > * selector
 		:css('display', 'block')
 		:node(require('Module:Countdown')._create(stream))
@@ -112,7 +113,7 @@ unusual status.
 ]]
 function DisplayHelper.MapAndStatus(game)
 	local mapText = game.map
-		and '[[' .. game.map .. ']]'
+		and ('[[' .. game.map .. ']]')
 		or 'Unknown'
 	if game.resultType == 'np' or game.resultType == 'default' then
 		mapText = '<s>' .. mapText .. '</s>'
@@ -121,17 +122,17 @@ function DisplayHelper.MapAndStatus(game)
 	local statusText = nil
 	if game.resultType == 'default' then
 		if game.walkover == 'L' then
-			statusText = '<i>(w/o)</i>'
+			statusText = '&nbsp;<i>(w/o)</i>'
 		elseif game.walkover == 'FF' then
-			statusText = '<i>(ff)</i>'
+			statusText = '&nbsp;<i>(ff)</i>'
 		elseif game.walkover == 'DQ' then
-			statusText = '<i>(dq)</i>'
+			statusText = '&nbsp;<i>(dq)</i>'
 		else
-			statusText = '<i>(def.)</i>'
+			statusText = '&nbsp;<i>(def.)</i>'
 		end
 	end
 
-	return mapText .. (statusText and '&nbsp;' .. statusText or '')
+	return mapText .. (statusText or '')
 end
 
 --[[

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=starcraft2
+-- wiki=commons
 -- page=Module:OpponentDisplay
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -316,7 +316,7 @@ function OpponentDisplay.BlockLiteral(props)
 	return DisplayUtil.applyOverflowStyles(mw.html.create('div'), props.overflow or 'wrap')
 		:addClass('brkts-opponent-block-literal')
 		:addClass(props.flip and 'flipped' or nil)
-		:node(props.name)
+		:node(Logic.emptyOr(props.name, '&nbsp;'))
 end
 
 --[[

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local PlayerDisplay = require('Module:Player/Display')
 local Table = require('Module:Table')

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=starcraft2
+-- wiki=commons
 -- page=Module:Player/Display
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -88,6 +88,7 @@ function PlayerDisplay.InlinePlayer(props)
 
 	return mw.html.create('span'):addClass('inline-player')
 		:addClass(props.flip and 'flipped' or nil)
+		:css('white-space', 'pre')
 		:wikitext(text)
 end
 

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -47,7 +47,7 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 	local nameNode = html.create('span'):addClass('name')
 		:wikitext(props.showLink ~= false and player.pageName
 			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
-			or player.displayName
+			or Logic.emptyOr(player.displayName, '&nbsp;')
 		)
 	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
 

--- a/components/match2/wikis/starcraft2/match_legacy.lua
+++ b/components/match2/wikis/starcraft2/match_legacy.lua
@@ -45,7 +45,12 @@ function p.storeGames(match, match2)
 	for gameIndex, game in ipairs(match2.match2games or {}) do
 		game.extradata = json.parseIfString(game.extradata or '{}') or game.extradata
 
-		if game.mode == '1v1' and game.extradata.isSubMatch == 'false' then
+		if
+			game.mode == '1v1' and
+			game.extradata.isSubMatch == 'false' and
+			game.winner ~= 'skip' and
+			game.map ~= 'Definitions'
+		then
 			game.opponent1 = game.extradata.opponent1
 			game.opponent2 = game.extradata.opponent2
 			game.date = match.date


### PR DESCRIPTION
copy modules from live that have some minor bug fixes/changes
--> so the automated copy from git to wiki doesn't cause issues with those modules

*  components/match2/commons/match_group_display_helper.lua
* * `&nbsp;` handling & needed bracket
* components/match2/commons/opponent_display.lua
* * add `&nbsp;` fallback for literals
* * import `Module:Logic`
* components/match2/commons/player_display.lua
* * add css whitespace pre
* components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
* * add `&nbsp;` fallback for players
* components/match2/wikis/starcraft2/match_legacy.lua
* * change formatting a bit & add additional conditions for games/maps to be stored as legacy match
