### PR TITLE
Add missing space

### DIFF
--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -105,7 +105,7 @@ end
 
 function CustomLeague:appendLiquipediatierDisplay()
 	if String.isEmpty(_args.pctier) and Logic.readBool(_args.valvepremier) then
-		return Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox')
+		return ' ' .. Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox')
 	end
 	return ''
 end


### PR DESCRIPTION
## Summary
Add missing space between tier and valve logo

## How did you test this change?
/dev module

![Screenshot 2022-05-19 07 27 09](https://user-images.githubusercontent.com/75081997/169216983-ec0df42d-e596-4110-b81c-f437fba1e545.png)
upper one the old (wikicode) infobox, lower one the one with the current /Custom
with the proposed change it looks like the old version again
