### PR TITLE
Add a wrapper function for mass LPDB queries

### DIFF
--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -34,6 +34,3 @@ function Lpdb._defaultBbreakCallbackFunction()
 end
 
 return Lpdb
-
-
-return Lpdb

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -42,7 +42,7 @@ example:
 
 	return foundMatchIds
 ]==]
-function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, limit)
+function Lpdb.executeMassQuery(tableName, queryParameters, itemChecker, limit)
 	queryParameters.offset = queryParameters.offset or 0
 	queryParameters.limit = queryParameters.limit or _MAXIMUM_QUERY_LIMIT
 	limit = limit or math.huge
@@ -50,9 +50,9 @@ function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, lim
 	while queryParameters.offset < limit do
 		queryParameters.limit = math.min(queryParameters.limit, limit - queryParameters.offset)
 
-		local lpdbData = mw.ext.LiquipediaDB.lpdb(lpdbTable, queryParameters)
+		local lpdbData = mw.ext.LiquipediaDB.lpdb(tableName, queryParameters)
 		for _, value in ipairs(lpdbData) do
-			if callbackFunction(value) == false then
+			if itemChecker(value) == false then
 				return
 			end
 		end

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -8,6 +8,8 @@
 
 local Lpdb = {}
 
+local _MAXIMUM_QUERY_LIMIT = 5000
+
 -- Executes a mass query.
 --[==[
 Loops LPDB queries to e.g.
@@ -42,7 +44,7 @@ example:
 ]==]
 function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, limit)
 	queryParameters.offset = queryParameters.offset or 0
-	queryParameters.limit = queryParameters.limit or 5000
+	queryParameters.limit = queryParameters.limit or _MAXIMUM_QUERY_LIMIT
 	limit = limit or math.huge
 
 	while queryParameters.offset < limit do
@@ -50,15 +52,14 @@ function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, lim
 
 		local lpdbData = mw.ext.LiquipediaDB.lpdb(lpdbTable, queryParameters)
 		for _, value in ipairs(lpdbData) do
-			local success = callbackFunction(value)
-			if success == false then
+			if callbackFunction(value) == false then
 				return
 			end
 		end
 
 		queryParameters.offset = queryParameters.offset + #lpdbData
 		if #lpdbData < queryParameters.limit then
-			return
+			break
 		end
 	end
 end

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -8,8 +8,6 @@
 
 local Lpdb = {}
 
-local Table = require('Module:Table')
-
 function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, limit)
 	queryParameters.offset = queryParameters.offset or 0
 	queryParameters.limit = queryParameters.limit or 5000

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -9,7 +9,7 @@
 local Lpdb = {}
 
 -- Executes a mass query.
