### PR TITLE
Change luacheck reporting display on GitHub

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -21,4 +21,13 @@ jobs:
 
       - name: test
         run: |
-          luacheck ./
+          luacheck ./ |
+          luacheck ./ --formatter=JUnit > report.xml
+
+      - name: junit
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'report.xml'
+          check_name: 'junit-report'
+


### PR DESCRIPTION
## Summary
This would add a second check result to pull request that looks like this:
![grafik](https://user-images.githubusercontent.com/3266537/159388466-a95ac76f-58d3-43a6-b303-2fd2ad383471.png)
If the details link is clicked, a page would open that looks something like this, detailing the errors without having to look through the entire list in the CLI output.
![grafik](https://user-images.githubusercontent.com/3266537/159388598-9649f492-803a-4841-af78-27e56dc4417b.png)
If you don't think this is valuable, feel free to just close it.

## How did you test this change?
I tested this on a private repository.
