### PR TITLE
Use Opponent.toName for highlight key

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -46,25 +46,11 @@ function DisplayHelper.opponentIsHighlightable(opponent)
 	end
 end
 
---[[
-Builds a hash of the opponent that is used to visually highlight their progress
-in the bracket.
-]]
-function DisplayHelper.makeOpponentHighlightKey(opponent)
-	if opponent.type == 'literal' then
-		return opponent.name and string.lower(opponent.name) or ''
-	elseif opponent.type == 'team' then
-		return opponent.template or ''
-	else
-		return table.concat(Array.map(opponent.players or {}, function(player) return player.pageName or '' end), ',')
-	end
-end
-
 function DisplayHelper.addOpponentHighlight(node, opponent)
 	local canHighlight = DisplayHelper.opponentIsHighlightable(opponent)
 	return node
 		:addClass(canHighlight and 'brkts-opponent-hover' or nil)
-		:attr('aria-label', canHighlight and DisplayHelper.makeOpponentHighlightKey(opponent) or nil)
+		:attr('aria-label', canHighlight and Opponent.toName(opponent) or nil)
 end
 
 -- Expands a header code by making a RPC call.


### PR DESCRIPTION
## Summary
`DisplayHelper.makeOpponentHighlightKey` and `Opponent.toName` serve a similar purpose: to convert a opponent to a string key. Only one is needed.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
sc2 tournament test pages
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
