### PR TITLE
Adjust region & location handling for teams

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -27,6 +27,7 @@ local Team = Class.new(BasicInfobox)
 
 local _LINK_VARIANT = 'team'
 local _region
+local _location = {}
 
 function Team.run(frame)
 	local team = Team(frame)
@@ -61,7 +62,7 @@ function Team:createInfobox()
 			children = {
 				Cell{
 					name = 'Region',
-					content = {self:_createRegion(args.region, args.location)}
+					content = {self:_createRegion(args.region)}
 				}
 			}
 		},
@@ -142,8 +143,8 @@ function Team:createInfobox()
 	return builtInfobox
 end
 
-function Team:_createRegion(region, country)
-	region = Region.run({region = region, country = country})
+function Team:_createRegion(region)
+	region = Region.run({region = region, country = _location[1]})
 	if type(region) == 'table' then
 		_region = region.region
 		return region.display
@@ -155,6 +156,9 @@ function Team:_createLocation(location)
 		return ''
 	end
 
+	location = Flags._CountryName(location) or location
+	table.insert(_location, location)
+
 	return Flags._Flag(location) ..
 			'&nbsp;' ..
 			'[[:Category:' .. location .. '|' .. location .. ']]'
@@ -165,8 +169,8 @@ function Team:_setLpdbData(args, links)
 
 	local lpdbData = {
 		name = name,
-		location = args.location,
-		location2 = args.location2,
+		location = _location[1],
+		location2 = _location[2],
 		logo = args.image,
 		logodark = args.imagedark or args.imagedarkmode,
 		createdate = args.created,

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -12,6 +12,7 @@ local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
 local Links = require('Module:Links')
 local Flags = require('Module:Flags')
+local Region = require('Module:Region')
 local BasicInfobox = require('Module:Infobox/Basic')
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -25,6 +26,7 @@ local Builder = Widgets.Builder
 local Team = Class.new(BasicInfobox)
 
 local _LINK_VARIANT = 'team'
+local _region
 
 function Team.run(frame)
 	local team = Team(frame)
@@ -54,10 +56,13 @@ function Team:createInfobox()
 				self:_createLocation(args.location2)
 			}
 		},
-		Cell{
-			name = 'Region',
-			content = {
-				self:_createRegion(args.region)
+		Customizable{
+			id = 'region',
+			children = {
+				Cell{
+					name = 'Region',
+					content = {self:_createRegion(args.region, args.location)}
+				}
 			}
 		},
 		Cell{name = 'Coaches', content = {args.coaches}},
@@ -137,12 +142,12 @@ function Team:createInfobox()
 	return builtInfobox
 end
 
-function Team:_createRegion(region)
-	if region == nil or region == '' then
-		return ''
+function Team:_createRegion(region, country)
+	region = Region.run({region = region, country = country})
+	if type(region) == 'table' then
+		_region = region.region
+		return region.display
 	end
-
-	return Template.safeExpand(self.infobox.frame, 'Region', {region})
 end
 
 function Team:_createLocation(location)
@@ -168,7 +173,7 @@ function Team:_setLpdbData(args, links)
 		disbanddate = args.disbanded,
 		coach = args.coaches,
 		manager = args.manager,
-		region = args.region,
+		region = _region,
 		links = mw.ext.LiquipediaDB.lpdb_create_json(
 			Links.makeFullLinksForTableItems(links or {}, 'team')
 		),

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -7,7 +7,6 @@
 --
 
 local Class = require('Module:Class')
-local Template = require('Module:Template')
 local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
 local Links = require('Module:Links')

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -114,6 +114,7 @@ function CustomInjector:parse(id, widgets)
 			})
 			index = index + 1
 		end
+	elseif id == 'region' then return {}
 	end
 	return widgets
 end


### PR DESCRIPTION
__Region__
* use region module instead of template
* store region standardized instead of as raw input
* make region cell customizable

__Location__
* use standardized country names for display and storage
* use the standardized country name for the region module usage

__SC2__
* Kick region display