### PR TITLE
Fix typo in unofficial world champ infobox

### DIFF
--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -92,7 +92,7 @@ function UnofficialWorldChampion:createInfobox()
 		},
 		Title{name = 'Most Times Held'},
 		Cell{
-			name = (args['most times held no'] or '?') .. ' days',
+			name = (args['most times held no'] or '?') .. ' times',
 			content = { args['most times held'] },
 		},
 		Customizable{id = 'custom', children = {}},


### PR DESCRIPTION
## Summary
Adjust "days" —> "times" in the "most times held" section

## How did you test this change?
live
