### PR TITLE
Write resolved game name into LPDB (AoE)

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -264,6 +264,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	local _, mappages = CustomLeague:_getMaps(args)
 	lpdbData['maps'] = table.concat(mappages, ';')
 
+	lpdbData['game'] = GameLookup.getName({args.game})
 	lpdbData['patch'] = args.patch
 	lpdbData['participantsnumber'] = args.team_number or args.player_number
 	lpdbData['extradata'] = {


### PR DESCRIPTION
## Summary
- Resolve the game before writing it to LPDB
Modules querying LPDB data expect the full game name and not a shorthand

## How did you test this change?
Tested manually that the Module depending on this (BracketMatchSummary) works as intended in previews iff the full name is in LPDB.
Won't break, but fix LPDB data, as that will be exactly the same like it was before using the Module.

