### PR TITLE
Add option for series cell to only display LIS icons

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -66,7 +66,7 @@ function League:createInfobox()
 				self:_createSeries(
 					{
 						shouldSetVariable = true,
-						diaplayManualIcons = not Logic.readBool(args.icon_display_from_lis),
+						diaplayManualIcons = not Logic.readBool(args.icon_display_from_lis or true),
 					},
 					args.series,
 					args.abbreviation,

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -66,7 +66,7 @@ function League:createInfobox()
 				self:_createSeries(
 					{
 						shouldSetVariable = true,
-						diaplayManualIcons = not Logic.readBool(args.icon_display_from_lis or true),
+						diaplayManualIcons = Logic.readBool(args.display_series_icon_from_manual_input),
 					},
 					args.series,
 					args.abbreviation,

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -22,6 +22,7 @@ local LeagueIcon = require('Module:LeagueIcon')
 local WarningBox = require('Module:WarningBox')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local PrizePoolCurrency = require('Module:Prize pool currency')
+local Logic = require('Module:Logic')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -63,13 +64,20 @@ function League:createInfobox()
 			name = 'Series',
 			content = {
 				self:_createSeries(
+					{
+						shouldSetVariable = true,
+						diaplayManualIcons = not Logic.readBool(args.icon_display_from_lis),
+					},
 					args.series,
 					args.abbreviation,
-					true,
 					args.icon,
 					args.icondarkmode
 				),
-				self:_createSeries(args.series2, args.abbreviation2)
+				self:_createSeries(
+					{shouldSetVariable = false},
+					args.series2,
+					args.abbreviation2
+				)
 			}
 		},
 		Builder{
@@ -366,14 +374,15 @@ function League:_createLocation(args)
 	return content
 end
 
-function League:_createSeries(series, abbreviation, shouldSetVariable, icon, iconDark)
+function League:_createSeries(options, series, abbreviation, icon, iconDark)
 	if String.isEmpty(series) then
 		return nil
 	end
+	options = options or {}
 
 	local output = LeagueIcon.display{
-		icon = icon,
-		iconDark = iconDark,
+		icon = options.diaplayManualIcons and icon or nil,
+		iconDark = options.diaplayManualIcons and iconDark or nil,
 		series = series,
 		abbreviation = abbreviation,
 		date = Variables.varDefault('tournament_enddate')
@@ -383,7 +392,7 @@ function League:_createSeries(series, abbreviation, shouldSetVariable, icon, ico
 		output = ''
 	else
 		output = output .. ' '
-		if shouldSetVariable then
+		if options.shouldSetVariable then
 			League:_setIconVariable(output, icon, iconDark)
 		end
 	end

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -66,7 +66,7 @@ function League:createInfobox()
 				self:_createSeries(
 					{
 						shouldSetVariable = true,
-						diaplayManualIcons = Logic.readBool(args.display_series_icon_from_manual_input),
+						displayManualIcons = Logic.readBool(args.display_series_icon_from_manual_input),
 					},
 					args.series,
 					args.abbreviation,
@@ -381,8 +381,8 @@ function League:_createSeries(options, series, abbreviation, icon, iconDark)
 	options = options or {}
 
 	local output = LeagueIcon.display{
-		icon = options.diaplayManualIcons and icon or nil,
-		iconDark = options.diaplayManualIcons and iconDark or nil,
+		icon = options.displayManualIcons and icon or nil,
+		iconDark = options.displayManualIcons and iconDark or nil,
 		series = series,
 		abbreviation = abbreviation,
 		date = Variables.varDefault('tournament_enddate')


### PR DESCRIPTION
## Summary
Add option for series cell to only display LIS icons instead of manually entered icons
(as requested by martin in the `Templates/Modules Sync` on tuesday)

## How did you test this change?
still to be tested