### PR TITLE
Add Infobox League for AOV

### DIFF
--- a/components/infobox/wikis/arenaofvalor/infobox_league.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league.lua
@@ -80,6 +80,9 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.extradata = {
+		individual = String.isNotEmpty(args.player_number) and 'true' or '',
+	}
 
 	return lpdbData
 end
@@ -87,7 +90,7 @@ end
 function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
 	Variables.varDefine('tournament_publishertier', _args['garena-sponsored'])
-		--Legacy Vars:
+	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end
 

--- a/components/infobox/wikis/arenaofvalor/infobox_league.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league.lua
@@ -72,6 +72,7 @@ function CustomInjector:parse(id, widgets)
 		if _args.team_number then
 			table.insert(widgets, Title{name = 'Teams'})
 		    table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+		end
 	end
 	return widgets
 end
@@ -142,7 +143,6 @@ function CustomLeague:_createTierDisplay()
 		(hasInvalidTier and '[[Category:Pages with invalid Tier]]' or '') ..
 		(hasInvalidTierType and '[[Category:Pages with invalid Tiertype]]' or '')
 	return output
-end
 end
 
 return CustomLeague

--- a/components/infobox/wikis/arenaofvalor/infobox_league.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league.lua
@@ -71,7 +71,7 @@ function CustomInjector:parse(id, widgets)
 		--teams section
 		if _args.team_number then
 			table.insert(widgets, Title{name = 'Teams'})
-		    table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
 		end
 	end
 	return widgets

--- a/components/infobox/wikis/arenaofvalor/infobox_league.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league.lua
@@ -1,0 +1,161 @@
+---
+-- @Liquipedia
+-- wiki=arenaofvalor
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+local Tier = require('Module:Tier')
+local PageLink = require('Module:Page')
+local Class = require('Module:Class')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local PrizePoolCurrency = require('Module:Prize pool currency')
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _game
+
+local _TODAY = os.date('%Y-%m-%d', os.time())
+local _GAME = mw.loadData('Module:GameVersion')
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_args = league.args
+
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'gamesettings' then
+		return {
+			Cell{name = 'Game version', content = {
+					CustomLeague._getGameVersion()
+				}},
+			}
+	elseif id == 'prizepool' then
+		return {
+			Cell{
+				name = 'Prize pool',
+				content = {CustomLeague:_createPrizepool()}
+			},
+		}
+	elseif id == 'liquipediatier' then
+		return {
+			Cell{
+				name = 'Liquipedia tier',
+				content = {CustomLeague:_createTierDisplay()},
+				classes = {_args['moonton-sponsored'] == 'true' and 'valvepremier-highlighted' or ''},
+			},
+		}
+	elseif id == 'customcontent' then
+		if _args.player_number then
+			table.insert(widgets, Title{name = 'Players'})
+			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
+		end
+
+		--teams section
+		if _args.team_number or (not String.isEmpty(_args.team1)) then
+			Variables.varDefine('is_team_tournament', 1)
+			table.insert(widgets, Title{name = 'Teams'})
+		end
+		table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+	end
+	return widgets
+end
+
+function League:addToLpdb(lpdbData, args)
+	lpdbData.game = _game or args.game
+	lpdbData.participantsnumber = args.player_number or args.team_number
+
+	return lpdbData
+end
+
+function League:defineCustomPageVariables()
+	Variables.varDefine('tournament_game', _game or _args.game)
+	Variables.varDefine('tournament_publishertier', _args['garena-sponsored'])
+		--Legacy Vars:
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+end
+
+function CustomLeague._getGameVersion()
+	local game = string.lower(_args.game or '')
+	_game = _GAME[game]
+	return _game
+end
+
+function CustomLeague:_createPrizepool()
+	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
+		return nil
+	end
+	local date
+	if String.isNotEmpty(_args.currency_rate) then
+		date = _args.currency_date
+	end
+
+	return PrizePoolCurrency._get({
+		prizepool = _args.prizepool,
+		prizepoolusd = _args.prizepoolusd,
+		currency = _args.localcurrency,
+		rate = _args.currency_rate,
+		date = date or Variables.varDefault('tournament_enddate', _TODAY),
+	})
+end
+
+function CustomLeague:_createTierDisplay()
+	local tier = _args.liquipediatier or ''
+	local tierType = _args.liquipediatiertype or _args.tiertype or ''
+	if String.isEmpty(tier) then
+		return nil
+	end
+
+	local tierText = Tier['text'][tier]
+	local hasInvalidTier = tierText == nil
+	tierText = tierText or tier
+
+	local hasInvalidTierType = false
+
+	local output = '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
+		.. '[[Category:' .. tierText .. ' Tournaments]]'
+
+	if not String.isEmpty(tierType) then
+		tierType = Tier['types'][string.lower(tierType or '')] or tierType
+		hasInvalidTierType = Tier['types'][string.lower(tierType or '')] == nil
+		tierType = '[[' .. tierType .. ' Tournaments|' .. tierType .. ']]'
+			.. '[[Category:' .. tierType .. ' Tournaments]]'
+		output = tierType .. '&nbsp;(' .. output .. ')'
+	end
+
+	output = output ..
+		(hasInvalidTier and '[[Category:Pages with invalid Tier]]' or '') ..
+		(hasInvalidTierType and '[[Category:Pages with invalid Tiertype]]' or '')
+	return output
+end
+
+function CustomLeague._getPatchVersion()
+	if String.isEmpty(_args.patch) then return nil end
+	local content = PageLink.makeInternalLink(_args.patch, 'Patch ' .. _args.patch)
+	if not String.isEmpty(_args.epatch) then
+		content = content .. '&nbsp;&ndash;&nbsp;'
+		content = content .. PageLink.makeInternalLink(_args.epatch, 'Patch ' .. _args.epatch)
+	end
+
+	return content
+end
+
+return CustomLeague

