### PR TITLE
Round earnings to integer instead of 2 decimals

### DIFF
--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -119,7 +119,7 @@ function Earnings.calculate(conditions, year, mode, perYear, divisionFactor)
 		end
 	end
 
-	return MathUtils._round(totalEarnings, 2)
+	return MathUtils._round(totalEarnings)
 end
 
 ---
@@ -150,11 +150,11 @@ function Earnings.calculatePerYear(conditions, divisionFactor)
 	end
 
 	for year, earningsOfYear in pairs(earningsData) do
-		totalEarningsByYear[tonumber(year)] = MathUtils._round(earningsOfYear, 2)
+		totalEarningsByYear[tonumber(year)] = MathUtils._round(earningsOfYear)
 		totalEarnings = totalEarnings + earningsOfYear
 	end
 
-	totalEarnings = MathUtils._round(totalEarnings, 2)
+	totalEarnings = MathUtils._round(totalEarnings)
 
 	return totalEarnings, totalEarningsByYear
 end


### PR DESCRIPTION
## Summary
Round earnings to integer instead of 2 decimals

## How did you test this change?
sandbox on sc2, works as intended