### PR TITLE
Revert "Adjust region & location handling for teams"

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -7,11 +7,11 @@
 --
 
 local Class = require('Module:Class')
+local Template = require('Module:Template')
 local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
 local Links = require('Module:Links')
 local Flags = require('Module:Flags')
-local Region = require('Module:Region')
 local BasicInfobox = require('Module:Infobox/Basic')
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -25,8 +25,6 @@ local Builder = Widgets.Builder
 local Team = Class.new(BasicInfobox)
 
 local _LINK_VARIANT = 'team'
-local _region
-local _location = {}
 
 function Team.run(frame)
 	local team = Team(frame)
@@ -56,13 +54,10 @@ function Team:createInfobox()
 				self:_createLocation(args.location2)
 			}
 		},
-		Customizable{
-			id = 'region',
-			children = {
-				Cell{
-					name = 'Region',
-					content = {self:_createRegion(args.region)}
-				}
+		Cell{
+			name = 'Region',
+			content = {
+				self:_createRegion(args.region)
 			}
 		},
 		Cell{name = 'Coaches', content = {args.coaches}},
@@ -143,20 +138,17 @@ function Team:createInfobox()
 end
 
 function Team:_createRegion(region)
-	region = Region.run({region = region, country = _location[1]})
-	if type(region) == 'table' then
-		_region = region.region
-		return region.display
+	if region == nil or region == '' then
+		return ''
 	end
+
+	return Template.safeExpand(self.infobox.frame, 'Region', {region})
 end
 
 function Team:_createLocation(location)
 	if location == nil or location == '' then
 		return ''
 	end
-
-	location = Flags._CountryName(location) or location
-	table.insert(_location, location)
 
 	return Flags._Flag(location) ..
 			'&nbsp;' ..
@@ -168,15 +160,15 @@ function Team:_setLpdbData(args, links)
 
 	local lpdbData = {
 		name = name,
-		location = _location[1],
-		location2 = _location[2],
+		location = args.location,
+		location2 = args.location2,
 		logo = args.image,
 		logodark = args.imagedark or args.imagedarkmode,
 		createdate = args.created,
 		disbanddate = args.disbanded,
 		coach = args.coaches,
 		manager = args.manager,
-		region = _region,
+		region = args.region,
 		links = mw.ext.LiquipediaDB.lpdb_create_json(
 			Links.makeFullLinksForTableItems(links or {}, 'team')
 		),

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -78,8 +78,6 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		lpdbData.extradata['earningsin' .. year] = (earningsInYear or ''):gsub(',', ''):gsub('$', '')
 	end
 
-	lpdbData.region = args.region
-
 	return lpdbData
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -114,7 +114,6 @@ function CustomInjector:parse(id, widgets)
 			})
 			index = index + 1
 		end
-	elseif id == 'region' then return {}
 	end
 	return widgets
 end


### PR DESCRIPTION
Reverts Liquipedia/Lua-Modules#467

This module does not replicate the functionality of Template:Region and thus should be reverted.

The module does not:

- Set SMW
- Set variables
- Properly set LPDB on all wikis

#479 was a temp fix for the last issue, which thus can also be reverted.