### PR TITLE
Add game version to LPDB in `Module:Infobox/League/Custom` on AoE

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -224,8 +224,9 @@ function CustomLeague:defineCustomPageVariables(args)
 
 	Variables.varDefine('game', GameLookup.getName({args.game}))
 	Variables.varDefine('tournament_game', GameLookup.getName({args.game}))
-	Variables.varDefine('tournament_patch', args.patch)
-	Variables.varDefine('patch', args.patch)
+	Variables.varDefine('tournament_patch', args.patch or args.voobly)
+	Variables.varDefine('patch', args.patch or args.voobly)
+	Variables.varDefine('tournament_gameversion', args.version)
 	Variables.varDefine('tournament_mode',
 		(not String.isEmpty(args.mode)) and args.mode or
 		(not String.isEmpty(args.team_number)) and 'team' or

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -281,12 +281,13 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData['maps'] = table.concat(mappages, ';')
 
 	lpdbData['game'] = GameLookup.getName({args.game})
-	lpdbData['patch'] = args.patch
+	lpdbData['patch'] = args.patch or args.voobly
 	lpdbData['participantsnumber'] = args.team_number or args.player_number
 	lpdbData['extradata'] = {
 		region = args.region,
 		deadline = DateClean(args.deadline or ''),
-		gamemode = table.concat(CustomLeague:_getGameModes(args, false), ',')
+		gamemode = table.concat(CustomLeague:_getGameModes(args, false), ','),
+		version = args.version
 	}
 
 	return lpdbData

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -224,6 +224,8 @@ function CustomLeague:defineCustomPageVariables(args)
 
 	Variables.varDefine('game', GameLookup.getName({args.game}))
 	Variables.varDefine('tournament_game', GameLookup.getName({args.game}))
+	-- Currently, args.patch shall be used for official patches,
+	-- whereas voobly is used to denote non-official version played via voobly
 	Variables.varDefine('tournament_patch', args.patch or args.voobly)
 	Variables.varDefine('patch', args.patch or args.voobly)
 	Variables.varDefine('tournament_gameversion', args.version)
@@ -282,13 +284,15 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData['maps'] = table.concat(mappages, ';')
 
 	lpdbData['game'] = GameLookup.getName({args.game})
+	-- Currently, args.patch shall be used for official patches,
+	-- whereas voobly is used to denote non-official version played via voobly
 	lpdbData['patch'] = args.patch or args.voobly
 	lpdbData['participantsnumber'] = args.team_number or args.player_number
 	lpdbData['extradata'] = {
 		region = args.region,
 		deadline = DateClean(args.deadline or ''),
 		gamemode = table.concat(CustomLeague:_getGameModes(args, false), ','),
-		version = args.version
+		gameversion = args.version
 	}
 
 	return lpdbData


### PR DESCRIPTION
## Summary
* Add missing information regarding voobly and gameversion to LPDB (Was not added in the old infobox, but is now needed to correctly determine the Game and Version.)
* Also set variables to be able to re-add information in case of overriden extradata.

## How did you test this change?
Tested by manually calling the parser function to set these values.
