### PR TITLE
Use Lua.requireDev for modules with dev and non-dev versions

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -69,14 +69,9 @@ Called from MatchGroup/Display
 -- @returns module
 ]]
 WikiSpecificBase.getMatchGroupModule = function(matchGroupType)
-	local DevFlags = require('Module:DevFlags')
-	if matchGroupType == 'matchlist' then
-		return DevFlags.matchGroupDev and Lua.requireIfExists('Module:MatchGroup/Display/Matchlist/dev')
-			or require('Module:MatchGroup/Display/Matchlist')
-	else -- matchGroupType == 'bracket'
-		return DevFlags.matchGroupDev and Lua.requireIfExists('Module:MatchGroup/Display/Bracket/dev')
-			or require('Module:MatchGroup/Display/Bracket')
-	end
+	return matchGroupType == 'matchlist'
+		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
+		or Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
 end
 
 return WikiSpecificBase

--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -1,16 +1,26 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Display/Bracket
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Math = require('Module:Math')
-local OpponentDisplay = require('Module:OpponentDisplay')
 local StringUtils = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local html = mw.html
 local _NON_BREAKING_SPACE = '&nbsp;'

--- a/components/match2/commons/match_group_display_bracket_template.lua
+++ b/components/match2/commons/match_group_display_bracket_template.lua
@@ -7,11 +7,13 @@
 --
 
 local Arguments = require('Module:Arguments')
-local BracketDisplay = require('Module:MatchGroup/Display/Bracket')
 local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
+
+local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
 
 local BracketTemplateDisplay = {propTypes = {}}
 

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -154,9 +154,7 @@ in a different props.MatchSummaryContainer in the Bracket and Matchlist
 components.
 ]]
 DisplayHelper.DefaultMatchSummaryContainer = function(props)
-	local DevFlags = require('Module:DevFlags')
-	local MatchSummaryModule = DevFlags.matchGroupDev and Lua.requireIfExists('Module:MatchSummary/dev')
-		or require('Module:MatchSummary')
+	local MatchSummaryModule = Lua.import('Module:MatchSummary', {requireDevIfEnabled = true})
 
 	if MatchSummaryModule.getByMatchId then
 		return MatchSummaryModule.getByMatchId(props)

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -1,12 +1,22 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Display/Matchlist
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
-local OpponentDisplay = require('Module:OpponentDisplay')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local MatchlistDisplay = {propTypes = {}, types = {}}
 

