### PR TITLE
Do not add category in userspace (Person)

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -347,10 +347,15 @@ function Person:_createLocation(country, location, personType)
 	local countryDisplay = Flags.CountryName(country)
 	local demonym = Localisation(countryDisplay)
 
+	local category = ''
+	if Namespace.isMain() then
+		category = '[[Category:' .. demonym .. ' ' .. personType .. 's]]'
+	end
+
 	return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' ..
-				'[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]'
-				.. '[[Category:' .. demonym .. ' ' .. personType .. 's]]'
-				.. (location ~= nil and (',&nbsp;' .. location) or '')
+		'[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]' ..
+		category ..
+		(location ~= nil and (',&nbsp;' .. location) or '')
 end
 
 function Person:_createTeam(team, link)


### PR DESCRIPTION
## Summary

For wikis not overriding `_createLocation` in their Player implemenation, the default handling in Common's Infobox Person is to set the country category in all spaces. This currently affects the wikis Starcraft2, (Mobile Legends) and Halo.
It was determined on discord that the category shouldn't be set in userspace. https://discord.com/channels/93055209017729024/874304000718172200/943890994921889852

## How did you test this change?
Tested in preview mode on SC2 userspace & mainspace page. 
Works as expected.