### PR TITLE
Fix team2 page resolve

### DIFF
--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -171,7 +171,7 @@ function CustomPlayer:adjustLPDB(lpdbData)
 	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {_args.country})
 
 	if String.isNotEmpty(_args.team2) then
-		lpdbData.extradata.team2 = Team.page(_args.team2)
+		lpdbData.extradata.team2 = mw.ext.TeamTemplate.raw(_args.team2).page
 	end
 
 	return lpdbData


### PR DESCRIPTION
## Summary

The resolve of the team2 was missing the first parameter (frame) in it's function call, which would throw a lua error.
Changed the resolve to use the raw functionality, to match what commons does with team1. 

## How did you test this change?

Live
