### PR TITLE
Store Weapons into LPDB + Update Game appearances cell name

### DIFF
--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -12,7 +12,6 @@ local BasicInfobox = require('Module:Infobox/Basic')
 local Flags = require('Module:Flags')
 local String = require('Module:StringUtils')
 local Widgets = require('Module:Infobox/Widget/All')
-local WarningBox = require('Module:WarningBox')
 local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
@@ -21,8 +20,6 @@ local Builder = Widgets.Builder
 local Customizable = Widgets.Customizable
 
 local Weapon = Class.new(BasicInfobox)
-
-local _warnings = {}
 
 function Weapon.run(frame)
 	local weapon = Weapon(frame)
@@ -112,7 +109,7 @@ function Weapon:createInfobox()
 		self:setLpdbData(args)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
+	return builtInfobox
 end
 
 function Weapon:_createLocation(location)
@@ -137,14 +134,9 @@ function Weapon:nameDisplay(args)
 end
 
 function Weapon:setLpdbData(args)
-	local name = args.romanized_name or self.name
-
 	local lpdbData = {
-		name = name,
-		location = self:getStandardLocationValue(args.location),
-		location2 = self:getStandardLocationValue(args.location2),
+		name = self.name,
 		image = args.image,
-		imagedark = args.imagedark or args.imagedarkmode,
 		extradata = {}
 	}
 
@@ -152,24 +144,6 @@ function Weapon:setLpdbData(args)
 
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
 	mw.ext.LiquipediaDB.lpdb_datapoint('weapon_' .. self.name, lpdbData)
-end
-
-function Weapon:getStandardLocationValue(location)
-	if String.isEmpty(location) then
-		return nil
-	end
-
-	local locationToStore = Flags.CountryName(location)
-
-	if String.isEmpty(locationToStore) then
-		table.insert(
-			_warnings,
-			'"' .. location .. '" is not supported as a value for locations'
-		)
-		locationToStore = nil
-	end
-
-	return locationToStore
 end
 
 function Weapon:addToLpdb(lpdbData, args)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -12,6 +12,7 @@ local BasicInfobox = require('Module:Infobox/Basic')
 local Flags = require('Module:Flags')
 local String = require('Module:StringUtils')
 local Widgets = require('Module:Infobox/Widget/All')
+local WarningBox = require('Module:WarningBox')
 local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
@@ -20,6 +21,8 @@ local Builder = Widgets.Builder
 local Customizable = Widgets.Customizable
 
 local Weapon = Class.new(BasicInfobox)
+
+local _warnings = {}
 
 function Weapon.run(frame)
 	local weapon = Weapon(frame)
@@ -109,7 +112,7 @@ function Weapon:createInfobox()
 		self:setLpdbData(args)
 	end
 
-	return builtInfobox
+	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
 end
 
 function Weapon:_createLocation(location)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -10,7 +10,6 @@ local Class = require('Module:Class')
 local Namespace = require('Module:Namespace')
 local BasicInfobox = require('Module:Infobox/Basic')
 local Flags = require('Module:Flags')
-local String = require('Module:StringUtils')
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Header = Widgets.Header
@@ -137,6 +136,8 @@ function Weapon:setLpdbData(args)
 	local lpdbData = {
 		name = self.name,
 		image = args.image,
+		type = 'weapon',
+		information = self.name,
 		extradata = {}
 	}
 
@@ -151,3 +152,4 @@ function Weapon:addToLpdb(lpdbData, args)
 end
 
 return Weapon
+

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -137,7 +137,7 @@ function Weapon:setLpdbData(args)
 		name = self.name,
 		image = args.image,
 		type = 'weapon',
-		information = self.name,
+		information = name,
 		extradata = {}
 	}
 

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -137,7 +137,6 @@ function Weapon:setLpdbData(args)
 		name = self.name,
 		image = args.image,
 		type = 'weapon',
-		information = name,
 		extradata = {}
 	}
 


### PR DESCRIPTION
## Summary
Adds default support for LPDB storage for the Weapon Infobox. Also adjusts a few fields to be customizable to help support custom module saving. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested via dev module and testing pages
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
