### PR TITLE
Migrate Infobox patch

### DIFF
--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -60,9 +60,10 @@ function BasicInfobox:getAllArgsForBase(args, base, options)
 	options = options or {}
 	local makeLink = Logic.readBool(options.makeLink)
 
-	local baseArg = args[base]
+	local baseArg = args[base] or args[base .. '1']
 	if makeLink then
-		baseArg = '[[' .. (args[base .. 'link'] or baseArg)
+		local link = args[base .. 'link'] or args[base .. '1link'] or baseArg
+		baseArg = '[[' .. link
 			.. '|' .. baseArg .. ']]'
 	end
 

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local BasicInfobox = require('Module:Infobox/Basic')
 local Class = require('Module:Class')
 local BasicInfobox = require('Module:Infobox/Basic')
 local Namespace = require('Module:Namespace')
@@ -22,10 +21,10 @@ local Map = Class.new(BasicInfobox)
 
 function Map.run(frame)
 	local map = Map(frame)
-	return map:createInfobox(frame)
+	return map:createInfobox()
 end
 
-function Map:createInfobox(frame)
+function Map:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
 
@@ -45,7 +44,7 @@ function Map:createInfobox(frame)
 		self:_setLpdbData(args)
 	end
 
-	return infobox:build()
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local BasicInfobox = require('Module:Infobox/Basic')
 local Namespace = require('Module:Namespace')
+local Hotkey = require('Module:Hotkey')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -6,10 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local BasicInfobox = require('Module:Infobox/Basic')
 local Class = require('Module:Class')
 local BasicInfobox = require('Module:Infobox/Basic')
 local Namespace = require('Module:Namespace')
-local Hotkey = require('Module:Hotkey')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -22,10 +22,10 @@ local Map = Class.new(BasicInfobox)
 
 function Map.run(frame)
 	local map = Map(frame)
-	return map:createInfobox()
+	return map:createInfobox(frame)
 end
 
-function Map:createInfobox()
+function Map:createInfobox(frame)
 	local infobox = self.infobox
 	local args = self.args
 
@@ -45,7 +45,7 @@ function Map:createInfobox()
 		self:_setLpdbData(args)
 	end
 
-	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
+	return infobox:build()
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -6,10 +6,20 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local BasicInfobox = require('Module:Infobox/Basic')
 local Class = require('Module:Class')
-local Table = require('Module:Table')
+local BasicInfobox = require('Module:Infobox/Basic/dev')
 local Namespace = require('Module:Namespace')
+local Table = require('Module:Table')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Header = Widgets.Header
+local Title = Widgets.Title
+local Center = Widgets.Center
+local Chronology = Widgets.Chronology
+local Builder = Widgets.Builder
+local Customizable = Widgets.Customizable
+local Highlights = require('Module:Infobox/Widget/Highlights')
 
 local Patch = Class.new(BasicInfobox)
 
@@ -21,36 +31,55 @@ end
 function Patch:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
-	infobox.highlights = self._highlights
 
-	infobox:name(args.name)
-	infobox:image(args.image, args.defaultImage)
-	infobox:centeredCell(args.caption)
-	infobox:header('Patch Information', true)
-	infobox:cell('Version', args.version)
-	infobox:cell('Release', args.release)
-	self:addCustomCells(infobox, args)
-
-	local chronologyData = self:getChronologyData(args)
-
-	infobox:header('Highlights', args.highlight1)
-	infobox:highlights(self:_getHighlights(args))
-	infobox:header('Chronology', not Table.isEmpty(chronologyData))
-	infobox:chronology(chronologyData)
-	infobox:centeredCell(args.footnotes)
-	self:addCustomContent(infobox, args)
-	infobox:bottom(self:createBottomContent(infobox))
+	local widgets = {
+		Header{name = args.name, image = args.image},
+		Center{content = {args.caption}},
+		Title{name = 'Patch Information'},
+		Cell{name = 'Version', content = {args.version}},
+		Customizable{id = 'release', children = {
+				Cell{name = 'Release', content = {args.release}},
+			}
+		},
+		Customizable{id = 'custom', children = {}},
+		Builder{
+			builder = function()
+				local highlights = self:getAllArgsForBase(args, 'highlight')
+				if not Table.isEmpty(highlights) then
+					return {
+						Title{name = 'Highlights'},
+						Highlights{content = highlights}
+					}
+				end
+			end
+		},
+		Builder{
+			builder = function()
+				local chronologyData = self:getChronologyData(args)
+				if not Table.isEmpty(chronologyData) then
+					return {
+						Title{name = 'Chronology'},
+						Chronology{
+							content = chronologyData
+						}
+					}
+				end
+			end
+		},
+		Customizable{id = 'customcontent', children = {}},
+		Center{content = {args.footnotes}},
+	}
 
 	if Namespace.isMain() then
 		infobox:categories('Patches')
