### PR TITLE
Player handling use explicit information

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -562,12 +562,14 @@ function mapFunctions.getParticipantsData(map)
 				local assists = stats['assists']
 				local agent = stats['agent']
 				local averageCombatScore = stats['acs']
+				local playerName = stats['player']
 
 				participant.kills = Logic.isEmpty(kills) and participant.kills or kills
 				participant.deaths = Logic.isEmpty(deaths) and participant.deaths or deaths
 				participant.assists = Logic.isEmpty(assists) and participant.assists or assists
 				participant.agent = Logic.isEmpty(agent) and participant.agent or agent
 				participant.acs = Logic.isEmpty(averageCombatScore) and participant.averagecombatscore or averageCombatScore
+				participant.player = Logic.isEmpty(playerName) and participant.player or playerName
 
 				if not Table.isEmpty(participant) then
 					participants[o .. '_' .. player] = participant

--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -109,8 +109,7 @@ function p.storeGames(match, match2)
 				for player = 1, 5 do
 					local data = participants[team..'_'..player]
 					if data then
-						-- TODO: Needs fixing
-						-- game.extradata['t'..team..'p'..player] = match2.match2opponents[team].match2players[player].name
+						game.extradata['t'..team..'p'..player] = data.player or ''
 						if data.kills and data.deaths and data.assists then
 							game.extradata['t'..team..'kda'..player] = data.kills..'/'..data.deaths..'/'..data.assists
 						end


### PR DESCRIPTION
## Summary

Use the explicitly given info in the PlayerStats input. This is important due to substitutes. In the currently (commented) method, they can't be seen as the player who played a match. 

## How did you test this change?
Live