### PR TITLE
Improve runtime of SC2 player pages significantly

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -356,7 +356,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		medals = CustomPlayer._addPlacementToMedals(medals, placement)
 	end
 
-	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)
+	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
 
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
@@ -503,7 +503,7 @@ function CustomPlayer._isAwardAchievement(data, tier)
 end
 
 function CustomPlayer._setAchievements(data, place)
-	local tier = tonumber(data.liquipediatier) or 0
+	local tier = tonumber(data.liquipediatier)
 	if CustomPlayer._isAwardAchievement(data, tier) then
 		table.insert(_awardAchievements, data)
 	elseif CustomPlayer._isAchievement(data, place, tier) then

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -342,7 +342,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		medals = CustomPlayer._addPlacementToMedals(medals, placement)
 	end
 
-	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
+	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)
 
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -334,10 +334,14 @@ function CustomPlayer._getEarningsMedalsData(player)
 	}
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 	local processPlacement = function(placement)
 =======
 	local processPlacement = function(item)
 >>>>>>> 95cf2ea (rename local functions)
+=======
+	local processPlacement = function(placement)
+>>>>>>> f04c3af (rename function param)
 		--handle earnings
 		earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, placement)
 

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -353,7 +353,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		medals = CustomPlayer._addPlacementToMedals(medals, placement)
 	end
 
-	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
+	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)
 
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -33,7 +33,6 @@ local ColumnName = Condition.ColumnName
 local _EPT_SEASON = mw.loadData('Module:Series/EPT/config').currentSeason
 
 local _PAGENAME = mw.title.getCurrentTitle().prefixedText
-local _DISCARD_PLACEMENT = 99
 local _ALLOWED_PLACES = {1, 2, 3, 4, '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
@@ -376,11 +375,11 @@ end
 
 function CustomPlayer._addPlacementToMedals(medals, data)
 	if data.liquipediatiertype ~= 'Qualifier' then
-		local place = CustomPlayer._Placements(data.placement)
+		local place = CustomPlayer._getPlacement(data.placement)
 		CustomPlayer._setAchievements(data, place)
 		if
 			(data.players or {}).type == 'solo'
-			and place <= 3
+			and place and place <= 3
 		then
 			local tier = data.liquipediatier or 'undefined'
 			if not medals[place] then
@@ -403,15 +402,13 @@ function CustomPlayer._setVarsFromTable(table)
 	end
 end
 
-function CustomPlayer._Placements(value)
+function CustomPlayer._getPlacement(value)
 	if String.isNotEmpty(value) then
 		value = tonumber(mw.text.split(value, '-')[1])
 		if Table.includes(_ALLOWED_PLACES, value) then
 			return value
 		end
 	end
-
-	return _DISCARD_PLACEMENT
 end
 
 function CustomPlayer._setAchievements(data, place)
@@ -426,12 +423,14 @@ function CustomPlayer._setAchievements(data, place)
 end
 
 function CustomPlayer._isAchievement(data, place, tier)
-	return tier == 1 and place <= 4 or
-		tier == 2 and place <= 2 or
-		#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
-			tier == 2 and place <= 4 or
-			tier == 3 and place <= 2 or
-			tier == 4 and place <= 1
+	return place and (
+			tier == 1 and place <= 4 or
+			tier == 2 and place <= 2 or
+			#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
+				tier == 2 and place <= 4 or
+				tier == 3 and place <= 2 or
+				tier == 4 and place <= 1
+			)
 		)
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -33,13 +33,6 @@ local ColumnName = Condition.ColumnName
 local _EPT_SEASON = mw.loadData('Module:Series/EPT/config').currentSeason
 
 local _PAGENAME = mw.title.getCurrentTitle().prefixedText
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-local _DISCARD_PLACEMENT = 99
->>>>>>> 2923967 (Update infobox_person_player_custom.lua)
-=======
->>>>>>> 8fd50b4 (Update infobox_person_player_custom.lua)
 local _ALLOWED_PLACES = {1, 2, 3, 4, '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
@@ -340,15 +333,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		order = 'liquipediatier asc, placement asc, weight desc',
 	}
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 	local processPlacement = function(placement)
-=======
-	local processPlacement = function(item)
->>>>>>> 95cf2ea (rename local functions)
-=======
-	local processPlacement = function(placement)
->>>>>>> f04c3af (rename function param)
 		--handle earnings
 		earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, placement)
 
