### PR TITLE
Add HiddenDataBox for AoE

### DIFF
--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -1,0 +1,41 @@
+---
+-- @Liquipedia
+-- wiki=ageofempires
+-- page=Module:HiddenDataBox/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Variables = require('Module:Variables')
+local BasicHiddenDataBox = require('Module:HiddenDataBox')
+local CustomHiddenDataBox = {}
+
+function CustomHiddenDataBox.run(args)
+	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+	return BasicHiddenDataBox.run(args)
+end
+
+function CustomHiddenDataBox:addCustomVariables(args, queryResult)
+	--legacy variables
+	Variables.varDefine('tournament_parent_name', Variables.varDefault('tournament_parentname', ''))
+	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier', ''))
+	Variables.varDefine('tournament_tiertype', Variables.varDefault('tournament_liquipediatiertype', ''))
+
+	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate', ''))
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate', ''))
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate', ''))
+
+	Variables.varDefine('date', Variables.varDefault('tournament_enddate', ''))
+	Variables.varDefine('edate', Variables.varDefault('tournament_enddate', ''))
+	Variables.varDefine('sdate', Variables.varDefault('tournament_startdate', ''))
+
+	--headtohead option
+	Variables.varDefine('tournament_headtohead', args.headtohead)
+	Variables.varDefine('headtohead', args.headtohead)
+
+	--gamemode
+	BasicHiddenDataBox:checkAndAssign('tournament_gamemode', args.gamemode, queryResult.gamemode)
+end
+
+return Class.export(CustomHiddenDataBox)


### PR DESCRIPTION
## Summary
Migrate the HiddenDataBox to be commons- and LPDB-based.

## How did you test this change?
Tested by calling the Module/Sandbox instead of the old template on pages where it is used, e.g.
https://liquipedia.net/ageofempires/Visible_Cup/4/Swiss_Stage/Round_1-2 or https://liquipedia.net/ageofempires/AOElympics/2020/1v1/Hideout