### PR TITLE
Enable language flags

### DIFF
--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -62,6 +62,21 @@ function Flags.Icon(args, flagName)
 	end
 end
 
+function Flags.LanguageIcon(args, langName)
+	if type(args) == 'string' then
+		langName = args
+		args = {}
+	elseif String.isEmpty(langName) then
+		langName = args.language or args.flag
+	end
+	if String.isEmpty(langName) then
+		return ''
+	end
+	langName = Flags._convertToLangKey(langName)
+
+	return Flags.Icon(args, langName)
+end
+
 -- Converts a country name, flag code, or alias to a standardized country name
 function Flags.CountryName(flagName)
 	if String.isEmpty(flagName) then
@@ -95,9 +110,9 @@ function Flags.CountryCode(flagName, format)
 
 	if flagKey then
 		if format == 'alpha3' then
-			return Flags._getAlpha3CodesByKey()[flagKey]
+			return Flags._getAlpha3CodesByKey()[flagKey] or Flags._getLanguageCodesByKey()[flagKey]
 		else
-			return Flags._getAlpha2CodesByKey()[flagKey]
+			return Flags._getAlpha2CodesByKey()[flagKey] or Flags._getLanguageCodesByKey()[flagKey]
 		end
 	end
 	mw.log('Unknown flag: ', flagName)
@@ -110,6 +125,10 @@ end)
 
 Flags._getAlpha3CodesByKey = FnUtil.memoize(function()
 	return Table.map(MasterData.threeLetter, function(key, code) return code, key end)
+end)
+
+Flags._getLanguageCodesByKey = FnUtil.memoize(function()
+	return Table.map(MasterData.languages, function(key, code) return code, key end)
 end)
 
 
@@ -133,6 +152,10 @@ function Flags._convertToKey(flagName)
 		or MasterData.threeLetter[flagName]
 		or MasterData.aliases[flagName]
 		or (MasterData.data[flagName] and flagName)
+end
+
+function Flags._convertToLangKey(langName)
+	return MasterData.languages[langName] or langName
 end
 
 return Class.export(Flags)

--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -110,7 +110,7 @@ function Flags.CountryCode(flagName, format)
 
 	if flagKey then
 		if format == 'alpha3' then
-			return Flags._getAlpha3CodesByKey()[flagKey] or Flags._getLanguageCodesByKey()[flagKey]
+			return Flags._getAlpha3CodesByKey()[flagKey] or Flags._getLanguage3LetterCodesByKey()[flagKey]
 		else
 			return Flags._getAlpha2CodesByKey()[flagKey] or Flags._getLanguageCodesByKey()[flagKey]
 		end
@@ -128,7 +128,11 @@ Flags._getAlpha3CodesByKey = FnUtil.memoize(function()
 end)
 
 Flags._getLanguageCodesByKey = FnUtil.memoize(function()
-	return Table.map(MasterData.languages, function(key, code) return code, key end)
+	return Table.map(MasterData.languageTwoLetter, function(key, code) return code, key end)
+end)
+
+Flags._getLanguage3LetterCodesByKey = FnUtil.memoize(function()
+	return Table.map(MasterData.languageThreeLetter, function(key, code) return code, key end)
 end)
 
 
@@ -155,7 +159,9 @@ function Flags._convertToKey(flagName)
 end
 
 function Flags._convertToLangKey(langName)
-	return MasterData.languages[langName] or langName
+	return MasterData.languageTwoLetter[langName]
+		or MasterData.languageThreeLetter[langName]
+		or langName
 end
 
 return Class.export(Flags)

--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -62,7 +62,7 @@ function Flags.Icon(args, flagName)
 	end
 end
 
