### PR TITLE
Store `publishertier` into smw for WR match2

### DIFF
--- a/components/match2/wikis/wildrift/match_legacy.lua
+++ b/components/match2/wikis/wildrift/match_legacy.lua
@@ -154,6 +154,7 @@ function MatchLegacy.storeMatchSMW(match, match2)
 			Variables.varDefault('tournament_name', mw.title.getCurrentTitle().prefixedText)
 		),
 		'Has tournament icon=' .. Variables.varDefault('tournament_icon', ''),
+		'Is riot premier=' .. Variables.varDefault('tournament_riot_premier', ''),
 		'Has winner=' .. (match.winner or ''),
 		'Has team left score=' .. (match.opponent1score or '0'),
 		'Has team right score=' .. (match.opponent2score or '0'),


### PR DESCRIPTION
## Summary ##
Title. It wasnt added originally. This is to help publishertier being registered for matches (including ability to show yellow highlights on upcoming matches, both the current and the upcoming match2 ticker)

## Side Note ## 
I've temporarily tested it out by adding this line in the module on wiki, but its still empty. Maybe there is something I have to set inside the https://liquipedia.net/wildrift/index.php?title=Template:HiddenDataBox&action=edit to make it work (like in LoL PC wiki the publishertier lpdb would appear as **1** in the LPDB datas)

![image](https://user-images.githubusercontent.com/88981446/169686421-8d640bd9-e109-49f6-be8d-6670e89f5909.png)
( <https://liquipedia.net/wildrift/Special:LiquipediaDB/Icons_Global_Championship/2022/Play-ins> )
