### PR TITLE
Improve Economy Tab of BigMatch

### DIFF
--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -240,7 +240,7 @@ function BigMatch:economy(match, opponent1, opponent2)
 		local function processRound(index, storage)
 			local round = map.rounds[index]
 
-			-- Chart Ext and API Ext don't agree on name yet
+			-- TODO: Chart Ext and API Ext don't agree on name yet
 			if round.winby == 'detonate' then
 				round.winby = 'explosion'
 			end


### PR DESCRIPTION

## Summary

Split the Eco Charts into first half, second half and OT, as the chart is only intended to be used with at most 12 rows.
Also mapped the input 'detonate' to 'explosion' as the two extensions don't agree on what it should be called (yet).

## How did you test this change?

Live