### PR TITLE
Allow historical earnings queries for teams

### DIFF
--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -72,8 +72,8 @@ end
 -- @teams - list of teams
 -- @year - (optional) the year to calculate earnings for
 -- @mode - (optional) the mode to calculate earnings for
--- @noRedirect - (optional) team redirects get not resolved before query
 -- @queryHistorical - (optional) fetch the pageNames from the subTemplates of the entered team template
+-- @noRedirect - (optional) team redirects get not resolved before query (only available if queryHistorical is not used)
 -- @perYear - (optional) query all earnings per year and return the values in a lua table
 function Earnings.calculateForTeam(args)
 	args = args or {}

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -7,10 +7,12 @@
 --
 
 local Earnings = {}
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local MathUtils = require('Module:Math')
 local String = require('Module:StringUtils')
-local Logic = require('Module:Logic')
-local Class = require('Module:Class')
+local Table = require('Module:Table')
+local Team = require('Module:Team')
 
 local _DEFAULT_DATE = '1970-01-01 00:00:00'
 local _MAX_QUERY_LIMIT = 5000
@@ -66,24 +68,42 @@ end
 
 ---
 -- Entry point for teams
--- @team - the team for which the earnings shall be calculated
+-- @team - the team (either pageName or team template) for which the earnings shall be calculated
+-- @teams - list of teams
 -- @year - (optional) the year to calculate earnings for
 -- @mode - (optional) the mode to calculate earnings for
--- @noRedirect - (optional) player redirects get not resolved before query
+-- @noRedirect - (optional) team redirects get not resolved before query
+-- @queryHistorical - (optional) fetch the pageNames from the subTemplates of the entered team template
 -- @perYear - (optional) query all earnings per year and return the values in a lua table
 function Earnings.calculateForTeam(args)
 	args = args or {}
-	local team = args.team
+	local teams = args.teams or {}
+	table.insert(teams, args.team)
 
-	if String.isEmpty(team) then
+	if Table.isEmpty(teams) then
 		return 0
 	end
-	if not Logic.readBool(args.noRedirect) then
-		team = mw.ext.TeamLiquidIntegration.resolve_redirect(team)
+
+	local queryTeams = {}
+	if Logic.readBool(args.queryHistorical) then
+		for _, team in pairs(teams) do
+			local historicalNames = Team.queryHistoricalNames(team)
+			for _, historicalTeam in pairs(historicalNames) do
+				table.insert(queryTeams, historicalTeam)
+			end
+		end
+	elseif not Logic.readBool(args.noRedirect) then
+		for index, team in pairs(queryTeams) do
+			queryTeams[index] = mw.ext.TeamLiquidIntegration.resolve_redirect(team)
+		end
+	else
+		queryTeams = teams
 	end
 
-	local teamConditions = '([[participant::' .. team .. ']] OR [[extradata_participantteam::' .. team .. ']])'
-
+	local formatParicipant = function(lpdbField, participants)
+		return '([['..lpdbField..'::'.. table.concat(participants, ']] OR [['..lpdbField..'::') ..']])'
+	end
+	local teamConditions = '('.. formatParicipant('participant', queryTeams) ..' OR '.. formatParicipant('extradata_participantteam',  queryTeams) ..')'
 	return Earnings.calculate(teamConditions, args.year, args.mode, args.perYear, Earnings.divisionFactorTeam)
 end
 
@@ -105,6 +125,7 @@ function Earnings.calculate(conditions, year, mode, perYear, divisionFactor)
 	end
 
 	local prizePoolColumn = Earnings._getPrizePoolType(divisionFactor)
+
 	local lpdbQueryData = mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = conditions,
 		query = 'mode, sum::' .. prizePoolColumn,

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -57,7 +57,6 @@ function Earnings.calculateForPlayer(args)
 	end
 
 	local playerConditions = '([[participant::' .. player .. ']] OR [[participant::' .. playerAsPageName .. ']]'
