### PR TITLE
Fix Header for Halo Map Infobox

### DIFF
--- a/components/infobox/wikis/halo/infobox_map_custom.lua
+++ b/components/infobox/wikis/halo/infobox_map_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=halo
--- page=Module:Infobox/Map
+-- page=Module:Infobox/Map/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -82,10 +82,6 @@ function CustomMap._getGameMode()
 	end
 
 	return modeDisplayTable
-end
-
-function CustomMap:createWidgetInjector()
-	return CustomInjector()
 end
 
 function CustomMap:addToLpdb(lpdbData)


### PR DESCRIPTION
## Summary
Correcting the file path for the module in the comment header. Also removing one of the two `function CustomMap:createWidgetInjector()
    return CustomInjector()
end`

## How did you test this change?
Untested. However the module at the desired file location already exists. Will archive the Module Infobox/Map once merged
