### PR TITLE
Fixed lua error in Match2 -> Match1 mapping

### DIFF
--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -185,7 +185,7 @@ function p.convertParameters(match2)
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == "team" then
 			match[prefix] = opponent.name
-			match[prefix.."score"] = tonumber(opponent.score or 0) >= 0 and opponent.score or 0
+			match[prefix.."score"] = tonumber(opponent.score) or 0 >= 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1,10 do
 				local player = opponentmatch2players[i] or {}
@@ -197,7 +197,7 @@ function p.convertParameters(match2)
 		elseif opponent.type == "solo" then
 			local player = opponentmatch2players[1] or {}
 			match[prefix] = player.name
-			match[prefix.."score"] = tonumber(opponent.score or 0) >= 0 and opponent.score or 0
+			match[prefix.."score"] = tonumber(opponent.score) or 0 >= 0 and opponent.score or 0
 			match[prefix.."flag"] = player.flag
 		elseif opponent.type == "literal" then
 			match[prefix] = 'TBD'


### PR DESCRIPTION
## Summary

An `or 0` in an incorrect place, causing lua errors if opponent.score were to be a string. 
While opponent.score should never be a string (see guidelines), throwing a lua error is not the way to go if it were to happen.

## How did you test this change?

Tested it live.
https://liquipedia.net/rainbowsix/index.php?title=Module%3AMatch%2FLegacy&type=revision&diff=384314&oldid=373959
