### PR TITLE
Add default prizePool function to commons infobox league

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -261,6 +261,11 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_enddate',
 	self:_cleanDate(args.edate) or self:_cleanDate(args.date))
 
+	-- gets overwritten by the League:createPrizepool call if args.prizepool
+	-- or args.prizepoolusd is a valid input
+	-- if wikis want it unset they can unset it via the defineCustomPageVariables() call
+	Variables.varDefine('tournament_currency', args.localcurrency or '')
+
 	self:defineCustomPageVariables(args)
 end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -23,8 +23,6 @@ local WarningBox = require('Module:WarningBox')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local PrizePoolCurrency = require('Module:Prize pool currency')
 
-local _TODAY = os.date('%Y-%m-%d', os.time())
-
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Header = Widgets.Header

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local Template = require('Module:Template')
 local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
-local String = require('Module:String')
+local String = require('Module:StringUtils')
 local Links = require('Module:Links')
 local Flags = require('Module:Flags')
 local Localisation = require('Module:Localisation')
@@ -21,6 +21,7 @@ local Page = require('Module:Page')
 local LeagueIcon = require('Module:LeagueIcon')
 local WarningBox = require('Module:WarningBox')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
+local PrizePoolCurrency = require('Module:Prize pool currency')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -132,7 +133,13 @@ function League:createInfobox()
 		},
 		Cell{name = 'Venue', content = {args.venue}},
 		Cell{name = 'Format', content = {args.format}},
-		Customizable{id = 'prizepool', children = {}},
+		Customizable{id = 'prizepool', children = {
+			Cell{
+					name = 'Prize pool',
+					content = {self:createPrizepool(args)},
+				},
+			},
+		},
 		Cell{name = 'Date', content = {args.date}},
 		Cell{name = 'Start Date', content = {args.sdate}},
 		Cell{name = 'End Date', content = {args.edate}},
@@ -201,6 +208,25 @@ end
 --- Allows for overriding this functionality
 function League:addToLpdb(lpdbData, args)
 	return lpdbData
+end
+
+--- Allows for overriding this functionality
+function League:createPrizepool(args)
+	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
+		return nil
+	end
+	local date
+	if String.isNotEmpty(args.currency_rate) then
+		date = args.currency_date
+	end
+
+	return PrizePoolCurrency._get{
+		prizepool = args.prizepool,
+		prizepoolusd = args.prizepoolusd,
+		currency = args.localcurrency,
+		rate = args.currency_rate,
+		date = date or Variables.varDefault('tournament_enddate', _TODAY),
+	}
 end
 
 function League:_definePageVariables(args)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -47,7 +47,7 @@ function League:createInfobox()
 	local links
 
 	-- set Variables here already so they are available in functions
-	-- we call from here on, e.g. createPrizepool
+	-- we call from here on, e.g. _createPrizepool
 	self:_definePageVariables(args)
 
 	local widgets = {
@@ -136,7 +136,7 @@ function League:createInfobox()
 		Customizable{id = 'prizepool', children = {
 			Cell{
 					name = 'Prize pool',
-					content = {self:createPrizepool(args)},
+					content = {self:_createPrizepool(args)},
 				},
 			},
 		},
@@ -210,8 +210,7 @@ function League:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
---- Export this function as it gets called for some checks in /Custom
-function League:createPrizepool(args)
+function League:_createPrizepool(args)
 	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
 		return nil
 	end
@@ -261,7 +260,7 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_enddate',
 	self:_cleanDate(args.edate) or self:_cleanDate(args.date))
 
-	-- gets overwritten by the League:createPrizepool call if args.prizepool
+	-- gets overwritten by the League:_createPrizepool call if args.prizepool
 	-- or args.prizepoolusd is a valid input
 	-- if wikis want it unset they can unset it via the defineCustomPageVariables() call
 	Variables.varDefine('tournament_currency', args.localcurrency or '')

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -23,6 +23,8 @@ local WarningBox = require('Module:WarningBox')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local PrizePoolCurrency = require('Module:Prize pool currency')
 
+local _TODAY = os.date('%Y-%m-%d', os.time())
+
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Header = Widgets.Header

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -210,7 +210,7 @@ function League:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
---- Allows for overriding this functionality
+--- Export this function as it gets called for some checks in /Custom
 function League:createPrizepool(args)
 	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
 		return nil

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -227,7 +227,7 @@ function League:createPrizepool(args)
 		prizepoolusd = args.prizepoolusd,
 		currency = args.localcurrency,
 		rate = args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
