### PR TITLE
Store data into LPDB

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -558,29 +558,17 @@ function PrizePool:_storeLpdb()
 		type = Variables.varDefault('tournament_type'),
 		liquipediatier = Variables.varDefault('tournament_liquipediatier'),
 		liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype'),
-		-- publishertier = ,
 		icon = Variables.varDefault('tournament_icon'),
 		icondark = Variables.varDefault('tournament_icondark'),
 		game = Variables.varDefault('tournament_game'),
 		-- TODO: Add PrizePoolIndex as a field?
 	}
-	local setWeight = function(lpdbEntry)
-		lpdbEntry.weight = lpdbEntry.weight or Template.safeExpand(
-			mw.getCurrentFrame(), 'Weight', {
-				math.max(lpdbEntry.prizemoney, 1),
-				lpdbTournamentData.liquipediatier,
-				lpdbEntry.place,
-				lpdbTournamentData.type
-			})
-	end
 
 	local lpdbData = {}
 	for _, placement in ipairs(self.placements) do
 		local lpdbEntries = placement:_getLpdbData()
 
 		Array.forEach(lpdbEntries, function(lpdbEntry) Table.mergeInto(lpdbEntry, lpdbTournamentData) end)
-
-		Array.forEach(lpdbEntries, setWeight)
 
 		Array.extendWith(lpdbData, lpdbEntries)
 	end
@@ -808,7 +796,7 @@ function Placement:_getLpdbData()
 			extradata = {}
 
 			-- TODO: We need to create additional LPDB Fields
-			-- match2 opponents (opponent, opponenttemplate, opponentplayers, opponenttype)
+			-- match2 opponents (opponentname, opponenttemplate, opponentplayers, opponenttype)
 			-- Qualified To struct (json?)
 			-- Points struct (json?)
 			-- lastvs match2 opponent (json?)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -545,6 +545,8 @@ function PrizePool:setLpdbInjector(lpdbInjector)
 end
 
 function PrizePool:_storeLpdb()
