### PR TITLE
Remove Legacy Date Vars for SC2

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -521,19 +521,6 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_ticker_name', _args.tickername or name)
 	Variables.varDefine('tournament_abbreviation', _args.abbreviation or '')
 
-	--Legacy date vars
-	local sdate = Variables.varDefault('tournament_startdate', '')
-	local edate = Variables.varDefault('tournament_enddate', '')
-	Variables.varDefine('infobox_date', edate)
-	Variables.varDefine('infobox_sdate', sdate)
-	Variables.varDefine('infobox_edate', edate)
-	Variables.varDefine('date', edate)
-	Variables.varDefine('sdate', sdate)
-	Variables.varDefine('edate', edate)
-	Variables.varDefine('tournament_date', edate)
-	Variables.varDefine('formatted_tournament_date', sdate)
-	Variables.varDefine('formatted_tournament_edate', edate)
-
 	--override var to standardize its entries
 	Variables.varDefine('tournament_game', (_GAMES[string.lower(_args.game)] or {})[1] or _GAMES[_GAME_WOL][1])
 
@@ -565,7 +552,7 @@ function CustomLeague:defineCustomPageVariables()
 	end
 	Variables.varDefine('tournament_finished', finished or 'false')
 	--month and day
-	local monthAndDay = string.match(edate, '%d%d-%d%d') or ''
+	local monthAndDay = string.match(Variables.varDefault('tournament_enddate', ''), '%d%d-%d%d') or ''
 	Variables.varDefine('Month_Day', monthAndDay)
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -200,16 +200,6 @@ function HiddenInfoboxLeague._definePageVariables()
 	local edate = HiddenInfoboxLeague._cleanDate(_args.edate) or HiddenInfoboxLeague._cleanDate(_args.date)
 	Variables.varDefine('tournament_startdate', sdate)
 	Variables.varDefine('tournament_enddate', edate)
-	--Legacy date vars
-	Variables.varDefine('infobox_date', edate)
-	Variables.varDefine('infobox_sdate', sdate)
-	Variables.varDefine('infobox_edate', edate)
-	Variables.varDefine('date', edate)
-	Variables.varDefine('sdate', sdate)
-	Variables.varDefine('edate', edate)
-	Variables.varDefine('tournament_date', edate)
-	Variables.varDefine('formatted_tournament_date', sdate)
-	Variables.varDefine('formatted_tournament_edate', edate)
 
 	--Legacy vars
 	Variables.varDefine('tournament_tier', tier)


### PR DESCRIPTION
## Summary
Remove Legacy Date Vars for SC2 in
* `Module:Infobox/League/Custom`
* `Module:Infobox/League/Hidden`

The usage of those vars has been removed on all sc2 modules.
For commons Modules that are used on SC2 they were changed so that they use the new ones (if they exist) and use the legacy vars as a fallback.

## How did you test this change?
pushed to the modules (these Modules are not yet used on live) and checked display and storage data on a few pages when using is on them (temporarily)