### PR TITLE
Make error message a widget

### DIFF
--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -35,17 +35,16 @@ function Widget:tryMake()
 		function()
 			result = self:make()
 		end,
-		function(message)
+		function(errorMessage)
 			mw.log('-----Error in Widget:tryMake()-----')
 			mw.logObject(message, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			errorOutput = String.interpolate(_ERROR_TEXT, {errorMessage = message})
-			errorOutput = {ErrorWidget({content = errorOutput})}
+			errorOutput = {ErrorWidget({errorMessage = errorMessage})}
 		end
 	)
 
-	-- if no error occurs then `erroOutput` is nil, so the result is taken
+	-- if no error occurs then `errorOutput` is nil, so the result is taken
 	return errorOutput or result
 end
 
@@ -62,7 +61,7 @@ end
 ErrorWidget = Class.new(
 	Widget,
 	function(self, input)
-		self.content = input.content
+		self.errorMessage = input.errorMessage
 	end
 )
 
@@ -72,9 +71,10 @@ function ErrorWidget:make()
 	}
 end
 
-function ErrorWidget:_create(content)
+function ErrorWidget:_create(errorMessage)
+	local errorOutput = String.interpolate(_ERROR_TEXT, {errorMessage = errorMessage})
 	local errorDiv = mw.html.create('div')
-		:node(content)
+		:node(errorOutput)
 
 	return mw.html.create('div'):node(errorDiv)
 end

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -35,12 +35,12 @@ function Widget:tryMake()
 		function()
 			result = self:make()
 		end,
-		function(message)
+		function(errorMessage)
 			mw.log('-----Error in Widget:tryMake()-----')
-			mw.logObject(message, 'error')
+			mw.logObject(errorMessage, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			errorOutput = {ErrorWidget({errorMessage = message})}
+			errorOutput = {ErrorWidget({errorMessage = errorMessage})}
 		end
 	)
 

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -73,8 +73,7 @@ end
 
 function ErrorWidget:_create(errorMessage)
 	local errorOutput = String.interpolate(_ERROR_TEXT, {errorMessage = errorMessage})
-	local errorDiv = mw.html.create('div')
-		:node(errorOutput)
+	local errorDiv = mw.html.create('div'):node(errorOutput)
 
 	return mw.html.create('div'):node(errorDiv)
 end

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -35,12 +35,12 @@ function Widget:tryMake()
 		function()
 			result = self:make()
 		end,
-		function(errorMessage)
+		function(message)
 			mw.log('-----Error in Widget:tryMake()-----')
-			mw.logObject(errorMessage, 'error')
+			mw.logObject(message, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			errorOutput = {ErrorWidget({errorMessage = errorMessage})}
+			errorOutput = {ErrorWidget({errorMessage = message})}
 		end
 	)
 
