### PR TITLE
Store heroes standardized and add warning for invalid entries

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -21,7 +21,6 @@ local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
-local Builder = require('Module:Infobox/Widget/Builder')
 
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role


### PR DESCRIPTION
depends on #1431

## Summary
* order required modules alphabetically
* during heroIcon display if an invalid hero is entered add a warning (incl. a tracking category)
* store signatureHero data with standardized names instead of the entered ones

## How did you test this change?
/dev module
![Screenshot 2022-06-25 20 23 22](https://user-images.githubusercontent.com/75081997/175785986-18c56aea-2077-48ad-8db0-e5639cf25037.png)
