### PR TITLE
[mg7] Consolidate match group entry points

### DIFF
--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -6,41 +6,32 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local FeatureFlag = require('Module:FeatureFlag')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+
+local MatchGroupDisplay = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
 
 local MatchGroup = {}
 
 -- Entry point used by Template:Bracket
+-- Deprecated
 function MatchGroup.bracket(frame)
-	return MatchGroup.luaBracket(frame, Arguments.getArgs(frame))
+	return MatchGroupDisplay.TemplateBracket(frame)
 end
 
-function MatchGroup.luaBracket(frame, args)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		MatchGroupBase.enableInstrumentation()
-		local display = MatchGroupBase.luaBracket(frame, args)
-		MatchGroupBase.disableInstrumentation()
-		return display
-	end)
+-- Deprecated
+function MatchGroup.luaBracket(_, args)
+	return MatchGroupDisplay.TemplateBracket(args)
 end
 
 -- Entry point used by Template:Matchlist
+-- Deprecated
 function MatchGroup.matchlist(frame)
-	return MatchGroup.luaMatchlist(frame, Arguments.getArgs(frame))
+	return MatchGroupDisplay.TemplateMatchlist(frame)
 end
 
-function MatchGroup.luaMatchlist(frame, args)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		MatchGroupBase.enableInstrumentation()
-		local display = MatchGroupBase.luaMatchlist(frame, args)
-		MatchGroupBase.disableInstrumentation()
-		return display
-	end)
+-- Deprecated
+function MatchGroup.luaMatchlist(_, args)
+	return MatchGroupDisplay.TemplateMatchlist(args)
 end
 
 return MatchGroup

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -6,132 +6,89 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
 local FeatureFlag = require('Module:FeatureFlag')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local getArgs = require('Module:Arguments').getArgs
+local MatchGroupUtil = require('Module:MatchGroup/Util')
 
-local MatchGroupUtil
+local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
 local MatchGroupDisplay = {}
 
--- Unused entry point
-function MatchGroupDisplay.bracket(frame)
-	local args = getArgs(frame)
-	return MatchGroupDisplay.luaBracket(frame, args)
+--[[
+Reads a matchlist input spec, saves it to LPDB, and displays the matchlist.
+]]
+function MatchGroupDisplay.MatchlistBySpec(args, matchBuilder)
+	local options, warnings = MatchGroupBase.readOptions(args, 'matchlist')
+	local matches = MatchGroupInput.readMatchlist(options.bracketId, args, matchBuilder)
+	MatchGroupBase.saveMatchGroup(options.bracketId, matches, options.saveToLpdb)
+
+	local matchlistNode
+	if options.show then
+		local MatchlistDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('matchlist')
+		matchlistNode = MatchlistDisplay.luaGet(mw.getCurrentFrame(), {
+			options.bracketId,
+			attached = args.attached,
+			collapsed = args.collapsed,
+			nocollapse = args.nocollapse,
+			width = args.width or args.matchWidth,
+		}, matches)
+	end
+
+	return table.concat(Array.extend(
+		tostring(matchlistNode),
+		Array.map(warnings, MatchGroupDisplay.WarningBox)
+	), '')
 end
 
--- Displays a bracket specified by id with custom headers
-function MatchGroupDisplay.customBracket(frame, args, matches)
-	if not args then
-		args = getArgs(frame)
+--[[
+Reads a bracket input spec, saves it to LPDB, and displays the bracket.
+]]
+function MatchGroupDisplay.BracketBySpec(args, matchBuilder)
+	local options, warnings = MatchGroupBase.readOptions(args, 'bracket')
+	local matches = MatchGroupInput.readBracket(options.bracketId, args, matchBuilder)
+	MatchGroupBase.saveMatchGroup(options.bracketId, matches, options.saveToLpdb)
+
+	local bracketNode
+	if options.show then
+		local BracketDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('bracket')
+		bracketNode = BracketDisplay.luaGet(mw.getCurrentFrame(), {
+			options.bracketId,
+			emptyRoundTitles = args.emptyRoundTitles,
+			headerHeight = args.headerHeight,
+			hideMatchLine = args.hideMatchLine,
+			hideRoundTitles = args.hideRoundTitles,
+			matchHeight = args.matchHeight,
+			matchWidth = args.matchWidth,
+			matchWidthMobile = args.matchWidthMobile,
+			opponentHeight = args.opponentHeight,
+			qualifiedHeader = args.qualifiedHeader,
+		}, matches)
 	end
 
