### PR TITLE
Fix role categories not set on Dota

### DIFF
--- a/components/infobox/wikis/dota2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_player_custom.lua
@@ -259,8 +259,10 @@ function CustomPlayer._createRole(key, role)
 		return nil
 	end
 
-	return '[[:Category:' .. roleData.category .. '|' ..
+	local categoryCoreText = 'Category:' .. roleData.category .. '|' ..
 		Variables.varDefineEcho(key or 'role', roleData.variable) .. ']]'
+
+	return '[[' .. categoryCoreText .. '[[:' .. categoryCoreText
 end
 
 


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

Correctly sets role categories on Dota, instead of just linking them.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
live