### PR TITLE
Create the prizepool table

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -26,8 +26,8 @@ local WidgetInjector = Lua.import('Module:Infobox/Widget/Injector', {requireDevI
 
 local WidgetFactory = require('Module:Infobox/Widget/Factory')
 local WidgetTable = require('Module:Widget/Table')
-local WidgetTableRow = require('Module:Widget/Table/Row')
-local WidgetTableCell = require('Module:Widget/Table/Cell')
+local TableRow = require('Module:Widget/Table/Row')
+local TableCell = require('Module:Widget/Table/Cell')
 
 --- @class PrizePool
 local PrizePool = Class.new(function(self, ...) self:init(...) end)
@@ -229,9 +229,9 @@ function PrizePool:build()
 end
 
 function PrizePool:_buildHeader()
-	local headerRow = WidgetTableRow{css = {['font-weight'] = 'bold'}}
+	local headerRow = TableRow{css = {['font-weight'] = 'bold'}}
 
-	headerRow:addCell(WidgetTableCell{content = {'Place'}})
+	headerRow:addCell(TableCell{content = {'Place'}})
 
 	for _, prize in ipairs(self.prizes) do
 		local prizeTypeData = self.prizeTypes[prize.type]
@@ -240,7 +240,7 @@ function PrizePool:_buildHeader()
 	end
 
 	-- TODO: Add support for party types
-	headerRow:addCell(WidgetTableCell{content = {'Team'}})
+	headerRow:addCell(TableCell{content = {'Team'}})
 
 	return headerRow
 end
@@ -252,10 +252,10 @@ function PrizePool:_buildRows()
 		-- TODO Cutoff
 
 		for _, opponent in ipairs(placement.opponents) do
-			local row = WidgetTableRow{}
+			local row = TableRow{}
 
 			row:addClass(placement:getBackground())
-			row:addCell(WidgetTableCell{
+			row:addCell(TableCell{
 				content = {placement:getMedal() or '' , NON_BREAKING_SPACE, placement:displayPlace()},
 				css = {['font-weight'] = 'bolder'}
 			})
@@ -270,7 +270,7 @@ function PrizePool:_buildRows()
 				end
 
 				if not cell then
-					cell = WidgetTableCell{content = {DASH}}
+					cell = TableCell{content = {DASH}}
 				end
 
 				row:addCell(cell)
@@ -278,7 +278,7 @@ function PrizePool:_buildRows()
 
 			-- TODO: Proper Support for Party Types
 			local opponentDisplay = OpponentDisplay.InlineOpponent{opponent = opponent.opponentData}
-			row:addCell(WidgetTableCell{content = {opponentDisplay}, css = {['text-align'] = 'left'}})
+			row:addCell(TableCell{content = {opponentDisplay}, css = {['text-align'] = 'left'}})
 
 			table.insert(rows, row)
 		end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -329,7 +329,7 @@ function PrizePool._comparePrizes(x, y)
 end
 
 function PrizePool:build()
-	local table = WidgetTable{css = {['text-align'] = 'center'}, classes={'general-collapsible', 'collapsed'}}
+	local table = WidgetTable{}
 
 	table:addRow(self:_buildHeader())
 
@@ -366,6 +366,7 @@ end
 
 function PrizePool:_buildRows()
 	local rows = {}
+
 	for _, placement in ipairs(self.placements) do
 		-- TODO RowSpan
 		-- TODO Cutoff
@@ -397,11 +398,12 @@ function PrizePool:_buildRows()
 
 			-- TODO: Proper Support for Party Types
 			local opponentDisplay = OpponentDisplay.InlineOpponent{opponent = opponent.opponentData}
-			row:addCell(TableCell{content = {opponentDisplay}, css = {['text-align'] = 'left'}})
+			row:addCell(TableCell{content = {opponentDisplay}, css = {['justify-content'] = 'left'}})
 
 			table.insert(rows, row)
 		end
 	end
+
 	return rows
 end
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -398,7 +398,7 @@ function PrizePool:_buildRows()
 
 			-- TODO: Proper Support for Party Types
 			local opponentDisplay = OpponentDisplay.InlineOpponent{opponent = opponent.opponentData}
-			row:addCell(TableCell{content = {opponentDisplay}, css = {['justify-content'] = 'left'}})
+			row:addCell(TableCell{content = {opponentDisplay}, css = {['justify-content'] = 'start'}})
 
 			table.insert(rows, row)
 		end


### PR DESCRIPTION
## Summary

Uses the Widgets and prize type functions created in #1400 and #1403 respectively to display the full Prize Pool Table.

There are still some outstanding functionality, such as merging rows ("rowspan") and having proper support for Party (Solo, Duo etc) type opponents.

## How did you test this change?

![image](https://user-images.githubusercontent.com/3426850/174585691-6130ad11-0590-47d3-9441-444b39079956.png)

