### PR TITLE
Initial support for LPDB field type

### DIFF
--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -17,6 +17,7 @@ local Table = require('Module:Table')
 -- TODO: Decided on all valid types
 -- TODO: Move to dedicated module
 local _VALID_TYPES = {'player', 'staff'}
+local _DEFAULT_TYPE = 'player'
 
 local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain]]'
 local _ICON_SUBSTITUTE = '[[image:Substitution.svg|18px|baseline|Sub|link=|alt=Substitution]]'
@@ -45,7 +46,7 @@ local SquadRow = Class.new(
 		end
 
 		self.lpdbData = {}
-		self.lpdbData.type = 'player'
+		self.lpdbData.type = _DEFAULT_TYPE
 	end)
 
 SquadRow.specialTeamsTemplateMapping = {

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -12,6 +12,11 @@ local Player = require('Module:Player')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Template = require('Module:Template')
 local Flags = require('Module:Flags')
+local Table = require('Module:Table')
+
+-- TODO: Decided on all valid types
+-- TODO: Move to dedicated module
+local _VALID_TYPES = {'player', 'staff'}
 
 local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain]]'
 local _ICON_SUBSTITUTE = '[[image:Substitution.svg|18px|baseline|Sub|link=|alt=Substitution]]'
@@ -40,6 +45,7 @@ local SquadRow = Class.new(
 		end
 
 		self.lpdbData = {}
+		self.lpdbData.type = 'player'
 	end)
 
 SquadRow.specialTeamsTemplateMapping = {
@@ -160,6 +166,14 @@ function SquadRow:newteam(args)
 
 	self.content:node(cell)
 
+	return self
+end
+
+function SquadRow:setType(type)
+	type = type:lower()
+	if Table.includes(_VALID_TYPES, type) then
+		self.lpdbData.type = type
+	end
 	return self
 end
 


### PR DESCRIPTION
## Summary

Add support to set the new lpdb fields `type` in the SquadPlayer table. Default value is `player`. Only accepted values are `player` & `staff` at the moment, but more are to be added in the future depending on discussion outcomes on the discord.

## How did you test this change?

Tested on Rocket League using /dev modules.