### PR TITLE
Add Apex infobox league

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -239,6 +239,21 @@ function CustomLeague:addToLpdb(lpdbData)
 		['is ea major'] = Variables.varDefault('tournament_ea_major', '')
 	}
 
+	--retrieve sponsors from _args.sponsors if sponsorX, X=1,...,3, is empty
+	if
+		String.isEmpty(_args.sponsor1) and
+		String.isEmpty(_args.sponsor2) and
+		String.isEmpty(_args.sponsor3) and
+		not String.isEmpty(_args.sponsor)
+	then
+		lpdbData.sponsors = {}
+		local sponsors = mw.text.split(_args.sponsor, '<br>', true)
+		for key, item in pairs(sponsors) do
+			lpdbData.sponsors['sponsor' .. key] = item
+		end
+		lpdbData.sponsors = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.sponsors)
+	end
+
 	return lpdbData
 end
 


### PR DESCRIPTION
## Summary
Add Custom part for Apex infobox league implementation

## How did you test this change?
- [x] Create a test page (copied from a live page) in main space and compare LPDB data
* * only differences are intended (e.g. storing sponsors as a json)
- [x] compared cars that get set
* * several new ones are set (due to the standardisation)
- [x] hjp checked and compared looks to old infobox on at least 5 pages
- [x] kano checked and compare looks to old infobox on a few pages