### PR TITLE
Adjust sc(2) input processing order of players in teams

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -617,7 +617,7 @@ function StarcraftMatchGroupInput.ProcessLiteralOpponentInput(opp)
 	}
 end
 
-function StarcraftMatchGroupInput.getPlayersLegacy(playerData)
+function StarcraftMatchGroupInput.getManuallyEnteredPlayers(playerData)
 	local players = {}
 	playerData = Json.parseIfString(playerData) or {}
 	for playerIndex = 1, MAX_NUM_PLAYERS do
@@ -640,7 +640,7 @@ function StarcraftMatchGroupInput.getPlayersLegacy(playerData)
 	return players
 end
 
-function StarcraftMatchGroupInput.getPlayers(teamName)
+function StarcraftMatchGroupInput.getPlayersFromVariables(teamName)
 	local players = {}
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		local name = Variables.varDefault(teamName .. '_p' .. playerIndex)
@@ -684,9 +684,9 @@ function StarcraftMatchGroupInput.ProcessTeamOpponentInput(opp, date)
 		name, icon, opp.template = StarcraftMatchGroupInput.processTeamTemplateInput(opp.template, date)
 	end
 	name = mw.ext.TeamLiquidIntegration.resolve_redirect(name or '')
-	local players = StarcraftMatchGroupInput.getPlayers(name)
+	local players = StarcraftMatchGroupInput.getManuallyEnteredPlayers(opp.players)
 	if Logic.isEmpty(players) then
-		players = StarcraftMatchGroupInput.getPlayersLegacy(opp.players)
+		players = StarcraftMatchGroupInput.getPlayersFromVariables(name)
 	end
 
 	return {


### PR DESCRIPTION
## Summary
* Adjust sc(2) input processing order of players in teams so that the manually input is taken if entered and the variables from teamCards are only used if no manual input was given
* Rename functions to fit the new order better

## How did you test this change?
/dev module and tested it via preview on a few pages (plus saving it on one page)
- lpdb data looks good
- display looks good