### PR TITLE
Fix empty Achievements Section

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -118,7 +118,7 @@ function Team:createInfobox()
 			children = {
 				Builder{
 					builder = function()
-						if args.achievements then
+						if String.isNotEmpty(args.achievements) then
 							return {
 								Title{name = 'Achievements'},
 								Center{content = {args.achievements}}


### PR DESCRIPTION
## Summary

If args.achivements is the empty string, the code will insert an empty Achievements Section.

Before:
![image](https://user-images.githubusercontent.com/3426850/164786787-e6589049-304b-4479-a771-c0b9d7e9a097.png)

After:
![image](https://user-images.githubusercontent.com/3426850/164786802-fe66e4c8-5081-4257-8f95-3d943c3447a5.png)


## How did you test this change?

Dev modules
