### PR TITLE
Add `inheritedHeader` to `match2bracketdata`

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -45,7 +45,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 			bracketData.type = 'matchlist'
 			bracketData.title = matchIndex == 1 and args.title or nil
 			bracketData.header = args['M' .. matchIndex .. 'header'] or bracketData.header
-			bracketData.roundheader = MatchGroupInput._roundHeader(bracketData.header)
+			bracketData.inheritedheader = MatchGroupInput._inheritedHeader(bracketData.header)
 			bracketData.matchIndex = matchIndex
 
 			match.parent = context.tournamentParent
@@ -113,7 +113,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 
 		bracketData.type = 'bracket'
 		bracketData.header = args[matchKey .. 'header'] or bracketData.header
-		bracketData.roundheader = MatchGroupInput._roundHeader(bracketData.header)
+		bracketData.inheritedheader = MatchGroupInput._inheritedHeader(bracketData.header)
 
 		match.parent = context.tournamentParent
 		bracketData.bracketindex = context.bracketIndex
@@ -235,10 +235,10 @@ end
 
 local getContentLanguage = FnUtil.memoize(mw.getContentLanguage)
 
-function MatchGroupInput._roundHeader(headerInput)
-	local roundHeader = headerInput or globalVars:get('roundHeader')
-	globalVars:set('roundHeader', roundHeader)
-	return roundHeader
+function MatchGroupInput._inheritedHeader(headerInput)
+	local inheritedHeader = headerInput or globalVars:get('inheritedHeader')
+	globalVars:set('inheritedHeader', inheritedHeader)
+	return inheritedHeader
 end
 
 function MatchGroupInput.readDate(dateString)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -45,6 +45,7 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 			bracketData.type = 'matchlist'
 			bracketData.title = matchIndex == 1 and args.title or nil
 			bracketData.header = args['M' .. matchIndex .. 'header'] or bracketData.header
+			bracketData.roundheader = MatchGroupInput._roundHeader(bracketData.header)
 			bracketData.matchIndex = matchIndex
 
 			match.parent = context.tournamentParent
@@ -112,6 +113,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 
 		bracketData.type = 'bracket'
 		bracketData.header = args[matchKey .. 'header'] or bracketData.header
+		bracketData.roundheader = MatchGroupInput._roundHeader(bracketData.header)
 
 		match.parent = context.tournamentParent
 		bracketData.bracketindex = context.bracketIndex
@@ -232,6 +234,12 @@ function MatchGroupInput.applyOverrideArgs(matches, args)
 end
 
 local getContentLanguage = FnUtil.memoize(mw.getContentLanguage)
+
+function MatchGroupInput._roundHeader(headerInput)
+	local roundHeader = headerInput or globalVars:get('roundHeader')
+	globalVars:set('roundHeader', roundHeader)
+	return roundHeader
+end		
 
 function MatchGroupInput.readDate(dateString)
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -239,7 +239,7 @@ function MatchGroupInput._roundHeader(headerInput)
 	local roundHeader = headerInput or globalVars:get('roundHeader')
 	globalVars:set('roundHeader', roundHeader)
 	return roundHeader
-end	
+end
 
 function MatchGroupInput.readDate(dateString)
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -239,7 +239,7 @@ function MatchGroupInput._roundHeader(headerInput)
 	local roundHeader = headerInput or globalVars:get('roundHeader')
 	globalVars:set('roundHeader', roundHeader)
 	return roundHeader
-end		
+end	
 
 function MatchGroupInput.readDate(dateString)
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>


### PR DESCRIPTION
## Summary
Add `inheritedHeader` to `match2bracketdata` per the discussion in the discord.
https://discord.com/channels/93055209017729024/756217678493909143/961630621229277213

Decision of final name of the property still pending.

## How did you test this change?
/dev module
![Screenshot 2022-04-07 17 08 52](https://user-images.githubusercontent.com/75081997/162231900-0d7c2d4e-c454-40e7-a3bf-3821f1c26278.png)
roundheader (renamed to inheritedHeader) present without header being present (R1M2):
![Screenshot 2022-04-07 17 08 57](https://user-images.githubusercontent.com/75081997/162231904-d599ba54-21dd-4336-af25-edf7dbe6a77f.png)