@@ -417,59 +402,13 @@ function CustomPlayer._setVarsFromTable(table)
 	end
 end
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 function CustomPlayer._getPlacement(value)
-=======
-function CustomPlayer._Placements(value)
->>>>>>> 2923967 (Update infobox_person_player_custom.lua)
-=======
-function CustomPlayer._getPlacement(value)
->>>>>>> 8fd50b4 (Update infobox_person_player_custom.lua)
 	if String.isNotEmpty(value) then
 		value = tonumber(mw.text.split(value, '-')[1])
 		if Table.includes(_ALLOWED_PLACES, value) then
 			return value
 		end
 	end
-<<<<<<< HEAD
-<<<<<<< HEAD
-end
-
-function CustomPlayer._setAchievements(data, place)
-	local tier = tonumber(data.liquipediatier)
-	if CustomPlayer._isAwardAchievement(data, tier) then
-		table.insert(_awardAchievements, data)
-	elseif CustomPlayer._isAchievement(data, place, tier) then
-		table.insert(_achievements, data)
-	elseif (#_achievementsFallBack + #_achievements) < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
-		table.insert(_achievementsFallBack, data)
-	end
-end
-
-function CustomPlayer._isAchievement(data, place, tier)
-	return place and (
-			tier == 1 and place <= 4 or
-			tier == 2 and place <= 2 or
-			#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
-				tier == 2 and place <= 4 or
-				tier == 3 and place <= 2 or
-				tier == 4 and place <= 1
-			)
-		)
-end
-
-function CustomPlayer._isAwardAchievement(data, tier)
-	return String.isNotEmpty((data.extradata or {}).award) and (
-		tier == 1 or
-		tier == 2 and data.individualprizemoney > 50
-	)
-=======
-
-	return _DISCARD_PLACEMENT
->>>>>>> 2923967 (Update infobox_person_player_custom.lua)
-=======
->>>>>>> 8fd50b4 (Update infobox_person_player_custom.lua)
 end
 
 function CustomPlayer._setAchievements(data, place)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -315,6 +315,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
 		ConditionTree(BooleanOperator.any):add({
 			ConditionNode(ColumnName('individualprizemoney'), Comparator.gt, '0'),
+			ConditionNode(ColumnName('extradata_award'), Comparator.neq, ''),
 			ConditionTree(BooleanOperator.all):add({
 				ConditionNode(ColumnName('players_type'), Comparator.gt, 'solo'),
 				placementConditions,

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -182,14 +182,14 @@ function CustomPlayer._getMatchupData(player)
 	end
 
 	local foundData = false
-	local itemChecker = function(match)
+	local processMatch = function(match)
 		foundData = true
 		vs = CustomPlayer._addScoresToVS(vs, match.match2opponents, player)
 		local year = string.sub(match.date, 1, 4)
 		years[tonumber(year)] = year
 	end
 
-	Lpdb.executeMassQuery('match2', queryParameters, itemChecker)
+	Lpdb.executeMassQuery('match2', queryParameters, processMatch)
 
 	if foundData then
 		local category
@@ -334,7 +334,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		order = 'liquipediatier asc, weight desc',
 	}
 
-	local itemChecker = function(item)
+	local processPlacement = function(item)
 		--handle earnings
 		earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, item)
 
@@ -342,7 +342,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		medals = CustomPlayer._addPlacementToMedals(medals, item)
 	end
 
-	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
+	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)
 
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -502,6 +502,34 @@ function CustomPlayer._isAwardAchievement(data, tier)
 	)
 end
 
