### PR TITLE
Hide Opponent Link if it's TBD

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
+local Opponent = require('Module:Opponent')
 
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
@@ -51,9 +52,11 @@ function Header:rightOpponent(content)
 end
 
 function Header:createOpponent(opponent, side)
+	local showLink = not Opponent.isTbd(opponent) and true or false
 	return OpponentDisplay.BlockOpponent{
 		flip = side == 'left',
 		opponent = opponent,
+		showLink = showLink,
 		overflow = 'wrap',
 		teamStyle = 'short',
 	}


### PR DESCRIPTION
## Summary

If the Opponent is a TBD (based on the logic in Module:Opponent.isTbd()), don't insert a link.

Before:
![image](https://user-images.githubusercontent.com/3426850/164885930-ce8d0e31-f42f-4771-95d9-3086801229c0.png)

After:
![image](https://user-images.githubusercontent.com/3426850/164885972-33d20993-156c-4d68-b945-c8c7579d06a6.png)


## How did you test this change?

Dev Module