### PR TITLE
Use same order of infobox buttons and name as template

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -39,7 +39,7 @@ function Infobox:name(name)
     infoboxHeader   :addClass('infobox-header')
                     :addClass('wiki-backgroundcolor-light')
                     :node(self:_createInfoboxButtons())
-	                :wikitext(pagename)
+                    :wikitext(pagename)
     self.content:node(mw.html.create('div'):node(infoboxHeader))
     return self
 end


### PR DESCRIPTION
Before
=====
![image](https://user-images.githubusercontent.com/5138348/131109902-f1bf6371-c3a0-4d80-8b0d-650b7b184d12.png)

After
=====
Same situation as in legacy templates

![image](https://user-images.githubusercontent.com/5138348/131109929-343cb591-8dec-4833-939e-8a7a5f4440d3.png)
