### PR TITLE
Adjust achievements display

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -94,8 +94,16 @@ function Team:createInfobox()
 		Customizable{
 			id = 'achievements',
 			children = {
-				Title{name = 'Achievements'},
-				Center{content = {args.achievements}}
+				Builder{
+					builder = function()
+						if args.achievements then
+							return {
+								Title{name = 'Achievements'},
+								Center{content = {args.achievements}}
+							}
+						end
+					end
+				}
 			}
 		},
 		Customizable{


### PR DESCRIPTION
## Summary
* only display achievements header if there are achievements

## How did you test this change?
temporarily created the module locally on R6 (they are implementing the /Custom atm) and tested it there
