### PR TITLE
[pl6] Add Module:Stream/Ext

### DIFF
--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -1,0 +1,54 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Links/Stream
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+--[[
+Module containing utility functions for streaming platforms.
+]]
+local StreamLinks = {}
+
+--[[
+List of streaming platforms supported in Module:Countdown. This is a subset of
+the list in Module:Links
+]]
+StreamLinks.countdownPlatformNames = {
+	'afreeca',
+	'afreecatv',
+	'bilibili',
+	'cc163',
+	'dailymotion',
+	'douyu',
+	'facebook',
+	'huomao',
+	'huya',
+	'loco',
+	'mildom',
+	'nimo',
+	'pandatv',
+	'play2live',
+	'smashcast',
+	'stream',
+	'tl',
+	'trovo',
+	'twitch',
+	'twitch2',
+	'youtube',
+}
+
+--[[
+Extracts the streaming platform args from an argument table for use in
+Module:Countdown.
+]]
+function StreamLinks.readCountdownStreams(args)
+	local stream = {}
+	for _, platformName in ipairs(StreamLinks.countdownPlatformNames) do
+		stream[platformName] = args[platformName]
+	end
+	return stream
+end
+
+return StreamLinks


### PR DESCRIPTION
## Summary

Streaming specific subset of Module:Links

StreamExt.readCountdownStreams can be used to extract the streaming platform args from an argument table for use in
Module:Countdown.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
used by starcraft's GroupTableLeague
https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/DH_NA
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
