### PR TITLE
Make LeagueIcon handling consistent

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -31,6 +31,8 @@ local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
 local Chronology = Widgets.Chronology
 
+local _FILLER_ICON = '<span class="league-icon-small-image">[[File:Logo filler event.png|link=]]</span>'
+
 local League = Class.new(BasicInfobox)
 
 League.warnings = {}
@@ -42,7 +44,6 @@ end
 
 function League:createInfobox()
 	local args = self.args
-	local frame = mw.getCurrentFrame()
 	local links
 
 	-- set Variables here already so they are available in functions
@@ -57,14 +58,13 @@ function League:createInfobox()
 			name = 'Series',
 			content = {
 				self:_createSeries(
-					frame,
 					args.series,
 					args.abbreviation,
 					true,
 					args.icon,
 					args.icondarkmode
 				),
-				self:_createSeries(frame, args.series2, args.abbreviation2)
+				self:_createSeries(args.series2, args.abbreviation2)
 			}
 		},
 		Builder{
@@ -327,23 +327,24 @@ function League:_createLocation(args)
 	return content
 end
 
-function League:_createSeries(frame, series, abbreviation, isFirst, icon, iconDark)
+function League:_createSeries(series, abbreviation, isFirst, icon, iconDark)
 	if String.isEmpty(series) then
 		return nil
 	end
 
-	local output = ''
+	local output = LeagueIcon.display({
+		icon = icon,
+		iconDark = iconDark,
+		series = series,
+		abbreviation = abbreviation,
+		date = Variables.varDefault('tournament_enddate')
+	})
 
-	if Page.exists('Template:LeagueIconSmall/' .. series:lower()) then
-		output = Template.safeExpand(
-			frame,
-			'LeagueIconSmall/' .. series:lower(),
-			{ date = Variables.varDefault('tournament_enddate') }
-		) .. ' '
-		if isFirst then
-			League:_setIconVariable(output, icon, iconDark)
-		end
+	if isFirst and output ~= _FILLER_ICON then
+		League:_setIconVariable(output, icon, iconDark)
 	end
+
+	output = output .. ' '
 
 	if not Page.exists(series) then
 		if String.isEmpty(abbreviation) then

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -325,7 +325,7 @@ function League:_createLocation(args)
 	return content
 end
 
-function League:_createSeries(series, abbreviation, setVariable, icon, iconDark)
+function League:_createSeries(series, abbreviation, shouldSetVariable, icon, iconDark)
 	if String.isEmpty(series) then
 		return nil
 	end
@@ -342,13 +342,9 @@ function League:_createSeries(series, abbreviation, setVariable, icon, iconDark)
 		output = ''
 	else
 		output = output .. ' '
-		if setVariable then
+		if shouldSetVariable then
 			League:_setIconVariable(output, icon, iconDark)
 		end
-	end
-
-	if setVariable and output ~= LeagueIcon.display{} then
-		League:_setIconVariable(output, icon, iconDark)
 	end
 
 	if not Page.exists(series) then

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -31,8 +31,6 @@ local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
 local Chronology = Widgets.Chronology
 
-local _FILLER_ICON = '<span class="league-icon-small-image">[[File:Logo filler event.png|link=]]</span>'
-
 local League = Class.new(BasicInfobox)
 
 League.warnings = {}
@@ -327,24 +325,31 @@ function League:_createLocation(args)
 	return content
 end
 
-function League:_createSeries(series, abbreviation, isFirst, icon, iconDark)
+function League:_createSeries(series, abbreviation, setVariable, icon, iconDark)
 	if String.isEmpty(series) then
 		return nil
 	end
 
-	local output = LeagueIcon.display({
+	local output = LeagueIcon.display{
 		icon = icon,
 		iconDark = iconDark,
 		series = series,
 		abbreviation = abbreviation,
 		date = Variables.varDefault('tournament_enddate')
-	})
+	}
 
-	if isFirst and output ~= _FILLER_ICON then
-		League:_setIconVariable(output, icon, iconDark)
+	if output == LeagueIcon.display{} then
+		output = ''
+	else
+		output = output .. ' '
+		if setVariable then
+			League:_setIconVariable(output, icon, iconDark)
+		end
 	end
 
-	output = output .. ' '
+	if setVariable and output ~= LeagueIcon.display{} then
+		League:_setIconVariable(output, icon, iconDark)
+	end
 
 	if not Page.exists(series) then
 		if String.isEmpty(abbreviation) then


### PR DESCRIPTION
## Summary
Currently for the Display we use the `LeagueIconSmall` (LIS) templates (ignoring manually input icons), while for the LPDB/wiki-var storage we use the manually set icons and only use the LIS templates as fallback.
This PR switches the display so that it will consider the manually input icons too.
Namely it now uses the `LeagueIcon` module instead of directly expanding the LIS templates.
This makes the behavior of storage and display consistent for the icons

## How did you test this change?
/dev sandbox