### PR TITLE
Do not resolve redirect on series value in bw infobox league

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -277,7 +277,7 @@ function CustomLeague:defineCustomPageVariables()
 	-- do not reslolve redirect on the series input
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them
-	Variables.varDefine('tournament_series', args.series)
+	Variables.varDefine('tournament_series', _args.series)
 end
 
 function CustomLeague:addToLpdb(lpdbData)
@@ -295,7 +295,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	-- do not reslolve redirect on the series input
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them
-	lpdbData.series = args.series
+	lpdbData.series = _args.series
 
 	return lpdbData
 end

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -274,6 +274,10 @@ function CustomLeague:defineCustomPageVariables()
 	end
 
 	Variables.varDefine('tournament_finished', tostring(finished))
+	-- do not reslolve redirect on the series input
+	-- BW wiki has several series that are displayed on the same page
+	-- hence they need to not RR them
+	Variables.varDefine('tournament_series', args.series)
 end
 
 function CustomLeague:addToLpdb(lpdbData)
@@ -288,6 +292,10 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.participantsnumber = Variables.varDefault('tournament_playerNumber', _args.team_number or 0)
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
+	-- do not reslolve redirect on the series input
+	-- BW wiki has several series that are displayed on the same page
+	-- hence they need to not RR them
+	lpdbData.series = args.series
 
 	return lpdbData
 end

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -274,7 +274,7 @@ function CustomLeague:defineCustomPageVariables()
 	end
 
 	Variables.varDefine('tournament_finished', tostring(finished))
-	-- do not reslolve redirect on the series input
+	-- do not resolve redirect on the series input
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them
 	Variables.varDefine('tournament_series', _args.series)

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -292,7 +292,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.participantsnumber = Variables.varDefault('tournament_playerNumber', _args.team_number or 0)
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
-	-- do not reslolve redirect on the series input
+	-- do not resolve redirect on the series input
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them
 	lpdbData.series = _args.series


### PR DESCRIPTION
## Summary
Do not resolve redirect on series value in bw infobox league.
BW wiki has several series that are displayed on the same page, hence they need to not RR them.
(I dislike it but it is what it is ...)

## How did you test this change?
/dev module and pushed live afterwards