### PR TITLE
[mg18] Slightly simplify Starcraft's MatchGroupInput

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,6 +8,7 @@ std = {
 		"ipairs",
 		"math",
 		"mw",
+		"next",
 		"os",
 		"package",
 		"pairs",

--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -54,7 +54,7 @@ Called from MatchGroup/Util
 -- @returns match
 ]]
 WikiSpecificBase.matchFromRecord = FnUtil.lazilyDefineFunction(function()
-	return require('Module:MatchGroup/Util').matchFromRecord
+	return Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true}).matchFromRecord
 end)
 
 --[[

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -12,8 +12,9 @@ local FeatureFlag = require('Module:FeatureFlag')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 local Match = {}
 

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -100,17 +100,8 @@ function MatchGroupBase.saveMatchGroup(bracketId, matches, storeInLpdb)
 	end)
 
 	-- store match data as variable to bypass LPDB on the same page
-	Variables.varDefine('match2bracket_' .. bracketId, MatchGroupBase._convertDataForStorage(storedData))
+	Variables.varDefine('match2bracket_' .. bracketId, Json.stringify(storedData))
 	Variables.varDefine('match2bracketindex', Variables.varDefault('match2bracketindex', 0) + 1)
-end
-
-function MatchGroupBase._convertDataForStorage(data)
-	for _, match in ipairs(data) do
-		for _, game in ipairs(match.match2games) do
-			game.scores = Json.parse(game.scores)
-		end
-	end
-	return Json.stringify(data)
 end
 
 function MatchGroupBase.enableInstrumentation()

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -19,17 +19,21 @@ local Match = Lua.import('Module:Match', {requireDevIfEnabled = true})
 local MatchGroupBase = {}
 
 function MatchGroupBase.readOptions(args, matchGroupType)
+	local store = Logic.readBoolOrNil(args.store)
 	local options = {
 		bracketId = MatchGroupBase.readBracketId(args.id),
 		matchGroupType = matchGroupType,
-		saveToLpdb = Logic.nilOr(Logic.readBoolOrNil(args.store), true),
 		shouldWarnMissing = Logic.nilOr(Logic.readBoolOrNil(args.warnMissing), true),
 		show = not Logic.readBool(args.hide),
+		storeMatch1 = Logic.nilOr(Logic.readBoolOrNil(args.storeMatch1), store, true),
+		storeMatch2 = Logic.nilOr(Logic.readBoolOrNil(args.storeMatch2), store, true),
+		storeSmw = Logic.nilOr(Logic.readBoolOrNil(args.storeSmw), store, true),
 	}
+	options.store = Logic.nilOr(store, options.storeMatch2 or options.storeMatch1 or options.storeSmw)
 
 	local warnings = {}
 
-	if options.saveToLpdb or not Logic.readBool(args.noDuplicateCheck) then
+	if options.store or not Logic.readBool(args.noDuplicateCheck) then
 		local warning = MatchGroupBase._checkBracketDuplicate(options.bracketId)
 		if warning then
 			table.insert(warnings, warning)
@@ -94,14 +98,24 @@ function MatchGroupBase._checkBracketDuplicate(bracketId)
 	end
 end
 
-function MatchGroupBase.saveMatchGroup(bracketId, matches, storeInLpdb)
-	local storedData = Array.map(matches, function(match)
-		return Match.store(match, storeInLpdb)
-	end)
+function MatchGroupBase.saveMatchGroup(bracketId, matches, options)
+	local recordsInMatches = Array.map(matches, Match.splitRecordsByType)
 
-	-- store match data as variable to bypass LPDB on the same page
-	Variables.varDefine('match2bracket_' .. bracketId, Json.stringify(storedData))
-	Variables.varDefine('match2bracketindex', Variables.varDefault('match2bracketindex', 0) + 1)
+	-- Store matches in a page variable to bypass LPDB on the same page
+	if options.show then
+		local matchRecords = Array.map(recordsInMatches, function(records)
+			Match.populateEdges(records)
+			return records.matchRecord
+		end)
+		Variables.varDefine('match2bracket_' .. bracketId, Json.stringify(matchRecords))
+		Variables.varDefine('match2bracketindex', Variables.varDefault('match2bracketindex', 0) + 1)
+	end
+
+	if options.store then
+		for _, records in ipairs(recordsInMatches) do
+			Match.store(records, options)
+		end
+	end
 end
 
 function MatchGroupBase.enableInstrumentation()

--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -1,0 +1,283 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Coordinates
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local IteratorUtil = require('Module:IteratorUtil')
+local MathUtil = require('Module:MathUtil')
+local StringUtils = require('Module:StringUtils')
+local Table = require('Module:Table')
+local TreeUtil = require('Module:TreeUtil')
+
+local MatchGroupCoordinates = {}
+
+function MatchGroupCoordinates.dfsFrom(bracketDatasById, start)
+	return TreeUtil.dfs(
+		function(matchId)
+			return bracketDatasById[matchId].lowerMatchIds
+		end,
+		start
+	)
+end
+
+function MatchGroupCoordinates.dfs(bracket)
+	return IteratorUtil.flatMap(function(_, rootMatchId)
+		return MatchGroupCoordinates.dfsFrom(bracket.bracketDatasById, rootMatchId)
+	end, ipairs(bracket.rootMatchIds))
+end
+
+function MatchGroupCoordinates.computeUpperMatchIds(bracketDatasById)
+	local upperMatchIds = {}
+	for matchId, bracketData in pairs(bracketDatasById) do
+		for _, lowerMatchId in ipairs(bracketData.lowerMatchIds) do
+			upperMatchIds[lowerMatchId] = matchId
+		end
+	end
+	return upperMatchIds
+end
+
+function MatchGroupCoordinates.computeSections(bracket)
+	local sectionIxs = {}
+	local sections = {}
+	for matchId in MatchGroupCoordinates.dfs(bracket) do
+		local bracketData = bracket.bracketDatasById[matchId]
+		local upperMatch = bracketData.upperMatchId and bracket.bracketDatasById[bracketData.upperMatchId]
+		local isNewSection = bracketData.header ~= nil
+			and (not upperMatch or matchId ~= upperMatch.lowerMatchIds[1])
+		if isNewSection then
+			table.insert(sections, {})
+		end
+		table.insert(sections[#sections], matchId)
+		sectionIxs[matchId] = #sections
+	end
+	return sections, sectionIxs
+end
+
+function MatchGroupCoordinates.computeDepthsFrom(bracketDatasById, startMatchId)
+	local depths = {}
+	local maxDepth = -1
+	local function visit(matchId, depth)
+		local bracketData = bracketDatasById[matchId]
+		depths[matchId] = depth
+		maxDepth = math.max(maxDepth, depth + bracketData.skipRound)
+		for _, lowerMatchId in ipairs(bracketData.lowerMatchIds) do
+			visit(lowerMatchId, depth + 1 + bracketData.skipRound)
+		end
+	end
+	visit(startMatchId, 0)
+	return depths, maxDepth + 1
+end
+
+function MatchGroupCoordinates.computeSemanticDepths(bracket, sectionIxs)
+	local depths = {}
+	local function visit(matchId, depth)
+		local lowerMatchIds = bracket.bracketDatasById[matchId].lowerMatchIds
+		local lastLowerId = #lowerMatchIds and lowerMatchIds[#lowerMatchIds]
+		local isGrandFinal = lastLowerId and sectionIxs[lastLowerId] ~= sectionIxs[matchId]
+		if isGrandFinal then
+			depth = depth - 1
+		end
+		depths[matchId] = depth
+		for _, lowerMatchId in ipairs(lowerMatchIds) do
+			visit(lowerMatchId, depth + 1)
+		end
+	end
+
+	local groups, _ = Array.groupBy(
+		bracket.rootMatchIds,
+		function(rootMatchId) return sectionIxs[rootMatchId] end
+	)
+	for _, group in ipairs(groups) do
+		local initialDepth = MathUtil.ilog2(#group) + 1
+		for _, rootMatchId in ipairs(group) do
+			visit(rootMatchId, initialDepth)
+		end
+	end
+
+	return depths
+end
+
+function MatchGroupCoordinates.computeRounds(bracket)
+	local rounds = {}
+	local roundPropsByMatchId = {}
+	for _, rootMatchId in ipairs(bracket.rootMatchIds) do
+		local depths, depthCount = MatchGroupCoordinates.computeDepthsFrom(bracket.bracketDatasById, rootMatchId)
+		for _ = #rounds + 1, depthCount do
+			table.insert(rounds, {})
+		end
+
+		for matchId, depth in pairs(depths) do
+			roundPropsByMatchId[matchId] = {
+				depth = depth,
+				depthCount = depthCount,
+			}
+		end
+	end
+
+	for _, rootMatchId in ipairs(bracket.rootMatchIds) do
+		for matchId in MatchGroupCoordinates.dfsFrom(bracket.bracketDatasById, rootMatchId) do
+			local roundProps = roundPropsByMatchId[matchId]
+
+			-- All roots are left aligned, except the third place match which is right aligned
+			local roundIndex = StringUtils.endsWith(matchId, 'RxMTP')
+				and #rounds
+				or roundProps.depthCount - roundProps.depth
+
+			table.insert(rounds[roundIndex], matchId)
+			roundProps.matchIndexInRound = #rounds[roundIndex]
+			roundProps.roundIndex = roundIndex
+		end
+	end
+
+	return rounds, roundPropsByMatchId
+end
+
+function MatchGroupCoordinates.computeSemanticRounds(sections, roundPropsByMatchId)
+	local semanticRoundIxs = {}
+
+	for _, section in ipairs(sections) do
+		local rounds = {}
+		for _, matchId in ipairs(section) do
+			local roundIndex = roundPropsByMatchId[matchId].roundIndex
+			for _ = #rounds + 1, roundIndex do
+				table.insert(rounds, {})
+			end
+			table.insert(rounds[roundIndex], matchId)
+		end
+
+		local semanticRoundIx = 1
+		for _, round in ipairs(rounds) do
+			for _, matchId in ipairs(round) do
+				semanticRoundIxs[matchId] = semanticRoundIx
+			end
+			if #round ~= 0 then
+				semanticRoundIx = semanticRoundIx + 1
+			end
+		end
+	end
+
+	return semanticRoundIxs
+end
+
+--[[
+Computes properties of a match that describe its position within
+the overall bracket.
+
+Brackets are partitioned vertically into sections and roots, and
+partitioned horizontally into rounds, columns, depths, and semantic
+depths.
+
+Section: Refers to the upper/lower bracket. Single-elim brackets
+have one section, double-elim have two. More complicated brackets
+can have 3+ sections. The grand finals match is considered to be
+part of the upper bracket.
+
+Root: Roots are matches that don't advance to another match in the
+bracket. Roots vertically partition the bracket into non-connected
+trees. A common use case for multiple roots is if a bracket is
+truncated after a round. For example, 16SE-4Qual concludes after the
+Ro8, so it has 4 roots.
+
+Round: Rounds are semantic labeling of matches that tracks progress
+within a tournament - higher rounds occur later in the tournament.
+Brackets created with the bracket designer have matches of the same
+round appear in one column. Custom brackets can have rounds not
+aligned with columns. Match IDs are grouped by rounds.
+
+Column: The bracket display uses a column layout for matches. The
+columns partition the bracket horizontally. For most brackets, there
+is no difference between columns and rounds.
+
+Depth: The depth of a match is its distance from its root match.
+Root matches have depth 0, each additional round increases the depth
+by 1. Skipped rounds are included in the depth.
+
+Semantic depth: The semantic depth encodes the X in "Round of X".
+Specifically it is the base 2 logarithm of X, so that the finals has
+semantic depth 1, semifinals 2, quarterfinals 3, etc. In double
+elimination brackets, the upper bracket finals and lower bracket
+finals have semantic depth 1, and the grand finals has semantic
+depth 0. Ignores skipped rounds.
+
+Fields reference:
+coords.depth: 0-based depth (distance from root). Includes skipped rounds.
+coords.depthCount = How deep the tree from the root extends. This is usually 1
+more than the max depth, but can be deeper if there are childless matches with
+skipRound set.
+coords.matchIndexInRound: Index of the match within the round containing it.
+coords.rootIndex: Index of the root whose tree contains the match.
+coords.roundCount: Number of rounds in the bracket.
+coords.roundIndex: Index of the round containing the match.
+coords.sectionCount: Number of sections in the bracket.
+coords.sectionIndex: Index of the section containing the match. (0=upper, 1=lower for double elim)
+coords.semanticDepth: 1 for Finals, 2 for Semi-finals, 3 for Quarterfinals, etc. 0 for Grand Finals.
+coords.semanticRoundIndex: Index of the round, skipping rounds that have no matches in the section
+
+All indexes start from 0. coords.depth is 0-based and coords.semanticDepth is 1-based (0 denotes grand final).
+
+]]
+function MatchGroupCoordinates.computeCoordinates(bracket)
+	local sections, sectionIxs = MatchGroupCoordinates.computeSections(bracket)
+	local rounds, roundPropsByMatchId = MatchGroupCoordinates.computeRounds(bracket)
+	local semanticDepths = MatchGroupCoordinates.computeSemanticDepths(bracket, sectionIxs)
+	local semanticRoundIxs = MatchGroupCoordinates.computeSemanticRounds(sections, roundPropsByMatchId)
+
+	local coordinatesByMatchId = {}
+	for rootIndex, rootMatchId in ipairs(bracket.rootMatchIds) do
+		for matchId in MatchGroupCoordinates.dfsFrom(bracket.bracketDatasById, rootMatchId) do
+			coordinatesByMatchId[matchId] = Table.merge(
+				roundPropsByMatchId[matchId],
+				{
+					rootIndex = rootIndex,
+					roundCount = #rounds,
+					sectionCount = #sections,
+					sectionIndex = sectionIxs[matchId],
+					semanticDepth = semanticDepths[matchId],
+					semanticRoundIndex = semanticRoundIxs[matchId],
+				}
+			)
+		end
+	end
+
+	return {
+		coordinatesByMatchId = coordinatesByMatchId,
+		rounds = rounds,
+		sections = sections,
+	}
+end
+
+--[[
+Same as MatchGroupCoordinates.computeCoordinates, but only for the fields
+necessary to display the bracket.
+]]
+function MatchGroupCoordinates.computeCoordinatesRestricted(bracket)
+	local sections, sectionIxs = MatchGroupCoordinates.computeSections(bracket)
+	local rounds, roundPropsByMatchId = MatchGroupCoordinates.computeRounds(bracket)
+
+	local coordinatesByMatchId = {}
+	for rootIndex, rootMatchId in ipairs(bracket.rootMatchIds) do
+		for matchId in MatchGroupCoordinates.dfsFrom(bracket.bracketDatasById, rootMatchId) do
+			coordinatesByMatchId[matchId] = Table.merge(
+				roundPropsByMatchId[matchId],
+				{
+					rootIndex = rootIndex,
+					roundCount = #rounds,
+					sectionCount = #sections,
+					sectionIndex = sectionIxs[matchId],
+				}
+			)
+		end
+	end
+
+	return {
+		coordinatesByMatchId = coordinatesByMatchId,
+		rounds = rounds,
+		sections = sections,
+	}
+end
+
+return MatchGroupCoordinates

--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -250,34 +250,4 @@ function MatchGroupCoordinates.computeCoordinates(bracket)
 	}
 end
 
---[[
-Same as MatchGroupCoordinates.computeCoordinates, but only for the fields
-necessary to display the bracket.
-]]
-function MatchGroupCoordinates.computeCoordinatesRestricted(bracket)
-	local sections, sectionIxs = MatchGroupCoordinates.computeSections(bracket)
-	local rounds, roundPropsByMatchId = MatchGroupCoordinates.computeRounds(bracket)
-
-	local coordinatesByMatchId = {}
-	for rootIndex, rootMatchId in ipairs(bracket.rootMatchIds) do
-		for matchId in MatchGroupCoordinates.dfsFrom(bracket.bracketDatasById, rootMatchId) do
-			coordinatesByMatchId[matchId] = Table.merge(
-				roundPropsByMatchId[matchId],
-				{
-					rootIndex = rootIndex,
-					roundCount = #rounds,
-					sectionCount = #sections,
-					sectionIndex = sectionIxs[matchId],
-				}
-			)
-		end
-	end
-
-	return {
-		coordinatesByMatchId = coordinatesByMatchId,
-		rounds = rounds,
-		sections = sections,
-	}
-end
-
 return MatchGroupCoordinates

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -11,10 +11,10 @@ local Array = require('Module:Array')
 local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 
 local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 local MatchGroupDisplay = {}
 

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -24,7 +24,7 @@ Reads a matchlist input spec, saves it to LPDB, and displays the matchlist.
 function MatchGroupDisplay.MatchlistBySpec(args)
 	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'matchlist')
 	local matches = MatchGroupInput.readMatchlist(options.bracketId, args)
-	MatchGroupBase.saveMatchGroup(options.bracketId, matches, options.saveToLpdb)
+	MatchGroupBase.saveMatchGroup(options.bracketId, matches, options)
 
 	local matchlistNode
 	if options.show then
@@ -49,7 +49,7 @@ Reads a bracket input spec, saves it to LPDB, and displays the bracket.
 function MatchGroupDisplay.BracketBySpec(args)
 	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'bracket')
 	local matches, bracketWarnings = MatchGroupInput.readBracket(options.bracketId, args, options)
-	MatchGroupBase.saveMatchGroup(options.bracketId, matches, options.saveToLpdb)
+	MatchGroupBase.saveMatchGroup(options.bracketId, matches, options)
 
 	local bracketNode
 	if options.show then

--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -263,8 +263,8 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 		-- Don't show the header if it's disabled. Also don't show the header
 		-- if it is the first match of a round because a higher round match can
 		-- show it instead.
-		local upperBracketData = bracket.upperMatchIds[matchId]
-			and bracket.bracketDatasById[bracket.upperMatchIds[matchId]]
+		local upperBracketData = bracketData.upperMatchId
+			and bracket.bracketDatasById[bracketData.upperMatchId]
 		local isFirstChild = upperBracketData
 			and matchId == upperBracketData.lowerMatchIds[1]
 		local showHeader = bracketData.header and not isFirstChild
@@ -277,9 +277,10 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 	-- matches. When it gets to a root, it then traverses the roots in
 	-- reverse order until it gets to the first root.
 	local function getParent(matchId)
-		local coords = bracket.coordsByMatchId[matchId]
-		return bracket.upperMatchIds[matchId]
-			or coords.rootIx ~= 1 and bracket.rootMatchIds[coords.rootIx - 1]
+		local bracketData = bracket.bracketDatasById[matchId]
+		local coords = bracket.coordinatesByMatchId[matchId]
+		return bracketData.upperMatchId
+			or coords.rootIndex ~= 1 and bracket.rootMatchIds[coords.rootIndex - 1]
 			or nil
 	end
 
@@ -290,19 +291,19 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 
 	-- Determine the individual headers appearing in header rows
 	for matchId, bracketData in pairs(bracket.bracketDatasById) do
-		local coords = bracket.coordsByMatchId[matchId]
+		local coords = bracket.coordinatesByMatchId[matchId]
 		if bracketData.header then
 			local headerRow = getHeaderRow(matchId)
 			local brMatch = bracketData.bracketResetMatchId and bracket.matchesById[bracketData.bracketResetMatchId]
-			headerRow[coords.roundIx] = {
+			headerRow[coords.roundIndex] = {
 				hasBrMatch = brMatch and true or false,
 				header = bracketData.header,
-				roundIx = coords.roundIx,
+				roundIx = coords.roundIndex,
 			}
 		end
 		if bracketData.qualWin then
 			local headerRow = getHeaderRow(matchId)
-			local roundIx = coords.roundIx + 1 + bracketData.qualSkip
+			local roundIx = coords.roundIndex + 1 + bracketData.qualSkip
 			headerRow[roundIx] = {
 				header = config.qualifiedHeader or '!q',
 				roundIx = roundIx,

--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -13,13 +13,13 @@ local DisplayUtil = require('Module:DisplayUtil')
 local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local MathUtil = require('Module:MathUtil')
 local StringUtils = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local html = mw.html

--- a/components/match2/commons/match_group_display_bracket_template.lua
+++ b/components/match2/commons/match_group_display_bracket_template.lua
@@ -10,10 +10,10 @@ local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
 
 local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 local BracketTemplateDisplay = {propTypes = {}}
 

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -11,8 +11,9 @@ local DisplayUtil = require('Module:DisplayUtil')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 local DisplayHelper = {}
 local _NONBREAKING_SPACE = '&nbsp;'

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -11,11 +11,11 @@ local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local MatchlistDisplay = {propTypes = {}, types = {}}

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -24,22 +24,23 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 	Variables.varDefine('bracket_header', sectionHeader)
 	local tournamentParent = Variables.varDefault('tournament_parent', '')
 
-	local function readMatch(matchIndex)
+	local matches = {}
+	for matchKey, matchArgs in Table.iter.pairsByPrefix(args, 'M') do
+		local matchIndex = tonumber(matchKey:match('(%d+)$'))
 		local matchId = string.format('%04d', matchIndex)
 
-		local matchArgs = args['M' .. matchIndex]
-		if not matchArgs then
-			return
-		end
+		matchArgs = Json.parse(matchArgs)
 
-		matchArgs = Json.parseIfString(matchArgs)
 		matchArgs.bracketid = bracketId
 		matchArgs.matchid = matchId
 		local match = require('Module:Brkts/WikiSpecific').processMatch(mw.getCurrentFrame(), matchArgs)
 		match.parent = tournamentParent
 
+		table.insert(matches, match)
+
 		-- Add more fields to bracket data
-		local bracketData = Json.parse(match.bracketdata or '{}')
+		match.bracketdata = match.bracketdata or {}
+		local bracketData = match.bracketdata
 		bracketData.type = 'matchlist'
 		local nextMatchId = bracketId .. '_' .. string.format('%04d', matchIndex + 1)
 		bracketData.next = args['M' .. (matchIndex + 1)] and nextMatchId or nil
@@ -47,13 +48,9 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 		bracketData.header = args['M' .. matchIndex .. 'header'] or bracketData.header
 		bracketData.bracketindex = Variables.varDefault('match2bracketindex', 0)
 		bracketData.sectionheader = sectionHeader
-
-		match.bracketdata = Json.stringify(bracketData)
-
-		return match
 	end
 
-	return Array.mapIndexes(readMatch)
+	return matches
 end
 
 function MatchGroupInput.readBracket(bracketId, args, options)
@@ -92,6 +89,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 
 		matchArgs = Json.parseIfString(matchArgs)
 			or Json.parse(Lua.import('Module:Match', {requireDevIfEnabled = true}).toEncodedJson({}))
+
 		matchArgs.bracketid = bracketId
 		matchArgs.matchid = matchId
 		local match = require('Module:Brkts/WikiSpecific').processMatch(mw.getCurrentFrame(), matchArgs)
@@ -101,7 +99,8 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 		local bracketData = bracketDatasById[matchId]
 		MatchGroupInput._validateBracketData(bracketData, matchKey)
 
-		Table.mergeInto(bracketData, Json.parse(match.bracketdata or '{}'))
+		match.bracketdata = Table.mergeInto(bracketData, match.bracketdata or {})
+
 		bracketData.type = 'bracket'
 		bracketData.header = args[matchKey .. 'header'] or bracketData.header
 		bracketData.bracketindex = Variables.varDefault('match2bracketindex', 0)
@@ -125,7 +124,6 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 			bracketData.bracketreset = ''
 		end
 
-		match.bracketdata = Json.stringify(bracketData)
 		return match
 	end
 

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -21,7 +21,7 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled
 local MatchGroupInput = {}
 
 function MatchGroupInput.readMatchlist(bracketId, args)
-	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
+	local sectionHeader = args.section or String.nilIfEmpty(Variables.varDefault('bracket_header'))
 	Variables.varDefine('bracket_header', sectionHeader)
 	local tournamentParent = Variables.varDefault('tournament_parent', '')
 
@@ -47,7 +47,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 		bracketData.next = args['M' .. (matchIndex + 1)] and nextMatchId or nil
 		bracketData.title = matchIndex == 1 and args.title or nil
 		bracketData.header = args['M' .. matchIndex .. 'header'] or bracketData.header
-		bracketData.bracketindex = Variables.varDefault('match2bracketindex', 0)
+		bracketData.bracketindex = tonumber(Variables.varDefault('match2bracketindex')) or 0
 		bracketData.sectionheader = sectionHeader
 	end
 
@@ -59,7 +59,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 	local templateId = args[1]
 	assert(templateId, 'argument \'1\' (templateId) is empty')
 
-	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
+	local sectionHeader = args.section or String.nilIfEmpty(Variables.varDefault('bracket_header'))
 	Variables.varDefine('bracket_header', sectionHeader)
 	local tournamentParent = Variables.varDefault('tournament_parent', '')
 
@@ -104,7 +104,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 
 		bracketData.type = 'bracket'
 		bracketData.header = args[matchKey .. 'header'] or bracketData.header
-		bracketData.bracketindex = Variables.varDefault('match2bracketindex', 0)
+		bracketData.bracketindex = tonumber(Variables.varDefault('match2bracketindex')) or 0
 		bracketData.sectionheader = sectionHeader
 
 		if match.winnerto then
@@ -117,12 +117,23 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 		end
 
 		-- Kick bracketData.thirdplace if no 3rd place match
-		if bracketData.thirdplace ~= '' and not args.RxMTP then
-			bracketData.thirdplace = ''
+		if not args.RxMTP then
+			bracketData.thirdplace = nil
 		end
 		-- Kick bracketData.bracketreset if no reset match
-		if bracketData.bracketreset ~= '' and not args.RxMBR then
-			bracketData.bracketreset = ''
+		if not args.RxMBR then
+			bracketData.bracketreset = nil
+		end
+
+		if not bracketData.lowerEdges then
+			local opponentCount = 0
+			for _, _ in Table.iter.pairsByPrefix(match, 'opponent') do
+				opponentCount = opponentCount + 1
+			end
+			bracketData.lowerEdges = Array.map(
+				MatchGroupUtil.autoAssignLowerEdges(#bracketData.lowerMatchIds, opponentCount),
+				MatchGroupUtil.indexTableToRecord
+			)
 		end
 
 		return match
@@ -150,27 +161,43 @@ function MatchGroupInput._fetchBracketDatas(templateId, bracketId)
 		return (bracketId or '') .. '_' .. baseMatchId
 	end
 
-	return Table.map(matches, function(_, match)
+	-- Convert 0 based array to 1 based array
+	local function shiftArrayIndex(elems)
+		return Array.extend(elems[0], elems)
+	end
+
+	local bracketDatasById = Table.map(matches, function(_, match)
 		local bracketData = match.match2bracketdata
-		if String.nilIfEmpty(bracketData.toupper) then
-			bracketData.toupper = replaceBracketId(bracketData.toupper)
-		end
-		if String.nilIfEmpty(bracketData.tolower) then
-			bracketData.tolower = replaceBracketId(bracketData.tolower)
-		end
-		if String.nilIfEmpty(bracketData.thirdplace) then
-			bracketData.thirdplace = replaceBracketId(bracketData.thirdplace)
-		end
-		if String.nilIfEmpty(bracketData.bracketreset) then
-			bracketData.bracketreset = replaceBracketId(bracketData.bracketreset)
-		end
+
+		-- Convert 0 based array to 1 based array
+		bracketData.advanceSpots = bracketData.advanceSpots and shiftArrayIndex(bracketData.advanceSpots)
+		bracketData.lowerEdges = bracketData.lowerEdges and shiftArrayIndex(bracketData.lowerEdges)
+		bracketData.lowerMatchIds = bracketData.lowerMatchIds and shiftArrayIndex(bracketData.lowerMatchIds)
+
+		-- Rewrite bracket name of match IDs
+		bracketData.bracketreset = String.nilIfEmpty(bracketData.bracketreset) and replaceBracketId(bracketData.bracketreset)
+		bracketData.lowerMatchIds = bracketData.lowerMatchIds and Array.map(bracketData.lowerMatchIds, replaceBracketId)
+		bracketData.thirdplace = String.nilIfEmpty(bracketData.thirdplace) and replaceBracketId(bracketData.thirdplace)
+		bracketData.tolower = String.nilIfEmpty(bracketData.tolower) and replaceBracketId(bracketData.tolower)
+		bracketData.toupper = String.nilIfEmpty(bracketData.toupper) and replaceBracketId(bracketData.toupper)
+		bracketData.upperMatchId = bracketData.upperMatchId and replaceBracketId(bracketData.upperMatchId)
+
+		-- Remove/convert deprecated fields
+		bracketData.lowerMatchIds = bracketData.lowerMatchIds or MatchGroupUtil.computeLowerMatchIdsFromLegacy(bracketData)
+		bracketData.tolower = bracketData.lowerMatchIds[#bracketData.lowerMatchIds]
+		bracketData.toupper = bracketData.lowerMatchIds[#bracketData.lowerMatchIds - 1]
+		bracketData.rootIndex = nil
 
 		local _, baseMatchId = MatchGroupUtil.splitMatchId(match.match2id)
 		return baseMatchId, bracketData
 	end)
+
+	MatchGroupUtil.populateMissingUpperMatchIds(bracketDatasById)
+
+	return bracketDatasById
 end
 
-local BRACKET_DATA_PARAMS = {'header', 'tolower', 'toupper', 'qualwin', 'quallose', 'skipround'}
+local BRACKET_DATA_PARAMS = {'type'}
 
 function MatchGroupInput._validateBracketData(bracketData, matchKey)
 	if bracketData == nil then

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -12,10 +12,11 @@ local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 local MatchGroupInput = {}
 

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -255,4 +255,14 @@ function MatchGroupInput.fetchStandaloneMatch(matchId)
 	end)
 end
 
+local getContentLanguage = FnUtil.memoize(mw.getContentLanguage)
+
+function MatchGroupInput.readDate(dateString)
+	local timezoneOffset = dateString:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
+	local matchDate = String.explode(dateString, '<', 0):gsub('-', '')
+	local dateIsExact = String.contains(matchDate .. timezoneOffset, '[%+%-]')
+	local date = getContentLanguage():formatDate('c', matchDate .. timezoneOffset)
+	return date, dateIsExact
+end
+
 return MatchGroupInput

--- a/components/match2/commons/match_group_template.lua
+++ b/components/match2/commons/match_group_template.lua
@@ -1,0 +1,97 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Template
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Lua = require('Module:Lua')
+local StringUtils = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Template = require('Module:Template')
+
+local Match = Lua.import('Module:Match', {requireDevIfEnabled = true})
+local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+
+local MatchGroupTemplate = {}
+
+-- Entry point from Template:BracketDocumentation
+function MatchGroupTemplate.readAndStoreTemplate()
+	local argsList = Template.retrieveReturnValues('MatchGroupTemplate')
+
+	-- Read bracket datas from input spec
+	local bracket = MatchGroupTemplate.read(argsList)
+
+	-- Compute coordinates and attach to bracket datas
+	local bracketCoordinates = MatchGroupCoordinates.computeCoordinates(bracket)
+	for matchId, bracketData in pairs(bracket.bracketDatasById) do
+		bracketData.coordinates = bracketCoordinates.coordinatesByMatchId[matchId]
+	end
+
+	-- Store bracket with placeholder match and opponent data in LPDB
+	MatchGroupTemplate.store(bracket)
+end
+
+function MatchGroupTemplate.read(argsList)
+	local bracketDatas = Array.map(argsList, MatchGroupTemplate.readBracketData)
+
+	local bracket = {
+		bracketDatasById = Table.map(
+			bracketDatas,
+			function(_, bracketData) return bracketData.matchId, bracketData end
+		),
+		rootMatchIds = {},
+	}
+
+	local upperMatchIds = MatchGroupCoordinates.computeUpperMatchIds(bracket.bracketDatasById)
+	for _, bracketData in ipairs(bracketDatas) do
+		local upperMatchId = upperMatchIds[bracketData.matchId]
+		if not upperMatchId
+			and not StringUtils.endsWith(bracketData.matchId, 'RxMBR') then
+			table.insert(bracket.rootMatchIds, bracketData.matchId)
+		end
+		bracketData.upperMatchId = upperMatchId
+	end
+
+	return bracket
+end
+
+function MatchGroupTemplate.store(bracket)
+	for matchId, bracketData in pairs(bracket.bracketDatasById) do
+		local bracketId, baseMatchId = MatchGroupUtil.splitMatchId(matchId)
+		bracketData.matchId = nil
+
+		local opponent = {
+			name = MatchGroupUtil.matchIdToKey(baseMatchId),
+			type = 'literal',
+		}
+		local match = {
+			bracketid = bracketId,
+			match2bracketdata = MatchGroupUtil.bracketDataToRecord(bracketData),
+			matchid = baseMatchId,
+			opponent1 = opponent,
+		}
+		Match.store(match)
+	end
+end
+
+function MatchGroupTemplate.readBracketData(args)
+	local pageName = mw.title.getCurrentTitle().text
+	local function joinPageName(baseMatchId)
+		return pageName .. '_' .. baseMatchId
+	end
+
+	args.type = 'bracket'
+	local bracketData = MatchGroupUtil.bracketDataFromRecord(args)
+	bracketData.bracketResetMatchId = bracketData.bracketResetMatchId and joinPageName(bracketData.bracketResetMatchId)
+	bracketData.lowerMatchIds = Array.map(bracketData.lowerMatchIds, joinPageName)
+	bracketData.matchId = joinPageName(args.matchid)
+	bracketData.thirdPlaceMatchId = bracketData.thirdPlaceMatchId and joinPageName(bracketData.thirdPlaceMatchId)
+	bracketData.upperMatchId = bracketData.upperMatchId and joinPageName(bracketData.upperMatchId)
+	return bracketData
+end
+
+return MatchGroupTemplate

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -348,6 +348,32 @@ function MatchGroupUtil.bracketDataFromRecord(data)
 	end
 end
 
+function MatchGroupUtil.bracketDataToRecord(bracketData)
+	local coordinates = bracketData.coordinates
+	return {
+		bracketreset = bracketData.bracketResetMatchId,
+		coordinates = coordinates and MatchGroupUtil.indexTableToRecord(coordinates),
+		header = bracketData.header,
+		lowerEdges = bracketData.lowerEdges and Array.map(bracketData.lowerEdges, MatchGroupUtil.indexTableToRecord),
+		lowerMatchIds = bracketData.lowerMatchIds,
+		qualWinLiteral = bracketData.qualwinLiteral,
+		quallose = bracketData.qualLose and 'true' or nil,
+		qualloseLiteral = bracketData.qualLoseLiteral,
+		qualskip = bracketData.qualSkip ~= 0 and bracketData.qualSkip or nil,
+		qualwin = bracketData.qualWin and 'true' or nil,
+		skipround = bracketData.skipRound ~= 0 and bracketData.skipRound or nil,
+		thirdplace = bracketData.thirdPlaceMatchId,
+		type = bracketData.type,
+		upperMatchId = bracketData.upperMatchId,
+
+		-- Deprecated
+		bracketsection = coordinates
+			and MatchGroupUtil.sectionIndexToString(coordinates.sectionIndex, coordinates.sectionCount),
+		tolower = bracketData.lowerMatchIds[#bracketData.lowerMatchIds],
+		toupper = bracketData.lowerMatchIds[#bracketData.lowerMatchIds - 1],
+	}
+end
+
 function MatchGroupUtil.opponentFromRecord(record)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	return {
@@ -550,6 +576,28 @@ function MatchGroupUtil.indexTableFromRecord(record)
 			return key, value
 		end
 	end)
+end
+
+-- Convert 1-based indexes to 0-based
+function MatchGroupUtil.indexTableToRecord(coordinates)
+	return Table.map(coordinates, function(key, value)
+		if key:match('Index') then
+			return key, value - 1
+		else
+			return key, value
+		end
+	end)
+end
+
+-- Deprecated
+function MatchGroupUtil.sectionIndexToString(sectionIndex, sectionCount)
+	if sectionIndex == 1 then
+		return 'upper'
+	elseif sectionIndex == sectionCount then
+		return 'lower'
+	else
+		return 'mid'
+	end
 end
 
 --[[

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -11,7 +11,6 @@ local FeatureFlag = require('Module:FeatureFlag')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local wikiSpec = require('Module:Brkts/WikiSpecific')
 
@@ -65,14 +64,9 @@ function MatchSubobjects.luaGetMap(frame, args)
 		args = wikiSpec.processMap(frame, args)
 
 		local participants = args.participants or {}
-		if type(participants) == 'string' then
-			participants = Json.parse(participants)
-		end
 		for key, item in pairs(participants) do
 			if not key:match('%d_%d') then
 				error('Key \'' .. key .. '\' in match2game.participants has invalid format: \'<number>_<number>\' expected')
-			elseif type(item) == 'string' and String.startsWith(item, '{') then
-				participants[key] = Json.parse(item)
 			elseif type(item) ~= 'table' then
 				error('Item \'' .. tostring(item) .. '\' in match2game.participants has invalid format: table expected')
 			end

--- a/components/match2/commons/match_summary_ffa.lua
+++ b/components/match2/commons/match_summary_ffa.lua
@@ -12,12 +12,12 @@ local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Ordinal = require('Module:Ordinal')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 --[[

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -11,11 +11,11 @@ local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 local TypeUtil = require('Module:TypeUtil')
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
 
 local zeroWidthSpace = '&#8203;'

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -9,9 +9,11 @@
 local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
+local Lua = require('Module:Lua')
 local TypeUtil = require('Module:TypeUtil')
 local Flags = require('Module:Flags')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 --[[
 Display components for players.

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -8,13 +8,13 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
-local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local Table = require('Module:Table')
 
 local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 local RaceColor = Lua.loadDataIfExists('Module:RaceColorClass') or {}
+local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
 local StarcraftMatchSummary = Lua.import('Module:MatchSummary/Starcraft', {requireDevIfEnabled = true})
 local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -8,11 +8,11 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
-local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local Table = require('Module:Table')
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
+local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
 local StarcraftMatchSummary = Lua.import('Module:MatchSummary/Starcraft', {requireDevIfEnabled = true})
 local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -382,7 +382,7 @@ function StarcraftMatchGroupInput.SubMatchStructure(match)
 				game = match['map' .. i].game,
 				liquipediatier = match['map' .. i].liquipediatier,
 				liquipediatiertype = match['map' .. i].liquipediatiertype,
-				participants = participants,
+				participants = Table.deepCopy(participants),
 				mode = match['map' .. i].mode,
 				resulttype = 'submatch',
 				subgroup = k,

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -7,6 +7,7 @@
 --
 
 local FnUtil = require('Module:FnUtil')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -14,7 +15,6 @@ local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local config = Lua.loadDataIfExists('Module:Match/Config') or {}
-local json = require('Module:Json')
 local cleanFlag = require('Module:Flags').CountryName
 local defaultIcon
 
@@ -46,11 +46,6 @@ local StarcraftMatchGroupInput = {}
 
 -- called from Module:MatchGroup
 function StarcraftMatchGroupInput.processMatch(_, match)
-	if type(match) == 'string' then
-		match = json.parse(match)
-	end
-
-	-- process match
 	match = StarcraftMatchGroupInput.getDateStuff(match)
 	match = StarcraftMatchGroupInput.getTournamentVars(match)
 	if match.ffa == 'true' then
@@ -143,7 +138,7 @@ end
 
 function StarcraftMatchGroupInput.getVodStuff(match)
 	match.stream = match.stream or {}
-	match.stream = json.stringify({
+	match.stream = {
 		stream = Logic.emptyOr(match.stream, Variables.varDefault('stream')),
 		twitch = Logic.emptyOr(match.twitch, Variables.varDefault('twitch')),
 		twitch2 = Logic.emptyOr(match.twitch2, Variables.varDefault('twitch2')),
@@ -154,14 +149,14 @@ function StarcraftMatchGroupInput.getVodStuff(match)
 		smashcast = Logic.emptyOr(match.smashcast, Variables.varDefault('smashcast')),
 		youtube = Logic.emptyOr(match.youtube, Variables.varDefault('youtube')),
 		trovo = Logic.emptyOr(match.trovo, Variables.varDefault('trovo'))
-	})
+	}
 	match.vod = Logic.emptyOr(match.vod)
 
 	return match
 end
 
 function StarcraftMatchGroupInput.getLinks(match)
-	match.links = json.stringify({
+	match.links = {
 		preview = match.preview,
 		preview2 = match.preview2,
 		interview = match.interview,
@@ -169,16 +164,15 @@ function StarcraftMatchGroupInput.getLinks(match)
 		review = match.review,
 		recap = match.recap,
 		lrthread = match.lrthread,
-	})
+	}
 	return match
 end
 
 function StarcraftMatchGroupInput.getExtraData(match)
-	local extradata
 	if match.ffa == 'true' then
-		extradata = getStarcraftFfaInputModule().getExtraData(match)
+		match.extradata = getStarcraftFfaInputModule().getExtraData(match)
 	else
-		extradata = {
+		match.extradata = {
 			noQuery = match.noQuery,
 			matchsection = Variables.varDefault('matchsection'),
 			comment = match.comment,
@@ -211,7 +205,6 @@ function StarcraftMatchGroupInput.getExtraData(match)
 		}
 	end
 
-	match.extradata = json.stringify(extradata)
 	return match
 end
 
@@ -240,13 +233,8 @@ function StarcraftMatchGroupInput.adjustData(match)
 
 	--main processing done here
 	local subgroup = 0
-	for i = 1, MAX_NUM_MAPS do
-		if match['map' .. i] then
-			--parse the stringified map arguments to be a table again
-			match['map' .. i] = json.parseIfString(match['map' .. i])
-		else
-			break
-		end
+	for mapKey, _ in Table.iter.pairsByPrefix(match, 'map') do
+		local i = tonumber(mapKey:match('(%d+)$'))
 		match, subgroup = StarcraftMatchGroupInput.MapInput(match, i, subgroup)
 	end
 
@@ -260,16 +248,6 @@ function StarcraftMatchGroupInput.adjustData(match)
 
 	if string.find(match.mode, 'team') then
 		match = StarcraftMatchGroupInput.SubMatchStructure(match)
-	else
-		for i = 1, MAX_NUM_MAPS do
-			if match['map' .. i] then
-				--stringify maps if not team match (for team matches it is done via the above function)
-				match['map' .. i].participants = json.stringify(match['map' .. i].participants)
-				match['map' .. i] = json.stringify(match['map' .. i])
-			else
-				break
-			end
-		end
 	end
 
 	match = StarcraftMatchGroupInput.MatchWinnerProcessing(match)
@@ -375,19 +353,6 @@ function StarcraftMatchGroupInput.MatchWinnerProcessing(match)
 		else
 			match['opponent' .. opponentIndex].placement = 2
 		end
-
-		--stringify player data
-		for key, _ in ipairs(match['opponent' .. opponentIndex].match2players) do
-			match['opponent' .. opponentIndex].match2players[key].extradata =
-				json.stringify(match['opponent' .. opponentIndex].match2players[key].extradata)
-		end
-		match['opponent' .. opponentIndex].match2players = json.stringify(match['opponent' .. opponentIndex].match2players)
-
-		--stringify opponent extradata
-		match['opponent' .. opponentIndex].extradata = json.stringify(match['opponent' .. opponentIndex].extradata)
-
-		--stringify opponents
-		match['opponent' .. opponentIndex] = json.stringify(match['opponent' .. opponentIndex])
 	end
 
 	return match
@@ -417,11 +382,11 @@ function StarcraftMatchGroupInput.SubMatchStructure(match)
 				game = match['map' .. i].game,
 				liquipediatier = match['map' .. i].liquipediatier,
 				liquipediatiertype = match['map' .. i].liquipediatiertype,
-				participants = json.stringify(participants),
+				participants = participants,
 				mode = match['map' .. i].mode,
 				resulttype = 'submatch',
 				subgroup = k,
-				extradata = json.stringify({
+				extradata = {
 					header = (match['subGroup' .. k .. 'header'] or '') ~= '' and match['subGroup' .. k .. 'header'] or
 						(match['subgroup' .. k .. 'header'] or '') ~= '' and match['subgroup' .. k .. 'header'] or
 						match['submatch' .. k .. 'header'],
@@ -431,7 +396,7 @@ function StarcraftMatchGroupInput.SubMatchStructure(match)
 					isSubMatch = 'true',
 					opponent1 = opp['1'],
 					opponent2 = opp['2']
-				}),
+				},
 				['type'] = match['type'],
 				scores = { 0, 0 },
 				winner = 0
@@ -442,9 +407,6 @@ function StarcraftMatchGroupInput.SubMatchStructure(match)
 			elseif tonumber(match['map' .. i].winner) == 2 then
 				SubMatches[k].scores[2] = SubMatches[k].scores[2] + 1
 			end
-			--stringify map
-			match['map' .. i].participants = json.stringify(match['map' .. i].participants)
-			match['map' .. i] = json.stringify(match['map' .. i])
 		else
 			break
 		end
@@ -472,8 +434,6 @@ OpponentInput functions
 function StarcraftMatchGroupInput.OpponentInput(match)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		if not Logic.isEmpty(match['opponent' .. opponentIndex]) then
-			--parse the stringified opponent arguments to be a table again
-			match['opponent' .. opponentIndex] = json.parseIfString(match['opponent' .. opponentIndex])
 
 			--fix legacy winner
 			if (match['opponent' .. opponentIndex].win or '') ~= '' then
@@ -654,7 +614,7 @@ function StarcraftMatchGroupInput.ProcessLiteralOpponentInput(opp)
 			flag = cleanFlag(flag),
 			extradata = { faction = FACTIONS[string.lower(race)] or 'u' }
 		}
-		local extradata = json.parseIfString(opp.extradata or '{}')
+		local extradata = opp.extradata or {}
 		extradata.hasRaceOrFlag = true
 	end
 
@@ -669,7 +629,7 @@ end
 
 function StarcraftMatchGroupInput.getPlayersLegacy(playerData)
 	local players = {}
-	playerData = json.parseIfString(playerData) or {}
+	playerData = Json.parseIfString(playerData) or {}
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		local name = mw.ext.TeamLiquidIntegration.resolve_redirect((playerData['p' .. playerIndex .. 'link'] or '') ~= ''
 			and playerData['p' .. playerIndex .. 'link'] or playerData['p' .. playerIndex] or '')
@@ -1033,7 +993,6 @@ function StarcraftMatchGroupInput.ProcessPlayerMapData(map, match, OppNumber)
 	map.mode = map_mode
 
 	map.participants = participants
-	map.extradata = json.stringify(map.extradata)
 	return map
 end
 
@@ -1073,8 +1032,6 @@ function StarcraftMatchGroupInput.processContest(match)
 	local Rscore1 = {}
 	local Rscore2 = {}
 	for opponentIndex = 1, 2 do
-		match['opponent' .. opponentIndex] = json.parseIfString(match['opponent' .. opponentIndex])
-		match['opponent' .. opponentIndex].extradata = json.parseIfString(match['opponent' .. opponentIndex].extradata)
 		local Opp = match['opponent' .. opponentIndex]
 		local ResultOpp = match.contest.opponents[opponentIndex]
 		ResultOpp.extradata = ResultOpp.extradata or {}
@@ -1101,11 +1058,6 @@ function StarcraftMatchGroupInput.processContest(match)
 		points = points + match.contest.points.diff
 	elseif tostring(match.winner) == tostring(match.contest.winner) then
 		points = points + match.contest.points.win
-	end
-
-	for opponentIndex = 1, 2 do
-		match['opponent' .. opponentIndex].extradata = json.stringify(match['opponent' .. opponentIndex].extradata)
-		match['opponent' .. opponentIndex] = json.stringify(match['opponent' .. opponentIndex])
 	end
 
 	match.contest = nil

--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -8,10 +8,12 @@
 
 local Array = require('Module:Array')
 local Logic = require('Module:Logic')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
+local Lua = require('Module:Lua')
 local String = require('Module:String')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 --[[
 Utility functions for match group related things specific to the starcraft and starcraft2 wikis.

--- a/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
@@ -9,10 +9,10 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
-local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local Table = require('Module:Table')
 
 local FfaMatchSummary = Lua.import('Module:MatchSummary/Ffa', {requireDevIfEnabled = true})
+local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
 local StarcraftMatchSummary = Lua.import('Module:MatchSummary/Starcraft', {requireDevIfEnabled = true})
 local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -10,10 +10,10 @@ local Array = require('Module:Array')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
-local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
 local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 	getTinyIcon = function() end,

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -11,11 +11,11 @@ local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
 local StarcraftPlayerDisplay = Lua.import('Module:Player/Display/Starcraft', {requireDevIfEnabled = true})
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 	getBigIcon = function() end,

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -10,12 +10,12 @@ local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local StarcraftMatchGroupUtil = require('Module:MatchGroup/Util/Starcraft')
 local StarcraftPlayerUtil = require('Module:Player/Util/Starcraft')
 local String = require('Module:StringUtils')
 local TypeUtil = require('Module:TypeUtil')
 
 local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
+local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 	getSmallIcon = function() end,
 }

--- a/components/match2/commons/template_match.lua
+++ b/components/match2/commons/template_match.lua
@@ -88,7 +88,7 @@ function TemplateMatch.storeVarsToLPDB()
 
 	-- store matches
 	for _, match in pairs(matches) do
-		Match.store(match, true)
+		Match.store(match)
 	end
 end
 

--- a/components/match2/commons/template_match.lua
+++ b/components/match2/commons/template_match.lua
@@ -88,9 +88,6 @@ function TemplateMatch.storeVarsToLPDB()
 
 	-- store matches
 	for _, match in pairs(matches) do
-		-- bracketdata needs to be json encoded again
-		match.bracketdata = json.stringify(match.bracketdata)
-
 		Match.store(match, true)
 	end
 end

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -31,8 +31,6 @@ local CustomMatchGroupInput = {}
 
 -- called from Module:MatchGroup
 function CustomMatchGroupInput.processMatch(_, match)
-	match = Json.parseIfString(match)
-
 	-- Count number of maps, check for empty maps to remove, and automatically count score
 	match = matchFunctions.getBestOf(match)
 	match = matchFunctions.getScoreFromMapWinners(match)
@@ -49,9 +47,6 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processMap(_, map)
-	map = Json.parseIfString(map)
-
-	-- process map
 	map = mapFunctions.getExtraData(map)
 	map = mapFunctions.getScoresAndWinner(map)
 	map = mapFunctions.getTournamentVars(map)
@@ -61,8 +56,6 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processOpponent(_, opponent)
-	opponent = Json.parseIfString(opponent)
-
 	-- check for empty opponent and convert to literal
 	if type(opponent) == 'table' and opponent.type == 'team' and Logic.isEmpty(opponent.template) then
 		opponent.name = ''
@@ -80,7 +73,6 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processPlayer(_, player)
-	player = Json.parseIfString(player)
 	return player
 end
 
@@ -243,7 +235,6 @@ function matchFunctions.getScoreFromMapWinners(match)
 		if String.isEmpty(match['opponent' .. index]) then
 			break
 		end
-		match['opponent' .. index] = Json.parseIfString(match['opponent' .. index])
 		opponentNumber = index
 	end
 	local newScores = {}
@@ -309,7 +300,7 @@ end
 
 function matchFunctions.getVodStuff(match)
 	match.stream = match.stream or {}
-	match.stream = Json.stringify{
+	match.stream = {
 		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
 		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
 		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
@@ -325,7 +316,8 @@ function matchFunctions.getVodStuff(match)
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))
 
-	local links = {}
+	match.links = {}
+	local links = match.links
 	if match.preview then links.preview = match.preview end
 	if match.siegegg then links.siegegg = 'https://siege.gg/matches/' .. match.siegegg end
 	if match.opl then links.opl = 'https://www.opleague.eu/match/' .. match.opl end
@@ -334,14 +326,12 @@ function matchFunctions.getVodStuff(match)
 	if match.lpl then links.lpl = 'https://letsplay.live/match/' .. match.lpl end
 	if match.r6esports then links.r6esports = 'https://www.r6esports.com.br/en/match/' .. match.r6esports end
 	if match.stats then links.stats = match.stats end
-	match.links = Json.stringify(links)
 
 	-- apply vodgames
 	for index = 1, MAX_NUM_VODGAMES do
 		local vodgame = match['vodgame' .. index]
 		if not Logic.isEmpty(vodgame) then
-			local map = Logic.emptyOr(match['map' .. index], nil, {})
-			map = Json.parseIfString(map)
+			local map = match['map' .. index] or {}
 			map.vod = map.vod or vodgame
 			match['map' .. index] = map
 		end
@@ -350,12 +340,12 @@ function matchFunctions.getVodStuff(match)
 end
 
 function matchFunctions.getExtraData(match)
-	match.extradata = Json.stringify{
+	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
 		lastgame = Variables.varDefault('last_game'),
 		comment = match.comment,
-		mapveto = Json.stringify(matchFunctions.getMapVeto(match)),
-		mvp = Json.stringify(matchFunctions.getMVP(match)),
+		mapveto = matchFunctions.getMapVeto(match),
+		mvp = matchFunctions.getMVP(match),
 		isconverted = 0
 	}
 	return match
@@ -407,8 +397,6 @@ function matchFunctions.getOpponents(match)
 		-- read opponent
 		local opponent = match['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
-			opponent = Json.parseIfString(opponent)
-
 			--retrieve name and icon for teams from team templates
 			if opponent.type == 'team' and
 				not Logic.isEmpty(opponent.template, match.date) then
@@ -478,8 +466,7 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 	local count = 1
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
-		local player = match['opponent' .. opponentIndex .. '_p' .. playerIndex] or {}
-		player = Json.parseIfString(player)
+		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
 		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
@@ -497,7 +484,7 @@ end
 
 -- Parse extradata information
 function mapFunctions.getExtraData(map)
-	map.extradata = Json.stringify{
+	map.extradata = {
 		comment = map.comment,
 	}
 	return map

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -8,12 +8,11 @@
 
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require('Module:Logic')
+local MapModes = require('Module:MapModes')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local OpponentDisplay = require('Module:OpponentDisplay')
-local Template = require('Module:Template')
-local MapModes = require('Module:MapModes')
 local Table = require('Module:Table')
-local Json = require('Module:Json')
+local Template = require('Module:Template')
 
 local htmlCreate = mw.html.create
 
@@ -117,7 +116,6 @@ function p.getByMatchId(args)
 
 	-- Vetoes
 	local vetoData = (match.extradata or {}).mapveto
-	vetoData = Json.parseIfString(vetoData or '{}')
 	if not Table.isEmpty(vetoData) then
 		for index, vetoMap in ipairs(vetoData) do
 			local vetoElements = p._getVetoDisplay(vetoMap.map, vetoMap.by)

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -8,11 +8,13 @@
 
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MapModes = require('Module:MapModes')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local OpponentDisplay = require('Module:OpponentDisplay')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 local htmlCreate = mw.html.create
 

--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=rainbow_six
+-- wiki=rainbowsix
 -- page=Module:Brkts/WikiSpecific
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/components/match2/wikis/rainbow_six/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbow_six/match_group_input_custom.lua
@@ -32,8 +32,6 @@ local CustomMatchGroupInput = {}
 
 -- called from Module:MatchGroup
 function CustomMatchGroupInput.processMatch(_, match)
-	match = Json.parseIfString(match)
-
 	-- Count number of maps, check for empty maps to remove, and automatically count score
 	match = matchFunctions.getBestOf(match)
 	match = matchFunctions.removeUnsetMaps(match)
@@ -51,9 +49,6 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processMap(_, map)
-	map = Json.parseIfString(map)
-
-	-- process map
 	map = mapFunctions.getExtraData(map)
 	map = mapFunctions.getScoresAndWinner(map)
 	map = mapFunctions.getTournamentVars(map)
@@ -63,8 +58,6 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processOpponent(_, opponent)
-	opponent = Json.parseIfString(opponent)
-
 	-- check for empty team and convert to literal
 	if type(opponent) == 'table' and opponent.type == 'team' and Logic.isEmpty(opponent.template) then
 		opponent.name = ''
@@ -82,7 +75,6 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processPlayer(_, player)
-	player = Json.parseIfString(player)
 	return player
 end
 
@@ -252,8 +244,8 @@ end
 -- 2) At least one map has a winner
 function matchFunctions.getScoreFromMapWinners(match)
 	-- For best of 1, display the results of the single map
-	local opponent1 = Json.parseIfString(match.opponent1)
-	local opponent2 = Json.parseIfString(match.opponent2)
+	local opponent1 = match.opponent1
+	local opponent2 = match.opponent2
 	local newScores = {}
 	local foundScores = false
 	if match.bestof == 1 then
@@ -324,7 +316,7 @@ end
 
 function matchFunctions.getVodStuff(match)
 	match.stream = match.stream or {}
-	match.stream = Json.stringify{
+	match.stream = {
 		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
 		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
 		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
@@ -340,7 +332,8 @@ function matchFunctions.getVodStuff(match)
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))
 
-	local links = {}
+	match.links = {}
+	local links = match.links
 	if match.preview then links.preview = match.preview end
 	if match.siegegg then links.siegegg = 'https://siege.gg/matches/' .. match.siegegg end
 	if match.opl then links.opl = 'https://www.opleague.eu/match/' .. match.opl end
@@ -349,14 +342,12 @@ function matchFunctions.getVodStuff(match)
 	if match.lpl then links.lpl = 'https://letsplay.live/match/' .. match.lpl end
 	if match.r6esports then links.r6esports = 'https://www.r6esports.com.br/en/match/' .. match.r6esports end
 	if match.stats then links.stats = match.stats end
-	match.links = Json.stringify(links)
 
 	-- apply vodgames
 	for index = 1, MAX_NUM_VODGAMES do
 		local vodgame = match['vodgame' .. index]
 		if not Logic.isEmpty(vodgame) then
-			local map = Logic.emptyOr(match['map' .. index], nil, {})
-			map = Json.parseIfString(map)
+			local map = match['map' .. index] or {}
 			map.vod = map.vod or vodgame
 			match['map' .. index] = map
 		end
@@ -365,12 +356,12 @@ function matchFunctions.getVodStuff(match)
 end
 
 function matchFunctions.getExtraData(match)
-	match.extradata = Json.stringify{
+	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
 		lastgame = Variables.varDefault('last_game'),
 		comment = match.comment,
-		mapveto = Json.stringify(matchFunctions.getMapVeto(match)),
-		mvp = Json.stringify(matchFunctions.getMVP(match)),
+		mapveto = matchFunctions.getMapVeto(match),
+		mvp = matchFunctions.getMVP(match),
 		isconverted = 0
 	}
 	return match
@@ -430,7 +421,6 @@ function matchFunctions.getOpponents(match)
 		-- read opponent
 		local opponent = match['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
-			opponent = Json.parseIfString(opponent)
 
 			--retrieve name and icon for teams from team templates
 			if opponent.type == 'team' and
@@ -516,13 +506,13 @@ end
 
 -- Parse extradata information, particularally info about halfs and operator bans
 function mapFunctions.getExtraData(map)
-	map.extradata = Json.stringify{
+	map.extradata = {
 		comment = map.comment,
-		t1firstside = Json.stringify{map.t1firstside, ot = map.t1firstsideot},
-		t1halfs = Json.stringify{atk = map.t1atk, def = map.t1def, otatk = map.t1otatk, otdef = map.t1otdef},
-		t2halfs = Json.stringify{atk = map.t2atk, def = map.t2def, otatk = map.t2otatk, otdef = map.t2otdef},
-		t1bans = Json.stringify{map.t1ban1, map.t1ban2},
-		t2bans = Json.stringify{map.t2ban1, map.t2ban2},
+		t1firstside = {map.t1firstside, ot = map.t1firstsideot},
+		t1halfs = {atk = map.t1atk, def = map.t1def, otatk = map.t1otatk, otdef = map.t1otdef},
+		t2halfs = {atk = map.t2atk, def = map.t2def, otatk = map.t2otatk, otdef = map.t2otdef},
+		t1bans = {map.t1ban1, map.t1ban2},
+		t2bans = {map.t2ban1, map.t2ban2},
 		pick = map.pick
 	}
 	return map

--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -10,12 +10,12 @@ local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local MatchSummary = require('Module:MatchSummary/Base')
 local OperatorIcon = require('Module:OperatorIcon')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local _GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'

--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -8,7 +8,6 @@
 
 local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
-local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
@@ -443,7 +442,7 @@ function CustomMatchSummary._createBody(match)
 
 	-- Add Match MVP(s)
 	if match.extradata.mvp then
-		local mvpData = Json.parse(match.extradata.mvp)
+		local mvpData = match.extradata.mvp
 		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MVP()
 			for _, player in ipairs(mvpData.players) do
@@ -458,7 +457,7 @@ function CustomMatchSummary._createBody(match)
 
 	-- Add the Map Vetoes
 	if match.extradata.mapveto then
-		local vetoData = Json.parse(match.extradata.mapveto)
+		local vetoData = match.extradata.mapveto
 		if vetoData then
 			local mapVeto = MapVeto()
 
@@ -492,9 +491,9 @@ function CustomMatchSummary._createMap(game)
 	team1Score:setMapScore(game.scores[1])
 
 	-- Detailed scores
-	local team1Halfs = Json.parse(extradata.t1halfs) or {}
-	local team2Halfs = Json.parse(extradata.t2halfs) or {}
-	local firstSides = Json.parse(extradata.t1firstside) or {}
+	local team1Halfs = extradata.t1halfs or {}
+	local team2Halfs = extradata.t2halfs or {}
+	local firstSides = extradata.t1firstside or {}
 
 	local firstSide = (firstSides[1] or ''):lower()
 	local oppositeSide = CustomMatchSummary._getOppositeSide(firstSide)
@@ -528,7 +527,7 @@ function CustomMatchSummary._createMap(game)
 	team2Score:setMapScore(game.scores[2])
 
 	-- Operator bans
-	local operatorBans = {team1 = Json.parse(extradata.t1bans) or {}, team2 = Json.parse(extradata.t2bans) or {}}
+	local operatorBans = {team1 = extradata.t1bans or {}, team2 = extradata.t2bans or {}}
 	local team1OperatorBans = OperatorBans():setLeft()
 	local team2OperatorBans = OperatorBans():setRight()
 

--- a/components/match2/wikis/rocketleague/match_group_display_bracket_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_display_bracket_custom.lua
@@ -8,11 +8,11 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
 
 local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
 local CustomOpponentDisplay = Lua.import('Module:OpponentDisplay/Custom', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
 local CustomBracketDisplay = {propTypes = {}}
 

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -9,9 +9,9 @@
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Template = require('Module:Template')
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')

--- a/components/match2/wikis/starcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft/brkts_wiki_specific.lua
@@ -12,13 +12,14 @@ local Table = require('Module:Table')
 
 local WikiSpecific = Table.copy(require('Module:Brkts/WikiSpecific/Base'))
 
+WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
+	local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
+	return StarcraftMatchGroupUtil.matchFromRecord
+end)
+
 WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
 	local InputModule = Lua.import('Module:MatchGroup/Input/Starcraft', {requireDevIfEnabled = true})
 	return InputModule.processMatch
-end)
-
-WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
-	return require('Module:MatchGroup/Util/Starcraft').matchFromRecord
 end)
 
 function WikiSpecific.getMatchGroupContainer(matchGroupType)

--- a/components/match2/wikis/starcraft/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft/match_group_legacy.lua
@@ -148,13 +148,7 @@ function Legacy._convertSingle(realKey, val, match, mapping, flattened)
 			for innerKey, innerVal in pairs(val) do
 				nestedArgs[innerKey] = _args[innerVal] or flattened[innerVal]
 			end
-			if String.startsWith(realKey, "opponent") then
-				match[realKey] = json.stringify(nestedArgs)
-			elseif String.startsWith(realKey, "map") then
-				match[realKey] = nestedArgs
-			else
-				match[realKey] = nestedArgs
-			end
+			match[realKey] = nestedArgs
 		end
 	elseif noSkip then
 		local options = String.split(val, "|")

--- a/components/match2/wikis/starcraft/match_group_legacy_default.lua
+++ b/components/match2/wikis/starcraft/match_group_legacy_default.lua
@@ -82,7 +82,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxDx
 		opponent1 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "D" .. round.D,
+		"R" .. round.R .. "D" .. round.D,
 		flag = "R" .. round.R .. "D" .. round.D .. "flag",
 		race = "R" .. round.R .. "D" .. round.D .. "race",
 		score = "R" .. round.R .. "D" .. round.D .. "score",
@@ -94,7 +94,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxWx
 		opponent1 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "W" .. round.W,
+		"R" .. round.R .. "W" .. round.W,
 		flag = "R" .. round.R .. "W" .. round.W .. "flag",
 		race = "R" .. round.R .. "W" .. round.W .. "race",
 		score = "R" .. round.R .. "W" .. round.W .. "score" .. (reset and "2" or ""),
@@ -110,7 +110,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxDx
 		opponent2 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "D" .. round.D,
+		"R" .. round.R .. "D" .. round.D,
 		flag = "R" .. round.R .. "D" .. round.D .. "flag",
 		race = "R" .. round.R .. "D" .. round.D .. "race",
 		score = "R" .. round.R .. "D" .. round.D .. "score",
@@ -122,7 +122,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxWx
 		opponent2 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "W" .. round.W,
+		"R" .. round.R .. "W" .. round.W,
 		flag = "R" .. round.R .. "W" .. round.W .. "flag",
 		race = "R" .. round.R .. "W" .. round.W .. "race",
 		score = "R" .. round.R .. "W" .. round.W .. "score" .. (reset and "2" or ""),
@@ -132,8 +132,8 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		round.W = round.W + 1
 	end
 
-	opponent1["$notEmpty$"] = opponent1["1"]
-	opponent2["$notEmpty$"] = opponent2["1"]
+	opponent1["$notEmpty$"] = opponent1[1]
+	opponent2["$notEmpty$"] = opponent2[1]
 
 	match = {
 		opponent1 = opponent1,

--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -12,13 +12,14 @@ local Table = require('Module:Table')
 
 local WikiSpecific = Table.copy(require('Module:Brkts/WikiSpecific/Base'))
 
+WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
+	local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
+	return StarcraftMatchGroupUtil.matchFromRecord
+end)
+
 WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
 	local InputModule = Lua.import('Module:MatchGroup/Input/Starcraft', {requireDevIfEnabled = true})
 	return InputModule.processMatch
-end)
-
-WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
-	return require('Module:MatchGroup/Util/Starcraft').matchFromRecord
 end)
 
 function WikiSpecific.getMatchGroupContainer(matchGroupType)

--- a/components/match2/wikis/starcraft2/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft2/match_group_legacy.lua
@@ -189,13 +189,7 @@ function Legacy._convertSingle(realKey, val, match, mapping, flattened)
 			for innerKey, innerVal in pairs(val) do
 				nestedArgs[innerKey] = _args[innerVal] or flattened[innerVal]
 			end
-			if String.startsWith(realKey, 'opponent') then
-				match[realKey] = json.stringify(nestedArgs)
-			elseif String.startsWith(realKey, 'map') then
-				match[realKey] = nestedArgs
-			else
-				match[realKey] = nestedArgs
-			end
+			match[realKey] = nestedArgs
 		end
 	elseif noSkip then
 		local options = String.split(val, '|')
@@ -228,10 +222,9 @@ function Legacy.checkAdvantage(score, opponent)
 	local scoreAdvantage, scoreSum = string.match(score,
 					'<abbr title="Winner\'s bracket advantage of (%d) game">(%d)</abbr>')
 	if scoreAdvantage then
-		opponent = json.parseIfString(opponent or {})
+		opponent = opponent or {}
 		opponent.score = scoreSum
 		opponent.advantage = scoreAdvantage
-		opponent = json.stringify(opponent)
 	end
 	return opponent
 end

--- a/components/match2/wikis/starcraft2/match_group_legacy_default.lua
+++ b/components/match2/wikis/starcraft2/match_group_legacy_default.lua
@@ -82,7 +82,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxDx
 		opponent1 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "D" .. round.D,
+		"R" .. round.R .. "D" .. round.D,
 		flag = "R" .. round.R .. "D" .. round.D .. "flag",
 		race = "R" .. round.R .. "D" .. round.D .. "race",
 		score = "R" .. round.R .. "D" .. round.D .. "score",
@@ -94,7 +94,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxWx
 		opponent1 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "W" .. round.W,
+		"R" .. round.R .. "W" .. round.W,
 		flag = "R" .. round.R .. "W" .. round.W .. "flag",
 		race = "R" .. round.R .. "W" .. round.W .. "race",
 		score = "R" .. round.R .. "W" .. round.W .. "score" .. (reset and "2" or ""),
@@ -110,7 +110,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxDx
 		opponent2 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "D" .. round.D,
+		"R" .. round.R .. "D" .. round.D,
 		flag = "R" .. round.R .. "D" .. round.D .. "flag",
 		race = "R" .. round.R .. "D" .. round.D .. "race",
 		score = "R" .. round.R .. "D" .. round.D .. "score",
@@ -122,7 +122,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		-- RxWx
 		opponent2 = {
 		["type"] = "type",
-		["1"] = "R" .. round.R .. "W" .. round.W,
+		"R" .. round.R .. "W" .. round.W,
 		flag = "R" .. round.R .. "W" .. round.W .. "flag",
 		race = "R" .. round.R .. "W" .. round.W .. "race",
 		score = "R" .. round.R .. "W" .. round.W .. "score" .. (reset and "2" or ""),
@@ -132,8 +132,8 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		round.W = round.W + 1
 	end
 
-	opponent1["$notEmpty$"] = opponent1["1"]
-	opponent2["$notEmpty$"] = opponent2["1"]
+	opponent1["$notEmpty$"] = opponent1[1]
+	opponent2["$notEmpty$"] = opponent2[1]
 
 	match = {
 		opponent1 = opponent1,
@@ -183,7 +183,7 @@ function p.matchMappingFromCustom(data)
 		['finished'] = data.opp1 .. 'win|' .. data.opp2 .. 'win',
 		['opponent1'] = {
 			['$notEmpty$'] = data.opp1,
-			['1'] = data.opp1,
+			data.opp1,
 			['flag'] = data.opp1 .. 'flag',
 			['race'] = data.opp1 .. 'race',
 			['score'] = data.opp1 .. 'score',
@@ -192,7 +192,7 @@ function p.matchMappingFromCustom(data)
 			},
 		['opponent2'] = {
 			['$notEmpty$'] = data.opp2,
-			['1'] = data.opp2,
+			data.opp2,
 			['flag'] = data.opp2 .. 'flag',
 			['race'] = data.opp2 .. 'race',
 			['score'] = data.opp2 .. 'score',

--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -10,7 +10,6 @@ local Arguments = require("Module:Arguments")
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
 local DivTable = require('Module:DivTable')
-local Json = require('Module:Json')
 local Links = require('Module:Links')
 local Logic = require('Module:Logic')
 local Match = require("Module:Match")
@@ -63,7 +62,7 @@ function BigMatch:header(match, opponent1, opponent2, tournament)
 	local teamLeft = self:_createTeamContainer('left', opponent1.name, opponent1.score, false)
 	local teamRight = self:_createTeamContainer('right', opponent2.name, opponent2.score, false)
 
-	local stream = Json.parse(match.stream or '{}')
+	local stream = Table.copy(match.stream)
 	stream.date = mw.getContentLanguage():formatDate('r', match.date)
 	stream.finished = Logic.readBool(match.finished) and 'true' or ''
 	local divider = self:_createTeamSeparator(match.format, stream)
@@ -86,8 +85,8 @@ function BigMatch:overview(match)
 	while match['map' .. ind] ~= nil do
 		local map = match['map' .. ind]
 		local didLeftWin = map.winner == 1
-		local extradata = Json.parse(map.extradata or '')
-		local scores = Json.parse(map.scores or '')
+		local extradata = map.extradata
+		local scores = map.scores
 		local wasNotPlayed = map.resulttype == 'np'
 
 		boxLeft :row(
@@ -105,7 +104,7 @@ function BigMatch:overview(match)
 
 	local boxRight = DivTable.create():setStriped(true)
 
-	local stream = Json.parse(match.stream or "{}")
+	local stream = match.stream
 	local link = ''
 	for key, value in pairs(stream) do
 		link = link .. '[' .. Links.makeFullLink(key, value) .. ' <i class="lp-icon lp-' .. key .. '></i>] '
@@ -142,13 +141,13 @@ function BigMatch:stats(frame, match, playerLookUp, opponents)
 			break;
 		end
 
-		local extradata = Json.parse(map.extradata or {})
+		local extradata = map.extradata
 
 		tabs['name' .. ind] = 'Map ' .. ind
 
 		local container = mw.html.create('div'):addClass('fb-match-page-valorant-stats')
 
-		local participants = Json.parse(map.participants or '{}')
+		local participants = map.participants
 		if not Table.isEmpty(participants) then
 			for i = 1, 2 do
 				container:node(self:_createTeamStatsBanner(opponents[i].name, extradata['op1startside'], i == 1))

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -10,11 +10,11 @@ local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require("Module:Logic")
 local Lua = require('Module:Lua')
-local MatchGroupUtil = require('Module:MatchGroup/Util')
 local MatchSummary = require('Module:MatchSummary/Base')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local Agents = Class.new(


### PR DESCRIPTION
## Summary
* Move date processing to `MatchGroupInput.readDate`
* Make use of new iterator functions in `Table.iter`
* Some of the hard limits (MAX_NUM_MAPS = 20, MAX_NUM_OPPONENTS = 8 in ffa, etc) have been removed
* Mostly it's just replacing `match['map' .. i].asdf` with `map.asdf`

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested in /dev with starcraft tournament test suite

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
