### PR TITLE
Add Display Type SingleMatch

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -71,12 +71,27 @@ Called from MatchGroup/Display
 -- @returns module
 ]]
 function WikiSpecificBase.getMatchGroupContainer(matchGroupType)
-	if matchGroupType == 'matchlist' then
-		return Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
-	elseif matchGroupType == 'singleMatch' then
-		return Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true}).SingleMatchContainer
-	else
-		return Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true}).BracketContainer
+	return matchGroupType == 'matchlist'
+		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
+		or Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true}).BracketContainer
+end
+
+--[[
+Returns a display component for single match. The display component must
+be a container, i.e. it takes in a match ID rather than a matches.
+See the default implementation (pointed to below) for details.
+
+To customize single match display for a wiki, override this to return
+a display component with the wiki-specific customizations.
+
+Called from MatchGroup/Display
+
+-- @returns module
+]]
+function WikiSpecificBase.getMatchContainer(displayMode)
+    if displayMode == 'singleMatch' then
+        -- Single match, displayed flat on a page (no popup)
+        return Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true}).SingleMatchContainer
 	end
 end
 

--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -73,8 +73,8 @@ Called from MatchGroup/Display
 function WikiSpecificBase.getMatchGroupContainer(matchGroupType)
 	if matchGroupType == 'matchlist' then
 		return Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
-	elseif matchGroupType == 'singlematch' then
-		return Lua.import('Module:MatchGroup/Display/Singlematch', {requireDevIfEnabled = true}).SinglematchContainer
+	elseif matchGroupType == 'singleMatch' then
+		return Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true}).SingleMatchContainer
 	else
 		return Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true}).BracketContainer
 	end

--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -71,9 +71,13 @@ Called from MatchGroup/Display
 -- @returns module
 ]]
 function WikiSpecificBase.getMatchGroupContainer(matchGroupType)
-	return matchGroupType == 'matchlist'
-		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
-		or Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true}).BracketContainer
+	if matchGroupType == 'matchlist' then
+		return Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
+	elseif matchGroupType == 'singlematch' then
+		return Lua.import('Module:MatchGroup/Display/Singlematch', {requireDevIfEnabled = true}).SinglematchContainer
+	else
+		return Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true}).BracketContainer
+	end
 end
 
 return WikiSpecificBase

--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -89,9 +89,9 @@ Called from MatchGroup/Display
 -- @returns module
 ]]
 function WikiSpecificBase.getMatchContainer(displayMode)
-    if displayMode == 'singleMatch' then
-        -- Single match, displayed flat on a page (no popup)
-        return Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true}).SingleMatchContainer
+	if displayMode == 'singleMatch' then
+		-- Single match, displayed flat on a page (no popup)
+		return Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true}).SingleMatchContainer
 	end
 end
 

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -110,14 +110,18 @@ function MatchGroupDisplay.MatchByMatchId(args)
 	args.id = bracketId
 	args[1] = bracketId
 	assert(bracketId, 'Missing bracket ID')
-	assert(args.matchid, 'Missing match ID')
-	local matchIdLength = string.len(args.matchid)
-	args.matchid = string.rep('0', 4 - matchIdLength) .. args.matchid
 
 	local matches = MatchGroupUtil.fetchMatches(bracketId)
 	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