-	if not matches or #matches == 0 then
-		args[1] = args.id or args[1] or ''
-		matches = MatchGroupDisplay._getMatches(args[1])
-	end
-
-	if args.title ~= '' and args.title ~= nil then
-		matches[1].bracketData.title = args.title
-	end
-
-	for index, match in ipairs(matches) do
-		local round, matchInRound = MatchGroupDisplay._getMatchIndexFromMatchId(match.matchId, args[1])
-
-		if round and matchInRound then
-			local matchId = 'R' .. round .. 'M' .. matchInRound
-			if args[matchId .. 'header'] ~= '' and args[matchId .. 'header'] ~= nil then
-				matches[index].bracketData.header = args[matchId .. 'header']
-			end
-		end
-	end
-
-	return MatchGroupDisplay.luaBracket(frame, args, matches)
+	return table.concat(Array.extend(
+		Array.map(warnings, MatchGroupDisplay.WarningBox),
+		tostring(bracketNode)
+	), '')
 end
 
-function MatchGroupDisplay.luaBracket(frame, args, matches)
-	mw.log("drawing from lua")
-	local BracketDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('bracket')
-	return BracketDisplay.luaGet(frame, args, matches)
-end
+--[[
+Displays a matchlist or bracket specified by ID.
+]]
+function MatchGroupDisplay.MatchGroupById(args)
+	local bracketId = args.id or args[1]
 
--- Unused entry point
-function MatchGroupDisplay.matchlist(frame)
-	local args = getArgs(frame)
-	return MatchGroupDisplay.luaMatchlist(frame, args)
-end
-
--- Displays a matchlist specified by id with custom headers
-function MatchGroupDisplay.customMatchlist(frame, args, matches)
-	if not args then
-		args = getArgs(frame)
-	end
-
-	if not matches or #matches == 0 then
-		args[1] = args.id or args[1] or ''
-		matches = MatchGroupDisplay._getMatches(args[1])
-	end
-
-	if args.title ~= '' and args.title ~= nil then
-		matches[1].bracketData.title = args.title
-	end
-
-	for index, _ in ipairs(matches) do
-		if args['M' .. index .. 'header'] ~= '' and args['M' .. index .. 'header'] ~= nil then
-			matches[index].bracketData.header = args['M' .. index .. 'header']
-		end
-	end
-
-	return MatchGroupDisplay.luaMatchlist(frame, args, matches)
-end
-
-function MatchGroupDisplay.luaMatchlist(frame, args, matches)
-	local MatchlistDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('matchlist')
-	return MatchlistDisplay.luaGet(frame, args, matches)
-end
-
--- Displays a match group (bracket or matchlist) specified by ID. The match group is read from LPDB.
--- Entry point invoked directly from wikicode
-function MatchGroupDisplay.Display(frame)
-	local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-	MatchGroupBase.enableInstrumentation()
-
-	local args = getArgs(frame)
-	args[1] = args.id or args[1] or ''
-	local bracketId = args[1]
-
-	local matches = MatchGroupDisplay._getMatches(bracketId)
-
+	local matches = MatchGroupUtil.fetchMatches(bracketId)
+	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
 	local matchGroupType = matches[1].bracketData.type
 
