### PR TITLE
[coords5d] Read coordinates from lpdb

### DIFF
--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -253,4 +253,40 @@ function MatchGroupCoordinates.computeCoordinates(bracket)
 	}
 end
 
+--[[
+Returns a list of sections. Each section contains the matchIds for the matches
+in that section of a bracket. The bracket must have coordinates data
+previously computed.
+
+The list is identical to the one returned by
+MatchGroupCoordinates.computeSections.
+]]
+function MatchGroupCoordinates.getSectionsFromCoordinates(bracket)
+	return MatchGroupCoordinates.groupMatchIdsByField(bracket, 'sectionIndex')
+end
+
+--[[
+Returns a list of rounds. Each round contains the matchIds for the matches in
+that round of a bracket. The bracket must have coordinates data previously
+computed.
+
+The list is identical to the one returned by
+MatchGroupCoordinates.computeRounds.
+]]
+function MatchGroupCoordinates.getRoundsFromCoordinates(bracket)
+	return MatchGroupCoordinates.groupMatchIdsByField(bracket, 'roundIndex')
+end
+
+function MatchGroupCoordinates.groupMatchIdsByField(bracket, fieldName)
+	local countFieldName = fieldName:gsub('Index$', 'Count')
+	local count = Table.getByPathOrNil(bracket.matches, {1, 'bracketData', 'coordinates', countFieldName}) or 0
+
+	local byField = Array.map(Array.range(1, count), function() return {} end)
+	for matchId in MatchGroupCoordinates.dfs(bracket) do
+		local coordinates = bracket.coordinatesByMatchId[matchId]
+		table.insert(byField[coordinates[fieldName]], matchId)
+	end
+	return byField
+end
+
 return MatchGroupCoordinates

--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -278,9 +278,9 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 	-- reverse order until it gets to the first root.
 	local function getParent(matchId)
 		local bracketData = bracket.bracketDatasById[matchId]
-		local coords = bracket.coordsByMatchId[matchId]
+		local coords = bracket.coordinatesByMatchId[matchId]
 		return bracketData.upperMatchId
-			or coords.rootIx ~= 1 and bracket.rootMatchIds[coords.rootIx - 1]
+			or coords.rootIndex ~= 1 and bracket.rootMatchIds[coords.rootIndex - 1]
 			or nil
 	end
 
@@ -291,19 +291,19 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 
 	-- Determine the individual headers appearing in header rows
 	for matchId, bracketData in pairs(bracket.bracketDatasById) do
-		local coords = bracket.coordsByMatchId[matchId]
+		local coords = bracket.coordinatesByMatchId[matchId]
 		if bracketData.header then
 			local headerRow = getHeaderRow(matchId)
 			local brMatch = bracketData.bracketResetMatchId and bracket.matchesById[bracketData.bracketResetMatchId]
