### PR TITLE
Discussion basis - enforcing numeric tiers (here for R6)

### DIFF
--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -217,7 +217,7 @@ function CustomLeague:_createLiquipediaTierDisplay()
 	if not Logic.isNumeric(tier) then
 		table.insert(
 			_league.warnings,
-			tierString .. ' is not numeric[[Category:Pages with non-numeric tier]]'
+			tier .. ' is not numeric[[Category:Pages with non-numeric tier]]'
 		)
 	end
 

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -11,6 +11,7 @@ local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 local Tier = require('Module:Tier')
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
@@ -197,8 +198,11 @@ function CustomLeague:_createLiquipediaTierDisplay()
 	local function buildTierString(tierString)
 		local tierText = Tier.text[tierString]
 		if not tierText then
-			table.insert(_league.warnings, tierString .. ' is not a known Liquipedia Tier/Tiertype')
-			return '[[Category:Pages invalid tier or tiertype]]'
+			table.insert(
+				_league.warnings,
+				tierString .. ' is not a known Liquipedia Tier/Tiertype[[Category:Pages invalid tier or tiertype]]'
+			)
+			return ''
 		else
 			return '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
 		end
@@ -211,8 +215,10 @@ function CustomLeague:_createLiquipediaTierDisplay()
 	end
 
 	if not Logic.isNumeric(tier) then
-		table.insert(_league.warnings, tierString .. ' is not numeric')
-		tierDisplay = tierDisplay .. '[[Category:Pages with non-numeric tier]]'
+		table.insert(
+			_league.warnings,
+			tierString .. ' is not numeric[[Category:Pages with non-numeric tier]]'
+		)
 	end
 
 	return tierDisplay

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -198,7 +198,7 @@ function CustomLeague:_createLiquipediaTierDisplay()
 		local tierText = Tier.text[tierString]
 		if not tierText then
 			table.insert(_league.warnings, tierString .. ' is not a known Liquipedia Tier/Tiertype')
-			return ''
+			return '[[Category:Pages invalid tier or tiertype]]'
 		else
 			return '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
 		end
@@ -208,6 +208,11 @@ function CustomLeague:_createLiquipediaTierDisplay()
 
 	if String.isNotEmpty(tierType) then
 		tierDisplay = buildTierString(tierType) .. '&nbsp;(' .. tierDisplay .. ')'
+	end
+
+	if not Logic.isNumeric(tier) then
+		table.insert(_league.warnings, tierString .. ' is not numeric')
+		tierDisplay = tierDisplay .. '[[Category:Pages with non-numeric tier]]'
 	end
 
 	return tierDisplay


### PR DESCRIPTION
## Summary
* Add tracking category for unsupported tier/tiertype usage
* Check if tiers are numerical
* * Add warning if tier is not numeric
* * Add tracking category if tier is not numeric

The combination of checking that tiers are in the list of supported tiers and types plus the isNumeric check will enforce that tiers are among the allowed numeric values.

Alternative solution would be to have sep. lists for tier and tiertype in `Module:Tier` and checking against those.
Then we would need to adjust the `buildTierString` function though because it needs to access different subtables depending if it is tier or tiertype.
(SC2 took that route but our tier function also has a few other changes in regards to where it links plus an alias allowed for tiertype.)

Imo we also should add tracking categories so wikis can easier find pages with invalid tier/tiertype

(Took R6 as an example as most infobox league modules use a similar function to build the LP tier display. We might even consider providing it via commons.)

## Pros & Cons 
### Pro this PR
* Code is pretty simple and easy to read and hence easy to add.
* Does not need changing much in other modules that use `Module:Tier`.

### Con this PR (aka pro doing it with sep. subtables in `Module:Tier`)
* If the Tier Module used numerics for tiertypes then this will not really work. The sep. subtables in `Module:Tier` would 100% enforce it.

## How did you test this change?
not yet tested, atm just discussion basis