-		self:addToLpdb(infobox, args)
+		self:addToLpdb(args)
 	end
 
-	return infobox:build()
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 --- Allows for overriding this functionality
-function Patch:addToLpdb(infobox, args)
+function Patch:addToLpdb(args)
 	local date = args.release
 	local monthAndDay = mw.getContentLanguage():formatDate('m-d', date)
 	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, {
@@ -64,43 +93,6 @@ end
 --- Allows for overriding this functionality
 function Patch:getChronologyData(args)
 	return { previous = args.previous, next = args.next }
-end
-
-function Patch:_getHighlights(args)
-	local highlights = {}
-
-	if args.highlight1 or args.highlight then
-		table.insert(highlights, args.highlight1 or args.highlight)
-	end
-
-	for index = 2, 99 do
-		if args['highlight' .. index] then
-			table.insert(highlights, args['highlight' .. index])
-		else
-			break
-		end
-	end
-	return highlights
-end
-
---extend Infobox class
-function Patch:_highlights(data)
-	if Table.isEmpty(data) then
-		return self
-	end
-
-	local div = mw.html.create('div')
-	local highlights = mw.html.create('ul')
-
-	for _, item in ipairs(data) do
-		highlights:tag('li'):wikitext(item):done()
-	end
-
-	div:node(highlights)
-
-	self.content:node(div)
-
-	return self
 end
 
 return Patch

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -7,7 +7,7 @@
 --
 
 local Class = require('Module:Class')
-local BasicInfobox = require('Module:Infobox/Basic/dev')
+local BasicInfobox = require('Module:Infobox/Basic')
 local Namespace = require('Module:Namespace')
 local Table = require('Module:Table')
 

--- a/components/infobox/commons/infobox_patch_custom.lua
+++ b/components/infobox/commons/infobox_patch_custom.lua
@@ -6,13 +6,22 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Class = require('Module:Class')
 local Patch = require('Module:Infobox/Patch')
+local Injector = require('Module:Infobox/Widget/Injector')
 
-local CustomPatch = {}
+local CustomPatch = Class.new()
+
+local CustomInjector = Class.new(Injector)
 
 function CustomPatch.run(frame)
-	local patch = Patch(frame)
-	return patch:createInfobox()
+	local customPatch = Patch(frame)
+	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
+	return customPatch:createInfobox(frame)
+end
+
+function CustomPatch:createWidgetInjector()
+	return CustomInjector()
 end
 
 return CustomPatch

--- a/components/infobox/commons/infobox_widget_highlights.lua
+++ b/components/infobox/commons/infobox_widget_highlights.lua
@@ -1,0 +1,41 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Widget/Highlights
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Widget = require('Module:Infobox/Widget')
+local Table = require('Module:Table')
+
+local Highlights = Class.new(
+	Widget,
+	function(self, input)
+		self.list = input.content
+	end
+)
+
+function Highlights:make()
+	return Highlights:_highlights(self.list)
+end
+
+function Highlights:_highlights(list)
+	if list == nil or Table.size(list) == 0 then
+		return nil
+	end
+
+	local div = mw.html.create('div')
+	local highlights = mw.html.create('ul')
+
+	for _, item in ipairs(list) do
+		highlights:tag('li'):wikitext(item):done()
+	end
+
+	div:node(highlights)
+
+	return {div}
+end
+
+return Highlights

--- a/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
@@ -21,12 +21,12 @@ local _args
 local CustomInjector = Class.new(Injector)
 
 function CustomPatch.run(frame)
-    local customPatch = Patch(frame)
+	local customPatch = Patch(frame)
 	_args = customPatch.args
 	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
 	customPatch.getChronologyData = CustomPatch.getChronologyData
 	customPatch.addToLpdb = CustomPatch.addToLpdb
-    return customPatch:createInfobox(frame)
+	return customPatch:createInfobox(frame)
 end
 
 function CustomPatch:createWidgetInjector()

--- a/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
@@ -6,62 +6,93 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Class = require('Module:Class')
 local Patch = require('Module:Infobox/Patch')
+local Namespace = require('Module:Namespace')
+local String = require('Module:StringUtils')
+local RaceIcon = require('Module:RaceIcon')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
 
-local StarCraft2Patch = {}
+local CustomPatch = Class.new()
 
-function StarCraft2Patch.run(frame)
-	local patch = Patch(frame)
-	patch.addCustomCells = StarCraft2Patch.addCustomCells
-	patch.getChronologyData = StarCraft2Patch.getChronologyData
-	patch.addToLpdb = StarCraft2Patch.addToLpdb
-	return patch:createInfobox()
+local _args
+
+local CustomInjector = Class.new(Injector)
+
+function CustomPatch.run(frame)
+    local customPatch = Patch(frame)
+	_args = customPatch.args
+	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
+	customPatch.getChronologyData = CustomPatch.getChronologyData
+	customPatch.addToLpdb = CustomPatch.addToLpdb
+    return customPatch:createInfobox(frame)
 end
 
-function StarCraft2Patch:addCustomCells(infobox, args)
-	infobox:cell('SEA Release Date', args.searelease)
-	infobox:cell('NA Release Date', args.narelease)
-	infobox:cell('EU Release Date', args.eurelease)
-	infobox:cell('KR Release Date', args.korrelease)
-	return infobox
+function CustomPatch:createWidgetInjector()
+	return CustomInjector()
 end
 
-function StarCraft2Patch:addToLpdb(infobox, args)
-	local date = args.narelease or args.eurelease
+function CustomInjector:parse(id, widgets)
+	if id == 'release' then
+		return {
+			Cell{
+				name = 'SEA Release Date',
+				content = {_args.searelease}
+			},
+			Cell{
+				name = 'NA Release Date',
+				content = {_args.narelease}
+			},
+			Cell{
+				name = 'EU Release Date',
+				content = {_args.eurelease}
+			},
+			Cell{
+				name = 'KR Release Date',
+				content = {_args.korrelease}
+			},
+		}
+	end
+	return widgets
+end
+
+function CustomPatch:addToLpdb()
+	local date = _args.narelease or _args.eurelease
 	local monthAndDay = mw.getContentLanguage():formatDate('m-d', date)
 	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, {
-		name = args.name,
+		name = _args.name,
 		type = 'patch',
 		information = monthAndDay,
 		date = date,
 	})
 end
 
