### PR TITLE
Extracting position bg and tournaments data

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -15,7 +15,8 @@ local AutomaticPointsTable = Class.new(
 	function(self, frame)
 		self.frame = frame
 		self.args = Arguments.getArgs(frame)
-		self:parseInput()
+		self:parseInput(self.args)
+
 	end
 )
 
@@ -29,18 +30,23 @@ function AutomaticPointsTable.run(frame)
 	return nil
 end
 
+function AutomaticPointsTable:parseInput(args)
+	self:parsePositionBackgroundData(args)
+	self:parseTournaments(args)
+end
+
 --- parses the pbg arguments, these are the background colors of specific positions
 --- Usually used to indicate where a team in a specific position will end up qualifying to
-function AutomaticPointsTable:parsePositionBackgroundData()
-	local args = self.args
+function AutomaticPointsTable:parsePositionBackgroundData(args)
+
 	self.pbg = {}
 	for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
 		table.insert(self.pbg, background)
 	end
 end
 
-function AutomaticPointsTable:parseTournaments()
-	local args = self.args
+function AutomaticPointsTable:parseTournaments(args)
+
 	self.tournaments = {}
 	for _, tournament in Table.iter.pairsByPrefix(args, 'tournament') do
 		table.insert(self.tournaments, (Json.parse(tournament)))

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -15,7 +15,7 @@ local AutomaticPointsTable = Class.new(
 	function(self, frame)
 		self.frame = frame
 		self.args = Arguments.getArgs(frame)
-		self:parseInput(self.args)
+		self.parsedInput = self:parseInput(self.args)
 
 	end
 )
@@ -24,34 +24,39 @@ function AutomaticPointsTable.run(frame)
 	local pointsTable = AutomaticPointsTable(frame)
 
 
-	mw.logObject(pointsTable.pbg)
-	mw.logObject(pointsTable.tournaments)
+	mw.logObject(pointsTable.parsedInput.pbg)
+	mw.logObject(pointsTable.parsedInput.tournaments)
 
 	return nil
 end
 
 function AutomaticPointsTable:parseInput(args)
-	self:parsePositionBackgroundData(args)
-	self:parseTournaments(args)
+	local pbg = self:parsePositionBackgroundData(args)
+	local tournaments = self:parseTournaments(args)
+	return {
+		pbg = pbg,
+		tournaments = tournaments
+	}
 end
 
 --- parses the pbg arguments, these are the background colors of specific positions
 --- Usually used to indicate where a team in a specific position will end up qualifying to
 function AutomaticPointsTable:parsePositionBackgroundData(args)
-
-	self.pbg = {}
+	local pbg = {}
 	for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
-		table.insert(self.pbg, background)
+		table.insert(pbg, background)
 	end
+	return pbg
 end
 
 function AutomaticPointsTable:parseTournaments(args)
 
-	self.tournaments = {}
+	local tournaments = {}
 	for _, tournament in Table.iter.pairsByPrefix(args, 'tournament') do
-		table.insert(self.tournaments, (Json.parse(tournament)))
+		table.insert(tournaments, (Json.parse(tournament)))
 	end
-	return nil
+	return tournaments
+
 end
 
 return AutomaticPointsTable

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -16,15 +16,13 @@ local AutomaticPointsTable = Class.new(
 	function(self, frame)
 		self.frame = frame
 		self.args = Arguments.getArgs(frame)
+		self:parseInput()
 	end
 )
 
 function AutomaticPointsTable.run(frame)
 	local pointsTable = AutomaticPointsTable(frame)
 
-	pointsTable:extractPositionBackgroundData()
-
-	pointsTable:extractTournaments()
 
 	mw.logObject(pointsTable.pbg)
 	mw.logObject(pointsTable.tournaments)
@@ -32,7 +30,9 @@ function AutomaticPointsTable.run(frame)
 	return nil
 end
 
-function AutomaticPointsTable:extractPositionBackgroundData()
+--- parses the pbg arguments, these are the background colors of specific positions
+--- Usually used to indicate where a team in a specific position will end up qualifying to
+function AutomaticPointsTable:parsePositionBackgroundData()
 	local args = self.args
 	self.pbg = {}
 	for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
