### PR TITLE
Update t1firstside to always be an object

### DIFF
--- a/components/match2/wikis/rainbow_six/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbow_six/match_group_input_custom.lua
@@ -488,7 +488,7 @@ end
 function mapFunctions.getExtraData(map)
 	map.extradata = {
 		comment = map.comment,
-		t1firstside = {map.t1firstside, ot = map.t1firstsideot},
+		t1firstside = {rt = map.t1firstside, ot = map.t1firstsideot},
 		t1halfs = {atk = map.t1atk, def = map.t1def, otatk = map.t1otatk, otdef = map.t1otdef},
 		t2halfs = {atk = map.t2atk, def = map.t2def, otatk = map.t2otatk, otdef = map.t2otdef},
 		t1bans = {map.t1ban1, map.t1ban2},

--- a/components/match2/wikis/rainbow_six/match_legacy.lua
+++ b/components/match2/wikis/rainbow_six/match_legacy.lua
@@ -77,10 +77,10 @@ function p.storeGames(match, match2)
 			extradata.t2halfs = json.parseIfString(extradata.t2halfs)
 			local team1 = {}
 			local team2 = {}
-			if extradata.t1firstside[1] == "atk" then
+			if extradata.t1firstside.rt == "atk" then
 				team1 = {"atk", extradata.t1halfs.atk or 0, extradata.t1halfs.def or 0}
 				team2 = {"def", extradata.t2halfs.atk or 0, extradata.t2halfs.def or 0}
-			elseif extradata.t1firstside[1] == "def" then
+			elseif extradata.t1firstside.rt == "def" then
 				team2 = {"atk", extradata.t2halfs.atk or 0, extradata.t2halfs.def or 0}
 				team1 = {"def", extradata.t1halfs.atk or 0, extradata.t1halfs.def or 0}
 			end

--- a/components/match2/wikis/rainbow_six/match_summary.lua
+++ b/components/match2/wikis/rainbow_six/match_summary.lua
@@ -452,7 +452,7 @@ function CustomMatchSummary._createMap(game)
 	local team2Halfs = extradata.t2halfs or {}
 	local firstSides = extradata.t1firstside or {}
 
-	local firstSide = (firstSides[1] or ''):lower()
+	local firstSide = (firstSides.rt or ''):lower()
 	local oppositeSide = CustomMatchSummary._getOppositeSide(firstSide)
 
 	if not Logic.isEmpty(firstSide) then


### PR DESCRIPTION
## Summary

I use the new API through an object-oriented language that doesn't like when a field can either be an array or an object. This change makes it so `t1firstside` is always an object. I named the new field `rt` for "regular time", which is in line with the other field name which is called `ot` for "overtime".


## How did you test this change?

I made these exact changes to the modules on the rainbowsix wiki. Then I both purged and null edited the [Six Invitational 2022 page](https://liquipedia.net/rainbowsix/Six_Invitational/2022). All matches and match summaries looked the same after the purge. The API response does now include the field even if a game doesn't go to overtime (not the exact same matches, just showing the changes):
```
"{\"t1firstside\": {\"rt\": \"atk\"}, \"t2halfs\": {\"atk\": \"3\", \"def\": \"4\"}, \"t1bans\": [\"nokk\", \"melusi\"], \"t2bans\": [\"hibana\", \"Valkyrie\"], \"t1halfs\": {\"atk\": \"2\", \"def\": \"1\"}}"
```
instead of
```
"{\"t1firstside\": [\"atk\"], \"t2halfs\": {\"atk\": \"1\", \"def\": \"1\"}, \"t1bans\": [\"Thatcher\", \"Mira\"], \"t2bans\": [\"Flores\", \"Goyo\"], \"t1halfs\": {\"atk\": \"5\", \"def\": \"2\"}}"
```
and
```
"{\"t1firstside\": {\"ot\": \"atk\", \"rt\": \"atk\"}, \"t2halfs\": {\"otdef\": \"0\", \"otatk\": \"0\", \"atk\": \"3\", \"def\": \"3\"}, \"t1bans\": [\"Montagne\", \"Valkyrie\"], \"t2bans\": [\"Finka\", \"Jager\"], \"t1halfs\": {\"otdef\": \"1\", \"otatk\": \"1\", \"atk\": \"3\", \"def\": \"3\"}}"
```
instead of
```
"{\"t1firstside\": {\"ot\": \"atk\", \"1\": \"def\"}, \"t2halfs\": {\"otdef\": \"0\", \"otatk\": \"1\", \"atk\": \"1\", \"def\": \"5\"}, \"t1bans\": [\"that\", \"valkyrie\"], \"t2bans\": [\"nokk\", \"wamai\"], \"t1halfs\": {\"otdef\": \"0\", \"otatk\": \"2\", \"atk\": \"1\", \"def\": \"5\"}}"
```
