### PR TITLE
Create widget factory

### DIFF
--- a/components/infobox/commons/dev_infobox.lua
+++ b/components/infobox/commons/dev_infobox.lua
@@ -7,8 +7,7 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
-local Customizable = require('Module:Infobox/Widget/Customizable')
+local WidgetFactory = require('Module:Infobox/Widget/Factory')
 
 local Infobox = Class.new()
 
@@ -51,25 +50,16 @@ function Infobox:build(widgets)
 			return error('Infobox:build can only accept Widgets')
 		end
 
-		local contentItems
-
-		if widget:is_a(Customizable) then
-			widget:setWidgetInjector(self.injector)
-			contentItems = {}
-			for _, child in pairs(widget:make() or {}) do
-				if child['is_a'] == nil or child:is_a(Widget) == false then
-					return error('Customizable can only contain Widgets as children')
-				end
-				for _, item in pairs(child:make() or {}) do
-					table.insert(contentItems, item)
-				end
-			end
-		else
-			contentItems = widget:make()
-		end
+		local contentItems = WidgetFactory.work(widget, self.injector)
 
 		for _, node in pairs(contentItems or {}) do
-			self.content:node(node)
+			if type(node) == 'table' then
+				for _, innerNode in pairs(node or {}) do
+					self.content:node(innerNode)
+				end
+			else
+				self.content:node(node)
+			end
 		end
 	end
 

--- a/components/infobox/commons/dev_infobox.lua
+++ b/components/infobox/commons/dev_infobox.lua
@@ -53,13 +53,7 @@ function Infobox:build(widgets)
 		local contentItems = WidgetFactory.work(widget, self.injector)
 
 		for _, node in pairs(contentItems or {}) do
-			if type(node) == 'table' then
-				for _, innerNode in pairs(node or {}) do
-					self.content:node(innerNode)
-				end
-			else
-				self.content:node(node)
-			end
+			self.content:node(node)
 		end
 	end
 

--- a/components/infobox/commons/infobox_widget_factory.lua
+++ b/components/infobox/commons/infobox_widget_factory.lua
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Builder = require('Module:Infobox/Widget/Builder')
 local Customizable = require('Module:Infobox/Widget/Customizable')
-local Widget = require('Module:Infobox/Widget/Widget')
+local Widget = require('Module:Infobox/Widget')
 
 local WidgetFactory = Class.new()
 

--- a/components/infobox/commons/infobox_widget_factory.lua
+++ b/components/infobox/commons/infobox_widget_factory.lua
@@ -1,3 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Widget/Factory
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Class = require('Module:Class')
 local Builder = require('Module:Infobox/Widget/Builder')
 local Customizable = require('Module:Infobox/Widget/Customizable')

--- a/components/infobox/commons/infobox_widget_factory.lua
+++ b/components/infobox/commons/infobox_widget_factory.lua
@@ -1,0 +1,38 @@
+local Class = require('Module:Class')
+local Builder = require('Module:Infobox/Widget/Builder')
+local Customizable = require('Module:Infobox/Widget/Customizable')
+local Widget = require('Module:Infobox/Widget/Widget')
+
+local WidgetFactory = Class.new()
+
+function WidgetFactory.work(widget, injector)
+	local convertedWidgets = {}
+
+	if widget:is_a(Builder) then
+		local children = widget:make()
+
+		for _, child in pairs(children or {}) do
+			local childOutput = WidgetFactory.work(child, injector)
+			-- Our child might contain a list of children, so we need to iterate
+			for _, item in pairs(childOutput) do
+				table.insert(convertedWidgets, item)
+			end
+		end
+	elseif widget:is_a(Customizable) then
+		widget:setWidgetInjector(injector)
+		for _, child in pairs(widget:make() or {}) do
+			if child['is_a'] == nil or child:is_a(Widget) == false then
+				return error('Customizable can only contain Widgets as children')
+			end
+			for _, item in pairs(child:make() or {}) do
+				table.insert(convertedWidgets, item)
+			end
+		end
+	else
+		return widget:make()
+	end
+
+	return convertedWidgets
+end
+
+return WidgetFactory


### PR DESCRIPTION
Extracts conversion from Widget to HTML to its own module, in case it's ever needed outside of Module:Infobox. Also adds logic to make `Builder` work