### PR TITLE
Allow table of matches as input for MatchlistContainer

### DIFF
--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -52,11 +52,11 @@ MatchlistDisplay.propTypes.MatchlistContainer = {
 Display component for a tournament matchlist. The matchlist is specified by ID.
 The component fetches the match data from LPDB or page variables.
 ]]
-function MatchlistDisplay.MatchlistContainer(props)
+function MatchlistDisplay.MatchlistContainer(props, matches)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.MatchlistContainer)
 	return MatchlistDisplay.Matchlist({
 		config = props.config,
-		matches = MatchGroupUtil.fetchMatches(props.bracketId),
+		matches = matches or MatchGroupUtil.fetchMatches(props.bracketId),
 	})
 end
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_matchlist_starcraft.lua
@@ -17,7 +17,7 @@ local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', 
 
 local StarcraftMatchlistDisplay = {}
 
-function StarcraftMatchlistDisplay.MatchlistContainer(props)
+function StarcraftMatchlistDisplay.MatchlistContainer(props, matches)
 	return MatchlistDisplay.Matchlist({
 		config = Table.merge(props.config, {
 			MatchSummaryContainer = StarcraftMatchSummary.MatchSummaryContainer,
@@ -25,7 +25,7 @@ function StarcraftMatchlistDisplay.MatchlistContainer(props)
 			Score = StarcraftMatchlistDisplay.Score,
 			matchHasDetails = StarcraftMatchGroupUtil.matchHasDetails,
 		}),
-		matches = MatchGroupUtil.fetchMatches(props.bracketId),
+		matches = matches or MatchGroupUtil.fetchMatches(props.bracketId),
 	})
 end
 


### PR DESCRIPTION
## Summary
Allow table of matches (retrieved via lpdb queries, but the list does not belong to the same matchGroup) as input for MatchlistContainer, so that other modules can easily call the display for those.

## How did you test this change?
/dev modules together with a module i am building which needs this option.
(the module i am building is not yet ready, but it already has the display functionality that uses the matchlist display)
--> https://liquipedia.net/starcraft2/Module:HeadToHeadMatchHistory

![Screenshot 2022-01-19 17 30 17](https://user-images.githubusercontent.com/75081997/150173432-e57187b3-fae4-448b-b4d9-95d780e28545.png)

