### PR TITLE
Allow adding class to Cell

### DIFF
--- a/components/infobox/commons/infobox_cell.lua
+++ b/components/infobox/commons/infobox_cell.lua
@@ -23,6 +23,11 @@ function Cell:new(description)
 	return self
 end
 
+function Cell:addClass(class)
+	self.root:addClass(class)
+	return self
+end
+
 function Cell:options(args)
 	self.args = args
 	return self


### PR DESCRIPTION
For certain cells we would like to have the ability to add a CSS class to the root. An example of this is `liquipediatier`

![image](https://user-images.githubusercontent.com/5138348/130796742-f2aadc7d-ceae-4e08-ae28-e2d3e3800bc7.png)
