### PR TITLE
Avoid divide by zero causing "inf" weight

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -231,7 +231,7 @@ end
 
 function NotabilityChecker._calculateDateLoss(date)
 	local timestamp = _lang:formatDate('U', date)
-	local differenceSeconds = _NOW - timestamp
+	local differenceSeconds = math.max(_NOW - timestamp, 0) -- No dates in the future
 	return math.floor(differenceSeconds / _SECONDS_IN_YEAR) + 1
 end
 


### PR DESCRIPTION
## Summary

If a placement's date entry is in the future, the _calculateDateLoss could return 0, later causing a divide by zero. Lua handles divides by zero without crashing, but the value of the float will be set to infinite, not allowing the score of the team/person to be ascertained. 

This PR removes the possibility for a future date by not allowing negative values in `differenceSeconds` (negative would mean in the future), which is the RC of the divide by zero.

## How did you test this change?

Put it on /dev