### PR TITLE
Switch MatchTicker module in 2 sc2 infoboxes

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -18,7 +18,7 @@ local Class = require('Module:Class')
 local CleanRace = require('Module:CleanRace')
 local Json = require('Module:Json')
 local Lpdb = require('Module:Lpdb')
-local Matches = require('Module:Upcoming ongoing and recent matches player/new')
+local MatchTicker = require('Module:MatchTicker/Participant')
 local Math = require('Module:Math')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -186,9 +186,7 @@ end
 
 function CustomPlayer:createBottomContent(infobox)
 	if _shouldQueryData then
-		return tostring(Matches._get_ongoing({})) ..
-			tostring(Matches._get_upcoming({})) ..
-			tostring(Matches._get_recent({}))
+		return MatchTicker.run({player = _PAGENAME})
 	end
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lpdb = require('Module:Lpdb')
-local Matches = require('Module:Upcoming ongoing and recent matches team/new')
+local MatchTicker = require('Module:MatchTicker/Participant')
 local Math = require('Module:Math')
 local Namespace = require('Module:Namespace')
 local RaceIcon = require('Module:RaceIcon')
@@ -127,9 +127,7 @@ end
 
 function CustomTeam:createBottomContent()
 	if _doStore then
-		return tostring(Matches._get_ongoing()) ..
-			tostring(Matches._get_upcoming()) ..
-			tostring(Matches._get_recent())
+		return MatchTicker.run({team = _team.pagename})
 	end
 end
 


### PR DESCRIPTION
## Summary
Switch MatchTicker module in 2 sc2 infoboxes player/commentator and team
The old match ticker has several issues that the new one fixes.

## How did you test this change?
tested some months ago + again today