### PR TITLE
Make singleMatch its own bracket type as requested by vogan

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -77,6 +77,8 @@ Called from MatchGroup
 function WikiSpecificBase.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
 		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
+		or matchGroupType == 'singleMatch'
+			and Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true}).SingleMatchContainer
 		or Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true}).BracketContainer
 end
 

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -85,12 +85,12 @@ function MatchGroup.SingleMatch(args)
 	args.matchid = '0001'
 	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'match')
 	local matches = MatchGroupInput.readSingleMatch(options.bracketId, args, options)
+	args.id = options.bracketId
 	Match.storeMatchGroup(matches, options)
 
 	local singleMatchNode
 	if options.show then
-		local fullMatchId = options.bracketId .. '_' .. args.matchid
-		singleMatchNode = MatchGroup._displaySingleMatch(args, fullMatchId)
+		singleMatchNode = MatchGroup.MatchByMatchId(args)
 	end
 
 	local parts = Array.extend(
@@ -149,18 +149,13 @@ function MatchGroup.MatchByMatchId(args)
 
 	assert(match, 'Match bracketId= ' .. bracketId .. ' matchId=' .. matchId .. ' not found')
 
-	return MatchGroup._displaySingleMatch(args, fullMatchId)
-end
-
-function MatchGroup._displaySingleMatch(args, fullMatchId)
 	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
 	local SingleMatchContainer = WikiSpecific.getMatchGroupContainer('singleMatch')
 	return SingleMatchContainer({
-			matchId = fullMatchId,
-			config = SingleMatchDisplay.configFromArgs(args),
-		})
+		matchId = fullMatchId,
+		config = SingleMatchDisplay.configFromArgs(args),
+	})
 end
-
 
 -- Entry point of Template:Matchlist
 function MatchGroup.TemplateMatchlist(frame)

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -79,6 +79,29 @@ function MatchGroup.Bracket(args)
 end
 
 --[[
+	Sets up a SingleMatch. The match is saved to LPDB.
+]]
+function MatchGroup.SingleMatch(args)
+	args.matchid = '0001'
+	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'match')
+	local matches = MatchGroupInput.readSingleMatch(options.bracketId, args, options)
+	Match.storeMatchGroup(matches, options)
+
+	local singleMatchNode
+	if options.show then
+		local fullMatchId = options.bracketId .. '_' .. args.matchid
+		singleMatchNode = MatchGroup._displaySingleMatch(args, fullMatchId)
+	end
+
+	local parts = Array.extend(
+		{singleMatchNode},
+		Array.map(optionsWarnings, WarningBox.display)
+	)
+
+	return table.concat(Array.map(parts, tostring))
+end
+
+--[[
 Displays a matchlist or bracket specified by ID.
 ]]
 function MatchGroup.MatchGroupById(args)
@@ -126,14 +149,16 @@ function MatchGroup.MatchByMatchId(args)
 
 	assert(match, 'Match bracketId= ' .. bracketId .. ' matchId=' .. matchId .. ' not found')
 
-	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
-	local config = SingleMatchDisplay.configFromArgs(args)
+	return MatchGroup._displaySingleMatch(args, fullMatchId)
+end
 
-	local MatchGroupContainer = WikiSpecific.getMatchContainer('singleMatch')
-	return MatchGroupContainer({
-		matchId = fullMatchId,
-		config = config,
-	})
+function MatchGroup._displaySingleMatch(args, fullMatchId)
+	local SingleMatchDisplay = Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true})
+	local SingleMatchContainer = WikiSpecific.getMatchGroupContainer('singleMatch')
+	return SingleMatchContainer({
+			matchId = fullMatchId,
+			config = SingleMatchDisplay.configFromArgs(args),
+		})
 end
 
 
@@ -147,6 +172,12 @@ end
 function MatchGroup.TemplateBracket(frame)
 	local args = Arguments.getArgs(frame)
 	return MatchGroup.Bracket(args)
+end
+
+-- Entry point of Template:SingleMatch
+function MatchGroup.TemplateSingleMatch(frame)
+	local args = Arguments.getArgs(frame)
+	return MatchGroup.SingleMatch(args)
 end
 
 -- Entry point of Template:ShowSingleMatch

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -37,6 +37,8 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 	if Logic.readBool(args.isLegacy) then
 		if matchGroupType == 'matchlist' then
 			table.insert(warnings, 'This is a legacy matchlist! Please use the new matchlist instead.')
+		elseif matchGroupType == 'match' then
+			table.insert(warnings, 'This is a legacy singleMatch! Please use the new singleMatch instead.')
 		else
 			table.insert(warnings, 'This is a legacy bracket! Please use the new bracket instead.')
 		end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -65,6 +65,34 @@ function MatchGroupInput._matchlistMatchIdFromIndex(matchIndex)
 	return string.format('%04d', matchIndex)
 end
 
