### PR TITLE
Temporary follow up fixes to #532

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -129,6 +129,7 @@ function Match._storePlayers(args, staticid, opponentIndex)
 		-- read player
 		local player = args['opponent' .. opponentIndex .. '_p' .. playerIndex]
 		if player == nil then break end
+		player = Json.parseIfString(player)
 
 		player.extradata = stringifyNonEmpty(player.extradata)
 
@@ -160,12 +161,12 @@ function Match._storeOpponents(args, staticid, opponentPlayers)
 		-- read opponent
 		local opponent = args['opponent' .. opponentIndex]
 		if opponent == nil then	break end
-
+		opponent = Json.parseIfString(opponent)
 		opponent.extradata = stringifyNonEmpty(opponent.extradata)
 
 		-- get nested players if exist
 		if not Logic.isEmpty(opponent.match2players) then
-			local players = opponent.match2players or {}
+			local players = Json.parseIfString(opponent.match2players) or {}
 			for playerIndex, player in ipairs(players) do
 				args['opponent' .. opponentIndex .. '_p' .. playerIndex] = player
 			end
@@ -204,6 +205,8 @@ function Match._storeGames(args, staticid)
 	for gameIndex = 1, 100 do
 		-- read game
 		local game = args['game' .. gameIndex] or args['map' .. gameIndex]
+		game = Json.parseIfString(game)
+		if game == 'null' then game = nil end
 		if game == nil then
 			break
 		end

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -23,7 +23,7 @@ function MatchSubobjects.getOpponent(frame)
 	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
 		local MatchSubobjects_ = Lua.import('Module:Match/Subobjects', {requireDevIfEnabled = true})
 		return MatchSubobjects_.withPerformanceSetup(function()
-			return MatchSubobjects_.luaGetOpponent(frame, args)
+			return Json.stringify(MatchSubobjects_.luaGetOpponent(frame, args))
 		end)
 	end)
 end
@@ -34,7 +34,7 @@ function MatchSubobjects.luaGetOpponent(frame, args)
 	end
 
 	args = wikiSpec.processOpponent(frame, args)
-	return Json.stringify({
+	return {
 		extradata = args.extradata,
 		icon = args.icon,
 		match2players = args.players or args.match2players,
@@ -43,7 +43,7 @@ function MatchSubobjects.luaGetOpponent(frame, args)
 		template = args.template,
 		type = args.type,
 		-- other variables such as placement and status are set from Module:MatchGroup
-	})
+	}
 end
 
 function MatchSubobjects.getMap(frame)
@@ -51,7 +51,7 @@ function MatchSubobjects.getMap(frame)
 	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
 		local MatchSubobjects_ = Lua.import('Module:Match/Subobjects', {requireDevIfEnabled = true})
 		return MatchSubobjects_.withPerformanceSetup(function()
-			return MatchSubobjects_.luaGetMap(frame, args)
+			return Json.stringify(MatchSubobjects_.luaGetMap(frame, args))
 		end)
 	end)
 end
@@ -73,7 +73,7 @@ function MatchSubobjects.luaGetMap(frame, args)
 		end
 		args.participants = participants
 
-		return Json.stringify({
+		return {
 			date = args.date,
 			extradata = args.extradata,
 			game = args.game,
@@ -89,17 +89,17 @@ function MatchSubobjects.luaGetMap(frame, args)
 			vod = args.vod,
 			walkover = args.walkover,
 			winner = args.winner,
-		})
+		}
 	end
 end
 
 function MatchSubobjects.getRound(frame)
 	local args = Arguments.getArgs(frame)
-	return MatchSubobjects.luaGetRound(frame, args)
+	return Json.stringify(MatchSubobjects.luaGetRound(frame, args))
 end
 
 function MatchSubobjects.luaGetRound(frame, args)
-	return Json.stringify(args)
+	return args
 end
 
 function MatchSubobjects.getPlayer(frame)
@@ -107,19 +107,19 @@ function MatchSubobjects.getPlayer(frame)
 	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
 		local MatchSubobjects_ = Lua.import('Module:Match/Subobjects', {requireDevIfEnabled = true})
 		return MatchSubobjects_.withPerformanceSetup(function()
-			return MatchSubobjects_.luaGetPlayer(frame, args)
+			return Json.stringify(MatchSubobjects_.luaGetPlayer(frame, args))
 		end)
 	end)
 end
 
 function MatchSubobjects.luaGetPlayer(frame, args)
 	args = wikiSpec.processPlayer(frame, args)
-	return Json.stringify({
+	return {
 		displayname = args.displayname,
 		extradata = args.extradata,
 		flag = args.flag,
 		name = args.name,
-	})
+	}
 end
 
 function MatchSubobjects.withPerformanceSetup(f)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -434,6 +434,7 @@ OpponentInput functions
 function StarcraftMatchGroupInput.OpponentInput(match)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		if not Logic.isEmpty(match['opponent' .. opponentIndex]) then
+			match['opponent' .. opponentIndex] = Json.parseIfString(match['opponent' .. opponentIndex])
 
 			--fix legacy winner
 			if (match['opponent' .. opponentIndex].win or '') ~= '' then
@@ -734,6 +735,7 @@ MapInput functions
 
 ]]--
 function StarcraftMatchGroupInput.MapInput(match, i, subgroup)
+	match['map' .. i] = Json.parseIfString(match['map' .. i])
 	--redirect maps
 	if match['map' .. i].map ~= 'TBD' then
 		match['map' .. i].map = mw.ext.TeamLiquidIntegration.resolve_redirect(match['map' .. i].map or '')

--- a/components/match2/wikis/rocketleague/legacy_match_list.lua
+++ b/components/match2/wikis/rocketleague/legacy_match_list.lua
@@ -145,11 +145,13 @@ function LegacyMatchList.convertSwissMatchMaps(frame)
 		if player ~= 'TBD' then
 			args['opponent' .. index] = MatchSubobjects.luaGetOpponent(frame, {
 					type = 'solo',
-					match2players = '[' .. json.stringify({
-						name = playerLink,
-						displayname = player,
-						flag = args['p' .. index .. 'flag'],
-					}) .. ']',
+					match2players = {
+						{
+							name = playerLink,
+							displayname = player,
+							flag = args['p' .. index .. 'flag'],
+						},
+					},
 					template = args['p' .. index .. 'team'],
 					score = score,
 				})

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -226,7 +226,7 @@ function matchFunctions.getOpponents(args)
 	local isScoreSet = false
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		-- read opponent
-		local opponent = args['opponent' .. opponentIndex]
+		local opponent = Json.parseIfString(args['opponent' .. opponentIndex])
 		if not Logic.isEmpty(opponent) then
 			--retrieve name and icon for teams from team templates
 			if opponent.type == 'team' and


### PR DESCRIPTION
## Summary
Some json-encoded subobjects from legacy brackets leaked into json-free zone set up in #532. This sets up a few checks to decode the json-encoded subobjects.

Also change `Module:Match/Subobjects` to not json encode which called from lua.

It's likely this is adding more checks than actually needed. Can go through and clean them up later.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Various pages on RL
https://liquipedia.net/rocketleague/Collegiate_Rocket_League/2021/Fall/Eastern
https://liquipedia.net/rocketleague/Rocket_Hockey_League/Season_8/League_Play/Split_2/Champions_Division
https://liquipedia.net/rocketleague/Feer/Show_Match/Overzero_vs_Wizz
https://liquipedia.net/starcraft2/StayAtHome_Story_Cup/3

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
