### PR TITLE
Add Table.groupBy, Table.entries

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -213,6 +213,30 @@ function Table.any(tbl, predicate)
 	return false
 end
 
+--[[
+Groups entries of a table according to a grouping function.
+
+Example:
+local function parity(_, x) return x % 2 end
+Table.groupBy({a = 3, b = 4, c = 5}, parity)
+-- Returns
+{
+	0 = {b = 4},
+	1 = {a = 3, c = 5},
+}
+]]
+function Table.groupBy(tbl, f)
+	local groups = {}
+	for key, value in pairs(tbl) do
+		local groupKey = f(key, value)
+		if not groups[groupKey] then
+			groups[groupKey] = {}
+		end
+		groups[groupKey][key] = value
+	end
+	return groups
+end
+
 -- Removes a key from a table and returns its value.
 function Table.extract(tbl, key)
 	local value = tbl[key]
@@ -248,7 +272,7 @@ function Table.setByPath(tbl, path, value)
 end
 
 --[[
-Returns the unique key in an table. Returns nil if the table is empty or has
+Returns the unique key in a table. Returns nil if the table is empty or has
 multiple keys.
 ]]
 function Table.uniqueKey(tbl)
@@ -258,6 +282,18 @@ function Table.uniqueKey(tbl)
 		key0 = key
 	end
 	return key0
+end
+
+--[[
+Returns the entries of a table as an array of key value pairs. The ordering of
+the array is not specified.
+]]
+function Table.entries(tbl)
+	local entries = {}
+	for key, value in pairs(tbl) do
+		table.insert(entries, {key, value})
+	end
+	return entries
 end
 
 -- Polyfill of lua 5.2 table.pack


### PR DESCRIPTION
## Summary

Adds Table.groupBy, which groups entries of a table according to a grouping function.

Also adds Table.entries.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
```
local function parity(_, x) return x % 2 end
Table.groupBy({a = 3, b = 4, c = 5}, parity)
-- Returns 
{
	0 = {b = 4},
	1 = {a = 3, c = 5},
}
```
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
