### PR TITLE
Add "Disbanded Teams" category

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -147,10 +147,11 @@ function CustomTeam:addToLpdb(lpdbData)
 end
 
 function CustomTeam.getWikiCategories()
+	local categories = {}
 	if String.isNotEmpty(_team.args.disbanded) then
-		return {'Disbanded Teams'}
+		table.insert(categories, 'Disbanded Teams')
 	end
-	return {}
+	return categories
 end
 
 -- gets a list of sub/accademy teams of the team

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -43,6 +43,7 @@ function CustomTeam.run(frame)
 	local team = Team(frame)
 	_team = team
 	team.createBottomContent = CustomTeam.createBottomContent
+	team.getWikiCategories = CustomTeam.getWikiCategories
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	return team:createInfobox(frame)
@@ -143,6 +144,13 @@ function CustomTeam:addToLpdb(lpdbData)
 	lpdbData.region = nil
 	lpdbData.extradata.subteams = CustomTeam.listSubTeams()
 	return lpdbData
+end
+
+function CustomTeam.getWikiCategories()
+	if String.isNotEmpty(_team.args.disbanded) then
+		return {'Disbanded Teams'}
+	end
+	return {}
 end
 
 -- gets a list of sub/accademy teams of the team


### PR DESCRIPTION
## Summary
Add "Disbanded Teams" category for sc2 infobox team.
Using the /Custom version for this, because atm most wikis do not have the category:
![614AD764-DB73-407A-97FD-386A909DF516](https://user-images.githubusercontent.com/75081997/148106043-29f3cc63-138f-4a34-b837-330de52c284a.jpeg)


## How did you test this change?
pushed live