### PR TITLE
Unify earnings display between team and person infoboxes

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -95,7 +95,7 @@ function Team:createInfobox()
 							totalEarnings = '$' .. Language:formatNum(_totalEarnings)
 						end
 						return {
-							Cell{name = 'Earnings', content = {totalEarnings}}
+							Cell{name = 'Approx. Total Winnings', content = {totalEarnings}}
 						}
 					end
 				}

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -71,7 +71,7 @@ function CustomInjector:parse(id, widgets)
 			earningsFromPlayersDisplay = '$' .. Language:formatNum(_earnings_by_players_while_on_team)
 		end
 		return {
-			Cell{name = 'Earnings', content = {earningsDisplay}},
+			Cell{name = 'Approx. Total Winnings', content = {earningsDisplay}},
 			Cell{name = _PLAYER_EARNINGS_ABBREVIATION, content = {earningsFromPlayersDisplay}},
 		}
 	elseif id == 'achievements' then


### PR DESCRIPTION
## Summary
Unify earnings display between team and person infoboxes

## How did you test this change?
N/A (only chnages displayed text, no actual changes to functionality)