### PR TITLE
[try2] Convert existing code to use Error object

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local Error = require('Module:Error')
 local FeatureFlag = require('Module:FeatureFlag')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
@@ -69,12 +70,13 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 	local bracketDatasById = Logic.try(function()
 		return MatchGroupInput._fetchBracketDatas(templateId, bracketId)
 	end)
-		:catch(function(message)
-			if FeatureFlag.get('prompt_purge_bracket_template') and String.endsWith(message, 'does not exist') then
-				table.insert(warnings, message .. ' (Maybe [[Template:' .. templateId .. ']] needs to be purged?)')
+		:catch(function(err)
+			assert(Error.isError(err))
+			if FeatureFlag.get('prompt_purge_bracket_template') and String.endsWith(err.message, 'does not exist') then
+				table.insert(warnings, err.message .. ' (Maybe [[Template:' .. templateId .. ']] needs to be purged?)')
 				return {}
 			else
-				error(message)
+				error(err)
 			end
 		end)
 		:get()

--- a/standard/error.lua
+++ b/standard/error.lua
@@ -1,0 +1,69 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Error
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+
+--[[
+A minimal error class, whose purpose is to allow additional fields to be
+attached to an error message string. It has only one method, the __tostring
+metamethod, and one required field, error.message.
+
+The class is intended to be open, meaning that its fields are all public and
+can be used for any purpose. By convention, the following fields have specific
+meanings:
+
+error.message: A short error message describing the error. (Required)
+
+error.stacks: The stack traces of the error. The first stack trace is the one
+last thrown. Subsequent stack traces are from when the error was rethrown by an
+error handler handling the same error.
+
+error.originalErrors: When an error handler throws (not a rethrow), the original
+error that it was handling is tracked here.
+
+error.childErrors: A composite error is one that aggregates many errors into a
+summary. Composite errors will place child errors here.
+
+error.innerError: Used when an error instance wraps something that's not a
+message string.
+
+error.header: Generic error handlers like Logic.tryOrElseLog will place a
+preamble-like text here to give some context to the error.
+
+error.noStack: Disables the stack trace
+
+]]
+local Error = Class.new(function(self, any)
+	-- Normalize the various ways an error can be thrown
+	if type(any) == 'string' then
+		self.message = any
+	elseif type(any) == 'table' then
+		local props = any
+		for key, value in pairs(props) do
+			self[key] = value
+		end
+	elseif any ~= nil then
+		self.message = tostring(any)
+		self.innerError = any
+	end
+
+	self.message = self.message or 'Unknown error'
+end)
+
+function Error.isError(error)
+	return type(error) == 'table'
+		and type(error.is_a) == 'function'
+		and error:is_a(Error)
+		and type(error.message) == 'string'
+end
+
+function Error:__tostring()
+	return self.message
+end
+
+return Error

--- a/standard/error_display.lua
+++ b/standard/error_display.lua
@@ -1,0 +1,81 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Error/Display
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local ErrorExt = require('Module:Error/Ext')
+local TypeUtil = require('Module:TypeUtil')
+
+local ErrorDisplay = {types = {}, propTypes = {}}
+
+-- Error instance
+ErrorDisplay.types.Error = TypeUtil.struct{
+	childErrors = TypeUtil.optional(TypeUtil.array(ErrorDisplay.types.Error)),
+	header = 'string?',
+	innerError = 'any',
+	message = 'string',
+	originalErrors = TypeUtil.optional(TypeUtil.array(ErrorDisplay.types.Error)),
+	stacks = TypeUtil.optional(TypeUtil.array('string')),
+}
+
+ErrorDisplay.propTypes.Box = {
+	hasDetails = 'boolean?',
+	loggedInOnly = 'boolean?',
+	text = 'string',
+}
+
+function ErrorDisplay.Box(props)
+	local div = mw.html.create('div'):addClass('navigation-not-searchable ambox-wrapper')
+		:addClass('ambox wiki-bordercolor-dark wiki-backgroundcolor-light')
+		:addClass(props.loggedInOnly ~= false and 'show-when-logged-in' or nil)
+		:addClass('ambox-red')
+
+	local tbl = mw.html.create('table')
+	local tr = tbl:tag('tr')
+	tr:tag('td'):addClass('ambox-image')
+		:wikitext('[[File:Emblem-important.svg|40px|link=]]')
+	tr:tag('td'):addClass('ambox-text')
+		:wikitext(props.text)
+		:wikitext(props.hasDetails and ' (stack trace logged)' or nil)
+
+	return div:node(tbl)
+end
+
+function ErrorDisplay.ErrorBox(error)
+	return ErrorDisplay.Box({
+		hasDetails = error.stacks ~= nil,
+		text = tostring(error),
+	})
+end
+
+--[[
+Shows the message and stack trace of a lua error. Suitable for use in a popup.
+]]
+function ErrorDisplay.ErrorDetails(error)
+	local errorDetailsNode = mw.html.create('div'):addClass('error-details')
+
+	errorDetailsNode:tag('div'):addClass('error-details-text')
+		:addClass('error')
+		:css('font-weight', 'bold')
+		:wikitext(error.header)
+		:wikitext(error.message)
+
+	local stackTraceString = ErrorExt.makeFullStackTrace(error)
+	if stackTraceString ~= '' then
+		errorDetailsNode:tag('div'):addClass('error-details-stacks')
+			:wikitext(stackTraceString)
+	end
+
+	local extraPropsString = ErrorExt.printExtraProps(error)
+	if extraPropsString then
+		errorDetailsNode:tag('div'):addClass('error-details-additional-props')
+			:wikitext(extraPropsString)
+	end
+
+	return errorDetailsNode
+end
+
+return ErrorDisplay

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -1,0 +1,69 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Error/Ext
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Table = require('Module:Table')
+
+local ErrorExt = {}
+
+function ErrorExt.log(error)
+	mw.log(ErrorExt.makeFullDetails(error))
+	mw.log()
+end
+
+local function tableOrEmpty(tbl)
+	return type(tbl) == 'table' and tbl or {}
+end
+
+function ErrorExt.makeFullDetails(error)
+	local parts = Array.extend(
+		error.header,
+		error.message,
+		ErrorExt.makeFullStackTrace(error),
+		ErrorExt.printExtraProps(error)
+	)
+	return table.concat(parts, '\n')
+end
+
+--[[
+Builds a string for fields not covered by the other functions in this module.
+Returns nil if there are no extra fields.
+]]
+function ErrorExt.printExtraProps(error)
+	local extraProps = Table.copy(error)
+	extraProps.message = nil
+	extraProps.header = nil
+	extraProps.stacks = nil
+	extraProps.originalErrors = nil
+	if type(extraProps.childErrors) == 'table' then
+		extraProps.childErrors = Array.map(extraProps.childErrors, ErrorExt.makeFullDetails)
+	end
+
+	if Table.isNotEmpty(extraProps) then
+		return 'Additional properties: \n' .. mw.dumpObject(extraProps)
+	else
+		return nil
+	end
+end
+
+function ErrorExt.makeFullStackTrace(error)
+	local parts = Array.extend(
+		error.stacks,
+		Array.flatMap(tableOrEmpty(error.originalErrors), function(originalError)
+			return {
+				'',
+				'Error was thrown while handling:',
+				originalError.message,
+				ErrorExt.makeFullStackTrace(originalError),
+			}
+		end)
+	)
+	return table.concat(parts, '\n')
+end
+
+return ErrorExt


### PR DESCRIPTION
## Summary
Converts ResultOrError.Error to store Error instances instead of scalar string messages. Its `:catch(onError)` will pass the Error instance to onError instead of a string. `ResultOrError.try` will still catch errors of any type.

Also changed ResultOrError:catch() to distinguish between rethrowing the original error vs throwing a new error, when in the middle of handling the original error.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested in try5

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
