### PR TITLE
Add CopyPaste Generator support for SingleMatch

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste.lua
+++ b/components/match2/commons/get_match_group_copy_paste.lua
@@ -173,4 +173,21 @@ function copyPaste.matchlist(frame, args)
 	return '<pre class="selectall" width=50%>' .. mw.text.nowiki(out) .. '</pre>'
 end
 
+function copyPaste.singleMatch(frame, args)
+	if not args then
+		args = getArgs(frame)
+	end
+
+	local bestof = tonumber(args.bestof or 3) or 3
+	local opponents = tonumber(args.opponents or 2) or 2
+	local mode = WikiSpecific.getMode(args.mode)
+
+	local out = WikiSpecific.getStart(nil, copyPaste.generateID(), 'singlematch', args)
+
+	out = out .. '\n|' ..
+		WikiSpecific.getMatchCode(bestof, mode, 1, opponents, args)
+		.. '\n}}'
+	return '<pre class="selectall" width=50%>' .. mw.text.nowiki(out) .. '</pre>'
+end
+
 return copyPaste

--- a/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
+++ b/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
@@ -85,8 +85,11 @@ end
 function wikiCopyPaste.getStart(template, id, modus, args)
 	local out = tostring(mw.message.new('BracketConfigBracketTemplate'))
 	if out == '⧼BracketConfigBracketTemplate⧽' then
-		out = '{{#invoke:MatchGroup|' ..
-			(modus == 'bracket' and ('bracket|Bracket/' .. template) or 'matchlist') ..
+		out = '{{' .. (
+			(modus == 'bracket' and
+				('Bracket|Bracket/' .. template)
+			) or (modus == 'singlematch' and 'SingleMatch')
+			or 'Matchlist') ..
 			'|id=' .. id
 	else
 		out = string.gsub(out, '<nowiki>', '')
@@ -95,7 +98,12 @@ function wikiCopyPaste.getStart(template, id, modus, args)
 		out = string.gsub(out, '<<bracketid>>', id)
 		out = string.gsub(out, '^{{#invoke:[mM]atchGroup|[bB]racket', 'Bracket')
 		out = string.gsub(out, '[Bb]racket|<<templatename>>',
-			(modus == 'bracket' and ('Bracket|Bracket/' .. template) or 'matchlist'))
+			(
+				modus == 'bracket' and ('Bracket|Bracket/' .. template)
+				or modus == 'singlematch' and 'SingleMatch'
+				or 'Matchlist'
+			)
+		)
 	end
 
 	return out

--- a/components/match2/commons/starcraft_starcraft2/get_match_group_copy_paste_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/get_match_group_copy_paste_starcraft.lua
@@ -119,8 +119,11 @@ function wikiCopyPaste.getStart(template, id, modus, args)
 		mw.text.nowiki('-->') .. '\n' .. mw.text.nowiki('<!--') ..
 		' For Opponent Copy-Paste-Code see Liquipedia:Brackets/Opponents#Copy-Paste ' ..
 		mw.text.nowiki('-->')) or ''
-	return '{{' .. (modus == 'bracket' and
-		('Bracket|Bracket/' .. template) or 'Matchlist') ..
+	return '{{' .. (
+		(modus == 'bracket' and
+			('Bracket|Bracket/' .. template)
+		) or (modus == 'singlematch' and 'SingleMatch')
+		or 'Matchlist') ..
 		'|id=' .. id .. tooltip
 end
 


### PR DESCRIPTION
## Summary
Add CopyPaste Generator support for SingleMatch
Usage mostly via https://liquipedia.net/starcraft2/Special:RunQuery/SingleMatchCopyPaste (Form to be added on other wikis too)

## How did you test this change?
per sandbox and then pushed live