### PR TITLE
Add Logic.isNotEmpty, Table.isNotEmpty, StringUtils.isNotEmpty

### DIFF
--- a/standard/logic.lua
+++ b/standard/logic.lua
@@ -38,6 +38,14 @@ function Logic.isEmpty(val)
 	end
 end
 
+function Logic.isNotEmpty(val)
+	if type(val) == 'table' then
+		return require('Module:Table').isNotEmpty(val)
+	else
+		return val ~= nil and val ~= ''
+	end
+end
+
 function Logic.readBool(val)
 	return val == 'true' or val == true or val == '1' or val == 1
 end

--- a/standard/string_utils.lua
+++ b/standard/string_utils.lua
@@ -51,6 +51,10 @@ function String.isEmpty(str)
 	return str == nil or str == ''
 end
 
+function String.isNotEmpty(str)
+	return str ~= nil and str ~= ''
+end
+
 -- index counts up from 0
 function String.explode(str, delimiter, index)
 	return String.split(str, delimiter)[index + 1] or ''

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -70,6 +70,10 @@ function Table.isEmpty(tbl)
 	return true
 end
 
+function Table.isNotEmpty(tbl)
+	return not Table.isEmpty(tbl)
+end
+
 function Table.copy(tbl)
 	local result = {}
 


### PR DESCRIPTION
## Summary
There are 450 `Logic/Table/StringUtils.isEmpty` calls in this repo, and the majority (260) of them occur as `not Logic/Table/StringUtils.isEmpty(x)`. 

I added `Logic/Table/StringUtils.isNotEmpty` to tailor to this usage. So instead of writing `not Logic.isEmpty(x)` one can instead write `Logic.isNotEmpty(x)`.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested as a part of #534 

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
