### PR TITLE
Switch to named arguments for widgets

### DIFF
--- a/components/infobox/commons/infobox_widget_center.lua
+++ b/components/infobox/commons/infobox_widget_center.lua
@@ -11,8 +11,8 @@ local Widget = require('Module:Infobox/Widget')
 
 local Center = Class.new(
 	Widget,
-	function(self, ...)
-		self.content = {...}
+	function(self, input)
+		self.content = input.content
 	end
 )
 

--- a/components/infobox/commons/infobox_widget_chronology.lua
+++ b/components/infobox/commons/infobox_widget_chronology.lua
@@ -12,8 +12,8 @@ local Table = require('Module:Table')
 
 local Chronology = Class.new(
 	Widget,
-	function(self, links)
-		self.links = links
+	function(self, input)
+		self.links = input.content
 	end
 )
 

--- a/components/infobox/commons/infobox_widget_customizable.lua
+++ b/components/infobox/commons/infobox_widget_customizable.lua
@@ -12,9 +12,9 @@ local Injector = require('Module:Infobox/Widget/Injector')
 
 local Customizable = Class.new(
 	Widget,
-	function(self, id, widgets)
-		self.id = self:assertExistsAndCopy(id)
-		self.widgets = widgets
+	function(self, input)
+		self.id = self:assertExistsAndCopy(input.id)
+		self.children = input.children
 	end
 )
 
@@ -29,12 +29,12 @@ end
 
 function Customizable:make()
 	if self.injector == nil then
-		return self.widgets
+		return self.children
 	end
 	if self.id == ' custom' then
-		return self.injector:addCustomCells(self.widgets)
+		return self.injector:addCustomCells(self.children)
 	end
-	return self.injector:parse(self.id, self.widgets)
+	return self.injector:parse(self.id, self.children)
 end
 
 return Customizable

--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -13,9 +13,9 @@ local Table = require('Module:Table')
 
 local Links = Class.new(
 	Widget,
-	function(self, links, variant)
-		self.links = links
-		self.variant = variant
+	function(self, input)
+		self.links = input.content
+		self.variant = input.variant
 	end
 )
 

--- a/components/infobox/commons/infobox_widget_title.lua
+++ b/components/infobox/commons/infobox_widget_title.lua
@@ -12,7 +12,7 @@ local Widget = require('Module:Infobox/Widget')
 local Title = Class.new(
 	Widget,
 	function(self, input)
-		self.content = self:assertExistsAndCopy(input)
+		self.content = self:assertExistsAndCopy(input.name)
 	end
 )
 


### PR DESCRIPTION
Always use named arguments for widgets

For all widgets:

- `name` will be used for display values
- `id` will be used for ... identifiers
- `content` will be used for content of that widget
- `child`/`children` denote inner widgets, e.g. in Customizable
- return values are always **lists** of widgets.