### PR TITLE
Make type a customizable cell in infobox league

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -88,28 +88,31 @@ function League:createInfobox()
 				Cell{name = 'Server', content = {args.server}}
 			}
 		},
-		Builder{
-			builder = function()
-				local value = tostring(args.type):lower()
-				if value == 'offline' then
-					self.infobox:categories('Offline Tournaments')
-				elseif value == 'online' then
-					self.infobox:categories('Online Tournaments')
-				else
-					self.infobox:categories('Unknown Type Tournaments')
-				end
+		Customizable{id = 'type', children = {
+				Builder{
+					builder = function()
+						local value = tostring(args.type):lower()
+						if value == 'offline' then
+							self.infobox:categories('Offline Tournaments')
+						elseif value == 'online' then
+							self.infobox:categories('Online Tournaments')
+						else
+							self.infobox:categories('Unknown Type Tournaments')
+						end
 
-				if not String.isEmpty(args.type) then
-					return {
-						Cell{
-							name = 'Type',
-							content = {
-								args.type:sub(1,1):upper()..args.type:sub(2)
+						if not String.isEmpty(args.type) then
+							return {
+								Cell{
+									name = 'Type',
+									content = {
+										args.type:sub(1,1):upper()..args.type:sub(2)
+									}
+								}
 							}
-						}
-					}
-				end
-			end
+						end
+					end
+				}
+			}
 		},
 		Cell{
 			name = 'Location',


### PR DESCRIPTION
## Summary
Make type a customizable cell in infobox league, so that it can be overwritten on sc2 (we have an additional type "Online/Offline")

## How did you test this change?
doesn't change anything, except that it will be overwritable
sandboxes on sc2