### PR TITLE
Allow not setting `Injector:parse` in /Custom infoboxes

### DIFF
--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local Injector = Class.new()
 
 function Injector:parse(id, widgets)
-	return {}
+	return widgets
 end
 
 function Injector:addCustomCells(widgets)


### PR DESCRIPTION
## Summary
Allow not setting `Injector:parse` in /Custom infoboxes by returning `widgets` instead of `{}`

## How did you test this change?
/dev modules