### PR TITLE
Squads: Add support for former & inactive status

### DIFF
--- a/components/squad/squad.lua
+++ b/components/squad/squad.lua
@@ -15,6 +15,7 @@ local Squad = Class.new()
 Squad.TYPE_ACTIVE = 0
 Squad.TYPE_INACTIVE = 1
 Squad.TYPE_FORMER = 2
+TYPE_FORMER_INACTIVE = 3
 
 function Squad:init(frame)
 	self.frame = frame

--- a/components/squad/squad.lua
+++ b/components/squad/squad.lua
@@ -15,7 +15,7 @@ local Squad = Class.new()
 Squad.TYPE_ACTIVE = 0
 Squad.TYPE_INACTIVE = 1
 Squad.TYPE_FORMER = 2
-TYPE_FORMER_INACTIVE = 3
+Squad.TYPE_FORMER_INACTIVE = 3
 
 function Squad:init(frame)
 	self.frame = frame

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -81,7 +81,7 @@ function CustomSquad.run(frame)
 	squad:init(frame):title()
 
 	local args = squad.args
-	
+
 	if squad.type == Squad.TYPE_FORMER then
 		local index = 1
 		while args['p' .. index] ~= nil or args[index] or squad.type ~= Squad.TYPE_FORMER_INACTIVE do
@@ -89,11 +89,11 @@ function CustomSquad.run(frame)
 			if player.inactivedate then
 				squad.type = Squad.TYPE_FORMER_INACTIVE
 			end
-			
+
 			index = index + 1
 		end
 	end
-	
+
 	squad.header = CustomSquad.header
 	squad:header()
 

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -34,7 +34,11 @@ function CustomSquad.header(self)
 			:node(makeHeader('Name'))
 			:node(makeHeader('Position'))
 			:node(makeHeader('Join Date'))
-	if self.type == Squad.TYPE_INACTIVE or self.type == Squad.TYPE_FORMER_INACTIVE then
+	if self.type == Squad.TYPE_INACTIVE then
+		headerRow	:node(makeHeader('Inactive Date'))
+				:node(makeHeader('Active Team'))
+	end
+	if self.type == Squad.TYPE_FORMER_INACTIVE then
 		headerRow	:node(makeHeader('Inactive Date'))
 				:node(makeHeader('Last Active Team'))
 	end

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -30,15 +30,17 @@ function CustomSquad.header(self)
 	local headerRow = mw.html.create('tr'):addClass('HeaderRow')
 
 	headerRow	:node(makeHeader('ID'))
-				:node(makeHeader())
-				:node(makeHeader('Name'))
-				:node(makeHeader('Position'))
-				:node(makeHeader('Join Date'))
-	if self.type == Squad.TYPE_FORMER then
+			:node(makeHeader())
+			:node(makeHeader('Name'))
+			:node(makeHeader('Position'))
+			:node(makeHeader('Join Date'))
+	if self.type == Squad.TYPE_INACTIVE or self.type == Squad.TYPE_FORMER_INACTIVE then
+		headerRow	:node(makeHeader('Inactive Date'))
+				:node(makeHeader('Last Active Team'))
+	end
+	if self.type == Squad.TYPE_FORMER or self.type == Squad.TYPE_FORMER_INACTIVE then
 		headerRow	:node(makeHeader('Leave Date'))
-					:node(makeHeader('New Team'))
-	elseif self.type == Squad.TYPE_INACTIVE then
-		headerRow:node(makeHeader('Inactive Date'))
+				:node(makeHeader('New Team'))
 	end
 
 	self.content:node(headerRow)
@@ -76,10 +78,24 @@ end
 function CustomSquad.run(frame)
 	local squad = Squad()
 
-	squad.header = CustomSquad.header
-	squad:init(frame):title():header()
+	squad:init(frame):title()
 
 	local args = squad.args
+	
+	if squad.type == Squad.TYPE_FORMER then
+		local index = 1
+		while args['p' .. index] ~= nil or args[index] or squad.type ~= Squad.TYPE_FORMER_INACTIVE do
+			local player = Json.parseIfString(args['p' .. index] or args[index])
+			if player.inactivedate then
+				squad.type = Squad.TYPE_FORMER_INACTIVE
+			end
+			
+			index = index + 1
+		end
+	end
+	
+	squad.header = CustomSquad.header
+	squad:header()
 
 	local index = 1
 	while args['p' .. index] ~= nil or args[index] do
@@ -98,7 +114,15 @@ function CustomSquad.run(frame)
 			:position{position = player.position, role = mw.language.new('en'):ucfirst(player.role or '')}
 			:date(player.joindate, 'Join Date:&nbsp;', 'joindate')
 
-		if squad.type == Squad.TYPE_FORMER then
+		if squad.type == Squad.TYPE_INACTIVE or squad.type == Squad.TYPE_FORMER_INACTIVE then
+			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
+			row:newteam{
+				newteam = player.activeteam,
+				newteamrole = player.activeteamrole,
+				newteamdate = player.inactivedate
+			}
+		end
+		if squad.type == Squad.TYPE_FORMER or squad.type == Squad.TYPE_FORMER_INACTIVE then
 			row:date(player.leavedate, 'Leave Date:&nbsp;', 'leavedate')
 			row:newteam{
 				newteam = player.newteam,
@@ -106,8 +130,6 @@ function CustomSquad.run(frame)
 				newteamdate = player.newteamdate,
 				leavedate = player.leavedate
 			}
-		elseif squad.type == Squad.TYPE_INACTIVE then
-			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 		end
 
 		squad:row(row:create(


### PR DESCRIPTION
## Summary

Add support for former & inactive status to Squad

![image](https://user-images.githubusercontent.com/42477808/169262319-9aed4b49-1f78-41dc-97f0-613c83837494.png)

![image](https://user-images.githubusercontent.com/42477808/169262336-e5094c83-cfc2-4d82-ab78-20599f89fa21.png)

## How did you test this change?

/dev modules

https://liquipedia.net/dota2/User:Lenya_01/16
