### PR TITLE
Don't clear JSON encoded fields in match2

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -216,26 +216,26 @@ function Match.copyRecords(matchRecord)
 	})
 end
 
-local function stringifyIfNotEmpty(tbl)
-	return Table.isNotEmpty(tbl) and Json.stringify(tbl) or nil
+local function stringifyIfTable(tbl)
+	return type(tbl) == 'table' and Json.stringify(tbl) or nil
 end
 
 function Match.encodeJson(matchRecord)
-	matchRecord.match2bracketdata = stringifyIfNotEmpty(matchRecord.match2bracketdata)
-	matchRecord.stream = stringifyIfNotEmpty(matchRecord.stream)
-	matchRecord.links = stringifyIfNotEmpty(matchRecord.links)
-	matchRecord.extradata = stringifyIfNotEmpty(matchRecord.extradata)
+	matchRecord.match2bracketdata = stringifyIfTable(matchRecord.match2bracketdata)
+	matchRecord.stream = stringifyIfTable(matchRecord.stream)
+	matchRecord.links = stringifyIfTable(matchRecord.links)
+	matchRecord.extradata = stringifyIfTable(matchRecord.extradata)
 
 	for _, opponentRecord in ipairs(matchRecord.match2opponents) do
-		opponentRecord.extradata = stringifyIfNotEmpty(opponentRecord.extradata)
+		opponentRecord.extradata = stringifyIfTable(opponentRecord.extradata)
 		for _, playerRecord in ipairs(opponentRecord.match2players) do
-			playerRecord.extradata = stringifyIfNotEmpty(playerRecord.extradata)
+			playerRecord.extradata = stringifyIfTable(playerRecord.extradata)
 		end
 	end
 	for _, gameRecord in ipairs(matchRecord.match2games) do
-		gameRecord.extradata = stringifyIfNotEmpty(gameRecord.extradata)
-		gameRecord.participants = stringifyIfNotEmpty(gameRecord.participants)
-		gameRecord.scores = stringifyIfNotEmpty(gameRecord.scores)
+		gameRecord.extradata = stringifyIfTable(gameRecord.extradata)
+		gameRecord.participants = stringifyIfTable(gameRecord.participants)
+		gameRecord.scores = stringifyIfTable(gameRecord.scores)
 	end
 end
 


### PR DESCRIPTION
## Summary
Don't clear blank tables in JSON encoded fields in match2 records. Instead just store blank tables outputted from match input processing. This behavior should be a bit more predictable.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Inspect match2 records of pages with blank tables in JSON encoded fields. https://liquipedia.net/starcraft2/Special:LiquipediaDB/StayAtHome_Story_Cup/4

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
