### PR TITLE
[coords6] Save new bracketdata fields to lpdb

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -101,7 +101,6 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 
 		-- Add more fields to bracket data
 		local bracketData = bracketDatasById[matchId]
-		MatchGroupInput._validateBracketData(bracketData, matchKey)
 
 		match.bracketdata = Table.mergeInto(bracketData, match.bracketdata or {})
 
@@ -119,13 +118,28 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 				.. MatchGroupUtil.matchIdFromKey(match.loserto)
 		end
 
-		-- Kick bracketData.thirdplace if no 3rd place match
-		if bracketData.thirdplace ~= '' and not args.RxMTP then
-			bracketData.thirdplace = ''
+		-- Remove bracketData.thirdplace if no 3rd place match
+		-- TODO omit field instead of storing empty string
+		if not args.RxMTP then
+			bracketData.thirdplace = nil
 		end
-		-- Kick bracketData.bracketreset if no reset match
-		if bracketData.bracketreset ~= '' and not args.RxMBR then
-			bracketData.bracketreset = ''
+		bracketData.thirdplace = bracketData.thirdplace or ''
+
+		-- Remove bracketData.bracketreset if no reset match
+		if not args.RxMBR then
+			bracketData.bracketreset = nil
+		end
+		bracketData.bracketreset = bracketData.bracketreset or ''
+
+		if not bracketData.loweredges then
+			local opponentCount = 0
+			for _, _ in Table.iter.pairsByPrefix(match, 'opponent') do
+				opponentCount = opponentCount + 1
+			end
+			bracketData.loweredges = Array.map(
+				MatchGroupUtil.autoAssignLowerEdges(#bracketData.lowerMatchIds, opponentCount),
+				MatchGroupUtil.indexTableToRecord
+			)
 		end
 
 		return match
@@ -153,38 +167,39 @@ function MatchGroupInput._fetchBracketDatas(templateId, bracketId)
 		return (bracketId or '') .. '_' .. baseMatchId
 	end
 
+	-- Convert 0 based array to 1 based array
+	local function shiftArrayIndex(elems)
+		return Array.extend(elems[0], elems)
+	end
+
 	return Table.map(matches, function(_, match)
 		local bracketData = match.match2bracketdata
-		if String.nilIfEmpty(bracketData.toupper) then
-			bracketData.toupper = replaceBracketId(bracketData.toupper)
-		end
-		if String.nilIfEmpty(bracketData.tolower) then
-			bracketData.tolower = replaceBracketId(bracketData.tolower)
-		end
-		if String.nilIfEmpty(bracketData.thirdplace) then
-			bracketData.thirdplace = replaceBracketId(bracketData.thirdplace)
-		end
-		if String.nilIfEmpty(bracketData.bracketreset) then
-			bracketData.bracketreset = replaceBracketId(bracketData.bracketreset)
-		end
+
+		-- Convert 0 based array to 1 based array
+		-- TODO this can be removed if the bracketa data is fetched using cross wiki lpdb
+		bracketData.loweredges = bracketData.loweredges and shiftArrayIndex(bracketData.loweredges)
+		bracketData.lowerMatchIds = bracketData.lowerMatchIds and shiftArrayIndex(bracketData.lowerMatchIds)
+
+		-- Rewrite bracket name of match IDs
+		bracketData.bracketreset = String.nilIfEmpty(bracketData.bracketreset) and replaceBracketId(bracketData.bracketreset)
+		bracketData.lowerMatchIds = bracketData.lowerMatchIds and Array.map(bracketData.lowerMatchIds, replaceBracketId)
+		bracketData.thirdplace = String.nilIfEmpty(bracketData.thirdplace) and replaceBracketId(bracketData.thirdplace)
+		bracketData.tolower = String.nilIfEmpty(bracketData.tolower) and replaceBracketId(bracketData.tolower)
+		bracketData.toupper = String.nilIfEmpty(bracketData.toupper) and replaceBracketId(bracketData.toupper)
+		bracketData.upperMatchId = bracketData.upperMatchId and replaceBracketId(bracketData.upperMatchId)
+
+		-- Remove/convert deprecated fields
+		bracketData.lowerMatchIds = bracketData.lowerMatchIds or MatchGroupUtil.computeLowerMatchIdsFromLegacy(bracketData)
+		bracketData.tolower = bracketData.lowerMatchIds[#bracketData.lowerMatchIds] or ''
+		bracketData.toupper = bracketData.lowerMatchIds[#bracketData.lowerMatchIds - 1] or ''
+		bracketData.rootIndex = nil
+
+		-- Don't store advanceSpots
+		bracketData.advancespots = nil
 
 		local _, baseMatchId = MatchGroupUtil.splitMatchId(match.match2id)
 		return baseMatchId, bracketData
 	end)
-end
-
-local BRACKET_DATA_PARAMS = {'header', 'tolower', 'toupper', 'qualwin', 'quallose', 'skipround'}
-
-function MatchGroupInput._validateBracketData(bracketData, matchKey)
-	if bracketData == nil then
-		error('bracketData of match ' .. matchKey .. ' is missing')
-	end
-
-	for _, param in ipairs(BRACKET_DATA_PARAMS) do
-		if bracketData[param] == nil then
-			error('bracketData of match ' .. matchKey .. ' is missing parameter \'' .. param .. '\'')
-		end
-	end
 end
 
 function MatchGroupInput.applyOverrideArgs(matches, args)

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -355,7 +355,7 @@ function MatchGroupUtil.matchFromRecord(record)
 	local opponents = Array.map(record.match2opponents, MatchGroupUtil.opponentFromRecord)
 	local bracketData = MatchGroupUtil.bracketDataFromRecord(Json.parseIfString(record.match2bracketdata))
 	if bracketData.type == 'bracket' then
-		bracketData.lowerEdges = bracketData.lowerEdges
+		bracketData.lowerEdges = bracketData.loweredges
 			or MatchGroupUtil.autoAssignLowerEdges(#bracketData.lowerMatchIds, #opponents)
 	end
 
@@ -382,13 +382,13 @@ end
 
 function MatchGroupUtil.bracketDataFromRecord(data)
 	if data.type == 'bracket' then
-		local advanceSpots = data.advanceSpots or MatchGroupUtil.computeAdvanceSpots(data)
+		local advanceSpots = data.advancespots or MatchGroupUtil.computeAdvanceSpots(data)
 		return {
 			advanceSpots = advanceSpots,
 			bracketResetMatchId = nilIfEmpty(data.bracketreset),
 			coordinates = data.coordinates and MatchGroupUtil.indexTableFromRecord(data.coordinates),
 			header = nilIfEmpty(data.header),
-			lowerEdges = data.lowerEdges and Array.map(data.lowerEdges, MatchGroupUtil.indexTableFromRecord),
+			lowerEdges = data.loweredges and Array.map(data.loweredges, MatchGroupUtil.indexTableFromRecord),
 			lowerMatchIds = data.lowerMatchIds or MatchGroupUtil.computeLowerMatchIdsFromLegacy(data),
 			qualLose = advanceSpots[2] and advanceSpots[2].type == 'qualify',
 			qualLoseLiteral = nilIfEmpty(data.qualloseLiteral),


### PR DESCRIPTION
## Summary
This change fetches the new `bracketData` fields (`lowerMatchIds` `lowerEdges` `upperMatchId` and `coordinates`) in the match input processing pipeline so they can be stored in lpdb along with the reset of the match. 
- `lowerMatchIds` and `upperMatchId` are stored in lpdb. They fetched from the bracket template if available (i.e. recently purged). Otherwise they are computed.
- `lowerEdges` is stored in lpdb. It is computed unless it is specified during input spec processing.
- `coordinates` is fetched from the bracket template. It is not computed if the bracket has not been purged to include coordinates data. It is then stored in lpdb.
- `advanceSpots` is more complicated so I have left it out for now. I'll leave lpdb storage of `advanceSpots` some other time. 

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Starcraft 2 tournament test suite
https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Bracket_Layout
https://liquipedia.net/starcraft/Liquipedia:BracketUpdate/Tests/Artosis
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
