### PR TITLE
Add `Module:RecentMatches`

### DIFF
--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -72,7 +72,8 @@ end
 function RecentMatches._row(data)
 	MatchGroupWorkaround.applyPlayerBugWorkaround(data)
 	local winner = tonumber(data.winner or 0) or 0
-	local tableClass = RecentMatches.getTableClass(winner, data.publishertier or '')
+	data.winner = winner
+	local tableClass = RecentMatches.getTableClass(data)
 
 	local opponentLeft = data.match2opponents[1]
 	local opponentRight = data.match2opponents[2]
@@ -131,18 +132,18 @@ function RecentMatches._checkForInelligableOpponent(opponent)
 end
 
 -- overridable functions
-function RecentMatches.getTableClass(winner, publishertier)
+function RecentMatches.getTableClass(data)
 	local tableClass = 'wikitable wikitable-striped infobox_matches_content recent-matches-'
 
-	if winner == 1 then
+	if data.winner == 1 then
 		tableClass = tableClass .. 'left'
-	elseif winner == 2 then
+	elseif data.winner == 2 then
 		tableClass = tableClass .. 'right'
 	else
 		tableClass = tableClass .. 'draw'
 	end
 
-	if String.isNotEmpty(publishertier) then
+	if String.isNotEmpty(data.publishertier) then
 		tableClass = tableClass .. '-publishertier'
 	end
 

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -44,46 +44,6 @@ function RecentMatches.run(args)
 	return display
 end
 
--- overridable functions
-function RecentMatches.requireOpponentModules()
-	return Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true}),
-		Lua.import('Module:Opponent', {requireDevIfEnabled = true})
-end
-
-function RecentMatches.buildConditions(args)
-	local featured = args.featured == 'true'
-
-	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
-	if featured then
-		conditions = conditions .. ' AND [[publishertier::>]]'
-	end
-
-	return conditions
-end
-
-function RecentMatches.scoreDisplay(opponentLeft, opponentRight, winner)
-	local leftScore = RecentMatches.getOpponentScore(opponentLeft)
-	local rightScore = RecentMatches.getOpponentScore(opponentRight)
-
-	local scoreDisplay = RecentMatches._displayOpponentScore(leftScore, winner == 1)
-		.. ':'
-		.. RecentMatches._displayOpponentScore(rightScore, winner == 2)
-
-	return scoreDisplay
-end
-
-function RecentMatches.getOpponentScore(opponent)
-	local score
-	if opponent.status == _SCORE_STATUS then
-		score = opponent.score
-	else
-		score = opponent.status or ''
-	end
-
-	return score
-end
-
--- helper functions
 function RecentMatches._displayOpponentScore(score, isWinner)
 	return (isWinner and '<b>' or '')
 		.. score
@@ -240,6 +200,45 @@ function RecentMatches._lowerRow(data)
 	return mw.html.create('span')
 		:node(countdownDisplay)
 		:node(tournamentDisplay)
+end
+
+-- overridable functions
+function RecentMatches.requireOpponentModules()
+	return Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true}),
+		Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+end
+
+function RecentMatches.buildConditions(args)
+	local featured = args.featured == 'true'
+
+	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
+	if featured then
+		conditions = conditions .. ' AND [[publishertier::>]]'
+	end
+
+	return conditions
+end
+
+function RecentMatches.scoreDisplay(opponentLeft, opponentRight, winner)
+	local leftScore = RecentMatches.getOpponentScore(opponentLeft)
+	local rightScore = RecentMatches.getOpponentScore(opponentRight)
+
+	local scoreDisplay = RecentMatches._displayOpponentScore(leftScore, winner == 1)
+		.. ':'
+		.. RecentMatches._displayOpponentScore(rightScore, winner == 2)
+
+	return scoreDisplay
+end
+
+function RecentMatches.getOpponentScore(opponent)
+	local score
+	if opponent.status == _SCORE_STATUS then
+		score = opponent.score
+	else
+		score = opponent.status or ''
+	end
+
+	return score
 end
 
 return Class.export(RecentMatches)

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -12,12 +12,18 @@ local String = require('Module:StringUtils')
 local Lua = require("Module:Lua")
 local LeagueIcon = require("Module:LeagueIcon")
 local VodLink = require("Module:VodLink")
+local Table = require("Module:Table")
 
 local OpponentDisplay, Opponent
 
 local _CURRENT_DATE_STAMP = mw.getContentLanguage():formatDate('c')
 local _ABBR_UTC = '<abbr data-tz="+0:00" title="Coordinated Universal Time (UTC)">UTC</abbr>'
 local _SCORE_STATUS = 'S'
