### PR TITLE
Avoid nil concat in preview with empty opponents

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -248,6 +248,9 @@ function matchFunctions.isFeatured(match)
 end
 
 function matchFunctions.currentEarnings(name)
+	if String.isEmpty(name) then
+		return 0
+	end
 	local data = mw.ext.LiquipediaDB.lpdb('team', {
 		conditions = '[[name::' .. name .. ']]',
 		query = 'extradata'


### PR DESCRIPTION
## Summary
Avoid nil concat in preview with empty opponents

## How did you test this change?
pushed to live
