### PR TITLE
Add location to Infobox/Map

### DIFF
--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -35,6 +35,7 @@ function Map:createInfobox(frame)
 		Cell{name = 'Creator', content = {
 				args.creator or args['created-by'], args.creator2 or args['created-by2']}, options = { makeLink = true }
 		},
+		Cell{name = 'Location', content = {args.location}},
 		Cell{name = 'Release Date', content = {args.releasedate}},
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},


### PR DESCRIPTION
## Summary
Adds location as a default value. There are 28 wikis that are (or will) use Infobox/Map, with 23 of those wikis already having the template (1 wiki has no usage of this template). There are 9 wikis that currently use location as a parameter, which seems like a lot to force that field to be in custom versions. Most of those use just plain wiki text for the location, a few use a flag. 

## How did you test this change?
Code was tested via this module: https://liquipedia.net/commons/Module:Sandbox/Fenrir
and was tested on various wikis via ``{{#invoke:Infobox/Map|run|``
An actual testing page was set up here: https://liquipedia.net/overwatch/User:Fenrir.SPAZ/Sandbox
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
