### PR TITLE
Create Infobox/Hero for Mobile Legends

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Unit = require('Module:Infobox/Unit/dev')
+local Unit = require('Module:Infobox/Unit')
 local String = require('Module:StringUtils')
 local Namespace = require('Module:Namespace')
 local ClassIcon = require('Module:ClassIcon')
@@ -18,7 +18,6 @@ local Table = require('Module:Table')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local Header = require('Module:Infobox/Widget/Header')
 local Breakdown = require('Module:Infobox/Widget/Breakdown')
 
 local CustomHero = {}
@@ -79,16 +78,16 @@ function CustomInjector:addCustomCells()
 	end
 	table.insert(widgets, Title{name = 'Esports Statistics'})
 	
-function _HeroStatsDisplay() 
-			local stats = HeroWL.create({hero = _args.heroname or _pagename})
-			stats = mw.text.split(stats, ';')
-			local winPercentage = (tonumber(stats[1]) or 0) / ((tonumber(stats[1]) or 0) + (tonumber(stats[2]) or 1))
-			winPercentage = Math.round({winPercentage, 4}) * 100
-			local statsDisplay = (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
+function HeroStatsDisplay()
+		local stats = HeroWL.create({hero = _args.heroname or _pagename})
+		stats = mw.text.split(stats, ';')
+		local winPercentage = (tonumber(stats[1]) or 0) / ((tonumber(stats[1]) or 0) + (tonumber(stats[2]) or 1))
+		winPercentage = Math.round({winPercentage, 4}) * 100
+		local HeroStatsDisplay = (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
 	return stats
 end
 	
-			table.insert(widgets, Cell{name = 'Win Rate', content = {_HeroStatsDisplay}})
+		table.insert(widgets, Cell{name = 'Win Rate', content = {_HeroStatsDisplay}})
 
 	return widgets
 end

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -78,18 +78,15 @@ function CustomInjector:addCustomCells()
 	end
 	table.insert(widgets, Title{name = 'Esports Statistics'})
 
-function HeroStatsDisplay()
-		local stats = HeroWL.create({hero = _args.heroname or _pagename})
-		stats = mw.text.split(stats, ';')
-		local winPercentage = (tonumber(stats[1]) or 0) / ((tonumber(stats[1]) or 0) + (tonumber(stats[2]) or 1))
-		winPercentage = Math.round({winPercentage, 4}) * 100
-		local HeroStatsDisplay = (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
-	return stats
+	table.insert(widgets, Cell{name = 'Win Rate', content = {CustomHero._heroStatsDisplay()}})
+	return widgets
 end
 
-		table.insert(widgets, Cell{name = 'Win Rate', content = {HeroStatsDisplay}})
-
-	return widgets
+function CustomHero._heroStatsDisplay()
+	local stats = mw.text.split(HeroWL.create({hero = _args.heroname or _pagename}), ';')
+	local winPercentage = (tonumber(stats[1]) or 0) / ((tonumber(stats[1]) or 0) + (tonumber(stats[2]) or 1))
+	winPercentage = Math.round({winPercentage, 4}) * 100
+	return (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -76,8 +76,8 @@ function CustomInjector:addCustomCells()
 			table.insert(widgets, Cell{name = display, content = {_args[key]}})
 		end
 	end
-	table.insert(widgets, Title{name = 'Esports Statistics'})
 
+	table.insert(widgets, Title{name = 'Esports Statistics'})
 	table.insert(widgets, Cell{name = 'Win Rate', content = {CustomHero._heroStatsDisplay()}})
 	return widgets
 end
@@ -91,33 +91,32 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'type' then
+		local breakDowns = {
+			lane = 'Lane',
+			primaryrole = 'Primary Role',
+			secondaryrole = 'Secondary Role',
+		}
 		local breakDownContents = {}
-		local lane = _args.lane
-		if String.isNotEmpty(lane) then
-			lane = '<b>Lane</b><br>' .. ClassIcon.display({}, lane)
-			table.insert(breakDownContents, lane)
-		end
-		local primaryRole = _args.primaryrole
-		if String.isNotEmpty(primaryRole) then
-			primaryRole = '<b>Primary Role</b><br>' .. ClassIcon.display({}, primaryRole)
-			table.insert(breakDownContents, primaryRole)
-		end
-		local secondaryRole = _args.secondaryrole
-		if String.isNotEmpty(secondaryRole) then
-			secondaryRole = '<b>Secondary Role</b><br>' .. ClassIcon.display({}, secondaryRole)
-			table.insert(breakDownContents, secondaryRole)
+		for key, display in pairs(breakDowns) do
+			if String.isNotEmpty(_args[key]) then
+				lane = '<b>'.. display..'</b><br>' .. ClassIcon.display({}, _args[key])
+				table.insert(breakDownContents, _args[key])
+			end
 		end
 		return {
 			Breakdown{classes = {'infobox-center'}, content = breakDownContents},
 			Cell{name = 'Real Name', content = {_args.realname}},
 		}
 	elseif id == 'cost' then
+		local costTypes = {
+			costbp = _BATTLE_POINTS_ICON,
+			costdia = _DIAMONDS_ICON,
+		}
 		local costs = {}
-		if String.isNotEmpty(_args.costbp) then
-			table.insert(costs, _args.costbp .. ' ' .. _BATTLE_POINTS_ICON)
-		end
-		if String.isNotEmpty(_args.costdia) then
-			table.insert(costs, _args.costdia .. ' ' .. _DIAMONDS_ICON)
+		for key, icon in pairs(breakDowns) do
+			if String.isNotEmpty(_args[key]) then
+				table.insert(costs, _args[key] .. ' ' .. icon)
+			end
 		end
 		return {
 			Cell{name = 'Price', content = {table.concat(costs, '&emsp;&ensp;')}},
@@ -135,11 +134,11 @@ function CustomHero.getWikiCategories()
 	local categories = {}
 	if Namespace.isMain() then
 		categories = {'Heroes'}
-		if String.isNotEmpty(_args.attacktype) then
-			table.insert(categories, _args.attacktype .. ' Heroes')
-		end
-		if String.isNotEmpty(_args.primaryrole) then
-			table.insert(categories, _args.primaryrole .. ' Heroes')
+		local categoryDefinitions = {attacktype, primaryrole}
+		for _, key in pairs(categoryDefinitions) do
+			if String.isNotEmpty(_args[key]) then
+				table.insert(costs, _args[key] .. ' Heroes')
+			end
 		end
 	end
 	return categories

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -77,7 +77,7 @@ function CustomInjector:addCustomCells()
 		end
 	end
 	table.insert(widgets, Title{name = 'Esports Statistics'})
-	
+
 function HeroStatsDisplay()
 		local stats = HeroWL.create({hero = _args.heroname or _pagename})
 		stats = mw.text.split(stats, ';')
@@ -86,8 +86,8 @@ function HeroStatsDisplay()
 		local HeroStatsDisplay = (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
 	return stats
 end
-	
-		table.insert(widgets, Cell{name = 'Win Rate', content = {_HeroStatsDisplay}})
+
+		table.insert(widgets, Cell{name = 'Win Rate', content = {HeroStatsDisplay}})
 
 	return widgets
 end

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -99,8 +99,8 @@ function CustomInjector:parse(id, widgets)
 		local breakDownContents = {}
 		for key, display in pairs(breakDowns) do
 			if String.isNotEmpty(_args[key]) then
-				lane = '<b>'.. display..'</b><br>' .. ClassIcon.display({}, _args[key])
-				table.insert(breakDownContents, _args[key])
+				local displayText = '<b>'.. display..'</b><br>' .. ClassIcon.display({}, _args[key])
+				table.insert(breakDownContents, displayText)
 			end
 		end
 		return {
@@ -113,7 +113,7 @@ function CustomInjector:parse(id, widgets)
 			costdia = _DIAMONDS_ICON,
 		}
 		local costs = {}
-		for key, icon in pairs(breakDowns) do
+		for key, icon in pairs(costTypes) do
 			if String.isNotEmpty(_args[key]) then
 				table.insert(costs, _args[key] .. ' ' .. icon)
 			end
@@ -134,10 +134,10 @@ function CustomHero.getWikiCategories()
 	local categories = {}
 	if Namespace.isMain() then
 		categories = {'Heroes'}
-		local categoryDefinitions = {attacktype, primaryrole}
+		local categoryDefinitions = {'attacktype', 'primaryrole'}
 		for _, key in pairs(categoryDefinitions) do
 			if String.isNotEmpty(_args[key]) then
-				table.insert(costs, _args[key] .. ' Heroes')
+				table.insert(categories, _args[key] .. ' Heroes')
 			end
 		end
 	end

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -6,13 +6,14 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Unit = require('Module:Infobox/Unit')
+local Unit = require('Module:Infobox/Unit/dev')
 local String = require('Module:StringUtils')
 local Namespace = require('Module:Namespace')
 local ClassIcon = require('Module:ClassIcon')
 local Math = require('Module:Math')
 local HeroWL = require('Module:HeroWL')
 local Class = require('Module:Class')
+local Table = require('Module:Table')
 
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
@@ -20,7 +21,7 @@ local Title = require('Module:Infobox/Widget/Title')
 local Header = require('Module:Infobox/Widget/Header')
 local Breakdown = require('Module:Infobox/Widget/Breakdown')
 
-local CustomHero = Class.new()
+local CustomHero = {}
 
 local CustomInjector = Class.new(Injector)
 
@@ -28,8 +29,8 @@ local _args
 
 local _pagename = mw.title.getCurrentTitle().text
 
-local _BATTLE_POINTS_ICON = '[[File:Mobile_Legends_BP_icon.png|x16px|Battle Points|link=Battle Points]]'
-local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Diamonds|x16px|link=Diamonds]]'
+local _BATTLE_POINTS_ICON = '[[File:Mobile_Legends_BP_icon.png|x16px|Battle Points|link=Battle Point]]'
+local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Diamonds|x16px|link=Diamond]]'
 
 function CustomHero.run(frame)
 	local unit = Unit(frame)
@@ -45,64 +46,55 @@ end
 
 function CustomInjector:addCustomCells()
 	local widgets = {
-		Cell{name = 'Resource Bar', content = {_args.secondarybar}},
-		Cell{name = 'Secondary Bar', content = {_args.secondarybar1}},
+		Cell{name = 'Specialty', content = {_args.specialty}},
+		Cell{name = 'Attack Type', content = {_args.attacktype}},
+		Cell{name = 'Resource Bar', content = {_args.resourcebar}},
+		Cell{name = 'Secondary Bar', content = {_args.secondarybar}},
 		Cell{name = 'Secondary Attributes', content = {_args.secondaryattributes1}},
 		Cell{name = 'Release Date', content = {_args.releasedate}},
-		Cell{name = 'Species', content = {_args.species}},
-		Cell{name = 'Year of birth', content = {_args.birth}},
-		Cell{name = 'Faction(s)', content = {_args.factions}},
 	}
 
-	if
-		String.isNotEmpty(_args.hp) or
-		String.isNotEmpty(_args.hplvl) or
-		String.isNotEmpty(_args.hpreg) or
-		String.isNotEmpty(_args.hpreglvl)
-	then
+	local statisticsCells = {
+		hp = 'Health',
+		hpreg = 'Health Regen',
+		mana = 'Mana',
+		manareg = 'Mana Regen',
+		cdr = 'Cooldown Reduction',
+		energy = 'Energy',
+		energyreg = 'Energy Regen',
+		attacktype = 'Attack Type',
+		damage = 'Attack Damage',
+		attackspeed = 'Attack Speed',
+		attackrange = 'Attack Range',
+		ap = 'Ability Power',
+		armor = 'Armor',
+		magicresistance = 'Magic Resistance',
+		movespeed = 'Movement Speed',
+	}
+	if Table.any(_args, function(key) return statisticsCells[key] end) then
 		table.insert(widgets, Title{name = 'Base Statistics'})
+		for key, display in pairs(statisticsCells) do
+			table.insert(widgets, Cell{name = display, content = {_args[key]}})
+		end
 	end
-
-	table.insert(widgets, Cell{name = 'Health', content = {_args.hp}})
-	table.insert(widgets, Cell{name = 'Health Regen', content = {_args.hpreg}})
-	table.insert(widgets, Cell{name = 'Mana', content = {_args.mana}})
-	table.insert(widgets, Cell{name = 'Mana Regen', content = {_args.manareg}})
-	table.insert(widgets, Cell{name = 'Cooldown Reduction', content = {_args.cdr}})
-	table.insert(widgets, Cell{name = 'Energy', content = {_args.energy}})
-	table.insert(widgets, Cell{name = 'Energy Regen', content = {_args.energyreg}})
-	table.insert(widgets, Cell{name = 'Attack Type', content = {_args.attacktype}})
-	table.insert(widgets, Cell{name = 'Attack Damage', content = {_args.damage}})
-	table.insert(widgets, Cell{name = 'Attack Speed', content = {_args.attackspeed}})
-	table.insert(widgets, Cell{name = 'Attack Range', content = {_args.attackrange}})
-	table.insert(widgets, Cell{name = 'Ability Power', content = {_args.ap}})
-	table.insert(widgets, Cell{name = 'Armor', content = {_args.armor}})
-	table.insert(widgets, Cell{name = 'Magic Resistance', content = {_args.magicresistance}})
-	table.insert(widgets, Cell{name = 'Movement Speed', content = {_args.movespeed}})
 	table.insert(widgets, Title{name = 'Esports Statistics'})
-
-	local stats = HeroWL.create({hero = _args.heroname or _pagename})
-	stats = mw.text.split(stats, ';')
-	local winPercentage = (tonumber(stats[1]) or 0) / ((tonumber(stats[1]) or 0) + (tonumber(stats[2]) or 1))
-	winPercentage = Math.round({winPercentage, 4}) * 100
-	local statsDisplay = (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
-	table.insert(widgets, Cell{name = 'Win Rate', content = {statsDisplay}})
+	
+function _HeroStatsDisplay() 
+			local stats = HeroWL.create({hero = _args.heroname or _pagename})
+			stats = mw.text.split(stats, ';')
+			local winPercentage = (tonumber(stats[1]) or 0) / ((tonumber(stats[1]) or 0) + (tonumber(stats[2]) or 1))
+			winPercentage = Math.round({winPercentage, 4}) * 100
+			local statsDisplay = (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
+	return stats
+end
+	
+			table.insert(widgets, Cell{name = 'Win Rate', content = {_HeroStatsDisplay}})
 
 	return widgets
 end
 
 function CustomInjector:parse(id, widgets)
-	if id == 'header' then
-		return {
-			Header{
-				name = _args.heroname,
-				subHeader = _args.title,
-				image = _args.image,
-				imageDefault = _args.default,
-				imageDark = _args.imagedark or _args.imagedarkmode,
-				imageDefaultDark = _args.defaultdark or _args.defaultdarkmode,
-			},
-		}
-	elseif id == 'type' then
+	if id == 'type' then
 		local breakDownContents = {}
 		local lane = _args.lane
 		if String.isNotEmpty(lane) then

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -1,0 +1,180 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:Infobox/Unit/Hero
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Unit = require('Module:Infobox/Unit')
+local String = require('Module:StringUtils')
+local Namespace = require('Module:Namespace')
+local Template = require('Module:Template')
+local Math = require('Module:Math')
+local HeroWL = require('Module:HeroWL')
+local Class = require('Module:Class')
+
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Center = require('Module:Infobox/Widget/Center')
+local Title = require('Module:Infobox/Widget/Title')
+local Header = require('Module:Infobox/Widget/Header')
+local Breakdown = require('Module:Infobox/Widget/Breakdown')
+
+local CustomHero = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+local _pagename = mw.title.getCurrentTitle().text
+local _frame
+
+local _BATTLE_POINTS_ICON = '[[File:Mobile_Legends_BP_icon.png|x16px|Blue Essence|link=Battle Points]]'
+local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Riot Points|x16px|link=Diamond]]'
+
+function CustomHero.run(frame)
+	local unit = Unit(frame)
+	_args = unit.args
+	_frame = frame
+	_args.informationType = 'Hero'
+
+	unit.getWikiCategories = CustomHero.getWikiCategories
+	unit.setLpdbData = CustomHero.setLpdbData
+	unit.createWidgetInjector = CustomHero.createWidgetInjector
+
+	return unit:createInfobox(frame)
+end
+
+function CustomInjector:addCustomCells()
+	local widgets = {
+		Cell{name = 'Resource Bar', content = {_args.secondarybar}},
+		Cell{name = 'Secondary Bar', content = {_args.secondarybar1}},
+		Cell{name = 'Secondary Attributes', content = {_args.secondaryattributes1}},
+		Cell{name = 'Release Date', content = {_args.releasedate}},
+		Cell{name = 'Species', content = {_args.species}},
+		Cell{name = 'Year of birth', content = {_args.birth}},
+		Cell{name = 'Faction(s)', content = {_args.factions}},
+	}
+
+	if not (
+		String.isEmpty(_args.hp) and
+		String.isEmpty(_args.hplvl) and
+		String.isEmpty(_args.hpreg) and
+		String.isEmpty(_args.hpreglvl)
+	) then
+		table.insert(widgets, Title{name = 'Base Statistics'})
+	end
+
+	table.insert(widgets, Cell{name = 'Health', content = {_args.hp}})
+	table.insert(widgets, Cell{name = 'Health Regen', content = {_args.hpreg}})
+	table.insert(widgets, Cell{name = 'Mana', content = {_args.mana}})
+	table.insert(widgets, Cell{name = 'Mana Regen', content = {_args.manareg}})
+	table.insert(widgets, Cell{name = 'Cooldown Reduction', content = {_args.cdr}})
+	table.insert(widgets, Cell{name = 'Energy', content = {_args.energy}})
+	table.insert(widgets, Cell{name = 'Energy Regen', content = {_args.energyreg}})
+	table.insert(widgets, Cell{name = 'Attack Type', content = {_args.attacktype}})
+	table.insert(widgets, Cell{name = 'Attack Damage', content = {_args.damage}})
+	table.insert(widgets, Cell{name = 'Attack Speed', content = {_args.attackspeed}})
+	table.insert(widgets, Cell{name = 'Attack Range', content = {_args.attackrange}})
+	table.insert(widgets, Cell{name = 'Ability Power', content = {_args.ap}})
+	table.insert(widgets, Cell{name = 'Armor', content = {_args.armor}})
+	table.insert(widgets, Cell{name = 'Magic Resistance', content = {_args.magicresistance}})
+	table.insert(widgets, Cell{name = 'Movement Speed', content = {_args.movespeed}})
+	table.insert(widgets, Title{name = 'Esports Statistics'})
+
+	local stats = HeroWL.create({hero = _args.heroname or _pagename})
+	stats = mw.text.split(stats, ';')
+	local winPercentage = (tonumber(stats[1]) or 0) / ((tonumber(stats[1]) or 0) + (tonumber(stats[2]) or 1))
+	winPercentage = Math.round({winPercentage, 4}) * 100
+	local statsDisplay = (stats[1] or 0) .. 'W : ' .. (stats[2] or 0) .. 'L (' .. winPercentage .. '%)'
+	table.insert(widgets, Cell{name = 'Win Rate', content = {statsDisplay}})
+
+	return widgets
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'header' then
+		return {
+			Header{
+				name = _args.heroname,
+				subHeader = _args.title,
+				image = _args.image,
+				imageDefault = _args.default,
+				imageDark = _args.imagedark or _args.imagedarkmode,
+				imageDefaultDark = _args.defaultdark or _args.defaultdarkmode,
+			},
+		}
+	elseif id == 'caption' then
+		table.insert(widgets, Center{content = {_args.quote}})
+	elseif id == 'type' then
+		local breakDownContents = {}
+		local lane = _args.lane
+		if not String.isEmpty(lane) then
+			lane = '<b>Lane</b><br>' .. Template.safeExpand(_frame, 'Class icon', {lane}, '')
+			table.insert(breakDownContents, lane)
+		end
+		local primaryRole = _args.primaryrole
+		if not String.isEmpty(primaryRole) then
+			primaryRole = '<b>Primary Role</b><br>' .. Template.safeExpand(_frame, 'Class icon', {primaryRole}, '')
+			table.insert(breakDownContents, primaryRole)
+		end
+		local secondaryRole = _args.secondaryrole
+		if not String.isEmpty(secondaryRole) then
+			secondaryRole = '<b>Secondary Role</b><br>' .. Template.safeExpand(_frame, 'Class icon', {secondaryRole}, '')
+			table.insert(breakDownContents, secondaryRole)
+		end
+		return {
+			Breakdown{classes = {'infobox-center'}, content = breakDownContents},
+			Cell{name = 'Real Name', content = {_args.realname}},
+		}
+	elseif id == 'cost' then
+		local cost = ''
+		if not String.isEmpty(_args.costbp) then
+			cost = cost .. _args.costbp .. ' ' .. _BATTLE_POINTS_ICON
+		end
+		if not String.isEmpty(_args.costdia) then
+			if cost ~= '' then
+				cost = cost .. '&emsp;&ensp;'
+			end
+			cost = cost .. _args.costdia .. ' ' .. _DIAMONDS_ICON
+		end
+		return {
+			Cell{name = 'Price', content = {cost}},
+		}
+	end
+
+	return widgets
+end
+
+function CustomHero:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomHero.getWikiCategories()
+	local categories = {}
+	if Namespace.isMain() then
+		categories = {'Heroes'}
+		if not String.isEmpty(_args.attacktype) then
+			table.insert(categories, _args.attacktype .. ' Heroes')
+		end
+		if not String.isEmpty(_args.primaryrole) then
+			table.insert(categories, _args.primaryrole .. ' Heroes')
+		end
+	end
+	return categories
+end
+
+function CustomHero.setLpdbData()
+	local lpdbData = {
+		type = 'hero',
+		name = _args.heroname or _pagename,
+		image = _args.image,
+		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
+			releasedate = _args.releasedate,
+		})
+	}
+	mw.ext.LiquipediaDB.lpdb_datapoint('hero_' .. (_args.heroname or _pagename), lpdbData)
+end
+
+return CustomHero

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -16,7 +16,6 @@ local Class = require('Module:Class')
 
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
-local Center = require('Module:Infobox/Widget/Center')
 local Title = require('Module:Infobox/Widget/Title')
 local Header = require('Module:Infobox/Widget/Header')
 local Breakdown = require('Module:Infobox/Widget/Breakdown')
