### PR TITLE
Adjust Stream handling in match2 input processing

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -13,6 +13,7 @@ local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
+local Streams = require('Module:Links/Stream')
 
 local config = Lua.loadDataIfExists('Module:Match/Config') or {}
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
@@ -132,19 +133,7 @@ function StarcraftMatchGroupInput.getTournamentVars(match)
 end
 
 function StarcraftMatchGroupInput.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.youtube, Variables.varDefault('youtube')),
-		trovo = Logic.emptyOr(match.trovo, Variables.varDefault('trovo'))
-	}
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod)
 
 	return match

--- a/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
@@ -14,6 +14,7 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 local ChampionNames = mw.loadData('Module:HeroNames')
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -323,20 +324,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		nimo = Logic.emptyOr(match.stream.nimo or match.nimo, Variables.varDefault('nimo')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube')),
-		facebook = Logic.emptyOr(match.stream.facebook or match.facebook, Variables.varDefault('facebook')),
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.links = {}

--- a/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
@@ -324,7 +324,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.links = {}

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -143,7 +143,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	-- apply vodgames

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -15,6 +15,7 @@ local Table = require('Module:Table')
 local Template = require('Module:Template')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -142,20 +143,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube')),
-		trovo = Logic.emptyOr(match.stream.trovo or match.trovo, Variables.varDefault('trovo')),
-		facebook = Logic.emptyOr(match.stream.facebook or match.facebook, Variables.varDefault('facebook')),
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	-- apply vodgames

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -293,7 +293,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -14,6 +14,7 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -292,19 +293,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube')),
-		facebook = Logic.emptyOr(match.stream.facebook or match.facebook, Variables.varDefault('facebook')),
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))

--- a/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
@@ -14,6 +14,7 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 local ChampionNames = mw.loadData('Module:HeroNames')
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -323,20 +324,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		nimo = Logic.emptyOr(match.stream.nimo or match.nimo, Variables.varDefault('nimo')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube')),
-		facebook = Logic.emptyOr(match.stream.facebook or match.facebook, Variables.varDefault('facebook')),
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.links = {}

--- a/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
@@ -324,7 +324,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.links = {}

--- a/components/match2/wikis/rainbow_six/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbow_six/match_group_input_custom.lua
@@ -309,7 +309,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))

--- a/components/match2/wikis/rainbow_six/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbow_six/match_group_input_custom.lua
@@ -13,6 +13,7 @@ local Opponent = require('Module:Opponent')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -308,19 +309,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube')),
-		facebook = Logic.emptyOr(match.stream.facebook or match.facebook, Variables.varDefault('facebook')),
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -168,7 +168,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	-- apply vodgames

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -19,6 +19,7 @@ local Template = require('Module:Template')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
 local getIconName = require('Module:IconName').luaGet
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -167,18 +168,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube'))
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	-- apply vodgames

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -13,6 +13,7 @@ local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -293,19 +294,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube')),
-		facebook = Logic.emptyOr(match.stream.facebook or match.facebook, Variables.varDefault('facebook')),
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -294,7 +294,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -15,6 +15,7 @@ local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
 local getIconName = require('Module:IconName').luaGet
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -117,18 +118,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube'))
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	-- apply vodgames

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -118,7 +118,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	-- apply vodgames

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -324,7 +324,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	Streams.processStreams(match)
+	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.links = {}

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -14,6 +14,7 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 local ChampionNames = mw.loadData('Module:ChampionNames')
+local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
@@ -323,22 +324,7 @@ function matchFunctions.getTournamentVars(match)
 end
 
 function matchFunctions.getVodStuff(match)
-	match.stream = match.stream or {}
-	match.stream = {
-		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault('stream')),
-		twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault('twitch')),
-		twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault('twitch2')),
-		nimo = Logic.emptyOr(match.stream.nimo or match.nimo, Variables.varDefault('nimo')),
-		trovo = Logic.emptyOr(match.stream.trovo or match.trovo, Variables.varDefault('trovo')),
-		huya = Logic.emptyOr(match.stream.huya or match.huya, Variables.varDefault('huya')),
-		afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault('afreeca')),
-		afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault('afreecatv')),
-		dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault('dailymotion')),
-		douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault('douyu')),
-		smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault('smashcast')),
-		youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault('youtube')),
-		facebook = Logic.emptyOr(match.stream.facebook or match.facebook, Variables.varDefault('facebook')),
-	}
+	Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.links = {}

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -65,22 +65,29 @@ function StreamLinks.resolve(platformName, streamValue)
 end
 
 --[[
-Extracts the streaming platform args from an argument table or a nested streams table inside the arguments table.
+Extracts the streaming platform args from an argument table or a nested stream table inside the arguments table.
 Uses variable fallbacks and resolves stream redirects.
 ]]
 function StreamLinks.processStreams(args)
