### PR TITLE
Create infobox_weapon.lua

### DIFF
--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -30,53 +30,56 @@ function Weapon:createInfobox()
 	local args = self.args
 
 	local widgets = {
-	Header{
-		name = self:nameDisplay(args),
-		image = args.image,
-		imageDefault = args.default,
-		imageDark = args.imagedark or args.imagedarkmode,
-		imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-		subHeader = self:subHeader(args),
-	},
-	Center{content = {args.caption}},
-	Title{name = (args.informationType or 'Weapon') .. ' Information'},
-	Cell{
-		name = 'Class',
-		content = self:getAllArgsForBase(args, 'class', {makeLink = true}),
-	},
-	Cell{
-		name = 'Origin',
-		content = {self:_createLocation(args.origin)},
-	},
-	Cell{name = 'Price', content = {args.price}},
-	Cell{name = 'Kill Award', content = {args.killaward}},
-	Cell{name = 'Base Damage', content = {args.damage}},
-	Cell{name = 'Magazine Size', content = {args.magsize}},
-	Cell{name = 'Ammo Capacity', content = {args.ammocap}},
-	Cell{name = 'Reload Speed', content = {args.reloadspeed}},
-	Cell{name = 'Rate of Fire', content = {args.rateoffire}},
-	Cell{name = 'Firing Mode', content = {args.firemode}},
-	Customizable{
-		id = 'side',
-		children = {
-			Cell{name = 'Side', content = {args.side}},
-		}
-	},
-	Customizable{id = 'type', children = {
-		Builder{
-			builder = function()
-				local users = self:getAllArgsForBase(args, 'user', {makeLink = true})
-				return {
-					Cell{
-						name = #users > 1 and 'Users' or 'User',
-						content = users,
-					}
+		Header{
+			name = self:nameDisplay(args),
+			image = args.image,
+			imageDefault = args.default,
+			imageDark = args.imagedark or args.imagedarkmode,
+			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+			subHeader = self:subHeader(args),
+		},
+		Center{content = {args.caption}},
+		Title{name = (args.informationType or 'Weapon') .. ' Information'},
+		Cell{
+			name = 'Class',
+			content = self:getAllArgsForBase(args, 'class', {makeLink = true}),
+		},
+		Cell{
+			name = 'Origin',
+			content = {self:_createLocation(args.origin)},
+		},
+		Cell{name = 'Price', content = {args.price}},
+		Cell{name = 'Kill Award', content = {args.killaward}},
+		Cell{name = 'Base Damage', content = {args.damage}},
+		Cell{name = 'Magazine Size', content = {args.magsize}},
+		Cell{name = 'Ammo Capacity', content = {args.ammocap}},
+		Cell{name = 'Reload Speed', content = {args.reloadspeed}},
+		Cell{name = 'Rate of Fire', content = {args.rateoffire}},
+		Cell{name = 'Firing Mode', content = {args.firemode}},
+		Customizable{
+			id = 'side',
+			children = {
+				Cell{name = 'Side', content = {args.side}},
+			}
+		},
+		Customizable{
+			id = 'type',
+			children = {
+				Builder{
+					builder = function()
+						local users = self:getAllArgsForBase(args, 'user', {makeLink = true})
+						return {
+							Cell{
+								name = #users > 1 and 'Users' or 'User',
+								content = users,
+							}
+						}
+					end
 				}
-			end
-		}
-	}},
-	Customizable{id = 'custom', children = {}},
-	Center{content = {args.footnotes}},
+			}
+		},
+		Customizable{id = 'custom', children = {}},
+		Center{content = {args.footnotes}},
 	}
 
 	infobox:categories('Weapons')
@@ -92,7 +95,7 @@ function Weapon:createInfobox()
 end
 
 function Weapon:subHeader(args)
-    return nil
+	return nil
 end
 
 function Weapon:_createLocation(location)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -32,11 +32,11 @@ function Weapon:createInfobox()
 	local widgets = {
 		Header{
 			name = self:nameDisplay(args),
+			subHeader = self:subHeader(args),
 			image = args.image,
 			imageDefault = args.default,
 			imageDark = args.imagedark or args.imagedarkmode,
 			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-			subHeader = self:subHeader(args),
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Weapon') .. ' Information'},
@@ -63,7 +63,7 @@ function Weapon:createInfobox()
 			}
 		},
 		Customizable{
-			id = 'type',
+			id = 'user',
 			children = {
 				Builder{
 					builder = function()
@@ -78,6 +78,7 @@ function Weapon:createInfobox()
 				}
 			}
 		},
+		Cell{name = 'Game Appearence(s)', content = {args.games}},
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},
 	}

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -95,10 +95,6 @@ function Weapon:createInfobox()
 	return builtInfobox
 end
 
