### PR TITLE
Add MapVeto support for Valorant

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -20,6 +20,7 @@ local Streams = require('Module:Links/Stream')
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
 local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L' }
+local ALLOWED_VETOES = { 'decider', 'pick', 'ban', 'defaultban' }
 local MAX_NUM_OPPONENTS = 2
 local MAX_NUM_PLAYERS = 10
 local MAX_NUM_VODGAMES = 20
@@ -138,6 +139,7 @@ function matchFunctions.getExtraData(match)
 	local opponent2 = match.opponent2 or {}
 	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
+		mapveto = matchFunctions.getMapVeto(match),
 		team1icon = getIconName(opponent1.template or ''),
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
@@ -146,6 +148,36 @@ function matchFunctions.getExtraData(match)
 		isconverted = 0
 	}
 	return match
+end
+
+-- Parse the mapVeto input
+function matchFunctions.getMapVeto(match)
+	if not match.mapveto then return nil end
+
+	match.mapveto = Json.parseIfString(match.mapveto)
+
+	local vetotypes = mw.text.split(match.mapveto.types or '', ',')
+	local deciders = mw.text.split(match.mapveto.decider or '', ',')
+	local vetostart = match.mapveto.firstpick or ''
+	local deciderIndex = 1
+
+	local data = {}
+	for index, vetoType in ipairs(vetotypes) do
+		vetoType = mw.text.trim(vetoType):lower()
+		if not Table.includes(ALLOWED_VETOES, vetoType) then
+			return nil -- Any invalid input will not store (ie hide) all vetoes.
+		end
+		if vetoType == 'decider' then
+			table.insert(data, {type = vetoType, decider = deciders[deciderIndex]})
+			deciderIndex = deciderIndex + 1
+		else
+			table.insert(data, {type = vetoType, team1 = match.mapveto['t1map'..index], team2 = match.mapveto['t2map'..index]})
+		end
+	end
+	if data[1] then
+		data[1].vetostart = vetostart
+	end
+	return data
 end
 
 function matchFunctions.getOpponents(args)

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -183,7 +183,7 @@ function MapVeto:addRound(vetotype, map1, map2)
 	if Logic.isEmpty(map2) then
 		map2 = 'TBD'
 	else
-		map2 = '[['..map2..']]'
+		map2 = '[[' .. map2 .. ']]'
 	end
 	local class
 	local vetoText

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -162,7 +162,7 @@ function MapVeto:addDecider(map)
 	if Logic.isEmpty(map) then
 		map = 'TBD'
 	else
-		map = '[['..map..']]'
+		map = '[[' .. map .. ']]'
 	end
 	local row = mw.html.create('tr'):addClass('brkts-popup-mapveto-vetoround')
 

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -178,7 +178,7 @@ function MapVeto:addRound(vetotype, map1, map2)
 	if Logic.isEmpty(map1) then
 		map1 = 'TBD'
 	else
-		map1 = '[['..map1..']]'
+		map1 = '[[' .. map1 .. ']]'
 	end
 	if Logic.isEmpty(map2) then
 		map2 = 'TBD'

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -17,6 +17,9 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDev
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
 
