### PR TITLE
Add points storage into extradata

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -874,8 +874,8 @@ function Placement:_getLpdbData()
 			participant = Opponent.toName(opponent.opponentData)
 		end
 
-		local prizeMoney = tonumber(self:_getPrizeRewardForOpponent(opponent, PRIZE_TYPE_USD .. 1)) or 0
-		local pointsReward = self:_getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
+		local prizeMoney = tonumber(self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_USD .. 1)) or 0
+		local pointsReward = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
 		local lpdbData = {
 			image = image,
 			imagedark = imageDark,
@@ -914,7 +914,7 @@ function Placement:_getLpdbData()
 	return entries
 end
 
-function Placement:_getPrizeRewardForOpponent(opponent, prize)
+function Placement:getPrizeRewardForOpponent(opponent, prize)
 	return opponent.prizeRewards[prize] or self.prizeRewards[prize]
 end
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -874,7 +874,8 @@ function Placement:_getLpdbData()
 			participant = Opponent.toName(opponent.opponentData)
 		end
 
-		local prizeMoney = tonumber(opponent.prizeRewards[PRIZE_TYPE_USD .. 1] or self.prizeRewards[PRIZE_TYPE_USD .. 1]) or 0
+		local prizeMoney = tonumber(self:_getPrizeRewardForOpponent(opponent, PRIZE_TYPE_USD .. 1)) or 0
+		local pointsReward = self:_getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
 		local lpdbData = {
 			image = image,
 			imagedark = imageDark,
@@ -892,7 +893,9 @@ function Placement:_getLpdbData()
 			lastscore = (opponent.additionalData.LASTVSSCORE or {}).score,
 			lastvsscore = (opponent.additionalData.LASTVSSCORE or {}).vsscore,
 			groupscore = opponent.additionalData.GROUPSCORE,
-			extradata = {}
+			extradata = {
+				prizepoints = tostring(pointsReward or ''),
+			}
 
 			-- TODO: We need to create additional LPDB Fields
 			-- match2 opponents (opponentname, opponenttemplate, opponentplayers, opponenttype)
@@ -909,6 +912,10 @@ function Placement:_getLpdbData()
 	end
 
 	return entries
+end
+
+function Placement:_getPrizeRewardForOpponent(opponent, prize)
+	return opponent.prizeRewards[prize] or self.prizeRewards[prize]
 end
 
 function Placement:_setUsdFromRewards(prizesToUse, prizeTypes)


### PR DESCRIPTION
## Summary

Add simple points storage, mirroring the method used on majority of main wikis, that being `points1` is saved into lpdb extradata field `prizepoints`.

## How did you test this change?
Dev module

![image](https://user-images.githubusercontent.com/3426850/178113248-018079b1-39ea-469a-9b2c-e47a940492bd.png)
