### PR TITLE
Added queryPlacements

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -152,7 +152,6 @@ function AutomaticPointsTable:queryPlacements(tournaments)
 
 			result.points = tonumber(result.extradata.prizepoints)
 			result.securedPoints = tonumber(result.extradata.securedpoints)
-			
 			table.insert(tournament.placements, result)
 		end
 	)

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -137,14 +137,13 @@ function AutomaticPointsTable:queryPlacements(tournaments)
 		function(index, t)
 			tree:add(ConditionNode(columnName, Comparator.eq, t.name))
 			tournamentIndices[t.name] = index
+			t.placements = {}
 		end
 	)
 	local conditions = tree:toString()
 
 	queryParams.conditions = conditions
 	local allQueryResult = mw.ext.LiquipediaDB.lpdb('placement', queryParams)
-
-	local indexedResults = {}
 
 	Table.iter.forEach(allQueryResult,
 		function(result)
@@ -154,9 +153,6 @@ function AutomaticPointsTable:queryPlacements(tournaments)
 			result.points = tonumber(result.extradata.prizepoints)
 			result.securedPoints = tonumber(result.extradata.securedpoints)
 			
-			if Table.isEmpty(tournament.placements) then
-				tournament.placements = {}
-			end
 			table.insert(tournament.placements, result)
 		end
 	)

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -8,9 +8,16 @@
 
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
+local Condition = require('Module:Condition')
 local Json = require('Module:Json')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+
+local ConditionTree = Condition.Tree
+local ConditionNode = Condition.Node
+local Comparator = Condition.Comparator
+local BooleanOperator = Condition.BooleanOperator
+local ColumnName = Condition.ColumnName
 
 local AutomaticPointsTable = Class.new(
 	function(self, frame)


### PR DESCRIPTION
**This is a different implementation for the same function in https://github.com/Liquipedia/Lua-Modules/pull/948 - this solves the issue mentioned in https://github.com/Liquipedia/Lua-Modules/pull/948#issuecomment-1011575312**

## Summary

In this PR, I added the a function to perform the required LPDB queries to query for all the results in the provided tournaments to the template

## How did you test this change?

The Module after this change is deployed in user-space and is working as intended
https://liquipedia.net/rocketleague/index.php?title=Module:Sandbox/AutoPointsTable/Rewrite/GH/3/2

This part might require tweaks to some wikis' prizepool table later, as it depends on lpdb objects stored in the prizepools to get the amount of points for every placement.

The following image is an example output for some of the placements:
![image](https://user-images.githubusercontent.com/28851891/149246376-6d2ee998-7014-4aa7-84f0-fd4078c4552a.png)