### PR TITLE
Standardize sc2 `tournament_game` variable

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -530,6 +530,9 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('formatted_tournament_date', sdate)
 	Variables.varDefine('formatted_tournament_edate', edate)
 
+	--override var to standardize its entries
+	Variables.varDefine('tournament_game', (_GAMES[string.lower(_args.game)] or {})[1] or _GAMES[_GAME_WOL][1])
+
 	--SC2 specific vars
 	Variables.varDefine('tournament_mode', _args.mode or '1v1')
 	Variables.varDefine('headtohead', _args.headtohead or 'true')


### PR DESCRIPTION
## Summary
Standardize sc2 `tournament_game` variable

## How did you test this change?
pushed to live (module not in use atm) and checked on a few pages (with different games set)