### PR TITLE
Allow `infobox-header-3` class in title

### DIFF
--- a/components/infobox/commons/infobox_widget_title.lua
+++ b/components/infobox/commons/infobox_widget_title.lua
@@ -23,7 +23,7 @@ function Title:make()
 	}
 end
 
-function Title:_create(infoDescription. level)
+function Title:_create(infoDescription, level)
 	level = tonumber(level or 2)
 	--only allow "3" as manual entry for the level
 	if level ~= 3 then

--- a/components/infobox/commons/infobox_widget_title.lua
+++ b/components/infobox/commons/infobox_widget_title.lua
@@ -13,20 +13,27 @@ local Title = Class.new(
 	Widget,
 	function(self, input)
 		self.content = self:assertExistsAndCopy(input.name)
+		self.level = input.level
 	end
 )
 
 function Title:make()
 	return {
-		Title:_create(self.content)
+		Title:_create(self.content, self.level)
 	}
 end
 
-function Title:_create(infoDescription)
+function Title:_create(infoDescription. level)
+	level = tonumber(level or 2)
+	--only allow "3" as manual entry for the level
+	if level ~= 3 then
+		level = 2
+	end
+
 	local header = mw.html.create('div')
 	header	:addClass('infobox-header')
 			:addClass('wiki-backgroundcolor-light')
-			:addClass('infobox-header-2')
+			:addClass('infobox-header-' .. level)
 			:wikitext(infoDescription)
 	return mw.html.create('div'):node(header)
 end


### PR DESCRIPTION
Allow `infobox-header-3` class in `Module:Infobox/Widget/Title`

![Screenshot 2021-09-09 07 33 17](https://user-images.githubusercontent.com/75081997/132628831-93294af3-54e2-4d8d-82d7-52fb64e7c755.png)
