### PR TITLE
Creating Infobox League for Pokemon

### DIFF
--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -1,0 +1,125 @@
+---
+-- @Liquipedia
+-- wiki=pokemon
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+local Template = require('Module:Template')
+local Class = require('Module:Class')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local Table = require('Module:Table')
+local Logic = require('Module:Logic')
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _game
+local _mode
+local _format
+
+local _GAME = mw.loadData('Module:GameVersion')
+local _MODES = mw.loadData('Module:GameModes')
+local _FORMATS = mw.loadData('Module:GameFormats')
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_args = league.args
+
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'gamesettings' then
+		return {
+			Cell{name = 'Game version', content = {
+					CustomLeague._getGameVersion()
+				}
+			},
+			Cell{name = 'Game mode', content = {
+					CustomLeague:_getGameMode()
+				}
+			},
+			Cell{name = 'Format', content = {
+					CustomLeague:_getGameFormat()
+				}
+			},
+		}
+	elseif id == 'customcontent' then
+		if _args.player_number then
+			table.insert(widgets, Title{name = 'Players'})
+			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
+		end
+
+		--teams section
+		if _args.team_number then
+			table.insert(widgets, Title{name = 'Teams'})
+			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+		end
+	end
+	return widgets
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.game = args.game
+	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.publishertier = args.pokemonpremier
+	lpdbData.extradata = {
+		individual = String.isNotEmpty(args.player_number) and 'true' or '',
+	}
+
+	return lpdbData
+end
+
+function CustomLeague:defineCustomPageVariables()
+	Variables.varDefine('tournament_game', _game or _args.game)
+	Variables.varDefine('tournament_publishertier', _args['pokemonpremier'])
+	--Legacy Vars:
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+end
+
+function CustomLeague._getGameVersion()
+	local game = string.lower(_args.game or '')
+	_game = _GAME[game]
+	return _game
+end
+
+function CustomLeague:liquipediaTierHighlighted()
+	return Logic.readBool(_args.pubgpremier)
+end
+
+function CustomLeague:_getGameMode()
+	if String.isEmpty(_args.mode) then
+		return nil
+	end
+	local mode = _MODES[string.lower(_args.mode or '')] or _MODES['default']
+	return mode
+end
+
+function CustomLeague:_getGameFormat()
+	if String.isEmpty(_args.format) then
+		return nil
+	end
+
+	local format = string.lower(_args.format or '')
+
+	return _FORMATS[format] or _FORMATS['default']
+end
+
+return CustomLeague

--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -96,6 +96,7 @@ function CustomLeague:_getGameMode()
 	if String.isEmpty(_args.mode) then
 		return nil
 	end
+
 	return _MODES[_args.mode:lower()] or _MODES['default']
 end
 

--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -58,7 +58,6 @@ function CustomInjector:parse(id, widgets)
 		if _args.player_number then
 			table.insert(widgets, Title{name = 'Players'})
 			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
-
 		elseif _args.team_number then
 			table.insert(widgets, Title{name = 'Teams'})
 			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
@@ -87,7 +86,7 @@ function CustomLeague:defineCustomPageVariables()
 end
 
 function CustomLeague._getGameVersion()
-	local game = string.lower(_args.game or '')
+	_game = _GAME[string.lower(_args.game or '')]
 	return _game
 end
 

--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -28,6 +28,7 @@ local _FORMATS = mw.loadData('Module:GameFormats')
 function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
+	_args.format = CustomLeague:_getGameFormat()
 
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
@@ -52,19 +53,13 @@ function CustomInjector:parse(id, widgets)
 					CustomLeague:_getGameMode()
 				}
 			},
-			Cell{name = 'Format', content = {
-					CustomLeague:_getGameFormat()
-				}
-			},
 		}
 	elseif id == 'customcontent' then
 		if _args.player_number then
 			table.insert(widgets, Title{name = 'Players'})
 			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
-		end
 
-		--teams section
-		if _args.team_number then
+		elseif _args.team_number then
 			table.insert(widgets, Title{name = 'Teams'})
 			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
 		end
@@ -87,12 +82,12 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
 	Variables.varDefine('tournament_publishertier', _args['pokemonpremier'])
 	--Legacy Vars:
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end
 
 function CustomLeague._getGameVersion()
 	local game = string.lower(_args.game or '')
-	_game = _GAME[game]
 	return _game
 end
 
@@ -104,7 +99,7 @@ function CustomLeague:_getGameMode()
 	if String.isEmpty(_args.mode) then
 		return nil
 	end
