### PR TITLE
Create Infobox/Player for Mobile Legends

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
@@ -86,11 +86,6 @@ function CustomPlayer:adjustLPDB(lpdbData)
 		role2 = _role2.role
 	}
 
-	local region = Region.run({region = _args.region, country = _args.country})
-	if type(region) == 'table' then
-		lpdbData.region = region.region
-	end
-
 	return lpdbData
 end
 

--- a/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
@@ -86,6 +86,11 @@ function CustomPlayer:adjustLPDB(lpdbData)
 		role2 = _role2.role
 	}
 
+	local region = Region.run({region = _args.region, country = _args.country})
+	if type(region) == 'table' then
+		lpdbData.region = region.region
+	end
+
 	return lpdbData
 end
 

--- a/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
@@ -1,0 +1,97 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:Infobox/Person/Player
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Player = require('Module:Infobox/Person')
+local String = require('Module:StringUtils')
+local Class = require('Module:Class')
+local Earnings = require('Module:Earnings')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Role = require('Module:Role')
+local Region = require('Module:Region')
+
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local Center = require('Module:Infobox/Widget/Center')
+
+local _pagename = mw.title.getCurrentTitle().prefixedText
+local _role
+local _role2
+local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
+
+local CustomPlayer = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+function CustomPlayer.run(frame)
+	local player = Player(frame)
+	_args = player.args
+
+	player.calculateEarnings = CustomPlayer.calculateEarnings
+	player.adjustLPDB = CustomPlayer.adjustLPDB
+	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+
+	return player:createInfobox(frame)
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'history' then
+		local manualHistory = _args.history
+		local automatedHistory = TeamHistoryAuto._results({
+			convertrole = 'true',
+			player = _pagename
+		}) or ''
+		automatedHistory = tostring(automatedHistory)
+		if automatedHistory == _EMPTY_AUTO_HISTORY then
+			automatedHistory = nil
+		end
+
+		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+			return {
+				Title{name = 'History'},
+				Center{content = {manualHistory}},
+				Center{content = {automatedHistory}},
+			}
+		end
+	elseif id == 'region' then return {}
+	elseif id == 'role' then
+		_role = Role.run({role = _args.role})
+		_role2 = Role.run({role = _args.role2})
+		return {
+			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
+		}
+	end
+	return widgets
+end
+
+function CustomPlayer:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomPlayer:calculateEarnings()
+	return Earnings.calc_player({ args = { player = _pagename }})
+end
+
+function CustomPlayer:adjustLPDB(lpdbData)
+	lpdbData.extradata = {
+		isplayer = _role.isPlayer or 'true',
+		role = _role.role,
+		role2 = _role2.role
+	}
+
+	local region = Region.run({region = _args.region, country = _args.country})
+	if type(region) == 'table' then
+		lpdbData.region = region.region
+	end
+
+	return lpdbData
+end
+
+return CustomPlayer

--- a/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_player_custom.lua
@@ -9,7 +9,6 @@
 local Player = require('Module:Infobox/Person')
 local String = require('Module:StringUtils')
 local Class = require('Module:Class')
-local Earnings = require('Module:Earnings')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Role = require('Module:Role')
 local Region = require('Module:Region')
@@ -34,7 +33,6 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_args = player.args
 
-	player.calculateEarnings = CustomPlayer.calculateEarnings
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
@@ -73,10 +71,6 @@ end
 
 function CustomPlayer:createWidgetInjector()
 	return CustomInjector()
-end
-
-function CustomPlayer:calculateEarnings()
-	return Earnings.calc_player({ args = { player = _pagename }})
 end
 
 function CustomPlayer:adjustLPDB(lpdbData)


### PR DESCRIPTION
## Summary

Infobox Player for the Mobile Legends Wiki
Module: https://liquipedia.net/mobilelegends/Module:Infobox/Person/Player
Template: https://liquipedia.net/mobilelegends/index.php?title=Template:Infobox_player&action=edit

Both is derived from Halo version couple months ago (Halo for comparision: https://liquipedia.net/halo/index.php?title=Module:Infobox/Person/Player&action=edit) , few parameters have been changed adjusted including

- Removal of game appearances, as Mobile Legends doesnt hosted multiple games, those are no ned

Beside that nothing differs from Halo.

## How did you test this change?

![image](https://user-images.githubusercontent.com/88981446/141643916-b2c5a53f-7584-44a9-bd36-9d1bfee9bde1.png)
https://liquipedia.net/mobilelegends/XINNN


