### PR TITLE
Convert data to flatten locations table (LPDB Json)

### DIFF
--- a/standard/locale.lua
+++ b/standard/locale.lua
@@ -6,7 +6,13 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Flags = require('Module:Flags')
+local Region = require('Module:Region')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
 
 local Locale = {}
 
@@ -35,6 +41,64 @@ function Locale.formatLocation(args)
 
 	formattedLocation = formattedLocation .. (args.country or '')
 	return formattedLocation
+end
+
+function Locale.formatLocations(args)
+	local LOCATION_KEYS = {'venue', 'city', 'country', 'region'}
+	local locations = Array.mapIndexes(function(index)
+		local getLocationData = function(_, parameter)
+			return parameter, args[parameter .. index]
+		end
+
+		local location = Table.mapValues(Table.map(LOCATION_KEYS, getLocationData), String.nilIfEmpty)
+
+		if index == 1 then
+			local getLocationDataIndexless = function(_, parameter)
+				return parameter, location[parameter] or args[parameter]
+			end
+
+			location = Table.mapValues(Table.map(LOCATION_KEYS, getLocationDataIndexless), String.nilIfEmpty)
+		end
+
+		if Table.isEmpty(location) then
+			return
+		end
+
+		-- Always normalize region name
+		if not location.region and location.country then
+			-- Check if the country provided is actually a region
+			location.region = String.nilIfEmpty(Region.run{region = location.country, onlyRegion = true})
+
+			-- If it actually was a region, it's no longer a country, otherwise get the Region from the country
+			if location.region then
+				location.country = nil
+			else
+				location.region = String.nilIfEmpty(Region.run{country = location.country, onlyRegion = true})
+			end
+
+		elseif location.region then
+			location.region = String.nilIfEmpty(Region.run{region = location.region, onlyRegion = true})
+		end
+
+		-- Convert country to alpha2
+		if location.country then
+			location.country = String.nilIfEmpty(Flags.CountryCode(location.country))
+		end
+
+		return location
+	end)
+
+	local flattenTable = function (tbl)
+		local newTable = {}
+		Table.iter.forEachPair(tbl, function (outerKey, innerTable)
+			Table.iter.forEachPair(innerTable, function (innerKey, innerValue)
+				newTable[innerKey .. outerKey] = innerValue
+			end)
+		end)
+		return newTable
+	end
+
+	return flattenTable(locations)
 end
 
 

--- a/standard/region/commons/region.lua
+++ b/standard/region/commons/region.lua
@@ -11,6 +11,7 @@ local Class = require('Module:Class')
 local Flag = require('Module:Flags')
 local String = require('Module:String')
 local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
 local regionData = mw.loadData('Module:Region/Data')
 local countryToRegionData = Lua.loadDataIfExists('Module:Region/CountryData', {})
 
@@ -19,8 +20,8 @@ local noEntryFoundCategory = '[[Category:Pages using unsupported region values]]
 function Region.run(args)
 	args = args or {}
 	local region = args.region
-	local shouldOnlyReturnRegionName = args.onlyRegion == 'true'
-	local shouldOnlyReturnDisplay = args.onlyDisplay == 'true'
+	local shouldOnlyReturnRegionName = Logic.readBool(args.onlyRegion)
+	local shouldOnlyReturnDisplay = Logic.readBool(args.onlyDisplay)
 
 	--determine region from country if region is empty
 	if String.isEmpty(region) then


### PR DESCRIPTION
## Summary

Convert an arbitrary table input to a table intended to be stored by LPDB into the `locations` json field.

## Background
Make the current `location` parameter more granular. We are requesting the following property scheme for locations:

  

`venue` ➝ `city` ➝ `country` ➝ `region`

  

These would be added to a LPDB JSON property `locations`. It would replace the current `location` & `location2` in Teams and Tournaments. It would also make `venue` (Tournaments) and `region` (Teams) redundant. For compatibility reasons, don't remove any of the legacy properties yet.

  

The keys that would be part of the JSON would be as follows:

`venue` : string

`city` : string

`country` : alpha2 code, so string, but always very short. If community doesn't want alpha2, LPDB is allowed to store as full name string.

`region` : string

  

All keys would be suffixed with an integer, in order to support multiple locations. For example, `country1`, `country2`. All keys are optional.

## How did you test this change?

```
mw.logObject(p.formatLocations{venue = 'Abc', country1 = 'Sweden', country2='Europe'})
table#1 {
  ["country1"] = "se",
  ["region2"] = "Europe",
  ["venue1"] = "Abc",
}
```
(Note: Doesn't have a `Module:Region/CountryData` and hence cannot get the Region of a country - this functionality is untested).