### PR TITLE
Add Earnings for AOV

### DIFF
--- a/components/earnings/wikis/arenaofvalor/earnings.lua
+++ b/components/earnings/wikis/arenaofvalor/earnings.lua
@@ -1,0 +1,29 @@
+---
+-- @Liquipedia
+-- wiki=arenaofvalor
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+CustomEarnings.defaultNumberOfPlayersInTeam = 5
+
+-- Legacy entry points
+function CustomEarnings.calc_player(input)
+    local args = input.args
+
+    return CustomEarnings.calculateForPlayer(args)
+end
+
+function CustomEarnings.calc_team(input)
+    local args = input.args
+
+    return CustomEarnings.calculateForTeam(args)
+end
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
Since AOV and ML will share pretty much the same set of modules/infobox, while Player infobox is still the old version for AOV  I decide to put earnings up first

same file as ML #1007 

## How did you test this change?
As of right now Infobox Player has not adapted to a new version that is using this module on AOV wiki, but AOV's Infobox will be a port of #999 (InfoPlayer for ML) they should be pretty much compatible.