### PR TITLE
Infobox League for Wild Rift

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -1,0 +1,155 @@
+---
+-- @Liquipedia
+-- wiki=wildrift
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+local Tier = require('Module:Tier')
+local PageLink = require('Module:Page')
+local Class = require('Module:Class')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local PrizePoolCurrency = require('Module:Prize pool currency')
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+local _TODAY = os.date('%Y-%m-%d', os.time())
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_args = league.args
+
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'gamesettings' then
+		return {
+			Cell{name = 'Patch', content = {
+					CustomLeague._getPatchVersion()
+				}},
+			}
+	elseif id == 'prizepool' then
+		return {
+			Cell{
+				name = 'Prize pool',
+				content = {CustomLeague:_createPrizepool()}
+			},
+		}
+	elseif id == 'liquipediatier' then
+		return {
+			Cell{
+				name = 'Liquipedia tier',
+				content = {CustomLeague:_createTierDisplay()},
+				classes = {_args['riotpremier'] == 'true' and 'valvepremier-highlighted' or ''},
+			},
+		}
+	elseif id == 'customcontent' then
+		if _args.player_number then
+			table.insert(widgets, Title{name = 'Players'})
+			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
+		end
+
+		--teams section
+		if _args.team_number or (not String.isEmpty(_args.team1)) then
+			Variables.varDefine('is_team_tournament', 1)
+			table.insert(widgets, Title{name = 'Teams'})
+		end
+		table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+	end
+	return widgets
+end
+
+function League:addToLpdb(lpdbData, args)
+	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.publishertier =  _args['riotpremier'] == 'true' and 'true' or nil
+
+	return lpdbData
+end
+
+function League:defineCustomPageVariables()
+	Variables.varDefine('tournament_patch', _args.patch)
+	Variables.varDefine('tournament_endpatch', _args.epatch)
+
+	Variables.varDefine('tournament_publishertier', _args['riotpremier'])
+		--Legacy Vars:
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+end
+
+function CustomLeague:_createPrizepool()
+	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
+		return nil
+	end
+	local date
+	if String.isNotEmpty(_args.currency_rate) then
+		date = _args.currency_date
+	end
+
+	return PrizePoolCurrency._get({
+		prizepool = _args.prizepool,
+		prizepoolusd = _args.prizepoolusd,
+		currency = _args.localcurrency,
+		rate = _args.currency_rate,
+		date = date or Variables.varDefault('tournament_enddate', _TODAY),
+	})
+end
+
+function CustomLeague:_createTierDisplay()
+	local tier = _args.liquipediatier or ''
+	local tierType = _args.liquipediatiertype or _args.tiertype or ''
+	if String.isEmpty(tier) then
+		return nil
+	end
+
+	local tierText = Tier['text'][tier]
+	local hasInvalidTier = tierText == nil
+	tierText = tierText or tier
+
+	local hasInvalidTierType = false
+
+	local output = '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
+		.. '[[Category:' .. tierText .. ' Tournaments]]'
+
+	if not String.isEmpty(tierType) then
+		tierType = Tier['types'][string.lower(tierType or '')] or tierType
+		hasInvalidTierType = Tier['types'][string.lower(tierType or '')] == nil
+		tierType = '[[' .. tierType .. ' Tournaments|' .. tierType .. ']]'
+			.. '[[Category:' .. tierType .. ' Tournaments]]'
+		output = tierType .. '&nbsp;(' .. output .. ')'
+	end
+
+	output = output ..
+		(hasInvalidTier and '[[Category:Pages with invalid Tier]]' or '') ..
+		(hasInvalidTierType and '[[Category:Pages with invalid Tiertype]]' or '')
+	return output
+end
+
+function CustomLeague._getPatchVersion()
+	if String.isEmpty(_args.patch) then return nil end
+	local content = PageLink.makeInternalLink(_args.patch, 'Patch ' .. _args.patch)
+	if not String.isEmpty(_args.epatch) then
+		content = content .. '&nbsp;&ndash;&nbsp;'
+		content = content .. PageLink.makeInternalLink(_args.epatch, 'Patch ' .. _args.epatch)
+	end
+
+	return content
+end
+
+return CustomLeague

--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -15,15 +15,12 @@ local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local PrizePoolCurrency = require('Module:Prize pool currency')
 local Logic = require('Module:Logic')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
-
-local _TODAY = os.date('%Y-%m-%d', os.time())
 
 function CustomLeague.run(frame)
 	local league = League(frame)
@@ -47,13 +44,6 @@ function CustomInjector:parse(id, widgets)
 					CustomLeague._getPatchVersion()
 				}},
 			}
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -92,24 +82,6 @@ function League:defineCustomPageVariables()
 	Variables.varDefine('tournament_publishertier', _args['riotpremier'])
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
-end
-
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createTierDisplay()

--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -16,6 +16,7 @@ local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local PrizePoolCurrency = require('Module:Prize pool currency')
+local Logic = require('Module:Logic')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -79,7 +80,7 @@ end
 
 function League:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.publishertier =  _args['riotpremier'] == 'true' and 'true' or nil
+	lpdbData.publishertier =  Logic.readBool(_args['riotpremier']) and 'true' or nil
 
 	return lpdbData
 end
@@ -89,7 +90,7 @@ function League:defineCustomPageVariables()
 	Variables.varDefine('tournament_endpatch', _args.epatch)
 
 	Variables.varDefine('tournament_publishertier', _args['riotpremier'])
-		--Legacy Vars:
+	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end
 


### PR DESCRIPTION
## Summary
Looking to migrate the infobox on Wild Rift (under old version) to a new version
_**The Infobox is a direct clone of Mobile Legends which was already merged**_

## How did you test this change?
Test Page: https://liquipedia.net/wildrift/User:Hesketh2/dev

I also have put the /dev version on a test for one of the tournaments here : <https://liquipedia.net/wildrift/TapTap_Cup/Season_2> for checks on LPDB usage

Other stuff such as 
- the team's earnings and achievements (both infobox and achievements table still in Old Verison)
- the player's earnings and achievements  (both infobox and achievements table still in Old Verison)
both does function normally as of now

## Side Note (IT HAS BEEN FIXED)
Right now it has a conflicting issue with the tournaments list module on the mainpage ( <https://liquipedia.net/wildrift/Module:TournamentsList> ) that It misses a **File:** prefix when calling an icon and causes an error. This is why I'm having this as a draft since I dont know how to fix it

![image](https://user-images.githubusercontent.com/88981446/166882184-80d2d89b-4c65-4e7f-93c7-5af99792251e.png)