-			headerRow[coords.roundIx] = {
+			headerRow[coords.roundIndex] = {
 				hasBrMatch = brMatch and true or false,
 				header = bracketData.header,
-				roundIx = coords.roundIx,
+				roundIx = coords.roundIndex,
 			}
 		end
 		if bracketData.qualWin then
 			local headerRow = getHeaderRow(matchId)
-			local roundIx = coords.roundIx + 1 + bracketData.qualSkip
+			local roundIx = coords.roundIndex + 1 + bracketData.qualSkip
 			headerRow[roundIx] = {
 				header = config.qualifiedHeader or '!q',
 				roundIx = roundIx,

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -14,7 +14,6 @@ local Lua = require('Module:Lua')
 local MatchGroupWorkaround = require('Module:MatchGroup/Workaround')
 local StringUtils = require('Module:StringUtils')
 local Table = require('Module:Table')
-local TreeUtil = require('Module:TreeUtil')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
 
@@ -245,17 +244,21 @@ function MatchGroupUtil.makeBracketFromRecords(matchRecords)
 
 	local bracket = {
 		bracketDatasById = bracketDatasById,
+		coordinatesByMatchId = Table.mapValues(matchesById, function(match) return match.bracketData.coordinates end),
 		matches = matches,
 		matchesById = matchesById,
 		rootMatchIds = MatchGroupUtil.computeRootMatchIds(bracketDatasById),
 		type = 'bracket',
 	}
 
-	local roundPropsByMatchId, rounds = MatchGroupUtil.computeRounds(bracket.bracketDatasById, bracket.rootMatchIds)
-	Table.mergeInto(bracket, {
-		coordsByMatchId = roundPropsByMatchId,
-		rounds = rounds,
-	})
+	if firstCoordinates then
+		Table.mergeInto(bracket, {
+			rounds = MatchGroupCoordinates.getRoundsFromCoordinates(bracket),
+			sections = MatchGroupCoordinates.getSectionsFromCoordinates(bracket),
+		})
+	else
+		MatchGroupUtil.backfillCoordinates(bracket)
+	end
 
 	MatchGroupUtil.populateAdvanceSpots(bracket)
 
@@ -293,6 +296,19 @@ function MatchGroupUtil.backfillUpperMatchIds(bracketDatasById)
 
 	for matchId, bracketData in pairs(bracketDatasById) do
 		bracketData.upperMatchId = upperMatchIds[matchId]
+	end
+end
+
+--[[
+Populate bracketData.coordinates if it is missing. This can happen if the
+bracket template has not been recently purged.
+]]
+function MatchGroupUtil.backfillCoordinates(matchGroup)
+	local bracketCoordinates = MatchGroupCoordinates.computeCoordinates(matchGroup)
+
+	Table.mergeInto(matchGroup, bracketCoordinates)
+	for matchId, bracketData in pairs(matchGroup.bracketDatasById) do
+		bracketData.coordinates = bracketCoordinates.coordinatesByMatchId[matchId]
 	end
 end
 
@@ -397,6 +413,7 @@ function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
 			advanceSpots = advanceSpots,
 			bracketResetMatchId = nilIfEmpty(data.bracketreset),
 			bracketSection = data.bracketsection,
+			coordinates = data.coordinates and MatchGroupUtil.indexTableFromRecord(data.coordinates),
 			header = nilIfEmpty(data.header),
 			lowerEdges = lowerEdges,
 			lowerMatchIds = lowerMatchIds,
@@ -479,67 +496,6 @@ function MatchGroupUtil.gameFromRecord(record)
 		walkover = nilIfEmpty(record.walkover),
 		winner = tonumber(record.winner),
 	}
-end
-
-function MatchGroupUtil.dfsFrom(bracketDatasById, start)
-	return TreeUtil.dfs(
-		function(matchId)
-			return bracketDatasById[matchId].lowerMatchIds
-		end,
-		start
-	)
-end
-
-function MatchGroupUtil.computeDepthsFrom(bracketDatasById, startMatchId)
-	local depths = {}
-	local maxDepth = -1
-	local function visit(matchId, depth)
-		local bracketData = bracketDatasById[matchId]
-		depths[matchId] = depth
-		maxDepth = math.max(maxDepth, depth + bracketData.skipRound)
-		for _, lowerMatchId in ipairs(bracketData.lowerMatchIds) do
-			visit(lowerMatchId, depth + 1 + bracketData.skipRound)
-		end
-	end
-	visit(startMatchId, 0)
-	return depths, maxDepth + 1
-end
-
--- TODO store and read this from LPDB
-function MatchGroupUtil.computeRounds(bracketDatasById, rootMatchIds)
-	local rounds = {}
-	local roundPropsByMatchId = {}
-	for _, rootMatchId in ipairs(rootMatchIds) do
-		local depths, depthCount = MatchGroupUtil.computeDepthsFrom(bracketDatasById, rootMatchId)
-		for _ = #rounds + 1, depthCount do
-			table.insert(rounds, {})
-		end
-
-		for matchId, depth in pairs(depths) do
-			roundPropsByMatchId[matchId] = {
-				depth = depth,
-				depthCount = depthCount,
-			}
-		end
-	end
-
-	for rootIx, rootMatchId in ipairs(rootMatchIds) do
-		for matchId in MatchGroupUtil.dfsFrom(bracketDatasById, rootMatchId) do
-			local roundProps = roundPropsByMatchId[matchId]
-
-			-- All roots are left aligned, except the third place match which is right aligned
-			local roundIx = StringUtils.endsWith(matchId, 'RxMTP')
-				and #rounds
-				or roundProps.depthCount - roundProps.depth
-
-			table.insert(rounds[roundIx], matchId)
-			roundProps.matchIxInRound = #rounds[roundIx]
-			roundProps.rootIx = rootIx
-			roundProps.roundIx = roundIx
-		end
-	end
-
-	return roundPropsByMatchId, rounds
 end
 
 function MatchGroupUtil.populateAdvanceSpots(bracket)
@@ -638,6 +594,17 @@ function MatchGroupUtil.parseOrCopyExtradata(recordExtradata)
 	return type(recordExtradata) == 'string' and Json.parse(recordExtradata)
 		or type(recordExtradata) == 'table' and Table.copy(recordExtradata)
 		or {}
+end
+
+-- Convert 0-based indexes to 1-based
+function MatchGroupUtil.indexTableFromRecord(record)
+	return Table.map(record, function(key, value)
+		if key:match('Index') and type(value) == 'number' then
+			return key, value + 1
+		else
+			return key, value
+		end
+	end)
 end
 
 --[[


### PR DESCRIPTION
## Summary
Read match coordinates from lpdb if it is present. Otherwise compute it in MatchGroupUtil. The bracket.sections and bracket.rounds arrays aren't directly stored in lpdb so they need to be rebuilt from the coordinates data.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
