### PR TITLE
Define variables for extradata to be able to re-add them

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -252,6 +252,11 @@ function CustomLeague:defineCustomPageVariables(args)
 
 	-- Legacy notability vars
 	Variables.varDefine('tournament_notability_mod', args.notabilitymod or 1)
+
+	-- Variables for extradata to be added again in
+	-- Module:Prize pool, Module:Prize pool team, Module:TeamCard and Module:TeamCard2
+	Variables.varDefine('tournament_deadline', DateClean(args.deadline or ''))
+	Variables.varDefine('tournament_gamemode', table.concat(CustomLeague:_getGameModes(args, false), ','))
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)


### PR DESCRIPTION
## Summary
Define variables for data being inserted into extradata, as that is overriden in other modules on the page.
Those variables are needed to re-add that data.

## How did you test this change?
- Checked for existence of this variables via insource-search
- Tested correct values of variables in sandbox

