### PR TITLE
Update custom input processing

### DIFF
--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -178,7 +178,9 @@ function matchFunctions.getOpponents(args)
 		sumscores[map.winner] = (sumscores[map.winner] or 0) + 1
 	end
 
-	local bestof = tonumber(args.bestof or 5) or 5
+	local bestof = Logic.emptyOr(args.bestof, Variables.varDefault('bestof', 5))
+	bestof = tonumber(bestof) or 5
+	Variables.varDefine('bestof', bestof)
 	local firstTo = math.ceil(bestof / 2)
 
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
@@ -276,7 +278,9 @@ end
 -- map related functions
 --
 function mapFunctions.getExtraData(map)
-	local bestof = tonumber(map.bestof or 3) or 3
+	local bestof = Logic.emptyOr(map.bestof, Variables.varDefault('map_bestof', 3))
+	bestof = tonumber(bestof) or 3
+	Variables.varDefine('map_bestof', bestof)
 	map.extradata = {
 		bestof = bestof,
 		comment = map.comment,

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -352,7 +352,7 @@ function mapFunctions.getParticipantsData(map)
 		) do
 			local brawlerRaw = map['team' .. opponentIndex .. 'pick' .. pickIndex]
 				or map['t' .. opponentIndex .. 'p' .. pickIndex]
-			local brawler = BrawlerNames[brawler]
+			local brawler = BrawlerNames[brawlerRaw]
 			if not brawler then
 				error('Unsupported brawler input ' .. brawlerRaw)
 			end
@@ -363,7 +363,7 @@ function mapFunctions.getParticipantsData(map)
 			pickIndex = pickIndex + 1
 		end
 	end
-	
+
 	map.extradata.maximumpickindex = maximumPickIndex
 	map.participants = participants
 	return map

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -282,7 +282,7 @@ function mapFunctions.getExtraData(map)
 		bestof = bestof,
 		comment = map.comment,
 		header = map.header,
-		maptype = map.type,
+		maptype = map.maptype,
 	}
 
 	local bans = {}

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -293,7 +293,7 @@ function mapFunctions.getExtraData(map)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		bans['team' .. opponentIndex] = {}
 		for _, ban in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'b') do
-			ban = mapFunctions._CleanBrawlerName(ban)
+			ban = mapFunctions._cleanBrawlerName(ban)
 			table.insert(bans['team' .. opponentIndex], ban)
 		end
 	end
@@ -340,7 +340,7 @@ function mapFunctions.getParticipantsData(map)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		for pickKey, brawler in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
 			local pickIndex = tonumber(string.sub(pickKey, -1))
-			brawler = mapFunctions._CleanBrawlerName(brawler)
+			brawler = mapFunctions._cleanBrawlerName(brawler)
 			participants[opponentIndex .. '_' .. pickIndex] = {brawler=brawler}
 			if maximumPickIndex < pickIndex then
 				maximumPickIndex = pickIndex
@@ -353,7 +353,7 @@ function mapFunctions.getParticipantsData(map)
 	return map
 end
 
-function mapFunctions._CleanBrawlerName(brawlerRaw)
+function mapFunctions._cleanBrawlerName(brawlerRaw)
 	local brawler = BrawlerNames[string.lower(brawlerRaw)]
 	if not brawler then
 		error('Unsupported brawler input: ' .. brawlerRaw)

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -356,7 +356,7 @@ end
 function mapFunctions._CleanBrawlerName(brawlerRaw)
 	local brawler = BrawlerNames[string.lower(brawlerRaw)]
 	if not brawler then
-		error('Unsupported brawler input ' .. brawlerRaw)
+		error('Unsupported brawler input: ' .. brawlerRaw)
 	end
 
 	return brawler

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -292,16 +292,9 @@ function mapFunctions.getExtraData(map)
 
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		bans['team' .. opponentIndex] = {}
-		local banIndex = 1
-		while String.isNotEmpty(map['t' .. opponentIndex .. 'b' .. banIndex]) do
-			local banRaw = map['t' .. opponentIndex .. 'b' .. banIndex]
-			local ban = BrawlerNames[string.lower(banRaw)]
-			if not ban then
-				error('Unsupported ban input ' .. ban)
-			end
+		for _, ban in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'b') do
+			ban = mapFunctions._CleanBrawlerName(ban)
 			table.insert(bans['team' .. opponentIndex], ban)
-
-			banIndex = banIndex + 1
 		end
 	end
 
@@ -345,24 +338,28 @@ function mapFunctions.getParticipantsData(map)
 
 	local maximumPickIndex = 0
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
-		local pickIndex = 1
-		while String.isNotEmpty(map['t' .. opponentIndex .. 'p' .. pickIndex]) do
-			local brawlerRaw = map['t' .. opponentIndex .. 'p' .. pickIndex]
-			local brawler = BrawlerNames[string.lower(brawlerRaw)]
-			if not brawler then
-				error('Unsupported brawler input ' .. brawlerRaw)
-			end
+		for pickKey, brawler in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
+			local pickIndex = tonumber(string.sub(pickKey, -1))
+			brawler = mapFunctions._CleanBrawlerName(brawler)
 			participants[opponentIndex .. '_' .. pickIndex] = {brawler=brawler}
 			if maximumPickIndex < pickIndex then
 				maximumPickIndex = pickIndex
 			end
