### PR TITLE
Removed resulttype 'submatch' for legacy matches (on the starcraft 1 wiki)

### DIFF
--- a/components/match2/wikis/starcraft/match_legacy.lua
+++ b/components/match2/wikis/starcraft/match_legacy.lua
@@ -105,7 +105,9 @@ function p.storeGames(match, match2)
 			submatch.winner = game.winner or ''
 			submatch.walkover = game.walkover or ''
 			submatch.finished = match2.finished or '0'
-			submatch.resulttype = game.resulttype
+			if submatch.resulttype ~= 'submatch' then
+				submatch.resulttype = game.resulttype
+			end
 			submatch.mode = '1v1'
 			submatch.date = game.date
 			submatch.dateexact = match2.dateexact or ''

--- a/components/match2/wikis/starcraft/match_legacy.lua
+++ b/components/match2/wikis/starcraft/match_legacy.lua
@@ -105,7 +105,7 @@ function p.storeGames(match, match2)
 			submatch.winner = game.winner or ''
 			submatch.walkover = game.walkover or ''
 			submatch.finished = match2.finished or '0'
-			if submatch.resulttype ~= 'submatch' then
+			if game.resulttype ~= 'submatch' then
 				submatch.resulttype = game.resulttype
 			end
 			submatch.mode = '1v1'


### PR DESCRIPTION
Player matches table will show the score as "W : " if resulttype isn't empty

## Summary

Player matches table shows "W :   " as the score instead of "1 : 0" for submatches of team matches using the new brackets, i looked at the differences between the lpdb entrys for team matches using the old matchgroups and the new matchgroups and noticed that the new one has an entry for resulttype and the old one doesn't.
In the Module:Player matches table on commons, the function updateScores checks if resulttype is not empty and changes the score to "W : ".

```lua
 local updateScores = function(winner, resulttype, PlayerNo, homeScore, awayScore, result)
	local scores = {}
	if resulttype ~= '' then
		if winner == tostring(PlayerNo) then
			scores = {'W', RESULTTYPES[resulttype]}
			result = 'win'
		elseif winner == tostring(3-PlayerNo) then
			scores = {RESULTTYPES[resulttype], 'W'}
			result = 'lose'
		end
	else
		scores = {homeScore, awayScore}
	end
	return scores, result
end
```

**(sorry i can't format)**

And that is why i want to remove it from the legacy matches

## How did you test this change?

Unfortunately I did not test this change. I have no idea how i'm supposed to test it. But I added it in the first place ( https://liquipedia.net/starcraft/index.php?title=Module%3AMatch%2FLegacy&type=revision&diff=327231&oldid=327122 ), so I know it wasn't added with any specific purpose in mind