### PR TITLE
Create base Infobox User

### DIFF
--- a/components/infobox/commons/infobox_person_user.lua
+++ b/components/infobox/commons/infobox_person_user.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Person/User/Custom
+-- page=Module:Infobox/Person/User
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --


### PR DESCRIPTION
## Summary
Changes the default base for Infobox User away from Infobox User Custom. 

Goal for this change is to fix the naming scheme of the Infobox Persons. 

Infobox/Person as base
Infobox/Person/User (and User/Custom) for Userspace users
Infobox/Person/Player (and Player/Custom) for Player pages
and so on



<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Currently being tested here:
Sandbox - https://liquipedia.net/commons/User:Fenrir.SPAZ/Sandbox 
Person/User - https://liquipedia.net/commons/Module:Infobox/Person/User/dev
Person/User/Custom - liquipedia.net/commons/Module:Infobox/Person/User/Custom/dev

Players are not included on this PR
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
