### PR TITLE
Add template entry point to Standings Store

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -65,8 +65,8 @@ function StandingsStorage.fromTemplate(frame)
 		data.participant = 'tbd'
 		data.participantdisplay = 'TBD'
 	end
-	data.match = {data.win_m or 0, data.tie_m or 0, data.lost_m or 0}
-	data.game = {data.win_g or 0, data.tie_g or 0, data.lost_g or 0}
+	data.match = {data.win_m, data.tie_m, data.lose_m}
+	data.game = {data.win_g, data.tie_g, data.lose_g}
 	return StandingsStorage.run(data.placement, data)
 end
 

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -58,13 +58,21 @@ function StandingsStorage.fromTemplate(frame)
 
 	if data.team then
 		-- finds [[page|display]] and skips images (images have multiple |)
-		data.team = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
+		local teamParsed = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
+		local date = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', nil)
+		local team
+
+		-- Input contains an actual team
 		if data.team and mw.ext.TeamTemplate.teamexists(data.team) then
-			local date = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', nil)
-			local team = mw.ext.TeamTemplate.raw(data.team, date)
+			team = mw.ext.TeamTemplate.raw(data.team, date)
+		-- Input is link (possiblity with icon etc), and we managed to parse it
+		elseif teamParsed and mw.ext.TeamTemplate.teamexists(teamParsed) then
+			team = mw.ext.TeamTemplate.raw(teamParsed, date)
+		end
+
+		if team then
 			data.participant = team.page
 			data.participantdisplay = team.name
-			data.participantflag = ''
 			data.icon = team.image
 			data.icondark = team.imagedark
 		else
@@ -72,8 +80,9 @@ function StandingsStorage.fromTemplate(frame)
 			data.participantdisplay = 'TBD'
 		end
 	elseif data.player then
-		data.participant, data.participantdisplay = string.match(data.team, '%[%[([^|]-)|([^|]-)%]%]')
+		data.participant, data.participantdisplay = string.match(data.player, '%[%[([^|]-)|([^|]-)%]%]')
 		-- TODO: sanity checks and parse flag
+		-- TODO: handle more input cases
 	end
 
 	data.match = {data.win_m, data.tie_m, data.lose_m}

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -57,8 +57,8 @@ function StandingsStorage.fromTemplate(frame)
 	end
 
 	if data.team then
-		-- finds [[page|display]] and skips images (images have multiple |)
-		local teamParsed = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
+		-- attempts to find [[teamPage|teamDisplay]] and skips images (images have multiple |)
+		local teamPage = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
 		local date = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', nil)
 		local team
 
@@ -66,8 +66,8 @@ function StandingsStorage.fromTemplate(frame)
 		if data.team and mw.ext.TeamTemplate.teamexists(data.team) then
 			team = mw.ext.TeamTemplate.raw(data.team, date)
 		-- Input is link (possiblity with icon etc), and we managed to parse it
-		elseif teamParsed and mw.ext.TeamTemplate.teamexists(teamParsed) then
-			team = mw.ext.TeamTemplate.raw(teamParsed, date)
+		elseif teamPage and mw.ext.TeamTemplate.teamexists(teamPage) then
+			team = mw.ext.TeamTemplate.raw(teamPage, date)
 		end
 
 		if team then

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
 local Flags = require('Module:Flags')
 local Variables = require('Module:Variables')
 
@@ -43,6 +44,30 @@ function StandingsStorage.run(index, data)
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json({data.extradata or {}})
 		}
 	)
