### PR TITLE
Add Brkts/WikiSpecific for Arena of Valor

### DIFF
--- a/components/match2/wikis/arenaofvalor/brkts_wikispecific.lua
+++ b/components/match2/wikis/arenaofvalor/brkts_wikispecific.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- wiki=arenaofvalor
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
+
+--
+-- Override functons
+--
+function WikiSpecific.matchHasDetails(match)
+	return match.dateIsExact
+		or match.date ~= _EPOCH_TIME_EXTENDED
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.games
+end
+
+WikiSpecific.defaultIcon = 'Mobile Legends allmode.png'
+
+return WikiSpecific

--- a/components/match2/wikis/arenaofvalor/brkts_wikispecific.lua
+++ b/components/match2/wikis/arenaofvalor/brkts_wikispecific.lua
@@ -25,6 +25,6 @@ function WikiSpecific.matchHasDetails(match)
 		or 0 < #match.games
 end
 
-WikiSpecific.defaultIcon = 'Mobile Legends allmode.png'
+WikiSpecific.defaultIcon = 'Arena of Valor allmode.png'
 
 return WikiSpecific


### PR DESCRIPTION
## Summary

I have decide to work on implementing Match2 for **Arena of Valor**, another Mobile MOBA to have all Mobile MOBA had match2 installed (the others are **Mobile Legends** and **Wildrift**)

AOV will inherit the necessary match2 modules that is from **Mobile Legends** which is almost near-perfect identical in terms of setups 

## How did you test this change?
Pushed Live, with https://liquipedia.net/arenaofvalor/Arena_of_Valor_Bangladesh_Championship/2021/Qualifiers/Khulna as the first live page to use match2 brackets

## Side Note
**I have notice that there isn't **arenaofvalor** folders in the match2 section yet, I dont know how to create one so I'll will pause other module PRs (MatchGroup, MatchSummary, Legacy) so that the folder can be created, then I can put the rest up later**