### PR TITLE
Convert match2 bestof to match1 object

### DIFF
--- a/components/match2/wikis/dota2/match_legacy.lua
+++ b/components/match2/wikis/dota2/match_legacy.lua
@@ -52,6 +52,7 @@ function MatchLegacy._convertParameters(match2)
 	-- Handle extradata fields
 	match.extradata = {}
 	local extradata = Json.parseIfString(match2.extradata)
+	match.extradata.gamecount = tostring(match2.bestof)
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.mvpteam = extradata.mvpteam
 	match.extradata.mvp = extradata.mvp


### PR DESCRIPTION
## Summary

Missing in #1105 as didn't find any page setting it. But seems like there were a bunch and my sampling was bad. 
The match2 bestof value should be set in the `gamecount` extradata field of match1.

Before (note match 1 & 3):
![bild](https://user-images.githubusercontent.com/3426850/158981846-ae6b4ed9-0d91-45e4-8867-b2cca497e73b.png)

After:
![bild](https://user-images.githubusercontent.com/5138348/158982646-959c33d6-0311-445b-b7cd-01ad7c4aee1c.png)



## How did you test this change?

Live
