### PR TITLE
Empty Squad Custom for Commons

### DIFF
--- a/components/squad/squad_custom.lua
+++ b/components/squad/squad_custom.lua
@@ -1,0 +1,22 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Squad/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+-- local Squad = require('Module:Squad')
+-- local SquadRow = require('Module:Squad/Row')
+
+local CustomSquad = {}
+
+function CustomSquad.run(frame)
+	-- This function needs to be implemented on the local wiki is using manual Squad Tables
+end
+
+function CustomSquad.runAuto(playerList, squadType)
+	-- This function needs to be implemented on the local wiki if using SquadAuto
+end
+
+return CustomSquad

--- a/components/squad/squad_custom.lua
+++ b/components/squad/squad_custom.lua
@@ -12,11 +12,11 @@
 local CustomSquad = {}
 
 function CustomSquad.run(frame)
-	-- This function needs to be implemented on the local wiki is using manual Squad Tables
+	error("CustomSquad.run() needs to be implemented on the local wiki if using manual Squad Tables")
 end
 
 function CustomSquad.runAuto(playerList, squadType)
-	-- This function needs to be implemented on the local wiki if using SquadAuto
+	error("CustomSquad.runAuto() needs to be implemented on the local wiki if using SquadAuto")
 end
 
 return CustomSquad


### PR DESCRIPTION
## Summary

Empty Squad Custom for Commons. Module existing was required for import [here](https://liquipedia.net/commons/index.php?title=Module:SquadAuto&action=edit#mw-ce-l8) for wikis without an implementation.

## How did you test this change?
N/A

