### PR TITLE
Add missing matchsection in league

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -58,6 +58,7 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata = {}
 	local extradata = Json.parseIfString(match2.extradata)
 	match.extradata.gamecount = tostring(match2.bestof)
+	match.extradata.matchsection = extradata.matchsection
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
 		match.extradata.mvp = table.concat(mvp.players, ",")


### PR DESCRIPTION
## Summary

League's match1 doesn't convert `matchsection`, making swisstables unusable.

## How did you test this change?
Live
