### PR TITLE
Support new lpdb tables `standingstable` and `standingsentry`

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -218,7 +218,7 @@ function StandingsStorage.fromTemplateEntry(frame)
 			team = mw.ext.TeamTemplate.raw(teamPage, date)
 		end
 
-		opponentArgs = {type = 'team'}
+		opponentArgs = {type = Opponent.team}
 
 		if team then
 			opponentArgs.template = team.templatename

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -7,14 +7,122 @@
 --
 
 local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
 local Flags = require('Module:Flags')
+local Json = require('Module:Json')
+local Opponent = require('Module:Opponent')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local StandingsStorage = {}
-local SCOREBOARD_FALLBACK = {0, 0, 0}
+local ALLOWED_SCORE_BOARD_KEYS = {'w', 'd', 'l'}
+local SCOREBOARD_FALLBACK = {w = 0, d = 0, l = 0}
+local SCOREBOARD_LEGACY_FALLBACK = {0, 0, 0}
 
-function StandingsStorage.run(index, data)
+function StandingsStorage.run(data)
+	if Table.isEmpty(data) then
+		return
+	end
+
+	if data.opponentLibrary then
+		Opponent = require('Module:'.. data.opponentLibrary)
+	end
+
+	local standingsIndex = tonumber(data.standingsindex) or 0
+
+	data.roundcount = tonumber(data.roundcount) or Array.reduce(
+		Array.map(data.entries, function (entry) return tonumber (entry.roundindex) end),
+		math.max)
+
+	StandingsStorage.table(data)
+
+	Array.forEach(data.entries, function (entry)
+		StandingsStorage.entry(entry, standingsIndex)
+		StandingsStorage.runLegacy(entry.slotIndex, entry) -- Deprecated
+	end)
+end
+
+function StandingsStorage.table(data)
+	local title = data.title or ''
+	local cleanedTitle = title:gsub('<.->.-</.->', '')
+
+	local extradata = {
+		roundcount = data.roundcount,
+		stagename = data.stagename or Variables.varDefault('bracket_header'),
+	}
+
+	mw.ext.LiquipediaDB.lpdb_standingstable('standingsTable_' .. data.standingsindex,
+		{
+			tournament = Variables.varDefault('tournament_name', ''),
+			parent = Variables.varDefault('tournament_parent', ''),
+			standingsindex = tonumber(data.standingsindex),
+			title = mw.text.trim(cleanedTitle),
+			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),
+			type = data.type,
+			matches = mw.ext.LiquipediaDB.lpdb_create_json(data.matches or {}),
+			extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, data.extradata)),
+		}
+	)
+end
+
+function StandingsStorage.entry(entry, standingsIndex)
+	local roundIndex = tonumber(entry.roundindex)
+	local slotIndex = tonumber(entry.slotindex)
+
+	local extradata = {
+		enddate = entry.enddate,
+		roundfinished = entry.finished,
+		placerange = entry.placerange,
+		slotindex = slotIndex,
+	}
+
+	local lpdbEntry = {
+		parent = Variables.varDefault('tournament_parent', ''),
+		standingsindex = standingsIndex,
+		placement = entry.placement or entry.rank,
+		definitestatus = entry.definitestatus or entry.bg,
+		currentstatus = entry.currentstatus or entry.pbg,
+		placementchange = entry.placementchange or entry.change,
+		scoreboard = mw.ext.LiquipediaDB.lpdb_create_json{
+			match = StandingsStorage.toScoreBoardEntry(entry.match),
+			overtime = StandingsStorage.toScoreBoardEntry(entry.overtime),
+			game = StandingsStorage.toScoreBoardEntry(entry.game),
+			points = tonumber(entry.points),
+			diff = tonumber(entry.diff),
+			buchholz = tonumber(entry.buchholz),
+		},
+		roundindex = roundIndex,
+		extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, entry.extradata)),
+	}
+
+	mw.ext.LiquipediaDB.lpdb_standingsentry(
+		'standing_' .. standingsIndex .. '_' .. entry.roundindex .. '_' .. slotIndex,
+		Table.merge(lpdbEntry, Opponent.toLpdbStruct(entry.opponent))
+	)
+end
+
+function StandingsStorage.toScoreBoardEntry(data)
+	if Table.isEmpty(data) then
+		return
+	end
+
+	local filterScoreBoard = function (_, key)
+		return ALLOWED_SCORE_BOARD_KEYS[key] and true or false
+	end
+
+	-- Need to use Array.filter here. Because strangely enough Table.filter has no access to keys...
+	local scoreBoard = Table.mapValues(Array.filter(data, filterScoreBoard), tonumber)
+
+	if not scoreBoard.w or not scoreBoard.l then
+		mw.logObject(scoreBoard, 'invalid scoreBoardEntry')
+		return SCOREBOARD_FALLBACK
+	end
+
+	return scoreBoard
+end
+
+--- @deprecated
+function StandingsStorage.runLegacy(index, data)
 	local title = data.title or ''
 	local cleanedTitle = title:gsub('<.->.-</.->', '')
 	mw.ext.LiquipediaDB.lpdb_standing(
@@ -50,15 +158,26 @@ function StandingsStorage.run(index, data)
 	)
 end
 
