### PR TITLE
Add links to VOD, SiegeGG and r6esports.br to SMW match

### DIFF
--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -31,8 +31,8 @@ function p.storeMatch(match2)
 end
 
 function p.storeMatchSMW(match, match2)
-	local streams = match.stream or {}
-	if type(streams) == "string" then streams = json.parse(streams) end
+	local streams = json.parseIfString(match.stream or {})
+	local links = json.parseIfString(match.links or {})
 	local icon = Variables.varDefault("tournament_icon")
 	mw.smw.subobject({
 		"legacymatch_" .. match2.match2id,
@@ -46,6 +46,9 @@ function p.storeMatchSMW(match, match2)
 		"Has match twitch=" .. (streams.twitch or ""),
 		"Has match twitch2=" .. (streams.twitch2 or ""),
 		"Has match youtube=" .. (streams.youtube or ""),
+		"Has match vod=" .. (match.vod or ""),
+		"Has siegegg=" .. (links.siegegg or ""),
+		"Has r6esports=" .. (links.r6esports or ""),
 		"Has tournament name=" .. Logic.emptyOr(match.tickername, match.name, ""),
 		"Has tournament icon=" .. (icon or ""),
 		"Has winner=" .. (match.winner or ""),


### PR DESCRIPTION
## Summary

This is a pull request to add more available data to the API, so links to VoDs, SiegeGG pages and r6esports pages can be retrieved automatically by people that want to use those. It also changes streams handling to use `parseIfString` from the json module.

## How did you test this change?

I tested this change by looking at the SMW data of EUL 2021 Stage 3 matches, like [this one](https://liquipedia.net/rainbowsix/Special:Browse/:European-20League-2F2021-2FStage-203-23legacymatch-5FuUYjvppIot-5F0001).  Since this doesn't edit existing data there should be no issues (besides the process for dealing with `match.stream`, but was done by Rathoz so I assume it doesn't generate issues).