-function Flags.LanguageIcon(args, langName)
+function Flags.languageIcon(args, langName)
 	if type(args) == 'string' then
 		langName = args
 		args = {}

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1791,7 +1791,7 @@ local aliases = {
 -- This table includes
 -- ISO 639-1 (language iso) values
 -- for languages that have a special flag
-local languages = {
+local languageTwoLetter = {
 	--language flag abbreviations
 	['en'] = 'englishspeaking',
 	['de'] = 'germanspeaking',
@@ -1800,10 +1800,23 @@ local languages = {
 	['ru'] = 'russianspeaking',
 }
 
+-- This table includes
+-- ISO 639-2/T (language iso) values
+-- for languages that have a special flag
+local languageThreeLetter = {
+	--language flag abbreviations
+	['eng'] = 'englishspeaking',
+	['deu'] = 'germanspeaking',
+	['spa'] = 'spanishspeaking',
+	['por'] = 'portuguesespeaking',
+	['rus'] = 'russianspeaking',
+}
+
 return {
 	data = data,
 	twoLetter = twoLetter,
 	threeLetter = threeLetter,
 	aliases = aliases,
-	languages = languages
+	languageTwoLetter = languageTwoLetter,
+	languageThreeLetter = languageThreeLetter,
 }

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1139,10 +1139,30 @@ local data = {
 		name = 'World',
 		flag = 'File:World hd.png'
 	},
+	['englishspeaking'] = {
+		name = 'English Speaking',
+		flag = 'File:UsGb hd.png'
+	},
+	['germanspeaking'] = {
+		name = 'German Speaking',
+		flag = 'File:DeAt hd.png'
+	},
+	['spanishspeaking'] = {
+		name = 'Spanish Speaking',
+		flag = 'File:EsMx hd.png'
+	},
+	['portuguesespeaking'] = {
+		name = 'Portuguese Speaking',
+		flag = 'File:PtBr hd.png'
+	},
+	['russianspeaking'] = {
+		name = 'Russian Speaking',
+		flag = 'File:RuBy hd.png'
+	},
 	['filler'] = {
 		name = '',
 		flag = 'File:Space filler flag.png'
-	}
+	},
 }
 
 -- This table includes:
@@ -1751,6 +1771,13 @@ local aliases = {
 	--minus the spaces in cut of the flag names
 	['southgeorgiaandth'] = 'southgeorgiaandthesouthsandwichislands',
 	['southgeorgiaandthesouthsandwichisl'] = 'southgeorgiaandthesouthsandwichislands',
+
+	--language flag abbreviations
+	['usuk'] = 'englishspeaking'
+	['deat'] = 'germanspeaking'
+	['esmx'] = 'spanishspeaking'
+	['ptbr'] = 'portuguesespeaking'
+	['ruby'] = 'russianspeaking'
 
 	['ff'] = 'filler',
 	['fillerflag'] = 'filler',

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1773,11 +1773,11 @@ local aliases = {
 	['southgeorgiaandthesouthsandwichisl'] = 'southgeorgiaandthesouthsandwichislands',
 
 	--language flag abbreviations
-	['usuk'] = 'englishspeaking'
-	['deat'] = 'germanspeaking'
-	['esmx'] = 'spanishspeaking'
-	['ptbr'] = 'portuguesespeaking'
-	['ruby'] = 'russianspeaking'
+	['usuk'] = 'englishspeaking',
+	['deat'] = 'germanspeaking',
+	['esmx'] = 'spanishspeaking',
+	['ptbr'] = 'portuguesespeaking',
+	['ruby'] = 'russianspeaking',
 
 	['ff'] = 'filler',
 	['fillerflag'] = 'filler',

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1779,14 +1779,31 @@ local aliases = {
 	['ptbr'] = 'portuguesespeaking',
 	['ruby'] = 'russianspeaking',
 
+	--language flag aliases
+	['engspeaking'] = 'englishspeaking',
+	['gerspeaking'] = 'germanspeaking',
+
 	['ff'] = 'filler',
 	['fillerflag'] = 'filler',
 	['unknown'] = 'filler',
+}
+
+-- This table includes
+-- ISO 639-1 (language iso) values
+-- for languages that have a special flag
+local languages = {
+	--language flag abbreviations
+	['en'] = 'englishspeaking',
+	['de'] = 'germanspeaking',
+	['es'] = 'spanishspeaking',
+	['pt'] = 'portuguesespeaking',
+	['ru'] = 'russianspeaking',
 }
 
 return {
 	data = data,
 	twoLetter = twoLetter,
 	threeLetter = threeLetter,
-	aliases = aliases
+	aliases = aliases,
+	languages = languages
 }


### PR DESCRIPTION
## Summary
Adjust `Module:Flags` and `Module:Flags/MasterData` so that they enables the usage of language flags.
* Language flags can now be displayed via function `LanguageIcon`
* * It first converts language values to keys that then can be used by the `Icon` function
* Enable iso key retrieval for language flags
* Add necessary table entries to `Module:Flags/MasterData` for that

This also removes the `Pages with unknown flags` Category for the added language flags if this module is used.

## How did you test this change?
sandboxes on sc2

## Remark
Via function `CountryCode` we could easily store all flags as alpha2 isos (or language isos) as long as they have an iso
(else it returns `''`)
(also has support for alpha3 iso for country flags via the format variable/param)