### PR TITLE
Adjust Person infobox module for non-representing players

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -49,6 +49,13 @@ function Person:createInfobox()
 		error('You need to specify an "id"')
 	end
 
+	-- check if non-representing is used and set an according value in self
+	-- so it can be accessed in the /Custom modules
+	args.country = Person:getStandardNationalityValue(args.country or args.nationality)
+	if args.country ~= Person:getStandardNationalityValue('non-representing') then
+		self.notNonRepresenting = true
+	end
+
 	_shouldStoreData = Person:shouldStoreData(args)
 	-- set custom variables here already so they are available
 	-- in functions we call from here on
@@ -209,7 +216,7 @@ function Person:_setLpdbData(args, links, status, personType)
 		name = args.romanized_name or args.name,
 		romanizedname = args.romanized_name or args.name,
 		localizedname = String.isNotEmpty(args.romanized_name) and args.name or nil,
-		nationality = Person:getStandardNationalityValue(args.country or args.nationality),
+		nationality = args.country, -- already standardized above
 		nationality2 = Person:getStandardNationalityValue(args.country2 or args.nationality2),
 		nationality3 = Person:getStandardNationalityValue(args.country3 or args.nationality3),
 		birthdate = Variables.varDefault('player_birthdate'),
@@ -395,7 +402,11 @@ function Person:getCategories(args, birthDisplay, personType, status)
 		local team = args.teamlink or args.team
 		local categories = { personType .. 's' }
 
-		if args.country2 or args.nationality2 then
+		if
+			self.notNonRepresenting and (args.country2 or args.nationality2)
+			or args.country3
+			or args.nationality3
+		then
 			table.insert(categories, 'Dual Citizenship ' .. personType .. 's')
 		end
 		if args.death_date then

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -52,8 +52,8 @@ function Person:createInfobox()
 	-- check if non-representing is used and set an according value in self
 	-- so it can be accessed in the /Custom modules
 	args.country = Person:getStandardNationalityValue(args.country or args.nationality)
-	if args.country ~= Person:getStandardNationalityValue('non-representing') then
-		self.notNonRepresenting = true
+	if args.country == Person:getStandardNationalityValue('non-representing') then
+		self.nonRepresenting = true
 	end
 
 	_shouldStoreData = Person:shouldStoreData(args)
@@ -403,7 +403,7 @@ function Person:getCategories(args, birthDisplay, personType, status)
 		local categories = { personType .. 's' }
 
 		if
-			self.notNonRepresenting and (args.country2 or args.nationality2)
+			not self.nonRepresenting and (args.country2 or args.nationality2)
 			or args.country3
 			or args.nationality3
 		then

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -33,10 +33,12 @@ local CustomPlayer = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
+local _player
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_args = player.args
+	_player = player
 	player.args.informationType = player.args.informationType or 'Player'
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
@@ -174,7 +176,12 @@ function CustomPlayer:getCategories(args, birthDisplay, personType, status)
 			personTypeSuffix = 'es'
 		end
 
-		if args.country2 or args.nationality2 then
+		--_player
+		if
+			_player.notNonRepresenting and (args.country2 or args.nationality2)
+			or args.country3
+			or args.nationality3
+		then
 			table.insert(categories, 'Dual Citizenship ' .. personType .. personTypeSuffix)
 		end
 		if args.death_date then

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -178,7 +178,7 @@ function CustomPlayer:getCategories(args, birthDisplay, personType, status)
 
 		--_player
 		if
-			_player.notNonRepresenting and (args.country2 or args.nationality2)
+			not _player.nonRepresenting and (args.country2 or args.nationality2)
 			or args.country3
 			or args.nationality3
 		then


### PR DESCRIPTION
## Summary
Adjust Person infobox module for non-representing players
- do a check if the first entered country is the non-representing one
--> if so set a variable in self so that it is available for later usage and in the /Custom modules
- adjust the Dual Citizenship check to account for non-representing value
- adjust RL /Custom accordingly as that is the only wiki that overwrites that function

## How did you test this change?
/dev module(s)
![Screenshot 2022-05-17 10 39 09](https://user-images.githubusercontent.com/75081997/168770821-738c67ce-d1df-4ad6-a316-0cd97be7ad67.png)
![Screenshot 2022-05-17 10 39 28](https://user-images.githubusercontent.com/75081997/168770824-13324319-ce64-467e-92cc-5dd54c5703ce.png)
![Screenshot 2022-05-17 10 41 54](https://user-images.githubusercontent.com/75081997/168770827-ea1ec10f-6cfe-4208-ae7c-4b268d62ce29.png)

