### PR TITLE
Default parent if not set

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -220,6 +220,7 @@ function League:_definePageVariables(args)
 
 	Variables.varDefine('tournament_game', string.lower(args.game or ''))
 
+	-- Using current page title as parent is intended. See PR #1087 for background.
 	Variables.varDefine('tournament_parent', args.parent or mw.title.getCurrentTitle().prefixedText)
 	Variables.varDefine('tournament_parentname', args.parentname)
 	Variables.varDefine('tournament_subpage', args.subpage)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -221,7 +221,7 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_game', string.lower(args.game or ''))
 
 	Variables.varDefine('tournament_parent', args.parent or mw.title.getCurrentTitle().prefixedText)
-	Variables.varDefine('tournament_parentname', args.parentname or args.name)
+	Variables.varDefine('tournament_parentname', args.parentname)
 	Variables.varDefine('tournament_subpage', args.subpage)
 
 	Variables.varDefine('tournament_startdate',

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -220,7 +220,7 @@ function League:_definePageVariables(args)
 
 	Variables.varDefine('tournament_game', string.lower(args.game or ''))
 
-	-- Using current page title as parent is intended. See PR #1087 for background.
+	-- If no parent is available, set pagename instead to ease querying
 	Variables.varDefine('tournament_parent', args.parent or mw.title.getCurrentTitle().prefixedText)
 	Variables.varDefine('tournament_parentname', args.parentname)
 	Variables.varDefine('tournament_subpage', args.subpage)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -220,8 +220,8 @@ function League:_definePageVariables(args)
 
 	Variables.varDefine('tournament_game', string.lower(args.game or ''))
 
-	Variables.varDefine('tournament_parent', args.parent)
-	Variables.varDefine('tournament_parentname', args.parentname)
+	Variables.varDefine('tournament_parent', args.parent or mw.title.getCurrentTitle().prefixedText)
+	Variables.varDefine('tournament_parentname', args.parentname or args.name)
 	Variables.varDefine('tournament_subpage', args.subpage)
 
 	Variables.varDefine('tournament_startdate',

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -193,7 +193,7 @@ function HiddenInfoboxLeague._definePageVariables()
 	Variables.varDefine('tournament_game', (_GAMES[string.lower(_args.game or '')] or {})[1] or _GAMES[_GAME_WOL][1])
 
 	Variables.varDefine('tournament_parent', _args.parent or mw.title.getCurrentTitle().prefixedText)
-	Variables.varDefine('tournament_parentname', _args.parentname or _args.name)
+	Variables.varDefine('tournament_parentname', _args.parentname)
 	Variables.varDefine('tournament_subpage', _args.subpage)
 
 	local sdate = HiddenInfoboxLeague._cleanDate(_args.sdate) or HiddenInfoboxLeague._cleanDate(_args.date)

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -192,7 +192,7 @@ function HiddenInfoboxLeague._definePageVariables()
 
 	Variables.varDefine('tournament_game', (_GAMES[string.lower(_args.game or '')] or {})[1] or _GAMES[_GAME_WOL][1])
 
-	-- Using current page title as parent is intended. See PR #1087 for background.
+	-- If no parent is available, set pagename instead to ease querying
 	Variables.varDefine('tournament_parent', _args.parent or mw.title.getCurrentTitle().prefixedText)
 	Variables.varDefine('tournament_parentname', _args.parentname)
 	Variables.varDefine('tournament_subpage', _args.subpage)

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -192,8 +192,8 @@ function HiddenInfoboxLeague._definePageVariables()
 
 	Variables.varDefine('tournament_game', (_GAMES[string.lower(_args.game or '')] or {})[1] or _GAMES[_GAME_WOL][1])
 
-	Variables.varDefine('tournament_parent', _args.parent)
-	Variables.varDefine('tournament_parentname', _args.parentname)
+	Variables.varDefine('tournament_parent', _args.parent or mw.title.getCurrentTitle().prefixedText)
+	Variables.varDefine('tournament_parentname', _args.parentname or _args.name)
 	Variables.varDefine('tournament_subpage', _args.subpage)
 
 	local sdate = HiddenInfoboxLeague._cleanDate(_args.sdate) or HiddenInfoboxLeague._cleanDate(_args.date)

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -192,6 +192,7 @@ function HiddenInfoboxLeague._definePageVariables()
 
 	Variables.varDefine('tournament_game', (_GAMES[string.lower(_args.game or '')] or {})[1] or _GAMES[_GAME_WOL][1])
 
+	-- Using current page title as parent is intended. See PR #1087 for background.
 	Variables.varDefine('tournament_parent', _args.parent or mw.title.getCurrentTitle().prefixedText)
 	Variables.varDefine('tournament_parentname', _args.parentname)
 	Variables.varDefine('tournament_subpage', _args.subpage)


### PR DESCRIPTION
## Summary

### Background

As discussed multiple times on the discord, such as 
https://discord.com/channels/93055209017729024/802175956286177311/927935117622661170
https://discord.com/channels/93055209017729024/874304000718172200/935522534147899462
https://discord.com/channels/93055209017729024/874304000718172200/935854580531613796

Reasoning is improved querying of tournament data when a tournament is split across multiple pages.

### Implementation
Setting the wiki-variable `tournament_parent` always in Infobox League. By default, the current logic will apply (`|parent=...`) and if missing will use the Pagename of the page (including userspace prefix) and `|name=` respectively.
Applying this wiki-variable will then cause downstream Modules, such as match2, to set their LPDB-property `parent`.
Some Template/Modules may need to be updated to actually store parent, specifically in the ones where the property was recently added, such as Broadcaster, Standings and match2game.

## How did you test this change?

Tested live on R6