-			pickIndex = pickIndex + 1
 		end
 	end
 
 	map.extradata.maximumpickindex = maximumPickIndex
 	map.participants = participants
 	return map
+end
+
+function mapFunctions._CleanBrawlerName(brawlerRaw)
+	local brawler = BrawlerNames[string.lower(brawlerRaw)]
+	if not brawler then
+		error('Unsupported brawler input ' .. brawlerRaw)
+	end
+
+	return brawler
 end
 
 --

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -53,7 +53,6 @@ function CustomMatchGroupInput.processMap(frame, map)
 	map = mapFunctions.getScoresAndWinner(map)
 	map = mapFunctions.getTournamentVars(map)
 	map = mapFunctions.getParticipantsData(map)
-mw.logObject(map)
 
 	return map
 end
@@ -295,7 +294,7 @@ function mapFunctions.getExtraData(map)
 			String.isNotEmpty(map['t' .. opponentIndex .. 'b' .. banIndex])
 		) do
 			local banRaw = map['team' .. opponentIndex .. 'ban' .. banIndex] or map['t' .. opponentIndex .. 'b' .. banIndex]
-			local ban = BrawlerNames[banRaw]
+			local ban = BrawlerNames[string.lower(banRaw)]
 			if not ban then
 				error('Unsupported ban input ' .. ban)
 			end
@@ -352,11 +351,11 @@ function mapFunctions.getParticipantsData(map)
 		) do
 			local brawlerRaw = map['team' .. opponentIndex .. 'pick' .. pickIndex]
 				or map['t' .. opponentIndex .. 'p' .. pickIndex]
-			local brawler = BrawlerNames[brawlerRaw]
+			local brawler = BrawlerNames[string.lower(brawlerRaw)]
 			if not brawler then
 				error('Unsupported brawler input ' .. brawlerRaw)
 			end
-			map.participants[opponentIndex .. '_' .. pickIndex] = {brawler=brawler}
+			participants[opponentIndex .. '_' .. pickIndex] = {brawler=brawler}
 			if maximumPickIndex < pickIndex then
 				maximumPickIndex = pickIndex
 			end

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -293,10 +293,7 @@ function mapFunctions.getExtraData(map)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		bans['team' .. opponentIndex] = {}
 		local banIndex = 1
-		while (
-			String.isNotEmpty(map['team' .. opponentIndex .. 'ban' .. banIndex]) or
-			String.isNotEmpty(map['t' .. opponentIndex .. 'b' .. banIndex])
-		) do
+		while String.isNotEmpty(map['t' .. opponentIndex .. 'b' .. banIndex]) do
 			local banRaw = map['team' .. opponentIndex .. 'ban' .. banIndex] or map['t' .. opponentIndex .. 'b' .. banIndex]
 			local ban = BrawlerNames[string.lower(banRaw)]
 			if not ban then
@@ -349,10 +346,7 @@ function mapFunctions.getParticipantsData(map)
 	local maximumPickIndex = 0
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		local pickIndex = 1
-		while (
-			String.isNotEmpty(map['team' .. opponentIndex .. 'pick' .. pickIndex])
-			or String.isNotEmpty(map['t' .. opponentIndex .. 'p' .. pickIndex])
-		) do
+		while String.isNotEmpty(map['t' .. opponentIndex .. 'p' .. pickIndex]) do
 			local brawlerRaw = map['team' .. opponentIndex .. 'pick' .. pickIndex]
 				or map['t' .. opponentIndex .. 'p' .. pickIndex]
 			local brawler = BrawlerNames[string.lower(brawlerRaw)]

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -294,7 +294,7 @@ function mapFunctions.getExtraData(map)
 		bans['team' .. opponentIndex] = {}
 		local banIndex = 1
 		while String.isNotEmpty(map['t' .. opponentIndex .. 'b' .. banIndex]) do
-			local banRaw = map['team' .. opponentIndex .. 'ban' .. banIndex] or map['t' .. opponentIndex .. 'b' .. banIndex]
+			local banRaw = map['t' .. opponentIndex .. 'b' .. banIndex]
 			local ban = BrawlerNames[string.lower(banRaw)]
 			if not ban then
 				error('Unsupported ban input ' .. ban)
@@ -347,8 +347,7 @@ function mapFunctions.getParticipantsData(map)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		local pickIndex = 1
 		while String.isNotEmpty(map['t' .. opponentIndex .. 'p' .. pickIndex]) do
-			local brawlerRaw = map['team' .. opponentIndex .. 'pick' .. pickIndex]
-				or map['t' .. opponentIndex .. 'p' .. pickIndex]
+			local brawlerRaw = map['t' .. opponentIndex .. 'p' .. pickIndex]
 			local brawler = BrawlerNames[string.lower(brawlerRaw)]
 			if not brawler then
 				error('Unsupported brawler input ' .. brawlerRaw)


### PR DESCRIPTION
## Summary
Added support for:
- read brawler picks and bans per map
- remove bans from match as they are not used according to @jojimenezt 
- read map type
- read match mvp

## How did you test this change?
live (system so far only used on test pages)