### PR TITLE
Fix variables in `Module:Infobox/League/Custom`

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -252,10 +252,8 @@ function CustomLeague:defineCustomPageVariables(args)
 
 	-- Legacy tier vars
 	Variables.varDefine('tournament_lptier', liquipediatier)
-	Variables.varDefine('tournament_tier', liquipediatiertype or liquipediatier)
-	Variables.varDefine('tournament_tier2', args.liquipediatier2)
+	Variables.varDefine('tournament_tier', liquipediatier)
 	Variables.varDefine('tournament_tiertype', liquipediatiertype)
-	Variables.varDefine('tournament_tiertype2', args.liquipediatiertype2)
 	Variables.varDefine('ltier', liquipediatier == 1 and 1 or
 		liquipediatier == 2 and 2 or
 		liquipediatier == 3 and 3 or 4
@@ -268,6 +266,9 @@ function CustomLeague:defineCustomPageVariables(args)
 	-- Module:Prize pool, Module:Prize pool team, Module:TeamCard and Module:TeamCard2
 	Variables.varDefine('tournament_deadline', DateClean(args.deadline or ''))
 	Variables.varDefine('tournament_gamemode', table.concat(CustomLeague:_getGameModes(args, false), ','))
+
+	-- headtohead
+	Variables.varDefine('tournament_headtohead', args.headtohead)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -232,7 +232,6 @@ function CustomLeague:defineCustomPageVariables(args)
 		'1v1'
 	)
 	Variables.varDefine('tournament_headtohead', args.headtohead)
-	Variables.varDefine('headtohead', args.headtohead)
 
 	-- clean liquipediatiers:
 	-- tier should be a number defining a tier

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -232,6 +232,7 @@ function CustomLeague:defineCustomPageVariables(args)
 		'1v1'
 	)
 	Variables.varDefine('tournament_headtohead', args.headtohead)
+	Variables.varDefine('headtohead', args.headtohead)
 
 	-- clean liquipediatiers:
 	-- tier should be a number defining a tier
@@ -266,9 +267,6 @@ function CustomLeague:defineCustomPageVariables(args)
 	-- Module:Prize pool, Module:Prize pool team, Module:TeamCard and Module:TeamCard2
 	Variables.varDefine('tournament_deadline', DateClean(args.deadline or ''))
 	Variables.varDefine('tournament_gamemode', table.concat(CustomLeague:_getGameModes(args, false), ','))
-
-	-- headtohead
-	Variables.varDefine('tournament_headtohead', args.headtohead)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)


### PR DESCRIPTION
## Summary
* Remove tournament_tier2, tournament_tiertype2 vars (not used on AoE)
* correct wrong setting of tournament_tier (was set in RL style)

## How did you test this change?
* Searched for occurrences where tier2, tiertype2 are set on AoE (none)
* Usage of `tournament_tier` was already replaced by `tournament_liquipediatier` in all Modules/Templates on AoE, fixing wrong content only for consistency.
