### PR TITLE
fix capitalisation of aoe wiki name in aoe notability checker config

### DIFF
--- a/components/notability/wikis/ageofempires/notability_checker_config.lua
+++ b/components/notability/wikis/ageofempires/notability_checker_config.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=AgeOfEmpires
+-- wiki=ageofempires
 -- page=Module:NotabilityChecker/config
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute


### PR DESCRIPTION
## Summary
wiki should correspond with server url path

## How did you test this change?

