### PR TITLE
Fixes legacy storage interfering with match2 storage

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -92,14 +92,22 @@ function Match.storeMatchGroup(matchRecords, options)
 		Array.forEach(matchRecordsCopy, Match.encodeJson)
 	end
 
+	if options.storeMatch2 then
+		local recordsList
+		if LegacyMatch then
+			recordsList = Array.map(matchRecordsCopy, Match.splitRecordsByType)
+			Array.forEach(recordsList, Match.populateSubobjectReferences)
+		end
+		Array.forEach(matchRecordsCopy, Match._storeMatch2InLpdb)
+		if LegacyMatch then
+			Array.forEach(recordsList, Match.populateSubobjectReferences)
+		end
+	end
+
 	if LegacyMatch then
 		Array.forEach(matchRecordsCopy, function(matchRecord)
 			LegacyMatch.storeMatch(matchRecord, options)
 		end)
-	end
-
-	if options.storeMatch2 then
-		Array.forEach(matchRecordsCopy, Match._storeMatch2InLpdb)
 	end
 end
 


### PR DESCRIPTION
## Summary
Fixes legacy storage interfering with match2 storage by putting match2 storage first. Match2 storage removes some edges so they need to be added back.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
https://liquipedia.net/starcraft2/ITaX_Super_Series/69
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
