### PR TITLE
Save (team)`template` to LPDB Team

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -227,6 +227,13 @@ function Team:_setLpdbData(args, links)
 	local name = args.romanized_name or self.name
 	local earnings = _totalEarnings
 
+	local team = self.pagename
+	local teamTemplate
+	if team and mw.ext.TeamTemplate.teamexists(team) then
+		local teamRaw = mw.ext.TeamTemplate.raw(team)
+		teamTemplate = teamRaw.historicaltemplate or teamRaw.templatename
+	end
+
 	local lpdbData = {
 		name = name,
 		location = self:getStandardLocationValue(args.location),
@@ -240,6 +247,7 @@ function Team:_setLpdbData(args, links)
 		disbanddate = args.disbanded,
 		coach = args.coaches,
 		manager = args.manager,
+		template = teamTemplate,
 		links = mw.ext.LiquipediaDB.lpdb_create_json(
 			Links.makeFullLinksForTableItems(links or {}, 'team')
 		),


### PR DESCRIPTION
## Summary

Save the team-`template` of a team if it can be automatically inferred. In the future may add a parameter for it


## How did you test this change?

/dev module
![image](https://user-images.githubusercontent.com/3426850/179245478-9e4c8148-827c-4e93-9de3-b42b648ec225.png)
