### PR TITLE
Add Legacy storage modules for Mobile Legends

### DIFF
--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -166,5 +166,5 @@ function MatchLegacy.storeMatchSMW(match, match2)
 			'Has match ' .. key .. '=' .. item
 		)
 	end
-
+end
 return MatchLegacy

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -166,5 +166,8 @@ function MatchLegacy.storeMatchSMW(match, match2)
 			'Has match ' .. key .. '=' .. item
 		)
 	end
+	
+	mw.smw.subobject(data)
 end
+
 return MatchLegacy

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -166,7 +166,6 @@ function MatchLegacy.storeMatchSMW(match, match2)
 			'Has match ' .. key .. '=' .. item
 		)
 	end
-	
 	mw.smw.subobject(data)
 end
 

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -75,7 +75,7 @@ function MatchLegacy._convertParameters(match2)
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == 'team' then
 			match[prefix] = opponent.name
-			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1, 10 do
 				local player = opponentmatch2players[i] or {}
@@ -87,7 +87,7 @@ function MatchLegacy._convertParameters(match2)
 		elseif opponent.type == 'solo' then
 			local player = opponentmatch2players[1] or {}
 			match[prefix] = player.name
-			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix..'flag'] = player.flag
 		elseif opponent.type == 'literal' then
 			match[prefix] = 'TBD'

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -1,0 +1,219 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:Match/Legacy
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local MatchLegacy = {}
+
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+function MatchLegacy.storeMatch(match2)
+	local match = MatchLegacy._convertParameters(match2)
+
+	match.games = MatchLegacy.storeGames(match, match2)
+
+	MatchLegacy.storeMatchSMW(match, match2)
+
+	return mw.ext.LiquipediaDB.lpdb_match(
+		'legacymatch_' .. match2.match2id,
+		match
+	)
+end
+
+function MatchLegacy._convertParameters(match2)
+	local match = Table.deepCopy(match2)
+	for key, _ in pairs(match) do
+		if String.startsWith(key, 'match2') then
+			match[key] = nil
+		end
+	end
+	match.links = nil
+
+	if String.isNotEmpty(match.walkover) then
+		match.resulttype = match.walkover
+		match.walkover = match.winner
+	end
+
+	match.staticid = 'Legacy_' .. match2.match2id
+
+	-- Handle extradata fields
+	match.extradata = {}
+	local extradata = Json.parseIfString(match2.extradata)
+	match.extradata.matchsection = extradata.matchsection
+	match.extradata.mvpteam = extradata.mvpteam
+	match.extradata.mvp = extradata.mvp
+	match.extradata.comment = extradata.comment
+
+	local opponents = match2.match2opponents or {}
+	match.extradata.team1icon = (opponents[1] or {}).icon
+	match.extradata.team2icon = (opponents[2] or {}).icon
+	match.extradata.opponent1literal = tostring((opponents[1] or {}).type == 'literal')
+	match.extradata.opponent2literal = tostring((opponents[2] or {}).type == 'literal')
+	match.extradata.opponent1game = 'false'
+	match.extradata.opponent2game = 'false'
+
+	local games = match2.match2games or {}
+	for key, game in ipairs(games) do
+		if String.isNotEmpty(game.vod) then
+			match.extradata['vodgame' .. key] = game.vod
+		end
+	end
+
+	match.extradata = mw.ext.LiquipediaDB.lpdb_create_json(match.extradata)
+
+	-- Handle Opponents
+	local handleOpponent = function (index)
+		local prefix = 'opponent'..index
+		local opponent = match2.match2opponents[index] or {}
+		local opponentmatch2players = opponent.match2players or {}
+		if opponent.type == 'team' then
+			match[prefix] = opponent.name
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) >= 0 and opponent.score or 0
+			local opponentplayers = {}
+			for i = 1, 10 do
+				local player = opponentmatch2players[i] or {}
+				opponentplayers['p' .. i] = player.name or ''
+				opponentplayers['p' .. i .. 'flag'] = player.flag or ''
+				opponentplayers['p' .. i .. 'dn'] = player.displayname or ''
+			end
+			match[prefix..'players'] = mw.ext.LiquipediaDB.lpdb_create_json(opponentplayers)
+		elseif opponent.type == 'solo' then
+			local player = opponentmatch2players[1] or {}
+			match[prefix] = player.name
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) >= 0 and opponent.score or 0
+			match[prefix..'flag'] = player.flag
+		elseif opponent.type == 'literal' then
+			match[prefix] = 'TBD'
+		end
+	end
+
+	handleOpponent(1)
+	handleOpponent(2)
+
+	return match
+end
+
+function MatchLegacy.storeGames(match, match2)
+	local games = ''
+	for gameIndex, game2 in ipairs(match2.match2games or {}) do
+		local game = Table.deepCopy(game2)
+
+		-- Extradata
+		local extradata = Json.parseIfString(game2.extradata)
+		game.extradata = {}
+		game.extradata.gamenumber = gameIndex
+		for key, item in pairs(extradata) do
+			local teamIndex, typeIndicator, typeIndex = string.match(key, 'team(%d)(%a+)(%d)')
+			if typeIndicator and typeIndex then
+				local newKey = 't' .. teamIndex .. string.sub(typeIndicator, 1, 1) .. typeIndex
+				game.extradata[newKey] = item
+			end
+		end
+		game.extradata.team1side = extradata.team1side
+		game.extradata.team2side = extradata.team2side
+
+		game.extradata = mw.ext.LiquipediaDB.lpdb_create_json(game.extradata)
+
+		-- Other stuff
+		game.opponent1 = match.opponent1
+		game.opponent2 = match.opponent2
+		game.opponent1flag = match.opponent1flag
+		game.opponent2flag = match.opponent2flag
+		game.date = match.date
+		local winner = tonumber(game.winner) or 0
+		game.opponent1score = winner == 1 and 1 or 0
+		game.opponent2score = winner == 2 and 1 or 0
+		local res = mw.ext.LiquipediaDB.lpdb_game(
+			'legacygame_' .. match2.match2id .. gameIndex,
+			game
+		)
+		games = games .. res
+	end
+	return games
+end
+
+function MatchLegacy.storeMatchSMW(match, match2)
+	local data = {
+		'legacymatch_' .. match2.match2id,
+		'is map number=1',
+		'has team left=' .. (match.opponent1 or ''),
+		'has team right=' .. (match.opponent2 or ''),
+		'Has map date=' .. (match.date or ''),
+		'Has tournament=' .. mw.title.getCurrentTitle().prefixedText,
+		'Has tournament tier=' .. (match.liquipediatier or ''),
+		'Has tournament name=' .. Logic.emptyOr(
+			match.tickername,
+			match.name,
+			Variables.varDefault('tournament_name', mw.title.getCurrentTitle().prefixedText)
+		),
+		'Has tournament icon=' .. Variables.varDefault('tournament_icon', ''),
+		'Has winner=' .. (match.winner or ''),
+		'Has team left score=' .. (String.isEmpty(match.opponent1score) and '0' or match.opponent1score),
+		'Has team right score=' .. (String.isEmpty(match.opponent2score) and '0' or match.opponent2score),
+		'Has exact time=' .. (Logic.readBool(match.dateexact) and 'true' or 'false'),
+		'Is finished=' .. (Logic.readBool(match.finished) and 'true' or 'false'),
+		'Has teams=' .. (match.opponent1 or ''),
+		'Has teams=' .. (match.opponent2 or ''),
+		'Has teams name=' .. (match.opponent1 or ''),
+		'Has teams name=' .. (match.opponent2 or ''),
+		'Has calendar description=- ' .. (match.opponent1 or '') .. ' vs ' .. (match.opponent2 or '') .. ' on ' .. match.date,
+	}
+
+	local streams = match.stream or {}
+	streams = Json.parseIfString(streams)
+	for key, item in pairs(streams) do
+		table.insert(
+			data,
+			'Has match ' .. key .. '=' .. item
+		)
+	end
+
+	local extradata = match.extradata or {}
+	extradata = Json.parseIfString(extradata)
+	for key, item in pairs(extradata) do
+		if String.startsWith(key, 'vodgame') then
+			table.insert(
+				data,
+				'Has match ' .. key .. '=' .. item
+			)
+		end
+	end
+
+	local mvpTable = mw.text.split(extradata.mvp or '', ',')
+	local mvpTeamsTable = mw.text.split(extradata.mvpteam or '', ',')
+	if String.isNotEmpty(mvpTable[1]) then
+		for key, item in pairs(mvpTable) do
+			local mvp = mw.text.trim(item)
+			local mvpTeam = mw.text.trim(mvpTeamsTable[key] or '')
+			if Logic.isNumeric(mvpTeam) then
+				mvpTeam = match['opponent' .. mvpTeam]
+			else
+				mvpTeam = mvpTeam or ''
+			end
+			table.insert(
+				data,
+				'Has mvp ' .. key .. '=' .. mvp .. '§§§§' .. mvpTeam .. '§§§§0'
+			)
+		end
+	end
+
+	if match.dateexact then
+		--shift date about 1 hour
+		local calendarEndDate = string.gsub(match.date, '+00:00', '-01:00')
+		table.insert(
+			data,
+			'Has calendar end date=' .. calendarEndDate
+		)
+	end
+
+	mw.smw.subobject(data)
+end
+
+return MatchLegacy

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -169,8 +169,6 @@ function MatchLegacy.storeMatchSMW(match, match2)
 
 	local extradata = match.extradata or {}
 	extradata = Json.parseIfString(extradata)
