### PR TITLE
Set date vars in series

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_series_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_series_custom.lua
@@ -212,8 +212,9 @@ function CustomSeries._setDateMatchVar(date, edate, sdate)
 	date = string.match(date or '', '%d%d%d%d%-%d%d%-%d%d')
 		or string.match(edate or '', '%d%d%d%d%-%d%d%-%d%d')
 		or string.match(sdate or '', '%d%d%d%d%-%d%d%-%d%d') or ''
-	local sdate = string.match(date or '', '%d%d%d%d%-%d%d%-%d%d')
-		or string.match(sdate or '', '%d%d%d%d%-%d%d%-%d%d') or ''
+	sdate = string.match(date or '', '%d%d%d%d%-%d%d%-%d%d')
+		or string.match(sdate or '', '%d%d%d%d%-%d%d%-%d%d')
+		or string.match(edate or '', '%d%d%d%d%-%d%d%-%d%d') or ''
 
 	VarDefine('date', date)
 	VarDefine('tournament_enddate', date)


### PR DESCRIPTION
## Summary
Set `tournament_enddate` and `tournament_startdate` vars in SC2 infobox series.
(Since we have matches and prizepools on some series pages we need infobox series to set those.)

## How did you test this change?
N/A