### PR TITLE
Make region customizable

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -54,10 +54,15 @@ function Team:createInfobox()
 				self:_createLocation(args.location2)
 			}
 		},
-		Cell{
-			name = 'Region',
-			content = {
-				self:_createRegion(args.region)
+		Customizable{
+			id = 'region',
+			children = {
+				Cell{
+					name = 'Region',
+					content = {
+						self:_createRegion(args.region)
+					}
+				},
 			}
 		},
 		Cell{name = 'Coaches', content = {args.coaches}},


### PR DESCRIPTION
## Summary

Make `region` customizable in infobox team so we can kick it (e.g. sc2) or override it (e.g. halo)
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?
-->

## How did you test this change?
Doesn't change the behavior of the module unless override is used in a custom part.
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
