### PR TITLE
Recreate original caster match summary for RL

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -231,8 +231,8 @@ function p._getCasterInformation(name, flag, id)
 			limit = 1,
 		})
 		if type(data) == 'table' and data[1] then
-			flag = String.isEmpty(flag) and data[1].flag or flag
-			id = String.isEmpty(id) and data[1].id or id
+			flag = String.isNotEmpty(flag) and flag or data[1].flag
+			id = String.isNotEmpty(id) and id or data[1].id
 		end
 	end
 	if String.isNotEmpty(flag) then

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -193,10 +193,10 @@ function matchFunctions.getExtraData(match)
 		table.insert(casters, p._getCasterInformation(
 			name,
 			match[key .. 'flag'],
-			match[key .. 'id']
+			match[key .. 'name']
 		))
 	end
-	table.sort(casters, function(c1, c2) return c1.name:lower() < c2.name:lower() end)
+	table.sort(casters, function(c1, c2) return c1.dname:lower() < c2.dname:lower() end)
 
 	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
@@ -212,14 +212,14 @@ function matchFunctions.getExtraData(match)
 	return match
 end
 
-function p._getCasterInformation(name, flag, id)
+function p._getCasterInformation(name, flag, dname)
 	if String.isEmpty(flag) then
 		flag = Variables.varDefault(name .. '_flag')
 	end
-	if String.isEmpty(id) then
-		id = Variables.varDefault(name .. '_dn')
+	if String.isEmpty(dname) then
+		dname = Variables.varDefault(name .. '_dn')
 	end
-	if String.isEmpty(flag) or String.isEmpty(id) then
+	if String.isEmpty(flag) or String.isEmpty(dname) then
 		local parent = Variables.varDefault(
 			'tournament_parent',
 			mw.title.getCurrentTitle().text
@@ -232,21 +232,21 @@ function p._getCasterInformation(name, flag, id)
 		})
 		if type(data) == 'table' and data[1] then
 			flag = String.isNotEmpty(flag) and flag or data[1].flag
-			id = String.isNotEmpty(id) and id or data[1].id
+			dname = String.isNotEmpty(dname) and dname or data[1].id
 		end
 	end
 	if String.isNotEmpty(flag) then
 		Variables.varDefine(name .. '_flag', flag)
 	end
-	if String.isEmpty(id) then
-		id = name
+	if String.isEmpty(dname) then
+		dname = name
 	end
-	if String.isNotEmpty(id) then
-		Variables.varDefine(name .. '_dn', id)
+	if String.isNotEmpty(dname) then
+		Variables.varDefine(name .. '_dn', dname)
 	end
 	return {
 		name = name,
-		id = id,
+		dname = dname,
 		flag = flag,
 	}
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -196,7 +196,7 @@ function matchFunctions.getExtraData(match)
 			match[key .. 'name']
 		))
 	end
-	table.sort(casters, function(c1, c2) return c1.dname:lower() < c2.dname:lower() end)
+	table.sort(casters, function(c1, c2) return c1.displayName:lower() < c2.displayName:lower() end)
 
 	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
@@ -212,14 +212,14 @@ function matchFunctions.getExtraData(match)
 	return match
 end
 
-function p._getCasterInformation(name, flag, dname)
+function p._getCasterInformation(name, flag, displayName)
 	if String.isEmpty(flag) then
 		flag = Variables.varDefault(name .. '_flag')
 	end
-	if String.isEmpty(dname) then
-		dname = Variables.varDefault(name .. '_dn')
+	if String.isEmpty(displayName) then
+		displayName = Variables.varDefault(name .. '_dn')
 	end
-	if String.isEmpty(flag) or String.isEmpty(dname) then
+	if String.isEmpty(flag) or String.isEmpty(displayName) then
 		local parent = Variables.varDefault(
 			'tournament_parent',
 			mw.title.getCurrentTitle().text
@@ -232,21 +232,21 @@ function p._getCasterInformation(name, flag, dname)
 		})
 		if type(data) == 'table' and data[1] then
 			flag = String.isNotEmpty(flag) and flag or data[1].flag
-			dname = String.isNotEmpty(dname) and dname or data[1].id
+			displayName = String.isNotEmpty(displayName) and displayName or data[1].id
 		end
 	end
 	if String.isNotEmpty(flag) then
 		Variables.varDefine(name .. '_flag', flag)
 	end
-	if String.isEmpty(dname) then
-		dname = name
+	if String.isEmpty(displayName) then
+		displayName = name
 	end
-	if String.isNotEmpty(dname) then
-		Variables.varDefine(name .. '_dn', dname)
+	if String.isNotEmpty(displayName) then
+		Variables.varDefine(name .. '_dn', displayName)
 	end
 	return {
 		name = name,
-		dname = dname,
+		displayName = displayName,
 		flag = flag,
 	}
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -189,9 +189,14 @@ function matchFunctions.getExtraData(match)
 	local opponent2 = match.opponent2 or {}
 
 	local casters = {}
-	for _, caster in Table.iter.pairsByPrefix(match, 'caster') do
-		table.insert(casters, caster)
+	for key, name in Table.iter.pairsByPrefix(match, 'caster') do
+		table.insert(casters, p._getCasterInformation(
+			name,
+			match[key .. 'flag'],
+			match[key .. 'id']
+		))
 	end