-function Weapon:subHeader(args)
-	return nil
-end
-
 function Weapon:_createLocation(location)
 	if location == nil then
 		return ''
@@ -106,6 +102,10 @@ function Weapon:_createLocation(location)
 
 	return Flags.Icon({flag = location, shouldLink = true}) .. '&nbsp;' ..
 		'[[:Category:' .. location .. '|' .. location .. ']]'
+end
+
+function Weapon:subHeader(args)
+	return nil
 end
 
 function Weapon:getWikiCategories(args)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -20,86 +20,86 @@ local Customizable = Widgets.Customizable
 local Weapon = Class.new(BasicInfobox)
 
 function Weapon.run(frame)
-    local weapon = Weapon(frame)
-    return weapon:createInfobox()
+	local weapon = Weapon(frame)
+	return weapon:createInfobox()
 end
 
 function Weapon:createInfobox()
-    local infobox = self.infobox
-    local args = self.args
+	local infobox = self.infobox
+	local args = self.args
 
-    local widgets = {
-        Header{
-            name = self:nameDisplay(args),
-            image = args.image,
-            imageDefault = args.default,
-            imageDark = args.imagedark or args.imagedarkmode,
-            imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-        },
-        Center{content = {args.caption}},
-        Title{name = (args.informationType or 'Weapon') .. ' Information'},
-		Cell{
-			name = 'Class',
-			content = self:getAllArgsForBase(args, 'class', {makeLink = true}),
-		},
-		Cell{
-			name = 'Origin',
-			content = {self:_createLocation(args.origin)},
-		},
-		Cell{name = 'Price', content = {args.price}},
-		Cell{name = 'Kill Award', content = {args.killaward}},
-		Cell{name = 'Base Damage', content = {args.damage}},
-		Cell{name = 'Magazine Size', content = {args.magsize}},
-		Cell{name = 'Ammo Capacity', content = {args.ammocap}},
-		Cell{name = 'Reload Speed', content = {args.reloadspeed}},
-		Cell{name = 'Rate of Fire', content = {args.rateoffire}},
-		Cell{name = 'Firing Mode', content = {args.firemode}},
-		Customizable{
-			id = 'side',
-			children = {
-				Cell{name = 'Side', content = {args.side}},
+	local widgets = {
+	Header{
+		name = self:nameDisplay(args),
+		image = args.image,
+		imageDefault = args.default,
+		imageDark = args.imagedark or args.imagedarkmode,
+		imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+	},
+	Center{content = {args.caption}},
+	Title{name = (args.informationType or 'Weapon') .. ' Information'},
+	Cell{
+		name = 'Class',
+		content = self:getAllArgsForBase(args, 'class', {makeLink = true}),
+	},
+	Cell{
+		name = 'Origin',
+		content = {self:_createLocation(args.origin)},
+	},
+	Cell{name = 'Price', content = {args.price}},
+	Cell{name = 'Kill Award', content = {args.killaward}},
+	Cell{name = 'Base Damage', content = {args.damage}},
+	Cell{name = 'Magazine Size', content = {args.magsize}},
+	Cell{name = 'Ammo Capacity', content = {args.ammocap}},
+	Cell{name = 'Reload Speed', content = {args.reloadspeed}},
+	Cell{name = 'Rate of Fire', content = {args.rateoffire}},
+	Cell{name = 'Firing Mode', content = {args.firemode}},
+	Customizable{
+		id = 'side',
+		children = {
+			Cell{name = 'Side', content = {args.side}},
+		}
+	},
+	Customizable{
+		id = 'user',
+		children = {
+			Cell{
+				name = 'User(s)',
+				content = self:getAllArgsForBase(args, 'user', {makeLink = true}),
 			}
-		},
-		Customizable{
-            id = 'user',
-            children = {
-				Cell{
-					name = 'User(s)',
-					content = self:getAllArgsForBase(args, 'user', {makeLink = true}),
-				}
-            }
-        },
-        Customizable{id = 'custom', children = {}},
-        Center{content = {args.footnotes}},
-    }
+		}
+	},
+	Customizable{id = 'custom', children = {}},
+	Center{content = {args.footnotes}},
+	}
 
-    infobox:categories('Weapons')
-    infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:categories('Weapons')
+	infobox:categories(unpack(self:getWikiCategories(args)))
 
-    local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
+	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	if Namespace.isMain() then
-        self:setLpdbData(args)
-    end
+		self:setLpdbData(args)
+	end
 
-    return builtInfobox
+	return builtInfobox
 end
 
 function Weapon:_createLocation(location)
 	if location == nil then
-		return ''
-	end
+	return ''
+end
 
-	return Flags.Icon({flag = location, shouldLink = true}) .. '&nbsp;' ..
-				'[[:Category:' .. location .. '|' .. location .. ']]'
+return Flags.Icon({flag = location, shouldLink = true}) .. '&nbsp;' ..
+	'[[:Category:' .. location .. '|' .. location .. ']]'
 end
 
 function Weapon:getWikiCategories(args)
-    return {}
+	return {}
 end
 
 function Weapon:nameDisplay(args)
-    return args.name
+	return args.name
 end
 
 function Weapon:setLpdbData(args)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -9,9 +9,6 @@ local Class = require('Module:Class')
 local Namespace = require('Module:Namespace')
 local BasicInfobox = require('Module:Infobox/Basic')
 local Flags = require('Module:Flags')
-local String = require('Module:String')
-local Page = require('Module:Page')
-local Table = require('Module:Table')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -78,7 +78,7 @@ function Weapon:createInfobox()
 				}
 			}
 		},