@@ -28,7 +27,6 @@ local CustomInjector = Class.new(Injector)
 local _args
 
 local _pagename = mw.title.getCurrentTitle().text
-local _frame
 
 local _BATTLE_POINTS_ICON = '[[File:Mobile_Legends_BP_icon.png|x16px|Battle Points|link=Battle Points]]'
 local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Diamonds|x16px|link=Diamonds]]'
@@ -36,7 +34,6 @@ local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Diamonds|x16px|li
 function CustomHero.run(frame)
 	local unit = Unit(frame)
 	_args = unit.args
-	_frame = frame
 	_args.informationType = 'Hero'
 
 	unit.getWikiCategories = CustomHero.getWikiCategories

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -105,8 +105,6 @@ function CustomInjector:parse(id, widgets)
 				imageDefaultDark = _args.defaultdark or _args.defaultdarkmode,
 			},
 		}
-	elseif id == 'caption' then
-		table.insert(widgets, Center{content = {_args.quote}})
 	elseif id == 'type' then
 		local breakDownContents = {}
 		local lane = _args.lane

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -9,7 +9,7 @@
 local Unit = require('Module:Infobox/Unit')
 local String = require('Module:StringUtils')
 local Namespace = require('Module:Namespace')
-local Template = require('Module:Template')
+local ClassIcon = require('Module:ClassIcon')
 local Math = require('Module:Math')
 local HeroWL = require('Module:HeroWL')
 local Class = require('Module:Class')
