### PR TITLE
[BigMatch] Code Cleanup

### DIFF
--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -278,7 +278,7 @@ end
 function BigMatch:_processHalf(map, startRound, endRound, groupColors)
 	local roundData = {}
 	for round = startRound, endRound do
-		Table.insert(roundData, self:_processRound(map, round))
+		table.insert(roundData, self:_processRound(map, round))
 	end
 	return roundData
 end

--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -286,11 +286,6 @@ end
 function BigMatch:_processRound(map, roundIndex)
 	local round = map.rounds[roundIndex]
 
-	-- TODO: Chart Ext and API Ext don't agree on name yet
-	if round.winby == 'detonate' then
-		round.winby = 'explosion'
-	end
-
 	return {
 		name = 'Round ' .. roundIndex,
 		winby = round.winby,

--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -275,7 +275,7 @@ function BigMatch:economy(match, opponent1, opponent2)
 	return Tabs.dynamic(tabs)
 end
 
-function BigMatch:_processHalf(map, startRound, endRound, groupColors)
+function BigMatch:_processHalf(map, startRound, endRound)
 	local roundData = {}
 	for round = startRound, endRound do
 		table.insert(roundData, self:_processRound(map, round))


### PR DESCRIPTION
## Summary

* Removed workaround that was in place due to Chart and API Ext not agreeing on name (they now agree on name)
* Fixed typo (had `Table` instead of `table`)
* Removed unused parameter in function call

## How did you test this change?

Live https://liquipedia.net/valorant/Match:ID_c0gBtlJP3i_R02-M001
