### PR TITLE
Store new Stream Key Format

### DIFF
--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -124,9 +124,6 @@ function StreamKey:new(tbl, languageCode, index)
 		platform = tbl.platform
 		languageCode = tbl.languageCode
 		index = tbl.index
-	-- Input is another table, assume format is {platform, languageCode, index}
-	elseif type(tbl) == 'table' then
-		platform, languageCode, index = unpack(tbl)
 	-- All three parameters are supplied
 	elseif languageCode and index then
 		platform = tbl

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -152,7 +152,7 @@ function StreamLinks.processStreams(forwardedInputArgs)
 
 				streamValue = StreamLinks.resolve(lookUpPlatform, streamValue)
 			end
-			
+
 			if FeatureFlag.get('new_stream_format') then
 				local key = StreamLinks.legacyToKey(platformName)
 				streams[key] = streamValue

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -152,7 +152,7 @@ end
 function StreamKey:_fromLegacy(input)
 	for _, platform in pairs(StreamLinks.countdownPlatformNames) do
 		-- The intersection of values in countdownPlatformNames and keys in streamPlatformLookupNames
-		-- are not valid platforms.
+		-- are not valid platforms. For example "twitch2" is not a valid platform.
 		if not StreamLinks.streamPlatformLookupNames[platform] then
 			-- Check if this platform matches the input
 			if string.find(input, platform, 1, true) then

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -90,7 +90,8 @@ function StreamKey:new(tbl, languageCode, index)
 	elseif type(tbl) == 'string' then
 		local components = mw.text.split(tbl, '_', true)
 		if #components == 1 then
-			platform, languageCode, index = self:_fromLegacy(tbl)
+			platform, index = self:_fromLegacy(tbl)
+			languageCode = 'en'
 		elseif #components == 3 then
 			platform, languageCode, index = unpack(components)
 		end
@@ -103,23 +104,20 @@ function StreamKey:new(tbl, languageCode, index)
 	self.languageCode = self.languageCode:lower()
 end
 
-function StreamKey:_fromLegacy(platform)
-	local languageCode = 'en'
-	for _, validPlatform in pairs(StreamLinks.countdownPlatformNames) do
+function StreamKey:_fromLegacy(input)
+	for _, platform in pairs(StreamLinks.countdownPlatformNames) do
 		-- The intersection between countdownPlatformNames and streamPlatformLookupNames are not valid platforms.
-		if not StreamLinks.streamPlatformLookupNames[validPlatform] then
-			-- Let's find the actual platform of the input. (Eg. "twitch" in the input "twitch35")
-			-- Offset will be the location of the last letter of the actual platform
-			local _, offset = platform:find(validPlatform, 1, true)
-			if offset then
+		if not StreamLinks.streamPlatformLookupNames[platform] then
+			-- Check if this platform matches the input
+			if string.find(input, platform, 1, true) then
 				local index
-				-- If there's more than just the platform name in the input means there's an index at the end
-				if #platform > #validPlatform then
-					index = tonumber(platform:sub(offset+1))
+				-- If the input is longer than the platform, there's an index at the end
+				if #input > #platform then
+					index = tonumber(input:sub(#platform+1))
 				else
 					index = 1
 				end
-				return validPlatform, languageCode, index
+				return platform, index
 			end
 		end
 	end

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -11,6 +11,7 @@ Module containing utility functions for streaming platforms.
 ]]
 local StreamLinks = {}
 
+local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
@@ -114,11 +115,13 @@ function StreamLinks.processStreams(forwardedInputArgs)
 
 				streamValue = StreamLinks.resolve(platform, streamValue)
 			end
-			local key = StreamLinks._buildKey(platform, languageCode, count)
-			streams[key] = streamValue
 
