### PR TITLE
Add subheader support to Infobox Unit

### DIFF
--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -40,6 +40,7 @@ function Unit:createInfobox()
 					imageDefault = args.default,
 					imageDark = args.imagedark or args.imagedarkmode,
 					imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+					subHeader = self:subHeaderDisplay(args)
 				},
 			}
 		},
@@ -126,6 +127,11 @@ function Unit:nameDisplay(args)
 end
 
 function Unit:setLpdbData(args)
+end
+
+--- Allows for overriding this functionality
+function Unit:subHeaderDisplay(args)
+	return args.title
 end
 
 return Unit


### PR DESCRIPTION
This change is similar to #910 but for Unit, also for Hero/Champion infoboxes in MOBA games where they would have a title name in tandem with the actual character name

## How did you test this change?
![image](https://user-images.githubusercontent.com/88981446/151530471-28ddf7f6-2e0a-4c9c-ad47-d3a6eba8dafd.png)

Tested from https://liquipedia.net/mobilelegends/User:Hesketh2/unit 
the setup in that page uses a /dev module for both Base Unit and for adjusting Infobox Hero for ML ( #714 ) which is the original cause for this commons PR