+---@deprecated
 function StandingsStorage.verifyScoreBoardEntry(entry)
 	-- A valid scoreboard entry must have 3 values in an array
 	if #entry ~= 3 then
-		return SCOREBOARD_FALLBACK
+		return SCOREBOARD_LEGACY_FALLBACK
 	end
 	return entry
 end
 
-function StandingsStorage.fromTemplate(frame)
+function StandingsStorage.fromTemplateHeader(frame)
+	local data = Arguments.getArgs(frame)
+
+	if not data.standingsindex then
+		return
+	end
+
+	return StandingsStorage.table(data)
+end
+
+function StandingsStorage.fromTemplateEntry(frame)
 	local data = Arguments.getArgs(frame)
 
 	if not data.standingsindex or not data.roundindex or not data.placement then
@@ -68,10 +187,14 @@ function StandingsStorage.fromTemplate(frame)
 		return
 	end
 
-	if data.team then
+	local date = Variables.varDefault('tournament_startdate', Variables.varDefault('tournament_enddate'))
+
+	local opponentArgs
+	if data.opponent then
+		opponentArgs = Json.parseIfString(data.opponent)
+	elseif data.team then
 		-- attempts to find [[teamPage|teamDisplay]] and skips images (images have multiple |)
 		local teamPage = string.match(data.team, '%[%[([^|]-)|[^|]-%]%]')
-		local date = Variables.varDefault('tournament_startdate', Variables.varDefault('tournament_enddate'))
 		local team
 
 		-- Input contains an actual team
@@ -82,24 +205,42 @@ function StandingsStorage.fromTemplate(frame)
 			team = mw.ext.TeamTemplate.raw(teamPage, date)
 		end
 
+		opponentArgs = {type = 'team'}
+
 		if team then
+			opponentArgs.team = team.templatename
+
+			-- Legacy
 			data.participant = team.page
 			data.participantdisplay = team.name
 			data.icon = team.image
 			data.icondark = team.imagedark
 		else
+			-- Legacy
 			data.participant = 'tbd'
 			data.participantdisplay = 'TBD'
 		end
 	elseif data.player then
-		data.participant, data.participantdisplay = string.match(data.player, '%[%[([^|]-)|([^|]-)%]%]')
 		-- TODO: sanity checks and parse flag
 		-- TODO: handle more input cases
+		data.participant, data.participantdisplay = string.match(data.player, '%[%[([^|]-)|([^|]-)%]%]')
+		opponentArgs = {link = data.participant, name = data.participantdisplay}
 	end
