### PR TITLE
Add limit argument to limit the number of teams displayed in the table

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -45,8 +45,8 @@ function AutomaticPointsTable.run(frame)
 	local pointsData = pointsTable:getPointsData(teamsWithResults, tournamentsWithResults)
 	local sortedData = pointsTable:sortData(pointsData)
 	local sortedDataWithPositions = pointsTable:addPositionData(sortedData)
-
 	local positionBackgrounds = pointsTable.parsedInput.positionBackgrounds
+	local limit = pointsTable.parsedInput.limit
 
 	-- A display module is a module that takes in 3 arguments and returns some html,
 	-- which will be displayed when this module is invoked
@@ -56,12 +56,14 @@ function AutomaticPointsTable.run(frame)
 	else
 		usedDisplayModule = TableDisplay
 	end
-	local divTable = usedDisplayModule(
 
+	local divTable = usedDisplayModule(
 		sortedDataWithPositions,
 		tournamentsWithResults,
-		positionBackgrounds
+		positionBackgrounds,
+		limit
 	)
+
 	return divTable:create()
 end
 
@@ -70,11 +72,19 @@ function AutomaticPointsTable:parseInput(args)
 	local tournaments = self:parseTournaments(args)
 	local teams = self:parseTeams(args, #tournaments)
 	local minified = Logic.readBool(args.minified)
+	local limit
+	if args.limit then
+		limit = tonumber(args.limit)
+	else
+		limit = #teams
+	end
+
 	return {
 		positionBackgrounds = positionBackgrounds,
 		tournaments = tournaments,
 		teams = teams,
-		shouldTableBeMinified = minified
+		shouldTableBeMinified = minified,
+		limit = limit
 	}
 end
 
@@ -314,8 +324,8 @@ function AutomaticPointsTable:addPositionData(pointsData)
 			dataPoint.position = teamPosition
 			previousTotalPoints = dataPoint.totalPoints
 			previousTiebreakerPoints = dataPoint.tiebreakerPoints
-			return index, dataPoint
 
+			return index, dataPoint
 		end
 	)
 end

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -72,13 +72,7 @@ function AutomaticPointsTable:parseInput(args)
 	local tournaments = self:parseTournaments(args)
 	local teams = self:parseTeams(args, #tournaments)
 	local minified = Logic.readBool(args.minified)
-	local limit
-	if args.limit then
-		limit = tonumber(args.limit)
-	else
-		limit = #teams
-	end
-
+	local limit = tonumber(args.limit) or #teams
 	return {
 		positionBackgrounds = positionBackgrounds,
 		tournaments = tournaments,

--- a/components/automatic-points-table/commons/display.lua
+++ b/components/automatic-points-table/commons/display.lua
@@ -79,7 +79,6 @@ function PointsDivTable:create()
 	self:row(headerRow)
 
 	local limit = self.limit
-	local pointsData = {}
 	Table.iter.forEachIndexed(self.pointsData, function(index, teamPointsData)
 		if index > limit then return end
 		local positionBackground = self.positionBackgrounds[index]

--- a/components/automatic-points-table/commons/display.lua
+++ b/components/automatic-points-table/commons/display.lua
@@ -19,7 +19,7 @@ local _POINTS_TYPE = {
 }
 
 local PointsDivTable = Class.new(
-	function(self, pointsData, tournaments, positionBackgrounds)
+	function(self, pointsData, tournaments, positionBackgrounds, limit)
 		self.root = mw.html.create('div') :addClass('divTable')
 			:addClass('border-color-grey') :addClass('border-bottom')
 
@@ -40,6 +40,7 @@ local PointsDivTable = Class.new(
 		self.pointsData = pointsData
 		self.tournaments = tournaments
 		self.positionBackgrounds = positionBackgrounds
+		self.limit = limit
 	end
 )
 
@@ -77,7 +78,10 @@ function PointsDivTable:create()
 	local headerRow = TableHeaderRow(self.tournaments)
 	self:row(headerRow)
 
+	local limit = self.limit
+	local pointsData = {}
 	Table.iter.forEachIndexed(self.pointsData, function(index, teamPointsData)
+		if index > limit then return end
 		local positionBackground = self.positionBackgrounds[index]
 		self:row(TableRow(teamPointsData, self.tournaments, positionBackground))
 	end)

--- a/components/automatic-points-table/commons/minified-display.lua
+++ b/components/automatic-points-table/commons/minified-display.lua
@@ -10,23 +10,24 @@ local Class = require('Module:Class')
 local Table = require('Module:Table')
 
 local PointsDivTable = Class.new(
-	function(self, pointsData, tournaments, positionBackgrounds)
+	function(self, pointsData, tournaments, positionBackgrounds, limit)
 		self.root = mw.html.create('div') :addClass('divTable')
 			:addClass('border-color-grey') :addClass('border-bottom')
 
 		local innerWrapper = mw.html.create('div') :addClass('fixed-size-table-container')
 			:addClass('border-color-grey')
-			:css('width', '283px')
+			:css('width', '310px')
 			:node(self.root)
 
 		self.wrapper = mw.html.create('div') :addClass('table-responsive')
-			:addClass('automatic-points-table')
+			:addClass('automatic-points-table') :addClass('minified')
 			:node(innerWrapper)
 
 		self.rows = {}
 		self.pointsData = pointsData
 		self.tournaments = tournaments
 		self.positionBackgrounds = positionBackgrounds
+		self.limit = limit
 	end
 )
 
@@ -64,7 +65,10 @@ function PointsDivTable:create()
 	local headerRow = TableHeaderRow(self.tournaments)
 	self:row(headerRow)
 
+	local limit = self.limit
+	local pointsData = {}
 	Table.iter.forEachIndexed(self.pointsData, function(index, teamPointsData)
+		if index > limit then return end
 		local positionBackground = self.positionBackgrounds[index]
 		self:row(TableRow(teamPointsData, self.tournaments, positionBackground))
 	end)
@@ -150,6 +154,7 @@ function TableHeaderRow:create()
 		additionalClass = 'team'
 	}, {
 		text = 'Points',
+		additionalClass = 'total'
 	}}
 	Table.iter.forEach(headers, function(h) self:headerCell(h) end)
 

--- a/components/automatic-points-table/commons/minified-display.lua
+++ b/components/automatic-points-table/commons/minified-display.lua
@@ -66,7 +66,6 @@ function PointsDivTable:create()
 	self:row(headerRow)
 
 	local limit = self.limit
-	local pointsData = {}
 	Table.iter.forEachIndexed(self.pointsData, function(index, teamPointsData)
 		if index > limit then return end
 		local positionBackground = self.positionBackgrounds[index]


### PR DESCRIPTION
## Summary

This change is made to add a limit arg to the module to limit the number of teams displayed by the table.

## How did you test this change?

Deployed in Sandbox [here](https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/9)
Example images:
- Normal table limited to 8 teams
![image](https://user-images.githubusercontent.com/28851891/172279552-f31cfff7-3447-4747-9415-3d2fcfadbec4.png)
- Minified table limited to 4 teams
![image](https://user-images.githubusercontent.com/28851891/172279610-85f0190c-181a-4f18-83ea-49e092294689.png)
