### PR TITLE
Don't call function that doesn't exist

### DIFF
--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -127,7 +127,15 @@ function OpponentDisplay.InlineOpponent(props)
 		return opponent.name or ''
 
 	elseif opponent.type == 'solo' then
-		return OpponentDisplay.PlayerInlineOpponent(props)
+		if not opponent.players then
+			return
+		end
+
+		return PlayerDisplay.InlinePlayer{
+			player = opponent.players[1],
+			flip = props.flip,
+			dq = props.dq,
+		}
 
 	else
 		error('Unrecognized opponent.type ' .. opponent.type)

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -127,10 +127,6 @@ function OpponentDisplay.InlineOpponent(props)
 		return opponent.name or ''
 
 	elseif opponent.type == 'solo' then
-		if not opponent.players then
-			return
-		end
-
 		return PlayerDisplay.InlinePlayer{
 			player = opponent.players[1],
 			flip = props.flip,


### PR DESCRIPTION
## Summary

OpponentDisplay.PlayerInlineOpponent doesn't exist. Change to use PlayerDisplay.InlinePlayer instead for solo players.

## How did you test this change?

dev module