-	for key, item in pairs(extradata) do
-	end
 
 	mw.smw.subobject(data)
 end

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -75,7 +75,7 @@ function MatchLegacy._convertParameters(match2)
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == 'team' then
 			match[prefix] = opponent.name
-			match[prefix..'score'] = (tonumber(opponent.score) or 0) >= 0 and opponent.score or 0
+			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1, 10 do
 				local player = opponentmatch2players[i] or {}
@@ -87,7 +87,7 @@ function MatchLegacy._convertParameters(match2)
 		elseif opponent.type == 'solo' then
 			local player = opponentmatch2players[1] or {}
 			match[prefix] = player.name
-			match[prefix..'score'] = (tonumber(opponent.score) or 0) >= 0 and opponent.score or 0
+			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix..'flag'] = player.flag
 		elseif opponent.type == 'literal' then
 			match[prefix] = 'TBD'
@@ -109,13 +109,6 @@ function MatchLegacy.storeGames(match, match2)
 		local extradata = Json.parseIfString(game2.extradata)
 		game.extradata = {}
 		game.extradata.gamenumber = gameIndex
-		for key, item in pairs(extradata) do
-			local teamIndex, typeIndicator, typeIndex = string.match(key, 'team(%d)(%a+)(%d)')
-			if typeIndicator and typeIndex then
-				local newKey = 't' .. teamIndex .. string.sub(typeIndicator, 1, 1) .. typeIndex
-				game.extradata[newKey] = item
-			end
-		end
 		game.extradata.team1side = extradata.team1side
 		game.extradata.team2side = extradata.team2side
 
