### PR TITLE
Correct Wild Rift's icons and remove irrelevant parameters

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_unit_champion.lua
+++ b/components/infobox/wikis/wildrift/infobox_unit_champion.lua
@@ -30,8 +30,8 @@ local _args
 local _pagename = mw.title.getCurrentTitle().text
 local _frame
 
-local _BLUE_ESSENCE_ICON = '[[File:Blue Essence Icon.png|x16px|Blue Essence|link=Blue Essence]]'
-local _RP_POINTS_ICON = '[[File:RP_Points.png|Riot Points|x16px|link=Riot Points]]'
+local _BLUE_MOTES_ICON = '[[File:Blue Motes icon.png|20px|Blue Motes|link=Blue Motes]]'
+local _WILD_CORES_ICON = '[[File:Wild Cores icon.png|20px|Wild Cores|link=Wild Cores]]'
 
 function CustomChampion.run(frame)
 	local unit = Unit(frame)
@@ -52,9 +52,6 @@ function CustomInjector:addCustomCells()
 		Cell{name = 'Secondary Bar', content = {_args.secondarybar1}},
 		Cell{name = 'Secondary Attributes', content = {_args.secondaryattributes1}},
 		Cell{name = 'Release Date', content = {_args.releasedate}},
-		Cell{name = 'Species', content = {_args.species}},
-		Cell{name = 'Year of birth', content = {_args.birth}},
-		Cell{name = 'Faction(s)', content = {_args.factions}},
 	}
 
 	if not (
@@ -137,13 +134,13 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'cost' then
 		local cost = ''
 		if not String.isEmpty(_args.costbe) then
-			cost = cost .. _args.costbe .. ' ' .. _BLUE_ESSENCE_ICON
+			cost = cost .. _args.costbe .. ' ' .. _BLUE_MOTES_ICON
 		end
 		if not String.isEmpty(_args.costrp) then
 			if cost ~= '' then
 				cost = cost .. '&emsp;&ensp;'
 			end
-			cost = cost .. _args.costrp .. ' ' .. _RP_POINTS_ICON
+			cost = cost .. _args.costrp .. ' ' .. _WILD_CORES_ICON
 		end
 		return {
 			Cell{name = 'Price', content = {cost}},


### PR DESCRIPTION
Blue Essence is Blue Motes in Wild Rift and has a different icon. The same goes for RP and Wild Cores.

Parameters `species`, `birth`, and `factions` are also irrelevant to this certain infobox.

## Summary

Changing the icons to match what is in-game seems like a good change to me. I also considered changing the parameter name from `cost_be` and `cost_rp` to `cost_bm` and `cost_wc`, but that's a change for another day.

## How did you test this change?

![image](https://user-images.githubusercontent.com/96150089/151358416-28ce8743-ce35-42ae-9022-1b6cad54a0e4.png)

Does this break LPDB on any of the wikis? Nope.
Are all needed page variables still set? Yes.
Does this break SMW on any of the wikis? No.
