### PR TITLE
Fix Header images

### DIFF
--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -23,7 +23,6 @@ local Header = Class.new(
 function Header:make()
 	return {
 		Header:_name(self.name),
-		Header:_subHeader(self.subHeader),
 		Header:_image(self.image, self.imageDefault, self.size)
 	}
 end


### PR DESCRIPTION
#380 breaks images when `subHeader` is not supplied. Disable `subHeader`, for now.