### PR TITLE
Adjust sc2 MatchSummary veto & Caster Display

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -170,9 +170,7 @@ function StarcraftMatchSummary.Body(props)
 	for ix, veto in ipairs(match.vetoes) do
 		local vetoNode = StarcraftMatchSummary.Veto(veto)
 		if ix == 1 then
-			vetoNode = html.create('div')
-				:node(StarcraftMatchSummary.GameHeader({header = 'Vetoes'}))
-				:node(vetoNode)
+			body:node(StarcraftMatchSummary.VetoHeader{header = 'Vetoes'})
 		end
 		body:node(vetoNode:addClass('brkts-popup-body-element'))
 	end
@@ -180,7 +178,7 @@ function StarcraftMatchSummary.Body(props)
 	-- Match casters
 	if match.casters then
 		body:node(
-			html.create('div'):addClass('brkts-popup-sc-game-comment')
+			html.create('div'):addClass('brkts-popup-body-element brkts-popup-sc-game-comment')
 				:node('Caster(s): ' .. match.casters)
 		)
 	end
@@ -336,6 +334,17 @@ function StarcraftMatchSummary.GameHeader(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.GameHeader)
 	return html.create('div')
 		:addClass('brkts-popup-sc-game-header')
+		:wikitext(props.header)
+end
+
+StarcraftMatchSummary.propTypes.VetoHeader = {
+	header = 'string',
+}
+
+function StarcraftMatchSummary.VetoHeader(props)
+	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.VetoHeader)
+	return html.create('div')
+		:addClass('brkts-popup-body-element brkts-popup-sc-game-header brkts-popup-sc-veto-center')
 		:wikitext(props.header)
 end
 


### PR DESCRIPTION
stacked on #840 

## Summary
Currently the SC2 MatchSummary has
- the same striped background for the veto header and the first veto
- the same striped background for the last veto and the casters information
This PR changes that and gives each of them its own row and hence changing striped backgrounds

before:
![before](https://user-images.githubusercontent.com/75081997/145578717-271a9a65-d464-4f43-b19d-0b029da55464.png)

after:
![after](https://user-images.githubusercontent.com/75081997/145578716-a00c53eb-eb75-4b6e-ba20-25e785f5061f.png)

## How did you test this change?
`/dev` module + previews