### PR TITLE
Store teamtemplate in lpdb_player

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -217,7 +217,6 @@ function Person:_setLpdbData(args, links, status, personType)
 		image = args.image,
 		region = _region,
 		team = teamLink or args.teamlink or args.team,
-		teampagename = teamLink,
 		teamtemplate = teamTemplate,
 		status = status,
 		type = personType,

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -195,6 +195,14 @@ end
 function Person:_setLpdbData(args, links, status, personType)
 	links = Links.makeFullLinksForTableItems(links, _LINK_VARIANT)
 
+	local teamLink, teamTemplate
+	local team = args.teamlink or args.team
+	if team and mw.ext.TeamTemplate.teamexists(team) then
+		local teamRaw = mw.ext.TeamTemplate.raw(team)
+		teamLink = teamRaw.page
+		teamTemplate = teamRaw.templatename
+	end
+
 	local lpdbData = {
 		id = args.id or mw.title.getCurrentTitle().prefixedText,
 		alternateid = args.ids,
@@ -208,7 +216,9 @@ function Person:_setLpdbData(args, links, status, personType)
 		deathdate = Variables.varDefault('player_deathdate'),
 		image = args.image,
 		region = _region,
-		team = args.teamlink or args.team,
+		team = teamLink or args.teamlink or args.team,
+		teampagename = teamLink,
+		teamtemplate = teamTemplate,
 		status = status,
 		type = personType,
 		earnings = _totalEarnings,
@@ -400,6 +410,11 @@ function Person:getCategories(args, birthDisplay, personType, status)
 		end
 		if String.isEmpty(birthDisplay) then
 			table.insert(categories, personType .. 's with unknown birth date')
+		end
+
+		local team = args.teamlink or args.team
+		if team and not mw.ext.TeamTemplate.teamexists(team) then
+			table.insert(categories, 'Players with invalid team')
 		end
 
 		return categories

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -201,6 +201,11 @@ function CustomPlayer:getCategories(args, birthDisplay, personType, status)
 			table.insert(categories, 'SARPBC Players')
 		end
 
+		local team = args.teamlink or args.team
+		if team and not mw.ext.TeamTemplate.teamexists(team) then
+			table.insert(categories, 'Players with invalid team')
+		end
+
 		return categories
 	end
 	return {}


### PR DESCRIPTION
## Summary

Store `teamtemplate` (child-TT if historical) into lpdb_player. 
Field `team` is now automatically retrieved from the teamtemplate, if it can be resolved, otherwise fallback on previous method.
Add tracking category to commons + Rocket League for invalid values in `|team=`/`|teamlink=`.

## How did you test this change?

Tested on a couple of players with /dev.
