### PR TITLE
[try0] Simplify match2 entry points

### DIFF
--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -6,10 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
 local MatchGroupBase = {}
 
@@ -91,20 +89,6 @@ function MatchGroupBase._checkBracketDuplicate(bracketId)
 		local category = '[[Category:Pages with duplicate Bracketid]]'
 		mw.addWarning(warning)
 		return warning .. category
-	end
-end
-
-function MatchGroupBase.enableInstrumentation()
-	if FeatureFlag.get('perf') then
-		local config = Lua.loadDataIfExists('Module:MatchGroup/Config')
-		local perfConfig = Table.getByPathOrNil(config, {'perf'}) or {}
-		require('Module:Performance/Util').startInstrumentation(perfConfig)
-	end
-end
-
-function MatchGroupBase.disableInstrumentation()
-	if FeatureFlag.get('perf') then
-		require('Module:Performance/Util').stopAndSave()
 	end
 end
 

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -9,11 +9,12 @@
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local FeatureFlag = require('Module:FeatureFlag')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Table = require('Module:Table')
 
 local Match = Lua.import('Module:Match', {requireDevIfEnabled = true})
 local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
+local MatchGroupConfig = Lua.loadDataIfExists('Module:MatchGroup/Config')
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
@@ -111,44 +112,32 @@ function MatchGroupDisplay.WarningBox(text)
 	return div:node(tbl)
 end
 
+
 -- Entry point of Template:Matchlist
 function MatchGroupDisplay.TemplateMatchlist(frame)
 	local args = Arguments.getArgs(frame)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchGroupDisplay_ = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
-		local MatchGroupBase_ = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		MatchGroupBase_.enableInstrumentation()
-		local result = MatchGroupDisplay_.MatchlistBySpec(args)
-		MatchGroupBase_.disableInstrumentation()
-		return result
-	end)
+	return MatchGroupDisplay.MatchlistBySpec(args)
 end
 
 -- Entry point of Template:Bracket
 function MatchGroupDisplay.TemplateBracket(frame)
 	local args = Arguments.getArgs(frame)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchGroupDisplay_ = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
-		local MatchGroupBase_ = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		MatchGroupBase_.enableInstrumentation()
-		local result = MatchGroupDisplay_.BracketBySpec(args)
-		MatchGroupBase_.disableInstrumentation()
-		return result
-	end)
+	return MatchGroupDisplay.BracketBySpec(args)
 end
 
--- Entry point of Template:ShowBracket
+-- Entry point of Template:ShowBracket, Template:DisplayMatchGroup
 function MatchGroupDisplay.TemplateShowBracket(frame)
 	local args = Arguments.getArgs(frame)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchGroupDisplay_ = Lua.import('Module:MatchGroup/Display', {requireDevIfEnabled = true})
-		local MatchGroupBase_ = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled = true})
-		MatchGroupBase_.enableInstrumentation()
-		local result = MatchGroupDisplay_.MatchGroupById(args)
-		MatchGroupBase_.disableInstrumentation()
-		return result
-	end)
+	return MatchGroupDisplay.MatchGroupById(args)
 end
+
+if FeatureFlag.get('perf') then
+	MatchGroupDisplay.perfConfig = Table.getByPathOrNil(MatchGroupConfig, {'perf'})
+	require('Module:Performance/Util').setupEntryPoints(MatchGroupDisplay)
+end
+
+Lua.autoInvokeEntryPoints(MatchGroupDisplay, 'Module:MatchGroup/Display')
+
 
 MatchGroupDisplay.deprecatedCategory = '[[Category:Pages using deprecated Match Group functions]]'
 

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -20,12 +20,7 @@ local MatchSubobjects = {}
 
 function MatchSubobjects.getOpponent(frame)
 	local args = Arguments.getArgs(frame)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchSubobjects_ = Lua.import('Module:Match/Subobjects', {requireDevIfEnabled = true})
