### PR TITLE
Remove special tier handling in RL Infobox League

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -200,7 +200,6 @@ function CustomLeague:defineCustomPageVariables(args)
 	-- Legacy tier vars
 	Variables.varDefine('tournament_lptier', args.liquipediatier)
 	Variables.varDefine('tournament_tier', args.liquipediatiertype or args.liquipediatier)
-	Variables.varDefine('tournament_tier2', args.liquipediatier2)
 	Variables.varDefine('tournament_tiertype', args.liquipediatiertype)
 	Variables.varDefine('tournament_tiertype2', args.liquipediatiertype2)
 	Variables.varDefine('ltier', args.liquipediatier == 1 and 1 or

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -199,7 +199,7 @@ function CustomLeague:defineCustomPageVariables(args)
 
 	-- Legacy tier vars
 	Variables.varDefine('tournament_lptier', args.liquipediatier)
-	Variables.varDefine('tournament_tier', args.liquipediatiertype or args.liquipediatier)
+	Variables.varDefine('tournament_tier', args.liquipediatier)
 	Variables.varDefine('tournament_tiertype', args.liquipediatiertype)
 	Variables.varDefine('tournament_tiertype2', args.liquipediatiertype2)
 	Variables.varDefine('ltier', args.liquipediatier == 1 and 1 or

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -116,15 +116,14 @@ function CustomLeague:_createTier(args)
 	local content = ''
 
 	local tier = args.liquipediatier
+	local type = args.liquipediatiertype
+	local type2 = args.liquipediatiertype2
 
 	if String.isEmpty(tier) then
 		return nil
 	end
 
 	local tierDisplay = Template.safeExpand(mw.getCurrentFrame(), 'TierDisplay/' .. tier)
-	local tier2 = args.liquipediatier2
-	local type = args.liquipediatiertype
-	local type2 = args.liquipediatiertype2
 
 	if not String.isEmpty(type) then
 		local typeDisplay = Template.safeExpand(mw.getCurrentFrame(), 'TierDisplay/' .. type)
@@ -137,11 +136,6 @@ function CustomLeague:_createTier(args)
 		content = content .. ' ([[' .. tierDisplay .. ' Tournaments|' .. tierDisplay .. ']])'
 	else
 		content = content .. '[[' .. tierDisplay .. ' Tournaments|' .. tierDisplay .. ']]'
-
-		if not String.isEmpty(tier2) then
-			local tier2Display = Template.safeExpand(mw.getCurrentFrame(), 'TierDisplay/' .. tier2)
-			content = content .. ' ([[' .. tier2Display .. ' Tournaments|' .. tier2Display .. ']])'
-		end
 	end
 
 	content = content .. '[[Category:' .. tierDisplay .. ' Tournaments]]'

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -220,10 +220,6 @@ function CustomLeague:defineCustomPageVariables(args)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	if not String.isEmpty(args.liquipediatiertype) then
-		lpdbData['liquipediatier'] = args.liquipediatiertype
-	end
-
 	lpdbData['game'] = 'rocket league'
 	lpdbData['patch'] = args.patch
 	lpdbData['participantsnumber'] = args.team_number or args.player_number
@@ -231,8 +227,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		region = args.region,
 		mode = args.mode,
 		notabilitymod = args.notabilitymod,
-		liquipediatier2 =
-			(not String.isEmpty(args.liquipediatiertype) and args.liquipediatier) or args.liquipediatier2,
 		liquipediatiertype2 = args.liquipediatiertype2,
 		participantsnumber =
 			not String.isEmpty(args.team_number) and args.team_number or args.player_number,

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -211,7 +211,6 @@ function matchFunctions.getExtraData(match)
 		lastgame = Variables.varDefault('last_game'),
 		comment = match.comment,
 		octane = match.octane,
-		liquipediatier2 = Variables.varDefault('tournament_tier2'),
 		isconverted = 0,
 		isfeatured = matchFunctions.isFeatured(match)
 	}

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -161,7 +161,6 @@ function matchFunctions.getExtraData(match)
 		lastgame = Variables.varDefault('last_game'),
 		comment = match.comment,
 		octane = match.octane,
-		liquipediatier2 = Variables.varDefault('tournament_tier2'),
 		isconverted = 0
 	}
 	return match


### PR DESCRIPTION
## Summary

Removing the legacy handling of tiers in Rocket League. This means dropping extradata.tier2 and not writing the tiertype into tournament.tier.

https://liquipedia.net/rocketleague/index.php?search=insource%3A%22liquipediatier%3DMonthly%22&title=Special%3ASearch&profile=default&fulltext=1
https://liquipedia.net/rocketleague/index.php?search=insource%3A%22liquipediatier%3DWeekly%22&title=Special%3ASearch&profile=default&fulltext=1
https://liquipedia.net/rocketleague/index.php?search=insource%3A%22liquipediatier%3DQualifier%22&title=Special%3ASearch&profile=default&fulltext=1

Bot should change these 175 tournaments from `|liquipediatier=Qualifier|liquipediatier2=...`  to `|liquipediatier=...|liquipediatiertype=Qualifier`. The format with tiertype in the wikicode is widely used outside these 175 (4159 tournaments using tiertype). (eg https://liquipedia.net/rocketleague/index.php?title=Rocket_League_Championship_Series%2F2021-22%2FFall%2FAsia-Pacific_Qualifier&action=edit&section=0) 

The bot job isn't required technically, but already existing code is breaking due to that wiki format isn't setting all fields as intended. I would bot these myself I was home, but I'm not for the next week.

Edit: Bot job is done.


## How did you test this change?

Module:TournamentList is the only one using these fields in lpdb_tournament. Said module has been been tested to work with the change.
https://liquipedia.net/rocketleague/index.php?title=Rocket_League_Championship_Series/2021-22/Fall/Asia-Pacific_Qualifier&diff=1011313&oldid=1006940