### PR TITLE
Create infobox league for Naraka

### DIFF
--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -82,7 +82,7 @@ function CustomLeague:_getGameMode()
 
 	local mode = _MODES[string.lower(_args.mode or '')] or _MODES['default']
 
-	return mode 
+	return mode
 end
 
 return CustomLeague

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -24,7 +24,7 @@ local _MODES = {
 	default = '[[Category:Unknown Mode Tournaments]]',
 }
 _MODES.solos = _MODES.solo
-_MODES.trio = _MODES.trios
+_MODES.trios = _MODES.trio
 
 function CustomLeague.run(frame)
 	local league = League(frame)
@@ -67,7 +67,7 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = args.platform
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.publishertier = args.pubgpremier
+	lpdbData.publishertier = args.narakapremier
 	lpdbData.extradata = {
 		individual = String.isNotEmpty(args.player_number) and 'true' or '',
 	}
@@ -76,7 +76,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 end
 
 function CustomLeague:_getGameMode()
-	if String.isEmpty(_args.perspective) and String.isEmpty(_args.mode) then
+	if String.isEmpty(_args.mode) then
 		return nil
 	end
 

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -8,14 +8,10 @@
 
 local League = require('Module:Infobox/League')
 local String = require('Module:StringUtils')
-local Variables = require('Module:Variables')
-local Template = require('Module:Template')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
-local Table = require('Module:Table')
-local Logic = require('Module:Logic')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -36,7 +32,6 @@ function CustomLeague.run(frame)
 
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
-	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
 	return league:createInfobox(frame)

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -30,10 +30,6 @@ function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
 
-	league.addToLpdb = CustomLeague.addToLpdb
-	league.createWidgetInjector = CustomLeague.createWidgetInjector
-	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
-
 	return league:createInfobox(frame)
 end
 

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -32,7 +32,6 @@ function CustomLeague.run(frame)
 	
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
-
 	return league:createInfobox(frame)
 end
 

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -1,0 +1,94 @@
+---
+-- @Liquipedia
+-- wiki=naraka
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+local Template = require('Module:Template')
+local Class = require('Module:Class')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local Table = require('Module:Table')
+local Logic = require('Module:Logic')
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+local _MODES = {
+	solo = 'Solo[[Category:Solo Mode Tournaments]]',
+	trio = 'Trios[[Category:Trios Mode Tournaments]]',
+	default = '[[Category:Unknown Mode Tournaments]]',
+}
+_MODES.solos = _MODES.solo
+_MODES.trio = _MODES.trios
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_args = league.args
+
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'gamesettings' then
+		return {
+			Cell{name = 'Game mode', content = {
+					CustomLeague:_getGameMode()
+				}
+			},
+		}
+	elseif id == 'customcontent' then
+		if _args.player_number then
+			table.insert(widgets, Title{name = 'Players'})
+			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
+		end
+
+		--teams section
+		if _args.team_number then
+			table.insert(widgets, Title{name = 'Teams'})
+			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+		end
+	end
+	return widgets
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.game = args.platform
+	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.publishertier = args.pubgpremier
+	lpdbData.extradata = {
+		individual = String.isNotEmpty(args.player_number) and 'true' or '',
+	}
+
+	return lpdbData
+end
+
+function CustomLeague:_getGameMode()
+	if String.isEmpty(_args.perspective) and String.isEmpty(_args.mode) then
+		return nil
+	end
+
+	local mode = _MODES[string.lower(_args.mode or '')] or _MODES['default']
+
+	return mode 
+end
+
+
+return CustomLeague

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -29,7 +29,6 @@ _MODES.trios = _MODES.trio
 function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
-	
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	return league:createInfobox(frame)

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -77,7 +77,7 @@ function CustomLeague:_getGameMode()
 		return nil
 	end
 
-	return _MODES[string.lower(_args.mode or '')] or _MODES['default']
+	return _MODES[_args.mode:lower()] or _MODES['default']
 end
 
 return CustomLeague

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -66,7 +66,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.narakapremier
 	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
+		individual = String.isNotEmpty(args.player_number)
 	}
 
 	return lpdbData

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -80,9 +80,7 @@ function CustomLeague:_getGameMode()
 		return nil
 	end
 
-	local mode = _MODES[string.lower(_args.mode or '')] or _MODES['default']
-
-	return mode
+	return _MODES[string.lower(_args.mode or '')] or _MODES['default']
 end
 
 return CustomLeague

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -29,6 +29,9 @@ _MODES.trios = _MODES.trio
 function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
+	
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
 
 	return league:createInfobox(frame)
 end

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -85,5 +85,4 @@ function CustomLeague:_getGameMode()
 	return mode 
 end
 
-
 return CustomLeague

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -53,10 +53,7 @@ function CustomInjector:parse(id, widgets)
 		if _args.player_number then
 			table.insert(widgets, Title{name = 'Players'})
 			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
-		end
-
-		--teams section
-		if _args.team_number then
+		elseif _args.team_number then
 			table.insert(widgets, Title{name = 'Teams'})
 			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
 		end


### PR DESCRIPTION


## Summary

Create Infobox League for the Naraka wiki. 

## How did you test this change?
Currently tested on:
https://liquipedia.net/naraka/Module:Infobox/League/Custom/Dev
https://liquipedia.net/naraka/Europe_Scrim/June/Week_2/Solo

https://liquipedia.net/naraka/Ryomen/Results (To test if results aren't affected)