### PR TITLE
Fix edge case in Json.parseIfString

### DIFF
--- a/standard/json.lua
+++ b/standard/json.lua
@@ -32,7 +32,11 @@ function json.parse(obj)
 end
 
 function json.parseIfString(obj)
-	return type(obj) == 'string' and json.parse(obj) or obj
+	if type(obj) == 'string' then
+		return json.parse(obj)
+	else
+		return obj
+	end
 end
 
 return json


### PR DESCRIPTION
## Summary
`Json.parseIfString` returns the wrong value when passed 'null'. This fixes it to return the correct value `nil`.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
```
Json.parseIfString('null')
-- Returns nil
```
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
