### PR TITLE
Set location category for teams

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -12,6 +12,7 @@ local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
 local Links = require('Module:Links')
 local Flags = require('Module:Flags')
+local Localisation = require('Module:Localisation')
 local String = require('Module:StringUtils')
 local WarningBox = require('Module:WarningBox')
 local BasicInfobox = require('Module:Infobox/Basic')
@@ -168,9 +169,17 @@ function Team:_createLocation(location)
 		return ''
 	end
 
+	local locationDisplay = Flags.CountryName(location)
+	if String.isNotEmpty(locationDisplay) then
+		locationDisplay = '[[:Category:' .. locationDisplay
+			.. '|' .. locationDisplay .. ']]'
+	end
+	local demonym = Localisation.getLocalisation(locationDisplay)
+
 	return Flags.Icon({flag = location, shouldLink = true}) ..
 			'&nbsp;' ..
-			'[[:Category:' .. location .. '|' .. location .. ']]'
+			(String.isNotEmpty(demonym) and '[[Category:' .. demonym .. ' Teams]]' or '') ..
+			locationDisplay
 end
 
 function Team:getStandardLocationValue(location)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -180,7 +180,7 @@ function Team:_createLocation(location)
 	return Flags.Icon({flag = location, shouldLink = true}) ..
 			'&nbsp;' ..
 			(String.isNotEmpty(demonym) and '[[Category:' .. demonym .. ' Teams]]' or '') ..
-			locationDisplay
+			(locationDisplay or '')
 end
 
 function Team:getStandardLocationValue(location)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -170,11 +170,12 @@ function Team:_createLocation(location)
 	end
 
 	local locationDisplay = self:getStandardLocationValue(location)
+	local demonym
 	if String.isNotEmpty(locationDisplay) then
+		demonym = Localisation.getLocalisation(locationDisplay)
 		locationDisplay = '[[:Category:' .. locationDisplay
 			.. '|' .. locationDisplay .. ']]'
 	end
-	local demonym = Localisation.getLocalisation(locationDisplay)
 
 	return Flags.Icon({flag = location, shouldLink = true}) ..
 			'&nbsp;' ..

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -169,7 +169,7 @@ function Team:_createLocation(location)
 		return ''
 	end
 
-	local locationDisplay = Flags.CountryName(location)
+	local locationDisplay = self:getStandardLocationValue(location)
 	if String.isNotEmpty(locationDisplay) then
 		locationDisplay = '[[:Category:' .. locationDisplay
 			.. '|' .. locationDisplay .. ']]'


### PR DESCRIPTION
stacked on #708 
## Summary
Set location category for teams. The old infoboxes set those categories, the new ones do currently not set it

## How did you test this change?
via sandbox on sc2