### PR TITLE
Added parseTeams

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -61,7 +61,7 @@ end
 function AutomaticPointsTable:parseTeams(args)
 	local teams = {}
 	for _, team in Table.iter.pairsByPrefix(args, 'team') do
-		parsedTeam = Json.parse(team)
+		local parsedTeam = Json.parse(team)
 		parsedTeam.aliases = self:parseAliases(parsedTeam)
 		parsedTeam.deductions = self:parseDeductions(parsedTeam)
 		parsedTeam.manualPoints = self:parseManualPoints(parsedTeam)

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -119,8 +119,8 @@ end
 function AutomaticPointsTable:parseManualPoints(team)
 	local manualPoints = {}
 	for key, value in pairs(team) do
-
 		if type(key) == 'string' and string.find(key, 'points%d+') then
+
 			local pointsIndex = tonumber(String.split(key, 'points')[1])
 			local points = tonumber(value)
 

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -74,11 +74,11 @@ end
 --- of the tournaments, in which case aliases are required to correctly query the team's results & points
 function AutomaticPointsTable:parseAliases(team)
 	local aliases = {}
-	for argKey, argVal in pairs(team) do
-		if type(argKey) == 'string' and string.find(argKey, 'alias%d+') then
-			local aliasIndexString = String.split(argKey, 'alias')[1]
+	for key, value in pairs(team) do
+		if type(key) == 'string' and string.find(key, 'alias%d+') then
+			local aliasIndexString = String.split(key, 'alias')[1]
 			local aliasIndex = tonumber(aliasIndexString)
-			local aliasName = argVal
+			local aliasName = value
 			aliases[aliasIndex] = aliasName
 		end
 	end
@@ -91,19 +91,19 @@ function AutomaticPointsTable:parseDeductions(team)
 	local deductions = {}
 	for key, value in pairs(team) do
 
-		if type(argKey) == 'string' then
-			if string.find(argKey, 'deduction%d+note') then
-				local deductionIndex = tonumber(string.match(argKey, '%d+'))
-				local deductionNote = argVal
+		if type(key) == 'string' then
+			if string.find(key, 'deduction%d+note') then
+				local deductionIndex = tonumber(string.match(key, '%d+'))
+				local deductionNote = value
 
 				if not deductions[deductionIndex] then
 					deductions[deductionIndex] = {}
 				end
 
 				deductions[deductionIndex].note = deductionNote
-			elseif string.find(argKey, 'deduction%d+') then
-				local deductionIndex = tonumber(String.split(argKey, 'deduction')[1])
-				local deductionAmount = argVal
+			elseif string.find(key, 'deduction%d+') then
+				local deductionIndex = tonumber(String.split(key, 'deduction')[1])
+				local deductionAmount = value
 
 				if not deductions[deductionIndex] then
 					deductions[deductionIndex] = {}
@@ -120,9 +120,9 @@ function AutomaticPointsTable:parseManualPoints(team)
 	local manualPoints = {}
 	for key, value in pairs(team) do
 
-		if type(argKey) == 'string' and string.find(argKey, 'points%d+') then
-			local pointsIndex = tonumber(String.split(argKey, 'points')[1])
-			local points = tonumber(argVal)
+		if type(key) == 'string' and string.find(key, 'points%d+') then
+			local pointsIndex = tonumber(String.split(key, 'points')[1])
+			local points = tonumber(value)
 
 			manualPoints[pointsIndex] = points
 		end

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -87,19 +87,18 @@ end
 function AutomaticPointsTable:parseDeductions(team, tournamentCount)
 	local deductions = {}
 	for index = 1, tournamentCount do
-		if String.isNotEmpty(team['deduction' .. index .. 'note']) then
-			if not deductions[index] then
-				deductions[index] = {}
-			end
-			deductions[index].note = team['deduction' .. index .. 'note']
-		end
 		if String.isNotEmpty(team['deduction' .. index]) then
 			if not deductions[index] then
 				deductions[index] = {}
 			end
 			deductions[index].amount = tonumber(team['deduction' .. index])
+
+			if String.isNotEmpty(team['deduction' .. index .. 'note']) then
+				deductions[index].note = team['deduction' .. index .. 'note']
+			end
 		end
 	end
