### PR TITLE
Change match1 player saving

### DIFF
--- a/components/match2/wikis/rocketleague/match_legacy.lua
+++ b/components/match2/wikis/rocketleague/match_legacy.lua
@@ -106,10 +106,8 @@ function p._convertParameters(match2)
 		local opponent1players = {}
 		for i = 1,10 do
 			local player = opponent1match2players[i] or {}
-			table.insert(opponent1players, {
-					["p" .. i] = player.name or "",
-					["p" .. i .. "flag"] = player.flag or ""
-				})
+			opponent1players["p" .. i] = player.name or ""
+			opponent1players["p" .. i .. "flag"] = player.flag or ""
 		end
 		match.opponent1players = json.stringify(opponent1players)
 	elseif opponent1.type == "solo" then
@@ -129,10 +127,8 @@ function p._convertParameters(match2)
 		local opponent2players = {}
 		for i = 1,10 do
 			local player = opponent2match2players[i] or {}
-			table.insert(opponent2players, {
-					["p" .. i] = player.name or "",
-					["p" .. i .. "flag"] = player.flag or ""
-				})
+			opponent2players["p" .. i] = player.name or ""
+			opponent2players["p" .. i .. "flag"] = player.flag or ""
 		end
 		match.opponent2players = json.stringify(opponent2players)
 	elseif opponent2.type == "solo" then


### PR DESCRIPTION
## Summary

Rocket League's legacy module is saving player info (opponent1players, opponent2players) in a datastucture that modules retrieving the information don't expect, causing lua error and missing data. 
![image](https://user-images.githubusercontent.com/3426850/139692764-7f4e4ecc-a2a4-4bf3-a2bb-0e81960f5ee4.png) 
The RL modules that use the information are Module:Rating/Run (and Module:Rating/Display via a data object that /Run saves in smw) and Module:TeamsMatchup/versus (which is used on the stream page).
![image](https://user-images.githubusercontent.com/3426850/139693689-087c9c13-038c-434d-9901-50d3bf6ac004.png)


## How did you test this change?

Did a quick live test. 
https://liquipedia.net/rocketleague/index.php?title=Module:Match/Legacy&diff=989058&oldid=969501
Purged the page of a tournament and checked the stream page.
Where previously the stream page would give out a lua error, it now successfully rendered the additional information.
![image](https://user-images.githubusercontent.com/3426850/139693200-c0fe7c13-83a9-47bf-a5cb-51ba66df0cd8.png)

For the Rating's Module, the roster display is commented out (because it hasn't been working), hence it shouldn't affect anything. If there's an interest, the roster display should be possible to be re-added once this PR is live.
I'll keep a close eye and close communication with the RL team just in case. 