### PR TITLE
Move subobject field culling to the end

### DIFF
--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -35,16 +35,7 @@ function MatchSubobjects.luaGetOpponent(frame, args)
 
 	args = wikiSpec.processOpponent(frame, args)
 	args.match2players = args.players or Json.parseIfString(args.match2players)
-	return {
-		extradata = args.extradata,
-		icon = args.icon,
-		match2players = args.match2players,
-		name = args.name,
-		score = args.score,
-		template = args.template,
-		type = args.type,
-		-- other variables such as placement and status are set from Module:MatchGroup
-	}
+	return args
 end
 
 function MatchSubobjects.getMap(frame)
@@ -64,33 +55,16 @@ function MatchSubobjects.luaGetMap(frame, args)
 	else
 		args = wikiSpec.processMap(frame, args)
 
-		local participants = args.participants or {}
-		for key, item in pairs(participants) do
+		args.participants = args.participants or {}
+		for key, item in pairs(args.participants) do
 			if not key:match('%d_%d') then
 				error('Key \'' .. key .. '\' in match2game.participants has invalid format: \'<number>_<number>\' expected')
 			elseif type(item) ~= 'table' then
 				error('Item \'' .. tostring(item) .. '\' in match2game.participants has invalid format: table expected')
 			end
 		end
-		args.participants = participants
 
-		return {
-			date = args.date,
-			extradata = args.extradata,
-			game = args.game,
-			length = args.length,
-			map = args.map,
-			mode = args.mode,
-			participants = args.participants,
-			resulttype = args.resulttype,
-			rounds = args.rounds,
-			scores = args.scores,
-			subgroup = args.subgroup,
-			type = args.type,
-			vod = args.vod,
-			walkover = args.walkover,
-			winner = args.winner,
-		}
+		return args
 	end
 end
 
@@ -114,13 +88,7 @@ function MatchSubobjects.getPlayer(frame)
 end
 
 function MatchSubobjects.luaGetPlayer(frame, args)
-	args = wikiSpec.processPlayer(frame, args)
-	return {
-		displayname = args.displayname,
-		extradata = args.extradata,
-		flag = args.flag,
-		name = args.name,
-	}
+	return wikiSpec.processPlayer(frame, args)
 end
 
 function MatchSubobjects.withPerformanceSetup(f)


### PR DESCRIPTION
## Summary
Module:Subbobject removes fields that won't be saved to lpdb right after subobject processing. I think this is done too early in the process, so I moved the culling to right before the lpdb calls are made.

This allows passing non-lpdb fields between subobject processing and match processing. And reduces the risk of fields inadvertently added to subobjects during match processing.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
tournament test suites on wikis

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
