### PR TITLE
Preserve original Links array

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -14,7 +14,7 @@ local Table = require('Module:Table')
 local Links = Class.new(
 	Widget,
 	function(self, input)
-		self.links = input.content
+		self.links = Table.copy(input.content)
 		self.variant = input.variant
 	end
 )


### PR DESCRIPTION
#363 sorted the infobox links, and set links that were iterated past to nil. This is fine, except that this mutates the original links array in Module:Infobox_X. This PR copies the memory instead, so that it is not mutated.