### PR TITLE
Update infobox_league.lua

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -427,7 +427,7 @@ end
 
 -- Given the format `pagename|displayname`, returns pagename
 function League:_getPageNameFromChronology(item)
-	if item == nil or not string.find(item, '|') then
+	if item == nil then
 		return ''
 	end
 


### PR DESCRIPTION
## Summary
As @mbergen mentioned in #640 the current function would not store entries that do not have the `|` in them.
This PR fixes that.

The `string.find` isn't needed, because `mw.text.split(item, '|')[1]` will just be `item` if it doesn't contain a `|`.

## How did you test this change?
via sandbox on sc2