### PR TITLE
Add `fromLpdbStruct` and `toLpdbStruct` in `Module:Opponent`

### DIFF
--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -355,7 +355,7 @@ function Opponent.toLpdbStruct(opponent, resolveTeamToPageName)
 
 	if opponent.type == Opponent.team then
 		if resolveTeamToPageName then
-			storageStruct.opponentname = Opponent.teamTemplateResolveRedirect(template)
+			storageStruct.opponentname = Opponent.teamTemplateResolveRedirect(opponent.template)
 		end
 	elseif Opponent.typeIsParty(opponent.type) then
 		local players = {}
@@ -381,7 +381,7 @@ function Opponent.teamTemplateResolveRedirect(template)
 	end
 
 	if mw.ext.TeamTemplate.teamexists(template) then
-		local page = mw.ext.TeamTemplate.raw(pageName).page
+		local page = mw.ext.TeamTemplate.raw(template).page
 		return mw.ext.TeamLiquidIntegration.resolve_redirect(page)
 	end
 

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -344,7 +344,7 @@ function Opponent.fromMatch2Record(record)
 end
 
 --[[
-Reads an opponent struct and builds a storage struct for standing/prizePool from it
+Reads an opponent struct and builds a standings/placement lpdb struct from it
 ]]
 function Opponent.toLpdbStruct(opponent)
 	-- this already handles literal and team opponents

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -347,8 +347,6 @@ end
 Reads an opponent struct and builds a standings/placement lpdb struct from it
 ]]
 function Opponent.toLpdbStruct(opponent)
-	-- this already handles literal and team opponents
-	-- for team opponents the players will get added via TeamCards
 	local storageStruct = {
 		opponentname = Opponent.toName(opponent),
 		opponenttemplate = opponent.template,

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -371,7 +371,7 @@ function Opponent.toLpdbStruct(opponent)
 end
 
 --[[
-Reads a standing/prizePool storage struct and builds an opponent struct from it
+Reads a standings or placement lpdb structure and builds an opponent struct from it
 ]]
 function Opponent.fromLpdbStruct(storageStruct)
 	local partySize = Opponent.partySize(storageStruct.opponenttype)

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -358,11 +358,13 @@ function Opponent.toLpdbStruct(opponent)
 	if Opponent.typeIsParty(opponent.type) then
 		local players = {}
 		for playerIndex, player in ipairs(opponent.players) do
-			players['p' .. playerIndex .. 'dn'] = player.displayName
-			players['p' .. playerIndex .. 'flag'] = player.flag
-			players['p' .. playerIndex] = player.pageName
-			players['p' .. playerIndex .. 'team'] = Opponent.toName({type = Opponent.team, template = player.team})
-			players['p' .. playerIndex .. 'template'] = player.team
+			local prefix = 'p' .. playerIndex
+
+			players[prefix] = player.pageName
+			players[prefix .. 'dn'] = player.displayName
+			players[prefix .. 'flag'] = player.flag
+			players[prefix .. 'team'] = Opponent.toName({type = Opponent.team, template = player.team})
+			players[prefix .. 'template'] = player.team
 		end
 		storageStruct.opponentplayers = players
 	end

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -353,7 +353,8 @@ function Opponent.toLpdbStruct(opponent)
 		opponenttype = opponent.type,
 	}
 
-	-- add players for party types
+	-- Add players for Party Type opponents.
+	-- Team's will have their players added via the TeamCard.
 	if Opponent.typeIsParty(opponent.type) then
 		local players = {}
 		for playerIndex, player in ipairs(opponent.players) do

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -347,6 +347,8 @@ end
 Reads an opponent struct and builds a storage struct for standing/prizePool from it
 ]]
 function Opponent.toLpdbStruct(opponent, resolveTeamToPageName)
+	-- this already handles literal and team opponents
+	-- (modulo resolveTeamToPageName if needed)
 	local storageStruct = {
 		opponentname = opponent.name,
 		opponenttemplate = opponent.template,
@@ -413,7 +415,7 @@ function Opponent.fromLpdbStruct(storageStruct)
 			type = storageStruct.type,
 		}
 		return opponent
-	else
+	else -- literal and team opponents can be handled the same way
 		return {
 			name = storageStruct.opponentname,
 			template = storageStruct.opponenttemplate,

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -375,6 +375,11 @@ function Opponent.toLpdbStruct(opponent, resolveTeamToPageName)
 	return storageStruct
 end
 
+-- function to resolve teamTemplate to pagename and resolve redirect on it
+-- needed for wikis that store redirected
+-- also works as a workaround if there are still duplicate teamTemplates on a wiki
+-- or if the teamplate name does not fit the pagename while the pagename is already another teamTemplate
+-- (which btw. can not be fixed in several cases due to the lock due to std logos)
 function Opponent.teamTemplateResolveRedirect(template)
 	if String.isEmpy(template) then
 		return nil


### PR DESCRIPTION
## Summary
Add `fromLpdbStruct` and `toLpdbStruct` in `Module:Opponent` for conversion between opponent structs and lpsb storage structs for prizePool/standingEntry

## How did you test this change?
/dev module
only simulated tests with made up data porting from one format to the other and back
can not really be tested as standings first would need switching to new system or lpdb_placement getting adjusted

works as intended from what i can see in the tests

with the plans for lpdb keys matching in standing entries and placements we can also import from standings to prize pools easier