### PR TITLE
Added getPointsData

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -132,18 +132,23 @@ function AutomaticPointsTable:parseManualPoints(team, tournamentCount)
 	return manualPoints
 end
 
-function AutomaticPointsTable:queryPlacements(teams, tournaments)
-	-- to get a team index, use reverseAliasLookupTable[tournamentIndex][alias]
-	local reverseAliasLookupTable = {}
+function AutomaticPointsTable:generateReverseAliasLookupTable(teams, tournaments)
+	local LookupTable = {}
 	for tournamentIndex = 1, #tournaments do
-		reverseAliasLookupTable[tournamentIndex] = {}
+		LookupTable[tournamentIndex] = {}
 		Table.iter.forEachIndexed(teams,
 			function(index, team)
 				local alias = mw.language.getContentLanguage():ucfirst(team.aliases[tournamentIndex])
-				reverseAliasLookupTable[tournamentIndex][alias] = index
+				LookupTable[tournamentIndex][alias] = index
 			end
 		)
 	end
+	return LookupTable
+end
+
+function AutomaticPointsTable:queryPlacements(teams, tournaments)
+	-- to get a team index, use reverseAliasLookupTable[tournamentIndex][alias]
+	local reverseAliasLookupTable = self:generateReverseAliasLookupTable(teams, tournaments)
 
 	local queryParams = {
 		limit = 5000,
@@ -208,7 +213,6 @@ function AutomaticPointsTable:getPointsData(teams, tournaments)
 					tournaments[tournamentIndex].deductionsVisible = true
 					totalPoints = totalPoints - dataWithDeduction.deduction.amount
 				end
-				
 				teamPointsData[tournamentIndex] = tournamentTeamPointsData
 			end
 			teamPointsData.totalPoints = totalPoints

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -154,8 +154,8 @@ end
 
 
 function AutomaticPointsTable:queryPlacements(teams, tournaments)
-	-- to get a team index, use reverseAliasLookupTable[tournamentIndex][alias]
-	local reverseAliases = self:generateReverseAliasLookupTable(teams, tournaments)
+	-- to get a team index, use reverseAliases[tournamentIndex][alias]
+	local reverseAliases = self:generateReverseAliases(teams, tournaments)
 
 	local queryParams = {
 		limit = 5000,
@@ -207,7 +207,7 @@ function AutomaticPointsTable:getPointsData(teams, tournaments)
 				local manualPoints = team.manualPoints[tournamentIndex]
 				local placement = team.results[tournamentIndex]
 
-				local pointsForTournament = self:calculatePointsForTournament(manualPoints, placement)
+				local pointsForTournament = self:calculatePointsForTournament(placement, manualPoints)
 				if Table.isNotEmpty(pointsForTournament) then
 					totalPoints = totalPoints + pointsForTournament.amount
 				end
@@ -259,17 +259,6 @@ function AutomaticPointsTable:calculatePointsForTournament(placement, manualPoin
 	end
 
 	return {}
-end
-
-function AutomaticPointsTable:getDeductionData(deduction, pointsData)
-	if deduction ~= nil then
-		local deductionAmount = deduction.amount
-		if deductionAmount ~= nil then
-			pointsData.deduction = deduction
-		end
-	end
-
-	return pointsData
 end
 
 return AutomaticPointsTable

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -19,6 +19,12 @@ local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
+local _POINTS_TYPE = {
+	'MANUAL' = 1,
+	'PRIZE' = 2,
+	'SECURED' = 3,
+}
+
 local AutomaticPointsTable = Class.new(
 	function(self, frame)
 		self.frame = frame

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -188,7 +188,7 @@ function AutomaticPointsTable:queryPlacements(teams, tournaments)
 			table.insert(tournament.placements, result)
 
 			local participant = result.participant
-			local teamIndex = reverseAliasLookupTable[tournamentIndex][participant]
+			local teamIndex = reverseAliases[tournamentIndex][participant]
 			if teamIndex ~= nil then
 				teams[teamIndex].results[tournamentIndex] = result
 			end

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -213,12 +213,12 @@ function AutomaticPointsTable:getPointsData(teams, tournaments)
 				end
 
 				local deduction = team.deductions[tournamentIndex]
-				pointsForTournament.deduction = deduction ~= nil and deduction or nil
-				if Table.isNotEmpty(pointsForTournament.deduction) then
+				if Table.isNotEmpty(deduction) then
+					pointsForTournament.deduction = deduction
 					-- will only show the deductions column if there's atleast one team with
 					-- some deduction for a tournament
 					tournaments[tournamentIndex].shouldDeductionsBeVisible = true
-					totalPoints = totalPoints - (pointsForTournament.deduction.amount or 0)
+					totalPoints = totalPoints - (deduction.amount or 0)
 				end
 
 				teamPointsData[tournamentIndex] = pointsForTournament

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -193,6 +193,8 @@ function AutomaticPointsTable:getPointsData(teams, tournaments)
 			local teamPointsData = {}
 			local totalPoints = 0
 			for tournamentIndex = 1, #tournaments do
+				local manualPoints = team.manualPoints[tournamentIndex]
+				local placement = team.results[tournamentIndex]
 				local tournamentTeamPointsData = self:getTournamentTeamPointsData(manualPoints, placement)
 				if Table.isNotEmpty(tournamentTeamPointsData) then
 					totalPoints = totalPoints + tournamentTeamPointsData.amount


### PR DESCRIPTION
## Summary

In this PR, I added getPointsData function which calculates the total points for every team and parses the points from manual points, queried points, secured points and deductions.
This is in preparation for rendering the table.

## How did you test this change?

The module after this change is [deployed in sandbox](https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/4), here's a screenshot showing the points data for a single team:

![image](https://user-images.githubusercontent.com/28851891/149845537-21fa27b3-916f-451d-8010-6dfe66c0d14f.png)

> The table at index 1, is the team points gained in the tournament at index 1.
> The three tables; _table#46, table#47 and table#48_ are empty because this team hasn't participated in the corresponding tournaments.