### PR TITLE
Add support for Wrapping content in Table Cells

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -32,7 +32,7 @@ local WidgetInjector = Lua.import('Module:Infobox/Widget/Injector', {requireDevI
 local WidgetFactory = require('Module:Infobox/Widget/Factory')
 local WidgetTable = require('Module:Widget/Table')
 local TableRow = require('Module:Widget/Table/Row')
-local TableCell = require('Module:Widget/Table/Cell/dev')
+local TableCell = require('Module:Widget/Table/Cell')
 
 --- @class PrizePool
 local PrizePool = Class.new(function(self, ...) self:init(...) end)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -32,7 +32,7 @@ local WidgetInjector = Lua.import('Module:Infobox/Widget/Injector', {requireDevI
 local WidgetFactory = require('Module:Infobox/Widget/Factory')
 local WidgetTable = require('Module:Widget/Table')
 local TableRow = require('Module:Widget/Table/Row')
-local TableCell = require('Module:Widget/Table/Cell')
+local TableCell = require('Module:Widget/Table/Cell/dev')
 
 --- @class PrizePool
 local PrizePool = Class.new(function(self, ...) self:init(...) end)
@@ -457,7 +457,7 @@ function PrizePool:_buildRows()
 					end
 
 					Array.extendWith(lastCellOfType.content, cell.content)
-					table.insert(cell.css, {'flex-direction', 'column'})
+					lastCellOfType.css['flex-direction'] = 'column'
 
 					return nil
 				end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -103,7 +103,7 @@ PrizePool.prizeTypes = {
 		headerDisplay = function (data)
 			local currencyData = Currency.raw(BASE_CURRENCY)
 			local currencyText = currencyData.text.prefix .. currencyData.text.suffix
-			return TableCell{content = {currencyText}}
+			return TableCell{content = {{currencyText}}}
 		end,
 
 		row = 'usdprize',
@@ -112,7 +112,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {'$', Currency.formatMoney(data)}}
+				return TableCell{content = {{'$', Currency.formatMoney(data)}}}
 			end
 		end,
 	},
@@ -133,7 +133,7 @@ PrizePool.prizeTypes = {
 			}
 		end,
 		headerDisplay = function (data)
-			return TableCell{content = {data.currencyText}}
+			return TableCell{content = {{data.currencyText}}}
 		end,
 
 		row = 'localprize',
@@ -150,7 +150,7 @@ PrizePool.prizeTypes = {
 					table.insert(displayText, headerData.symbol)
 				end
 
-				return TableCell{content = displayText}
+				return TableCell{content = {displayText}}
 			end
 		end,
 
@@ -211,7 +211,7 @@ PrizePool.prizeTypes = {
 				table.insert(content, '[[' .. headerData.link .. ']]')
 			end
 
-			return TableCell{content = content}
+			return TableCell{content = {content}}
 		end,
 
 		mergeDisplayColumns = true,
@@ -250,7 +250,7 @@ PrizePool.prizeTypes = {
 				table.insert(headerDisplay, text)
 			end
 
-			return TableCell{content = headerDisplay}
+			return TableCell{content = {headerDisplay}}
 		end,
 
 		row = 'points',
@@ -259,7 +259,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {LANG:formatNum(data)}}
+				return TableCell{content = {{LANG:formatNum(data)}}}
 			end
 		end,
 	},
@@ -271,7 +271,7 @@ PrizePool.prizeTypes = {
 			return {title = input}
 		end,
 		headerDisplay = function (data)
-			return TableCell{content = {data.title}}
+			return TableCell{content = {{data.title}}}
 		end,
 
 		row = 'freetext',
@@ -280,7 +280,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if String.isNotEmpty(data) then
-				return TableCell{content = {data}}
+				return TableCell{content = {{data}}}
 			end
 		end,
 	}
@@ -430,7 +430,7 @@ function PrizePool:_buildRows()
 
 			if opponentIndex == 1 then
 				local placeCell = TableCell{
-					content = {placement:getMedal() or '' , NON_BREAKING_SPACE, placement:displayPlace()},
+					content = {{placement:getMedal() or '' , NON_BREAKING_SPACE, placement:displayPlace()}},
 					css = {['font-weight'] = 'bolder'},
 				}
 				placeCell.rowSpan = #placement.opponents
@@ -453,10 +453,11 @@ function PrizePool:_buildRows()
 				if lastCellOfType and prizeTypeData.mergeDisplayColumns then
 
 					if Table.isNotEmpty(lastCellOfType.content) and Table.isNotEmpty(cell.content) then
-						lastCellOfType:addContent(tostring(mw.html.create('hr'):css('flex-basis', '100%')))
+						lastCellOfType:addContent(tostring(mw.html.create('hr'):css('width', '100%')))
 					end
 
 					Array.extendWith(lastCellOfType.content, cell.content)
+					table.insert(cell.css, {'flex-direction', 'column'})
 
 					return nil
 				end

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -54,7 +54,7 @@ function TableCell:_concatContent()
 			Array.forEach(content, function (inner)
 				wrapper:node(inner)
 			end)
-			return wrapper
+			return tostring(wrapper)
 		else
 			return content
 		end

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Widget = require('Module:Infobox/Widget')
 
@@ -41,9 +42,23 @@ function TableCell:make()
 
 	cell:css(self.css)
 
-	cell:wikitext(table.concat(self.content))
+	cell:node(self:_concatContent())
 
 	return {cell}
+end
+
+function TableCell:_concatContent()
+	return table.concat(Array.map(self.content, function (content)
+		if type(content) == 'table' then
+			local wrapper = mw.html.create('div')
+			Array.forEach(content, function (inner)
+				wrapper:node(inner)
+			end)
+			return wrapper
+		else
+			return content
+		end
+	end))
 end
 
 return TableCell


### PR DESCRIPTION
## Summary

This PR changes the stucture of `content` in a Widget Table Cell from a flat array of strings into a mixed one with support for both strings and tables with strings.

String will be handed in the same way as before, however a lua-table will be automatically wrapped in a div. This is good practice when working with flexboxes.

The changes in the Prize Pool is to adjust to this behavior & fixes the issue with overly wide columns when line breaks occur.

## How did you test this change?
Using dev modules.

Old:
![image](https://user-images.githubusercontent.com/3426850/178016955-58ff957f-60e9-44e5-8c6a-f1e37881d68c.png)

New:
![image](https://user-images.githubusercontent.com/3426850/178016611-4c5f5f25-1314-44d8-bd7c-e04d5b98416e.png)
