### PR TITLE
Change AgentIcon templates to module version for VAL match2

### DIFF
--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -6,16 +6,16 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local AgentIcon = require("Module:AgentIcon")
-local Arguments = require("Module:Arguments")
+local AgentIcon = require('Module:AgentIcon')
+local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
 local DivTable = require('Module:DivTable')
-local Json = require("Module:Json")
+local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Links = require('Module:Links')
 local Logic = require('Module:Logic')
-local Match = require("Module:Match")
+local Match = require('Module:Match')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
@@ -39,7 +39,7 @@ function BigMatch.run(frame)
 	match = CustomMatchGroupInput.processMatch(frame, match, {isStandalone = true})
 
 	local identifiers = bigMatch:_getId()
-	match['bracketid'] = "MATCH_" .. identifiers[1]
+	match['bracketid'] = 'MATCH_' .. identifiers[1]
 	match['matchid'] = identifiers[2]
 	-- Don't store match1 as BigMatch records are not complete
 	Match.store(match, {storeMatch1 = false, storeSmw = false})
@@ -95,7 +95,7 @@ function BigMatch:header(match, opponent1, opponent2, tournament)
 	if tournament.link and tournament.name then
 		tournamentRow:wikitext('[[' .. tournament.link .. '|' .. tournament.name .. ']]')
 	end
-	return mw.html.create('div'):addClass("fb-match-page-header")
+	return mw.html.create('div'):addClass('fb-match-page-header')
 								:node(tournamentRow)
 								:node(teamsRow)
 end
@@ -146,7 +146,7 @@ function BigMatch:overview(match)
 			))
 		)
 		:row(
-			DivTable.Row():cell(mw.html.create('div'):wikitext(match.patch and "Patch " .. match.patch))
+			DivTable.Row():cell(mw.html.create('div'):wikitext(match.patch and 'Patch ' .. match.patch))
 		)
 	boxRight = boxRight:create()
 	boxRight:addClass('fb-match-page-box')

--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -19,7 +19,6 @@ local Match = require('Module:Match')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
-local Template = require('Module:Template')
 local CustomMatchGroupInput = Lua.import('Module:MatchGroup/Input/Custom', {requireDevIfEnabled = true})
 
 local BigMatch = Class.new()

--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local AgentIcon = require("Module:AgentIcon")
 local Arguments = require("Module:Arguments")
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
@@ -206,7 +207,7 @@ function BigMatch:stats(frame, match, playerLookUp, opponents)
 						)
 						:cell(
 							mw.html.create('div')	:addClass('fb-match-page-valorant-stats-agent')
-													:wikitext(Template.safeExpand(frame, 'AgentIcon/' .. player['agent']))
+													:wikitext(AgentIcon._getBracketIcon{player['agent']})
 						)
 						:cell(mw.html.create('div'):wikitext(player['kills']))
 						:cell(mw.html.create('div'):wikitext(player['deaths']))

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local AgentIcon = require("Module:AgentIcon")
 local Class = require('Module:Class')
 local Logic = require("Module:Logic")
 local Lua = require('Module:Lua')
@@ -43,7 +44,7 @@ function Agents:add(frame, agent)
 		return self
 	end
 
-	self.text = self.text .. Template.safeExpand(frame, 'AgentBracket/' .. agent)
+	self.text = self.text .. AgentIcon._getBracketIcon{agent}
 	return self
 end
 

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -6,9 +6,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local AgentIcon = require("Module:AgentIcon")
+local AgentIcon = require('Module:AgentIcon')
 local Class = require('Module:Class')
-local Logic = require("Module:Logic")
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local Template = require('Module:Template')


### PR DESCRIPTION
## Summary

Update Module:BigMatch and Module:MatchSummary on VALORANT to use Module:AgentIcon instead of multiple Template:AgentIcon/* and Template:AgentBracket/*, so when a new agent is out, we only need to update a single module instead of creating templates.

## How did you test this change?

/dev module

