### PR TITLE
Fix ranking for teams that have different name and pagename

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -42,7 +42,7 @@ function CustomInjector:addCustomCells(widgets)
 	})
 	local rankingSuccess, rlcsRanking = pcall(TeamRanking.run, {
 		ranking = Variables.varDefault('ranking_name', ''),
-		team = _team.args.name
+		team = _team.pagename
 	})
 	if not rankingSuccess then
 		rlcsRanking = CustomInjector:wrapErrorMessage(rlcsRanking)


### PR DESCRIPTION
## Summary

Some teams - namely NRG - have a different name and pagename, hence their ranking doesn't show up on their teampage, that's because the Ranking LPDB datapoints are created using the pagename.

## How did you test this change?

It's really hard to test this change, however the _team.pagename is already used in multiple areas in the same module and it's working as intended.
