### PR TITLE
Add Official Device for WR Infobox League

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -38,12 +38,10 @@ function CustomLeague:createWidgetInjector()
 end
 
 function CustomInjector:parse(id, widgets)
-	if id == 'gamesettings' then
-		return {
-			Cell{name = 'Patch', content = {
-					CustomLeague._getPatchVersion()
-				}},
-			}
+	if id == 'sponsors' then
+		table.insert(widgets, Cell{name = 'Official Device', content = {_args.device}})
+	elseif id == 'gamesettings' then
+		return {Cell{name = 'Patch', content = {CustomLeague._getPatchVersion()}}}
 	elseif id == 'customcontent' then
 		if _args.player_number then
 			table.insert(widgets, Title{name = 'Players'})
@@ -70,6 +68,7 @@ end
 function League:defineCustomPageVariables()
 	Variables.varDefine('tournament_patch', _args.patch)
 	Variables.varDefine('tournament_endpatch', _args.epatch)
+	Variables.varDefine('tournament_device', _args.device)
 
 	Variables.varDefine('tournament_publishertier', _args['riotpremier'])
 


### PR DESCRIPTION
## Summary
new parameter for Infobox League which allow a display of the official phone device use in the tournament, mostly these are used for official majors (S-Tier) which most of times these are publicly known info (or addressed by the tournament itself)

## How did you test this change?
https://liquipedia.net/wildrift/User:Hesketh2/test

## Side Note
post-any needed touchups, I'll proceed for the other mobile wikis that alredy has standard infobox league (3 other games that I can recall)