### PR TITLE
Fix country display in dota infobox player

### DIFF
--- a/components/infobox/wikis/dota2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_player_custom.lua
@@ -238,8 +238,8 @@ function CustomPlayer._createLocation(country)
 		return nil
 	end
 	local countryDisplay = Flags.CountryName(country)
-	countryDisplay = '[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]'
 	local demonym = Localisation.getLocalisation(countryDisplay)
+	countryDisplay = '[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]'
 
 	local roleCategory = _ROLES_CATEGORY[_args.role or ''] or 'Players'
 	local role2Category = _ROLES_CATEGORY[_args.role2 or ''] or 'Players'


### PR DESCRIPTION
## Summary
Fix country display in dota infobox player (switch 2 lines)
Bug introduced in #1201. 

## How did you test this change?
