### PR TITLE
Add Earnings for ML

### DIFF
--- a/components/earnings/wikis/mobilelegends/earnings.lua
+++ b/components/earnings/wikis/mobilelegends/earnings.lua
@@ -1,0 +1,29 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+CustomEarnings.defaultNumberOfPlayersInTeam = 5
+
+-- Legacy entry points
+function CustomEarnings.calc_player(input)
+    local args = input.args
+
+    return CustomEarnings.calculateForPlayer(args)
+end
+
+function CustomEarnings.calc_team(input)
+    local args = input.args
+
+    return CustomEarnings.calculateForTeam(args)
+end
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
## Summary
Add earnings module for Mobile Legends
same file as https://github.com/Liquipedia/Lua-Modules/blob/main/components/earnings/wikis/halo/earnings.lua with number of default player  changed

## How did you test this change?
Already Live 
https://liquipedia.net/mobilelegends/Wise
