### PR TITLE
Add Table.iter.pairsByPrefix

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -249,6 +249,34 @@ function Table.iter.spairs(tbl, order)
 	end
 end
 
+--[[
+Iterates over table entries whose keys are prefixed numbers. The entries are
+visited in order, starting from 1. The iteration stops upon a skipped number.
+
+Example:
+local args = {
+	p1 = {},
+	p2 = {},
+	p3 = {},
+	foo = {},
+	p10 = {},
+}
+for key, player in Table.iter.pairsByPrefix(args, 'p') do
+	mw.log(key)
+end
+
+will print out 'p1 p2 p3'
+]]
+function Table.iter.pairsByPrefix(tbl, prefix)
+	local i = 1
+	return function()
+		local key = prefix .. i
+		local value = tbl[key]
+		i = i + 1
+		return value and key, value or nil
+	end
+end
+
 function Table.iter.forEach(tbl, lambda)
 	for _, item in ipairs(tbl) do
 		lambda(item)


### PR DESCRIPTION
stacked on #503

## Summary
`Table.iter.prefix` Iterates over table entries whose keys are prefixed numbers. The entries are
visited in order, starting from 1. The iteration stops upon a skipped number.

Example:
```
local args = {
	p1 = {},
	p2 = {},
	p3 = {},
	foo = {},
	p10 = {},
}
for key, player in Table.iter.prefix(args, 'p') do
	mw.log(key)
end
```
will print out 'p1 p2 p3'
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
```
local args = {
	p1 = {},
	p2 = {},
	p3 = {},
	foo = {},
	p10 = {},
}
for key, player in Table.iter.prefix(args, 'p') do
	mw.log(key)
end
```
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
