### PR TITLE
Add support for Swiss tables

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -34,6 +34,7 @@ function StandingsStorage.run(index, data)
 				game = data.game, -- [won, draw, lost]
 				points = data.points,
 				diff = data.diff,
+				buchholz = data.buchholz,
 			}),
 			standingsindex = data.standingsindex,
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -19,6 +19,7 @@ function StandingsStorage.run(index, data)
 		{
 			title = mw.text.trim(cleanedTitle),
 			tournament = data.tournament,
+			type = data.type,
 			participant = data.participant,
 			participantdisplay = data.participantdisplay,
 			participantflag = Flags.CountryCode(data.participantflag),
@@ -33,7 +34,6 @@ function StandingsStorage.run(index, data)
 				game = data.game, -- [won, draw, lost]
 				points = data.points,
 				diff = data.diff,
-
 			}),
 			standingsindex = data.standingsindex,
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),


### PR DESCRIPTION
## Summary

Save `type` and `buchholz` fields if present.
* The LPDB field `type` doesn't yet exist, but it is in the process of being created. `type` should initially be either `league` or `swiss`
* `buchholz` goes into the scoreboard. This PR can be merged before the field is made available, it will start automatically populating once it is available.

## How did you test this change?

Dev module
![image](https://user-images.githubusercontent.com/3426850/166423247-8326b8c3-2a55-43fc-956f-61fe10c1d7c5.png)