--- a/components/infobox/wikis/arenaofvalor/infobox_league.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league.lua
@@ -76,14 +76,14 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function League:addToLpdb(lpdbData, args)
+function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.participantsnumber = args.player_number or args.team_number
 
 	return lpdbData
 end
 
-function League:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
 	Variables.varDefine('tournament_publishertier', _args['garena-sponsored'])
 		--Legacy Vars:

--- a/components/infobox/wikis/arenaofvalor/infobox_league.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league.lua
@@ -10,7 +10,6 @@ local League = require('Module:Infobox/League')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 local Tier = require('Module:Tier')
-local PageLink = require('Module:Page')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
@@ -144,8 +143,6 @@ function CustomLeague:_createTierDisplay()
 		(hasInvalidTierType and '[[Category:Pages with invalid Tiertype]]' or '')
 	return output
 end
-
-	return content
 end
 
 return CustomLeague

--- a/components/infobox/wikis/arenaofvalor/infobox_league.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league.lua
@@ -60,7 +60,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{
 				name = 'Liquipedia tier',
 				content = {CustomLeague:_createTierDisplay()},
-				classes = {_args['moonton-sponsored'] == 'true' and 'valvepremier-highlighted' or ''},
+				classes = {_args['garena-sponsored'] == 'true' and 'valvepremier-highlighted' or ''},
 			},
 		}
 	elseif id == 'customcontent' then
@@ -70,11 +70,9 @@ function CustomInjector:parse(id, widgets)
 		end
 
 		--teams section
-		if _args.team_number or (not String.isEmpty(_args.team1)) then
-			Variables.varDefine('is_team_tournament', 1)
+		if _args.team_number then
 			table.insert(widgets, Title{name = 'Teams'})
-		end
-		table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+		    table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
 	end
 	return widgets
 end
@@ -146,14 +144,6 @@ function CustomLeague:_createTierDisplay()
 		(hasInvalidTierType and '[[Category:Pages with invalid Tiertype]]' or '')
 	return output
 end
-
-function CustomLeague._getPatchVersion()
-	if String.isEmpty(_args.patch) then return nil end
-	local content = PageLink.makeInternalLink(_args.patch, 'Patch ' .. _args.patch)
-	if not String.isEmpty(_args.epatch) then
-		content = content .. '&nbsp;&ndash;&nbsp;'
-		content = content .. PageLink.makeInternalLink(_args.epatch, 'Patch ' .. _args.epatch)
-	end
 
 	return content
 end


### PR DESCRIPTION
## Summary
Infobox League for Arena of Valor

Based on #961 (ML's recently merged Infobox League) with a change.

Since AoV never had tracking of patches at all (not even used in other tour pages from what I see) coupled with AoV has multiple game version that needs to be labelled.

I decide to replace section that would show patches with Game Versions instead and that's the only thing different, the rest are same as #961

## How did you test this change?
Since its already going live so I put some of the pages on mainspace to check things

- https://liquipedia.net/arenaofvalor/Arena_of_Valor_Bangladesh_Championship/2021
- https://liquipedia.net/arenaofvalor/Arena_of_Valor_International_Championship/2021

## Side Note
This will later be used as a basis for the Infobox League on the PUBG Mobile Wiki Split
exclude the two wiki-specific ( |perspective= and |mode= ), the rest is likely 1:1 compatible