-	local streams = args.streams or {}
-
-	-- handle args.stream differently due to it having no platform
-	streams.stream = Logic.emptyOr(streams.stream or args.stream, Variables.varDefault('stream'))
+	local streams = {}
+	if type(args.stream) == 'table' then
+		streams = args.stream
+	end
 
 	for _, platformName in pairs(StreamLinks.countdownPlatformNames) do
-		local streamValue = Logic.emptyOr(streams[platformName] or args[platformName], Variables.varDefault(platformName))
-
-		-- stream has no platform
+		-- stream has no platform and might be a table or a string
 		if platformName == 'stream' then
+			local streamValue = streams.stream
+			if String.isEmpty(streamValue) and type(args.stream) == 'string' then
+				streamValue = args.stream
+			end
+			if String.isEmpty(streamValue) then
+				streamValue = Variables.varDefault(platformName)
+			end
 			streams.stream = streamValue
 		else
+			local streamValue = Logic.emptyOr(streams[platformName] or args[platformName], Variables.varDefault(platformName))
+
 			-- twitch2 is not a platform but uses the twitch platform instead
 			local lookUpPlatform = platformName
 			if platformName == 'twitch2' then

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -43,6 +43,9 @@ StreamLinks.countdownPlatformNames = {
 	'youtube',
 }
 
