### PR TITLE
Add support for fetch results as coach

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -112,7 +112,7 @@ function NotabilityChecker._calculatePlayerNotability(player)
 	for i = 2, Config.MAX_NUMBER_OF_PARTICIPANTS do
 		conditions = conditions .. ' OR [[players_p' .. tostring(i) .. '::' .. player .. ']]'
 	end
-	for i= 1, Config.MAX_NUMBER_OF_COACHES do
+	for i = 1, Config.MAX_NUMBER_OF_COACHES do
 		conditions = conditions .. ' OR [[players_c' .. tostring(i) .. '::' .. player .. ']]'
 	end
 

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -112,6 +112,9 @@ function NotabilityChecker._calculatePlayerNotability(player)
 	for i = 2, Config.MAX_NUMBER_OF_PARTICIPANTS do
 		conditions = conditions .. ' OR [[players_p' .. tostring(i) .. '::' .. player .. ']]'
 	end
+	for i= 1, Config.MAX_NUMBER_OF_COACHES do
+		conditions = conditions .. ' OR [[players_c' .. tostring(i) .. '::' .. player .. ']]'
+	end
 
 	local data = mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = Config.PLACEMENT_LIMIT,

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -26,14 +26,14 @@ function NotabilityChecker.run(args)
 	local isTeamResult = args.team ~= nil
 
 	if args.player1 then
-		local players = {}
+		local people = {}
 		local index = 1
 		while not String.isEmpty(args['player' .. tostring(index)]) do
-			local player = args['player' .. tostring(index)]
-			table.insert(players, player)
+			local person = args['player' .. tostring(index)]
+			table.insert(people, person)
 			index = index + 1
 		end
-		weight, output = NotabilityChecker._calculateRosterNotability(args.team, players)
+		weight, output = NotabilityChecker._calculateRosterNotability(args.team, people)
 	elseif args.team then
 		weight, output = NotabilityChecker._runForTeam(args.team)
 	end
@@ -42,13 +42,13 @@ function NotabilityChecker.run(args)
 	output = output .. '\'\'\'Final weight:\'\'\' ' .. tostring(weight) .. '\n\n'
 
 	if weight < Config.NOTABILITY_THRESHOLD_NOTABLE and weight > Config.NOTABILITY_THRESHOLD_MIN then
-		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'player') ..
+		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person') ..
 		' is \'\'\'OPEN FOR DISCUSSION\'\'\'\n'
 	elseif weight < Config.NOTABILITY_THRESHOLD_MIN then
-		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'player') ..
+		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person') ..
 		' is \'\'\'NOT NOTABLE\'\'\'\n'
 	else
-		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'player') ..
+		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person') ..
 		' is \'\'\'NOTABLE\'\'\'\n'
 	end
 
@@ -67,7 +67,7 @@ function NotabilityChecker._runForTeam(team)
 	return weight, output
 end
 
-function NotabilityChecker._calculateRosterNotability(team, players)
+function NotabilityChecker._calculateRosterNotability(team, people)
 	local weight = 0
 	local output = ''
 	if team then
@@ -76,20 +76,20 @@ function NotabilityChecker._calculateRosterNotability(team, players)
 		weight = weight + teamWeight
 	end
 
-	output = output .. '===Player Results===\n'
+	output = output .. '===People Results===\n'
 
-	local playerAverage = 0
-	for _, player in pairs(players) do
-		local playerWeight = NotabilityChecker._calculatePlayerNotability(player)
+	local average = 0
+	for _, person in pairs(people) do
+		local personWeight = NotabilityChecker._calculatePersonNotability(person)
 		output = output .. mw.getCurrentFrame():expandTemplate{
-			title = 'NotabilityPlayerMatchesTable', args = {title = player}}
-		output = output .. '*\'\'\'Player:\'\'\' [[' .. player .. ']] \'\'\'Weight:\'\'\' ' ..
-			tonumber(playerWeight) .. '\n\n'
-		playerAverage = playerAverage + tonumber(playerWeight or 0)
+			title = 'NotabilityPlayerMatchesTable', args = {title = person}}
+		output = output .. '*\'\'\'Person:\'\'\' [[' .. person .. ']] \'\'\'Weight:\'\'\' ' ..
+			tonumber(personWeight) .. '\n\n'
+			average = average + tonumber(personWeight or 0)
 	end
 