+
+	data.opponent = Opponent.resolve(Opponent.readOpponentArgs(opponentArgs) or Opponent.tbd(), date)
+
+	data.match = {w = data.win_m, d = data.tie_m, l = data.lose_m}
+	data.game = {w = data.win_g, d = data.tie_g, l = data.lose_g}
+	StandingsStorage.entry(data, data.standingsindex)
 
 	data.match = {data.win_m, data.tie_m, data.lose_m}
 	data.game = {data.win_g, data.tie_g, data.lose_g}
-	return StandingsStorage.run(data.placement, data)
+	StandingsStorage.runLegacy(data.standingsindex, data)
+end
+
+-- Legacy input
+function StandingsStorage.fromTemplate(frame)
+	return StandingsStorage.fromTemplateEntry(frame)
 end
 
 return StandingsStorage

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -7,18 +7,19 @@
 --
 
 local Arguments = require('Module:Arguments')
-local Array = require('Module:Array')
-local Flags = require('Module:Flags')
-local Json = require('Module:Json')
-local Opponent = require('Module:Opponent')
-local Table = require('Module:Table')
-local Variables = require('Module:Variables')
+local Array = require('Module:Array') ---@module "standard.array"
+local Flags = require('Module:Flags') ---@module "standard.flags"
+local Json = require('Module:Json') ---@module "standard.json"
+local Opponent = require('Module:Opponent') ---@module "opponent"
+local Table = require('Module:Table') ---@module "standard.table"
+local Variables = require('Module:Variables') ---@module "variables"
 
 local StandingsStorage = {}
 local ALLOWED_SCORE_BOARD_KEYS = {'w', 'd', 'l'}
 local SCOREBOARD_FALLBACK = {w = 0, d = 0, l = 0}
 local SCOREBOARD_LEGACY_FALLBACK = {0, 0, 0}
 
+---@param data table
 function StandingsStorage.run(data)
 	if Table.isEmpty(data) then
 		return
@@ -38,10 +39,11 @@ function StandingsStorage.run(data)
 
 	Array.forEach(data.entries, function (entry)
 		StandingsStorage.entry(entry, standingsIndex)
-		StandingsStorage.legacy(entry.slotIndex, entry) -- Deprecated
+		StandingsStorage.legacy(entry.slotIndex, entry)
 	end)
 end
 
+---@param data table
 function StandingsStorage.table(data)
 	local title = data.title or ''
 	local cleanedTitle = title:gsub('<.->.-</.->', '')
@@ -65,6 +67,8 @@ function StandingsStorage.table(data)
 	)
 end
 
+---@param entry table
+---@param standingsIndex number
 function StandingsStorage.entry(entry, standingsIndex)
 	local roundIndex = tonumber(entry.roundindex)
 	local slotIndex = tonumber(entry.slotindex)
@@ -101,6 +105,7 @@ function StandingsStorage.entry(entry, standingsIndex)
 	)
 end
 
+---@param data table
 function StandingsStorage.toScoreBoardEntry(data)
 	if Table.isEmpty(data) then
 		return
@@ -122,6 +127,8 @@ function StandingsStorage.toScoreBoardEntry(data)
 end
 
 --- @deprecated
+---@param index number
+---@param data table
 function StandingsStorage.legacy(index, data)
 	local title = data.title or ''
 	local cleanedTitle = title:gsub('<.->.-</.->', '')
@@ -159,6 +166,8 @@ function StandingsStorage.legacy(index, data)
 end
 
 ---@deprecated
+---@param entry table
+---@return table
 function StandingsStorage.verifyScoreBoardEntry(entry)
 	-- A valid scoreboard entry must have 3 values in an array
 	if #entry ~= 3 then
@@ -167,6 +176,7 @@ function StandingsStorage.verifyScoreBoardEntry(entry)
 	return entry
 end
 
+---@param frame table
 function StandingsStorage.fromTemplateHeader(frame)
 	local data = Arguments.getArgs(frame)
 
