### PR TITLE
[pl8] Combine opponent and match input processing

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 local WikiSpecificBase = {}
 
 -- called from Module:MatchGroup
--- called after processMap/processOpponent/processPlayer
+-- called after processMap/processPlayer
 -- used to alter match related parameters, e.g. automatically setting the winner
 -- @parameter frame - the frame object
 -- @parameter match - a match
@@ -33,18 +33,6 @@ WikiSpecificBase.processMap = FnUtil.lazilyDefineFunction(function()
 	local InputModule = Lua.import('Module:MatchGroup/Input/Custom', {requireDevIfEnabled = true})
 	return InputModule and InputModule.processMap
 		or error('Function "processMap" not implemented on wiki in "Module:MatchGroup/Input/Custom"')
-end)
-
--- called from Module:Match/Subobjects
--- used to transform wiki-specific input of templates to the generalized
--- format that is required by Module:MatchGroup
--- @parameter frame - the frame object
--- @parameter opponent - a opponent
--- @returns the opponent after changes have been applied
-WikiSpecificBase.processOpponent = FnUtil.lazilyDefineFunction(function()
-	local InputModule = Lua.import('Module:MatchGroup/Input/Custom', {requireDevIfEnabled = true})
-	return InputModule and InputModule.processOpponent
-		or error('Function "processOpponent" not implemented on wiki in "Module:MatchGroup/Input/Custom"')
 end)
 
 -- called from Module:Match/Subobjects

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -27,6 +27,7 @@ function Match.storeFromArgs(frame)
 end
 
 function Match.toEncodedJson(frame)
+	FeatureFlag.set('combined_opponent_input', true)
 	local args = Arguments.getArgs(frame)
 	return Match._toEncodedJson(args)
 end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -12,6 +12,7 @@ local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -302,6 +303,30 @@ function MatchGroupInput.fetchStandaloneMatch(matchId)
 	return Array.find(matches, function(match)
 		return match.match2id == matchId
 	end)
+end
+
+--[[
+Merges an opponent struct into a match2 opponent record.
+]]
+function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+	if opponent.type == Opponent.team then
+		record.template = record.template or opponent.template
+
+	elseif Opponent.typeIsParty(opponent.type) then
+		record.match2players = record.match2players
+			or Array.map(opponent.players, function(player)
+				return {
+					displayname = player.displayName,
+					flag = player.flag,
+					name = player.pageName,
+				}
+			end)
+	end
+
+	record.name = Opponent.toName(opponent)
+	record.type = opponent.type
+
+	return record
 end
 
 return MatchGroupInput

--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -203,7 +203,7 @@ function Legacy._convertSingle(realKey, val, match, mapping, flattened, source)
 				nestedArgs[innerKey] = _args[innerVal] or flattened[innerVal]
 			end
 			if String.startsWith(realKey, 'opponent') then
-				match[realKey] = MatchSubobjects.luaGetOpponent(_frame, nestedArgs)
+				match[realKey] = nestedArgs
 			elseif String.startsWith(realKey, 'map') then
 				match[realKey] = MatchSubobjects.luaGetMap(_frame, nestedArgs)
 			else

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -11,27 +11,9 @@ local FeatureFlag = require('Module:FeatureFlag')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 local wikiSpec = require('Module:Brkts/WikiSpecific')
 
-local ALLOWED_OPPONENT_TYPES = { 'literal', 'team', 'solo', 'duo', 'trio', 'quad' }
-
 local MatchSubobjects = {}
-
-function MatchSubobjects.getOpponent(frame)
-	local args = Arguments.getArgs(frame)
-	return Json.stringify(MatchSubobjects.luaGetOpponent(frame, args))
-end
-
-function MatchSubobjects.luaGetOpponent(frame, args)
-	if not Table.includes(ALLOWED_OPPONENT_TYPES, args.type) then
-		error('Unknown opponent type ' .. args.type)
-	end
-
-	args = wikiSpec.processOpponent(frame, args)
-	args.match2players = args.players or Json.parseIfString(args.match2players)
-	return args
-end
 
 function MatchSubobjects.getMap(frame)
 	local args = Arguments.getArgs(frame)
