### PR TITLE
Disable duplicate check for non storage legacy match lists

### DIFF
--- a/components/match2/wikis/starcraft2/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_maps_legacy.lua
@@ -151,6 +151,7 @@ function MatchMapsLegacy.close()
 	if Logic.readBool(matchlistVars:get('store')) then
 		matches.store = true
 	else
+		matches.noDuplicateCheck = true
 		matches.store = false
 	end
 


### PR DESCRIPTION
## Summary
Disable duplicate check for non storage legacy match lists.
If the matches do not store the matchlist does not need to check if the id already exists or not as it only displays.
This is often the case on older transcluded pages.

## How did you test this change?
pushed live