### PR TITLE
Add `vod=` option in `Matchlist`

### DIFF
--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -193,15 +193,14 @@ MatchlistDisplay.propTypes.Title = {
 Display component for a title in a matchlist.
 ]]
 function MatchlistDisplay.Title(props)
+	local VodLink = require('Module:VodLink')
+
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Title)
 	local titleNode = mw.html.create('div'):addClass('brkts-matchlist-title')
 		:wikitext(props.title)
-		:node(props.vod and mw.html.create('span')
-				:addClass('plainlinks vodlink')
-				:css('position', 'absolute')
-				:css('right', '52px')
-				:attr('title', 'Watch VOD')
-				:wikitext('[[File:VOD Icon.png|link=' .. props.vod .. ']]')
+		:node(props.vod and VodLink.display{vod = props.vod}
+			:css('position', 'absolute')
+			:css('right', '52px')
 		or nil)
 
 	return DisplayUtil.applyOverflowStyles(titleNode, 'wrap')

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -94,6 +94,7 @@ function MatchlistDisplay.Matchlist(props)
 		local titleNode = index == 1
 			and MatchlistDisplay.Title({
 				title = match.bracketData.title or 'Match List',
+				vod = match.bracketData.vod or nil,
 			})
 			or nil
 
@@ -185,6 +186,7 @@ end
 
 MatchlistDisplay.propTypes.Title = {
 	title = 'string',
+	vod = 'string?',
 }
 
 --[[
@@ -194,6 +196,13 @@ function MatchlistDisplay.Title(props)
 	DisplayUtil.assertPropTypes(props, MatchlistDisplay.propTypes.Title)
 	local titleNode = mw.html.create('div'):addClass('brkts-matchlist-title')
 		:wikitext(props.title)
+		:node(props.vod and mw.html.create('span')
+				:addClass('plainlinks vodlink')
+				:css('position', 'absolute')
+				:css('right', '52px')
+				:attr('title', 'Watch VOD')
+				:wikitext('[[File:VOD Icon.png|link=' .. props.vod .. ']]')
+		or nil)
 
 	return DisplayUtil.applyOverflowStyles(titleNode, 'wrap')
 end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -44,6 +44,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 
 			bracketData.type = 'matchlist'
 			bracketData.title = matchIndex == 1 and args.title or nil
+			bracketData.vod = matchIndex == 1 and args.vod or nil
 			bracketData.header = args['M' .. matchIndex .. 'header'] or bracketData.header
 			bracketData.matchIndex = matchIndex
 

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -72,10 +72,11 @@ MatchGroupUtil.types.MatchCoordinates = TypeUtil.struct({
 	semanticRoundIndex = 'number',
 })
 MatchGroupUtil.types.MatchlistBracketData = TypeUtil.struct({
+	dateHeader = 'boolean?',
 	header = 'string?',
 	title = 'string?',
-	dateHeader = 'boolean?',
 	type = TypeUtil.literal('matchlist'),
+	vod = 'string?',
 })
 MatchGroupUtil.types.BracketData = TypeUtil.union(
 	MatchGroupUtil.types.MatchlistBracketData,
@@ -404,10 +405,11 @@ function MatchGroupUtil.bracketDataFromRecord(data)
 		}
 	else
 		return {
-			header = nilIfEmpty(data.header),
 			dateHeader = nilIfEmpty(data.dateheader),
+			header = nilIfEmpty(data.header),
 			title = nilIfEmpty(data.title),
 			type = 'matchlist',
+			vod = nilIfEmpty(data.vod),
 		}
 	end
 end


### PR DESCRIPTION
## Summary

In match1 we could set `vod=` in `MatchListStart`.
![image](https://user-images.githubusercontent.com/42477808/160841125-4d1e8534-ea63-4d9c-a48f-d052eb422e11.png)

Add `vod=` option in `Matchlist` like in match1.
![image](https://user-images.githubusercontent.com/42477808/160840241-ea16a63c-2b6f-46b9-85e7-2e7e3467a105.png)

## How did you test this change?

/dev modules
