### PR TITLE
Add minified display to display a minified version of the table

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -50,10 +50,14 @@ function AutomaticPointsTable.run(frame)
 
 	-- A display module is a module that takes in 3 arguments and returns some html,
 	-- which will be displayed when this module is invoked
-	local displayModules = {TableDisplay, MinifiedDisplay}
-	local displayModuleIndex = pointsTable.parsedInput.shouldTableBeMinified and 2 or 1
-	local UsedDisplayModule = displayModules[displayModuleIndex]
-	local divTable = UsedDisplayModule(
+	local usedDisplayModule
+	if pointsTable.parsedInput.shouldTableBeMinified then
+		usedDisplayModule = MinifiedDisplay
+	else
+		usedDisplayModule = TableDisplay
+	end
+	local divTable = usedDisplayModule(
+
 		sortedDataWithPositions,
 		tournamentsWithResults,
 		positionBackgrounds

--- a/components/automatic-points-table/commons/minified-display.lua
+++ b/components/automatic-points-table/commons/minified-display.lua
@@ -169,7 +169,6 @@ function TableHeaderRow:headerCell(header)
 
 	local additionalClass = header.additionalClass
 	if additionalClass then
-
 		outerDiv:addClass(additionalClass)
 	end
 	outerDiv:node(innerDiv)


### PR DESCRIPTION
Add minified display to display a minified version of the table with 3 columns only.

## Summary

When displaying tables for multiple regions, it becomes very overwhelming to look at all the data, so it'd be more suitable to look at the total points for every team in every region.

## How did you test this change?

The minified version compared to the normal version can be seen below one another [in this page](https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/8)
Here's an image of the minified table:
![image](https://user-images.githubusercontent.com/28851891/171401490-352fb0c4-5056-4228-85fd-682604dc6ff4.png)
