### PR TITLE
parse -> parseIfString in rainbowsix Match/Legacy

### DIFF
--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -59,17 +59,17 @@ function p.storeGames(match, match2)
 	for gameIndex, game2 in ipairs(match2.match2games or {}) do
 		local game = Table.deepCopy(game2)
 		-- Extradata
-		local extradata = json.parse(game2.extradata)
+		local extradata = json.parseIfString(game2.extradata)
 		game.extradata = {}
 		game.extradata.gamenumber = gameIndex
 		if extradata.t1bans and extradata.t2bans then
-			game.extradata.opponent1bans = table.concat(json.parse(extradata.t1bans), ", ")
-			game.extradata.opponent2bans = table.concat(json.parse(extradata.t2bans), ", ")
+			game.extradata.opponent1bans = table.concat(json.parseIfString(extradata.t1bans), ", ")
+			game.extradata.opponent2bans = table.concat(json.parseIfString(extradata.t2bans), ", ")
 		end
 		if extradata.t1firstside and extradata.t1halfs and extradata.t2halfs then
-			extradata.t1firstside = json.parse(extradata.t1firstside)
-			extradata.t1halfs = json.parse(extradata.t1halfs)
-			extradata.t2halfs = json.parse(extradata.t2halfs)
+			extradata.t1firstside = json.parseIfString(extradata.t1firstside)
+			extradata.t1halfs = json.parseIfString(extradata.t1halfs)
+			extradata.t2halfs = json.parseIfString(extradata.t2halfs)
 			local team1 = {}
 			local team2 = {}
 			if extradata.t1firstside[1] == "atk" then
@@ -137,9 +137,9 @@ function p.convertParameters(match2)
 
 	-- Handle extradata fields
 	match.extradata = {}
-	local extradata = json.parse(match2.extradata)
+	local extradata = json.parseIfString(match2.extradata)
 
-	local mvp = json.parse(extradata.mvp)
+	local mvp = json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
 		match.extradata.mvp = table.concat(mvp.players, ",")
 		match.extradata.mvp = match.extradata.mvp .. ";" .. mvp.points
@@ -147,7 +147,7 @@ function p.convertParameters(match2)
 
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.bestofx = tostring(match2.bestof)
-	local bracketData = json.parse(match2.match2bracketdata)
+	local bracketData = json.parseIfString(match2.match2bracketdata)
 	if type(bracketData) == "table" and bracketData.type == "bracket" and bracketData.header then
 		local headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
 		if not headerName or headerName == "" then
@@ -160,7 +160,7 @@ function p.convertParameters(match2)
 		end
 	end
 
-	local veto = json.parse(extradata.mapveto)
+	local veto = json.parseIfString(extradata.mapveto)
 	if veto then
 		for k, round in ipairs(veto) do
 			if k == 1 then


### PR DESCRIPTION
## Summary
These fields should be no longer json encoded, so don't parse if unneeded.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Check match1 output on https://liquipedia.net/rainbowsix/APAC_League/2021/North_Division/Stage_3
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
