### PR TITLE
Make use of feature flags

### DIFF
--- a/components/match2/commons/display_util.lua
+++ b/components/match2/commons/display_util.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local FeatureFlag = require('Module:FeatureFlag')
 local FnUtil = require('Module:FnUtil')
 local TypeUtil = require('Module:TypeUtil')
 
@@ -16,17 +17,16 @@ local DisplayUtil = {propTypes = {}, types = {}}
 Checks that the props to be used by a display component satisfy type
 constraints. Throws if it does not.
 
-For performance reasons, type checking is disabled unless the forceTypeCheck
-developer flag is enabled via {{#vardefine:forceTypeCheck|1}}. Certain other
-developer flags like matchGroupDev can also enable type checking.
+For performance reasons, type checking is disabled unless the dev or force_type_check
+feature flags are enabled. (Via {{#vardefine:feature_force_type_check|1}} for
+instance.)
 
 By default this only checks types of properties, and not their contents. If
-forceTypeCheck is enabled, then the contents of table properties are checked up
-to 4 deep. Specify options.maxDepth to increase the depth.
+the force_type_check feature is enabled, then the contents of table properties
+are checked up to 4 deep. Specify options.maxDepth to increase the depth.
 ]]
 DisplayUtil.assertPropTypes = function(props, propTypes, options)
-	local DevFlags = require('Module:DevFlags')
-	if not (DevFlags.matchGroupDev or DevFlags.forceTypeCheck) then
+	if not (FeatureFlag.get('dev') or FeatureFlag.get('force_type_check')) then
 		return
 	end
 
@@ -36,7 +36,7 @@ DisplayUtil.assertPropTypes = function(props, propTypes, options)
 		props,
 		TypeUtil.struct(propTypes),
 		{
-			maxDepth = options.maxDepth or (DevFlags.forceTypeCheck and 5 or 1),
+			maxDepth = options.maxDepth or (FeatureFlag.get('force_type_check') and 5 or 1),
 			name = 'props',
 		}
 	)

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -6,9 +6,12 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local MatchGroupDisplay = {}
-local MatchGroupUtil
+local FeatureFlag = require('Module:FeatureFlag')
 local getArgs = require('Module:Arguments').getArgs
+
+local MatchGroupUtil
+
+local MatchGroupDisplay = {}
 
 -- Unused entry point
 function MatchGroupDisplay.bracket(frame)
@@ -103,8 +106,9 @@ end
 
 -- Entry point invoked directly from wikicode
 function MatchGroupDisplay.DisplayDev(frame)
-	require('Module:DevFlags').matchGroupDev = true
-	return MatchGroupDisplay.Display(frame)
+	return FeatureFlag.with({dev = true}, function()
+		return MatchGroupDisplay.Display(frame)
+	end)
 end
 
 function MatchGroupDisplay._getMatches(id)

--- a/components/match2/wikis/valorant/match_group.lua
+++ b/components/match2/wikis/valorant/match_group.lua
@@ -6,8 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local MatchGroup = require('Module:MatchGroup/Base')
 local Arguments = require('Module:Arguments')
+local FeatureFlag = require('Module:FeatureFlag')
+local Logic = require('Module:Logic')
+local MatchGroup = require('Module:MatchGroup/Base')
 local Table = require('Module:Table')
 
 local CustomMatchGroup = {}
@@ -15,20 +17,26 @@ local CustomMatchGroup = {}
 local _matches = {}
 local _bracketId = ''
 
+-- Entry point used by Template:Matchlist in valorant wiki
 function CustomMatchGroup.matchlist(frame)
 	local args = Arguments.getArgs(frame)
 	_bracketId = CustomMatchGroup._getBracketData(args)
 	_matches = CustomMatchGroup._getMatches(_bracketId)
 
-	return MatchGroup.luaMatchlist(frame, args, CustomMatchGroup._matchBuilder)
+	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
+		return MatchGroup.luaMatchlist(frame, args, CustomMatchGroup._matchBuilder)
+	end)
 end
 
+-- Entry point used by Template:Bracket in valorant wiki
 function CustomMatchGroup.bracket(frame)
 	local args = Arguments.getArgs(frame)
 	_bracketId = CustomMatchGroup._getBracketData(args)
 	_matches = CustomMatchGroup._getMatches(_bracketId)
 
-	return MatchGroup.luaBracket(frame, args, CustomMatchGroup._matchBuilder)
+	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
+		return MatchGroup.luaBracket(frame, args, CustomMatchGroup._matchBuilder)
+	end)
 end
 
 function CustomMatchGroup._getBracketData(args)

--- a/standard/feature_flag.lua
+++ b/standard/feature_flag.lua
@@ -67,24 +67,28 @@ end
 Runs a function inside a scope where the specified flags are set.
 ]]
 function FeatureFlag.with(flags, f)
+	if Table.isEmpty(flags) then
+		return f()
+	end
+
 	-- Remember previous flags
 	local oldFlags = Table.map(flags, function(flag, value)
 		return flag, mw.ext.VariablesLua.var('feature_' .. flag)
 	end)
 
 	-- Set new flags
-	for flag, value in ipairs(flags) do
+	for flag, value in pairs(flags) do
 		FeatureFlag.set(flag, value)
 	end
 
 	return Logic.try(f)
-		.finally(function()
+		:finally(function()
 			-- Restore previous flags
-			for flag, oldValue in ipairs(oldFlags) do
+			for flag, oldValue in pairs(oldFlags) do
 				mw.ext.VariablesLua.vardefine('feature_' .. flag, oldValue)
 			end
 		end)
-		.get()
+		:get()
 end
 
 function FeatureFlag.getConfig(flag)


### PR DESCRIPTION
Changes code that previously used `Module:DevFlags` to use `Module:FeatureFlag`

### From wikicode
To `#invoke` a dev module from wikicode, one must enable the dev flag *and* invoke the `/dev`-suffixed module. Enabling the dev flag will not automatically select the dev module. If the dev module is invoked without setting the dev flag, then it won't use the `/dev` suffixed dependency modules.

`Template:Invoke` eliminates this source of error by selecting the module (dev or non-dev) depending on the dev flag, and providing an easy way to set the dev flag.

Usage:
`{{Invoke|Magpie|theive}}` will invoke `Module:Magpie` or `Module:Magpie/dev` depending on whether the `dev` feature flag is enabled.
`{{Invoke|Magpie|theive|dev=1}}` enables the dev flag and invokes `Module:Magpie/dev`
`{{Invoke|Magpie|theive|dev=0}}` disables the dev flag and invokes `Module:Magpie`

The dev flag set by Template:Invoke is scoped - it will revert to its previous value after the template call. To set an unscoped dev flag, write to the feature variable directly: `{{#vardefine:feature_dev|1}}`.

### From lua
- `FeatureFlag.get('dev')`
- `FeatureFlag.set('dev', 1)`
- `FeatureFlag.with({dev = true}, function() ... end)` to enable only in a function scope
- etc