### PR TITLE
Legacy Mapping for R6 Prizepool

### DIFF
--- a/components/prize_pool/wikis/rainbowsix/prize_pool_legacy.lua
+++ b/components/prize_pool/wikis/rainbowsix/prize_pool_legacy.lua
@@ -1,0 +1,163 @@
+---
+-- @Liquipedia
+-- wiki=rainbowsix
+-- page=Module:PrizePool/Legacy
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Currency = require('Module:LocalCurrency')
+local Json = require('Module:Json')
+local Lua = require('Module:Lua')
+local Points = mw.loadData('Module:Points/data')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Template = require('Module:Template')
+
+local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabled = true})
+
+local LegacyPrizePool = {}
+local nextPoints, nextQual, nextFreetext = 1, 1, 1
+local inputToId = {}
+local qualCache = {}
+
+-- Template entry point
+function LegacyPrizePool.run()
+	local args = Template.retrieveReturnValues('LegacyPrizePool')
+	local header = Array.sub(args, 1, 1)[1]
+	local slots = Array.sub(args, 2)
+
+	local newArgs = {}
+
+	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
+	newArgs.cutafter = header.cutafter
+
+	if Currency.raw(header.localcurrency) then
+		newArgs.localcurrency = header.localcurrency
+		inputToId.localprize = 'localprize'
+	else
+		LegacyPrizePool._assignType(newArgs, header, 'localcurrency')
+	end
+
+	LegacyPrizePool._assignType(newArgs, header, 'points')
+	LegacyPrizePool._assignType(newArgs, header, 'points2')
+	LegacyPrizePool._assignType(newArgs, header, 'points3')
+
+	if args.indiv then
+		newArgs.type = {type = 'solo'}
+	else
+		newArgs.type = {type = 'team'}
+	end
+
+	mw.logObject(inputToId)
+	for slotIndex, slot in ipairs(slots) do
+		newArgs[slotIndex] = LegacyPrizePool._mapSlot(slot)
+	end
+	for link, idx in pairs(qualCache) do
+		newArgs['qualifies' .. idx] = link
+	end
+	mw.logObject(newArgs)
+
+	return CustomPrizePool.run(newArgs)
+end
+
+function LegacyPrizePool._mapSlot(slot)
+	if not slot.place then
+		return {}
+	end
+
+	local newData = {}
+	if slot.place:lower() == 'dq' or slot.place:lower() == 'dnp' then
+		newData[slot.place:lower()] = true
+	else
+		newData.place = slot.place
+	end
+
+	newData.date = slot.date
+	newData.usdprize = (slot.usdprize and slot.usdprize ~= '0') and slot.usdprize or nil
+
+	Table.iter.forEachPair(inputToId, function(parameter, newParameter)
+		if parameter == 'localcurrency' then
+			parameter = 'localprize'
+		end
+		local input = slot[parameter]
+		if newParameter == 'seed' then
+			local links = LegacyPrizePool._parseWikiLink(input)
+			for _, link in ipairs(links) do
+				if not qualCache[link] then
+					qualCache[link] = nextQual
+					nextQual = nextQual + 1
+				end
+				newData['qualified' .. qualCache[link]] = true
+			end
+		elseif input and input ~= 0 then
+			newData[newParameter] = input
+		end
+	end)
+
+	for opponentIndex = 1, 128 do
+		if not slot[opponentIndex] then
+			break
+		end
+
+		local newOpponent = {}
+		newOpponent[1] = slot[opponentIndex]
+		newOpponent.date = slot['date' .. opponentIndex]
+		newOpponent.wdl = slot['wdl' .. opponentIndex]
+		newOpponent.lastvs = slot['lastvs' .. opponentIndex]
+		newOpponent.lastscore = slot['lastscore' .. opponentIndex]
+		newOpponent.lastvsscore = slot['lastvsscore' .. opponentIndex]
+
+		newData[opponentIndex] = Json.stringify(newOpponent)
+	end
+
+	return newData
+end
+
+function LegacyPrizePool._assignType(assignTo, args, parameter)
+	local input = args[parameter]
+	if LegacyPrizePool._isValidPoints(input) then
+		assignTo['points' .. nextPoints] = input
+		inputToId[parameter] = 'points' .. nextPoints
+		nextPoints = nextPoints + 1
+	elseif input == 'seed' then
+		inputToId[parameter] = 'seed'
+	elseif String.isNotEmpty(input) then
+		assignTo['freetext' .. nextFreetext] = mw.getContentLanguage():ucfirst(input)
+		inputToId[parameter] = 'freetext' .. nextFreetext
+		nextFreetext = nextFreetext + 1
+	end
+end
+
+function LegacyPrizePool._isValidPoints(input)
+	return Points[input] and true or false
+end
+
+function LegacyPrizePool._parseWikiLink(input)
+	if not input then
+		return {}
+	end
+
+	local links = {}
+
+	for inputSection in mw.text.gsplit(input, '<[hb]r/?>') do
+		local cleanedInput = inputSection:gsub('%[', ''):gsub('%]', '')
+		if cleanedInput:find('|') then
+			local linkParts = mw.text.split(cleanedInput, '|', true)
+			local link = linkParts[1]
+
+			if link:sub(1, 1) == '/' then
+				-- Relative link
+				link = mw.title.getCurrentTitle().fullText .. link
+			end
+			link = link:gsub(' ', '_')
+
+			table.insert(links, link)
+		end
+	end
+
+	return links
+end
+
+return LegacyPrizePool

