### PR TITLE
Squads: Don't clean player input

### DIFF
--- a/components/squad/squad_row.lua
+++ b/components/squad/squad_row.lua
@@ -63,7 +63,10 @@ function SquadRow:id(args)
 
 	local cell = mw.html.create('td')
 	cell:addClass('ID')
+
+	args['noclean'] = true
 	cell:wikitext('\'\'\'' .. Player._player(args) .. '\'\'\'')
+	args['noclean'] = nil
 
 	if String.isNotEmpty(args.captain) then
 		cell:wikitext('&nbsp;' .. _ICON_CAPTAIN)


### PR DESCRIPTION
## Summary

Don't clean the Player input parameters. It causes issues with displaynames with special characters.

Before:
![image](https://user-images.githubusercontent.com/3426850/169031345-b16f2338-cbc3-49b7-83e4-a5f13c8c5881.png)

After:
![image](https://user-images.githubusercontent.com/3426850/169031425-a7bb1db6-d623-4c0f-b69e-e5159bc35c6c.png)


## How did you test this change?

Tested live on dota2 with a dev module of Squads.