-	Table.filter(matches, function(match) return MatchGroupUtil.splitMatchId(match.matchId) == args.matchid end)
-	assert(#matches ~= 0, 'Match matchId=' .. args.matchid .. ' not found')
+
+	if (#matches > 1) then
+		assert(args.matchid, 'Missing match ID')
+		local matchIdLength = string.len(args.matchid)
+		args.matchid = string.rep('0', 4 - matchIdLength) .. args.matchid
+
+		matches = Table.filter(matches, function(match) return MatchGroupUtil.splitMatchId(match.matchId) == args.matchid end)
+		assert(#matches ~= 0, 'Match matchId=' .. args.matchid .. ' not found')
+	end
 
 	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
 	local config = SingleMatchDisplay.configFromArgs(args)

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -112,25 +112,22 @@ function MatchGroupDisplay.MatchByMatchId(args)
 	assert(bracketId, 'Missing bracket ID')
 
 	local matches = MatchGroupUtil.fetchMatches(bracketId)
-	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
+	assert(#matches > 0, 'No data found for bracketId=' .. bracketId)
 
 	if (#matches > 1) then
 		assert(args.matchid, 'Missing match ID')
 		local matchIdLength = string.len(args.matchid)
 		args.matchid = string.rep('0', 4 - matchIdLength) .. args.matchid
-
-		matches = Table.filter(matches, function(match) return MatchGroupUtil.splitMatchId(match.matchId) == args.matchid end)
-		assert(#matches ~= 0, 'Match matchId=' .. args.matchid .. ' not found')
+		matches = Table.filter(matches, function(match) local _, matchid = MatchGroupUtil.splitMatchId(match.matchId) return matchid == args.matchid end)
+		assert(#matches == 1, 'Match matchId=' .. args.matchid .. ' not found')
 	end
 
 	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
 	local config = SingleMatchDisplay.configFromArgs(args)
 
-	MatchGroupInput.applyOverrideArgs(matches, args)
-
 	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('singleMatch')
 	return MatchGroupContainer({
-		bracketId = bracketId,
+		match = matches[1],
 		config = config,
 	})
 end

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -72,7 +72,32 @@ function MatchGroupDisplay.BracketBySpec(args)
 end
 
 --[[
-Displays a matchlist or bracket specified by ID.
+Reads a singlematch input spec, saves it to LPDB, and displays the singlematch.
+]]
+function MatchGroupDisplay.SinglematchBySpec(args)
+	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'singlematch')
+	local matches = MatchGroupInput.readSinglematch(options.bracketId, args)
+	Match.storeMatchGroup(matches, options)
+
+	local matchNode
+	if options.show then
+		local SinglematchDisplay = Lua.import('Module:MatchGroup/Display/Singlematch', {requireDevIfEnabled = true})
+		local SinglematchContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('singlematch')
+		matchNode = SinglematchContainer({
+			bracketId = options.bracketId,
+			config = SinglematchDisplay.configFromArgs(args),
+		})
+	end
+
+	local parts = Array.extend(
+		{matchNode},
+		Array.map(optionsWarnings, MatchGroupDisplay.WarningBox)
+	)
+	return table.concat(Array.map(parts, tostring))
+end
+
+--[[
+Displays a singlematch, a matchlist or bracket specified by ID.
 ]]
 function MatchGroupDisplay.MatchGroupById(args)
 	local bracketId = args.id or args[1]
@@ -88,6 +113,9 @@ function MatchGroupDisplay.MatchGroupById(args)
 	if matchGroupType == 'matchlist' then
 		local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
 		config = MatchlistDisplay.configFromArgs(args)
+	elseif matchGroupType == 'singlematch' then
+		local SinglematchDisplay = Lua.import('Module:MatchGroup/Display/Singlematch', {requireDevIfEnabled = true})
+		config = SinglematchDisplay.configFromArgs(args)
 	else
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
 		config = BracketDisplay.configFromArgs(args)
@@ -123,6 +151,12 @@ end
 function MatchGroupDisplay.TemplateBracket(frame)
 	local args = Arguments.getArgs(frame)
 	return MatchGroupDisplay.BracketBySpec(args)
+end
+
+-- Entry point of Template:Singlematch
+function MatchGroupDisplay.TemplateSinglematch(frame)
+	local args = Arguments.getArgs(frame)
+	return MatchGroupDisplay.SinglematchBySpec(args)
 end
 
 -- Entry point of Template:ShowBracket, Template:DisplayMatchGroup

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -122,7 +122,7 @@ function MatchGroupDisplay.MatchByMatchId(args)
 	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
 	local config = SingleMatchDisplay.configFromArgs(args)
 
-	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('singleMatch')
+	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchContainer('singleMatch')
 	return MatchGroupContainer({
 		matchId = fullMatchId,
 		config = config,

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -118,7 +118,12 @@ function MatchGroupDisplay.MatchByMatchId(args)
 		assert(args.matchid, 'Missing match ID')
 		local matchIdLength = string.len(args.matchid)
 		args.matchid = string.rep('0', 4 - matchIdLength) .. args.matchid
-		matches = Table.filter(matches, function(match) local _, matchid = MatchGroupUtil.splitMatchId(match.matchId) return matchid == args.matchid end)
+
+		matches = Table.filter(matches, function(match)
+			local _, matchid = MatchGroupUtil.splitMatchId(match.matchId) 
+			return matchid == args.matchid end
+		)
+
 		assert(#matches == 1, 'Match matchId=' .. args.matchid .. ' not found')
 	end
 

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -17,6 +17,7 @@ local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled
 local MatchGroupConfig = Lua.loadDataIfExists('Module:MatchGroup/Config')
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local MatchGroupDisplay = {}
 
@@ -31,7 +32,7 @@ function MatchGroupDisplay.MatchlistBySpec(args)
 	local matchlistNode
 	if options.show then
 		local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
-		local MatchlistContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('matchlist')
+		local MatchlistContainer = WikiSpecific.getMatchGroupContainer('matchlist')
 		matchlistNode = MatchlistContainer({
 			bracketId = options.bracketId,
 			config = MatchlistDisplay.configFromArgs(args),
@@ -56,7 +57,7 @@ function MatchGroupDisplay.BracketBySpec(args)
 	local bracketNode
 	if options.show then
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
-		local BracketContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('bracket')
+		local BracketContainer = WikiSpecific.getMatchGroupContainer('bracket')
 		bracketNode = BracketContainer({
 			bracketId = options.bracketId,
 			config = BracketDisplay.configFromArgs(args),
@@ -95,7 +96,7 @@ function MatchGroupDisplay.MatchGroupById(args)
 
 	MatchGroupInput.applyOverrideArgs(matches, args)
 
-	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer(matchGroupType)
+	local MatchGroupContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
 	return MatchGroupContainer({
 		bracketId = bracketId,
 		config = config,
@@ -122,7 +123,7 @@ function MatchGroupDisplay.MatchByMatchId(args)
 	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
 	local config = SingleMatchDisplay.configFromArgs(args)
 
-	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchContainer('singleMatch')
+	local MatchGroupContainer = WikiSpecific.getMatchContainer('singleMatch')
 	return MatchGroupContainer({
 		matchId = fullMatchId,
 		config = config,

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -161,7 +161,7 @@ function MatchGroupDisplay.TemplateBracket(frame)
 	return MatchGroupDisplay.BracketBySpec(args)
 end
 
--- Entry point of Template:SingleMatch
+-- Entry point of Template:ShowSingleMatch
 function MatchGroupDisplay.TemplateShowSingleMatch(frame)
 	local args = Arguments.getArgs(frame)
 	return MatchGroupDisplay.MatchByMatchId(args)

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -111,6 +111,8 @@ function MatchGroupDisplay.MatchByMatchId(args)
 	args[1] = bracketId
 	assert(bracketId, 'Missing bracket ID')
 	assert(args.matchid, 'Missing match ID')
+	local matchIdLength = string.len(args.matchid)
+	args.matchid = string.rep('0', 4 - matchIdLength) .. args.matchid
 
 	local matches = MatchGroupUtil.fetchMatches(bracketId)
 	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -120,7 +120,7 @@ function MatchGroupDisplay.MatchByMatchId(args)
 		args.matchid = string.rep('0', 4 - matchIdLength) .. args.matchid
 
 		matches = Table.filter(matches, function(match)
-			local _, matchid = MatchGroupUtil.splitMatchId(match.matchId) 
+			local _, matchid = MatchGroupUtil.splitMatchId(match.matchId)
 			return matchid == args.matchid end
 		)
 

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -124,7 +124,7 @@ function MatchGroupDisplay.MatchByMatchId(args)
 
 	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('singleMatch')
 	return MatchGroupContainer({
-		match = fullMatchId,
+		matchId = fullMatchId,
 		config = config,
 	})
 end

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -106,33 +106,25 @@ end
 Displays a singleMatch specified by a bracket ID and matchID.
 ]]
 function MatchGroupDisplay.MatchByMatchId(args)
-	local bracketId = args.id or args[1]
-	args.id = bracketId
-	args[1] = bracketId
+	local bracketId = args.id
+	local matchId = args.matchid
 	assert(bracketId, 'Missing bracket ID')
+	assert(matchId, 'Missing match ID')
 
-	local matches = MatchGroupUtil.fetchMatches(bracketId)
-	assert(#matches > 0, 'No data found for bracketId=' .. bracketId)
+	matchId = MatchGroupUtil.matchIdFromKey(matchId)
 
-	if (#matches > 1) then
-		assert(args.matchid, 'Missing match ID')
-		local matchIdLength = string.len(args.matchid)
-		args.matchid = string.rep('0', 4 - matchIdLength) .. args.matchid
+	local matchGroup = MatchGroupUtil.fetchMatchGroup(bracketId)
+	local fullMatchId = bracketId .. '_' .. matchId
+	local match = matchGroup.matchesById[fullMatchId]
 
-		matches = Table.filter(matches, function(match)
-			local _, matchid = MatchGroupUtil.splitMatchId(match.matchId)
-			return matchid == args.matchid end
-		)
-
-		assert(#matches == 1, 'Match matchId=' .. args.matchid .. ' not found')
-	end
+	assert(match, 'Match bracketId= ' .. bracketId .. ' matchId=' .. matchId .. ' not found')
 
 	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
 	local config = SingleMatchDisplay.configFromArgs(args)
 
 	local MatchGroupContainer = require('Module:Brkts/WikiSpecific').getMatchGroupContainer('singleMatch')
 	return MatchGroupContainer({
-		match = matches[1],
+		match = fullMatchId,
 		config = config,
 	})
 end

--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:MatchGroup/Display/Singlematch
+-- page=Module:MatchGroup/Display/SingleMatch
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -16,50 +16,50 @@ local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHa
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
-local SinglematchDisplay = {propTypes = {}, types = {}}
+local SingleMatchDisplay = {propTypes = {}, types = {}}
 
-SinglematchDisplay.configFromArgs = function(args)
+SingleMatchDisplay.configFromArgs = function(args)
 	return {
 		width = tonumber(string.gsub(args.width or '', 'px', ''), nil),
 	}
 end
 
-SinglematchDisplay.types.SinglematchConfig = TypeUtil.struct({
+SingleMatchDisplay.types.SingleMatchConfig = TypeUtil.struct({
 	MatchSummaryContainer = 'function',
 	matchHasDetails = 'function',
 	width = 'number',
 })
-SinglematchDisplay.types.SinglematchConfigOptions = TypeUtil.struct(
-	Table.mapValues(SinglematchDisplay.types.SinglematchConfig.struct, TypeUtil.optional)
+SingleMatchDisplay.types.SingleMatchConfigOptions = TypeUtil.struct(
+	Table.mapValues(SingleMatchDisplay.types.SingleMatchConfig.struct, TypeUtil.optional)
 )
 
-SinglematchDisplay.propTypes.SinglematchContainer = {
+SingleMatchDisplay.propTypes.SingleMatchContainer = {
 	bracketId = 'string',
-	config = TypeUtil.optional(SinglematchDisplay.types.SinglematchConfigOptions),
+	config = TypeUtil.optional(SingleMatchDisplay.types.SingleMatchConfigOptions),
 }
 
 --[[
-Display component for a singlematch. The singlematch is specified by ID.
+Display component for a singleMatch. The singleMatch is specified by ID.
 The component fetches the match data from LPDB or page variables.
 ]]
-function SinglematchDisplay.SinglematchContainer(props)
-	DisplayUtil.assertPropTypes(props, SinglematchDisplay.propTypes.SinglematchContainer)
-	return SinglematchDisplay.Singlematch({
+function SingleMatchDisplay.SingleMatchContainer(props)
+	DisplayUtil.assertPropTypes(props, SingleMatchDisplay.propTypes.SingleMatchContainer)
+	return SingleMatchDisplay.SingleMatch({
 		config = props.config,
 		matches = MatchGroupUtil.fetchMatches(props.bracketId),
 	})
 end
 
-SinglematchDisplay.propTypes.Singlematch = {
-	config = TypeUtil.optional(SinglematchDisplay.types.SinglematchConfigOptions),
+SingleMatchDisplay.propTypes.SingleMatch = {
+	config = TypeUtil.optional(SingleMatchDisplay.types.SingleMatchConfigOptions),
 	matches = TypeUtil.array(MatchGroupUtil.types.Match),
 }
 
 --[[
-Display component for a singlematch. Match data is specified in the input.
+Display component for a singleMatch. Match data is specified in the input.
 ]]
-function SinglematchDisplay.Singlematch(props)
-	DisplayUtil.assertPropTypes(props, SinglematchDisplay.propTypes.Singlematch)
+function SingleMatchDisplay.SingleMatch(props)
+	DisplayUtil.assertPropTypes(props, SingleMatchDisplay.propTypes.SingleMatch)
 
 	local propsConfig = props.config or {}
 	local config = {
@@ -68,7 +68,7 @@ function SinglematchDisplay.Singlematch(props)
 		width = propsConfig.width or 400,
 	}
 
-	local singlematchNode = mw.html.create('div'):addClass('brkts-popup brkts-match-info-popup')
+	local singleMatchNode = mw.html.create('div'):addClass('brkts-popup brkts-match-info-popup')
 		:css('overflow', 'hidden')
 		:css('position', 'unset')
 		:css('max-height', 'unset')
@@ -79,28 +79,28 @@ function SinglematchDisplay.Singlematch(props)
 		return ''
 	end
 
-	local matchNode = SinglematchDisplay.Match{
+	local matchNode = SingleMatchDisplay.Match{
 		MatchSummaryContainer = config.MatchSummaryContainer,
 		match = props.matches[1],
 		matchHasDetails = config.matchHasDetails,
 	}
 
-	singlematchNode:node(matchNode:css('width', config.width .. 'px'))
+	singleMatchNode:node(matchNode:css('width', config.width .. 'px'))
 
-	return singlematchNode
+	return singleMatchNode
 end
 
-SinglematchDisplay.propTypes.Match = {
+SingleMatchDisplay.propTypes.Match = {
 	MatchSummaryContainer = 'function',
 	match = MatchGroupUtil.types.Match,
 	matchHasDetails = 'function',
 }
 
 --[[
-Display component for a match in a singlematch. Consists of the match summary.
+Display component for a match in a singleMatch. Consists of the match summary.
 ]]
-function SinglematchDisplay.Match(props)
-	DisplayUtil.assertPropTypes(props, SinglematchDisplay.propTypes.Match)
+function SingleMatchDisplay.Match(props)
+	DisplayUtil.assertPropTypes(props, SingleMatchDisplay.propTypes.Match)
 
 	local matchSummaryNode = DisplayUtil.TryPureComponent(props.MatchSummaryContainer, {
 		bracketId = props.match.matchId:match('^(.*)_'), -- everything up to the final '_'
@@ -110,4 +110,4 @@ function SinglematchDisplay.Match(props)
 	return matchSummaryNode
 end
 
-return Class.export(SinglematchDisplay)
+return Class.export(SingleMatchDisplay)

--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -32,20 +32,25 @@ SingleMatchDisplay.types.SingleMatchConfigOptions = TypeUtil.struct(
 )
 
 SingleMatchDisplay.propTypes.SingleMatchContainer = {
-	bracketId = 'string',
+	matchId = 'string',
 	config = TypeUtil.optional(SingleMatchDisplay.types.SingleMatchConfigOptions),
 }
 
 --[[
-Display component for a singleMatch. The singleMatch is specified by ID.
+Display component for a singleMatch. The singleMatch is specified by matchID.
 The component fetches the match data from LPDB or page variables.
 ]]
 function SingleMatchDisplay.SingleMatchContainer(props)
 	DisplayUtil.assertPropTypes(props, SingleMatchDisplay.propTypes.SingleMatchContainer)
-	return SingleMatchDisplay.SingleMatch({
-		config = props.config,
-		match = props.match,
-	})
+
+	local bracketId, matchId = MatchGroupUtil.splitMatchId(props.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId)
+	return match
+		and SingleMatchDisplay.SingleMatch({
+			config = props.config,
+			match = match,
+		})
+		or ''
 end
 
 SingleMatchDisplay.propTypes.SingleMatch = {
@@ -70,11 +75,6 @@ function SingleMatchDisplay.SingleMatch(props)
 		:css('position', 'unset')
 		:css('max-height', 'unset')
 		:css('width', config.width .. 'px')
-
-	if not props.match then
-		-- No match, simply return
-		return ''
-	end
 
 	local matchNode = SingleMatchDisplay.Match{
 		MatchSummaryContainer = config.MatchSummaryContainer,

--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -1,0 +1,113 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Display/Singlematch
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local DisplayHelper = require('Module:MatchGroup/Display/Helper')
+local DisplayUtil = require('Module:DisplayUtil')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+
+local SinglematchDisplay = {propTypes = {}, types = {}}
+
+SinglematchDisplay.configFromArgs = function(args)
+	return {
+		width = tonumber(string.gsub(args.width or '', 'px', ''), nil),
+	}
+end
+
+SinglematchDisplay.types.SinglematchConfig = TypeUtil.struct({
+	MatchSummaryContainer = 'function',
+	matchHasDetails = 'function',
+	width = 'number',
+})
+SinglematchDisplay.types.SinglematchConfigOptions = TypeUtil.struct(
+	Table.mapValues(SinglematchDisplay.types.SinglematchConfig.struct, TypeUtil.optional)
+)
+
+SinglematchDisplay.propTypes.SinglematchContainer = {
+	bracketId = 'string',
+	config = TypeUtil.optional(SinglematchDisplay.types.SinglematchConfigOptions),
+}
+
+--[[
+Display component for a singlematch. The singlematch is specified by ID.
+The component fetches the match data from LPDB or page variables.
+]]
+function SinglematchDisplay.SinglematchContainer(props)
+	DisplayUtil.assertPropTypes(props, SinglematchDisplay.propTypes.SinglematchContainer)
+	return SinglematchDisplay.Singlematch({
+		config = props.config,
+		matches = MatchGroupUtil.fetchMatches(props.bracketId),
+	})
+end
+
+SinglematchDisplay.propTypes.Singlematch = {
+	config = TypeUtil.optional(SinglematchDisplay.types.SinglematchConfigOptions),
+	matches = TypeUtil.array(MatchGroupUtil.types.Match),
+}
+
+--[[
+Display component for a singlematch. Match data is specified in the input.
+]]
+function SinglematchDisplay.Singlematch(props)
+	DisplayUtil.assertPropTypes(props, SinglematchDisplay.propTypes.Singlematch)
+
+	local propsConfig = props.config or {}
+	local config = {
+		MatchSummaryContainer = propsConfig.MatchSummaryContainer or DisplayHelper.DefaultMatchSummaryContainer,
+		matchHasDetails = propsConfig.matchHasDetails or matchHasDetailsWikiSpecific or DisplayHelper.defaultMatchHasDetails,
+		width = propsConfig.width or 400,
+	}
+
+	local singlematchNode = mw.html.create('div'):addClass('brkts-popup brkts-match-info-popup')
+		:css('overflow', 'hidden')
+		:css('position', 'unset')
+		:css('max-height', 'unset')
+		:css('width', config.width .. 'px')
+
+	if #props.matches == 0 then
+		-- No match, simply return
+		return ''
+	end
+
+	local matchNode = SinglematchDisplay.Match{
+		MatchSummaryContainer = config.MatchSummaryContainer,
+		match = props.matches[1],
+		matchHasDetails = config.matchHasDetails,
+	}
+
+	singlematchNode:node(matchNode:css('width', config.width .. 'px'))
+
+	return singlematchNode
+end
+
+SinglematchDisplay.propTypes.Match = {
+	MatchSummaryContainer = 'function',
+	match = MatchGroupUtil.types.Match,
+	matchHasDetails = 'function',
+}
+
+--[[
+Display component for a match in a singlematch. Consists of the match summary.
+]]
+function SinglematchDisplay.Match(props)
+	DisplayUtil.assertPropTypes(props, SinglematchDisplay.propTypes.Match)
+
+	local matchSummaryNode = DisplayUtil.TryPureComponent(props.MatchSummaryContainer, {
+		bracketId = props.match.matchId:match('^(.*)_'), -- everything up to the final '_'
+		matchId = props.match.matchId,
+	})
+
+	return matchSummaryNode
+end
+
+return Class.export(SinglematchDisplay)

--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -43,8 +43,9 @@ The component fetches the match data from LPDB or page variables.
 function SingleMatchDisplay.SingleMatchContainer(props)
 	DisplayUtil.assertPropTypes(props, SingleMatchDisplay.propTypes.SingleMatchContainer)
 
-	local bracketId, matchId = MatchGroupUtil.splitMatchId(props.matchId)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId)
+	local bracketId, _ = MatchGroupUtil.splitMatchId(props.matchId)
+
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, props.matchId)
 	return match
 		and SingleMatchDisplay.SingleMatch({
 			config = props.config,

--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -101,6 +101,7 @@ function SingleMatchDisplay.Match(props)
 	local matchSummaryNode = DisplayUtil.TryPureComponent(props.MatchSummaryContainer, {
 		bracketId = props.match.matchId:match('^(.*)_'), -- everything up to the final '_'
 		matchId = props.match.matchId,
+		config = {showScore = true},
 	})
 
 	return matchSummaryNode

--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -12,7 +12,6 @@ local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
-local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
@@ -26,7 +25,6 @@ end
 
 SingleMatchDisplay.types.SingleMatchConfig = TypeUtil.struct({
 	MatchSummaryContainer = 'function',
-	matchHasDetails = 'function',
 	width = 'number',
 })
 SingleMatchDisplay.types.SingleMatchConfigOptions = TypeUtil.struct(
@@ -46,13 +44,13 @@ function SingleMatchDisplay.SingleMatchContainer(props)
 	DisplayUtil.assertPropTypes(props, SingleMatchDisplay.propTypes.SingleMatchContainer)
 	return SingleMatchDisplay.SingleMatch({
 		config = props.config,
-		matches = MatchGroupUtil.fetchMatches(props.bracketId),
+		match = props.match,
 	})
 end
 
 SingleMatchDisplay.propTypes.SingleMatch = {
 	config = TypeUtil.optional(SingleMatchDisplay.types.SingleMatchConfigOptions),
-	matches = TypeUtil.array(MatchGroupUtil.types.Match),
+	match = MatchGroupUtil.types.Match,
 }
 
 --[[
@@ -64,7 +62,6 @@ function SingleMatchDisplay.SingleMatch(props)
 	local propsConfig = props.config or {}
 	local config = {
 		MatchSummaryContainer = propsConfig.MatchSummaryContainer or DisplayHelper.DefaultMatchSummaryContainer,
-		matchHasDetails = propsConfig.matchHasDetails or matchHasDetailsWikiSpecific or DisplayHelper.defaultMatchHasDetails,
 		width = propsConfig.width or 400,
 	}
 
@@ -74,15 +71,14 @@ function SingleMatchDisplay.SingleMatch(props)
 		:css('max-height', 'unset')
 		:css('width', config.width .. 'px')
 
-	if #props.matches == 0 then
+	if not props.match then
 		-- No match, simply return
 		return ''
 	end
 
 	local matchNode = SingleMatchDisplay.Match{
 		MatchSummaryContainer = config.MatchSummaryContainer,
-		match = props.matches[1],
-		matchHasDetails = config.matchHasDetails,
+		match = props.match,
 	}
 
 	singleMatchNode:node(matchNode:css('width', config.width .. 'px'))
@@ -93,7 +89,6 @@ end
 SingleMatchDisplay.propTypes.Match = {
 	MatchSummaryContainer = 'function',
 	match = MatchGroupUtil.types.Match,
-	matchHasDetails = 'function',
 }
 
 --[[

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -23,34 +23,6 @@ local globalVars = PageVariableNamespace()
 
 local MatchGroupInput = {}
 
-function MatchGroupInput.readSinglematch(bracketId, args)
-	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
-	Variables.varDefine('bracket_header', sectionHeader)
-	local tournamentParent = Variables.varDefault('tournament_parent', '')
-
-	local matches = {}
-	local matchArgs = args[1]
-	if matchArgs then
-		matchArgs = Json.parse(matchArgs)
-
-		matchArgs.bracketid = bracketId
-		matchArgs.matchid = 1
-		local match = require('Module:Brkts/WikiSpecific').processMatch(mw.getCurrentFrame(), matchArgs)
-		match.parent = tournamentParent
-
-		table.insert(matches, match)
-
-		-- Add more fields to bracket data
-		match.bracketdata = match.bracketdata or {}
-		local bracketData = match.bracketdata
-		bracketData.type = 'singlematch'
-		bracketData.bracketindex = Variables.varDefault('match2bracketindex', 0)
-		bracketData.sectionheader = sectionHeader
-	end
-
-	return matches
-end
-
 function MatchGroupInput.readMatchlist(bracketId, args)
 	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
 	Variables.varDefine('bracket_header', sectionHeader)
@@ -226,7 +198,7 @@ function MatchGroupInput.applyOverrideArgs(matches, args)
 		for index, match in ipairs(matches) do
 			match.bracketData.header = args['M' .. index .. 'header'] or match.bracketData.header
 		end
-	elseif matchGroupType == 'bracket' then
+	else
 		for _, match in ipairs(matches) do
 			local _, baseMatchId = MatchGroupUtil.splitMatchId(match.matchId)
 			local matchKey = MatchGroupUtil.matchIdToKey(baseMatchId)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -23,6 +23,34 @@ local globalVars = PageVariableNamespace()
 
 local MatchGroupInput = {}
 
+function MatchGroupInput.readSinglematch(bracketId, args)
+	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
+	Variables.varDefine('bracket_header', sectionHeader)
+	local tournamentParent = Variables.varDefault('tournament_parent', '')
+
+	local matches = {}
+	local matchArgs = args[1]
+	if matchArgs then
+		matchArgs = Json.parse(matchArgs)
+
+		matchArgs.bracketid = bracketId
+		matchArgs.matchid = 1
+		local match = require('Module:Brkts/WikiSpecific').processMatch(mw.getCurrentFrame(), matchArgs)
+		match.parent = tournamentParent
+
+		table.insert(matches, match)
+
+		-- Add more fields to bracket data
+		match.bracketdata = match.bracketdata or {}
+		local bracketData = match.bracketdata
+		bracketData.type = 'singlematch'
+		bracketData.bracketindex = Variables.varDefault('match2bracketindex', 0)
+		bracketData.sectionheader = sectionHeader
+	end
+
+	return matches
+end
+
 function MatchGroupInput.readMatchlist(bracketId, args)
 	local sectionHeader = args.section or Variables.varDefault('bracket_header') or ''
 	Variables.varDefine('bracket_header', sectionHeader)
@@ -198,7 +226,7 @@ function MatchGroupInput.applyOverrideArgs(matches, args)
 		for index, match in ipairs(matches) do
 			match.bracketData.header = args['M' .. index .. 'header'] or match.bracketData.header
 		end
-	else
+	elseif matchGroupType == 'bracket' then
 		for _, match in ipairs(matches) do
 			local _, baseMatchId = MatchGroupUtil.splitMatchId(match.matchId)
 			local matchKey = MatchGroupUtil.matchIdToKey(baseMatchId)

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -61,8 +61,12 @@ MatchGroupUtil.types.MatchlistBracketData = TypeUtil.struct({
 	title = 'string?',
 	type = TypeUtil.literal('matchlist'),
 })
+MatchGroupUtil.types.SinglematchBracketData = TypeUtil.struct({
+	type = TypeUtil.literal('singlematch'),
+})
 MatchGroupUtil.types.BracketData = TypeUtil.union(
 	MatchGroupUtil.types.MatchlistBracketData,
+	MatchGroupUtil.types.SinglematchBracketData,
 	MatchGroupUtil.types.BracketBracketData
 )
 
@@ -143,7 +147,7 @@ MatchGroupUtil.types.MatchGroup = TypeUtil.struct({
 	rootMatchIds = TypeUtil.array('string'),
 	matches = TypeUtil.array(MatchGroupUtil.types.Match),
 	matchesById = TypeUtil.table('string', MatchGroupUtil.types.Match),
-	type = TypeUtil.literalUnion('matchlist, bracket'),
+	type = TypeUtil.literalUnion('matchlist', 'bracket', 'singlematch'),
 	upperMatchIds = TypeUtil.table('string', 'string'),
 })
 
@@ -327,11 +331,15 @@ function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
 			thirdPlaceMatchId = nilIfEmpty(data.thirdplace),
 			type = 'bracket',
 		}
-	else
+	elseif data.type == 'matchlist' then
 		return {
 			header = nilIfEmpty(data.header),
 			title = nilIfEmpty(data.title),
 			type = 'matchlist',
+		}
+	elseif data.type == 'singlematch' then
+		return {
+			type = 'singlematch',
 		}
 	end
 end

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -614,7 +614,13 @@ function MatchGroupUtil.matchIdFromKey(matchKey)
 		return matchKey
 	end
 	local round, matchInRound = matchKey:match('^R(%d+)M(%d+)$')
-	return 'R' .. string.format('%02d', round) .. '-M' .. string.format('%03d', matchInRound)
+	if round and matchInRound then
+		-- Bracket format
+		return 'R' .. string.format('%02d', round) .. '-M' .. string.format('%03d', matchInRound)
+	else
+		-- Matchlist format
+		return string.format('%04d', matchKey)
+	end
 end
 
 return MatchGroupUtil

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -61,12 +61,8 @@ MatchGroupUtil.types.MatchlistBracketData = TypeUtil.struct({
 	title = 'string?',
 	type = TypeUtil.literal('matchlist'),
 })
-MatchGroupUtil.types.SinglematchBracketData = TypeUtil.struct({
-	type = TypeUtil.literal('singlematch'),
-})
 MatchGroupUtil.types.BracketData = TypeUtil.union(
 	MatchGroupUtil.types.MatchlistBracketData,
-	MatchGroupUtil.types.SinglematchBracketData,
 	MatchGroupUtil.types.BracketBracketData
 )
 
@@ -147,7 +143,7 @@ MatchGroupUtil.types.MatchGroup = TypeUtil.struct({
 	rootMatchIds = TypeUtil.array('string'),
 	matches = TypeUtil.array(MatchGroupUtil.types.Match),
 	matchesById = TypeUtil.table('string', MatchGroupUtil.types.Match),
-	type = TypeUtil.literalUnion('matchlist', 'bracket', 'singlematch'),
+	type = TypeUtil.literalUnion('matchlist', 'bracket'),
 	upperMatchIds = TypeUtil.table('string', 'string'),
 })
 
@@ -331,15 +327,11 @@ function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
 			thirdPlaceMatchId = nilIfEmpty(data.thirdplace),
 			type = 'bracket',
 		}
-	elseif data.type == 'matchlist' then
+	else
 		return {
 			header = nilIfEmpty(data.header),
 			title = nilIfEmpty(data.title),
 			type = 'matchlist',
-		}
-	elseif data.type == 'singlematch' then
-		return {
-			type = 'singlematch',
 		}
 	end
 end


### PR DESCRIPTION
## Summary

New display type to replace the {{ShowMatch}} template of the old bracket system. {{ShowMatch}} of old displays the custom header, together with the standard MatchSummary. Example of the old {{ShowMatch}} can be found at https://liquipedia.net/rainbowsix/Six_Major/2020/Stage_2/Latin_America/Mexico#Results 

The new display type added in this PR, called *SingleMatch*, displays the match2 MatchSummary as is. Hence it's recommended, but not required, that before using the new display type to add support for displaying the Match Score in the Match Summary (PR #704 adds that for R6 and VAL, #718 for SC and SC2).

SingleMatch is **not** a parse, storage & display like that of Matchlist and Bracket. It is only a Display Type. 
Entry point is MatchGroupDisplay.TemplateShowSingleMatch. There are two mandatory fields `id` (bracketid) and `matchid` and one optional `width`. A template `{{ShowSingleMatch}}` has been created on commons to invoke the module at the entry point.

A wrapper template from the display to replace {{ShowMatch}}, {{SingleMatch}}, has been created on commons. It takes the same input format as a matchlist and then displays with SingleMatch.
```
{{Matchlist|hide=true|id={{{id|}}}|M1={{{M1|}}}}}
{{ShowSingleMatch|id={{{id|}}}|matchid=1|width={{{width|}}}}}
```
First the template calls MatchList, but only the parse & storage parts (hide=true skips the rendering). This is followed up by a call to the entry points with the `(bracket)id`. The ShowSingleMatch will retrieve the parsed match and display it in the SingleMatch display mode.

## How did you test this change?

Tested both {{SingleMatch}} and via {{ShowSingleMatch}}. 
https://liquipedia.net/rainbowsix/User:Rathoz/Leagues/NewBrackets#On_Page

Since this display type is new, code changes doesn't affected any existing parse, storage or display. Only change in existing code is in `MatchGroupUtil.matchIdFromKey` where the functionality has been added so the function can parse matchlist keys instead of throwing lua errors on them.