### PR TITLE
Add `YearsActive` commons implementation

### DIFF
--- a/components/infobox/extensions/commons/years_active.lua
+++ b/components/infobox/extensions/commons/years_active.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEnabled = true})
 
 -- wiki specific settings
-CustomActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
+CustomActiveYears.defaultNumberOfStoredPlayersPerPlacement = 10
 CustomActiveYears.additionalConditions = ''
 
 return Class.export(CustomActiveYears)

--- a/components/infobox/extensions/commons/years_active.lua
+++ b/components/infobox/extensions/commons/years_active.lua
@@ -12,7 +12,6 @@ local Lua = require('Module:Lua')
 local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEnabled = true})
 
 -- wiki specific settings
-CustomActiveYears.startYear = 1970
 CustomActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
 CustomActiveYears.additionalConditions = ''
 

--- a/components/infobox/extensions/commons/years_active.lua
+++ b/components/infobox/extensions/commons/years_active.lua
@@ -1,0 +1,19 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:YearsActive
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEnabled = true})
+
+-- wiki specific settings
+CustomActiveYears.startYear = 1970
+CustomActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
+CustomActiveYears.additionalConditions = ''
+
+return Class.export(CustomActiveYears)

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -27,7 +27,7 @@ local _CURRENT_YEAR = tonumber(os.date('%Y'))
 
 -- overwritable per wiki
 ActiveYears.startYear = Info.startYear
-ActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
+ActiveYears.defaultNumberOfStoredPlayersPerPlacement = 10
 ActiveYears.additionalConditions = ''
 
 ---
@@ -56,7 +56,7 @@ function ActiveYears.display(args)
 
 	local prefix = args.prefix or 'p'
 
-	local playerPositionLimit = tonumber(args.playerPositionLimit) or ActiveYears.defaultNumberOfStoredPlayersPerMatch
+	local playerPositionLimit = tonumber(args.playerPositionLimit) or ActiveYears.defaultNumberOfStoredPlayersPerPlacement
 	if playerPositionLimit <=0 then
 		error('"playerPositionLimit" has to be >= 1')
 	end

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -10,6 +10,7 @@ local ActiveYears = {}
 
 local Class = require('Module:Class')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 local Logic = require('Module:Logic')
 local Info = mw.loadData('Module:Info')
 
@@ -78,6 +79,22 @@ function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLi
 end
 
 function ActiveYears._calculate(conditions)
+	local years = ActiveYears._getYears(conditions)
+
+	if Table.isEmpty(years) then
+		return 'Player has no results.'
+	end
+
+	local sortedYears = ActiveYears._sortYears(years)
+
+	-- Generate output for activity ranges
+	local output = table.concat(ActiveYears._groupYears(sortedYears), ',</br>')
+
+	-- Return text with years active
+	return output
+end
+
+function ActiveYears._getYears(conditions)
 	local years = {}
 	local offset = 0
 	local count = _MAX_QUERY_LIMIT
@@ -92,7 +109,7 @@ function ActiveYears._calculate(conditions)
 		})
 
 		if offset == 0 and #lpdbQueryData == 0 then
-			return 'Player has no results.'
+			return {}
 		end
 
 		-- Find all years for which the player has at least one placement
@@ -105,15 +122,8 @@ function ActiveYears._calculate(conditions)
 		offset = offset + _MAX_QUERY_LIMIT
 	end
 
-	local sortedYears = ActiveYears._sortYears(years)
-
-	-- Generate output for activity ranges
-	local output = table.concat(ActiveYears._groupYears(sortedYears), ',</br>')
-
-	-- Return text with years active
-	return output
+	return years
 end
-
 
 function ActiveYears._groupYears(sortedYears)
 	local startYear
@@ -138,9 +148,6 @@ function ActiveYears._groupYears(sortedYears)
 
 	return yearRanges
 end
-
-
-
 
 function ActiveYears._sortYears(years)
 	-- Sort years chronologically

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -14,6 +14,7 @@ local Table = require('Module:Table')
 local Logic = require('Module:Logic')
 local Info = mw.loadData('Module:Info')
 local Lpdb = require('Module:Lpdb')