+function CustomPlayer._setAchievements(data, place)
+	local tier = tonumber(data.liquipediatier) or 0
+	if CustomPlayer._isAwardAchievement(data, tier) then
+		table.insert(_awardAchievements, data)
+	elseif CustomPlayer._isAchievement(data, place, tier) then
+		table.insert(_achievements, data)
+	elseif (#_achievementsFallBack + #_achievements) < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
+		table.insert(_achievementsFallBack, data)
+	end
+end
+
+function CustomPlayer._isAchievement(data, place, tier)
+	return tier == 1 and place <= 4 or
+		tier == 2 and place <= 2 or
+		#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
+			tier == 2 and place <= 4 or
+			tier == 3 and place <= 2 or
+			tier == 4 and place <= 1
+		)
+end
+
+function CustomPlayer._isAwardAchievement(data, tier)
+	return String.isNotEmpty((data.extradata or {}).award) and (
+		tier == 1 or 
+		tier == 2 and data.individualprizemoney > 50
+	)
+end
+
 function CustomPlayer._getRank(player)
 	local rank_region = require('Module:EPT player region ' .. _EPT_SEASON)[player]
 		or {'noregion'}

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -514,12 +514,14 @@ function CustomPlayer._setAchievements(data, place)
 end
 
 function CustomPlayer._isAchievement(data, place, tier)
-	return tier == 1 and place <= 4 or
-		tier == 2 and place <= 2 or
-		#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
-			tier == 2 and place <= 4 or
-			tier == 3 and place <= 2 or
-			tier == 4 and place <= 1
+	return place and (
+			tier == 1 and place <= 4 or
+			tier == 2 and place <= 2 or
+			#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
+				tier == 2 and place <= 4 or
+				tier == 3 and place <= 2 or
+				tier == 4 and place <= 1
+			)
 		)
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -434,7 +434,7 @@ end
 
 function CustomPlayer._isAwardAchievement(data, tier)
 	return String.isNotEmpty((data.extradata or {}).award) and (
-		tier == 1 or 
+		tier == 1 or
 		tier == 2 and data.individualprizemoney > 50
 	)
 end

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -525,7 +525,7 @@ end
 
 function CustomPlayer._isAwardAchievement(data, tier)
 	return String.isNotEmpty((data.extradata or {}).award) and (
-		tier == 1 or 
+		tier == 1 or
 		tier == 2 and data.individualprizemoney > 50
 	)
 end

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -356,7 +356,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		medals = CustomPlayer._addPlacementToMedals(medals, placement)
 	end
 
-	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
+	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)
 
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -441,6 +441,34 @@ function CustomPlayer._isAwardAchievement(data, tier)
 	)
 end
 
+function CustomPlayer._setAchievements(data, place)
+	local tier = tonumber(data.liquipediatier) or 0
+	if CustomPlayer._isAwardAchievement(data, tier) then
+		table.insert(_awardAchievements, data)
+	elseif CustomPlayer._isAchievement(data, place, tier) then
+		table.insert(_achievements, data)
+	elseif (#_achievementsFallBack + #_achievements) < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
+		table.insert(_achievementsFallBack, data)
+	end
+end
+
+function CustomPlayer._isAchievement(data, place, tier)
+	return tier == 1 and place <= 4 or
+		tier == 2 and place <= 2 or
+		#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
+			tier == 2 and place <= 4 or
+			tier == 3 and place <= 2 or
+			tier == 4 and place <= 1
+		)
+end
+
+function CustomPlayer._isAwardAchievement(data, tier)
+	return String.isNotEmpty((data.extradata or {}).award) and (
+		tier == 1 or 
+		tier == 2 and data.individualprizemoney > 50
+	)
+end
+
 function CustomPlayer._getRank(player)
 	local rank_region = require('Module:EPT player region ' .. _EPT_SEASON)[player]
 		or {'noregion'}

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -347,7 +347,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
 		_achievements = Array.extendWith(_achievements, _achievementsFallBack)