@@ -76,7 +58,7 @@ function MatchSubobjects.luaGetPlayer(frame, args)
 	return wikiSpec.processPlayer(frame, args)
 end
 
-local _ENTRY_POINT_NAMES = {'getOpponent', 'getMap', 'getPlayer', 'getRound'}
+local _ENTRY_POINT_NAMES = {'getMap', 'getPlayer', 'getRound'}
 
 if FeatureFlag.get('perf') then
 	local Match = Lua.import('Module:Match', {requireDevIfEnabled = true})

--- a/components/match2/wikis/rainbow_six/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbow_six/match_group_input_custom.lua
@@ -9,6 +9,7 @@
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
@@ -61,21 +62,17 @@ function CustomMatchGroupInput.processMap(_, map)
 	return map
 end
 
--- called from Module:Match/Subobjects
-function CustomMatchGroupInput.processOpponent(_, opponent)
-	-- check for empty team and convert to literal
-	if type(opponent) == 'table' and opponent.type == 'team' and Logic.isEmpty(opponent.template) then
-		opponent.name = ''
-		opponent.type = 'literal'
+function CustomMatchGroupInput.processOpponent(record, date)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	-- Convert byes to literals
+	if opponent.type == Opponent.team and opponent.template:lower() == 'bye' then
+		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
-	-- check for lazy bye's and convert them to literals
-	if type(opponent) == 'table' and string.lower(opponent.template or '') == 'bye' then
-			opponent.name = 'BYE'
-			opponent.type = 'literal'
-	end
-
-	return opponent
+	Opponent.resolve(opponent, date)
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
 -- called from Module:Match/Subobjects
