### PR TITLE
Adjust Legacy Matchlist MatchGroup calls

### DIFF
--- a/components/match2/wikis/rocketleague/legacy/legacy_match_list.lua
+++ b/components/match2/wikis/rocketleague/legacy/legacy_match_list.lua
@@ -55,7 +55,7 @@ function LegacyMatchList.convertMatchList(frame)
 	args.isLegacy = true
 
 	--pass the adjusted arguments to the MatchGroup
-	return require('Module:MatchGroup').luaMatchlist(frame, args)
+	return require('Module:MatchGroup').TemplateMatchlist(args)
 end
 
 function LegacyMatchList.convertMatchMaps(frame)

--- a/components/match2/wikis/starcraft2/legacy/legacy_player_cross_table.lua
+++ b/components/match2/wikis/starcraft2/legacy/legacy_player_cross_table.lua
@@ -12,7 +12,7 @@ local getArgs = require('Module:Arguments').getArgs
 local json = require('Module:Json')
 local Variables = require('Module:Variables')
 local Logic = require('Module:Logic')
-local MatchList = require('Module:MatchGroup').luaMatchlist
+local MatchList = require('Module:MatchGroup').TemplateMatchlist
 
 local _MAX_NUMBER_OF_OPPONENTS = 10
 local _MAX_NUMBER_OF_MAPS = 99
@@ -69,7 +69,7 @@ function LegacyPlayerCrossTable.playerCrossTableToMatch2(frame)
 	newArgs.id = args.id
 	newArgs.isLegacy = true
 
-	return MatchList(frame, newArgs)
+	return MatchList(newArgs)
 end
 
 --sub functions


### PR DESCRIPTION
## Summary
Adjust Legacy Matchlist MatchGroup calls to use the intended calls instead of the deprecated functions

## How did you test this change?
dev modules (on sc2 pushed live)