### PR TITLE
Use dev of Brkts/WikiSpecific/Base if dev-mode is enabled

### DIFF
--- a/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbow_six/brkts_wiki_specific.lua
@@ -12,7 +12,7 @@ local Table = require('Module:Table')
 
 local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 
-local WikiSpecific = Table.copy(require('Module:Brkts/WikiSpecific/Base'))
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
 
 WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
 	local InputModule = Lua.import('Module:MatchGroup/Input/Custom', {requireDevIfEnabled = true})


### PR DESCRIPTION
## Summary

Use the dev module of Brkts/WikiSpecific/Base if dev mode is available. 

## How did you test this change?

Put it live

