### PR TITLE
Stop overwriting Commons extradata

### DIFF
--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -84,7 +84,6 @@ function CustomPlayer:createWidgetInjector()
 end
 
 function CustomPlayer:adjustLPDB(lpdbData)
-	
 	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
 	lpdbData.extradata.role = _role.role
 	lpdbData.extradata.role2 = _role2.role

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -84,11 +84,10 @@ function CustomPlayer:createWidgetInjector()
 end
 
 function CustomPlayer:adjustLPDB(lpdbData)
-	lpdbData.extradata = {
-		isplayer = _role.isPlayer or 'true',
-		role = _role.role,
-		role2 = _role2.role
-	}
+	
+	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
+	lpdbData.extradata.role = _role.role
+	lpdbData.extradata.role2 = _role2.role
 
 	local region = Region.run({region = _args.region, country = _args.country})
 	if type(region) == 'table' then


### PR DESCRIPTION



## Summary

lpdpData.extradata is no longer overwritten, but added to. It will now contain data for the Statistics Portal to use for player earnings, which was currently being deleted in the overwrite.


## How did you test this change?

Was tested here [https://liquipedia.net/halo/index.php?title=Module:Infobox/Person/Player/Custom/Dev&action=edit] and directly invoked on a player page in preview mode to check the lpdbdata using "mw.logObject"
