### PR TITLE
Allow for tournament_game storage in match2 in halo wiki

### DIFF
--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -24,6 +24,7 @@ local MAX_NUM_MAPS = 9
 local DEFAULT_BESTOF = 3
 
 local _EPOCH_TIME = '1970-01-01 00:00:00'
+local _GAME = mw.loadData('Module:GameVersion')
 
 -- containers for process helper functions
 local matchFunctions = {}
@@ -218,6 +219,12 @@ function CustomMatchGroupInput.getDefaultWinner(table)
 	return -1
 end
 
+-- Take raw game input and format it to standard
+function CustomMatchGroupInput.getGameVersion(game)
+	_game = _GAME[game]
+	return _game
+end
+
 --
 -- match related functions
 --
@@ -288,6 +295,9 @@ function matchFunctions.getTournamentVars(match)
 	match.liquipediatier = Logic.emptyOr(match.liquipediatier, Variables.varDefault('tournament_tier'))
 	match.liquipediatiertype = Logic.emptyOr(match.liquipediatiertype, Variables.varDefault('tournament_tier_type'))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
+	local game = Logic.emptyOr(game, Variables.varDefault('tournament_game'))
+	game = CustomMatchGroupInput.getGameVersion(game)
+	match.game = game
 	return match
 end
 
@@ -480,6 +490,9 @@ function mapFunctions.getTournamentVars(map)
 	map.icondark = Logic.emptyOr(map.iconDark, Variables.varDefault("tournament_icon_dark"))
 	map.liquipediatier = Logic.emptyOr(map.liquipediatier, Variables.varDefault('tournament_tier'))
 	map.liquipediatiertype = Logic.emptyOr(map.liquipediatiertype, Variables.varDefault('tournament_tier_type'))
+	local game = Logic.emptyOr(game, Variables.varDefault('tournament_game'))
+	game = CustomMatchGroupInput.getGameVersion(game)
+	map.game = game
 	return map
 end
 

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -294,9 +294,8 @@ function matchFunctions.getTournamentVars(match)
 	match.liquipediatier = Logic.emptyOr(match.liquipediatier, Variables.varDefault('tournament_tier'))
 	match.liquipediatiertype = Logic.emptyOr(match.liquipediatiertype, Variables.varDefault('tournament_tier_type'))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
-	local game = Logic.emptyOr(game, Variables.varDefault('tournament_game'))
-	game = CustomMatchGroupInput.getGameVersion(game)
-	match.game = game
+	local game = Logic.emptyOr(match.game, Variables.varDefault('tournament_game'))
+	match.game = CustomMatchGroupInput.getGameVersion(game)
 	return match
 end
 

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -488,9 +488,8 @@ function mapFunctions.getTournamentVars(map)
 	map.icondark = Logic.emptyOr(map.iconDark, Variables.varDefault("tournament_icon_dark"))
 	map.liquipediatier = Logic.emptyOr(map.liquipediatier, Variables.varDefault('tournament_tier'))
 	map.liquipediatiertype = Logic.emptyOr(map.liquipediatiertype, Variables.varDefault('tournament_tier_type'))
-	local game = Logic.emptyOr(game, Variables.varDefault('tournament_game'))
-	game = CustomMatchGroupInput.getGameVersion(game)
-	map.game = game
+	local game = Logic.emptyOr(map.game, Variables.varDefault('tournament_game'))
+	map.game = CustomMatchGroupInput.getGameVersion(game)
 	return map
 end
 

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -221,8 +221,7 @@ end
 
 -- Take raw game input and format it to standard
 function CustomMatchGroupInput.getGameVersion(gameRaw)
-	local game = _GAME[gameRaw]
-	return game
+	return _GAME[gameRaw]
 end
 
 --

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -220,9 +220,9 @@ function CustomMatchGroupInput.getDefaultWinner(table)
 end
 
 -- Take raw game input and format it to standard
-function CustomMatchGroupInput.getGameVersion(game)
-	_game = _GAME[game]
-	return _game
+function CustomMatchGroupInput.getGameVersion(gameRaw)
+	local game = _GAME[gameRaw]
+	return game
 end
 
 --

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -219,11 +219,6 @@ function CustomMatchGroupInput.getDefaultWinner(table)
 	return -1
 end
 
--- Take raw game input and format it to standard
-function CustomMatchGroupInput.getGameVersion(gameRaw)
-	return _GAME[gameRaw]
-end
-
 --
 -- match related functions
 --
@@ -295,7 +290,7 @@ function matchFunctions.getTournamentVars(match)
 	match.liquipediatiertype = Logic.emptyOr(match.liquipediatiertype, Variables.varDefault('tournament_tier_type'))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
 	local game = Logic.emptyOr(match.game, Variables.varDefault('tournament_game'))
-	match.game = CustomMatchGroupInput.getGameVersion(game)
+	match.game = _GAME[game or '']
 	return match
 end
 
@@ -489,7 +484,7 @@ function mapFunctions.getTournamentVars(map)
 	map.liquipediatier = Logic.emptyOr(map.liquipediatier, Variables.varDefault('tournament_tier'))
 	map.liquipediatiertype = Logic.emptyOr(map.liquipediatiertype, Variables.varDefault('tournament_tier_type'))
 	local game = Logic.emptyOr(map.game, Variables.varDefault('tournament_game'))
-	map.game = CustomMatchGroupInput.getGameVersion(game)
+	map.game = _GAME[game or '']
 	return map
 end
 


### PR DESCRIPTION
## Summary

It was suggested to allow separation by different halo titles when searching headtohead history between teams. To allow for the headtohead module to use "game" as a condition variable, it needed to be stored in match2 lpdb data.

The module additionally references "Module:GameVersion" to take the raw input for the game version, and format it to a uniform standard so as to be easily identifiable as belonging to the same game when specified with a lpdb query. The field can then be changed to a "token" input on the head to head form, eliminating the need for users to format the game correctly when they input it

## How did you test this change?

An existing tournament was copied to a test page here [https://liquipedia.net/halo/Dark_meluca/TournamentTest] for which a /dev version of the module was created with the added functionality. 

![image](https://user-images.githubusercontent.com/97838082/152140304-46691d22-4b6e-4f85-a936-1602fe7b91e1.png)

As can be seen, match2.game now contains the game type, whereas before it was a blank field