### PR TITLE
Support default team logo

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -36,7 +36,11 @@ function Team:createInfobox(frame)
 	local args = self.args
 
 	local widgets = {
-		Header{name = args.name, image = args.image},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDefault = args.default,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Team Information'},
 		Cell{


### PR DESCRIPTION
#321 removed support for "default" team logos for when a team does not have a logo.