### PR TITLE
Rename race to faction (SC, SC2)

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -748,7 +748,7 @@ function StarcraftMatchGroupInput.MapInput(match, i, subgroup)
 	--determine score, resulttype, walkover and winner
 	match['map' .. i] = StarcraftMatchGroupInput.MapWinnerProcessing(match['map' .. i])
 
-	--get participants data for the map + get map mode + winnerrace and loserrace
+	--get participants data for the map + get map mode + winnerfaction and loserfaction
 	--(w/l race stuff only for 1v1 maps)
 	match['map' .. i] = StarcraftMatchGroupInput.ProcessPlayerMapData(match['map' .. i], match, 2)
 
@@ -969,11 +969,11 @@ function StarcraftMatchGroupInput.ProcessPlayerMapData(map, match, OppNumber)
 
 		if map_mode == '1v1' and OppNumber == 2 then
 			if tonumber(map.winner or 0) == 1 then
-				map.extradata.winnerrace = raceOP[1]
-				map.extradata.loserrace = raceOP[2]
+				map.extradata.winnerfaction = raceOP[1]
+				map.extradata.loserfaction = raceOP[2]
 			elseif tonumber(map.winner or 0) == 2 then
-				map.extradata.winnerrace = raceOP[2]
-				map.extradata.loserrace = raceOP[1]
+				map.extradata.winnerfaction = raceOP[2]
+				map.extradata.loserfaction = raceOP[1]
 			end
 			map.extradata.opponent1 = PL[1]
 			map.extradata.opponent2 = PL[2]

--- a/components/match2/wikis/starcraft/match_legacy.lua
+++ b/components/match2/wikis/starcraft/match_legacy.lua
@@ -54,6 +54,9 @@ function Legacy._storeGames(match, match2)
 			game.opponent1score = scores[1] or 0
 			game.opponent2score = scores[2] or 0
 
+			game.extradata.winnerrace = game.extradata.winnerfaction
+			game.extradata.loserrace = game.extradata.loserfaction
+
 			-- participants holds additional playerdata per match, e.g. the faction (=race)
 			-- participants is stored as opponentID_playerID, so e.g. for opponent2, player1 it is "2_1"
 			local playerdata = json.parseIfString(game.participants or '{}') or game.participants

--- a/components/match2/wikis/starcraft2/match_legacy.lua
+++ b/components/match2/wikis/starcraft2/match_legacy.lua
@@ -58,6 +58,9 @@ function p.storeGames(match, match2)
 			game.opponent1score = scores[1] or 0
 			game.opponent2score = scores[2] or 0
 
+			game.extradata.winnerrace = game.extradata.winnerfaction
+			game.extradata.loserrace = game.extradata.loserfaction
+
 			-- participants holds additional playerdata per match, e.g. the faction (=race)
 			-- participants is stored as opponentID_playerID, so e.g. for opponent2, player1 it is '2_1'
 			local playerdata = json.parseIfString(game.participants or '{}') or game.participants


### PR DESCRIPTION
## Summary
Rename race to faction in lpdb match2game.extradata storage
Adjust legacy modules accordingly

goal is to standardize race/... to the term faction

## How did you test this change?
pushed to live, compared lpdb data entries (legacy ones are still the same, match2game is changed as intended)
checked the current and the match2 query version of the module that uses this data and it works as intended