### PR TITLE
Add option to store a list of sub/accademy teams to extradata

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -152,6 +152,9 @@ function CustomTeam.listSubTeams()
 		return nil
 	end
 	local subTeams = Team:getAllArgsForBase(_team.args, 'subteam')
+	for key, item in pairs(subTeams) do
+		subTeams[key] = mw.ext.TeamLiquidIntegration.resolve_redirect(item)
+	end
 	return Json.stringify(subTeams)
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -156,7 +156,7 @@ function CustomTeam.listSubTeams()
 	for key, item in pairs(subTeams) do
 		subTeamsToStore['subteam' .. key] = mw.ext.TeamLiquidIntegration.resolve_redirect(item)
 	end
-	return Json.stringify(subTeams)
+	return Json.stringify(subTeamsToStore)
 end
 
 function CustomTeam.playerBreakDown(args)

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Team = require('Module:Infobox/Team')
+local Json = require('Module:Json')
 local Variables = require('Module:Variables')
 local String = require('Module:StringUtils')
 local Achievements = require('Module:Achievements in infoboxes')
@@ -139,7 +140,19 @@ end
 function CustomTeam:addToLpdb(lpdbData)
 	lpdbData.earnings = _earnings or 0
 	lpdbData.region = nil
+	lpdbData.extradata.subteams = CustomTeam.listSubTeams()
 	return lpdbData
+end
+
+-- gets a list of sub/accademy teams of the team
+-- this data can be used in results queries to include
+-- results of accademy teams of the current team
+function CustomTeam.listSubTeams()
+	if String.isEmpty(_team.args.team2) then
+		return nil
+	end
+	local subTeams = Team:getAllArgsForBase(_team.args, 'subteam')
+	return Json.stringify(subTeams)
 end
 
 function CustomTeam.playerBreakDown(args)

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -148,7 +148,7 @@ end
 -- this data can be used in results queries to include
 -- results of accademy teams of the current team
 function CustomTeam.listSubTeams()
-	if String.isEmpty(_team.args.team2) then
+	if String.isEmpty(_team.args.subteam) and String.isEmpty(_team.args.subteam1) then
 		return nil
 	end
 	local subTeams = Team:getAllArgsForBase(_team.args, 'subteam')

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -152,8 +152,9 @@ function CustomTeam.listSubTeams()
 		return nil
 	end
 	local subTeams = Team:getAllArgsForBase(_team.args, 'subteam')
+	local subTeamsToStore = {}
 	for key, item in pairs(subTeams) do
-		subTeams[key] = mw.ext.TeamLiquidIntegration.resolve_redirect(item)
+		subTeamsToStore['subteam' .. key] = mw.ext.TeamLiquidIntegration.resolve_redirect(item)
 	end
 	return Json.stringify(subTeams)
 end

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -153,8 +153,8 @@ function CustomTeam.listSubTeams()
 	end
 	local subTeams = Team:getAllArgsForBase(_team.args, 'subteam')
 	local subTeamsToStore = {}
-	for key, item in pairs(subTeams) do
-		subTeamsToStore['subteam' .. key] = mw.ext.TeamLiquidIntegration.resolve_redirect(item)
+	for index, subTeam in pairs(subTeams) do
+		subTeamsToStore['subteam' .. index] = mw.ext.TeamLiquidIntegration.resolve_redirect(subTeam)
 	end
 	return Json.stringify(subTeamsToStore)
 end


### PR DESCRIPTION
## Summary
Add option to store a list of sub/accademy teams to extradata
We want to use that list in some placement queries so that the placements of accademy/sub teams are also counted for the current team.

## How did you test this change?
via sandbox and after that temp pushed to live