-	local mode = _MODES[string.lower(_args.mode or '')] or _MODES['default']
+	local mode = _MODES[_args.mode:lower()] or _MODES['default']
 	return mode
 end
 
@@ -113,9 +108,7 @@ function CustomLeague:_getGameFormat()
 		return nil
 	end
 
-	local format = string.lower(_args.format or '')
-
-	return _FORMATS[format] or _FORMATS['default']
+	return _FORMATS[_args.format:lower()] or _FORMATS['default']
 end
 
 return CustomLeague

--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -9,12 +9,10 @@
 local League = require('Module:Infobox/League')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
-local Template = require('Module:Template')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local Table = require('Module:Table')
 local Logic = require('Module:Logic')
 
 local CustomLeague = Class.new()
@@ -22,8 +20,6 @@ local CustomInjector = Class.new(Injector)
 
 local _args
 local _game
-local _mode
-local _format
 
 local _GAME = mw.loadData('Module:GameVersion')
 local _MODES = mw.loadData('Module:GameModes')

--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -89,15 +89,14 @@ function CustomLeague._getGameVersion()
 end
 
 function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args.pubgpremier)
+	return Logic.readBool(_args.pokemonpremier)
 end
 
 function CustomLeague:_getGameMode()
 	if String.isEmpty(_args.mode) then
 		return nil
 	end
-	local mode = _MODES[_args.mode:lower()] or _MODES['default']
-	return mode
+	return _MODES[_args.mode:lower()] or _MODES['default']
 end
 
 function CustomLeague:_getGameFormat()

--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -97,7 +97,7 @@ function CustomLeague:_getGameMode()
 		return nil
 	end
 
-	return _MODES[_args.mode:lower()] or _MODES['default']
+	return _MODES[_args.mode:lower()]
 end
 
 function CustomLeague:_getGameFormat()
@@ -105,7 +105,7 @@ function CustomLeague:_getGameFormat()
 		return nil
 	end
 
-	return _FORMATS[_args.format:lower()] or _FORMATS['default']
+	return _FORMATS[_args.format:lower()]
 end
 
 return CustomLeague

--- a/components/infobox/wikis/infobox_league_custom.lua
+++ b/components/infobox/wikis/infobox_league_custom.lua
@@ -19,7 +19,6 @@ local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
-local _game
 
 local _GAME = mw.loadData('Module:GameVersion')
 local _MODES = mw.loadData('Module:GameModes')
@@ -67,7 +66,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.game = args.game
+	lpdbData.game = CustomLeague._getGameVersion()
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.pokemonpremier
 	lpdbData.extradata = {
@@ -78,7 +77,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 end
 
 function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_game', _game or _args.game)
+	Variables.varDefine('tournament_game', CustomLeague._getGameVersion())
 	Variables.varDefine('tournament_publishertier', _args['pokemonpremier'])
 	--Legacy Vars:
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
@@ -86,8 +85,7 @@ function CustomLeague:defineCustomPageVariables()
 end
 
 function CustomLeague._getGameVersion()
-	_game = _GAME[string.lower(_args.game or '')]
-	return _game
+	return _GAME[string.lower(_args.game or '')]
 end
 
 function CustomLeague:liquipediaTierHighlighted()


### PR DESCRIPTION
## Summary
Planned to do a major cleaning of Pokemon which saw  a lot of template is over a year untouched. I decide to begin with Infobox League then later will be Match2 that was like sitting there half a year

**Based on the PUBGMOBILE Box, removed platforms with Modes and Games kept as the wiki contains multiple games, multiple modes and both teams/indivs**

## How did you test this change?
The test pages <https://liquipedia.net/pokemon/User:Hesketh2/Test>

Did some quick /dev test on the main pages looks to work fine, and results reflect correctly for achievements

## Side Note
**I need to solve this matter before it goes trhough**

OLD INFOBOX: <https://liquipedia.net/pokemon/Template:Infobox_league>
GAME FORMAT MODULE: <https://liquipedia.net/pokemon/index.php?search=Module%3AGameFormats>

Different from other games, The old infobox in Pokemon has a **|format=** input as a code input so type the corresponding input and will show the corresponding ruleset

![image](https://user-images.githubusercontent.com/88981446/174614650-55a24b49-1022-475e-a00b-dd5469d1831e.png)

I try duplicate the way Games are being called through reading a **GameVersion** module, The results is two format parameters being displayed. Is there a way to hide the base one and shows the custom only, or would be better to change the custom format parameter to something else then request bot change?





