### PR TITLE
Rewrite RL MatchSummary to use MatchSummary/Base Classes

### DIFF
--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -40,7 +40,7 @@ local Casters = Class.new(
 )
 
 function Casters:addCaster(caster)
-	if not Logic.isEmpty(caster) then
+	if Logic.isNotEmpty(caster) then
 		table.insert(self.casters, '[[' .. caster .. ']]')
 	end
 	return self
@@ -200,12 +200,12 @@ function CustomMatchSummary.getByMatchId(args)
 	if
 		Table.isNotEmpty(vods) or
 		String.isNotEmpty(match.vod) or
-		not Logic.isEmpty(match.extradata.octane)
+		Logic.isNotEmpty(match.extradata.octane)
 	then
 		local footer = MatchSummary.Footer()
 
 		-- Octane
-		if not Logic.isEmpty(match.extradata.octane) then
+		if Logic.isNotEmpty(match.extradata.octane) then
 			footer:addElement(_OCTANE_PREFIX .. match.extradata.octane .. _OCTANE_SUFFIX)
 		end
 
@@ -298,7 +298,7 @@ function CustomMatchSummary._createGame(game)
 		:node(mw.html.create('div'):node('[[' .. game.map .. ']]'))
 	if Logic.readBool(extradata.ot) then
 		centerNode:node(mw.html.create('div'):node('- OT'))
-		if not Logic.isEmpty(extradata.otlength) then
+		if Logic.isNotEmpty(extradata.otlength) then
 			centerNode:node(mw.html.create('div'):node('(' .. extradata.otlength .. ')'))
 		end
 	end

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -145,7 +145,7 @@ function Header:soloOpponentTeam(opponent, date)
 	if opponent.type == 'solo' then
 		local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
 		local display = teamExists
-			and mw.ext.TeamTemplate.teamicon(opponent.template, match.date)
+			and mw.ext.TeamTemplate.teamicon(opponent.template, date)
 			or _TBD_ICON
 		return mw.html.create('div'):wikitext(display)
 			:addClass('brkts-popup-header-opponent-solo-team')

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -342,7 +342,7 @@ function CustomMatchSummary._createGame(game)
 		row:addElement(MatchSummary.Break():create())
 	end
 	if String.isNotEmpty(extradata.t1goals) then
-		row:addElement(CustomMatchSummary._(extradata.t1goals, 1))
+		row:addElement(CustomMatchSummary._goalDisaplay(extradata.t1goals, 1))
 	end
 	if String.isNotEmpty(game.comment) then
 		row:addElement(mw.html.create('div')
@@ -352,13 +352,13 @@ function CustomMatchSummary._createGame(game)
 		)
 	end
 	if String.isNotEmpty(extradata.t2goals) then
-		row:addElement(CustomMatchSummary._(extradata.t2goals, 2))
+		row:addElement(CustomMatchSummary._goalDisaplay(extradata.t2goals, 2))
 	end
 
 	return row
 end
 
