### PR TITLE
Fix #1117

### DIFF
--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -103,7 +103,9 @@ function MatchGroupBase._isduplicate(bracketId)
 	local page = mw.title.getCurrentTitle()
 
 	local queryData = mw.ext.LiquipediaDB.lpdb('match2', {
-		conditions = '[[namespace::' .. page.namespace .. ']] AND [[pagename::!' .. page.text .. ']] AND [[match2bracketid::' .. bracketId .. ']]',
+		conditions = '[[namespace::' .. page.namespace .. ']]'
+			.. ' AND [[pagename::!' .. page.text .. ']]'
+			.. ' AND [[match2bracketid::' .. bracketId .. ']]',
 		query = 'pagename, namespace',
 	})
 	if type(queryData) == 'table' and queryData[1] then

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -104,7 +104,7 @@ function MatchGroupBase._isduplicate(bracketId)
 
 	local queryData = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = '[[namespace::' .. page.namespace .. ']]'
-			.. ' AND [[pagename::!' .. page.text .. ']]'
+			.. ' AND [[pagename::!' .. page.text:gsub(' ', '_') .. ']]'
 			.. ' AND [[match2bracketid::' .. bracketId .. ']]',
 		query = 'pagename, namespace',
 	})


### PR DESCRIPTION
## Summary
Fix the duplicate check issue.
Currently the bracketId duplicate check will sometimes (mostly after an edit of a user without editor rights or if a page wasn't purged for several weeks) show warnings for duplicate ids even if there aren't any real duplicates.
This is most likely due to the extension checking for the bracketId via LPDB and include the current page in that check.
This PR changes this behaviour.
To also catch duplicate bracketIds from the same page it now checks for the wiki-var that gets set by the matchGroup instead.
If that wiki-var is unset then no bracket with that bracketId exists on the page.
Meanwhile in the query for the bracketIds it will now limit it to the according name space (don't know if the extension did that) and exclude the current page to not get the before mentioined false-positives.

## How did you test this change?
/dev module + some test pages in user space as well as main space, especially:
- check if duplicate id from 2 pages gets caught
- check if duplicate id on the same page gets caught