### PR TITLE
Treat match status blank/missing (not started) as a standard status

### DIFF
--- a/components/match2/wikis/dota2/matchgroup_input_custom.lua
+++ b/components/match2/wikis/dota2/matchgroup_input_custom.lua
@@ -229,7 +229,7 @@ end
 
 -- Check if any opponent has a none-standard status
 function CustomMatchGroupInput.placementCheckSpecialStatus(table)
-	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ~= _STATUS_SCORE end)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ~= _STATUS_SCORE and String.isNotEmpty(scoreinfo.status) end)
 end
 
 -- function to check for forfeits


### PR DESCRIPTION
## Summary

This fixes an issue where all matches (technically the matches opponents) with the "not started" status would be automatically marked as finished. This was noticed while testing PR #1111, since before that PR the opponents would have 'S' status instead of not started.

## How did you test this change?

Live, as match2 is not live yet to dota2.