### PR TITLE
Populate teampagename in lpdb for persons

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -218,6 +218,7 @@ function Person:_setLpdbData(args, links, status, personType)
 		image = args.image,
 		region = _region,
 		team = teamLink or args.teamlink or args.team,
+		teampagename = teamLink or args.teamlink or args.team,
 		teamtemplate = teamTemplate,
 		status = status,
 		type = personType,


### PR DESCRIPTION
## Summary
Populate teampagename in lpdb for persons.
Since the lpdb field exists we can populate it.

## How did you test this change?
under way