### PR TITLE
Resolve organizer pages before writing them to LPDB

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -251,8 +251,9 @@ function League:_setLpdbData(args, links)
 		endpatch = args.endpatch or args.epatch,
 		type = args.type,
 		organizers = mw.ext.LiquipediaDB.lpdb_create_json(
-			League:_resolveAllRedirectsInTable(
-				League:_getNamedTableofAllArgsForBase(args, 'organizer')
+			Table.mapValues(
+				League:_getNamedTableofAllArgsForBase(args, 'organizer'),
+				mw.ext.TeamLiquidIntegration.resolve_redirect
 			)
 		),
 		startdate = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', '1970-01-01'),
@@ -477,17 +478,6 @@ function League:_fetchAbbreviation()
 	if type(seriesData) == 'table' and seriesData[1] then
 		return seriesData[1].abbreviation
 	end
-end
-
--- Given a table, resolves all redirects in any value of the table
-function League:_resolveAllRedirectsInTable(table)
-	if table == nil then return nil end
-
-	for key, value in pairs(table) do
-		table[key] = mw.ext.TeamLiquidIntegration.resolve_redirect(value)
-	end
-
-	return table
 end
 
 return League

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -251,7 +251,9 @@ function League:_setLpdbData(args, links)
 		endpatch = args.endpatch or args.epatch,
 		type = args.type,
 		organizers = mw.ext.LiquipediaDB.lpdb_create_json(
-			League:_getNamedTableofAllArgsForBase(args, 'organizer')
+			League:_resolveAllRedirectsInTable(
+				League:_getNamedTableofAllArgsForBase(args, 'organizer')
+			)
 		),
 		startdate = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', '1970-01-01'),
 		enddate = Variables.varDefault('tournament_enddate', '1970-01-01'),
@@ -475,6 +477,17 @@ function League:_fetchAbbreviation()
 	if type(seriesData) == 'table' and seriesData[1] then
 		return seriesData[1].abbreviation
 	end
+end
+
+-- Given a table, resolves all redirects in any value of the table
+function League:_resolveAllRedirectsInTable(table)
+	if table == nil then return nil end
+
+	for key, value in pairs(table) do
+		table[key] = mw.ext.TeamLiquidIntegration.resolve_redirect(value)
+	end
+
+	return table
 end
 
 return League


### PR DESCRIPTION
## Summary
Resolves redirects of organizers before entering them into LPDB.

Organizers are often entered with names/pages that are redirects, and that is making it hard to query for tournaments of a specific organizer, e.g. to list them on the organizer's page.
Resolving redirects before saving organizers allows to have them saved consistently under a single name.

## How did you test this change?
Tested correct behavior of the introduced function in a [sandbox](https://liquipedia.net/ageofempires/Module:SyntacticSalt/sandbox4)

Tested correct LPDB entry with a /dev Infobox on commons/AoE

