### PR TITLE
Save parent to match2game if set

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -322,7 +322,6 @@ end
 
 function Match._prepareGameRecordForStore(matchRecord, gameRecord)
 	gameRecord.parent = matchRecord.parent
-	gameRecord.parentname = matchRecord.parentname
 	Match.clampFields(gameRecord, Match.gameFields)
 end
 
@@ -388,7 +387,6 @@ Match.gameFields = Table.map({
 	'map',
 	'mode',
 	'parent',
-	'parentname',
 	'participants',
 	'resulttype',
 	'rounds',

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -306,7 +306,7 @@ function Match._prepareRecordsForStore(records)
 		end
 	end
 	for _, gameRecord in ipairs(records.gameRecords) do
-		Match.clampFields(gameRecord, Match.gameFields)
+		Match._prepareGameRecordForStore(records.matchRecord, gameRecord)
 	end
 end
 
@@ -319,6 +319,13 @@ function Match._prepareMatchRecordForStore(match)
 	match.section = Variables.varDefault('last_heading', 'none')
 	Match.clampFields(match, Match.matchFields)
 end
+
+function Match._prepareGameRecordForStore(matchRecord, gameRecord)
+	gameRecord.parent = matchRecord.parent
+	gameRecord.parentname = matchRecord.parentname
+	Match.clampFields(gameRecord, Match.gameFields)
+end
+
 
 Match.matchFields = Table.map({
 	'bestof',
@@ -380,6 +387,8 @@ Match.gameFields = Table.map({
 	'length',
 	'map',
 	'mode',
+	'parent',
+	'parentname',
 	'participants',
 	'resulttype',
 	'rounds',


### PR DESCRIPTION
## Summary

If the match2's parent value is set, set it also for match2game. This will save the value to the lpdb property (`parent`) in the match2game lpdb.

## How did you test this change?

Tested with /dev