### PR TITLE
[SUGGESTION] Allow matches to be manually set as not finished

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -306,7 +306,7 @@ function matchFunctions.getOpponents(args)
 	end
 
 	-- see if match should actually be finished if score is set
-	if isScoreSet and not Logic.readBool(args.finished) then
+	if isScoreSet and Logic.readBoolOrNil(args.finished) == nil then
 		local currentUnixTime = os.time(os.date('!*t'))
 		local lang = mw.getContentLanguage()
 		local matchUnixTime = tonumber(lang:formatDate('U', args.date))

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -305,9 +305,9 @@ function matchFunctions.getOpponents(args)
 		args.resulttype = 'default'
 	end
 
-	local autofinished = String.isEmpty(args.autofinished) and args.autofinished or true
+	local autofinished = String.isNotEmpty(args.autofinished) and args.autofinished or true
 	-- see if match should actually be finished if score is set
-	if isScoreSet and not Logic.readBool(args.finished) and Logic.readBool(autofinished) then
+	if isScoreSet and Logic.readBool(autofinished) and not Logic.readBool(args.finished) then
 		local currentUnixTime = os.time(os.date('!*t'))
 		local lang = mw.getContentLanguage()
 		local matchUnixTime = tonumber(lang:formatDate('U', args.date))

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -305,8 +305,9 @@ function matchFunctions.getOpponents(args)
 		args.resulttype = 'default'
 	end
 
+	local autofinished = String.isEmpty(args.autofinished) and args.autofinished or true
 	-- see if match should actually be finished if score is set
-	if isScoreSet and Logic.readBoolOrNil(args.finished) == nil then
+	if isScoreSet and not Logic.readBool(args.finished) and Logic.readBool(autofinished) then
 		local currentUnixTime = os.time(os.date('!*t'))
 		local lang = mw.getContentLanguage()
 		local matchUnixTime = tonumber(lang:formatDate('U', args.date))


### PR DESCRIPTION
## Summary
 Allow matches to be manually set as not finished via `|finished=false`

## How did you test this change?
temporarily pushed to live