--- a/components/match2/commons/match_summary_ffa.lua
+++ b/components/match2/commons/match_summary_ffa.lua
@@ -1,14 +1,24 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchSummary/FFA
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
-local OpponentDisplay = require('Module:OpponentDisplay/dev')
 local Ordinal = require('Module:Ordinal')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 --[[
 Module containing display components for match summaries of free-for-all matches.

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -10,11 +10,13 @@ local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
-local PlayerDisplay = require('Module:Player/Display')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 local TypeUtil = require('Module:TypeUtil')
+
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
 
 local zeroWidthSpace = '&#8203;'
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -6,17 +6,17 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local BracketDisplay = require('Module:MatchGroup/Display/Bracket')
 local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
-local OpponentDisplay = require('Module:OpponentDisplay')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
-local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft')
 local Table = require('Module:Table')
 
+local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 local RaceColor = Lua.loadDataIfExists('Module:RaceColorClass') or {}
+local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 
 local html = mw.html
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -1,10 +1,20 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Display/Matchlist/Starcraft
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
-local MatchlistDisplay = require('Module:MatchGroup/Display/Matchlist')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
-local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft')
 local Table = require('Module:Table')
+
+local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
+local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 
 local StarcraftMatchlistDisplay = {}
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -6,15 +6,16 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
+
 local config = Lua.loadDataIfExists('Module:Match/Config') or {}
 local json = require('Module:Json')
 local cleanFlag = require('Module:Flags')._CountryName
-local FFA
 local defaultIcon
 
 local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
@@ -33,6 +34,10 @@ local MODES2 = {
 	['literal'] = 'literal',
 }
 
+local getStarCraftFFAInputModule = FnUtil.memoize(function()
+	return Lua.import('Module:MatchGroup/Input/StarCraft/FFA', {requireDevIfEnabled = true})
+end)
+
 --[[
 Module for converting input args of match group objects into LPDB records. This
 module is specific to the StarCraft and StarCraft2 wikis.
@@ -49,12 +54,7 @@ function StarCraftMatchGroupInput.processMatch(_, match)
 	match = StarCraftMatchGroupInput.getDateStuff(match)
 	match = StarCraftMatchGroupInput.getTournamentVars(match)
 	if match.ffa == 'true' then
-		if not FFA then
-			FFA = require('Module:DevFlags').matchGroupDev
-				and Lua.requireIfExists('Module:MatchGroup/Input/StarCraft/FFA/dev')
-				or require('Module:MatchGroup/Input/StarCraft/FFA')
-		end
-		match = FFA.adjustData(match)
+		match = getStarCraftFFAInputModule().adjustData(match)
 	else
 		match = StarCraftMatchGroupInput.adjustData(match)
 	end
@@ -176,7 +176,7 @@ end
 function StarCraftMatchGroupInput.getExtraData(match)
 	local extradata
 	if match.ffa == 'true' then
-		extradata = FFA.getExtraData(match)
+		extradata = getStarCraftFFAInputModule().getExtraData(match)
 	else
 		extradata = {
 			noQuery = match.noQuery,

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -6,17 +6,14 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local FFA = {}
-
 local json = require('Module:Json')
 local Variables = require('Module:Variables')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Table = require('Module:Table')
-local config = Lua.moduleExists('Module:Match/Config') and mw.loadData('Module:Match/Config') or {}
-local WikiSpecific = require('Module:DevFlags').matchGroupDev
-	and Lua.requireIfExists('Module:MatchGroup/Input/StarCraft/dev')
-	or require('Module:MatchGroup/Input/StarCraft')
+
+local config = Lua.loadDataIfExists('Module:Match/Config') or {}
+local StarcraftMatchGroupInput = Lua.import('Module:MatchGroup/Input/StarCraft', {requireDevIfEnabled = true})
 
 local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
 local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }
@@ -41,6 +38,8 @@ local ALOWED_BG = {
 	['drop'] = 'down',
 	['proceed'] = 'up',
 	}
+
+local FFA = {}
 
 function FFA.adjustData(match)
 	local OppNumber = 0
@@ -382,22 +381,22 @@ function FFA.OpponentInput(match, OppNumber, noscore)
 			--process input depending on type
 			if match['opponent' .. opponentIndex]['type'] == 'solo' then
 				match['opponent' .. opponentIndex] =
-					WikiSpecific.ProcessSoloOpponentInput(match['opponent' .. opponentIndex])
+					StarcraftMatchGroupInput.ProcessSoloOpponentInput(match['opponent' .. opponentIndex])
 			elseif match['opponent' .. opponentIndex]['type'] == 'duo' then
 				match['opponent' .. opponentIndex] =
-					WikiSpecific.ProcessDuoOpponentInput(match['opponent' .. opponentIndex])
+					StarcraftMatchGroupInput.ProcessDuoOpponentInput(match['opponent' .. opponentIndex])
 			elseif match['opponent' .. opponentIndex]['type'] == 'trio' then
 				match['opponent' .. opponentIndex] =
-					WikiSpecific.ProcessOpponentInput(match['opponent' .. opponentIndex], 3)
+					StarcraftMatchGroupInput.ProcessOpponentInput(match['opponent' .. opponentIndex], 3)
 			elseif match['opponent' .. opponentIndex]['type'] == 'quad' then
 				match['opponent' .. opponentIndex] =
-					WikiSpecific.ProcessOpponentInput(match['opponent' .. opponentIndex], 4)
+					StarcraftMatchGroupInput.ProcessOpponentInput(match['opponent' .. opponentIndex], 4)
 			elseif match['opponent' .. opponentIndex]['type'] == 'team' then
 				match['opponent' .. opponentIndex] =
-					WikiSpecific.ProcessTeamOpponentInput(match['opponent' .. opponentIndex], match.date)
+					StarcraftMatchGroupInput.ProcessTeamOpponentInput(match['opponent' .. opponentIndex], match.date)
 			elseif match['opponent' .. opponentIndex]['type'] == 'literal' then
 				match['opponent' .. opponentIndex] =
-					WikiSpecific.ProcessLiteralOpponentInput(match['opponent' .. opponentIndex])
+					StarcraftMatchGroupInput.ProcessLiteralOpponentInput(match['opponent' .. opponentIndex])
 			else
 				error('Unsupported Opponent Type')
 			end
@@ -452,7 +451,7 @@ function FFA.MapInput(match, i, subgroup, noscore, OppNumber)
 	match['map' .. i].date = match.date
 
 	--get participants data for the map + get map mode
-	match['map' .. i] = WikiSpecific.ProcessPlayerMapData(match['map' .. i], match, OppNumber)
+	match['map' .. i] = StarcraftMatchGroupInput.ProcessPlayerMapData(match['map' .. i], match, OppNumber)
 
 	--determine scores, resulttype, walkover and winner
 	match['map' .. i] = FFA.MapScoreProcessing(match['map' .. i], OppNumber, noscore)

--- a/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
@@ -1,10 +1,20 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchSummary/FFA/Starcraft
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Class = require('Module:Class')
-local FFAMatchSummary = require('Module:MatchSummary/FFA')
+local Lua = require('Module:Lua')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
-local StarcraftMatchSummary = require('Module:MatchSummary/Starcraft/dev')
-local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft/dev')
 local Table = require('Module:Table')
+
+local FFAMatchSummary = Lua.import('Module:MatchSummary/FFA', {requireDevIfEnabled = true})
+local StarcraftMatchSummary = Lua.import('Module:MatchSummary/Starcraft', {requireDevIfEnabled = true})
+local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 
 local CustomFfaMatchSummary = {propTypes = {}}
 

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -13,8 +13,8 @@ local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
-local StarcraftOpponentDisplay = require('Module:OpponentDisplay/Starcraft')
 
+local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 	getTinyIcon = function() end,
 }
@@ -36,7 +36,7 @@ StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
 function StarcraftMatchSummary.MatchSummaryContainer(props)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
 	local MatchSummary = match.isFFA
-		and require('Module:MatchSummary/FFA/Starcraft').FFAMatchSummary
+		and Lua.import('Module:MatchSummary/FFA/Starcraft', {requireDevIfEnabled = true}).FFAMatchSummary
 		or StarcraftMatchSummary.MatchSummary
 	return MatchSummary({match = match})
 end

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -11,12 +11,12 @@ local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local OpponentDisplay = require('Module:OpponentDisplay')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
-local StarcraftPlayerDisplay = require('Module:Player/Display/Starcraft')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local StarcraftPlayerDisplay = Lua.import('Module:Player/Display/Starcraft', {requireDevIfEnabled = true})
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 	getBigIcon = function() end,
 }

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -10,12 +10,12 @@ local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local PlayerDisplay = require('Module:Player/Display')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local StarcraftPlayerUtil = require('Module:Player/Util/Starcraft')
 local String = require('Module:StringUtils')
 local TypeUtil = require('Module:TypeUtil')
 
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 	getSmallIcon = function() end,
 }

--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -10,12 +10,14 @@ local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local MatchSummary = require('Module:MatchSummary/Base')
 local OperatorIcon = require('Module:OperatorIcon')
-local OpponentDisplay = require('Module:OpponentDisplay')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local _GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
 local _NO_CHECK = '[[File:NoCheck.png|link=]]'

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -1,8 +1,10 @@
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require("Module:Logic")
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
-local OpponentDisplay = require('Module:OpponentDisplay')
 local Template = require('Module:Template')
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local htmlCreate = mw.html.create
 

--- a/components/match2/wikis/rocketleague/opponent_display.lua
+++ b/components/match2/wikis/rocketleague/opponent_display.lua
@@ -10,11 +10,13 @@ local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
-local PlayerDisplay = require('Module:Player/Display')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 local TypeUtil = require('Module:TypeUtil')
+
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
 
 local OpponentDisplay = {propTypes = {}, types = {}}
 

--- a/components/match2/wikis/starcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft/brkts_wiki_specific.lua
@@ -13,9 +13,7 @@ local Table = require('Module:Table')
 local WikiSpecific = Table.copy(require('Module:Brkts/WikiSpecific/Base'))
 
 WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
-	local InputModule = require('Module:DevFlags').matchGroupDev
-		and Lua.requireIfExists('Module:MatchGroup/Input/StarCraft/dev')
-		or require('Module:MatchGroup/Input/StarCraft')
+	local InputModule = Lua.import('Module:MatchGroup/Input/StarCraft', {requireDevIfEnabled = true})
 	return InputModule.processMatch
 end)
 
