### PR TITLE
enable `darkmodeforced` in infoboxes

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -24,7 +24,7 @@ function Infobox:create(frame, gameName, forceDarkMode)
 	self.root	:addClass('fo-nttax-infobox-wrapper')
 				:addClass('infobox-' .. gameName)
 	if forceDarkMode then
-		self.root	:addClass('infobox-darkmodeforced')
+		self.root:addClass('infobox-darkmodeforced')
 	end
 
 	self.injector = nil

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -13,7 +13,7 @@ local Variables = require('Module:Variables')
 local Infobox = Class.new()
 
 --- Inits the Infobox instance
-function Infobox:create(frame, gameName)
+function Infobox:create(frame, gameName, forceDarkMode)
 	self.frame = frame
 	self.root = mw.html.create('div')
 	self.adbox = mw.html.create('div')	:addClass('fo-nttax-infobox-adbox')
@@ -23,6 +23,9 @@ function Infobox:create(frame, gameName)
 											:addClass('wiki-bordercolor-light')
 	self.root	:addClass('fo-nttax-infobox-wrapper')
 				:addClass('infobox-' .. gameName)
+	if forceDarkMode then
+		self.root	:addClass('infobox-darkmodeforced')
+	end
 
 	self.injector = nil
 	return self

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -22,7 +22,7 @@ local BasicInfobox = Class.new(
 			return error('Please provide a wiki!')
 		end
 
-		self.infobox = Infobox:create(frame, self.args.wiki)
+		self.infobox = Infobox:create(frame, self.args.wiki, Logic.readBool(self.args.darkmodeforced))
 	end
 )
 


### PR DESCRIPTION
## Summary
enable `darkmodeforced` in infoboxes

## How did you test this change?
`/dev` modules for the modules that get changed + for infobox person and infobox person/player (on sc2)

![Screenshot 2021-11-04 11 50 14](https://user-images.githubusercontent.com/75081997/140301383-840d00d9-f5ea-4f89-9c95-796791ab2c99.png)
