### PR TITLE
Allow disabling missing match warning in brackets

### DIFF
--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -20,9 +20,10 @@ local MatchGroupBase = {}
 function MatchGroupBase.readOptions(args, matchGroupType)
 	local options = {
 		bracketId = MatchGroupBase.readBracketId(args.id),
-		show = not Logic.readBool(args.hide),
-		saveToLpdb = Logic.nilOr(Logic.readBoolOrNil(args.store), true),
 		matchGroupType = matchGroupType,
+		saveToLpdb = Logic.nilOr(Logic.readBoolOrNil(args.store), true),
+		shouldWarnMissing = Logic.nilOr(Logic.readBoolOrNil(args.warnMissing), true),
+		show = not Logic.readBool(args.hide),
 	}
 
 	local warnings = {}

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -48,7 +48,7 @@ Reads a bracket input spec, saves it to LPDB, and displays the bracket.
 ]]
 function MatchGroupDisplay.BracketBySpec(args)
 	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'bracket')
-	local matches, bracketWarnings = MatchGroupInput.readBracket(options.bracketId, args)
+	local matches, bracketWarnings = MatchGroupInput.readBracket(options.bracketId, args, options)
 	MatchGroupBase.saveMatchGroup(options.bracketId, matches, options.saveToLpdb)
 
 	local bracketNode

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -11,6 +11,7 @@ local FeatureFlag = require('Module:FeatureFlag')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -55,7 +56,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 	return Array.mapIndexes(readMatch)
 end
 
-function MatchGroupInput.readBracket(bracketId, args)
+function MatchGroupInput.readBracket(bracketId, args, options)
 	local warnings = {}
 	local templateId = args[1]
 	assert(templateId, 'argument \'1\' (templateId) is empty')
@@ -89,7 +90,8 @@ function MatchGroupInput.readBracket(bracketId, args)
 			table.insert(missingMatchKeys, matchKey)
 		end
 
-		matchArgs = Json.parseIfString(matchArgs) or {}
+		matchArgs = Json.parseIfString(matchArgs)
+			or Json.parse(Lua.import('Module:Match', {requireDevIfEnabled = true}).toEncodedJson({}))
 		matchArgs.bracketid = bracketId
 		matchArgs.matchid = matchId
 		local match = require('Module:Brkts/WikiSpecific').processMatch(mw.getCurrentFrame(), matchArgs)
@@ -131,7 +133,7 @@ function MatchGroupInput.readBracket(bracketId, args)
 	table.sort(matchIds)
 	local matches = Array.map(matchIds, readMatch)
 
-	if #missingMatchKeys ~= 0 then
+	if #missingMatchKeys ~= 0 and options.shouldWarnMissing then
 		table.insert(warnings, 'Missing matches: ' .. table.concat(missingMatchKeys, ', '))
 	end
 


### PR DESCRIPTION
## Summary
Allows the use of
```
{{Bracket|Bracket/4H2L1DH2LLH4H2H2L1DLLL|id=DWAkb4zHaJ|warnMissing=false}}
```
to show an empty bracket without specifying `R1M1=...` etc. Useful for testing and debugging. If `warnMissing=true` (default) it would show the same empty bracket but with a warning for the missing matches.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->
![image](https://user-images.githubusercontent.com/85348434/136061903-0d47e2ed-1794-42f2-a25a-3e32de29e028.png)

## How did you test this change?
Use https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Bracket_Layout

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
