### PR TITLE
Create Wiki Specific Brkts for OW

### DIFF
--- a/components/match2/wikis/overwatch/brkts_wiki_specific.lua
+++ b/components/match2/wikis/overwatch/brkts_wiki_specific.lua
@@ -1,0 +1,28 @@
+---
+-- @Liquipedia
+-- wiki=overwatch
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
+
+--
+-- Override functons
+--
+function WikiSpecific.matchHasDetails(match)
+	return match.dateIsExact
+		or match.date ~= _EPOCH_TIME_EXTENDED
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.games
+end
+
+return WikiSpecific


### PR DESCRIPTION
## Summary
Adding the Match Summary module for the Overwatch wiki using match2. Display is incredibly similar to Halo 

## How did you test this change?
All changes tested here: https://liquipedia.net/overwatch/User:Fenrir.SPAZ/Sandbox
