### PR TITLE
Add Template.storeReturnValue/retrieveReturnValues

### DIFF
--- a/standard/page_variable_namespace.lua
+++ b/standard/page_variable_namespace.lua
@@ -14,12 +14,16 @@ local Namespace = Class.new(function(self, prefix)
 	self.prefix = prefix
 end)
 
-function Namespace.get(self, key)
+function Namespace:get(key)
 	return StringUtils.nilIfEmpty(mw.ext.VariablesLua.var(self.prefix .. key))
 end
 
-function Namespace.set(self, key, value)
+function Namespace:set(key, value)
 	mw.ext.VariablesLua.vardefine(self.prefix .. key, StringUtils.nilIfEmpty(value))
+end
+
+function Namespace:delete(key)
+	self:set(key, nil)
 end
 
 local CachedTable = Class.new(function(self, table)
@@ -27,16 +31,20 @@ local CachedTable = Class.new(function(self, table)
 	self.table = table
 end)
 
-function CachedTable.get(self, key)
+function CachedTable:get(key)
 	if not self.results[key] then
 		self.results[key] = self.table:get(key)
 	end
 	return self.results[key]
 end
 
-function CachedTable.set(self, key, value)
+function CachedTable:set(key, value)
 	self.results[key] = nil
 	self.table:set(key, value)
+end
+
+function CachedTable:delete(key)
+	self:set(key, nil)
 end
 
 local PageVariableNamespace = {}

--- a/standard/template.lua
+++ b/standard/template.lua
@@ -6,6 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
+local Json = require('Module:Json')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
+
 local Template = {}
 
 function Template.safeExpand(frame, title, args, defaultTemplate)
@@ -20,6 +24,57 @@ end
 
 function Template.expandTemplate(frame, title, args)
 	return frame:expandTemplate {title = title, args = args}
+end
+
+--[[
+Stores a value that a function would otherwise return in a place to be later
+retrieved by Template.retrieveReturnValues. Used to return values across
+template boundaries.
+]]
+function Template.stashReturnValue(value, namespace)
+	local pageVars = PageVariableNamespace(namespace or 'Template.return')
+	local count = tonumber(pageVars:get('count')) or 0
+	count = count + 1
+	pageVars:set(count, Json.stringify(value))
+	pageVars:set('count', count)
+	return ''
+end
+
+--[[
+Retrieves all values stashed by Template.stashReturnValue.
+]]
+function Template.retrieveReturnValues(namespace)
+	local pageVars = PageVariableNamespace(namespace or 'Template.return')
+
+	local count = tonumber(pageVars:get('count')) or 0
+	pageVars:delete('count')
+
+	local values = {}
+	for i = 1, count do
+		values[i] = Json.parse(pageVars:get(i))
+		pageVars:delete(i)
+	end
+	return values
+end
+
+--[[
+Variant of Template.stashReturnValue suitable for use by #invoke. Stores the
+arguments of a template call in a place to be later retrieved by
+Template.retrieveReturnValues. {{#invoke:Template|stashArgs}} has the same
+interface as {{#invoke:Json|fromArgs}}.
+
+Usage:
+
+{{#invoke:Template|stashArgs|foo=3|namespace=Magpie}}
+
+will make {foo = '3'} available for retrival via Template.retrieveReturnValues('Magpie') .
+
+]]
+function Template.stashArgs(frame)
+	local args = Arguments.getArgs(frame)
+	local namespace = args.namespace
+	args.namespace = nil
+	return Template.stashReturnValue(args, namespace)
 end
 
 return Template


### PR DESCRIPTION
## Summary
`Template.storeReturn/retrieveReturns` is used for returning data from a child template to a parent template for templates that don't follow the standard parent-child pattern.

The standard parent child pattern is

```
{{Parent
|child1={{Child}}
|child2={{Child}}
...
}}
```

`Template:Prize pool` uses a non-standard pattern
```
{{Parent1}}
{{Child}}
{{Child}}
...
{{Parent2}}
```

As is `Template:ParticipantTable` on starcraft:
```
{{Parent
|{{Child}}{{Child}}...
}}
```

Returning a JSON formatted string in the child is great for the standard pattern, but won't work for the non-standard ones. `storeReturn/retrieveReturns` supports the non-standard patterns by JSON formatting the child return values and temporarily storing them on page variables.

Also changed the function declarations in Module:PageVariableNamespace

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Used by starcraft's dev `Template:ParticipantTable`
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
