### PR TITLE
Add workaround for player indexing bug

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
+local MatchGroupWorkaround = require('Module:MatchGroup/Workaround')
 local StringUtils = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TreeUtil = require('Module:TreeUtil')
@@ -156,7 +157,7 @@ function MatchGroupUtil.fetchMatchRecords(bracketId)
 	if varData then
 		return Json.parse(varData)
 	else
-		return mw.ext.LiquipediaDB.lpdb(
+		local matchRecords = mw.ext.LiquipediaDB.lpdb(
 			'match2',
 			{
 				conditions = '([[namespace::0]] or [[namespace::>0]]) AND [[match2bracketid::' .. bracketId .. ']]',
@@ -164,6 +165,10 @@ function MatchGroupUtil.fetchMatchRecords(bracketId)
 				limit = 5000,
 			}
 		)
+		for _, matchRecord in ipairs(matchRecords) do
+			MatchGroupWorkaround.applyPlayerBugWorkaround(matchRecord)
+		end
+		return matchRecords
 	end
 end
 

--- a/components/match2/commons/match_group_workaround.lua
+++ b/components/match2/commons/match_group_workaround.lua
@@ -1,0 +1,44 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Workaround
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local FeatureFlag = require('Module:FeatureFlag')
+local Table = require('Module:Table')
+
+local MatchGroupWorkaround = {}
+
+--[[
+Applies a workaround to a match record for the bug where player records are
+sometimes attached to the wrong opponent record. See https://github.com/Liquipedia/Lua-Modules/pull/528
+for a more detailed description.
+]]
+function MatchGroupWorkaround.applyPlayerBugWorkaround(matchRecord)
+	if not FeatureFlag.get('issue528_workaround') then
+		return
+	end
+
+	local playerRecords = Table.getByPathOrNil(matchRecord, {'match2opponents', 1, 'match2players'})
+	if not playerRecords then return end
+
+	-- The bug is present if any of the player records attached to the first opponent are from other opponents
+	local bugIsPresent = Array.any(playerRecords, function(playerRecord) return playerRecord.opid ~= 1 end)
+	if not bugIsPresent then return end
+
+	mw.log('MatchGroupWorkaround.applyPlayerBugWorkaround: Applying workaround for matchid=' .. matchRecord.match2id)
+
+	local allPlayerRecords = Array.flatMap(matchRecord.match2opponents, function(opponentRecord)
+		return opponentRecord.match2players or {}
+	end)
+	local _, byOpponentIx = Array.groupBy(allPlayerRecords, function(playerRecord) return playerRecord.opid end)
+	for opponentIx, opponentRecord in ipairs(matchRecord.match2opponents) do
+		opponentRecord.match2players = byOpponentIx[opponentIx] or {}
+		Array.sortInPlaceBy(opponentRecord.match2players, function(playerRecord) return playerRecord.id end)
+	end
+end
+
+return MatchGroupWorkaround


### PR DESCRIPTION
stacked on #476

## Summary
This is a lua workaround to the lpdb bug where players are sometimes assigned to a different opponent. See hjpa's description below for more details.

The workaround is to recompute the player-opponent assignment when the match group is fetched in `MatchGroupUtil.fetchMatchRecords`.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

Before
![image](https://user-images.githubusercontent.com/85348434/135794062-430a52b3-65c8-4ecc-804f-f8d7dc4f944f.png)

After
![image](https://user-images.githubusercontent.com/85348434/135794076-1445c867-384d-46a9-8e43-5e5938ae7a08.png)

## How did you test this change?
Turn on `feature_issue528_workaround`
Inspect
https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/WTL_0
https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Wide_Load

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
