### PR TITLE
Fix width of Goaltimes

### DIFF
--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -105,7 +105,7 @@ function CustomMatchSummary.getByMatchId(args)
 						game.extradata.t1goals .. '</abbr>')
 				table.insert(gameElements, mw.html.create('div')
 					:node(goals)
-					:css('max-width', '15%')
+					:css('max-width', '50%')
 					:css('maxfont-size', '11px;'))
 			end
 			if game.comment then
@@ -128,7 +128,7 @@ function CustomMatchSummary.getByMatchId(args)
 						game.extradata.t2goals .. '</abbr>')
 				table.insert(gameElements, mw.html.create('div')
 					:node(goals)
-					:css('max-width', '15%')
+					:css('max-width', '50%')
 					:css('maxfont-size', '11px;'))
 			end
 			body = CustomMatchSummary._addFlexRow(body, gameElements, 'brkts-popup-body-game')


### PR DESCRIPTION
## Summary
Width of the Goaltime is wrong. 15% will break after every single timestamp, while it should fill out the row to the middle. Increased max-width from 15% to 50%.

## How did you test this change?
Live 