### PR TITLE
Add Brkts/WikiSpecific for Mobile Legends

### DIFF
--- a/components/infobox/wikis/mobilelegends/brkts_wikispecific.lua
+++ b/components/infobox/wikis/mobilelegends/brkts_wikispecific.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
+
+--
+-- Override functons
+--
+function WikiSpecific.matchHasDetails(match)
+	return match.dateIsExact
+		or match.date ~= _EPOCH_TIME_EXTENDED
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.games
+end
+
+WikiSpecific.defaultIcon = 'Mobile Legends allmode.png'
+
+return WikiSpecific


### PR DESCRIPTION
## Summary

Module:Brkts/WikiSpecific for Mobile Legends

This is basically the #746 but that was for Wildrift, this one is for ML.

the only thing that was changed here is the .png image file.

## How did you test this change?
pushed to live (already in use)
