### PR TITLE
Calculate match draw

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -356,8 +356,8 @@ function matchFunctions.getOpponents(args)
 		winner == '0' or (
 			Logic.readBool(args.finished) and
 			#opponents == 2 and
-			opponents[1].status == 'S' and
-			opponents[2].status == 'S' and
+			opponents[1].status == _STATUS_SCORE and
+			opponents[2].status == _STATUS_SCORE and
 			opponents[1].score == opponents[2].score
 		)
 	then
@@ -366,7 +366,7 @@ function matchFunctions.getOpponents(args)
 	elseif
 		Logic.readBool(args.finished) and
 		#opponents == 2 and
-		opponents[1].status ~= 'S' and
+		opponents[1].status ~= _STATUS_SCORE and
 		opponents[1].status == opponents[2].status
 	then
 		args.winner = 0

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -363,6 +363,13 @@ function matchFunctions.getOpponents(args)
 	then
 		args.winner = 0
 		args.resulttype = _RESULT_TYPE_DRAW
+	elseif
+		Logic.readBool(args.finished) and
+		#opponents == 2 and
+		opponents[1].status ~= 'S' and
+		opponents[1].status == opponents[2].status
+	then
+		args.winner = 0
 	end
 	return args
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -356,8 +356,8 @@ function matchFunctions.getOpponents(args)
 		winner == '0' or (
 			Logic.readBool(args.finished) and
 			#opponents == 2 and
-			opponents[1].status == _STATUS_SCORE and
-			opponents[2].status == _STATUS_SCORE and
+			opponents[1].status == _STATUS_HAS_SCORE and
+			opponents[2].status == _STATUS_HAS_SCORE and
 			opponents[1].score == opponents[2].score
 		)
 	then
@@ -366,7 +366,7 @@ function matchFunctions.getOpponents(args)
 	elseif
 		Logic.readBool(args.finished) and
 		#opponents == 2 and
-		opponents[1].status ~= _STATUS_SCORE and
+		opponents[1].status ~= _STATUS_HAS_SCORE and
 		opponents[1].status == opponents[2].status
 	then
 		args.winner = 0

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -351,7 +351,16 @@ function matchFunctions.getOpponents(args)
 			args['opponent' .. opponentIndex] = opponent
 		end
 	end
-	if winner == _RESULT_TYPE_DRAW or winner == '0' then
+	if
+		winner == _RESULT_TYPE_DRAW or
+		winner == '0' or (
+			Logic.readBool(args.finished) and
+			#opponents == 2 and
+			opponents[1].status == 'S' and
+			opponents[2].status == 'S' and
+			opponents[1].score == opponents[2].score
+		)
+	then
 		args.winner = 0
 		args.resulttype = _RESULT_TYPE_DRAW
 	end


### PR DESCRIPTION
## Summary
If `winner` is not set to `draw` (or `0`) try to calculate if we still have a draw

Calculates draw status automatically if
* the match is set as finished,
* we have exactly 2 opponents in the match,
* status of both opponents is `S` (i.e. they both have proper scores) and
* the scores of the opponents are the same

Additionally sets `winner = 0` if
* the match is set as finished,
* we have exactly 2 opponents in the match,
* status of both opponents is not `S`
* the statuses of the opponents are the same

This is only a suggestion, if you want it take it if not just close the PR^^

## How did you test this change?
via /dev version of the module