### PR TITLE
Fix Team Display in infobox person

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -315,7 +315,7 @@ end
 function Person:_createTeam(team, link)
 	link = link or team
 	if link == nil or link == '' then
-		return ''
+		return nil
 	end
 
 	if mw.ext.TeamTemplate.teamexists(link) then


### PR DESCRIPTION
## Summary
Fix Team Display in infobox person implementations

## How did you test this change?
pushed to live

before:
![Screenshot 2021-11-02 12 50 01](https://user-images.githubusercontent.com/75081997/139841018-c2a8df97-5485-42a7-a2a3-7a89e20357d8.png)

after:
![Screenshot 2021-11-02 12 49 26](https://user-images.githubusercontent.com/75081997/139841030-b9077b61-5c58-44a4-bf38-f690137e2a38.png)
