### PR TITLE
Fix `bosniaandherzegovina` flags data

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1766,10 +1766,12 @@ local aliases = {
 	['u.s.minoroutlyingislands'] = 'unitedstatesminoroutlyingislands',
 	['global'] = 'world',
 	--needed due to lpdb length restrictions
-	--first for inside matches --> max length 20
-	--second for inside player --> max length 40
+	--for inside matches --> max length 20
 	--minus the spaces in cut of the flag names
 	['southgeorgiaandth'] = 'southgeorgiaandthesouthsandwichislands',
+	['bosniaandherzegovi'] = 'bosniaandherzegovina',
+	--for inside player --> max length 40
+	--minus the spaces in cut of the flag names
 	['southgeorgiaandthesouthsandwichisl'] = 'southgeorgiaandthesouthsandwichislands',
 
 	--language flag abbreviations


### PR DESCRIPTION
## Summary
`Bosnia and Herzegovina` is too long for storage in match2 lpdb, so it gets cut of there.
This PR adds an alias in the flags data so that the cut version gets found by the flags module too.

## How did you test this change?
pushed live
