### PR TITLE
Squads: Add support for TeamRole parameter

### DIFF
--- a/components/squad/squad.lua
+++ b/components/squad/squad.lua
@@ -91,8 +91,9 @@ function Squad:header()
 	local headerRow = mw.html.create('tr'):addClass('HeaderRow')
 
 		headerRow	:node(makeHeader('ID'))
+					:node(makeHeader()) -- "Team Icon" (most commmonly used for loans)
 					:node(makeHeader('Name'))
-					:node(makeHeader())
+					:node(makeHeader()) -- "Role"
 					:node(makeHeader('Join Date'))
 	if self.type == Squad.TYPE_FORMER then
 		headerRow	:node(makeHeader('Leave Date'))

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -73,14 +73,17 @@ function SquadRow:id(args)
 		cell:wikitext('&nbsp;' .. _ICON_SUBSTITUTE)
 	end
 
+	local teamNode = mw.html.create('td')
 	if mw.ext.TeamTemplate.teamexists(string.lower(args.team or '')) then
-		cell:wikitext(mw.ext.TeamTemplate.teampart(args.team:lower()))
+		teamNode:wikitext(mw.ext.TeamTemplate.teamicon(args.team:lower()))
 		if args.teamrole then
-			cell:wikitext('\'\''.. args.teamrole ..'\'\'')
+			teamNode:css('text-align', 'center')
+			teamNode:tag('div'):css('font-size', '85%'):wikitext('(\'\''.. args.teamrole ..'\'\')')
 		end
 	end
 
 	self.content:node(cell)
+	self.content:node(teamNode)
 
 	self.lpdbData['id'] = args[1]
 	self.lpdbData['nationality'] = Flags.CountryName(args.flag)

--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -75,6 +75,9 @@ function SquadRow:id(args)
 
 	if mw.ext.TeamTemplate.teamexists(string.lower(args.team or '')) then
 		cell:wikitext(mw.ext.TeamTemplate.teampart(args.team:lower()))
+		if args.teamrole then
+			cell:wikitext('\'\''.. args.teamrole ..'\'\'')
+		end
 	end
 
 	self.content:node(cell)

--- a/components/squad/wikis/arenaofvalor/squad_custom.lua
+++ b/components/squad/wikis/arenaofvalor/squad_custom.lua
@@ -30,6 +30,7 @@ function CustomSquad.header(self)
 	local headerRow = mw.html.create('tr'):addClass('HeaderRow')
 
 		headerRow	:node(makeHeader('ID'))
+					:node(makeHeader())
 					:node(makeHeader('Name'))
 					:node(makeHeader())
 					:node(makeHeader('Position'))

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -30,6 +30,7 @@ function CustomSquad.header(self)
 	local headerRow = mw.html.create('tr'):addClass('HeaderRow')
 
 		headerRow	:node(makeHeader('ID'))
+					:node(makeHeader())
 					:node(makeHeader('Name'))
 					:node(makeHeader())
 					:node(makeHeader('Position'))


### PR DESCRIPTION
## Summary

Add support for `|teamrole=`.

This PR splits the "team icon" to its own column, and adds the "team role" below, if supplied.

Old dota2 table:
![image](https://user-images.githubusercontent.com/3426850/168799919-295672a3-81f9-459a-98ae-931984a1584a.png)

Standardized Squads table With teamrole support
![image](https://user-images.githubusercontent.com/3426850/168827106-6711c096-ad91-436b-a0aa-b77210a1832c.png)


## How did you test this change?

Tested on dota2 and SC2