-			-- Insert legacy format as well for backwards compatibility
-			streams[platformName] = streamValue
+			if FeatureFlag.get('new_stream_format') then
+				local key = StreamLinks._buildKey(platform, languageCode, count)
+				streams[key] = streamValue
+			else
+				streams[platformName] = streamValue
+			end
 		end
 	end
 

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -81,7 +81,7 @@ function StreamLinks._buildKey(platform, languageCode, index)
 	assert(Logic.isNumeric(index), 'StreamLinks: Numeric Platform Index is required.')
 	languageCode = languageCode:lower()
 	index = tonumber(index)
-	return platform + "_" + languageCode + "_" + index
+	return platform .. "_" .. languageCode .. "_" .. index
 end
 
 --[[

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -108,10 +108,10 @@ function StreamLinks.processStreams(forwardedInputArgs)
 end
 
 --- StreamKey Class
--- Contains the truple that makes up a stream key
+-- Contains the triplet that makes up a stream key
 -- [platform, languageCode, index]
 StreamLinks.StreamKey = Class.new(
-	function (self,...)
+	function (self, ...)
 		self:new(...)
 	end
 )
@@ -151,14 +151,15 @@ end
 
 function StreamKey:_fromLegacy(input)
 	for _, platform in pairs(StreamLinks.countdownPlatformNames) do
-		-- The intersection between countdownPlatformNames and streamPlatformLookupNames are not valid platforms.
+		-- The intersection of values in countdownPlatformNames and keys in streamPlatformLookupNames
+		-- are not valid platforms.
 		if not StreamLinks.streamPlatformLookupNames[platform] then
 			-- Check if this platform matches the input
 			if string.find(input, platform, 1, true) then
 				local index
 				-- If the input is longer than the platform, there's an index at the end
 				if #input > #platform then
-					index = tonumber(input:sub(#platform+1))
+					index = tonumber(input:sub(#platform + 1))
 				else
 					index = 1
 				end
@@ -169,7 +170,7 @@ function StreamKey:_fromLegacy(input)
 end
 
 function StreamKey:toString()
-	return self.platform .. "_" .. self.languageCode .. "_" .. self.index
+	return self.platform .. '_' .. self.languageCode .. '_' .. self.index
 end
 
 function StreamKey:toLegacy()

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -119,9 +119,8 @@ function StreamLinks.processStreams(forwardedInputArgs)
 			if FeatureFlag.get('new_stream_format') then
 				local key = StreamLinks._buildKey(platform, languageCode, count)
 				streams[key] = streamValue
-			else
-				streams[platformName] = streamValue
 			end
+			streams[platformName] = streamValue
 		end
 	end
 

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -156,12 +156,11 @@ function StreamKey:_fromLegacy(input)
 		if not StreamLinks.streamPlatformLookupNames[platform] then
 			-- Check if this platform matches the input
 			if string.find(input, platform, 1, true) then
-				local index
+				local index = 1
 				-- If the input is longer than the platform, there's an index at the end
+				-- e.g. twitch2
 				if #input > #platform then
 					index = tonumber(input:sub(#platform + 1))
-				else
-					index = 1
 				end
 				return platform, index
 			end

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -173,7 +173,11 @@ function StreamKey:toString()
 end
 
 function StreamKey:toLegacy()
-	return self.platform .. (self.index > 1 and self.index or '')
+	-- Return twitch instead of twitch1
+	if self.index == 1 then
+		return self.platform
+	end
+	return self.platform .. self.index
 end
 
 function StreamKey:_isValid()

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -119,19 +119,24 @@ local StreamKey = StreamLinks.StreamKey
 
 function StreamKey:new(tbl, languageCode, index)
 	local platform
+	-- Input is another StreamKey - Make a copy
 	if StreamKey._isStreamKey(tbl) then
 		platform = tbl.platform
 		languageCode = tbl.languageCode
 		index = tbl.index
+	-- Input is another table, assume format is {platform, languageCode, index}
 	elseif type(tbl) == 'table' then
 		platform, languageCode, index = unpack(tbl)
+	-- All three parameters are supplied
 	elseif languageCode and index then
 		platform = tbl
 	elseif type(tbl) == 'string' then
 		local components = mw.text.split(tbl, '_', true)
+		-- Input is in legacy format (eg. twitch2)
 		if #components == 1 then
 			platform, index = self:_fromLegacy(tbl)
 			languageCode = 'en'
+		-- Input is a StreamKey in string format
 		elseif #components == 3 then
 			platform, languageCode, index = unpack(components)
 		end

--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -152,13 +152,13 @@ end
 function StreamKey:_fromLegacy(input)
 	for _, platform in pairs(StreamLinks.countdownPlatformNames) do
 		-- The intersection of values in countdownPlatformNames and keys in streamPlatformLookupNames
-		-- are not valid platforms. For example "twitch2" is not a valid platform.
+		-- are not valid platforms. E.g. "twitch2" is not a valid platform.
 		if not StreamLinks.streamPlatformLookupNames[platform] then
 			-- Check if this platform matches the input
 			if string.find(input, platform, 1, true) then
 				local index = 1
 				-- If the input is longer than the platform, there's an index at the end
-				-- e.g. twitch2
+				-- Eg. In "twitch2", the 2 would the index.
 				if #input > #platform then
 					index = tonumber(input:sub(#platform + 1))
 				end


### PR DESCRIPTION
## Summary

### Standardize Stream Key Formats

In order to get away from improvised historic solutions like `twitch2`, a new format will be used from streams when saving into LPDB. This format would 
1) Allow for infinite usages of a single platform 
2) Allow setting language code for the streams

The format that was decided on is `platform_languageCode_counter`, so for example `twitch_en_1` and `twitch_en_2` instead of `twitch` and `twitch2`.

The initial scope of support will be only saving into LPDB from match2, reading from LPDB for match2 display and conversion from match2 to match1 (match1 will use the old formats). No change to the wikicode or the page setup.

In a future we should look at getting all streams we have information about into the DB. But that's **___currently out of scope___**
![image](https://user-images.githubusercontent.com/3426850/165743951-6d37c945-ae03-4850-942e-ea93904e324e.png)


### This PR

This PR adds functionality to store streams in LPDB as new formats, it's locked behind a feature flag.
### Other 

#### Match1 backwards compatibility
If determined as required, follow up PR will remove the new format from match1 storage.

#### Countdown (display)
Module:Countdown has been updated to handle the new formats.
https://liquipedia.net/commons/index.php?title=Module%3ACountdown&type=revision&diff=420779&oldid=414377

After this PR has been merged, this can be changed to use `StreamKey` class instead, using the `:toLegacy()` method.

#### SC2 StreamPage (LPDB Condition)
Has been updated to handle both old format and the default new equivalent (eg `twitch` -> `twitch_en_1`)
https://liquipedia.net/starcraft2/index.php?title=Module%3AStreamPage&type=revision&diff=2207005&oldid=2173251 

## How did you test this change?

Tested using /dev modules

### Unit tests for StreamKey
```lua
mw.log(StreamLinks.StreamKey('twitch2'))
-- twitch_en_2
mw.log(StreamLinks.StreamKey('twitch'))
-- twitch_en_1
mw.log(StreamLinks.StreamKey('cc163'))
-- cc163_en_1
mw.log(StreamLinks.StreamKey('cc1633'))
-- cc163_en_3

mw.log(StreamLinks.StreamKey('twitch2'):toLegacy())
-- twitch2
mw.log(StreamLinks.StreamKey('twitch'):toLegacy())
-- twitch
mw.log(StreamLinks.StreamKey('cc163'):toLegacy())
-- cc163
mw.log(StreamLinks.StreamKey('cc1633'):toLegacy())
-- cc1633

mw.log(StreamLinks.StreamKey('twitch_en_2'):toLegacy())
-- twitch2
mw.log(StreamLinks.StreamKey('twitch_en_1'):toLegacy())
-- twitch
mw.log(StreamLinks.StreamKey('cc163_en_1'):toLegacy())
-- cc163
mw.log(StreamLinks.StreamKey('cc163_en_3'):toLegacy())
-- cc1633
```