### PR TITLE
Add support for special teams

### DIFF
--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -3,6 +3,7 @@ local String = require('Module:String')
 local Player = require('Module:Player')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Template = require('Module:Template')
+local Table = require('Module:Table')
 
 local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain]]'
 local _ICON_SUBSTITUTE = '[[image:Substitution.svg|18px|baseline|Sub|link=|alt=Substitution]]'
@@ -30,6 +31,12 @@ local SquadRow = Class.new(
 			self.content:css('background-color', _COLOR_BACKGROUND_COACH)
 		end
 	end)
+
+SquadRow.specialTeamsTemplateMapping = {
+	retired = 'Team/retired',
+	inactive = 'Team/inactive',
+}
+
 
 function SquadRow:id(args)
 	local cell = mw.html.create('td')
@@ -105,8 +112,8 @@ function SquadRow:newteam(args)
 			cell:wikitext(mw.ext.TeamTemplate.team(args.newteam:lower(),
 				args.newteamdate or ReferenceCleaner.clean(args.leavedate)))
 		elseif self.options.useTemplatesForSpecialTeams then
-			if newteam == 'retired' or newteam == 'inactive' then
-				cell:wikitext(Template.safeExpand(mw.getCurrentFrame(), 'Team/' .. newteam))
+			if Table.includes(SquadRow.specialTeamsTemplateMapping, newteam) then
+				cell:wikitext(Template.safeExpand(mw.getCurrentFrame(), SquadRow.specialTeamsTemplateMapping[newteam]))
 			end
 		end
 

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -2,6 +2,7 @@ local Class = require('Module:Class')
 local String = require('Module:String')
 local Player = require('Module:Player')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
+local Template = require('Module:Template')
 
 local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain]]'
 local _ICON_SUBSTITUTE = '[[image:Substitution.svg|18px|baseline|Sub|link=|alt=Substitution]]'
@@ -9,9 +10,10 @@ local _ICON_SUBSTITUTE = '[[image:Substitution.svg|18px|baseline|Sub|link=|alt=S
 local _COLOR_BACKGROUND_COACH = '#e5e5e5'
 
 local SquadRow = Class.new(
-	function(self, frame, role)
+	function(self, frame, role, options)
 		self.frame = frame
 		self.content = mw.html.create('tr'):addClass('Player')
+		self.options = options or {}
 
 		role = string.lower(role or '')
 
@@ -102,16 +104,21 @@ function SquadRow:newteam(args)
 		if mw.ext.TeamTemplate.teamexists(newteam) then
 			cell:wikitext(mw.ext.TeamTemplate.team(args.newteam:lower(),
 				args.newteamdate or ReferenceCleaner.clean(args.leavedate)))
+		elseif self.options.useTemplatesForSpecialTeams then
+			if newteam == 'retired' or newteam == 'inactive' then
+				cell:wikitext(Template.safeExpand(mw.getCurrentFrame(), newteam))
+			end
 		end
+
 
 		if not String.isEmpty(args.newteamrole) then
 			cell:wikitext('&nbsp;\'\'<small>(' .. args.newteamrole .. ')</small>\'\'')
 		end
+
 	end
 
 	self.content:node(cell)
 	return self
-
 end
 
 function SquadRow:create()

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -107,13 +107,14 @@ function SquadRow:newteam(args)
 		cell:node(mobileStuffDiv)
 
 
-		local newteam = args.newteam:lower()
-		if mw.ext.TeamTemplate.teamexists(newteam) then
+		local newTeam = args.newteam:lower()
+		if mw.ext.TeamTemplate.teamexists(newTeam) then
 			cell:wikitext(mw.ext.TeamTemplate.team(args.newteam:lower(),
 				args.newteamdate or ReferenceCleaner.clean(args.leavedate)))
 		elseif self.options.useTemplatesForSpecialTeams then
-			if Table.includes(SquadRow.specialTeamsTemplateMapping, newteam) then
-				cell:wikitext(Template.safeExpand(mw.getCurrentFrame(), SquadRow.specialTeamsTemplateMapping[newteam]))
+			local newTeamTemplate = SquadRow.specialTeamsTemplateMapping[newTeam]
+			if newTeamTemplate then
+				cell:wikitext(Template.safeExpand(mw.getCurrentFrame(), newTeamTemplate))
 			end
 		end
 

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -3,7 +3,6 @@ local String = require('Module:String')
 local Player = require('Module:Player')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Template = require('Module:Template')
-local Table = require('Module:Table')
 
 local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain]]'
 local _ICON_SUBSTITUTE = '[[image:Substitution.svg|18px|baseline|Sub|link=|alt=Substitution]]'

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -106,7 +106,7 @@ function SquadRow:newteam(args)
 				args.newteamdate or ReferenceCleaner.clean(args.leavedate)))
 		elseif self.options.useTemplatesForSpecialTeams then
 			if newteam == 'retired' or newteam == 'inactive' then
-				cell:wikitext(Template.safeExpand(mw.getCurrentFrame(), newteam))
+				cell:wikitext(Template.safeExpand(mw.getCurrentFrame(), 'Team/' .. newteam))
 			end
 		end
 


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

Builds on #636 and implements support for "special" teams, like "retired" which if enabled by the wiki will call the template `{{Team/retired}}`, etc

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
Tested in sandbox 
![image](https://user-images.githubusercontent.com/5138348/143025838-a600e666-b1b6-4a0c-bf87-443c3e900296.png)
