### PR TITLE
Change interface of starcraft's Template:MatchExternalLink

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local DisplayUtil = require('Module:DisplayUtil')
 local TypeUtil = require('Module:TypeUtil')
@@ -137,11 +138,11 @@ function StarcraftMatchExternalLinks.MatchExternalLinks(props)
 	return list
 end
 
--- Called by Template:MatchExternalLink
+-- Entry point of Template:MatchExternalLink
 function StarcraftMatchExternalLinks.TemplateMatchExternalLink(frame)
-	local args = require('Module:Arguments').getArgs(frame)
-	args.number = tonumber(args.number)
-	return StarcraftMatchExternalLinks.ExternalLink(args)
+	local args = Arguments.getArgs(frame)
+	local links = StarcraftMatchExternalLinks.extractFromArgs(args)
+	return StarcraftMatchExternalLinks.MatchExternalLinks({links = links})
 end
 
 return StarcraftMatchExternalLinks


### PR DESCRIPTION
## Summary

Changes the interface of `{{MatchExternalLink}}` from
```
{{MatchExternalLink|type=vod|number=9|url=https://www.youtube.com/watch?v=ziz3dryrT0g}}
```
to
```
{{MatchExternalLink|vod9=https://www.youtube.com/watch?v=ziz3dryrT0g}}
```

It also supports multiple links now, 
```
{{MatchExternalLink
|lrthread=https://tl.net/forum/sc2-tournaments/558748-gsl-2020-code-s-ro24-group-b
|review=https://tl.net/forum/starcraft-2/558779-code-s-ro24-soo-bunny-inno-scarlett-advance
}}
```
The old interface was pretty awful... don't know what I was thinking.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
https://liquipedia.net/starcraft2/Template:MatchExternalLink

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
