### PR TITLE
1v1 notability modifier for Rocket League

### DIFF
--- a/components/notability/wikis/rocketleague/notability_checker_config.lua
+++ b/components/notability/wikis/rocketleague/notability_checker_config.lua
@@ -223,8 +223,7 @@ function Config.adjustScoreForMode(score, mode)
 	local modeMod = 1
 	if mode == "2v2" then
 		modeMod = 0.5
-	end
-	if mode == "1v1" then
+	elseif mode == "1v1" then
 		modeMod = 0.25
 	end
 	return score * modeMod

--- a/components/notability/wikis/rocketleague/notability_checker_config.lua
+++ b/components/notability/wikis/rocketleague/notability_checker_config.lua
@@ -224,6 +224,9 @@ function Config.adjustScoreForMode(score, mode)
 	if mode == "2v2" then
 		modeMod = 0.5
 	end
+	if mode == "1v1" then
+		modeMod = 0.25
+	end
 	return score * modeMod
 end
 


### PR DESCRIPTION
Added a custom modifier for 1v1 tournaments within the RL wiki to be a quarter of the usual notability distribution.