### PR TITLE
Add school tier LPDB storage to RL infobox team

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -91,7 +91,7 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		lpdbData.logo = 'File:' .. args.image
 	end
 
-	local isSchoolTierTeam = string.lower(args.regionsubtier or '') == school
+	local isSchoolTierTeam = string.lower(args.regionsubtier or '') == 'school'
 
 	lpdbData.extradata = {
 		rating = Variables.varDefault('rating'),

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -91,11 +91,9 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		lpdbData.logo = 'File:' .. args.image
 	end
 
-	local isSchoolTierTeam = string.lower(args.regionsubtier or '') == 'school'
-
 	lpdbData.extradata = {
 		rating = Variables.varDefault('rating'),
-		isschooltierteam = isSchoolTierTeam
+		tier = string.lower(args.regionsubtier or '')
 	}
 	for year = _START_YEAR, _CURRENT_YEAR do
 		local id = args.id or _team.pagename

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -91,7 +91,12 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		lpdbData.logo = 'File:' .. args.image
 	end
 
-	lpdbData.extradata = { rating = Variables.varDefault('rating') }
+	local isSchoolTierTeam = string.lower(args.regionsubtier or '') == school
+
+	lpdbData.extradata = {
+		rating = Variables.varDefault('rating'),
+		isschooltierteam = isSchoolTierTeam
+	}
 	for year = _START_YEAR, _CURRENT_YEAR do
 		local id = args.id or _team.pagename
 		local earningsInYear = Template.safeExpand(mw.getCurrentFrame(), 'Total earnings of', {year = year, id})

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -93,7 +93,7 @@ function CustomTeam:addToLpdb(lpdbData, args)
 
 	lpdbData.extradata = {
 		rating = Variables.varDefault('rating'),
-		tier = string.lower(args.regionsubtier or '')
+		tier = string.lower(args.tier or '')
 	}
 	for year = _START_YEAR, _CURRENT_YEAR do
 		local id = args.id or _team.pagename


### PR DESCRIPTION
## Summary
Add school tier LPDB storage to RL infobox team (as requested by Basincc)

## How did you test this change?
not tested as it only adds additional storage to LPDB that is not yet used anywhere

## To-Do after the merge
1. Apply it to the module (since bots are a bit broken)
2. Adjust the template to also store it in SMW (the team portal still uses SMW)
3. Purge all team pages to update their LPDB and SMW data
4. adjust query condition on the team portal page(s) so that school teams do not show up there
5. Create a new team portal sub page for the school teams & start creating team pages for it