### PR TITLE
Added "top-tier" category and changed maps.

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_item_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_item_custom.lua
@@ -29,7 +29,7 @@ local _categories = {}
 local _CATEGORY_DISPLAY = {
 	finished = 'Upgraded [[Category:Upgraded Items]]',
 	upgraded = 'Upgraded [[Category:Upgraded Items]]',
-	['top-tier'] = 'Top-Tier [[Category:Top-Tier Items',
+	['top-tier'] = 'Top-Tier [[Category:Top-Tier Items]]',
 	advanced = 'Mid-Tier [[Category:Mid-Tier Items]]',
 	['mid-tier'] = 'Mid-Tier [[Category:Mid-Tier Items]]',
 	['mid tier'] = 'Mid-Tier [[Category:Mid-Tier Items]]',
@@ -234,7 +234,7 @@ function CustomInjector:parse(id, widgets)
 			}
 		else return {} end
 	elseif id == 'maps' then
-		if not (String.isEmpty(_args.sr) and
+		if not (String.isEmpty(_args.wr) and
 			String.isEmpty(_args.ha))
 		then
 			table.insert(widgets, Cell{name = '[[Wild Rift (Map)|Wild Rift]]', content = {_args.wr}})

--- a/components/infobox/wikis/wildrift/infobox_item_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_item_custom.lua
@@ -29,6 +29,7 @@ local _categories = {}
 local _CATEGORY_DISPLAY = {
 	finished = 'Upgraded [[Category:Upgraded Items]]',
 	upgraded = 'Upgraded [[Category:Upgraded Items]]',
+	['top-tier'] = 'Top-Tier [[Category:Top-Tier Items',
 	advanced = 'Mid-Tier [[Category:Mid-Tier Items]]',
 	['mid-tier'] = 'Mid-Tier [[Category:Mid-Tier Items]]',
 	['mid tier'] = 'Mid-Tier [[Category:Mid-Tier Items]]',
@@ -236,7 +237,7 @@ function CustomInjector:parse(id, widgets)
 		if not (String.isEmpty(_args.sr) and
 			String.isEmpty(_args.ha))
 		then
-			table.insert(widgets, Cell{name = '[[Summoner\'s Rift]]', content = {_args.sr}})
+			table.insert(widgets, Cell{name = '[[Wild Rift (Map)|Wild Rift]]', content = {_args.wr}})
 			table.insert(widgets, Cell{name = '[[Howling Abyss]]', content = {_args.ha}})
 		else return {} end
 	elseif id == 'recipe' then


### PR DESCRIPTION
## Summary

Wild Rift recently changed Upgraded items to Top-Tier items, so this change does that. For the maps, "Summoner's Rift" simply was the wrong name for the map. I changed the link and the parameter `sr` to `wr`.

## How did you test this change?

  - Does this break LPDB on any of the wikis?
  - No.
  
  - Are all needed page variables still set?
  - Yes.
  
  - Does this break SMW on any of the wikis?
  - No.