### PR TITLE
Adding default parameters for Infobox Map

### DIFF
--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -36,7 +36,6 @@ function Map:createInfobox(frame)
 				args.creator or args['created-by'], args.creator2 or args['created-by2']}, options = { makeLink = true }
 		},
 		Cell{name = 'Release Date', content = {args.releasedate}},
-		Cell{name = 'Game', content = {args.game}, options = { makeLink = true }},
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},
 	}
@@ -65,7 +64,6 @@ function Map:_setLpdbData(args)
 		type = 'map',
 		image = args.image,
 		date = args.releasedate,
-		--game = args.game,
 		extradata = { creator = args.creator }
 	}
 

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -64,6 +64,8 @@ function Map:_setLpdbData(args)
 		name = self.name,
 		type = 'map',
 		image = args.image,
+		releasedate = args.releasedate,
+		game = args.game,
 		extradata = { creator = args.creator }
 	}
 

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -35,6 +35,8 @@ function Map:createInfobox(frame)
 		Cell{name = 'Creator', content = {
 				args.creator or args['created-by'], args.creator2 or args['created-by2']}, options = { makeLink = true }
 		},
+		Cell{name = 'Release Date', content = {args.releasedate}}
+		Cell{name = 'Game', content = {_args.game}, options = { makeLink = true }}
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},
 	}

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -35,8 +35,8 @@ function Map:createInfobox(frame)
 		Cell{name = 'Creator', content = {
 				args.creator or args['created-by'], args.creator2 or args['created-by2']}, options = { makeLink = true }
 		},
-		Cell{name = 'Release Date', content = {args.releasedate}}
-		Cell{name = 'Game', content = {_args.game}, options = { makeLink = true }}
+		Cell{name = 'Release Date', content = {args.releasedate}},
+		Cell{name = 'Game', content = {args.game}, options = { makeLink = true }},
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},
 	}

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -64,8 +64,8 @@ function Map:_setLpdbData(args)
 		name = self.name,
 		type = 'map',
 		image = args.image,
-		releasedate = args.releasedate,
-		game = args.game,
+		date = args.releasedate,
+		--game = args.game,
 		extradata = { creator = args.creator }
 	}
 


### PR DESCRIPTION
Adding Release date and Game as default parameters

## Summary
Adds 2 new default parameters for the Map Infobox, that being the maps release date, and the game the map is used for. 

**EDIT:** Game/Game Version removed from this PR. Further conversations are needed
## How did you test this change?
Tested on Commons. Page was created in Userspace and moved to Mainspace. LPDB output shown below on the Mainspace version. Following the test, the page was moved back to https://liquipedia.net/commons/User:Fenrir.SPAZ/Sandbox
![image](https://user-images.githubusercontent.com/58013431/148996937-67d25d0d-7fb1-4664-ba16-cb3a8905f74b.png)
![image](https://user-images.githubusercontent.com/58013431/148996987-64602047-928f-42ac-81f6-b9fae613a585.png)