+
 	return deductions
 end
 

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -9,6 +9,7 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Json = require('Module:Json')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local AutomaticPointsTable = Class.new(
@@ -23,6 +24,7 @@ function AutomaticPointsTable.run(frame)
 	local pointsTable = AutomaticPointsTable(frame)
 	mw.logObject(pointsTable.parsedInput.pbg)
 	mw.logObject(pointsTable.parsedInput.tournaments)
+	mw.logObject(pointsTable.parsedInput.teams)
 
 	return nil
 end
@@ -30,9 +32,11 @@ end
 function AutomaticPointsTable:parseInput(args)
 	local pbg = self:parsePositionBackgroundData(args)
 	local tournaments = self:parseTournaments(args)
+	local teams = self:parseTeams(args)
 	return {
 		pbg = pbg,
-		tournaments = tournaments
+		tournaments = tournaments,
+		teams = teams
 	}
 end
 
@@ -52,6 +56,72 @@ function AutomaticPointsTable:parseTournaments(args)
 		table.insert(tournaments, (Json.parse(tournament)))
 	end
 	return tournaments
+end
+
+function AutomaticPointsTable:parseTeams(args)
+	local teams = {}
+	for _, team in Table.iter.pairsByPrefix(args, 'team') do
+		parsedTeam = Json.parse(team)
+		parsedTeam.aliases = self:parseAliases(parsedTeam)
+		parsedTeam.deductions = self:parseDeductions(parsedTeam)
+		parsedTeam.manualPoints = self:parseManualPoints(parsedTeam)
+		table.insert(teams, parsedTeam)
+	end
+	return teams
+end
+
+function AutomaticPointsTable:parseAliases(team)
+	local aliases = {}
+	for argKey, argVal in pairs(team) do
+		if type(argKey) == 'string' and string.find(argKey, 'alias%d+') then
+			local aliasIndexString = String.split(argKey, 'alias')[1]
+			local aliasIndex = tonumber(aliasIndexString)
+			local aliasName = argVal
+			aliases[aliasIndex] = aliasName
+		end
+	end
+	return aliases
+end
+
+function AutomaticPointsTable:parseDeductions(team)
+	local deductions = {}
+	for argKey, argVal in pairs(team) do
+		if type(argKey) == 'string' then
+			if string.find(argKey, 'deduction%d+note') then
+				local deductionIndex = tonumber(string.match(argKey, '%d+'))
+				local deductionNote = argVal
+
+				if not deductions[deductionIndex] then
+					deductions[deductionIndex] = {}
+				end
+
+				deductions[deductionIndex].note = deductionNote
+			elseif string.find(argKey, 'deduction%d+') then
+				local deductionIndex = tonumber(String.split(argKey, 'deduction')[1])
+				local deductionAmount = argVal
+
+				if not deductions[deductionIndex] then
+					deductions[deductionIndex] = {}
+				end
+
+				deductions[deductionIndex].amount = tonumber(deductionAmount)
+			end
+		end
+	end
+	return deductions
+end
+
+function AutomaticPointsTable:parseManualPoints(team)
+	local manualPoints = {}
+	for argKey, argVal in pairs(team) do
+		if type(argKey) == 'string' and string.find(argKey, 'points%d+') then
+			local pointsIndex = tonumber(String.split(argKey, 'points')[1])
+			local points = tonumber(argVal)
+
+			manualPoints[pointsIndex] = points
+		end
+	end
+	return manualPoints
 end
 
 return AutomaticPointsTable

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -70,6 +70,8 @@ function AutomaticPointsTable:parseTeams(args)
 	return teams
 end
 
+--- Parses the team aliases, used in cases where a team is picked up by an org or changed name in some
+--- of the tournaments, in which case aliases are required to correctly query the team's results & points
 function AutomaticPointsTable:parseAliases(team)
 	local aliases = {}
 	for argKey, argVal in pairs(team) do
@@ -83,9 +85,12 @@ function AutomaticPointsTable:parseAliases(team)
 	return aliases
 end
 
+--- Parses the teams' deductions, used in cases where a team has disbanded or made a roster change
+--- that causes them to lose a portion or all of their points that they've accumulated up until that change
 function AutomaticPointsTable:parseDeductions(team)
 	local deductions = {}
-	for argKey, argVal in pairs(team) do
+	for key, value in pairs(team) do
+
 		if type(argKey) == 'string' then
 			if string.find(argKey, 'deduction%d+note') then
 				local deductionIndex = tonumber(string.match(argKey, '%d+'))
@@ -113,7 +118,8 @@ end
 
 function AutomaticPointsTable:parseManualPoints(team)
 	local manualPoints = {}
-	for argKey, argVal in pairs(team) do
+	for key, value in pairs(team) do
+
 		if type(argKey) == 'string' and string.find(argKey, 'points%d+') then
 			local pointsIndex = tonumber(String.split(argKey, 'points')[1])
 			local points = tonumber(argVal)


### PR DESCRIPTION
## Summary

Added parseTeam() which parses the teams provided in the arguments of the module

## How did you test this change?

The module is deployed in Sandbox and is working as intended after making this change:
https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/2

here's a screenshot showing a portion of the teams table
![image](https://user-images.githubusercontent.com/28851891/148614171-6d3d084b-c110-46d2-a080-03578b0e0fc4.png)
