### PR TITLE
Remove unused code

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local Config = require('Module:NotabilityChecker/config')
 local String = require('Module:String')
-local LuaUtils = require('Module:LuaUtils')
 local Array = require('Module:Array')
 local Table = require('Module:Table')
 

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -219,22 +219,7 @@ function NotabilityChecker._parseTier(placement)
 		return tonumber(placement.liquipediatier), nil
 	end
 
-	-- If true, this is a wiki that uses a legacy system where extradata.liquipediatier
-	-- contains the numerical liquipediatier, and liquipediatier contains the type.
-	local isWikiThatUsesLiquipediaTier2 = placement.liquipediatier == placement.liquipediatiertype
-
-	if not isWikiThatUsesLiquipediaTier2 then
-		return tonumber(placement.liquipediatier), placement.liquipediatiertype:lower()
-	end
-
-	local liquipediaTier2 = placement.extradata['liquipediatier2']
-	if String.isEmpty(liquipediaTier2) then
-		local tournament = LuaUtils.lpdb.getSingle('tournament',
-			{ conditions = '[[pagename::' .. placement.pagename .. ']]' })
-		liquipediaTier2 = (tournament or { extradata = {} }).extradata['liquipediatier2'] or ''
-	end
-
-	return tonumber(liquipediaTier2), placement.liquipediatiertype:lower()
+	return tonumber(placement.liquipediatier), placement.liquipediatiertype:lower()
 end
 
 function NotabilityChecker._parseNotabilityMod(notabilityMod)

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -236,8 +236,4 @@ function NotabilityChecker._calculateDateLoss(date)
 	return math.floor(differenceSeconds / _SECONDS_IN_YEAR) + 1
 end
 
-function NotabilityChecker._firstToLower(s)
-	return s:sub(1, 1):lower() .. s:sub(2)
-end
-
 return Class.export(NotabilityChecker)


### PR DESCRIPTION
## Summary

* As Rocket League no longer uses tier2, the entire special handling for tier2 is removed.
* Removed unused private function

## How did you test this change?

Put it on /dev. 

* On R6 made the Template invoke the /dev module. 

* On RL compared the output of `require('Module:NotabilityChecker').run{player1='Talon'}` and `require('Module:NotabilityChecker/dev').run{player1='Talon'}` which were identical. 