### PR TITLE
Add default date in case of missing date vars

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -73,7 +73,7 @@ function StarcraftMatchGroupInput.readDate(matchArgs)
 		Variables.varDefine('matchDate', dateProps.date)
 		return dateProps
 	else
-		local suggestedDate = Variables.varDefaultMulti('matchDate', 'Match_date', 'date', 'sdate', 'edate') or '1970-01-01'
+		local suggestedDate = Variables.varDefaultMulti('matchDate', 'Match_date', 'date', 'sdate', 'edate', '1970-01-01')
 		return {
 			date = MatchGroupInput.getInexactDate(suggestedDate),
 			dateexact = false,


### PR DESCRIPTION
## Summary
Add default date in case of missing date vars, so that previews do not error and pages without set date (e.g. in userspace) do not error

## How did you test this change?
Pushed to live to remove error messages in previews