### PR TITLE
Fix a gsub + trim combination issue in Player/Ext

### DIFF
--- a/components/match2/commons/player_ext.lua
+++ b/components/match2/commons/player_ext.lua
@@ -29,11 +29,11 @@ PlayerExt.extractFromLink('[[Dream (Korean Terran player)|Dream]]')
 -- returns 'Dream (Korean Terran player)', 'Dream'
 --]===]
 function PlayerExt.extractFromLink(name)
-	name = mw.text.trim(
-		name:gsub('%b{}', '')
-			:gsub('%b<>', '')
-			:gsub('%b[]', '')
-	)
+	name = name
+		:gsub('%b{}', '')
+		:gsub('%b<>', '')
+		:gsub('%b[]', '')
+	name = mw.text.trim(name)
 
 	local pageName, displayName = unpack(mw.text.split(name, '|', true))
 	if displayName and displayName ~= '' then


### PR DESCRIPTION
## Summary
Fix some gsub issues

`gsub` has a second return value that then gets evaluated by the `mw.text.trim` function.
To avoid that adjust the use cases so that the gsub results is stored into the variable before calling `mw.text.trim` onto that variable.

## How did you test this change?
live