@@ -40,16 +40,11 @@ function AutomaticPointsTable:extractPositionBackgroundData()
 	end
 end
 
-function AutomaticPointsTable:extractTournaments()
+function AutomaticPointsTable:parseTournaments()
 	local args = self.args
 	self.tournaments = {}
-	for argKey, argVal in pairs(args) do
-		if (type(argVal) == 'string') and (string.find(argKey, 'tournament')) then
-			local tournamentIndexString = String.split(argKey, 'tournament')[1]
-			local tournamentIndex = tonumber(tournamentIndexString)
-			local unpackedTournament = Json.parse(argVal)
-			self.tournaments[tournamentIndex] = unpackedTournament
-		end
+	for _, tournament in Table.iter.pairsByPrefix(args, 'tournament') do
+		table.insert(self.tournaments, (Json.parse(tournament)))
 	end
 	return nil
 end

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -50,7 +50,6 @@ function AutomaticPointsTable:parsePositionBackgroundData(args)
 end
 
 function AutomaticPointsTable:parseTournaments(args)
-
 	local tournaments = {}
 	for _, tournament in Table.iter.pairsByPrefix(args, 'tournament') do
 		table.insert(tournaments, (Json.parse(tournament)))

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -16,14 +16,11 @@ local AutomaticPointsTable = Class.new(
 		self.frame = frame
 		self.args = Arguments.getArgs(frame)
 		self.parsedInput = self:parseInput(self.args)
-
 	end
 )
 
 function AutomaticPointsTable.run(frame)
 	local pointsTable = AutomaticPointsTable(frame)
-
-
 	mw.logObject(pointsTable.parsedInput.pbg)
 	mw.logObject(pointsTable.parsedInput.tournaments)
 
@@ -55,7 +52,6 @@ function AutomaticPointsTable:parseTournaments(args)
 		table.insert(tournaments, (Json.parse(tournament)))
 	end
 	return tournaments
-
 end
 
 return AutomaticPointsTable

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -9,7 +9,6 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Json = require('Module:Json')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local AutomaticPointsTable = Class.new(

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -1,0 +1,57 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:AutomaticPointsTable
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Json = require('Module:Json')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local AutomaticPointsTable = Class.new(
+	function(self, frame)
+		self.frame = frame
+		self.args = Arguments.getArgs(frame)
+	end
+)
+
+function AutomaticPointsTable.run(frame)
+	local pointsTable = AutomaticPointsTable(frame)
+
+	pointsTable:extractPositionBackgroundData()
+
+	pointsTable:extractTournaments()
+
+	mw.logObject(pointsTable.pbg)
+	mw.logObject(pointsTable.tournaments)
+
+	return nil
+end
+
+function AutomaticPointsTable:extractPositionBackgroundData()
+	local args = self.args
+	self.pbg = {}
+	for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
+		table.insert(self.pbg, background)
+	end
+end
+
+function AutomaticPointsTable:extractTournaments()
+	local args = self.args
+	self.tournaments = {}
+	for argKey, argVal in pairs(args) do
+		if (type(argVal) == 'string') and (string.find(argKey, 'tournament')) then
+			local tournamentIndexString = String.split(argKey, 'tournament')[1]
+			local tournamentIndex = tonumber(tournamentIndexString)
+			local unpackedTournament = Json.parse(argVal)
+			self.tournaments[tournamentIndex] = unpackedTournament
+		end
+	end
+	return nil
+end
+
+return AutomaticPointsTable


### PR DESCRIPTION
## Summary

- Automatic Points Table is a table that automatically fills in its points from tournaments' prize pool templates.
- This is the first of many pull requests that will build up to the fully functional module.

## How did you test this change?

- This was deployed in Module Sandbox here: https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/1
- **mw.logObject()** is used to view the constructed dictionaries that represent the extracted position background and tournaments data
In the following image, the **pbg** dictionary is surrounded by a **red** square, while the **tournaments** dictionary is surrounded by a **blue** square
![image](https://user-images.githubusercontent.com/28851891/148290740-c1531879-9b86-45fb-9784-741b67846340.png)
