### PR TITLE
Empty the LPDB fallback value for section

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -316,7 +316,7 @@ function Match._prepareMatchRecordForStore(match)
 	match.match2bracketdata = match.match2bracketdata or match.bracketdata
 	match.match2bracketid = match.match2bracketid or match.bracketid
 	match.match2id = match.match2id or match.bracketid .. '_' .. match.matchid
-	match.section = Variables.varDefault('last_heading', 'none'):gsub('<.->', '')
+	match.section = Variables.varDefault('last_heading', ''):gsub('<.->', '')
 	Match.clampFields(match, Match.matchFields)
 end
 


### PR DESCRIPTION
## Summary

Standings and Match2 currently uses two different fallback values if last heading is missing when inserting into LPDB. Standing is using `<blank>` and match2 is using `none`. 

Per conversation on the discord (https://discord.com/channels/93055209017729024/372075546231832576/954366452905938974) and PR #1120, the value should be `<blank>` as fallback.

## How did you test this change?

Not tested