### PR TITLE
Create abbreviation module

### DIFF
--- a/standard/abbreviation.lua
+++ b/standard/abbreviation.lua
@@ -11,7 +11,7 @@ local Abbreviation = {}
 local Class = require('Module:Class')
 local String = require('Module:StringUtils')
 
-function Abbreviation.make(title, text)
+function Abbreviation.make(text, title)
 	if String.isEmpty(title) or String.isEmpty(text) then
 		return nil
 	end

--- a/standard/abbreviation.lua
+++ b/standard/abbreviation.lua
@@ -1,0 +1,21 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Abbreviation
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Abbreviation = {}
+
+local Class = require('Module:Class')
+local String = require('Module:StringUtils')
+
+function Abbreviation.make(title, text)
+	if String.isEmpty(title) or String.isEmpty(text) then
+		return nil
+	end
+	return '<abbr title="' .. title .. '>' .. text .. '</abbr>'
+end
+
+return Class.export(Abbreviation)


### PR DESCRIPTION
## Summary
Abbreviations are used quite often in Modules.
To avoid recreating the function for it over and over again (or even worse expanding the abbr template) we could add this module and require its function `.make` instead.

## How did you test this change?
new module so just pushed live
tested direct invoke display in my userspace:
![Screenshot 2022-01-25 10 29 58](https://user-images.githubusercontent.com/75081997/150950005-4ce0e93b-3c89-4c9c-b81d-9bac7310eb96.png)

also works when called via a different (sandbox) module
