### PR TITLE
Add parameters for OpencastStreams to `Module:Infobox/League/Custom`

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -270,7 +270,7 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_deadline', DateClean(args.deadline or ''))
 	Variables.varDefine('tournament_gamemode', table.concat(CustomLeague:_getGameModes(args, false), ','))
 
-	-- StreamSearch
+	-- Variables for Template:OpencastStreams
 	Variables.varDefine('tournament_opencast', args.opencast)
 	Variables.varDefine('tournament_opencastname', args.opencastname)
 end

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -269,6 +269,10 @@ function CustomLeague:defineCustomPageVariables(args)
 	-- Module:Prize pool, Module:Prize pool team, Module:TeamCard and Module:TeamCard2
 	Variables.varDefine('tournament_deadline', DateClean(args.deadline or ''))
 	Variables.varDefine('tournament_gamemode', table.concat(CustomLeague:_getGameModes(args, false), ','))
+
+	-- StreamSearch
+	Variables.varDefine('tournament_opencast', args.opencast)
+	Variables.varDefine('tournament_opencastname', args.opencastname)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -99,7 +99,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'prizepool' then
 		return {
 			Cell{
-				name = 'Prize pool',
+				name = 'Prize Pool',
 				content = {CustomLeague:_createPrizepool(args)}
 			}
 		}


### PR DESCRIPTION
## Summary
Since open casting is most often used ther, AoE wiki wants to have a version of `Template:Streams` that has links to search for streams based on the tournament name or a custom search string.
This PR adds a parameter `opencast` to enable this search, and a parameter `opencastname` to specify a custom search string, to be used by a `Template:OpencastStreams`.
Parameters are directly passed to variables.

## How did you test this change?
Tested in a [Sandbox](https://liquipedia.net/ageofempires/Module:SyntacticSalt/sandbox2/doc)

