### PR TITLE
Switch SC(2) Match Input Processing to use the new standard date vars

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -73,7 +73,7 @@ function StarcraftMatchGroupInput.readDate(matchArgs)
 		Variables.varDefine('matchDate', dateProps.date)
 		return dateProps
 	else
-		local suggestedDate = Variables.varDefaultMulti('matchDate', 'Match_date', 'date', 'sdate', 'edate', '1970-01-01')
+		local suggestedDate = Variables.varDefaultMulti('matchDate', 'Match_date', 'tournament_startdate', 'tournament_enddate', '1970-01-01')
 		return {
 			date = MatchGroupInput.getInexactDate(suggestedDate),
 			dateexact = false,

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -73,7 +73,13 @@ function StarcraftMatchGroupInput.readDate(matchArgs)
 		Variables.varDefine('matchDate', dateProps.date)
 		return dateProps
 	else
-		local suggestedDate = Variables.varDefaultMulti('matchDate', 'Match_date', 'tournament_startdate', 'tournament_enddate', '1970-01-01')
+		local suggestedDate = Variables.varDefaultMulti(
+			'matchDate',
+			'Match_date',
+			'tournament_startdate',
+			'tournament_enddate',
+			'1970-01-01'
+		)
 		return {
 			date = MatchGroupInput.getInexactDate(suggestedDate),
 			dateexact = false,


### PR DESCRIPTION
## Summary
Switch SC(2) Match Input Processing to use the new standard date vars.
As a preparation both infoboxes on SC (old template version) and SC2 (new standardized version) now additionally store the new (standard) date variables `tournament_startdate` and `tournament_enddate`.

## How did you test this change?
/dev module