### PR TITLE
Catch bs entries to first unnamed argument in match maps calls

### DIFF
--- a/components/match2/wikis/starcraft2/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_maps_legacy.lua
@@ -134,6 +134,10 @@ function MatchMapsLegacy.close()
 	local matches = Template.retrieveReturnValues('LegacyMatchlist')
 
 	for matchIndex, match in ipairs(matches) do
+		-- catch bs entries to first unnamed argument in match maps calls
+		-- this needs to be empty for the _toEncodedJson call
+		match[1] = nil
+
 		matches['M' .. matchIndex] = Match._toEncodedJson(match)
 		matches[matchIndex] = nil
 	end


### PR DESCRIPTION
## Summary
Catch bs entries to first unnamed argument in match maps calls.

## How did you test this change?
live