### PR TITLE
Add option to display scores in SC/SC2 MatchSummary headers

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -87,24 +87,25 @@ function StarcraftMatchSummary.Header(props)
 			opponent = opponent,
 			overflow = 'wrap',
 			showFlag = false,
-			showLink = opponent.type == 'team',
+			showLink = opponent.type == 'team' or showScore,
 		})
 		local showScore = (props.config or {}).showScore
 		local side = (flip and 'left' or 'right')
 
 		local display = html.create('div')
-			:addClass('brkts-popup-header-opponent')
-			:addClass('brkts-popup-header-opponent-' .. side)
 
 		if showScore then
-			table.insert(opponentDisplay, StarcraftOpponentDisplay.BlockScore{
+			display:addClass('brkts-popup-header-opponent-' .. side)
+				:css('width', '50%')
+
+			local scoreDisplay = StarcraftOpponentDisplay.BlockScore{
 				isWinner = opponent.placement == 1 or opponent.advances,
 				scoreText = StarcraftOpponentDisplay.InlineScore(opponent),
-				side = side,
-			})
-		end
-		if showScore then
-			display:css('width', '50%')
+			}
+			scoreDisplay:addClass('brkts-popup-header-opponent-score-' .. side)
+			table.insert(opponentDisplay, scoreDisplay)
+		else
+			display:addClass('brkts-popup-header-opponent')
 		end
 		if not flip then
 			opponentDisplay = Array.reverse(opponentDisplay)

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -84,14 +84,23 @@ function StarcraftMatchSummary.Header(props)
 			showFlag = false,
 			showLink = opponent.type == 'team',
 		})
-			:addClass('brkts-popup-header-opponent')
 	end
 
-	local header = html.create('div'):addClass('brkts-popup-header-dev')
+	local headerLeft = html.create('div')
+		:addClass('brkts-popup-header-opponent')
+		:addClass('brkts-popup-header-opponent-left')
+		:css('width', '50%')
 		:node(renderOpponent(1))
 		:node(StarcraftMatchSummary._createScore(match.opponents[1], 'left'))
+	local headerRight = html.create('div')
+		:addClass('brkts-popup-header-opponent')
+		:addClass('brkts-popup-header-opponent-right')
+		:css('width', '50%')
 		:node(StarcraftMatchSummary._createScore(match.opponents[2], 'right'))
 		:node(renderOpponent(2))
+	local header = html.create('div'):addClass('brkts-popup-header-dev')
+		:node(headerLeft)
+		:node(headerRight)
 
 	return header
 end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -119,7 +119,7 @@ function StarcraftMatchSummary._createScore(opponent, side, showScore)
 		scoreText = showScore and StarcraftOpponentDisplay.InlineScore(opponent) or '',
 		side = side
 	}
-end 
+end
 
 StarcraftMatchSummary.propTypes.Body = {
 	match = StarcraftMatchGroupUtil.types.Match,

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -91,12 +91,20 @@ function StarcraftMatchSummary.Header(props)
 		:addClass('brkts-popup-header-opponent-left')
 		:css('width', '50%')
 		:node(renderOpponent(1))
-		:node(StarcraftMatchSummary._createScore(match.opponents[1], 'left'))
+		:node(StarcraftMatchSummary._createScore(
+			match.opponents[1],
+			'left',
+			match.showScore
+		))
 	local headerRight = html.create('div')
 		:addClass('brkts-popup-header-opponent')
 		:addClass('brkts-popup-header-opponent-right')
 		:css('width', '50%')
-		:node(StarcraftMatchSummary._createScore(match.opponents[2], 'right'))
+		:node(StarcraftMatchSummary._createScore(
+			match.opponents[2],
+			'right',
+			match.showScore
+		))
 		:node(renderOpponent(2))
 	local header = html.create('div'):addClass('brkts-popup-header-dev')
 		:node(headerLeft)
@@ -105,13 +113,13 @@ function StarcraftMatchSummary.Header(props)
 	return header
 end
 
-function StarcraftMatchSummary._createScore(opponent, side)
+function StarcraftMatchSummary._createScore(opponent, side, showScore)
 	return StarcraftOpponentDisplay.BlockScore{
 		isWinner = opponent.placement == 1 or opponent.advances,
-		scoreText = StarcraftOpponentDisplay.InlineScore(opponent),
+		scoreText = showScore and StarcraftOpponentDisplay.InlineScore(opponent) or '',
 		side = side
 	}
-end
+end 
 
 StarcraftMatchSummary.propTypes.Body = {
 	match = StarcraftMatchGroupUtil.types.Match,

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -36,15 +36,18 @@ StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
 
 function StarcraftMatchSummary.MatchSummaryContainer(props)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
+	local config = {
+		showScore = props.config or false
+	}
 	local MatchSummary = match.isFfa
 		and Lua.import('Module:MatchSummary/Ffa/Starcraft', {requireDevIfEnabled = true}).FfaMatchSummary
 		or StarcraftMatchSummary.MatchSummary
-	return MatchSummary({match = match, config = props.config})
+	return MatchSummary({match = match, config = config})
 end
 
 StarcraftMatchSummary.propTypes.MatchSummary = {
 	match = StarcraftMatchGroupUtil.types.Match,
-	config = 'table?'
+	config = 'table'
 }
 
 function StarcraftMatchSummary.MatchSummary(props)
@@ -71,14 +74,14 @@ end
 
 StarcraftMatchSummary.propTypes.Header = {
 	match = StarcraftMatchGroupUtil.types.Match,
-	config = 'table?'
+	config = 'table'
 }
 
 function StarcraftMatchSummary.Header(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.Header)
 	local match = props.match
 
-	local showScore = (props.config or {}).showScore or false
+	local showScore = props.config.showScore
 
 	local renderOpponent = function(opponentIx)
 		local opponent = match.opponents[opponentIx]

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -78,6 +78,8 @@ function StarcraftMatchSummary.Header(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.Header)
 	local match = props.match
 
+	local showScore = (props.config or {}).showScore
+
 	local renderOpponent = function(opponentIx)
 		local opponent = match.opponents[opponentIx]
 		local flip = opponentIx == 1
@@ -89,7 +91,6 @@ function StarcraftMatchSummary.Header(props)
 			showFlag = false,
 			showLink = opponent.type == 'team' or showScore,
 		})