@@ -174,9 +184,10 @@ function StandingsStorage.fromTemplateHeader(frame)
 		return
 	end
 
-	return StandingsStorage.table(data)
+	StandingsStorage.table(data)
 end
 
+---@param frame table
 function StandingsStorage.fromTemplateEntry(frame)
 	local data = Arguments.getArgs(frame)
 
@@ -241,9 +252,11 @@ function StandingsStorage.fromTemplateEntry(frame)
 	StandingsStorage.legacy(data.slotIndex, data)
 end
 
--- Legacy input
+-- Legacy input method
+---@deprecated
+---@param frame table
 function StandingsStorage.fromTemplate(frame)
-	return StandingsStorage.fromTemplateEntry(frame)
+	StandingsStorage.fromTemplateEntry(frame)
 end
 
 return StandingsStorage

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -38,7 +38,7 @@ function StandingsStorage.run(data)
 
 	Array.forEach(data.entries, function (entry)
 		StandingsStorage.entry(entry, standingsIndex)
-		StandingsStorage.runLegacy(entry.slotIndex, entry) -- Deprecated
+		StandingsStorage.legacy(entry.slotIndex, entry) -- Deprecated
 	end)
 end
 
@@ -122,7 +122,7 @@ function StandingsStorage.toScoreBoardEntry(data)
 end
 
 --- @deprecated
