### PR TITLE
OW hard limit for signature hero

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -43,6 +43,7 @@ local _ROLES = {
 _ROLES['assistant coach'] = _ROLES.coach
 
 local _SIZE_HERO = '25x25px'
+local MAX_NUMBER_OF_SIGNATURE_HEROES = 3
 
 local CustomPlayer = Class.new()
 
@@ -93,6 +94,7 @@ function CustomInjector:addCustomCells(widgets)
 			return HeroIcon.getImage{hero, size = _SIZE_HERO}
 		end
 	)
+	heroIcons = Array.sub(heroIcons, 1, MAX_NUMBER_OF_SIGNATURE_HEROES)
 
 	if Table.isNotEmpty(heroIcons) then
 		table.insert(widgets,
@@ -108,7 +110,7 @@ function CustomInjector:addCustomCells(widgets)
 	-- Active in Games
 	Cell{
 		name = 'Game Appearances',
-		content = GameAppearances.player({ player = _pagename })
+		content = GameAppearances.player({player = _pagename})
 	}
 	return widgets
 end
@@ -120,6 +122,9 @@ function CustomPlayer:adjustLPDB(lpdbData)
 	-- store signature heroes with standardized name
 	for heroIndex, hero in ipairs(Player:getAllArgsForBase(_args, 'hero')) do
 		lpdbData.extradata['signatureHero' .. heroIndex] = HeroIcon.getHeroName(hero)
+		if heroIndex == MAX_NUMBER_OF_SIGNATURE_HEROES then
+			break
+		end
 	end
 
 	lpdbData.type = Variables.varDefault('isplayer') == 'true' and 'player' or 'staff'


### PR DESCRIPTION
## Summary
As requested by the contributors of the wiki, this will cap the number of displayed and stored Signatures Heroes from the current number supported to three (3). 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Via Dev module and tested live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