-		Cell{name = 'Game Appearence(s)', content = {args.games}},
+		Cell{name = 'Game Appearance(s)', content = {args.games}},
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},
 	}

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -87,11 +87,11 @@ end
 
 function Weapon:_createLocation(location)
 	if location == nil then
-	return ''
-end
+		return ''
+	end
 
-return Flags.Icon({flag = location, shouldLink = true}) .. '&nbsp;' ..
-	'[[:Category:' .. location .. '|' .. location .. ']]'
+	return Flags.Icon({flag = location, shouldLink = true}) .. '&nbsp;' ..
+		'[[:Category:' .. location .. '|' .. location .. ']]'
 end
 
 function Weapon:getWikiCategories(args)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -1,4 +1,3 @@
----
 -- @Liquipedia
 -- wiki=commons
 -- page=Module:Infobox/Weapon
@@ -8,8 +7,6 @@
 
 local Class = require('Module:Class')
 local Namespace = require('Module:Namespace')
-local Hotkey = require('Module:Hotkey')
-local String = require('Module:String')
 local BasicInfobox = require('Module:Infobox/Basic')
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -22,88 +19,88 @@ local Customizable = Widgets.Customizable
 local Weapon = Class.new(BasicInfobox)
 
 function Weapon.run(frame)
-	local weapon = Weapon(frame)
-	return weapon:createInfobox()
+    local weapon = Weapon(frame)
+    return weapon:createInfobox()
 end
 
 function Weapon:createInfobox()
