### PR TITLE
Support submatch with only aggregate map info

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -175,18 +175,12 @@ function StarcraftMatchGroupInput.getExtraData(match)
 			veto5by = (match.vetoplayer5 or '') ~= '' and match.vetoplayer5 or match.vetoopponent5,
 			veto6by = (match.vetoplayer6 or '') ~= '' and match.vetoplayer6 or match.vetoopponent6,
 			contestname = (match.contestname or '') ~= '' and (match.contestname .. ' Bracket Contest') or nil,
-			subGroup1header = StarcraftMatchGroupInput.getSubGroupHeader(1, match),
-			subGroup2header = StarcraftMatchGroupInput.getSubGroupHeader(2, match),
-			subGroup3header = StarcraftMatchGroupInput.getSubGroupHeader(3, match),
-			subGroup4header = StarcraftMatchGroupInput.getSubGroupHeader(4, match),
-			subGroup5header = StarcraftMatchGroupInput.getSubGroupHeader(5, match),
-			subGroup6header = StarcraftMatchGroupInput.getSubGroupHeader(6, match),
-			subGroup7header = StarcraftMatchGroupInput.getSubGroupHeader(7, match),
-			subGroup8header = StarcraftMatchGroupInput.getSubGroupHeader(8, match),
-			subGroup9header = StarcraftMatchGroupInput.getSubGroupHeader(9, match),
 			headtohead = match.headtohead,
 			ffa = 'false',
 		}
+		for subGroupIndex = 1, MAX_NUM_MAPS do
+			match.extradata['subGroup' .. subGroupIndex .. 'header'] = StarcraftMatchGroupInput.getSubGroupHeader(subGroupIndex, match)
+		end
 	end
 
 	return match
@@ -386,7 +380,11 @@ function StarcraftMatchGroupInput.SubMatchStructure(match)
 				winner = 0
 			}
 			--adjust sub-match scores
-			if tonumber(match['map' .. i].winner) == 1 then
+			if match['map' .. i].map and String.startsWith(match['map' .. i].map, 'Submatch') then
+				for opponentIx, score in ipairs(SubMatches[k].scores) do
+					SubMatches[k].scores[opponentIx] = score + (match['map' .. i].scores[opponentIx] or 0)
+				end
+			elseif tonumber(match['map' .. i].winner) == 1 then
 				SubMatches[k].scores[1] = SubMatches[k].scores[1] + 1
 			elseif tonumber(match['map' .. i].winner) == 2 then
 				SubMatches[k].scores[2] = SubMatches[k].scores[2] + 1
@@ -632,6 +630,7 @@ function StarcraftMatchGroupInput.getManuallyEnteredPlayers(playerData)
 			break
 		end
 	end
+
 	return players
 end
 
@@ -651,6 +650,7 @@ function StarcraftMatchGroupInput.getPlayersFromVariables(teamName)
 			break
 		end
 	end
+
 	return players
 end
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -179,7 +179,8 @@ function StarcraftMatchGroupInput.getExtraData(match)
 			ffa = 'false',
 		}
 		for subGroupIndex = 1, MAX_NUM_MAPS do
-			match.extradata['subGroup' .. subGroupIndex .. 'header'] = StarcraftMatchGroupInput.getSubGroupHeader(subGroupIndex, match)
+			match.extradata['subGroup' .. subGroupIndex .. 'header']
+				= StarcraftMatchGroupInput.getSubGroupHeader(subGroupIndex, match)
 		end
 	end
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -269,7 +269,11 @@ function StarcraftMatchGroupUtil.constructSubmatch(games, match)
 		scores[opponentIx] = 0
 	end
 	for _, game in pairs(games) do
-		if game.winner then
+		if game.map and String.startsWith(game.map, 'Submatch') then
+			for opponentIx, score in pairs(scores) do
+				scores[opponentIx] = score + (game.scores[opponentIx] or 0)
+			end
+		elseif game.winner then
 			scores[game.winner] = (scores[game.winner] or 0) + 1
 		end
 	end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -158,7 +158,7 @@ function StarcraftMatchSummary.Body(props)
 
 		-- Show the submatch score if any submatch consists of more than one game
 		local showScore = Array.any(match.submatches, function(submatch)
-			return 1 < #submatch.games
+			return #submatch.games > 1
 				or #submatch.games == 1 and String.startsWith(submatch.games[1].map or '', 'Submatch')
 		end)
 

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
@@ -156,7 +157,10 @@ function StarcraftMatchSummary.Body(props)
 	else -- match.opponentMode == 'team'
 
 		-- Show the submatch score if any submatch consists of more than one game
-		local showScore = Array.any(match.submatches, function(submatch) return 1 < #submatch.games end)
+		local showScore = Array.any(match.submatches, function(submatch)
+			return 1 < #submatch.games
+				or #submatch.games == 1 and String.startsWith(submatch.games[1].map or '', 'Submatch')
+		end)
 
 		for _, submatch in ipairs(match.submatches) do
 			body:node(
@@ -260,7 +264,10 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 	local centerNode = html.create('div')
 		:addClass('brkts-popup-sc-submatch-center')
 	for _, game in ipairs(submatch.games) do
-		if game.map or game.winner then
+		if
+			(game.map or game.winner) and
+			not String.startsWith(game.map or '', 'Submatch')
+		then
 			centerNode:node(StarcraftMatchSummary.Game(game))
 		end
 	end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -157,6 +157,7 @@ function StarcraftMatchSummary.Body(props)
 	else -- match.opponentMode == 'team'
 
 		-- Show the submatch score if any submatch consists of more than one game
+		-- or if the Map name starts with 'Submatch' (and the submatch has a game)
 		local showScore = Array.any(match.submatches, function(submatch)
 			return #submatch.games > 1
 				or #submatch.games == 1 and String.startsWith(submatch.games[1].map or '', 'Submatch')


### PR DESCRIPTION
## Summary
- Support submatch with only aggregate map info
- allow subgroup headers for > 9 subgroups

## How did you test this change?
/dev modules

![Screenshot 2022-04-12 10 55 49](https://user-images.githubusercontent.com/75081997/162922188-a0c32a1f-e07a-472d-865f-f89ad70913a5.png)