### PR TITLE
Remove HTML from Title field

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -12,10 +12,12 @@ local Variables = require('Module:Variables')
 local StandingsStorage = {}
 
 function StandingsStorage.run(index, data)
+	local title = data.title or ''
+	local cleanedTitle = title:gsub('<.->.-</.->', '')
 	mw.ext.LiquipediaDB.lpdb_standing(
 		'standing_' .. data.standingsindex .. '_' .. data.roundindex .. '_' .. index,
 		{
-			title = data.title,
+			title = mw.text.trim(cleanedTitle),
 			tournament = data.tournament,
 			participant = data.participant,
 			participantdisplay = data.participantdisplay,


### PR DESCRIPTION
## Summary

If the title of a GroupTableLeague (GTL) contains a flag or icon, this is entered as HTML into LPDB_standings's title field.

This PR will remove all HTML tags and their inner content from the GTL's title before storing into LPDB. 
Example:
`<span foo="bar">Lorum Ipsum</span> Cool Title` will become `Cool Title`.

Before:
![bild](https://user-images.githubusercontent.com/3426850/159973625-b28b5fbd-d9fe-4598-a52b-25fbaab7e4ad.png)


After:
![bild](https://user-images.githubusercontent.com/3426850/159973559-056fc865-d9a6-4542-b369-7af9251255ec.png)


## How did you test this change?

Tested using dev modules