### PR TITLE
Create Infobox/Widget/Center

### DIFF
--- a/components/infobox/commons/infobox_widget_center.lua
+++ b/components/infobox/commons/infobox_widget_center.lua
@@ -1,0 +1,35 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Widget/Center
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Widget = require('Module:Infobox/Widget')
+
+local Center = Class.new(
+	Widget,
+	function(self, ...)
+		self.content = {...}
+	end
+)
+
+function Center:make()
+	return {
+		Center:_create(self.content)
+	}
+end
+
+function Center:_create(content)
+	local centered = mw.html.create('div'):addClass('infobox-center')
+
+	for _, item in pairs(content) do
+		centered:wikitext(item)
+	end
+
+	return mw.html.create('div'):node(centered)
+end
+
+return Center


### PR DESCRIPTION
Stacks on #305, see #304 for overview.

Creates a Center widget for the infobox, previously called `centeredCell`

![image](https://user-images.githubusercontent.com/5138348/131516512-55de68ea-c03b-4ac2-80ee-cacda5e0b158.png)
