### PR TITLE
Exception handling in widget creation

### DIFF
--- a/components/infobox/commons/infobox_widget_factory.lua
+++ b/components/infobox/commons/infobox_widget_factory.lua
@@ -8,9 +8,15 @@
 
 local Class = require('Module:Class')
 local Customizable = require('Module:Infobox/Widget/Customizable')
+local String = require('Module:StringUtils')
 local Widget = require('Module:Infobox/Widget')
 
 local WidgetFactory = Class.new()
+
+local _ERROR_TEXT = '<span style="color:#ff0000;font-weight:bold" class="show-when-logged-in">' ..
+					'Unexpected Error, report this in #bugs on our [https://discord.gg/liquipedia Discord]. ' ..
+					'${errorMessage}' ..
+					'</span>[[Category:Pages with script errors]]'
 
 function WidgetFactory.work(widget, injector)
 	local convertedWidgets = {}
@@ -20,22 +26,30 @@ function WidgetFactory.work(widget, injector)
 	end
 
 	if widget:is_a(Customizable) then
-		for _, child in ipairs(widget:make() or {}) do
+		for _, child in ipairs(WidgetFactory._makeWidget(widget) or {}) do
 			if child['is_a'] == nil or child:is_a(Widget) == false then
 				return error('Customizable can only contain Widgets as children')
 			end
 
 			child:setContext({injector = injector})
 
-			for _, item in ipairs(child:make() or {}) do
+			for _, item in ipairs(WidgetFactory._makeWidget(child) or {}) do
 				table.insert(convertedWidgets, item)
 			end
 		end
 	else
-		return widget:make()
+		return WidgetFactory._makeWidget(widget)
 	end
 
 	return convertedWidgets
+end
+
+function WidgetFactory._makeWidget(widget)
+	local result, output = pcall(widget.make, widget) -- Equivalent of widget:make()
+	if not result then
+		output = {String.interpolate(_ERROR_TEXT, {errorMessage = output})}
+	end
+	return output
 end
 
 return WidgetFactory


### PR DESCRIPTION
## Summary

Basic exception handling wrapped around the invocation of Widget:make()

The idea is to localize the impact of a lua error to just the area (cell, header etc) where it occurs. This is for two primary reasons, firstly the majority of the Infobox can still be displayed and as such we can minimize user impact. Secondly to minimize or remove the impact on the LPDB storage, so that consumers of LPDB (Modules & API) of it aren't (as) affected.

The error messages are hidden for logged out users.

Forced Example:
Error in the `Header` Widget & in the `Cell` `Team Captain`

Logged in view:
![image](https://user-images.githubusercontent.com/3426850/164749029-7f70d50d-99e2-4788-8f31-5e9f3e6b129e.png)

Logged out view:
![image](https://user-images.githubusercontent.com/3426850/164749256-2faecf4b-e86c-4340-b983-018ad88232b6.png)


## How did you test this change?

Dev modules, want to do additional tests before putting live.