### PR TITLE
Kick Region in sc2

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -115,6 +115,7 @@ function CustomInjector:parse(id, widgets)
 			index = index + 1
 		end
 	end
+	elseif id == 'history' then return {} end
 	return widgets
 end
 
@@ -132,6 +133,7 @@ end
 
 function CustomTeam:addToLpdb(lpdbData)
 	lpdbData.earnings = _earnings or 0
+	lpdbData.region = nil
 	return lpdbData
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -8,6 +8,7 @@
 
 local Team = require('Module:Infobox/Team')
 local Variables = require('Module:Variables')
+local Flags = require('Module:Flags')
 local String = require('Module:StringUtils')
 local Achievements = require('Module:Achievements in infoboxes')
 local RaceIcon = require('Module:RaceIcon').getSmallIcon

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -134,7 +134,13 @@ end
 function CustomTeam:addToLpdb(lpdbData)
 	lpdbData.earnings = _earnings or 0
 	lpdbData.region = nil
+	lpdbData.location = CustomTeam._getStandardLocationValue(args.location)
+	lpdbData.location2 = CustomTeam._getStandardLocationValue(args.location2)
 	return lpdbData
+end
+
+function CustomTeam._getStandardLocationValue(location)
+	return Flags._CountryName(location) or location
 end
 
 function CustomTeam.playerBreakDown(args)

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -114,8 +114,8 @@ function CustomInjector:parse(id, widgets)
 			})
 			index = index + 1
 		end
+	elseif id == 'history' then return {}
 	end
-	elseif id == 'history' then return {} end
 	return widgets
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -134,8 +134,8 @@ end
 function CustomTeam:addToLpdb(lpdbData)
 	lpdbData.earnings = _earnings or 0
 	lpdbData.region = nil
-	lpdbData.location = CustomTeam._getStandardLocationValue(args.location)
-	lpdbData.location2 = CustomTeam._getStandardLocationValue(args.location2)
+	lpdbData.location = CustomTeam._getStandardLocationValue(_team.args.location)
+	lpdbData.location2 = CustomTeam._getStandardLocationValue(_team.args.location2)
 	return lpdbData
 end
 


### PR DESCRIPTION
## Summary
* Kick Region in sc2 as it is not needed nor wanted
* store locations in a cleaned way (so that e.g. `usa`, `us` and `United States` are stored as the same value)

## How did you test this change?
I just kick some stuff
The module isn't used (yet) so it can not really break something, the currently used module doesn't set region (nor displays it) too...
The currently used module stores locations in a clean way too ...