### PR TITLE
Adjust series default tier handling

### DIFF
--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -142,7 +142,6 @@ function Series:createInfobox(frame)
 			next = args.next,
 			next2 = args.next2,
 			prizepool = args.prizepool,
-			liquipediatier = args.liquipediatier,
 			liquipediatier = Tier.text.tiers
 				and Tier.text.tiers[string.lower(args.liquipediatier or '')]
 				or args.liquipediatiertype,

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -6,18 +6,24 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
-local Template = require('Module:Template')
-local Table = require('Module:Table')
-local Namespace = require('Module:Namespace')
-local Locale = require('Module:Locale')
-local ReferenceCleaner = require('Module:ReferenceCleaner')
-local Localisation = require('Module:Localisation')
-local Links = require('Module:Links')
-local String = require('Module:String')
-local Flags = require('Module:Flags')
-local WarningBox = require('Module:WarningBox')
 local BasicInfobox = require('Module:Infobox/Basic')
+local Class = require('Module:Class')
+local Flags = require('Module:Flags')
+local Links = require('Module:Links')
+local Locale = require('Module:Locale')
+local Localisation = require('Module:Localisation')
+local Namespace = require('Module:Namespace')
+local ReferenceCleaner = require('Module:ReferenceCleaner')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Template = require('Module:Template')
+local Tier = require('Module:Tier')
+local WarningBox = require('Module:WarningBox')
+
+local _TIER_MODE_TYPES = 'types'
+local _TIER_MODE_TIERS = 'tiers'
+local _INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
+	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -56,10 +62,9 @@ function Series:createInfobox(frame)
 			id = 'liquipediatier',
 			children = {
 				Cell{
-					name = 'Liquipedia Tier',
-					content = {
-						self:_createTier(args.liquipediatier, (args.liquipediatiertype or args.tiertype))
-					}
+					name = 'Liquipedia tier',
+					content = {self:createLiquipediaTierDisplay(args)},
+					classes = {self:liquipediaTierHighlighted(args) and 'valvepremier-highlighted' or ''},
 				},
 			}
 		},
@@ -138,6 +143,12 @@ function Series:createInfobox(frame)
 			next2 = args.next2,
 			prizepool = args.prizepool,
 			liquipediatier = args.liquipediatier,
+			liquipediatier = Tier.text.tiers
+				and Tier.text.tiers[string.lower(args.liquipediatier or '')]
+				or args.liquipediatiertype,
+			liquipediatiertype = Tier.text.types
+				and Tier.text.types[string.lower(args.liquipediatiertype or '')]
+				or args.liquipediatiertype,
 			publishertier = args.publishertier,
 			launcheddate = ReferenceCleaner.clean(args.launcheddate or args.sdate or args.inaugurated),
 			defunctdate = ReferenceCleaner.clean(args.defunctdate or args.edate),
@@ -184,30 +195,50 @@ function Series:addToLpdb(lpdbData)
 	return lpdbData
 end
 
-function Series:_createTier(tier, tierType)
-	if tier == nil or tier == '' then
-		return ''
+function Series:createLiquipediaTierDisplay(args)
+	local tier = args.liquipediatier
+	local tierType = args.liquipediatiertype
+	if String.isEmpty(tier) then
+		return nil
 	end
 
-	local output = ''
-
-	local hasTierType = tierType ~= nil and tierType ~= ''
-
-	if hasTierType then
-		local tierTypeDisplay = Template.safeExpand(self.infobox.frame, 'TierDisplay/' .. tierType)
-		output = output .. '[[' .. tierTypeDisplay .. '_Tournaments|' .. tierTypeDisplay .. ']]'
-		output = output .. '&nbsp;('
-
+	local function buildTierString(tierString, tierMode)
+		local tierText
+		if not Tier.text[tierMode] then -- allow legacy tier modules
+			tierText = Tier.text[tierString]
+		else -- default case, i.e. tier module with intended format
+			tierText = Tier.text[tierMode][tierString:lower()]
+		end
+		if not tierText then
+			tierMode = tierMode == _TIER_MODE_TYPES and 'Tiertype' or 'Tier'
+			table.insert(
+				self.warnings,
+				String.interpolate(_INVALID_TIER_WARNING, {tierString = tierString, tierMode = tierMode})
+			)
+			return ''
+		else
+			self.infobox:categories(tierText .. ' Tournaments')
+			return '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
+		end
 	end
 
