### PR TITLE
Allow wiki categories without overwriting commons categories

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -434,7 +434,7 @@ function Person:getCategories(args, birthDisplay, personType, status)
 			table.insert(categories, 'Players with invalid team')
 		end
 
-		return categories
+		return self:getWikiCategories(categories)
 	end
 	return {}
 end

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -439,6 +439,11 @@ function Person:getCategories(args, birthDisplay, personType, status)
 	return {}
 end
 
+--- Allows for overriding this functionality
+function Person:getWikiCategories(categories)
+	return categories
+end
+
 function Person._createAgeCalculationErrorMessage(text)
 	-- Return formatted message text for an error.
 	local strongStart = '<strong class="error">Error: '


### PR DESCRIPTION
## Summary
Allow adding wiki-specific categories without overwriting the commons `getCategories` function that already sets several categories in person infoboxes

## How did you test this change?
/dev modules