### PR TITLE
Use better date for resolving opponents when date is missing

### DIFF
--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -25,7 +25,7 @@ local MAX_NUM_VODGAMES = 9
 local MAX_NUM_MAPS = 9
 local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
 
-local _EPOCH_TIME = '1970-01-01 00:00:00'
+local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 
 -- containers for process helper functions
 local matchFunctions = {}
@@ -70,6 +70,17 @@ function CustomMatchGroupInput.processOpponent(record, date)
 	-- Convert byes to literals
 	if opponent.type == Opponent.team and opponent.template:lower() == 'bye' then
 		opponent = {type = Opponent.literal, name = 'BYE'}
+	end
+
+	-- If date if epoch, resolve using tournament dates instead
+	-- Epoch indicates that the match is missing a date, but in order to get correct child team template
+	-- We need a present date and not 1970
+	if date == _EPOCH_TIME_EXTENDED then
+		date = Variables.varDefaultMulti(
+			'tournament_enddate',
+			'tournament_startdate',
+			_EPOCH_TIME_EXTENDED
+		)
 	end
 
 	Opponent.resolve(opponent, date)
@@ -288,7 +299,7 @@ function matchFunctions.readDate(matchArgs)
 		return dateProps
 	else
 		return {
-			date = mw.getContentLanguage():formatDate('c', _EPOCH_TIME),
+			date = _EPOCH_TIME_EXTENDED,
 			dateexact = false,
 		}
 	end

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -72,18 +72,19 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
+	local teamTemplateDate = date
 	-- If date if epoch, resolve using tournament dates instead
-	-- Epoch indicates that the match is missing a date, but in order to get correct child team template
-	-- We need a present date and not 1970
-	if date == _EPOCH_TIME_EXTENDED then
-		date = Variables.varDefaultMulti(
+	-- Epoch indicates that the match is missing a date
+	-- In order to get correct child team template, we will use an approximately date and not 1970-01-01
+	if teamTemplateDate == _EPOCH_TIME_EXTENDED then
+		teamTemplateDate = Variables.varDefaultMulti(
 			'tournament_enddate',
 			'tournament_startdate',
 			_EPOCH_TIME_EXTENDED
 		)
 	end
 
-	Opponent.resolve(opponent, date)
+	Opponent.resolve(opponent, teamTemplateDate)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -73,7 +73,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 	end
 
 	local teamTemplateDate = date
-	-- If date if epoch, resolve using tournament dates instead
+	-- If date is epoch, resolve using tournament dates instead
 	-- Epoch indicates that the match is missing a date
 	-- In order to get correct child team template, we will use an approximately date and not 1970-01-01
 	if teamTemplateDate == _EPOCH_TIME_EXTENDED then


### PR DESCRIPTION
## Summary

If a match is missing a date, we want to store it as Epoch 0.

However, this would cause the original team template to always be used in historicals if a match had to date. To improve this, this PR will use the tournament date when resolving opponents if the date is missing.

Once this PR gets merged, will create followup PRs for other games using epoch as default date.

Before (Note G2 Icon):
![bild](https://user-images.githubusercontent.com/3426850/159161683-2c5da202-e5b8-4227-b9ba-b9a336440716.png)

After:
![bild](https://user-images.githubusercontent.com/3426850/159161706-bf868d51-f272-426c-bfc3-9cf1c3bb7aa6.png)

## How did you test this change?

Dev modules on R6