+--[[
+Lookup table of allowed inputs that use a plattform with a different name
+]]
 StreamLinks.streamPlatformLookupNames = {
 	twitch2 = 'twitch',
 }

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -14,7 +14,6 @@ local StreamLinks = {}
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
-local Table = require('Module:Table')
 
 --[[
 List of streaming platforms supported in Module:Countdown. This is a subset of
@@ -79,7 +78,7 @@ Uses variable fallbacks and resolves stream redirects.
 function StreamLinks.processStreams(forwardedInputArgs)
 	local streams = {}
 	if type(forwardedInputArgs.stream) == 'table' then
-		streams = Table.copy(forwardedInputArgs.stream)
+		streams = forwardedInputArgs.stream
 		forwardedInputArgs.stream = nil
 	end
 

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -79,9 +79,9 @@ Uses variable fallbacks and resolves stream redirects.
 function StreamLinks.processStreams(args)
 	local streams = {}
 	if type(args.stream) == 'table' then
- 		streams = Table.copy(args.stream)
- 		args.stream = nil
- 	end
+		streams = Table.copy(args.stream)
+		args.stream = nil
+	end
 
 	for _, platformName in pairs(StreamLinks.countdownPlatformNames) do
 		local streamValue = Logic.emptyOr(streams[platformName], args[platformName], Variables.varDefault(platformName))

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -84,7 +84,11 @@ function StreamLinks.processStreams(forwardedInputArgs)
 	end
 
 	for _, platformName in pairs(StreamLinks.countdownPlatformNames) do
-		local streamValue = Logic.emptyOr(streams[platformName], forwardedInputArgs[platformName], Variables.varDefault(platformName))
+		local streamValue = Logic.emptyOr(
+			streams[platformName],
+			forwardedInputArgs[platformName],
+			Variables.varDefault(platformName)
+		)
 
 		if String.isNotEmpty(streamValue) then
 			-- stream has no platform

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -43,6 +43,10 @@ StreamLinks.countdownPlatformNames = {
 	'youtube',
 }
 
+StreamLinks.streamPlatformLookupNames = {
+	twitch2 = 'twitch',
+}
+
 --[[
 Extracts the streaming platform args from an argument table for use in
 Module:Countdown.
@@ -91,10 +95,7 @@ function StreamLinks.processStreams(args)
 			local streamValue = Logic.emptyOr(streams[platformName] or args[platformName], Variables.varDefault(platformName))
 
 			-- twitch2 is not a platform but uses the twitch platform instead
-			local lookUpPlatform = platformName
-			if platformName == 'twitch2' then
-				lookUpPlatform = 'twitch'
-			end
+			local lookUpPlatform = StreamLinks.streamPlatformLookupNames[platformName] or platformName
 
 			if String.isNotEmpty(streamValue) then
 				streams[platformName] = StreamLinks.resolve(lookUpPlatform, streamValue)

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -76,15 +76,15 @@ end
 Extracts the streaming platform args from an argument table or a nested stream table inside the arguments table.
 Uses variable fallbacks and resolves stream redirects.
 ]]
-function StreamLinks.processStreams(args)
+function StreamLinks.processStreams(forwardedInputArgs)
 	local streams = {}
-	if type(args.stream) == 'table' then
-		streams = Table.copy(args.stream)
-		args.stream = nil
+	if type(forwardedInputArgs.stream) == 'table' then
+		streams = Table.copy(forwardedInputArgs.stream)
+		forwardedInputArgs.stream = nil
 	end
 
 	for _, platformName in pairs(StreamLinks.countdownPlatformNames) do
-		local streamValue = Logic.emptyOr(streams[platformName], args[platformName], Variables.varDefault(platformName))
+		local streamValue = Logic.emptyOr(streams[platformName], forwardedInputArgs[platformName], Variables.varDefault(platformName))
 
 		if String.isNotEmpty(streamValue) then
 			-- stream has no platform

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -11,6 +11,10 @@ Module containing utility functions for streaming platforms.
 ]]
 local StreamLinks = {}
 
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
 --[[
 List of streaming platforms supported in Module:Countdown. This is a subset of
 the list in Module:Links
@@ -49,6 +53,47 @@ function StreamLinks.readCountdownStreams(args)
 		stream[platformName] = args[platformName]
 	end
 	return stream
+end
+
+--[[
+Resolves the value of a stream given the platform
+]]
+function StreamLinks.resolve(platformName, streamValue)
+	local streamLink = mw.ext.StreamPage.resolve_stream(platformName, streamValue)
+
+	return string.gsub(streamLink, 'Special:Stream/' .. platformName, '')
+end
+
+--[[
+Extracts the streaming platform args from an argument table or a nested streams table inside the arguments table.
+Uses variable fallbacks and resolves stream redirects.
+]]
+function StreamLinks.processStreams(args)
+	local streams = args.streams or {}
+
+	-- handle args.stream differently due to it having no platform
+	streams.stream = Logic.emptyOr(streams.stream or args.stream, Variables.varDefault('stream'))
+
+	for _, platformName in pairs(StreamLinks.countdownPlatformNames) do
+		local streamValue = Logic.emptyOr(streams[platformName] or args[platformName], Variables.varDefault(platformName))
+
+		-- stream has no platform
+		if platformName == 'stream' then
+			streams.stream = streamValue
+		else
+			-- twitch2 is not a platform but uses the twitch platform instead
+			local lookUpPlatform = platformName
+			if platformName == 'twitch2' then
+				lookUpPlatform = 'twitch'
+			end
+
+			if String.isNotEmpty(streamValue) then
+				streams[platformName] = StreamLinks.resolve(lookUpPlatform, streamValue)
+			end
+		end
+	end
+
+	return streams
 end
 
 return StreamLinks

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -84,7 +84,9 @@ function StreamLinks.processStreams(args)
 			if String.isEmpty(streamValue) then
 				streamValue = Variables.varDefault(platformName)
 			end
-			streams.stream = streamValue
+			if String.isNotEmpty(streamValue) then
+				streams.stream = streamValue
+			end
 		else
 			local streamValue = Logic.emptyOr(streams[platformName] or args[platformName], Variables.varDefault(platformName))
 

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -97,7 +97,6 @@ function StreamLinks.processStreams(args)
 		else
 			local streamValue = Logic.emptyOr(streams[platformName] or args[platformName], Variables.varDefault(platformName))
 
-			-- twitch2 is not a platform but uses the twitch platform instead
 			local lookUpPlatform = StreamLinks.streamPlatformLookupNames[platformName] or platformName
 
 			if String.isNotEmpty(streamValue) then


### PR DESCRIPTION
## Summary
Fix Stream Storage in match2 as mentioned in #1029 
* add functions to `Module:Links/Stream` that can be used by the /Custom modules
* adjust the /Custom modules to use that functionality provided via commons

## How did you test this change?
/dev modules, tested for sc2, sc and RL