### PR TITLE
Add Infobox League for VALORANT

### DIFF
--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -17,7 +17,7 @@ local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 local PageLink = require('Module:Page')
 local PrizePoolCurrency = require('Module:Prize pool currency')
-local RIOT_SPONSORED = [[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
+local RIOT_SPONSORED = '[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
 
 local _TODAY = os.date('%Y-%m-%d', os.time())
 

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -52,7 +52,7 @@ function CustomInjector:addCustomCells(widgets)
 	})
 	table.insert(widgets, Cell{
 		name = 'Patch',
-		content = {CustomLeague:_createGameCell(args)}
+		content = {CustomLeague:_createPatchCell(args)}
 	})
 
 	return widgets
@@ -106,7 +106,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 end
 
 
-function CustomLeague:_createGameCell(args)
+function CustomLeague:_createPatchCell(args)
 	if String.isEmpty(args.patch) then
 		return nil
 	end

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -17,7 +17,8 @@ local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 local PageLink = require('Module:Page')
 local PrizePoolCurrency = require('Module:Prize pool currency')
-local RIOT_SPONSORED_ICON = '[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
+local RIOT_SPONSORED_ICON = 
+		'[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
 
 local _TODAY = os.date('%Y-%m-%d', os.time())
 
@@ -101,7 +102,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 	lpdbData.publishertier = args['riot-sponsored']
 	lpdbData.participantsnumber = args.team_number
-	lpdbData.liquipediatiertype = args.liquipediatiertype or _DEFAULT_TIERTYPE
+	lpdbData.liquipediatiertype = args.liquipediatiertype 
 	return lpdbData
 end
 
@@ -116,7 +117,8 @@ function CustomLeague:_createGameCell(args)
 	if String.isEmpty(args.epatch) and not String.isEmpty(args.patch) then
 		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]'
 	elseif not String.isEmpty(args.epatch) then
-		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. '&ndash;' .. '[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
+		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. '&ndash;' .. 
+			'[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
 	end
 
 	return content
@@ -185,7 +187,6 @@ end
 
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
-	
 	local tier = args.liquipediatier
 	local tierType = args.liquipediatiertype
 

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -121,9 +121,9 @@ function CustomLeague:_createPatchCell(args)
 	end
 	local content
 
-	if String.isEmpty(args.epatch) and not String.isEmpty(args.patch) then
+	if String.isEmpty(args.epatch) then
 		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]'
-	elseif not String.isEmpty(args.epatch) then
+	else
 		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. '&ndash;' ..
 		'[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
 	end

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -48,7 +48,7 @@ function CustomInjector:addCustomCells(widgets)
 	local args = _args
 	table.insert(widgets, Cell{
 		name = 'Teams',
-		content = (args.team_number)
+		content = {args.team_number}
 	})
 	table.insert(widgets, Cell{
 		name = 'Patch',

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -97,18 +97,7 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)
-	local icon_dark
-	local banner_dark
-	
-	if String.isNotEmpty(args.icon_darkmode) then
-		icon_dark = 'File:' .. args.icon_darkmode
-	end
-	
-	if String.isNotEmpty(args.banner_darkmode) then
-		banner_dark = 'File:' .. args.banner_darkmode
-	end
-	
+function CustomLeague:addToLpdb(lpdbData, args)	
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 	lpdbData.participantsnumber = args.team_number
 	lpdbData.liquipediatiertype = args.liquipediatiertype
@@ -122,7 +111,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		icon_darkmode = args.icon_darkmode or args.icon,
 		banner_darkmode = args.banner_darkmode or args.banner,
 	}
-	
 	return lpdbData
 end
 
@@ -131,7 +119,6 @@ function CustomLeague:_createPatchCell(args)
 	if String.isEmpty(args.patch) then
 		return nil
 	end
-
 	local content
 
 	if String.isEmpty(args.epatch) and not String.isEmpty(args.patch) then
@@ -246,7 +233,6 @@ function CustomLeague:getWikiCategories(args)
 	if String.isNotEmpty(female) then
 		table.insert(categories, 'Female Tournaments')
 	end
-
 	return categories
 end
 

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -97,7 +97,7 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)	
+function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 	lpdbData.participantsnumber = args.team_number
 	lpdbData.liquipediatiertype = args.liquipediatiertype
@@ -229,7 +229,7 @@ function CustomLeague:getWikiCategories(args)
 	if String.isNotEmpty(tierType) and String.isNotEmpty(Tier.text[tierType]) then
 		table.insert(categories, Tier.text[tierType] .. ' Tournaments')
 	end
-	
+
 	if String.isNotEmpty(female) then
 		table.insert(categories, 'Female Tournaments')
 	end

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -17,8 +17,8 @@ local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 local PageLink = require('Module:Page')
 local PrizePoolCurrency = require('Module:Prize pool currency')
