### PR TITLE
Infobox's calling the wrong Hotkey function

### DIFF
--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -108,7 +108,7 @@ function Building:_getHotkeys(args)
 	local display
 	if not String.isEmpty(args.hotkey) then
 		if not String.isEmpty(args.hotkey2) then
-			display = Hotkey.hotkey(args.hotkey, args.hotkey2, 'slash')
+			display = Hotkey.hotkey2(args.hotkey, args.hotkey2, 'slash')
 		else
 			display = Hotkey.hotkey(args.hotkey)
 		end

--- a/components/infobox/commons/infobox_skill.lua
+++ b/components/infobox/commons/infobox_skill.lua
@@ -103,7 +103,7 @@ function Skill:_getHotkeys(args)
 	local display
 	if not String.isEmpty(args.hotkey) then
 		if not String.isEmpty(args.hotkey2) then
-			display = Hotkey.hotkey(args.hotkey, args.hotkey2, 'slash')
+			display = Hotkey.hotkey2(args.hotkey, args.hotkey2, 'slash')
 		else
 			display = Hotkey.hotkey(args.hotkey)
 		end

--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -114,7 +114,7 @@ function Unit:_getHotkeys(args)
 	local display
 	if not String.isEmpty(args.hotkey) then
 		if not String.isEmpty(args.hotkey2) then
-			display = Hotkey.hotkey(args.hotkey, args.hotkey2, 'slash')
+			display = Hotkey.hotkey2(args.hotkey, args.hotkey2, 'slash')
 		else
 			display = Hotkey.hotkey(args.hotkey)
 		end

--- a/components/infobox/wikis/starcraft2/infobox_skill_ability.lua
+++ b/components/infobox/wikis/starcraft2/infobox_skill_ability.lua
@@ -171,7 +171,7 @@ function Ability:getHotkeys()
 	local display
 	if not String.isEmpty(_args.hotkey) then
 		if not String.isEmpty(_args.hotkey2) then
-			display = Hotkeys.hotkey(_args.hotkey, _args.hotkey2, 'slash')
+			display = Hotkeys.hotkey2(_args.hotkey, _args.hotkey2, 'slash')
 		else
 			display = Hotkeys.hotkey(_args.hotkey)
 		end

--- a/components/infobox/wikis/starcraft2/infobox_skill_spell.lua
+++ b/components/infobox/wikis/starcraft2/infobox_skill_spell.lua
@@ -217,7 +217,7 @@ function Spell:getHotkeys()
 	local display
 	if not String.isEmpty(_args.hotkey) then
 		if not String.isEmpty(_args.hotkey2) then
-			display = Hotkeys.hotkey(_args.hotkey, _args.hotkey2, 'slash')
+			display = Hotkeys.hotkey2(_args.hotkey, _args.hotkey2, 'slash')
 		else
 			display = Hotkeys.hotkey(_args.hotkey)
 		end


### PR DESCRIPTION
## Summary

Fix issue where various infoboxes calls the wrong hotkey function when there are two hotkeys.

![image](https://user-images.githubusercontent.com/3426850/179241789-e653871f-fc62-4682-b812-a746a51944a8.png)


## How did you test this change?

N/A