### PR TITLE
[coords7] Store bracketData.coordinates in lpdb for bracket templates

### DIFF
--- a/components/match2/commons/bracket_template.lua
+++ b/components/match2/commons/bracket_template.lua
@@ -1,0 +1,146 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Bracket/Template
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Template = require('Module:Template')
+
+local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+local Match = Lua.import('Module:Match', {requireDevIfEnabled = true})
+local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+
+local BracketTemplate = {}
+
+-- Entry point of Template:BracketDocumentation
+function BracketTemplate.TemplateBracketDocumentation()
+	local argsList = Template.retrieveReturnValues('BracketTemplate')
+	local bracket = BracketTemplate.readBracket(argsList)
+
+	BracketTemplate.store(bracket)
+	return BracketTemplate.BracketDocumentation({templateId = bracket.templateId})
+end
+
+function BracketTemplate.BracketDocumentation(props)
+	local parts = {
+		[[
+==Bracket==
+]],
+		BracketTemplate.BracketContainer({bracketId = props.templateId}),
+		[[
+
+==Template==
+Refresh the page to generate a new ID.
+]],
+		mw.html.create('pre'):addClass('brkts-template-container'),
+	}
+	return table.concat(Array.map(parts, tostring))
+end
+
+function BracketTemplate.BracketContainer(props)
+	return BracketDisplay.Bracket({
+		bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId),
+		config = Table.merge(props.config, {
+			OpponentEntry = function() return mw.html.create('div'):addClass('brkts-opponent-entry') end,
+			matchHasDetails = function() return false end,
+		})
+	})
+end
+
+function BracketTemplate.readBracket(argsList)
+	local bracketDataList = Array.map(argsList, BracketTemplate.readBracketData)
+
+	local bracket = {
+		bracketDatasById = Table.map(
+			bracketDataList,
+			function(_, bracketData) return bracketData.matchId, bracketData end
+		),
+		rootMatchIds = {},
+		templateId = mw.title.getCurrentTitle().text,
+	}
+
+	-- Populate in bracketData.upperMatchId and rootMatchIds
+	local upperMatchIds = MatchGroupCoordinates.computeUpperMatchIds(bracket.bracketDatasById)
+	for _, bracketData in ipairs(bracketDataList) do
+		local upperMatchId = upperMatchIds[bracketData.matchId]
+		if not upperMatchId
+			and not String.endsWith(bracketData.matchId, 'RxMBR') then
+			table.insert(bracket.rootMatchIds, bracketData.matchId)
+		end
+		bracketData.upperMatchId = upperMatchId
+	end
+
+	-- Populate bracketData.coordinates
+	local bracketCoordinates = MatchGroupCoordinates.computeCoordinates(bracket)
+	for matchId, bracketData in pairs(bracket.bracketDatasById) do
+		bracketData.coordinates = bracketCoordinates.coordinatesByMatchId[matchId]
+	end
+
+	return bracket
+end
+
+function BracketTemplate.readBracketData(args)
+	local pageName = mw.title.getCurrentTitle().text
+	local function joinPageName(baseMatchId)
+		return pageName .. '_' .. baseMatchId
+	end
+
+	args.type = 'bracket'
+	local bracketData = MatchGroupUtil.bracketDataFromRecord(args)
+	bracketData.bracketResetMatchId = bracketData.bracketResetMatchId and joinPageName(bracketData.bracketResetMatchId)
+	bracketData.lowerMatchIds = Array.map(bracketData.lowerMatchIds, joinPageName)
+	bracketData.matchId = joinPageName(args.matchid)
+	bracketData.thirdPlaceMatchId = bracketData.thirdPlaceMatchId and joinPageName(bracketData.thirdPlaceMatchId)
+	bracketData.upperMatchId = bracketData.upperMatchId and joinPageName(bracketData.upperMatchId)
+	return bracketData
+end
+
+function BracketTemplate.store(bracket)
+	BracketTemplate.storeBracket(bracket)
+	BracketTemplate.storeDatapoint(bracket.templateId)
+end
+
+--[[
+Store bracket with placeholder match and opponent data in commons wiki LPDB
+]]
+function BracketTemplate.storeBracket(bracket)
+	for matchId, bracketData in pairs(bracket.bracketDatasById) do
+		local bracketId, baseMatchId = MatchGroupUtil.splitMatchId(matchId)
+		bracketData.matchId = nil
+
+		local opponent = {
+			name = MatchGroupUtil.matchIdToKey(baseMatchId),
+			type = 'literal',
+		}
+		local match = {
+			bracketid = bracketId,
+			match2bracketdata = MatchGroupUtil.bracketDataToRecord(bracketData),
+			matchid = baseMatchId,
+			opponent1 = opponent,
+		}
+		Match.store(match)
+	end
+end
+
+function BracketTemplate.storeDatapoint(templateId)
+	mw.ext.LiquipediaDB.lpdb_datapoint('ExtensionBracket_' .. templateId, {
+		type = 'extension bracket',
+	})
+end
+
+BracketTemplate.perfConfig = {
+	locations = {
+		'Module:Bracket/Template|*',
+		'Module:MatchGroup/Coordinates|*',
+		'Module:MatchGroup/Display/Bracket|*',
+	}
+}
+
+return BracketTemplate

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -409,6 +409,30 @@ function MatchGroupUtil.bracketDataFromRecord(data)
 	end
 end
 
