### PR TITLE
Add index to pairsByPrefix

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -476,7 +476,7 @@ function Table.iter.pairsByPrefix(tbl, prefix)
 		local key = prefix .. i
 		local value = tbl[key]
 		i = i + 1
-		return value and key, value, (i - 1) or nil
+		return value and (key, value, (i - 1)) or nil
 	end
 end
 

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -476,7 +476,11 @@ function Table.iter.pairsByPrefix(tbl, prefix)
 		local key = prefix .. i
 		local value = tbl[key]
 		i = i + 1
-		return value and (key, value, (i - 1)) or nil
+		if value then
+			return key, value, (i - 1)
+		else
+			return nil
+		end
 	end
 end
 

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -464,7 +464,7 @@ local args = {
 	foo = {},
 	p10 = {},
 }
-for key, player in Table.iter.pairsByPrefix(args, 'p') do
+for key, player, index in Table.iter.pairsByPrefix(args, 'p') do
 	mw.log(key)
 end
 
@@ -476,7 +476,7 @@ function Table.iter.pairsByPrefix(tbl, prefix)
 		local key = prefix .. i
 		local value = tbl[key]
 		i = i + 1
-		return value and key, value or nil
+		return value and key, value, (i - 1) or nil
 	end
 end
 


### PR DESCRIPTION
## Summary

Add the index as a third value in pairsByPrefix, in addition to the key and value. 

## How did you test this change?

https://liquipedia.net/rainbowsix/Module:Sandbox/Rathoz

Returned the expected output
```
p1	table
p2	table
p3	table
p1	table	1
p2	table	2
p3	table	3
```