### PR TITLE
[coords12] Proposal: Rename match2bracketdata.sectionheader -> stage

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -50,7 +50,8 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 		bracketData.bracketindex = context.bracketIndex
 		bracketData.groupRoundIndex = tonumber(match.round) or context.groupRoundIndex
 		bracketData.pageSection = context.pageSection
-		bracketData.sectionheader = context.stage
+		bracketData.sectionheader = context.stage --Deprecated
+		bracketData.stage = context.stage
 
 		return match
 	end)
@@ -108,7 +109,8 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 		bracketData.bracketindex = context.bracketIndex
 		bracketData.groupRoundIndex = tonumber(match.round) or context.groupRoundIndex
 		bracketData.pageSection = context.pageSection
-		bracketData.sectionheader = context.stage
+		bracketData.sectionheader = context.stage --Deprecated
+		bracketData.stage = context.stage
 
 		if match.winnerto then
 			bracketData.winnerto = (match.winnertobracket and match.winnertobracket .. '_' or '')
@@ -257,7 +259,7 @@ function MatchGroupInput.readContext(args)
 		bracketIndex = tonumber(globalVars:get('match2bracketindex')) or 0,
 		groupRoundIndex = MatchGroupInput.readGroupRoundIndex(args),
 		pageSection = args.matchsection or globalVars:get('matchsection'),
-		stage = args.section or globalVars:get('bracket_header'),
+		stage = args.stage or args.section or globalVars:get('bracket_header'), -- args.section is deprecated
 		tournamentParent = globalVars:get('tournament_parent'),
 	}
 


### PR DESCRIPTION
## Summary
`match2.match2bracketdata.sectionheader` encodes the stage that the match belongs to, e.g. "Group Stage", "Playoffs", "Round of 24", etc. It is usually the title of the h3 section containing the match, and set with `==={{Stage|...}}===`.

The naming for it is not the best - it's called `sectionheader` in the match record, `section` in the input args, and `bracket_header` in page variables, none of which describes the true purpose, which is to encode the stage. Also, #777 adds storage for the h4/h5 section name, which provides impetus to rename the h3 section name.

This pr changes `match2bracketdata.sectionheader` to `match2bracketdata.stage` while retaining `match2bracketdata.sectionheader` for backwards compatibility. The match group param is changed from `|section=` to `|stage=`, with `|section=` still supported for backwards compatibility. The page variable name is not changed. (can be done in the future)



<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