-	local MatchGroupModule = require('Module:Brkts/WikiSpecific').getMatchGroupModule(matchGroupType)
-	local display = MatchGroupModule.luaGet(frame, args, matches)
-	MatchGroupBase.disableInstrumentation()
-	return display
-end
+	MatchGroupInput.applyOverrideArgs(matches, args)
 
--- Entry point invoked directly from wikicode
-function MatchGroupDisplay.DisplayDev(frame)
-	return FeatureFlag.with({dev = true}, function()
-		return MatchGroupDisplay.Display(frame)
-	end)
-end
-
-function MatchGroupDisplay._getMatches(id)
-	if not MatchGroupUtil then
-		MatchGroupUtil = require('Module:MatchGroup/Util')
-	end
-	local matches = MatchGroupUtil.fetchMatches(id)
-	if #matches == 0 then
-		error('No data found for bracketId=' .. id)
-	end
-	return matches
-end
-
-function MatchGroupDisplay._getMatchIndexFromMatchId(matchId, bracketId)
-	matchId = string.gsub(matchId, bracketId .. '_', '')
-	local round, matchInRound = string.match(matchId, '^R(%d+)%-M(%d+)$')
-	return tonumber(round or ''), tonumber(matchInRound or '')
+	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupModule(matchGroupType)
+	return MatchGroupContainer.luaGet(mw.getCurrentFrame(), args, matches)
 end
 
 function MatchGroupDisplay.WarningBox(text)
@@ -142,6 +99,80 @@ function MatchGroupDisplay.WarningBox(text)
 		:tag('td'):addClass('ambox-image'):wikitext('[[File:Emblem-important.svg|40px|link=]]'):done()
 		:tag('td'):addClass('ambox-text'):wikitext(text)
 	return div:node(tbl)
+end
+
+-- Entry point of Template:Matchlist
+function MatchGroupDisplay.TemplateMatchlist(frame)
+	local args = Arguments.getArgs(frame)
+	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
+		local MatchGroupDisplay_ = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
+		MatchGroupBase.enableInstrumentation()
+		local result = MatchGroupDisplay_.MatchlistBySpec(args)
+		MatchGroupBase.disableInstrumentation()
+		return result
+	end)
+end
+
+-- Entry point of Template:Bracket
+function MatchGroupDisplay.TemplateBracket(frame)
+	local args = Arguments.getArgs(frame)
+	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
+		local MatchGroupDisplay_ = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
+		MatchGroupBase.enableInstrumentation()
+		local result = MatchGroupDisplay_.BracketBySpec(args)
+		MatchGroupBase.disableInstrumentation()
+		return result
+	end)
+end
+
+-- Entry point of Template:ShowBracket
+function MatchGroupDisplay.TemplateShowBracket(frame)
+	local args = Arguments.getArgs(frame)
+	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
+		local MatchGroupDisplay_ = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
+		MatchGroupBase.enableInstrumentation()
+		local result = MatchGroupDisplay_.MatchGroupByID(args)
+		MatchGroupBase.disableInstrumentation()
+		return result
+	end)
+end
+
+-- Unused entry point
+-- Deprecated
+function MatchGroupDisplay.bracket(frame)
+	return MatchGroupDisplay.TemplateBracket(frame)
+end
+
+-- Deprecated
+function MatchGroupDisplay.luaBracket(frame, args, matches)
+	local BracketDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('bracket')
+	return BracketDisplay.luaGet(frame, args, matches)
+end
+
+-- Unused entry point
+-- Deprecated
+function MatchGroupDisplay.matchlist(frame)
+	return MatchGroupDisplay.TemplateMatchlist(frame)
+end
+
+-- Deprecated
+function MatchGroupDisplay.luaMatchlist(frame, args, matches)
+	local MatchlistDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('matchlist')
+	return MatchlistDisplay.luaGet(frame, args, matches)
+end
+
+-- Entry point from Template:ShowBracket and direct #invoke
+-- Deprecated
+function MatchGroupDisplay.Display(frame)
+	return MatchGroupDisplay.TemplateShowBracket(frame)
+end
+
+-- Entry point from direct #invoke
+-- Deprecated
+function MatchGroupDisplay.DisplayDev(frame)
+	local args = Arguments.getArgs(frame)
+	args.dev = true
+	return MatchGroupDisplay.TemplateShowBracket(args)
 end
 
 return MatchGroupDisplay

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -259,4 +259,36 @@ function MatchGroupInput._convertMatchIdentifier(identifier)
 	return roundPrefix .. string.format('%02d', roundNumber) .. '-' .. matchPrefix .. string.format('%03d', matchNumber)
 end
 