+local Set = require('Module:Set')
 
 local Condition = require('Module:Condition')
 local ConditionTree = Condition.Tree
@@ -103,21 +104,22 @@ function ActiveYears._calculate(conditions)
 		return 'Player has no results.'
 	end
 
-	local sortedYears = ActiveYears._sortYears(years)
+	-- Sort years chronologically
+	table.sort(years)
 
 	-- Generate output for activity ranges
-	local output = table.concat(ActiveYears._groupYears(sortedYears), ',</br>')
+	local output = table.concat(ActiveYears._groupYears(years), ',</br>')
 
 	-- Return text with years active
 	return output
 end
 
 function ActiveYears._getYears(conditions)
-	local years = {}
+	local years = Set{}
 	local checkYear = function(placement)
 		-- set the year in which the placement happened as true (i.e. active)
 		local year = tonumber(string.sub(placement.date, 1, 4))
-		years[year] = true
+		years:add(year)
 	end
 	local queryParameters = {
 		conditions = conditions,
@@ -126,7 +128,7 @@ function ActiveYears._getYears(conditions)
 	}
 	Lpdb.executeMassQuery('placement', queryParameters, checkYear)
 
-	return years
+	return years:toArray()
 end
 
 function ActiveYears._groupYears(sortedYears)
@@ -151,17 +153,6 @@ function ActiveYears._groupYears(sortedYears)
 	end
 
 	return yearRanges
-end
-
-function ActiveYears._sortYears(years)
-	-- Sort years chronologically
-	local sortedYears = {}
-	for year in pairs(years) do
-		table.insert(sortedYears, year)
-	end
-	table.sort(sortedYears)
-
-	return sortedYears
 end
 
 function ActiveYears._insertYears(startYear, endYear, yearRanges)

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -91,8 +91,8 @@ function ActiveYears._calculate(conditions)
 		end
 
 		-- Find all years for which the player has at least one placement
-		for key, item in ipairs(lpdbQueryData) do
-			year = tonumber(string.sub(item.date, 1, 4))
+		for _, item in ipairs(lpdbQueryData) do
+			local year = tonumber(string.sub(item.date, 1, 4))
 			years[year] = 0
 		end
 

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -116,7 +116,8 @@ function ActiveYears._calculate(conditions)
 	for index, year in ipairs(sortedYears) do
 		if index == 1 then
 			_startYear = year
-		elseif year - _endYear ~= 1 then
+		elseif year - _endYear > 1 then
+		-- If the difference is greater than 1 we have skipped a year, so we have to insert
 			ActiveYears._insertYears()
 			_startYear = year
 		end

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -11,13 +11,14 @@ local ActiveYears = {}
 local Class = require('Module:Class')
 local String = require('Module:StringUtils')
 local Logic = require('Module:Logic')
+local Info = mw.loadData('Module:Info')
 
 local _DEFAULT_DATE = '1970-01-01 00:00:00'
 local _CURRENT_YEAR = tonumber(os.date('%Y'))
 local _MAX_QUERY_LIMIT = 5000
 
 -- overwritable per wiki
-ActiveYears.startYear = 1970
+ActiveYears.startYear = Info.startYear
 ActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
 ActiveYears.additionalConditions = ''
 

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -115,29 +115,16 @@ function ActiveYears._calculate(conditions)
 	for index, year in ipairs(sortedYears) do
 		if index == 1 then
 			startYear = year
-			endYear = year
-		else
-			if year - endYear == 1 then
-				endYear = year
-			else
-				if startYear == endYear then
-					table.insert(yearRanges, tostring(startYear))
-				else
-					table.insert(yearRanges, tostring(startYear) .. ' - ' .. tostring(endYear))
-				end
-				startYear = year
-				endYear = year
-			end
+		elseif year - endYear ~= 1 then
+			yearRanges = ActiveYears._insertYears(startYear, endYear, yearRanges)
+			startYear = year
 		end