@@ -24,16 +22,9 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 end)
 
 function WikiSpecific.getMatchGroupModule(matchGroupType)
-	local DevFlags = require('Module:DevFlags')
-	if matchGroupType == 'matchlist' then
-		return DevFlags.matchGroupDev
-			and Lua.requireIfExists('Module:MatchGroup/Display/Matchlist/Starcraft/dev')
-			or require('Module:MatchGroup/Display/Matchlist/Starcraft')
-	else -- matchGroupType == 'bracket'
-		return DevFlags.matchGroupDev
-			and Lua.requireIfExists('Module:MatchGroup/Display/Bracket/Starcraft/dev')
-			or require('Module:MatchGroup/Display/Bracket/Starcraft')
-	end
+	return matchGroupType == 'matchlist'
+		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true})
+		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true})
 end
 
 --Default Logo for Teams without Team Template

--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -13,9 +13,7 @@ local Table = require('Module:Table')
 local WikiSpecific = Table.copy(require('Module:Brkts/WikiSpecific/Base'))
 
 WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
-	local InputModule = require('Module:DevFlags').matchGroupDev
-		and Lua.requireIfExists('Module:MatchGroup/Input/StarCraft/dev')
-		or require('Module:MatchGroup/Input/StarCraft')
+	local InputModule = Lua.import('Module:MatchGroup/Input/StarCraft', {requireDevIfEnabled = true})
 	return InputModule.processMatch
 end)
 
