### PR TITLE
Add Prize Summary info to Prize Pool

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -367,6 +367,12 @@ function PrizePool._comparePrizes(x, y)
 end
 
 function PrizePool:build()
+	local wrapper = mw.html.create('div'):css('overflow-x', 'auto')
+
+	if self.options.prizeSummary then
+		wrapper:wikitext(self:_getPrizeSummaryText())
+	end
+
 	local table = WidgetTable{classes = {'collapsed', 'general-collapsible', 'prizepooltable'}}
 
 	table:addRow(self:_buildHeader())
@@ -376,8 +382,6 @@ function PrizePool:build()
 	end
 
 	table:setContext{self._widgetInjector}
-
-	local wrapper = mw.html.create('div'):css('overflow-x', 'auto')
 	for _, node in ipairs(WidgetFactory.work(table, self._widgetInjector)) do
 		wrapper:node(node)
 	end
@@ -387,6 +391,29 @@ function PrizePool:build()
 	end
 
 	return wrapper
+end
+
+function PrizePool:_getPrizeSummaryText()
+	local tba = Abbreviation.make('TBA', 'To Be Announced')
+	local tournamentCurrency = Variables.varDefault('tournament_currency')
+	local baseMoneyRaw = Variables.varDefault('tournament_prizepool_usd', tba)
+	local baseMoneyDisplay = Currency.display(BASE_CURRENCY, baseMoneyRaw, {formatValue = true})
+
+	local displayText = {baseMoneyDisplay}
+
+	if tournamentCurrency and tournamentCurrency:upper() ~= BASE_CURRENCY then
+		local localMoneyRaw = Variables.varDefault('tournament_prizepool_local', tba)
+		local localMoneyDisplay = Currency.display(tournamentCurrency, localMoneyRaw, {formatValue = true})
+
+		table.insert(displayText, 1, localMoneyDisplay)
+		table.insert(displayText, 2,' (≃ ')
+		table.insert(displayText, ')')
+	end
+
+	table.insert(displayText, ' are spread among the teams as seen below:')
+	table.insert(displayText, '<br>')
+
+	return table.concat(displayText)
 end
 
 function PrizePool:_buildHeader()


### PR DESCRIPTION
## Summary

Add an Automatic Prize Summary Info. It's toggle in options. By default it can be turned off with `|prizesummary=no`. Wiki customs can change the settings behavior if needed. It uses information from the Infobox rather than the Prizepool, as it's quite common for upcoming tournaments to have a known prizepool (wich is set in the infobox), but the share is not known and hence no money data added to the prize pool.
![image](https://user-images.githubusercontent.com/3426850/178223602-d03dc3c7-9b36-4dc3-948f-25fe076b3ea2.png)

## How did you test this change?

/dev module