### PR TITLE
Add Squad to PUBG (Desktop Wiki)

### DIFF
--- a/components/squad/wikis/pubg/squad_custom.lua
+++ b/components/squad/wikis/pubg/squad_custom.lua
@@ -1,0 +1,62 @@
+---
+-- @Liquipedia
+-- wiki=pubg
+-- page=Module:Squad/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Squad = require('Module:Squad')
+local SquadRow = require('Module:Squad/Row')
+local Json = require('Module:Json')
+local Variables = require('Module:Variables')
+local ReferenceCleaner = require('Module:ReferenceCleaner')
+
+local CustomSquad = {}
+
+function CustomSquad.run(frame)
+	local squad = Squad()
+	squad:init(frame):title():header()
+
+	local args = squad.args
+
+	local index = 1
+	while args['p' .. index] ~= nil or args[index] do
+		local player = Json.parseIfString(args['p' .. index] or args[index])
+		local row = SquadRow(frame, player.role)
+		row	:id({
+				player.id,
+				flag = player.flag,
+				link = player.link,
+				captain = player.captain,
+				role = player.role,
+				team = player.team,
+			})
+			:name({name = player.name})
+			:role({role = player.role})
+			:date(player.joindate, 'Join Date:&nbsp;', 'joindate')
+
+		if squad.type == Squad.TYPE_FORMER then
+			row:date(player.leavedate, 'Leave Date:&nbsp;', 'leavedate')
+			row:newteam({
+				newteam = player.newteam,
+				newteamrole = player.newteamrole,
+				newteamdate = player.newteamdate,
+				leavedate = player.leavedate
+			})
+		elseif squad.type == Squad.TYPE_INACTIVE then
+			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
+		end
+
+		squad:row(row:create(
+			Variables.varDefault('squad_name',
+			mw.title.getCurrentTitle().prefixedText) .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+		))
+
+		index = index + 1
+	end
+
+	return squad:create()
+end
+
+return CustomSquad

--- a/components/squad/wikis/pubg/squad_custom.lua
+++ b/components/squad/wikis/pubg/squad_custom.lua
@@ -23,7 +23,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] ~= nil or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = SquadRow(frame, player.role)
+		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
 		row	:id({
 				player.id,
 				flag = player.flag,


### PR DESCRIPTION
## Summary

The new squad modules, the custom module hasnt been implemented for PUBG yet so I take this opportunity to do it, so PUBG (and the mobile wiki later on) can use new Squad if they dont wish to do AutoSquad (or if its not viable transfer-wise)

**This one is directly pasted from the version on Rocket League because I want to scrap roles column out of it, and RL one dont have role column (comparing to Mobile Legends) so that fits my need**

## How did you test this change?
https://liquipedia.net/pubg/Valdus_Esports

## Side Note 
After this is merged I'll use the same one for PUBG MOBILE later.