@@ -57,12 +57,12 @@ function CustomInjector:addCustomCells()
 		Cell{name = 'Faction(s)', content = {_args.factions}},
 	}
 
-	if not (
-		String.isEmpty(_args.hp) and
-		String.isEmpty(_args.hplvl) and
-		String.isEmpty(_args.hpreg) and
-		String.isEmpty(_args.hpreglvl)
-	) then
+	if
+		String.isNotEmpty(_args.hp) or
+		String.isNotEmpty(_args.hplvl) or
+		String.isNotEmpty(_args.hpreg) or
+		String.isNotEmpty(_args.hpreglvl)
+	then
 		table.insert(widgets, Title{name = 'Base Statistics'})
 	end
 
@@ -110,18 +110,18 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'type' then
 		local breakDownContents = {}
 		local lane = _args.lane
-		if not String.isEmpty(lane) then
-			lane = '<b>Lane</b><br>' .. Template.safeExpand(_frame, 'Class icon', {lane}, '')
+		if String.isNotEmpty(lane) then
+			lane = '<b>Lane</b><br>' .. ClassIcon.display({}, lane)
 			table.insert(breakDownContents, lane)
 		end
 		local primaryRole = _args.primaryrole
-		if not String.isEmpty(primaryRole) then
-			primaryRole = '<b>Primary Role</b><br>' .. Template.safeExpand(_frame, 'Class icon', {primaryRole}, '')
+		if String.isNotEmpty(primaryRole) then
+			primaryRole = '<b>Primary Role</b><br>' .. ClassIcon.display({}, primaryRole)
 			table.insert(breakDownContents, primaryRole)
 		end
 		local secondaryRole = _args.secondaryrole
