### PR TITLE
Kick extra colon in the "Misc Mode" cell name

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -53,7 +53,7 @@ function CustomInjector:addCustomCells(widgets)
 		content = {CustomLeague:_createGameCell(args.game)}
 	})
 	table.insert(widgets, Cell{
-		name = 'Misc Mode:',
+		name = 'Misc Mode',
 		content = {args.miscmode}
 	})
 


### PR DESCRIPTION
## Summary
Kick extra colon
![unknown](https://user-images.githubusercontent.com/75081997/166207857-3cf3f4a9-7f1f-45f9-8017-3fad980e9c02.png)

## How did you test this change?
N/A