### PR TITLE
Remove `File:` prefix on LPDB Team image field

### DIFF
--- a/components/infobox/wikis/halo/infobox_team_custom.lua
+++ b/components/infobox/wikis/halo/infobox_team_custom.lua
@@ -48,9 +48,9 @@ end
 
 function CustomTeam:addToLpdb(lpdbData, args)
 	if not String.isEmpty(args.teamcardimage) then
-		lpdbData.logo = 'File:' .. args.teamcardimage
+		lpdbData.logo = args.teamcardimage
 	elseif not String.isEmpty(args.image) then
-		lpdbData.logo = 'File:' .. args.image
+		lpdbData.logo = args.image
 	end
 
 	lpdbData.region = _region

--- a/components/infobox/wikis/rainbowsix/infobox_team_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_team_custom.lua
@@ -35,9 +35,9 @@ end
 
 function CustomTeam:addToLpdb(lpdbData, args)
 	if not String.isEmpty(args.teamcardimage) then
-		lpdbData.logo = 'File:' .. args.teamcardimage
+		lpdbData.logo = args.teamcardimage
 	elseif not String.isEmpty(args.image) then
-		lpdbData.logo = 'File:' .. args.image
+		lpdbData.logo = args.image
 	end
 
 	lpdbData.region = Variables.varDefault('region', '')

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -62,9 +62,9 @@ end
 
 function CustomTeam:addToLpdb(lpdbData, args)
 	if not String.isEmpty(args.teamcardimage) then
-		lpdbData.logo = 'File:' .. args.teamcardimage
+		lpdbData.logo = args.teamcardimage
 	elseif not String.isEmpty(args.image) then
-		lpdbData.logo = 'File:' .. args.image
+		lpdbData.logo = args.image
 	end
 
 	lpdbData.extradata.rating = Variables.varDefault('rating')

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -58,9 +58,9 @@ end
 
 function CustomTeam:addToLpdb(lpdbData, args)
 	if not String.isEmpty(args.teamcardimage) then
-		lpdbData.logo = 'File:' .. args.teamcardimage
+		lpdbData.logo = args.teamcardimage
 	elseif not String.isEmpty(args.image) then
-		lpdbData.logo = 'File:' .. args.image
+		lpdbData.logo = args.image
 	end
 
 	lpdbData.region = Variables.varDefault('region', '')


### PR DESCRIPTION
## Summary

Remove the `File:` prefix on logo storage in lpdb_team on Halo, R6, Rl and Valorant.

`File:` prefix breaks the LPDB guidelines. 
Surrounding Template and Modules have been updated to support this change. 

## How did you test this change?

Tested on R6