### PR TITLE
Fix missing Hero Bans

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -240,8 +240,11 @@ function CustomMatchSummary._createBody(match)
 	if not Table.isEmpty(showGameBans) then
 		local heroBan = HeroBan()
 
-		for gameIndex, banData in ipairs(showGameBans) do
-			heroBan:banRow(banData, gameIndex, banData.numberOfBans)
+		for gameIndex in ipairs(match.games) do
+			local banData = showGameBans[gameIndex]
+			if banData then
+				heroBan:banRow(banData, gameIndex, banData.numberOfBans)
+			end
 		end
 
 		body:addRow(heroBan)


### PR DESCRIPTION
## Summary

If a map has no hero bans, all subsequent maps' hero bans would not be displayed. 
This has been fixed in this PR by iterating on the maps instead of hero bans per map.

Before:
![bild](https://user-images.githubusercontent.com/3426850/158823279-3f311a86-8d4c-4c60-989c-6519f1f37cf0.png)

After:
![bild](https://user-images.githubusercontent.com/3426850/158823179-25017fe8-3646-4899-a372-af42e50fda8e.png)


## How did you test this change?

Live