### PR TITLE
Adjust `steam` link for rocketleague

### DIFF
--- a/standard/links/wikis/rocketleague/links_custom_data.lua
+++ b/standard/links/wikis/rocketleague/links_custom_data.lua
@@ -1,0 +1,13 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague
+-- page=Module:Links/CustomData
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+    prefixes = {
+        steam = {'https://steamcommunity.com/'},
+    },
+}


### PR DESCRIPTION
## Summary
Adjust `steam` link for rocketleague as requested by tino

## How did you test this change?
pushed live