### PR TITLE
Use matchsection as section for some last_heading

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -19,6 +19,10 @@ local Variables = require('Module:Variables')
 
 local MatchGroupConfig = Lua.loadDataIfExists('Module:MatchGroup/Config')
 
+-- These last_headings are considered sub headings
+-- and matchsection should be used instead if available
+local SUB_SECTIONS = {'high', 'mid', 'low'}
+
 local globalVars = PageVariableNamespace()
 
 local Match = {}
@@ -316,8 +320,20 @@ function Match._prepareMatchRecordForStore(match)
 	match.match2bracketdata = match.match2bracketdata or match.bracketdata
 	match.match2bracketid = match.match2bracketid or match.bracketid
 	match.match2id = match.match2id or match.bracketid .. '_' .. match.matchid
-	match.section = Variables.varDefault('last_heading', ''):gsub('<.->', '')
+	match.section = Match._getSection()
 	Match.clampFields(match, Match.matchFields)
+end
+
+function Match._getSection()
+	local cleanHtml = function(rawString)
+		return rawString:gsub('<.->', '')
+	end
+	local lastHeading = cleanHtml(Variables.varDefault('last_heading', ''))
+	local matchSection = cleanHtml(Variables.varDefault('matchsection', ''))
+	if Logic.isNotEmpty(matchSection) and Table.includes(SUB_SECTIONS, lastHeading:lower()) then
+		return matchSection
+	end
+	return lastHeading
 end
 
 function Match._prepareGameRecordForStore(matchRecord, gameRecord)


### PR DESCRIPTION
## Summary

Swiss tournaments on the wiki often split their rounds into High & Low (and Mid when applicable). This can for instance be seen on https://liquipedia.net/counterstrike/PGL/2022/Antwerp/Europe_A#Swiss_Results .
Since these are headings, wiki variable `last_heading` will be set to eg `High`, which is then stored in match2's `section` field. Having what should be 3 different section all being named `High` in the database is unwanted. Rather we'd want them to be named Round X or similar.
Since automatic swiss standings require the wiki variable `matchsection` to be set to function properly, and it must always be set to `Round X` to function, which is the parent heading.

So to solve the issue, with this PR, if the wiki variable `last_heading` has one of a few predetermined values (`high`, `mid` & `low` at the moment), the `section` will be use wiki variable `matchsection` instead, assuming that it has been set.

## How did you test this change?

Tested on https://liquipedia.net/rainbowsix/EPS/2020/Season_5/Open_Qualifier#Detailed_Result (for the high/mod/low behavior) and on 
https://liquipedia.net/rainbowsix/User:Rathoz/Leagues/NewBrackets#Single_Match (for "normal" behavior) 