@@ -67,7 +67,7 @@ ErrorWidget = Class.new(
 
 function ErrorWidget:make()
 	return {
-		ErrorWidget:_create(self.content)
+		ErrorWidget:_create(self.errorMessage)
 	}
 end
 

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -11,7 +11,6 @@ local String = require('Module:StringUtils')
 
 local Widget = Class.new()
 
-
 local _ERROR_TEXT = '<span style="color:#ff0000;font-weight:bold" class="show-when-logged-in">' ..
 					'Unexpected Error, report this in #bugs on our [https://discord.gg/liquipedia Discord]. ' ..
 					'${errorMessage}' ..

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -37,7 +37,7 @@ function Widget:tryMake()
 		end,
 		function(errorMessage)
 			mw.log('-----Error in Widget:tryMake()-----')
-			mw.logObject(message, 'error')
+			mw.logObject(errorMessage, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
 			errorOutput = {ErrorWidget({errorMessage = errorMessage})}

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -10,7 +10,7 @@ local Injector = require('Module:Infobox/Widget/Injector')
 local String = require('Module:StringUtils')
 
 local Widget = Class.new()
-local ErrorWidget
+
 
 local _ERROR_TEXT = '<span style="color:#ff0000;font-weight:bold" class="show-when-logged-in">' ..
 					'Unexpected Error, report this in #bugs on our [https://discord.gg/liquipedia Discord]. ' ..
@@ -40,7 +40,7 @@ function Widget:tryMake()
 			mw.logObject(errorMessage, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			errorOutput = {ErrorWidget({errorMessage = errorMessage})}
+			errorOutput = {Widget.ErrorWidget({errorMessage = errorMessage})}
 		end
 	)
 
@@ -58,7 +58,7 @@ end
 
 -- error widget for displaying errors of widgets
 -- have to add it here instead of a sep. module to avoid circular requires
-ErrorWidget = Class.new(
+local ErrorWidget = Class.new(
 	Widget,
 	function(self, input)
 		self.errorMessage = input.errorMessage
@@ -77,5 +77,7 @@ function ErrorWidget:_create(errorMessage)
 
 	return mw.html.create('div'):node(errorDiv)
 end
+
+Widget.ErrorWidget = ErrorWidget
 
 return Widget

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -8,8 +8,10 @@
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local Widget = Class.new()
+local ErrorWidget
 
 local _ERROR_TEXT = '<span style="color:#ff0000;font-weight:bold" class="show-when-logged-in">' ..
 					'Unexpected Error, report this in #bugs on our [https://discord.gg/liquipedia Discord]. ' ..
@@ -29,10 +31,18 @@ function Widget:make()
 end
 
 function Widget:tryMake()
+	-- todo: make it xpcall and do the traceback in there
 	local result, output = pcall(self.make, self) -- Equivalent of self:make()
 	if not result then
+		-- log stacked trace call and log self
+		mw.log('-----Error in Widget:tryMake()-----')
+		mw.logObject(output, 'error')
+		mw.logObject(self, 'widget')
+		mw.log(debug.traceback())
 		output = {String.interpolate(_ERROR_TEXT, {errorMessage = output})}
+		output = {ErrorWidget({content = output})}
 	end
+
 	return output
 end
 
@@ -42,6 +52,35 @@ function Widget:setContext(context)
 		(context.injector['is_a'] == nil or context.injector:is_a(Injector) == false) then
 		return error('Valid Injector from Infobox/Widget/Injector needs to be provided')
 	end
+end
+
+-- error widget for displaying errors of child widgets
+-- have to add it here instead of a sep. module to avoid circular requires
+ErrorWidget = Class.new(
+	Widget,
+	function(self, input)
+		self.content = input.content
+	end
+)
+
+function ErrorWidget:make()
+	return {
+		ErrorWidget:_create(self.content)
+	}
+end
+
+function ErrorWidget:_create(content)
+	if Table.isEmpty(content) then
+		return nil
+	end
+
+	local errorDiv = mw.html.create('div'):addClass('infobox-center')
+
+	for _, item in pairs(content) do
+		errorDiv:wikitext(item)
+	end
+
+	return mw.html.create('div'):node(errorDiv)
 end
 
 return Widget

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -40,7 +40,7 @@ function Widget:tryMake()
 			mw.logObject(errorMessage, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			errorOutput = {Widget.ErrorWidget({errorMessage = errorMessage})}
+			errorOutput = {Widget.ErrorWidget{errorMessage = errorMessage}}
 		end
 	)
 

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -74,7 +74,7 @@ function ErrorWidget:_create(content)
 		return nil
 	end
 
-	local errorDiv = mw.html.create('div'):addClass('infobox-center')
+	local errorDiv = mw.html.create('div')
 
 	for _, item in pairs(content) do
 		errorDiv:wikitext(item)

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -30,7 +30,7 @@ function Widget:make()
 end
 
 function Widget:tryMake()
-	local result, erroOutput
+	local result, errorOutput
 	xpcall(
 		function()
 			result = self:make()
@@ -40,8 +40,8 @@ function Widget:tryMake()
 			mw.logObject(message, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			erroOutput = String.interpolate(_ERROR_TEXT, {errorMessage = message})
-			erroOutput = {ErrorWidget({content = erroOutput})}
+			errorOutput = String.interpolate(_ERROR_TEXT, {errorMessage = message})
+			errorOutput = {ErrorWidget({content = errorOutput})}
 		end
 	)
 

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -8,7 +8,6 @@
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local String = require('Module:StringUtils')
-local Table = require('Module:Table')
 
 local Widget = Class.new()
 local ErrorWidget

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -29,22 +29,20 @@ function Widget:make()
 end
 
 function Widget:tryMake()
-	local result, errorOutput
-	xpcall(
+	local _, output = xpcall(
 		function()
-			result = self:make()
+			return self:make()
 		end,
 		function(errorMessage)
 			mw.log('-----Error in Widget:tryMake()-----')
 			mw.logObject(errorMessage, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			errorOutput = {Widget.Error{errorMessage = errorMessage}}
+			return {Widget.Error({errorMessage = errorMessage})}
 		end
 	)
 
-	-- if no error occurs then `errorOutput` is nil, so the result is taken
-	return errorOutput or result
+	return output
 end
 
 function Widget:setContext(context)

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -46,7 +46,7 @@ function Widget:tryMake()
 	)
 
 	-- if no error occurs then `erroOutput` is nil, so the result is taken
-	return erroOutput or result
+	return errorOutput or result
 end
 
 function Widget:setContext(context)

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -39,7 +39,7 @@ function Widget:tryMake()
 			mw.logObject(errorMessage, 'error')
 			mw.logObject(self, 'widget')
 			mw.log(debug.traceback())
-			errorOutput = {Widget.ErrorWidget{errorMessage = errorMessage}}
+			errorOutput = {Widget.Error{errorMessage = errorMessage}}
 		end
 	)
 
@@ -77,6 +77,6 @@ function ErrorWidget:_create(errorMessage)
 	return mw.html.create('div'):node(errorDiv)
 end
 
-Widget.ErrorWidget = ErrorWidget
+Widget.Error = ErrorWidget
 
 return Widget

--- a/components/infobox/commons/infobox_widget_error.lua
+++ b/components/infobox/commons/infobox_widget_error.lua
@@ -6,4 +6,4 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-return require('Module:Infobox/Widget').ErrorWidget
+return require('Module:Infobox/Widget').Error

--- a/components/infobox/commons/infobox_widget_error.lua
+++ b/components/infobox/commons/infobox_widget_error.lua
@@ -1,0 +1,9 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Widget/Error
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return require('Module:Infobox/Widget').ErrorWidget

--- a/components/infobox/commons/infobox_widgets.lua
+++ b/components/infobox/commons/infobox_widgets.lua
@@ -17,5 +17,6 @@ Widgets.Links = require('Module:Infobox/Widget/Links')
 Widgets.Chronology = require('Module:Infobox/Widget/Chronology')
 Widgets.Builder = require('Module:Infobox/Widget/Builder')
 Widgets.Breakdown = require('Module:Infobox/Widget/Breakdown')
+Widgets.Error = require('Module:Infobox/Widget/Error')
 
 return Widgets


### PR DESCRIPTION
## Summary
Make error message a widget so that errors in children are displayed properly.

Atm if the childs cause the error we just get the following error message with a really unhelpful trace:
![Screenshot 2022-05-18 09 28 56](https://user-images.githubusercontent.com/75081997/168982384-7e211abb-ddc9-4354-a080-a400b8f45e7c.png)

After this change it looks like this:
![Screenshot 2022-05-18 10 14 56](https://user-images.githubusercontent.com/75081997/168991814-eecb0a13-ddf8-45eb-bc00-8801104366fd.png)
(in the above example 2 errors were forced intentionally)

Additionally it logs the widget that causes the error as well as a traceback:
![Screenshot 2022-05-18 10 14 49](https://user-images.githubusercontent.com/75081997/168991930-a9cc904e-cc8b-4192-ab0d-787088d18d98.png)

## How did you test this change?
/dev modules (a bunch of them)

If you want to test it yourself. On SC2 I added a version of infobox league using the /dev stuff that has no intentional error and a version of infobox league that causes an intentional error:
* https://liquipedia.net/starcraft2/Template:Infobox_league/dev (no error)
* https://liquipedia.net/starcraft2/Template:Infobox_league/error (intentional error)