+local _ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]'
+local _ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
+
 local Agents = Class.new(
 	function(self)
 		self.root = mw.html.create('div')
@@ -119,6 +122,112 @@ function Score:create()
 	return self.root
 end
 
+-- Map Veto Class
+local MapVeto = Class.new(
+	function(self)
+		self.root = mw.html.create('div'):addClass('brkts-popup-mapveto')
+		self.table = self.root:tag('table')
+			:addClass('wikitable-striped'):addClass('collapsible'):addClass('collapsed')
+		self:createHeader()
+	end
+)
+
+function MapVeto:createHeader()
+	self.table:tag('tr')
+		:tag('th'):css('width','33%'):done()
+		:tag('th'):css('width','34%'):wikitext('Map Veto'):done()
+		:tag('th'):css('width','33%'):done()
+	return self
+end
+
+function MapVeto:vetoStart(firstVeto)
+	local textLeft
+	local textCenter
+	local textRight
+	if firstVeto == 1 then
+		textLeft = '\'\'\'Start Map Veto\'\'\''
+		textCenter = _ARROW_LEFT
+	elseif firstVeto == 2 then
+		textCenter = _ARROW_RIGHT
+		textRight = '\'\'\'Start Map Veto\'\'\''
+	else return self end
+	self.table:tag('tr'):addClass('brkts-popup-mapveto-vetostart')
+		:tag('th'):wikitext(textLeft or ''):done()
+		:tag('th'):wikitext(textCenter):done()
+		:tag('th'):wikitext(textRight or ''):done()
+	return self
+end
+
+function MapVeto:addDecider(map)
+	if Logic.isEmpty(map) then
+		map = 'TBD'
+	else
+		map = '[['..map..']]'
+	end
+	local row = mw.html.create('tr'):addClass('brkts-popup-mapveto-vetoround')
+
+	self:addColumnVetoType(row, 'brkts-popup-mapveto-decider', 'DECIDER')
+	self:addColumnVetoMap(row, map)
+	self:addColumnVetoType(row, 'brkts-popup-mapveto-decider', 'DECIDER')
+
+	self.table:node(row)
+	return self
+end
+
+function MapVeto:addRound(vetotype, map1, map2)
+	if Logic.isEmpty(map1) then
+		map1 = 'TBD'
+	else
+		map1 = '[['..map1..']]'
+	end
+	if Logic.isEmpty(map2) then
+		map2 = 'TBD'
+	else
+		map2 = '[['..map2..']]'
+	end
+	local class
+	local vetoText
+	if vetotype == 'ban' then
+		vetoText = 'BAN'
+		class = 'brkts-popup-mapveto-ban'
+	elseif vetotype == 'pick' then
+		vetoText = 'PICK'
+		class = 'brkts-popup-mapveto-pick'
+	elseif vetotype == 'defaultban' then
+		vetoText = 'DEFAULT BAN'
+		class = 'brkts-popup-mapveto-defaultban'
+	else
+		return self
+	end
+
+	local row = mw.html.create('tr'):addClass('brkts-popup-mapveto-vetoround')
+
+	self:addColumnVetoMap(row, map1)
+	self:addColumnVetoType(row, class, vetoText)
+	self:addColumnVetoMap(row, map2)
+
+	self.table:node(row)
+	return self
+end
+
+function MapVeto:addColumnVetoType(row, styleClass, vetoText)
+	row:tag('td')
+		:tag('span')
+			:addClass(styleClass)
+			:addClass('brkts-popup-mapveto-vetotype')
+			:wikitext(vetoText)
+	return self
+end
+
+function MapVeto:addColumnVetoMap(row,map)
+	row:tag('td'):wikitext(map):done()
+	return self
+end
+
+function MapVeto:create()
+	return self.root
+end
+
 local CustomMatchSummary = {}
 
 function CustomMatchSummary.getByMatchId(args)
@@ -183,6 +292,26 @@ function CustomMatchSummary._createBody(frame, match)
 	for _, game in ipairs(match.games) do
 		if game.map then
 			body:addRow(CustomMatchSummary._createMap(frame, game))
+		end
+	end
+
+	if match.extradata.mapveto then
+		local vetoData = match.extradata.mapveto
+		if vetoData then
+			local mapVeto = MapVeto()
+
+			for _, vetoRound in ipairs(vetoData) do
+				if vetoRound.vetostart then
+					mapVeto:vetoStart(tonumber(vetoRound.vetostart))
+				end
+				if vetoRound.type == 'decider' then
+					mapVeto:addDecider(vetoRound.decider)
+				else
+					mapVeto:addRound(vetoRound.type, vetoRound.team1, vetoRound.team2)
+				end
+			end
+
+			body:addRow(mapVeto)
 		end
 	end
 


### PR DESCRIPTION
## Summary

Add mapVeto support. Match1 backwards compatibility already has support for it.

## How did you test this change?
Final testing will be done in the feature branch.
