### PR TITLE
Center Game.length display vertically

### DIFF
--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -230,6 +230,7 @@ function CustomMatchSummary._createGame(game, gameIndex)
 	row:addElement(CustomMatchSummary._opponentChampionsDisplay(championsData[1], _NUM_CHAMPIONS_PICK, false))
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))
 	row:addElement(mw.html.create('div')
+		:addClass('brkts-popup-body-element-vertical-centered')
 		:wikitext(CustomMatchSummary._createAbbreviation{
 			title = String.isEmpty(game.length) and ('Game ' .. gameIndex .. ' picks') or 'Match Length',
 			text = game.length or ('Game ' .. gameIndex),


### PR DESCRIPTION
## Summary
Center Game.length display vertically via css class
```css
.brkts-popup-body-element-vertical-centered {
	display: flex;
	align-items: center;
}
```

## How did you test this change?
pushed live (match2 system not in use on that wiki)