### PR TITLE
Use `player_number` for `participantsnumber`

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -182,7 +182,7 @@ function RLLeague:addToLpdb(lpdbData, args)
 
 	lpdbData['game'] = 'rocket league'
 	lpdbData['patch'] = args.patch
-	lpdbData['participantsnumber'] = args.team_number
+	lpdbData['participantsnumber'] = args.team_number or args.player_number
 	lpdbData['extradata'] = {
 		region = args.region,
 		mode = args.mode,


### PR DESCRIPTION
Fix for Rocket League 1v1 tournaments not having a `participantsnumber`