### PR TITLE
Generalize metadata generation for tournaments

### DIFF
--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -2,6 +2,7 @@ local String = require('Module:String')
 local Localisation = require('Module:Localisation')
 local Template = require('Module:Template')
 local Games = require('Module:Games')
+local Variables = require('Module:Variables')
 
 local MetadataGenerator = {}
 
@@ -29,7 +30,7 @@ function MetadataGenerator.tournament(args)
 	end
 
 	local ttype = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
-	local riot = mw.ext.VariablesLua.var('metadesc-riot') ~= '' and mw.ext.VariablesLua.var('metadesc-riot')
+	local riot = Variables.varDefault('metadesc-riot')
 	local date, tense = MetadataGenerator.getDate(args.edate or args.date, args.sdate)
 
 	local teams = args.team_number
@@ -38,7 +39,13 @@ function MetadataGenerator.tournament(args)
 	local game = (not String.isEmpty(args.game) and args.game ~= 'csgo') and Games.abbr[args.game]
 
 	local prizepoolusd = args.prizepoolusd and ('$' .. args.prizepoolusd .. ' USD') or nil
-	local prizepool = prizepoolusd or (args.prizepool and args.localcurrency and (mw.ext.VariablesLua.var('localcurrencysymbol') .. args.prizepool .. mw.ext.VariablesLua.var('localcurrencysymbolafter') .. ' ' .. mw.ext.VariablesLua.var('localcurrencycode')))
+	local prizepool = prizepoolusd or (
+		args.prizepool and args.localcurrency and (
+			Variables.varDefault('localcurrencysymbol', '') .. args.prizepool ..
+			Variables.varDefault('localcurrencysymbolafter', '') .. ' ' ..
+			Variables.varDefault('localcurrencycode', '')
+		)
+	)
 	local charity = args.charity == 'true' and true
 	local dateVerb = (tense == 'past' and 'took place ') or (tense == 'future' and 'will take place ') or 'takes place '
 	local dateVerbRiot = (tense == 'past' and ' which took place ') or (tense == 'future' and ' which will take place ') or ' taking place '

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -71,7 +71,7 @@ function MetadataGenerator.tournament(args)
 end
 
 function MetadataGenerator.getDate(date, sdate)
-	if not date then
+	if String.isEmpty(date) then
 		return nil
 	end
 

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -1,9 +1,18 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MetadataGenerator
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local String = require('Module:String')
 local Localisation = require('Module:Localisation')
 local Template = require('Module:Template')
 local Games = require('Module:Games')
 local Variables = require('Module:Variables')
 local StringUtils = require('Module:StringUtils')
+local Class = require('Module:Class')
 
 local MetadataGenerator = {}
 
@@ -27,13 +36,15 @@ function MetadataGenerator.tournament(args)
 	local tier = args.liquipediatier and Template.safeExpand(frame, 'TierDisplay', {args.liquipediatier}) or nil
 
 	if tier then
-		tier = tonumber(Template.safeExpand(frame, 'TierDisplay/number', {args.liquipediatier})) > 4 and tier:lower() or tier
+		tier = (tonumber(
+			Template.safeExpand(frame, 'TierDisplay/number', {args.liquipediatier})
+		) or 0) > 4 and tier:lower() or tier
 	else
 		tier = 'Unknown Tier'
 	end
 
 	local tierType = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
-	local publisher = Variables.varDefault(args.publisherDescription)
+	local publisher = Variables.varDefault(args.publisherdescription, '')
 	local date, tense = MetadataGenerator.getDate(args.edate or args.date, args.sdate)
 
 	local teams = args.team_number
