### PR TITLE
Improve Widget TableCell

### DIFF
--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -35,6 +35,11 @@ function TableCell:make()
 		['border-top'] = '1px solid #bbb',
 		['background'] = 'inherit',
 		['padding'] = '4px',
+		['display'] = 'flex',
+		['align-items'] = 'center',
+		['justify-content'] = 'center',
+		['grid-row'] = self.rowSpan and 'span ' .. self.rowSpan or nil,
+		['grid-column'] = self.colSpan and 'span ' .. self.colSpan or nil,
 	}
 
 	for _, class in ipairs(self.classes) do


### PR DESCRIPTION
## Summary

* Improve the display of TableCell Widget when there are multiple lines (either by `br` or by `rowspan`), specifically centers it by default.

* Add support for RowSpan and ColSpan in the TableCell Widget

## How did you test this change?

Previously, all the content in a cells would be top aligned instead of center aligned. Now looks like this
![image](https://user-images.githubusercontent.com/3426850/174805077-64302539-681b-444d-909e-7b70316ec831.png)

Previously rowspan wasn't possible, but it has been added now.
![image](https://user-images.githubusercontent.com/3426850/174804604-25f44669-3d52-4a76-8db3-94e7f2e3e9b1.png)
