### PR TITLE
Storing Game into PUBGM Infobox League

### DIFF
--- a/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
@@ -120,7 +120,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.game = _game or args.game
+	lpdbData.game = _platform or args.platform
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.pubgpremier
 	lpdbData.extradata = {


### PR DESCRIPTION
## Summary

because PUBGM InfoLeague uses **platform** to define instead of **game** I had to change that line to make LPDB Data store platform as game

Goal is to utilize this for Module Tournaments Portal Table, so that it can filter by the platform (sub-game versions in this case)

