### PR TITLE
Fix custom earnings bug for infobox player

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -36,7 +36,6 @@ local _shouldStoreData
 local _region
 local _warnings = {}
 local _earningsPerYear = {}
-local _totalEarnings
 
 function Person.run(frame)
 	local person = Person(frame)
@@ -207,7 +206,7 @@ function Person:_setLpdbData(args, links, status, personType, earnings)
 		team = args.teamlink or args.team,
 		status = status,
 		type = personType,
-		earnings = _totalEarnings,
+		earnings = earnings,
 		links = links,
 		extradata = {},
 	}
@@ -297,11 +296,12 @@ end
 
 --- Allows for overriding this functionality
 function Person:calculateEarnings(args)
-	_totalEarnings, _earningsPerYear = Earnings.calculateForPlayer{
+	local totalEarnings
+	totalEarnings, _earningsPerYear = Earnings.calculateForPlayer{
 		player = args.earnings or self.pagename,
 		perYear = true
 	}
-	return _totalEarnings
+	return totalEarnings
 end
 
 function Person:_createRegion(region, country)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -36,6 +36,7 @@ local _shouldStoreData
 local _region
 local _warnings = {}
 local _earningsPerYear = {}
+local _totalEarnings
 
 function Person.run(frame)
 	local person = Person(frame)
@@ -58,7 +59,7 @@ function Person:createInfobox()
 	--set those already here as they are needed in several functions below
 	local links = Links.transform(args)
 	local personType = self:getPersonType(args)
-	local earnings = self:calculateEarnings(args)
+	_totalEarnings, _earningsPerYear = self:calculateEarnings(args)
 
 	local ageCalculationSuccess, age = pcall(AgeCalculation.run, {
 			birthdate = args.birth_date,
@@ -114,9 +115,9 @@ function Person:createInfobox()
 		Cell{name = 'Nicknames', content = {args.nicknames}},
 		Builder{
 			builder = function()
-				if earnings and earnings ~= 0 then
+				if _totalEarnings and _totalEarnings ~= 0 then
 					return {
-						Cell{name = 'Total Earnings', content = {'$' .. Language:formatNum(earnings)}},
+						Cell{name = 'Total Earnings', content = {'$' .. Language:formatNum(_totalEarnings)}},
 					}
 				end
 			end
@@ -179,15 +180,14 @@ function Person:createInfobox()
 			args,
 			links,
 			statusToStore,
-			personType.store,
-			earnings
+			personType.store
 		)
 	end
 
 	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
 end
 
-function Person:_setLpdbData(args, links, status, personType, earnings)
+function Person:_setLpdbData(args, links, status, personType)
 	links = Links.makeFullLinksForTableItems(links, _LINK_VARIANT)
 
 	local lpdbData = {
@@ -206,7 +206,7 @@ function Person:_setLpdbData(args, links, status, personType, earnings)
 		team = args.teamlink or args.team,
 		status = status,
 		type = personType,
-		earnings = earnings,
+		earnings = _totalEarnings,
 		links = links,
 		extradata = {},
 	}
@@ -296,12 +296,10 @@ end
 
 --- Allows for overriding this functionality
 function Person:calculateEarnings(args)
-	local totalEarnings
-	totalEarnings, _earningsPerYear = Earnings.calculateForPlayer{
+	return Earnings.calculateForPlayer{
 		player = args.earnings or self.pagename,
 		perYear = true
 	}
-	return totalEarnings
 end
 
 function Person:_createRegion(region, country)

--- a/components/infobox/wikis/starcraft2/infobox_person_commentator.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_commentator.lua
@@ -337,10 +337,6 @@ function CustomCommentator:adjustLPDB(lpdbData, _, personType)
 		extradata.factionhistorical = true
 	end
 
-	for key, item in pairs(_earningsGlobal or {}) do
-		extradata['earningsin' .. key] = item
-	end
-
 	lpdbData.extradata = extradata
 
 	return lpdbData
@@ -350,7 +346,7 @@ function CustomCommentator:calculateEarnings()
 	local earningsTotal
 	earningsTotal, _earningsGlobal = CustomCommentator._getEarningsMedalsData(self.pagename)
 	earningsTotal = Math.round{earningsTotal, 2}
-	return earningsTotal
+	return earningsTotal, _earningsGlobal
 end
 
 function CustomCommentator._getLPDBrecursive(cond, query, queryType)

--- a/components/infobox/wikis/starcraft2/infobox_person_player.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player.lua
@@ -368,10 +368,6 @@ function CustomPlayer:adjustLPDB(lpdbData, _, personType)
 		extradata.factionhistorical = true
 	end
 
-	for key, item in pairs(_earningsGlobal or {}) do
-		extradata['earningsin' .. key] = item
-	end
-
 	lpdbData.extradata = extradata
 
 	return lpdbData
@@ -381,7 +377,7 @@ function CustomPlayer:calculateEarnings()
 	local earningsTotal
 	earningsTotal, _earningsGlobal = CustomPlayer._getEarningsMedalsData(self.pagename)
 	earningsTotal = Math.round{earningsTotal, 2}
-	return earningsTotal
+	return earningsTotal, _earningsGlobal
 end
 
 function CustomPlayer._getLPDBrecursive(cond, query, queryType)


### PR DESCRIPTION
## Summary
Fix a bug with LPDB storage of earnings if a CUSTOM earnings functions is used

## How did you test this change?
sandbox + pushed to live afterwards
only affects sc2 (all other wikis either do not yet use the module or do not have a custom earnings function)