+		date = date or Variables.varDefault('tournament_enddate'),
 	}
 end
 

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -12,7 +12,6 @@ local Variables = require('Module:Variables')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Class = require('Module:Class')
 local GameLookup = require('Module:GameLookup')
-local PrizePool = require('Module:Prize pool currency')
 local MapMode = require('Module:MapMode')
 local GameModeLookup = require('Module:GameModeLookup')
 local Injector = require('Module:Infobox/Widget/Injector')
@@ -96,13 +95,6 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Title{name = 'Maps'})
 			table.insert(widgets, Center{content = maps})
 		end
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool(args)}
-			}
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -170,31 +162,6 @@ function CustomLeague:_createTier(args)
 	else
 		content = content .. tierDisplay
 	end
-
-	return content
-end
-
-function CustomLeague:_createPrizepool(args)
-	if String.isEmpty(args.prizepool) and
-		String.isEmpty(args.prizepoolusd) then
-			return nil
-	end
-
-	local date
-	if not String.isEmpty(args.currency_rate) then
-		date = args.currency_date
-	else
-		date = args.edate or args.date
-	end
-
-	local content = PrizePool._get({
-			prizepool = args.prizepool,
-			prizepoolusd = args.prizepoolusd,
-			currency = args.localcurrency,
-			rate = args.currency_rate,
-			date = date
-		}
-	)
 
 	return content
 end

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -17,8 +17,6 @@ local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 
-local PrizePoolCurrency = require('Module:Prize pool currency')
-
 local _GAME_MODE = mw.loadData('Module:GameMode')
 local _EA_ICON = '&nbsp;[[File:EA icon.png|x15px|middle|link=Electronic Arts|'
 	.. 'Tournament sponsored by Electronirc Arts & Respawn.]]'
@@ -54,13 +52,6 @@ function CustomInjector:parse(id, widgets)
 					CustomLeague._getPlatform()
 				}})
 		return widgets
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()},
-			},
-		}
 	elseif id == 'liquipediatier' then
 		local algsTier = _args.algstier
 		if not String.isEmpty(algsTier) then
@@ -101,24 +92,6 @@ function CustomInjector:addCustomCells(widgets)
 	table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
 
 	return widgets
-end
-
-function CustomLeague:_createPrizepool()
-	local date
-	if not String.isEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createLiquipediaTierDisplay()

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -20,7 +20,6 @@ local Center = require('Module:Infobox/Widget/Center')
 local _GAME_MODE = mw.loadData('Module:GameMode')
 local _EA_ICON = '&nbsp;[[File:EA icon.png|x15px|middle|link=Electronic Arts|'
 	.. 'Tournament sponsored by Electronirc Arts & Respawn.]]'
-local _TODAY = os.date('%Y-%m-%d', os.time())
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -21,7 +21,6 @@ local CustomInjector = Class.new(Injector)
 local _args
 local _game
 
-local _TODAY = os.date('%Y-%m-%d', os.time())
 local _GAME = mw.loadData('Module:GameVersion')
 
 function CustomLeague.run(frame)

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -14,7 +14,6 @@ local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local PrizePoolCurrency = require('Module:Prize pool currency')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -47,13 +46,6 @@ function CustomInjector:parse(id, widgets)
 					CustomLeague._getGameVersion()
 				}},
 			}
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -98,24 +90,6 @@ function CustomLeague._getGameVersion()
 	local game = string.lower(_args.game or '')
 	_game = _GAME[game]
 	return _game
-end
-
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createTierDisplay()

--- a/components/infobox/wikis/brawlhalla/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlhalla/infobox_league_custom.lua
@@ -14,7 +14,6 @@ local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local PrizePoolCurrency = require('Module:Prize pool currency')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -52,13 +51,6 @@ function CustomInjector:parse(id, widgets)
 				content = {args.doubles_number}
 			})
 		end
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool(args)}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -93,25 +85,6 @@ function CustomLeague:_createLiquipediaTierDisplay(args)
 	end
 
 	return tierDisplay
-end
-
-function CustomLeague:_createPrizepool(args)
-	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
-		return nil
-	end
-
-	local date
-	if String.isNotEmpty(args.currency_rate) then
-		date = args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = args.prizepool,
-		prizepoolusd = args.prizepoolusd,
-		currency = args.localcurrency,
-		rate = args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:defineCustomPageVariables(args)

