### PR TITLE
Fix RL Infobox car

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_unit_car.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unit_car.lua
@@ -74,4 +74,8 @@ function CustomUnit:setLpdbData(args)
 	mw.ext.LiquipediaDB.lpdb_datapoint(objectName, lpdbData)
 end
 
+function CustomInjector:parse(_, widgets)
+	return widgets
+end
+
 return CustomUnit


### PR DESCRIPTION
## Summary
RL infobox car implementation was missing the Injector:parse function, hence so e stuff got lost when calling the injector. This PR adds the Injector:parse function (which does nothing).

## How did you test this change?
pushed live