+		endYear = year
 	end
 	if endYear == _CURRENT_YEAR then
 		table.insert(yearRanges, tostring(startYear) .. ' - ' .. "'''Present'''")
 	else
-		if startYear == endYear then
-			table.insert(yearRanges, tostring(startYear))
-		else
-			table.insert(yearRanges, tostring(startYear) .. ' - ' .. tostring(endYear))
-		end
+		yearRanges = ActiveYears._insertYears(startYear, endYear, yearRanges)
 	end
 
 	-- Generate output for activity ranges
@@ -145,6 +132,16 @@ function ActiveYears._calculate(conditions)
 
 	-- Return text with years active
 	return output
+end
+
+function ActiveYears._insertYears(startYear, endYear, yearRanges)
+	if startYear == endYear then
+		table.insert(yearRanges, tostring(startYear))
+	else
+		table.insert(yearRanges, tostring(startYear) .. ' - ' .. tostring(endYear))
+	end
+	
+	return yearRanges
 end
 
 return Class.export(ActiveYears)

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -94,7 +94,7 @@ function ActiveYears._calculate(conditions)
 		-- Find all years for which the player has at least one placement
 		for _, item in ipairs(lpdbQueryData) do
 			local year = tonumber(string.sub(item.date, 1, 4))
-			years[year] = 0
+			years[year] = true
 		end
 
 		count = #lpdbQueryData

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -17,6 +17,10 @@ local _DEFAULT_DATE = '1970-01-01 00:00:00'
 local _CURRENT_YEAR = tonumber(os.date('%Y'))
 local _MAX_QUERY_LIMIT = 5000
 
+local _startYear
+local _endYear
+local _yearRanges = {}
+
 -- overwritable per wiki
 ActiveYears.startYear = Info.startYear
 ActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
@@ -109,39 +113,34 @@ function ActiveYears._calculate(conditions)
 	table.sort(sortedYears)
 
 	-- Determine activity ranges by grouping consecutive years
-	local startYear
-	local endYear
-	local yearRanges = {}
 	for index, year in ipairs(sortedYears) do
 		if index == 1 then
-			startYear = year
-		elseif year - endYear ~= 1 then
-			yearRanges = ActiveYears._insertYears(startYear, endYear, yearRanges)
-			startYear = year
+			_startYear = year
+		elseif year - _endYear ~= 1 then
+			ActiveYears._insertYears()
+			_startYear = year
 		end
-		endYear = year
+		_endYear = year
 	end
-	if endYear == _CURRENT_YEAR then
-		table.insert(yearRanges, tostring(startYear) .. ' - ' .. "'''Present'''")
+	if _endYear == _CURRENT_YEAR then
+		table.insert(_yearRanges, tostring(_startYear) .. ' - ' .. "'''Present'''")
 	else
-		yearRanges = ActiveYears._insertYears(startYear, endYear, yearRanges)
+		ActiveYears._insertYears()
 	end
 
 	-- Generate output for activity ranges
-	local output = table.concat(yearRanges, ',</br>')
+	local output = table.concat(_yearRanges, ',</br>')
 
 	-- Return text with years active
 	return output
 end
 
-function ActiveYears._insertYears(startYear, endYear, yearRanges)
-	if startYear == endYear then
-		table.insert(yearRanges, tostring(startYear))
+function ActiveYears._insertYears()
+	if _startYear == _endYear then
+		table.insert(_yearRanges, tostring(_startYear))
 	else
-		table.insert(yearRanges, tostring(startYear) .. ' - ' .. tostring(endYear))
+		table.insert(_yearRanges, tostring(_startYear) .. ' - ' .. tostring(_endYear))
 	end
-	
-	return yearRanges
 end
 
 return Class.export(ActiveYears)

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -141,14 +141,7 @@ function ActiveYears._calculate(conditions)
 	end
 
 	-- Generate output for activity ranges
