### PR TITLE
Allow `participantlink` in player earnings query conditions

### DIFF
--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -55,6 +55,7 @@ function Earnings.calculateForPlayer(args)
 	end
 
 	local playerConditions = '([[participant::' .. player .. ']] OR [[participant::' .. playerAsPageName .. ']]'
+		.. ' OR [[participantlink::' .. player .. ']] OR [[participantlink::' .. playerAsPageName .. ']]'
 	for playerIndex = 1, playerPositionLimit do
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. player .. ']]'
 		playerConditions = playerConditions .. ' OR [[players_' .. prefix .. playerIndex .. '::' .. playerAsPageName .. ']]'


### PR DESCRIPTION
## Summary
Allow `participantlink` in player earnings query conditions

## How did you test this change?
from #1314