### PR TITLE
Standardise Infobox/League parent storage

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -330,7 +330,7 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_game', string.lower(args.game or ''))
 
 	-- If no parent is available, set pagename instead to ease querying
-	local parent = _args.parent or mw.title.getCurrentTitle().prefixedText
+	local parent = args.parent or mw.title.getCurrentTitle().prefixedText
 	parent = string.gsub(parent, ' ', '_')
 	Variables.varDefine('tournament_parent', parent)
 	Variables.varDefine('tournament_parentname', args.parentname)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -330,7 +330,9 @@ function League:_definePageVariables(args)
 	Variables.varDefine('tournament_game', string.lower(args.game or ''))
 
 	-- If no parent is available, set pagename instead to ease querying
-	Variables.varDefine('tournament_parent', args.parent or mw.title.getCurrentTitle().prefixedText)
+	local parent = _args.parent or mw.title.getCurrentTitle().prefixedText
+	parent = string.gsub(parent, ' ', '_')
+	Variables.varDefine('tournament_parent', parent)
 	Variables.varDefine('tournament_parentname', args.parentname)
 	Variables.varDefine('tournament_subpage', args.subpage)
 

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -193,7 +193,9 @@ function HiddenInfoboxLeague._definePageVariables()
 	Variables.varDefine('tournament_game', (_GAMES[string.lower(_args.game or '')] or {})[1] or _GAMES[_GAME_WOL][1])
 
 	-- If no parent is available, set pagename instead to ease querying
-	Variables.varDefine('tournament_parent', _args.parent or mw.title.getCurrentTitle().prefixedText)
+	local parent = _args.parent or mw.title.getCurrentTitle().prefixedText
+	parent = string.gsub(parent, ' ', '_')
+	Variables.varDefine('tournament_parent', parent)
 	Variables.varDefine('tournament_parentname', _args.parentname)
 	Variables.varDefine('tournament_subpage', _args.subpage)
 


### PR DESCRIPTION
## Summary
Standardise parent storage
--> always use underscore instead of space

## How did you test this change?
/dev module