### PR TITLE
Fix typo

### DIFF
--- a/components/infobox/commons/infobox_person_user.lua
+++ b/components/infobox/commons/infobox_person_user.lua
@@ -66,7 +66,7 @@ function CustomInjector:addCustomCells()
 end
 
 function CustomUser:_getFavouriteTeams()
-	local foundArgs = User:getAllArgsForBase(_args, 'fav-team-1')
+	local foundArgs = User:getAllArgsForBase(_args, 'fav-team-')
 
 	local display = ''
 	for _, item in ipairs(foundArgs) do

--- a/components/infobox/wikis/starcraft2/infobox_person_user.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_user.lua
@@ -103,7 +103,7 @@ function CustomInjector:addCustomCells()
 end
 
 function CustomUser:_getFavouriteTeams()
-	local foundArgs = User:getAllArgsForBase(_args, 'fav-team-1')
+	local foundArgs = User:getAllArgsForBase(_args, 'fav-team-')
 
 	local display = ''
 	for _, item in ipairs(foundArgs) do


### PR DESCRIPTION
## Summary
Fix typo in commons and sc2 version of `infobox user`

## How did you test this change?
before:
![Screenshot 2021-10-05 12 13 59](https://user-images.githubusercontent.com/75081997/136004647-a35ec338-35ad-4dc7-81e6-0e4d7601d507.png)
after:
![Screenshot 2021-10-05 12 14 01](https://user-images.githubusercontent.com/75081997/136004651-d368d7db-e21f-4975-9022-83f7084d9bb5.png)

