### PR TITLE
Adjust chronology storgae for sc2

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -577,8 +577,8 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.status = status
 	lpdbData.maps = CustomLeague:_concatArgs('map')
 	lpdbData.participantsnumber = Variables.varDefault('tournament_playerNumber', _args.team_number or 0)
-	lpdbData.next = CustomLeague:_getPageNameFromChronology(_next)
-	lpdbData.previous = CustomLeague:_getPageNameFromChronology(_previous)
+	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
+	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
 
 	return lpdbData
 end

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -608,8 +608,11 @@ function CustomLeague:_createNoWrappingSpan(content)
 end
 
 function CustomLeague:_getPageNameFromChronology(item)
-	if item == nil or not string.find(item, '|') then
+	if String.isEmpty(item) then
 		return ''
+	end
+	if not string.find(item, '|') then
+		return item
 	end
 
 	return mw.text.split(item, '|')[1]

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -28,6 +28,8 @@ local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
+local _next
+local _previous
 
 local _ABBR_USD = '<abbr title="United States Dollar">USD</abbr>'
 local _TODAY = os.date('%Y-%m-%d', os.time())
@@ -275,10 +277,10 @@ function CustomLeague._getGameVersion()
 end
 
 function CustomLeague._getChronologyData()
-	local next, previous = CustomLeague._computeChronology()
+	_next, _previous = CustomLeague._computeChronology()
 	return {
-		previous = previous,
-		next = next,
+		previous = _previous,
+		next = _next,
 		previous2 = _args.previous2,
 		next2 = _args.next2,
 		previous3 = _args.previous3,
@@ -575,6 +577,8 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.status = status
 	lpdbData.maps = CustomLeague:_concatArgs('map')
 	lpdbData.participantsnumber = Variables.varDefault('tournament_playerNumber', _args.team_number or 0)
+	lpdbData.next = CustomLeague:_getPageNameFromChronology(_next)
+	lpdbData.previous = CustomLeague:_getPageNameFromChronology(_previous)
 
 	return lpdbData
 end
@@ -601,6 +605,14 @@ function CustomLeague:_createNoWrappingSpan(content)
 	span:css('white-space', 'nowrap')
 		:node(content)
 	return span
+end
+
+function CustomLeague:_getPageNameFromChronology(item)
+	if item == nil or not string.find(item, '|') then
+		return ''
+	end
+
+	return mw.text.split(item, '|')[1]
 end
 
 return CustomLeague

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -611,9 +611,6 @@ function CustomLeague:_getPageNameFromChronology(item)
 	if String.isEmpty(item) then
 		return ''
 	end
-	if not string.find(item, '|') then
-		return item
-	end
 
 	return mw.text.split(item, '|')[1]
 end


### PR DESCRIPTION
## Summary
Adjust chronology storgae for sc2
Since SC2 determines next/previous semi automatically we need some small adjustments to store them properly.

## How did you test this change?
sandbox