### PR TITLE
Fix legacy bracket template id passing

### DIFF
--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -68,7 +68,7 @@ function Legacy.get(frame)
 
 	local newArgs = Legacy._convert(mapping)
 	newArgs.id = bracketid
-	newArgs['1'] = templateid
+	newArgs[1] = templateid
 
 	newArgs.store = storage
 	newArgs.noDuplicateCheck = _args.noDuplicateCheck

--- a/components/match2/wikis/starcraft/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft/match_group_legacy.lua
@@ -47,7 +47,7 @@ function Legacy.get(frame)
 
 	local newArgs = Legacy._convert(mapping)
 	newArgs.id = bracketid
-	newArgs["1"] = templateid
+	newArgs[1] = templateid
 
 	return MatchGroup.luaBracket(frame, newArgs)
 end

--- a/components/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft2/match_group_legacy.lua
@@ -62,7 +62,7 @@ function Legacy.get(frame)
 
 	local newArgs = Legacy._convert(mapping)
 	newArgs.id = bracketid
-	newArgs['1'] = templateid
+	newArgs[1] = templateid
 
 	newArgs.store = storage
 	newArgs.noDuplicateCheck = _args.noDuplicateCheck


### PR DESCRIPTION
## Summary
Legacy brackets aren't passing the right param for template ID. changed it to use args[1] instead of args['1'].

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Apply changes and inspect a page with legacy brackets https://liquipedia.net/starcraft2/2019_WCS_Summer/Playoffs
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
