### PR TITLE
Fix Link order in infoboxes

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -83,11 +83,17 @@ function Links:make()
 
 	for _, group in Table.iter.spairs(_PRIORITY_GROUPS) do
 		for _, key in ipairs(group) do
-			if self.links[self:_removeAppendedNumber(key)] ~= nil then
+			if self.links[key] ~= nil then
 				infoboxLinks:wikitext(' ' .. self:_makeLink(key, self.links[key]))
-
-				-- Remove links from the collection
+				-- Remove link from the collection
 				self.links[key] = nil
+
+				local index = 2
+				while self.links[key .. index] ~= nil do
+					infoboxLinks:wikitext(' ' .. self:_makeLink(key, self.links[key .. index]))
+					-- Remove link from the collection
+					self.links[key .. index] = nil
+				end
 			end
 		end
 	end


### PR DESCRIPTION
## Summary
* `self:_removeAppendedNumber` is not needed there due to the key coming from the `_PRIORITY_GROUPS` and hence not having the appended number
* display links with the same base as key (i.e. if they only have an appended number) one after another behind the one without appended number

## How did you test this change?
Tested on halo wiki by creating the module (with the changes) there (hence not using the commons module), see if it throws and if it does what it is supposed to do, delete the halo module again

Before image:
![Screenshot 2021-10-01 17 04 02](https://user-images.githubusercontent.com/75081997/135643745-f6a5e3e5-dbb4-45a0-a13b-a1785fa4ab3b.png)
After Image:
![Screenshot 2021-10-01 17 03 50](https://user-images.githubusercontent.com/75081997/135643827-606e72f1-3a9d-4adb-8ff5-8771e0f95daf.png)


