### PR TITLE
Create TeamCard Storage

### DIFF
--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -29,17 +29,20 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		end
 	end
 
-	local smw_prefix = args.smw_prefix or args['smw prefix'] or Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
+	local smwPrefix = args.smw_prefix or args['smw prefix'] or
+                      Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
 	local qualifierText, qualifierInternal, qualifierExternal = Qualifier.parseQualifier(args.qualifier)
+    local title = mw.title.getCurrentTitle().text
+    local endDate = Variables.varDefault('tournament_edate', Variables.varDefault('tournament_date'))
 
 	local lpdbData = {
-		tournament = Variables.varDefault('tournament name pp', Variables.varDefault('tournament_name', mw.title.getCurrentTitle().text)),
+		tournament = Variables.varDefault('tournament name pp', Variables.varDefault('tournament_name', title)),
 		series = Variables.varDefault('tournament_series'),
 		parent = Variables.varDefault('tournament_parent'),
 		image = image,
 		imagedark = imageDark,
 		startdate = Variables.varDefault('tournament_sdate', Variables.varDefault('tournament_date')),
-		date = args.date or Variables.varDefault('enddate_' .. team .. smw_prefix .. '_date', Variables.varDefault('tournament_edate', Variables.varDefault('tournament_date'))),
+		date = args.date or Variables.varDefault('enddate_' .. team .. smwPrefix .. '_date', endDate),
 		participant = team,
 		participanttemplate = teamTemplate,
 		players = players,
@@ -58,20 +61,20 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 	}
 
 	-- If a custom override for LPDB exists, use it
-	lpdbData = Custom.adjustLPDB and Custom.adjustLPDB(lpdbData, team, args, smw_prefix) or lpdbData
+	lpdbData = Custom.adjustLPDB and Custom.adjustLPDB(lpdbData, team, args, smwPrefix) or lpdbData
 
 	-- Create jsons on json fields
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata)
 	lpdbData.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.players)
 
 	-- Name must match prize pool insertion
-	local storageName = Custom.getLPDBStorageName and Custom.getLPDBStorageName(team, smw_prefix)
+	local storageName = Custom.getLPDBStorageName and Custom.getLPDBStorageName(team, smwPrefix)
 
 	if not storageName then
 		-- Default name format if no custom exists
 		storageName = 'ranking'
-		if String.isNotEmpty(smw_prefix) then
-			storageName = storageName .. '_' .. smw_prefix
+		if String.isNotEmpty(smwPrefix) then
+			storageName = storageName .. '_' .. smwPrefix
 		end
 		storageName = storageName .. '_' ..  mw.ustring.lower(team)
 		if team == 'TBD' then

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -33,16 +33,18 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 					  or Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
 	local qualifierText, qualifierPage, qualifierUrl = Qualifier.parseQualifier(args.qualifier)
 	local title = mw.title.getCurrentTitle().text
-	local endDate = Variables.varDefault('tournament_edate', Variables.varDefault('tournament_date'))
+	local date = Variables.varDefault('tournament_date')
+	local endDate = Variables.varDefault('tournament_enddate', Variables.varDefault('tournament_edate', date))
+	local startDate = Variables.varDefault('tournament_startdate', Variables.varDefault('tournament_sdate', date))
 
 	local lpdbData = {
-		tournament = Variables.varDefault('tournament name pp', Variables.varDefault('tournament_name', title)),
+		tournament = Variables.varDefault('tournament name pp') or Variables.varDefault('tournament_name') or title,
 		series = Variables.varDefault('tournament_series'),
 		parent = Variables.varDefault('tournament_parent'),
 		image = image,
 		imagedark = imageDark,
-		startdate = Variables.varDefault('tournament_sdate', Variables.varDefault('tournament_date')),
-		date = args.date or Variables.varDefault('enddate_' .. team .. smwPrefix .. '_date', endDate),
+		startdate = startDate,
+		date = args.date or Variables.varDefault('enddate_' .. team .. smwPrefix .. '_date') or endDate,
 		participant = team,
 		participanttemplate = teamTemplateName,
 		players = players,
@@ -68,14 +70,14 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 	lpdbData.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.players)
 
 	-- Name must match prize pool insertion
-	local storageName = Custom.getLPDBStorageName and Custom.getLPDBStorageName(team, smwPrefix)
-						or TeamCardStorage._getDefaultStorageName(team, smwPrefix)
+	local storageName = Custom.getLPDBObjectName and Custom.getLPDBObjectName(team, smwPrefix)
+						or TeamCardStorage._getLPDBObjectName(team, smwPrefix)
 
 	mw.ext.LiquipediaDB.lpdb_placement(storageName, lpdbData)
 end
 
--- Default storage (object) name format
-function TeamCardStorage._getDefaultStorageName(team, smwPrefix)
+-- Build the standard LPDB "Object Name", which is used as primary key in the DB record
+function TeamCardStorage._getLPDBObjectName(team, smwPrefix)
 	local storageName = 'ranking'
 	if String.isNotEmpty(smwPrefix) then
 		storageName = storageName .. '_' .. smwPrefix

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -15,14 +15,14 @@ local Variables = require('Module:Variables')
 local TeamCardStorage = {}
 
 function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
