### PR TITLE
Create age module

### DIFF
--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -172,6 +172,9 @@ function Age:makeDisplay()
 		else
 			result.birth = self.birthDate:makeDisplay() .. ' (age ' .. age .. ')'
 		end
+	else
+		result.death = self.deathDate:makeDisplay()
+		result.birth = self.birthDate:makeDisplay()
 	end
 
 	return result

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -46,10 +46,6 @@ local Date = Class.new(
 	end
 )
 
-function Date:makeIso()
-	return mw.getContentLanguage():formatDate('c', self.time)
-end
-
 function Date:getEarliestPossible()
 	return os.time({
 		year = self.year or _EPOCH_DATE.year,

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -58,13 +58,13 @@ function Date:makeDisplay()
 end
 
 function Date:makeIso()
-	if self.isEmpty then
+	if self.isEmpty or not self.isExact then
 		return ''
 	end
 
-	local year = self.year or _EPOCH_DATE.year
-	local month = self.month or _EPOCH_DATE.month
-	local day = self.day or _EPOCH_DATE.day
+	local year = self.year
+	local month = self.month
+	local day = self.day
 
 	return year .. '-' .. month .. '-' .. day
 end

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -52,9 +52,14 @@ function Date:makeDisplay()
 		return ''
 	end
 
+	local formatString = self:_getFormatString()
 	local timestamp = self:getEarliestPossible()
 
-	return os.date('%B %e, %Y', timestamp)
+	if formatString then
+		return os.date(formatString, timestamp)
+	end
+
+	return ''
 end
 
 function Date:makeIso()
@@ -67,6 +72,22 @@ function Date:makeIso()
 	local day = self.day
 
 	return year .. '-' .. month .. '-' .. day
+end
+
+function Date:_getFormatString()
+	if self.year then
+		if self.month and self.day then
+			return '%B %e, %Y'
+		elseif self.month then
+			return '%B, %Y'
+		else -- Ignore day if we do not know the month
+			return '%Y'
+		end
+	elseif self.month and self.day then
+		return '%B %e'
+	elseif self.month then
+		return '%B'
+	end
 end
 
 function Date:getEarliestPossible()

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -8,16 +8,25 @@ local _DEFAULT_DAYS_IN_MONTH = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 
 local _MONTH_DECEMBER = 12
 local _CURRENT_YEAR = tonumber(mw.getContentLanguage():formatDate('Y'))
 
+---
+-- Represents a date
+--
+-- Before accessing the `year`, `month` and `day` values, please verify
+-- whether `isExact` or `isEmpty` are set to false or true respectively.
+--
+-- `isExact`: Whether this is a complete date, consisting of YYYY-MM-DD
+-- `isEmpty`: Whether there is a date here at all.
+-- `time`: Time in seconds
 local Date = Class.new(
 	function(self, dateString)
 		if String.isEmpty(dateString) then
-			self.exact = false
-			self.empty = true
+			self.isExact = false
+			self.isEmpty = true
 			return
 		end
 
-		self.empty = false
-		self.exact = true
+		self.isEmpty = false
+		self.isExact = true
 		local fields = mw.text.split(dateString, '-')
 
 		self.year = tonumber(fields[1])
@@ -25,7 +34,7 @@ local Date = Class.new(
 		self.day = tonumber(fields[3])
 
 		if self.year == nil or self.month == nil or self.day == nil then
-			self.exact = false
+			self.isExact = false
 		else
 			self.time = os.time({
 				year = self.year,
@@ -69,18 +78,18 @@ local Age = Class.new(
 
 function Age:calculate()
 	local endDate
-	if self.deathDate.empty then
+	if self.deathDate.isEmpty then
 		endDate = os.time()
 	else
 		endDate = self.deathDate.time
 	end
 
-	if self.birthDate.exact and (self.deathDate.exact or self.deathDate.empty) then
+	if self.birthDate.isExact and (self.deathDate.exact or self.deathDate.isEmpty) then
 		return self:_secondsToAge(os.difftime(endDate, self.birthDate.time))
-	elseif self.birthDate.year and (self.deathDate.year or self.deathDate.empty) then
+	elseif self.birthDate.year and (self.deathDate.year or self.deathDate.isEmpty) then
 		local minEndDate
 		local maxEndDate
-		if self.deathDate.empty then
+		if self.deathDate.isEmpty then
 			minEndDate = os.time()
 			maxEndDate = os.time()
 		else
@@ -120,7 +129,7 @@ end
 
 function AgeCalculation._assertValidDates(birthDate, deathDate)
 	local earliestPossibleBirthDate = birthDate:getEarliestPossible()
-	if deathDate.exact then
+	if deathDate.isExact then
 		if earliestPossibleBirthDate > deathDate:getLatestPossible() then
 			return error('Death date can not be before birth date')
 		end

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -1,0 +1,139 @@
+local Class = require('Module:Class')
+local String = require('Module:String')
+
+local AgeCalculation = {}
+
+local _EPOCH_DATE = { year = 1970, month = 1, day = 1 }
+local _DEFAULT_DAYS_IN_MONTH = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
+local _MONTH_DECEMBER = 12
+local _CURRENT_YEAR = tonumber(mw.getContentLanguage():formatDate('Y'))
+
+local Date = Class.new(
+	function(self, dateString)
+		if String.isEmpty(dateString) then
+			self.exact = false
+			self.empty = true
+			return
+		end
+
+		self.empty = false
+		self.exact = true
+		local fields = mw.text.split(dateString, '-')
+
+		self.year = tonumber(fields[1])
+		self.month = tonumber(fields[2])
+		self.day = tonumber(fields[3])
+
+		if self.year == nil or self.month == nil or self.day == nil then
+			self.exact = false
+		else
+			self.time = os.time({
+				year = self.year,
+				month = self.month,
+				day = self.day
+			})
+		end
+
+	end
+)
+
+function Date:makeIso()
+	return mw.getContentLanguage():formatDate('c', self.time)
+end
+
+function Date:getEarliestPossible()
+	return os.time({
+		year = self.year or _EPOCH_DATE.year,
+		month = self.month or _EPOCH_DATE.month,
+		day = self.day or _EPOCH_DATE.day,
+	})
+end
+
+function Date:getLatestPossible()
+	return os.time({
+		year = self.year or _CURRENT_YEAR,
+		month = self.month or _MONTH_DECEMBER,
+		day = self.day or _DEFAULT_DAYS_IN_MONTH[self.month or _MONTH_DECEMBER],
+	})
+end
+
+local BirthDate = Class.new(Date)
+local DeathDate = Class.new(Date)
+
+local Age = Class.new(
+	function(self, birthDate, deathDate)
+		self.birthDate = birthDate
+		self.deathDate = deathDate
+	end
+)
+
+function Age:calculate()
+	local endDate
+	if self.deathDate.empty then
+		endDate = os.time()
+	else
+		endDate = self.deathDate.time
+	end
+
+	if self.birthDate.exact and (self.deathDate.exact or self.deathDate.empty) then
+		return self:_secondsToAge(os.difftime(endDate, self.birthDate.time))
+	elseif self.birthDate.year and (self.deathDate.year or self.deathDate.empty) then
+		local minEndDate
+		local maxEndDate
+		if self.deathDate.empty then
+			minEndDate = os.time()
+			maxEndDate = os.time()
+		else
+			minEndDate = self.deathDate:getEarliestPossible()
+			maxEndDate = self.deathDate:getLatestPossible()
+		end
+
+		local minAge = self:_secondsToAge(os.difftime(minEndDate, self.birthDate:getLatestPossible()))
+		local maxAge = self:_secondsToAge(os.difftime(maxEndDate, self.birthDate:getEarliestPossible()))
+
+		-- If our min and max age values are identical, then we can just display that value. Else,
+		-- we have to display a range of ages
+		if minAge == maxAge then
+			return minAge
+		else
+			return minAge .. '-' .. maxAge
+		end
+	end
+
+	return nil
+end
+
+function Age:_secondsToAge(seconds)
+	return math.floor(seconds / 60 / 60 / 24 / 365.25)
+end
+
+function AgeCalculation.run(args)
+	local birthDate = BirthDate(args.birthdate)
+	local deathDate = DeathDate(args.deathdate)
+
+	AgeCalculation._assertValidDates(birthDate, deathDate)
+
+	local age = Age(birthDate, deathDate)
+
+	return age:calculate()
+end
+
+function AgeCalculation._assertValidDates(birthDate, deathDate)
+	local earliestPossibleBirthDate = birthDate:getEarliestPossible()
+	if deathDate.exact then
+		if earliestPossibleBirthDate > deathDate:getLatestPossible() then
+			return error('Death date can not be before birth date')
+		end
+
+		if deathDate:getEarliestPossible() > os.time() then
+			return error('Death date out of allowed range')
+		end
+	end
+
+	if earliestPossibleBirthDate > os.time() or
+		earliestPossibleBirthDate < os.time(_EPOCH_DATE) then
+			return error('Birth date out of allowed range')
+	end
+end
+
+return Class.export(AgeCalculation)

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -141,9 +141,10 @@ function Age:makeDisplay()
 	if age ~= nil then
 		if not self.deathDate.isEmpty then
 			result.death = self.deathDate:makeDisplay() .. ' (aged ' .. age .. ')'
+			result.birth = self.birthDate:makeDisplay()
+		else
+			result.birth = self.birthDate:makeDisplay() .. ' (age ' .. age .. ')'
 		end
-
-		result.birth = self.birthDate:makeDisplay() .. ' (age ' .. age .. ')'
 	end
 
 	return result


### PR DESCRIPTION
Create an age module, allowing calculation of ages. This PR improves over both the current legacy implementation, as well as #400, by providing a class-based structure for calculating the age, improving readability.

In contrast to previous implementations, this module uses `os.time()` extensively to guarantee correctness (and again improve readability).

The module is not yet complete compared to previous implementations, it does not yet set categories, variables, etc. This is to prompt discussion on how exactly we would like to structure the interaction between templates, modules, etc when it comes to these features.

![image](https://user-images.githubusercontent.com/5138348/133407550-b7dfdcae-7054-47db-9ed6-8c62857b8f97.png)