+ 	local prizePoolIndex = (tonumber(Variables.varDefault('prizepool_index')) or 0) + 1
+ 	Variables.varDefine('prizepool_index', prizePoolIndex)
 	local lpdbTournamentData = {
 		tournament = Variables.varDefault('tournament_name'),
 		parent = Variables.varDefault('tournament_parent'),

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -296,6 +296,7 @@ end
 function PrizePool:_setLpdbData()
 	local lpdbTournamentData = {
 		tournament = Variables.varDefault('tournament_name'),
+		parent = Variables.varDefault('tournament_parent'),
 		series = Variables.varDefault('tournament_series'),
 		shortname = Variables.varDefault('tournament_tickername'),
 		startdate = Variables.varDefaultMulti('tournament_startdate', 'tournament_sdate', 'sdate', ''),
@@ -525,7 +526,6 @@ function Placement:_setLpdbData()
 		else
 			participant = Opponent.toName(opponent.opponentData)
 		end
-		local lastVsScore = mw.text.split(opponent.additionalData.LASTVSSCORE or '', '-')
 
 		local lpdbData = {
 			image = image,
@@ -538,8 +538,8 @@ function Placement:_setLpdbData()
 			placement = self.placeStart .. (self.placeStart ~= self.placeEnd and ('-' .. self.placeEnd) or ''),
 			prizemoney = tonumber(opponent.prizeRewards[PRIZE_TYPE_USD .. 1] or self.prizeRewards[PRIZE_TYPE_USD .. 1]) or 0,
 			lastvs = Opponent.toName(opponent.additionalData.LASTVS or {}),
-			lastscore = lastVsScore[1],
-			lastvsscore = lastVsScore[2],
+			lastscore = (opponent.additionalData.LASTVSSCORE or {}).score,
+			lastvsscore = (opponent.additionalData.LASTVSSCORE or {}).vsscore,
 			groupscore = opponent.additionalData.GROUPSCORE,
 			extradata = {}
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -565,16 +565,6 @@ function PrizePool:_storeLpdb()
 		-- TODO: Add PrizePoolIndex as a field?
 	}
 
-	local setWeight = function(lpdbEntry)
-		lpdbEntry.weight = lpdbEntry.weight or Template.safeExpand(
-			mw.getCurrentFrame(), 'Weight', {
-				math.max(lpdbEntry.prizemoney, 1),
-				lpdbTournamentData.liquipediatier,
-				lpdbEntry.place,
-				lpdbTournamentData.type
-			})
-	end
-
 	local lpdbData = {}
 	for _, placement in ipairs(self.placements) do
 		local lpdbEntries = placement:_getLpdbData()

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -565,8 +565,8 @@ function PrizePool:_storeLpdb()
 		-- TODO: Add PrizePoolIndex as a field?
 	}
 
-	local setWeight = function(lpdbEntry)
-		lpdbEntry.weight = lpdbEntry.weight or Template.safeExpand(
+    local setWeight = function(lpdbEntry)
+        lpdbEntry.weight = lpdbEntry.weight or Template.safeExpand(
 			mw.getCurrentFrame(), 'Weight', {
 				math.max(lpdbEntry.prizemoney, 1),
 				lpdbTournamentData.liquipediatier,

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -521,7 +521,7 @@ function Placement:_setLpdbData()
 			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template)
 			participant = teamTemplate and teamTemplate.page or ''
 			image = teamTemplate.image
-			image = teamTemplate.imagedark
+			imageDark = teamTemplate.imagedark
 		else
 			participant = Opponent.toName(opponent.opponentData)
 		end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -383,7 +383,7 @@ function PrizePool:build()
 	end
 
 	if self.options.storeLpdb then
-		self:_setLpdbData()
+		self:_storeLpdb()
 	end
 
 	return wrapper
@@ -544,7 +544,7 @@ function PrizePool:setLpdbInjector(lpdbInjector)
 	return self
 end
 
-function PrizePool:_setLpdbData()
+function PrizePool:_storeLpdb()
 	local lpdbTournamentData = {
 		tournament = Variables.varDefault('tournament_name'),
 		parent = Variables.varDefault('tournament_parent'),
@@ -573,7 +573,7 @@ function PrizePool:_setLpdbData()
 
 	local lpdbData = {}
 	for _, placement in ipairs(self.placements) do
-		local lpdbEntries = placement:_setLpdbData()
+		local lpdbEntries = placement:_getLpdbData()
 
 		Array.forEach(lpdbEntries, function(lpdbEntry) Table.mergeInto(lpdbEntry, lpdbTournamentData) end)
 
@@ -765,7 +765,7 @@ function Placement:_parseOpponentArgs(input, date)
 	return Opponent.resolve(opponentData, date)
 end
 
-function Placement:_setLpdbData()
+function Placement:_getLpdbData()
 	local entries = {}
 	for _, opponent in ipairs(self.opponents) do
 		local participant, image, imageDark, players

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -810,7 +810,7 @@ function Placement:_getLpdbData()
 			extradata = {}
 
 			-- TODO: We need to create additional LPDB Fields
-			-- match2 opponents (opponent, opponenttemplate, opponentplayers at minimum)
+			-- match2 opponents (opponent, opponenttemplate, opponentplayers, opponenttype at minimum)
 			-- Qualified To struct (json?)
 			-- Points struct (json?)
 		}

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -564,9 +564,8 @@ function PrizePool:_storeLpdb()
 		game = Variables.varDefault('tournament_game'),
 		-- TODO: Add PrizePoolIndex as a field?
 	}
-
-    local setWeight = function(lpdbEntry)
-        lpdbEntry.weight = lpdbEntry.weight or Template.safeExpand(
+	local setWeight = function(lpdbEntry)
+		lpdbEntry.weight = lpdbEntry.weight or Template.safeExpand(
 			mw.getCurrentFrame(), 'Weight', {
 				math.max(lpdbEntry.prizemoney, 1),
 				lpdbTournamentData.liquipediatier,

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -565,6 +565,16 @@ function PrizePool:_storeLpdb()
 		-- TODO: Add PrizePoolIndex as a field?
 	}
 
+	local setWeight = function(lpdbEntry)
+		lpdbEntry.weight = lpdbEntry.weight or Template.safeExpand(
+			mw.getCurrentFrame(), 'Weight', {
+				math.max(lpdbEntry.prizemoney, 1),
+				lpdbTournamentData.liquipediatier,
+				lpdbEntry.place,
+				lpdbTournamentData.type
+			})
+	end
+
 	local lpdbData = {}
 	for _, placement in ipairs(self.placements) do
 		local lpdbEntries = placement:_getLpdbData()

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -545,8 +545,8 @@ function PrizePool:setLpdbInjector(lpdbInjector)
 end
 
 function PrizePool:_storeLpdb()
-	 local prizePoolIndex = (tonumber(Variables.varDefault('prizepool_index')) or 0) + 1
-	 Variables.varDefine('prizepool_index', prizePoolIndex)
+	local prizePoolIndex = (tonumber(Variables.varDefault('prizepool_index')) or 0) + 1
+	Variables.varDefine('prizepool_index', prizePoolIndex)
 
 	local lpdbTournamentData = {
 		tournament = Variables.varDefault('tournament_name'),

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -299,7 +299,7 @@ function PrizePool:_setLpdbData()
 		series = Variables.varDefault('tournament_series'),
 		shortname = Variables.varDefault('tournament_tickername'),
 		startdate = Variables.varDefaultMulti('tournament_startdate', 'tournament_sdate', 'sdate', ''),
-		-- mode = ,
+		mode = Variables.varDefault('tournament_mode'),
 		type = Variables.varDefault('tournament_type'),
 		liquipediatier = Variables.varDefault('tournament_liquipediatier'),
 		liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype'),

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -593,7 +593,7 @@ function PrizePool:_storeLpdb()
 	for _, lpdbEntry in ipairs(lpdbData) do
 		lpdbEntry.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.players or {})
 		lpdbEntry.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.extradata or {})
-		mw.ext.LiquipediaDB.lpdb_placement('ranking_' .. mw.ustring.lower(lpdbEntry.participant), lpdbEntry)
+		mw.ext.LiquipediaDB.lpdb_placement('ranking_' .. prizePoolIndex .. '_' .. mw.ustring.lower(lpdbEntry.participant), lpdbEntry)
 	end
 
 	return self

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -66,6 +66,9 @@ PrizePool.config = {
 	storeLpdb = {
 		default = true,
 	},
+	resolveRedirect = {
+		default = false,
+	}
 }
 
 PrizePool.prizeTypes = {
@@ -520,7 +523,12 @@ function Placement:_setLpdbData()
 		local participant, image, imageDark
 		if opponent.opponentData.type == Opponent.team then
 			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template)
+
 			participant = teamTemplate and teamTemplate.page or ''
+			if self.parent.options.resolveRedirect then
+				participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
+			end
+
 			image = teamTemplate.image
 			imageDark = teamTemplate.imagedark
 		else

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -545,8 +545,8 @@ function PrizePool:setLpdbInjector(lpdbInjector)
 end
 
 function PrizePool:_storeLpdb()
- 	local prizePoolIndex = (tonumber(Variables.varDefault('prizepool_index')) or 0) + 1
- 	Variables.varDefine('prizepool_index', prizePoolIndex)
+	 local prizePoolIndex = (tonumber(Variables.varDefault('prizepool_index')) or 0) + 1
+	 Variables.varDefine('prizepool_index', prizePoolIndex)
 
 	local lpdbTournamentData = {
 		tournament = Variables.varDefault('tournament_name'),


### PR DESCRIPTION
## Summary

Store the prizepool data into LPDB.

Limitation in the PR: Only the standard 3 opponent types are supported (Solo, Team & Literal). No support added for other Duos etc (wouldn't be supported by the current lpdb fields anyway)

## How did you test this change?

![image](https://user-images.githubusercontent.com/3426850/177331561-e67f1642-0c23-4889-aaf6-cb4653f29274.png)
