### PR TITLE
Save Dark Mode Icon in Standings

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -24,6 +24,7 @@ function StandingsStorage.run(index, data)
 			participantdisplay = data.participantdisplay,
 			participantflag = Flags.CountryCode(data.participantflag),
 			icon = data.icon,
+			icondark = data.icondark,
 			placement = data.placement or data.rank,
 			definitestatus = data.definitestatus or data.bg,
 			currentstatus = data.currentstatus or data.pbg,


### PR DESCRIPTION
## Summary

Save dark mode icon in Standings, if supplied.

## How did you test this change?

Tested using /dev