### PR TITLE
Extract the inner loop of _calculateWeight()

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -157,10 +157,10 @@ end
 function NotabilityChecker.calculateTournament(tier, tierType, placement, date, notabilityMod, mode)
 	local dateLossModifier = NotabilityChecker._calculateDateLoss(date)
 	local notabilityModifier = NotabilityChecker._parseNotabilityMod(notabilityMod)
-	tier, tierType = NotabilityChecker._parseTier(tier, tierType)
+	local parsedTier, parsedTierType = NotabilityChecker._parseTier(tier, tierType)
 
 	local weight = NotabilityChecker._calculateWeightForTournament(
-		tier, tierType, placement, dateLossModifier, notabilityModifier, mode
+		parsedTier, parsedTierType, placement, dateLossModifier, notabilityModifier, mode
 	)
 
 	if NotabilityChecker.LOGGING then

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -134,7 +134,7 @@ function NotabilityChecker._calculateWeight(placementData)
 
 	for _, placement in pairs(placementData) do
 		if not String.isEmpty(placement.placement) then
-			if NotabilityChecker._EXTRA_LOGGING then
+			if NotabilityChecker.EXTRA_LOGGING then
 				mw.log('Tournament: ' .. placement.tournament)
 			end
 
@@ -163,7 +163,7 @@ function NotabilityChecker.calculateTournament(tier, tierType, placement, date, 
 		tier, tierType, placement, dateLoss, notabilityMod, mode
 	)
 
-	if NotabilityChecker._EXTRA_LOGGING then
+	if NotabilityChecker.EXTRA_LOGGING then
 		mw.log('weight: ' .. weight,
 			'mod: ' .. notabilityMod,
 			'mode: ' .. mode

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -154,10 +154,10 @@ function NotabilityChecker._calculateWeight(placementData)
 	return finalWeight
 end
 
-function NotabilityChecker.calculateTournament(liquipediatier, liquipediatiertype, placement, date, notabilityMod, mode)
+function NotabilityChecker.calculateTournament(tier, tierType, placement, date, notabilityMod, mode)
 	local dateLoss = NotabilityChecker._calculateDateLoss(date)
 	notabilityMod = NotabilityChecker._parseNotabilityMod(notabilityMod)
-	local tier, tierType = NotabilityChecker._parseTier(liquipediatier, liquipediatiertype)
+	tier, tierType = NotabilityChecker._parseTier(tier, tierType)
 
 	local weight = NotabilityChecker._calculateWeightForTournament(
 		tier, tierType, placement, dateLoss, notabilityMod, mode
@@ -231,12 +231,12 @@ function NotabilityChecker._preparePlacement(placement)
 	return placement
 end
 
-function NotabilityChecker._parseTier(liquipediatier, liquipediatiertype)
-	if String.isEmpty(liquipediatiertype) then
-		return tonumber(liquipediatier), nil
+function NotabilityChecker._parseTier(tier, tierType)
+	if String.isEmpty(tierType) then
+		return tonumber(tier), nil
 	end
 
-	return tonumber(liquipediatier), liquipediatiertype:lower()
+	return tonumber(tier), tierType:lower()
 end
 
 function NotabilityChecker._parseNotabilityMod(notabilityMod)

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -18,7 +18,7 @@ local _lang = mw.language.new('en')
 local _NOW = os.time()
 local _SECONDS_IN_YEAR = 365.2425 * 86400
 
-NotabilityChecker._EXTRA_LOGGING = true
+NotabilityChecker.EXTRA_LOGGING = true
 
 function NotabilityChecker.run(args)
 

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -18,7 +18,7 @@ local _lang = mw.language.new('en')
 local _NOW = os.time()
 local _SECONDS_IN_YEAR = 365.2425 * 86400
 
-NotabilityChecker.EXTRA_LOGGING = true
+NotabilityChecker.LOGGING = true
 
 function NotabilityChecker.run(args)
 
@@ -134,7 +134,7 @@ function NotabilityChecker._calculateWeight(placementData)
 
 	for _, placement in pairs(placementData) do
 		if not String.isEmpty(placement.placement) then
-			if NotabilityChecker.EXTRA_LOGGING then
+			if NotabilityChecker.LOGGING then
 				mw.log('Tournament: ' .. placement.tournament)
 			end
 
@@ -155,17 +155,17 @@ function NotabilityChecker._calculateWeight(placementData)
 end
 
 function NotabilityChecker.calculateTournament(tier, tierType, placement, date, notabilityMod, mode)
-	local dateLoss = NotabilityChecker._calculateDateLoss(date)
-	notabilityMod = NotabilityChecker._parseNotabilityMod(notabilityMod)
+	local dateLossModifier = NotabilityChecker._calculateDateLoss(date)
+	local notabilityModifier = NotabilityChecker._parseNotabilityMod(notabilityMod)
 	tier, tierType = NotabilityChecker._parseTier(tier, tierType)
 
 	local weight = NotabilityChecker._calculateWeightForTournament(
-		tier, tierType, placement, dateLoss, notabilityMod, mode
+		tier, tierType, placement, dateLossModifier, notabilityModifier, mode
 	)
 
-	if NotabilityChecker.EXTRA_LOGGING then
+	if NotabilityChecker.LOGGING then
 		mw.log('weight: ' .. weight,
-			'mod: ' .. notabilityMod,
+			'mod: ' .. notabilityModifier,
 			'mode: ' .. mode
 		)
 	end


### PR DESCRIPTION
## Summary

Extracted the inner loop of _calculateWeight() function and made the extracted function public. 

This is preparation for a commons version of https://liquipedia.net/rainbowsix/Module:Notable_teams_and_players_without_page, which is in used on 10ish wikis. This module calculates the points for every person or team on a wiki and lists the ones without a page whom are notable. In order to not duplicate calculation code, using the calculations of the Notability Checker is better.

For performance reasons, make the logging optional.

## How did you test this change?

Put it on /dev