### PR TITLE
[mg13] Simplify matchlist/bracket container interface

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -58,20 +58,22 @@ WikiSpecificBase.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 end)
 
 --[[
-Returns the module for the matchlist or bracket display modules. The returned
-module must have a luaGet method.
+Returns the matchlist or bracket display component. The display component must
+be a container, i.e. it takes in a bracket ID rather than a list of matches in
+a match group object. See the default implementation (pointed to below) for
+details.
 
 To customize matchlists and brackets for a wiki, override this to return
-display modules with the wiki-specific customizations.
+a display component with the wiki-specific customizations.
 
 Called from MatchGroup/Display
 
 -- @returns module
 ]]
-WikiSpecificBase.getMatchGroupModule = function(matchGroupType)
+function WikiSpecificBase.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
-		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
-		or Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
+		or Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true}).BracketContainer
 end
 
 return WikiSpecificBase

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -28,14 +28,12 @@ function MatchGroupDisplay.MatchlistBySpec(args)
 
 	local matchlistNode
 	if options.show then
-		local MatchlistDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('matchlist')
-		matchlistNode = MatchlistDisplay.luaGet(mw.getCurrentFrame(), {
-			options.bracketId,
-			attached = args.attached,
-			collapsed = args.collapsed,
-			nocollapse = args.nocollapse,
-			width = args.width or args.matchWidth,
-		}, matches)
+		local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
+		local MatchlistContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('matchlist')
+		matchlistNode = MatchlistContainer({
+			bracketId = options.bracketId,
+			config = MatchlistDisplay.configFromArgs(args),
+		})
 	end
 
 	local parts = Array.extend(
@@ -55,19 +53,12 @@ function MatchGroupDisplay.BracketBySpec(args)
 
 	local bracketNode
 	if options.show then
-		local BracketDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('bracket')
-		bracketNode = BracketDisplay.luaGet(mw.getCurrentFrame(), {
-			options.bracketId,
-			emptyRoundTitles = args.emptyRoundTitles,
-			headerHeight = args.headerHeight,
-			hideMatchLine = args.hideMatchLine,
-			hideRoundTitles = args.hideRoundTitles,
-			matchHeight = args.matchHeight,
-			matchWidth = args.matchWidth,
-			matchWidthMobile = args.matchWidthMobile,
-			opponentHeight = args.opponentHeight,
-			qualifiedHeader = args.qualifiedHeader,
-		}, matches)
+		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+		local BracketContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('bracket')
+		bracketNode = BracketContainer({
+			bracketId = options.bracketId,
+			config = BracketDisplay.configFromArgs(args),
+		})
 	end
 
 	local parts = Array.extend(
@@ -91,10 +82,22 @@ function MatchGroupDisplay.MatchGroupById(args)
 	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
 	local matchGroupType = matches[1].bracketData.type
 
+	local config
+	if matchGroupType == 'matchlist' then
+		local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
+		config = MatchlistDisplay.configFromArgs(args)
+	else
+		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+		config = BracketDisplay.configFromArgs(args)
+	end
+
 	MatchGroupInput.applyOverrideArgs(matches, args)
 
-	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupModule(matchGroupType)
-	return MatchGroupContainer.luaGet(mw.getCurrentFrame(), args, matches)
+	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer(matchGroupType)
+	return MatchGroupContainer({
+		bracketId = bracketId,
+		config = config,
+	})
 end
 
 function MatchGroupDisplay.WarningBox(text)
@@ -152,9 +155,8 @@ function MatchGroupDisplay.bracket(frame)
 end
 
 -- Deprecated
-function MatchGroupDisplay.luaBracket(frame, args, matches)
-	local BracketDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('bracket')
-	return tostring(BracketDisplay.luaGet(frame, args, matches)) .. MatchGroupDisplay.deprecatedCategory
+function MatchGroupDisplay.luaBracket(_, args)
+	return tostring(MatchGroupDisplay.MatchGroupById(args)) .. MatchGroupDisplay.deprecatedCategory
 end
 
 -- Unused entry point
@@ -164,9 +166,8 @@ function MatchGroupDisplay.matchlist(frame)
 end
 
 -- Deprecated
-function MatchGroupDisplay.luaMatchlist(frame, args, matches)
-	local MatchlistDisplay = require('Module:Brkts/WikiSpecific').getMatchGroupModule('matchlist')
-	return tostring(MatchlistDisplay.luaGet(frame, args, matches)) .. MatchGroupDisplay.deprecatedCategory
+function MatchGroupDisplay.luaMatchlist(_, args)
+	return tostring(MatchGroupDisplay.MatchGroupById(args)) .. MatchGroupDisplay.deprecatedCategory
 end
 
 -- Entry point from Template:ShowBracket and direct #invoke

--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -27,14 +27,6 @@ local _NON_BREAKING_SPACE = '&nbsp;'
 
 local BracketDisplay = {propTypes = {}, types = {}}
 
--- Called by MatchGroup/Display
-function BracketDisplay.luaGet(_, args)
-	return BracketDisplay.BracketContainer({
-		bracketId = args[1],
-		config = BracketDisplay.configFromArgs(args),
-	})
-end
-
 function BracketDisplay.configFromArgs(args)
 	return {
 		headerHeight = tonumber(args.headerHeight),

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -20,14 +20,6 @@ local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnable
 
 local MatchlistDisplay = {propTypes = {}, types = {}}
 
--- Called by MatchGroup/Display
-function MatchlistDisplay.luaGet(_, args)
-	return MatchlistDisplay.MatchlistContainer({
-		bracketId = args[1],
-		config = MatchlistDisplay.configFromArgs(args),
-	})
-end
-
 MatchlistDisplay.configFromArgs = function(args)
 	return {
 		attached = Logic.readBoolOrNil(args.attached),

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -7,7 +7,6 @@
 --
 
 local Class = require('Module:Class')
-local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
@@ -23,30 +22,15 @@ local html = mw.html
 
 local StarcraftBracketDisplay = {propTypes = {}}
 
-function StarcraftBracketDisplay.luaGet(_, args)
-	return StarcraftBracketDisplay.BracketContainer({
-		bracketId = args[1],
-		config = BracketDisplay.configFromArgs(args),
-	})
-end
-
 function StarcraftBracketDisplay.BracketContainer(props)
-	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.BracketContainer)
-	return StarcraftBracketDisplay.Bracket({
-		config = props.config,
-		bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId),
-	})
-end
-
-function StarcraftBracketDisplay.Bracket(props)
-	DisplayUtil.assertPropTypes(props, BracketDisplay.propTypes.Bracket)
+	local bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId)
 	return BracketDisplay.Bracket({
-		bracket = props.bracket,
+		bracket = bracket,
 		config = Table.merge(props.config, {
 			MatchSummaryContainer = StarcraftMatchSummary.MatchSummaryContainer,
 			OpponentEntry = StarcraftBracketDisplay.OpponentEntry,
 			matchHasDetails = StarcraftMatchGroupUtil.matchHasDetails,
-			opponentHeight = StarcraftBracketDisplay.computeBracketOpponentHeight(props.bracket.matchesById),
+			opponentHeight = StarcraftBracketDisplay.computeBracketOpponentHeight(bracket.matchesById),
 		})
 	})
 end

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -7,7 +7,6 @@
 --
 
 local Class = require('Module:Class')
-local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
@@ -19,23 +18,7 @@ local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', 
 
 local StarcraftMatchlistDisplay = {}
 
-function StarcraftMatchlistDisplay.luaGet(_, args)
-	return StarcraftMatchlistDisplay.MatchlistContainer({
-		bracketId = args[1],
-		config = MatchlistDisplay.configFromArgs(args),
-	})
-end
-
 function StarcraftMatchlistDisplay.MatchlistContainer(props)
-	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.MatchlistContainer)
-	return StarcraftMatchlistDisplay.Matchlist({
-		config = props.config,
-		matches = MatchGroupUtil.fetchMatches(props.bracketId),
-	})
-end
-
-function StarcraftMatchlistDisplay.Matchlist(props)
-	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Matchlist)
 	return MatchlistDisplay.Matchlist({
 		config = Table.merge(props.config, {
 			MatchSummaryContainer = StarcraftMatchSummary.MatchSummaryContainer,
@@ -43,7 +26,7 @@ function StarcraftMatchlistDisplay.Matchlist(props)
 			Score = StarcraftMatchlistDisplay.Score,
 			matchHasDetails = StarcraftMatchGroupUtil.matchHasDetails,
 		}),
-		matches = props.matches,
+		matches = MatchGroupUtil.fetchMatches(props.bracketId),
 	})
 end
 

