### PR TITLE
Fix small sc/sc2 bug with literals in matches

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -619,7 +619,7 @@ function StarcraftMatchGroupInput.ProcessLiteralOpponentInput(opponent)
 	local flag = opponent.flag or ''
 
 	local players = {}
-	if String.isEmpty(race) or String.isEmpty(flag) then
+	if String.isNotEmpty(race) or String.isNotEmpty(flag) then
 		players[1] = {
 			displayname = opponent[1],
 			name = '',


### PR DESCRIPTION
## Summary
Fix a small bug where race/flag for literals was not shown if both were set

## How did you test this change?
first /dev, then live