### PR TITLE
Add timeout and caster support to RL matches

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -188,10 +188,8 @@ function matchFunctions.getExtraData(match)
 	local opponent2 = match.opponent2 or {}
 
 	local casters = {}
-	local casterIndex = 1
-	while String.isNotEmpty(match['caster' .. casterIndex]) do
-		table.insert(casters, match['caster' .. casterIndex])
-		casterIndex = casterIndex + 1
+	for _, caster in Table.iter.pairsByPrefix(match, 'caster') do
+		table.insert(casters, caster)
 	end
 
 	match.extradata = {

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -386,7 +386,7 @@ function mapFunctions.getExtraData(map)
 	for _, timeoutValue in pairs(timeoutInput) do
 		table.insert(timeouts, tonumber(timeoutValue))
 	end
-	
+
 	map.extradata = {
 		ot = map.ot,
 		otlength = map.otlength,

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -394,7 +394,7 @@ function mapFunctions.getExtraData(map)
 		--the following is used to store 'mapXtYgoals' from LegacyMatchLists
 		t1goals = map.t1goals,
 		t2goals = map.t2goals,
-		timeout = (#timeouts > 0) and Json.stringify(timeouts) or nil
+		timeout = Table.isNotEmpty(timeouts) and Json.stringify(timeouts) or nil
 	}
 	return map
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -186,6 +186,14 @@ end
 function matchFunctions.getExtraData(match)
 	local opponent1 = match.opponent1 or {}
 	local opponent2 = match.opponent2 or {}
+
+	local casters = {}
+	local casterIndex = 1
+	while String.isNotEmpty(match['caster' .. casterIndex]) do
+		table.insert(casters, match['caster' .. casterIndex])
+		casterIndex = casterIndex + 1
+	end
+
 	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
 		team1icon = getIconName(opponent1.template or ''),
@@ -194,7 +202,8 @@ function matchFunctions.getExtraData(match)
 		comment = match.comment,
 		octane = match.octane,
 		isconverted = 0,
-		isfeatured = matchFunctions.isFeatured(match)
+		isfeatured = matchFunctions.isFeatured(match),
+		casters = (#casters > 0) and Json.stringify(casters) or nil,
 	}
 	return match
 end
@@ -372,6 +381,12 @@ end
 -- map related functions
 --
 function mapFunctions.getExtraData(map)
+	local timeoutInput = mw.text.split(map.timeout or '', ',')
+	local timeouts = {}
+	for _, timeoutValue in pairs(timeoutInput) do
+		table.insert(timeouts, tonumber(timeoutValue))
+	end
+	
 	map.extradata = {
 		ot = map.ot,
 		otlength = map.otlength,
@@ -380,6 +395,7 @@ function mapFunctions.getExtraData(map)
 		--the following is used to store 'mapXtYgoals' from LegacyMatchLists
 		t1goals = map.t1goals,
 		t2goals = map.t2goals,
+		timeout = (#timeouts > 0) and Json.stringify(timeouts) or nil
 	}
 	return map
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -379,10 +379,7 @@ end
 -- map related functions
 --
 function mapFunctions.getExtraData(map)
-	local timeouts = {}
-	for _, timeoutValue in pairs(mw.text.split(map.timeout or '', ',')) do
-		table.insert(timeouts, tonumber(timeoutValue))
-	end
+	local timeouts = Array.extractValues(Table.mapValues(mw.text.split(map.timeout or '', ','), tonumber))
 
 	map.extradata = {
 		ot = map.ot,

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -203,7 +203,7 @@ function matchFunctions.getExtraData(match)
 		octane = match.octane,
 		isconverted = 0,
 		isfeatured = matchFunctions.isFeatured(match),
-		casters = (#casters > 0) and Json.stringify(casters) or nil,
+		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}
 	return match
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -381,9 +381,8 @@ end
 -- map related functions
 --
 function mapFunctions.getExtraData(map)
-	local timeoutInput = mw.text.split(map.timeout or '', ',')
 	local timeouts = {}
-	for _, timeoutValue in pairs(timeoutInput) do
+	for _, timeoutValue in pairs(mw.text.split(map.timeout or '', ',')) do
 		table.insert(timeouts, tonumber(timeoutValue))
 	end
 

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -10,6 +10,7 @@ local p = require('Module:Brkts/WikiSpecific/Base')
 
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
+local Array = require('Module:Array')
 local Lua = require('Module:Lua')
 local Opponent = require('Module:Opponent')
 local PageVariableNamespace = require('Module:PageVariableNamespace')

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -10,8 +10,6 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Json = require('Module:Json')
 local Table = require('Module:Table')
-local String = require('Module:StringUtils')
-local Abbreviation = require('Module:Abbreviation')
 local VodLink = require('Module:VodLink')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -8,6 +8,10 @@
 
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Json = require('Module:Json')
+local Table = require('Module:Table')
+local String = require('Module:StringUtils')
+local Abbreviation = require('Module:Abbreviation')
 local VodLink = require('Module:VodLink')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
@@ -96,6 +100,29 @@ function CustomMatchSummary.getByMatchId(args)
 					:css('font-size','85%')
 					:css('margin','auto'))
 			end
+			if game.extradata.timeout then
+				local timeouts = Json.parseIfString(game.extradata.timeout)
+				table.insert(gameElements, CustomMatchSummary._breakNode())
+				table.insert(gameElements,
+					mw.html.create('div')
+						:addClass('brkts-popup-spaced')
+						:node(Table.includes(timeouts, 1) and
+							'[[File:Cooldown_Clock.png|14x14px|link=]]' or
+							'[[File:NoCheck.png|link=]]')
+				)
+				table.insert(gameElements,
+					mw.html.create('div')
+						:addClass('brkts-popup-spaced')
+						:node(mw.html.create('div'):node('Timeout'))
+				)
+				table.insert(gameElements,
+					mw.html.create('div')
+						:addClass('brkts-popup-spaced')
+						:node(Table.includes(timeouts, 2) and
+							'[[File:Cooldown_Clock.png|14x14px|link=]]' or
+							'[[File:NoCheck.png|link=]]')
+				)
+			end
 			local hasCommentLineBreakNode = false
 			if game.extradata.t1goals then
 				table.insert(gameElements, CustomMatchSummary._breakNode())
@@ -136,6 +163,20 @@ function CustomMatchSummary.getByMatchId(args)
 	end
 	wrapper:node(body):node(CustomMatchSummary._breakNode())
 
+	-- casters
+	if match.extradata.casters then
+		local casters = Json.parseIfString(match.extradata.casters)
+		for index, caster in pairs(casters) do
+			casters[index] = '[[' .. caster .. ']]'
+		end
+		local casterRow = mw.html.create('div')
+			:addClass('brkts-popup-comment')
+			:css('white-space','normal')
+			:css('font-size','85%')
+			:node('<b>Caster' .. (#casters > 1 and 's' or '') .. ':</b><br>')
+			:node(table.concat(casters, ', '))
+		wrapper:node(casterRow):node(CustomMatchSummary._breakNode())
+	end
 	-- comment
 	if match.comment then
 		local comment = mw.html.create('div')

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -17,6 +17,8 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
 local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
+local _COOLDOWN_ICON = '[[File:Cooldown_Clock.png|14x14px|link=]]'
+local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 local CustomMatchSummary = {}
 
@@ -105,8 +107,8 @@ function CustomMatchSummary.getByMatchId(args)
 					mw.html.create('div')
 						:addClass('brkts-popup-spaced')
 						:node(Table.includes(timeouts, 1) and
-							'[[File:Cooldown_Clock.png|14x14px|link=]]' or
-							'[[File:NoCheck.png|link=]]')
+							_COOLDOWN_ICON or
+							_NO_CHECK)
 				)
 				table.insert(gameElements,
 					mw.html.create('div')
@@ -117,8 +119,8 @@ function CustomMatchSummary.getByMatchId(args)
 					mw.html.create('div')
 						:addClass('brkts-popup-spaced')
 						:node(Table.includes(timeouts, 2) and
-							'[[File:Cooldown_Clock.png|14x14px|link=]]' or
-							'[[File:NoCheck.png|link=]]')
+							_COOLDOWN_ICON or
+							_NO_CHECK)
 				)
 			end
 			local hasCommentLineBreakNode = false

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -171,8 +171,8 @@ function CustomMatchSummary.getByMatchId(args)
 			:addClass('brkts-popup-comment')
 			:css('white-space','normal')
 			:css('font-size','85%')
-			:node('<b>Caster' .. (#casters > 1 and 's' or '') .. ':</b><br>')
-			:node(table.concat(casters, ', '))
+			:wikitext('<b>Caster' .. (#casters > 1 and 's' or '') .. ':</b><br>')
+			:wikitext(table.concat(casters, ', '))
 		wrapper:node(casterRow):node(CustomMatchSummary._breakNode())
 	end
 	-- comment


### PR DESCRIPTION
## Summary
Adds support for
- timeout storage and display
- caster storage and display
within matches on the RL wiki as requested by contributors of the wiki.
![Screenshot 2022-03-26 14 19 53](https://user-images.githubusercontent.com/75081997/160241452-53c3b346-ae26-46bb-8bfa-e24315c0fca8.png)
![Screenshot 2022-03-26 14 20 32](https://user-images.githubusercontent.com/75081997/160241455-b75a28c4-4583-4173-82b3-2b3110a5dccf.png)



## How did you test this change?
/dev modules