### PR TITLE
Selectively show `organizers` plural

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -63,7 +63,22 @@ function League:createInfobox()
 				self:_createSeries(frame, args.series2, args.abbreviation2)
 			}
 		},
-		Cell{name = 'Organizer(s)', content = self:_createOrganizers(args)},
+		Builder{
+			builder = function()
+				local organizers = self:_createOrganizers(args)
+				mw.log('hello')
+				mw.logObject(organizers)
+				mw.log(Table.size(organizers))
+				local title = Table.size(organizers) == 1 and 'Organizer' or 'Organizers'
+
+				return {
+					Cell{
+						name = title,
+						content = organizers
+					}
+				}
+			end
+		},
 		Customizable{
 			id = 'sponsors',
 			children = {

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -66,9 +66,6 @@ function League:createInfobox()
 		Builder{
 			builder = function()
 				local organizers = self:_createOrganizers(args)
-				mw.log('hello')
-				mw.logObject(organizers)
-				mw.log(Table.size(organizers))
 				local title = Table.size(organizers) == 1 and 'Organizer' or 'Organizers'
 
 				return {


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

Counterstrike has requested that instead of showing "Organizer(s)", we show either "Organizer" or "Organizers" depending on the number of organizers. This PR implements that.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->

Pushed to https://liquipedia.net/commons/Module:Infobox/League/dev

And then tested on counterstrike. This is not overridable by wikis, so behaviour is the same everywhere.

![image](https://user-images.githubusercontent.com/5138348/140287596-83cfa472-4ffb-423c-9b1d-355d8deb9d37.png)

