### PR TITLE
Add Widgets for CSS-Grid based tables

### DIFF
--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -31,24 +31,28 @@ function Table:addClass(class)
 end
 
 function Table:make()
-	local table = mw.html.create('div')
-	table:css{display = 'inline-grid', ['border-right'] = '1px solid #bbb', ['border-bottom'] = '1px solid #bbb'}
-	table:css('grid-template-rows', 'repeat(' .. #self.rows .. ', auto)')
-	table:css('grid-template-columns', 'repeat(' .. self:_getMaxCells() .. ', auto)')
+	local displayTable = mw.html.create('div')
+	displayTable:css{
+		['display'] = 'inline-grid',
+		['border-right'] = '1px solid #bbb',
+		['border-bottom'] = '1px solid #bbb',
+		['grid-template-rows'] = 'repeat(' .. #self.rows .. ', auto)',
+		['grid-template-columns'] = 'repeat(' .. self:_getMaxCells() .. ', auto)',
+	}
 
 	for _, class in ipairs(self.classes) do
-		table:addClass(class)
+		displayTable:addClass(class)
 	end
 
-	table:css(self.css)
+	displayTable:css(self.css)
 
 	for _, row in ipairs(self.rows) do
 		for _, node in ipairs(WidgetFactory.work(row, self.injector)) do
-			table:node(node)
+			displayTable:node(node)
 		end
 	end
 
-	return {table}
+	return {displayTable}
 end
 
 function Table:_getMaxCells()

--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -1,0 +1,61 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Table
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Widget = require('Module:Infobox/Widget')
+local WidgetFactory = require('Module:Infobox/Widget/Factory')
+
+local Table = Class.new(
+	Widget,
+	function(self, input)
+		self.rows = input.rows or {}
+		self.classes = input.classes or {}
+		self.css = input.css or {}
+	end
+)
+
+function Table:addRow(row)
+	table.insert(self.rows, row)
+	return self
+end
+
+function Table:addClass(class)
+	table.insert(self.classes, class)
+	return self
+end
+
+function Table:make()
+	local table = mw.html.create('div')
+	table:css{display = 'inline-grid', ['border-right'] = '1px solid #bbb', ['border-bottom'] = '1px solid #bbb'}
+	table:css('grid-template-rows', 'repeat(' .. #self.rows .. ', auto)')
+	table:css('grid-template-columns', 'repeat(' .. self:_getMaxCells() .. ', auto)')
+
+	for _, class in ipairs(self.classes) do
+		table:addClass(class)
+	end
+
+	table:css(self.css)
+
+	for _, row in ipairs(self.rows) do
+		for _, node in ipairs(WidgetFactory.work(row, self.injector)) do
+			table:node(node)
+		end
+	end
+
+	return {table}
+end
+
+function Table:_getMaxCells()
+	local getNumberCells = function(row)
+		return row:getCellCount()
+	end
+	return Array.reduce(Array.map(self.rows, getNumberCells), math.max)
+end
+
+return Table

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -1,0 +1,47 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Table/Cell
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Widget = require('Module:Infobox/Widget')
+
+local TableCell = Class.new(
+	Widget,
+	function(self, input)
+		self.content = input.content or {}
+		self.classes = input.classes or {}
+		self.css = input.css or {}
+	end
+)
+
+function TableCell:addContent(text)
+	table.insert(self.content, text)
+	return self
+end
+
+function TableCell:addClass(class)
+	table.insert(self.classes, class)
+	return self
+end
+
+function TableCell:make()
+	local cell = mw.html.create('div')
+	cell:css('border-left', '1px solid #bbb'):css('border-top', '1px solid #bbb'):css('background', 'inherit')
+	cell:css('padding', '5px'):css('line-height', '1.42857143')
+
+	for _, class in ipairs(self.classes) do
+		cell:addClass(class)
+	end
+
+	cell:css(self.css)
+
+	cell:wikitext(table.concat(self.content))
+
+	return {cell}
+end
+
+return TableCell

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -30,8 +30,12 @@ end
 
 function TableCell:make()
 	local cell = mw.html.create('div')
-	cell:css('border-left', '1px solid #bbb'):css('border-top', '1px solid #bbb'):css('background', 'inherit')
-	cell:css('padding', '5px'):css('line-height', '1.42857143')
+	cell:css{
+		['border-left'] = '1px solid #bbb',
+		['border-top'] = '1px solid #bbb',
+		['background'] = 'inherit',
+		['padding'] = '4px',
+	}
 
 	for _, class in ipairs(self.classes) do
 		cell:addClass(class)

--- a/components/widget/widget_table_row.lua
+++ b/components/widget/widget_table_row.lua
@@ -1,0 +1,54 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Table/Row
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Widget = require('Module:Infobox/Widget')
+local WidgetFactory = require('Module:Infobox/Widget/Factory')
+
+local TableRow = Class.new(
+	Widget,
+	function(self, input)
+		self.cells = input.cells or {}
+		self.classes = input.classes or {}
+		self.css = input.css or {}
+	end
+)
+
+function TableRow:addCell(cell)
+	table.insert(self.cells, cell)
+	return self
+end
+
+function TableRow:addClass(class)
+	table.insert(self.classes, class)
+	return self
+end
+
+function TableRow:getCellCount()
+	return #self.cells
+end
+
+function TableRow:make()
+	local row = mw.html.create('div'):css('display', 'contents')
+
+	for _, class in ipairs(self.classes) do
+		row:addClass(class)
+	end
+
+	row:css(self.css)
+
+	for _, cell in ipairs(self.cells) do
+		for _, node in ipairs(WidgetFactory.work(cell, self.injector)) do
+			row:node(node)
+		end
+	end
+
+	return {row}
+end
+
+return TableRow


### PR DESCRIPTION
## Summary

Create Widgets for CSS Tables based on Grids.

The TableWidget contains an Array of TableRowWidgets, which in turns has an Array of TableCellWidgets.

The inherited children from TableCells that was part of the RFC has been dropped for now.

There are various outstanding features, most specifically rowspan and colspan and also some of the CSS should be moved into Classes. To be implemented in future PRs.

## How did you test this change?

![image](https://user-images.githubusercontent.com/3426850/174585634-9ccfa58d-50ad-4198-be3c-ba93ca1c1a27.png)
