### PR TITLE
Adjust SC2 `adjustLPDB` functions in `Infobox/Person/...`

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_commentator.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_commentator.lua
@@ -322,16 +322,16 @@ function CustomCommentator._addScoresToVS(vs, opponents, commentator)
 end
 
 function CustomCommentator:adjustLPDB(lpdbData, _, personType)
-	local extradata = {
-		race = _raceData.race,
-		faction = _raceData.faction,
-		faction2 = _raceData.faction2,
-		lc_id = string.lower(self.pagename),
-		teamname = _args.team,
-		role = _args.role,
-		role2 = _args.role2,
-		militaryservice = _militaryStore,
-	}
+	local extradata = lpdbData.extradata
+	extradata.race = _raceData.race
+	extradata.faction = _raceData.faction
+	extradata.faction2 = _raceData.faction2
+	extradata.lc_id = string.lower(self.pagename)
+	extradata.teamname = _args.team
+	extradata.role = _args.role
+	extradata.role2 = _args.role2
+	extradata.militaryservice = _militaryStore
+
 	if Variables.varDefault('racecount') then
 		extradata.racehistorical = true
 		extradata.factionhistorical = true

--- a/components/infobox/wikis/starcraft2/infobox_person_player.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player.lua
@@ -352,17 +352,17 @@ function CustomPlayer._addScoresToVS(vs, opponents, player)
 end
 
 function CustomPlayer:adjustLPDB(lpdbData, _, personType)
-	local extradata = {
-		race = _raceData.race,
-		faction = _raceData.faction,
-		faction2 = _raceData.faction2,
-		lc_id = string.lower(self.pagename),
-		teamname = _args.team,
-		role = _args.role,
-		role2 = _args.role2,
-		militaryservice = _militaryStore,
-		activeplayer = (not _statusStore) and Variables.varDefault('isActive', '') or '',
-	}
+	local extradata = lpdbData.extradata
+	extradata.race = _raceData.race
+	extradata.faction = _raceData.faction
+	extradata.faction2 = _raceData.faction2
+	extradata.lc_id = string.lower(self.pagename)
+	extradata.teamname = _args.team
+	extradata.role = _args.role
+	extradata.role2 = _args.role2
+	extradata.militaryservice = _militaryStore
+	extradata.activeplayer = (not _statusStore) and Variables.varDefault('isActive', '') or ''
+
 	if Variables.varDefault('racecount') then
 		extradata.racehistorical = true
 		extradata.factionhistorical = true


### PR DESCRIPTION
## Summary
Adjust SC2 `adjustLPDB` functions in `Infobox/Person/Player` and `Infobox/Person/Commentator` so that they add to extradata instead of overwriting it.
This ensures that the earnings by year that are set via the commons module are still present when storing to LPDB.

## How did you test this change?
pushed to live, works as intended now
