### PR TITLE
Earnings - Update default players per team

### DIFF
--- a/components/earnings/wikis/halo/earnings.lua
+++ b/components/earnings/wikis/halo/earnings.lua
@@ -11,7 +11,7 @@ local Lua = require('Module:Lua')
 
 local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
 
-CustomEarnings.defaultNumberOfPlayersInTeam = 3
+CustomEarnings.defaultNumberOfPlayersInTeam = 4
 
 -- Legacy entry points
 function CustomEarnings.calc_player(input)

--- a/components/earnings/wikis/valorant/earnings.lua
+++ b/components/earnings/wikis/valorant/earnings.lua
@@ -11,7 +11,7 @@ local Lua = require('Module:Lua')
 
 local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
 
-CustomEarnings.defaultNumberOfPlayersInTeam = 3
+CustomEarnings.defaultNumberOfPlayersInTeam = 5
 
 -- Legacy entry points
 function CustomEarnings.calc_player(input)


### PR DESCRIPTION
## Summary

Update default players per team sizes for Valorant and Halo to match reality.