@@ -24,16 +22,9 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 end)
 
 function WikiSpecific.getMatchGroupModule(matchGroupType)
-	local DevFlags = require('Module:DevFlags')
-	if matchGroupType == 'matchlist' then
-		return DevFlags.matchGroupDev
-			and Lua.requireIfExists('Module:MatchGroup/Display/Matchlist/Starcraft/dev')
-			or require('Module:MatchGroup/Display/Matchlist/Starcraft')
-	else -- matchGroupType == 'bracket'
-		return DevFlags.matchGroupDev
-			and Lua.requireIfExists('Module:MatchGroup/Display/Bracket/Starcraft/dev')
-			or require('Module:MatchGroup/Display/Bracket/Starcraft')
-	end
+	return matchGroupType == 'matchlist'
+		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true})
+		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true})
 end
 
 --Default Logo for Teams without Team Template

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -9,11 +9,13 @@
 local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require("Module:Logic")
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local MatchSummary = require('Module:MatchSummary/Base')
-local OpponentDisplay = require('Module:OpponentDisplay')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local Agents = Class.new(
 	function(self)


### PR DESCRIPTION
Makes it easier to copy changes between dev and non-dev versions of a module. Can now do a file copy without having to add or remove '/dev' in requires. Also in preparation of a rework of Module:DevFlags