-	local infobox = self.infobox
-	local args = self.args
+    local infobox = self.infobox
+    local args = self.args
 
-	local widgets = {
-		Header{
-			name = self:nameDisplay(args),
-			image = args.image,
-			imageDefault = args.default,
-			imageDark = args.imagedark or args.imagedarkmode,
-			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-		},
-		Center{content = {args.caption}},
-		Title{name = (args.informationType or 'Weapon') .. ' Information'},
-		Customizable{
-			id = 'class',
-			children = {
-				Cell{name = 'Class', content = {args.class}},
-			}
-		},
-		Customizable{
-			id = 'damage',
-			children = {
-				Cell{name = 'Base Damage', content = {args.damage}},
-			}
-		},
-		Customizable{
-			id = 'magazine',
-			children = {
-				Cell{name = 'Magazine Size', content = {args.magazine}},
-			}
-		},
+    local widgets = {
+        Header{
+            name = self:nameDisplay(args),
+            image = args.image,
+            imageDefault = args.default,
+            imageDark = args.imagedark or args.imagedarkmode,
+            imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+        },
+        Center{content = {args.caption}},
+        Title{name = (args.informationType or 'Weapon') .. ' Information'},
         Customizable{
-			id = 'capacity',
-			children = {
-				Cell{name = 'Ammo Capacity', content = {args.capacity}},
-			}
-		},
-		Customizable{
-			id = 'rof',
-			children = {
-				Cell{name = 'Rate of Fire', content = {args.rof}},
-			}
-		},
-		Customizable{
-			id = 'reload',
-			children = {
-				Cell{name = 'Reload Speed', content = {args.reload}},
-			}
-		},
-		Customizable{
-			id = 'mode',
-			children = {
-				Cell{name = 'Firing Mode', content = {args.reload}},
-			}
-		},
-		Customizable{id = 'custom', children = {}},
-		Center{content = {args.footnotes}},
-	}
+            id = 'class',
+            children = {
+                Cell{name = 'Class', content = {args.class}},
+            }
+        },
+        Customizable{
+            id = 'damage',
+            children = {
+                Cell{name = 'Base Damage', content = {args.damage}},
+            }
+        },
+        Customizable{
+            id = 'magazine',
+            children = {
+                Cell{name = 'Magazine Size', content = {args.magazine}},
+            }
+        },
+        Customizable{
+            id = 'ammo',
+            children = {
+                Cell{name = 'Ammo Capacity', content = {args.ammo}},
+            }
+        },
+        Customizable{
+            id = 'rof',
+            children = {
+                Cell{name = 'Rate of Fire', content = {args.rof}},
+            }
+        },
+        Customizable{
+            id = 'reload',
+            children = {
+                Cell{name = 'Reload Speed', content = {args.reload}},
+            }
+        },
+        Customizable{
+            id = 'mode',
+            children = {
+                Cell{name = 'Firing Mode', content = {args.mode}},
+            }
+        },
+        Customizable{id = 'custom', children = {}},
+        Center{content = {args.footnotes}},
+    }
 
-	infobox:categories('Weapons')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+    infobox:categories('Weapons')
+    infobox:categories(unpack(self:getWikiCategories(args)))
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
+    local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
+	
 	if Namespace.isMain() then
-		self:setLpdbData(args)
-	end
+        self:setLpdbData(args)
+    end
 
-	return builtInfobox
+    return builtInfobox
 end
 
 function Weapon:getWikiCategories(args)
-	return {}
+    return {}
 end
 
 function Weapon:nameDisplay(args)
-	return args.name
+    return args.name
 end
 
 function Weapon:setLpdbData(args)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -87,7 +87,7 @@ function Weapon:createInfobox()
     infobox:categories(unpack(self:getWikiCategories(args)))
 
     local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-	
+
 	if Namespace.isMain() then
         self:setLpdbData(args)
     end

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -9,12 +9,16 @@ local Class = require('Module:Class')
 local Namespace = require('Module:Namespace')
 local BasicInfobox = require('Module:Infobox/Basic')
 local Flags = require('Module:Flags')