-	local team, teamTemplate
+	local team, teamTemplateName
 	local image, imageDark
 
 	if type(teamObject) == 'table' then
 		if teamObject.team2 or teamObject.team3 then
 			team = 'TBD'
 		else
-			teamTemplate = teamObject.teamtemplate
+			teamTemplateName = teamObject.teamtemplate
 			team = teamObject.lpdb
 			image = args.image1
 			imageDark = args.imagedark1
@@ -44,7 +44,7 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		startdate = Variables.varDefault('tournament_sdate', Variables.varDefault('tournament_date')),
 		date = args.date or Variables.varDefault('enddate_' .. team .. smwPrefix .. '_date', endDate),
 		participant = team,
-		participanttemplate = teamTemplate,
+		participanttemplate = teamTemplateName,
 		players = players,
 		individualprizemoney = playerPrize,
 		mode = Variables.varDefault('tournament_mode', 'team'),
@@ -72,22 +72,19 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 						or TeamCardStorage._getDefaultStorageName(team, smwPrefix)
 
 	mw.ext.LiquipediaDB.lpdb_placement(storageName, lpdbData)
-
-	if team == 'TBD' then
-		-- Increase the wiki-variable TBD_placements by 1
-		Variables.varDefine('TBD_placements', tonumber(Variables.varDefault('TBD_placements', '1')) + 1)
-	end
 end
 
 -- Default storage (object) name format
-function TeamCardStorage.getDefaultStorageName(team, smwPrefix)
+function TeamCardStorage._getDefaultStorageName(team, smwPrefix)
 	local storageName = 'ranking'
 	if String.isNotEmpty(smwPrefix) then
 		storageName = storageName .. '_' .. smwPrefix
 	end
 	storageName = storageName .. '_' ..  mw.ustring.lower(team)
 	if team == 'TBD' then
-		storageName = storageName .. '_' .. Variables.varDefault('TBD_placements', '1')
+		local placement = tonumber(Variables.varDefault('TBD_placements', '1'))
+		storageName = storageName .. '_' .. placement
+		Variables.varDefine('TBD_placements', placement + 1)
 	end
 	return storageName
 end

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -29,11 +29,11 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		end
 	end
 
-	local smwPrefix = args.smw_prefix or args['smw prefix'] or
-                      Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
+	local smwPrefix = args.smw_prefix or args['smw prefix']
+					  or Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
 	local qualifierText, qualifierInternal, qualifierExternal = Qualifier.parseQualifier(args.qualifier)
-    local title = mw.title.getCurrentTitle().text
-    local endDate = Variables.varDefault('tournament_edate', Variables.varDefault('tournament_date'))
+	local title = mw.title.getCurrentTitle().text
+	local endDate = Variables.varDefault('tournament_edate', Variables.varDefault('tournament_date'))
 
 	local lpdbData = {
 		tournament = Variables.varDefault('tournament name pp', Variables.varDefault('tournament_name', title)),
@@ -69,24 +69,27 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 
 	-- Name must match prize pool insertion
 	local storageName = Custom.getLPDBStorageName and Custom.getLPDBStorageName(team, smwPrefix)
-
-	if not storageName then
-		-- Default name format if no custom exists
-		storageName = 'ranking'
-		if String.isNotEmpty(smwPrefix) then
-			storageName = storageName .. '_' .. smwPrefix
-		end
-		storageName = storageName .. '_' ..  mw.ustring.lower(team)
-		if team == 'TBD' then
-			storageName = storageName .. '_' .. Variables.varDefault('TBD_placements', '1')
-		end
-	end
+						or TeamCardStorage._getDefaultStorageName(team, smwPrefix)
 
 	mw.ext.LiquipediaDB.lpdb_placement(storageName, lpdbData)
 
 	if team == 'TBD' then
+		-- Increase the wiki-variable TBD_placements by 1
 		Variables.varDefine('TBD_placements', tonumber(Variables.varDefault('TBD_placements', '1')) + 1)
 	end
+end
+
+-- Default storage (object) name format
+function TeamCardStorage.getDefaultStorageName(team, smwPrefix)
+	local storageName = 'ranking'
+	if String.isNotEmpty(smwPrefix) then
+		storageName = storageName .. '_' .. smwPrefix
+	end
+	storageName = storageName .. '_' ..  mw.ustring.lower(team)
+	if team == 'TBD' then
+		storageName = storageName .. '_' .. Variables.varDefault('TBD_placements', '1')
+	end
+	return storageName
 end
 
 return TeamCardStorage

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -31,7 +31,7 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 
 	local smwPrefix = args.smw_prefix or args['smw prefix']
 					  or Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
-	local qualifierText, qualifierInternal, qualifierExternal = Qualifier.parseQualifier(args.qualifier)
+	local qualifierText, qualifierPage, qualifierUrl = Qualifier.parseQualifier(args.qualifier)
 	local title = mw.title.getCurrentTitle().text
 	local endDate = Variables.varDefault('tournament_edate', Variables.varDefault('tournament_date'))
 
@@ -55,8 +55,8 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		liquipediatier = Variables.varDefault('tournament_liquipediatier'),
 		liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype'),
 		qualifier = qualifierText,
-		qualifierpage = qualifierInternal,
-		qualifierurl = qualifierExternal,
+		qualifierpage = qualifierPage,
+		qualifierurl = qualifierUrl,
 		extradata = {},
 	}
 

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -26,8 +26,7 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		end
 	end
 
