### PR TITLE
Sort Links in Infobox

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -40,6 +40,7 @@ local _PRIORITY_GROUPS = {
 		'easa-d',
 		'esl',
 		'faceit',
+		'gamersclub',
 		'matcherino',
 		'matcherinolink',
 		'sostronk',

--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -30,8 +30,23 @@ local _PRIORITY_GROUPS = {
 		'website'
 	},
 	league = {
+		'5ewin',
+		'abiosgaming',
+		'aligulac',
+		'battlefy',
+		'challonge',
+		'cybergamer',
+		'esea',
+		'easa-d',
+		'esl',
+		'faceit',
+		'matcherino',
+		'matcherinolink',
+		'sostronk',
+		'toornament',
 		'bracket',
-		'rules'
+		'rules',
+		'rulebook',
 	},
 	social = {
 		'discord',

--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -23,21 +23,67 @@ local _ICON_KEYS_TO_RENAME = {
 	matcherinolink = 'matcherino'
 }
 
+local _PRIORITY_GROUPS = {
+	core = {
+		'home',
+		'site',
+		'website'
+	},
+	league = {
+		'bracket',
+		'rules'
+	},
+	social = {
+		'discord',
+		'facebook',
+		'instagram',
+		'reddit',
+		'snapchat',
+		'steam',
+		'steamalternative',
+		'telegram',
+		'tiktok',
+		'twitter',
+		'vk',
+		'weibo'
+	},
+	streams = {
+		'twitch',
+		'youtube',
+		'afreeca',
+		'dlive'
+	}
+}
+
 function Links:make()
 	local infoboxLinks = mw.html.create('div')
 	infoboxLinks	:addClass('infobox-center')
 					:addClass('infobox-icons')
 
+	for _, group in Table.iter.spairs(_PRIORITY_GROUPS) do
+		for _, key in ipairs(group) do
+			if self.links[self:_removeAppendedNumber(key)] ~= nil then
+				infoboxLinks:wikitext(' ' .. self:_makeLink(key, self.links[key]))
+
+				-- Remove links from the collection
+				self.links[key] = nil
+			end
+		end
+	end
+
 	for key, value in Table.iter.spairs(self.links) do
-		key = self:_removeAppendedNumber(key)
-		local link = '[' .. UtilLinks.makeFullLink(key, value, self.variant) ..
-			' <i class="lp-icon lp-' .. (_ICON_KEYS_TO_RENAME[key] or key) .. '></i>]'
-		infoboxLinks:wikitext(' ' .. link)
+		infoboxLinks:wikitext(' ' .. self:_makeLink(key, value))
 	end
 
 	return {
 		mw.html.create('div'):node(infoboxLinks)
 	}
+end
+
+function Links:_makeLink(key, value)
+	key = self:_removeAppendedNumber(key)
+	return '[' .. UtilLinks.makeFullLink(key, value, self.variant) ..
+		' <i class="lp-icon lp-' .. (_ICON_KEYS_TO_RENAME[key] or key) .. '></i>]'
 end
 
 --remove appended number

--- a/standard/links.lua
+++ b/standard/links.lua
@@ -31,6 +31,7 @@ local _PREFIXES = {
 	facebook = 'http://facebook.com/',
 	faceit = 'https://www.faceit.com/en/players/',
 	fanclub = '',
+	gamersclub = 'https://csgo.gamersclub.gg/campeonatos/csgo/',
 	gplus = 'http://plus.google.com/-plus',
 	home = '',
 	huomaotv = 'http://www.huomao.com/',

--- a/standard/links.lua
+++ b/standard/links.lua
@@ -11,6 +11,8 @@ local Class = require('Module:Class')
 local Links = {}
 
 local _PREFIXES = {
+	['5ewin'] = 'https://arena.5eplay.com/tournament/',
+	abiosgaming = 'https://abiosgaming.com/tournaments/',
 	afreeca = 'http://afreecatv.com/',
 	aligulac = 'https://aligulac.com/results/events/',
 	aoezone = 'https://aoezone.net/',
@@ -23,6 +25,8 @@ local _PREFIXES = {
 	discord = 'https://discord.gg/',
 	dlive = 'https://www.dlive.tv/',
 	douyu = 'http://www.douyu.com/',
+	esea = 'https://play.esea.net/events/',
+	['esea-d'] = 'https://play.esea.net/league/standings?divisionId=',
 	esl = '',
 	facebook = 'http://facebook.com/',
 	faceit = 'https://www.faceit.com/en/players/',
@@ -44,6 +48,7 @@ local _PREFIXES = {
 	rules = '',
 	site = '',
 	sk = 'http://sk-gaming.com/member/',
+	sostronk = 'https://www.sostronk.com/tournament/',
 	snapchat = 'https://www.snapchat.com/add/',
 	steam = 'https://steamcommunity.com/id/',
 	steamalternative = 'https://steamcommunity.com/profiles/',


### PR DESCRIPTION
Sort and group the links in the Infobox in preferred order.

This is a specific request from Counter-Strike, but I've seen it pondered by other wikis too.

Before
======
![image](https://user-images.githubusercontent.com/5138348/132317024-6cdecd57-f9cc-4439-9d6b-bf6c9966374c.png)

After
======
![image](https://user-images.githubusercontent.com/5138348/132317048-0190ba2b-1266-4559-bf43-8cb91a808815.png)
