### PR TITLE
Adjust display for aggregated submatches

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -119,10 +119,16 @@ end
 Displays the map name and link, and the status of the match if it had an
 unusual status.
 ]]
-function DisplayHelper.MapAndStatus(game)
-	local mapText = game.map
-		and ('[[' .. game.map .. ']]')
-		or 'Unknown'
+function DisplayHelper.MapAndStatus(game, config)
+	config = config or {}
+	local mapText
+	if game.map and not config.noLink then
+		mapText = '[[' .. game.map .. ']]'
+	elseif game.map then
+		mapText = game.map
+	else
+		mapText = 'Unknown'
+	end
 	if game.resultType == 'np' or game.resultType == 'default' then
 		mapText = '<s>' .. mapText .. '</s>'
 	end

--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -269,7 +269,7 @@ function StarcraftMatchGroupUtil.constructSubmatch(games, match)
 		scores[opponentIx] = 0
 	end
 	for _, game in pairs(games) do
-		if game.map and String.startsWith(game.map, 'Submatch') then
+		if game.map and String.startsWith(game.map, 'Submatch') and not game.resultType then
 			for opponentIx, score in pairs(scores) do
 				scores[opponentIx] = score + (game.scores[opponentIx] or 0)
 			end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -199,11 +199,11 @@ function StarcraftMatchSummary.Body(props)
 	return body
 end
 
-function StarcraftMatchSummary.Game(game)
+function StarcraftMatchSummary.Game(game, config)
 	DisplayUtil.assertPropTypes(game, StarcraftMatchGroupUtil.types.Game.struct)
 
 	local centerNode = html.create('div'):addClass('brkts-popup-sc-game-center')
-		:wikitext(DisplayHelper.MapAndStatus(game))
+		:wikitext(DisplayHelper.MapAndStatus(game, config))
 
 	local winnerIcon = function(opponentIx)
 		return game.resultType == 'draw' and StarcraftMatchSummary.ColoredIcon('YellowLine')
@@ -265,10 +265,7 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 	local centerNode = html.create('div')
 		:addClass('brkts-popup-sc-submatch-center')
 	for _, game in ipairs(submatch.games) do
-		if
-			(game.map or game.winner) and
-			not String.startsWith(game.map or '', 'Submatch')
-		then
+		if game.map or game.winner then
 			centerNode:node(StarcraftMatchSummary.Game(game))
 		end
 	end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -151,10 +151,7 @@ function StarcraftMatchSummary.Body(props)
 	if match.opponentMode == 'uniform' then
 		for _, game in ipairs(match.games) do
 			if game.map or game.winner then
-				body:node(StarcraftMatchSummary.Game(
-						game,
-						{noLink = String.startsWith(game.map or '', 'Submatch')}
-					):addClass('brkts-popup-body-element'))
+				body:node(StarcraftMatchSummary.Game(game):addClass('brkts-popup-body-element'))
 			end
 		end
 	else -- match.opponentMode == 'team'
@@ -269,7 +266,11 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 		:addClass('brkts-popup-sc-submatch-center')
 	for _, game in ipairs(submatch.games) do
 		if game.map or game.winner then
-			centerNode:node(StarcraftMatchSummary.Game(game))
+			centerNode:node(StarcraftMatchSummary.Game(
+					game,
+					{noLink = String.startsWith(game.map or '', 'Submatch')}
+				)
+			)
 		end
 	end
 

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -151,7 +151,10 @@ function StarcraftMatchSummary.Body(props)
 	if match.opponentMode == 'uniform' then
 		for _, game in ipairs(match.games) do
 			if game.map or game.winner then
-				body:node(StarcraftMatchSummary.Game(game):addClass('brkts-popup-body-element'))
+				body:node(StarcraftMatchSummary.Game(
+						game,
+						{noLink = String.startsWith(game.map or '', 'Submatch')}
+					):addClass('brkts-popup-body-element'))
 			end
 		end
 	else -- match.opponentMode == 'team'


### PR DESCRIPTION
## Summary
* Display `Submatch X` (without link) instead of blank
* Display submatch-scores properly (instead of `-1`) if the submatch has a result type

## How did you test this change?
/dev modules
![Screenshot 2022-04-28 17 45 44](https://user-images.githubusercontent.com/75081997/165792292-52fea9b2-565e-49a9-9a2c-8a7a6238a839.png)