### PR TITLE
Create Customizable widget

### DIFF
--- a/components/infobox/commons/dev_infobox.lua
+++ b/components/infobox/commons/dev_infobox.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Customizable = require('Module:Infobox/Widget/Customizable')
 
 local Infobox = Class.new()
 
@@ -21,6 +22,8 @@ function Infobox:create(frame, gameName)
                                             :addClass('wiki-bordercolor-light')
     self.root   :addClass('fo-nttax-infobox-wrapper')
                 :addClass('infobox-' .. gameName)
+
+	self.injector = nil
     return self
 end
 
@@ -35,11 +38,19 @@ function Infobox:categories(...)
     return self
 end
 
+function Infobox:widgetInjector(injector)
+	self.injector = injector
+end
+
 --- Returns completed infobox
 function Infobox:build(widgets)
 	for _, widget in pairs(widgets) do
 		if widget['is_a'] == nil then
 			return error('Infobox:build can only accept Widgets')
+		end
+
+		if widget:is_a(Customizable) then
+			widget:setWidgetInjector(self.injector)
 		end
 
 		local contentItems = widget:make()

--- a/components/infobox/commons/dev_infobox.lua
+++ b/components/infobox/commons/dev_infobox.lua
@@ -23,7 +23,7 @@ function Infobox:create(frame, gameName)
     self.root   :addClass('fo-nttax-infobox-wrapper')
                 :addClass('infobox-' .. gameName)
 
-	self.injector = nil
+    self.injector = nil
     return self
 end
 

--- a/components/infobox/commons/infobox_widget_customizable.lua
+++ b/components/infobox/commons/infobox_widget_customizable.lua
@@ -26,6 +26,9 @@ function Customizable:setWidgetInjector(injector)
 end
 
 function Customizable:make()
+	if self.injector == nil then
+		return self.widgets
+	end
 	return self.injector:parse(self.id, self.widgets)
 end
 

--- a/components/infobox/commons/infobox_widget_customizable.lua
+++ b/components/infobox/commons/infobox_widget_customizable.lua
@@ -1,0 +1,32 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Widget/Customizable
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Widget = require('Module:Infobox/Widget')
+local Injector = require('Module:Infobox/Widget/Injector')
+
+local Customizable = Class.new(
+	Widget,
+	function(self, id, widgets)
+		self.id = self:assertExistsAndCopy(id)
+		self.widgets = widgets
+	end
+)
+
+function Customizable:setWidgetInjector(injector)
+	if injector:is_a(Injector) == false then
+		return error('Valid Injector from Infobox/Widget/Injector needs to be provided')
+	end
+	self.injector = injector
+end
+
+function Customizable:make()
+	return self.injector:parse(self.id, self.widgets)
+end
+
+return Customizable

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -1,0 +1,18 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Widget/Injector
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+
+local Injector = Class.new()
+
+function Injector:parse(id, widgets)
+	return error('You need to implement the parse function in your widget injector!')
+end
+
+return Injector
+


### PR DESCRIPTION
Stacks on #305, see #304 for overview.

Creates the `Customizable` widget, accepting an ID and a list of widgets, and which using the `Injector`, can be used to specify wiki-specific widgets in groupings that make sense. For example:

```lua
Customizable(
	'tier',
	{
		Cell('Liquipedia tier', args.liquipediatier),
		Cell('Liquipedia tier type', args.liquipediatiertype)
	}
),
```

A wiki could now add cells to this grouping of tier, thereby keeping all tier-related properties together.