@@ -418,14 +415,11 @@ function matchFunctions.getOpponents(match)
 		-- read opponent
 		local opponent = match['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
+			CustomMatchGroupInput.processOpponent(opponent, match.date)
 
-			--retrieve name and icon for teams from team templates
-			if opponent.type == 'team' and
-				not Logic.isEmpty(opponent.template, match.date) then
-					local name, icon, template = opponentFunctions.getTeamNameAndIcon(opponent.template, match.date)
-					opponent.template = template or opponent.template
-					opponent.name = opponent.name or name
-					opponent.icon = opponent.icon or icon
+			-- Retrieve icon for team
+			if opponent.type == Opponent.team then
+				opponent.icon = opponentFunctions.getIcon(opponent.template)
 			end
 
 			-- apply status
@@ -566,23 +560,9 @@ end
 --
 -- opponent related functions
 --
-function opponentFunctions.getTeamNameAndIcon(template, date)
-	local team, icon
-	date = mw.getContentLanguage():formatDate('Y-m-d', date or '')
-	template = (template or ''):lower():gsub('_', ' ')
-	if template ~= '' and template ~= 'noteam' and
-		mw.ext.TeamTemplate.teamexists(template) then
-
-		local templateData = mw.ext.TeamTemplate.raw(template, date)
-		icon = templateData.image
-		if icon == '' then
-			icon = templateData.legacyimage
-		end
-		team = templateData.page
-		template = templateData.templatename or template
-	end
-
-	return team, icon, template
+function opponentFunctions.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	return raw and Logic.emptyOr(raw.image, raw.legacyimage)
 end
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/rocketleague/legacy/legacy_match_list.lua
+++ b/components/match2/wikis/rocketleague/legacy/legacy_match_list.lua
@@ -90,11 +90,11 @@ function LegacyMatchList.convertMatchMaps(frame)
 		end
 
 		if template ~= 'tbd' then
-			args['opponent' .. index] = MatchSubobjects.luaGetOpponent(frame, {
-					type = 'team',
-					template = template,
-					score = score,
-				})
+			args['opponent' .. index] = {
+				score = score,
+				template = template,
+				type = 'team',
+			}
 		end
 		args['opponent' .. index .. 'literal'] = args['team' .. index .. 'literal']
 
@@ -145,18 +145,14 @@ function LegacyMatchList.convertSwissMatchMaps(frame)
 			end
 		end
 		if player ~= 'TBD' then
-			args['opponent' .. index] = MatchSubobjects.luaGetOpponent(frame, {
-					type = 'solo',
-					match2players = {
-						{
-							name = playerLink,
-							displayname = player,
-							flag = args['p' .. index .. 'flag'],
-						},
-					},
-					template = args['p' .. index .. 'team'],
-					score = score,
-				})
+			args['opponent' .. index] = {
+				flag = args['p' .. index .. 'flag'],
+				link = playerLink,
+				name = player,
+				score = score,
+				template = args['p' .. index .. 'team'],
+				type = 'solo',
+			}
 		end
 		args['opponent' .. index .. 'literal'] = args['team' .. index .. 'literal']
 

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -11,6 +11,7 @@ local p = require('Module:Brkts/WikiSpecific/Base')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -32,7 +33,6 @@ local _RESULT_TYPE_DRAW = 'draw'
 local _EARNINGS_LIMIT_FOR_FEATURED = 10000
 local _CURRENT_YEAR = os.date('%Y')
 
-local _frame
 local globalVars = PageVariableNamespace()
 
 -- containers for process helper functions
@@ -42,7 +42,6 @@ local opponentFunctions = {}
 
 -- called from Module:MatchGroup
 function p.processMatch(frame, match)
-	_frame = frame
 	Table.mergeInto(
 		match,
 		matchFunctions.readDate(match)
@@ -57,7 +56,6 @@ end
 
 -- called from Module:Match/Subobjects
 function p.processMap(frame, map)
-	_frame = frame
 	map = mapFunctions.getExtraData(map)
 	map = mapFunctions.getScoresAndWinner(map)
 	map = mapFunctions.getTournamentVars(map)
@@ -66,41 +64,35 @@ function p.processMap(frame, map)
 	return map
 end
 
--- called from Module:Match/Subobjects
-function p.processOpponent(frame, opponent)
-	_frame = frame
-	if not Logic.isEmpty(opponent.template) and
-		string.lower(opponent.template) == 'bye' then
-			opponent.name = 'BYE'
-			opponent.type = 'literal'
+function p.processOpponent(record, date)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	-- Convert byes to literals
+	if opponent.type == Opponent.team and opponent.template:lower() == 'bye' then
+		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
-	--fix for legacy conversion
-	local players = opponent.players or opponent.match2players
-	if opponent.type == 'solo' and players == nil then
-		opponent = opponentFunctions.getSoloFromLegacy(opponent)
-	end
+	Opponent.resolve(opponent, date)
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 
 	--score2 & score3 support for every match
-	local score2 = tonumber(opponent.score2 or '')
-	local score3 = tonumber(opponent.score3 or '')
+	local score2 = tonumber(record.score2 or '')
+	local score3 = tonumber(record.score3 or '')
 	if score2 then
-		opponent.extradata = {
+		record.extradata = {
 			score2 = score2,
 			score3 = score3,
-			set1win = Logic.readBool(opponent.set1win),
-			set2win = Logic.readBool(opponent.set2win),
-			set3win = Logic.readBool(opponent.set3win),
+			set1win = Logic.readBool(record.set1win),
+			set2win = Logic.readBool(record.set2win),
+			set3win = Logic.readBool(record.set3win),
 			additionalScores = true
 		}
 	end
-
-	return opponent
 end
 
 -- called from Module:Match/Subobjects
 function p.processPlayer(frame, player)
-	_frame = frame
 	return player
 end
 
@@ -264,18 +256,15 @@ function matchFunctions.getOpponents(args)
 	local isScoreSet = false
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		-- read opponent
-		local opponent = Json.parseIfString(args['opponent' .. opponentIndex])
+		local opponent = args['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
-			--retrieve name and icon for teams from team templates
-			if opponent.type == 'team' and
-				not Logic.isEmpty(opponent.template, args.date) then
-					local name, icon, template = opponentFunctions.getTeamNameAndIcon(opponent.template, args.date)
-					opponent.template = template
-					opponent.name = mw.ext.TeamLiquidIntegration.resolve_redirect(
-						opponent.name or name or
-						opponentFunctions.getTeamName(opponent.template)
-						or '')
-					opponent.icon = opponent.icon or icon or opponentFunctions.getIconName(opponent.template)
+			p.processOpponent(opponent, args.date)
+
+			-- Retrieve icon and legacy name for team
+			if opponent.type == Opponent.team then
+				opponent.icon = opponentFunctions.getTeamIcon(opponent.template)
+					or opponentFunctions.getLegacyTeamIcon(opponent.template)
+				opponent.name = opponent.name or opponentFunctions.getLegacyTeamName(opponent.template)
 			end
 
 			-- apply status
@@ -518,61 +507,28 @@ end
 --
 -- opponent related functions
 --
-function opponentFunctions.getTeamNameAndIcon(template, date)
-	local icon, team
-	template = string.lower(template or ''):gsub('_', ' ')
-	if template ~= '' and template ~= 'noteam' and
-		mw.ext.TeamTemplate.teamexists(template) then
-
-		local templateData = mw.ext.TeamTemplate.raw(template, date)
-		icon = templateData.image
-		if icon == '' then
-			icon = templateData.legacyimage
-		end
-		team = templateData.page
-		template = templateData.templatename or template
-	end
-
-	return team, icon, template
+function opponentFunctions.getTeamIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	return raw and Logic.emptyOr(raw.image, raw.legacyimage)
 end
 
 --the following 2 functions are a fallback
 --they are only useful if the team template doesn't exist
 --in the team template extension
-function opponentFunctions.getTeamName(template)
-	if template ~= nil then
-		local team = Template.expandTemplate(_frame, 'Team', { template })
-		team = team:gsub('%&', '')
-		team = String.split(team, 'link=')[2]
-		team = String.split(team, ']]')[1]
-		return team
-	else
-		return nil
-	end
+function opponentFunctions.getLegacyTeamName(template)
+	local team = Template.expandTemplate(mw.getCurrentFrame(), 'Team', { template })
+	team = team:gsub('%&', '')
+	team = String.split(team, 'link=')[2]
+	team = String.split(team, ']]')[1]
+	return team
 end
 
-function opponentFunctions.getIconName(template)
-	if template ~= nil then
-		local icon = Template.expandTemplate(_frame, 'Team', { template })
-		icon = icon:gsub('%&', '')
-		icon = String.split(icon, 'File:')[2]
-		icon = String.split(icon, '|')[1]
-		return icon
-	else
-		return nil
-	end
-end
-
---needed for legacy conversion to work for solo brackets
-function opponentFunctions.getSoloFromLegacy(opponent)
-	local player = {
-		name = opponent.name,
-		displayname = opponent.displayname or opponent.name,
-		flag = opponent.flag
-	}
-	opponent.match2players = {player}
-	opponent.name = nil
-	return opponent
+function opponentFunctions.getLegacyTeamIcon(template)
+	local icon = Template.expandTemplate(mw.getCurrentFrame(), 'Team', { template })
+	icon = icon:gsub('%&', '')
+	icon = String.split(icon, 'File:')[2]
+	icon = String.split(icon, '|')[1]
+	return icon
 end
 
 return p

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -9,6 +9,7 @@
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
@@ -60,21 +61,17 @@ function CustomMatchGroupInput.processMap(_, map)
 	return map
 end
 
--- called from Module:Match/Subobjects
-function CustomMatchGroupInput.processOpponent(_, opponent)
-	-- check for empty opponent and convert to literal
-	if type(opponent) == 'table' and opponent.type == 'team' and Logic.isEmpty(opponent.template) then
-		opponent.name = ''
-		opponent.type = 'literal'
+function CustomMatchGroupInput.processOpponent(record, date)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	-- Convert byes to literals
+	if opponent.type == Opponent.team and opponent.template:lower() == 'bye' then
+		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
-	-- check for lazy bye's and convert them to literals
-	if type(opponent) == 'table' and string.lower(opponent.template or '') == 'bye' then
-			opponent.name = 'BYE'
-			opponent.type = 'literal'
-	end
-
-	return opponent
+	Opponent.resolve(opponent, date)
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
 -- called from Module:Match/Subobjects
@@ -387,16 +384,11 @@ function matchFunctions.getOpponents(match)
 		-- read opponent
 		local opponent = match['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
-			--retrieve name and icon for teams from team templates
-			if opponent.type == 'team' and
-				not Logic.isEmpty(opponent.template, match.date) then
-					local name, icon, template = opponentFunctions.getTeamNameAndIcon(opponent.template, match.date)
-					opponent.template = template or opponent.template
-					opponent.name = opponent.name or name
-					opponent.icon = opponent.icon or icon
-			end
-			if not String.isEmpty(opponent.name) then
-				opponent.name = mw.ext.TeamLiquidIntegration.resolve_redirect(opponent.name)
+			CustomMatchGroupInput.processOpponent(opponent, match.date)
+
+			-- Retrieve icon for team
+			if opponent.type == Opponent.team then
+				opponent.icon = opponentFunctions.getIcon(opponent.template)
 			end
 
 			-- apply status
@@ -534,23 +526,9 @@ end
 --
 -- opponent related functions
 --
-function opponentFunctions.getTeamNameAndIcon(template, date)
-	local team, icon
-	date = mw.getContentLanguage():formatDate('Y-m-d', date or '')
-	template = (template or ''):lower():gsub('_', ' ')
-	if template ~= '' and template ~= 'noteam' and
-		mw.ext.TeamTemplate.teamexists(template) then
-
-		local templateData = mw.ext.TeamTemplate.raw(template, date)
-		icon = templateData.image
-		if icon == '' then
-			icon = templateData.legacyimage
-		end
-		team = templateData.page
-		template = templateData.templatename or template
-	end
-
-	return team, icon, template
+function opponentFunctions.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	return raw and Logic.emptyOr(raw.image, raw.legacyimage)
 end
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/starcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft/brkts_wiki_specific.lua
@@ -47,8 +47,4 @@ function WikiSpecific.processMap(frame, map)
 	return map
 end
 
-function WikiSpecific.processOpponent(frame, opponent)
-	return opponent
-end
-
 return WikiSpecific

--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -47,8 +47,4 @@ function WikiSpecific.processMap(frame, map)
 	return map
 end
 
-function WikiSpecific.processOpponent(frame, opponent)
-	return opponent
-end
-
 return WikiSpecific


### PR DESCRIPTION
## Summary
This changes opponent processing to be done at the same time as match processing, instead of in a previous stage. The approach is the one taken by starcraft/starcraft2. This PR changes all wikis to use that approach.

The advantage of the starcraft approach is that:
- Opponent processing is all in lua instead of half template half lua.
- The match2 opponent notation is no longer tied to `{{Match}}` contexts. This makes match2 opponent notation available in other components like GroupTableLeague, PrizePool and OpponentList.
- By making use of Opponent.readOpponentArgs, the input of duo/trio/quad opponent types are automatically enabled in match2 wikis.
- The code flow is much simpler, by using a single entry point and avoiding indirections like `WikiSpecific.processOpponent`.
- The new code should be faster because the total number of loaded modules is reduced

Overview of changes:
- `Template:SoloOpponent`, `Template:TeamOpponent`, `Template:LiteralOpponent` no longer does input processing. They just pass through inputs args as json now. 
- The input parsing logic in those templates is taken over by `Opponent.readOpponentArgs` and `MatchGroupInput.coerceOpponentRecord`.
- `WikiSpecific.processOpponent` and `MatchSubobjects.luaGetOpponent` are removed. The functions they used to point to are now called directly.
- Custom opponent processing is performed in the entry point for {{Match}} instead of its own entry point.

**Push instructions:** Please notify @warnull before push so a quick final test can be performed.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
tournament test suite on various wikis
https://liquipedia.net/rocketleague/Liquipedia:BracketUpdate/Tests/Suji
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
