### PR TITLE
Adjust Sc2 player_number handling

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -110,7 +110,7 @@ function CustomInjector:parse(id, widgets)
 		local playerBreakDownEvent = CustomLeague._playerBreakDownEvent() or {}
 		local playerNumber = playerRaceBreakDown.playerNumber or playerBreakDownEvent.playerNumber or 0
 		--make playerNumber available for commons category check
-		_args.player_number = playerNumber
+		_args.player_number = playerNumber ~= 0 and playerNumber or nil
 		Variables.varDefine('tournament_playerNumber', playerNumber)
 		if playerNumber > 0 then
 			table.insert(widgets, Title{name = 'Player breakdown'})

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -108,9 +108,9 @@ function CustomInjector:parse(id, widgets)
 		--player breakdown
 		local playerRaceBreakDown = CustomLeague._playerRaceBreakDown() or {}
 		local playerBreakDownEvent = CustomLeague._playerBreakDownEvent() or {}
-		local playerNumber = playerRaceBreakDown.playerNumber or playerBreakDownEvent.playerNumber or 0
 		--make playerNumber available for commons category check
-		_args.player_number = playerNumber ~= 0 and playerNumber or nil
+		_args.player_number = playerRaceBreakDown.playerNumber or playerBreakDownEvent.playerNumber
+		local playerNumber = _args.player_number or 0
 		Variables.varDefine('tournament_playerNumber', playerNumber)
 		if playerNumber > 0 then
 			table.insert(widgets, Title{name = 'Player breakdown'})


### PR DESCRIPTION
## Summary
Adjust Sc2 `player_number` handling to suppress the `[[Category:Individual Tournaments]]` if it is 0 (i.e. not set or 0 set and can not be calculated from race numbers)

## How did you test this change?
/dev module