### PR TITLE
Adjust SC/SC2 teamhistory queries

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/player_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_util_starcraft.lua
@@ -116,6 +116,7 @@ function StarcraftPlayerUtil.fetchTeam(pageName, date)
 		'([[extradata_joindate::<' .. date .. ']] OR [[extradata_joindate::' .. date .. ']])',
 		'[[extradata_joindate::>]]',
 		'[[extradata_leavedate::>' .. date .. ']]',
+		'[[extradata_position::player]]',
 	}
 	local rows = mw.ext.LiquipediaDB.lpdb('datapoint', {
 		conditions = table.concat(conditions, ' AND '),


### PR DESCRIPTION
## Summary
This is to allow storing non player team history on player pages (e.g. as coach, manager, etc.).
Player pages are already adjusted and purged (last week).
e.g. if a player is a player for team A and a coach for team B we now can store both and the query will only fetch team A

## How did you test this change?
Sandboxes and test pages