### PR TITLE
Make map scores numerical

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -387,6 +387,7 @@ function mapFunctions.getScoresAndWinner(map)
 		local obj = {}
 		if not Logic.isEmpty(score) then
 			if TypeUtil.isNumeric(score) then
+				score = tonumber(score)
 				obj.status = 'S'
 				obj.score = score
 				obj.index = scoreIndex


### PR DESCRIPTION
## Summary
Atm map scores are stored as a string if manually entered and as a number if summed up from goal times
with this change we will store them as numbers in both cases

## How did you test this change?
using `Module:MatchGroup/Input/Custom/dev` and logs + previews