### PR TITLE
Adjust number of maximum players in a placement

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -36,7 +36,7 @@ local _PAGENAME = mw.title.getCurrentTitle().prefixedText
 local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local _ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local _EARNING_MODES = {['solo'] = '1v1', ['team'] = 'team'}
-local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
+local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 20
 local _MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS = 10
 local _MAXIMUM_NUMBER_OF_ACHIEVEMENTS = 40
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -45,7 +45,7 @@ local _earnings_by_players_while_on_team = 0
 local _EARNINGS_MODES = {team = 'team'}
 local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local _DISCARD_PLACEMENT = 99
-local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 30
+local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 20
 local _PLAYER_EARNINGS_ABBREVIATION = '<abbr title="Earnings of players while on the team">Player earnings</abbr>'
 
 function CustomTeam.run(frame)


### PR DESCRIPTION
## Summary
We cleaned some very old pages and marked players that did not play in them but were listed in the teamCards as DNP. Hence they are not stored into the player field in the placement anymore.
Due to that we now have no pages left with >20 players in a placement. Hence we can finally lower the number and reduce runtime on pages conditioning on that data significantly.

## How did you test this change?
N/A