-		_achievements = Array.sub(_achievements, 1, 10)
+		_achievements = Array.sub(_achievements, 1, _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS)
 	end
 	if #_achievements > 0 then
 		Variables.varDefine('achievements', Json.stringify(_achievements))

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -34,7 +34,7 @@ local _EPT_SEASON = mw.loadData('Module:Series/EPT/config').currentSeason
 
 local _PAGENAME = mw.title.getCurrentTitle().prefixedText
 local _DISCARD_PLACEMENT = 99
-local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
+local _ALLOWED_PLACES = {1, 2, 3, 4, '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
 local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
@@ -342,7 +342,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		medals = CustomPlayer._addPlacementToMedals(medals, placement)
 	end
 
-	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)
+	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
 
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
@@ -404,16 +404,18 @@ function CustomPlayer._setVarsFromTable(table)
 end
 
 function CustomPlayer._Placements(value)
-	value = String.isNotEmpty(value) and value or _DISCARD_PLACEMENT
-	value = tonumber(mw.text.split(value, '-')[1]) or _DISCARD_PLACEMENT
-	if not Table.includes(_ALLOWED_PLACES, tostring(value)) then
-		value = _DISCARD_PLACEMENT
+	if String.isNotEmpty(value) then
+		value = tonumber(mw.text.split(value, '-')[1])
+		if Table.includes(_ALLOWED_PLACES, value) then
+			return value
+		end
 	end
-	return value
+
+	return _DISCARD_PLACEMENT
 end
 
 function CustomPlayer._setAchievements(data, place)
-	local tier = tonumber(data.liquipediatier) or 0
+	local tier = tonumber(data.liquipediatier)
 	if CustomPlayer._isAwardAchievement(data, tier) then
 		table.insert(_awardAchievements, data)
 	elseif CustomPlayer._isAchievement(data, place, tier) then

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -16,6 +16,10 @@ local Variables = require('Module:Variables')
 local Achievements = require('Module:Achievements in infoboxes')._player
 local CleanRace = require('Module:CleanRace')
 local Math = require('Module:Math')
+local Json = require('Module:Json')
+local Lpdb = require('Module:Lpdb')
+local Table = require('Module:Table')
+local Array = require('Module:Array')
 local Matches = require('Module:Upcoming ongoing and recent matches player/new')
 
 local Condition = require('Module:Condition')
@@ -29,17 +33,22 @@ local ColumnName = Condition.ColumnName
 local _EPT_SEASON = mw.loadData('Module:Series/EPT/config').currentSeason
 
 local _PAGENAME = mw.title.getCurrentTitle().prefixedText
-local _DISCARD_PLACEMENT = '99'
+local _DISCARD_PLACEMENT = 99
 local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
 local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
+local _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS = 10
+local _MAXIMUM_NUMBER_OF_ACHIEVEMENTS = 40
 
 --race stuff
 local _AVAILABLE_RACES = {'p', 't', 'z', 'r', 'total'}
 local _RACE_FIELD_AS_CATEGORY_LINK = true
 
 local _earningsGlobal = {}
+local _achievements = {}
+local _awardAchievements = {}
+local _achievementsFallBack = {}
 local _CURRENT_YEAR = tonumber(os.date('%Y'))
 local _shouldQueryData
 
@@ -158,10 +167,10 @@ end
 function CustomPlayer._getMatchupData(player)
 	local yearsActive
 	player = string.gsub(player, '_', ' ')
-	local cond = '[[opponent::' .. player .. ']] AND [[walkover::]] AND [[winner::>]]'
-	local query = 'match2opponents, date'
-
-	local data = CustomPlayer._getLPDBrecursive(cond, query, 'match2')
+	local queryParameters = {
+		conditions = '[[opponent::' .. player .. ']] AND [[walkover::]] AND [[winner::>]]',
+		query = 'match2opponents, date',
+	}
 
 	local years = {}
 	local vs = {}
@@ -172,12 +181,17 @@ function CustomPlayer._getMatchupData(player)
 		end
 	end
 