-	playerAverage = playerAverage / Table.size(players)
-	weight = weight + playerAverage
+	average = average / Table.size(people)
+	weight = weight + average
 
 	return weight, output
 end
@@ -104,16 +104,16 @@ function NotabilityChecker._calculateTeamNotability(team)
 	return NotabilityChecker._calculateWeight(data)
 end
 
-function NotabilityChecker._calculatePlayerNotability(player)
-	player = mw.ext.TeamLiquidIntegration.resolve_redirect(player)
+function NotabilityChecker._calculatePersonNotability(person)
+	person = mw.ext.TeamLiquidIntegration.resolve_redirect(person)
 
-	local conditions = '[[players_p' .. tostring(1) .. '::' .. player .. ']]' ..
-		' OR [[participant::' .. player .. ']]'
+	local conditions = '[[players_p' .. tostring(1) .. '::' .. person .. ']]' ..
+		' OR [[participant::' .. person .. ']]'
 	for i = 2, Config.MAX_NUMBER_OF_PARTICIPANTS do
-		conditions = conditions .. ' OR [[players_p' .. tostring(i) .. '::' .. player .. ']]'
+		conditions = conditions .. ' OR [[players_p' .. tostring(i) .. '::' .. person .. ']]'
 	end
 	for i = 1, Config.MAX_NUMBER_OF_COACHES do
-		conditions = conditions .. ' OR [[players_c' .. tostring(i) .. '::' .. player .. ']]'
+		conditions = conditions .. ' OR [[players_c' .. tostring(i) .. '::' .. person .. ']]'
 	end
 
 	local data = mw.ext.LiquipediaDB.lpdb('placement', {

--- a/components/notability/wikis/rocketleague/notability_checker_config.lua
+++ b/components/notability/wikis/rocketleague/notability_checker_config.lua
@@ -23,6 +23,7 @@ Config.TIER_TYPE_SCHOOL = 'school'
 Config.PLACEMENT_LIMIT = 2000
 
 Config.MAX_NUMBER_OF_PARTICIPANTS = 10
+Config.MAX_NUMBER_OF_COACHES = 0
 
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =


### PR DESCRIPTION
## Summary

The current NotabilityChecker only queries the database with the prefix `p` in lpdb_placement.players. However many wikis insert both the prefixes `p` and `c`, the latter being used coaches. 

For example:
R6: https://liquipedia.net/rainbowsix/Special:LiquipediaDB/Six_Invitational/2022/Asia_Pacific#placement
Dota2: https://liquipedia.net/dota2/Special:LiquipediaDB/I-League/2021/2#placement (check the second entry, not the first)
CS: https://liquipedia.net/counterstrike/Special:LiquipediaDB/PGL/2021/Stockholm#placement
Apex: https://liquipedia.net/apexlegends/Special:LiquipediaDB/Apex_Legends_Global_Series/Championship/North_America/2021#placement (second entry)
League: https://liquipedia.net/leagueoflegends/Special:LiquipediaDB/VCS/2021/Winter#placement

This PR would add support to the NotabilityChecker to query both `p` and `c`, so that coaches can be found using the NotabilityChecker. This is done so the notability of a coach can be determined using the NotabilityChecker.

If `Config.MAX_NUMBER_OF_COACHES` is set to 0, no prefix `c` results will be queried from the database.

Since RL isn't using this today, so this PR is setting `MAX_NUMBER_OF_COACHES = 0` for Rocket League.

For R6 (#893) `MAX_NUMBER_OF_COACHES` is set to `5` to match the functionality of the current, none-standardized, Notability Checker.

Both the new `MAX_NUMBER_OF_COACHES` and the existing `MAX_NUMBER_OF_PARTICIPANTS` should be looked at being migrated to Module:Info at a later point.

## How did you test this change?

Put it on /dev and tested on R6 and RL.

After deploy, remove the /dev from R6 https://liquipedia.net/rainbowsix/Template:Notability_checker