### PR TITLE
Adding throwable cells PUBG Weapon Infobox

### DIFF
--- a/components/infobox/wikis/pubg/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_weapon_custom.lua
@@ -39,6 +39,14 @@ function CustomInjector:addCustomCells(widgets)
 		name = 'Ammo Type',
 		content = {args.ammotype}
 	})
+	table.insert(widgets, Cell{
+		name = 'Throw Speed',
+		content = {args.throwspeed}
+	})
+	table.insert(widgets, Cell{
+		name = 'Throw Cooldown',
+		content = {args.throwcooldown}
+	})
 	if String.isNotEmpty(args.map1) then
 		local maps = {}
 


### PR DESCRIPTION
Adjusting the infobox to have support for throwable weapons.

## Summary
The current Infobox Weapon does not support the parameters for throw speed and throw cooldown. Under the consideration that throw speed *could* replace reload speed, throw cooldown is needed as a new cell regardless. This will be unused for all infobox uses that are not throwable weapons

## How did you test this change?
Tested live and on user page: https://liquipedia.net/pubg/User:Fenrir.SPAZ/Sandbox

