### PR TITLE
Store tournament extradata into a wiki var

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -278,6 +278,10 @@ function League:_setLpdbData(args, links)
 	lpdbData = self:addToLpdb(lpdbData, args)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
 	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. self.name, lpdbData)
+
+	-- store extradata (as a json string) into a wiki variable
+	-- so it can be adjusted in later modules (e.g. prize pools)
+	Variables.varDefine('tournament_extradata', lpdbData.extradata)
 end
 
 function League:_getNamedTableofAllArgsForBase(args, base)


### PR DESCRIPTION
## Summary
Store tournament extradata into a wiki var so it can be used in modules/templates further down on the page.
E.g. on several wikis prize pools sets some additional extradata into the tournament extradata. So if the infobox tournament set extradata it gets overwritten then. To be able to properly add the data to extradata (without killing the already set data) this wiki variable can be accessed and merged with the data to be added to extradata.

## How did you test this change?
N/A just sets an additional variable that is not used anywhere atm