### PR TITLE
Bracket alignment fixes

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -526,6 +526,8 @@ function BracketDisplay.NodeBody(props)
 	end
 
 	return html.create('div'):addClass('brkts-round-body')
+		:css('--skip-round', match.bracketData.skipRound)
+		:css('--qual-skip', match.bracketData.qualSkip)
 		:node(lowerNode)
 		:node(lowerNode and BracketDisplay.NodeLowerConnectors(props) or nil)
 		:node(centerNode)
@@ -640,9 +642,7 @@ function BracketDisplay.NodeLowerConnectors(props)
 	end
 	local jointCount = math.max(jointIxAbove, jointIxBelow)
 
-	local lowerConnectorsNode = mw.html.create('div')
-		:addClass('brkts-round-lower-connectors')
-		:css('--skip-round', match.bracketData.skipRound)
+	local lowerConnectorsNode = mw.html.create('div'):addClass('brkts-round-lower-connectors')
 
 	-- Draw connectors between lower round matches and this match
 	for ix, x in ipairs(lowerMatches) do
@@ -700,9 +700,7 @@ function BracketDisplay.NodeQualConnectors(props)
 	local layout = props.layoutsByMatchId[props.matchId]
 	local config = props.config
 
-	local qualConnectorsNode = mw.html.create('div')
-		:addClass('brkts-round-qual-connectors')
-		:css('--qual-skip', match.bracketData.qualSkip)
+	local qualConnectorsNode = mw.html.create('div'):addClass('brkts-round-qual-connectors')
 
 	-- Qualified winner connector
 	local leftTop = layout.matchMarginTop + layout.matchHeight / 2


### PR DESCRIPTION
Fixes an issue with skipRound not being applied to child matches. Previously this wasn't a problem because match nodes were right aligned in the bracket.

Before ![image](https://user-images.githubusercontent.com/85348434/134084855-5c515c7b-afcc-4c5d-a4be-fc7937f7e3f2.png)

After ![image](https://user-images.githubusercontent.com/85348434/134084840-3d216c2a-53c4-47f2-b6bd-c1b24ca1b3a2.png)
