### PR TITLE
Use new MatchTicker on SC2

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -16,7 +16,7 @@ local Variables = require('Module:Variables')
 local Achievements = require('Module:Achievements in infoboxes')._player
 local CleanRace = require('Module:CleanRace')
 local Math = require('Module:Math')
-local Matches = require('Module:Upcoming ongoing and recent matches player/new')
+local MatchTicker = require('Module:MatchTicker/Participant')
 
 local _EPT_SEASON = 2021
 
@@ -139,9 +139,7 @@ end
 
 function CustomPlayer:createBottomContent(infobox)
 	if _shouldQueryData then
-		return tostring(Matches._get_ongoing({})) ..
-			tostring(Matches._get_upcoming({})) ..
-			tostring(Matches._get_recent({}))
+		return MatchTicker.run({player = _PAGENAME})
 	end
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -12,7 +12,7 @@ local Variables = require('Module:Variables')
 local String = require('Module:StringUtils')
 local Achievements = require('Module:Achievements in infoboxes')
 local RaceIcon = require('Module:RaceIcon').getSmallIcon
-local Matches = require('Module:Upcoming ongoing and recent matches team/new')
+local MatchTicker = require('Module:MatchTicker/Participant')
 local Math = require('Module:Math')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
@@ -133,9 +133,7 @@ end
 
 function CustomTeam:createBottomContent()
 	if doStore then
-		return tostring(Matches._get_ongoing({})) ..
-			tostring(Matches._get_upcoming({})) ..
-			tostring(Matches._get_recent({}))
+		return MatchTicker.run({team = pagename})
 	end
 end
 


### PR DESCRIPTION
## Summary
Use new MatchTicker on SC2
--> adjust the modules using the old one
--> draft until the new matchTicker has been merged (might take some while^^)

## How did you test this change?
sandboxes