-		if not String.isEmpty(secondaryRole) then
-			secondaryRole = '<b>Secondary Role</b><br>' .. Template.safeExpand(_frame, 'Class icon', {secondaryRole}, '')
+		if String.isNotEmpty(secondaryRole) then
+			secondaryRole = '<b>Secondary Role</b><br>' .. ClassIcon.display({}, secondaryRole)
 			table.insert(breakDownContents, secondaryRole)
 		end
 		return {
@@ -129,18 +129,15 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Real Name', content = {_args.realname}},
 		}
 	elseif id == 'cost' then
-		local cost = ''
-		if not String.isEmpty(_args.costbp) then
-			cost = cost .. _args.costbp .. ' ' .. _BATTLE_POINTS_ICON
+		local costs = {}
+		if String.isNotEmpty(_args.costbp) then
+			table.insert(costs, _args.costbp .. ' ' .. _BATTLE_POINTS_ICON)
 		end
-		if not String.isEmpty(_args.costdia) then
-			if cost ~= '' then
-				cost = cost .. '&emsp;&ensp;'
-			end
-			cost = cost .. _args.costdia .. ' ' .. _DIAMONDS_ICON
+		if String.isNotEmpty(_args.costdia) then
+			table.insert(costs, _args.costdia .. ' ' .. _DIAMONDS_ICON)
 		end
 		return {
-			Cell{name = 'Price', content = {cost}},
+			Cell{name = 'Price', content = {table.concat(costs, '&emsp;&ensp;')}},
 		}
 	end
 
