### PR TITLE
Fix Match1 issue on R6 after #763

### DIFF
--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -189,7 +189,7 @@ function p.convertParameters(match2)
 		local opponent = match2.match2opponents[index] or {}
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == "team" then
-			match[prefix] = mw.ext.TeamTemplate.teampage(opponent.name)
+			match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
 			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1,10 do

--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -189,7 +189,7 @@ function p.convertParameters(match2)
 		local opponent = match2.match2opponents[index] or {}
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == "team" then
-			match[prefix] = opponent.name
+			match[prefix] = mw.ext.TeamTemplate.teampage(opponent.name)
 			match[prefix.."score"] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1,10 do


### PR DESCRIPTION
## Summary

R6's match1 saves unredirected teamtemplate pages in Match1 opponents. 

#763 added resolve redirect on the match2 `name` (pagename) field. 

This PR adds an extra step in the Match1 handling to save the unresolved pagename.

## How did you test this change?

Tested live