### PR TITLE
Remove BigMatch link for Valorant

### DIFF
--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -174,11 +174,11 @@ function CustomMatchSummary._createBody(frame, match)
 	local streamElement = DisplayHelper.MatchCountdownBlock(match)
 	body:addRow(MatchSummary.Row():addElement(streamElement))
 
-	local matchPageElement = mw.html.create('center')
-	matchPageElement   :wikitext('[[Match:ID_' .. match.matchId .. '|Match Page]]')
-					:css('display', 'block')
-					:css('margin', 'auto')
-	body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(matchPageElement))
+--	local matchPageElement = mw.html.create('center')
+--	matchPageElement   :wikitext('[[Match:ID_' .. match.matchId .. '|Match Page]]')
+--					:css('display', 'block')
+--					:css('margin', 'auto')
+--	body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(matchPageElement))
 
 	for _, game in ipairs(match.games) do
 		if game.map then

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -174,12 +174,6 @@ function CustomMatchSummary._createBody(frame, match)
 	local streamElement = DisplayHelper.MatchCountdownBlock(match)
 	body:addRow(MatchSummary.Row():addElement(streamElement))
 
---	local matchPageElement = mw.html.create('center')
---	matchPageElement   :wikitext('[[Match:ID_' .. match.matchId .. '|Match Page]]')
---					:css('display', 'block')
---					:css('margin', 'auto')
---	body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(matchPageElement))
-
 	for _, game in ipairs(match.games) do
 		if game.map then
 			body:addRow(CustomMatchSummary._createMap(frame, game))


### PR DESCRIPTION
## Summary

Not looking at adding BigMatch for the initial rollout, hence removing the link.

## How did you test this change?
Final testing will be done in the feature branch.
