### PR TITLE
Add Infobox Player for ML

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -1,0 +1,88 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:Infobox/Person/Player
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Player = require('Module:Infobox/Person')
+local String = require('Module:StringUtils')
+local Class = require('Module:Class')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Role = require('Module:Role')
+
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local Center = require('Module:Infobox/Widget/Center')
+
+local _pagename = mw.title.getCurrentTitle().prefixedText
+local _role
+local _role2
+local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
+
+local CustomPlayer = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+function CustomPlayer.run(frame)
+	local player = Player(frame)
+	_args = player.args
+
+	player.adjustLPDB = CustomPlayer.adjustLPDB
+	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+
+	return player:createInfobox(frame)
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'history' then
+		local manualHistory = _args.history
+		local automatedHistory = TeamHistoryAuto._results({
+			convertrole = 'true',
+			player = _pagename
+		}) or ''
+		automatedHistory = tostring(automatedHistory)
+		if automatedHistory == _EMPTY_AUTO_HISTORY then
+			automatedHistory = nil
+		end
+
+		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+			return {
+				Title{name = 'History'},
+				Center{content = {manualHistory}},
+				Center{content = {automatedHistory}},
+			}
+		end
+	elseif id == 'role' then
+		_role = Role.run({role = _args.role})
+		_role2 = Role.run({role = _args.role2})
+		return {
+			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
+		}
+	end
+	return widgets
+end
+
+function CustomPlayer:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomPlayer:calculateEarnings()
+	return Earnings.calc_player({ args = { player = _pagename }})
+end
+
+function CustomPlayer:adjustLPDB(lpdbData)
+	lpdbData.extradata = {
+		isplayer = _role.isPlayer or 'true',
+		role = _role.role,
+		role2 = _role2.role
+	}
+
+	return lpdbData
+end
+
+return CustomPlayer

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=mobilelegends
--- page=Module:Infobox/Person/Player
+-- page=Module:Infobox/Person/Player/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -11,6 +11,7 @@ local String = require('Module:StringUtils')
 local Class = require('Module:Class')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Role = require('Module:Role')
+local Region = require('Module:Region')
 
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
@@ -57,6 +58,7 @@ function CustomInjector:parse(id, widgets)
 				Center{content = {automatedHistory}},
 			}
 		end
+	elseif id == 'region' then return {}
 	elseif id == 'role' then
 		_role = Role.run({role = _args.role})
 		_role2 = Role.run({role = _args.role2})
@@ -71,16 +73,15 @@ function CustomPlayer:createWidgetInjector()
 	return CustomInjector()
 end
 
-function CustomPlayer:calculateEarnings()
-	return Earnings.calc_player({ args = { player = _pagename }})
-end
-
 function CustomPlayer:adjustLPDB(lpdbData)
-	lpdbData.extradata = {
-		isplayer = _role.isPlayer or 'true',
-		role = _role.role,
-		role2 = _role2.role
-	}
+	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
+	lpdbData.extradata.role = _role.role
+	lpdbData.extradata.role2 = _role2.role
+
+	local region = Region.run({region = _args.region, country = _args.country})
+	if type(region) == 'table' then
+		lpdbData.region = region.region
+	end
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
My next plan is to look at the Infobox Modules for Mobile Legends, League has already added, Player is up next. 

*I'll rely on improving the ML ones to be able to port for Wild Rift and AOV later on.*

Similar to League, Player is a **pasteover** from Halo, **no changes has been made since Dec6 2021** so there maybe a lot of catch up/clean up.

## How did you test this change?
Already going live, here's few of the live pages:
- https://liquipedia.net/mobilelegends/Wise
- https://liquipedia.net/mobilelegends/Baloyskie

## Side Note
Totally unrelated?, but in ML I did not make /Custom in ML wiki and calls off from the /Custom in Commons directly ( https://liquipedia.net/commons/index.php?title=Module:Infobox/Team/Custom&action=edit ) totally fine with no issue so far since the wiki's installation, do we still need to make one for the wiki or can just stay using commons