### PR TITLE
Fix Achievements display

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player.lua
@@ -133,7 +133,7 @@ function CustomInjector:parse(id, widgets)
 			end
 
 			local allkills = CustomPlayer._getAllkills()
-			if not String.isEmpty(allkills) then
+			if not String.isEmpty(allkills) and allkills ~= '0' then
 				table.insert(achievementCells, Cell{
 						name = 'All-kills',
 						content = {_ALLKILLICON .. allkills}

--- a/components/infobox/wikis/starcraft2/infobox_person_player.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player.lua
@@ -140,7 +140,7 @@ function CustomInjector:parse(id, widgets)
 					})
 			end
 
-			if achievementCells ~= {} then
+			if next(achievementCells) then
 				table.insert(achievementCells, 1, Title{name = 'Achievements'})
 			end
 		end


### PR DESCRIPTION
stacked on #676 

## Summary
* Do not show Achievements header if no achievements are set
* do not display allkills if the query return `'0'`

## How did you test this change?
pushed to live to fix the bug