### PR TITLE
Adjust earnings to allow differently stored player pagenames

### DIFF
--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -33,19 +33,19 @@ Earnings.defaultNumberOfStoredPlayersPerMatch = 10
 function Earnings.calculateForPlayer(args)
 	args = args or {}
 	local player = args.player
-	local playerAsPageName
 
 	if String.isEmpty(player) then
 		return 0
 	end
 	if not Logic.readBool(args.noRedirect) then
 		player = mw.ext.TeamLiquidIntegration.resolve_redirect(player)
+	else
+		player = player:gsub('_', ' ')
 	end
 
 	-- since TeamCards on some wikis store players with underscores and some with spaces
 	-- we need to check for both options
-	playerAsPageName = player:gsub(' ', '_')
-	player = player:gsub('_', ' ')
+	local playerAsPageName = player:gsub(' ', '_')
 
 	local prefix = args.prefix or 'p'
 

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -33,6 +33,7 @@ Earnings.defaultNumberOfStoredPlayersPerMatch = 10
 function Earnings.calculateForPlayer(args)
 	args = args or {}
 	local player = args.player
+	local playerAsPageName
 
 	if String.isEmpty(player) then
 		return 0
@@ -41,6 +42,11 @@ function Earnings.calculateForPlayer(args)
 		player = mw.ext.TeamLiquidIntegration.resolve_redirect(player)
 	end
 
+	-- since TeamCards on some wikis store players with underscores and some with spaces
+	-- we need to check for both options
+	playerAsPageName = player:gsub(' ', '_')
+	player = player:gsub('_', ' ')
+
 	local prefix = args.prefix or 'p'
 
 	local playerPositionLimit = tonumber(args.playerPositionLimit) or Earnings.defaultNumberOfStoredPlayersPerMatch
@@ -48,9 +54,10 @@ function Earnings.calculateForPlayer(args)
 		error('"playerPositionLimit" has to be >= 1')
 	end
 
-	local playerConditions = '([[participant::' .. player .. ']]'
+	local playerConditions = '([[participant::' .. player .. ']] OR [[participant::' .. playerAsPageName .. ']]'
 	for playerIndex = 1, playerPositionLimit do
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. player .. ']]'
+		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. playerAsPageName .. ']]'
 	end
 	playerConditions = playerConditions .. ')'
 


### PR DESCRIPTION
## Summary
Sadly atm we have a bunch of different TeamCards on the wikis.
Some of the teamCards store the players pages with undersocres replacing spaces, some use spaces instead of underscores.
> `PlayerA_(unique_identifier)` vs `PlayerA (unique identifier)`

To resolve this issue this PR adjusts the query conditions so that they fetch data for both cases.

## How did you test this change?
via Sandbox