### PR TITLE
Update brawlstars match2 input processing

### DIFF
--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -226,6 +226,20 @@ function matchFunctions.getOpponents(args)
 	--set resulttype to 'default' if walkover is set
 	if args.walkover then
 		args.resulttype = 'default'
+	elseif isScoreSet then
+		-- if isScoreSet is true we have scores from at least one opponent
+		-- in case the other opponent(s) have no score set manually and
+		-- no sumscore set we have to set them to 0 now so they are
+		-- not displayed as blank
+		for _, opponent in pairs(opponents) do
+			if
+				String.isEmpty(opponent.status)
+				and String.isEmpty(opponent.score)
+			then
+				opponent.score = 0
+				opponent.status = 'S'
+			end
+		end
 	end
 
 	-- see if match should actually be finished if score is set
@@ -338,10 +352,15 @@ function mapFunctions.getParticipantsData(map)
 
 	local maximumPickIndex = 0
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
-		for pickKey, brawler in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
-			local pickIndex = tonumber(string.sub(pickKey, -1))
-			brawler = mapFunctions._cleanBrawlerName(brawler)
-			participants[opponentIndex .. '_' .. pickIndex] = {brawler=brawler}
+		for playerKey, player in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
+			local index = tonumber(string.sub(playerKey, -1))
+			local brawler = map['t' .. opponentIndex .. 'c' .. index] or ''
+			local pickIndex = 0
+			if String.isNotEmpty(brawler) then
+				pickIndex = index
+				brawler = mapFunctions._cleanBrawlerName(brawler)
+			end
+			participants[opponentIndex .. '_' .. index] = {brawler=brawler, player = player}
 			if maximumPickIndex < pickIndex then
 				maximumPickIndex = pickIndex
 			end

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -353,14 +353,15 @@ function mapFunctions.getParticipantsData(map)
 	local maximumPickIndex = 0
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		for playerKey, player in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
-			local index = tonumber(string.sub(playerKey, -1))
-			local brawler = map['t' .. opponentIndex .. 'c' .. index] or ''
-			local pickIndex = 0
-			if String.isNotEmpty(brawler) then
-				pickIndex = index
-				brawler = mapFunctions._cleanBrawlerName(brawler)
-			end
-			participants[opponentIndex .. '_' .. index] = {brawler=brawler, player = player}
+			local playerIndex = tonumber(string.sub(playerKey, -1))
+			participants[opponentIndex .. '_' .. playerIndex] = {player = player}
+		end
+
+		for pickKey, brawler in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'c') do
+			local pickIndex = tonumber(string.sub(pickKey, -1))
+			brawler = mapFunctions._cleanBrawlerName(brawler)
+			participants[opponentIndex .. '_' .. pickIndex] = participants[opponentIndex .. '_' .. pickIndex] or {}
+			participants[opponentIndex .. '_' .. pickIndex].brawler = brawler
 			if maximumPickIndex < pickIndex then
 				maximumPickIndex = pickIndex
 			end

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -352,13 +352,11 @@ function mapFunctions.getParticipantsData(map)
 
 	local maximumPickIndex = 0
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
-		for playerKey, player in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
-			local playerIndex = tonumber(string.sub(playerKey, -1))
+		for playerKey, player, playerIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
 			participants[opponentIndex .. '_' .. playerIndex] = {player = player}
 		end
 
-		for pickKey, brawler in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'c') do
-			local pickIndex = tonumber(string.sub(pickKey, -1))
+		for pickKey, brawler, pickIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'c') do
 			brawler = mapFunctions._cleanBrawlerName(brawler)
 			participants[opponentIndex .. '_' .. pickIndex] = participants[opponentIndex .. '_' .. pickIndex] or {}
 			participants[opponentIndex .. '_' .. pickIndex].brawler = brawler

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -352,11 +352,11 @@ function mapFunctions.getParticipantsData(map)
 
 	local maximumPickIndex = 0
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
-		for playerKey, player, playerIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
+		for _, player, playerIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
 			participants[opponentIndex .. '_' .. playerIndex] = {player = player}
 		end
 
-		for pickKey, brawler, pickIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'c') do
+		for _, brawler, pickIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'c') do
 			brawler = mapFunctions._cleanBrawlerName(brawler)
 			participants[opponentIndex .. '_' .. pickIndex] = participants[opponentIndex .. '_' .. pickIndex] or {}
 			participants[opponentIndex .. '_' .. pickIndex].brawler = brawler


### PR DESCRIPTION
## Summary
Update brawlstars match2 input processing
- fix a bug where score and status were not set correctly
- adjust pick input as wisched by the wiki
- add input for players per map

## How did you test this change?
live (system not yet in use)
