### PR TITLE
Create Valorant Infobox Team

### DIFF
--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -19,12 +19,12 @@ local CustomTeam = {}
 local _team
 
 function CustomTeam.run(frame)
-    local team = Team(frame)
+	local team = Team(frame)
 	_team = team
-    team.addCustomCells = CustomTeam.addCustomCells
+	team.addCustomCells = CustomTeam.addCustomCells
 	team.addToLpdb = CustomTeam.addToLpdb
-    team.calculateEarnings = CustomTeam.calculateEarnings
-    return team:createInfobox(frame)
+	team.calculateEarnings = CustomTeam.calculateEarnings
+	return team:createInfobox(frame)
 end
 
 function CustomTeam:createBottomContent()
@@ -36,18 +36,13 @@ function CustomTeam:createBottomContent()
 end
 
 function CustomInjector:addCustomCells(widgets)
-    Variables.varDefine('rating', args.rating)
-    local teamName = args.rankingname or team.pagename or team.name
-    local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})
+	Variables.varDefine('rating', args.rating)
+	local teamName = args.rankingname or team.pagename or team.name
+	local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})
 
-table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]', content = {args.rating or 'Not enough data'}})
-table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', content = {vctRanking}})
-    return widgets
-
-end
-
-function CustomTeam.calculateEarnings(team, args)
-    return Earnings.calculateForTeam({team = team.pagename or team.name})
+	table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]', content = {args.rating or 'Not enough data'}})
+	table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', content = {vctRanking}})
+	return widgets
 end
 
 function CustomTeam:addToLpdb(lpdbData, args)

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -17,14 +17,11 @@ local TeamRanking = require('Module:TeamRanking')
 
 local CustomTeam = {}
 
-local CustomInjector = Class.new(Injector)
-
 local _team
 
 function CustomTeam.run(frame)
 	local team = Team(frame)
 	_team = team
-	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.addToLpdb = CustomTeam.addToLpdb
 	return team:createInfobox(frame)
 end
@@ -37,18 +34,6 @@ function CustomTeam:createBottomContent()
 	)
 end
 
-function CustomInjector:addCustomCells(widgets, args)
-	Variables.varDefine('rating', args.rating)
-	local teamName = args.rankingname or _team.pagename or _team.name
-	local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})
-
-	table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]',
-			content = {args.rating or 'Not enough data'}})
-	table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]',
-			content = {vctRanking}})
-	return widgets
-end
-
 function CustomTeam:addToLpdb(lpdbData, args)
 	if not String.isEmpty(args.teamcardimage) then
 		lpdbData.logo = 'File:' .. args.teamcardimage
@@ -59,10 +44,6 @@ function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.region = Variables.varDefault('region', '')
 
 	return lpdbData
-end
-
-function CustomTeam:createWidgetInjector()
-	return CustomInjector()
 end
 
 return CustomTeam

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -10,16 +10,19 @@ local Team = require('Module:Infobox/Team')
 local Variables = require('Module:Variables')
 local String = require('Module:String')
 local Template = require('Module:Template')
+local Injector = require('Module:Infobox/Widget/Injector')
 local TeamRanking = require('Module:TeamRanking')
 
 local CustomTeam = {}
+
+local CustomInjector = Class.new(Injector)
 
 local _team
 
 function CustomTeam.run(frame)
 	local team = Team(frame)
 	_team = team
-	team.addCustomCells = CustomTeam.addCustomCells
+	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.addToLpdb = CustomTeam.addToLpdb
 	return team:createInfobox(frame)
 end
@@ -52,6 +55,10 @@ function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.region = Variables.varDefault('region', '')
 
 	return lpdbData
+end
+
+function CustomTeam:createWidgetInjector()
+	return CustomInjector()
 end
 
 return CustomTeam

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -10,6 +10,7 @@ local Team = require('Module:Infobox/Team')
 local Variables = require('Module:Variables')
 local String = require('Module:String')
 local Template = require('Module:Template')
