### PR TITLE
Fix Stream Storage in match2

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -13,6 +13,7 @@ local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Opponent = require('Module:Opponent')
+local Variables = require('Module:Variables')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -328,6 +329,30 @@ function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 	record.type = opponent.type
 
 	return record
+end
+
+--[[
+Processes stream inputs
+- automatically looks up the according variable
+- resolves the stream redirects so they can be found properly by StreamPage templates
+]]
+function MatchGroupInput.processStream(match, platformName, variableName)
+	if String.isEmpty(platformName) then
+		return nil
+	end
+
+	if String.isEmpty(variableName) then
+		variableName = platformName
+	end
+	
+	local streamValue = Logic.emptyOr(match[platformName], Variables.varDefault(variableName))
+	if String.isEmpty(streamValue) then
+		return nil
+	end
+
+	local streamLink = mw.ext.StreamPage.resolve_stream(platformName, streamValue)
+
+	return string.gsub(streamLink, 'Special:Stream/' .. platformName, '')
 end
 
 return MatchGroupInput

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -345,7 +345,9 @@ function MatchGroupInput.processStream(match, platformName, variableName)
 		variableName = platformName
 	end
 
-	local streamValue = Logic.emptyOr(match[platformName], Variables.varDefault(variableName))
+	local streams = match.streams or {}
+
+	local streamValue = Logic.emptyOr(streams[platformName] or match[platformName], Variables.varDefault(variableName))
 	if String.isEmpty(streamValue) then
 		return nil
 	end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -344,7 +344,7 @@ function MatchGroupInput.processStream(match, platformName, variableName)
 	if String.isEmpty(variableName) then
 		variableName = platformName
 	end
-	
+
 	local streamValue = Logic.emptyOr(match[platformName], Variables.varDefault(variableName))
 	if String.isEmpty(streamValue) then
 		return nil

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -134,16 +134,16 @@ end
 function StarcraftMatchGroupInput.getVodStuff(match)
 	match.stream = match.stream or {}
 	match.stream = {
-		stream = Logic.emptyOr(match.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.youtube, Variables.varDefault('youtube')),
-		trovo = Logic.emptyOr(match.trovo, Variables.varDefault('trovo'))
+		stream = MatchGroupInput.processStream(match, 'stream'),
+		twitch = MatchGroupInput.processStream(match, 'twitch'),
+		twitch2 = MatchGroupInput.processStream(match, 'twitch2'),
+		afreeca = MatchGroupInput.processStream(match, 'afreeca'),
+		afreecatv = MatchGroupInput.processStream(match, 'afreecatv'),
+		dailymotion = MatchGroupInput.processStream(match, 'dailymotion'),
+		douyu = MatchGroupInput.processStream(match, 'douyu'),
+		smashcast = MatchGroupInput.processStream(match, 'smashcast'),
+		youtube = MatchGroupInput.processStream(match, 'youtube'),
+		trovo = MatchGroupInput.processStream(match, 'trovo'),
 	}
 	match.vod = Logic.emptyOr(match.vod)
 


### PR DESCRIPTION
## Summary
Fix Stream Storage in match2 as mentioned in #1029 
* add a function to `match_group_input.lua` that can be used by the /Custom modules
* adjust the sc/sc2 /Custom module (as it is how i tested this PR)
(will open a PR for the other /Custom modules once this PR is approved)

## How did you test this change?
dev modules, works as intended