### PR TITLE
Create match ticker (+ sc2 custom)

### DIFF
--- a/components/match2/commons/match_ticker.lua
+++ b/components/match2/commons/match_ticker.lua
@@ -1,0 +1,22 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchTicker
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local MatchTicker = Class.new()
+
+MatchTicker.Display = Lua.import('Module:MatchTicker/Display', {requireDevIfEnabled = true})
+
+MatchTicker.Query = Lua.import('Module:MatchTicker/Query', {requireDevIfEnabled = true})
+
+MatchTicker.HelperFunctions = MatchTicker.Display.HelperFunctions
+
+--overwrite stuff if needed
+
+return MatchTicker

--- a/components/match2/wikis/starcraft2/match_ticker.lua
+++ b/components/match2/wikis/starcraft2/match_ticker.lua
@@ -1,0 +1,44 @@
+---
+-- @Liquipedia
+-- wiki=starcraft2
+-- page=Module:MatchTicker
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
+
+local Condition = require('Module:Condition')
+local ConditionNode = Condition.Node
+local Comparator = Condition.Comparator
+local ColumnName = Condition.ColumnName
+
+local MatchTicker = Class.new()
+
+MatchTicker.Display = Lua.import('Module:MatchTicker/Display', {requireDevIfEnabled = true})
+
+MatchTicker.Query = Lua.import('Module:MatchTicker/Query', {requireDevIfEnabled = true})
+
+MatchTicker.HelperFunctions = MatchTicker.Display.HelperFunctions
+
+--overwrite stuff
+MatchTicker.Display.OpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
+MatchTicker.Display.Opponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
+
+function MatchTicker.Query.BaseConditions:build(queryArgs)
+	if Logic.readBool(queryArgs.featured) then
+		self.conditionTree:add({ConditionNode(ColumnName('extradata_featured'), Comparator.eq, 'true')})
+	end
+
+	return self.conditionTree
+end
+
+MatchTicker.HelperFunctions.tbdIdentifier = 'definitions'
+MatchTicker.HelperFunctions.featuredClass = 'sc2premier-highlighted'
+MatchTicker.HelperFunctions.isFeatured = function(matchData)
+	return Logic.readBool((matchData.extradata or {}).featured)
+end
+
+return MatchTicker

--- a/components/match2/wikis/starcraft2/match_ticker.lua
+++ b/components/match2/wikis/starcraft2/match_ticker.lua
@@ -28,6 +28,7 @@ MatchTicker.Display.OpponentDisplay = Lua.import('Module:OpponentDisplay/Starcra
 MatchTicker.Display.Opponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
 
 function MatchTicker.Query.BaseConditions:build(queryArgs)
+	self.conditionTree:add({ConditionNode(ColumnName('extradata_ffa'), Comparator.eq, 'false')})
 	if Logic.readBool(queryArgs.featured) then
 		self.conditionTree:add({ConditionNode(ColumnName('extradata_featured'), Comparator.eq, 'true')})
 	end

--- a/components/match2/wikis/starcraft2/match_ticker.lua
+++ b/components/match2/wikis/starcraft2/match_ticker.lua
@@ -30,7 +30,7 @@ MatchTicker.Display.Opponent = Lua.import('Module:Opponent/Starcraft', {requireD
 function MatchTicker.Query.BaseConditions:build(queryArgs)
 	self.conditionTree:add({ConditionNode(ColumnName('extradata_ffa'), Comparator.eq, 'false')})
 	if Logic.readBool(queryArgs.featured) then
-		self.conditionTree:add({ConditionNode(ColumnName('publishertier'), Comparator.eq, 'true')})
+		self.conditionTree:add(ConditionNode(ColumnName('publishertier'), Comparator.eq, 'true'))
 	end
 
 	return self.conditionTree

--- a/components/match2/wikis/starcraft2/match_ticker.lua
+++ b/components/match2/wikis/starcraft2/match_ticker.lua
@@ -33,7 +33,7 @@ function MatchTicker.Query.BaseConditions:build(queryArgs)
 		self.conditionTree:add(ConditionNode(ColumnName('publishertier'), Comparator.eq, 'true'))
 	end
 
-	return self.conditionTree
+	return self.conditionTree:toString()
 end
 
 MatchTicker.HelperFunctions.tbdIdentifier = 'definitions'

--- a/components/match2/wikis/starcraft2/match_ticker.lua
+++ b/components/match2/wikis/starcraft2/match_ticker.lua
@@ -30,7 +30,7 @@ MatchTicker.Display.Opponent = Lua.import('Module:Opponent/Starcraft', {requireD
 function MatchTicker.Query.BaseConditions:build(queryArgs)
 	self.conditionTree:add({ConditionNode(ColumnName('extradata_ffa'), Comparator.eq, 'false')})
 	if Logic.readBool(queryArgs.featured) then
-		self.conditionTree:add({ConditionNode(ColumnName('extradata_featured'), Comparator.eq, 'true')})
+		self.conditionTree:add({ConditionNode(ColumnName('publishertier'), Comparator.eq, 'true')})
 	end
 
 	return self.conditionTree


### PR DESCRIPTION
## Summary
Add basic (and sc2 specific) match ticker module to combine the Display components, helper functions and Query components into one accessible/overwritable module.
This module then would be called by the `MatchTicker/Tournament`, `MatchTicker/Participant` and `MatchTicker/MainPage` modules. (For those i would open PRs once the first 4 PRs are reviewed and we deem it okay to go this route.)

## How did you test this change?
Sandboxes

## Remark
This PR together with several other PRs will set up the match2 match ticker.
Depends on #1066 and #1067 and #1068
(#832 additionally holds the other modules that would follow after these 4 PRs.)