### PR TITLE
Show upcoming games in Match Summary

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -189,9 +189,7 @@ function CustomMatchSummary._createBody(match)
 	-- Iterate each map
 	for gameIndex, game in ipairs(match.games) do
 		local rowDisplay = CustomMatchSummary._createGame(game, gameIndex)
-		if rowDisplay then
-			body:addRow(rowDisplay)
-		end
+		body:addRow(rowDisplay)
 	end
 
 	-- Add Match MVP(s)
@@ -274,14 +272,6 @@ function CustomMatchSummary._createGame(game, gameIndex)
 		end
 		heroesData[1].side = extradata.team1side
 		heroesData[2].side = extradata.team2side
-	end
-
-	if
-		String.isEmpty(game.length) and
-		String.isEmpty(game.winner) and
-		heroesDataIsEmpty
-	then
-		return nil
 	end
 
 	row:addClass('brkts-popup-body-game')

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -259,16 +259,14 @@ function CustomMatchSummary._createGame(game, gameIndex)
 	if game.mode == Opponent.solo then
 		numberOfHeroes = _NUM_HEROES_PICK_SOLO
 	end
+
 	local heroesData = {{}, {}}
-	local heroesDataIsEmpty = true
 	for heroIndex = 1, numberOfHeroes do
 		if String.isNotEmpty(extradata['team1hero' .. heroIndex]) then
 			heroesData[1][heroIndex] = extradata['team1hero' .. heroIndex]
-			heroesDataIsEmpty = false
 		end
 		if String.isNotEmpty(extradata['team2hero' .. heroIndex]) then
 			heroesData[2][heroIndex] = extradata['team2hero' .. heroIndex]
-			heroesDataIsEmpty = false
 		end
 		heroesData[1].side = extradata.team1side
 		heroesData[2].side = extradata.team2side


### PR DESCRIPTION
## Summary

Replacing #1125 based on feedback and as such is the new followup PR to #1118.

Use-case: End users can easily see what Best of X upcoming (or ongoing) matches are

Before:
![bild](https://user-images.githubusercontent.com/3426850/159114845-ebf11658-e95f-4c32-ab11-d09b40e6c481.png)
![bild](https://user-images.githubusercontent.com/3426850/159114876-a3675c68-31e6-4085-99d0-40b1e68db154.png)

After:
![bild](https://user-images.githubusercontent.com/3426850/159114861-7a7f66ed-7b3a-4b87-8a7c-0d7eaca3c29c.png)
![bild](https://user-images.githubusercontent.com/3426850/159114901-09971ff9-55ab-499f-922e-4dd546e67e93.png)



## How did you test this change?
Live
