### PR TITLE
Fixing Wild Rift Infobox Item bad argument error 

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_item_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_item_custom.lua
@@ -301,9 +301,10 @@ function CustomItem.getWikiCategories()
 		if not (String.isEmpty(_args.movespeed) and String.isEmpty(_args.movespeedmult)) then
 			table.insert(_categories, 'Movement Speed Items')
 		end
-
-		return _categories
 	end
+	
+	return _categories
+	
 end
 
 function CustomItem.nameDisplay()

--- a/components/infobox/wikis/wildrift/infobox_item_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_item_custom.lua
@@ -302,9 +302,9 @@ function CustomItem.getWikiCategories()
 			table.insert(_categories, 'Movement Speed Items')
 		end
 	end
-	
+
 	return _categories
-	
+
 end
 
 function CustomItem.nameDisplay()


### PR DESCRIPTION
Fixing a bad argument error as reported in Discord (solution from HJP) 
![image](https://user-images.githubusercontent.com/58013431/146882154-9796d573-4534-4630-8588-1cea3ea59bf5.png)


Change was implemented by HJP on the Wiki module: https://liquipedia.net/wildrift/index.php?title=Module%3AInfobox%2FItem%2FCustom&type=revision&diff=83504&oldid=82663