### PR TITLE
Standardize nationality storage

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -183,7 +183,7 @@ function Person:createInfobox()
 		)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayMultiFromTable(_warnings)
+	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
 end
 
 function Person:_setLpdbData(args, links, status, personType, earnings)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -183,7 +183,7 @@ function Person:createInfobox()
 		)
 	end
 
-	return tostring(builtInfobox) .. self:_addWarnings()
+	return tostring(builtInfobox) .. WarningBox.displayMultiFromTable(_warnings)
 end
 
 function Person:_setLpdbData(args, links, status, personType, earnings)
@@ -230,17 +230,10 @@ function Person:getStandardNationalityValue(nationality)
 			_warnings,
 			'"' .. nationality .. '" is not supported as a value for nationalities'
 		)
+		nationalityToStore = nil
 	end
 
 	return nationalityToStore
-end
-
-function Person:_addWarnings()
-	local warningsDisplay = ''
-	for _, warning in pairs(_warnings) do
-		warningsDisplay = warningsDisplay .. tostring(WarningBox.display(warning))
-	end
-	return warningsDisplay
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -228,7 +228,7 @@ function Person:getStandardNationalityValue(nationality)
 	if String.isEmpty(nationalityToStore) then
 		table.insert(
 			_warnings,
-			nationality .. ' is not supported as a value for nationalities'
+			'"' .. nationality .. '" is not supported as a value for nationalities'
 		)
 	end
 

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -238,7 +238,7 @@ end
 function Person:_addWarnings()
 	local warningsDisplay = ''
 	for _, warning in pairs(_warnings) do
-		warningsDisplay = warningsDisplay .. WarningBox.display(warning)
+		warningsDisplay = warningsDisplay .. tostring(WarningBox.display(warning))
 	end
 	return warningsDisplay
 end

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -192,9 +192,9 @@ function Person:_setLpdbData(args, links, status, personType, earnings)
 		name = args.romanized_name or args.name,
 		romanizedname = args.romanized_name or args.name,
 		localizedname = String.isNotEmpty(args.romanized_name) and args.name or nil,
-		nationality = args.country or args.nationality,
-		nationality2 = args.country2 or args.nationality2,
-		nationality3 = args.country3 or args.nationality3,
+		nationality = Person:getStandardLocationValue(args.country or args.nationality),
+		nationality2 = Person:getStandardLocationValue(args.country2 or args.nationality2),
+		nationality3 = Person:getStandardLocationValue(args.country3 or args.nationality3),
 		birthdate = Variables.varDefault('player_birthdate'),
 		deathdate = Variables.varDefault('player_deathhdate'),
 		image = args.image,
@@ -212,6 +212,10 @@ function Person:_setLpdbData(args, links, status, personType, earnings)
 	local storageType = self:getStorageType(args, personType, status)
 
 	mw.ext.LiquipediaDB.lpdb_player(storageType .. '_' .. (args.id or self.name), lpdbData)
+end
+
+function Person:getStandardLocationValue(location)
+	return Flags.CountryName(location)
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -214,6 +214,7 @@ function Person:_setLpdbData(args, links, status, personType, earnings)
 	mw.ext.LiquipediaDB.lpdb_player(storageType .. '_' .. (args.id or self.name), lpdbData)
 end
 
+-- Allows this function to be used in /Custom
 function Person:getStandardLocationValue(location)
 	return Flags.CountryName(location)
 end


### PR DESCRIPTION
stacked on #728 

## Summary
Standardize the lpdb values of nationality, nationality2 and nationality3.
Display a Warning Box if the entry is not supported.

## How does the normalization on the user input work?
The implementation uses function `CountryName()` of `Module:Flags`. It converts a country name, flag code, or alias to a standardized country name.

## How did you test this change?
temporarily created the module on sc2
![Screenshot 2021-11-16 15 22 15](https://user-images.githubusercontent.com/75081997/142002916-9d4be873-906e-4211-bf2d-ac576f03e510.png)
