### PR TITLE
Normalize location and location2 before saving to lpdb (Infobox Team)

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -178,8 +178,8 @@ function Team:_setLpdbData(args, links)
 
 	local lpdbData = {
 		name = name,
-		location = _getStandardLocationValue(args.location),
-		location2 = _getStandardLocationValue(args.location2),
+		location = self:_getStandardLocationValue(args.location),
+		location2 = self:_getStandardLocationValue(args.location2),
 		logo = args.image,
 		logodark = args.imagedark or args.imagedarkmode,
 		createdate = args.created,

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -12,6 +12,8 @@ local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
 local Links = require('Module:Links')
 local Flags = require('Module:Flags')
+local String = require('Module:StringUtils')
+local WarningBox = require('Module:WarningBox')
 local BasicInfobox = require('Module:Infobox/Basic')
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -25,6 +27,8 @@ local Builder = Widgets.Builder
 local Team = Class.new(BasicInfobox)
 
 local _LINK_VARIANT = 'team'
+
+local _warnings = {}
 
 function Team.run(frame)
 	local team = Team(frame)
@@ -148,7 +152,7 @@ function Team:createInfobox()
 		self:defineCustomPageVariables(args)
 	end
 
-	return builtInfobox
+	return tostring(builtInfobox) .. WarningBox.displayMultiFromTable(_warnings)
 end
 
 function Team:_createRegion(region)
@@ -169,8 +173,22 @@ function Team:_createLocation(location)
 			'[[:Category:' .. location .. '|' .. location .. ']]'
 end
 
-function Team:_getStandardLocationValue(location)
-	return Flags.CountryName(location) or location
+function Team:getStandardLocationValue(location)
+	if String.isEmpty(location) then
+		return nil
+	end
+
+	local locationToStore = Flags.CountryName(location)
+
+	if String.isEmpty(locationToStore) then
+		table.insert(
+			_warnings,
+			'"' .. location .. '" is not supported as a value for locations'
+		)
+		locationToStore = nil
+	end
+
+	return locationToStore
 end
 
 function Team:_setLpdbData(args, links)
@@ -178,8 +196,8 @@ function Team:_setLpdbData(args, links)
 
 	local lpdbData = {
 		name = name,
-		location = self:_getStandardLocationValue(args.location),
-		location2 = self:_getStandardLocationValue(args.location2),
+		location = self:getStandardLocationValue(args.location),
+		location2 = self:getStandardLocationValue(args.location2),
 		logo = args.image,
 		logodark = args.imagedark or args.imagedarkmode,
 		createdate = args.created,

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -152,7 +152,7 @@ function Team:createInfobox()
 		self:defineCustomPageVariables(args)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayMultiFromTable(_warnings)
+	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
 end
 
 function Team:_createRegion(region)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -169,13 +169,17 @@ function Team:_createLocation(location)
 			'[[:Category:' .. location .. '|' .. location .. ']]'
 end
 
+function Team:_getStandardLocationValue(location)
+	return Flags.CountryName(location) or location
+end
+
 function Team:_setLpdbData(args, links)
 	local name = args.romanized_name or self.name
 
 	local lpdbData = {
 		name = name,
-		location = args.location,
-		location2 = args.location2,
+		location = _getStandardLocationValue(args.location),
+		location2 = _getStandardLocationValue(args.location2),
 		logo = args.image,
 		logodark = args.imagedark or args.imagedarkmode,
 		createdate = args.created,

--- a/components/infobox/wikis/halo/infobox_team_custom.lua
+++ b/components/infobox/wikis/halo/infobox_team_custom.lua
@@ -9,7 +9,6 @@
 local Team = require('Module:Infobox/Team')
 local Earnings = require('Module:Earnings')
 local Variables = require('Module:Variables')
-local Flags = require('Module:Flags')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
@@ -63,7 +62,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomTeam:_createRegion(region, location)
-	region = Region.run({region = region, country = CustomTeam:_getStandardLocationValue(location)})
+	region = Region.run({region = region, country = Team:getStandardLocationValue(location)})
 	if type(region) == 'table' then
 		_region = region.region
 		return region.display
@@ -85,15 +84,9 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		lpdbData.extradata['earningsin' .. year] = (earningsInYear or ''):gsub(',', ''):gsub('$', '')
 	end
 
-	lpdbData.location = CustomTeam:_getStandardLocationValue(_team.args.location)
-	lpdbData.location2 = CustomTeam:_getStandardLocationValue(_team.args.location2)
 	lpdbData.region = _region
 
 	return lpdbData
-end
-
-function CustomTeam:_getStandardLocationValue(location)
-	return Flags.CountryName(location) or location
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -140,13 +140,7 @@ end
 function CustomTeam:addToLpdb(lpdbData)
 	lpdbData.earnings = _earnings or 0
 	lpdbData.region = nil
-	lpdbData.location = CustomTeam._getStandardLocationValue(_team.args.location)
-	lpdbData.location2 = CustomTeam._getStandardLocationValue(_team.args.location2)
 	return lpdbData
-end
-
-function CustomTeam._getStandardLocationValue(location)
-	return Flags.CountryName(location) or location
 end
 
 function CustomTeam.playerBreakDown(args)

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -8,7 +8,6 @@
 
 local Team = require('Module:Infobox/Team')
 local Variables = require('Module:Variables')
-local Flags = require('Module:Flags')
 local String = require('Module:StringUtils')
 local Achievements = require('Module:Achievements in infoboxes')
 local RaceIcon = require('Module:RaceIcon').getSmallIcon


### PR DESCRIPTION
## Summary

Normalize the input values of location and location2. 
Two of the three wikis using standardised team infobox does this already in custom's (sc2 & halo), while the 3rd (rl) has no queries looking at lpdb_team.location. 

## How does the normalization on the user input work?

The implementation uses Module:Flags function CountryName(). That function converts a country name, flag code, or alias to a standardized country name.

Examples on how the normalization/standardization work:
- uk -> United Kingdom
- eu -> Europe
- fRanCe -> France
- Holland -> Netherlands

Starcraft2 & Halo wikis already do this. It would be an addition for Rocket League, but as previously said, Rocket League have no identified dependencies on the field. 

## How did you test this change?

SC2: Tested by hjp (sandboxes)
Halo: Tested by me on Liquid using sandboxes
RL: Tested by me on G2 & FaZe using sandboxes