### PR TITLE
Set wiki-vars for earningsinYEAR for teams

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -242,6 +242,8 @@ function Team:_setLpdbData(args, links)
 
 	for year, earningsOfYear in pairs(_earnings) do
 		lpdbData.extradata['earningsin' .. year] = earningsOfYear
+		--make these values available for smw storage
+		Variables.varDefine('earningsin' .. year, earningsOfYear)
 	end
 
 	lpdbData = self:addToLpdb(lpdbData, args)


### PR DESCRIPTION
## Summary
Set wiki-vars for earningsinYEAR for teams so that those vars can be used to store in smw.

## How did you test this change?
/dev module