### PR TITLE
Adjust tier and tiertype vars

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -173,6 +173,7 @@ function CustomLeague:_createLiquipediaTierDisplay()
 
 	Variables.varDefine('tournament_tier', tier)
 	Variables.varDefine('tournament_tiertype', tierType)
+	--overwrite wiki var `tournament_liquipediatiertype` to allow `args.tiertype` as alias entry point for tiertype
 	Variables.varDefine('tournament_liquipediatiertype', tierType)
 	return tierDisplay
 end

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -172,7 +172,6 @@ function CustomLeague:_createLiquipediaTierDisplay()
 		(hasTypeSetAsTier and '[[Category:Pages with Tiertype set as Tier]]' or '')
 
 	Variables.varDefine('tournament_tier', tier)
-	Variables.varDefine('tournament_liquipediatier', tier)
 	Variables.varDefine('tournament_tiertype', tierType)
 	Variables.varDefine('tournament_liquipediatiertype', tierType)
 	return tierDisplay

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -172,7 +172,9 @@ function CustomLeague:_createLiquipediaTierDisplay()
 		(hasTypeSetAsTier and '[[Category:Pages with Tiertype set as Tier]]' or '')
 
 	Variables.varDefine('tournament_tier', tier)
+	Variables.varDefine('tournament_liquipediatier', tier)
 	Variables.varDefine('tournament_tiertype', tierType)
+	Variables.varDefine('tournament_liquipediatiertype', tierType)
 	return tierDisplay
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -221,7 +221,6 @@ function CustomLeague:_createTierDisplay()
 		(hasInvalidTierType and '[[Category:Pages with invalid Tiertype]]' or '')
 
 	Variables.varDefine('tournament_tier', tier)
-	Variables.varDefine('tournament_liquipediatier', tier)
 	Variables.varDefine('tournament_tiertype', tierType)
 	Variables.varDefine('tournament_liquipediatiertype', tierType)
 	return output

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -222,6 +222,7 @@ function CustomLeague:_createTierDisplay()
 
 	Variables.varDefine('tournament_tier', tier)
 	Variables.varDefine('tournament_tiertype', tierType)
+	--overwrite wiki var `tournament_liquipediatiertype` to allow `args.tiertype` as alias entry point for tiertype
 	Variables.varDefine('tournament_liquipediatiertype', tierType)
 	return output
 end

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -221,7 +221,9 @@ function CustomLeague:_createTierDisplay()
 		(hasInvalidTierType and '[[Category:Pages with invalid Tiertype]]' or '')
 
 	Variables.varDefine('tournament_tier', tier)
+	Variables.varDefine('tournament_liquipediatier', tier)
 	Variables.varDefine('tournament_tiertype', tierType)
+	Variables.varDefine('tournament_liquipediatiertype', tierType)
 	return output
 end
 


### PR DESCRIPTION
## Summary
Alternative to #699 
overwrites the liquipediatiertype wiki var on apex and sc2 so that the alias can be used

## How did you test this change?
pushed to live on sc2 (module not in use yet)
Apex change is the same