+local String = require('Module:String')
+local Page = require('Module:Page')
+local Table = require('Module:Table')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
+local Builder = Widgets.Builder
 local Customizable = Widgets.Customizable
 
 local Weapon = Class.new(BasicInfobox)
@@ -60,15 +64,19 @@ function Weapon:createInfobox()
 			Cell{name = 'Side', content = {args.side}},
 		}
 	},
-	Customizable{
-		id = 'user',
-		children = {
-			Cell{
-				name = 'User(s)',
-				content = self:getAllArgsForBase(args, 'user', {makeLink = true}),
-			}
+	Customizable{id = 'type', children = {
+		Builder{
+			builder = function()
+				local users = self:getAllArgsForBase(args, 'user', {makeLink = true})
+				return {
+					Cell{
+						name = #users > 1 and 'Users' or 'User',
+						content = users,
+					}
+				}
+			end
 		}
-	},
+	}},
 	Customizable{id = 'custom', children = {}},
 	Center{content = {args.footnotes}},
 	}

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -39,6 +39,7 @@ function Weapon:createInfobox()
 		imageDefault = args.default,
 		imageDark = args.imagedark or args.imagedarkmode,
 		imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+		subHeader = self:subHeader(args),
 	},
 	Center{content = {args.caption}},
 	Title{name = (args.informationType or 'Weapon') .. ' Information'},
@@ -91,6 +92,10 @@ function Weapon:createInfobox()
 	end
 
 	return builtInfobox
+end
+
+function Weapon:subHeader(args)
+    return nil
 end
 
 function Weapon:_createLocation(location)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -8,6 +8,7 @@
 local Class = require('Module:Class')
 local Namespace = require('Module:Namespace')
 local BasicInfobox = require('Module:Infobox/Basic')
+local Flags = require('Module:Flags')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -37,46 +38,35 @@ function Weapon:createInfobox()
         },
         Center{content = {args.caption}},
         Title{name = (args.informationType or 'Weapon') .. ' Information'},