-function StarCraft2Patch:getChronologyData(args)
+function CustomPatch:getChronologyData()
 	local data = {}
-	if args.previous == nil and args.next == nil then
-		if args.previoushbu then
-			data.previous = 'Balance Update ' .. args.previoushbu .. '|#' .. args.previoushbu
+	if _args.previous == nil and _args.next == nil then
+		if _args.previoushbu then
+			data.previous = 'Balance Update ' .. _args.previoushbu .. '|#' .. _args.previoushbu
 		end
-		if args.nexthbu then
-			data.next = 'Balance Update ' .. args.nexthbu .. '|#' .. args.nexthbu
+		if _args.nexthbu then
+			data.next = 'Balance Update ' .. _args.nexthbu .. '|#' .. _args.nexthbu
 		end
 	else
-		if args.previous then
-			data.previous = 'Patch ' .. args.previous .. '|' .. args.previous
+		if _args.previous then
+			data.previous = 'Patch ' .. _args.previous .. '|' .. _args.previous
 		end
-		if args.next then
-			data.next = 'Patch ' .. args.next .. '|' .. args.next
+		if _args.next then
+			data.next = 'Patch ' .. _args.next .. '|' .. _args.next
 		end
-		if args.previoushbu then
-			data.previous2 = 'Balance Update ' .. args.previoushbu .. '|#' .. args.previoushbu
+		if _args.previoushbu then
+			data.previous2 = 'Balance Update ' .. _args.previoushbu .. '|#' .. _args.previoushbu
 		end
-		if args.nexthbu then
-			data.next2 = 'Balance Update ' .. args.nexthbu .. '|#' .. args.nexthbu
+		if _args.nexthbu then
+			data.next2 = 'Balance Update ' .. _args.nexthbu .. '|#' .. _args.nexthbu
 		end
 	end
 
 	return data
 end
 
-return StarCraft2Patch
+return CustomPatch

--- a/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
@@ -8,9 +8,6 @@
 
 local Class = require('Module:Class')
 local Patch = require('Module:Infobox/Patch')
-local Namespace = require('Module:Namespace')
-local String = require('Module:StringUtils')
-local RaceIcon = require('Module:RaceIcon')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 


### PR DESCRIPTION
Migrates Infobox/Patch over to table based layout, see #304. Merges into #321 
* adjust function `getAllArgsForBase` in `Module:Infobox/Basic` a bit
* add `Module:Infobox/Widget/Highlights`
* migrate `Module:Infobox/Patch`
* migrate `Module:Infobox/Patch/Custom` base version on commons
* migrate `Module:Infobox/Patch/Custom` SC2