### PR TITLE
Activate "TemplatesForSpecialTeams" on Rocket League

### DIFF
--- a/components/squad/wikis/rocketleague/squad_custom.lua
+++ b/components/squad/wikis/rocketleague/squad_custom.lua
@@ -23,7 +23,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] ~= nil or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = SquadRow(frame, player.role)
+		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
 		row	:id({
 				player.id,
 				flag = player.flag,


### PR DESCRIPTION
## Summary

Activate useTemplatesForSpecialTeams option on Rocket League's SquadTable, by request.

![image](https://user-images.githubusercontent.com/3426850/166507447-9ed08300-17c0-4bd7-bf15-7f03b7295d49.png)


## How did you test this change?

Dev Module