### PR TITLE
Support `individualprizemoney` lpdb field in earnings module

### DIFF
--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -142,7 +142,8 @@ function Earnings.calculatePerYear(conditions, divisionFactor)
 		for _, item in pairs(lpdbQueryData) do
 			local year = string.sub(item.date, 1, 4)
 			local prizeMoney = tonumber(item[prizePoolColumn]) or 0
-			earningsData[year] = (earningsData[year] or 0) + Earnings._applyDivisionFactor(prizeMoney, divisionFactor, item['mode'])
+			earningsData[year] = (earningsData[year] or 0)
+				+ Earnings._applyDivisionFactor(prizeMoney, divisionFactor, item['mode'])
 		end
 		count = #lpdbQueryData
 		offset = offset + _MAX_QUERY_LIMIT

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -104,9 +104,16 @@ function Earnings.calculate(conditions, year, mode, perYear, divisionFactor)
 		return Earnings.calculatePerYear(conditions, divisionFactor)
 	end
 
+	local query = 'mode, '
+	if divisionFactor == nil then
+		query = query .. ''
+	else
+		query = query .. ''
+	end
+
 	local lpdbQueryData = mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = conditions,
-		query = 'sum::prizemoney, mode, sum::individualprizemoney',
+		query = 'mode, ' .. (divisionFactor == nil and 'sum::individualprizemoney' or 'sum::prizemoney'),
 		groupby = 'mode asc'
 	})
 
@@ -137,7 +144,7 @@ function Earnings.calculatePerYear(conditions, divisionFactor)
 	while count == _MAX_QUERY_LIMIT do
 		local lpdbQueryData = mw.ext.LiquipediaDB.lpdb('placement', {
 			conditions = conditions,
-			query = 'prizemoney, mode, date, individualprizemoney',
+			query = 'mode, date, ' .. (divisionFactor == nil and 'individualprizemoney' or 'prizemoney'),
 			limit = _MAX_QUERY_LIMIT,
 			offset = offset
 		})

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -199,7 +199,7 @@ end
 
 function Earnings._applyDivisionFactor(totalEarnings, prizeMoney, divisionFactor, mode)
 	if divisionFactor and prizeMoney then
-		prizeMoney = prizeMoney / divisionFactor(item['mode'])
+		prizeMoney = prizeMoney / divisionFactor(mode)
 	end
 	return totalEarnings + prizeMoney
 end

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -115,7 +115,7 @@ function Earnings.calculate(conditions, year, mode, perYear, divisionFactor)
 
 	for _, item in ipairs(lpdbQueryData) do
 		local prizeMoney = item['sum_' .. prizePoolColumn]
-		totalEarnings = Earnings._applyDivisionFactor(totalEarnings, prizeMoney, divisionFactor, item['mode'])
+		totalEarnings = totalEarnings + Earnings._applyDivisionFactor(prizeMoney, divisionFactor, item['mode'])
 	end
 
 	return MathUtils._round(totalEarnings)

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -115,10 +115,7 @@ function Earnings.calculate(conditions, year, mode, perYear, divisionFactor)
 
 	for _, item in ipairs(lpdbQueryData) do
 		local prizeMoney = item['sum_' .. prizePoolColumn]
-		if divisionFactor ~= nil and item['sum_prizemoney'] ~= nil then
-			prizeMoney = prizeMoney / divisionFactor(item['mode'])
-		end
-		totalEarnings = totalEarnings + prizeMoney
+		totalEarnings = Earnings._applyDivisionFactor(totalEarnings, prizeMoney, divisionFactor, item['mode'])
 	end
 
 	return MathUtils._round(totalEarnings)
@@ -145,10 +142,7 @@ function Earnings.calculatePerYear(conditions, divisionFactor)
 		for _, item in pairs(lpdbQueryData) do
 			local year = string.sub(item.date, 1, 4)
 			local prizeMoney = tonumber(item[prizePoolColumn]) or 0
-			if divisionFactor ~= nil then
-				prizeMoney = prizeMoney / divisionFactor(item['mode'])
-			end
-			earningsData[year] = (earningsData[year] or 0) + prizeMoney
+			earningsData[year] = Earnings._applyDivisionFactor(earningsData[year] or 0, prizeMoney, divisionFactor, item['mode'])
 		end
 		count = #lpdbQueryData
 		offset = offset + _MAX_QUERY_LIMIT
@@ -201,6 +195,13 @@ end
 
 function Earnings._getPrizePoolType(divisionFactor)
 	return divisionFactor == nil and 'individualprizemoney' or 'prizemoney'
