### PR TITLE
Add `addCustomCells` to `Injector`

### DIFF
--- a/components/infobox/commons/infobox_widget_customizable.lua
+++ b/components/infobox/commons/infobox_widget_customizable.lua
@@ -31,6 +31,9 @@ function Customizable:make()
 	if self.injector == nil then
 		return self.widgets
 	end
+	if self.id == ' custom' then
+		return self.injector:addCustomCells(self.widgets)
+	end
 	return self.injector:parse(self.id, self.widgets)
 end
 

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local Injector = Class.new()
 
 function Injector:parse(id, widgets)
-	return error('You need to implement the parse function in your widget injector!')
+	return {}
 end
 
 function Injector:addCustomCells(widgets)

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -14,5 +14,9 @@ function Injector:parse(id, widgets)
 	return error('You need to implement the parse function in your widget injector!')
 end
 
+function Injector:addCustomCells(widgets)
+	return {}
+end
+
 return Injector
 


### PR DESCRIPTION
Add the function `addCustomCells` to `Injector` so we avoid having custom modules always having to check `id == 'custom'`.