### PR TITLE
Lower case `gameName` for the css class append

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -22,7 +22,7 @@ function Infobox:create(frame, gameName, forceDarkMode)
 	self.content = mw.html.create('div')	:addClass('fo-nttax-infobox')
 											:addClass('wiki-bordercolor-light')
 	self.root	:addClass('fo-nttax-infobox-wrapper')
-				:addClass('infobox-' .. gameName)
+				:addClass('infobox-' .. gameName:lower())
 	if forceDarkMode then
 		self.root:addClass('infobox-darkmodeforced')
 	end


### PR DESCRIPTION
## Summary
Lower case the `gameName` for the css class append.

## How did you test this change?
to be done (but should not be problematic)
* `gameName` can not be empty as the nil check in https://liquipedia.net/commons/index.php?title=Module:Infobox/Basic&action=edit#mw-ce-l21 prevents it (if it were nil the current string-concat would fail too)
* css class names (for the onfobox classes) are all lower case