### PR TITLE
Add Table.deepMergeInto

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -174,6 +174,35 @@ function Table.merge(...)
 end
 
 --[[
+Recursively merges entries from the second table into the first table,
+overriding existing entries. The first table is mutated in the process.
+
+Can be called with more than two tables. The additional tables are merged into
+the first table in succession.
+
+Example:
+Table.deepMergeInto({a = {x = 3, y = 4}}, {a = {y = 5}})
+
+-- Returns {a = {x = 3, y = 5}}
+]]
+function Table.deepMergeInto(target, ...)
+	local tbls = Table.pack(...)
+
+	for i = 1, tbls.n do
+		if type(tbls[i]) == 'table' then
+			for key, value in pairs(tbls[i]) do
+				if type(target[key]) == 'table' and type(value) == 'table' then
+					Table.deepMergeInto(target[key], value)
+				else
+					target[key] = value
+				end
+			end
+		end
+	end
+	return target
+end
+
+--[[
 Applies a function to each entry in a table and places the results as entries
 in a new table.
 


### PR DESCRIPTION
## Summary
Add Table.deepMergeInto
Recursively merges entries from the second table into the first table,
overriding existing entries. The first table is mutated in the process.

Can be called with more than two tables. The additional tables are merged into
the first table in succession.

Usage
```
Table.deepMergeInto({a = {x = 3, y = 4}}, {a = {y = 5}})

-- Returns {a = {x = 3, y = 5}}
```
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

```
Table.deepMergeInto({a = {x = 3, y = 4}}, {a = {y = 5}})

-- Returns {a = {x = 3, y = 5}}
```
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
