### PR TITLE
Fix dota2 finished calculation on even numbered bestOf's

### DIFF
--- a/components/match2/wikis/dota2/matchgroup_input_custom.lua
+++ b/components/match2/wikis/dota2/matchgroup_input_custom.lua
@@ -470,7 +470,7 @@ function matchFunctions.getOpponents(match)
 
 	-- see if match should actually be finished if bestof limit was reached
 	if isScoreSet and not Logic.readBool(match.finished) then
-		local firstTo = math.floor(match.bestof/2)
+		local firstTo = math.floor(match.bestof / 2)
 		for _, item in pairs(opponents) do
 			if tonumber(item.score or 0) > firstTo then
 				match.finished = true

--- a/components/match2/wikis/dota2/matchgroup_input_custom.lua
+++ b/components/match2/wikis/dota2/matchgroup_input_custom.lua
@@ -470,9 +470,9 @@ function matchFunctions.getOpponents(match)
 
 	-- see if match should actually be finished if bestof limit was reached
 	if isScoreSet and not Logic.readBool(match.finished) then
-		local firstTo = math.ceil(match.bestof/2)
+		local firstTo = math.floor(match.bestof/2)
 		for _, item in pairs(opponents) do
-			if tonumber(item.score or 0) >= firstTo then
+			if tonumber(item.score or 0) > firstTo then
 				match.finished = true
 				break
 			end


### PR DESCRIPTION
## Summary

The current implementation for automatically finishing a match only handles odd numbered bestofs. 
This PR updates the logic to not totally break on even numbered bestof. 
In the new implementation a tied bo2 will require a manual `|finished=true` and will work fully for 2-0's. But most importantly it it won't prematurely finish the match once a single map is completed, which the current implementation does..

The last case currently not working as expected (tie) will be fixed in a followup PR.

This PR (and the followup) will also need to be applied to: AoV, Halo, ML, Splitgate & Wildrift.

## How did you test this change?

Live