+function MatchGroupInput.applyOverrideArgs(matches, args)
+	local bracketId = args.id or args[1]
+	local matchGroupType = matches[1].bracketData.type
+
+	if args.title then
+		matches[1].bracketData.title = args.title
+	end
+
+	if matchGroupType == 'matchlist' then
+		for index, _ in ipairs(matches) do
+			local overrideHeader = args['M' .. index .. 'header']
+			if overrideHeader then
+				matches[index].bracketData.header = overrideHeader
+			end
+		end
+	else
+		for index, match in ipairs(matches) do
+			local round, matchInRound = match.matchId:gsub(bracketId .. '_', ''):match('^R(%d+)%-M(%d+)$')
+			round = tonumber(round or '')
+			matchInRound = tonumber(matchInRound or '')
+
+			if round and matchInRound then
+				local matchPrefix = 'R' .. round .. 'M' .. matchInRound
+				local overrideHeader = args[matchPrefix .. 'header']
+				if overrideHeader then
+					matches[index].bracketData.header = overrideHeader
+				end
+			end
+		end
+	end
+end
+
 return MatchGroupInput

--- a/components/match2/wikis/valorant/match_group.lua
+++ b/components/match2/wikis/valorant/match_group.lua
@@ -24,8 +24,8 @@ function CustomMatchGroup.matchlist(frame)
 	_matches = CustomMatchGroup._getMatches(_bracketId)
 
 	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		return MatchGroupBase.luaMatchlist(frame, args, CustomMatchGroup._matchBuilder)
+		local MatchGroupDisplay = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
+		return MatchGroupDisplay.MatchlistBySpec(args, CustomMatchGroup._matchBuilder)
 	end)
 end
 
@@ -36,8 +36,8 @@ function CustomMatchGroup.bracket(frame)
 	_matches = CustomMatchGroup._getMatches(_bracketId)
 
 	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		return MatchGroupBase.luaBracket(frame, args, CustomMatchGroup._matchBuilder)
+		local MatchGroupDisplay = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
+		return MatchGroupDisplay.BracketBySpec(args, CustomMatchGroup._matchBuilder)
 	end)
 end
 
@@ -50,7 +50,10 @@ function CustomMatchGroup._getBracketData(args)
 	-- make sure bracket id is valid
 	FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
 		local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		MatchGroupBase._validateBracketID(bracketId)
+		local _, message = MatchGroupBase.validateBaseBracketId(bracketId)
+		if message then
+			error(message)
+		end
 	end)
 
 	return bracketId


### PR DESCRIPTION
This consolidates all entry points that display matchlist/brackets to just 3 from templates and 3 in lua.

Templates:
- Template:Matchlist -> MatchGroupDisplay.TemplateMatchlist
- Template:Bracket -> MatchGroupDisplay.TemplateBracket
- Template:ShowBracket -> MatchGroupDisplay.TemplateShowBracket

In lua:
- MatchGroupDisplay.MatchlistBySpec
- MatchGroupDisplay.BracketBySpec
- MatchGroupDisplay.MatchGroupById

All other entry points have been marked deprecated and will be soon removed

The functionality in customMatchlist/customBracket, which allows overriding headers when displaying match groups by id, has been merged into MatchGroupDisplay.MatchGroupById.