+	table.sort(casters, function(c1, c2) return c1.name:lower() < c2.name:lower() end)
 
 	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
@@ -205,6 +210,42 @@ function matchFunctions.getExtraData(match)
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}
 	return match
+end
+
+function p._getCasterInformation(name, flag, id)
+	if String.isEmpty(flag) then
+		flag = Variables.varDefault(name .. '_flag')
+	end
+	if String.isEmpty(id) then
+		id = Variables.varDefault(name .. '_dn')
+	end
+	if String.isEmpty(flag) or String.isEmpty(id) then
+		local parent = Variables.varDefault('tournament_parent')
+		local pageName = mw.ext.TeamLiquidIntegration.resolve_redirect(name)
+		local data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
+			conditions = '[[page::' .. pageName .. ']] AND [[parent::' .. parent .. ']]',
+			query = 'flag, id',
+			limit = 1,
+		})
+		if type(data) == 'table' and data[1] then
+			flag = String.isEmpty(flag) and data[1].flag or flag
+			id = String.isEmpty(id) and data[1].id or id
+		end
+	end
+	if String.isNotEmpty(flag) then
+		Variables.varDefine(name .. '_flag', flag)
+	end
+	if String.isEmpty(id) then
+		id = name
+	end
+	if String.isNotEmpty(id) then
+		Variables.varDefine(name .. '_dn', id)
+	end
+	return {
+		name = name,
+		id = id,
+		flag = flag,
+	}
 end
 
 function matchFunctions.isFeatured(match)

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -220,7 +220,10 @@ function p._getCasterInformation(name, flag, id)
 		id = Variables.varDefault(name .. '_dn')
 	end
 	if String.isEmpty(flag) or String.isEmpty(id) then
-		local parent = Variables.varDefault('tournament_parent')
+		local parent = Variables.varDefault(
+			'tournament_parent',
+			mw.title.getCurrentTitle().text
+		)
 		local pageName = mw.ext.TeamLiquidIntegration.resolve_redirect(name)
 		local data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
 			conditions = '[[page::' .. pageName .. ']] AND [[parent::' .. parent .. ']]',

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -42,7 +42,7 @@ local Casters = Class.new(
 
 function Casters:addCaster(caster)
 	if Logic.isNotEmpty(caster) then
-		local nameDisplay = '[[' .. caster.name .. '|' .. caster.dname .. ']]'
+		local nameDisplay = '[[' .. caster.name .. '|' .. caster.displayName .. ']]'
 		if caster.flag then
 			table.insert(self.casters, Flags.Icon(caster['flag']) .. ' ' .. nameDisplay)
 		else

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -14,6 +14,7 @@ local VodLink = require('Module:VodLink')
 local Json = require('Module:Json')
 local Abbreviation = require('Module:Abbreviation')
 local String = require('Module:StringUtils')
+local Flags = require('Module:Flags')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
@@ -41,15 +42,21 @@ local Casters = Class.new(
 
 function Casters:addCaster(caster)
 	if Logic.isNotEmpty(caster) then
-		table.insert(self.casters, '[[' .. caster .. ']]')
+		local nameDisplay = caster.id or caster.name
+		nameDisplay = '[[' .. caster.name .. '|' .. nameDisplay .. ']]'
+		if caster.flag then
+			table.insert(self.casters, Flags.Icon(caster['flag']) .. ' ' .. nameDisplay)
+		else
+			table.insert(self.casters, nameDisplay)
+		end
 	end
 	return self
 end
 
 function Casters:create()
 	return self.root
-		:wikitext('<b>Caster' .. (#self.casters > 1 and 's' or '') .. ':</b><br>')
-		:wikitext(table.concat(self.casters, ', '))
+		:wikitext('Caster' .. (#self.casters > 1 and 's' or '') .. ': ')
+		:wikitext(table.concat(self.casters, #self.casters > 2 and ', ' or ' & '))
 end
 
 -- Custom Header Class

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -42,8 +42,7 @@ local Casters = Class.new(
 
 function Casters:addCaster(caster)
 	if Logic.isNotEmpty(caster) then
-		local nameDisplay = caster.id or caster.name
-		nameDisplay = '[[' .. caster.name .. '|' .. nameDisplay .. ']]'
+		local nameDisplay = '[[' .. caster.name .. '|' .. caster.dname .. ']]'
 		if caster.flag then
 			table.insert(self.casters, Flags.Icon(caster['flag']) .. ' ' .. nameDisplay)
 		else


### PR DESCRIPTION
Continuation of this [pull-request](https://github.com/Liquipedia/Lua-Modules/pull/1146) which was automatically closed.

## Summary

This change is to return the format of the casting on the match summary back to how it was [originally showcased](https://twitter.com/LiquipediaRL/status/1508509085842522117).
The reason it was changed away from this was because it was stored in a comment.
This edit changes the presentation of the parameters to look how it was in the comment-era.

## How did you test this change?

/dev module
![image](https://user-images.githubusercontent.com/42142350/160918651-18b71095-7e06-442c-97ed-86974ef12896.png)
