### PR TITLE
Add Server display (& storage) support for sc/sc2 maps inside matches

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -767,8 +767,9 @@ function StarcraftMatchGroupInput._mapInput(match, mapIndex, subGroupIndex)
 	map.extradata = {
 		comment = map.comment or '',
 		header = map.header or '',
+		isSubMatch = 'false',
 		noQuery = match.noQuery,
-		isSubMatch = 'false'
+		server = map.server,
 	}
 
 	-- inherit stuff from match data


### PR DESCRIPTION
## Summary
Add Server display (& storage) support for sc/sc2 maps inside matches
* read from the input inside the map template and stored into the game/map extradata
* in matchsummary handled similarly to map comments

## How did you test this change?
/dev

not yet decided if wanted or not, but it works and is a pretty easy and straight forward change^^

![Screenshot 2022-06-12 18 33 54](https://user-images.githubusercontent.com/75081997/173243616-e8497724-9363-4624-bb11-37a6876ad0f1.png)

