### PR TITLE
Adjust Person category handling

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -384,18 +384,15 @@ end
 --- Allows for overriding this functionality
 function Person:getCategories(args, birthDisplay, personType, status)
 	if _shouldStoreData then
+		local team = args.teamlink or args.team
 		local categories = { personType .. 's' }
 
-		if not args.teamlink and not args.team then
-			table.insert(categories, 'Teamless ' .. personType .. 's')
-		end
 		if args.country2 or args.nationality2 then
 			table.insert(categories, 'Dual Citizenship ' .. personType .. 's')
 		end
 		if args.death_date then
 			table.insert(categories, 'Deceased ' .. personType .. 's')
-		end
-		if
+		elseif
 			args.retired == 'yes' or args.retired == 'true'
 			or string.lower(status or '') == 'retired'
 			or string.match(args.retired or '', '%d%d%d%d')--if retired has year set apply the retired category
@@ -403,6 +400,9 @@ function Person:getCategories(args, birthDisplay, personType, status)
 			table.insert(categories, 'Retired ' .. personType .. 's')
 		else
 			table.insert(categories, 'Active ' .. personType .. 's')
+			if not team then
+				table.insert(categories, 'Teamless ' .. personType .. 's')
+			end
 		end
 		if not args.image then
 			table.insert(categories, personType .. 's with no profile picture')
@@ -411,7 +411,6 @@ function Person:getCategories(args, birthDisplay, personType, status)
 			table.insert(categories, personType .. 's with unknown birth date')
 		end
 
-		local team = args.teamlink or args.team
 		if team and not mw.ext.TeamTemplate.teamexists(team) then
 			table.insert(categories, 'Players with invalid team')
 		end


### PR DESCRIPTION
## Summary
- a person can only be teamless if they are not dead and not retired (technically they are, but they are not looking for a team then)
- a dead person can not be active

## How did you test this change?
dev module