### PR TITLE
Adjust resulttype in match1 legacy storage

### DIFF
--- a/components/match2/wikis/brawlstars/match_legacy.lua
+++ b/components/match2/wikis/brawlstars/match_legacy.lua
@@ -127,8 +127,10 @@ function p.convertParameters(match2)
 	end
 
 	if match.walkover == 'ff' or match.walkover == 'dq' then
+		match.resulttype = match.walkover
 		match.walkover = match.winner
 	elseif match.walkover == 'l' then
+		match.resulttype = match.walkover
 		match.walkover = nil
 	end
 


### PR DESCRIPTION
## Summary
Adjust resulttype in match1 legacy storage so it fits the pattern used by the matchTicker

## How did you test this change?
/dev module and after that live