### PR TITLE
Fix bug where missing displayname would result in empty string for previous/next in LPDB

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -425,9 +425,9 @@ function League:_isChronologySet(previous, next)
 	return not (String.isEmpty(previous) and String.isEmpty(next))
 end
 
--- Given the format `pagename|displayname`, returns pagename
+-- Given the format `pagename|displayname`, returns pagename or the parameter, otherwise
 function League:_getPageNameFromChronology(item)
-	if item == nil or not string.find(item, '|') then
+	if item == nil then
 		return ''
 	end
 


### PR DESCRIPTION
## Summary
The current version from #640 introduces a bug where nothing will be written to LPDB for previous/next if those parameters do not contain a `|` (because, e.g. the pagename can be used as a displayname already).

Removing the shortcut altogether fixes this, because `mw.text.split(string, '|', true)[1]` will contain the whole string when no `|` is found.

## How did you test this change?
Tested behavior of mw.text.split within a sandbox/luaconsole