--- a/components/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -32,10 +32,10 @@ WikiSpecific.processPlayer = FnUtil.lazilyDefineFunction(function()
 	return InputModule.processPlayer
 end)
 
-function WikiSpecific.getMatchGroupModule(matchGroupType)
+function WikiSpecific.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
-		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
-		or Lua.import('Module:MatchGroup/Display/Bracket/Custom', {requireDevIfEnabled = true})
+		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
+		or Lua.import('Module:MatchGroup/Display/Bracket/Custom', {requireDevIfEnabled = true}).BracketContainer
 end
 
 return WikiSpecific

--- a/components/match2/wikis/rocketleague/match_group_display_bracket_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_display_bracket_custom.lua
@@ -16,13 +16,6 @@ local CustomOpponentDisplay = Lua.import('Module:OpponentDisplay/Custom', {requi
 
 local CustomBracketDisplay = {propTypes = {}}
 
-function CustomBracketDisplay.luaGet(_, args)
-	return CustomBracketDisplay.BracketContainer({
-		bracketId = args[1],
-		config = BracketDisplay.configFromArgs(args),
-	})
-end
-
 function CustomBracketDisplay.BracketContainer(props)
 	return BracketDisplay.Bracket({
 		bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId),

--- a/components/match2/wikis/starcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft/brkts_wiki_specific.lua
@@ -21,10 +21,10 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 	return require('Module:MatchGroup/Util/Starcraft').matchFromRecord
 end)
 
-function WikiSpecific.getMatchGroupModule(matchGroupType)
+function WikiSpecific.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
-		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true})
-		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true})
+		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true}).MatchlistContainer
+		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true}).BracketContainer
 end
 
 --Default Logo for Teams without Team Template

--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -21,10 +21,10 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 	return require('Module:MatchGroup/Util/Starcraft').matchFromRecord
 end)
 
-function WikiSpecific.getMatchGroupModule(matchGroupType)
+function WikiSpecific.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
-		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true})
-		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true})
+		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true}).MatchlistContainer
+		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true}).BracketContainer
 end
 
 --Default Logo for Teams without Team Template


### PR DESCRIPTION
- Remove luaGet on Matchlist and Bracket display modules, and instead call the container directly.
- Change Brkts/WikiSpecific getMatchGroupModule to getMatchGroupContainer
- configFromArgs isn't wiki customizable right now. Could add when needed. 