-		local showScore = (props.config or {}).showScore
 		local side = (flip and 'left' or 'right')
 
 		local display = html.create('div')

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -89,18 +89,24 @@ function StarcraftMatchSummary.Header(props)
 			showFlag = false,
 			showLink = opponent.type == 'team',
 		})
-		if (props.config or {}).showScore then
+		local showScore = (props.config or {}).showScore
+		local side = (flip and 'left' or 'right')
+
+		local display = html.create('div')
+			:addClass('brkts-popup-header-opponent')
+			:addClass('brkts-popup-header-opponent-' .. side)
+
+		if showScore then
 			table.insert(opponentDisplay, StarcraftOpponentDisplay.BlockScore{
 				isWinner = opponent.placement == 1 or opponent.advances,
 				scoreText = StarcraftOpponentDisplay.InlineScore(opponent),
-				side = flip and 'right' or 'left'
+				side = side,
 			})
 		end
-		local display = html.create('div')
-			:addClass('brkts-popup-header-opponent')
-			:addClass('brkts-popup-header-opponent-left')
-			:css('width', '50%')
-		if flip then
+		if showScore then
+			display:css('width', '50%')
+		end
+		if not flip then
 			opponentDisplay = Array.reverse(opponentDisplay)
 		end
 		for _, item in ipairs(opponentDisplay) do

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -78,7 +78,7 @@ function StarcraftMatchSummary.Header(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.Header)
 	local match = props.match
 
-	local showScore = (props.config or {}).showScore
+	local showScore = (props.config or {}).showScore or false
 
 	local renderOpponent = function(opponentIx)
 		local opponent = match.opponents[opponentIx]

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -100,7 +100,8 @@ function StarcraftMatchSummary.Header(props)
 
 		if showScore then
 			display:addClass('brkts-popup-header-opponent-' .. side)
