### PR TITLE
[try7] Auto set up performance instrumentation from Lua.invoke

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -441,7 +441,6 @@ end
 
 if FeatureFlag.get('perf') then
 	Match.perfConfig = Table.getByPathOrNil(MatchGroupConfig, {'subobjectPerf'})
-	require('Module:Performance/Util').setupEntryPoints(Match, {'toEncodedJson'})
 end
 
 Lua.autoInvokeEntryPoints(Match, 'Module:Match', {'toEncodedJson'})

--- a/components/match2/commons/match_group_display.lua
+++ b/components/match2/commons/match_group_display.lua
@@ -171,7 +171,6 @@ end
 
 if FeatureFlag.get('perf') then
 	MatchGroupDisplay.perfConfig = Table.getByPathOrNil(MatchGroupConfig, {'perf'})
-	require('Module:Performance/Util').setupEntryPoints(MatchGroupDisplay)
 end
 
 Lua.autoInvokeEntryPoints(MatchGroupDisplay, 'Module:MatchGroup/Display')

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -86,7 +86,6 @@ local _ENTRY_POINT_NAMES = {'getOpponent', 'getMap', 'getPlayer', 'getRound'}
 if FeatureFlag.get('perf') then
 	local Match = Lua.import('Module:Match', {requireDevIfEnabled = true})
 	MatchSubobjects.perfConfig = Match.perfConfig
-	require('Module:Performance/Util').setupEntryPoints(MatchSubobjects, _ENTRY_POINT_NAMES)
 end
 
 Lua.autoInvokeEntryPoints(MatchSubobjects, 'Module:Match/Subobjects', _ENTRY_POINT_NAMES)


### PR DESCRIPTION
## Summary
Automatically sets up performance instrumentation if using Lua.invoke or auto-invoke functionality. This makes it easier set up performance instrumentation on modules. `PerformanceUtil.setupEntryPoints` is no longer needed. The `perfConfig` field on modules is now optional. If it is missing then the module is instrumented by default. 

This approach avoids the issue where the directly invoked function wasn't included in performance table due to the instrumentation being after the function had already started.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested on live modules and https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Tests/DH_EU/Legacy
![image](https://user-images.githubusercontent.com/85348434/142774822-8e3b6137-be7b-4bf9-bada-b59d5154266b.png)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
