### PR TITLE
Add Gender field to default `Infobox user`

### DIFF
--- a/components/infobox/commons/infobox_person_user.lua
+++ b/components/infobox/commons/infobox_person_user.lua
@@ -51,6 +51,7 @@ end
 
 function CustomInjector:addCustomCells()
 	local widgets = {
+		Cell{name = 'Gender', content = {_args.gender}},
 		Cell{name = 'Languages', content = {_args.languages}},
 		Cell{name = 'Favorite players', content = CustomUser:_getArgsfromBaseDefault('fav-player', 'fav-players')},
 		Cell{name = 'Favorite casters', content = CustomUser:_getArgsfromBaseDefault('fav-caster', 'fav-casters')},


### PR DESCRIPTION
## Summary
Add Gender field to default `Infobox user`

RL, CS and some others have that field.
After this imo RL, CS and several others can directly use the commons based `Module:Infobox/Person/User` for their invoke in `infobox user`

## How did you test this change?
just adding a simple field, not tested