### PR TITLE
Fix lack of instance initialization in MatchSummary

### DIFF
--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -246,7 +246,7 @@ function CustomMatchSummary.getByMatchId(args)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
 	local frame = mw.getCurrentFrame()
 
-	local matchSummary = MatchSummary:init('480px')
+	local matchSummary = MatchSummary():init('480px')
 	matchSummary:header(CustomMatchSummary._createHeader(frame, match))
 				:body(CustomMatchSummary._createBody(frame, match))
 


### PR DESCRIPTION
## Summary

Valorant wiki for some reason isn't creating a new instance of the MatchSummary(Base). This effectively means they're reusing the same object for every match. That has weird knock-on effects, such as sub-elements from previous matches showing up on successive matches.

## How did you test this change?

Live