### PR TITLE
Fix countryDisplay when not in main space

### DIFF
--- a/components/infobox/wikis/dota2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_player_custom.lua
@@ -238,6 +238,7 @@ function CustomPlayer._createLocation(country)
 		return nil
 	end
 	local countryDisplay = Flags.CountryName(country)
+	countryDisplay = '[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]'
 	local demonym = Localisation.getLocalisation(countryDisplay)
 
 	local roleCategory = _ROLES_CATEGORY[_args.role or ''] or 'Players'
@@ -245,12 +246,11 @@ function CustomPlayer._createLocation(country)
 
 	local categories = ''
 	if Namespace.isMain() then
-		categories = '[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]'
-		.. '[[Category:' .. demonym .. ' ' .. roleCategory .. ']]'
+		categories = '[[Category:' .. demonym .. ' ' .. roleCategory .. ']]'
 		.. '[[Category:' .. demonym .. ' ' .. role2Category .. ']]'
 	end
 
-	return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' .. categories
+	return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' .. countryDisplay .. categories
 
 end
 


### PR DESCRIPTION
## Summary
Fix countryDisplay for dota2 infobox player when not in main space.
![unknown](https://user-images.githubusercontent.com/75081997/166268629-943fdd27-8445-4975-b783-429ba6c5430b.png)

## How did you test this change?
/dev module
