### PR TITLE
Add MatchGroupUtil.indexTableToRecord

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -637,6 +637,17 @@ function MatchGroupUtil.indexTableFromRecord(record)
 	end)
 end
 
+-- Convert 1-based indexes to 0-based
+function MatchGroupUtil.indexTableToRecord(coordinates)
+	return Table.map(coordinates, function(key, value)
+		if key:match('Index') and type(value) == 'number' then
+			return key, value - 1
+		else
+			return key, value
+		end
+	end)
+end
+
 --[[
 Splits a matchId like h5HXaqbSVP_R02-M002 into the bracket ID h5HXaqbSVP and
 the base match ID R02-M002.


### PR DESCRIPTION
## Summary
Add `MatchGroupUtil.indexTableToRecord`

`MatchGroupUtil.indexTableToRecord` was accidently left out of #559. It wasn't caught previously because coords6-coords8 were intended to be merged as a whole, and so coords6 wasn't tested independently.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live modules
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
