### PR TITLE
Add Literal as allowed mode in CopyPasta/Base

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
+++ b/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
@@ -17,7 +17,7 @@ adjust this to fit the needs of your wiki^^
 local wikiCopyPaste = {}
 
 --allowed opponent types on the wiki
-local MODES = { 
+local MODES = {
 	['solo'] = 'solo',
 	['team'] = 'team',
 	['literal'] = 'literal',

--- a/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
+++ b/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
@@ -17,7 +17,11 @@ adjust this to fit the needs of your wiki^^
 local wikiCopyPaste = {}
 
 --allowed opponent types on the wiki
-local MODES = { ['solo'] = 'solo', ['team'] = 'team' }
+local MODES = { 
+	['solo'] = 'solo',
+	['team'] = 'team',
+	['literal'] = 'literal',
+}
 
 --default opponent type (used if the entered mode is not found in the above table)
 local DefaultMode = 'team'


### PR DESCRIPTION
## Summary

wikiCopyPaste._getOpponent already uses literal. Adding it in allowed modes so that doesn't need to get overwritten by wiki-customs.

## How did you test this change?

N/A