### PR TITLE
Recreate original caster match summary for RL

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -197,6 +197,7 @@ function matchFunctions.getExtraData(match)
 			})
 		end
 	end
+	table.sort(casters, function(c1, c2) return c1.name:lower() < c2.name:lower() end)
 
 	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -189,8 +189,12 @@ function matchFunctions.getExtraData(match)
 	local opponent2 = match.opponent2 or {}
 
 	local casters = {}
-	for _, caster in Table.iter.pairsByPrefix(match, 'caster') do
-		table.insert(casters, caster)
+	local casters_flags = {}
+	for key, caster in Table.iter.pairsByPrefix(match, 'caster') do
+		if not String.endsWith(key, 'flag') then
+			table.insert(casters, caster)
+			casters_flags[caster] = match[key .. 'flag']
+		end
 	end
 
 	match.extradata = {
@@ -203,6 +207,7 @@ function matchFunctions.getExtraData(match)
 		isconverted = 0,
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
+		casters_flags = casters_flags,
 	}
 	return match
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -193,7 +193,7 @@ function matchFunctions.getExtraData(match)
 		if string.match(key, 'caster%d+$') then
 			table.insert(casters, {
 				name = name,
-				flag = match[key .. 'flag'] ~= nil and match[key .. 'flag'] or getPlayerFlag(name)
+				flag = match[key .. 'flag'] or getPlayerFlag(name)
 			})
 		end
 	end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -189,11 +189,11 @@ function matchFunctions.getExtraData(match)
 	local opponent2 = match.opponent2 or {}
 
 	local casters = {}
-	local casters_flags = {}
+	local casterFlags = {}
 	for key, caster in Table.iter.pairsByPrefix(match, 'caster') do
 		if not String.endsWith(key, 'flag') then
 			table.insert(casters, caster)
-			casters_flags[caster] = match[key .. 'flag']
+			casterFlags[caster] = match[key .. 'flag']
 		end
 	end
 
@@ -207,7 +207,7 @@ function matchFunctions.getExtraData(match)
 		isconverted = 0,
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
-		casters_flags = casters_flags,
+		casterFlags = casterFlags,
 	}
 	return match
 end

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -14,6 +14,7 @@ local VodLink = require('Module:VodLink')
 local Json = require('Module:Json')
 local Abbreviation = require('Module:Abbreviation')
 local String = require('Module:StringUtils')
+local Flags = require('Module:Flags')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
@@ -48,19 +49,19 @@ function Casters:addCaster(caster)
 end
 
 function Casters:getFlag(caster)
-	local nationality = 'world'
+	local flagName = 'world'
 	if self.casterFlags[caster] ~= nil then
-		nationality = self.casterFlags[caster]
+		flagName = self.casterFlags[caster]
 	else
 		local data = mw.ext.LiquipediaDB.lpdb('player', {
 			conditions = '[[pagename::' .. mw.ext.TeamLiquidIntegration.resolve_redirect( caster ):gsub('%s+', '_') .. ']]',
 			query = 'nationality'
 		})
 		if type(data) == 'table' and data[1] then
-			nationality = data[1]['nationality']:lower()
+			flagName = data[1]['nationality']:lower()
 		end
 	end
-	return mw.getCurrentFrame():expandTemplate{ title = 'flag/' .. nationality }
+	return Flags.Icon(flagName)
 end
 
 function Casters:create()

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -30,13 +30,13 @@ local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
 
 -- Custom Caster Class
 local Casters = Class.new(
-	function(self, casters_flags)
+	function(self, casterFlags)
 		self.root = mw.html.create('div')
 			:addClass('brkts-popup-comment')
 			:css('white-space','normal')
 			:css('font-size','85%')
 		self.casters = {}
-		self.casters_flags = casters_flags
+		self.casterFlags = casterFlags
 	end
 )
 
@@ -49,8 +49,8 @@ end
 
 function Casters:getFlag(caster)
 	local nationality = 'world'
-	if self.casters_flags[caster] ~= nil then
-		nationality = self.casters_flags[caster]
+	if self.casterFlags[caster] ~= nil then
+		nationality = self.casterFlags[caster]
 	else
 		local data = mw.ext.LiquipediaDB.lpdb('player', {
 			conditions = '[[pagename::' .. mw.ext.TeamLiquidIntegration.resolve_redirect( caster ):gsub('%s+', '_') .. ']]',
@@ -283,8 +283,8 @@ function CustomMatchSummary._createBody(match)
 	-- casters
 	if String.isNotEmpty(match.extradata.casters) then
 		local casters = Json.parseIfString(match.extradata.casters)
-		local casters_flags = match.extradata.casters_flags
-		local casterRow = Casters(casters_flags)
+		local casterFlags = match.extradata.casterFlags
+		local casterRow = Casters(casterFlags)
 		table.sort(casters)
 		for _, caster in pairs(casters) do
 			casterRow:addCaster(caster)

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -31,37 +31,20 @@ local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
 
 -- Custom Caster Class
 local Casters = Class.new(
-	function(self, casterFlags)
+	function(self)
 		self.root = mw.html.create('div')
 			:addClass('brkts-popup-comment')
 			:css('white-space','normal')
 			:css('font-size','85%')
 		self.casters = {}
-		self.casterFlags = casterFlags
 	end
 )
 
 function Casters:addCaster(caster)
 	if Logic.isNotEmpty(caster) then
-		table.insert(self.casters, self:getFlag(caster) .. ' [[' .. caster .. ']]')
+		table.insert(self.casters, Flags.Icon(caster['flag']) .. ' [[' .. caster['name'] .. ']]')
 	end
 	return self
-end
-
-function Casters:getFlag(caster)
-	local flagName = 'world'
-	if self.casterFlags[caster] ~= nil then
-		flagName = self.casterFlags[caster]
-	else
-		local data = mw.ext.LiquipediaDB.lpdb('player', {
-			conditions = '[[pagename::' .. mw.ext.TeamLiquidIntegration.resolve_redirect( caster ):gsub('%s+', '_') .. ']]',
-			query = 'nationality'
-		})
-		if type(data) == 'table' and data[1] then
-			flagName = data[1]['nationality']:lower()
-		end
-	end
-	return Flags.Icon(flagName)
 end
 
 function Casters:create()
@@ -284,9 +267,7 @@ function CustomMatchSummary._createBody(match)
 	-- casters
 	if String.isNotEmpty(match.extradata.casters) then
 		local casters = Json.parseIfString(match.extradata.casters)
-		local casterFlags = match.extradata.casterFlags
-		local casterRow = Casters(casterFlags)
-		table.sort(casters)
+		local casterRow = Casters()
 		for _, caster in pairs(casters) do
 			casterRow:addCaster(caster)
 		end


### PR DESCRIPTION
## Summary

This change is to return the format of the casting on the match summary back to how it was [originally showcased](https://twitter.com/LiquipediaRL/status/1508509085842522117).
The reason it was changed away from this was because it was stored in a comment.
This edit changes the presentation of the parameters to look how it was in the comment-era.

## How did you test this change?

/dev module
![image](https://user-images.githubusercontent.com/42142350/160918651-18b71095-7e06-442c-97ed-86974ef12896.png)
