### PR TITLE
Fix variable tournament_startdate to be filled from args.sdate or date

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -204,7 +204,8 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_parentname', args.parentname)
 	Variables.varDefine('tournament_subpage', args.subpage)
 
-	Variables.varDefine('tournament_startdate', self:_cleanDate(args.sdate))
+	Variables.varDefine('tournament_startdate',
+	self:_cleanDate(args.sdate) or self:_cleanDate(args.date))
 	Variables.varDefine('tournament_enddate',
 	self:_cleanDate(args.edate) or self:_cleanDate(args.date))
 


### PR DESCRIPTION
## Summary

In the case of one day tournaments, only date is filled in the infobox. Therefore, sdate = edate = date, and all date variables have to be fed from args.date

## How did you test this change?
Tested in a sandbox on ageofempires:
- that tournament_enddate is set correctly already
- that this change will achieve the same with tournament_startdate

Tested on RL:
- that prize pool and other downstream templates will use `tournament_startdate` if present, otherwise fallback to `tournament_enddate`
- Checked that setting the var in the infobox/directly after won't change LPDB data