### PR TITLE
Initial commit for automatic_points_table module

### DIFF
--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -50,7 +50,8 @@ function AutomaticPointsTable.run(frame)
 
   pointsTable:queryPlacements()
   pointsTable:calculatePointsAndTotals()
-  
+
+
   pointsTable:getSortedData()
   pointsTable:storeLPDB()
   

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -19,18 +19,17 @@ local split = require('Module:StringUtils').split
 local getArgs = require('Module:Arguments').getArgs
 
 function DivTable.Row:create()
-  for _, cell in pairs(self.cells) do
-      cell:css('border-right', '1px solid #bbbbbb')
+	for _, cell in pairs(self.cells) do
+			cell:css('border-right', '1px solid #bbbbbb')
 
-      cell:css('text-align', 'center')
-      if cell.alignLeft then
-        cell:css('text-align', 'left')
-      end
-      self.root:node(cell)
-  end
+			cell:css('text-align', 'center')
+			if cell.alignLeft then
+				cell:css('text-align', 'left')
+			end
+			self.root:node(cell)
+	end
 
-
-  return self.root
+	return self.root
 end
 
 local AutomaticPointsTable = Class.new(

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -1,0 +1,102 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:AutomaticPointsTable
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+---- This module creates a Points Table that automatically gets data from the prizepools
+---- of set tournaments
+
+local Class = require('Module:Class')
+local Table = require('Module:Table')
+local DivTable = require('Module:DivTable')
+local Json = require('Module:Json')
+local split = require('Module:StringUtils').split
+local getArgs = require('Module:Arguments').getArgs
+
+function DivTable.Row:create()
+  for _, cell in pairs(self.cells) do
+      cell:css('border-right', '1px solid #bbbbbb')
+
+      cell:css('text-align', 'center')
+      if cell.alignLeft then
+        cell:css('text-align', 'left')
+      end
+      self.root:node(cell)
+  end
+  
+  return self.root
+end
+
+local AutomaticPointsTable = Class.new(
+  function(self, frame)
+    self.frame = frame
+    self.args = getArgs(frame)
+  end
+)
+
+--- Main function
+function AutomaticPointsTable.run(frame)
+  local pointsTable = AutomaticPointsTable(frame)
+
+  pointsTable:extractPositionBackgroundData()
+
+  pointsTable:extractTournaments()
+  pointsTable:extractTeams()
+
+  pointsTable:queryPlacements()
+  pointsTable:calculatePointsAndTotals()
+  
+  pointsTable:getSortedData()
+  pointsTable:storeLPDB()
+  
+  pointsTable:setHeaders()
+  local divTable = pointsTable:divTableFromData()
+  return divTable
+end
+
+function AutomaticPointsTable:extractPositionBackgroundData()
+  local args = self.args
+  self.pbg = {}
+  for argKey, argVal in pairs(args) do
+    if string.find(argKey, 'pbg') then
+      local positionIndex = tonumber(split(argKey, 'pbg')[1])
+      self.pbg[positionIndex] = argVal
+    end
+  end
+end
+
+--- Extracts the tournaments while guaranteeing the order.
+function AutomaticPointsTable:extractTournaments()
+  local args = self.args
+  self.tournaments = {}
+  for argKey, argVal in pairs(args) do
+    if (type(argVal) == 'string') and (string.find(argKey, 'tournament')) then
+      local tournamentIndexString = split(argKey, 'tournament')[1]
+      local tournamentIndex = tonumber(tournamentIndexString)
+      local unpackedTournament = Json.parse(argVal)
+      self.tournaments[tournamentIndex] = unpackedTournament
+    end
+  end
+  return nil
+end
+
+--- Extracts the teams without guaranteeing the order.
+function AutomaticPointsTable:extractTeams()
+  local args = self.args
+  self.teams = {}
+  for argKey, argVal in pairs(args) do
+    if type(argVal) == 'string' and string.find(argKey, 'team') then
+      local unpackedTeam = Json.parse(argVal)
+      self:unpackAliases(unpackedTeam)
+      self:unpackDeductions(unpackedTeam)
+      self:unpackManualPoints(unpackedTeam)
+      table.insert(self.teams, unpackedTeam)
+    end
+  end
+  return nil
+end
+
+return AutomaticPointsTable

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -75,7 +75,7 @@ function AutomaticPointsTable:extractTournaments()
 	self.tournaments = {}
 	for argKey, argVal in pairs(args) do
 		if (type(argVal) == 'string') and (string.find(argKey, 'tournament')) then
-			local tournamentIndexString = split(argKey, 'tournament')[1]
+			local tournamentIndexString = String.split(argKey, 'tournament')[1]
 			local tournamentIndex = tonumber(tournamentIndexString)
 			local unpackedTournament = Json.parse(argVal)
 			self.tournaments[tournamentIndex] = unpackedTournament

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -62,11 +62,11 @@ function AutomaticPointsTable.run(frame)
 end
 
 function AutomaticPointsTable:extractPositionBackgroundData()
-  local args = self.args
-  self.pbg = {}
-  for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
-      table.insert(self.pbg, background)
-  end
+	local args = self.args
+	self.pbg = {}
+	for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
+			table.insert(self.pbg, background)
+	end
 end
 
 --- Extracts the tournaments while guaranteeing the order.

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -33,10 +33,10 @@ function DivTable.Row:create()
 end
 
 local AutomaticPointsTable = Class.new(
-  function(self, frame)
-    self.frame = frame
-    self.args = getArgs(frame)
-  end
+	function(self, frame)
+		self.frame = frame
+		self.args = getArgs(frame)
+	end
 )
 
 --- Main function

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -85,19 +85,20 @@ function AutomaticPointsTable:extractTournaments()
 end
 
 --- Extracts the teams without guaranteeing the order.
+--- Extracts the teams without guaranteeing the order.
 function AutomaticPointsTable:extractTeams()
-  local args = self.args
-  self.teams = {}
-  for argKey, argVal in pairs(args) do
-    if type(argVal) == 'string' and string.find(argKey, 'team') then
-      local unpackedTeam = Json.parse(argVal)
-      self:unpackAliases(unpackedTeam)
-      self:unpackDeductions(unpackedTeam)
-      self:unpackManualPoints(unpackedTeam)
-      table.insert(self.teams, unpackedTeam)
-    end
-  end
-  return nil
+	local args = self.args
+	self.teams = {}
+	for argKey, argVal in pairs(args) do
+		if type(argVal) == 'string' and string.find(argKey, 'team') then
+			local unpackedTeam = Json.parse(argVal)
+			self:unpackAliases(unpackedTeam)
+			self:unpackDeductions(unpackedTeam)
+			self:unpackManualPoints(unpackedTeam)
+			table.insert(self.teams, unpackedTeam)
+		end
+	end
+	return nil
 end
 
 return AutomaticPointsTable

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -27,7 +27,8 @@ function DivTable.Row:create()
       end
       self.root:node(cell)
   end
-  
+
+
   return self.root
 end
 

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -15,7 +15,8 @@ local Table = require('Module:Table')
 
 local DivTable = require('Module:DivTable')
 local Json = require('Module:Json')
-local split = require('Module:StringUtils').split
+local String = require('Module:StringUtils')
+
 local getArgs = require('Module:Arguments').getArgs
 
 function DivTable.Row:create()

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -10,7 +10,8 @@
 ---- of set tournaments
 
 local Class = require('Module:Class')
--- local Table = require('Module:Table')
+local Table = require('Module:Table')
+
 
 local DivTable = require('Module:DivTable')
 local Json = require('Module:Json')

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -37,7 +37,7 @@ end
 local AutomaticPointsTable = Class.new(
 	function(self, frame)
 		self.frame = frame
-		self.args = getArgs(frame)
+		self.args = Arguments.getArgs(frame)
 	end
 )
 

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -10,7 +10,8 @@
 ---- of set tournaments
 
 local Class = require('Module:Class')
-local Table = require('Module:Table')
+-- local Table = require('Module:Table')
+
 local DivTable = require('Module:DivTable')
 local Json = require('Module:Json')
 local split = require('Module:StringUtils').split

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -41,24 +41,22 @@ local AutomaticPointsTable = Class.new(
 
 --- Main function
 function AutomaticPointsTable.run(frame)
-  local pointsTable = AutomaticPointsTable(frame)
+	local pointsTable = AutomaticPointsTable(frame)
 
-  pointsTable:extractPositionBackgroundData()
+	pointsTable:extractPositionBackgroundData()
 
-  pointsTable:extractTournaments()
-  pointsTable:extractTeams()
+	pointsTable:extractTournaments()
+	pointsTable:extractTeams()
 
-  pointsTable:queryPlacements()
-  pointsTable:calculatePointsAndTotals()
+	pointsTable:queryPlacements()
+	pointsTable:calculatePointsAndTotals()
 
+	pointsTable:getSortedData()
+	pointsTable:storeLPDB()
 
-  pointsTable:getSortedData()
-  pointsTable:storeLPDB()
-
-
-  pointsTable:setHeaders()
-  local divTable = pointsTable:divTableFromData()
-  return divTable
+	pointsTable:setHeaders()
+	local divTable = pointsTable:divTableFromData()
+	return divTable
 end
 
 function AutomaticPointsTable:extractPositionBackgroundData()

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -64,11 +64,8 @@ end
 function AutomaticPointsTable:extractPositionBackgroundData()
   local args = self.args
   self.pbg = {}
-  for argKey, argVal in pairs(args) do
-    if string.find(argKey, 'pbg') then
-      local positionIndex = tonumber(split(argKey, 'pbg')[1])
-      self.pbg[positionIndex] = argVal
-    end
+  for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
+      table.insert(self.pbg, background)
   end
 end
 

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -14,7 +14,6 @@ local Table = require('Module:Table')
 local DivTable = require('Module:DivTable')
 local Json = require('Module:Json')
 local String = require('Module:StringUtils')
-
 local Arguments = require('Module:Arguments')
 
 

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -11,8 +11,6 @@
 
 local Class = require('Module:Class')
 local Table = require('Module:Table')
-
-
 local DivTable = require('Module:DivTable')
 local Json = require('Module:Json')
 local String = require('Module:StringUtils')

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -71,17 +71,17 @@ end
 
 --- Extracts the tournaments while guaranteeing the order.
 function AutomaticPointsTable:extractTournaments()
-  local args = self.args
-  self.tournaments = {}
-  for argKey, argVal in pairs(args) do
-    if (type(argVal) == 'string') and (string.find(argKey, 'tournament')) then
-      local tournamentIndexString = split(argKey, 'tournament')[1]
-      local tournamentIndex = tonumber(tournamentIndexString)
-      local unpackedTournament = Json.parse(argVal)
-      self.tournaments[tournamentIndex] = unpackedTournament
-    end
-  end
-  return nil
+	local args = self.args
+	self.tournaments = {}
+	for argKey, argVal in pairs(args) do
+		if (type(argVal) == 'string') and (string.find(argKey, 'tournament')) then
+			local tournamentIndexString = split(argKey, 'tournament')[1]
+			local tournamentIndex = tonumber(tournamentIndexString)
+			local unpackedTournament = Json.parse(argVal)
+			self.tournaments[tournamentIndex] = unpackedTournament
+		end
+	end
+	return nil
 end
 
 --- Extracts the teams without guaranteeing the order.

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -16,7 +16,6 @@ local Json = require('Module:Json')
 local String = require('Module:StringUtils')
 local Arguments = require('Module:Arguments')
 
-
 function DivTable.Row:create()
 	for _, cell in pairs(self.cells) do
 			cell:css('border-right', '1px solid #bbbbbb')

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -54,7 +54,8 @@ function AutomaticPointsTable.run(frame)
 
   pointsTable:getSortedData()
   pointsTable:storeLPDB()
-  
+
+
   pointsTable:setHeaders()
   local divTable = pointsTable:divTableFromData()
   return divTable

--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -17,7 +17,8 @@ local DivTable = require('Module:DivTable')
 local Json = require('Module:Json')
 local String = require('Module:StringUtils')
 
-local getArgs = require('Module:Arguments').getArgs
+local Arguments = require('Module:Arguments')
+
 
 function DivTable.Row:create()
 	for _, cell in pairs(self.cells) do


### PR DESCRIPTION
## Summary

Automatic Points Table is a table that automatically fills in its points from tournaments' prize pool templates.

This Pull Request contains 4 functions; extractPositionBackgroundData, extractTournaments, extractTeams and DivTable.Row:create

**DivTable.Row:create** overwrites the default css for DivCells to style it as required by this module.

Finally, the whole module is wrapped by the Class module, which allows for more customization when used in different wikis.

## How did you test this change?

This is the first of many pull requests required to push this module through, the module is currently 568 lines of code, hence it will likely use at least 6 pull requests.

The full module is deployed in Sandbox and is working as intended
https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite