### PR TITLE
Move Legacy matchlist Warning

### DIFF
--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -139,13 +139,13 @@ function p.luaMatchlist(frame, args, matchBuilder)
 	Variables.varDefine('match2bracketindex', Variables.varDefault('match2bracketindex', 0) + 1)
 
 	if args.hide ~= 'true' then
-		return _loggedInWarning .. category .. tostring(MatchGroupDisplay.luaMatchlist(frame, {
+		return category .. tostring(MatchGroupDisplay.luaMatchlist(frame, {
 			bracketid,
 			attached = args.attached,
 			collapsed = args.collapsed,
 			nocollapse = args.nocollapse,
 			width = args.width or args.matchWidth,
-		}))
+		})) .. _loggedInWarning
 	end
 	return _loggedInWarning .. category
 end


### PR DESCRIPTION
Move Legacy matchlist Warning so it is displayed after the matchlist instead of before it