### PR TITLE
Add 2 functions to `Module:MatchGroup/Coordinates`

### DIFF
--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -291,6 +291,9 @@ end
 
 --[[
 Compute the number of opponents from each round onward in a bracket.
+Computes an array, where each key is round (column) of the bracket,
+and the value is the number of opponents who are either in the
+current round (column) or are seeded into a later round (column).
 ]]
 function MatchGroupCoordinates.computeBracketOpponentCounts(bracket)
 	local countsByRound = MatchGroupCoordinates.computeRawCounts(bracket)
@@ -310,7 +313,7 @@ end
 --[[
 Computes the number of opponents from each round onward for each section in a
 bracket. Lower bracket counts may be negative. This indicates either that an
-opponent from the upper bracket dropped down to a earlier round, or that some
+opponent from the upper bracket dropped down to an earlier round, or that some
 opponents leave the tournament directly from the upper bracket.
 
 The third place match is not counted.

--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -289,4 +289,69 @@ function MatchGroupCoordinates.groupMatchIdsByField(bracket, fieldName)
 	return byField
 end
 
+--[[
+Compute the number of opponents from each round onward in a bracket.
+]]
+function MatchGroupCoordinates.computeBracketOpponentCounts(bracket)
+	local countsByRound = MatchGroupCoordinates.computeRawCounts(bracket)
+
+	-- Only include positive counts
+	return Array.map(countsByRound, function(countsInRound)
+		local sum = 0
+		for _, count in ipairs(countsInRound) do
+			if count >= 0 then
+				sum = sum + count
+			end
+		end
+		return sum
+	end)
+end
+
+--[[
+Computes the number of opponents from each round onward for each section in a
+bracket. Lower bracket counts may be negative. This indicates either that an
+opponent from the upper bracket dropped down to a earlier round, or that some
+opponents leave the tournament directly from the upper bracket.
+
+The third place match is not counted.
+]]
+function MatchGroupCoordinates.computeRawCounts(bracket)
+	if #bracket.sections > 2 then
+		-- Triple elimination brackets are not supported
+		return {}
+	end
+
+	local reverseRounds = Array.reverse(bracket.rounds)
+
+	local countsBySection = Array.map(Array.range(1, #bracket.sections), function(sectionIx) return 0 end)
+	local countsByReverseRound = {}
+	for _, round in ipairs(reverseRounds) do
+		for _, matchId in ipairs(round) do
+			local coordinates = bracket.coordinatesByMatchId[matchId]
+			local bracketData = bracket.bracketDatasById[matchId]
+
+			local sectionIndex = coordinates.sectionIndex
+			local count = 1
+			if not bracketData.upperMatchId then
+				count = count + 1
+				if String.endsWith(matchId, 'RxMTP') then
+					count = 0
+				end
+			elseif coordinates.semanticDepth == 1 then
+				-- UB or LB final into grand final
+				count = sectionIndex == 1 and 0 or 2
+			end
+			countsBySection[sectionIndex] = countsBySection[sectionIndex] + count
+
+			-- Loser of match drops down
+			if sectionIndex + 1 <= #bracket.sections and coordinates.semanticDepth ~= 0 then
+				countsBySection[sectionIndex + 1] = countsBySection[sectionIndex + 1] - 1
+			end
+		end
+		table.insert(countsByReverseRound, Table.copy(countsBySection))
+	end
+
+	return Array.reverse(countsByReverseRound)
+end
+
 return MatchGroupCoordinates


### PR DESCRIPTION
## Summary
Add
* `MatchGroupCoordinates.computeBracketOpponentCounts`
* * Computes the number of opponents from each round onward in a bracket.
* MatchGroupCoordinates.computeRawCounts
* * Computes the number of opponents from each round onward for each section in a bracket.

will be needed for prize pool automation

## How did you test this change?
basically live since months via dhe's `Module:MatchGroup/Coordinates/Ext` which only holds those 2 functions