### PR TITLE
Fix team legacy matchlist for non 1v1 submatches

### DIFF
--- a/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
@@ -119,8 +119,7 @@ end
 function MatchMapsTeamLegacy._setPlayersForOpponents(args, side, displayNames)
 	local prefix = 't' .. side .. 'p'
 
-	for playerKey, player in Table.iter.pairsByPrefix(args, prefix) do
-		local playerIndex = tonumber(string.sub(playerKey, -1, -1)) or ''
+	for playerKey, player, playerIndex in Table.iter.pairsByPrefix(args, prefix) do
 		_opponentPlayers[side][player] = {
 			race = args[playerKey .. 'race'],
 			flag = args[playerKey .. 'flag'],

--- a/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
@@ -107,19 +107,24 @@ function MatchMapsTeamLegacy._processMapOpponent(side, prefix, mapArgs, archon)
 		['t' .. side .. 'p3flag'] = _match2Args[prefix .. 't' .. side .. 'p3flag'],
 	}
 
-	MatchMapsTeamLegacy._setPlayersForOpponents(addToMapArgs, side, _match2Args[prefix .. 'p' .. side])
+	MatchMapsTeamLegacy._setPlayersForOpponents(addToMapArgs, side, {
+			_match2Args[prefix .. 'p' .. side],
+			_match2Args[prefix .. 't' .. side .. 'p2'],
+			_match2Args[prefix .. 't' .. side .. 'p3'],
+	})
 
 	return Table.mergeInto(mapArgs, addToMapArgs)
 end
 
-function MatchMapsTeamLegacy._setPlayersForOpponents(args, side, displayName)
+function MatchMapsTeamLegacy._setPlayersForOpponents(args, side, displayNames)
 	local prefix = 't' .. side .. 'p'
 
 	for playerKey, player in Table.iter.pairsByPrefix(args, prefix) do
+		local playerIndex = tonumber(string.sub(playerKey, -1, -1)) or ''
 		_opponentPlayers[side][player] = {
 			race = args[playerKey .. 'race'],
 			flag = args[playerKey .. 'flag'],
-			display = displayName,
+			display = displayNames[playerIndex],
 		}
 	end
 end


### PR DESCRIPTION
## Summary
For Archon, 2v2 and 3v3 opponents in team legacy matchlists the displayName of some players was set wrong, this PR fixes this bug.

## How did you test this change?
dev module and after testing with it pushed live