+local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local TeamRanking = require('Module:TeamRanking')
 
@@ -35,7 +36,7 @@ function CustomTeam:createBottomContent()
 	)
 end
 
-function CustomInjector:addCustomCells(widgets)
+function CustomInjector:addCustomCells(widgets, args)
 	Variables.varDefine('rating', args.rating)
 	local teamName = args.rankingname or team.pagename or team.name
 	local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -35,14 +35,14 @@ function CustomTeam:createBottomContent()
 	)
 end
 
-function CustomTeam.addCustomCells(team, infobox, args)
+function CustomInjector:addCustomCells(widgets)
     Variables.varDefine('rating', args.rating)
     local teamName = args.rankingname or team.pagename or team.name
     local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})
 
-    infobox :cell('[[Portal:Rating|LPRating]]', args.rating or 'Not enough data')
-            :cell('[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', vctRanking)
-    return infobox
+table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]', content = {args.rating or 'Not enough data'}})
+table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', content = {vctRanking}})
+    return widgets
 
 end
 

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -1,0 +1,62 @@
+---
+-- @Liquipedia
+-- wiki=valorant
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Team = require('Module:Infobox/Team')
+local Earnings = require('Module:Earnings')
+local Variables = require('Module:Variables')
+local String = require('Module:String')
+local TeamMatches = require('Module:Matches/Team')
+
+local TeamRanking = require('Module:TeamRanking')
+
+local CustomTeam = {}
+
+function CustomTeam.run(frame)
+    local team = Team(frame)
+    team.addCustomCells = CustomTeam.addCustomCells
+	team.addToLpdb = CustomTeam.addToLpdb
+    team.calculateEarnings = CustomTeam.calculateEarnings
+    return team:createInfobox(frame)
+end
+
+function CustomTeam:createBottomContent()
+	return Template.expandTemplate(
+		mw.getCurrentFrame(),
+		'Upcoming and ongoing matches of',
+		{team = _team.name or _team.pagename}
+	)
+end
+
+function CustomTeam.addCustomCells(team, infobox, args)
+    Variables.varDefine('rating', args.rating)
+    local teamName = args.rankingname or team.pagename or team.name
+    local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})
+
+    infobox :cell('[[Portal:Rating|LPRating]]', args.rating or 'Not enough data')
+            :cell('[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', vctRanking)
+    return infobox
+
+end
+
+function CustomTeam.calculateEarnings(team, args)
+    return Earnings.calculateForTeam({team = team.pagename or team.name})
+end
+
+function CustomTeam:addToLpdb(lpdbData, args)
+	if not String.isEmpty(args.teamcardimage) then
+		lpdbData.logo = 'File:' .. args.teamcardimage
+	elseif not String.isEmpty(args.image) then
+		lpdbData.logo = 'File:' .. args.image
+	end
+
+	lpdbData.region = Variables.varDefault('region', '')
+
+	return lpdbData
+end
+
+return CustomTeam

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -10,14 +10,17 @@ local Team = require('Module:Infobox/Team')
 local Earnings = require('Module:Earnings')
 local Variables = require('Module:Variables')
 local String = require('Module:String')
-local TeamMatches = require('Module:Matches/Team')
+local Template = require('Module:Template')
 
 local TeamRanking = require('Module:TeamRanking')
 
 local CustomTeam = {}
 
+local _team
+
 function CustomTeam.run(frame)
     local team = Team(frame)
+	_team = team
     team.addCustomCells = CustomTeam.addCustomCells
 	team.addToLpdb = CustomTeam.addToLpdb
     team.calculateEarnings = CustomTeam.calculateEarnings

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -7,11 +7,9 @@
 --
 
 local Team = require('Module:Infobox/Team')
-local Earnings = require('Module:Earnings')
 local Variables = require('Module:Variables')
 local String = require('Module:String')
 local Template = require('Module:Template')
