### PR TITLE
Fix params in ML Infobox Item

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
@@ -95,8 +95,8 @@ function CustomInjector:parse(id, widgets)
 			{name = 'Physical Attack', parameter = 'physatk'},
 			{name = 'Physical Penetration', parameter = 'physpen'},
 			{name = 'Magical Penetration', parameter = 'magicpen'},
-			{name = 'Cooldown Reduction', parameter = 'critchance'},
-			{name = 'Critical Chance', parameter = 'critreduction'},
+			{name = 'Cooldown Reduction', parameter = 'cdreduction'},
+			{name = 'Critical Chance', parameter = 'critchance'},
 			{name = 'Movement Speed', funct = '_movementSpeedDisplay'},
 		}
 		widgets = CustomItem._getAttributeCells(attributeCells)


### PR DESCRIPTION
## Summary
in the old one, **critchance** became parameter for **cooldown reduction**
and **critreduction** became **critical chance**

this PR is to reflect this correctly

## How did you test this change?
Going Live
