### PR TITLE
Fix issue with R6's match1.header

### DIFF
--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -153,15 +153,17 @@ function p.convertParameters(match2)
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.bestofx = tostring(match2.bestof)
 	local bracketData = json.parseIfString(match2.match2bracketdata)
-	if type(bracketData) == "table" and bracketData.type == "bracket" and bracketData.header then
-		local headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
-		if not headerName or headerName == "" then
-			headerName = Variables.varDefault("match_legacy_header_name")
-		else
-			Variables.varDefine("match_legacy_header_name", headerName)
+	if type(bracketData) == "table" and bracketData.type == "bracket" then
+		local headerName
+		if bracketData.header then
+			headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
 		end
-		if headerName and headerName ~= "" then
+		if String.isEmpty(headerName) then
+			headerName = Variables.varDefault("match_legacy_header_name")
+		end
+		if String.isNotEmpty(headerName) then
 			match.header = headerName
+			Variables.varDefine("match_legacy_header_name", headerName)
 		end
 	end
 


### PR DESCRIPTION
## Summary

Some PR is a the last few months have changed how match2bracketdata fields work. Previously the header would be set to empty string if not present on a match, now it's missing instead (nil).

Tweaked the code to deal with this (moved one part of the if statement into its own if statement inside the scope).

Also cleaned up the header code to be of higher code standard.

## How did you test this change?

Tested live