-		return MatchSubobjects_.withPerformanceSetup(function()
-			return Json.stringify(MatchSubobjects_.luaGetOpponent(frame, args))
-		end)
-	end)
+	return Json.stringify(MatchSubobjects.luaGetOpponent(frame, args))
 end
 
 function MatchSubobjects.luaGetOpponent(frame, args)
@@ -40,12 +35,7 @@ end
 
 function MatchSubobjects.getMap(frame)
 	local args = Arguments.getArgs(frame)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchSubobjects_ = Lua.import('Module:Match/Subobjects', {requireDevIfEnabled = true})
-		return MatchSubobjects_.withPerformanceSetup(function()
-			return Json.stringify(MatchSubobjects_.luaGetMap(frame, args))
-		end)
-	end)
+	return Json.stringify(MatchSubobjects.luaGetMap(frame, args))
 end
 
 function MatchSubobjects.luaGetMap(frame, args)
@@ -79,26 +69,21 @@ end
 
 function MatchSubobjects.getPlayer(frame)
 	local args = Arguments.getArgs(frame)
-	return FeatureFlag.with({dev = Logic.readBoolOrNil(args.dev)}, function()
-		local MatchSubobjects_ = Lua.import('Module:Match/Subobjects', {requireDevIfEnabled = true})
-		return MatchSubobjects_.withPerformanceSetup(function()
-			return Json.stringify(MatchSubobjects_.luaGetPlayer(frame, args))
-		end)
-	end)
+	return Json.stringify(MatchSubobjects.luaGetPlayer(frame, args))
 end
 
 function MatchSubobjects.luaGetPlayer(frame, args)
 	return wikiSpec.processPlayer(frame, args)
 end
 
-function MatchSubobjects.withPerformanceSetup(f)
-	if FeatureFlag.get('perf') then
-		local config = Lua.loadDataIfExists('Module:MatchGroup/Config')
-		local perfConfig = Table.getByPathOrNil(config, {'subobjectPerf'}) or {}
-		return require('Module:Performance/Util').withSetup(perfConfig, f)
-	else
-		return f()
-	end
+local _ENTRY_POINT_NAMES = {'getOpponent', 'getMap', 'getPlayer', 'getRound'}
+
+if FeatureFlag.get('perf') then
+	local Match = Lua.import('Module:Match', {requireDevIfEnabled = true})
+	MatchSubobjects.perfConfig = Match.perfConfig
+	require('Module:Performance/Util').setupEntryPoints(MatchSubobjects, _ENTRY_POINT_NAMES)
 end
+
+Lua.autoInvokeEntryPoints(MatchSubobjects, 'Module:Match/Subobjects', _ENTRY_POINT_NAMES)
 
 return MatchSubobjects

--- a/components/match2/test/lua_test.lua
+++ b/components/match2/test/lua_test.lua
@@ -1,0 +1,20 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Lua/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local suite = ScribuntoUnit:new()
+
+function suite:testClass()
+	self:assertEquals(require('Module:Lua/testcases'), suite)
+end
+
+Lua.autoInvokeEntryPoints(suite, 'Module:Lua/testcases', {'run'})
+
+return suite


### PR DESCRIPTION
## Summary
`{{#invoke|Lua|invoke|module=...|fn=...}}` is used in several situations:
- When the module is dev-enabled
- To work around the scribunto bug where the invoked module is not the same as the required module. (Needed for PerformanceUtil)
- In the future we may decide to add try-catch handling in Lua.invoke so that more lua errors can be automatically caught

Most entry points are invoked by only a single template, so converting the template to use the Lua.invoke wrapper is straightforward. However some entry points like the ones in Module:MatchGroup/Display are widely invoked, and it's difficult to migrate calls to Lua.invoke. Instead, the widely invoked entry points have Lua.invoke functionality built in.

This pr simplifies the way Lua.invoke is built in by making use of the Lua.wrapAutoInvoke wrapper, and simplifies how performance instrumentation is set up.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
starcraft2 and rocketleague tournament test suites
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
