### PR TITLE
Refactor display into a separate module

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -10,8 +10,9 @@ local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Condition = require('Module:Condition')
-local DivTable = require('Module:DivTable')
+local TableDisplay = require('Module:AutomaticPointsTable/Display')
 local Json = require('Module:Json')
+local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
@@ -49,30 +50,31 @@ function AutomaticPointsTable.run(frame)
 	-- mw.logObject(pointsTable.parsedInput.tournaments)
 	-- mw.logObject(pointsTable.parsedInput.teams)
 	-- mw.logObject(tournamentsWithPlacements)
-	mw.logObject(sortedDataWithPositions)
-
-	return pointsTable:generatePointsTable(sortedDataWithPositions, tournamentsWithResults)
+	-- mw.logObject(sortedDataWithPositions)
+	local positionBackgrounds = pointsTable.parsedInput.positionBackgrounds
+	local divTable = TableDisplay(sortedDataWithPositions, tournamentsWithResults, positionBackgrounds)
+	return divTable:create()
 end
 
 function AutomaticPointsTable:parseInput(args)
-	local pbg = self:parsePositionBackgroundData(args)
+	local positionBackgrounds = self:parsePositionBackgroundData(args)
 	local tournaments = self:parseTournaments(args)
 	local teams = self:parseTeams(args, #tournaments)
 	return {
-		pbg = pbg,
+		positionBackgrounds = positionBackgrounds,
 		tournaments = tournaments,
 		teams = teams
 	}
 end
 
---- parses the pbg arguments, these are the background colors of specific positions
---- Usually used to indicate where a team in a specific position will end up qualifying to
+--- parses the positionbg arguments, these are the background colors of specific
+--- positions, usually used to indicate if a team in a specific position will end up qualifying
 function AutomaticPointsTable:parsePositionBackgroundData(args)
-	local pbg = {}
-	for _, background in Table.iter.pairsByPrefix(args, 'pbg') do
-		table.insert(pbg, background)
+	local positionBackgrounds = {}
+	for _, background in Table.iter.pairsByPrefix(args, 'positionbg') do
+		table.insert(positionBackgrounds, background)
 	end
-	return pbg
+	return positionBackgrounds
 end
 
 function AutomaticPointsTable:parseTournaments(args)
@@ -90,6 +92,7 @@ function AutomaticPointsTable:parseTeams(args, tournamentCount)
 		parsedTeam.aliases = self:parseAliases(parsedTeam, tournamentCount)
 		parsedTeam.deductions = self:parseDeductions(parsedTeam, tournamentCount)
 		parsedTeam.manualPoints = self:parseManualPoints(parsedTeam, tournamentCount)
+		parsedTeam.tiebreakerPoints = tonumber(parsedTeam.tiebreaker_points) or 0
 		parsedTeam.results = {}
 		table.insert(teams, parsedTeam)
 	end
@@ -230,6 +233,7 @@ function AutomaticPointsTable:getPointsData(teams, tournaments)
 
 			teamPointsData.team = team
 			teamPointsData.totalPoints = totalPoints
+			teamPointsData.tiebreakerPoints = team.tiebreakerPoints
 			return teamPointsData
 		end
 	)
