### PR TITLE
Add League links for datdota and dotabuff

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -30,14 +30,14 @@ local _PREFIXES = {
 	},
 	cybergamer = {'https://au.cybergamer.com/profile/'},
 	datdota = {
-		'',
+		'https://www.datdota.com/leagues/',
 		player = 'https://datdota.com/players/',
 		team = 'https://datdota.com/teams/'
 	},
 	discord = {'https://discord.gg/'},
 	dlive = {'https://www.dlive.tv/'},
 	dotabuff = {
-		'',
+		'https://www.dotabuff.com/esports/leagues/',
 		player = 'https://dotabuff.com/esports/players/',
 		team = 'https://dotabuff.com/esports/teams/'
 	},


### PR DESCRIPTION
## Summary

Add League infobox links for the sites datdota and dotabuff

## How did you test this change?
n/a