### PR TITLE
use `Module:ReferenceCleaner` in function `League:_cleanDate`

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -19,6 +19,7 @@ local Variables = require('Module:Variables')
 local Locale = require('Module:Locale')
 local Page = require('Module:Page')
 local LeagueIcon = require('Module:LeagueIcon')
+local ReferenceCleaner = require('Module:ReferenceCleaner')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -428,12 +429,7 @@ function League:_cleanDate(date)
 	if self:_isUnknownDate(date) then
 		return nil
 	end
-
-	-- due to '-' and '?' being part of the 'magic' characters for patterns
-	-- we have to escape them with '%'
-	date = date:gsub('%-%?%?', '-01')
-	date = date:gsub('%-XX', '-01')
-	return date
+	return ReferenceCleaner.clean(date)
 end
 
 function League:_isUnknownDate(date)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -429,6 +429,8 @@ function League:_cleanDate(date)
 		return nil
 	end
 
+	-- due to '-' and '?' being part of the 'magic' characters for patterns
+	-- we have to escape them with '%'
 	date = date:gsub('%-%?%?', '-01')
 	date = date:gsub('%-XX', '-01')
 	return date

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -429,8 +429,8 @@ function League:_cleanDate(date)
 		return nil
 	end
 
-	date = date:gsub('-??', '-01')
-	date = date:gsub('-XX', '-01')
+	date = date:gsub('%-%?%?', '-01')
+	date = date:gsub('%-XX', '-01')
 	return date
 end
 


### PR DESCRIPTION
## Summary
Use `Module:ReferenceCleaner` instead of `gsubs` in a custom function in `Infobox league`

## How did you test this change?
temporarily created the module on sc2 and edited it there (sc2 does not yet use the standardized infobox league modules)
tested it with full, and partial (`-??` or `-XX`) dates