-function CustomMatchSummary._(goalesValue, side)
+function CustomMatchSummary._goalDisaplay(goalesValue, side)
 	local goalsDisplay = mw.html.create('div')
 		:cssText(side == 2 and 'float:right; margin-right:10px;')
 		:node(Abbreviation.make(

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -26,6 +26,8 @@ local _TIMEOUT = '[[File:Cooldown_Clock.png|14x14px|link=]]'
 local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link=http://octane.gg/matches/'
 local _OCTANE_SUFFIX = '|Octane matchpage]]'
 
+local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
+
 -- Custom Caster Class
 local Casters = Class.new(
 	function(self)
@@ -133,13 +135,13 @@ function Header:createScoreBoard(score, bestof, isNotFinished)
 	--[[
 		unbox this once score display is wanted due to usage of Template:SingleMatch
 		also kick the line below this comment
-	
+
 	return scoreBoardNode:node(score)
 	]]
 	return ''
 end
 
-function Header:soloOpponentTeam(opponent)
+function Header:soloOpponentTeam(opponent, date)
 	if opponent.type == 'solo' then
 		local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
 		local display = teamExists
@@ -211,7 +213,6 @@ function CustomMatchSummary.getByMatchId(args)
 		if String.isNotEmpty(match.vod) then
 			footer:addElement(VodLink.display{
 				vod = match.vod,
-				source = vod.url
 			})
 		end
 
@@ -220,7 +221,6 @@ function CustomMatchSummary.getByMatchId(args)
 			footer:addElement(VodLink.display{
 				gamenum = index,
 				vod = vod,
-				source = vod.url
 			})
 		end
 
@@ -234,7 +234,7 @@ function CustomMatchSummary._createHeader(match)
 	local header = Header()
 
 	header
-		:leftOpponentTeam(header:soloOpponentTeam(match.opponents[1]))
+		:leftOpponentTeam(header:soloOpponentTeam(match.opponents[1], match.date))
 		:leftOpponent(header:createOpponent(match.opponents[1], 1))
 		:scoreBoard(header:createScoreBoard(
 			header:createScoreDisplay(
@@ -245,7 +245,7 @@ function CustomMatchSummary._createHeader(match)
 			not match.finished
 		))
 		:rightOpponent(header:createOpponent(match.opponents[2], 2))
-		:rightOpponentTeam(header:soloOpponentTeam(match.opponents[2]))
+		:rightOpponentTeam(header:soloOpponentTeam(match.opponents[2], match.date))
 
 	return header
 end
@@ -267,7 +267,7 @@ function CustomMatchSummary._createBody(match)
 	if String.isNotEmpty(match.extradata.casters) then
 		local casters = Json.parseIfString(match.extradata.casters)
 		local casterRow = Casters()
-		for index, caster in pairs(casters) do
+		for _, caster in pairs(casters) do
 			casterRow:addCaster(caster)
 		end
 

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -27,8 +27,6 @@ local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link=http://octane.gg/match
 local _OCTANE_SUFFIX = '|Octane matchpage]]'
 
 local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
-local _COOLDOWN_ICON = '[[File:Cooldown_Clock.png|14x14px|link=]]'
-local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 -- Custom Caster Class
 local Casters = Class.new(

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -48,8 +48,8 @@ end
 
 function Casters:create()
 	return self.root
-		:node('<b>Caster' .. (#self.casters > 1 and 's' or '') .. ':</b><br>')
-		:node(table.concat(self.casters, ', '))
+		:wikitext('<b>Caster' .. (#self.casters > 1 and 's' or '') .. ':</b><br>')
+		:wikitext(table.concat(self.casters, ', '))
 end
 
 -- Custom Header Class

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -108,10 +108,6 @@ function Header:createScoreBoard(score, bestof, isNotFinished)
 		:addClass('brkts-popup-spaced')
 
 	if String.isNotEmpty(bestof) and isNotFinished then
-		--[[
-			unbox this once score display is wanted due to usage of Template:SingleMatch
-			also kick the line below this comment
-
 		return scoreBoardNode
 			:node(mw.html.create('span')
 				:css('line-height', '1.1')
@@ -128,17 +124,9 @@ function Header:createScoreBoard(score, bestof, isNotFinished)
 				))
 				:wikitext(')')
 			)
-		]]
-		return scoreBoardNode:node(Abbreviation.make('Bo' .. bestof, 'Best of ' .. bestof))
 	end
 
-	--[[
-		unbox this once score display is wanted due to usage of Template:SingleMatch
-		also kick the line below this comment
-
 	return scoreBoardNode:node(score)
-	]]
-	return ''
 end
 
 function Header:soloOpponentTeam(opponent, date)

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -378,7 +378,7 @@ function CustomMatchSummary._iconDisplay(icon, shouldDisplay, additionalElement,
 		:addClass('brkts-popup-spaced')
 		:node(additionalElement and flip and mw.html.create('div'):node(additionalElement) or nil)
 		:node(shouldDisplay and icon or _NO_CHECK)
-		:node(additionalElement and mw.html.create('div'):node(additionalElement) or nil)
+		:node(additionalElement and (not flip) and mw.html.create('div'):node(additionalElement) or nil)
 end
 
 return CustomMatchSummary

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -6,144 +6,185 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
+local Json = require('Module:Json')
+local Abbreviation = require('Module:Abbreviation')
+local String = require('Module:StringUtils')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
-local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
+local _GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
+local _NO_CHECK = '[[File:NoCheck.png|link=]]'
+local _TIMEOUT = '[[File:Cooldown_Clock.png|14x14px|link=]]'
+local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link=http://octane.gg/matches/'
+local _OCTANE_SUFFIX = '|Octane matchpage]]'
+
+-- Custom Caster Class
+local Casters = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+			:addClass('brkts-popup-comment')
+			:css('white-space','normal')
+			:css('font-size','85%')
+		self.casters = {}
+	end
+)
+
+function Casters:addCaster(caster)
+	if not Logic.isEmpty(caster) then
+		table.insert(self.casters, '[[' .. caster .. ']]')
+	end
+	return self
+end
+
+function Casters:create()
+	return self.root
+		:node('<b>Caster' .. (#self.casters > 1 and 's' or '') .. ':</b><br>')
+		:node(table.concat(self.casters, ', '))
+end
+
+-- Custom Header Class
+local Header = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+		self.root:addClass('brkts-popup-header-dev')
+	end
+)
+
+function Header:leftOpponentTeam(content)
+	self.leftElementAdditional = content
+	return self
+end
+
+function Header:rightOpponentTeam(content)
+	self.rightElementAdditional = content
+	return self
+end
+
+function Header:scoreBoard(content)
+	self.scoreBoard = content
+	return self
+end
+
+function Header:leftOpponent(content)
+	self.leftElement = content
+	return self
+end
+
+function Header:rightOpponent(content)
+	self.rightElement = content
+	return self
+end
+
+function Header:createScoreDisplay(opponent1, opponent2)
+	local function getScore(opponent)
+		return OpponentDisplay.BlockScore{
+			isWinner = opponent.placement == 1 or opponent.advances,
+			scoreText = OpponentDisplay.InlineScore(opponent),
+		}
+	end
+
+	return mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(
+			getScore(opponent1)
+				:css('margin-right', 0)
+		)
+		:node(' : ')
+		:node(getScore(opponent2))
+end
+
+function Header:createScoreBoard(score, bestof, isNotFinished)
+	local scoreBoardNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+
+	if String.isNotEmpty(bestof) and isNotFinished then
+		--[[
+			unbox this once score display is wanted due to usage of Template:SingleMatch
+			also kick the line below this comment
+
+		return scoreBoardNode
+			:node(mw.html.create('span')
+				:css('line-height', '1.1')
+				:css('width', '100%')
+				:css('text-align', 'center')
+				:node(score)
+			)
+			:node('<br>')
+			:node(mw.html.create('span')
+				:wikitext('(')
+				:node(Abbreviation.make(
+					'Bo' .. bestof,
+					'Best of ' .. bestof
+				))
+				:wikitext(')')
+			)
+		]]
+		return scoreBoardNode:node(Abbreviation.make('Bo' .. bestof, 'Best of ' .. bestof))
+	end
+
+	--[[
+		unbox this once score display is wanted due to usage of Template:SingleMatch
+		also kick the line below this comment
+	
+	return scoreBoardNode:node(score)
+	]]
+	return ''
+end
+
+function Header:soloOpponentTeam(opponent)
+	if opponent.type == 'solo' then
+		local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
+		local display = teamExists
+			and mw.ext.TeamTemplate.teamicon(opponent.template, match.date)
+			or _TBD_ICON
+		return mw.html.create('div'):wikitext(display)
+			:addClass('brkts-popup-header-opponent-solo-team')
+		end
+end
+
+function Header:createOpponent(opponent, opponentIndex)
+	return OpponentDisplay.BlockOpponent({
+		flip = opponentIndex == 1,
+		opponent = opponent,
+		overflow = 'wrap',
+		teamStyle = 'short',
+	})
+		:addClass(opponent.type ~= 'solo'
+			and 'brkts-popup-header-opponent'
+			or 'brkts-popup-header-opponent-solo-with-team')
+end
+
+function Header:create()
+	return self.root
+		:node(self.leftElementAdditional)
+		:node(self.leftElement)
+		:node(self.scoreBoard)
+		:node(self.rightElement)
+		:node(self.rightElementAdditional)
+end
+
 
 local CustomMatchSummary = {}
 
 function CustomMatchSummary.getByMatchId(args)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
 
-	local wrapper = mw.html.create('div')
-		:addClass('brkts-popup')
+	local matchSummary = MatchSummary():init()
 
-	local function renderOpponent(opponentIndex)
-		return OpponentDisplay.BlockOpponent({
-			flip = opponentIndex == 1,
-			opponent = match.opponents[opponentIndex],
-			overflow = 'wrap',
-			teamStyle = 'short',
-		})
-			:addClass(match.opponents[opponentIndex].type ~= 'solo'
-				and 'brkts-popup-header-opponent'
-				or 'brkts-popup-header-opponent-solo-with-team')
-	end
+	matchSummary:header(CustomMatchSummary._createHeader(match))
+				:body(CustomMatchSummary._createBody(match))
 
-	local function renderSoloOpponentTeam(opponentIndex)
-		local opponent = match.opponents[opponentIndex]
-		if opponent.type == 'solo' then
-			local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
-			local display = teamExists
-				and mw.ext.TeamTemplate.teamicon(opponent.template, match.date)
-				or _TBD_ICON
-			return mw.html.create('div'):wikitext(display)
-				:addClass('brkts-popup-header-opponent-solo-team')
-		else
-			return ''
-		end
-	end
-
-	-- header
-	local header = mw.html.create('div'):addClass('brkts-popup-header-dev')
-		:node(renderSoloOpponentTeam(1))
-		:node(renderOpponent(1))
-		:node(renderOpponent(2))
-		:node(renderSoloOpponentTeam(2))
-	wrapper:node(header):node(CustomMatchSummary._breakNode())
-
-	-- body
-	local body = mw.html.create('div'):addClass('brkts-popup-body')
-	body = CustomMatchSummary._addFlexRow(body, {DisplayHelper.MatchCountdownBlock(match)})
-	for _, game in ipairs(match.games) do
-		if game.map then
-			local centerNode = mw.html.create('div')
-					:addClass('brkts-popup-spaced')
-					:node(mw.html.create('div'):node('[[' .. game.map .. ']]'))
-			if Logic.readBool(game.extradata.ot) then
-				centerNode:node(mw.html.create('div'):node('- OT'))
-				if not Logic.isEmpty(game.extradata.otlength) then
-					centerNode:node(mw.html.create('div'):node('(' .. game.extradata.otlength .. ')'))
-				end
-			end
-			local gameElements = {
-				mw.html.create('div')
-					:addClass('brkts-popup-spaced')
-					:node(game.winner == 1 and
-						'[[File:GreenCheck.png|14x14px|link=]]' or
-						'[[File:NoCheck.png|link=]]')
-					:node(mw.html.create('div'):node(game.scores[1] or '')),
-				centerNode,
-				mw.html.create('div')
-					:addClass('brkts-popup-spaced')
-					:node(mw.html.create('div'):node(game.scores[2] or ''))
-					:node(game.winner == 2 and
-						'[[File:GreenCheck.png|14x14px|link=]]' or
-						'[[File:NoCheck.png|link=]]')
-			}
-			local gameHeader = game.header or ''
-			if gameHeader ~= '' then
-				table.insert(gameElements, 1, CustomMatchSummary._breakNode())
-				table.insert(gameElements, 1, mw.html.create('div')
-					:node(gameHeader)
-					:css('font-weight','bold')
-					:css('font-size','85%')
-					:css('margin','auto'))
-			end
-			local hasCommentLineBreakNode = false
-			if game.extradata.t1goals then
-				table.insert(gameElements, CustomMatchSummary._breakNode())
-				hasCommentLineBreakNode = true
-				local goals = mw.html.create('div')
-					:wikitext('<abbr title=\"Team 1 Goaltimes\">' ..
-						game.extradata.t1goals .. '</abbr>')
-				table.insert(gameElements, mw.html.create('div')
-					:node(goals)
-					:css('max-width', '50%')
-					:css('maxfont-size', '11px;'))
-			end
-			if game.comment then
-				if not hasCommentLineBreakNode then
-					table.insert(gameElements, CustomMatchSummary._breakNode())
-				end
-				hasCommentLineBreakNode = true
-				table.insert(gameElements, mw.html.create('div')
-					:node(game.comment)
-					:css('margin','auto')
-					:css('max-width', '60%'))
-			end
-			if game.extradata.t2goals then
-				if not hasCommentLineBreakNode then
-					table.insert(gameElements, CustomMatchSummary._breakNode())
-				end
-				local goals = mw.html.create('div')
-					:cssText('float:right;margin-right:10px;')
-					:wikitext('<abbr title=\"Team 2 Goaltimes\">' ..
-						game.extradata.t2goals .. '</abbr>')
-				table.insert(gameElements, mw.html.create('div')
-					:node(goals)
-					:css('max-width', '50%')
-					:css('maxfont-size', '11px;'))
-			end
-			body = CustomMatchSummary._addFlexRow(body, gameElements, 'brkts-popup-body-game')
-		end
-	end
-	wrapper:node(body):node(CustomMatchSummary._breakNode())
-
-	-- comment
 	if match.comment then
-		local comment = mw.html.create('div')
-			:addClass('brkts-popup-comment')
-			:css('white-space','normal')
-			:css('font-size','85%')
-			:node(match.comment)
-		wrapper:node(comment):node(CustomMatchSummary._breakNode())
+		local comment = MatchSummary.Comment():content(match.comment)
+		matchSummary:comment(comment)
 	end
 
 	-- footer
@@ -154,48 +195,190 @@ function CustomMatchSummary.getByMatchId(args)
 		end
 	end
 
-	local footerSet = false
-	local footer = mw.html.create('div')
-		:addClass('brkts-popup-footer')
-	local footerSpacer = mw.html.create('div')
+	if
+		Table.isNotEmpty(vods) or
+		String.isNotEmpty(match.vod) or
+		not Logic.isEmpty(match.extradata.octane)
+	then
+		local footer = MatchSummary.Footer()
+
+		-- Octane
+		if not Logic.isEmpty(match.extradata.octane) then
+			footer:addElement(_OCTANE_PREFIX .. match.extradata.octane .. _OCTANE_SUFFIX)
+		end
+
+		-- Match Vod
+		if String.isNotEmpty(match.vod) then
+			footer:addElement(VodLink.display{
+				vod = match.vod,
+				source = vod.url
+			})
+		end
+
+		-- Game Vods
+		for index, vod in pairs(vods) do
+			footer:addElement(VodLink.display{
+				gamenum = index,
+				vod = vod,
+				source = vod.url
+			})
+		end
+
+		matchSummary:footer(footer)
+	end
+
+	return matchSummary:create()
+end
+
+function CustomMatchSummary._createHeader(match)
+	local header = Header()
+
+	header
+		:leftOpponentTeam(header:soloOpponentTeam(match.opponents[1]))
+		:leftOpponent(header:createOpponent(match.opponents[1], 1))
+		:scoreBoard(header:createScoreBoard(
+			header:createScoreDisplay(
+				match.opponents[1],
+				match.opponents[2]
+			),
+			match.bestof,
+			not match.finished
+		))
+		:rightOpponent(header:createOpponent(match.opponents[2], 2))
+		:rightOpponentTeam(header:soloOpponentTeam(match.opponents[2]))
+
+	return header
+end
+
+function CustomMatchSummary._createBody(match)
+	local body = MatchSummary.Body()
+
+	body:addRow(MatchSummary.Row():addElement(DisplayHelper.MatchCountdownBlock(match)))
+
+	-- Iterate each map
+	for _, game in ipairs(match.games) do
+		if game.map then
+			local rowDisplay = CustomMatchSummary._createGame(game)
+			body:addRow(rowDisplay)
+		end
+	end
+
+	-- casters
+	if String.isNotEmpty(match.extradata.casters) then
+		local casters = Json.parseIfString(match.extradata.casters)
+		local casterRow = Casters()
+		for index, caster in pairs(casters) do
+			casterRow:addCaster(caster)
+		end
+
+		body:addRow(casterRow)
+	end
+
+	return body
+end
+
+function CustomMatchSummary._createGame(game)
+	local row = MatchSummary.Row()
+		:addClass('brkts-popup-body-game')
+	local extradata = game.extradata or {}
+
+	if String.isNotEmpty(game.header) then
+		local gameHeader = mw.html.create('div')
+			:css('font-weight','bold')
+			:css('font-size','85%')
+			:css('margin','auto')
+			:node(game.header)
+
+		row:addElement(gameHeader)
+		row:addElement(MatchSummary.Break():create())
+	end
+
+	local centerNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
-	if not Logic.isEmpty(match.extradata.octane) then
-		footerSet = true
-		footerSpacer:node('[[File:Octane_gg.png|14x14px|link=http://octane.gg/matches/' ..
-			match.extradata.octane ..
-			'|Octane matchpage]]')
+		:node(mw.html.create('div'):node('[[' .. game.map .. ']]'))
+	if Logic.readBool(extradata.ot) then
+		centerNode:node(mw.html.create('div'):node('- OT'))
+		if not Logic.isEmpty(extradata.otlength) then
+			centerNode:node(mw.html.create('div'):node('(' .. extradata.otlength .. ')'))
+		end
 	end
-	for index, vod in pairs(vods) do
-		footerSet = true
-		footerSpacer:node(VodLink.display{
-			gamenum = index,
-			vod = vod,
-		})
+
+	row:addElement(CustomMatchSummary._iconDisplay(
+		_GREEN_CHECK,
+		game.winner == 1,
+		game.scores[1],
+		1
+	))
+	row:addElement(centerNode)
+	row:addElement(CustomMatchSummary._iconDisplay(
+		_GREEN_CHECK,
+		game.winner == 2,
+		game.scores[2],
+		2
+	))
+
+	if extradata.timeout then
+		local timeouts = Json.parseIfString(extradata.timeout)
+		row:addElement(MatchSummary.Break():create())
+		row:addElement(CustomMatchSummary._iconDisplay(
+			_TIMEOUT,
+			Table.includes(timeouts, 1)
+		))
+		row:addElement(mw.html.create('div')
+			:addClass('brkts-popup-spaced')
+			:node(mw.html.create('div'):node('Timeout'))
+		)
+		row:addElement(CustomMatchSummary._iconDisplay(
+			_TIMEOUT,
+			Table.includes(timeouts, 2)
+		))
 	end
-	if footerSet then
-		footer:node(footerSpacer)
-		wrapper:node(footer)
+
+	if
+		String.isNotEmpty(extradata.t1goals)
+		or String.isNotEmpty(extradata.t2goals)
+		or String.isNotEmpty(game.comment)
+	then
+		row:addElement(MatchSummary.Break():create())
 	end
-	return wrapper
+	if String.isNotEmpty(extradata.t1goals) then
+		row:addElement(CustomMatchSummary._(extradata.t1goals, 1))
+	end
+	if String.isNotEmpty(game.comment) then
+		row:addElement(mw.html.create('div')
+			:css('margin','auto')
+			:css('max-width', '60%')
+			:node(game.comment)
+		)
+	end
+	if String.isNotEmpty(extradata.t2goals) then
+		row:addElement(CustomMatchSummary._(extradata.t2goals, 2))
+	end
+
+	return row
 end
 
-function CustomMatchSummary._addFlexRow(wrapper, contentElements, class, style)
-	local node = mw.html.create('div'):addClass('brkts-popup-body-element')
-	if not Logic.isEmpty(class) then
-		node:addClass(class)
-	end
-	for key, val in pairs(style or {}) do
-		node:css(key, val)
-	end
-	for _, element in ipairs(contentElements) do
-		node:node(element)
-	end
-	return wrapper:node(node)
-end
+function CustomMatchSummary._(goalesValue, side)
+	local goalsDisplay = mw.html.create('div')
+		:cssText(side == 2 and 'float:right; margin-right:10px;')
+		:node(Abbreviation.make(
+			goalesValue,
+			'Team ' .. side .. ' Goaltimes')
+		)
 
-function CustomMatchSummary._breakNode()
 	return mw.html.create('div')
-		:addClass('brkts-popup-break')
+			:css('max-width', '50%')
+			:css('maxfont-size', '11px;')
+			:node(goalsDisplay)
+end
+
+function CustomMatchSummary._iconDisplay(icon, shouldDisplay, additionalElement, side)
+	local flip = side == 2
+	return mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(additionalElement and flip and mw.html.create('div'):node(additionalElement) or nil)
+		:node(shouldDisplay and icon or _NO_CHECK)
+		:node(additionalElement and mw.html.create('div'):node(additionalElement) or nil)
 end
 
 return CustomMatchSummary

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Json = require('Module:Json')
 local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 local Json = require('Module:Json')


### PR DESCRIPTION
## Summary
* Rewrite RL MatchSummary to use MatchSummary/Base Classes
* Additionally adds Bestof display (as requested by RL contributors)
* Additionally has a comment that only has to be unboxed in case score display in matchsummary headers is wanted (also supported in combination with the bestof display)
* --> e.g. for usage of `Template:SingleMatch`

## How did you test this change?
/dev module
(also tested the stuff that was only added as comment)

both score and bestof display enabled
![Screenshot 2022-03-26 21 05 51](https://user-images.githubusercontent.com/75081997/160256633-e7558ef3-f785-406f-aedc-baa65d5c55c6.png)
with enabled score display and not entered bestof
![Screenshot 2022-03-26 21 06 10](https://user-images.githubusercontent.com/75081997/160256636-b2a73305-ff6e-475f-94c1-4ae97a5f2e23.png)
with bestof display and disabled score display
![Screenshot 2022-03-26 21 07 08](https://user-images.githubusercontent.com/75081997/160256637-b791dd57-b918-44fc-bd44-9aa72db26f28.png)

fixed the double score display on the right for maps (in the above screenshots it is still wrong)

## Remarks
* probably needs rebase once #1137 is merged
(contains the additions that get added in #1337 (just with different code due to now using the /Base classes))
* bestof display depends on #1138 as only after that is merged the bestof value is passed along to the matchsummary
