### PR TITLE
Use currency module instead of template in prizePool

### DIFF
--- a/standard/local_currency/local_currency.lua
+++ b/standard/local_currency/local_currency.lua
@@ -41,14 +41,14 @@ function LocalCurrency.template(frame)
 end
 
 function LocalCurrency.display(currencyCode, prizeValue, options)
-	if String.isEmpty(currencyCode) then
-		return nil
-	end
 	options = options or {}
 
-	local localCurrencyData = LocalCurrencyData[currencyCode:lower()]
+	local localCurrencyData = LocalCurrency.raw(currencyCode)
 
 	if not localCurrencyData then
+		if currencyCode then
+			mw.log('Invalid currency "' .. currencyCode .. '"')
+		end
 		return nil
 	end
 
@@ -69,6 +69,14 @@ function LocalCurrency.display(currencyCode, prizeValue, options)
 	end
 
 	return localCurrencyData.text.prefix .. (prizeValue or '') .. localCurrencyData.text.suffix
+end
+
+function LocalCurrency.raw(currencyCode)
+	if String.isEmpty(currencyCode) then
+		return nil
+	end
+
+	return LocalCurrencyData[currencyCode:lower()]
 end
 
 function LocalCurrency.formatMoney(value)


### PR DESCRIPTION
## Summary
Use currency module instead of template in prizePool
(redo of #1449 to clean up commit history)

## How did you test this change?
/dev modules