### PR TITLE
Add support for a less verbose input of player data

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -323,10 +323,11 @@ function mapFunctions.getParticipantsData(map)
 	for o = 1, MAX_NUM_OPPONENTS do
 		for player = 1, MAX_NUM_PLAYERS do
 			local participant = participants[o .. '_' .. player] or {}
-			local opstring = 'opponent' .. o .. '_p' .. player
-			local stats = map[opstring .. 'stats']
+			local opstring_big = 'opponent' .. o .. '_p' .. player
+			local opstring_normal = 't' .. o .. 'p' .. player
+			local stats = map[opstring_big .. 'stats'] or map[opstring_normal]
 
-			if stats ~= nil then
+			if stats then
 				stats = Json.parse(stats)
 
 				local kills = stats['kills']


### PR DESCRIPTION
## Summary

Short-hand which fits better in standard mode, as `opponent1_p1` is quite long. The new additional input would be `t1p1`, matching the current match1. This would have added benefit of improved contributor familiarity.

## How did you test this change?

Final testing will be done in the feature branch.