-	local output = ''
-	for index, range in ipairs(yearRanges) do
-		if index == 1 then
-			output = range
-		else
-			output = output .. ',</br>' .. range
-		end
-	end
+	local output = table.concat(yearRanges, ',</br>')
 
 	-- Return text with years active
 	return output

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -21,12 +21,6 @@ ActiveYears.startYear = 1970
 ActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
 ActiveYears.additionalConditions = ''
 
--- legacy entry point
-function ActiveYears.get(input)
-	local args = input.args
-	return ActiveYears.display(args)
-end
-
 ---
 -- Entry point
 -- @player - the player/individual for whom the active years shall be determined

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -1,0 +1,162 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:YearsActive/Base
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local ActiveYears = {}
+
+local Class = require('Module:Class')
+local String = require('Module:StringUtils')
+local Logic = require('Module:Logic')
+
+local _DEFAULT_DATE = '1970-01-01 00:00:00'
+local _CURRENT_YEAR = tonumber(os.date('%Y'))
+local _MAX_QUERY_LIMIT = 5000
+
+-- overwritable per wiki
+ActiveYears.startYear = 1970
+ActiveYears.defaultNumberOfStoredPlayersPerMatch = 10
+ActiveYears.additionalConditions = ''
+
+-- legacy entry point
+function ActiveYears.get(input)
+	local args = input.args
+	return ActiveYears.display(args)
+end
+
+---
+-- Entry point
+-- @player - the player/individual for whom the active years shall be determined
+-- @mode - (optional) the mode to calculate earnings for (used for LPDB conditions)
+-- @noRedirect - (optional) player redirects get not resolved before query
+-- @prefix - (optional) the prefix under which the players are stored in the placements
+-- @playerPositionLimit - (optional) the number for how many params the query should look in LPDB
+function ActiveYears.display(args)
+	args = args or {}
+	local player = args.player
+
+	if String.isEmpty(player) then
+		error('No player specified')
+	end
+	if not Logic.readBool(args.noRedirect) then
+		player = mw.ext.TeamLiquidIntegration.resolve_redirect(player)
+	else
+		player = player:gsub('_', ' ')
+	end
+
+	-- since TeamCards on some wikis store players with underscores and some with spaces
+	-- we need to check for both options
+	local playerAsPageName = player:gsub(' ', '_')
+
+	local prefix = args.prefix or 'p'
+
+	local playerPositionLimit = tonumber(args.playerPositionLimit) or ActiveYears.defaultNumberOfStoredPlayersPerMatch
+	if playerPositionLimit <=0 then
+		error('"playerPositionLimit" has to be >= 1')
+	end
+
+	local conditions = '([[participant::' .. player .. ']] OR [[participant::' .. playerAsPageName .. ']]'
+	for playerIndex = 1, playerPositionLimit do
+		conditions = conditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. player .. ']]'
+		conditions = conditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. playerAsPageName .. ']]'
+	end
+	conditions = conditions .. ')'
+
+	conditions = conditions .. ' AND [[date::!' .. _DEFAULT_DATE .. ']] AND (' ..
+		'[[date_year::>' .. ActiveYears.startYear .. ']] OR ' ..
+		'[[date_year::' .. ActiveYears.startYear .. ']])'
+
+	if String.isNotEmpty(args.mode) then
+		conditions = conditions .. ' AND [[mode::' .. args.mode .. ']]'
+	end
+
+	conditions = conditions .. ActiveYears.additionalConditions
+
+	return ActiveYears._calculate(conditions)
+end
+
+function ActiveYears._calculate(conditions)
+	local years = {}
+	local offset = 0
+	local count = _MAX_QUERY_LIMIT
+
+	while count == _MAX_QUERY_LIMIT do
+		local lpdbQueryData = mw.ext.LiquipediaDB.lpdb('placement', {
+			order = 'date asc',
+			conditions = conditions,
+			query = 'date',
+			limit = _MAX_QUERY_LIMIT,
+			offset = offset
+		})
+
+		if offset == 0 and #lpdbQueryData == 0 then
+			return 'Player has no results.'
+		end
+
+		-- Find all years for which the player has at least one placement
+		for key, item in ipairs(lpdbQueryData) do
+			year = tonumber(string.sub(item.date, 1, 4))
+			years[year] = 0
+		end
+
+		count = #lpdbQueryData
+		offset = offset + _MAX_QUERY_LIMIT
+	end
+
+	-- Sort years chronologically
+	local sortedYears = {}
+	for year in pairs(years) do
+		table.insert(sortedYears, year)
+	end
+	table.sort(sortedYears)
+
+	-- Determine activity ranges by grouping consecutive years
+	local startYear
+	local endYear
+	local yearRanges = {}
+	for index, year in ipairs(sortedYears) do
+		if index == 1 then
+			startYear = year
+			endYear = year
+		else
+			if year - endYear == 1 then
+				endYear = year
+			else
+				if startYear == endYear then
+					table.insert(yearRanges, tostring(startYear))
+				else
+					table.insert(yearRanges, tostring(startYear) .. ' - ' .. tostring(endYear))
+				end
+				startYear = year
+				endYear = year
+			end
+		end
+	end
+	if endYear == _CURRENT_YEAR then
+		table.insert(yearRanges, tostring(startYear) .. ' - ' .. "'''Present'''")
+	else
+		if startYear == endYear then
+			table.insert(yearRanges, tostring(startYear))
+		else
+			table.insert(yearRanges, tostring(startYear) .. ' - ' .. tostring(endYear))
+		end
+	end
+
+	-- Generate output for activity ranges
+	local output = ''
+	for index, range in ipairs(yearRanges) do
+		if index == 1 then
+			output = range
+		else
+			output = output .. ',</br>' .. range
+		end
+	end
+
+	-- Return text with years active
+	return output
+end
+
+return Class.export(ActiveYears)

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEnabled = true})
 
 -- wiki specific settings
