### PR TITLE
Change "Birth" to "Born"

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -70,7 +70,7 @@ function Person:createInfobox()
 			name = 'Nationality',
 			content = self:_createLocations(args, personType.category)
 		},
-		Cell{name = 'Birth', content = {age.birth}},
+		Cell{name = 'Born', content = {age.birth}},
 		Cell{name = 'Died', content = {age.death}},
 		Customizable{id = 'region', children = {
 			Cell{name = 'Region', content = {


### PR DESCRIPTION
## Summary
from admin discord:
> "Birth" and "Died" seems inconsistent
> one of birth/death or born/died should be used imo

## How did you test this change?
N/A (just change of 1 word that gets displayed)