### PR TITLE
Migrate infobox scene

### DIFF
--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -34,7 +34,7 @@ function Scene:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
 
-	local widgets = ({
+	local widgets = {
 		Header{name = self:createNameDisplay(args), image = args.image},
 		Center{content = {args.caption}},
 		Title{name = 'Scene Information'},
@@ -65,7 +65,7 @@ function Scene:createInfobox()
 				end
 			end
 		}
-	})
+	}
 
 	infobox:categories('Scene')
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -34,13 +34,13 @@ function Scene:createInfobox()
 	local args = self.args
 
 	local widgets = ({
-		Header{{name = self:createNameDisplay(args), image = args.image}},
+		Header{name = self:createNameDisplay(args), image = args.image},
 		Center{content = {args.caption}},
 		Title{name = 'Scene Information'},
-		Cell{{name = 'Region', content = {args.region}}},
-		Cell{{name = 'National team', content = {args.nationalteam}, options = {makeLink = true}}},
-		Cell{{name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})}},
-		Cell{{name = 'Size', content = {args.size}}},
+		Cell{name = 'Region', content = {args.region}},
+		Cell{name = 'National team', content = {args.nationalteam}, options = {makeLink = true}},
+		Cell{name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})},
+		Cell{name = 'Size', content = {args.size}},
 		Customizable{id = 'custom', children = {}},
 	})
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -37,7 +37,7 @@ function Scene:createInfobox()
 		Header({name = self:createNameDisplay(args), image = args.image}),
 		Center(args.caption),
 		Title('Scene Information'),
-		Cell({name = 'Regin', content = {args.region}}),
+		Cell({name = 'Region', content = {args.region}}),
 		Cell({name = 'National team', content = {args.nationalteam}, options = {makeLink = true}}),
 		Cell({name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})}),
 		Cell({name = 'Size', content = {args.size}}),

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -7,85 +7,72 @@
 --
 
 local Class = require('Module:Class')
-local Cell = require('Module:Infobox/Cell')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 local Localisation = require('Module:Localisation')
 local Flags = require('Module:Flags')
 local Links = require('Module:Links')
-local BasicInfobox = require('Module:Infobox/Basic')
+local InfoboxBasic = require('Module:Infobox/Basic')
+local String = require('Module:String')
 
-local Scene = Class.new(BasicInfobox)
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Header = Widgets.Header
+local Title = Widgets.Title
+local Center = Widgets.Center
+local Customizable = Widgets.Customizable
+
+local Scene = Class.new(InfoboxBasic)
 
 function Scene.run(frame)
-    local scene = Scene(frame)
-    return scene:createInfobox()
+	local scene = Scene(frame)
+	return scene:createInfobox()
 end
 
-function Scene:createInfobox(frame)
-    local infobox = self.infobox
-    local args = self.args
+function Scene:createInfobox()
+	local infobox = self.infobox
+	local args = self.args
 
-    local nameDisplay = self:createNameDisplay(args)
+	local widgets = ({
+		Header({name = self:createNameDisplay(args), image = args.image}),
+		Center(args.caption),
+		Title('Scene Information'),
+		Cell({name = 'National team', content = {args.nationalteam}, options = {makeLink = true}}),
+		Cell({name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})}),
+		Cell({name = 'Size', content = {args.size}}),
+		Customizable('custom', {}),
+	})
 
-    infobox :name(nameDisplay)
-            :image(args.image)
-            :centeredCell(args.caption)
-            :header('Scene Information', true)
-            :cell('Region', self:createRegion(args))
-            :fcell(Cell:new('National team'):options({makeLink = true}):content(args.nationalteam):make())
-            :fcell(Cell :new('Events')
-                        :options({makeLink = true})
-                        :content(
-                            args.event or args.event1,
-                            args.event2,
-                            args.event3,
-                            args.event4,
-                            args.event5
-                        ):make()
-            )
-            :cell('Size', args.size)
-    self:addCustomCells(infobox, args)
+	local links = Links.transform(args)
+	table.insert(widgets, Center(args.footnotes))
+	if not Table.isEmpty(links) then
+		table.insert(widgets, Title('Links'))
+		table.insert(widgets, Widgets.Links(links))
+	end
 
-    local links = Links.transform(args)
-    local achievements = self:getAchievements(infobox, args)
+	if not String.isEmpty(args.achievements) then
+		table.insert(widgets, Title('Achievements'))
+		table.insert(widgets, Center(args.achievements))
+	end
 
-    infobox :header('Links', not Table.isEmpty(links))
-            :links(links)
-            :header('Achievements', achievements)
-            :centeredCell(achievements)
-            :centeredCell(args.footnotes)
-    self:addCustomContent(infobox, args)
-    infobox:bottom(self:createBottomContent(infobox))
+	infobox:categories('Scene')
 