+local _INVALID_OPPONENTS = {
+	'tbd',
+	'tba',
+	'bye',
+}
 
 local RecentMatches = {}
 
@@ -88,12 +94,8 @@ function RecentMatches._checkForInelligableOpponent(opponent)
 	local name = string.lower(opponent.name or '')
 	local template = string.lower(opponent.template or '')
 
-	return name == 'bye'
-		or name == 'tba'
-		or name == 'tbd'
-		or template == 'bye'
-		or template == 'tba'
-		or template == 'tbd'
+	return Table.includes(_INVALID_OPPONENTS, name)
+		or Table.includes(_INVALID_OPPONENTS, template)
 		or (String.isEmpty(name) and String.isEmpty(template))
 end
 

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -19,6 +19,7 @@ local OpponentDisplay, Opponent
 local _CURRENT_DATE_STAMP = mw.getContentLanguage():formatDate('c')
 local _ABBR_UTC = '<abbr data-tz="+0:00" title="Coordinated Universal Time (UTC)">UTC</abbr>'
 local _SCORE_STATUS = 'S'
+local _DEFAULT_ICON = 'InfoboxIcon_Tournament.png'
 local _INVALID_OPPONENTS = {
 	'tbd',
 	'tba',
@@ -167,7 +168,7 @@ function RecentMatches._lowerRow(data)
 	end
 
 	--tournament icon and link
-	local icon = String.isNotEmpty(data.icon) and data.icon or 'InfoboxIcon_Tournament.png'
+	local icon = String.isNotEmpty(data.icon) and data.icon or _DEFAULT_ICON
 	local iconDark = String.isNotEmpty(data.icondark) and data.icondark or icon
 	local displayName = String.isNotEmpty(data.tickername) and data.tickername or data.tournament
 	local link = String.isNotEmpty(data.parent) and data.parent or data.pagename
@@ -184,7 +185,6 @@ function RecentMatches._lowerRow(data)
 				iconDark = iconDark,
 				link = link,
 				name = data.tournament,
-				--size = '25px',
 				options = {noTemplate = true},
 			})
 		)

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -155,6 +155,7 @@ function RecentMatches._lowerRow(data)
 		:css('font-size', '11px')
 		:node(Countdown._create{
 			rawdatetime = 'true',
+			finished = 'true',
 			date = date .. _ABBR_UTC,
 			separator = '&#8203;',
 		})

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -1,3 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:RecentMatches
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
 local String = require('Module:StringUtils')

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -239,14 +239,7 @@ function RecentMatches.buildQuery(args)
 end
 
 function RecentMatches.buildConditions(args)
