### PR TITLE
[coords1] Add bracketData.lowerEdges

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -29,9 +29,9 @@ Display related functions go in Module:MatchGroup/Display/Helper.
 ]]
 local MatchGroupUtil = {types = {}}
 
-MatchGroupUtil.types.LowerMatch = TypeUtil.struct({
-	matchId = 'string',
-	opponentIx = 'number',
+MatchGroupUtil.types.LowerEdge = TypeUtil.struct({
+	lowerMatchIndex = 'number',
+	opponentIndex = 'number',
 })
 MatchGroupUtil.types.AdvanceBg = TypeUtil.literalUnion('up', 'stayup', 'stay', 'staydown', 'down')
 MatchGroupUtil.types.AdvanceSpot = TypeUtil.struct({
@@ -44,7 +44,8 @@ MatchGroupUtil.types.BracketBracketData = TypeUtil.struct({
 	bracketResetMatchId = 'string?',
 	bracketSection = 'string',
 	header = 'string?',
-	lowerMatches = TypeUtil.array(MatchGroupUtil.types.LowerMatch),
+	lowerMatchIds = TypeUtil.array('string'),
+	lowerEdges = TypeUtil.array(MatchGroupUtil.types.LowerEdge),
 	qualLose = 'boolean?',
 	qualLoseLiteral = 'string?',
 	qualSkip = 'number?',
@@ -282,18 +283,21 @@ end
 
 function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
 	if data.type == 'bracket' then
-		local lowerMatches = {}
-		local midIx = math.ceil(opponentCount / 2)
+		local lowerEdges = {}
+		local lowerMatchIds = {}
+		local midIx = math.floor(opponentCount / 2)
 		if nilIfEmpty(data.toupper) then
-			table.insert(lowerMatches, {
-				matchId = data.toupper,
-				opponentIx = midIx,
+			table.insert(lowerMatchIds, data.toupper)
+			table.insert(lowerEdges, {
+				opponentIndex = midIx,
+				lowerMatchIndex = #lowerMatchIds,
 			})
 		end
 		if nilIfEmpty(data.tolower) then
-			table.insert(lowerMatches, {
-				matchId = data.tolower,
-				opponentIx = math.min(midIx + 1, opponentCount),
+			table.insert(lowerMatchIds, data.tolower)
+			table.insert(lowerEdges, {
+				opponentIndex = math.min(midIx + 1, opponentCount),
+				lowerMatchIndex = #lowerMatchIds,
 			})
 		end
 
@@ -316,7 +320,8 @@ function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
 			bracketResetMatchId = nilIfEmpty(data.bracketreset),
 			bracketSection = data.bracketsection,
 			header = nilIfEmpty(data.header),
-			lowerMatches = lowerMatches,
+			lowerEdges = lowerEdges,
+			lowerMatchIds = lowerMatchIds,
 			qualLose = advanceSpots[2] and advanceSpots[2].type == 'qualify',
 			qualLoseLiteral = nilIfEmpty(data.qualloseLiteral),
 			qualSkip = tonumber(data.qualskip) or data.qualskip == 'true' and 1 or 0,
@@ -401,8 +406,8 @@ function MatchGroupUtil.computeUpperMatchIds(matchesById)
 	local upperMatchIds = {}
 	for matchId, match in pairs(matchesById) do
 		if match.bracketData.type == 'bracket' then
-			for _, lowerMatch in ipairs(match.bracketData.lowerMatches) do
-				upperMatchIds[lowerMatch.matchId] = matchId
+			for _, lowerMatchId in ipairs(match.bracketData.lowerMatchIds) do
+				upperMatchIds[lowerMatchId] = matchId
 			end
 		end
 	end
@@ -427,10 +432,7 @@ end
 function MatchGroupUtil.dfsFrom(bracketDatasById, start)
 	return TreeUtil.dfs(
 		function(matchId)
-			return Array.map(
-				bracketDatasById[matchId].lowerMatches,
-				function(lowerMatch) return lowerMatch.matchId end
-			)
+			return bracketDatasById[matchId].lowerMatchIds
 		end,
 		start
 	)
@@ -443,8 +445,8 @@ function MatchGroupUtil.computeDepthsFrom(bracketDatasById, startMatchId)
 		local bracketData = bracketDatasById[matchId]
 		depths[matchId] = depth
 		maxDepth = math.max(maxDepth, depth + bracketData.skipRound)
-		for _, lowerMatch in ipairs(bracketData.lowerMatches) do
-			visit(lowerMatch.matchId, depth + 1 + bracketData.skipRound)
+		for _, lowerMatchId in ipairs(bracketData.lowerMatchIds) do
+			visit(lowerMatchId, depth + 1 + bracketData.skipRound)
 		end
 	end
 	visit(startMatchId, 0)
@@ -506,8 +508,8 @@ function MatchGroupUtil.populateAdvanceSpots(bracket)
 	local firstBracketData = bracket.bracketDatasById[bracket.rootMatchIds[1]]
 	local thirdPlaceMatchId = firstBracketData.thirdPlaceMatchId
 	if thirdPlaceMatchId and bracket.matchesById[thirdPlaceMatchId] then
-		for _, lowerMatch in ipairs(firstBracketData.lowerMatches) do
-			local bracketData = bracket.bracketDatasById[lowerMatch.matchId]
+		for _, lowerMatchId in ipairs(firstBracketData.lowerMatchIds) do
+			local bracketData = bracket.bracketDatasById[lowerMatchId]
 			bracketData.advanceSpots[2] = bracketData.advanceSpots[2]
 				or {bg = 'stayup', type = 'advance', matchId = thirdPlaceMatchId}
 		end


### PR DESCRIPTION
Depends on #533 

## Summary
`bracketData.lowerEdges` is a replacement for `bracketData.lowerMatches`. The main difference is that `bracketData.lowerEdges` is a many to many mapping between a match and its lower matches. It directly encodes the connector lines that appear in the bracket. 

`lowerEdges` is an array of
```
{
    opponentIx,
    lowerMatchIx,
}
```

The new `lowerEdges` structure enables many configurations that were not possible previously:
- lower match without connector
- single lower match advancing into two opponents
- two lower matches advancing into one opponent
- crossing of wires: first lower match advancing into second opponent, and second lower match advancing into first opponent

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Use https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Bracket_Layout

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
