### PR TITLE
Address Counter-Strike Infobox/League complaints

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -288,9 +288,7 @@ function League:_createLocation(details)
 		end
 
 		content = Flags._Flag(details.country) .. '&nbsp;' ..
-			'[[:Category:' .. nationality .. ' Tournaments|' ..
-			displayText .. ']]' ..
-			'[[Category:' .. nationality .. ' Tournaments]]'
+			displayText .. '[[Category:' .. nationality .. ' Tournaments]]'
 	end
 
 	if not String.isEmpty(details.country2) then
@@ -308,9 +306,7 @@ function League:_createLocation(details)
 			end
 
 			content = content .. Flags._Flag(details.country2) .. '&nbsp;' ..
-				'[[:Category:' .. nationality2 .. ' Tournaments|' ..
-				displayText .. ']]' ..
-				'[[Category:' .. nationality2 .. ' Tournaments]]'
+				displayText .. '[[Category:' .. nationality2 .. ' Tournaments]]'
 		end
 	end
 

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -124,7 +124,7 @@ function CustomInjector:parse(id, widgets)
 				content = {CustomLeague:_createEslProTierCell(args.eslprotier)}
 			},
 			Cell{
-				name = Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox'),
+				name = Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox') .. 'Tier',
 				content = {CustomLeague:_createValveTierCell(args.valvetier)},
 				classes = {'valvepremier-highlighted'}
 			},


### PR DESCRIPTION
Addresses the remaining two Counter-Strike issues:

- location should imo not link to Category:<country tournaments>
- like NiKoholic mentioned: valvetier should be <Valve logo> Tier (currently just the Valve logo)