-	local featured = args.featured == 'true'
-
-	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
-	if featured then
-		conditions = conditions .. ' AND [[publishertier::>]]'
-	end
-
-	return conditions
+	return '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
 end
 
 function RecentMatches.versus(opponentLeft, opponentRight, winner, _)

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -1,0 +1,237 @@
+local Class = require('Module:Class')
+local Countdown = require('Module:Countdown')
+local String = require('Module:StringUtils')
+local Lua = require("Module:Lua")
+local LeagueIcon = require("Module:LeagueIcon")
+local VodLink = require("Module:VodLink")
+
+local OpponentDisplay, Opponent
+
+local _CURRENT_DATE_STAMP = mw.getContentLanguage():formatDate('c')
+local _ABBR_UTC = '<abbr data-tz="+0:00" title="Coordinated Universal Time (UTC)">UTC</abbr>'
+local _SCORE_STATUS = 'S'
+
+local RecentMatches = {}
+
+function RecentMatches.run(args)
+	OpponentDisplay, Opponent = RecentMatches.requireOpponentModules()
+	args = args or {}
+	local conditions = RecentMatches.buildConditions(args)
+
+	local data = RecentMatches._getData(conditions)
+
+	if not data then
+		return mw.html.create('div')
+			:addClass('text-center')
+			:wikitext('<br/>No Recent Results<br/><br/>')
+	end
+
+	local display = ''
+
+	for _, item in ipairs(data) do
+		display = display .. RecentMatches._row(item)
+	end
+
+	return display
+end
+
+-- overridable functions
+function RecentMatches.requireOpponentModules()
+	return Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true}),
+		Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+end
+
+function RecentMatches.buildConditions(args)
+	local featured = args.featured == 'true'
+	local limit = tonumber(args.limit or 20) or 20
+
+	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
+	if featured then
+		conditions = conditions .. ' AND [[publishertier::>]]'
+	end
+
+	return conditions
+end
+
+function RecentMatches.scoreDisplay(opponentLeft, opponentRight, winner)
+	local leftScore = RecentMatches.getOpponentScore(opponentLeft)
+	local rightScore = RecentMatches.getOpponentScore(opponentRight)
+
+	local scoreDisplay = RecentMatches._displayOpponentScore(leftScore, winner == 1)
+		.. ':'
+		.. RecentMatches._displayOpponentScore(rightScore, winner == 2)
+
+	return scoreDisplay
+end
+
+function RecentMatches.getOpponentScore(opponent)
+	local score
+	if opponent.status == _SCORE_STATUS then
+		score = opponent.score
+	else
+		score = opponent.status or ''
+	end
+
+	return score
+end
+
+-- helper functions
+function RecentMatches._displayOpponentScore(score, isWinner)
+	return (isWinner and '<b>' or '')
+		.. score
+		.. (isWinner and '</b>' or '')
+end
+
+function RecentMatches._getData(conditions)
+	local data = mw.ext.LiquipediaDB.lpdb('match2', {
+		conditions = conditions,
+		order = 'date desc, liquipediatier asc, tournament asc',
+		query = 'match2opponents, winner, resulttype, pagename, tournament, '
+			.. 'tickername, icon, date, publishertier, vod, extradata, parent',
+			--readd icondark to the query once it is fixed in lpdb
+		limit = limit
+	})
+
+	if type(data[1]) == 'table' then
+		return data
+	end
+	mw.logObject(data)
+end
+
+function RecentMatches._getTableClass(winner, publishertier)
+	local class = 'wikitable wikitable-striped infobox_matches_content recent-matches-'
+
+	if winner == 1 then
+		class = class .. 'left'
+	elseif winner == 2 then
+		class = class .. 'right'
+	else
+		class = class .. 'draw'
+	end
+
+	if String.isNotEmpty(publishertier) then
+		class = class .. '-publishertier'
+	end
+
+	return class
+end
+
+function RecentMatches._checkForInelligableOpponent(opponent)
+	local name = string.lower(opponent.name or '')
+	local template = string.lower(opponent.template or '')
+
+	return name == 'bye'
+		or name == 'tba'
+		or name == 'tbd'
+		or template == 'bye'
+		or template == 'tba'
+		or template == 'tbd'
+		or (String.isEmpty(name) and String.isEmpty(template))
+end
+
+function RecentMatches._row(data)
+	local winner = tonumber(data.winner or 0) or 0
+	local tableClass = RecentMatches._getTableClass(winner, data.publishertier or '')
+
+	local output = mw.html.create('table')
+		:addClass(tableClass)
+
+	local opponentLeft = data.match2opponents[1]
+	local opponentRight = data.match2opponents[2]
+
+	if
+		RecentMatches._checkForInelligableOpponent(opponentLeft) or
+		RecentMatches._checkForInelligableOpponent(opponentRight)
+	then
+		return ''
+	end
+
+	local scoreDisplay = RecentMatches.scoreDisplay(opponentLeft, opponentRight, winner)
+
+	-- clean opponentData for display
+	opponentLeft = Opponent.fromMatch2Record(opponentLeft)
+	opponentRight = Opponent.fromMatch2Record(opponentRight)
+
+	-- get OpponentDisplays
+	opponentLeft = OpponentDisplay.InlineOpponent{opponent = opponentLeft}
+	opponentRight = OpponentDisplay.InlineOpponent{opponent = opponentRight, flip = true}
+
+	local lowerRow = RecentMatches._lowerRow(data)
+
+	output:tag('tr')
+		:tag('td')
+			:cssText(winner == 1 and 'font-weight:bold;' or '')
+			:addClass('team-left')
+			:node(opponentLeft)
+		:tag('td')
+			:addClass('versus')
+			:node(scoreDisplay)
+		:tag('td')
+			:cssText(winner == 2 and 'font-weight:bold;' or '')
+			:addClass('team-right')
+			:node(opponentRight)
+	:tag('tr')
+		:tag('td')
+			:addClass('match-filler')
+			:attr('colspan', 3)
+			:node(lowerRow)
+
+	return tostring(output)
+end
+
+function RecentMatches._lowerRow(data)
+	--countdown and vod stuff
+	local date = mw.getContentLanguage():formatDate( 'F j, Y - G:i', data.date )
+	local countdownDisplay = mw.html.create('span')
+		:addClass('match-countdown')
+		:css('font-size', '11px')
+		:node(Countdown._create{
+			rawdatetime = 'true',
+			date = date .. _ABBR_UTC,
+			separator = '&#8203;',
+		})
+		:node('&nbsp;&nbsp;')
+	if String.isNotEmpty(data.vod) then
+		countdownDisplay:node(VodLink.display{vod = data.vod})
+	end
+
+	--tournament icon and link
+	local icon = String.isNotEmpty(data.icon) and data.icon or 'InfoboxIcon_Tournament.png'
+	local iconDark = String.isNotEmpty(data.icondark) and data.icondark or icon
+	local displayName = String.isNotEmpty(data.tickername) and data.tickername or data.tournament
+	local link = String.isNotEmpty(data.parent) and data.parent or data.pagename
+
+	local tournamentDisplay = mw.html.create('div')
+		:css('min-width', '175px')
+		:css('max-width', '185px')
+		:css('float', 'right')
+		:css('white-space', 'nowrap')
+		:node(mw.html.create('span')
+			:css('float', 'right')
+			:node(LeagueIcon.display{
+				icon = icon,
+				iconDark = iconDark,
+				link = link,
+				name = data.tournament,
+				--size = '25px',
+				options = {noTemplate = true},
+			})
+		)
+		:node(mw.html.create('div')
+			:css('overflow', 'hidden')
+			:css('text-overflow', 'ellipsis')
+			:css('max-width', '170px')
+			:css('vertical-align', 'middle')
+			:css('white-space', 'nowrap')
+			:css('font-size', '11px')
+			:css('height', '16px')
+			:css('margin-top', '3px')
+			:wikitext('[[' .. link .. '|' .. displayName .. ']]&nbsp;')
+		)
+
+	return mw.html.create('span')
+		:node(countdownDisplay)
+		:node(tournamentDisplay)
+end
+
+return Class.export(RecentMatches)