--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -13,7 +13,7 @@ local Tier = require('Module:Tier')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
-local PrizePoolCurrency = require('Module:Prize pool currency')
+
 local SUPERCELL_SPONSORED_ICON = '[[File:Supercell icon.png|x18px|link=Supercell|Tournament sponsored by Supercell.]]'
 
 local _TODAY = os.date('%Y-%m-%d', os.time())
@@ -53,14 +53,7 @@ end
 
 function CustomInjector:parse(id, widgets)
 	local args = _args
-	if id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
-	elseif id == 'liquipediatier' then
+	if id == 'liquipediatier' then
 		local tierDisplay = CustomLeague:_createLiquipediaTierDisplay()
 		local class
 		if args['supercell-sponsored'] == 'true' then
@@ -83,24 +76,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.team_number
 
 	return lpdbData
-end
-
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createLiquipediaTierDisplay()

--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -16,8 +16,6 @@ local Cell = require('Module:Infobox/Widget/Cell')
 
 local SUPERCELL_SPONSORED_ICON = '[[File:Supercell icon.png|x18px|link=Supercell|Tournament sponsored by Supercell.]]'
 
-local _TODAY = os.date('%Y-%m-%d', os.time())
-
 local _args
 local _league
 

--- a/components/infobox/wikis/halo/infobox_league_custom.lua
+++ b/components/infobox/wikis/halo/infobox_league_custom.lua
@@ -8,7 +8,6 @@
 
 local League = require('Module:Infobox/League')
 local String = require('Module:String')
-local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 local Tier = require('Module:Tier')
 local PageLink = require('Module:Page')
@@ -26,8 +25,6 @@ local CustomInjector = Class.new(Injector)
 local _args
 local _game
 
-local _ABBR_USD = '<abbr title="United States Dollar">USD</abbr>'
-local _TODAY = os.date('%Y-%m-%d', os.time())
 local _GAME = mw.loadData('Module:GameVersion')
 
 function CustomLeague.run(frame)

--- a/components/infobox/wikis/halo/infobox_league_custom.lua
+++ b/components/infobox/wikis/halo/infobox_league_custom.lua
@@ -59,13 +59,6 @@ function CustomInjector:parse(id, widgets)
 					CustomLeague._getGameVersion()
 				}},
 			}
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()},
-			},
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -148,62 +141,6 @@ function CustomLeague:_concatArgs(base)
 	return table.concat(foundArgs, ';')
 end
 
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and
-		String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-
-	local localCurrency = _args.localcurrency
-	local prizePoolUSD = _args.prizepoolusd
-	local prizePool = _args.prizepool
-
-	prizePool = CustomLeague:_cleanPrizeValue(prizePool, localCurrency)
-	prizePoolUSD = CustomLeague:_cleanPrizeValue(prizePoolUSD)
-
-	if String.isEmpty(prizePool) and String.isEmpty(prizePoolUSD) then
-		return nil
-	end
-
-	if localCurrency then
-		localCurrency = string.upper(localCurrency)
-		local exchangeDate = Variables.varDefault('tournament_enddate', _TODAY)
-		local exchangeRate = CustomLeague:_currencyConversion(
-			1,
-			localCurrency,
-			exchangeDate
-		)
-		--set currency vars for usage in prize pools
-		Variables.varDefine('tournament_currency_rate', exchangeRate or '')
-		Variables.varDefine('tournament_currency', localCurrency)
-		if prizePool and not prizePoolUSD then
-			if not exchangeRate then
-				error('Invalid local currency "' .. localCurrency .. '"')
-			end
-			prizePoolUSD = exchangeRate * prizePool
-		end
-	end
-
-	Variables.varDefine('tournament_prizepoolusd', prizePoolUSD or prizePool)
-	Variables.varDefine('tournament_prizepoollocal', prizePool)
-
-	if prizePoolUSD and prizePool then
-		return Template.safeExpand(
-			mw.getCurrentFrame(),
-			'Local currency',
-			{(localCurrency or 'usd'):lower(), prizepool = CustomLeague:_displayPrizeValue(prizePool, 2)}
-		) .. '<br>(≃ $' .. CustomLeague:_displayPrizeValue(prizePoolUSD) .. ' ' .. _ABBR_USD .. ')'
-	elseif prizePoolUSD then
-		return '$' .. CustomLeague:_displayPrizeValue(prizePoolUSD, 2) .. ' ' .. _ABBR_USD
-	elseif prizePool then
-		return Template.safeExpand(
-			mw.getCurrentFrame(),
-			'Local currency',
-			{(localCurrency or 'usd'):lower(), prizepool = CustomLeague:_displayPrizeValue(prizePool, 2)}
-		)
-	end
-end
-
 function CustomLeague:_createTierDisplay()
 	local tier = _args.liquipediatier or ''
 	local tierType = _args.liquipediatiertype or _args.tiertype or ''
