### PR TITLE
Remove prizePoolIndex from team object name

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -772,7 +772,8 @@ end
 function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex)
 	local objectName = 'ranking_'
 	if lpdbEntry.opponenttype == Opponent.team then
-		return objectName .. mw.ustring.lower(lpdbEntry.participant)
+		local smwPrefix = Variables.varDefault('smw_prefix', '')
+		return objectName .. smwPrefix .. mw.ustring.lower(lpdbEntry.participant)
 	end
 	-- for non team opponents the pagename can be case sensitive
 	-- so objectname needs to be case sensitive to avoid edge cases


### PR DESCRIPTION
## Summary

Having Prize Pool Index makes the TeamCard unable to match the objectname to merge the data. Hence this PR removes Prize Pool Index from the ObjectName when it's a team.

Before:
![image](https://user-images.githubusercontent.com/3426850/178427411-54f90bcb-6094-4f3f-8eb7-bea8de203d8f.png)
![image](https://user-images.githubusercontent.com/3426850/178427439-7815deae-b4df-4a86-a399-8571f3c712d9.png)


After:
![image](https://user-images.githubusercontent.com/3426850/178427218-32851a57-8394-49a7-a8c0-9ccf199000f9.png)



## How did you test this change?

dev module