### PR TITLE
Update Infobox to allow "local/native" ID in Subheader

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -72,7 +72,7 @@ function Person:createInfobox()
 	end
 
 	local widgets = {
-		Header{name = self:nameDisplay(args), image = args.image, imageDefault = args.default},
+		Header{name = self:nameDisplay(args), image = args.image, imageDefault = args.default, subHeader = args.localid},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Player') .. ' Information'},
 		Cell{name = 'Name', content = {args.name}},

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -72,7 +72,12 @@ function Person:createInfobox()
 	end
 
 	local widgets = {
-		Header{name = self:nameDisplay(args), image = args.image, imageDefault = args.default, subHeader = args.localid},
+		Header{
+			name = self:nameDisplay(args),
+			image = args.image,
+			imageDefault = args.default,
+			subHeader = self:localIdDisplay(args)
+		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Player') .. ' Information'},
 		Cell{name = 'Name', content = {args.name}},
@@ -292,6 +297,11 @@ function Person:nameDisplay(args)
 	end
 
 	return display
+end
+
+--- Allows for overriding this functionality
+function Person:localIdDisplay(args)
+	return args.localid
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -76,7 +76,7 @@ function Person:createInfobox()
 			name = self:nameDisplay(args),
 			image = args.image,
 			imageDefault = args.default,
-			subHeader = self:localIdDisplay(args)
+			subHeader = self:subHeaderDisplay(args)
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Player') .. ' Information'},
@@ -300,7 +300,7 @@ function Person:nameDisplay(args)
 end
 
 --- Allows for overriding this functionality
-function Person:localIdDisplay(args)
+function Person:subHeaderDisplay(args)
 	return args.localid
 end
 


### PR DESCRIPTION
This change is used for players/people who have an official ID in non-roman characters.

Link towards discord messages on the topic.
https://discord.com/channels/93055209017729024/268719633366777856/928038413452599328

## Summary
dev modules (commons + sc2)

![Screenshot 2022-01-05 13 06 43](https://user-images.githubusercontent.com/75081997/148215133-c46c1089-299a-41d0-9840-ceeea45452d7.png)

