### PR TITLE
[coords5c] Read upperMatchIds from lpdb

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -263,8 +263,8 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 		-- Don't show the header if it's disabled. Also don't show the header
 		-- if it is the first match of a round because a higher round match can
 		-- show it instead.
-		local upperBracketData = bracket.upperMatchIds[matchId]
-			and bracket.bracketDatasById[bracket.upperMatchIds[matchId]]
+		local upperBracketData = bracketData.upperMatchId
+			and bracket.bracketDatasById[bracketData.upperMatchId]
 		local isFirstChild = upperBracketData
 			and matchId == upperBracketData.lowerMatchIds[1]
 		local showHeader = bracketData.header and not isFirstChild
@@ -277,8 +277,9 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 	-- matches. When it gets to a root, it then traverses the roots in
 	-- reverse order until it gets to the first root.
 	local function getParent(matchId)
+		local bracketData = bracket.bracketDatasById[matchId]
 		local coords = bracket.coordsByMatchId[matchId]
-		return bracket.upperMatchIds[matchId]
+		return bracketData.upperMatchId
 			or coords.rootIx ~= 1 and bracket.rootMatchIds[coords.rootIx - 1]
 			or nil
 	end

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -18,6 +18,7 @@ local TreeUtil = require('Module:TreeUtil')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
 
+local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local TBD_DISPLAY = '<abbr title="To Be Decided">TBD</abbr>'
@@ -237,17 +238,20 @@ function MatchGroupUtil.makeBracketFromRecords(matchRecords)
 	local matchesById = Table.map(matches, function(_, match) return match.matchId, match end)
 	local bracketDatasById = Table.mapValues(matchesById, function(match) return match.bracketData end)
 
-	local upperMatchIds, rootMatchIds = MatchGroupUtil.computeUpperMatchIds(matchesById)
+	local firstCoordinates = matches[1] and matches[1].bracketData.coordinates
+	if not firstCoordinates then
+		MatchGroupUtil.backfillUpperMatchIds(bracketDatasById)
+	end
+
 	local bracket = {
 		bracketDatasById = bracketDatasById,
 		matches = matches,
 		matchesById = matchesById,
-		rootMatchIds = rootMatchIds,
+		rootMatchIds = MatchGroupUtil.computeRootMatchIds(bracketDatasById),
 		type = 'bracket',
-		upperMatchIds = upperMatchIds,
 	}
 
-	local roundPropsByMatchId, rounds = MatchGroupUtil.computeRounds(bracket.bracketDatasById, rootMatchIds)
+	local roundPropsByMatchId, rounds = MatchGroupUtil.computeRounds(bracket.bracketDatasById, bracket.rootMatchIds)
 	Table.mergeInto(bracket, {
 		coordsByMatchId = roundPropsByMatchId,
 		rounds = rounds,
@@ -256,6 +260,40 @@ function MatchGroupUtil.makeBracketFromRecords(matchRecords)
 	MatchGroupUtil.populateAdvanceSpots(bracket)
 
 	return bracket
+end
+
+--[[
+Returns an array of all the IDs of root matches. The matches are sorted in
+display order.
+]]
+function MatchGroupUtil.computeRootMatchIds(bracketDatasById)
+	-- Matches without upper matches
+	local rootMatchIds = {}
+	for matchId, bracketData in pairs(bracketDatasById) do
+		if not bracketData.upperMatchId
+			and not StringUtils.endsWith(matchId, 'RxMBR') then
+			table.insert(rootMatchIds, matchId)
+		end
+	end
+
+	Array.sortInPlaceBy(rootMatchIds, function(matchId)
+		local coordinates = bracketDatasById[matchId].coordinates
+		return coordinates and {coordinates.rootIndex} or {-1, matchId}
+	end)
+
+	return rootMatchIds
+end
+
+--[[
+Populate bracketData.upperMatchId if it is missing. This can happen if the
+bracket template is missing data.
+]]
+function MatchGroupUtil.backfillUpperMatchIds(bracketDatasById)
+	local upperMatchIds = MatchGroupCoordinates.computeUpperMatchIds(bracketDatasById)
+
+	for matchId, bracketData in pairs(bracketDatasById) do
+		bracketData.upperMatchId = upperMatchIds[matchId]
+	end
 end
 
 --[[
@@ -371,6 +409,7 @@ function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
 			skipRound = tonumber(data.skipround) or data.skipround == 'true' and 1 or 0,
 			thirdPlaceMatchId = nilIfEmpty(data.thirdplace),
 			type = 'bracket',
+			upperMatchId = nilIfEmpty(data.upperMatchId),
 		}
 	else
 		return {
@@ -442,33 +481,6 @@ function MatchGroupUtil.gameFromRecord(record)
 	}
 end
 
-function MatchGroupUtil.computeUpperMatchIds(matchesById)
-	local upperMatchIds = {}
-	for matchId, match in pairs(matchesById) do
-		if match.bracketData.type == 'bracket' then
-			for _, lowerMatchId in ipairs(match.bracketData.lowerMatchIds) do
-				upperMatchIds[lowerMatchId] = matchId
-			end
-		end
-	end
-
-	-- Matches without upper matches
-	local rootMatchIds = {}
-	for matchId, _ in pairs(matchesById) do
-		if not upperMatchIds[matchId]
-			and not StringUtils.endsWith(matchId, 'RxMBR') then
-			table.insert(rootMatchIds, matchId)
-		end
-	end
-
-	-- Use custom ordering specified by rootIndex if present
-	Array.sortInPlaceBy(rootMatchIds, function(matchId)
-		return {matchesById[matchId].bracketData.rootIndex or -1, matchId}
-	end)
-
-	return upperMatchIds, rootMatchIds
-end
-
 function MatchGroupUtil.dfsFrom(bracketDatasById, start)
 	return TreeUtil.dfs(
 		function(matchId)
@@ -537,10 +549,9 @@ function MatchGroupUtil.populateAdvanceSpots(bracket)
 
 	-- Winner advances to upper match
 	for _, match in ipairs(bracket.matches) do
-		local upperMatchId = bracket.upperMatchIds[match.matchId]
-		if upperMatchId then
+		if match.bracketData.upperMatchId then
 			match.bracketData.advanceSpots[1] = match.bracketData.advanceSpots[1]
-				or {bg = 'up', type = 'advance', matchId = upperMatchId}
+				or {bg = 'up', type = 'advance', matchId = match.bracketData.upperMatchId}
 		end
 	end
 


### PR DESCRIPTION
## Summary
If `match2bracketdata.upperMatchId` is present in lpdb, then use that instead of computing it in MatchGroupUtil.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested as a part of #753 
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
