### PR TITLE
Fix config.showScore handling in starcraft MatchSummary

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -36,23 +36,25 @@ StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
 
 function StarcraftMatchSummary.MatchSummaryContainer(props)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
-	local config = {
-		showScore = props.config or false
-	}
 	local MatchSummary = match.isFfa
 		and Lua.import('Module:MatchSummary/Ffa/Starcraft', {requireDevIfEnabled = true}).FfaMatchSummary
 		or StarcraftMatchSummary.MatchSummary
-	return MatchSummary({match = match, config = config})
+	return MatchSummary({match = match, config = props.config})
 end
 
 StarcraftMatchSummary.propTypes.MatchSummary = {
 	match = StarcraftMatchGroupUtil.types.Match,
-	config = 'table'
+	config = 'table',
 }
 
 function StarcraftMatchSummary.MatchSummary(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.MatchSummary)
 	local match = props.match
+
+	local propsConfig = props.config or {}
+	local config = {
+		showScore = propsConfig.showScore or false,
+	}
 
 	-- Compute offraces
 	if match.opponentMode == 'uniform' then
@@ -67,7 +69,7 @@ function StarcraftMatchSummary.MatchSummary(props)
 		:addClass('brkts-popup')
 		:addClass('brkts-popup-sc')
 		:addClass(match.opponentMode == 'uniform' and 'brkts-popup-sc-uniform-match' or 'brkts-popup-sc-team-match')
-		:node(StarcraftMatchSummary.Header({match = match, config = props.config}))
+		:node(StarcraftMatchSummary.Header({match = match, config = config}))
 		:node(StarcraftMatchSummary.Body({match = match}))
 		:node(StarcraftMatchSummary.Footer({match = match, showHeadToHead = match.headToHead}))
 end


### PR DESCRIPTION
## Summary
FFAMatchSummary has its own showScore default, so the showScore default handling should be moved to a code path specific to non-FFA MatchSummary.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live modules
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
