### PR TITLE
Date inconsistency workaround

### DIFF
--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -44,6 +44,7 @@ local _LINK_DATA = {
 	stats = {icon = 'File:Match_Info_Stats.png', text = 'Match Statistics'},
 }
 
+local _EPOCH_TIME = '1970-01-01 00:00:00'
 local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 
 -- Operator Bans Class
@@ -416,20 +417,11 @@ end
 function CustomMatchSummary._createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact then
+	if match.dateIsExact or (match.date ~= _EPOCH_TIME_EXTENDED and match.date ~= _EPOCH_TIME) then
 		-- dateIsExact means we have both date and time. Show countdown
+		-- if match is not epoch=0, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(
 			DisplayHelper.MatchCountdownBlock(match)
-		))
-	elseif match.date ~= _EPOCH_TIME_EXTENDED then
-		-- if match is not epoch=0, we have a date, so display the date
-		-- TODO:Less code duplication, all html stuff is a copy from DisplayHelper.MatchCountdownBlock
-		body:addRow(MatchSummary.Row():addElement(
-			mw.html.create('div'):addClass('match-countdown-block')
-				:css('text-align', 'center')
-				-- Workaround for .brkts-popup-body-element > * selector
-				:css('display', 'block')
-				:wikitext(mw.getContentLanguage():formatDate('F d, Y', match.date))
 		))
 	end
 


### PR DESCRIPTION
## Summary

Date format is not consistant when entering MatchSummary. If the entrypoint has been a bracket/matchlist ("spec"), it's '1970-01-01T00:00:00+00:00' while if the entrypoint is via {{ShowBracket}} or {{ShowSingleMatch}} it's '1970-01-01 00:00:00'.

This is a workaround until the issue's source has been localized and fixed. 

Improving date handling in general on the R6 match2 is next thing on my match2 todo list and I'll track the source of this issue while at it.

Also cleaned up the code a bit since DisplayHelper.MatchCountdownBlock now supports dates without time properly.

## How did you test this change?

Put it in /dev and 1) check userspace testcases 2) checked selected live pages in preview mode with dev mode activated in said preview.