--- a/components/match2/commons/recent_matches.lua
+++ b/components/match2/commons/recent_matches.lua
@@ -25,8 +25,9 @@ function RecentMatches.run(args)
 	OpponentDisplay, Opponent = RecentMatches.requireOpponentModules()
 	args = args or {}
 	local conditions = RecentMatches.buildConditions(args)
+	local limit = tonumber(args.limit or 20) or 20
 
-	local data = RecentMatches._getData(conditions)
+	local data = RecentMatches._getData(conditions, limit)
 
 	if not data then
 		return mw.html.create('div')
@@ -51,7 +52,6 @@ end
 
 function RecentMatches.buildConditions(args)
 	local featured = args.featured == 'true'
-	local limit = tonumber(args.limit or 20) or 20
 
 	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
 	if featured then
@@ -90,7 +90,7 @@ function RecentMatches._displayOpponentScore(score, isWinner)
 		.. (isWinner and '</b>' or '')
 end
 
-function RecentMatches._getData(conditions)
+function RecentMatches._getData(conditions, limit)
 	local data = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = conditions,
 		order = 'date desc, liquipediatier asc, tournament asc',

--- a/components/match2/commons/starcraft_starcraft2/recent_matches_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/recent_matches_starcraft.lua
@@ -1,0 +1,87 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:RecentMatches/Starcraft
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require("Module:Lua")
+
+local StarcraftRecentMatches = Lua.import('Module:RecentMatches', {requireDevIfEnabled = true})
+
+local _CURRENT_DATE_STAMP = mw.getContentLanguage():formatDate('c')
+local _SCORE_STATUS = 'S'
+
+-- override functions
+function StarcraftRecentMatches.requireOpponentModules()
+	return Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true}),
+		Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
+end
+
+function StarcraftRecentMatches.buildConditions(args)
+	local featured = args.featured == 'true'
+	local limit = tonumber(args.limit or 20) or 20
+
+	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
+	if featured then
+		conditions = conditions .. ' AND [[extradata_featured::true]]'
+	end
+
+	return conditions
+end
+
+function StarcraftRecentMatches.scoreDisplay(opponentLeft, opponentRight, winner)
+	local leftScore, leftScore2 = StarcraftRecentMatches.getOpponentScore(opponentLeft)
+	local rightScore, rightScore2 = StarcraftRecentMatches.getOpponentScore(opponentRight)
+
+	local scoreDisplay = StarcraftRecentMatches._displayOpponentScore(leftScore, winner == 1)
+		.. ':'
+		.. StarcraftRecentMatches._displayOpponentScore(rightScore, winner == 2)
+
+	local hasScore2 = (leftScore2 + rightScore2) > 0
+
+	if hasScore2 then
+		local lowerScoreDisplay = mw.html.create('div')
+			:css('font-size', '80%')
+			:css('padding-bottom', '1px')
+			:wikitext('(' .. scoreDisplay .. ')')
+
+		local upperScore = StarcraftRecentMatches._displayOpponentScore(leftScore2, winner == 1)
+			.. ':'
+			.. StarcraftRecentMatches._displayOpponentScore(rightScore, winner == 2)
+
+		local upperScoreDisplay = mw.html.create('div')
+			:css('line-height', '1.1')
+			:wikitext(upperScore)
+		
+		scoreDisplay = mw.html.create('div')
+			:node(upperScoreDisplay)
+			:node(lowerScoreDisplay)
+	end
+
+	return scoreDisplay
+end
+
+function StarcraftRecentMatches.getOpponentScore(opponent)
+	local score
+	if opponent.status == _SCORE_STATUS then
+		score = tonumber(opponent.score)
+		if score == -1 then
+			score = 0
+		end
+	else
+		score = opponent.status or ''
+	end
+
+	--custom for sc2:
+	local score2 = 0
+	if type(opponent.extradata) == 'table' then
+		score2 = tonumber(opponent.extradata.score2 or '') or 0
+	end
+
+	return score, score2
+end
+
+return Class.export(StarcraftRecentMatches)

