### PR TITLE
Move `Infobox/Person/User` to `Infobox/Person/User/Custom`

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_user_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_user_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=starcraft2
--- page=Module:Infobox/Person/User
+-- page=Module:Infobox/Person/User/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --


### PR DESCRIPTION
## Summary
Move `Infobox/Person/User` to `Infobox/Person/User/Custom`

## How did you test this change?
N/A

## Request
please move the according module on the sc2 wiki before merging, so that we do not duplicate it
also adjust the invoke in the according template on sc2 so it will not error^^