### PR TITLE
Fix for disappearing ratings on Rocket League 

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -77,7 +77,7 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		local earningsInYear = Template.safeExpand(mw.getCurrentFrame(), 'Total earnings of', {year = year, id})
 		lpdbData.extradata['earningsin' .. year] = (earningsInYear or ''):gsub(',', ''):gsub('$', '')
 	end
-	
+
 	lpdbData.region = args.region
 
 	return lpdbData

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -77,6 +77,8 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		local earningsInYear = Template.safeExpand(mw.getCurrentFrame(), 'Total earnings of', {year = year, id})
 		lpdbData.extradata['earningsin' .. year] = (earningsInYear or ''):gsub(',', ''):gsub('$', '')
 	end
+	
+	lpdbData.region = args.region
 
 	return lpdbData
 end


### PR DESCRIPTION
Rocket league ratings require Region abbreviations in data storage, not the full names which the default Infobox inserts.