-CustomActiveYears.defaultNumberOfStoredPlayersPerMatch = 6
+CustomActiveYears.defaultNumberOfStoredPlayersPerPlacement = 6
 CustomActiveYears.additionalConditions = ''
 
 -- legacy entry point

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -12,7 +12,6 @@ local Lua = require('Module:Lua')
 local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEnabled = true})
 
 -- wiki specific settings
-CustomActiveYears.startYear = 1995
 CustomActiveYears.defaultNumberOfStoredPlayersPerMatch = 6
 CustomActiveYears.additionalConditions = ''
 

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -17,7 +17,7 @@ CustomActiveYears.additionalConditions = ''
 
 -- legacy entry point
 function CustomActiveYears.get(input)
-	local args = input.args
+	local args = input.args or input
 	return CustomActiveYears.display(args)
 end
 

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -17,6 +17,8 @@ CustomActiveYears.additionalConditions = ''
 
 -- legacy entry point
 function CustomActiveYears.get(input)
+	-- if invoked directly input == args
+	-- if passed from modules it might be a table that holds the args table
 	local args = input.args or input
 	return CustomActiveYears.display(args)
 end

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=rocketleague 
+-- wiki=rocketleague
 -- page=Module:YearsActive
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -1,0 +1,25 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague 
+-- page=Module:YearsActive
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEnabled = true})
+
+-- wiki specific settings
+CustomActiveYears.startYear = 1995
+CustomActiveYears.defaultNumberOfStoredPlayersPerMatch = 6
+CustomActiveYears.additionalConditions = ''
+
+-- legacy entry point
+function CustomActiveYears.get(input)
+	local args = input.args
+	return CustomActiveYears.display(args)
+end
+
+return Class.export(CustomActiveYears)


### PR DESCRIPTION
## Summary
Add an implementation of `YearsActive` via commons.
Wikis can set custom values (startYear, additionalConditions, defaultNumberOfStoredPlayersPerMatch) and legacy entry points via a wikispecific module

## How did you test this change?
* created the commons modules, tested them on sc2 and some other wikis via preview
* temp created a /test module on RL (due to them already having a module with that name (should be replaced with the new one)) and tested it via that
* * alias function works too (so that no replacement runs should be necessary)