### PR TITLE
Improve CSS on Valorant MatchSummary

### DIFF
--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -70,7 +70,7 @@ end
 local Score = Class.new(
 	function(self)
 		self.root = mw.html.create('div')
-		self.table = self.root:tag('table'):css('line-height', '20px')
+		self.table = self.root:tag('table'):css('line-height', '20px'):css('text-align', 'center')
 		self.top = mw.html.create('tr')
 		self.bottom = mw.html.create('tr')
 	end
@@ -78,14 +78,14 @@ local Score = Class.new(
 
 function Score:setLeft()
 	self.root   :css('float', 'left')
-				:css('margin-left', '5px')
+				:css('margin-left', '4px')
 
 	return self
 end
 
 function Score:setRight()
 	self.root   :css('float', 'right')
-				:css('margin-right', '5px')
+				:css('margin-right', '4px')
 
 	return self
 end
@@ -94,7 +94,7 @@ function Score:setMapScore(score)
 	local mapScore = mw.html.create('td')
 	mapScore:attr('rowspan', '2')
 			:css('font-size', '16px')
-			:css('width', '25px')
+			:css('width', '24px')
 			:wikitext(score or '')
 	self.top:node(mapScore)
 
@@ -105,7 +105,7 @@ function Score:addTopRoundScore(side, score)
 	local roundScore = mw.html.create('td')
 	roundScore  :addClass('bracket-popup-body-match-sidewins')
 				:css('color', self:_getSideColor(side))
-				:css('width', '7px')
+				:css('width', '12px')
 				:wikitext(score)
 	self.top:node(roundScore)
 	return self
@@ -115,7 +115,7 @@ function Score:addBottomRoundScore(side, score)
 	local roundScore = mw.html.create('td')
 	roundScore  :addClass('bracket-popup-body-match-sidewins')
 				:css('color', self:_getSideColor(side))
-				:css('width', '7px')
+				:css('width', '12px')
 				:wikitext(score)
 	self.bottom:node(roundScore)
 	return self


### PR DESCRIPTION
## Summary

* Change everything to use a mod 4 numbers
* Increased the width of side scores to account for 2 digit numbers
* Align scores to center in order to match match1

Before:
![image](https://user-images.githubusercontent.com/3426850/172362486-df0627b6-97d1-4576-84c5-e0612bf4131e.png)

After:
![unknown](https://user-images.githubusercontent.com/3426850/172362513-42c9c32b-200f-47c6-af4a-acdd7cfc3e83.png)


## How did you test this change?

Dev Module & preview
UAT by editors