### PR TITLE
Remove `birthdate >= _EPOCH_DATE` condition

### DIFF
--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -238,8 +238,7 @@ function AgeCalculation._assertValidDates(birthDate, deathDate)
 		end
 	end
 
-	if earliestPossibleBirthDate > os.time() or
-		earliestPossibleBirthDate < os.time(_EPOCH_DATE) then
+	if earliestPossibleBirthDate > os.time() then
 			error('Birth date out of allowed range. Please use ISO 8601 date format YYYY-MM-DD')
 	end
 


### PR DESCRIPTION
## Summary
Remove `earliestPossibleBirthDate >= os.time(_EPOCH_DATE) condition due to there existing people on the wikis that are born before 1970.
e,g,: https://liquipedia.net/starcraft2/SirScoots

## How did you test this change?
sandbox on sc2