### PR TITLE
Use id instead of name for `objectname`

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -211,7 +211,7 @@ function Person:_setLpdbData(args, links, status, personType, earnings)
 	lpdbData.links = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.links)
 	local storageType = self:getStorageType(args, personType, status)
 
-	mw.ext.LiquipediaDB.lpdb_player(storageType .. (args.id or self.name), lpdbData)
+	mw.ext.LiquipediaDB.lpdb_player(storageType .. '_' .. (args.id or self.name), lpdbData)
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -211,7 +211,7 @@ function Person:_setLpdbData(args, links, status, personType, earnings)
 	lpdbData.links = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.links)
 	local storageType = self:getStorageType(args, personType, status)
 
-	mw.ext.LiquipediaDB.lpdb_player(storageType .. self.name, lpdbData)
+	mw.ext.LiquipediaDB.lpdb_player(storageType .. (args.id or self.name), lpdbData)
 end
 
 --- Allows for overriding this functionality


### PR DESCRIPTION
## Summary
* For persons use id instead of name for `objectname`
* add missing underline in objectname

## How did you test this change?
pushed to live