### PR TITLE
Adjust SC2 infobox team

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -22,6 +22,14 @@ local Builder = require('Module:Infobox/Widget/Builder')
 local Center = require('Module:Infobox/Widget/Center')
 local Breakdown = require('Module:Infobox/Widget/Breakdown')
 
+local Condition = require('Module:Condition')
+
+local ConditionTree = Condition.Tree
+local ConditionNode = Condition.Node
+local Comparator = Condition.Comparator
+local BooleanOperator = Condition.BooleanOperator
+local ColumnName = Condition.ColumnName
+
 local doStore = true
 local pagename = mw.title.getCurrentTitle().prefixedText
 
@@ -37,6 +45,7 @@ local _earnings_by_players_while_on_team = 0
 local _ALLOWED_PLACES = { '1', '2', '3', '4', '3-4' }
 local _EARNINGS_MODES = { ['team'] = 'team' }
 local _DISCARD_PLACEMENT = 99
+local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
 local _PLAYER_EARNINGS_ABBREVIATION = '<abbr title="Earnings of players while on the team">Player earnings</abbr>'
 
 function CustomTeam.run(frame)
@@ -237,7 +246,7 @@ function CustomTeam._getLPDBrecursive(cond, query, queryType)
 		})
 		count = #additionalData
 		-- Merging
-		for i, item in ipairs(additionalData) do
+		for i, item in ipairs(additionalData or {}) do
 			data[offset + i] = item
 		end
 		offset = offset + count
@@ -247,15 +256,46 @@ function CustomTeam._getLPDBrecursive(cond, query, queryType)
 end
 
 function CustomTeam.getEarningsAndMedalsData(team)
-	local cond = '[[date::!1970-01-01 00:00:00]] AND ([[prizemoney::>0]] OR [[placement::' ..
-		table.concat(_ALLOWED_PLACES, ']] OR [[placement::')
-		.. ']]) AND(' .. '[[participant::' .. team .. ']] OR ' ..
-		'([[mode::!team_individual]] AND ([[extradata_participantteamclean::' ..
-		string.lower(team) .. ']] OR [[extradata_participantteamclean::' .. team .. ']] OR ' ..
-		'[[extradata_participantteam::' .. team .. ']])))'
-	local query = 'liquipediatier, placement, date, prizemoney, mode'
+	local query = 'liquipediatier, liquipediatiertype, placement, date, individualprizemoney, prizemoney, players'
 
-	local data = CustomTeam._getLPDBrecursive(cond, query, 'placement')
+	local playerTeamConditions = ConditionTree(BooleanOperator.any):add({
+	})
+	for playerIndex = 1, _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS do
+		playerTeamConditions:add({
+			ConditionNode(ColumnName('players_p' .. playerIndex .. 'team'), Comparator.eq, team),
+		})
+	end
+
+	local conditions = ConditionTree(BooleanOperator.all):add({
+		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
+		ConditionTree(BooleanOperator.any):add({
+			ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
+			ConditionNode(ColumnName('liquipediatiertype'), Comparator.eq, ''),
+		}),
+		ConditionTree(BooleanOperator.any):add({
+			ConditionNode(ColumnName('prizemoney'), Comparator.gt, '0'),
+			ConditionTree(BooleanOperator.all):add({
+				ConditionNode(ColumnName('players_type'), Comparator.eq, 'team'),
+				ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
+				ConditionTree(BooleanOperator.any):add({
+					ConditionNode(ColumnName('placement'), Comparator.eq, '1'),
+					ConditionNode(ColumnName('placement'), Comparator.eq, '2'),
+					ConditionNode(ColumnName('placement'), Comparator.eq, '3'),
+					ConditionNode(ColumnName('placement'), Comparator.eq, '4'),
+					ConditionNode(ColumnName('placement'), Comparator.eq, '3-4'),
+				}),
+			}),
+		}),
+		ConditionTree(BooleanOperator.any):add({
+			ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
+			ConditionTree(BooleanOperator.all):add({
+				ConditionNode(ColumnName('players_type'), Comparator.neq, 'team'),
+				playerTeamConditions
+			}),
+		}),
+	})
+
+	local data = CustomTeam._getLPDBrecursive(conditions:toString(), query, 'placement')
 
 	local earnings = {}
 	local medals = {}
@@ -271,9 +311,10 @@ function CustomTeam.getEarningsAndMedalsData(team)
 			earnings, playerEarnings = CustomTeam._addPlacementToEarnings(earnings, playerEarnings, item)
 
 			--handle medals
-			if item.mode == '1v1' then
+			local mode = (players or {}).type
+			if mode == 'solo' then
 				medals = CustomTeam._addPlacementToMedals(medals, item)
