### PR TITLE
Adjust LeagueIcon Module for Infobox/League

### DIFF
--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -57,6 +57,12 @@ function LeagueIcon._make(icon, iconDark, link, name, size)
 end
 
 --retrieve icon and iconDark from LeagueIconSmall templates
+--entry params
+--icon = icon for light mode
+--iconDark = icon for dark mode
+--series = series for which LeagueIconSmall is to be expanded
+--abbreviation = abbreviation for which LeagueIconSmall is to be expanded (if the series one doesn't exist)
+--leagueIconSmallTemplate = expanded LeagueIconSmall template as string (in case it was expanded before already)
 function LeagueIcon.getIconFromTemplate(icon, iconDark, series, abbreviation, date, leagueIconSmallTemplate)
 	leagueIconSmallTemplate = leagueIconSmallTemplate or LeagueIcon._getTemplate(series, abbreviation, date)
 

--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -57,14 +57,15 @@ function LeagueIcon._make(icon, iconDark, link, name, size)
 end
 
 --retrieve icon and iconDark from LeagueIconSmall templates
-function LeagueIcon.getIconFromTemplate(icon, iconDark, series, abbreviation, date)
-	local leagueIconSmallTemplate = LeagueIcon._getTemplate(series, abbreviation, date)
+function LeagueIcon.getIconFromTemplate(icon, iconDark, series, abbreviation, date, leagueIconSmallTemplate)
+	leagueIconSmallTemplate = leagueIconSmallTemplate or LeagueIcon._getTemplate(series, abbreviation, date)
 
 	--if LeagueIconSmall template exists retrieve the icons from it
 	if leagueIconSmallTemplate then
+		leagueIconSmallTemplate = mw.text.split(leagueIconSmallTemplate, 'File:')
+
 		if String.isEmpty(icon) then
 			--extract series icon from template:LeagueIconSmall
-			leagueIconSmallTemplate = mw.text.split(leagueIconSmallTemplate, 'File:')
 			icon = mw.text.split(leagueIconSmallTemplate[2] or '', '|')
 			icon = icon[1]
 		end

--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -24,8 +24,16 @@ function LeagueIcon.display(args)
 	local iconDark = args.iconDark
 	local icon = args.icon
 	if not Logic.readBool(options.noTemplate) and not (icon and iconDark) then
-		local stringOfExpandedTemplate = LeagueIcon.getTemplate({series = args.series, abbreviation = args.abbreviation, date = args.date})
-		icon, iconDark = LeagueIcon.getIconFromTemplate({icon = icon, iconDark = iconDark, stringOfExpandedTemplate = stringOfExpandedTemplate})
+		local stringOfExpandedTemplate = LeagueIcon.getTemplate({
+			series = args.series,
+			abbreviation = args.abbreviation,
+			date = args.date
+		})
+		icon, iconDark = LeagueIcon.getIconFromTemplate({
+			icon = icon,
+			iconDark = iconDark,
+			stringOfExpandedTemplate = stringOfExpandedTemplate
+		})
 	end
 
 	--if icon is not given and can not be retrieved return empty string

--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -24,7 +24,8 @@ function LeagueIcon.display(args)
 	local iconDark = args.iconDark
 	local icon = args.icon
 	if not Logic.readBool(options.noTemplate) and not (icon and iconDark) then
-		icon, iconDark = LeagueIcon.getIconFromTemplate(icon, iconDark, args.series, args.abbreviation, args.date)
+		local stringOfExpandedTemplate = LeagueIcon.getTemplate(args.series, args.abbreviation, args.date)
+		icon, iconDark = LeagueIcon.getIconFromTemplate({icon = icon, iconDark = iconDark, stringOfExpandedTemplate = stringOfExpandedTemplate})
 	end
 
 	--if icon is not given and can not be retrieved return empty string
@@ -57,28 +58,29 @@ function LeagueIcon._make(icon, iconDark, link, name, size)
 end
 
 --retrieve icon and iconDark from LeagueIconSmall templates
---entry params
+--entry params:
 --icon = icon for light mode
 --iconDark = icon for dark mode
---series = series for which LeagueIconSmall is to be expanded
---abbreviation = abbreviation for which LeagueIconSmall is to be expanded (if the series one doesn't exist)
---leagueIconSmallTemplate = expanded LeagueIconSmall template as string (in case it was expanded before already)
-function LeagueIcon.getIconFromTemplate(icon, iconDark, series, abbreviation, date, leagueIconSmallTemplate)
-	leagueIconSmallTemplate = leagueIconSmallTemplate or LeagueIcon._getTemplate(series, abbreviation, date)
+--stringOfExpandedTemplate = expanded LeagueIconSmall template as string
+function LeagueIcon.getIconFromTemplate(args)
+	args = args or {}
+	local icon = args.icon
+	local iconDark = args.iconDark
+	local stringOfExpandedTemplate = args.stringOfExpandedTemplate
 
 	--if LeagueIconSmall template exists retrieve the icons from it
-	if leagueIconSmallTemplate then
-		leagueIconSmallTemplate = mw.text.split(leagueIconSmallTemplate, 'File:')
+	if stringOfExpandedTemplate then
+		stringOfExpandedTemplate = mw.text.split(stringOfExpandedTemplate, 'File:')
 
 		if String.isEmpty(icon) then
 			--extract series icon from template:LeagueIconSmall
-			icon = mw.text.split(leagueIconSmallTemplate[2] or '', '|')
+			icon = mw.text.split(stringOfExpandedTemplate[2] or '', '|')
 			icon = icon[1]
 		end
 
 		--when Template:LeagueIconSmall has a darkmode icon retrieve that from the template too
 		if String.isEmpty(iconDark) then
-			iconDark = mw.text.split(leagueIconSmallTemplate[3] or '', '|')
+			iconDark = mw.text.split(stringOfExpandedTemplate[3] or '', '|')
 			iconDark = iconDark[1]
 		end
 	else
@@ -88,11 +90,11 @@ function LeagueIcon.getIconFromTemplate(icon, iconDark, series, abbreviation, da
 	return icon, iconDark
 end
 
-function LeagueIcon._getTemplate(series, abbreviation, date)
+function LeagueIcon.getTemplate(series, abbreviation, date)
 	local frame = mw.getCurrentFrame()
-	local leagueIconSmallTemplate = 'false'
+	local stringOfExpandedTemplate = 'false'
 	if not String.isEmpty(series) then
-		leagueIconSmallTemplate = Template.safeExpand(
+		stringOfExpandedTemplate = Template.safeExpand(
 			frame,
 			'LeagueIconSmall/' .. string.lower(series),
 			{ date = date },
@@ -100,18 +102,18 @@ function LeagueIcon._getTemplate(series, abbreviation, date)
 		)
 	end
 	--if LeagueIconSmall template doesn't exist for the series try the abbreviation
-	if leagueIconSmallTemplate == 'false' and not String.isEmpty(abbreviation) then
-		leagueIconSmallTemplate = Template.safeExpand(
+	if stringOfExpandedTemplate == 'false' and not String.isEmpty(abbreviation) then
+		stringOfExpandedTemplate = Template.safeExpand(
 			frame,
 			'LeagueIconSmall/' .. string.lower(abbreviation),
 			{ date = date },
 			'false'
 		)
 	end
-	if leagueIconSmallTemplate == 'false' then
+	if stringOfExpandedTemplate == 'false' then
 		return nil
 	end
-	return leagueIconSmallTemplate
+	return stringOfExpandedTemplate
 end
 
 --generate copy paste code for new LeagueIconSmall templates

--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -24,7 +24,7 @@ function LeagueIcon.display(args)
 	local iconDark = args.iconDark
 	local icon = args.icon
 	if not Logic.readBool(options.noTemplate) and not (icon and iconDark) then
-		local stringOfExpandedTemplate = LeagueIcon.getTemplate(args.series, args.abbreviation, args.date)
+		local stringOfExpandedTemplate = LeagueIcon.getTemplate({series = args.series, abbreviation = args.abbreviation, date = args.date})
 		icon, iconDark = LeagueIcon.getIconFromTemplate({icon = icon, iconDark = iconDark, stringOfExpandedTemplate = stringOfExpandedTemplate})
 	end
 
@@ -90,7 +90,11 @@ function LeagueIcon.getIconFromTemplate(args)
 	return icon, iconDark
 end
 
-function LeagueIcon.getTemplate(series, abbreviation, date)
+function LeagueIcon.getTemplate(args)
+	args = args or {}
+	local series = args.series
+	local abbreviation = args.abbreviation
+	local date = args.date
 	local frame = mw.getCurrentFrame()
 	local stringOfExpandedTemplate = 'false'
 	if not String.isEmpty(series) then


### PR DESCRIPTION
* Adjust LeagueIcon Module for Infobox/League
* Fix bug (`leagueIconSmallTemplate` not being split if we have an `icon` but no `iconDark`)