### PR TITLE
Make header customizable

### DIFF
--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -31,12 +31,17 @@ function Unit:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{
-			name = self:nameDisplay(args),
-			image = args.image,
-			imageDefault = args.default,
-			imageDark = args.imagedark or args.imagedarkmode,
-			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+		Customizable{
+			id = 'header',
+			children = {
+				Header{
+					name = self:nameDisplay(args),
+					image = args.image,
+					imageDefault = args.default,
+					imageDark = args.imagedark or args.imagedarkmode,
+					imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+				},
+			}
 		},
 		Customizable{
 			id = 'caption',


### PR DESCRIPTION
## Summary
Make header in infobox unit/champion/... customizable (wildrift needs an additional line between image and hence i need to be able to set the subheader there)

## How did you test this change?
doesn't change the behavior if not overwritten