@@ -163,7 +156,6 @@ function MatchLegacy.storeMatchSMW(match, match2)
 		'Has teams=' .. (match.opponent2 or ''),
 		'Has teams name=' .. (match.opponent1 or ''),
 		'Has teams name=' .. (match.opponent2 or ''),
-		'Has calendar description=- ' .. (match.opponent1 or '') .. ' vs ' .. (match.opponent2 or '') .. ' on ' .. match.date,
 	}
 
 	local streams = match.stream or {}
@@ -178,39 +170,6 @@ function MatchLegacy.storeMatchSMW(match, match2)
 	local extradata = match.extradata or {}
 	extradata = Json.parseIfString(extradata)
 	for key, item in pairs(extradata) do
-		if String.startsWith(key, 'vodgame') then
-			table.insert(
-				data,
-				'Has match ' .. key .. '=' .. item
-			)
-		end
-	end
-
-	local mvpTable = mw.text.split(extradata.mvp or '', ',')
-	local mvpTeamsTable = mw.text.split(extradata.mvpteam or '', ',')
-	if String.isNotEmpty(mvpTable[1]) then
-		for key, item in pairs(mvpTable) do
-			local mvp = mw.text.trim(item)
-			local mvpTeam = mw.text.trim(mvpTeamsTable[key] or '')
-			if Logic.isNumeric(mvpTeam) then
-				mvpTeam = match['opponent' .. mvpTeam]
-			else
-				mvpTeam = mvpTeam or ''
-			end
-			table.insert(
-				data,
-				'Has mvp ' .. key .. '=' .. mvp .. '§§§§' .. mvpTeam .. '§§§§0'
-			)
-		end
-	end
-
-	if match.dateexact then
-		--shift date about 1 hour
-		local calendarEndDate = string.gsub(match.date, '+00:00', '-01:00')
-		table.insert(
-			data,
-			'Has calendar end date=' .. calendarEndDate
-		)
 	end
 
 	mw.smw.subobject(data)

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -167,10 +167,4 @@ function MatchLegacy.storeMatchSMW(match, match2)
 		)
 	end
 
-	local extradata = match.extradata or {}
-	extradata = Json.parseIfString(extradata)
-
-	mw.smw.subobject(data)
-end
-
 return MatchLegacy


### PR DESCRIPTION
## Summary

Add legacy storage for Mobile Legends, while ML is a wiki that made post-Match2 was formed, Legacy is still needed for some storage stuff

These are a direct copypaste from Wild Rift's newest version, which incorporate changes from #763 (the original revision, #724 is already merged as well)

## How did you test this change?

Using the similar test method on #724  - https://liquipedia.net/mobilelegends/User:Hesketh2/sandbox
(as of 2:14AM UTC+8 on January 8 if things look weird that is because Mobile Legends has to wait until #927 was merged)


