### PR TITLE
Fix typo

### DIFF
--- a/components/match2/wikis/rocketleague/match_legacy.lua
+++ b/components/match2/wikis/rocketleague/match_legacy.lua
@@ -55,7 +55,7 @@ function p.storeMatchSMW(match, match2)
 		"Has exact time=" .. (Logic.readBool(match.dateexact) and "true" or "false"),
 		"Is finished=" .. (Logic.readBool(match.finished) and "true" or "false"),
 		"Has winner=" .. (match.winner or ""),
-		"Is featured match" .. ((match.extradata or {}).isfeatured and "true" or "false"),
+		"Is featured match=" .. ((match.extradata or {}).isfeatured and "true" or "false"),
 		"Has calendar icon=" .. (not Logic.isEmpty(icon) and "File:" .. icon or ""),
 		"Has calendar description=" .. " - " .. Logic.emptyOr(match.opponent1, "TBD")
 			.. " vs " .. Logic.emptyOr(match.opponent2, "TBD") .. " on "


### PR DESCRIPTION
## Summary
add missing `=`

## How did you test this change?
pushed to live
![Screenshot 2021-10-13 16 20 07](https://user-images.githubusercontent.com/75081997/137151816-a5ea93e5-c920-45a9-8ba2-a1aa423ef9ab.png)


