### PR TITLE
Recreate original caster match summary for RL (re of #1146)

### DIFF
--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -14,6 +14,7 @@ local VodLink = require('Module:VodLink')
 local Json = require('Module:Json')
 local Abbreviation = require('Module:Abbreviation')
 local String = require('Module:StringUtils')
+local Flags = require('Module:Flags')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
@@ -41,15 +42,21 @@ local Casters = Class.new(
 
 function Casters:addCaster(caster)
 	if Logic.isNotEmpty(caster) then
-		table.insert(self.casters, '[[' .. caster .. ']]')
+		local nameDisplay = caster.id or caster.name
+		nameDisplay = '[[' .. caster.name .. '|' .. nameDisplay .. ']]'
+		if caster.flag then
+			table.insert(self.casters, Flags.Icon(caster['flag']) .. ' ' .. nameDisplay)
+		else
+			table.insert(self.casters, nameDisplay)
+		end
 	end
 	return self
 end
 
 function Casters:create()
 	return self.root
-		:wikitext('<b>Caster' .. (#self.casters > 1 and 's' or '') .. ':</b><br>')
-		:wikitext(table.concat(self.casters, ', '))
+		:wikitext('Caster' .. (#self.casters > 1 and 's' or '') .. ': ')
+		:wikitext(table.concat(self.casters, #self.casters > 2 and ', ' or ' & '))
 end
 
 -- Custom Header Class


### PR DESCRIPTION
## Summary

This change is to return the format of the casting on the match summary back to how it was [originally showcased](https://twitter.com/LiquipediaRL/status/1508509085842522117).
The reason it was changed away from this was because it was stored in a comment.
This edit changes the presentation of the parameters to look how it was in the comment-era.

## How did you test this change?

/dev module
![image](https://user-images.githubusercontent.com/42142350/160918651-18b71095-7e06-442c-97ed-86974ef12896.png)


(text copied from #1146)