### PR TITLE
Adjust active person category handling

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -180,7 +180,6 @@ function CustomPlayer._getMatchupData(player)
 
 		local category
 		if years[_CURRENT_YEAR] or years[_CURRENT_YEAR - 1] or years[_CURRENT_YEAR - 2] then
-			category = 'Active players'
 			Variables.varDefine('isActive', 'true')
 		else
 			category = 'Players with no matches in the last three years'
@@ -190,7 +189,7 @@ function CustomPlayer._getMatchupData(player)
 
 		yearsActive = string.gsub(yearsActive, '<br>', '', 1)
 
-		if not (String.isEmpty(category) or String.isEmpty(yearsActive)) then
+		if String.isNotEmpty(category) and String.isNotEmpty(yearsActive) then
 			yearsActive = yearsActive .. '[[Category:' .. category .. ']]'
 		end
 


### PR DESCRIPTION
## Summary
Adjust active person category handling to not put players/casters into the active category if they had a match in the last 3 years.
Use commons determination for the active category instead.

## How did you test this change?
dev module