@@ -268,13 +272,15 @@ end
 function AutomaticPointsTable:sortData(pointsData, teams)
 	table.sort(pointsData,
 		function(a, b)
-			if a.totalPoints == b.totalPoints then
-				local aName = a.team.aliases[#a.team.aliases]
-				local bName = b.team.aliases[#b.team.aliases]
-				return aName < bName
-			else
+			if a.totalPoints ~= b.totalPoints then
 				return a.totalPoints > b.totalPoints
 			end
+			if a.tiebreakerPoints ~= b.tiebreakerPoints then
+				return a.tiebreakerPoints > b.tiebreakerPoints
+			end
+			local aName = a.team.aliases[#a.team.aliases]
+			local bName = b.team.aliases[#b.team.aliases]
+			return aName < bName
 		end
 	)
 
@@ -282,99 +288,25 @@ function AutomaticPointsTable:sortData(pointsData, teams)
 end
 
 function AutomaticPointsTable:addPositionData(pointsData)
-	local maxPoints = pointsData[1].totalPoints
-
 	local teamPosition = 0
-	local previousTeamPoints = maxPoints + 1
+	local previousTotalPoints = pointsData[1].totalPoints + 1
+	local previousTiebreakerPoints = pointsData[1].tiebreakerPoints + 1
 
 	return Table.map(pointsData,
 		function(index, dataPoint)
-			if dataPoint.totalPoints < previousTeamPoints then
+			local lessTotalPoints = dataPoint.totalPoints < previousTotalPoints
+			local equalTotalPoints = dataPoint.totalPoints == previousTotalPoints
+			local lessTiebreakerPoints = dataPoint.tiebreakerPoints < previousTiebreakerPoints
+			if lessTotalPoints or (equalTotalPoints and lessTiebreakerPoints) then
 				teamPosition = index
 			end
 			dataPoint.position = teamPosition
-			previousTeamPoints = dataPoint.totalPoints
+			previousTotalPoints = dataPoint.totalPoints
+			previousTiebreakerPoints = dataPoint.tiebreakerPoints
 			return index, dataPoint
 
 		end
 	)
-end
-
-function AutomaticPointsTable:generatePointsTable(pointsData, tournaments)
-local columnCount = Array.reduce(tournaments, function(count, t)
-			return count + (t.shouldDeductionsBeVisible and 2 or 1)
-		end, 0)
-	local headerRow = self:generateHeaderRow(tournaments)
-
-	local divTable = DivTable.create() :row(headerRow)
-	divTable.root :addClass('border-color-grey') :addClass('border-bottom')
-
-	-- for top and left borders
-	local divWrapper = mw.html.create('div') :addClass('fixed-size-table-container')
-		:addClass('border-color-grey')
-		:css('width', tostring(450 + (columnCount * 50)) .. 'px')
-		:node(divTable:create())
-
-	-- for mobile / responsive scrolling
-	local responsiveWrapper = mw.html.create('div') :addClass('table-responsive')
-		:addClass('automatic-points-table')
-		:node(divWrapper)
-
-	return responsiveWrapper
-end
-
-function AutomaticPointsTable:generateHeaderRow(tournaments)
-	local headerRow = DivTable.HeaderRow()
-	headerRow.root:addClass('diagonal')
-
-	-- fixed headers
-	local headers = {{
-		text = 'Ranking',
-		additionalClass = 'ranking'
-	}, {
-		text = 'Team',
-		additionalClass = 'team'
-	}, {
-		text = 'Total Points'
-	}}
-	Table.iter.forEach(headers,function(h) headerRow:cell(self:createHeaderCell(h)) end)
-	-- variable headers (according to tournaments in given in module arguments)
-	Table.iter.forEach(tournaments,
-		function(tournament)
-			headerRow:cell(self:createHeaderCell({
-				text = tournament.display and tournament.display or tournament.name
-			}))
-
-			if tournament.shouldDeductionsBeVisible == true then
-				local deductionsHeader = tournament['deductionsheader']
-				headerRow:cell(self:createHeaderCell({
-					text = deductionsHeader and deductionsHeader or 'Deductions'
-				}))
-			end
-		end
-	)
-
-	return headerRow
-end
-
-function AutomaticPointsTable:createHeaderCell(header)
-	local additionalClass = header.additionalClass
-
-	local innerDiv = self:wrapInDiv(header.text)
-		:addClass('border-color-grey')
-		:addClass('content')
-
-	local outerDiv = mw.html.create('div')
-		:addClass('diagonal-header-div-cell')
-	if additionalClass ~= nil then
-		outerDiv:addClass(additionalClass)
-	end
-	outerDiv:node(innerDiv)
-	return outerDiv
-end
-
-function AutomaticPointsTable:wrapInDiv(text)
-	return mw.html.create('div'):wikitext(tostring(text))
 end
 
 return AutomaticPointsTable

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -7,12 +7,10 @@
 --
 
 local Arguments = require('Module:Arguments')
-local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Condition = require('Module:Condition')
 local TableDisplay = require('Module:AutomaticPointsTable/Display')
 local Json = require('Module:Json')
-local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -9,7 +9,8 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Condition = require('Module:Condition')
-local TableDisplay = require('Module:AutomaticPointsTable/Display')
+local PointsDivTable = require('Module:AutomaticPointsTable/Display')
+
 local Json = require('Module:Json')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -50,7 +51,7 @@ function AutomaticPointsTable.run(frame)
 	-- mw.logObject(tournamentsWithPlacements)
 	-- mw.logObject(sortedDataWithPositions)
 	local positionBackgrounds = pointsTable.parsedInput.positionBackgrounds
-	local divTable = TableDisplay(sortedDataWithPositions, tournamentsWithResults, positionBackgrounds)
+	local divTable = PointsDivTable(sortedDataWithPositions, tournamentsWithResults, positionBackgrounds)
 	return divTable:create()
 end
 

--- a/components/automatic-points-table/commons/display.lua
+++ b/components/automatic-points-table/commons/display.lua
@@ -1,0 +1,240 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:AutomaticPointsTable/Display
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DivTable = require('Module:DivTable')
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local _POINTS_TYPE = {
+	MANUAL = 'MANUAL',
+	PRIZE = 'PRIZE',
+	SECURED = 'SECURED'
+}
+
+local CustomDivTable = Class.new(DivTable.DivTable,
+	function(self, pointsData, tournaments, positionBackgrounds)
+		self.root = mw.html.create('div') :addClass('divTable')
+			:addClass('border-color-grey') :addClass('border-bottom')
+
+		local columnCount = Array.reduce(tournaments, function(count, t)
+			return count + (t.shouldDeductionsBeVisible and 2 or 1)
+		end, 0)
+
+		local innerWrapper = mw.html.create('div') :addClass('fixed-size-table-container')
+			:addClass('border-color-grey')
+			:css('width', tostring(450 + (columnCount * 50)) .. 'px')
+			:node(self.root)
+
+		self.wrapper = mw.html.create('div') :addClass('table-responsive')
+			:addClass('automatic-points-table')
+			:node(innerWrapper)
+		
+		self.rows = {}
+		self.pointsData = pointsData
+		self.tournaments = tournaments
+		self.positionBackgrounds = positionBackgrounds
+	end
+)
+
+local CustomRow = Class.new(DivTable.Row,
+	function(self, pointsData, tournaments, positionBackground)
+		self.root = mw.html.create('div'):addClass('divRow')
+		self.cells = {}
+
+		local team = pointsData.team
+		-- row background
+		if team.bg ~= nil then
+			self.root:addClass('bg-' .. team.bg)
+		end
+		
+		self.pointsData = pointsData
+		self.tournaments = tournaments
+		self.team = team
+		self.positionBackground = positionBackground
+	end
+)
+
+local CustomHeaderRow = Class.new(DivTable.HeaderRow,
+	function(self, tournaments)
+		self.tournaments = tournaments
+		self.root = mw.html.create('div') :addClass('divHeaderRow') :addClass('diagonal')
+		self.cells = {}
+	end
+)
+
+function CustomDivTable:create()
+	local headerRow = CustomHeaderRow(self.tournaments)
+	self:row(headerRow)
+
+	Table.iter.forEachIndexed(self.pointsData, function(index, teamPointsData)
+		local positionBackground = self.positionBackgrounds[index]
+		self:row(CustomRow(teamPointsData, self.tournaments, positionBackground))
+	end)
+
+	for _, row in pairs(self.rows) do
+		self.root:node(row:create())
+	end
+
+	return self.wrapper
+end
+
+function CustomRow:create()
+	-- fixed cells
+	self:positionCell(self.pointsData.position, self.positionBackground)
+	self:nameCell(self.team)
+	self:totalCell(self.pointsData.totalPoints)
+	-- variable cells
+	Table.iter.forEachIndexed(self.pointsData, function(index, points)
+		local tournament = self.tournaments[index]
+		self:pointsCell(points, tournament)
+		if tournament.shouldDeductionsBeVisible then
+			self:deductionCell(points.deduction)
+		end
+	end)
+
+	for _, cell in pairs(self.cells) do
+		self.root:node(cell)
+	end
+	return self.root
+end
+
+function CustomRow:baseCell(text, bg, bold)
+	local div = wrapInDiv(text) :addClass('divCell') :addClass('va-middle')
+		:addClass('centered-cell')	:addClass('border-color-grey') :addClass('border-top-right')
+
+	if bg ~= nil then
+		div:addClass('bg-' .. bg)
+	end
+	if bold == true then
+		div:css('font-weight', 'bold')
+	end
+	return div
+end
+
+function CustomRow:totalCell(points)
+	local totalCell = self:baseCell(points, nil, true)
+	table.insert(self.cells, totalCell)
+	return self
+end
+
+function CustomRow:positionCell(position, bg)
+	local positionCell = self:baseCell(position .. '.', bg, true)
+	table.insert(self.cells, positionCell)
+	return self
+end
+
+function CustomRow:nameCell(team)
+	local lastAlias = team.aliases[#team.aliases]
+	local teamDisplay = team.display and team.display or mw.ext.TeamTemplate.team(lastAlias)
+	local nameCell = self:baseCell(teamDisplay, bg):addClass('name-cell')
+	table.insert(self.cells, nameCell)
+	return self
+end
+
+function CustomRow:pointsCell(points, tournament)
+	local finished = Logic.readBool(tournament.finished)
+	local pointString = points.amount ~= nil and points.amount or (finished and '-' or '')
+	local pointsCell = self:baseCell(pointString)
+	if points.type == _POINTS_TYPE.SECURED then
+		pointsCell:css('font-weight', 'lighter'):css('font-style', 'italic')
+	end
+	table.insert(self.cells, pointsCell)
+	return self
+end
+
+function CustomRow:deductionCell(deduction)
+	if Table.isEmpty(deduction) then
+		table.insert(self.cells, self:baseCell(''))
+		return self
+	end
+	local abbr = mw.html.create('abbr'):addClass('bg-down'):addClass('deduction-box')
+		:wikitext(deduction.amount)
+	if String.isNotEmpty(deduction.note) then
+		abbr:attr('title', deduction.note)
+	end
+	local deductionCell = self:baseCell(abbr)
+	table.insert(self.cells, deductionCell)
+	return self
+end
+
+function wrapInDiv(text)
+	return mw.html.create('div'):wikitext(tostring(text))
+end
+
+function CustomHeaderRow:cell(header)
+	local additionalClass = header.additionalClass
+
+	local innerDiv = wrapInDiv(header.text) :addClass('border-color-grey')
+		:addClass('content')
+
+	local outerDiv = mw.html.create('div') :addClass('divCell')
+		:addClass('diagonal-header-div-cell')
+	if additionalClass ~= nil then
+		outerDiv:addClass(additionalClass)
+	end
+	outerDiv:node(innerDiv)
+	table.insert(self.cells, outerDiv)
+	return self
+end
+
+function CustomHeaderRow:create()
+	-- fixed headers
+	local headers = {{
+		text = 'Ranking',
+		additionalClass = 'ranking'
+	}, {
+		text = 'Team',
+		additionalClass = 'team'
+	}, {
+		text = 'Total Points'
+	}}
+	Table.iter.forEach(headers, function(h) self:headerCell(h) end)
+	-- variable headers (according to tournaments in given in module arguments)
+	Table.iter.forEach(self.tournaments,
+		function(tournament)
+			self:headerCell({
+				text = tournament.display and tournament.display or tournament.name
+			})
+
+			if tournament.shouldDeductionsBeVisible == true then
+				local deductionsHeader = tournament['deductionsheader']
+				self:headerCell({
+					text = deductionsHeader and deductionsHeader or 'Deductions'
+				})
+			end
+		end
+	)
+
+	for _, cell in pairs(self.cells) do
+		self.root:node(cell)
+	end
+	return self.root
+end
+
+function CustomHeaderRow:headerCell(header)
+	local innerDiv = wrapInDiv(header.text)
+		:addClass('border-color-grey')
+		:addClass('content')
+
+	local outerDiv = mw.html.create('div') :addClass('divCell')
+		:addClass('diagonal-header-div-cell')
+
+	local additionalClass = header.additionalClass
+	if additionalClass ~= nil then
+		outerDiv:addClass(additionalClass)
+	end
+	outerDiv:node(innerDiv)
+
+	table.insert(self.cells, outerDiv)
+	return self
+end
+
+return CustomDivTable

--- a/components/automatic-points-table/commons/display.lua
+++ b/components/automatic-points-table/commons/display.lua
@@ -49,7 +49,6 @@ local TableRow = Class.new(
 		self.cells = {}
 
 		local team = pointsData.team
-		-- row background
 		if team.bg ~= nil then
 			self.root:addClass('bg-' .. team.bg)
 		end

--- a/components/automatic-points-table/commons/display.lua
+++ b/components/automatic-points-table/commons/display.lua
@@ -36,7 +36,7 @@ local CustomDivTable = Class.new(DivTable.DivTable,
 		self.wrapper = mw.html.create('div') :addClass('table-responsive')
 			:addClass('automatic-points-table')
 			:node(innerWrapper)
-		
+
 		self.rows = {}
 		self.pointsData = pointsData
 		self.tournaments = tournaments
@@ -54,7 +54,7 @@ local CustomRow = Class.new(DivTable.Row,
 		if team.bg ~= nil then
 			self.root:addClass('bg-' .. team.bg)
 		end
-		
+
 		self.pointsData = pointsData
 		self.tournaments = tournaments
 		self.team = team
@@ -106,6 +106,10 @@ function CustomRow:create()
 	return self.root
 end
 
+local function wrapInDiv(text)
+	return mw.html.create('div'):wikitext(tostring(text))
+end
+
 function CustomRow:baseCell(text, bg, bold)
 	local div = wrapInDiv(text) :addClass('divCell') :addClass('va-middle')
 		:addClass('centered-cell')	:addClass('border-color-grey') :addClass('border-top-right')
@@ -134,7 +138,7 @@ end
 function CustomRow:nameCell(team)
 	local lastAlias = team.aliases[#team.aliases]
 	local teamDisplay = team.display and team.display or mw.ext.TeamTemplate.team(lastAlias)
-	local nameCell = self:baseCell(teamDisplay, bg):addClass('name-cell')
+	local nameCell = self:baseCell(teamDisplay, team.bg):addClass('name-cell')
 	table.insert(self.cells, nameCell)
 	return self
 end
@@ -163,10 +167,6 @@ function CustomRow:deductionCell(deduction)
 	local deductionCell = self:baseCell(abbr)
 	table.insert(self.cells, deductionCell)
 	return self
-end
-
-function wrapInDiv(text)
-	return mw.html.create('div'):wikitext(tostring(text))
 end
 
 function CustomHeaderRow:cell(header)

--- a/components/automatic-points-table/commons/display.lua
+++ b/components/automatic-points-table/commons/display.lua
@@ -49,7 +49,7 @@ local TableRow = Class.new(
 		self.cells = {}
 
 		local team = pointsData.team
-		if team.bg nil then
+		if team.bg then
 			self.root:addClass('bg-' .. team.bg)
 		end
 

--- a/components/automatic-points-table/commons/display.lua
+++ b/components/automatic-points-table/commons/display.lua
@@ -49,7 +49,7 @@ local TableRow = Class.new(
 		self.cells = {}
 
 		local team = pointsData.team
-		if team.bg ~= nil then
+		if team.bg nil then
 			self.root:addClass('bg-' .. team.bg)
 		end
 
@@ -117,10 +117,10 @@ function TableRow:baseCell(text, bg, bold)
 	local div = wrapInDiv(text) :addClass('divCell') :addClass('va-middle')
 		:addClass('centered-cell')	:addClass('border-color-grey') :addClass('border-top-right')
 
-	if bg ~= nil then
+	if bg then
 		div:addClass('bg-' .. bg)
 	end
-	if bold == true then
+	if bold then
 		div:css('font-weight', 'bold')
 	end
 	return div
@@ -180,7 +180,7 @@ function TableHeaderRow:cell(header)
 
 	local outerDiv = mw.html.create('div') :addClass('divCell')
 		:addClass('diagonal-header-div-cell')
-	if additionalClass ~= nil then
+	if additionalClass then
 		outerDiv:addClass(additionalClass)
 	end
 	outerDiv:node(innerDiv)
@@ -207,7 +207,7 @@ function TableHeaderRow:create()
 				text = tournament.display and tournament.display or tournament.name
 			})
 
-			if tournament.shouldDeductionsBeVisible == true then
+			if tournament.shouldDeductionsBeVisible then
 				local deductionsHeader = tournament['deductionsheader']
 				self:headerCell({
 					text = deductionsHeader and deductionsHeader or 'Deductions'
@@ -231,7 +231,8 @@ function TableHeaderRow:headerCell(header)
 		:addClass('diagonal-header-div-cell')
 
 	local additionalClass = header.additionalClass
-	if additionalClass ~= nil then
+	if additionalClass then
+
 		outerDiv:addClass(additionalClass)
 	end
 	outerDiv:node(innerDiv)


### PR DESCRIPTION
## Summary

This is an attempt to separate the Display Code from the Logic of querying and calculating the points
This PR is a different approach to https://github.com/Liquipedia/Lua-Modules/pull/1017 

## How did you test this change?

Deployed in [Sandbox ](https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/8) and works just like https://github.com/Liquipedia/Lua-Modules/pull/1017