-			elseif item.mode == 'team' then
+			elseif mode == 'team' then
 				teamMedals = CustomTeam._addPlacementToMedals(teamMedals, item)
 			end
 		end

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -269,6 +269,7 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
 		ConditionTree(BooleanOperator.any):add({
 			ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
+			ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Qualifier'),
 			ConditionNode(ColumnName('liquipediatiertype'), Comparator.eq, ''),
 		}),
 		ConditionTree(BooleanOperator.any):add({

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -270,7 +270,6 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		ConditionTree(BooleanOperator.any):add({
 			ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
 			ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Qualifier'),
-			ConditionNode(ColumnName('liquipediatiertype'), Comparator.eq, ''),
 		}),
 		ConditionTree(BooleanOperator.any):add({
 			ConditionNode(ColumnName('prizemoney'), Comparator.gt, '0'),

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -43,6 +43,7 @@ local _team
 local _earnings = 0
 local _earnings_by_players_while_on_team = 0
 local _EARNINGS_MODES = { ['team'] = 'team' }
+local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local _DISCARD_PLACEMENT = 99
 local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
 local _PLAYER_EARNINGS_ABBREVIATION = '<abbr title="Earnings of players while on the team">Player earnings</abbr>'
@@ -265,6 +266,13 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		})
 	end
 
+	local placementConditions = ConditionTree(BooleanOperator.any)
+	for _, item in pairs(_ALLOWED_PLACES) do
+		placementConditions:add({
+			ConditionNode(ColumnName('placement'), Comparator.eq, item),
+		})
+	end
+
 	local conditions = ConditionTree(BooleanOperator.all):add({
 		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
 		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
@@ -274,13 +282,7 @@ function CustomTeam.getEarningsAndMedalsData(team)
 			ConditionTree(BooleanOperator.all):add({
 				ConditionNode(ColumnName('players_type'), Comparator.eq, 'team'),
 				ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
-				ConditionTree(BooleanOperator.any):add({
-					ConditionNode(ColumnName('placement'), Comparator.eq, '1'),
-					ConditionNode(ColumnName('placement'), Comparator.eq, '2'),
-					ConditionNode(ColumnName('placement'), Comparator.eq, '3'),
-					ConditionNode(ColumnName('placement'), Comparator.eq, '4'),
-					ConditionNode(ColumnName('placement'), Comparator.eq, '3-4'),
-				}),
+				placementConditions,
 			}),
 		}),
 		ConditionTree(BooleanOperator.any):add({

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -42,7 +42,6 @@ local _team
 
 local _earnings = 0
 local _earnings_by_players_while_on_team = 0
-local _ALLOWED_PLACES = { '1', '2', '3', '4', '3-4' }
 local _EARNINGS_MODES = { ['team'] = 'team' }
 local _DISCARD_PLACEMENT = 99
 local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
@@ -311,7 +310,7 @@ function CustomTeam.getEarningsAndMedalsData(team)
 			earnings, playerEarnings = CustomTeam._addPlacementToEarnings(earnings, playerEarnings, item)
 
 			--handle medals
-			local mode = (players or {}).type
+			local mode = (item.players or {}).type
 			if mode == 'solo' then
 				medals = CustomTeam._addPlacementToMedals(medals, item)
 			elseif mode == 'team' then

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -340,7 +340,8 @@ function CustomTeam.getEarningsAndMedalsData(team)
 end
 
 function CustomTeam._addPlacementToEarnings(earnings, playerEarnings, data)
-	local mode = _EARNINGS_MODES[data.mode] or 'other'
+	local mode = (data.players or {}).type
+	mode = _EARNINGS_MODES[mode] or 'other'
 	if not earnings[mode] then
 		earnings[mode] = {}
 	end

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -267,10 +267,8 @@ function CustomTeam.getEarningsAndMedalsData(team)
 
 	local conditions = ConditionTree(BooleanOperator.all):add({
 		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
-		ConditionTree(BooleanOperator.any):add({
-			ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
-			ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Qualifier'),
-		}),
+		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
+		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Qualifier'),
 		ConditionTree(BooleanOperator.any):add({
 			ConditionNode(ColumnName('prizemoney'), Comparator.gt, '0'),
 			ConditionTree(BooleanOperator.all):add({


### PR DESCRIPTION
## Summary
Adjust SC2 infobox team to fit the prize pool changes applied yesterday.
- adjust conditions as well as placement data handling according to the prize pool changes
- use condition module for building the conditions for the placement query

## How did you test this change?
tested via sandboxes for several days, pushed live yesterday (atm the infobox team template is calling the /dev module until after the PR is merged)