### PR TITLE
Fix lua ambiguity

### DIFF
--- a/components/match2/commons/match_summary_ffa.lua
+++ b/components/match2/commons/match_summary_ffa.lua
@@ -254,7 +254,7 @@ function FfaMatchSummary.PlacementCells(props)
 	-- Group placements to determine ties
 	local groups = Array.groupBy(
 		props.opponentIxs,
-		function(ix) return match.opponents[ix].placement or 'unique' .. ix end
+		function(ix) return match.opponents[ix].placement or ('unique' .. ix) end
 	)
 
 	-- Loop through placement groups and draw cells


### PR DESCRIPTION


## Summary

Lua Diagnostic was throw warning here that the statement was ambiguous. Got annoyed at the constant warning in my VSCode, so decided to fix it.

## How did you test this change?
Checked with warnull where the bracket was supposed to be.