@@ -155,10 +152,10 @@ function CustomHero.getWikiCategories()
 	local categories = {}
 	if Namespace.isMain() then
 		categories = {'Heroes'}
-		if not String.isEmpty(_args.attacktype) then
+		if String.isNotEmpty(_args.attacktype) then
 			table.insert(categories, _args.attacktype .. ' Heroes')
 		end
-		if not String.isEmpty(_args.primaryrole) then
+		if String.isNotEmpty(_args.primaryrole) then
 			table.insert(categories, _args.primaryrole .. ' Heroes')
 		end
 	end

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -30,8 +30,8 @@ local _args
 local _pagename = mw.title.getCurrentTitle().text
 local _frame
 
-local _BATTLE_POINTS_ICON = '[[File:Mobile_Legends_BP_icon.png|x16px|Blue Essence|link=Battle Points]]'
-local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Riot Points|x16px|link=Diamond]]'
+local _BATTLE_POINTS_ICON = '[[File:Mobile_Legends_BP_icon.png|x16px|Battle Points|link=Battle Points]]'
+local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Diamonds|x16px|link=Diamonds]]'
 
 function CustomHero.run(frame)
 	local unit = Unit(frame)


### PR DESCRIPTION
## Summary

Infobox Hero for the Mobile Legends Wiki
Module: https://liquipedia.net/mobilelegends/Module:Infobox/Unit/Hero
Template: https://liquipedia.net/mobilelegends/index.php?title=Template:Infobox_hero&action=edit

Both is derived from Wild Rift version which got both these added just a week ago, few parameters have been changed adjusted including

- costbe and costrp has been replaced by **costbp** and **costdia** to reflect the actual currency for those games (icon files already provided)

- everything that says Champion in it has been changed to be Hero, as Mobile Legends dont called their character Champion

- Rest of Base Stats are unchanged, as they are all present in both games

- **Region** as in LoL werent existed nor being properly mentioned in the game, however, Mobile Legends replaced this with a "Lane" section that provides their recommended lane  made for each hero

- The template similar to Wild Rift, is able to centered Lane and Primary Role, in case **noscr** is enabled for heroes that doesnt represented two roles at the same time

## How did you test this change?

![image](https://user-images.githubusercontent.com/88981446/141643431-f0d65b0f-3adb-4939-93db-d4f9bdb1b3c4.png)
https://liquipedia.net/mobilelegends/Chou

![image](https://user-images.githubusercontent.com/88981446/141643444-734dd8cd-5302-444f-aea7-3e583c87ce70.png)
https://liquipedia.net/mobilelegends/Zilong