-[==[
+--[==[
 Loops Lpdb queries to e.g.
 - circumvent the maximum limit of 5000
 - use additional filtering (e.g. because lpdb does not support it)

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -10,9 +10,9 @@ local Lpdb = {}
 
 -- Executes a mass query.
 --[==[
-Loops Lpdb queries to e.g.
+Loops LPDB queries to e.g.
 - circumvent the maximum limit of 5000
-- use additional filtering (e.g. because lpdb does not support it)
+- use additional filtering (e.g. because LPDB does not support it)
 	and query so long until a certain amount of elements is found
 	or additional limitations are reached
 

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -8,6 +8,38 @@
 
 local Lpdb = {}
 
+-- Executes a mass query.
+[==[
+Loops Lpdb queries to e.g.
+- circumvent the maximum limit of 5000
+- use additional filtering (e.g. because lpdb does not support it)
+	and query so long until a certain amount of elements is found
+	or additional limitations are reached
+
+example:
+	local foundMatchIds = {}
+	local getMatchId = function(match)
+		if #foundMatchIds < args.matchLimit then
+			if HeadToHead._fitsAdditionalConditions(args, match) then
+				table.insert(foundMatchIds, match.match2id)
+			end
+		else
+			return false
+		end
+	end
+
+	local queryParameters = {
+		conditions = conditions,
+		order = 'date ' .. args.order,
+		limit = _LPDB_QUERY_LIMIT,
+		query = 'pagename, winner, walkover, finished, date, dateexact, links, '
+			.. 'bestof, vod, tournament, tickername, shortname, icon, icondark, '
+			.. 'extradata, match2opponents, match2games, mode, match2id, match2bracketid',
+	}
+	Lpdb.executeMassQuery('match2', queryParameters, getMatchId)
+
+	return foundMatchIds
+]==]
 function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, limit)
 	queryParameters.offset = queryParameters.offset or 0
 	queryParameters.limit = queryParameters.limit or 5000

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -15,7 +15,7 @@ function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, lim
 	queryParameters.limit = queryParameters.limit or 5000
 	breakCallbackFunction = breakCallbackFunction or Lpdb._defaultBbreakCallbackFunction
 
-	local lpdbData = {}
+	local lpdbData
 	while queryParameters.offset < limit do
 		queryParameters.limit = math.min(queryParameters.limit, limit - queryParameters.offset)
 

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -1,0 +1,60 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Lpdb
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lpdb = {}
+
+local _DEFAULT_QUERY_LIMIT = 20
+local _DEFAULT_INITIAL_OFFSET = 0
+
+--[==[
+Wrapper for mass LPDB queries.
+Used when > 5000 results are needed (LPDB max limit is 5000) or when
+additional filtering is to be done after the query and memory is an issue.
+
+example:
+	local cond = '[[match2id::!]]'
+	local query = 'match2id'
+
+	local function queryFunct(foundElements, offset, maxQueryLimit)
+		local data = mw.ext.LiquipediaDB.lpdb('match2', {
+			limit = maxQueryLimit,
+			offset = offset,
+			conditions = cond,
+			query = query,
+		})
+
+		for _, item in ipairs(data) do
+			if string.match(item.match2id, '_0001') then
+				table.insert(foundElements, item.match2id)
+			end
+		end
+
+		return foundElements, #data
+	end
+
+	local queryData = Lpdb.massQueryWrapper(queryFunct, 0, 5000)
+]==]
+function Lpdb.massQueryWrapper(funct, initialOffset, maxQueryLimit, maxRounds)
+	local offset = initialOffset or _DEFAULT_INITIAL_OFFSET
+	local count = maxQueryLimit or _DEFAULT_QUERY_LIMIT
+	maxRounds = maxRounds or math.huge
+	local rounds = 0
+
+	local foundElements = {}
+
+	while count == maxQueryLimit and rounds < maxRounds do
+		foundElements, count = funct(foundElements, offset, maxQueryLimit)
+
+		offset = offset + maxQueryLimit
+		rounds = rounds + 1
+	end
+
+	return foundElements
+end
+
+return Lpdb

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -10,27 +10,27 @@ local Lpdb = {}
 
 local Table = require('Module:Table')
 
-function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, limit, breakCallbackFunction)
+function Lpdb.executeMassQuery(lpdbTable, queryParameters, callbackFunction, limit)
 	queryParameters.offset = queryParameters.offset or 0
 	queryParameters.limit = queryParameters.limit or 5000
-	breakCallbackFunction = breakCallbackFunction or Lpdb._defaultBbreakCallbackFunction
+	limit = limit or math.huge
 
-	local lpdbData
 	while queryParameters.offset < limit do
 		queryParameters.limit = math.min(queryParameters.limit, limit - queryParameters.offset)
 
-		lpdbData = mw.ext.LiquipediaDB.lpdb(lpdbTable, queryParameters)
-		Table.iter.forEachIndexed(lpdbData, callbackFunction)
+		local lpdbData = mw.ext.LiquipediaDB.lpdb(lpdbTable, queryParameters)
+		for _, value in ipairs(lpdbData) do
+			local success = callbackFunction(value)
+			if success == false then
+				return
+			end
+		end
 
 		queryParameters.offset = queryParameters.offset + #lpdbData
-		if #lpdbData < queryParameters.limit or breakCallbackFunction() then
-			break
+		if #lpdbData < queryParameters.limit then
+			return
 		end
 	end
-end
-
-function Lpdb._defaultBbreakCallbackFunction()
-	return false
 end
 
 return Lpdb

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -11,6 +11,9 @@ local StringUtils = require('Module:StringUtils')
 
 local Lua = {}
 
+local _DEFAULT_QUERY_LIMIT = 20
+local _DEFAULT_INITIAL_OFFSET = 0
+
 function Lua.moduleExists(name)
 	if package.loaded[name] then
 		return true
@@ -192,6 +195,51 @@ function Lua.getDefaultEntryPoints(module)
 		end
 	end
 	return fnNames
+end
+
+--[==[
+Wrapper for mass LPDB queries.
+
+example:
+	local cond = '[[match2id::!]]'
+	local query = 'match2id'
+
+	local function queryFunct(foundElements, offset, maxQueryLimit)
+		local data = mw.ext.LiquipediaDB.lpdb('match2', {
+			limit = maxQueryLimit,
+			offset = offset,
+			conditions = cond,
+			query = query,
+		})
+
+		for _, item in ipairs(data) do
+			if string.match(item.match2id, '_0001') then
+				table.insert(foundElements, item.match2id)
+			end
+		end
+
+		return foundElements, #data
+	end
+
+	local queryData = Lua.massQueryWrapper(queryFunct, 0, 5000)
+]==]
+function Lua.massQueryWrapper(funct, initialOffset, maxQueryLimit, maxRounds)
+	local offset = initialOffset or _DEFAULT_INITIAL_OFFSET
+	count = maxQueryLimit or _DEFAULT_QUERY_LIMIT
+	local count = maxQueryLimit
+	maxRounds = maxRounds or math.huge
+	local rounds = 0
+
+	local foundElements = {}
+
+	while count == maxQueryLimit and rounds < maxRounds do
+		foundElements, count = funct(foundElements, offset, maxQueryLimit)
+
+		offset = offset + maxQueryLimit
+		rounds = rounds + 1
+	end
+
+	return foundElements
 end
 
 return Lua

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -11,9 +11,6 @@ local StringUtils = require('Module:StringUtils')
 
 local Lua = {}
 
-local _DEFAULT_QUERY_LIMIT = 20
-local _DEFAULT_INITIAL_OFFSET = 0
-
 function Lua.moduleExists(name)
 	if package.loaded[name] then
 		return true
@@ -195,52 +192,6 @@ function Lua.getDefaultEntryPoints(module)
 		end
 	end
 	return fnNames
-end
-
---[==[
-Wrapper for mass LPDB queries.
-Used when > 5000 results are needed (LPDB max limit is 5000) or when
-additional filtering is to be done after the query and memory is an issue.
-
-example:
-	local cond = '[[match2id::!]]'
-	local query = 'match2id'
-
-	local function queryFunct(foundElements, offset, maxQueryLimit)
-		local data = mw.ext.LiquipediaDB.lpdb('match2', {
-			limit = maxQueryLimit,
-			offset = offset,
-			conditions = cond,
-			query = query,
-		})
-
-		for _, item in ipairs(data) do
-			if string.match(item.match2id, '_0001') then
-				table.insert(foundElements, item.match2id)
-			end
-		end
-
-		return foundElements, #data
-	end
-
-	local queryData = Lua.massQueryWrapper(queryFunct, 0, 5000)
-]==]
-function Lua.massQueryWrapper(funct, initialOffset, maxQueryLimit, maxRounds)
-	local offset = initialOffset or _DEFAULT_INITIAL_OFFSET
-	local count = maxQueryLimit or _DEFAULT_QUERY_LIMIT
-	maxRounds = maxRounds or math.huge
-	local rounds = 0
-
-	local foundElements = {}
-
-	while count == maxQueryLimit and rounds < maxRounds do
-		foundElements, count = funct(foundElements, offset, maxQueryLimit)
-
-		offset = offset + maxQueryLimit
-		rounds = rounds + 1
-	end
-
-	return foundElements
 end
 
 return Lua

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -226,7 +226,6 @@ example:
 function Lua.massQueryWrapper(funct, initialOffset, maxQueryLimit, maxRounds)
 	local offset = initialOffset or _DEFAULT_INITIAL_OFFSET
 	local count = maxQueryLimit or _DEFAULT_QUERY_LIMIT
-	local count = maxQueryLimit
 	maxRounds = maxRounds or math.huge
 	local rounds = 0
 

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -199,6 +199,8 @@ end
 
 --[==[
 Wrapper for mass LPDB queries.
+Used when > 5000 results are needed (LPDB max limit is 5000) or when
+additional filtering is to be done after the query and memory is an issue.
 
 example:
 	local cond = '[[match2id::!]]'

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -225,7 +225,7 @@ example:
 ]==]
 function Lua.massQueryWrapper(funct, initialOffset, maxQueryLimit, maxRounds)
 	local offset = initialOffset or _DEFAULT_INITIAL_OFFSET
-	count = maxQueryLimit or _DEFAULT_QUERY_LIMIT
+	local count = maxQueryLimit or _DEFAULT_QUERY_LIMIT
 	local count = maxQueryLimit
 	maxRounds = maxRounds or math.huge
 	local rounds = 0


### PR DESCRIPTION
## Summary
Add a wrapper function for mass LPDB queries.
Since we use that functionality in several modules it seems waranted to add the wrapper function to the Lua module so we can access it whenever we do mass queries.

## How did you test this change?
sandbox