### PR TITLE
Add lpdb store and resolve team name redirects

### DIFF
--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -196,9 +196,12 @@ function AutomaticPointsTable:generateReverseAliases(teams, tournaments)
 		reverseAliases[tournamentIndex] = {}
 		Table.iter.forEachIndexed(teams,
 			function(index, team)
-				local alias = mw.getContentLanguage():ucfirst(
-					mw.ext.TeamLiquidIntegration.resolve_redirect(team.aliases[tournamentIndex])
-				)
+				local alias
+				if Custom.resolveTeamNames then
+					alias = Custom.resolveTeamNames(team.aliases[tournamentIndex])
+				else
+					alias = team.aliases[tournamentIndex]
+				end
 				reverseAliases[tournamentIndex][alias] = index
 			end
 		)

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -70,6 +70,7 @@ function AutomaticPointsTable.run(frame)
 end
 
 function AutomaticPointsTable:storeLPDB(pointsData)
+	local date = os.date()
 	Table.iter.forEachIndexed(pointsData, function(index, teamPointsData)
 		local team = teamPointsData.team
 		local teamName = string.lower(team.aliases[#team.aliases])
@@ -78,10 +79,10 @@ function AutomaticPointsTable:storeLPDB(pointsData)
 		local position = teamPointsData.position
 		local totalPoints = teamPointsData.totalPoints
 		local objectData = {
-			type = lpdbName,
+			type = 'automatic points',
 			name = teamName,
 			information = position,
-			date = os.date(),
+			date = date,
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json({
 				position = position,
 				totalPoints = totalPoints

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -190,7 +190,7 @@ function AutomaticPointsTable:parseManualPoints(team, tournamentCount)
 	return manualPoints
 end
 
-function AutomaticPointsTable:generateReverseAliases(teams, tournaments, resolveRedirect)
+function AutomaticPointsTable:generateReverseAliases(teams, tournaments)
 	local reverseAliases = {}
 	local resolveRedirect = self.parsedInput.resolveRedirect
 	for tournamentIndex = 1, #tournaments do

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -9,6 +9,7 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Condition = require('Module:Condition')
+local Custom = require('Module:AutomaticPointsTable/Custom')
 local TableDisplay = require('Module:AutomaticPointsTable/Display')
 local MinifiedDisplay = require('Module:AutomaticPointsTable/MinifiedDisplay')
 local Json = require('Module:Json')

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -79,7 +79,8 @@ function AutomaticPointsTable:storeLPDB(pointsData)
 		local position = teamPointsData.position
 		local totalPoints = teamPointsData.totalPoints
 		local objectData = {
-			type = 'automatic points',
+			type = 'automatic_points',
+
 			name = teamName,
 			information = position,
 			date = date,

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -9,7 +9,6 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Condition = require('Module:Condition')
-local Custom = require('Module:AutomaticPointsTable/Custom')
 local TableDisplay = require('Module:AutomaticPointsTable/Display')
 local MinifiedDisplay = require('Module:AutomaticPointsTable/MinifiedDisplay')
 local Json = require('Module:Json')
@@ -81,7 +80,6 @@ function AutomaticPointsTable:storeLPDB(pointsData)
 		local totalPoints = teamPointsData.totalPoints
 		local objectData = {
 			type = 'automatic_points',
-
 			name = teamName,
 			information = position,
 			date = date,
@@ -102,13 +100,15 @@ function AutomaticPointsTable:parseInput(args)
 	local minified = Logic.readBool(args.minified)
 	local limit = tonumber(args.limit) or #teams
 	local lpdbName = args.lpdbName or mw.title.getCurrentTitle().text
+	local resolveRedirect = Logic.readBool(args.resolveRedirect)
 	return {
 		positionBackgrounds = positionBackgrounds,
 		tournaments = tournaments,
 		teams = teams,
 		shouldTableBeMinified = minified,
 		limit = limit,
-		lpdbName = lpdbName
+		lpdbName = lpdbName,
+		resolveRedirect = resolveRedirect,
 	}
 end
 
@@ -190,15 +190,16 @@ function AutomaticPointsTable:parseManualPoints(team, tournamentCount)
 	return manualPoints
 end
 
-function AutomaticPointsTable:generateReverseAliases(teams, tournaments)
+function AutomaticPointsTable:generateReverseAliases(teams, tournaments, resolveRedirect)
 	local reverseAliases = {}
+	local resolveRedirect = self.parsedInput.resolveRedirect
 	for tournamentIndex = 1, #tournaments do
 		reverseAliases[tournamentIndex] = {}
 		Table.iter.forEachIndexed(teams,
 			function(index, team)
 				local alias
-				if Custom.resolveTeamNames then
-					alias = Custom.resolveTeamNames(team.aliases[tournamentIndex])
+				if resolveRedirect then
+					alias = mw.ext.TeamLiquidIntegration.resolve_redirect(team.aliases[tournamentIndex])
 				else
 					alias = team.aliases[tournamentIndex]
 				end

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -193,7 +193,9 @@ function AutomaticPointsTable:generateReverseAliases(teams, tournaments)
 		reverseAliases[tournamentIndex] = {}
 		Table.iter.forEachIndexed(teams,
 			function(index, team)
-				local alias = mw.getContentLanguage():ucfirst(mw.ext.TeamLiquidIntegration.resolve_redirect(team.aliases[tournamentIndex]))
+				local alias = mw.getContentLanguage():ucfirst(
+					mw.ext.TeamLiquidIntegration.resolve_redirect(team.aliases[tournamentIndex])
+				)
 				reverseAliases[tournamentIndex][alias] = index
 			end
 		)

--- a/components/automatic-points-table/commons/automatic-points-table.lua
+++ b/components/automatic-points-table/commons/automatic-points-table.lua
@@ -57,6 +57,8 @@ function AutomaticPointsTable.run(frame)
 		usedDisplayModule = TableDisplay
 	end
 
+	pointsTable:storeLPDB(sortedDataWithPositions)
+
 	local divTable = usedDisplayModule(
 		sortedDataWithPositions,
 		tournamentsWithResults,
@@ -67,18 +69,43 @@ function AutomaticPointsTable.run(frame)
 	return divTable:create()
 end
 
+function AutomaticPointsTable:storeLPDB(pointsData)
+	Table.iter.forEachIndexed(pointsData, function(index, teamPointsData)
+		local team = teamPointsData.team
+		local teamName = string.lower(team.aliases[#team.aliases])
+		local lpdbName = self.parsedInput.lpdbName
+		local uniqueId = teamName .. '_' .. lpdbName
+		local position = teamPointsData.position
+		local totalPoints = teamPointsData.totalPoints
+		local objectData = {
+			type = lpdbName,
+			name = teamName,
+			information = position,
+			date = os.date(),
+			extradata = mw.ext.LiquipediaDB.lpdb_create_json({
+				position = position,
+				totalPoints = totalPoints
+			})
+		}
+
+		mw.ext.LiquipediaDB.lpdb_datapoint(uniqueId, objectData)
+	end)
+end
+
 function AutomaticPointsTable:parseInput(args)
 	local positionBackgrounds = self:parsePositionBackgroundData(args)
 	local tournaments = self:parseTournaments(args)
 	local teams = self:parseTeams(args, #tournaments)
 	local minified = Logic.readBool(args.minified)
 	local limit = tonumber(args.limit) or #teams
+	local lpdbName = args.lpdbName or mw.title.getCurrentTitle().text
 	return {
 		positionBackgrounds = positionBackgrounds,
 		tournaments = tournaments,
 		teams = teams,
 		shouldTableBeMinified = minified,
-		limit = limit
+		limit = limit,
+		lpdbName = lpdbName
 	}
 end
 
@@ -166,7 +193,7 @@ function AutomaticPointsTable:generateReverseAliases(teams, tournaments)
 		reverseAliases[tournamentIndex] = {}
 		Table.iter.forEachIndexed(teams,
 			function(index, team)
-				local alias = mw.language.getContentLanguage():ucfirst(team.aliases[tournamentIndex])
+				local alias = mw.getContentLanguage():ucfirst(mw.ext.TeamLiquidIntegration.resolve_redirect(team.aliases[tournamentIndex]))
 				reverseAliases[tournamentIndex][alias] = index
 			end
 		)


### PR DESCRIPTION
## Summary

This commit is made to store the rankings in lpdb objects for use in other different pages, specifically team pages

## How did you test this change?

Deployed in [Sandbox](https://liquipedia.net/rocketleague/Module:Sandbox/AutoPointsTable/Rewrite/GH/10)
Here's an example of the datapoints stored: 
![image](https://user-images.githubusercontent.com/28851891/173956815-e75db577-019e-4374-a3ea-ab421307bf12.png)