+function MatchGroupInput.readSingleMatch(bracketId, args)
+	-- legacy support for input param names
+	local match = args.match or args.R1M1 or args.M1 or args[1]
+
+	local matchId = '0001'
+	local matchArgs = Json.parse(match)
+
+	local context = MatchGroupInput.readContext(matchArgs, args)
+	MatchGroupInput.persistContextChanges(context)
+	
+	matchArgs.bracketid = bracketId
+	matchArgs.matchid = matchId
+	local match = WikiSpecific.processMatch(mw.getCurrentFrame(), matchArgs)
+
+	-- Add more fields to bracket data
+	match.bracketdata = match.bracketdata or {}
+	local bracketData = match.bracketdata
+
+	bracketData.type = 'match' --naming of the type still up for discussion
+
+	match.parent = context.tournamentParent
+	bracketData.bracketindex = context.bracketIndex
+	bracketData.groupRoundIndex = context.groupRoundIndex
+	bracketData.sectionheader = context.sectionHeader
+
+	return match
+end
+
 function MatchGroupInput.readBracket(bracketId, args, options)
 	local warnings = {}
 	local templateId = args[1]

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -74,10 +74,10 @@ function MatchGroupInput.readSingleMatch(bracketId, args)
 
 	local context = MatchGroupInput.readContext(matchArgs, args)
 	MatchGroupInput.persistContextChanges(context)
-	
+
 	matchArgs.bracketid = bracketId
 	matchArgs.matchid = matchId
-	local match = WikiSpecific.processMatch(mw.getCurrentFrame(), matchArgs)
+	match = WikiSpecific.processMatch(mw.getCurrentFrame(), matchArgs)
 
 	-- Add more fields to bracket data
 	match.bracketdata = match.bracketdata or {}

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -90,7 +90,7 @@ function MatchGroupInput.readSingleMatch(bracketId, args)
 	bracketData.groupRoundIndex = context.groupRoundIndex
 	bracketData.sectionheader = context.sectionHeader
 
-	return match
+	return {match}
 end
 
 function MatchGroupInput.readBracket(bracketId, args, options)

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -598,7 +598,7 @@ function MatchGroupUtil.populateAdvanceSpots(bracket, matchGroupType)
 		return
 	end
 
-	if matchGroupType == _TYPE_SINGLE_MATCH then
+	if matchGroupType ~= _TYPE_SINGLE_MATCH then
 		-- Loser of semifinals play in third place match
 		local firstBracketData = bracket.bracketDatasById[bracket.rootMatchIds[1]]
 		local thirdPlaceMatchId = firstBracketData.thirdPlaceMatchId

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -407,7 +407,7 @@ function MatchGroupUtil.matchFromRecord(record)
 end
 
 function MatchGroupUtil.bracketDataFromRecord(data)
-	if data.type == 'bracket' or data.type == 'match' then
+	if data.type == 'bracket' then
 		local advanceSpots = data.advancespots or MatchGroupUtil.computeAdvanceSpots(data)
 		return {
 			advanceSpots = advanceSpots,
@@ -425,6 +425,12 @@ function MatchGroupUtil.bracketDataFromRecord(data)
 			thirdPlaceMatchId = nilIfEmpty(data.thirdplace),
 			type = 'bracket',
 			upperMatchId = nilIfEmpty(data.upperMatchId),
+		}
+	elseif data.type == 'match' then
+		local advanceSpots = data.advancespots or MatchGroupUtil.computeAdvanceSpots(data)
+		return {
+			advanceSpots = advanceSpots,
+			type = 'match',
 		}
 	else
 		return {

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -431,7 +431,6 @@ function MatchGroupUtil.bracketDataFromRecord(data)
 			header = nilIfEmpty(data.header),
 			dateHeader = nilIfEmpty(data.dateheader),
 			title = nilIfEmpty(data.title),
-			vod = nilIfEmpty(data.vod),
 			type = 'matchlist',
 		}
 	end

--- a/components/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -14,6 +14,8 @@ local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {re
 function WikiSpecific.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
 		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
+		or matchGroupType == 'singleMatch'
+			and Lua.import('Module:MatchGroup/Display/SingleMatch', {requireDevIfEnabled = true}).SingleMatchContainer
 		or Lua.import('Module:MatchGroup/Display/Bracket/Custom', {requireDevIfEnabled = true}).BracketContainer
 end
 

--- a/components/match2/wikis/starcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft/brkts_wiki_specific.lua
@@ -25,6 +25,8 @@ end)
 function WikiSpecific.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
 		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true}).MatchlistContainer
+		or matchGroupType == 'singleMatch'
+			and Lua.import('Module:MatchGroup/Display/SingleMatch/Starcraft', {requireDevIfEnabled = true}).SingleMatchContainer
 		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true}).BracketContainer
 end
 

--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -25,6 +25,8 @@ end)
 function WikiSpecific.getMatchGroupContainer(matchGroupType)
 	return matchGroupType == 'matchlist'
 		and Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true}).MatchlistContainer
+		or matchGroupType == 'singleMatch'
+			and Lua.import('Module:MatchGroup/Display/SingleMatch/Starcraft', {requireDevIfEnabled = true}).SingleMatchContainer
 		or Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true}).BracketContainer
 end
 


### PR DESCRIPTION
## Summary
Make singleMatch its own bracket type as requested by @JaspervanRiet (for the app)

## How did you test this change?
sc2 test page: https://liquipedia.net/starcraft2/User:Hjpalpha/wip32 (looks like before)
test (via preview) on r6 (left current, right new):
![Screenshot 2022-04-05 12 51 12](https://user-images.githubusercontent.com/75081997/161738719-f47db9f4-3739-4124-83c9-380ab40af729.png)
(for further tests use `Template:SingleMatch/dev` as it calls the /dev version of the module that gets invoked and temp sets the `feature_dev` wiki var for the use of the singleMatch)

## Remark
Currently it sets `bracketdata.type = 'match'` (as suggested by vogan) if a different value is prefered we can of course change it