### PR TITLE
Map special letter places (w, d, l) in Legacy

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -20,7 +20,7 @@ local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabl
 local LegacyPrizePool = {}
 
 local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp'}
-local LETTER_PLACE_TO_NUMBER = {w = 1, d = 1, l = 1}
+local LETTER_PLACE_TO_NUMBER = {w = 1, d = 1, l = 2}
 
 local CACHED_DATA = {
 	next = {points = 1, qual = 1, freetext = 1},

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -20,6 +20,7 @@ local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabl
 local LegacyPrizePool = {}
 
 local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp'}
+local LETTER_PLACE_TO_NUMBER = {w = 1, d = 1, l = 1}
 
 local CACHED_DATA = {
 	next = {points = 1, qual = 1, freetext = 1},
@@ -80,7 +81,9 @@ function LegacyPrizePool.mapSlot(slot)
 	end
 
 	local newData = {}
-	if SPECIAL_PLACES[slot.place:lower()] then
+	if LETTER_PLACE_TO_NUMBER[slot.place:lower()] then
+		newData.place = LETTER_PLACE_TO_NUMBER[slot.place:lower()]
+	elseif SPECIAL_PLACES[slot.place:lower()] then
 		newData[SPECIAL_PLACES[slot.place:lower()]] = true
 	else
 		newData.place = slot.place


### PR DESCRIPTION
## Summary

Old prize pools had support for `w`, `d` and `l` as valid places. The new prize pools don't (yet at least). When doing legacy conversion, map the letter places into numeric places.

## How did you test this change?

Live test on https://liquipedia.net/rainbowsix/Six_Invitational/2017/PC#Prize_Pool_2 and https://liquipedia.net/rainbowsix/Six_Invitational/2020#Prize_Pool_2

![image](https://user-images.githubusercontent.com/3426850/178967604-4199ffb8-ba34-44ff-97a5-51f334607fc6.png)
![image](https://user-images.githubusercontent.com/3426850/178967626-d0d72673-92eb-4730-b062-9287d382d491.png)
