### PR TITLE
[coords5] Redirect Module:MatchGroup/Util to use coordinates module

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -263,8 +263,8 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 		-- Don't show the header if it's disabled. Also don't show the header
 		-- if it is the first match of a round because a higher round match can
 		-- show it instead.
-		local upperBracketData = bracket.upperMatchIds[matchId]
-			and bracket.bracketDatasById[bracket.upperMatchIds[matchId]]
+		local upperBracketData = bracketData.upperMatchId
+			and bracket.bracketDatasById[bracketData.upperMatchId]
 		local isFirstChild = upperBracketData
 			and matchId == upperBracketData.lowerMatchIds[1]
 		local showHeader = bracketData.header and not isFirstChild
@@ -277,9 +277,10 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 	-- matches. When it gets to a root, it then traverses the roots in
 	-- reverse order until it gets to the first root.
 	local function getParent(matchId)
-		local coords = bracket.coordsByMatchId[matchId]
-		return bracket.upperMatchIds[matchId]
-			or coords.rootIx ~= 1 and bracket.rootMatchIds[coords.rootIx - 1]
+		local bracketData = bracket.bracketDatasById[matchId]
+		local coords = bracket.coordinatesByMatchId[matchId]
+		return bracketData.upperMatchId
+			or coords.rootIndex ~= 1 and bracket.rootMatchIds[coords.rootIndex - 1]
 			or nil
 	end
 
@@ -290,19 +291,19 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 
 	-- Determine the individual headers appearing in header rows
 	for matchId, bracketData in pairs(bracket.bracketDatasById) do
-		local coords = bracket.coordsByMatchId[matchId]
+		local coords = bracket.coordinatesByMatchId[matchId]
 		if bracketData.header then
 			local headerRow = getHeaderRow(matchId)
 			local brMatch = bracketData.bracketResetMatchId and bracket.matchesById[bracketData.bracketResetMatchId]
-			headerRow[coords.roundIx] = {
+			headerRow[coords.roundIndex] = {
 				hasBrMatch = brMatch and true or false,
 				header = bracketData.header,
-				roundIx = coords.roundIx,
+				roundIx = coords.roundIndex,
 			}
 		end
 		if bracketData.qualWin then
 			local headerRow = getHeaderRow(matchId)
-			local roundIx = coords.roundIx + 1 + bracketData.qualSkip
+			local roundIx = coords.roundIndex + 1 + bracketData.qualSkip
 			headerRow[roundIx] = {
 				header = config.qualifiedHeader or '!q',
 				roundIx = roundIx,


### PR DESCRIPTION
## Summary
Changes to `Module:MatchGroup/Util`:
- Read coordinates from lpdb of it's available. Otherwise use `Module:MatchGroup/Coordinates` to compute it.
- Read `upperMatchId` from lpdb of it's available. Otherwise compute it with `MatchGroupCoords.computeUpperMatchIds`
- Update types for coordinates
- Split off `lowerEdge` and `advanceSpots` computation into separate functions. Read them from lpdb if available
- Deprecate `bracketData.bracketSection` in favor of `bracketData.coordinates.sectionIndex`
- Deprecate `bracketData.rootIndex` in favor of `bracketData.coordinates.rootIndex`
- Deprecate `bracketData.toupper/tolower` in favor of `bracketData.lowerMatchIds`

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Starcraft 2 tournament test suite 
https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Bracket_Layout
https://liquipedia.net/starcraft/Liquipedia:BracketUpdate/Tests/Artosis

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
