### PR TITLE
Add wildrift HiddenDataBox/Custom

### DIFF
--- a/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
@@ -8,6 +8,8 @@
 
 local Class = require('Module:Class')
 local BasicHiddenDataBox = require('Module:HiddenDataBox')
+local Variables = require('Module:Variables')
+
 local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
@@ -21,6 +23,7 @@ function CustomHiddenDataBox:addCustomVariables(args, queryResult)
 		args.riotpremier,
 		queryResult.publishertier
 	)
+	Variables.varDefine('tournament_riot_premier', Variables.varDefault('tournament_publishertier', ''))
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
@@ -1,0 +1,26 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:HiddenDataBox/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local BasicHiddenDataBox = require('Module:HiddenDataBox')
+local CustomHiddenDataBox = {}
+
+function CustomHiddenDataBox.run(args)
+	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+	return BasicHiddenDataBox.run(args)
+end
+
+function CustomHiddenDataBox:addCustomVariables(args, queryResult)
+	BasicHiddenDataBox:checkAndAssign(
+		'tournament_publishertier',
+		args.riotpremier,
+		queryResult.publishertier
+	)
+end
+
+return Class.export(CustomHiddenDataBox)

--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -72,8 +72,10 @@ function League:defineCustomPageVariables()
 	Variables.varDefine('tournament_endpatch', _args.epatch)
 
 	Variables.varDefine('tournament_publishertier', _args['riotpremier'])
+
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('tournament_riot_premier', _args['riotpremier'])
 end
 
 function CustomLeague:liquipediaTierHighlighted(args)


### PR DESCRIPTION
## Summary
Add wildrift HiddenDataBox/Custom
+ add legacy wiki-var `tournament_riot_premier` to infobox league as it is used by some templates/modules

## How did you test this change?
/dev module for infobox league
live for the HDB change