### PR TITLE
Change empty race display

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
@@ -114,7 +114,9 @@ function CustomPerson.getRaceData(race, asCategory)
 					.. '[[Category:' .. raceValue .. ' Players'
 			end
 		end
-		display = '[[' .. table.concat(raceTable or {}, ']],&nbsp;[[') .. ']]'
+		if raceTable then
+			display = '[[' .. table.concat(raceTable, ']],&nbsp;[[') .. ']]'
+		end
 	end
 
 	_raceData = {


### PR DESCRIPTION
## Summary
Change empty race display in SC2 infoboxes commentator and player to not show the cell instread of `[[]]`

## How did you test this change?
live