@@ -241,67 +178,6 @@ function CustomLeague._getGameVersion()
 	local game = string.lower(_args.game or '')
 	_game = _GAME[game]
 	return _game
-end
-
-function CustomLeague:_currencyConversion(localPrize, currency, exchangeDate)
-	if exchangeDate and currency and currency ~= 'USD' then
-		localPrize = tonumber(localPrize)
-		if localPrize then
-			local usdPrize = mw.ext.CurrencyExchange.currencyexchange(
-				localPrize,
-				currency,
-				'USD',
-				exchangeDate
-			)
-			if type(usdPrize) == 'number' then
-				return usdPrize
-			end
-		end
-	end
-
-	return nil
-end
-
-function CustomLeague:_displayPrizeValue(value, numDigits)
-	if String.isEmpty(value) or value == 0 or value == '0' then
-		return '-'
-	end
-
-	numDigits = tonumber(numDigits or 0) or 0
-	local factor = 10^numDigits
-	value = math.floor(value * factor + 0.5) / factor
-
-	--split value into
-	--left = first digit
-	--num = all remaining digits before a possible '.'
-	--right = the '.' and all digits after it (unless they are all 0 or do not exist)
-	local left, num, right = string.match(value, '^([^%d]*%d)(%d*)(.-)$')
-	if right:len() > 0 then
-		local decimal = string.sub('0' .. right, 3)
-		right = '.' .. decimal .. string.rep('0', 2 - string.len(decimal))
-	end
-	return left .. (num:reverse():gsub('(%d%d%d)','%1,'):reverse()) .. right
-end
-
-function CustomLeague:_cleanPrizeValue(value, currency)
-	if String.isEmpty(value) then
-		return nil
-	end
-
-	--remove currency abbreviations
-	value = value:gsub('<abbr.*abbr>', '')
-	value = value:gsub(',', '')
-
-	--remove currency symbol
-	if currency then
-		Template.safeExpand(mw.getCurrentFrame(), 'Local currency', {currency:lower()})
-		local symbol = Variables.varDefaultMulti('localcurrencysymbol', 'localcurrencysymbolafter') or ''
-		value = value:gsub(symbol, '')
-	else --remove $ symbol
-		value = value:gsub('%$', '')
-	end
-
-	return value
 end
 
 function CustomLeague:_makeMapList()

--- a/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
@@ -15,7 +15,6 @@ local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local PrizePoolCurrency = require('Module:Prize pool currency')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -46,13 +45,6 @@ function CustomInjector:parse(id, widgets)
 					CustomLeague._getPatchVersion()
 				}},
 			}
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -91,24 +83,6 @@ function League:defineCustomPageVariables()
 	Variables.varDefine('tournament_publishertier', _args['moonton-sponsored'])
 		--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
-end
-
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createTierDisplay()

--- a/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
@@ -21,8 +21,6 @@ local CustomInjector = Class.new(Injector)
 
 local _args
 
-local _TODAY = os.date('%Y-%m-%d', os.time())
-
 function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -16,9 +16,6 @@ local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 local PageLink = require('Module:Page')
-local PrizePoolCurrency = require('Module:Prize pool currency')
-
-local _TODAY = os.date('%Y-%m-%d', os.time())
 
 local _args
 local _league
@@ -86,13 +83,6 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Title{name = 'Maps'})
 			table.insert(widgets, Center{content = {table.concat(maps, '&nbsp;• ')}})
 		end
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		widgets = {
 			Cell{
@@ -130,24 +120,6 @@ end
 
 function CustomLeague:_validPublisherTier(publishertier)
 	return String.isNotEmpty(publishertier) and _BLIZZARD_TIERS[publishertier:lower()]
-end
-
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createLiquipediaTierDisplay()

--- a/components/infobox/wikis/pubg/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_league_custom.lua
@@ -15,7 +15,6 @@ local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local PrizePoolCurrency = require('Module:Prize pool currency')
 local Table = require('Module:Table')
 
 local CustomLeague = Class.new()
@@ -24,7 +23,6 @@ local CustomInjector = Class.new(Injector)
 local _args
 local _game
 
-local _TODAY = os.date('%Y-%m-%d', os.time())
 local _GAME = mw.loadData('Module:GameVersion')
 
 local _MODES = {
@@ -93,13 +91,6 @@ function CustomInjector:parse(id, widgets)
 				}
 			},
 		}
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -145,24 +136,6 @@ function CustomLeague._getGameVersion()
 	local game = string.lower(_args.game or '')
 	_game = _GAME[game]
 	return _game
