### PR TITLE
Add scaling support to Infobox Header

### DIFF
--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -90,7 +90,7 @@ function Header:_makeSizedImage(imageName, fileName, size, mode)
 		local scale = size:gsub('%%', '')
 		scale = tonumber(scale)
 		if scale then
-			size = 'frameless|upright=' .. (scale/100)
+			size = 'frameless|upright=' .. (scale / 100)
 			infoboxImage:addClass('infobox-fixed-size-image')
 		end
 	-- Default

--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -80,13 +80,24 @@ end
 
 function Header:_makeSizedImage(imageName, fileName, size, mode)
 	local infoboxImage = mw.html.create('div'):addClass('infobox-image ' .. mode)
-	size = tonumber(size or '')
-	if size then
-		size = size .. 'px'
+
+	-- Number (interpret as pixels)
+	if tonumber(size or '') then
+		size = tonumber(size) .. 'px'
 		infoboxImage:addClass('infobox-fixed-size-image')
+	-- Percentage (interpret as scaling)
+	elseif size:find('%%') then
+		local scale = size:gsub('%%', '')
+		scale = tonumber(scale)
+		if scale then
+			size = 'frameless|upright=' .. (scale/100)
+			infoboxImage:addClass('infobox-fixed-size-image')
+		end
+	-- Default
 	else
 		size = '600px'
 	end
+
 	local fullFileName = '[[File:' .. imageName .. '|center|' .. size .. ']]'
 	infoboxImage:wikitext(mw.getCurrentFrame():preprocess('{{#metaimage:' .. (fileName or '') .. '}}') .. fullFileName)
 


### PR DESCRIPTION
## Summary

Requested by dota2 for Infobox Teams, is in use on a handful of pages today with the legacy infoboxes, such as https://liquipedia.net/dota2/PSG.LGD 

Input for the new infobox here would be `|imagesize=65%` while the old dota2 infobox uses `|image_sizedefault=frameless|image_upright=0.65`. So once dota2 goes live with Infobox Team, this would need to be updated on those team pages.

You can read more about `frameless` and `upright` (used on line 93): https://www.mediawiki.org/wiki/Help:Images#Rendering_a_single_image 

## How did you test this change?

Dev modules & preview.
