### PR TITLE
Complete table rendering and update position calculations

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -15,7 +15,6 @@ local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local Team = require('Module:Team')
 
 local ConditionTree = Condition.Tree
 local ConditionNode = Condition.Node

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -67,11 +67,11 @@ function AutomaticPointsTable:parseInput(args)
 	}
 end
 
---- parses the position_background arguments, these are the background colors of specific
+--- parses the positionbg arguments, these are the background colors of specific
 --- positions, usually used to indicate if a team in a specific position will end up qualifying
 function AutomaticPointsTable:parsePositionBackgroundData(args)
 	local positionBackgrounds = {}
-	for _, background in Table.iter.pairsByPrefix(args, 'position_background') do
+	for _, background in Table.iter.pairsByPrefix(args, 'positionbg') do
 		table.insert(positionBackgrounds, background)
 	end
 	return positionBackgrounds


### PR DESCRIPTION
## Summary

This commit focused on two parts of the module:

1. Render the complete the complete table
2. Add more calculations to calculate team positions
3.1. Added tiebreaker points which are used to put teams ahead of each other when they're tied in total points - they aren't rendered in the table themselves.
3.2. If two teams have the same total points and different tiebreaker points they will have different positions, but if they have the same amount of total points and the same amount of tiebreaker points (could be 0) they will be tied for the same position and will be arranged alphabetically.

## How did you test this change?

Deployed in Sandbox and works as intended
![image](https://user-images.githubusercontent.com/28851891/151321371-00ff7bf2-5132-4c63-a898-57e2e40ae54d.png)