-	if type(data[1]) == 'table' then
-		for i=1, #data do
-			vs = CustomPlayer._addScoresToVS(vs, data[i].match2opponents, player)
-			years[tonumber(string.sub(data[i].date, 1, 4))] = string.sub(data[i].date, 1, 4)
-		end
+	local foundData = false
+	local itemChecker = function(match)
+		foundData = true
+		vs = CustomPlayer._addScoresToVS(vs, match.match2opponents, player)
+		local year = string.sub(match.date, 1, 4)
+		years[tonumber(year)] = year
+	end
 
+	Lpdb.executeMassQuery('match2', queryParameters, itemChecker)
+
+	if foundData then
 		local category
 		if years[_CURRENT_YEAR] or years[_CURRENT_YEAR - 1] or years[_CURRENT_YEAR - 2] then
 			Variables.varDefine('isActive', 'true')
@@ -280,31 +294,7 @@ function CustomPlayer:calculateEarnings()
 	return earningsTotal, _earningsGlobal
 end
 
-function CustomPlayer._getLPDBrecursive(cond, query, queryType)
-	local data = {} -- get LPDB results in here
-	local count
-	local offset = 0
-	repeat
-		local additionalData = mw.ext.LiquipediaDB.lpdb(queryType, {
-			conditions = cond,
-			query = query,
-			offset = offset,
-			limit = 5000
-		})
-		count = #additionalData
-		-- Merging
-		for i, item in ipairs(additionalData) do
-			data[offset + i] = item
-		end
-		offset = offset + count
-	until count ~= 5000
-
-	return data
-end
-
 function CustomPlayer._getEarningsMedalsData(player)
-	local query = 'liquipediatier, liquipediatiertype, placement, date, individualprizemoney, players'
-
 	local playerConditions = ConditionTree(BooleanOperator.any)
 	for playerIndex = 1, _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS do
 		playerConditions:add({
@@ -323,7 +313,6 @@ function CustomPlayer._getEarningsMedalsData(player)
 		playerConditions,
 		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
 		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
-		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Qualifier'),
 		ConditionTree(BooleanOperator.any):add({
 			ConditionNode(ColumnName('individualprizemoney'), Comparator.gt, '0'),
 			ConditionTree(BooleanOperator.all):add({
@@ -333,24 +322,38 @@ function CustomPlayer._getEarningsMedalsData(player)
 		}),
 	})
 
-	local data = CustomPlayer._getLPDBrecursive(conditions:toString(), query, 'placement')
-
 	local earnings = {}
 	local medals = {}
 	earnings['total'] = {}
 	medals['total'] = {}
 	local earnings_total = 0
 
-	if type(data[1]) == 'table' then
-		for _, item in pairs(data) do
-			--handle earnings
-			earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, item)
+	local queryParameters = {
+		conditions = conditions:toString(),
+		order = 'liquipediatier asc, weight desc',
+	}
 
-			--handle medals
-			medals = CustomPlayer._addPlacementToMedals(medals, item)
-		end
+	local itemChecker = function(item)
+		--handle earnings
+		earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, item)
+
+		--handle medals
+		medals = CustomPlayer._addPlacementToMedals(medals, item)
 	end
 
+	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
+
+	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
+	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
+		_achievements = Array.extendWith(_achievements, _achievementsFallBack)
+		_achievements = Array.sub(_achievements, 1, 10)
+	end
+	if #_achievements > 0 then
+		Variables.varDefine('achievements', Json.stringify(_achievements))
+	end
+	if #_awardAchievements > 0 then
+		Variables.varDefine('awardAchievements', Json.stringify(_awardAchievements))
+	end
 	CustomPlayer._setVarsFromTable(earnings)
 	CustomPlayer._setVarsFromTable(medals)
 
@@ -371,18 +374,20 @@ function CustomPlayer._addPlacementToEarnings(earnings, earnings_total, data)
 end
 
 function CustomPlayer._addPlacementToMedals(medals, data)
