### PR TITLE
Fix `extradata.isfeatured` in RL matches

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -209,7 +209,7 @@ function matchFunctions.isFeatured(match)
 	if
 		tonumber(match.liquipediatier or '') == 1
 		or tonumber(match.liquipediatier or '') == 2
-		or Variables.varDefault('tournament_rlcs_premier') == '1'
+		or Logic.readBool(Variables.varDefault('tournament_rlcs_premier'))
 		or not String.isEmpty(Variables.varDefault('match_featured_override'))
 	then
 		return true

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -209,7 +209,7 @@ function matchFunctions.isFeatured(match)
 	if
 		tonumber(match.liquipediatier or '') == 1
 		or tonumber(match.liquipediatier or '') == 2
-		or not String.isEmpty(Variables.varDefault('tournament_rlcs_premier'))
+		or Variables.varDefault('tournament_rlcs_premier') == '1'
 		or not String.isEmpty(Variables.varDefault('match_featured_override'))
 	then
 		return true


### PR DESCRIPTION
## Summary
Fix `extradata.isfeatured` in RL matches.
Infobox sets `"1"/"0"` while matches until now expected `something/empty`.

## How did you test this change?
/dev module