### PR TITLE
Store newteamtemplate in lpdb_squadplayer

### DIFF
--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -40,11 +40,6 @@ local SquadRow = Class.new(
 		end
 
 		self.lpdbData = {}
-
-		local pagename = mw.title.getCurrentTitle().text
-		if mw.ext.TeamTemplate.teamexists(pagename) then
-			self.lpdbData['teamtemplate'] = mw.ext.TeamTemplate.raw(pagename).templatename
-		end
 	end)
 
 SquadRow.specialTeamsTemplateMapping = {
@@ -144,11 +139,11 @@ function SquadRow:newteam(args)
 
 		local newTeam = args.newteam:lower()
 		if mw.ext.TeamTemplate.teamexists(newTeam) then
-			cell:wikitext(mw.ext.TeamTemplate.team(newTeam,
-				args.newteamdate or ReferenceCleaner.clean(args.leavedate)))
+			local date = args.newteamdate or ReferenceCleaner.clean(args.leavedate)
+			cell:wikitext(mw.ext.TeamTemplate.team(newTeam, date))
 
 			self.lpdbData['newteam'] = mw.ext.TeamTemplate.teampage(newTeam)
-			self.lpdbData['newteamtemplate'] = mw.ext.TeamTemplate.raw(newTeam).templatename
+			self.lpdbData['newteamtemplate'] = mw.ext.TeamTemplate.raw(newTeam, date).templatename
 		elseif self.options.useTemplatesForSpecialTeams then
 			local newTeamTemplate = SquadRow.specialTeamsTemplateMapping[newTeam]
 			if newTeamTemplate then

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -40,6 +40,11 @@ local SquadRow = Class.new(
 		end
 
 		self.lpdbData = {}
+
+		local pagename = mw.title.getCurrentTitle().text
+		if mw.ext.TeamTemplate.teamexists(pagename) then
+			self.lpdbData['teamtemplate'] = mw.ext.TeamTemplate.raw(pagename).templatename
+		end
 	end)
 
 SquadRow.specialTeamsTemplateMapping = {
@@ -143,6 +148,7 @@ function SquadRow:newteam(args)
 				args.newteamdate or ReferenceCleaner.clean(args.leavedate)))
 
 			self.lpdbData['newteam'] = mw.ext.TeamTemplate.teampage(newTeam)
+			self.lpdbData['newteamtemplate'] = mw.ext.TeamTemplate.raw(newTeam).templatename
 		elseif self.options.useTemplatesForSpecialTeams then
 			local newTeamTemplate = SquadRow.specialTeamsTemplateMapping[newTeam]
 			if newTeamTemplate then


### PR DESCRIPTION
## Summary

Store `newteamtemplate` (child-TT if historical) into lpdb_player.

Initially considered storing `teamtemplate` as well, but leaving it out for now as 1) Not sure which date for child TT to use 2) Unsure if required.

![bild](https://user-images.githubusercontent.com/3426850/159158623-1910a687-6df0-4490-8b38-de9335bc324d.png)


## How did you test this change?

Tested on a couple of teams on RL

