### PR TITLE
Avoid nil concats in `Module:GetMatchGroupCopyPaste`

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste.lua
+++ b/components/match2/commons/get_match_group_copy_paste.lua
@@ -131,7 +131,7 @@ function copyPaste.bracket(frame, args)
 		local matchKey = bracketData.matchKey
 		if matchKey == 'RxMTP' or matchKey == 'RxMBR' then
 			if args.extra == 'true' then
-				local header
+				local header = ''
 				if matchKey == 'RxMTP' then
 					header = '\n\n' .. '<!-- Third Place Match -->' .. '\n|' .. matchKey .. 'header='
 				end


### PR DESCRIPTION
## Summary
Avoid nil concats in `Module:GetMatchGroupCopyPaste`

## How did you test this change?
live to fix the bug