### PR TITLE
Remove default `:addCustomContent` function (stacked on #361)

### DIFF
--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -36,11 +36,6 @@ function BasicInfobox:addCustomCells(infobox, args)
 end
 
 --- Allows for overriding this functionality
-function BasicInfobox:addCustomContent(infobox, args)
-	return infobox
-end
-
---- Allows for overriding this functionality
 function BasicInfobox:createBottomContent()
 	return nil
 end

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -133,20 +133,20 @@ function CustomTeam:createBottomContent()
 end
 
 function CustomTeam.playerBreakDownDisplay(contents)
-	if type(contents) ~= 'table' or contents == {} then
-		return nil
-	end
+    if type(contents) ~= 'table' or contents == {} then
+        return nil
+    end
 
-	local div = mw.html.create('div')
-	local number = #contents
-	for _, content in ipairs(contents) do
-		local infoboxCustomCell = mw.html.create('div'):addClass('infobox-cell-' .. number
+    local div = mw.html.create('div')
+    local number = #contents
+    for _, content in ipairs(contents) do
+        local infoboxCustomCell = mw.html.create('div'):addClass('infobox-cell-' .. number
 			.. ' infobox-center')
-		infoboxCustomCell:wikitext(content)
-		div:node(infoboxCustomCell)
-	end
+        infoboxCustomCell:wikitext(content)
+        div:node(infoboxCustomCell)
+    end
 
-	return div
+    return div
 end
 
 function CustomTeam.storeToLPDB(args)

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -133,20 +133,20 @@ function CustomTeam:createBottomContent()
 end
 
 function CustomTeam.playerBreakDownDisplay(contents)
-    if type(contents) ~= 'table' or contents == {} then
-        return nil
-    end
+	if type(contents) ~= 'table' or contents == {} then
+		return nil
+	end
 
-    local div = mw.html.create('div')
-    local number = #contents
-    for _, content in ipairs(contents) do
-        local infoboxCustomCell = mw.html.create('div'):addClass('infobox-cell-' .. number
+	local div = mw.html.create('div')
+	local number = #contents
+	for _, content in ipairs(contents) do
+		local infoboxCustomCell = mw.html.create('div'):addClass('infobox-cell-' .. number
 			.. ' infobox-center')
-        infoboxCustomCell:wikitext(content)
-        div:node(infoboxCustomCell)
-    end
+		infoboxCustomCell:wikitext(content)
+		div:node(infoboxCustomCell)
+	end
 
-    return div
+	return div
 end
 
 function CustomTeam.storeToLPDB(args)


### PR DESCRIPTION
Remove default `:addCustomContent` function as it is no longer needed due to the rewrite (i think)