### PR TITLE
Add option to display Warnings in Infobox/League

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -19,6 +19,7 @@ local Variables = require('Module:Variables')
 local Locale = require('Module:Locale')
 local Page = require('Module:Page')
 local LeagueIcon = require('Module:LeagueIcon')
+local WarningBox = require('Module:WarningBox')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -31,6 +32,8 @@ local Builder = Widgets.Builder
 local Chronology = Widgets.Chronology
 
 local League = Class.new(BasicInfobox)
+
+League.warnings = {}
 
 function League.run(frame)
 	local league = League(frame)
@@ -179,7 +182,7 @@ function League:createInfobox()
 		self:_setLpdbData(args, links)
 	end
 
-	return builtInfobox
+	return tostring(builtInfobox) .. WarningBox.displayAll(League.warnings)
 end
 
 --- Allows for overriding this functionality


### PR DESCRIPTION
## Summary

Add the option to display warnings in Infobox/League. For example for incorrect values.


## How did you test this change?

Tested together with #707 in sandbox on R6