### PR TITLE
Fix length being parsed as number instead of string

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -383,7 +383,7 @@ function MatchGroupUtil.gameFromRecord(record)
 		comment = nilIfEmpty(Table.extract(extradata, 'comment')),
 		extradata = extradata,
 		header = nilIfEmpty(Table.extract(extradata, 'header')),
-		length = tonumber(record.length),
+		length = record.length,
 		map = nilIfEmpty(record.map),
 		mode = nilIfEmpty(record.mode),
 		participants = Json.parseIfString(record.participants) or {},


### PR DESCRIPTION
## Summary
`length` is a string not a number (containing a `:`) hence the `tonumber` will always return nil, this PR fixes that

## How did you test this change?
dev modules