### PR TITLE
Add `lrthread` to `Module:MatchGroup/Util`

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -146,6 +146,7 @@ MatchGroupUtil.types.Match = TypeUtil.struct({
 	vod = 'string?',
 	walkover = 'string?',
 	winner = 'number?',
+	lrthread = 'string?',
 })
 
 MatchGroupUtil.types.Team = TypeUtil.struct({
@@ -378,6 +379,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		vod = nilIfEmpty(record.vod),
 		walkover = nilIfEmpty(record.walkover),
 		winner = tonumber(record.winner),
+		lrthread = nilIfEmpty(record.lrthread),
 	}
 end
 


### PR DESCRIPTION
## Summary

 Currently `match.lrthread` in `Module:MatchSummary` is always `nil`.

If I understand correctly, this PR should fix it.

![image](https://user-images.githubusercontent.com/42477808/150419498-20447501-e25c-4ba2-87e0-81ee32e72f8f.png)