### PR TITLE
Ensure numbers are of number type and not strings

### DIFF
--- a/components/match2/wikis/rainbow_six/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbow_six/match_group_input_custom.lua
@@ -166,7 +166,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 			if #indexedScores ~= 2 then
 				error('Unexpected number of opponents when calculating map winner')
 			end
-			if indexedScores[1].score > indexedScores[2].score then
+			if tonumber(indexedScores[1].score) > tonumber(indexedScores[2].score) then
 				data.winner = 1
 			else
 				data.winner = 2


### PR DESCRIPTION
## Summary

Convert numeric strings to numbers before comparing them, avoiding lua error if one is a number and one is a string.

## How did you test this change?

Tested it live.
https://liquipedia.net/rainbowsix/index.php?title=Module%3AMatchGroup%2FInput%2FCustom&type=revision&diff=384320&oldid=374459