### PR TITLE
Create builder widget

### DIFF
--- a/components/infobox/commons/infobox_widget_builder.lua
+++ b/components/infobox/commons/infobox_widget_builder.lua
@@ -1,0 +1,23 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Widget/Builder
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Widget = require('Module:Infobox/Widget')
+
+local Builder = Class.new(
+	Widget,
+	function(self, input)
+		self.builder = input.builder
+	end
+)
+
+function Builder:make()
+	return self.builder()
+end
+
+return Builder


### PR DESCRIPTION
Creates the Builder widget. While its functionality is very simple, it enables clearer code.

Before
=======
```lua
    local widgets = ({
        Cell{name = 'Founded', content = {args.foundeddate},},
        Cell{name = 'Defunct', content = {args.defunctdate},},
    })

    if not String.isEmpty(args.companytype) and args.companytype == _COMPANY_TYPE_ORGANIZER then
        infobox:cell('Total prize money', self:_getOrganizerPrizepools())
        table.insert(widgets, Cell{
            name = 'Total prize money',
            content = {self:_getOrganizerPrizepools()}
        })

        infobox:categories('Tournament organizers')
    end
```

After
=====
```lua
    local widgets = ({
        Cell{name = 'Founded', content = {args.foundeddate},},
        Cell{name = 'Defunct', content = {args.defunctdate},},
        Builder{
            builder = function()
                if not String.isEmpty(args.companytype) and args.companytype == _COMPANY_TYPE_ORGANIZER then
                    infobox:categories('Tournament organizers')
                    return Cell{
                        name = 'Total prize money',
                        content = {self:_getOrganizerPrizepools()}
                    }
            end
        }
    })
```