### PR TITLE
Add imagesize passthrough on all infobox headers

### DIFF
--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -37,6 +37,7 @@ function Building:createInfobox()
 			imageDefault = args.default,
 			imageDark = args.imagedark or args.imagedarkmode,
 			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
 		Title{name = 'Building Information'},

--- a/components/infobox/commons/infobox_campaign.lua
+++ b/components/infobox/commons/infobox_campaign.lua
@@ -25,7 +25,12 @@ function Campaign:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = self.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = self.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 	}
 

--- a/components/infobox/commons/infobox_campaign_mission.lua
+++ b/components/infobox/commons/infobox_campaign_mission.lua
@@ -30,7 +30,12 @@ function Mission:createInfobox()
 
 	local widgets = {
 		Customizable{id = 'header', children = {
-				Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+				Header{
+					name = args.name,
+					image = args.image,
+					imageDark = args.imagedark or args.imagedarkmode,
+					size = args.imagesize,
+				},
 			}
 		},
 		Center{content = {args.caption}},

--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -38,7 +38,12 @@ function Company:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Company Information'},
 		Cell{

--- a/components/infobox/commons/infobox_game.lua
+++ b/components/infobox/commons/infobox_game.lua
@@ -29,7 +29,12 @@ function Game:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Game Information'},
 		Cell{name = 'Developer', content = self:getAllArgsForBase(args, 'developer')},

--- a/components/infobox/commons/infobox_item.lua
+++ b/components/infobox/commons/infobox_item.lua
@@ -38,7 +38,7 @@ function Item:createInfobox()
 					imageDefault = args.default,
 					imageDark = args.imagedark or args.imagedarkmode,
 					imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-					size = args.size
+					size = args.imagesize
 				},
 			}
 		},

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -50,7 +50,12 @@ function League:createInfobox()
 	self:_definePageVariables(args)
 
 	local widgets = {
-		Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'League Information'},
 		Cell{

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -29,7 +29,12 @@ function Map:createInfobox(frame)
 	local args = self.args
 
 	local widgets = {
-		Header{name = self:getNameDisplay(args), image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = self:getNameDisplay(args),
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Map Information'},
 		Cell{name = 'Creator', content = {

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -33,7 +33,12 @@ function Patch:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Patch Information'},
 		Cell{name = 'Version', content = {args.version}},

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -76,7 +76,8 @@ function Person:createInfobox()
 			name = self:nameDisplay(args),
 			image = args.image,
 			imageDefault = args.default,
-			subHeader = self:subHeaderDisplay(args)
+			subHeader = self:subHeaderDisplay(args),
+			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Player') .. ' Information'},

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -35,7 +35,12 @@ function Scene:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = self:createNameDisplay(args), image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = self:createNameDisplay(args),
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Scene Information'},
 		Cell{name = 'Region', content = {args.region}},

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -38,7 +38,12 @@ function Series:createInfobox(frame)
 	local args = self.args
 
 	local widgets = {
-		Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Series Information'},
 		Customizable{

--- a/components/infobox/commons/infobox_show.lua
+++ b/components/infobox/commons/infobox_show.lua
@@ -33,7 +33,12 @@ function Show:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Show Information'},
 		Cell{name = 'Host(s)', content = self:getAllArgsForBase(args, 'host', {makeLink = true})},

--- a/components/infobox/commons/infobox_skill.lua
+++ b/components/infobox/commons/infobox_skill.lua
@@ -35,7 +35,12 @@ function Skill:createInfobox()
 	end
 
 	local widgets = {
-		Header{name = args.name, image = args.image, size = args.imageSize, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = args.informationType .. ' Information'},
 		Cell{name = 'Caster(s)', content = self:getAllArgsForBase(args, 'caster', { makeLink = true })},

--- a/components/infobox/commons/infobox_strategy.lua
+++ b/components/infobox/commons/infobox_strategy.lua
@@ -35,7 +35,12 @@ function Strategy:createInfobox()
 
 	local widgets = {
 		Customizable{id = 'header', children = {
-				Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+				Header{
+					name = args.name,
+					image = args.image,
+					imageDark = args.imagedark or args.imagedarkmode,
+					size = args.imagesize,
+				},
 			}
 		},
 		Center{content = {args.caption}},

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -56,6 +56,7 @@ function Team:createInfobox()
 			imageDefault = args.default,
 			imageDark = args.imagedark or args.imagedarkmode,
 			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
 		Title{name = 'Team Information'},

--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -40,7 +40,8 @@ function Unit:createInfobox()
 					imageDefault = args.default,
 					imageDark = args.imagedark or args.imagedarkmode,
 					imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-					subHeader = self:subHeaderDisplay(args)
+					subHeader = self:subHeaderDisplay(args),
+					size = args.imagesize,
 				},
 			}
 		},

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -31,7 +31,12 @@ function UnofficialWorldChampion:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = 'Unofficial World Champion', image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = 'Unofficial World Champion',
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Current Champion'},
 		Center{content = { args['current champion'] }, classes = { 'infobox-size-20', 'infobox-bold' }},

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -38,6 +38,7 @@ function Weapon:createInfobox()
 			imageDefault = args.default,
 			imageDark = args.imagedark or args.imagedarkmode,
 			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Weapon') .. ' Information'},

--- a/components/infobox/commons/infobox_website.lua
+++ b/components/infobox/commons/infobox_website.lua
@@ -31,7 +31,12 @@ function Website:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{name = args.name, image = args.image, imageDark = args.imagedark or args.imagedarkmode},
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
 		Center{content = {args.caption}},
 		Title{name = 'Website Information'},
 		Cell{name = 'Type', content = {args.type}},


### PR DESCRIPTION
## Summary

Passthrough from `|imagesize=` to Header Image's size. 
Change Infobox Skill from `|imageSize=` to `|imagesize=`.
Change Infobox Item from `|size` to `|imagesize=`.
The latter two changes needs updated pages on the wiki. Infobox Skill is only used Starcraft2, Infobox Item is used by Wild Rift and Mobile Legends.

## How did you test this change?

Tested on Infobox Teams combined with #1168 & #1147.
