### PR TITLE
Create Infobox Character

### DIFF
--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -117,6 +117,21 @@ function Character:nameDisplay(args)
 end
 
 function Character:setLpdbData(args)
+	local lpdbData = {
+		name = self.name,
+		image = args.image,
+		type = 'character'
+		extradata = {},
+	}
+	
+	lpdbData = self:addToLpdb(lpdbData, args)
+
+	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
+	mw.ext.LiquipediaDB.lpdb_datapoint('character_' .. self.name, lpdbData)
+end
+
+function Character:addToLpdb(lpdbData, args)
+	return lpdbData
 end
 
 return Character

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -120,7 +120,7 @@ function Character:setLpdbData(args)
 	local lpdbData = {
 		name = self.name,
 		image = args.image,
-		type = 'character'
+		type = 'character',
 		extradata = {},
 	}
 	

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -123,7 +123,7 @@ function Character:setLpdbData(args)
 		type = 'character',
 		extradata = {},
 	}
-	
+
 	lpdbData = self:addToLpdb(lpdbData, args)
 
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -87,7 +87,7 @@ function Character:createInfobox()
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	if Namespace.isMain() then
-		infobox:categories('Characters')
+		infobox:categories(args.informationType or 'Character')
 		infobox:categories(unpack(self:getWikiCategories(args)))
 		self:setLpdbData(args)
 	end

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Hero
+-- page=Module:Infobox/Character
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -18,14 +18,14 @@ local Title = Widgets.Title
 local Center = Widgets.Center
 local Customizable = Widgets.Customizable
 
-local Hero = Class.new(BasicInfobox)
+local Character = Class.new(BasicInfobox)
 
-function Hero.run(frame)
-	local hero = Hero(frame)
-	return hero:createInfobox()
+function Character.run(frame)
+	local character = Character(frame)
+	return character:createInfobox()
 end
 
-function Hero:createInfobox()
+function Character:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
 
@@ -84,7 +84,7 @@ function Hero:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	infobox:categories('Heroes')
+	infobox:categories('Characters')
 	infobox:categories(unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
@@ -96,7 +96,7 @@ function Hero:createInfobox()
 	return builtInfobox
 end
 
-function Hero:_createLocation(location)
+function Character:_createLocation(location)
 	if location == nil then
 		return ''
 	end
@@ -105,19 +105,19 @@ function Hero:_createLocation(location)
 		'[[:Category:' .. location .. '|' .. location .. ']]'
 end
 
-function Hero:subHeader(args)
+function Character:subHeader(args)
 	return args.title
 end
 
-function Hero:getWikiCategories(args)
+function Character:getWikiCategories(args)
 	return {}
 end
 
-function Hero:nameDisplay(args)
+function Character:nameDisplay(args)
 	return args.name
 end
 
-function Hero:setLpdbData(args)
+function Character:setLpdbData(args)
 end
 
-return Hero
+return Character

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -40,7 +40,7 @@ function Character:createInfobox()
 			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
-		Title{name = (args.informationType or 'Hero') .. ' Information'},
+		Title{name = (args.informationType or 'Character') .. ' Information'},
 		Cell{name = 'Real Name', content = {args.realname}},
 		Customizable{
 			id = 'country',
@@ -84,12 +84,11 @@ function Character:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	infobox:categories('Characters')
-	infobox:categories(unpack(self:getWikiCategories(args)))
-
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	if Namespace.isMain() then
+		infobox:categories('Characters')
+		infobox:categories(unpack(self:getWikiCategories(args)))
 		self:setLpdbData(args)
 	end
 

--- a/components/infobox/commons/infobox_hero.lua
+++ b/components/infobox/commons/infobox_hero.lua
@@ -16,7 +16,6 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Builder = Widgets.Builder
 local Customizable = Widgets.Customizable
 
 local Hero = Class.new(BasicInfobox)

--- a/components/infobox/commons/infobox_hero.lua
+++ b/components/infobox/commons/infobox_hero.lua
@@ -1,0 +1,124 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Hero
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Namespace = require('Module:Namespace')
+local BasicInfobox = require('Module:Infobox/Basic')
+local Flags = require('Module:Flags')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Header = Widgets.Header
+local Title = Widgets.Title
+local Center = Widgets.Center
+local Builder = Widgets.Builder
+local Customizable = Widgets.Customizable
+
+local Hero = Class.new(BasicInfobox)
+
+function Hero.run(frame)
+	local hero = Hero(frame)
+	return hero:createInfobox()
+end
+
+function Hero:createInfobox()
+	local infobox = self.infobox
+	local args = self.args
+
+	local widgets = {
+		Header{
+			name = self:nameDisplay(args),
+			subHeader = self:subHeader(args),
+			image = args.image,
+			imageDefault = args.default,
+			imageDark = args.imagedark or args.imagedarkmode,
+			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+			size = args.imagesize,
+		},
+		Center{content = {args.caption}},
+		Title{name = (args.informationType or 'Hero') .. ' Information'},
+		Cell{name = 'Real Name', content = {args.realname}},
+		Customizable{
+			id = 'country',
+			children = {
+				Cell{
+					name = 'Country',
+					content = {
+						self:_createLocation(args.country)
+					}
+				},
+			}
+		},
+		Customizable{
+			id = 'role',
+			children = {
+				Cell{
+					name = 'Role',
+					content = {args.role}
+				},
+			}
+		},
+		Customizable{
+			id = 'class',
+			children = {
+				Cell{
+					name = 'Class',
+					content = {args.class}
+				},
+			}
+		},
+		Customizable{
+			id = 'release',
+			children = {
+				Cell{
+					name = 'Release Date',
+					content = {args.releasedate}
+				},
+			}
+		},
+		Customizable{id = 'custom', children = {}},
+		Center{content = {args.footnotes}},
+	}
+
+	infobox:categories('Heroes')
+	infobox:categories(unpack(self:getWikiCategories(args)))
+
+	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
+
+	if Namespace.isMain() then
+		self:setLpdbData(args)
+	end
+
+	return builtInfobox
+end
+
+function Hero:_createLocation(location)
+	if location == nil then
+		return ''
+	end
+
+	return Flags.Icon({flag = location, shouldLink = true}) .. '&nbsp;' ..
+		'[[:Category:' .. location .. '|' .. location .. ']]'
+end
+
+function Hero:subHeader(args)
+	return args.title
+end
+
+function Hero:getWikiCategories(args)
+	return {}
+end
+
+function Hero:nameDisplay(args)
+	return args.name
+end
+
+function Hero:setLpdbData(args)
+end
+
+return Hero


### PR DESCRIPTION
Creates a new Infobox called Character, that is meant to serve as the base for the Infoboxes: Hero, Agent, Operator, Legend, Character and Champion. 

Having spent some time looking at the infoboxes across various wikis, it would be a nightmare to combine them all into 1 infobox. My suggestion is to have a ``Infobox/Character/MOBBA`` (or something to that effect) that would account for the base parameters for wikis like League of Legends, Wild Rift, Dota 2, Mobile Legends and other very similar wikis. Otherwise you would have massive ``/Custom`` modules for those wikis that repeat a lot of the same functionality

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested via test [page](https://liquipedia.net/commons/User:Fenrir.SPAZ/Infobox_Hero)
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
