### PR TITLE
Add SC/SC2 part for SingleMatch

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
@@ -1,0 +1,26 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/Display/SingleMatch/Starcraft
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
+local StarcraftMatchSummary = Lua.import('Module:MatchSummary/Starcraft', {requireDevIfEnabled = true})
+
+local StarcraftSingleMatchDisplay = {propTypes = {}}
+
+function StarcraftSingleMatchDisplay.SingleMatchContainer(props)
+	return SingleMatchDisplay.SingleMatch({
+		match = props.match,
+		config = Table.merge(props.config, {
+			MatchSummaryContainer = StarcraftMatchSummary.MatchSummaryContainer,
+		})
+	})
+end
+
+return StarcraftSingleMatchDisplay


### PR DESCRIPTION
#stacked on 716

## Summary
Add SC/SC2 part for SingleMatch
since sc/sc2 has the matchsummary at a different location we have to adjust the confog a bit, this PR achieves that.

## How did you test this change?
pushed to live (doesn't change anything for live usage)

![Screenshot 2021-11-13 23 31 16](https://user-images.githubusercontent.com/75081997/141660932-7d12ccec-ee90-4b23-8d65-5e4b77f2b5fd.png)
