### PR TITLE
PrizePool - Fix opponent level type parsing

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -652,10 +652,8 @@ function Placement:_parseOpponents(args)
 			end
 
 			-- Parse Opponent Data
-			local typeStruct = Json.parseIfString(opponentInput.type)
-			if typeStruct then
-				PrizePool._assertOpponentStructType(typeStruct)
-				opponentInput.type = typeStruct.type
+			if opponentInput.type then
+				PrizePool._assertOpponentStructType(opponentInput)
 			else
 				opponentInput.type = self.parent.opponentType
 			end


### PR DESCRIPTION
## Summary

#1374 did not have correct parsing of opponent level type (if provided). It expected a `type` key containing a json table, while in reality it should just be a `type` key containing a string.

## How did you test this change?

"dev module"