### PR TITLE
Add Official Device for PUBGM Infobox League

### DIFF
--- a/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
@@ -73,7 +73,9 @@ function CustomLeague:createWidgetInjector()
 end
 
 function CustomInjector:parse(id, widgets)
-	if id == 'gamesettings' then
+	if id == 'sponsors' then
+		table.insert(widgets, Cell{name = 'Official Device', content = {_args.device}})
+	elseif id == 'gamesettings' then
 		return {
 			Cell{name = 'Game version', content = {
 					CustomLeague._getGameVersion()


### PR DESCRIPTION
## Summary
Same implementation as #1444 , Related code are a direct paste of the mentioned PR

## How did you test this change?
Briefly updated on the live module (before bot reverted) and functional well

## Side Note 
There will be two more wikis getting the same implementation (AoV & ML) after this, Brawl is a good one to have but im not familiar with their standard infoboxes yet.