### PR TITLE
Adding Tournaments to Valorant Infobox

### DIFF
--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -49,6 +49,10 @@ function CustomTeam:createBottomContent()
 		mw.getCurrentFrame(),
 		'Upcoming and ongoing matches of',
 		{team = _team.name or _team.pagename}
+	) .. Template.expandTemplate(
+		mw.getCurrentFrame(),
+		'Upcoming and ongoing tournaments of',
+		{team = _team.name or _team.pagename}
 	)
 end
 


### PR DESCRIPTION
## Summary
Adds Upcoming and Ongoing team tournaments to the bottom of the Valorant Infobox (by contributor request) 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested via [dev module ](https://liquipedia.net/valorant/Module:Infobox/Team/Custom/dev) on a [sandbox page](https://liquipedia.net/valorant/User:Fenrir.SPAZ/Sandbox_2)
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
