### PR TITLE
Allow easier player input in maps for sc/sc2

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -862,7 +862,9 @@ function StarcraftMatchGroupInput.ProcessPlayerMapData(map, match, OppNumber)
 			for j = 1, 4 do
 				if not Logic.isEmpty(map['t' .. i .. 'p' .. j]) then
 					if map['t' .. i .. 'p' .. j] ~= 'TBD' and map['t' .. i .. 'p' .. j] ~= 'TBA' then
-						map['t' .. i .. 'p' .. j] = mw.ext.TeamLiquidIntegration.resolve_redirect(map['t' .. i .. 'p' .. j])
+						local mapPlayer = map['t' .. i .. 'p' .. j .. 'link'] or
+							Variables.varDefault(map['t' .. i .. 'p' .. j] .. '_page', map['t' .. i .. 'p' .. j])
+						map['t' .. i .. 'p' .. j] = mw.ext.TeamLiquidIntegration.resolve_redirect(mapPlayer)
 
 						if map['opponent' .. i .. 'archon'] == 'true' then
 							PlayerData[map['t' .. i .. 'p' .. j]] = {

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -862,6 +862,9 @@ function StarcraftMatchGroupInput.ProcessPlayerMapData(map, match, OppNumber)
 			for j = 1, 4 do
 				if not Logic.isEmpty(map['t' .. i .. 'p' .. j]) then
 					if map['t' .. i .. 'p' .. j] ~= 'TBD' and map['t' .. i .. 'p' .. j] ~= 'TBA' then
+						-- allows fetching the link of the player from preset wiki vars
+						-- map['t' .. i .. 'p' .. j .. 'link'] for manual overwrite
+						-- map['t' .. i .. 'p' .. j] for the input of the displayName
 						local mapPlayer = map['t' .. i .. 'p' .. j .. 'link'] or
 							Variables.varDefault(map['t' .. i .. 'p' .. j] .. '_page', map['t' .. i .. 'p' .. j])
 						map['t' .. i .. 'p' .. j] = mw.ext.TeamLiquidIntegration.resolve_redirect(mapPlayer)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -865,9 +865,10 @@ function StarcraftMatchGroupInput.ProcessPlayerMapData(map, match, OppNumber)
 						-- allows fetching the link of the player from preset wiki vars
 						-- map['t' .. i .. 'p' .. j .. 'link'] for manual overwrite
 						-- map['t' .. i .. 'p' .. j] for the input of the displayName
-						local mapPlayer = map['t' .. i .. 'p' .. j .. 'link'] or
-							Variables.varDefault(map['t' .. i .. 'p' .. j] .. '_page', map['t' .. i .. 'p' .. j])
-						map['t' .. i .. 'p' .. j] = mw.ext.TeamLiquidIntegration.resolve_redirect(mapPlayer)
+						local playerIndex = 't' .. i .. 'p' .. j
+						local mapPlayer = map[playerIndex .. 'link'] or
+							Variables.varDefault(map[playerIndex] .. '_page') or map[playerIndex]
+						map[playerIndex] = mw.ext.TeamLiquidIntegration.resolve_redirect(mapPlayer)
 
 						if map['opponent' .. i .. 'archon'] == 'true' then
 							PlayerData[map['t' .. i .. 'p' .. j]] = {


### PR DESCRIPTION
## Summary
This is a (minor) Quality of Life change for editors when inputting maps in team matches.
Currently players have to be inputted as link values into the maps.
Since TeamCard was slightly changed to now also set the same wiki variables that participant lists set we now can use the display name and grab the full link from the wiki vars instead.

![Screenshot 2022-03-24 18 20 34](https://user-images.githubusercontent.com/75081997/159974241-8365bcce-d38f-46ba-8f46-bbc0a28383d7.png)

Only constraint for this is if 2+ players with the same displayName participate in the same event, then the link values still have to be set accordingly.

## How did you test this change?
dev modules