-		.. ' OR [[participantlink::' .. player .. ']] OR [[participantlink::' .. playerAsPageName .. ']]'
 	for playerIndex = 1, playerPositionLimit do
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. player .. ']]'
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. playerAsPageName .. ']]'

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -57,7 +57,7 @@ function Earnings.calculateForPlayer(args)
 	end
 
 	local playerConditions = '([[participant::' .. player .. ']] OR [[participant::' .. playerAsPageName .. ']]'
-		.. '[[participantlink::' .. player .. ']] OR [[participantlink::' .. playerAsPageName .. ']]'
+		.. ' OR [[participantlink::' .. player .. ']] OR [[participantlink::' .. playerAsPageName .. ']]'
 	for playerIndex = 1, playerPositionLimit do
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. player .. ']]'
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. playerAsPageName .. ']]'

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -101,9 +101,12 @@ function Earnings.calculateForTeam(args)
 	end
 
 	local formatParicipant = function(lpdbField, participants)
-		return '([['..lpdbField..'::'.. table.concat(participants, ']] OR [['..lpdbField..'::') ..']])'
+		return '([[' .. lpdbField .. '::' ..
+			table.concat(participants, ']] OR [[' .. lpdbField .. '::')
+			.. ']])'
 	end
-	local teamConditions = '('.. formatParicipant('participant', queryTeams) ..' OR '.. formatParicipant('extradata_participantteam',  queryTeams) ..')'
+	local teamConditions = '(' .. formatParicipant('participant', queryTeams) .. ' OR '
+		.. formatParicipant('extradata_participantteam',  queryTeams) ..')'
 	return Earnings.calculate(teamConditions, args.year, args.mode, args.perYear, Earnings.divisionFactorTeam)
 end
 

--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -57,6 +57,7 @@ function Earnings.calculateForPlayer(args)
 	end
 
 	local playerConditions = '([[participant::' .. player .. ']] OR [[participant::' .. playerAsPageName .. ']]'
+		.. '[[participantlink::' .. player .. ']] OR [[participantlink::' .. playerAsPageName .. ']]'
 	for playerIndex = 1, playerPositionLimit do
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. player .. ']]'
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. playerAsPageName .. ']]'
@@ -93,7 +94,7 @@ function Earnings.calculateForTeam(args)
 			end
 		end
 	elseif not Logic.readBool(args.noRedirect) then
-		for index, team in pairs(queryTeams) do
+		for index, team in pairs(teams) do
 			queryTeams[index] = mw.ext.TeamLiquidIntegration.resolve_redirect(team)
 		end
 	else
@@ -106,7 +107,8 @@ function Earnings.calculateForTeam(args)
 			.. ']])'
 	end
 	local teamConditions = '(' .. formatParicipant('participant', queryTeams) .. ' OR '
-		.. formatParicipant('extradata_participantteam',  queryTeams) ..')'
+		.. formatParicipant('extradata_participantteam',  queryTeams) .. ' OR '
+		.. formatParicipant('participantlink',  queryTeams) ..')'
 	return Earnings.calculate(teamConditions, args.year, args.mode, args.perYear, Earnings.divisionFactorTeam)
 end
 

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -89,7 +89,11 @@ function Team:createInfobox()
 				Builder{
 					builder = function()
 						_defaultEarningsFunctionUsed = true
-						_totalEarnings, _earnings = Earnings.calculateForTeam({team = self.pagename or self.name, perYear = true})
+						_totalEarnings, _earnings = Earnings.calculateForTeam{
+							team = self.pagename or self.name,
+							perYear = true,
+							queryHistorical = args.queryEarningsHistorical
+						}
 						Variables.varDefine('earnings', _totalEarnings) -- needed for SMW
 						local totalEarnings
 						if _totalEarnings > 0 then


### PR DESCRIPTION
## Summary
* Allow historical earnings queries for teams via `module:Earnings`
* Allow query for several teams at the same time (combined values, not values per team)
* Support `participantlink`
* pass along param in infobox team

## How did you test this change?
/dev modules
tested on:
* valorant (want the historical query)
* sc2, rl, r6 as references that it doesn't break the current usages