### PR TITLE
Create Squad for R6

### DIFF
--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -1,0 +1,75 @@
+---
+-- @Liquipedia
+-- wiki=rainbowsix
+-- page=Module:Squad/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Squad = require('Module:Squad')
+local SquadRow = require('Module:Squad/Row')
+local SquadAutoRefs = require('Module:SquadAuto/References')
+local Table = require('Module:Table')
+
+local CustomSquad = {}
+
+function CustomSquad.run(frame)
+	-- This function needs to be implemented on the local wiki is using manual Squad Tables
+end
+
+function CustomSquad.runAuto(playerList, squadType)
+	if Table.isEmpty(playerList) then
+		return
+	end
+
+	local squad = Squad()
+	squad:init(mw.getCurrentFrame())
+
+	squad.type = squadType
+
+	squad:title():header()
+
+	for _, player in pairs(playerList) do
+		squad:row(CustomSquad._playerRow(player, squad.type))
+	end
+
+	return squad:create()
+end
+
+function CustomSquad._playerRow(player, squadType)
+	--Get Reference(s)
+	local refTextJoin = SquadAutoRefs.useReferences(player.joindateRef, player.joindate)
+	local refTextLeave = SquadAutoRefs.useReferences(player.leavedateRef, player.leavedate)
+
+	local joinText = (player.joindatedisplay or player.joindate) .. ' ' .. refTextJoin
+	local leaveText = (player.leavedatedisplay or player.leavedate) .. ' ' .. refTextLeave
+
+	local row = SquadRow(mw.getCurrentFrame(), player.thisTeam.role)
+	row:id({
+		(player.idleavedate or player.id),
+		flag = player.flag,
+		link = player.page,
+		captain = player.captain,
+		role = player.thisTeam.role,
+		team = player.thisTeam.role == 'Loan' and player.oldTeam.team,
+	})
+	row:name({name = player.name})
+	row:role({role = player.thisTeam.role})
+	row:date(joinText, 'Join Date:&nbsp;', 'joindate')
+
+	if squadType == Squad.TYPE_FORMER then
+		row:date(leaveText, 'Leave Date:&nbsp;', 'leavedate')
+		row:newteam({
+			newteam = player.newTeam.team,
+			newteamrole = player.newTeam.role,
+			newteamdate = player.newTeam.date,
+			leavedate = player.newTeam.date
+		})
+	elseif squadType == Squad.TYPE_INACTIVE then
+		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
+	end
+
+	return row:create(mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. player.joindate)
+end
+
+return CustomSquad

--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -14,7 +14,7 @@ local Table = require('Module:Table')
 local CustomSquad = {}
 
 function CustomSquad.run(frame)
-	-- This function needs to be implemented on the local wiki is using manual Squad Tables
+	error("R6 wiki doesn't support manual Squad Tables")
 end
 
 function CustomSquad.runAuto(playerList, squadType)
@@ -38,11 +38,11 @@ end
 
 function CustomSquad._playerRow(player, squadType)
 	--Get Reference(s)
-	local refTextJoin = SquadAutoRefs.useReferences(player.joindateRef, player.joindate)
-	local refTextLeave = SquadAutoRefs.useReferences(player.leavedateRef, player.leavedate)
+	local joinReference = SquadAutoRefs.useReferences(player.joindateRef, player.joindate)
+	local leaveReference = SquadAutoRefs.useReferences(player.leavedateRef, player.leavedate)
 
-	local joinText = (player.joindatedisplay or player.joindate) .. ' ' .. refTextJoin
-	local leaveText = (player.leavedatedisplay or player.leavedate) .. ' ' .. refTextLeave
+	local joinText = (player.joindatedisplay or player.joindate) .. ' ' .. joinReference
+	local leaveText = (player.leavedatedisplay or player.leavedate) .. ' ' .. leaveReference
 
 	local row = SquadRow(mw.getCurrentFrame(), player.thisTeam.role)
 	row:id({


### PR DESCRIPTION
## Summary

R6 exclusively uses automatic Squad/Org Tables. The display & storage has been extracted into a Custom Squad implementation for the Squad tables, while the Org Tables still use the SquadAuto's implementation.

This module is called from: https://liquipedia.net/commons/index.php?title=Module:SquadAuto&action=edit#mw-ce-l602

## How did you test this change?

Live