-    infobox:categories('Scene')
-
-    return infobox:build()
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 --- Allows for overriding this functionality
 function Scene:createNameDisplay(args)
-    local name = args.name
-    local country = Flags._CountryName(args.country or args.scene)
-    if not name then
-        local localised = Localisation.getLocalisation(country)
-        local flag = Flags._Flag(country)
-        name = flag .. '&nbsp;' .. localised .. ((' ' .. args.gamenamedisplay) or '') .. ' scene'
-    end
+	local name = args.name
+	local country = Flags._CountryName(args.country or args.scene)
+	if not name then
+		local localised = Localisation.getLocalisation(country)
+		local flag = Flags._Flag(country)
+		name = flag .. '&nbsp;' .. localised .. ((' ' .. args.gamenamedisplay) or '') .. ' scene'
+	end
 
-    Variables.varDefine('country', country)
+	Variables.varDefine('country', country)
 
-    return name
-end
-
---- Allows for overriding this functionality
-function Scene:getAchievements(infobox, args)
-    return args.achievements
-end
-
---- Allows for overriding this functionality
-function Scene:createRegion(args)
-    return args.region
+	return name
 end
 
 return Scene

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -37,6 +37,7 @@ function Scene:createInfobox()
 		Header({name = self:createNameDisplay(args), image = args.image}),
 		Center(args.caption),
 		Title('Scene Information'),
+		Cell({name = 'Regin', content = {args.region}}),
 		Cell({name = 'National team', content = {args.nationalteam}, options = {makeLink = true}}),
 		Cell({name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})}),
 		Cell({name = 'Size', content = {args.size}}),

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -21,6 +21,7 @@ local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
 local Customizable = Widgets.Customizable
+local Builder = Widgets.Builder
 
 local Scene = Class.new(InfoboxBasic)
 
@@ -42,19 +43,29 @@ function Scene:createInfobox()
 		Cell{name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})},
 		Cell{name = 'Size', content = {args.size}},
 		Customizable{id = 'custom', children = {}},
+		Center{content = {args.footnotes}},
+		Builder{
+			builder = function()
+				local links = Links.transform(args)
+				if not Table.isEmpty(links) then
+					return {
+						Title{name = 'Links'},
+						Widgets.Links{content = links}
+					}
+				end
+			end
+		},
+		Builder{
+			builder = function()
+				if not String.isEmpty(args.achievements) then
+					return {
+						Title{name ='Achievements'},
+						Center{content = {args.achievements}}
+					}
+				end
+			end
+		}
 	})
-
-	local links = Links.transform(args)
-	table.insert(widgets, Center{content = {args.footnotes}})
-	if not Table.isEmpty(links) then
-		table.insert(widgets, Title{name = 'Links'})
-		table.insert(widgets, Widgets.Links{content = links})
-	end
-
-	if not String.isEmpty(args.achievements) then
-		table.insert(widgets, Title{name ='Achievements'})
-		table.insert(widgets, Center{content = {args.achievements}})
-	end
 
 	infobox:categories('Scene')
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -34,26 +34,26 @@ function Scene:createInfobox()
 	local args = self.args
 
 	local widgets = ({
-		Header({name = self:createNameDisplay(args), image = args.image}),
-		Center(args.caption),
-		Title('Scene Information'),
-		Cell({name = 'Region', content = {args.region}}),
-		Cell({name = 'National team', content = {args.nationalteam}, options = {makeLink = true}}),
-		Cell({name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})}),
-		Cell({name = 'Size', content = {args.size}}),
-		Customizable('custom', {}),
+		Header{{name = self:createNameDisplay(args), image = args.image}},
+		Center{content = {args.caption}},
+		Title{name = 'Scene Information'},
+		Cell{{name = 'Region', content = {args.region}}},
+		Cell{{name = 'National team', content = {args.nationalteam}, options = {makeLink = true}}},
+		Cell{{name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})}},
+		Cell{{name = 'Size', content = {args.size}}},
+		Customizable{id = 'custom', children = {}},
 	})
 
 	local links = Links.transform(args)
-	table.insert(widgets, Center(args.footnotes))
+	table.insert(widgets, Center{content = {args.footnotes}})
 	if not Table.isEmpty(links) then
-		table.insert(widgets, Title('Links'))
-		table.insert(widgets, Widgets.Links(links))
+		table.insert(widgets, Title{name = 'Links'})
+		table.insert(widgets, Widgets.Links{content = links})
 	end
 
 	if not String.isEmpty(args.achievements) then
-		table.insert(widgets, Title('Achievements'))
-		table.insert(widgets, Center(args.achievements))
+		table.insert(widgets, Title{name ='Achievements'})
+		table.insert(widgets, Center{content = {args.achievements}})
 	end
 
 	infobox:categories('Scene')


### PR DESCRIPTION
Migrates Infobox/Scene over to table based layout, see #304 . Merges into #321 
* has no custom versions on any wikis
* only used on sc2