### PR TITLE
Adjust prize pool in RL's Infobox league

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -54,7 +54,7 @@ function League:createInfobox()
 	local links
 
 	-- set Variables here already so they are available in functions
-	-- we call from here on, e.g. _createPrizepool
+	-- we call from here on, e.g. createPrizepool
 	self:_definePageVariables(args)
 
 	local widgets = {
@@ -339,7 +339,7 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_enddate',
 	self:_cleanDate(args.edate) or self:_cleanDate(args.date))
 
-	-- gets overwritten by the League:_createPrizepool call if args.prizepool
+	-- gets overwritten by the League:createPrizepool call if args.prizepool
 	-- or args.prizepoolusd is a valid input
 	-- if wikis want it unset they can unset it via the defineCustomPageVariables() call
 	Variables.varDefine('tournament_currency', args.localcurrency or '')

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -150,7 +150,7 @@ function League:createInfobox()
 		Customizable{id = 'prizepool', children = {
 			Cell{
 					name = 'Prize pool',
-					content = {self:_createPrizepool(args)},
+					content = {self:createPrizepool(args)},
 				},
 			},
 		},
@@ -281,7 +281,7 @@ function League:createLiquipediaTierDisplay(args)
 	return tierDisplay .. self.appendLiquipediatierDisplay(args)
 end
 
-function League:_createPrizepool(args)
+function League:createPrizepool(args)
 	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
 		return nil
 	end

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -7,11 +7,12 @@
 --
 
 local League = require('Module:Infobox/League')
-local String = require('Module:String')
+local String = require('Module:StringUtils')
 local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local TournamentNotability = require('Module:TournamentNotability')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
@@ -141,6 +142,14 @@ function CustomLeague:_createPrizepool(args)
 	if String.isEmpty(args.prizepool) and
 		String.isEmpty(args.prizepoolusd) then
 			return nil
+	end
+
+	local endDate = Variables.varDefault('tournament_enddate')
+	if
+		Logic.readBool(args.convertPrizePool) or
+		String.isNotEmpty(endDate) and os.date('%Y-%m-%d') >= endDate
+	then
+		return _league:createPrizepool(args)
 	end
 
 	local content

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -65,11 +65,11 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = _league.args
 	if id == 'customcontent' then
-		if not String.isEmpty(args.map1) then
+		if String.isNotEmpty(args.map1) then
 			local maps = {CustomLeague:_makeInternalLink(args.map1)}
 			local index = 2
 
-			while not String.isEmpty(args['map' .. index]) do
+			while String.isNotEmpty(args['map' .. index]) do
 				table.insert(maps, '&nbsp;• ' ..
 					tostring(CustomLeague:_createNoWrappingSpan(
 						CustomLeague:_makeInternalLink(args['map' .. index])
@@ -82,7 +82,7 @@ function CustomInjector:parse(id, widgets)
 		end
 
 
-		if not String.isEmpty(args.team_number) then
+		if String.isNotEmpty(args.team_number) then
 			table.insert(widgets, Title{name = 'Teams'})
 			table.insert(widgets, Cell{
 				name = 'Number of teams',
@@ -120,11 +120,11 @@ function CustomLeague:createLiquipediaTierDisplay(args)
 
 	local tierDisplay = Template.safeExpand(mw.getCurrentFrame(), 'TierDisplay/' .. tier)
 
-	if not String.isEmpty(type) then
+	if String.isNotEmpty(type) then
 		local typeDisplay = Template.safeExpand(mw.getCurrentFrame(), 'TierDisplay/' .. type)
 		content = content .. '[[' .. typeDisplay .. ' Tournaments|' .. type .. ']]'
 
-		if not String.isEmpty(type2) then
+		if String.isNotEmpty(type2) then
 			content = content .. ' ' .. type2
 		end
 
@@ -160,7 +160,7 @@ function CustomLeague:_createPrizepool(args)
 	if String.isEmpty(prizepool) then
 		content = '$' .. prizepoolInUsd .. ' ' .. Template.safeExpand(mw.getCurrentFrame(), 'Abbr/USD')
 	else
-		if not String.isEmpty(localCurrency) then
+		if String.isNotEmpty(localCurrency) then
 			content = Template.safeExpand(
 				mw.getCurrentFrame(),
 				'Local currency',
@@ -170,13 +170,13 @@ function CustomLeague:_createPrizepool(args)
 			content = prizepool
 		end
 
-		if not String.isEmpty(prizepoolInUsd) then
+		if String.isNotEmpty(prizepoolInUsd) then
 			content = content .. '<br>(≃ $' .. prizepoolInUsd .. ' ' ..
 				Template.safeExpand(mw.getCurrentFrame(), 'Abbr/USD') .. ')'
 		end
 	end
 
-	if not String.isEmpty(prizepoolInUsd) then
+	if String.isNotEmpty(prizepoolInUsd) then
 		Variables.varDefine('tournament_prizepoolusd', prizepoolInUsd:gsub(',', ''):gsub('$', ''))
 	end
 
@@ -225,7 +225,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		notabilitymod = args.notabilitymod,
 		liquipediatiertype2 = args.liquipediatiertype2,
 		participantsnumber =
-			not String.isEmpty(args.team_number) and args.team_number or args.player_number,
+			String.isNotEmpty(args.team_number) and args.team_number or args.player_number,
 		notabilitypercentage = args.edate ~= 'tba' and TournamentNotability.run() or ''
 	}
 
@@ -247,7 +247,7 @@ end
 function CustomLeague:_concatArgs(args, base)
 	local foundArgs = {args[base] or args[base .. '1']}
 	local index = 2
-	while not String.isEmpty(args[base .. index]) do
+	while String.isNotEmpty(args[base .. index]) do
 		table.insert(foundArgs, args[base .. index])
 		index = index + 1
 	end

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -26,6 +26,7 @@ local _SERIES_RLCS = 'Rocket League Championship Series'
 local _MODE_2v2 = '2v2'
 local _GAME_ROCKET_LEAGUE = 'rl'
 local _GAME_SARPBC = 'sarpbc'
+local _TODAY = os.date('%Y-%m-%d')
 
 local _league
 
@@ -147,7 +148,7 @@ function CustomLeague:_createPrizepool(args)
 	local endDate = Variables.varDefault('tournament_enddate')
 	if
 		Logic.readBool(args.convertPrizePool) or
-		String.isNotEmpty(endDate) and os.date('%Y-%m-%d') >= endDate
+		String.isNotEmpty(endDate) and _TODAY >= endDate
 	then
 		return _league:createPrizepool(args)
 	end


### PR DESCRIPTION
## Summary
Adjust prize pool in RL's Infobox league
* use commons version if the event is finished (today >= edate) or a switch param is set
* else use the only manual input for display

For that the commons function has to be exportet.

Additional cleanup: `not String.isEmpty` --> `String.isNotEmpty`

## How did you test this change?
/Dev module(s)