-	local tierDisplay = Template.safeExpand(self.infobox.frame, 'TierDisplay/' .. tier)
-	output = output .. '[[' .. tierDisplay .. '_Tournaments|' .. tierDisplay .. ']]'
+	local tierDisplay = buildTierString(tier, _TIER_MODE_TIERS)
 
-	if hasTierType then
-		output = output .. ')'
+	if String.isNotEmpty(tierType) then
+		tierDisplay = buildTierString(tierType, _TIER_MODE_TYPES) .. '&nbsp;(' .. tierDisplay .. ')'
 	end
 
-	return output
+	return tierDisplay .. self.appendLiquipediatierDisplay(args)
+end
+
+--- Allows for overriding this functionality
+function Series:liquipediaTierHighlighted(args)
+	return false
+end
+
+--- Allows for overriding this functionality
+function Series:appendLiquipediatierDisplay()
+	return ''
 end
 
 function Series:_getIconFromLeagueIconSmall(frame, lpdbData)

--- a/components/infobox/wikis/starcraft2/infobox_series_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_series_custom.lua
@@ -44,9 +44,12 @@ local _series
 
 function CustomSeries.run(frame)
 	local series = Series(frame)
-	series.createWidgetInjector = CustomSeries.createWidgetInjector
 	_args = series.args
 	_series = series
+
+	_args.liquipediatiertype = _args.liquipediatiertype or _args.tiertype
+
+	series.createWidgetInjector = CustomSeries.createWidgetInjector
 
 	return series:createInfobox(frame)
 end
@@ -88,24 +91,6 @@ function CustomInjector:addCustomCells(widgets)
 	}))
 
 	CustomSeries._addCustomVariables()
-
-	return widgets
-end
-
-function CustomInjector:parse(id, widgets)
-	if id == 'liquipediatier' then
-		return {
-			Cell{
-				name = 'Liquipedia tier',
-				content = {
-					CustomSeries._createLiquipediaTierDisplay(
-						_args.liquipediatier,
-						_args.liquipediatiertype or _args.tiertype
-					)
-				}
-			}
-		}
-	end
 
 	return widgets
 end
@@ -190,8 +175,8 @@ function CustomSeries._addCustomVariables()
 		local name = _args.name or mw.title.getCurrentTitle().text
 		Variables.varDefine('featured', _args.featured or '')
 		Variables.varDefine('headtohead', _args.headtohead or '')
-		Variables.varDefine('tournament_tier', _args.liquipediatier or '')
-		Variables.varDefine('tournament_tiertype', _args.liquipediatiertype or _args.tiertype or '')
+		Variables.varDefine('tournament_liquipediatier', _args.liquipediatier or '')
+		Variables.varDefine('tournament_liquipediatiertype', _args.liquipediatiertype or '')
 		Variables.varDefine('tournament_mode', _args.mode or '1v1')
 		Variables.varDefine('tournament_ticker_name', _args.tickername or name)
 		Variables.varDefine('tournament_shortname', _args.shortname or '')
@@ -234,7 +219,9 @@ function CustomSeries._validDateOr(...)
 end
 
 --function for custom tier handling
-function CustomSeries._createLiquipediaTierDisplay(tier, tierType)
+function CustomSeries.createLiquipediaTierDisplay()
+	local tier = _args.liquipediatier
+	local tierType = _args.liquipediatiertype
 	if String.isEmpty(tier) then
 		return nil
 	end


### PR DESCRIPTION
## Summary
Adjust series default tier handling
* allow overwriting of the function directly
* use tier module instead of expanding templates
* allow non cased entries
* add warnings for invalid tiers/tiertypes
* store liquipediatiertype (was apparently forgotten before)

tldr: use what we have for the league infobox already

## How did you test this change?
/dev module + /Custom/dev module on sc2 and rl

## ToDo
- [x] add sc2 /Customs changes
- [x] adjust #1292