-
 local TeamRanking = require('Module:TeamRanking')
 
 local CustomTeam = {}
@@ -23,7 +21,6 @@ function CustomTeam.run(frame)
 	_team = team
 	team.addCustomCells = CustomTeam.addCustomCells
 	team.addToLpdb = CustomTeam.addToLpdb
-	team.calculateEarnings = CustomTeam.calculateEarnings
 	return team:createInfobox(frame)
 end
 

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -11,6 +11,7 @@ local Variables = require('Module:Variables')
 local String = require('Module:String')
 local Template = require('Module:Template')
 local Class = require('Module:Class')
+local Cell = require('Module:Infobox/Widget/Cell')
 local Injector = require('Module:Infobox/Widget/Injector')
 local TeamRanking = require('Module:TeamRanking')
 
@@ -38,11 +39,13 @@ end
 
 function CustomInjector:addCustomCells(widgets, args)
 	Variables.varDefine('rating', args.rating)
-	local teamName = args.rankingname or team.pagename or team.name
+	local teamName = args.rankingname or _team.pagename or _team.name
 	local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})
 
-	table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]', content = {args.rating or 'Not enough data'}})
-	table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', content = {vctRanking}})
+	table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]', 
+			content = {args.rating or 'Not enough data'}})
+	table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', 
+			content = {vctRanking}})
 	return widgets
 end
 

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -8,18 +8,40 @@
 
 local Team = require('Module:Infobox/Team')
 local Variables = require('Module:Variables')
+local Class = require('Module:Class')
 local String = require('Module:String')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
 local Template = require('Module:Template')
 
-local CustomTeam = {}
+local CustomTeam = Class.new()
+local CustomInjector = Class.new(Injector)
 
 local _team
 
 function CustomTeam.run(frame)
 	local team = Team(frame)
 	_team = team
+	team.createWidgetInjector = CustomTeam.createWidgetInjector
+	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
 	return team:createInfobox(frame)
+end
+
+function CustomTeam:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	return widgets
+end
+
+function CustomInjector:addCustomCells(widgets)
+	table.insert(widgets, Cell{
+		name = 'In-Game Leader',
+		content = {_team.args.igl}
+	})
+	return widgets
 end
 
 function CustomTeam:createBottomContent()

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -42,9 +42,9 @@ function CustomInjector:addCustomCells(widgets, args)
 	local teamName = args.rankingname or _team.pagename or _team.name
 	local vctRanking = TeamRanking.get({ranking = 'VCT_2021_Ranking', team = teamName})
 
-	table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]', 
+	table.insert(widgets, Cell{name = '[[Portal:Rating|LPRating]]',
 			content = {args.rating or 'Not enough data'}})
-	table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]', 
+	table.insert(widgets, Cell{name = '[[VALORANT_Champions_Tour/2021/Circuit_Points|VCT Points]]',
 			content = {vctRanking}})
 	return widgets
 end

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -10,10 +10,6 @@ local Team = require('Module:Infobox/Team')
 local Variables = require('Module:Variables')
 local String = require('Module:String')
 local Template = require('Module:Template')
-local Class = require('Module:Class')
-local Cell = require('Module:Infobox/Widget/Cell')
-local Injector = require('Module:Infobox/Widget/Injector')
-local TeamRanking = require('Module:TeamRanking')
 
 local CustomTeam = {}
 


### PR DESCRIPTION
## Summary
Revised version based on the older one built a while back. Leaves functionality for the wiki rating.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Page was tested [here](https://liquipedia.net/valorant/User:Fenrir.SPAZ/Sandbox_2)
Currently, this infobox does not correctly display team earnings in LPDB
The other major change is the saving of the region name in LPDB from ``na`` --> ``North America``
![image](https://user-images.githubusercontent.com/58013431/168643600-12b75e67-09ce-4651-bc2b-6703c847852a.png)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
