### PR TITLE
Dota2 League Infobox Improvements

### DIFF
--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -26,7 +26,6 @@ local _GAMES = {
 	dota2 = {name = 'Dota 2', category = 'Dota 2 Competitions'},
 	dota = {name = 'DotA', category = 'DotA Competitions'},
 	hon = {name = 'Heroes of Newerth', category = 'Heroes of Newerth Competitions'},
-	['auto chess'] = {name = 'Auto Chess', category = 'Auto Chess Competitions'},
 }
 
 function CustomLeague.run(frame)
@@ -115,6 +114,7 @@ function CustomLeague:liquipediaTierHighlighted()
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.game = string.lower(args.game or 'dota2')
 	lpdbData.publishertier = args.pctier
 	lpdbData.participantsnumber = args.team_number or args.player_number
 	lpdbData.extradata = {
@@ -128,6 +128,11 @@ function CustomLeague:addToLpdb(lpdbData, args)
 end
 
 function CustomLeague:defineCustomPageVariables()
+	-- Custom Vars
+	Variables.varDefine('tournament_pro_circuit_points', _args.points or '')
+	local isIndividual = String.isNotEmpty(_args.individual) or String.isNotEmpty(_args.player_number)
+	Variables.varDefine('tournament_individual', isIndividual and 'true' or '')
+
 	--Legacy vars
 	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
 	Variables.varDefine('tournament_tier', _args.liquipediatier or '')


### PR DESCRIPTION
## Summary

Two wikivariables that were not set and defaulting the LPDB game field to dota2.

Remove Auto Chess. There's only one tournament on the wiki and its supposed to be moved to the Auto chess wiki instead (https://discord.com/channels/93055209017729024/213718409567928331/976450350598979634)

## How did you test this change?

Not yet live, tested on sandbox 