### PR TITLE
Added Player Data to match2game extradata

### DIFF
--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -466,7 +466,15 @@ end
 -- Parse extradata information
 function mapFunctions.getExtraData(map)
 	map.extradata = {
-		comment = map.comment,
+		comment = map.comment,		
+		t1p1 = {score = map.t1p1score, kills = map.t1p1kills, deaths = map.t1p1deaths},
+		t1p2 = {score = map.t1p2score, kills = map.t1p2kills, deaths = map.t1p2deaths},
+		t1p3 = {score = map.t1p3score, kills = map.t1p3kills, deaths = map.t1p3deaths},
+		t1p4 = {score = map.t1p4score, kills = map.t1p4kills, deaths = map.t1p4deaths},
+		t2p1 = {score = map.t2p1score, kills = map.t2p1kills, deaths = map.t2p1deaths},
+		t2p2 = {score = map.t2p2score, kills = map.t2p2kills, deaths = map.t2p2deaths},
+		t2p3 = {score = map.t2p3score, kills = map.t2p3kills, deaths = map.t2p3deaths},
+		t2p4 = {score = map.t2p4score, kills = map.t2p4kills, deaths = map.t2p4deaths},
 	}
 	return map
 end


### PR DESCRIPTION
## Summary

Individual player data, which is used for analysis and ranking in the main tournament broadcast can be easily recorded alongside map data to then be used across the wiki

## How did you test this change?

It can be seen to be capture in lpdb data here, where the match input custom file was manually changed and used before reverting to the default version.

https://liquipedia.net/splitgate/Special:LiquipediaDB/Splitgate_Pro_Series/2022/Winter/Regular_Season/Match_Day_1#match2game

Manipulation of the data to be used for display purposes has been tested to work, as can be seen here

https://liquipedia.net/splitgate/User:Dark_meluca/PlayerStatsTest