### PR TITLE
Use dark icon for dark mode

### DIFF
--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -61,7 +61,7 @@ function LeagueIcon._make(icon, iconDark, link, name, size)
 		:wikitext('[[File:' .. icon .. imageOptions)
 	local darkSpan = mw.html.create('span')
 		:addClass('league-icon-small-image darkmode')
-		:wikitext('[[File:' .. icon .. imageOptions)
+		:wikitext('[[File:' .. iconDark .. imageOptions)
 	return tostring(lightSpan) .. tostring(darkSpan)
 end
 


### PR DESCRIPTION
## Summary
Actually use dark icon for dark mode (fix typo)

## How did you test this change?
adjusted it in a sandbox and checked the display with invokes of that module