-	if (data.players or {}).type == 'solo' then
+	if data.liquipediatiertype ~= 'Qualifier' then
 		local place = CustomPlayer._Placements(data.placement)
-		if place ~= _DISCARD_PLACEMENT then
+		CustomPlayer._setAchievements(data, place)
+		if
+			(data.players or {}).type == 'solo'
+			and place <= 3
+		then
 			local tier = data.liquipediatier or 'undefined'
-			if data.liquipediatiertype ~= 'Qualifier' then
-				if not medals[place] then
-					medals[place] = {}
-				end
-				medals[place][tier] = (medals[place][tier] or 0) + 1
-				medals[place]['total'] = (medals[place]['total'] or 0) + 1
-				medals['total'][tier] = (medals['total'][tier] or 0) + 1
+			if not medals[place] then
+				medals[place] = {}
 			end
+			medals[place][tier] = (medals[place][tier] or 0) + 1
+			medals[place]['total'] = (medals[place]['total'] or 0) + 1
+			medals['total'][tier] = (medals['total'][tier] or 0) + 1
 		end
 	end
 
@@ -399,13 +404,39 @@ end
 
 function CustomPlayer._Placements(value)
 	value = String.isNotEmpty(value) and value or _DISCARD_PLACEMENT
-	value = mw.text.split(value, '-')[1]
-	if value ~= '1' and value ~= '2' and value ~= '3' then
+	value = tonumber(mw.text.split(value, '-')[1]) or _DISCARD_PLACEMENT
+	if not Table.includes(_ALLOWED_PLACES, tostring(value)) then
 		value = _DISCARD_PLACEMENT
-	elseif value == '3' then
-		value = 'sf'
 	end
 	return value
+end
+
+function CustomPlayer._setAchievements(data, place)
+	local tier = tonumber(data.liquipediatier) or 0
+	if CustomPlayer._isAwardAchievement(data, tier) then
+		table.insert(_awardAchievements, data)
+	elseif CustomPlayer._isAchievement(data, place, tier) then
+		table.insert(_achievements, data)
+	elseif (#_achievementsFallBack + #_achievements) < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
+		table.insert(_achievementsFallBack, data)
+	end
+end
+
+function CustomPlayer._isAchievement(data, place, tier)
+	return tier == 1 and place <= 4 or
+		tier == 2 and place <= 2 or
+		#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
+			tier == 2 and place <= 4 or
+			tier == 3 and place <= 2 or
+			tier == 4 and place <= 1
+		)
+end
+
+function CustomPlayer._isAwardAchievement(data, tier)
+	return String.isNotEmpty((data.extradata or {}).award) and (
+		tier == 1 or 
+		tier == 2 and data.individualprizemoney > 50
+	)
 end
 
 function CustomPlayer._getRank(player)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -34,9 +34,12 @@ local _EPT_SEASON = mw.loadData('Module:Series/EPT/config').currentSeason
 
 local _PAGENAME = mw.title.getCurrentTitle().prefixedText
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 local _DISCARD_PLACEMENT = 99
 >>>>>>> 2923967 (Update infobox_person_player_custom.lua)
