### PR TITLE
Add publishertier LPDB in Infobox League ML

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_league.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league.lua
@@ -79,6 +79,7 @@ end
 
 function League:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.publishertier =  _args['moonton-sponsored']
 
 	return lpdbData
 end

--- a/components/infobox/wikis/mobilelegends/infobox_league.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league.lua
@@ -79,7 +79,7 @@ end
 
 function League:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.publishertier =  _args['moonton-sponsored']
+	lpdbData.publishertier =  _args['moonton-sponsored'] == 'true' and 'true' or nil
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary

The change were made so that the tournament portal modules use in Portal:Tournaments can display yellow highlighted tiers (for events that has publishertier added), originally it can't recognize yellow tiers. 

## How did you test this change?
A test module (which is same as the main one with the addition of this PR) on the https://liquipedia.net/mobilelegends/M3_World_Championship page

It now appears in yellow at: https://liquipedia.net/mobilelegends/M_World_Championship (the tournament lists)

## Side Note
other wikis that I do PR infoboxes all had this missing (Halo, both PUBG, AOV) but i'll get this first and then do the same later on since Each wiki has its own different publishertier input (hcs-sponsored, pubgpremier, etc etc)

