### PR TITLE
Fix Faceit linking

### DIFF
--- a/standard/links.lua
+++ b/standard/links.lua
@@ -80,7 +80,7 @@ local _PREFIXES = {
 		aligulac = 'http://aligulac.com/players/',
 		esl = 'https://play.eslgaming.com/player/',
 		challonge = 'http://challonge.com/users/',
-		faceit = 'https://www.faceit.com/players/'
+		faceit = 'https://www.faceit.com/players/',
 	},
 }
 

--- a/standard/links.lua
+++ b/standard/links.lua
@@ -31,7 +31,7 @@ local _PREFIXES = {
 	esl = '',
 	facebook = 'http://facebook.com/',
 	['facebook-gaming'] = 'https://fb.gg/',
-	faceit = 'https://www.faceit.com/en/players/',
+	faceit = '',
 	['faceit-c'] = 'https://www.faceit.com/en/championship/',
 	fanclub = '',
 	gamersclub = 'https://csgo.gamersclub.gg/campeonatos/csgo/',
@@ -74,11 +74,13 @@ local _PREFIXES = {
 	team = {
 		aligulac = 'http://aligulac.com/teams/',
 		esl = 'https://play.eslgaming.com/team/',
+		faceit = 'https://www.faceit.com/teams/',
 	},
 	player = {
 		aligulac = 'http://aligulac.com/players/',
 		esl = 'https://play.eslgaming.com/player/',
-		challonge = 'http://challonge.com/users/'
+		challonge = 'http://challonge.com/users/',
+		faceit = 'https://www.faceit.com/players/'
 	},
 }
 


### PR DESCRIPTION
## Summary
Currently the format for Faceit is to assign all links to the players linking. However when you click a Faceit link on a team page it will never find the page correctly as it only looks for the link under the teams 

## How did you test this change?
Formatting was changed to the current ESL formatting (which currently works). Needs further testing for whether or not the link needs `/en/` in the link for the English version of the page
