### PR TITLE
Allow classes for centered cells

### DIFF
--- a/components/infobox/commons/infobox_widget_center.lua
+++ b/components/infobox/commons/infobox_widget_center.lua
@@ -14,21 +14,22 @@ local Center = Class.new(
 	Widget,
 	function(self, input)
 		self.content = input.content
+		self.style = input.style
 	end
 )
 
 function Center:make()
 	return {
-		Center:_create(self.content)
+		Center:_create(self.content, self.style)
 	}
 end
 
-function Center:_create(content)
+function Center:_create(content, style)
 	if Table.isEmpty(content) then
 		return nil
 	end
 
-	local centered = mw.html.create('div'):addClass('infobox-center')
+	local centered = mw.html.create('div'):addClass('infobox-center'):cssText(style)
 
 	for _, item in pairs(content) do
 		centered:wikitext(item)

--- a/components/infobox/commons/infobox_widget_center.lua
+++ b/components/infobox/commons/infobox_widget_center.lua
@@ -14,22 +14,25 @@ local Center = Class.new(
 	Widget,
 	function(self, input)
 		self.content = input.content
-		self.style = input.style
+		self.classes = input.classes
 	end
 )
 
 function Center:make()
 	return {
-		Center:_create(self.content, self.style)
+		Center:_create(self.content, self.classes)
 	}
 end
 
-function Center:_create(content, style)
+function Center:_create(content, classes)
 	if Table.isEmpty(content) then
 		return nil
 	end
 
-	local centered = mw.html.create('div'):addClass('infobox-center'):cssText(style)
+	local centered = mw.html.create('div'):addClass('infobox-center')
+	for _, class in ipairs(classes) do
+		centered:addClass(class)
+	end
 
 	for _, item in pairs(content) do
 		centered:wikitext(item)


### PR DESCRIPTION
Allow css styling for centered cells

wanted for `Module:Infobox/UnofficialWorldChampion`

![Screenshot 2021-09-08 08 59 28](https://user-images.githubusercontent.com/75081997/132461934-ed31afd9-2bcd-4bc0-a95d-e926b3822532.png)
![Screenshot 2021-09-08 09 00 19](https://user-images.githubusercontent.com/75081997/132461937-3be92d2b-60b3-4af0-b2fa-68d120259037.png)
