### PR TITLE
Match2->Match1: Fix incorrect score handling

### DIFF
--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -187,7 +187,7 @@ function p.convertParameters(match2)
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == "team" then
 			match[prefix] = opponent.name
-			match[prefix.."score"] = tonumber(opponent.score) or 0 >= 0 and opponent.score or 0
+			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1,10 do
 				local player = opponentmatch2players[i] or {}
@@ -199,7 +199,7 @@ function p.convertParameters(match2)
 		elseif opponent.type == "solo" then
 			local player = opponentmatch2players[1] or {}
 			match[prefix] = player.name
-			match[prefix.."score"] = tonumber(opponent.score) or 0 >= 0 and opponent.score or 0
+			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix.."flag"] = player.flag
 		elseif opponent.type == "literal" then
 			match[prefix] = 'TBD'


### PR DESCRIPTION
## Summary

Incorrect statement would always use opponent.score instead of using fallback (0) when it should have.

## How did you test this change?

Put it live