### PR TITLE
Add to and from LpdbStruct sc/sc2 specifics

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -73,4 +73,35 @@ function StarcraftOpponent.fromMatch2Record(record)
 	return opponent
 end
 
+function StarcraftOpponent.toLpdbStruct(opponent)
+	local storageStruct = Opponent.toLpdbStruct(opponent, true)
+
+	if Opponent.typeIsParty(opponent.type) then
+		if opponent.isArchon then
+			storageStruct.players.isArchon = true
+			storageStruct.players.faction = opponent.players[1].race
+		else
+			for playerIndex, player in pairs(opponent.players) do
+				storageStruct.players['p' .. playerIndex .. 'faction'] = player.race
+			end
+		end
+	end
+
+	return storageStruct
+end
+
+function StarcraftOpponent.fromLpdbStruct(storageStruct)
+	local opponent = Opponent.fromLpdbStruct(storageStruct)
+
+	if Opponent.partySize(storageStruct.opponenttype) then
+		opponent.isArchon = storageStruct.players.isArchon
+		for playerIndex, player in pairs(opponent.players) do
+			player.race = storageStruct['p' .. playerIndex .. 'faction']
+				or storageStruct.faction
+		end
+	end
+
+	return opponent
+end
+
 return StarcraftOpponent


### PR DESCRIPTION
## Summary
Add to and from LpdbStruct sc/sc2 specifics (race/faction and archon stuff)
stacked on #1387
also needs #1388 

## How did you test this change?
/dev module
only simulated tests with made up data porting from one format to the other and back
can not really be tested as standings first would need switching to new system or lpdb_placement getting adjusted

works as intended from what i can see in the tests

with the plans for lpdb keys matching in standing entries and placements we can also import from standings to prize pools easier