### PR TITLE
Add `Module:VodLink`

### DIFF
--- a/standard/vod_link.lua
+++ b/standard/vod_link.lua
@@ -1,0 +1,49 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:VodLink
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+
+local VodLink = {}
+
+function VodLink.display(args)
+	if Logic.readBool(args.novod) then
+		return mw.html.create('span')
+			:addClass('plainlinks')
+			:attr('title', 'Help Liquipedia find this VOD')
+			:wikitext('[[File:NoVod.png|link=]]')
+	end
+
+	local title
+	local fileName = 'VOD Icon'
+	if Logic.isNumeric(args.gamenum) then
+		title = 'Watch Game ' .. args.gamenum
+		if tonumber(args.gamenum) <= 11 then
+			fileName = fileName .. args.gamenum
+		end
+	else
+		title = args.htext or 'Watch VOD'
+	end
+	fileName = fileName .. '.png'
+
+	local link = args.vod or ''
+	--question if we actually need the tlpd stuff
+	--atm most wikis have it, but it seems very pointless except for sc/sc2
+	if args.source == 'tlpd' or args.source == 'tlpd-kr' then
+		link = 'https://www.tl.net/tlpd/sc2-korean/games/' .. link .. '/vod'
+	elseif args.source == 'tlpd-int' then
+		link = 'https://www.tl.net/tlpd/sc2-international/games/' .. link .. '/vod'
+	end
+
+	return mw.html.create('span')
+		:addClass('plainlinks vodlink')
+		:attr('title', title)
+		:wikitext('[[File:' .. fileName .. '|link=' .. link .. ']]')
+end
+
+return Class.export(VodLink, {frameOnly = true})

--- a/standard/vod_link.lua
+++ b/standard/vod_link.lua
@@ -8,7 +8,6 @@
 
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
-local String = require('Module:StringUtils')
 
 local VodLink = {}
 

--- a/standard/vod_link.lua
+++ b/standard/vod_link.lua
@@ -12,6 +12,10 @@ local Logic = require('Module:Logic')
 local VodLink = {}
 
 function VodLink.display(args)
+	if type(args) ~= 'table' or Logic.isEmpty(args) then
+		return ''
+	end
+
 	if Logic.readBool(args.novod) then
 		return mw.html.create('span')
 			:addClass('plainlinks')

--- a/standard/vod_link.lua
+++ b/standard/vod_link.lua
@@ -13,17 +13,13 @@ local String = require('Module:StringUtils')
 local VodLink = {}
 
 function VodLink.display(args)
-	if type(args) ~= 'table' then
-		return ''
-	end
+	args = args or {}
 
 	if Logic.readBool(args.novod) then
 		return mw.html.create('span')
 			:addClass('plainlinks')
 			:attr('title', 'Help Liquipedia find this VOD')
 			:wikitext('[[File:NoVod.png|link=]]')
-	elseif String.isEmpty(args.vod) then
-		return ''
 	end
 
 	local title

--- a/standard/vod_link.lua
+++ b/standard/vod_link.lua
@@ -8,11 +8,12 @@
 
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
 
 local VodLink = {}
 
 function VodLink.display(args)
-	if type(args) ~= 'table' or Logic.isEmpty(args) then
+	if type(args) ~= 'table' then
 		return ''
 	end
 
@@ -21,6 +22,8 @@ function VodLink.display(args)
 			:addClass('plainlinks')
 			:attr('title', 'Help Liquipedia find this VOD')
 			:wikitext('[[File:NoVod.png|link=]]')
+	elseif String.isEmpty(args.vod) then
+		return ''
 	end
 
 	local title


### PR DESCRIPTION
## Summary
Add `Module:VodLink` as a module version of `TemplateVodlink` which exists on quite a few wikis:
![Screenshot 2021-11-30 20 55 29](https://user-images.githubusercontent.com/75081997/144118437-f666adf4-ec69-43c5-82e1-330ccce64542.png)

## How did you test this change?

![Screenshot 2021-11-30 20 46 54](https://user-images.githubusercontent.com/75081997/144118489-9531ed07-89f0-4e2f-a19e-a99c48ce11da.png)

![Screenshot 2021-11-30 20 42 19](https://user-images.githubusercontent.com/75081997/144118471-1ccda5c6-eeba-4de6-ad7c-c3f86891b123.png)