-				:css('width', '50%')
+				:addClass('brkts-popup-sc-header-opponent-with-score')
+				:css('width', '50%')--temp needed until css is refreshed in cache
 
 			local scoreDisplay = StarcraftOpponentDisplay.BlockScore{
 				isWinner = opponent.placement == 1 or opponent.advances,

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -111,9 +111,7 @@ function StarcraftMatchSummary.Header(props)
 		if not flip then
 			opponentDisplay = Array.reverse(opponentDisplay)
 		end
-		for _, item in ipairs(opponentDisplay) do
-			display:node(item)
-		end
+		Array.extendWith(display.nodes, opponentDisplay)
 
 		return display
 	end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -89,9 +89,19 @@ function StarcraftMatchSummary.Header(props)
 
 	local header = html.create('div'):addClass('brkts-popup-header-dev')
 		:node(renderOpponent(1))
+		:node(StarcraftMatchSummary._createScore(match.opponents[1], 'left'))
+		:node(StarcraftMatchSummary._createScore(match.opponents[2], 'right'))
 		:node(renderOpponent(2))
 
 	return header
+end
+
+function StarcraftMatchSummary._createScore(opponent, side)
+	return StarcraftOpponentDisplay.BlockScore{
+		isWinner = opponent.placement == 1 or opponent.advances,
+		scoreText = StarcraftOpponentDisplay.InlineScore(opponent),
+		side = side
+	}
 end
 
 StarcraftMatchSummary.propTypes.Body = {

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -39,7 +39,7 @@ function StarcraftMatchSummary.MatchSummaryContainer(props)
 	local MatchSummary = match.isFfa
 		and Lua.import('Module:MatchSummary/Ffa/Starcraft', {requireDevIfEnabled = true}).FfaMatchSummary
 		or StarcraftMatchSummary.MatchSummary
-	return MatchSummary({match = match, config = config})
+	return MatchSummary({match = match, config = props.config})
 end
 
 StarcraftMatchSummary.propTypes.MatchSummary = {
@@ -64,7 +64,7 @@ function StarcraftMatchSummary.MatchSummary(props)
 		:addClass('brkts-popup')
 		:addClass('brkts-popup-sc')
 		:addClass(match.opponentMode == 'uniform' and 'brkts-popup-sc-uniform-match' or 'brkts-popup-sc-team-match')
-		:node(StarcraftMatchSummary.Header({match = match, config = config}))
+		:node(StarcraftMatchSummary.Header({match = match, config = props.config}))
 		:node(StarcraftMatchSummary.Body({match = match}))
 		:node(StarcraftMatchSummary.Footer({match = match, showHeadToHead = match.headToHead}))
 end
@@ -106,7 +106,7 @@ function StarcraftMatchSummary.Header(props)
 		for _, item in ipairs(opponentDisplay) do
 			display:node(item)
 		end
-		
+
 		return display
 	end
 	local header = html.create('div'):addClass('brkts-popup-header-dev')

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -241,6 +241,28 @@ end
 
 StarcraftOpponentDisplay.CheckMark = '<i class="fa fa-check forest-green-text" aria-hidden="true"></i>'
 
+StarcraftOpponentDisplay.propTypes.BlockScore = {
+	isWinner = 'boolean?',
+	scoreText = 'any',
+	side = 'string',
+}
+
+--[[
+Displays a score within the context of a block element.
+]]
+function StarcraftOpponentDisplay.BlockScore(props)
+	DisplayUtil.assertPropTypes(props, StarcraftOpponentDisplay.propTypes.BlockScore)
+
+	local scoreText = props.scoreText
+	if props.isWinner then
+		scoreText = '<b>' .. scoreText .. '</b>'
+	end
+
+	return html.create('div')
+		:wikitext(scoreText)
+		:addClass('brkts-popup-header-opponent-score-' .. (props.side or 'left') .. '-sc')
+end
+
 function StarcraftOpponentDisplay.InlineScore(opponent)
 	if opponent.status == 'S' then
 		local advantage = tonumber(opponent.extradata.advantage) or 0

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -244,7 +244,7 @@ StarcraftOpponentDisplay.CheckMark = '<i class="fa fa-check forest-green-text" a
 StarcraftOpponentDisplay.propTypes.BlockScore = {
 	isWinner = 'boolean?',
 	scoreText = 'any',
-	side = 'string',
+	side = 'string?',
 }
 
 --[[
@@ -258,9 +258,12 @@ function StarcraftOpponentDisplay.BlockScore(props)
 		scoreText = '<b>' .. scoreText .. '</b>'
 	end
 
-	return html.create('div')
+	local scoreDiv = html.create('div')
 		:wikitext(scoreText)
-		:addClass('brkts-popup-header-opponent-score-' .. (props.side or 'left'))
+	if props.side then
+		scoreDiv:addClass('brkts-popup-header-opponent-score-' .. props.side)
+	end
+	return scoreDiv
 end
 
 function StarcraftOpponentDisplay.InlineScore(opponent)

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -260,7 +260,7 @@ function StarcraftOpponentDisplay.BlockScore(props)
 
 	return html.create('div')
 		:wikitext(scoreText)
-		:addClass('brkts-popup-header-opponent-score-' .. (props.side or 'left') .. '-sc')
+		:addClass('brkts-popup-header-opponent-score-' .. (props.side or 'left'))
 end
 
 function StarcraftOpponentDisplay.InlineScore(opponent)

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -244,7 +244,6 @@ StarcraftOpponentDisplay.CheckMark = '<i class="fa fa-check forest-green-text" a
 StarcraftOpponentDisplay.propTypes.BlockScore = {
 	isWinner = 'boolean?',
 	scoreText = 'any',
-	side = 'string?',
 }
 
 --[[
@@ -258,12 +257,8 @@ function StarcraftOpponentDisplay.BlockScore(props)
 		scoreText = '<b>' .. scoreText .. '</b>'
 	end
 
-	local scoreDiv = html.create('div')
+	return html.create('div')
 		:wikitext(scoreText)
-	if props.side then
-		scoreDiv:addClass('brkts-popup-header-opponent-score-' .. props.side)
-	end
-	return scoreDiv
 end
 
 function StarcraftOpponentDisplay.InlineScore(opponent)


### PR DESCRIPTION
## Summary
Display scores in SC/SC2 MatchSummary headers if enabled (e.g. the `SingleMatch` display (added with #719 for sc2) will have it enabled)

## How did you test this change?
dev modules
![Screenshot 2021-11-13 22 35 37](https://user-images.githubusercontent.com/75081997/141659722-39519bab-d974-4dee-abb5-6b219ee62806.png)

