### PR TITLE
[mg3] Enable performance instrumentation for match group

### DIFF
--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -21,7 +21,10 @@ end
 function MatchGroup.luaBracket(frame, args)
 	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
 		local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		return MatchGroupBase.luaBracket(frame, args)
+		MatchGroupBase.enableInstrumentation()
+		local display = MatchGroupBase.luaBracket(frame, args)
+		MatchGroupBase.disableInstrumentation()
+		return display
 	end)
 end
 
@@ -33,7 +36,10 @@ end
 function MatchGroup.luaMatchlist(frame, args)
 	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
 		local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		return MatchGroupBase.luaMatchlist(frame, args)
+		MatchGroupBase.enableInstrumentation()
+		local display = MatchGroupBase.luaMatchlist(frame, args)
+		MatchGroupBase.disableInstrumentation()
+		return display
 	end)
 end
 

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -6,10 +6,12 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Match = require('Module:Match')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 local json = require('Module:Json')
 
@@ -402,6 +404,20 @@ function p._addLoggedInWarning(text)
 		:tag('td'):addClass('ambox-image'):wikitext('[[File:Emblem-important.svg|40px|link=]]'):done()
 		:tag('td'):addClass('ambox-text'):wikitext(text)
 	return tostring(div:node(tbl))
+end
+
+function p.enableInstrumentation()
+	if FeatureFlag.get('perf') then
+		local config = Lua.loadDataIfExists('Module:MatchGroup/Config')
+		local locations = Table.getByPathOrNil(config, {'perf', 'locations'}) or {}
+		require('Module:Performance/Util').startInstrumentation(locations)
+	end
+end
+
+function p.disableInstrumentation()
+	if FeatureFlag.get('perf') then
+		require('Module:Performance/Util').stopAndSave()
+	end
 end
 
 return p

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -7,6 +7,7 @@
 --
 
 local FeatureFlag = require('Module:FeatureFlag')
+local Lua = require('Module:Lua')
 local getArgs = require('Module:Arguments').getArgs
 
 local MatchGroupUtil
@@ -92,6 +93,9 @@ end
 -- Displays a match group (bracket or matchlist) specified by ID. The match group is read from LPDB.
 -- Entry point invoked directly from wikicode
 function MatchGroupDisplay.Display(frame)
+	local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
+	MatchGroupBase.enableInstrumentation()
+
 	local args = getArgs(frame)
 	args[1] = args.id or args[1] or ''
 	local bracketId = args[1]
@@ -101,7 +105,9 @@ function MatchGroupDisplay.Display(frame)
 	local matchGroupType = matches[1].bracketData.type
 
 	local MatchGroupModule = require('Module:Brkts/WikiSpecific').getMatchGroupModule(matchGroupType)
-	return MatchGroupModule.luaGet(frame, args, matches)
+	local display = MatchGroupModule.luaGet(frame, args, matches)
+	MatchGroupBase.disableInstrumentation()
+	return display
 end
 
 -- Entry point invoked directly from wikicode


### PR DESCRIPTION
Makes use of the performance instrumentation in https://liquipedia.net/commons/Module:Performance/Util

Usage:
Use `{{#vardefine:feature_match_group_instrumentation|1}}` on a page to enable
Configure which functions are tracked in https://liquipedia.net/commons/Module:MatchGroup/Config (or on wikis)
`{{#invoke:Performance/Util|ReportContainer}}` to bring up the results table
`{{#invoke:Performance/Util|ClearData}}` for when a page has more more than one table

Notes:
- Timings are tracked and aggregated across template boundaries. The exception is exclusive duration which isn't propagated upward across a template boundary

Example:
https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Wide_Load
![image](https://user-images.githubusercontent.com/85348434/134771300-a3e3cf6b-469a-4675-aec7-f2097426ca5d.png)