--- a/components/prize_pool/wikis/rainbowsix/prize_pool_legacy.lua
+++ b/components/prize_pool/wikis/rainbowsix/prize_pool_legacy.lua
@@ -37,7 +37,7 @@ function LegacyPrizePool.run()
 		newArgs.localcurrency = header.localcurrency
 		inputToId.localprize = 'localprize'
 	else
-		LegacyPrizePool._assignType(newArgs, header, 'localcurrency')
+		LegacyPrizePool._assignType(newArgs, header, 'localcurrency', 'localprize')
 	end
 
 	LegacyPrizePool._assignType(newArgs, header, 'points')
@@ -50,7 +50,6 @@ function LegacyPrizePool.run()
 		newArgs.type = {type = 'team'}
 	end
 
-	mw.logObject(inputToId)
 	for slotIndex, slot in ipairs(slots) do
 		newArgs[slotIndex] = LegacyPrizePool._mapSlot(slot)
 	end
@@ -78,9 +77,6 @@ function LegacyPrizePool._mapSlot(slot)
 	newData.usdprize = (slot.usdprize and slot.usdprize ~= '0') and slot.usdprize or nil
 
 	Table.iter.forEachPair(inputToId, function(parameter, newParameter)
-		if parameter == 'localcurrency' then
-			parameter = 'localprize'
-		end
 		local input = slot[parameter]
 		if newParameter == 'seed' then
 			local links = LegacyPrizePool._parseWikiLink(input)
@@ -109,23 +105,24 @@ function LegacyPrizePool._mapSlot(slot)
 		newOpponent.lastscore = slot['lastscore' .. opponentIndex]
 		newOpponent.lastvsscore = slot['lastvsscore' .. opponentIndex]
 
-		newData[opponentIndex] = Json.stringify(newOpponent)
+		newData[opponentIndex] = newOpponent
 	end
 
 	return newData
 end
 
-function LegacyPrizePool._assignType(assignTo, args, parameter)
+function LegacyPrizePool._assignType(assignTo, args, parameter, slotParam)
+	slotParam = slotParam or parameter
 	local input = args[parameter]
 	if LegacyPrizePool._isValidPoints(input) then
 		assignTo['points' .. nextPoints] = input
-		inputToId[parameter] = 'points' .. nextPoints
+		inputToId[slotParam] = 'points' .. nextPoints
 		nextPoints = nextPoints + 1
 	elseif input == 'seed' then
-		inputToId[parameter] = 'seed'
+		inputToId[slotParam] = 'seed'
 	elseif String.isNotEmpty(input) then
 		assignTo['freetext' .. nextFreetext] = mw.getContentLanguage():ucfirst(input)
-		inputToId[parameter] = 'freetext' .. nextFreetext
+		inputToId[slotParam] = 'freetext' .. nextFreetext
 		nextFreetext = nextFreetext + 1
 	end
 end


### PR DESCRIPTION
## Summary
First the old template stash their data into with variables with use of the Template module.
https://liquipedia.net/rainbowsix/index.php?title=Template%3APrize_pool_start&type=revision&diff=467826&oldid=447365
https://liquipedia.net/rainbowsix/index.php?title=Template%3APrize_pool_slot&type=revision&diff=467827&oldid=248709

Once this is live, all other code in the templates shall be removed, and Prize Pool End shall be updated to invoke `{{#invoke:PrizePool/Legacy|run}}` instead.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
