### PR TITLE
Adjust Legacy Bracket MatchGroup calls

### DIFF
--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -75,7 +75,7 @@ function Legacy.get(frame)
 	newArgs.noDuplicateCheck = _args.noDuplicateCheck
 	newArgs.isLegacy = true
 
-	return MatchGroup.luaBracket(frame, newArgs)
+	return MatchGroup.TemplateBracket(newArgs)
 end
 
 function Legacy.getTemplate(frame)

--- a/components/match2/wikis/starcraft/legacy/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft/legacy/match_group_legacy.lua
@@ -49,7 +49,7 @@ function Legacy.get(frame)
 	newArgs.id = bracketid
 	newArgs[1] = templateid
 
-	return MatchGroup.luaBracket(frame, newArgs)
+	return MatchGroup.TemplateBracket(newArgs)
 end
 
 function Legacy.getTemplate(frame)

--- a/components/match2/wikis/starcraft2/legacy/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_group_legacy.lua
@@ -68,7 +68,7 @@ function Legacy.get(frame)
 	newArgs.noDuplicateCheck = _args.noDuplicateCheck
 	newArgs.isLegacy = true
 
-	return MatchGroup.luaBracket(frame, newArgs)
+	return MatchGroup.TemplateBracket(newArgs)
 end
 
 function Legacy.getTemplate(frame)


### PR DESCRIPTION
## Summary
Adjust Legacy Bracket MatchGroup calls to use the intended calls instead of the deprecated functions

## How did you test this change?
dev modules