### PR TITLE
Fix #1047

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -23,12 +23,8 @@ local globalVars = PageVariableNamespace({cached = true})
 
 local MatchGroupInput = {}
 
-
---remove this once #1050 is merged;;; use module:Table instead
-local TournamentUtil = require('Module:Tournament/Util')
-
 function MatchGroupInput.readMatchlist(bracketId, args)
-	local matchKeys = TournamentUtil.mapInterleavedPrefix(args, {'M'}, FnUtil.identity)
+	local matchKeys = Table.mapInterleavedPrefix(args, {'M'}, FnUtil.identity)
 
 	return Array.map(matchKeys, function(matchKey, matchIndex)
 			local matchId = string.format('%04d', matchIndex)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -33,7 +33,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 	local matchKeys = TournamentUtil.mapInterleavedPrefix(args, {'M'}, FnUtil.identity)
 
 	return Array.map(matchKeys, function(matchKey, matchIndex)
-			local matchId = MatchGroupUtil.matchIdFromKey(matchIndex)
+			local matchId = string.format('%04d', matchIndex)
 			local matchArgs = Json.parse(args[matchKey])
 
 			local context = MatchGroupInput.readContext(matchArgs, args)
@@ -58,7 +58,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 			bracketData.sectionheader = context.sectionHeader
 			bracketData.dateheader = Logic.readBool(match.dateheader) or nil
 
-			local nextMatchId = bracketId .. '_' .. MatchGroupUtil.matchIdFromKey(matchIndex + 1)
+			local nextMatchId = bracketId .. '_' .. string.format('%04d', matchIndex + 1)
 			bracketData.next = matchIndex ~= #matchKeys and nextMatchId or nil
 
 			return match

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -24,7 +24,7 @@ local globalVars = PageVariableNamespace({cached = true})
 local MatchGroupInput = {}
 
 function MatchGroupInput.readMatchlist(bracketId, args)
-	local matchKeys = Table.mapInterleavedPrefix(args, {'M'}, FnUtil.identity)
+	local matchKeys = Table.mapArgumentsByPrefix(args, {'M'}, FnUtil.identity)
 
 	return Array.map(matchKeys, function(matchKey, matchIndex)
 			local matchId = string.format('%04d', matchIndex)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -28,8 +28,6 @@ local MatchGroupInput = {}
 local TournamentUtil = require('Module:Tournament/Util')
 
 function MatchGroupInput.readMatchlist(bracketId, args)
-	local matches = {}
-
 	local matchKeys = TournamentUtil.mapInterleavedPrefix(args, {'M'}, FnUtil.identity)
 
 	return Array.map(matchKeys, function(matchKey, matchIndex)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -16,6 +16,7 @@ local Opponent = require('Module:Opponent')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+local WikiSpecific = require('Module:Brkts/WikiSpecific')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 
@@ -27,7 +28,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 	local matchKeys = Table.mapArgumentsByPrefix(args, {'M'}, FnUtil.identity)
 
 	return Array.map(matchKeys, function(matchKey, matchIndex)
-			local matchId = string.format('%04d', matchIndex)
+			local matchId = MatchGroupInput._matchlistMatchIdFromIndex(matchIndex)
 			local matchArgs = Json.parse(args[matchKey])
 
 			local context = MatchGroupInput.readContext(matchArgs, args)
@@ -35,7 +36,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 
 			matchArgs.bracketid = bracketId
 			matchArgs.matchid = matchId
-			local match = require('Module:Brkts/WikiSpecific').processMatch(mw.getCurrentFrame(), matchArgs)
+			local match = WikiSpecific.processMatch(mw.getCurrentFrame(), matchArgs)
 
 			-- Add more fields to bracket data
 			match.bracketdata = match.bracketdata or {}
@@ -52,12 +53,16 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 			bracketData.sectionheader = context.sectionHeader
 			bracketData.dateheader = Logic.readBool(match.dateheader) or nil
 
-			local nextMatchId = bracketId .. '_' .. string.format('%04d', matchIndex + 1)
+			local nextMatchId = bracketId .. '_' .. MatchGroupInput._matchlistMatchIdFromIndex(matchIndex + 1)
 			bracketData.next = matchIndex ~= #matchKeys and nextMatchId or nil
 
 			return match
 		end
 	)
+end
+
+function MatchGroupInput._matchlistMatchIdFromIndex(matchIndex)
+	return string.format('%04d', matchIndex)
 end
 
 function MatchGroupInput.readBracket(bracketId, args, options)
@@ -98,7 +103,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 
 		matchArgs.bracketid = bracketId
 		matchArgs.matchid = matchId
-		local match = require('Module:Brkts/WikiSpecific').processMatch(mw.getCurrentFrame(), matchArgs)
+		local match = WikiSpecific.processMatch(mw.getCurrentFrame(), matchArgs)
 
 		-- Add more fields to bracket data
 		local bracketData = bracketDatasById[matchId]


### PR DESCRIPTION
## Please note
This PR assumes that #1050 is merged, so it should only be merged after #1050 has been merged (if we rename functions there we also need to rename the call in line 27 of this PR)

## Summary
Solves Issue #1047 
Currently the only allowed input format for matchlists is:
```wiki
{{matchlist|id=.....
	|M1={{Match|data here}}
	|M2={{Match|data here}}
	|M3={{Match|data here}}
}}
```
After this PR the following would be allowed too:
```wiki
{{matchlist|id=.....
	|{{Match|data here}}
	|{{Match|data here}}
	|{{Match|data here}}
}}
```
(It would also allow a mix of those, so e.g.:
```wiki
{{matchlist|id=.....
	|M1={{Match|data here}}
	|{{Match|data here}}
	|M3={{Match|data here}}
}}
```
## How did you test this change?
/dev module