+=======
+>>>>>>> 8fd50b4 (Update infobox_person_player_custom.lua)
 local _ALLOWED_PLACES = {1, 2, 3, 4, '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
@@ -415,16 +418,21 @@ function CustomPlayer._setVarsFromTable(table)
 end
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 function CustomPlayer._getPlacement(value)
 =======
 function CustomPlayer._Placements(value)
 >>>>>>> 2923967 (Update infobox_person_player_custom.lua)
+=======
+function CustomPlayer._getPlacement(value)
+>>>>>>> 8fd50b4 (Update infobox_person_player_custom.lua)
 	if String.isNotEmpty(value) then
 		value = tonumber(mw.text.split(value, '-')[1])
 		if Table.includes(_ALLOWED_PLACES, value) then
 			return value
 		end
 	end
+<<<<<<< HEAD
 <<<<<<< HEAD
 end
 
@@ -460,6 +468,8 @@ function CustomPlayer._isAwardAchievement(data, tier)
 
 	return _DISCARD_PLACEMENT
 >>>>>>> 2923967 (Update infobox_person_player_custom.lua)
+=======
+>>>>>>> 8fd50b4 (Update infobox_person_player_custom.lua)
 end
 
 function CustomPlayer._setAchievements(data, place)
@@ -474,12 +484,14 @@ function CustomPlayer._setAchievements(data, place)
 end
 
 function CustomPlayer._isAchievement(data, place, tier)
-	return tier == 1 and place <= 4 or
-		tier == 2 and place <= 2 or
-		#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
-			tier == 2 and place <= 4 or
-			tier == 3 and place <= 2 or
-			tier == 4 and place <= 1
+	return place and (
+			tier == 1 and place <= 4 or
+			tier == 2 and place <= 2 or
+			#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
+				tier == 2 and place <= 4 or
+				tier == 3 and place <= 2 or
+				tier == 4 and place <= 1
+			)
 		)
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -33,7 +33,7 @@ local ColumnName = Condition.ColumnName
 local _EPT_SEASON = mw.loadData('Module:Series/EPT/config').currentSeason
 
 local _PAGENAME = mw.title.getCurrentTitle().prefixedText
-local _ALLOWED_PLACES = {1, 2, 3, 4, '3-4'}
+local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
 local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
@@ -404,41 +404,11 @@ end
 
 function CustomPlayer._getPlacement(value)
 	if String.isNotEmpty(value) then
-		value = tonumber(mw.text.split(value, '-')[1])
+		value = mw.text.split(value, '-')[1]
 		if Table.includes(_ALLOWED_PLACES, value) then
-			return value
+			return tonumber(value)
 		end
 	end
-end
-
-function CustomPlayer._setAchievements(data, place)
-	local tier = tonumber(data.liquipediatier)
-	if CustomPlayer._isAwardAchievement(data, tier) then
-		table.insert(_awardAchievements, data)
-	elseif CustomPlayer._isAchievement(data, place, tier) then
-		table.insert(_achievements, data)
-	elseif (#_achievementsFallBack + #_achievements) < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
-		table.insert(_achievementsFallBack, data)
-	end
-end
-
-function CustomPlayer._isAchievement(data, place, tier)
-	return place and (
-			tier == 1 and place <= 4 or
-			tier == 2 and place <= 2 or
-			#_achievements < _MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
-				tier == 2 and place <= 4 or
-				tier == 3 and place <= 2 or
-				tier == 4 and place <= 1
-			)
-		)
-end
-
-function CustomPlayer._isAwardAchievement(data, tier)
-	return String.isNotEmpty((data.extradata or {}).award) and (
-		tier == 1 or
-		tier == 2 and data.individualprizemoney > 50
-	)
 end
 
 function CustomPlayer._setAchievements(data, place)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -464,7 +464,7 @@ end
 
 function CustomPlayer._isAwardAchievement(data, tier)
 	return String.isNotEmpty((data.extradata or {}).award) and (
-		tier == 1 or 
+		tier == 1 or
 		tier == 2 and data.individualprizemoney > 50
 	)
 end

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -331,7 +331,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 
 	local queryParameters = {
 		conditions = conditions:toString(),
-		order = 'liquipediatier asc, weight desc',
+		order = 'liquipediatier asc, placement asc, weight desc',
 	}
 
 	local processPlacement = function(item)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -333,7 +333,11 @@ function CustomPlayer._getEarningsMedalsData(player)
 		order = 'liquipediatier asc, placement asc, weight desc',
 	}
 
+<<<<<<< HEAD
 	local processPlacement = function(placement)
+=======
+	local processPlacement = function(item)
+>>>>>>> 95cf2ea (rename local functions)
 		--handle earnings
 		earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, placement)
 

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -33,6 +33,10 @@ local ColumnName = Condition.ColumnName
 local _EPT_SEASON = mw.loadData('Module:Series/EPT/config').currentSeason
 
 local _PAGENAME = mw.title.getCurrentTitle().prefixedText
