### PR TITLE
Adjust SC2 Earnings Display for teams and persons

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_commentator.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_commentator.lua
@@ -139,7 +139,7 @@ function CustomInjector:addCustomCells(widgets)
 
 	local currentYearEarnings = _earningsGlobal[tostring(_CURRENT_YEAR)]
 	if currentYearEarnings then
-		currentYearEarnings = Math.round{currentYearEarnings, 2}
+		currentYearEarnings = Math.round{currentYearEarnings}
 		currentYearEarnings = '$' .. mw.language.new('en'):formatNum(currentYearEarnings)
 	end
 
@@ -345,7 +345,7 @@ end
 function CustomCommentator:calculateEarnings()
 	local earningsTotal
 	earningsTotal, _earningsGlobal = CustomCommentator._getEarningsMedalsData(self.pagename)
-	earningsTotal = Math.round{earningsTotal, 2}
+	earningsTotal = Math.round{earningsTotal}
 	return earningsTotal, _earningsGlobal
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_person_player.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player.lua
@@ -167,7 +167,7 @@ function CustomInjector:addCustomCells(widgets)
 
 	local currentYearEarnings = _earningsGlobal[tostring(_CURRENT_YEAR)]
 	if currentYearEarnings then
-		currentYearEarnings = Math.round{currentYearEarnings, 2}
+		currentYearEarnings = Math.round{currentYearEarnings}
 		currentYearEarnings = '$' .. mw.language.new('en'):formatNum(currentYearEarnings)
 	end
 
@@ -376,7 +376,7 @@ end
 function CustomPlayer:calculateEarnings()
 	local earningsTotal
 	earningsTotal, _earningsGlobal = CustomPlayer._getEarningsMedalsData(self.pagename)
-	earningsTotal = Math.round{earningsTotal, 2}
+	earningsTotal = Math.round{earningsTotal}
 	return earningsTotal, _earningsGlobal
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -13,6 +13,7 @@ local String = require('Module:StringUtils')
 local Achievements = require('Module:Achievements in infoboxes')
 local RaceIcon = require('Module:RaceIcon').getSmallIcon
 local Matches = require('Module:Upcoming ongoing and recent matches team/new')
+local Math = require('Module:Math')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
@@ -284,9 +285,9 @@ function CustomTeam.getEarningsAndMedalsData(team)
 				information = playerEarnings,
 		})
 	end
-	_earnings_by_players_while_on_team = math.floor((playerEarnings or 0) + 0.5)
+	_earnings_by_players_while_on_team = Math.round{playerEarnings or 0}
 
-	return math.floor((earnings.team.total or 0) + 0.5)
+	return Math.round{earnings.team.total or 0}
 end
 
 function CustomTeam._addPlacementToEarnings(earnings, playerEarnings, data)

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -284,9 +284,9 @@ function CustomTeam.getEarningsAndMedalsData(team)
 				information = playerEarnings,
 		})
 	end
-	_earnings_by_players_while_on_team = math.floor((playerEarnings or 0) * 100 + 0.5) / 100
+	_earnings_by_players_while_on_team = math.floor((playerEarnings or 0) + 0.5)
 
-	return math.floor((earnings.team.total or 0) * 100 + 0.5) / 100
+	return math.floor((earnings.team.total or 0) + 0.5)
 end
 
 function CustomTeam._addPlacementToEarnings(earnings, playerEarnings, data)


### PR DESCRIPTION
## Summary
* round values to integers instead of with 2 decimals
* switch round function in infobox team to use the Math module instead of having the same function in the module

## How did you test this change?
temp pushed live