+function MatchGroupUtil.bracketDataToRecord(bracketData)
+	local coordinates = bracketData.coordinates
+	return {
+		bracketreset = bracketData.bracketResetMatchId,
+		bracketsection = coordinates
+			and MatchGroupUtil.sectionIndexToString(coordinates.sectionIndex, coordinates.sectionCount),
+		coordinates = coordinates and MatchGroupUtil.indexTableToRecord(coordinates),
+		header = bracketData.header,
+		lowerMatchIds = bracketData.lowerMatchIds,
+		loweredges = bracketData.lowerEdges and Array.map(bracketData.lowerEdges, MatchGroupUtil.indexTableToRecord),
+		quallose = bracketData.qualLose and 'true' or nil,
+		qualloseLiteral = bracketData.qualLoseLiteral,
+		qualskip = bracketData.qualSkip ~= 0 and bracketData.qualSkip or nil,
+		qualwin = bracketData.qualWin and 'true' or nil,
+		qualwinLiteral = bracketData.qualwinLiteral,
+		skipround = bracketData.skipRound ~= 0 and bracketData.skipRound or nil,
+		thirdplace = bracketData.thirdPlaceMatchId,
+		tolower = bracketData.lowerMatchIds[#bracketData.lowerMatchIds],
+		toupper = bracketData.lowerMatchIds[#bracketData.lowerMatchIds - 1],
+		type = bracketData.type,
+		upperMatchId = bracketData.upperMatchId,
+	}
+end
+
 function MatchGroupUtil.opponentFromRecord(record)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	return {
@@ -646,6 +670,16 @@ function MatchGroupUtil.indexTableToRecord(coordinates)
 			return key, value
 		end
 	end)
+end
+
+function MatchGroupUtil.sectionIndexToString(sectionIndex, sectionCount)
+	if sectionIndex == 1 then
+		return 'upper'
+	elseif sectionIndex == sectionCount then
+		return 'lower'
+	else
+		return 'mid'
+	end
 end
 
 --[[


### PR DESCRIPTION
## Summary
Bracket templates (e.g. Template:Bracket/8) now compute bracket coordinates (see #557) and stores them to lpdb. Brackets using the bracket templates can then avoid computing the bracket coordinates themselves.

**Additional changes**
- A few additional fields are stored: `bracketData.lowerMatchIds`, `bracketData.upperMatchId`, and `bracketData.lowerEdges`
-  `bracketData.rootIndex` is deprecated and no longer stored
- bracketData fields in lpdb now use the right type: numbers are encoded as JSON numbers instead of strings, and unspecified values are left out instead of using the empty string.
- For ease of merging the new code is in a new module `Module:MatchGroup/Template`. The old `Module:TemplateMatch` will be removed after the templates using them have been switched over.

**LPDB changes to existing fields:**
- Unspecified optional fields (`qualwin`, `thirdplace` etc) are no longer present in `match2bracketdata`. Previously they were assigned the empty string.
- `qualskip` and `skipround` are now numbers in `match2bracketdata` if non-zero. Previously they were numeric strings.

This affects the bracket templates (stored on commons) as well as brackets used for actual tournaments (on wikis).

The justification is: using the correct types for storage and removing unassigned fields makes it lpdb records easier to inspect and debug.

**Push instructions:** Please notify @warnull before push so a quick final test can be performed.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Add {{#vardefine:feature_dev|1}} to bracket templates and purge. Use https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/Bracket_Layout to check that the brackets work and are stored correctly in lpdb
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