+end
+
+function Earnings._applyDivisionFactor(totalEarnings, prizeMoney, divisionFactor, mode)
+	if divisionFactor and prizeMoney then
+		prizeMoney = prizeMoney / divisionFactor(item['mode'])
+	end
+	return totalEarnings + prizeMoney
 end
 
 return Class.export(Earnings)

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -104,13 +104,6 @@ function Earnings.calculate(conditions, year, mode, perYear, divisionFactor)
 		return Earnings.calculatePerYear(conditions, divisionFactor)
 	end
 
-	local query = 'mode, '
-	if divisionFactor == nil then
-		query = query .. ''
-	else
-		query = query .. ''
-	end
-
 	local lpdbQueryData = mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = conditions,
 		query = 'mode, ' .. (divisionFactor == nil and 'sum::individualprizemoney' or 'sum::prizemoney'),

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -197,11 +197,11 @@ function Earnings._getPrizePoolType(divisionFactor)
 	return divisionFactor == nil and 'individualprizemoney' or 'prizemoney'
 end
 
-function Earnings._applyDivisionFactor(totalEarnings, prizeMoney, divisionFactor, mode)
-	if divisionFactor and prizeMoney then
-		prizeMoney = prizeMoney / divisionFactor(mode)
+function Earnings._applyDivisionFactor(prizeMoney, divisionFactor, mode)
+	if divisionFactor then
+		return prizeMoney / divisionFactor(mode)
 	end
-	return totalEarnings + prizeMoney
+	return prizeMoney
 end
 
 return Class.export(Earnings)

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -142,7 +142,7 @@ function Earnings.calculatePerYear(conditions, divisionFactor)
 		for _, item in pairs(lpdbQueryData) do
 			local year = string.sub(item.date, 1, 4)
 			local prizeMoney = tonumber(item[prizePoolColumn]) or 0
-			earningsData[year] = Earnings._applyDivisionFactor(earningsData[year] or 0, prizeMoney, divisionFactor, item['mode'])
+			earningsData[year] = (earningsData[year] or 0) + Earnings._applyDivisionFactor(prizeMoney, divisionFactor, item['mode'])
 		end
 		count = #lpdbQueryData
 		offset = offset + _MAX_QUERY_LIMIT

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -106,7 +106,7 @@ function Earnings.calculate(conditions, year, mode, perYear, divisionFactor)
 
 	local lpdbQueryData = mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = conditions,
-		query = 'mode, ' .. (divisionFactor == nil and 'sum::individualprizemoney' or 'sum::prizemoney'),
+		query = 'mode, sum::' .. Earnings._divisionFactorSwitch(divisionFactor),
 		groupby = 'mode asc'
 	})
 
@@ -137,7 +137,7 @@ function Earnings.calculatePerYear(conditions, divisionFactor)
 	while count == _MAX_QUERY_LIMIT do
 		local lpdbQueryData = mw.ext.LiquipediaDB.lpdb('placement', {
 			conditions = conditions,
-			query = 'mode, date, ' .. (divisionFactor == nil and 'individualprizemoney' or 'prizemoney'),
+			query = 'mode, date, ' .. Earnings._divisionFactorSwitch(divisionFactor),
 			limit = _MAX_QUERY_LIMIT,
 			offset = offset
 		})
@@ -199,6 +199,10 @@ end
 -- customizable in /Custom
 function Earnings.divisionFactorTeam(mode)
 	return 1
+end
+
+function Earnings._divisionFactorSwitch(divisionFactor)
+	return divisionFactor == nil and 'individualprizemoney' or 'prizemoney'
 end
 
 return Class.export(Earnings)


### PR DESCRIPTION
## Summary
Support `individualprizemoney` lpdb field in earnings module
- leave the old stuff in until all wikis switched to use `individualprizemoney` in `lpdb_placement`
- add option to query via the `individualprizemoney` if there is no divisionfactor set (i.e. if a wiki has `individualprizemoney` populated they can just nil the `Earnings.divisionFactorPlayer` function via the custom part)

## How did you test this change?
tested on freefire, rl and sc2 via dev modules and previews

if the indiv prize money fields are populated the values differ slightly from the old ones in singular cases due to the old one not being exact if teams had not the default number of players (e.g. the case on freefire)
(not on sc2 as our custom earnings stuff already uses the indiv prize stuff)

if the indiv prize money fields are not populated then the new values would be 0 **IF** in the custom module the
```lua
CustomEarnings.divisionFactorPlayer = nil
CustomEarnings.divisionFactorTeam = nil
```
is set. If it is not set it will return the old values (as intended)