+end
+
+function StandingsStorage.fromTemplate(frame)
+	local data = Arguments.getArgs(frame)
+	if not data.standingsindex or not data.roundindex or not data.placement then
+		return
+	end
+
+	 -- finds [[page|display]] and skips images (images have multiple |)
+	data.team = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
+	if data.team and mw.ext.TeamTemplate.teamexists(data.team) then
+		local team = mw.ext.TeamTemplate.raw(data.team)
+		data.participant = team.page
+		data.participantdisplay = team.name
+		data.participantflag = ''
+		data.icon = team.image
+		data.icondark = team.imagedark
+	else
+		data.participant = 'tbd'
+		data.participantdisplay = 'TBD'
+	end
+	data.match = {data.win_m or 0, data.tie_m or 0, data.lost_m or 0}
+	data.game = {data.win_g or 0, data.tie_g or 0, data.lost_g or 0}
+	return StandingsStorage.run(data.placement, data)
 end
 
 return StandingsStorage

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -48,23 +48,34 @@ end
 
 function StandingsStorage.fromTemplate(frame)
 	local data = Arguments.getArgs(frame)
+
 	if not data.standingsindex or not data.roundindex or not data.placement then
 		return
 	end
-
-	 -- finds [[page|display]] and skips images (images have multiple |)
-	data.team = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
-	if data.team and mw.ext.TeamTemplate.teamexists(data.team) then
-		local team = mw.ext.TeamTemplate.raw(data.team)
-		data.participant = team.page
-		data.participantdisplay = team.name
-		data.participantflag = ''
-		data.icon = team.image
-		data.icondark = team.imagedark
-	else
-		data.participant = 'tbd'
-		data.participantdisplay = 'TBD'
+	if not data.team and not data.player then
+		return
 	end
+
+	if data.team then
+		-- finds [[page|display]] and skips images (images have multiple |)
+		data.team = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
+		if data.team and mw.ext.TeamTemplate.teamexists(data.team) then
+			local date = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', nil)
+			local team = mw.ext.TeamTemplate.raw(data.team, date)
+			data.participant = team.page
+			data.participantdisplay = team.name
+			data.participantflag = ''
+			data.icon = team.image
+			data.icondark = team.imagedark
+		else
+			data.participant = 'tbd'
+			data.participantdisplay = 'TBD'
+		end
+	elseif data.player then
+		data.participant, data.participantdisplay = string.match(data.team, '%[%[([^|]-)|([^|]-)%]%]')
+		-- TODO: sanity checks and parse flag
+	end
+
 	data.match = {data.win_m, data.tie_m, data.lose_m}
 	data.game = {data.win_g, data.tie_g, data.lose_g}
 	return StandingsStorage.run(data.placement, data)


### PR DESCRIPTION
## Summary

In order to add Standings LPDB for the old-school manual Group Tables (and Swiss), we require an separate entry point function to Standings Store.

The biggest reasoning is that some parsing is required around the Team. The manual tables _most often_ use {{TeamIcon|name}}, however since it's basically a freetext display field in the old template, variants exists. On line 55 the code parses out the Team Link from the long html string that `{{TeamIcon|}}` creates. It also formats the match/games w/d/l to match the format that the normal storage function expects. It then invokes the normal standings storage.

It has a failsafe, if any of the super critical parameters are missing, it will not attempt to store anything. 
If it cannot parse the team name, it will store the team as `TBD`.

Before use, it should be setup together with a small change in the manual group table header & footer.
https://liquipedia.net/rainbowsix/index.php?title=Template%3AGroupTableStart&type=revision&diff=445699&oldid=420014
https://liquipedia.net/rainbowsix/index.php?title=Template%3AGroupTableEnd&type=revision&diff=445701&oldid=1686

and changes done to R6 `Template:StandingsData` should be migrated over to commons. R6 template should be removed once commons is updated. Commons should not be updated until this PR has been merged. This change to the template also removed the lpdb datapoint of old. There seems to be no consumer of it, and it broke if there were two standings tables on the same page.
https://liquipedia.net/rainbowsix/index.php?title=Template:StandingsData&action=edit

Similar changes needs to be done to the wiki's manual swiss tables, to support swiss as well.
https://liquipedia.net/rainbowsix/index.php?title=Template:SwissTableStart&diff=prev&oldid=445698
https://liquipedia.net/rainbowsix/index.php?title=Template:SwissTableEnd&diff=prev&oldid=445702
https://liquipedia.net/rainbowsix/index.php?title=Template:SwissTableRow&&diff=445776&oldid=184166

## How did you test this change?

Tested on R6.
