### PR TITLE
Add custom content cell to series

### DIFF
--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -114,7 +114,8 @@ function Series:createInfobox(frame)
 					}
 				end
 			end
-		}
+		},
+		Customizable{id = 'customcontent', children = {}},
 	}
 
 	if Namespace.isMain() then


### PR DESCRIPTION
## Summary

Allows for adding wiki specific content after the Links. VAL and CS has Chronology at this spot, which is the immediate use case. 

## How did you test this change?

Dev module
