### PR TITLE
Automatically convert local cash to usd

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -595,18 +595,24 @@ function Placement:_parseOpponentArgs(input, date)
 end
 
 function Placement:_setUsdFromRewards(prizesToUse, prizeTypes)
-	for _, opponent in ipairs(self.opponents) do
+	Array.foreach(self.opponents, function(opponent)
 		if not opponent.prizeRewards[PRIZE_TYPE_USD .. 1] and not self.prizeRewards[PRIZE_TYPE_USD .. 1] then
-			local usdReward = 0
-			for _, prize in pairs(prizesToUse) do
-				local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id]
-				if localMoney and localMoney > 0 then
-					usdReward = usdReward + prizeTypes[prize.type].convertToUsd(prize.data, localMoney, opponent.date)
-				end
-			end
-			opponent.prizeRewards[PRIZE_TYPE_USD .. 1] = Math.round{usdReward, 2}
+			return
 		end
-	end
+
+		local usdReward = 0
+		Array.foreach(prizesToUse, function(prize)
+			local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id]
+
+			if not localMoney or localMoney <= 0 then
+				return
+			end
+
+			usdReward = usdReward + prizeTypes[prize.type].convertToUsd(prize.data, localMoney, opponent.date)
+		end)
+
+		opponent.prizeRewards[PRIZE_TYPE_USD .. 1] = Math.round{usdReward, 2}
+	end)
 end
 
 return PrizePool

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -13,6 +13,7 @@ local Json = require('Module:Json')
 local LeagueIcon = require('Module:LeagueIcon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Math = require('Module:Math')
 ---Note: This can be overwritten
 local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
@@ -594,13 +595,15 @@ end
 
 function Placement:_setUsdFromRewards(prizesToUse, prizeTypes)
 	for _, opponent in ipairs(self.opponents) do
-		if not opponent.prizeRewards[PRIZE_TYPE_USD .. 1] then
+		if not opponent.prizeRewards[PRIZE_TYPE_USD .. 1] and not self.prizeRewards[PRIZE_TYPE_USD .. 1] then
 			local usdReward = 0
 			for _, prize in pairs(prizesToUse) do
-				local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id] or 0
-				usdReward = usdReward + prizeTypes[prize.type].convertToUsd(prize.data, localMoney, opponent.date)
+				local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id]
+				if localMoney and localMoney > 0 then
+					usdReward = usdReward + prizeTypes[prize.type].convertToUsd(prize.data, localMoney, opponent.date)
+				end
 			end
-			opponent.prizeRewards[PRIZE_TYPE_USD .. 1] = math.floor(usdReward)
+			opponent.prizeRewards[PRIZE_TYPE_USD .. 1] = Math.round{usdReward, 2}
 		end
 	end
 end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -38,6 +38,7 @@ local Placement = Class.new(function(self, ...) self:init(...) end)
 local TODAY = os.date('%Y-%m-%d')
 local LANG = mw.language.getContentLanguage()
 local NON_BREAKING_SPACE = '&nbsp;'
+local BASE_CURRENCY = 'USD'
 
 local PRIZE_TYPE_USD = 'USD'
 local PRIZE_TYPE_LOCAL_CURRENCY = 'LOCAL_CURRENCY'
@@ -123,9 +124,9 @@ PrizePool.prizeTypes = {
 			end
 		end,
 
-    convertToUsd = function (headerData, data, date)
-			mw.ext.CurrencyExchange.currencyexchange(data, headerData.currency, 'USD', date)
-    end,
+		convertToUsd = function (headerData, data, date)
+			mw.ext.CurrencyExchange.currencyexchange(data, headerData.currency, BASE_CURRENCY, date)
+		end,
 	},
 	[PRIZE_TYPE_QUALIFIES] = {
 		sortOrder = 30,


### PR DESCRIPTION
## Summary

If there is a cash reward in a local currency and that automatic conversion of local to usd has not been turned off. Then convert the money to USD prizepool unless USD has been explicitly given.

Dependency on #1404 

## How did you test this change?

![image](https://user-images.githubusercontent.com/3426850/174858715-fcbe6880-ddbc-4d8d-ab01-cd40b041bc81.png)
