### PR TITLE
Adjust value display

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -91,7 +91,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {'$', LANG:formatNum(data)}}
+				return TableCell{content = {'$', PrizePool._formatPrize(data)}}
 			end
 		end,
 	},
@@ -112,7 +112,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				local displayText = {LANG:formatNum(data)}
+				local displayText = {PrizePool._formatPrize(data)}
 
 				if headerData.symbolFirst then
 					table.insert(displayText, 1, headerData.symbol)
@@ -227,7 +227,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {data}}
+				return TableCell{content = {LANG:formatNum(data)}}
 			end
 		end,
 	},
@@ -475,6 +475,21 @@ end
 --- Returns the default date based on wiki-variables set in the Infobox League
 function PrizePool._getTournamentDate()
 	return Variables.varDefaultMulti('tournament_enddate', 'tournament_edate', 'edate', TODAY)
+end
+
+--- Formats a number for display as currency
+function PrizePool._formatPrize(value)
+	value = Math.round{value, 2}
+
+	-- if number is non integer and has only 1 digit after the `.` we need to fill it up
+	-- e.g. .5 --> .50
+	local decimal = string.match(value, '%.(.-)$') or ''
+	if String.isNotEmpty(decimal) then
+		decimal = '.' .. decimal .. string.rep('0', 2 - string.len(decimal))
+		value = math.floor(value)
+	end
+
+	return LANG:formatNum(value) .. decimal
 end
 
 --- @class Placement


### PR DESCRIPTION
stacked on #1408

## Summary
Display currency values properly
- round them to 2 digits after the `.`
- for non-integers fill up the digits after the `.` to 2

Format Points value display (plain format num usage here)

## How did you test this change?
after:
![Screenshot 2022-06-30 08 14 35](https://user-images.githubusercontent.com/75081997/176606420-cd0906eb-e580-4093-b02a-89cecf568438.png)

before:
![Screenshot 2022-06-30 08 14 46](https://user-images.githubusercontent.com/75081997/176606427-38b1ab93-87f7-4e24-b332-c2e4740000f5.png)

