### PR TITLE
Fix date usage in Standings fromTemplate

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -60,7 +60,7 @@ function StandingsStorage.fromTemplate(frame)
 	if data.team then
 		-- attempts to find [[teamPage|teamDisplay]] and skips images (images have multiple |)
 		local teamPage = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
-		local date = Variables.varDefaultMulti('tournament_startdate', 'tournament_enddate', nil)
+		local date = Variables.varDefault('tournament_startdate', Variables.varDefault('tournament_enddate'))
 		local team
 
 		-- Input contains an actual team


### PR DESCRIPTION
## Summary

varDefaultMulti's behaviour is strange. It both tries to look up the final parameter, and return it in raw if it doesn't exist. While the `nil` was added there to have a `nil` return if the first two failed to look up, however since it tries to do a variable lookup on `nil`, that errored.

Using two nested varDefault instead to get the expected behaviour.

## How did you test this change?

Live