### PR TITLE
Add `.mapInterleavedPrefix` function to `Module:Table`

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -258,6 +258,13 @@ function Table.mapInterleavedPrefix(args, prefixes, f)
 	return Table.mapInterleaved(args, indexFromKey, f)
 end
 
+--[[
+Extracts keys based on a passed `indexFromKey` function interleaved with numeric indexes
+from an arguments table, and applies a transform to each key or index.
+
+Most common use-case will be `Table.mapInterleavedPrefix` where
+the `indexFromKey` function retrieves keys based on a prefix.
+]]
 function Table.mapInterleaved(args, indexFromKey, f)
 	local entriesByIndex = {}
 

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -262,7 +262,7 @@ end
 Extracts keys based on a passed `indexFromKey` function interleaved with numeric indexes
 from an arguments table, and applies a transform to each key or index.
 
-Most common use-case will be `Table.mapInterleavedPrefix` where
+Most common use-case will be `Table.mapArgumentsByPrefix` where
 the `indexFromKey` function retrieves keys based on a prefix.
 ]]
 function Table.mapArguments(args, indexFromKey, f)

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -236,7 +236,7 @@ In the template call
 	|player4=D
 }}
 
-Table.mapInterleavedPrefix(args, {'p', 'player'}, f)
+Table.mapArgumentsByPrefix(args, {'p', 'player'}, f)
 will invoke
 
 f(1, 1)

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -245,7 +245,7 @@ f(3, 3)
 f('player4', 4, 'player')
 
 ]]
-function Table.mapInterleavedPrefix(args, prefixes, f)
+function Table.mapArgumentsByPrefix(args, prefixes, f)
 	local function indexFromKey(key)
 		local prefix, index = key:match('^([%a_]+)(%d+)$')
 		if Table.includes(prefixes, prefix) then
@@ -255,7 +255,7 @@ function Table.mapInterleavedPrefix(args, prefixes, f)
 		end
 	end
 
-	return Table.mapInterleaved(args, indexFromKey, f)
+	return Table.mapArguments(args, indexFromKey, f)
 end
 
 --[[
@@ -265,7 +265,7 @@ from an arguments table, and applies a transform to each key or index.
 Most common use-case will be `Table.mapInterleavedPrefix` where
 the `indexFromKey` function retrieves keys based on a prefix.
 ]]
-function Table.mapInterleaved(args, indexFromKey, f)
+function Table.mapArguments(args, indexFromKey, f)
 	local entriesByIndex = {}
 
 	-- Non-numeric args

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -220,6 +220,75 @@ function Table.map(xTable, f)
 end
 
 --[[
+Extracts prefixed keys interleaved with numeric indexes from an arguments
+table, and applies a transform to each key or index.
+
+Used for template calls that support both prefixed and indexed params. See
+Module:ParticipantTable/Starcraft, Module:GroupTableLeage for examples of how
+it is used.
+
+Example:
+In the template call
+{{Foo
+	|A
+	|p2=B
+	|C
+	|player4=D
+}}
+
+Table.mapInterleavedPrefix(args, {'p', 'player'}, f)
+will invoke
+
+f(1, 1)
+f('p2', 2, 'p')
+f(3, 3)
+f('player4', 4, 'player')
+
+]]
+function Table.mapInterleavedPrefix(args, prefixes, f)
+	local function indexFromKey(key)
+		local prefix, index = key:match('^([%a_]+)(%d+)$')
+		if Table.includes(prefixes, prefix) then
+			return tonumber(index), prefix
+		else
+			return nil
+		end
+	end
+
+	return Table.mapInterleaved(args, indexFromKey, f)
+end
+
+function Table.mapInterleaved(args, indexFromKey, f)
+	local entriesByIndex = {}
+
+	-- Non-numeric args
+	for key, _ in pairs(args) do
+		local function post(index, ...)
+			if index and not entriesByIndex[index] then
+				entriesByIndex[index] = f(key, index, ...)
+			end
+		end
+		if type(key) == 'string' then
+			post(indexFromKey(key))
+		end
+	end
+
+	-- Numeric index entries fills in gaps of prefixN= entries
+	local entryIndex = 1
+	for argIndex = 1, math.huge do
+		if not args[argIndex] then
+			break
+		end
+		while entriesByIndex[entryIndex] do
+			entryIndex = entryIndex + 1
+		end
+		entriesByIndex[entryIndex] = f(argIndex, entryIndex)
+	end
+
+	return entriesByIndex
+end
+
+--[[
 Applies a function to each value in a table and places the results in a new
 table under the same keys.
 


### PR DESCRIPTION
## Summary
Add `.mapInterleavedPrefix` function to `Module:Table`
Extracts prefixed keys interleaved with numeric indexes from an arguments table, and applies a transform to each key or index.
Intended use is for template calls that support both prefixed and indexed params.
(want to try to build a solution for #1047 with this)
Orig function from warnull in a utils module that is not yet on the git. Think it fits here best though.
Cleaned up the variable names a bit.

## How did you test this change?
sandbox
only adds a new function, does not touch existing ones.