@@ -59,7 +70,7 @@ function MetadataGenerator.tournament(args)
 	output = StringUtils.interpolation('${name} is a${type}${locality}${game}${charity}${tierType}${organizer}', {
 		name = name,
 		type = type and ('n ' .. type:lower() .. ' ') or '',
-		locality = locality,
+		locality = locality and (locality .. ' ') or '',
 		game = game and (game .. ' ') or '',
 		charity = charity and 'charity ' or '',
 		tierType = tierType,
@@ -73,11 +84,11 @@ function MetadataGenerator.tournament(args)
 		output = output .. '. '
 	end
 
-	output = output .. StringUtils.interpolation('$This ${tier}${tierType} ', {
+	output = output .. StringUtils.interpolation('This ${tier}${tierType} ', {
 		tier = tierType ~= tier and (tier .. ' ') or '',
 		tierType = tierType
 	})
-	if publisher then
+	if not String.isEmpty(publisher) then
 		output = output .. StringUtils.interpolation('is a ${publisher}${tense}', {
 			publisher = publisher,
 			tense = ((date and dateVerbPublisher) or ((teams or players or prizepool) and ' featuring '))
@@ -154,4 +165,4 @@ function MetadataGenerator.getDate(date, sdate)
 	end
 end
 
-return MetadataGenerator
+return Class.export(MetadataGenerator)

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -13,6 +13,7 @@ local Games = require('Module:Games')
 local Variables = require('Module:Variables')
 local StringUtils = require('Module:StringUtils')
 local Class = require('Module:Class')
+local AnOrA = require('Module:A or an')
 
 local MetadataGenerator = {}
 
@@ -30,7 +31,7 @@ function MetadataGenerator.tournament(args)
 
 	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle()
 
-	local type = args.type or ''
+	local type = args.type
 	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)
 
 	local organizers = {
@@ -73,9 +74,10 @@ function MetadataGenerator.tournament(args)
 		(tense == 'future' and ' which will take place ') or
 		' taking place '
 
-	output = StringUtils.interpolate('${name} is a${type}${locality}${game}${charity}${tierType}${organizer}', {
+	output = StringUtils.interpolate('${name} is ${a}${type}${locality}${game}${charity}${tierType}${organizer}', {
 		name = name,
-		type = type and ('n ' .. type:lower() .. ' ') or '',
+		a = AnOrA._main(type or locality or game or (charity and 'charity' or nil) or tierType) .. ' ',
+		type = type and (type:lower() .. ' ') or '',
 		locality = locality and (locality .. ' ') or '',
 		game = game and (game .. ' ') or '',
 		charity = charity and 'charity ' or '',

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -1,0 +1,106 @@
+local String = require('Module:String')
+
+local MetadataGenerator = {}
+
+function MetadataGenerator.tournament(args)
+	local output
+	local frame = mw.getCurrentFrame()
+
+	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle()
+
+	local type = args.type
+	local locality = args.country and frame:expandTemplate({title = 'Localisation', args = {args.country}}) or nil
+	local organizers = {args['organizer-name'] or args.organizer, args['organizer2-name'] or args.organizer2, args['organizer3-name'] or args.organizer3}
+	local tier = args.liquipediatier and frame:expandTemplate({title = 'TierDisplay', args = {args.liquipediatier}}) or nil
+
+	if tier then
+		tier = tonumber(frame:expandTemplate({title = 'TierDisplay/number', args = {args.liquipediatier}})) > 4 and tier:lower() or tier else tier = 'Unknown Tier'
+	end
+
+	local ttype = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
+	local riot = mw.ext.VariablesLua.var('metadesc-riot') ~= '' and mw.ext.VariablesLua.var('metadesc-riot')
+	local date, tense = MetadataGenerator.getDate(args.edate or args.date, args.sdate)
+	local teams = args.team_number
+	local players = args.player_number
+	local game = args.game and args.game ~= 'csgo' and require('Module:Games').abbr[args.game]
+	local prizepoolusd = args.prizepoolusd and ('$' .. args.prizepoolusd .. ' USD') or nil
+	local prizepool = prizepoolusd or (args.prizepool and args.localcurrency and (mw.ext.VariablesLua.var('localcurrencysymbol') .. args.prizepool .. mw.ext.VariablesLua.var('localcurrencysymbolafter') .. ' ' .. mw.ext.VariablesLua.var('localcurrencycode')))
+	local charity = args.charity == 'true' and true
+	local dateVerb = (tense == 'past' and 'took place ') or (tense == 'future' and 'will take place ') or 'takes place '
+	local dateVerbRiot = (tense == 'past' and ' which took place ') or (tense == 'future' and ' which will take place ') or ' taking place '
+
+	output = name .. ' is a' .. (type and ('n ' .. type:lower() .. ' ') or '') .. (locality and (locality .. ' ') or '') .. (game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. ttype .. (organizers[1] and (' organized by ' .. organizers[1]) or '')
+
+	if organizers[2] then
+		output = output .. (organizers[3] and ', ' or ' and ') .. organizers[2] .. (organizers[3] and (', and ' .. organizers[3]) or '') .. '. '
+	else
+		output = output .. '. '
+	end
+
+	output = output .. 'This ' .. (ttype ~= tier and (tier .. ' ') or '') .. ttype .. ' '
+	if riot then
+		output = output .. 'is a ' .. riot .. ((date and dateVerbRiot) or ((teams or players or prizepool) and ' featuring '))
+	elseif date then
+		output = output .. dateVerb
+	elseif teams or players or prizepool then
+		output = output .. 'features '
+	end
+
+	if date then
+		output = output .. date .. ((teams or players or prizepool) and ' featuring ' or '')
+	end
+
+	if teams or players then
+		output = output .. ((teams and (teams .. ' teams')) or (players and (players .. ' players'))) .. (prizepool and ' ' or '')
+	end
+	if prizepool then
+		output = output .. ((teams or players) and 'competing over ' or '') .. 'a total ' .. (charity and 'charity ' or '') .. 'prize pool of ' .. prizepool
+	end
+
+	output = output .. '.'
+
+	return output
+end
+
+function MetadataGenerator.getDate(date, sdate)
+	if not date then
+		return nil
+	end
+
+	local noStartDay, noEndDay, tense
+	local startRaw = (sdate or date):gsub('%-[?X]+', '')
+	local endRaw = date:gsub('%-[?X]+', '')
+	local currentU = tonumber(os.date("!%s"))
+	local startU = tonumber(mw.getContentLanguage():formatDate('U', startRaw))
+	local endU = tonumber(mw.getContentLanguage():formatDate('U', endRaw))
+	local startMD = startRaw:sub(6)
+	local endMD = endRaw:sub(6)
+
+	if tonumber(startMD) then
+		noStartDay = true
+	end
+
+	if tonumber(endMD) then
+		noEndDay = true
+	end
+
+	if currentU > endU then
+		tense = 'past'
+	elseif currentU < startU then
+		tense = 'future'
+	elseif startU < currentU and currentU < endU then
+		tense = 'present'
+	end
+
+	if startU == endU then
+		return os.date("!on %b " .. (noStartDay and "??" or "%d") .. " %Y", endU), tense
+	elseif os.date("!%m, %Y", startU) == os.date("!%m %Y", endU) then
+		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' .. os.date("!" .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+	elseif os.date("!%Y", startU) == os.date("!%Y", endU) then
+		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' .. os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+	else
+		return os.date("!from %b " .. (noStartDay and "??" or "%d") .. " %Y", startU) .. ' to ' .. os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+	end
+end
+
+return MetadataGenerator

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -1,4 +1,5 @@
 local String = require('Module:String')
+local Localisation = require('Module:Localisation')
 
 local MetadataGenerator = {}
 
@@ -9,7 +10,7 @@ function MetadataGenerator.tournament(args)
 	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle()
 
 	local type = args.type
-	local locality = args.country and frame:expandTemplate({title = 'Localisation', args = {args.country}}) or nil
+	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)
 	local organizers = {args['organizer-name'] or args.organizer, args['organizer2-name'] or args.organizer2, args['organizer3-name'] or args.organizer3}
 	local tier = args.liquipediatier and frame:expandTemplate({title = 'TierDisplay', args = {args.liquipediatier}}) or nil
 
@@ -29,7 +30,7 @@ function MetadataGenerator.tournament(args)
 	local dateVerb = (tense == 'past' and 'took place ') or (tense == 'future' and 'will take place ') or 'takes place '
 	local dateVerbRiot = (tense == 'past' and ' which took place ') or (tense == 'future' and ' which will take place ') or ' taking place '
 
-	output = name .. ' is a' .. (type and ('n ' .. type:lower() .. ' ') or '') .. (locality and (locality .. ' ') or '') .. (game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. ttype .. (organizers[1] and (' organized by ' .. organizers[1]) or '')
+	output = name .. ' is a' .. (type and ('n ' .. type:lower() .. ' ') or '') .. locality .. (game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. ttype .. (organizers[1] and (' organized by ' .. organizers[1]) or '')
 
 	if organizers[2] then
 		output = output .. (organizers[3] and ', ' or ' and ') .. organizers[2] .. (organizers[3] and (', and ' .. organizers[3]) or '') .. '. '

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -18,7 +18,9 @@ function MetadataGenerator.tournament(args)
 	local organizers = {
 		args['organizer-name'] or args.organizer,
 		args['organizer2-name'] or args.organizer2,
-		args['organizer3-name'] or args.organizer3
+		args['organizer3-name'] or args.organizer3,
+		args['organizer4-name'] or args.organizer4,
+		args['organizer5-name'] or args.organizer5
 	}
 
 	local tier = args.liquipediatier and Template.safeExpand(frame, 'TierDisplay', {args.liquipediatier}) or nil
@@ -29,7 +31,7 @@ function MetadataGenerator.tournament(args)
 		tier = 'Unknown Tier'
 	end
 
-	local ttype = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
+	local tierType = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
 	local publisher = Variables.varDefault(args.publisherDescription)
 	local date, tense = MetadataGenerator.getDate(args.edate or args.date, args.sdate)
 
@@ -54,7 +56,7 @@ function MetadataGenerator.tournament(args)
 		' taking place '
 
 	output = name .. ' is a' .. (type and ('n ' .. type:lower() .. ' ') or '') .. locality ..
-		(game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. ttype ..
+		(game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. tierType ..
 		(organizers[1] and (' organized by ' .. organizers[1]) or '')
 
 	if organizers[2] then
@@ -64,7 +66,7 @@ function MetadataGenerator.tournament(args)
 		output = output .. '. '
 	end
 
-	output = output .. 'This ' .. (ttype ~= tier and (tier .. ' ') or '') .. ttype .. ' '
+	output = output .. 'This ' .. (tierType ~= tier and (tier .. ' ') or '') .. tierType .. ' '
 	if publisher then
 		output = output .. 'is a ' .. publisher .. ((date and dateVerbPublisher) or
 			((teams or players or prizepool) and ' featuring '))

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -30,7 +30,7 @@ function MetadataGenerator.tournament(args)
 
 	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle()
 
-	local type = args.type
+	local type = args.type or ''
 	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)
 
 	local organizers = {

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -21,6 +21,10 @@ function MetadataGenerator.tournament(args)
 		error('You must provide the publisherdescription param!')
 	end
 
+	if String.isEmpty(args.primarygame) then
+		error('You must provide the primarygame param!')
+	end
+
 	local output
 	local frame = mw.getCurrentFrame()
 
@@ -33,8 +37,6 @@ function MetadataGenerator.tournament(args)
 		args['organizer-name'] or args.organizer,
 		args['organizer2-name'] or args.organizer2,
 		args['organizer3-name'] or args.organizer3,
-		args['organizer4-name'] or args.organizer4,
-		args['organizer5-name'] or args.organizer5
 	}
 
 	local tier = args.liquipediatier and Template.safeExpand(frame, 'TierDisplay', {args.liquipediatier}) or nil
@@ -54,7 +56,7 @@ function MetadataGenerator.tournament(args)
 	local teams = args.team_number
 	local players = args.player_number
 
-	local game = (not String.isEmpty(args.game) and args.game ~= 'csgo') and Games.abbr[args.game]
+	local game = (not String.isEmpty(args.game) and args.game ~= args.primarygame) and Games.abbr[args.game]
 
 	local prizepoolusd = args.prizepoolusd and ('$' .. args.prizepoolusd .. ' USD') or nil
 	local prizepool = prizepoolusd or (
@@ -64,7 +66,7 @@ function MetadataGenerator.tournament(args)
 			Variables.varDefault('localcurrencycode', '')
 		)
 	)
-	local charity = args.charity == 'true' and true
+	local charity = args.charity == 'true'
 	local dateVerb = (tense == 'past' and 'took place ') or (tense == 'future' and 'will take place ') or 'takes place '
 	local dateVerbPublisher =
 		(tense == 'past' and ' which took place ') or

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -3,6 +3,7 @@ local Localisation = require('Module:Localisation')
 local Template = require('Module:Template')
 local Games = require('Module:Games')
 local Variables = require('Module:Variables')
+local StringUtils = require('Module:StringUtils')
 
 local MetadataGenerator = {}
 
@@ -55,9 +56,15 @@ function MetadataGenerator.tournament(args)
 		(tense == 'future' and ' which will take place ') or
 		' taking place '
 
-	output = name .. ' is a' .. (type and ('n ' .. type:lower() .. ' ') or '') .. locality ..
-		(game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. tierType ..
-		(organizers[1] and (' organized by ' .. organizers[1]) or '')
+	output = StringUtils.interpolation('${name} is a${type}${locality}${game}${charity}${tierType}${organizer}', {
+		name = name,
+		type = type and ('n ' .. type:lower() .. ' ') or '',
+		locality = locality,
+		game = game and (game .. ' ') or '',
+		charity = charity and 'charity ' or '',
+		tierType = tierType,
+		organizer = organizers[1] and (' organized by ' .. organizers[1]) or ''
+	})
 
 	if organizers[2] then
 		output = output .. (organizers[3] and ', ' or ' and ') ..
@@ -66,10 +73,15 @@ function MetadataGenerator.tournament(args)
 		output = output .. '. '
 	end
 
-	output = output .. 'This ' .. (tierType ~= tier and (tier .. ' ') or '') .. tierType .. ' '
+	output = output .. StringUtils.interpolation('$This ${tier}${tierType} ', {
+		tier = tierType ~= tier and (tier .. ' ') or '',
+		tierType = tierType
+	})
 	if publisher then
-		output = output .. 'is a ' .. publisher .. ((date and dateVerbPublisher) or
-			((teams or players or prizepool) and ' featuring '))
+		output = output .. StringUtils.interpolation('is a ${publisher}${tense}', {
+			publisher = publisher,
+			tense = ((date and dateVerbPublisher) or ((teams or players or prizepool) and ' featuring '))
+		})
 	elseif date then
 		output = output .. dateVerb
 	elseif teams or players or prizepool then
@@ -86,8 +98,11 @@ function MetadataGenerator.tournament(args)
 			(prizepool and ' ' or '')
 	end
 	if prizepool then
-		output = output .. ((teams or players) and 'competing over ' or '') ..
-			'a total ' .. (charity and 'charity ' or '') .. 'prize pool of ' .. prizepool
+		output = output .. StringUtils.interpolation('${competing}a total ${charity}prize pool of ${prizepool}', {
+			competing = (teams or players) and 'competing over ' or '',
+			charity = charity and 'charity ' or '',
+			prizepool = prizepool
+		})
 	end
 
 	output = output .. '.'

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -1,5 +1,6 @@
 local String = require('Module:String')
 local Localisation = require('Module:Localisation')
+local Template = require('Module:Template')
 
 local MetadataGenerator = {}
 
@@ -12,10 +13,12 @@ function MetadataGenerator.tournament(args)
 	local type = args.type
 	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)
 	local organizers = {args['organizer-name'] or args.organizer, args['organizer2-name'] or args.organizer2, args['organizer3-name'] or args.organizer3}
-	local tier = args.liquipediatier and frame:expandTemplate({title = 'TierDisplay', args = {args.liquipediatier}}) or nil
+	local tier = args.liquipediatier and Template.safeExpand(frame, 'TierDisplay', {args.liquipediatier}) or nil
 
 	if tier then
-		tier = tonumber(frame:expandTemplate({title = 'TierDisplay/number', args = {args.liquipediatier}})) > 4 and tier:lower() or tier else tier = 'Unknown Tier'
+		tier = tonumber(Template.safeExpand(frame, 'TierDisplay/number', {args.liquipediatier})) > 4 and tier:lower() or tier
+	else
+		tier = 'Unknown Tier'
 	end
 
 	local ttype = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -1,6 +1,7 @@
 local String = require('Module:String')
 local Localisation = require('Module:Localisation')
 local Template = require('Module:Template')
+local Games = require('Module:Games')
 
 local MetadataGenerator = {}
 
@@ -24,9 +25,12 @@ function MetadataGenerator.tournament(args)
 	local ttype = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
 	local riot = mw.ext.VariablesLua.var('metadesc-riot') ~= '' and mw.ext.VariablesLua.var('metadesc-riot')
 	local date, tense = MetadataGenerator.getDate(args.edate or args.date, args.sdate)
+
 	local teams = args.team_number
 	local players = args.player_number
-	local game = args.game and args.game ~= 'csgo' and require('Module:Games').abbr[args.game]
+
+	local game = (not String.isEmpty(args.game) and args.game ~= 'csgo') and Games.abbr[args.game]
+
 	local prizepoolusd = args.prizepoolusd and ('$' .. args.prizepoolusd .. ' USD') or nil
 	local prizepool = prizepoolusd or (args.prizepool and args.localcurrency and (mw.ext.VariablesLua.var('localcurrencysymbol') .. args.prizepool .. mw.ext.VariablesLua.var('localcurrencysymbolafter') .. ' ' .. mw.ext.VariablesLua.var('localcurrencycode')))
 	local charity = args.charity == 'true' and true

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -17,6 +17,10 @@ local Class = require('Module:Class')
 local MetadataGenerator = {}
 
 function MetadataGenerator.tournament(args)
+	if String.isEmpty(args.publisherdescription) then
+		error('You must provide the publisherdescription param!')
+	end
+
 	local output
 	local frame = mw.getCurrentFrame()
 

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -71,7 +71,7 @@ function MetadataGenerator.tournament(args)
 		(tense == 'future' and ' which will take place ') or
 		' taking place '
 
-	output = StringUtils.interpolation('${name} is a${type}${locality}${game}${charity}${tierType}${organizer}', {
+	output = StringUtils.interpolate('${name} is a${type}${locality}${game}${charity}${tierType}${organizer}', {
 		name = name,
 		type = type and ('n ' .. type:lower() .. ' ') or '',
 		locality = locality and (locality .. ' ') or '',
@@ -88,12 +88,12 @@ function MetadataGenerator.tournament(args)
 		output = output .. '. '
 	end
 
-	output = output .. StringUtils.interpolation('This ${tier}${tierType} ', {
+	output = output .. StringUtils.interpolate('This ${tier}${tierType} ', {
 		tier = tierType ~= tier and (tier .. ' ') or '',
 		tierType = tierType
 	})
 	if not String.isEmpty(publisher) then
-		output = output .. StringUtils.interpolation('is a ${publisher}${tense}', {
+		output = output .. StringUtils.interpolate('is a ${publisher}${tense}', {
 			publisher = publisher,
 			tense = ((date and dateVerbPublisher) or ((teams or players or prizepool) and ' featuring '))
 		})
@@ -113,7 +113,7 @@ function MetadataGenerator.tournament(args)
 			(prizepool and ' ' or '')
 	end
 	if prizepool then
-		output = output .. StringUtils.interpolation('${competing}a total ${charity}prize pool of ${prizepool}', {
+		output = output .. StringUtils.interpolate('${competing}a total ${charity}prize pool of ${prizepool}', {
 			competing = (teams or players) and 'competing over ' or '',
 			charity = charity and 'charity ' or '',
 			prizepool = prizepool

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -13,7 +13,13 @@ function MetadataGenerator.tournament(args)
 
 	local type = args.type
 	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)
-	local organizers = {args['organizer-name'] or args.organizer, args['organizer2-name'] or args.organizer2, args['organizer3-name'] or args.organizer3}
+
+	local organizers = {
+		args['organizer-name'] or args.organizer,
+		args['organizer2-name'] or args.organizer2,
+		args['organizer3-name'] or args.organizer3
+	}
+
 	local tier = args.liquipediatier and Template.safeExpand(frame, 'TierDisplay', {args.liquipediatier}) or nil
 
 	if tier then
@@ -103,11 +109,14 @@ function MetadataGenerator.getDate(date, sdate)
 	if startU == endU then
 		return os.date("!on %b " .. (noStartDay and "??" or "%d") .. " %Y", endU), tense
 	elseif os.date("!%m, %Y", startU) == os.date("!%m %Y", endU) then
-		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' .. os.date("!" .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' ..
+			os.date("!" .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
 	elseif os.date("!%Y", startU) == os.date("!%Y", endU) then
-		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' .. os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' ..
+			os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
 	else
-		return os.date("!from %b " .. (noStartDay and "??" or "%d") .. " %Y", startU) .. ' to ' .. os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+		return os.date("!from %b " .. (noStartDay and "??" or "%d") .. " %Y", startU) .. ' to ' ..
+			os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
 	end
 end
 

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -30,7 +30,7 @@ function MetadataGenerator.tournament(args)
 	end
 
 	local ttype = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
-	local riot = Variables.varDefault('metadesc-riot')
+	local publisher = Variables.varDefault(args.publisherDescription)
 	local date, tense = MetadataGenerator.getDate(args.edate or args.date, args.sdate)
 
 	local teams = args.team_number
@@ -48,19 +48,26 @@ function MetadataGenerator.tournament(args)
 	)
 	local charity = args.charity == 'true' and true
 	local dateVerb = (tense == 'past' and 'took place ') or (tense == 'future' and 'will take place ') or 'takes place '
-	local dateVerbRiot = (tense == 'past' and ' which took place ') or (tense == 'future' and ' which will take place ') or ' taking place '
+	local dateVerbPublisher =
+		(tense == 'past' and ' which took place ') or
+		(tense == 'future' and ' which will take place ') or
+		' taking place '
 
-	output = name .. ' is a' .. (type and ('n ' .. type:lower() .. ' ') or '') .. locality .. (game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. ttype .. (organizers[1] and (' organized by ' .. organizers[1]) or '')
+	output = name .. ' is a' .. (type and ('n ' .. type:lower() .. ' ') or '') .. locality ..
+		(game and (game .. ' ') or '') .. (charity and 'charity ' or '') .. ttype ..
+		(organizers[1] and (' organized by ' .. organizers[1]) or '')
 
 	if organizers[2] then
-		output = output .. (organizers[3] and ', ' or ' and ') .. organizers[2] .. (organizers[3] and (', and ' .. organizers[3]) or '') .. '. '
+		output = output .. (organizers[3] and ', ' or ' and ') ..
+			organizers[2] .. (organizers[3] and (', and ' .. organizers[3]) or '') .. '. '
 	else
 		output = output .. '. '
 	end
 
 	output = output .. 'This ' .. (ttype ~= tier and (tier .. ' ') or '') .. ttype .. ' '
-	if riot then
-		output = output .. 'is a ' .. riot .. ((date and dateVerbRiot) or ((teams or players or prizepool) and ' featuring '))
+	if publisher then
+		output = output .. 'is a ' .. publisher .. ((date and dateVerbPublisher) or
+			((teams or players or prizepool) and ' featuring '))
 	elseif date then
 		output = output .. dateVerb
 	elseif teams or players or prizepool then
@@ -72,10 +79,13 @@ function MetadataGenerator.tournament(args)
 	end
 
 	if teams or players then
-		output = output .. ((teams and (teams .. ' teams')) or (players and (players .. ' players'))) .. (prizepool and ' ' or '')
+		output = output .. ((teams and (teams .. ' teams')) or
+			(players and (players .. ' players'))) ..
+			(prizepool and ' ' or '')
 	end
 	if prizepool then
-		output = output .. ((teams or players) and 'competing over ' or '') .. 'a total ' .. (charity and 'charity ' or '') .. 'prize pool of ' .. prizepool
+		output = output .. ((teams or players) and 'competing over ' or '') ..
+			'a total ' .. (charity and 'charity ' or '') .. 'prize pool of ' .. prizepool
 	end
 
 	output = output .. '.'

--- a/components/infobox/extensions/test/metadata_generator_test.lua
+++ b/components/infobox/extensions/test/metadata_generator_test.lua
@@ -1,0 +1,24 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MetadataGenerator/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local MetadataGenerator = require('Module:MetadataGenerator')
+local Arguments = require('Module:Arguments')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local suite = ScribuntoUnit:new()
+
+local _EXPECTED_RESULT = 'Intel Extreme Masters XVI - Cologne is an offline German tournament organized by ESL.' ..
+	' This [[Template:TierDisplay]] tournament took place from Jul 06 to Jul 18 2021 featuring 24 teams competing over a total prize' ..
+	' pool of $1,000,000 USD.'
+
+function suite:testGenerator()
+	local args = Arguments.getArgs(mw.getCurrentFrame())
+	self:assertEquals(_EXPECTED_RESULT, MetadataGenerator.tournament(args))
+end
+
+return suite

--- a/components/infobox/extensions/test/metadata_generator_test.lua
+++ b/components/infobox/extensions/test/metadata_generator_test.lua
@@ -13,8 +13,8 @@ local ScribuntoUnit = require('Module:ScribuntoUnit')
 local suite = ScribuntoUnit:new()
 
 local _EXPECTED_RESULT = 'Intel Extreme Masters XVI - Cologne is an offline German tournament organized by ESL.' ..
-	' This [[Template:TierDisplay]] tournament took place from Jul 06 to Jul 18 2021 featuring 24 teams competing over a total prize' ..
-	' pool of $1,000,000 USD.'
+	' This [[Template:TierDisplay]] tournament took place from Jul 06 to Jul 18 2021 featuring 24 teams competing' ..
+	' over a total prize pool of $1,000,000 USD.'
 
 function suite:testGenerator()
 	local args = Arguments.getArgs(mw.getCurrentFrame())

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -17,7 +17,7 @@ local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
-local MetadataGenerator = require('Module:Metadata_generator')
+local MetadataGenerator = require('Module:MetadataGenerator')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -44,6 +44,7 @@ local _league
 function CustomLeague.run(frame)
 	local league = League(frame)
 	_league = league
+	_league.args['publisherdescription'] = 'metadesc-valve'
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
@@ -132,7 +133,7 @@ function CustomInjector:parse(id, widgets)
 		}
 	end
 
-	mw.getCurrentFrame():extensionTag{name = 'metadescl', MetadataGenerator.tournament(mw.getCurrentFrame())}
+	mw.getCurrentFrame():extensionTag{name = 'metadescl', MetadataGenerator.tournament(_league.args)}
 
 	return widgets
 end


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

Builds on #673 and generalizes the module to create one version for all wikis. Stacks on top of #681. Wikis only need to set `publisherdescription` in their infobox template/module. 

Note: I recommend reviewing by looking at every commit except the first. The first is just a copy, then after that I applied changes.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->

![image](https://user-images.githubusercontent.com/5138348/140510040-e2e21111-351c-479b-bf53-9bb860dd60d6.png)

Also see the added test.
