### PR TITLE
Add annotations to `Class.export`

### DIFF
--- a/standard/class.lua
+++ b/standard/class.lua
@@ -75,7 +75,10 @@ function Class.new(base, init)
 	return instance
 end
 
-
+---@generic T
+---@param class T
+---@param options ?table
+---@return T
 function Class.export(class, options)
 	for name, f in pairs(class) do
 		-- We only want to export functions, and only functions which are public (no underscore)


### PR DESCRIPTION
## Summary

Allows some intellisense (EmmyLua and sumneko-lua) to understand the Class.export function, making intellisense useful on Modules that return via Class.export.

## How did you test this change?
### Before:
![image](https://user-images.githubusercontent.com/3426850/179182202-21dae508-a16d-4e9e-be8e-d270669ec3f4.png)
![image](https://user-images.githubusercontent.com/3426850/179182342-6e9107a4-043d-4c67-b65a-e363b3d2bc75.png)

### After:
![image](https://user-images.githubusercontent.com/3426850/179182131-91d00c01-90fd-401a-ac36-4ce114e246a3.png)
![image](https://user-images.githubusercontent.com/3426850/179182469-07ad2d5d-82a2-467e-9d0b-ff2b33ed7875.png)

