### PR TITLE
Add default lp tier display function to commons infobox league

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -299,7 +299,7 @@ function League:_definePageVariables(args)
 			or args.liquipediatiertype
 	)
 	--[[ once tier modules all follow the new format we can simplify this again:
-	Variables.varDefine('tournament_liquipediatiertype', Tier.text.types[args.liquipediatiertype or ''])
+	Variables.varDefine('tournament_liquipediatiertype', Tier.text.types[string.lower(args.liquipediatiertype or '')])
 	]]
 
 	Variables.varDefine('tournament_type', args.type)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -293,7 +293,7 @@ function League:_definePageVariables(args)
 	Variables.varDefine(
 		'tournament_liquipediatiertype',
 		Tier.text.types
-			and Tier.text.types[args.liquipediatiertype or '']
+			and Tier.text.types[string.lower(args.liquipediatiertype or '')]
 			or args.liquipediatiertype
 	)
 	--[[ once tier modules all follow the new format we can simplify this again:

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -229,6 +229,11 @@ function League:liquipediaTierHighlighted(args)
 end
 
 --- Allows for overriding this functionality
+function League:appendLiquipediatierDisplay()
+	return ''
+end
+
+--- Allows for overriding this functionality
 function League:createLiquipediaTierDisplay(args)
 	local tier = args.liquipediatier
 	local tierType = args.liquipediatiertype
@@ -263,10 +268,6 @@ function League:createLiquipediaTierDisplay(args)
 	end
 
 	return tierDisplay .. self.appendLiquipediatierDisplay(args)
-end
-
-function League:appendLiquipediatierDisplay()
-	return ''
 end
 
 function League:_createPrizepool(args)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local Template = require('Module:Template')
 local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
-local String = require('Module:String')
+local String = require('Module:StringUtils')
 local Links = require('Module:Links')
 local Flags = require('Module:Flags')
 local Localisation = require('Module:Localisation')
@@ -21,6 +21,10 @@ local Page = require('Module:Page')
 local LeagueIcon = require('Module:LeagueIcon')
 local WarningBox = require('Module:WarningBox')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
+local Tier = require('Module:Tier')
+
+local _TIER_MODE_TYPES = 'types'
+local _TIER_MODE_TIERS = 'tiers'
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -132,7 +136,13 @@ function League:createInfobox()
 		},
 		Cell{name = 'Venue', content = {args.venue}},
 		Cell{name = 'Format', content = {args.format}},
-		Customizable{id = 'prizepool', children = {}},
+		Customizable{id = 'prizepool', children = {
+			Cell{
+					name = 'Prize pool',
+					content = {self:createPrizepool(args)},
+				},
+			},
+		},
 		Cell{name = 'Date', content = {args.date}},
 		Cell{name = 'Start Date', content = {args.sdate}},
 		Cell{name = 'End Date', content = {args.edate}},
@@ -201,6 +211,25 @@ end
 --- Allows for overriding this functionality
 function League:addToLpdb(lpdbData, args)
 	return lpdbData
+end
+
+--- Allows for overriding this functionality
+function League:createPrizepool(args)
+	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
+		return nil
+	end
+	local date
+	if String.isNotEmpty(args.currency_rate) then
+		date = args.currency_date
+	end
+
+	return PrizePoolCurrency._get{
+		prizepool = args.prizepool,
+		prizepoolusd = args.prizepoolusd,
+		currency = args.localcurrency,
+		rate = args.currency_rate,
+		date = date or Variables.varDefault('tournament_enddate', _TODAY),
+	}
 end
 
 function League:_definePageVariables(args)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -26,6 +26,8 @@ local PrizePoolCurrency = require('Module:Prize pool currency')
 
 local _TIER_MODE_TYPES = 'types'
 local _TIER_MODE_TIERS = 'tiers'
+local _INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
+	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -245,10 +247,7 @@ function League:createLiquipediaTierDisplay(args)
 			tierMode = tierMode == _TIER_MODE_TYPES and 'Tiertype' or 'Tier'
 			table.insert(
 				self.warnings,
-				String.interpolate(
-					'${tierString} is not a known Liquipedia ${tierMode}[[Category:Pages with invalid ${tierMode}]]',
-					{tierString = tierString, tierMode = tierMode}
-				)
+				String.interpolate(_INVALID_TIER_WARNING, {tierString = tierString, tierMode = tierMode})
 			)
 			return ''
 		else

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -245,8 +245,10 @@ function League:createLiquipediaTierDisplay(args)
 			tierMode = tierMode == _TIER_MODE_TYPES and 'Tiertype' or 'Tier'
 			table.insert(
 				self.warnings,
-				tierString .. ' is not a known Liquipedia ' .. tierMode
-					.. '[[Category:Pages with invalid ' .. tierMode .. ']]'
+				String.interpolate(
+					'${tierString} is not a known Liquipedia ${tierMode}[[Category:Pages with invalid ${tierMode}]]',
+					{tierString = tierString, tierMode = tierMode}
+				)
 			)
 			return ''
 		else

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -222,7 +222,7 @@ end
 --- Allows for overriding this functionality
 function League:createLiquipediaTierDisplay(args)
 	local tier = args.liquipediatier or ''
-	local tierType = args.liquipediatiertype or ''
+	local tierType = string.lower(args.liquipediatiertype or '')
 	if String.isEmpty(tier) then
 		return nil
 	end

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -228,8 +228,8 @@ end
 
 --- Allows for overriding this functionality
 function League:createLiquipediaTierDisplay(args)
-	local tier = args.liquipediatier or ''
-	local tierType = string.lower(args.liquipediatiertype or '')
+	local tier = args.liquipediatier
+	local tierType = args.liquipediatiertype
 	if String.isEmpty(tier) then
 		return nil
 	end
@@ -239,7 +239,7 @@ function League:createLiquipediaTierDisplay(args)
 		if not Tier.text[tierMode] then -- allow legacy tier modules
 			tierText = Tier.text[tierString]
 		else -- default case, i.e. tier module with intended format
-			tierText = Tier.text[tierMode][tierString]
+			tierText = Tier.text[tierMode][tierString:lower()]
 		end
 		if not tierText then
 			tierMode = tierMode == _TIER_MODE_TYPES and 'Tiertype' or 'Tier'
@@ -250,6 +250,7 @@ function League:createLiquipediaTierDisplay(args)
 			)
 			return ''
 		else
