### PR TITLE
[try3] Add Module:Error/Stash

### DIFF
--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -11,6 +11,11 @@ local Table = require('Module:Table')
 
 local ErrorExt = {}
 
+function ErrorExt.logAndStash(error)
+	require('Module:Error/Stash').add(error)
+	ErrorExt.log(error)
+end
+
 function ErrorExt.log(error)
 	mw.log(ErrorExt.makeFullDetails(error))
 	mw.log()

--- a/standard/error_stash.lua
+++ b/standard/error_stash.lua
@@ -1,0 +1,85 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Error/Stash
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Error = require('Module:Error')
+local Json = require('Module:Json')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
+
+local pageVars = PageVariableNamespace('ErrorStash')
+
+local localErrors = {}
+local deferred = false
+
+--[[
+A place to temporarily store errors so they can be displayed later. The errors
+must be error instances, not strings or primitives.
+]]
+local ErrorStash = {}
+
+--[[
+Adds an Error instance to the local store.
+
+If the current entry point has been marked to not display errors, then this
+will store the error to page variables instead.
+]]
+function ErrorStash.add(error)
+	if deferred then
+		local count = tonumber(pageVars:get('count')) or 0
+		pageVars:set('count', count + 1)
+		pageVars:set(count + 1, Json.stringify({error}))
+	else
+		table.insert(localErrors, error)
+	end
+end
+
+--[[
+Returns all errors (locally and from page variables), and clears the store.
+
+If the current entry point has been marked to not display errors, then this
+returns the empty array and does nothing.
+]]
+function ErrorStash.retrieve()
+	if deferred then return {} end
+
+	local errors = {}
+
+	local count = tonumber(pageVars:get('count')) or 0
+	pageVars:delete('count')
+	for i = 1, count do
+		Array.extendWith(errors, Array.map(Json.parse(pageVars:get(i)), Error))
+		pageVars:delete(i)
+	end
+
+	Array.extendWith(errors, localErrors)
+	localErrors = {}
+
+	return errors
+end
+
+--[[
+Moves all local errors to page variables, and signals that the current entry
+point should not display errors.
+
+This should be called by entry points that do not return wikicode. For entry
+points that are invoked with Lua.invoke (or equivalent), this can be called at
+any time. For others, this should be called near the end of lua execution, so
+that all errors are caught.
+]]
+function ErrorStash.deferDisplay()
+	if #localErrors > 0 then
+		local count = tonumber(pageVars:get('count')) or 0
+		pageVars:set('count', count + 1)
+		pageVars:set(count + 1, Json.stringify(localErrors))
+	end
+
+	localErrors = {}
+	deferred = true
+end
+
+return ErrorStash

--- a/standard/logic.lua
+++ b/standard/logic.lua
@@ -80,6 +80,54 @@ function Logic.try(f)
 	return require('Module:ResultOrError').try(f)
 end
 
+--[[
+Returns the result of a function if successful. Otherwise it returns the result
+of the second function.
+
+If the first function fails, its error is logged to the console and stashed
+away for display.
+
+Parameters:
+
+f() -> any
+Parameterless function, and returns at most a single value. Additional return
+values beyond the first are ignored.
+
+other(error: Error) -> any
+The thrown Error instance is its sole parameter. Additional return values
+beyond the first are ignored.
+
+makeError(error: Error) -> Error
+optional function that allows customizing the Error instance being logged and stashed.
+
+]]
+function Logic.tryOrElseLog(f, other, makeError)
+	return Logic.try(f)
+		:catch(function(error)
+			error.header = 'Error occured while calling a function: (caught by Logic.tryOrElseLog)'
+			if makeError then
+				error = makeError(error)
+			end
+
+			require('Module:Error/Ext').logAndStash(error)
+
+			if other then
+				return other(error)
+			end
+		end)
+		:get()
+end
+
+--[[
+Returns the result of a function if successful. Otherwise it returns nil.
+
+If the first function fails, its error is logged to the console and stashed
+away for display.
+]]
+function Logic.tryOrLog(f, makeError)
+	return Logic.tryOrElseLog(f, nil, makeError)
+end
+
 function Logic.isNumeric(val)
 	return tonumber(val) ~= nil
 end


### PR DESCRIPTION
## Summary
Module:Error/Stash provides a temporary place to store an error so it can be displayed later.

Usage
```
-- Log and stash an Error instance
ErrorUtil.logAndStash(error)

-- Or use one of the try wrappers that auto log errors
Logic.tryOrLog(function() ... end)

-- If the error stash needs to cross template boundaries (call this near the end of lua execution)
ErrorStash.deferDisplay()

-- Display all stashed errors
ErrorDisplay.StashedErrors({})
```

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested as a part of try5
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
