### PR TITLE
Fix typo in Standings extradata

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -40,7 +40,7 @@ function StandingsStorage.run(index, data)
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),
 			roundindex = data.roundindex,
 			parent = Variables.varDefault('tournament_parent', ''),
-			extradata = mw.ext.LiquipediaDB.lpdb_create_json({data.extradata or {}})
+			extradata = mw.ext.LiquipediaDB.lpdb_create_json(data.extradata or {})
 		}
 	)
 end


### PR DESCRIPTION
## Summary

Saw a typo in the extradata code, it currently adds an additional table around the extradata.

## How did you test this change?

Tested using /dev module