### PR TITLE
Fix an error in the RL match2 copy paste generator

### DIFF
--- a/components/match2/wikis/rocketleague/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rocketleague/get_match_group_copy_paste_wiki.lua
@@ -67,7 +67,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			'}}',
 			''
 		})
-		return table.concat(lines, '\n')
+		return table.concat(opponentLines, '\n')
 	else
 		out = out:gsub('<nowiki>', '')
 		out = out:gsub('</nowiki>', '')


### PR DESCRIPTION
## Summary
Fix a variable name in a table.concat, so that it doesn't nil concat

## How did you test this change?
adjusted on splitgate (which copied the rl module 1:1)