### PR TITLE
Fix age calculation

### DIFF
--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -190,7 +190,7 @@ function Age:makeDisplay()
 end
 
 function Age:_secondsToAge(seconds)
-	return math.ceil(seconds / 60 / 60 / 24 / 365.25)
+	return math.floor(seconds / 60 / 60 / 24 / 365.2425)
 end
 
 function AgeCalculation.run(args)

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -190,7 +190,7 @@ function Age:makeDisplay()
 end
 
 function Age:_secondsToAge(seconds)
-	return math.floor(seconds / 60 / 60 / 24 / 365.25)
+	return math.ceil(seconds / 60 / 60 / 24 / 365.25)
 end
 
 function AgeCalculation.run(args)


### PR DESCRIPTION
## Summary
Currently age calculation is off by up to almost 1 day:
![Screenshot 2022-02-22 17 21 02](https://user-images.githubusercontent.com/75081997/155174396-a0176e83-b516-4453-bc37-164cb24587e9.png)
(atm: seconds / 60 / 60 / 24 / 365.25 = 12.999826032398)

after the change:
![Screenshot 2022-02-22 17 21 06](https://user-images.githubusercontent.com/75081997/155174425-99133e02-8c89-497d-9a0c-ab74032fa0c0.png)
(atm: seconds / 60 / 60 / 24 / 365.2425 = 13.000092974759)

## How did you test this change?
sandbox