### PR TITLE
Add sortData

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -278,21 +278,6 @@ function AutomaticPointsTable:sortData(pointsData, teams)
 
 	local maxPoints = pointsData[#pointsData].totalPoints
 
-	-- In-case two teams are tied for the same team they will have the same position
-	local jointPosition = 0
-	local previousTeamPoints = maxPoints + 1
-
-	Table.iter.forEachIndexed(pointsData,
-		function(dataIndex, dataPoint)
-			if dataPoint.totalPoints < previousTeamPoints then
-				jointPosition = jointPosition + 1
-			else
-				jointPosition = dataIndex
-			end
-			dataPoint.position = jointPosition
-		end
-	)
-
 	return pointsData
 end
 


### PR DESCRIPTION
## Summary

Add sortData function which sorts the pointsData in order from highest to lower total points, this will be the same order in which the teams will be displayed in the table, top-to-bottom
This function also attaches the position of every team, so that it can be displayed in the position column in the table.

## How did you test this change?

Deployed in Sandbox and is working as intended
https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/5
Here are some screenshots:
first element
![image](https://user-images.githubusercontent.com/28851891/150363260-7ecb25be-1c51-4e5d-953e-2b008b53cde0.png)
2nd
![image](https://user-images.githubusercontent.com/28851891/150363307-15c4f9d4-f27d-4cb5-9954-167e6b87bee8.png)
3rd to last
![image](https://user-images.githubusercontent.com/28851891/150363401-72059e00-2a72-4834-8665-bc1527c94154.png)
