### PR TITLE
Add generatePointsTable (Headers only in this commit)

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -303,7 +303,7 @@ end
 function AutomaticPointsTable:generatePointsTable(pointsData, tournaments)
 local columnCount = Array.reduce(tournaments, function(count, t)
 			return count + (t.shouldDeductionsBeVisible and 2 or 1)
-		end)
+		end, 0)
 	local headerRow = self:generateHeaderRow(tournaments)
 
 	local divTable = DivTable.create() :row(headerRow)

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -373,7 +373,6 @@ function AutomaticPointsTable:createHeaderCell(header)
 	return outerDiv
 end
 
---- syntactic sugar
 function AutomaticPointsTable:wrapInDiv(text)
 	return mw.html.create('div'):wikitext(tostring(text))
 end

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -9,6 +9,7 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Condition = require('Module:Condition')
+local DivTable = require('Module:DivTable')
 local Json = require('Module:Json')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -49,7 +50,7 @@ function AutomaticPointsTable.run(frame)
 	-- mw.logObject(tournamentsWithPlacements)
 	mw.logObject(sortedDataWithPositions)
 
-	return nil
+	return pointsTable:generatePointsTable(sortedDataWithPositions, tournamentsWithResults)
 end
 
 function AutomaticPointsTable:parseInput(args)
@@ -296,6 +297,92 @@ function AutomaticPointsTable:addPositionData(pointsData)
 
 		end
 	)
+end
+
+function AutomaticPointsTable:generatePointsTable(pointsData, tournaments)
+	local columnCount = self:countColumns(tournaments)
+	local headerRow = self:generateHeaderRow(tournaments)
+
+	local divTable = DivTable.create() :row(headerRow)
+	divTable.root :addClass('border-color-grey') :addClass('border-bottom')
+
+	-- for top and left borders
+	local divWrapper = mw.html.create('div') :addClass('fixed-size-table-container')
+		:addClass('border-color-grey')
+		:css('width', tostring(450 + (columnCount * 50)) .. 'px')
+		:node(divTable:create())
+
+	-- for mobile / responsive scrolling
+	local responsiveWrapper = mw.html.create('div') :addClass('table-responsive')
+		:addClass('automatic-points-table')
+		:node(divWrapper)
+
+	return responsiveWrapper
+end
+
+function AutomaticPointsTable:countColumns(tournaments)
+	local columnCount = 0
+	-- tournaments with deductions have 2 columns
+	Table.iter.forEach(tournaments, function(t)
+		columnCount = columnCount + (t.shouldDeductionsBeVisible and 2 or 1)
+	end)
+	return columnCount
+end
+
+function AutomaticPointsTable:generateHeaderRow(tournaments)
+	local headerRow = DivTable.HeaderRow()
+	headerRow.root :addClass('diagonal')
+	-- fixed headers
+	local headers = {{
+		text = 'Ranking',
+		additionalClass = 'ranking'}, {
+		text = 'Team',
+		additionalClass = 'team' }, {
+		text = 'Total Points'
+	}}
+	Table.iter.forEach(headers,
+		function(header)
+			headerRow:cell(self:createHeaderCell(header))
+		end
+	)
+	-- variable headers (according to tournaments in given in module arguments)
+	Table.iter.forEach(tournaments,
+		function(tournament)
+			headerRow:cell(self:createHeaderCell({
+				text = tournament.display and tournament.display or tournament.name
+			}))
+
+			if tournament.shouldDeductionsBeVisible == true then
+				local deductionsHeader = tournament['deductionsheader']
+				headerRow:cell(self:createHeaderCell({
+					text = deductionsHeader and deductionsHeader or 'Deductions'
+				}))
+			end
+		end
+	)
+
+	return headerRow
+end
+
+function AutomaticPointsTable:createHeaderCell(header)
+	local additionalClass = header.additionalClass
+
+	local innerDiv = self:divWrap(header.text)
+		:addClass('border-color-grey')
+		:addClass('content')
+
+	local outerDiv = mw.html.create('div')
+		:addClass('diagonal-header-div-cell')
+	if additionalClass ~= nil then
+		outerDiv:addClass(additionalClass)
+	end
+	outerDiv:node(innerDiv)
+	return outerDiv
+end
+
+--- syntactic sugar
+function AutomaticPointsTable:divWrap(text)
+	return mw.html.create('div'):wikitext(tostring(text))
 end
 
 return AutomaticPointsTable

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -7,6 +7,7 @@
 --
 
 local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Condition = require('Module:Condition')
 local DivTable = require('Module:DivTable')
@@ -300,7 +301,9 @@ function AutomaticPointsTable:addPositionData(pointsData)
 end
 
 function AutomaticPointsTable:generatePointsTable(pointsData, tournaments)
-	local columnCount = self:countColumns(tournaments)
+local columnCount = Array.reduce(tournaments, function(count, t)
+			return count + (t.shouldDeductionsBeVisible and 2 or 1)
+		end)
 	local headerRow = self:generateHeaderRow(tournaments)
 
 	local divTable = DivTable.create() :row(headerRow)
@@ -320,31 +323,21 @@ function AutomaticPointsTable:generatePointsTable(pointsData, tournaments)
 	return responsiveWrapper
 end
 
-function AutomaticPointsTable:countColumns(tournaments)
-	local columnCount = 0
-	-- tournaments with deductions have 2 columns
-	Table.iter.forEach(tournaments, function(t)
-		columnCount = columnCount + (t.shouldDeductionsBeVisible and 2 or 1)
-	end)
-	return columnCount
-end
-
 function AutomaticPointsTable:generateHeaderRow(tournaments)
 	local headerRow = DivTable.HeaderRow()
-	headerRow.root :addClass('diagonal')
+	headerRow.root:addClass('diagonal')
+
 	-- fixed headers
 	local headers = {{
 		text = 'Ranking',
-		additionalClass = 'ranking'}, {
+		additionalClass = 'ranking'
+	}, {
 		text = 'Team',
-		additionalClass = 'team' }, {
+		additionalClass = 'team'
+	}, {
 		text = 'Total Points'
 	}}
-	Table.iter.forEach(headers,
-		function(header)
-			headerRow:cell(self:createHeaderCell(header))
-		end
-	)
+	Table.iter.forEach(headers,function(h) headerRow:cell(self:createHeaderCell(h)) end)
 	-- variable headers (according to tournaments in given in module arguments)
 	Table.iter.forEach(tournaments,
 		function(tournament)
@@ -367,7 +360,7 @@ end
 function AutomaticPointsTable:createHeaderCell(header)
 	local additionalClass = header.additionalClass
 
-	local innerDiv = self:divWrap(header.text)
+	local innerDiv = self:wrapInDiv(header.text)
 		:addClass('border-color-grey')
 		:addClass('content')
 
@@ -381,7 +374,7 @@ function AutomaticPointsTable:createHeaderCell(header)
 end
 
 --- syntactic sugar
-function AutomaticPointsTable:divWrap(text)
+function AutomaticPointsTable:wrapInDiv(text)
 	return mw.html.create('div'):wikitext(tostring(text))
 end
 


### PR DESCRIPTION
## Summary

Initial commit for generatePointsTable which creates the divTable which will contain the points
This commit only creates the headers and containers, the cells will be added in another commit

## How did you test this change?

[Deployed in Sandbox](https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/6)
Example output screenshot:
![image](https://user-images.githubusercontent.com/28851891/150532798-2c1ccb81-a677-4e78-b3b1-8b73cfa0d795.png)
