### PR TITLE
Remove Class.export from starcraft display components

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local TypeUtil = require('Module:TypeUtil')
 
@@ -145,4 +144,4 @@ function StarcraftMatchExternalLinks.TemplateMatchExternalLink(frame)
 	return StarcraftMatchExternalLinks.ExternalLink(args)
 end
 
-return Class.export(StarcraftMatchExternalLinks)
+return StarcraftMatchExternalLinks

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_bracket_starcraft.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
@@ -131,4 +130,4 @@ function StarcraftBracketDisplay.OpponentEntry(props)
 		:node(contestNode)
 end
 
-return Class.export(StarcraftBracketDisplay)
+return StarcraftBracketDisplay

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
@@ -56,4 +55,4 @@ function StarcraftMatchlistDisplay.Score(props)
 		:node(contentNode)
 end
 
-return Class.export(StarcraftMatchlistDisplay)
+return StarcraftMatchlistDisplay

--- a/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Placement = require('Module:Placement')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
@@ -92,4 +91,4 @@ function CustomFfaMatchSummary.computeRowHeight(match)
 	return maxHeight
 end
 
-return Class.export(CustomFfaMatchSummary)
+return CustomFfaMatchSummary

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -260,4 +259,4 @@ function StarcraftOpponentDisplay.InlineScore(opponent)
 	return OpponentDisplay.InlineScore(opponent)
 end
 
-return Class.export(StarcraftOpponentDisplay)
+return StarcraftOpponentDisplay

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -230,4 +229,4 @@ function StarcraftPlayerDisplay.Race(race)
 	)
 end
 
-return Class.export(StarcraftPlayerDisplay)
+return StarcraftPlayerDisplay


### PR DESCRIPTION
## Summary

The argument rewriting doesn't work with the only entry point (StarcraftPlayerDisplay.InlinePlayer). None of the other modules have entry points so Class.export isn't needed.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
changes for StarcraftPlayerDisplay are live

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
