### PR TITLE
Add MVP support for Valorant

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -342,9 +342,29 @@ function matchFunctions.getExtraData(match)
 	match.extradata = {
 		matchsection = Variables.varDefault('matchsection'),
 		mapveto = matchFunctions.getMapVeto(match),
+		mvp = matchFunctions.getMVP(match),
 		comment = match.comment,
 	}
 	return match
+end
+
+-- Parse MVP input
+function matchFunctions.getMVP(match)
+	if String.isEmpty(match.mvp) then
+		return nil
+	end
+
+	local mvppoints = tonumber(match.mvppoints) or 1
+
+	-- Split the input
+	local players = mw.text.split(match.mvp, ',')
+
+	-- Trim the input
+	for index,player in pairs(players) do
+		players[index] = mw.text.trim(player)
+	end
+
+	return {players=players, points=mvppoints}
 end
 
 -- Parse the mapVeto input

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -354,7 +354,7 @@ function matchFunctions.getMVP(match)
 		return nil
 	end
 
-	local mvppoints = tonumber(match.mvppoints) or 1
+	local mvpPoints = tonumber(match.mvppoints) or 1
 
 	-- Split the input
 	local players = mw.text.split(match.mvp, ',')
@@ -364,7 +364,7 @@ function matchFunctions.getMVP(match)
 		players[index] = mw.text.trim(player)
 	end
 
-	return {players=players, points=mvppoints}
+	return {players = players, points = mvpPoints}
 end
 
 -- Parse the mapVeto input

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -317,6 +317,22 @@ function CustomMatchSummary._createBody(frame, match)
 		end
 	end
 
+	-- Add Match MVP(s)
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
+			local mvp = MatchSummary.Mvp()
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
+			end
+			mvp:setPoints(mvpData.points)
+
+			body:addRow(mvp)
+		end
+
+	end
+
+	-- Add Map Veto
 	if match.extradata.mapveto then
 		local vetoData = match.extradata.mapveto
 		if vetoData then


### PR DESCRIPTION
## Summary

Add MVP Support for Valorant. Based on R6. 
Valorant do not store anything in match1 into LPDB or SMW, so not adding any match1 or SMW compatibility.

## How did you test this change?

Dev module with preview
![image](https://user-images.githubusercontent.com/3426850/171628531-4f3325b6-a5ab-407d-b6df-48ce83f6c2d0.png)
