### PR TITLE
Resolve redirects for next/previous

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -221,10 +221,10 @@ function League:_setLpdbData(args, links)
 		icon = Variables.varDefault('tournament_icon'),
 		icondark = Variables.varDefault('tournament_icondark'),
 		series = mw.ext.TeamLiquidIntegration.resolve_redirect(args.series or ''),
-		previous = mw.ext.TeamLiquidIntegration.resolve_redirect(args.previous or ''),
-		previous2 = mw.ext.TeamLiquidIntegration.resolve_redirect(args.previous2 or ''),
-		next = mw.ext.TeamLiquidIntegration.resolve_redirect(args.next or ''),
-		next2 = mw.ext.TeamLiquidIntegration.resolve_redirect(args.next2 or ''),
+		previous = mw.ext.TeamLiquidIntegration.resolve_redirect(self:_getPageNameFromChronology(args.previous)),
+		previous2 = mw.ext.TeamLiquidIntegration.resolve_redirect(self:_getPageNameFromChronology(args.previous2)),
+		next = mw.ext.TeamLiquidIntegration.resolve_redirect(self:_getPageNameFromChronology(args.next)),
+		next2 = mw.ext.TeamLiquidIntegration.resolve_redirect(self:_getPageNameFromChronology(args.next2)),
 		game = string.lower(args.game or ''),
 		patch = args.patch,
 		endpatch = args.endpatch or args.epatch,
@@ -423,6 +423,15 @@ function League:_isChronologySet(previous, next)
 	-- We only need to check the first of these params, since it makes no sense
 	-- to set next2 and not next, etc.
 	return not (String.isEmpty(previous) and String.isEmpty(next))
+end
+
+-- Given the format `pagename|displayname`, returns pagename
+function League:_getPageNameFromChronology(item)
+	if item == nil or not string.find(item, '|') then
+		return ''
+	end
+
+	return mw.text.split(item, '|')[1]
 end
 
 return League


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

The `next`/`previous` properties in Infobox/League contain pagenames. These should resolve redirects so that the data makes sense outside of the wiki.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->

Already live.