+			self.infobox:categories(tierText .. ' Tournaments')
 			return '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
 		end
 	end
@@ -289,7 +290,15 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_series', mw.ext.TeamLiquidIntegration.resolve_redirect(args.series or ''))
 
 	Variables.varDefine('tournament_liquipediatier', args.liquipediatier)
-	Variables.varDefine('tournament_liquipediatiertype', args.liquipediatiertype)
+	Variables.varDefine(
+		'tournament_liquipediatiertype',
+		Tier.text.types
+			and Tier.text.types[args.liquipediatiertype or '']
+			or args.liquipediatiertype
+	)
+	--[[ once tier modules all follow the new format we can simplify this again:
+	Variables.varDefine('tournament_liquipediatiertype', Tier.text.types[args.liquipediatiertype or ''])
+	]]
 
 	Variables.varDefine('tournament_type', args.type)
 	Variables.varDefine('tournament_status', args.status)
@@ -548,7 +557,6 @@ function League:_getPageNameFromChronology(item)
 
 	return mw.text.split(item, '|')[1]
 end
-
 
 -- Given a series, query its abbreviation if abbreviation is not set manually
 function League:_fetchAbbreviation()

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -262,8 +262,13 @@ function League:createLiquipediaTierDisplay(args)
 		tierDisplay = buildTierString(tierType, _TIER_MODE_TYPES) .. '&nbsp;(' .. tierDisplay .. ')'
 	end
 
-	return tierDisplay
+	return tierDisplay .. self.appendLiquipediatierDisplay(args)
 end
+
+function League:appendLiquipediatierDisplay()
+	return ''
+end
+
 function League:_createPrizepool(args)
 	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
 		return nil

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -136,18 +136,18 @@ function League:createInfobox()
 		},
 		Cell{name = 'Venue', content = {args.venue}},
 		Cell{name = 'Format', content = {args.format}},
-		Customizable{id = 'prizepool', children = {
-			Cell{
-					name = 'Prize pool',
-					content = {self:createPrizepool(args)},
-				},
-			},
-		},
+		Customizable{id = 'prizepool', children = {}},
 		Cell{name = 'Date', content = {args.date}},
 		Cell{name = 'Start Date', content = {args.sdate}},
 		Cell{name = 'End Date', content = {args.edate}},
 		Customizable{id = 'custom', children = {}},
-		Customizable{id = 'liquipediatier', children = {}},
+		Customizable{id = 'liquipediatier', children = {
+				Cell{
+					name = 'Liquipedia tier',
+					content = {self:createLiquipediaTierDisplay(args)},
+				},
+			},
+		},
 		Builder{
 			builder = function()
 				links = Links.transform(args)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -145,6 +145,7 @@ function League:createInfobox()
 				Cell{
 					name = 'Liquipedia tier',
 					content = {self:createLiquipediaTierDisplay(args)},
+					classes = {self:liquipediaTierHighlighted(args) and 'valvepremier-highlighted' or ''},
 				},
 			},
 		},
@@ -211,6 +212,11 @@ end
 --- Allows for overriding this functionality
 function League:addToLpdb(lpdbData, args)
 	return lpdbData
+end
+
+--- Allows for overriding this functionality
+function League:liquipediaTierHighlighted(args)
+	return false
 end
 
 --- Allows for overriding this functionality


### PR DESCRIPTION
## Summary
Add default lp tier display function to commons infobox league.

Since atm in several /Custom modules the tier display is the same and several more can just use it too.

Changes compared to current R6/... version:
* actually checks if the tier is valid (instead of also allowing types in the tiers entries)
* uses new structure (as discussed on discord) for module tier, but has fallback for old structure
* Sets tracking categories to find pages with wrong tier/tiertype entries

## How did you test this change?
/dev modules on several wikis both with overwrite and with adjuting /devs to not overwrite anymore
