### PR TITLE
Infobox Person: Wiki override on Link Variant

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -134,7 +134,7 @@ function Person:createInfobox()
 				if not Table.isEmpty(links) then
 					return {
 						Title{name = 'Links'},
-						Widgets.Links{content = links, variant = _LINK_VARIANT}
+						Widgets.Links{content = links, variant = self:getLinkVariant(args)}
 					}
 				end
 			end
@@ -194,7 +194,7 @@ function Person:createInfobox()
 end
 
 function Person:_setLpdbData(args, links, status, personType)
-	links = Links.makeFullLinksForTableItems(links, _LINK_VARIANT)
+	links = Links.makeFullLinksForTableItems(links, self:getLinkVariant(args))
 
 	local teamLink, teamTemplate
 	local team = args.teamlink or args.team
@@ -279,6 +279,11 @@ end
 --- Allows for overriding this functionality
 function Person:getStatusToStore(args)
 	return args.status
+end
+
+--- Allows for overriding this functionality
+function Person:getLinkVariant(args)
+	return _LINK_VARIANT
 end
 
 --- Allows for overriding this functionality


### PR DESCRIPTION
## Summary

For certain roles (on-screen talent such as casters), dota2 want to change a part of the link from `/player` to `/caster` (datdota) & `/players` to `/broadcasters` (for dotabuff).

My midnight solution was adding a possibility for wiki-override on the "Link Variant" sent to Module:Links.

This would allow dota2 to override the default 'Player' into 'Caster' for talents in their custom code, while setting up variants in Module:Links for datdota & dotabuff called 'Caster' with the separate links.

Dota2 discussion:
https://discord.com/channels/93055209017729024/213718409567928331/970434611891015790

## How did you test this change?

n/a just an idea