### PR TITLE
[try4] Add error isolation to match2 commons code

### DIFF
--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -98,13 +98,11 @@ Display component for a match in a singleMatch. Consists of the match summary.
 function SingleMatchDisplay.Match(props)
 	DisplayUtil.assertPropTypes(props, SingleMatchDisplay.propTypes.Match)
 
-	local matchSummaryNode = DisplayUtil.TryPureComponent(props.MatchSummaryContainer, {
+	return DisplayUtil.tryOrLog(props.MatchSummaryContainer, {
 		bracketId = props.match.matchId:match('^(.*)_'), -- everything up to the final '_'
 		matchId = props.match.matchId,
 		config = {showScore = true},
 	})
-
-	return matchSummaryNode
 end
 
 return Class.export(SingleMatchDisplay)

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -204,6 +204,7 @@ function MatchGroupUtil.makeMatchGroup(matchRecords)
 	}
 
 	if matchGroup.type == 'bracket' then
+		MatchGroupUtil.removeIncompleteEdges(matchGroup.bracketDatasById)
 		local roundPropsByMatchId, rounds = MatchGroupUtil.computeRounds(matchGroup.bracketDatasById, rootMatchIds)
 
 		MatchGroupUtil.populateAdvanceSpots(matchGroup)
@@ -434,6 +435,14 @@ function MatchGroupUtil.dfsFrom(bracketDatasById, start)
 		end,
 		start
 	)
+end
+
+function MatchGroupUtil.removeIncompleteEdges(bracketDatasById)
+	for _, bracketData in pairs(bracketDatasById) do
+		bracketData.lowerMatches = Array.filter(bracketData.lowerMatches, function(lowerMatch)
+			return bracketDatasById[lowerMatch.matchId] ~= nil
+		end)
+	end
 end
 
 function MatchGroupUtil.computeDepthsFrom(bracketDatasById, startMatchId)

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -9,6 +9,7 @@
 local Arguments = require('Module:Arguments')
 local FeatureFlag = require('Module:FeatureFlag')
 local Json = require('Module:Json')
+local ErrorStash = require('Module:Error/Stash')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
@@ -20,6 +21,7 @@ local MatchSubobjects = {}
 
 function MatchSubobjects.getOpponent(frame)
 	local args = Arguments.getArgs(frame)
+	ErrorStash.deferDisplay()
 	return Json.stringify(MatchSubobjects.luaGetOpponent(frame, args))
 end
 
@@ -35,6 +37,7 @@ end
 
 function MatchSubobjects.getMap(frame)
 	local args = Arguments.getArgs(frame)
+	ErrorStash.deferDisplay()
 	return Json.stringify(MatchSubobjects.luaGetMap(frame, args))
 end
 
@@ -60,6 +63,7 @@ end
 
 function MatchSubobjects.getRound(frame)
 	local args = Arguments.getArgs(frame)
+	ErrorStash.deferDisplay()
 	return Json.stringify(MatchSubobjects.luaGetRound(frame, args))
 end
 
@@ -69,6 +73,7 @@ end
 
 function MatchSubobjects.getPlayer(frame)
 	local args = Arguments.getArgs(frame)
+	ErrorStash.deferDisplay()
 	return Json.stringify(MatchSubobjects.luaGetPlayer(frame, args))
 end
 

--- a/components/match2/test/match_test.lua
+++ b/components/match2/test/match_test.lua
@@ -16,8 +16,6 @@ function suite:testSplitRecordsByType()
 		MatchTestConfig.EXPECTED_OUTPUT_AFTER_SPLIT, Match.splitRecordsByType(MatchTestConfig.EXAMPLE_MATCH))
 	self:assertDeepEquals(
 		MatchTestConfig.EXPECTED_OUTPUT_AFTER_SPLIT_SC2, Match.splitRecordsByType(MatchTestConfig.EXAMPLE_MATCH_SC2))
-	self:assertDeepEquals({}, Match.splitRecordsByType(nil))
-	self:assertDeepEquals({}, Match.splitRecordsByType('something'))
 end
 
 return suite

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local Logic = require('Module:Logic')
 local Table = require('Module:Table')
 
 local ErrorExt = {}
@@ -69,6 +70,25 @@ function ErrorExt.makeFullStackTrace(error)
 		end)
 	)
 	return table.concat(parts, '\n')
+end
+
+--[[
+Variant of Array.map that wraps an error handler around each element
+transformation. At the end, the successfully transformed elements are separated
+from the errors, and both are returned.
+]]
+function ErrorExt.mapTry(elems, f)
+	local errors = {}
+	local results = Array.map(elems, function(elem, index)
+		return Logic.try(function() return f(elem, index) end)
+			:catch(function(error)
+				error.elem = elem
+				error.index = index
+				table.insert(errors, error)
+			end)
+			:get()
+	end)
+	return results, errors
 end
 
 return ErrorExt


### PR DESCRIPTION
## Summary
Adds error isolation to several locations in the match input processing, lpdb storage, and display pipelines (commons only). Errors thrown within affected locations are isloated and won't prevent functioning of the rest of the pipeline . The errors are logged to the console and displayed to logged-in users. 

Sample output
![image](https://user-images.githubusercontent.com/85348434/138598823-16346681-c477-42ab-9694-e203604afdf7.png)
![image](https://user-images.githubusercontent.com/85348434/138598839-d06ed6a7-9111-45f6-9351-b3ce91ac0fc3.png)

![image](https://user-images.githubusercontent.com/85348434/138598573-d0c092ac-426e-46ef-9229-69090d08dcd2.png)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

Also changed Match.splitByTypes to throw on nil input

## How did you test this change?
Enable `feature_random_errors` on several tournaments in starcraft2 and rocketleague
Check unit tests for Module:Match

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
