### PR TITLE
Fix null pointer in Widget Header caused by #1168

### DIFF
--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -82,7 +82,8 @@ function Header:_makeSizedImage(imageName, fileName, size, mode)
 	local infoboxImage = mw.html.create('div'):addClass('infobox-image ' .. mode)
 
 	-- Number (interpret as pixels)
-	if tonumber(size or '') then
+	size = size or ''
+	if tonumber(size) then
 		size = tonumber(size) .. 'px'
 		infoboxImage:addClass('infobox-fixed-size-image')
 	-- Percentage (interpret as scaling)


### PR DESCRIPTION
## Summary

Missed to perform a test case in #1168, where by if no size was supplied to the header, there would be a null pointer on line 89.

As part of the lessons learned, an upcoming PR will mitigate the effect on the wiki if a similar thing occur in the future.

## How did you test this change?

Live
