### PR TITLE
Change matchHasDetail to check for Opponents instead of Games

### DIFF
--- a/components/match2/wikis/dota2/brkts_wikispecific.lua
+++ b/components/match2/wikis/dota2/brkts_wikispecific.lua
@@ -7,6 +7,7 @@
 --
 
 local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
 local Table = require('Module:Table')
 
 local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
@@ -22,7 +23,8 @@ function WikiSpecific.matchHasDetails(match)
 		or match.vod
 		or not Table.isEmpty(match.links)
 		or match.comment
-		or 0 < #match.games
+		or not Opponent.isTbd(match.opponents[1])
+		or not Opponent.isTbd(match.opponents[2])
 end
 
 return WikiSpecific


### PR DESCRIPTION
## Summary

This is the followup PR for the issue mentioned in #1118.

As dota2 always have their game set, so using games as a check if the match should have the MatchSummary popout or not is redundant, as it will always be true.

Change it to check if any opponent has been entered instead. 

Before:
![bild](https://user-images.githubusercontent.com/3426850/159113724-83097f31-49e2-4665-9114-5ccfb2e6883a.png)

After:
![bild](https://user-images.githubusercontent.com/3426850/159113737-8670bdcb-25fc-4f7e-b902-abbd1fc10dc3.png)


## How did you test this change?
Live
