### PR TITLE
Adjusting Rainbow Six notability points

### DIFF
--- a/components/notability/wikis/rainbowsix/notability_checker_config.lua
+++ b/components/notability/wikis/rainbowsix/notability_checker_config.lua
@@ -32,7 +32,7 @@ Config.PLACEMENT_QUERY =
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 600
-Config.NOTABILITY_THRESHOLD_NOTABLE = 800
+Config.NOTABILITY_THRESHOLD_NOTABLE = 700
 
 -- These are all the liquipediatiertypes which should be extra "penalised"
 -- for a lower placement, see also the placementDropOffFunction below.


### PR DESCRIPTION
## Summary
Adjusts the minimum requirement for notability on R6. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Change was tested live. Additional tests where done via sandbox (note the sandbox values differ slightly from the PRs)

https://liquipedia.net/rainbowsix/User:Okidokie98/Notability/Players
https://liquipedia.net/rainbowsix/Module:Notable_teams_and_players_without_page/Sandbox
https://liquipedia.net/rainbowsix/Module:NotabilityChecker/config/sandbox
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
