### PR TITLE
Fix Edge case alignment issue in MatchSummary

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -337,6 +337,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	for index = 1, numberOfHeroes do
 		local heroDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. color)
+			:addClass('brkts-popup-side-hero')
 			:addClass('brkts-popup-side-hero-hover')
 			:css('float', flip and 'right' or 'left')
 			:node(HeroIcon._getImage{


### PR DESCRIPTION
## Summary

If either team, or both teams, were missing the Team Side (Radiant or Dire), the hero icons would be out of allignement

Before (See Team 2 in Game 2):
![bild](https://user-images.githubusercontent.com/3426850/158828244-f31d3fba-5f7a-4159-943c-5e9f56f51d03.png)

After:
![bild](https://user-images.githubusercontent.com/3426850/158828292-b9129925-d9d4-40d8-a5bd-e54361d71325.png)

This CSS Change is the most significant part of the change:
https://liquipedia.net/commons/index.php?title=MediaWiki%3ACommon.css%2FBrackets.css&type=revision&diff=410855&oldid=408463
Extracted the margin and padding from `brkts-popup-side-color-dire` & `brkts-popup-side-color-radiant` into a new class called `brkts-popup-side-color`. 

## How did you test this change?

Live