### PR TITLE
Add Tier validation to HiddenDataBox

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -102,7 +102,7 @@ function HiddenDataBox.validateTier(tierString, tierMode)
 			INVALID_TIER_WARNING,
 			{
 				tierString = tierString,
-				tierMode = tierMode == TIER_MODE_TYPES and 'Tiertype' or 'Tier',
+				tierMode = tierMode == TIER_MODE_TYPES and 'Tier Type' or 'Tier',
 			}
 		)
 	end

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -9,6 +9,7 @@
 local BasicHiddenDataBox = require('Module:HiddenDataBox')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 
 local CustomHiddenDataBox = {}
@@ -58,7 +59,7 @@ function CustomHiddenDataBox.validateTier(tierString, tierMode)
 	if tierMode == TIER_MODE_TIERS and not Logic.isNumeric(tierValue) then
 		tierValue = Tier.number[tierValue]
 	end
-	tierValue = Tier.text[tierMode][tierString:lower()]
+	tierValue = Tier.text[tierMode][tierValue:lower()]
 	if not tierValue then
 		tierValue = tierString
 		warning = String.interpolate(

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -73,7 +73,7 @@ function CustomHiddenDataBox.validateTier(tierString, tierMode)
 		)
 	end
 
-	tierValue = (tierMode == TIER_MODE_TYPES and cleanedTierValue) or tierValue or tierString
+	tierValue = (tierMode == TIER_MODE_TYPES and cleanedTierValue) or tierValue
 
 	return tierValue, warning
 end

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -61,7 +61,7 @@ function CustomHiddenDataBox.validateTier(tierString, tierMode)
 	if tierMode == TIER_MODE_TIERS and not Logic.isNumeric(tierValue) then
 		tierValue = Tier.number[tierValue]
 	end
-	local cleanedTierValue = Tier.text[tierMode][tierValue:lower()]
+	local cleanedTierValue = Tier.text[tierMode][(tierValue or ''):lower()]
 	if not cleanedTierValue then
 		cleanedTierValue = tierString
 		warning = String.interpolate(

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -57,12 +57,13 @@ function CustomHiddenDataBox.validateTier(tierString, tierMode)
 	end
 	local warning
 	local tierValue = tierString
+	-- tier should be a number defining a tier
 	if tierMode == TIER_MODE_TIERS and not Logic.isNumeric(tierValue) then
 		tierValue = Tier.number[tierValue]
 	end
-	tierValue = Tier.text[tierMode][tierValue:lower()]
-	if not tierValue then
-		tierValue = tierString
+	local cleanedTierValue = Tier.text[tierMode][tierValue:lower()]
+	if not cleanedTierValue then
+		cleanedTierValue = tierString
 		warning = String.interpolate(
 			INVALID_TIER_WARNING,
 			{
@@ -72,7 +73,7 @@ function CustomHiddenDataBox.validateTier(tierString, tierMode)
 		)
 	end
 
-	tierValue = tierMode == TIER_MODE_TYPES and tierValue or tierString
+	tierValue = (tierMode == TIER_MODE_TYPES and cleanedTierValue) or tierValue or tierString
 
 	return tierValue, warning
 end

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -59,9 +59,9 @@ function CustomHiddenDataBox.validateTier(tierString, tierMode)
 	local tierValue = tierString
 	-- tier should be a number defining a tier
 	if tierMode == TIER_MODE_TIERS and not Logic.isNumeric(tierValue) then
-		tierValue = Tier.number[tierValue]
+		tierValue = Tier.number[tierValue:lower()] or tierValue
 	end
-	local cleanedTierValue = Tier.text[tierMode][(tierValue or ''):lower()]
+	local cleanedTierValue = Tier.text[tierMode][(tierValue):lower()]
 	if not cleanedTierValue then
 		cleanedTierValue = tierString
 		warning = String.interpolate(

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -10,6 +10,7 @@ local BasicHiddenDataBox = require('Module:HiddenDataBox')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
+local Tier = require('Module:Tier')
 local Variables = require('Module:Variables')
 
 local CustomHiddenDataBox = {}

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -68,7 +68,7 @@ function CustomHiddenDataBox.validateTier(tierString, tierMode)
 			INVALID_TIER_WARNING,
 			{
 				tierString = tierString,
-				tierMode = tierMode == TIER_MODE_TYPES and 'Tiertype' or 'Tier',
+				tierMode = tierMode == TIER_MODE_TYPES and 'Tier Type' or 'Tier',
 			}
 		)
 	end


### PR DESCRIPTION
## Summary
Add Tier validation to HiddenDataBox
- enforce valid inputs
- standardize the variable value that gets set and hence what is stored in lpdb via e.g. matches etc.
- display warnings if invalid tier/tiertype values are entered + set category

## How did you test this change?
/dev modules