-        Customizable{
-            id = 'class',
+		Cell{
+			name = 'Class',
+			content = self:getAllArgsForBase(args, 'class', {makeLink = true}),
+		},
+		Cell{
+			name = 'Origin',
+			content = {self:_createLocation(args.origin)},
+		},
+		Cell{name = 'Price', content = {args.price}},
+		Cell{name = 'Kill Award', content = {args.killaward}},
+		Cell{name = 'Base Damage', content = {args.damage}},
+		Cell{name = 'Magazine Size', content = {args.magsize}},
+		Cell{name = 'Ammo Capacity', content = {args.ammocap}},
+		Cell{name = 'Reload Speed', content = {args.reloadspeed}},
+		Cell{name = 'Rate of Fire', content = {args.rateoffire}},
+		Cell{name = 'Firing Mode', content = {args.firemode}},
+		Customizable{
+			id = 'side',
+			children = {
+				Cell{name = 'Side', content = {args.side}},
+			}
+		},
+		Customizable{
+            id = 'user',
             children = {
-                Cell{name = 'Class', content = {args.class}},
-            }
-        },
-        Customizable{
-            id = 'damage',
-            children = {
-                Cell{name = 'Base Damage', content = {args.damage}},
-            }
-        },
-        Customizable{
-            id = 'magazine',
-            children = {
-                Cell{name = 'Magazine Size', content = {args.magazine}},
-            }
-        },
-        Customizable{
-            id = 'ammo',
-            children = {
-                Cell{name = 'Ammo Capacity', content = {args.ammo}},
-            }
-        },
-        Customizable{
-            id = 'rof',
-            children = {
-                Cell{name = 'Rate of Fire', content = {args.rof}},
-            }
-        },
-        Customizable{
-            id = 'reload',
-            children = {
-                Cell{name = 'Reload Speed', content = {args.reload}},
-            }
-        },
-        Customizable{
-            id = 'mode',
-            children = {
-                Cell{name = 'Firing Mode', content = {args.mode}},
+				Cell{
+					name = 'User(s)',
+					content = self:getAllArgsForBase(args, 'user', {makeLink = true}),
+				}
             }
         },
         Customizable{id = 'custom', children = {}},
@@ -93,6 +83,15 @@ function Weapon:createInfobox()
     end
 
     return builtInfobox
+end
+
+function Weapon:_createLocation(location)
+	if location == nil then
+		return ''
+	end
+
+	return Flags.Icon({flag = location, shouldLink = true}) .. '&nbsp;' ..
+				'[[:Category:' .. location .. '|' .. location .. ']]'
 end
 
 function Weapon:getWikiCategories(args)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -1,0 +1,112 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Weapon
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Namespace = require('Module:Namespace')
+local Hotkey = require('Module:Hotkey')
+local String = require('Module:String')
+local BasicInfobox = require('Module:Infobox/Basic')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Header = Widgets.Header
+local Title = Widgets.Title
+local Center = Widgets.Center
+local Customizable = Widgets.Customizable
+
+local Weapon = Class.new(BasicInfobox)
+
+function Weapon.run(frame)
+	local weapon = Weapon(frame)
+	return weapon:createInfobox()
+end
+
+function Weapon:createInfobox()
+	local infobox = self.infobox
+	local args = self.args
+
+	local widgets = {
+		Header{
+			name = self:nameDisplay(args),
+			image = args.image,
+			imageDefault = args.default,
+			imageDark = args.imagedark or args.imagedarkmode,
+			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+		},
+		Center{content = {args.caption}},
+		Title{name = (args.informationType or 'Weapon') .. ' Information'},
+		Customizable{
+			id = 'class',
+			children = {
+				Cell{name = 'Class', content = {args.class}},
+			}
+		},
+		Customizable{
+			id = 'damage',
+			children = {
+				Cell{name = 'Base Damage', content = {args.damage}},
+			}
+		},
+		Customizable{
+			id = 'magazine',
+			children = {
+				Cell{name = 'Magazine Size', content = {args.magazine}},
+			}
+		},
+        Customizable{
+			id = 'capacity',
+			children = {
+				Cell{name = 'Ammo Capacity', content = {args.capacity}},
+			}
+		},
+		Customizable{
+			id = 'rof',
+			children = {
+				Cell{name = 'Rate of Fire', content = {args.rof}},
+			}
+		},
+		Customizable{
+			id = 'reload',
+			children = {
+				Cell{name = 'Reload Speed', content = {args.reload}},
+			}
+		},
+		Customizable{
+			id = 'mode',
+			children = {
+				Cell{name = 'Firing Mode', content = {args.reload}},
+			}
+		},
+		Customizable{id = 'custom', children = {}},
+		Center{content = {args.footnotes}},
+	}
+
+	infobox:categories('Weapons')
+	infobox:categories(unpack(self:getWikiCategories(args)))
+
+	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
+
+	if Namespace.isMain() then
+		self:setLpdbData(args)
+	end
+
+	return builtInfobox
+end
+
+function Weapon:getWikiCategories(args)
+	return {}
+end
+
+function Weapon:nameDisplay(args)
+	return args.name
+end
+
+function Weapon:setLpdbData(args)
+end
+
+return Weapon


### PR DESCRIPTION
## Summary
Creates a new standardized version of the Infobox weapon template. Currently used on R6, Valorant, CS, and others. Base module that will need /custom modules for the other wikis if they want further information displayed

## How did you test this change?
Changes were tested on the Siege wiki using the following pages;
Module test code: https://liquipedia.net/rainbowsix/Module:Sandbox/Fenrir
Test infobox template: https://liquipedia.net/rainboxsix/Templates:Infobox_weapon/dev
Testing page: https://liquipedia.net/rainboxsix/User:Fenrir.SPAZ/Sandbox
(Top section is the current infobox, bottom section is the standardized one that would be the base for all future custom versions)