-end
-
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createTierDisplay()

--- a/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
@@ -15,7 +15,6 @@ local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local PrizePoolCurrency = require('Module:Prize pool currency')
 local Table = require('Module:Table')
 
 local CustomLeague = Class.new()
@@ -24,7 +23,6 @@ local CustomInjector = Class.new(Injector)
 local _args
 local _game
 
-local _TODAY = os.date('%Y-%m-%d', os.time())
 local _GAME = mw.loadData('Module:GameVersion')
 
 local _MODES = {
@@ -89,13 +87,6 @@ function CustomInjector:parse(id, widgets)
 				}
 			},
 		}
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		return {
 			Cell{
@@ -141,24 +132,6 @@ function CustomLeague._getGameVersion()
 	local game = string.lower(_args.game or '')
 	_game = _GAME[game]
 	return _game
-end
-
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
 end
 
 function CustomLeague:_createTierDisplay()

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -16,9 +16,6 @@ local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
 local PageLink = require('Module:Page')
-local PrizePoolCurrency = require('Module:Prize pool currency')
-
-local _TODAY = os.date('%Y-%m-%d', os.time())
 
 local _args
 local _league
@@ -107,13 +104,6 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Title{name = 'Maps'})
 			table.insert(widgets, Center{content = {table.concat(maps, '&nbsp;• ')}})
 		end
-	elseif id == 'prizepool' then
-		return {
-			Cell{
-				name = 'Prize pool',
-				content = {CustomLeague:_createPrizepool()}
-			},
-		}
 	elseif id == 'liquipediatier' then
 		widgets = {
 			Cell{
@@ -169,24 +159,6 @@ function CustomLeague:_standardiseRawDate(dateString)
 	return dateString
 end
 
-function CustomLeague:_createPrizepool()
-	if String.isEmpty(_args.prizepool) and String.isEmpty(_args.prizepoolusd) then
-		return nil
-	end
-	local date
-	if String.isNotEmpty(_args.currency_rate) then
-		date = _args.currency_date
-	end
-
-	return PrizePoolCurrency._get({
-		prizepool = _args.prizepool,
-		prizepoolusd = _args.prizepoolusd,
-		currency = _args.localcurrency,
-		rate = _args.currency_rate,
-		date = date or Variables.varDefault('tournament_enddate', _TODAY),
-	})
-end
-
 function CustomLeague:_createLiquipediaTierDisplay()
 	local tier = _args.liquipediatier or ''
 	local tierType = _args.liquipediatiertype or ''
@@ -223,14 +195,6 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_tier_type', _args.liquipediatiertype or _DEFAULT_TIERTYPE)
 	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
 	Variables.varDefine('tournament_mode', _args.mode or '')
-
-	-- Module:Prize pool currency will usually set this variable.
-	-- However the module won't be run if certain arguments are not yet known
-	-- Set the Variable here if the createPrizepool returns nil
-	-- Needed in Module:Prize pool slot
-	if not CustomLeague:_createPrizepool() then
-		Variables.varDefine('tournament_currency', _args.localcurrency or '')
-	end
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')


### PR DESCRIPTION
## Summary
Add default prizePool function to commons infobox league.

Since atm in most /Custom modules the prizepool function is (basically) the same we imo should provide a default version via commmons.

## How did you test this change?
/dev modules (mostly on R6 so far)

## Remarks regarding conversion of the /Customs:
- [x] SC2: has a real custom function for it (allows non numeric inputs under some circumstances as well as `+` as a postfix); needs testing if the `tournament_currency` var needs to be unset again
----> no issues detected with adding the wiki var --> no changes via this PR
- [x] Halo: real custom function, but can probably also be switched to use commons version (needs proper testing and maybe some additional wiki vars be set in /Custom)
- [ ] RL: has no automatic conversion --> change would be an upgrade --> needs testing and feedback from contributors
- [ ] CS: same as RL (function identical)
- [x] R6, pubgm, pubg, ow, ml, brawlstars, brawlhalla, aov, apex, aoe all use the default function in the /Customs, so switching will not be an issue