-function StandingsStorage.runLegacy(index, data)
+function StandingsStorage.legacy(index, data)
 	local title = data.title or ''
 	local cleanedTitle = title:gsub('<.->.-</.->', '')
 	mw.ext.LiquipediaDB.lpdb_standing(
@@ -229,13 +229,16 @@ function StandingsStorage.fromTemplateEntry(frame)
 
 	data.opponent = Opponent.resolve(Opponent.readOpponentArgs(opponentArgs) or Opponent.tbd(), date)
 
+	-- Template don't have SlotIndex, use placement as workaround
+	data.slotIndex = data.placement
+
 	data.match = {w = data.win_m, d = data.tie_m, l = data.lose_m}
 	data.game = {w = data.win_g, d = data.tie_g, l = data.lose_g}
 	StandingsStorage.entry(data, data.standingsindex)
 
 	data.match = {data.win_m, data.tie_m, data.lose_m}
 	data.game = {data.win_g, data.tie_g, data.lose_g}
-	StandingsStorage.runLegacy(data.standingsindex, data)
+	StandingsStorage.legacy(data.slotIndex, data)
 end
 
 -- Legacy input

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -13,7 +13,7 @@ local Json = require('Module:Json') ---@module "standard.json"
 local Opponent = require('Module:Opponent') ---@module "opponent"
 local String = require('Module:StringUtils') ---@module "standard.string_utils"
 local Table = require('Module:Table') ---@module "standard.table"
-local Variables = require('Module:Variables') ---@module "standardvariables"
+local Variables = require('Module:Variables') ---@module "standard.variables"
 
 local StandingsStorage = {}
 local ALLOWED_SCORE_BOARD_KEYS = {'w', 'd', 'l'}

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -106,9 +106,10 @@ function StandingsStorage.entry(entry, standingsIndex)
 end
 
 ---@param data table
+---@return table
 function StandingsStorage.toScoreBoardEntry(data)
 	if Table.isEmpty(data) then
-		return
+		return SCOREBOARD_FALLBACK
 	end
 
 	local filterScoreBoard = function (_, key)
@@ -126,7 +127,7 @@ function StandingsStorage.toScoreBoardEntry(data)
 	return scoreBoard
 end
 
---- @deprecated
+---@deprecated
 ---@param index number
 ---@param data table
 function StandingsStorage.legacy(index, data)

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -234,8 +234,7 @@ function StandingsStorage.fromTemplateEntry(frame)
 			data.participantdisplay = 'TBD'
 		end
 	elseif data.player then
-		-- TODO: sanity checks and parse flag
-		-- TODO: handle more input cases
+		-- TODO: sanity checks
 		data.participant, data.participantdisplay = string.match(data.player, '%[%[([^|]-)|([^|]-)%]%]')
 		data.participantflag = string.match(data.player, '<span class="flag">%[%[File:[^|]-%.png|([^|]-)|')
 		opponentArgs = {

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -112,12 +112,12 @@ function StandingsStorage.toScoreBoardEntry(data)
 		return SCOREBOARD_FALLBACK
 	end
 
-	local filterScoreBoard = function (_, key)
-		return ALLOWED_SCORE_BOARD_KEYS[key] and true or false
+	local filterScoreBoard = function (key, value)
+		return key, Table.includes(ALLOWED_SCORE_BOARD_KEYS, key) and value or nil
 	end
 
-	-- Need to use Array.filter here. Because strangely enough Table.filter has no access to keys...
-	local scoreBoard = Table.mapValues(Array.filter(data, filterScoreBoard), tonumber)
+	-- Using Table.map to filter. Because strangely enough Table.filter has no access to keys...
+	local scoreBoard = Table.mapValues(Table.map(data, filterScoreBoard), tonumber)
 
 	if not scoreBoard.w or not scoreBoard.l then
 		mw.logObject(scoreBoard, 'invalid scoreBoardEntry')

--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -11,8 +11,9 @@ local Array = require('Module:Array') ---@module "standard.array"
 local Flags = require('Module:Flags') ---@module "standard.flags"
 local Json = require('Module:Json') ---@module "standard.json"
 local Opponent = require('Module:Opponent') ---@module "opponent"
+local String = require('Module:StringUtils') ---@module "standard.string_utils"
 local Table = require('Module:Table') ---@module "standard.table"
-local Variables = require('Module:Variables') ---@module "variables"
+local Variables = require('Module:Variables') ---@module "standardvariables"
 
 local StandingsStorage = {}
 local ALLOWED_SCORE_BOARD_KEYS = {'w', 'd', 'l'}
@@ -220,7 +221,7 @@ function StandingsStorage.fromTemplateEntry(frame)
 		opponentArgs = {type = 'team'}
 
 		if team then
-			opponentArgs.team = team.templatename
+			opponentArgs.template = team.templatename
 
 			-- Legacy
 			data.participant = team.page
@@ -236,7 +237,17 @@ function StandingsStorage.fromTemplateEntry(frame)
 		-- TODO: sanity checks and parse flag
 		-- TODO: handle more input cases
 		data.participant, data.participantdisplay = string.match(data.player, '%[%[([^|]-)|([^|]-)%]%]')
-		opponentArgs = {link = data.participant, name = data.participantdisplay}
+		data.participantflag = string.match(data.player, '<span class="flag">%[%[File:[^|]-%.png|([^|]-)|')
+		opponentArgs = {
+			link = data.participant,
+			name = data.participantdisplay,
+			type = Opponent.solo,
+			flag = data.participantflag
+		}
+		local race = string.match(data.player, '&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
+		if String.isNotEmpty(race) then
+			opponentArgs.race = race:sub(1, 1):lower()
+		end
 	end
 
 	data.opponent = Opponent.resolve(Opponent.readOpponentArgs(opponentArgs) or Opponent.tbd(), date)


### PR DESCRIPTION
## Summary
The LPDB Table `Standings` was recently deprecated in favor of two new DB Tables, `StandingsTable` and `StandingsEntry`. 

The PR aims to add data to the new db tables, and in the intermediate term, to the deprecated table as well. Removal storage into the deprecated table will be removed once there are no longer any consumers.


## How did you test this change?

![image](https://user-images.githubusercontent.com/3426850/178948881-9f436698-cf2a-4f21-948c-b13cff22e8b0.png)
![image](https://user-images.githubusercontent.com/3426850/178948898-cdfcd61a-1703-4207-bcf1-0c7009347fd1.png)