+<<<<<<< HEAD
+=======
+local _DISCARD_PLACEMENT = 99
+>>>>>>> 2923967 (Update infobox_person_player_custom.lua)
 local _ALLOWED_PLACES = {1, 2, 3, 4, '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
@@ -349,7 +353,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 		medals = CustomPlayer._addPlacementToMedals(medals, placement)
 	end
 
-	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)
+	Lpdb.executeMassQuery('placement', queryParameters, itemChecker)
 
 	-- if < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_achievements < _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
@@ -410,13 +414,18 @@ function CustomPlayer._setVarsFromTable(table)
 	end
 end
 
+<<<<<<< HEAD
 function CustomPlayer._getPlacement(value)
+=======
+function CustomPlayer._Placements(value)
+>>>>>>> 2923967 (Update infobox_person_player_custom.lua)
 	if String.isNotEmpty(value) then
 		value = tonumber(mw.text.split(value, '-')[1])
 		if Table.includes(_ALLOWED_PLACES, value) then
 			return value
 		end
 	end
+<<<<<<< HEAD
 end
 
 function CustomPlayer._setAchievements(data, place)
@@ -447,10 +456,14 @@ function CustomPlayer._isAwardAchievement(data, tier)
 		tier == 1 or
 		tier == 2 and data.individualprizemoney > 50
 	)
+=======
+
+	return _DISCARD_PLACEMENT
+>>>>>>> 2923967 (Update infobox_person_player_custom.lua)
 end
 
 function CustomPlayer._setAchievements(data, place)
-	local tier = tonumber(data.liquipediatier) or 0
+	local tier = tonumber(data.liquipediatier)
 	if CustomPlayer._isAwardAchievement(data, tier) then
 		table.insert(_awardAchievements, data)
 	elseif CustomPlayer._isAchievement(data, place, tier) then

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -334,12 +334,12 @@ function CustomPlayer._getEarningsMedalsData(player)
 		order = 'liquipediatier asc, placement asc, weight desc',
 	}
 
-	local processPlacement = function(item)
+	local processPlacement = function(placement)
 		--handle earnings
-		earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, item)
+		earnings, earnings_total = CustomPlayer._addPlacementToEarnings(earnings, earnings_total, placement)
 
 		--handle medals
-		medals = CustomPlayer._addPlacementToMedals(medals, item)
+		medals = CustomPlayer._addPlacementToMedals(medals, placement)
 	end
 
 	Lpdb.executeMassQuery('placement', queryParameters, processPlacement)


### PR DESCRIPTION
## Summary
Improve runtime of SC2 player pages significantly.
Since the SC2 infobox already queries all achievement worthy placement records and runs trough them to determine earnings and medal statistics data we decided to now also sort the achievements via that.
The so found achievements then get json-stringified and stored into a wiki var.
Achievements table module then just reads that wikivar, parses it and uses the so retrieved data instead of doing its own queries.
(Due to SC2 having team events with up to 30 players on a team the earnings and achievements/results queries are way more inefficient compared to other wikis so we try to actively reduce them and any redundancy.)

## How did you test this change?
/dev modules with preview tests on > a dozen player pages
Achievements (incl. awards) display as well as infobox display looks like intended.
Runtime improvement >30% of real time usage on pages of players with a sizable amount of results.
(Lua runtime improvement is due to changes in the display of the achievements table that are not related to this PR but get rolled out at the same time.)

## Examples
1. HeRoMaRinE:
![Screenshot_2022-04-15_13 55 06](https://user-images.githubusercontent.com/75081997/163588438-3bbb907c-95fa-40ee-bd10-a082f08ad736.png)
2. Dark:
![Screenshot_2022-04-15_14 54 40](https://user-images.githubusercontent.com/75081997/163588466-bce1c912-3933-4309-8085-c6d7c3d8ea72.png)

