### PR TITLE
Make sure there are no gaps in opponentX_pY (R6)

### DIFF
--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -484,7 +484,8 @@ end
 
 -- Get Playerdata from Vars (get's set in TeamCards)
 function matchFunctions.getPlayers(match, opponentIndex, teamName)
-	local count = 1 -- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
+	-- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
+	local count = 1
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = match['opponent' .. opponentIndex .. '_p' .. playerIndex] or {}

--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -484,6 +484,7 @@ end
 
 -- Get Playerdata from Vars (get's set in TeamCards)
 function matchFunctions.getPlayers(match, opponentIndex, teamName)
+	local count = 1 -- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = match['opponent' .. opponentIndex .. '_p' .. playerIndex] or {}
@@ -492,7 +493,8 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
-			match['opponent' .. opponentIndex .. '_p' .. playerIndex] = player
+			match['opponent' .. opponentIndex .. '_p' .. count] = player
+			count = count + 1
 		end
 	end
 	return match


### PR DESCRIPTION
match._storePlayers will throw away all players that occur after a gap in the opponentX list by breaking at the first empty entry.
An empty entry could occur for DNPs (did not play).
Tweaked the wikispect function so it won't create gaps in the index.