--- a/components/match2/commons/starcraft_starcraft2/recent_matches_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/recent_matches_starcraft.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local Lua = require("Module:Lua")
+local Logic = require("Module:Logic")
 
 local StarcraftRecentMatches = Lua.import('Module:RecentMatches', {requireDevIfEnabled = true})
 
@@ -21,7 +22,7 @@ function StarcraftRecentMatches.requireOpponentModules()
 end
 
 function StarcraftRecentMatches.buildConditions(args)
-	local featured = args.featured == 'true'
+	local featured = Logic.readBool(args.featured)
 
 	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
 	if featured then

--- a/components/match2/commons/starcraft_starcraft2/recent_matches_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/recent_matches_starcraft.lua
@@ -22,7 +22,6 @@ end
 
 function StarcraftRecentMatches.buildConditions(args)
 	local featured = args.featured == 'true'
-	local limit = tonumber(args.limit or 20) or 20
 
 	local conditions = '[[dateexact::1]] AND [[finished::1]] AND [[date::<' .. _CURRENT_DATE_STAMP .. ']]'
 	if featured then
@@ -55,7 +54,7 @@ function StarcraftRecentMatches.scoreDisplay(opponentLeft, opponentRight, winner
 		local upperScoreDisplay = mw.html.create('div')
 			:css('line-height', '1.1')
 			:wikitext(upperScore)
-		
+
 		scoreDisplay = mw.html.create('div')
 			:node(upperScoreDisplay)
 			:node(lowerScoreDisplay)


### PR DESCRIPTION
## Summary
* Add `Module:RecentMatches`
* Add `Module:RecentMatches/Starcraft` (SC + SC2 version of `/Custom`)

`Module:RecentMatches` is intended for the display of recent matches on the main page (via `Liquipedia:Upcoming and ongoing matches on mainpage/dynamic` which gets copied to `Liquipedia:Upcoming and ongoing matches on mainpage` every 10 minutes by fobot)

it "only" supports matches with 2 opponents (that are neither `tbd`, `tba` nor `bye` and not empty)

## How did you test this change?
sanboxes
https://liquipedia.net/starcraft2/User:Hjpalpha/wip27

![Screenshot 2021-12-02 21 17 25](https://user-images.githubusercontent.com/75081997/144496770-2b7f72b0-a62f-4516-a03f-1699c6c6522f.png)

on main page it will look like the current sc2 display there

## Sandboxes
* RecentMatches (commons): https://liquipedia.net/starcraft2/Module:Hjpalpha/sandbox13
* RecentMatches (SC/SC2): https://liquipedia.net/starcraft2/Module:Hjpalpha/sandbox14
* BaseModule: https://liquipedia.net/starcraft2/Module:Hjpalpha/sandbox15 (atm empty)