### PR TITLE
Improve Score Display for Bracket Reset and Match Sets

### DIFF
--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -87,9 +87,26 @@ end
 
 function Header:createScoreDisplay(opponent1, opponent2)
 	local function getScore(opponent)
+		local scoreText
+		local isWinner = opponent.placement == 1 or opponent.advances
+		if opponent.placement2 then
+			-- Bracket Reset, show W/L
+			if opponent.placement2 == 1 then
+				isWinner = true
+				scoreText = 'W'
+			else
+				isWinner = false
+				scoreText = 'L'
+			end
+		elseif opponent.extradata and opponent.extradata.additionalScores then
+			-- Match Series (Sets), show the series score
+			scoreText = (opponent.extradata.set1win and 1 or 0) + (opponent.extradata.set2win and 1 or 0) + (opponent.extradata.set3win and 1 or 0)
+		else
+			scoreText = OpponentDisplay.InlineScore(opponent)
+		end
 		return OpponentDisplay.BlockScore{
-			isWinner = opponent.placement == 1 or opponent.advances,
-			scoreText = OpponentDisplay.InlineScore(opponent),
+			isWinner = isWinner,
+			scoreText = scoreText,
 		}
 	end
 

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -100,7 +100,9 @@ function Header:createScoreDisplay(opponent1, opponent2)
 			end
 		elseif opponent.extradata and opponent.extradata.additionalScores then
 			-- Match Series (Sets), show the series score
-			scoreText = (opponent.extradata.set1win and 1 or 0) + (opponent.extradata.set2win and 1 or 0) + (opponent.extradata.set3win and 1 or 0)
+			scoreText = (opponent.extradata.set1win and 1 or 0)
+					  + (opponent.extradata.set2win and 1 or 0)
+					  + (opponent.extradata.set3win and 1 or 0)
 		else
 			scoreText = OpponentDisplay.InlineScore(opponent)
 		end


### PR DESCRIPTION
## Summary

Currently the Score in the MatchSummary displays the result of the first match in this popout header. Improve this based on discussions in RL channel.

For Match Sets, it should displays Sets won/lost.
For Bracket Reset, it should display W/L.

Before:
![image](https://user-images.githubusercontent.com/3426850/165294483-63f27c52-4fdb-4471-aeee-184ac2854cd5.png)
![image](https://user-images.githubusercontent.com/3426850/165294496-b03de155-d7d3-487c-acd3-6871f6341792.png)

After:
![image](https://user-images.githubusercontent.com/3426850/165294530-d5c80c30-c260-4a51-a9ee-d4b9fa5aed64.png)
![image](https://user-images.githubusercontent.com/3426850/165294543-602b968f-3525-4b67-b238-09cb0f87d767.png)


## How did you test this change?

Dev feature toggle with dev modules