-	local smwPrefix = args.smw_prefix or args['smw prefix']
-					  or Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
+	local smwPrefix = args.smw_prefix or Variables.varDefault('smw_prefix') or ''
 
 	-- Setup LPDB Data
 	local lpdbData = {}

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -1,0 +1,89 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:TeamCard/Storage
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Custom = require('Module:TeamCard/Custom')
+local String = require('Module:StringUtils')
+-- TODO: Once the Template calls are not needed (when RL has been moved to Module), deprecate Qualifier
+local Qualifier = require('Module:TeamCard/Qualifier')
+local Variables = require('Module:Variables')
+
+local TeamCardStorage = {}
+
+function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
+	local team, teamTemplate
+	local image, imageDark
+
+	if type(teamObject) == 'table' then
+		if teamObject.team2 or teamObject.team3 then
+			team = 'TBD'
+		else
+			teamTemplate = teamObject.teamtemplate
+			team = teamObject.lpdb
+			image = args.image1
+			imageDark = args.imagedark1
+		end
+	end
+
+	local smw_prefix = args.smw_prefix or args['smw prefix'] or Variables.varDefault('smw prefix', Variables.varDefault('smw_prefix', ''))
+	local qualifierText, qualifierInternal, qualifierExternal = Qualifier.parseQualifier(args.qualifier)
+
+	local lpdbData = {
+		tournament = Variables.varDefault('tournament name pp', Variables.varDefault('tournament_name', mw.title.getCurrentTitle().text)),
+		series = Variables.varDefault('tournament_series'),
+		parent = Variables.varDefault('tournament_parent'),
+		image = image,
+		imagedark = imageDark,
+		startdate = Variables.varDefault('tournament_sdate', Variables.varDefault('tournament_date')),
+		date = args.date or Variables.varDefault('enddate_' .. team .. smw_prefix .. '_date', Variables.varDefault('tournament_edate', Variables.varDefault('tournament_date'))),
+		participant = team,
+		participanttemplate = teamTemplate,
+		players = players,
+		individualprizemoney = playerPrize,
+		mode = Variables.varDefault('tournament_mode', 'team'),
+		publishertier = Variables.varDefault('tournament_publisher_tier'),
+		icon = Variables.varDefault('tournament_icon'),
+		icondark = Variables.varDefault('tournament_icondark'),
+		game = Variables.varDefault('tournament_game'),
+		liquipediatier = Variables.varDefault('tournament_liquipediatier'),
+		liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype'),
+		qualifier = qualifierText,
+		qualifierpage = qualifierInternal,
+		qualifierurl = qualifierExternal,
+		extradata = {},
+	}
+
+	-- If a custom override for LPDB exists, use it
+	lpdbData = Custom.adjustLPDB and Custom.adjustLPDB(lpdbData, team, args, smw_prefix) or lpdbData
+
+	-- Create jsons on json fields
+	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata)
+	lpdbData.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.players)
+
+	-- Name must match prize pool insertion
+	local storageName = Custom.getLPDBStorageName and Custom.getLPDBStorageName(team, smw_prefix)
+
+	if not storageName then
+		-- Default name format if no custom exists
+		storageName = 'ranking'
+		if String.isNotEmpty(smw_prefix) then
+			storageName = storageName .. '_' .. smw_prefix
+		end
+		storageName = storageName .. '_' ..  mw.ustring.lower(team)
+		if team == 'TBD' then
+			storageName = storageName .. '_' .. Variables.varDefault('TBD_placements', '1')
+		end
+	end
+
+	mw.ext.LiquipediaDB.lpdb_placement(storageName, lpdbData)
+
+	if team == 'TBD' then
+		Variables.varDefine('TBD_placements', tonumber(Variables.varDefault('TBD_placements', '1')) + 1)
+	end
+end
+
+return TeamCardStorage


### PR DESCRIPTION
## Summary

Intended to be jacked into the current Common's TeamCard, where it moves the LPDB Storage from exclusively on /Custom (see https://liquipedia.net/dota2/Module:TeamCard/Custom) to just the overriding the parts required by the wiki. This allows us a to have a standardized TeamCard Storage.

The new custom would look like https://liquipedia.net/rainbowsix/Module:TeamCard/Custom/sandbox

## How did you test this change?

/sandbox module (https://liquipedia.net/commons/index.php?title=Module%3ATeamCard%2Fsandbox&type=revision&diff=423372&oldid=422360) on R6.