### PR TITLE
Add Signature Hero input for ML Infobox Player

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -14,6 +14,7 @@ local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Role = require('Module:Role')
 local Region = require('Module:Region')
 local HeroIcon = require('Module:HeroIcon')
+local Table = require('Module:Table')
 
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
@@ -84,14 +85,16 @@ function CustomInjector:addCustomCells(widgets)
 						return HeroIcon.getImage{hero, size = _SIZE_HERO}
 					end
 				)
-				return {
-					Cell{
-						name = #heroIcons > 1 and 'Signature Heroes' or 'Signature Hero',
-						content = {
-							table.concat(heroIcons, '&nbsp;')
+				if Table.isNotEmpty(heroIcons) then
+					return {
+						Cell{
+							name = #heroIcons > 1 and 'Signature Heroes' or 'Signature Hero',
+							content = {
+								table.concat(heroIcons, '&nbsp;')
+							}
 						}
 					}
-				}
+				end
 			end
 		})
 	return widgets

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -8,19 +8,19 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Player = require('Module:Infobox/Person')
-local String = require('Module:StringUtils')
-local TeamHistoryAuto = require('Module:TeamHistoryAuto')
-local Role = require('Module:Role')
-local Region = require('Module:Region')
 local HeroIcon = require('Module:HeroIcon')
+local HeroNames = mw.loadData('Module:HeroNames')
+local Player = require('Module:Infobox/Person')
+local Region = require('Module:Region')
+local Role = require('Module:Role')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
-local Builder = require('Module:Infobox/Widget/Builder')
 
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
@@ -33,9 +33,11 @@ local CustomPlayer = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
+local _player
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
+	_player = player
 	_args = player.args
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
@@ -77,26 +79,33 @@ end
 
 function CustomInjector:addCustomCells(widgets)
 	-- Signature Heroes
-	table.insert(widgets,
-		Builder{
-			builder = function()
-				local heroIcons = Array.map(Player:getAllArgsForBase(_args, 'hero'),
-					function(hero, _)
-						return HeroIcon.getImage{hero, size = _SIZE_HERO}
-					end
+	local heroIcons = Array.map(Player:getAllArgsForBase(_args, 'hero'),
+		function(hero, _)
+			local standardizedHero = HeroNames[hero:lower()]
+			if not standardizedHero then
+				-- we have an invalid hero entry
+				-- add warning (including tracking category)
+				table.insert(
+					_player.warnings,
+					'Invalid hero input "' .. hero .. '"[[Category:Pages with invalid hero input]]'
 				)
-				if Table.isNotEmpty(heroIcons) then
-					return {
-						Cell{
-							name = #heroIcons > 1 and 'Signature Heroes' or 'Signature Hero',
-							content = {
-								table.concat(heroIcons, '&nbsp;')
-							}
-						}
-					}
-				end
 			end
-		})
+			return HeroIcon.getImage{standardizedHero or hero, size = _SIZE_HERO}
+		end
+	)
+
+	if Table.isNotEmpty(heroIcons) then
+		table.insert(
+			widgets,
+			Cell{
+				name = #heroIcons > 1 and 'Signature Heroes' or 'Signature Hero',
+				content = {
+					table.concat(heroIcons, '&nbsp;')
+				}
+			}
+		)
+	end
+
 	return widgets
 end
 
@@ -108,11 +117,11 @@ function CustomPlayer:adjustLPDB(lpdbData)
 	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
 	lpdbData.extradata.role = _role.role
 	lpdbData.extradata.role2 = _role2.role
-	lpdbData.extradata.signatureHero1 = _args.hero1 or _args.hero
-	lpdbData.extradata.signatureHero2 = _args.hero2
-	lpdbData.extradata.signatureHero3 = _args.hero3
-	lpdbData.extradata.signatureHero4 = _args.hero4
-	lpdbData.extradata.signatureHero5 = _args.hero5
+
+	-- store signature heroes with standardized name
+	for heroIndex, hero in ipairs(Player:getAllArgsForBase(_args, 'hero')) do
+		lpdbData.extradata['signatureHero' .. heroIndex] = HeroNames[hero:lower()]
+	end
 
 	local region = Region.run({region = _args.region, country = _args.country})
 	if type(region) == 'table' then

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -6,22 +6,26 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
+local Class = require('Module:Class')
 local Player = require('Module:Infobox/Person')
 local String = require('Module:StringUtils')
-local Class = require('Module:Class')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Role = require('Module:Role')
 local Region = require('Module:Region')
+local HeroIcon = require('Module:HeroIcon')
 
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
+local Builder = require('Module:Infobox/Widget/Builder')
 
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
 local _role2
 local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
+local _SIZE_HERO = '25x25px'
 
 local CustomPlayer = Class.new()
 
@@ -69,6 +73,30 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+
+function CustomInjector:addCustomCells(widgets)
+	-- Signature Heroes
+	table.insert(widgets,
+		Builder{
+			builder = function()
+				local heroIcons = Array.map(Player:getAllArgsForBase(_args, 'hero'),
+					function(hero, _)
+						return HeroIcon.getImage{hero, size = _SIZE_HERO}
+					end
+				)
+				return {
+					Cell{
+						name = #heroIcons > 1 and 'Signature Heroes' or 'Signature Hero',
+						content = {
+							table.concat(heroIcons, '&nbsp;')
+						}
+					}
+				}
+			end
+		})
+	return widgets
+end
+
 function CustomPlayer:createWidgetInjector()
 	return CustomInjector()
 end
@@ -77,6 +105,11 @@ function CustomPlayer:adjustLPDB(lpdbData)
 	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
 	lpdbData.extradata.role = _role.role
 	lpdbData.extradata.role2 = _role2.role
+	lpdbData.extradata.signatureHero1 = _args.hero1 or _args.hero
+	lpdbData.extradata.signatureHero2 = _args.hero2
+	lpdbData.extradata.signatureHero3 = _args.hero3
+	lpdbData.extradata.signatureHero4 = _args.hero4
+	lpdbData.extradata.signatureHero5 = _args.hero5
 
 	local region = Region.run({region = _args.region, country = _args.country})
 	if type(region) == 'table' then


### PR DESCRIPTION
depends on #1431 

## Summary
Add |heroX= input for the Signature Heroes for the ML Infobox Player 
(not really sure why It wasnt there in first place I probably forgot)

## How did you test this change?
https://liquipedia.net/mobilelegends/User:Hesketh2/Test

## Side Note
My actual goal of this change is to allow this {{Notable Players}} template to work with a wiki that dont use SMW (such as ML), but afaik the template still dont have any LPDB version at all so I decide to update the infobox first

![image](https://user-images.githubusercontent.com/88981446/175765853-c51ebfa3-b2f0-4964-ab0a-abe8de54b280.png)

 