### PR TITLE
Make warnings in person infobox accessible in /Custom

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -30,11 +30,12 @@ local Customizable = Widgets.Customizable
 
 local Person = Class.new(BasicInfobox)
 
+Person.warnings = {}
+
 local Language = mw.language.new('en')
 local _LINK_VARIANT = 'player'
 local _shouldStoreData
 local _region
-local _warnings = {}
 
 function Person.run(frame)
 	local person = Person(frame)
@@ -196,7 +197,7 @@ function Person:createInfobox()
 		)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
+	return tostring(builtInfobox) .. WarningBox.displayAll(self.warnings)
 end
 
 function Person:_setLpdbData(args, links, status, personType)
@@ -255,7 +256,7 @@ function Person:getStandardNationalityValue(nationality)
 
 	if String.isEmpty(nationalityToStore) then
 		table.insert(
-			_warnings,
+			self.warnings,
 			'"' .. nationality .. '" is not supported as a value for nationalities'
 		)
 		nationalityToStore = nil


### PR DESCRIPTION
## Summary
Make warnings in person infobox accessible in /Custom

## How did you test this change?
/dev modules
example usage:
![Screenshot 2022-06-25 20 23 22](https://user-images.githubusercontent.com/75081997/175785986-18c56aea-2077-48ad-8db0-e5639cf25037.png)
(adding a warning when invalid heroes are entered, since that part is in the /Custom we need to be able to access (and adjust) the warnings in the /Custom)