### PR TITLE
Fix afreecatv issue with stream links

### DIFF
--- a/standard/stream_links.lua
+++ b/standard/stream_links.lua
@@ -152,7 +152,7 @@ function StreamKey:_fromLegacy(input)
 		-- are not valid platforms. E.g. "twitch2" is not a valid platform.
 		if not StreamLinks.streamPlatformLookupNames[platform] then
 			-- Check if this platform matches the input
-			if string.find(input, platform, 1, true) then
+			if string.find(input, platform .. '%d-$') then
 				local index = 1
 				-- If the input is longer than the platform, there's an index at the end
 				-- Eg. In "twitch2", the 2 would the index.


### PR DESCRIPTION
## Summary
Fix afreecatv issue with stream links by changing the find condition.

Currently Pages using this module will error due to `afreeca` being a substring of `afreecatv`.
With this change is will not check if the platform name is simply found in the input but will also ensure that the input either ends after that substring or digits follow after the substring (and the input ends after those digits).

## How did you test this change?
/dev module