### PR TITLE
Change missing date to use EPOCH

### DIFF
--- a/components/match2/wikis/dota2/matchgroup_input_custom.lua
+++ b/components/match2/wikis/dota2/matchgroup_input_custom.lua
@@ -299,13 +299,8 @@ function matchFunctions.readDate(matchArgs)
 		dateProps.hasDate = true
 		return dateProps
 	else
-		local suggestedDate = Variables.varDefaultMulti(
-			'tournament_enddate',
-			'tournament_startdate',
-			_EPOCH_TIME
-		)
 		return {
-			date = MatchGroupInput.getInexactDate(suggestedDate),
+			date = mw.getContentLanguage():formatDate('c', _EPOCH_TIME),
 			dateexact = false,
 		}
 	end


### PR DESCRIPTION
## Summary

The previous version would call `getInexactDate` which adds a second to each match missing a date. This caused a chunk of matches to the times 1970-01-01 00:00:01, 1970-01-01 00:00:02, 1970-01-01 00:00:03 etc. While the logic in BrktWikiSpec and MatchSummary expects `1970-01-01 00:00:00` to determine missing date. This would display Jan 1st, 1970 on any match missing a date.

Before:
![bild](https://user-images.githubusercontent.com/3426850/158981090-9c87d05e-db4d-4b0e-9ca6-fac211d63d92.png)

After:
![bild](https://user-images.githubusercontent.com/3426850/158981385-a3e1a011-4972-48d2-93a7-e84b3b15536f.png)

(Separate issue can be seen in the after image, the popup shouldn't be available for this match, RCA is known, PR pending)


## How did you test this change?
Live