### PR TITLE
Add dq options to BlockPlayer

### DIFF
--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -21,6 +21,7 @@ Display components for players.
 local PlayerDisplay = {propTypes = {}}
 
 PlayerDisplay.propTypes.BlockPlayer = {
+	dq = 'boolean?',
 	flip = 'boolean?',
 	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
 	player = MatchGroupUtil.types.Player,
@@ -37,7 +38,7 @@ function PlayerDisplay.BlockPlayer(props)
 	local player = props.player
 
 	local zeroWidthSpace = '&#8203;'
-	local nameNode = mw.html.create('span'):addClass('name')
+	local nameNode = mw.html.create(props.dq and 's' or 'span'):addClass('name')
 		:wikitext(props.showLink ~= false and player.pageName
 			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
 			or Logic.emptyOr(player.displayName, zeroWidthSpace)

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -28,6 +28,7 @@ Display components for players used in the starcraft and starcraft2 wikis.
 local StarcraftPlayerDisplay = {propTypes = {}}
 
 StarcraftPlayerDisplay.propTypes.BlockPlayer = {
+	dq = 'boolean?',
 	flip = 'boolean?',
 	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
 	player = StarcraftMatchGroupUtil.types.Player,
@@ -45,7 +46,7 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 	local player = props.player
 
 	local zeroWidthSpace = '&#8203;'
-	local nameNode = html.create('span'):addClass('name')
+	local nameNode = html.create(props.dq and 's' or 'span'):addClass('name')
 		:wikitext(props.showLink ~= false and player.pageName
 			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
 			or Logic.emptyOr(player.displayName, zeroWidthSpace)


### PR DESCRIPTION
## Summary
Add dq options to `PlayerDisplay.BlockPlayer` and `StarcraftPlayerDisplay.BlockPlayer`, for parity with `InlinePlayer`

![image](https://user-images.githubusercontent.com/85348434/144478118-065c7244-b1a9-4bc5-8204-3d8d0d3de212.png)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
https://liquipedia.net/starcraft2/Liquipedia:Gallery/ParticipantTable
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
