### PR TITLE
Automate Tournament Link for Big Match

### DIFF
--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -15,6 +15,7 @@ local Lua = require('Module:Lua')
 local Links = require('Module:Links')
 local Logic = require('Module:Logic')
 local Match = require("Module:Match")
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
 local Template = require('Module:Template')
@@ -38,7 +39,7 @@ function BigMatch.run(frame)
 	Match.store(match, {storeMatch1 = false, storeSmw = false})
 
 	-- Attempty to automatically retrieve tournament link from the bracket
-	if Logic.isEmpty(args.tournamentlink) then
+	if String.isEmpty(args.tournamentlink) then
 		args.tournamentlink = bigMatch:_fetchTournamentLinkFromMatch(identifiers)
 	end
 
@@ -360,7 +361,9 @@ function BigMatch:_createPlayerLookUp(opponent1Players, opponent2Players)
 end
 
 function BigMatch:_fetchTournamentInfo(page)
-	if not page then return {} end
+	if not page then
+		return {}
+	end
 
 	return mw.ext.LiquipediaDB.lpdb('tournament', {
 		query = 'pagename, name, patch',
@@ -371,7 +374,7 @@ end
 function BigMatch:_fetchTournamentLinkFromMatch(identifiers)
 	local data = mw.ext.LiquipediaDB.lpdb('match2', {
 		query = 'parent, pagename',
-		conditions = '[[match2id::'.. table.concat(identifiers,'_') .. ']]',
+		conditions = '[[match2id::'.. table.concat(identifiers, '_') .. ']]',
 	})[1] or {}
 	return Logic.emptyOr(data.parent, data.pagename)
 end

--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -37,7 +37,12 @@ function BigMatch.run(frame)
 	-- Don't store match1 as BigMatch records are not complete
 	Match.store(match, {storeMatch1 = false, storeSmw = false})
 
-	local tournamentData = bigMatch:_fetchTournamentInfo(args.tournamentlink or '')
+	-- Attempty to automatically retrieve tournament link from the bracket
+	if Logic.isEmpty(args.tournamentlink) then
+		args.tournamentlink = bigMatch:_fetchTournamentLinkFromMatch(identifiers)
+	end
+
+	local tournamentData = bigMatch:_fetchTournamentInfo(args.tournamentlink)
 
 	match.patch = match.patch or tournamentData.patch
 	local tournament = {
@@ -355,10 +360,21 @@ function BigMatch:_createPlayerLookUp(opponent1Players, opponent2Players)
 end
 
 function BigMatch:_fetchTournamentInfo(page)
+	if not page then return {} end
+
 	return mw.ext.LiquipediaDB.lpdb('tournament', {
 		query = 'pagename, name, patch',
 		conditions = '[[pagename::'.. page .. ']]',
 	})[1] or {}
 end
+
+function BigMatch:_fetchTournamentLinkFromMatch(identifiers)
+	local data = mw.ext.LiquipediaDB.lpdb('match2', {
+		query = 'parent, pagename',
+		conditions = '[[match2id::'.. table.concat(identifiers,'_') .. ']]',
+	})[1] or {}
+	return Logic.emptyOr(data.parent, data.pagename)
+end
+
 
 return BigMatch


### PR DESCRIPTION

## Summary

Automatically retrieve Tournament Link for Big Match via the Tournament Match, so that less fields needs to be filled in manually by editors.

## How did you test this change?

Live as Big Match is not gone gold yet.
https://liquipedia.net/valorant/index.php?title=Match%3AID_c0gBtlJP3i_R02-M001&type=revision&diff=373764&oldid=373457