### PR TITLE
Fix Historical TT's in Legacy Brackets

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -314,7 +314,8 @@ end
 Merges an opponent struct into a match2 opponent record.
 
 If any property exists in both the record and opponent struct, the value from the opponent struct will be prioritized.
-Reason for this is that the opponent struct is retrived programmatically via Module:Opponent.
+The opponent struct is retrieved programmatically via Module:Opponent, by using the team template extension.
+Using the team template extension, the opponent struct is standardised and not user input dependant, unlike the record.
 ]]
 function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 	if opponent.type == Opponent.team then

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -315,7 +315,7 @@ Merges an opponent struct into a match2 opponent record.
 ]]
 function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 	if opponent.type == Opponent.team then
-		record.template = record.template or opponent.template
+		record.template = opponent.template or record.template
 
 	elseif Opponent.typeIsParty(opponent.type) then
 		record.match2players = record.match2players

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -312,6 +312,9 @@ end
 
 --[[
 Merges an opponent struct into a match2 opponent record.
+
+If any property exists in both the record and opponent struct, the value from the opponent struct will be prioritized.
+Reason for this is that the opponent struct is retrived programmatically via Module:Opponent.
 ]]
 function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 	if opponent.type == Opponent.team then


### PR DESCRIPTION
## Summary

Fix for #983 (Legacy Brackets don't use historical team templates). Apply the template fallback in correct order. 
`opponent` has the more up to date template information, being retrieved from `Module:Opponent.resolve`, while `record` is contains the arguments (from wikicode/legacy).

## How did you test this change?

Tested with `dev` feature toggle on R6, RL, SC2, ML & halo. 
No unintended side effects on any wiki.
Issue successfully seen solved on R6 & RL (ML, Halo doesn't use legacy, couldn't find a SC2 tournament to test with dev toggle on)
