### PR TITLE
Store Section Headers for matches

### DIFF
--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -60,6 +60,9 @@ function p.luaMatchlist(frame, args, matchBuilder)
 		)
 	end
 
+	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
+	Variables.varDefine('bracket_header', sectionHeader)
+
 	local storedData = {}
 	local currentMatchInWikicode = 'M1'
 
@@ -114,6 +117,7 @@ function p.luaMatchlist(frame, args, matchBuilder)
 		end
 
 		bd['bracketindex'] = Variables.varDefault('match2bracketindex', 0)
+		bd['sectionheader'] = sectionHeader
 
 		match['bracketdata'] = json.stringify(bd)
 
@@ -180,6 +184,9 @@ function p.luaBracket(frame, args, matchBuilder)
 	if Logic.readBool(args.isLegacy) then
 		_loggedInWarning = _loggedInWarning .. p._addLoggedInWarning('This is a Legacy bracket use the new brackets instead!')
 	end
+
+	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
+	Variables.varDefine('bracket_header', sectionHeader)
 
 	-- get bracket data from template
 	local bracketData = p._getBracketData(templateid, bracketid)
@@ -262,6 +269,8 @@ function p.luaBracket(frame, args, matchBuilder)
 			if bd['bracketreset'] ~= '' and not args['RxMBR'] then
 				bd['bracketreset'] = ''
 			end
+
+			bd['sectionheader'] = sectionHeader
 
 			match['bracketdata'] = json.stringify(bd)
 


### PR DESCRIPTION
Store Section Headers for matches

input option 1:
![Screenshot 2021-09-16 18 06 07](https://user-images.githubusercontent.com/75081997/133647059-d22eabef-f4a4-412a-a7d7-960c621569da.png)

input option 2:
![Screenshot 2021-09-16 18 06 47](https://user-images.githubusercontent.com/75081997/133647196-283e7142-3586-44b4-95bc-d48e6288193c.png)

lpdb data:
![Screenshot 2021-09-16 18 07 07](https://user-images.githubusercontent.com/75081997/133647296-6307cbe0-824f-4f64-8837-889b62dada93.png)
