### PR TITLE
Move/Rename Infobox Person modules to `.../Custom`

### DIFF
--- a/components/infobox/commons/infobox_person_user_custom.lua
+++ b/components/infobox/commons/infobox_person_user_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Person/User
+-- page=Module:Infobox/Person/User/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --

--- a/components/infobox/wikis/dota2/infobox_person_user_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_user_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=dota2
--- page=Module:Infobox/Person/User
+-- page=Module:Infobox/Person/User/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=halo
--- page=Module:Infobox/Person/Player
+-- page=Module:Infobox/Person/Player/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --

--- a/components/infobox/wikis/overwatch/infobox_person_user_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_user_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=overwatch
--- page=Module:Infobox/Person/User
+-- page=Module:Infobox/Person/User/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=rocketleague
--- page=Module:Infobox/Person/Player
+-- page=Module:Infobox/Person/Player/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --


### PR DESCRIPTION
## Summary
Move/Rename `Infobox/Person/...` modules to `Infobox/Person/.../Custom`


## How did you test this change?
N/A

## Request
please move the according modules before merging, so that we do not duplicate them
feel free to ping me and let me do the chore, but it has to be coordinated
also adjust the invokes in the according templates so it will not error
- [x] user on dota2
- [x] player on halo
- [x] user on overwatch
- [x] player on rocketleague
- [x] user on commons