### PR TITLE
Set `tournament_mode` in HiddenDataBox

### DIFF
--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -36,7 +36,7 @@ function CustomHiddenDataBox:addCustomVariables(args, queryResult)
 
 	-- tournament mode (1v1 or team)
 	BasicHiddenDataBox:checkAndAssign('tournament_mode', args.mode, queryResult.extradata.mode)
-	
+
 	--gamemode
 	BasicHiddenDataBox:checkAndAssign('tournament_gamemode', args.gamemode, queryResult.gamemode)
 end

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -34,6 +34,9 @@ function CustomHiddenDataBox:addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_headtohead', args.headtohead)
 	Variables.varDefine('headtohead', args.headtohead)
 
+	-- tournament mode (1v1 or team)
+	BasicHiddenDataBox:checkAndAssign('tournament_mode', args.mode, queryResult.extradata.mode)
+	
 	--gamemode
 	BasicHiddenDataBox:checkAndAssign('tournament_gamemode', args.gamemode, queryResult.gamemode)
 end


### PR DESCRIPTION
## Summary
Sets wiki variable `tournament_mode` in HDB, which is needed by some match modules for LPDB storage.

## How did you test this change?
/dev
