### PR TITLE
Save parent to standings if set

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -36,6 +36,8 @@ function StandingsStorage.run(index, data)
 			standingsindex = data.standingsindex,
 			section = Variables.varDefault('last_heading', ''),
 			roundindex = data.roundindex,
+			parent = Variables.varDefault('tournament_parent', ''),
+			parentname = Variables.varDefault('tournament_parentname', ''),
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json({data.extradata or {}})
 		}
 	)

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -37,7 +37,6 @@ function StandingsStorage.run(index, data)
 			section = Variables.varDefault('last_heading', ''),
 			roundindex = data.roundindex,
 			parent = Variables.varDefault('tournament_parent', ''),
-			parentname = Variables.varDefault('tournament_parentname', ''),
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json({data.extradata or {}})
 		}
 	)


### PR DESCRIPTION
## Summary

If the wiki variable for parent (`tournament_parent`) is set, save the values to the lpdb property (`parent`) in the standing table.

## How did you test this change?

Tested on R6