### PR TITLE
Tweak overflow:hidden handling

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -50,7 +50,7 @@ local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 -- Hero Ban Class
 local HeroBan = Class.new(
 	function(self)
-		self.root = mw.html.create('div'):addClass('brkts-popup-mapveto'):css('overflow', 'hidden')
+		self.root = mw.html.create('div'):addClass('brkts-popup-mapveto')
 		self.table = self.root:tag('table')
 			:addClass('wikitable-striped'):addClass('collapsible'):addClass('collapsed')
 		self:createHeader()
@@ -93,6 +93,7 @@ function CustomMatchSummary.getByMatchId(args)
 
 	local matchSummary = MatchSummary():init('400px')
 	matchSummary.root:css('flex-wrap', 'unset')
+	matchSummary.root:css('overflow', 'hidden')
 
 	matchSummary:header(CustomMatchSummary._createHeader(match))
 				:body(CustomMatchSummary._createBody(match))
@@ -282,7 +283,6 @@ function CustomMatchSummary._createGame(game, gameIndex)
 
 	row:addClass('brkts-popup-body-game')
 		:css('font-size', '80%')
-		:css('overflow', 'hidden')
 		:css('padding-left', '5px')
 		:css('padding-right', '5px')
 


### PR DESCRIPTION
## Summary

Move the overflow hidden from each "row" in the popup to instead cover the entire popup. This allows a single row to overflow into another row. Needed during hoovering

https://liquipedia.net/dota2/User:Lenya_01/15

Before:
![bild](https://user-images.githubusercontent.com/3426850/158649953-39d1a486-447c-4cb2-b055-f63fb13717a9.png)

After:
![bild](https://user-images.githubusercontent.com/3426850/158649927-004639f4-04fd-49e2-87ea-e87e9b9e0242.png)


## How did you test this change?

Still in userspace, put it live