-local RIOT_SPONSORED_ICON = 
-		'[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
+local RIOT_SPONSORED_ICON =
+			[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
 
 local _TODAY = os.date('%Y-%m-%d', os.time())
 
@@ -102,7 +102,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 	lpdbData.publishertier = args['riot-sponsored']
 	lpdbData.participantsnumber = args.team_number
-	lpdbData.liquipediatiertype = args.liquipediatiertype 
+	lpdbData.liquipediatiertype = args.liquipediatiertype
 	return lpdbData
 end
 
@@ -117,8 +117,8 @@ function CustomLeague:_createGameCell(args)
 	if String.isEmpty(args.epatch) and not String.isEmpty(args.patch) then
 		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]'
 	elseif not String.isEmpty(args.epatch) then
-		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. '&ndash;' .. 
-			'[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
+		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. '&ndash;' ..
+		'[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
 	end
 
 	return content

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -17,8 +17,7 @@ local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 local PageLink = require('Module:Page')
 local PrizePoolCurrency = require('Module:Prize pool currency')
-local RIOT_SPONSORED_ICON =
-			[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
+local RIOT_SPONSORED = [[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
 
 local _TODAY = os.date('%Y-%m-%d', os.time())
 
@@ -84,7 +83,7 @@ function CustomInjector:parse(id, widgets)
 		local tierDisplay = CustomLeague:_createLiquipediaTierDisplay()
 		local class
 		if args['riot-sponsored'] == 'true' then
-			tierDisplay = (tierDisplay or '').. '&nbsp;' .. RIOT_SPONSORED_ICON
+			tierDisplay = (tierDisplay or '').. '&nbsp;' .. RIOT_SPONSORED
 			class = {'valvepremier-highlighted'}
 		end
 		return {

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -17,7 +17,7 @@ local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 local PageLink = require('Module:Page')
 local PrizePoolCurrency = require('Module:Prize pool currency')
-local RIOT_SPONSORED = '[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
+local _RIOT_SPONSORED = '[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
 
 local _TODAY = os.date('%Y-%m-%d', os.time())
 
@@ -83,7 +83,7 @@ function CustomInjector:parse(id, widgets)
 		local tierDisplay = CustomLeague:_createLiquipediaTierDisplay()
 		local class
 		if args['riot-sponsored'] == 'true' then
-			tierDisplay = (tierDisplay or '').. '&nbsp;' .. RIOT_SPONSORED
+			tierDisplay = (tierDisplay or '') .. '&nbsp;' .. _RIOT_SPONSORED
 			class = {'valvepremier-highlighted'}
 		end
 		return {
@@ -164,8 +164,7 @@ function CustomLeague:_createPrizepool()
 end
 
 function CustomLeague:_createLiquipediaTierDisplay()
-	local tier = _args.liquipediatier or ''
-	local tierType = _args.liquipediatiertype or ''
+	local tier = _args.liquipediatier
 	if String.isEmpty(tier) then
 		return nil
 	end
@@ -182,6 +181,7 @@ function CustomLeague:_createLiquipediaTierDisplay()
 
 	local tierDisplay = buildTierString(tier)
 
+	local tierType = _args.liquipediatiertype
 	if String.isNotEmpty(tierType) then
 		tierDisplay = buildTierString(tierType) .. '&nbsp;(' .. tierDisplay .. ')'
 	end
@@ -192,14 +192,10 @@ end
 function CustomLeague:defineCustomPageVariables()
 	--Legacy vars
 	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
-	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
-	Variables.varDefine('tournament_name', _args.name or '')
+	Variables.varDefine('tournament_prizepool', Variables.varDefault('tournament_prizepoolusd'))
 	Variables.varDefine('tournament_short_name', _args.shortname or '')
 	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
 	Variables.varDefine('special_ticker_name', _args.tickername_special or '')
-	Variables.varDefine('tournament_icon', _args.icon or '')
-	Variables.varDefine('tournament_type', _args.type or '')
-	Variables.varDefine('tournament_series', _args.series or '')
 	Variables.varDefine('tournament_riot_premier', _args.riotpremier or '')
 	Variables.varDefine('tournament_riot_tier', _args.riotpremier or '')
 	Variables.varDefine('tournament_mode', _args.individual or '')

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -1,0 +1,210 @@
+---
+-- @Liquipedia
+-- wiki=valorant
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+local Tier = require('Module:Tier')
+local Class = require('Module:Class')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local Center = require('Module:Infobox/Widget/Center')
+local PageLink = require('Module:Page')
+local PrizePoolCurrency = require('Module:Prize pool currency')
+local RIOT_SPONSORED_ICON = '[[File:Riot Games Tier Icon.png|x18px|link=Riot Games|Tournament supported by Riot Games.]]'
+
+local _TODAY = os.date('%Y-%m-%d', os.time())
+
+local _args
+local _league
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_league = league
+	_args = _league.args
+
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.getWikiCategories = CustomLeague.getWikiCategories
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:addCustomCells(widgets)
+	local args = _args
+	table.insert(widgets, Cell{
+		name = 'Teams',
+		content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}
+	})
+	table.insert(widgets, Cell{
+		name = 'Patch',
+		content = {CustomLeague:_createGameCell(args)}
+	})
+
+	return widgets
+end
+
+function CustomInjector:parse(id, widgets)
+	local args = _args
+	if id == 'customcontent' then
+		if String.isNotEmpty(args.map1) then
+			local maps = {}
+
+			for _, map in ipairs(_league:getAllArgsForBase(args, 'map')) do
+				table.insert(maps, tostring(CustomLeague:_createNoWrappingSpan(
+					PageLink.makeInternalLink({}, map)
+				)))
+			end
+			table.insert(widgets, Title{name = 'Maps'})
+			table.insert(widgets, Center{content = {table.concat(maps, '&nbsp;• ')}})
+		end
+	elseif id == 'prizepool' then
+		return {
+			Cell{
+				name = 'Prize pool',
+				content = {CustomLeague:_createPrizepool()}
+			},
+		}
+	elseif id == 'liquipediatier' then
+		local tierDisplay = CustomLeague:_createLiquipediaTierDisplay()
+		local class
+		if args['riot-sponsored'] == 'true' then
+			tierDisplay = (tierDisplay or '').. '&nbsp;' .. RIOT_SPONSORED_ICON
+			class = {'valvepremier-highlighted'}
+		end
+		return {
+			Cell{
+				name = 'Liquipedia Tier',
+				content = {tierDisplay},
+				classes = class
+			}
+		}
+	end
+	return widgets
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
+	lpdbData.publishertier = args['riot-sponsored']
+	lpdbData.participantsnumber = args.team_number
+	lpdbData.liquipediatiertype = args.liquipediatiertype or _DEFAULT_TIERTYPE
+	return lpdbData
+end
+
+
+function CustomLeague:_createGameCell(args)
+	if String.isEmpty(args.patch) then
+		return nil
+	end
+
+	local content
+
+	if String.isEmpty(args.epatch) and not String.isEmpty(args.patch) then
+		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]'
+	elseif not String.isEmpty(args.epatch) then
+		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. '&ndash;' .. '[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
+	end
+
+	return content
+end
+
+function CustomLeague:_createPrizepool()
+	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
+		return nil
+	end
+	local date
+	if String.isNotEmpty(_args.currency_rate) then
+		date = _args.currency_date
+	end
+
+	return PrizePoolCurrency._get({
+		prizepool = _args.prizepool,
+		prizepoolusd = _args.prizepoolusd,
+		currency = _args.localcurrency,
+		rate = _args.currency_rate,
+		date = date or Variables.varDefault('tournament_enddate', _TODAY),
+	})
+end
+
+function CustomLeague:_createLiquipediaTierDisplay()
+	local tier = _args.liquipediatier or ''
+	local tierType = _args.liquipediatiertype or ''
+	if String.isEmpty(tier) then
+		return nil
+	end
+
+	local function buildTierString(tierString)
+		local tierText = Tier.text[tierString]
+		if not tierText then
+			table.insert(_league.warnings, tierString .. ' is not a known Liquipedia Tier/Tiertype')
+			return ''
+		else
+			return '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
+		end
+	end
+
+	local tierDisplay = buildTierString(tier)
+
+	if String.isNotEmpty(tierType) then
+		tierDisplay = buildTierString(tierType) .. '&nbsp;(' .. tierDisplay .. ')'
+	end
+
+	return tierDisplay
+end
+
+function CustomLeague:defineCustomPageVariables()
+	--Legacy vars
+	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
+	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
+	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
+
+	--Legacy date vars
+	local sdate = Variables.varDefault('tournament_startdate', '')
+	local edate = Variables.varDefault('tournament_enddate', '')
+	Variables.varDefine('tournament_sdate', sdate)
+	Variables.varDefine('tournament_edate', edate)
+	Variables.varDefine('tournament_date', edate)
+	Variables.varDefine('date', edate)
+	Variables.varDefine('sdate', sdate)
+	Variables.varDefine('edate', edate)
+end
+
+function CustomLeague:getWikiCategories(args)
+	local categories = {}
+	
+	local tier = args.liquipediatier
+	local tierType = args.liquipediatiertype
+
+	if String.isNotEmpty(tier) and String.isNotEmpty(Tier.text[tier]) then
+		table.insert(categories, Tier.text[tier]  .. ' Tournaments')
+	end
+
+	if String.isNotEmpty(tierType) and String.isNotEmpty(Tier.text[tierType]) then
+		table.insert(categories, Tier.text[tierType] .. ' Tournaments')
+	end
+
+	return categories
+end
+
+function CustomLeague:_createNoWrappingSpan(content)
+	local span = mw.html.create('span')
+		:css('white-space', 'nowrap')
+		:node(content)
+	return span
+end
+
+return CustomLeague


### PR DESCRIPTION
## Summary
Helping in the standirazing for infobox league in this wiki, actually I'm missing beta tournaments to the gameCell and female tournaments added to LPDB and as category also, and last missing add in LPDB under the var of publishertier if it's sponsored, major or nothing

## How did you test this change?

I tested the module in https://liquipedia.net/valorant/User:Jonajitru781/Champions comparing with the one on https://liquipedia.net/valorant/VALORANT_Champions_Tour/2021/Champions

Things to be particularly aware of:
 - This can break LPDB and SMW in VALORANT wiki 
 - Missing page variables: publishertier and female under LPDB