### PR TITLE
Annotate deprecated instead of just having a comment

### DIFF
--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -172,35 +172,35 @@ Lua.autoInvokeEntryPoints(MatchGroup, 'Module:MatchGroup')
 MatchGroup.deprecatedCategory = '[[Category:Pages using deprecated Match Group functions]]'
 
 -- Entry point used by Template:Bracket
--- Deprecated
+---@deprecated
 function MatchGroup.bracket(frame)
 	return MatchGroup.TemplateBracket(frame) .. MatchGroup.deprecatedCategory
 end
 
--- Deprecated
+---@deprecated
 function MatchGroup.luaBracket(_, args)
 	return MatchGroup.TemplateBracket(args) .. MatchGroup.deprecatedCategory
 end
 
 -- Entry point used by Template:Matchlist
--- Deprecated
+---@deprecated
 function MatchGroup.matchlist(frame)
 	return MatchGroup.TemplateMatchlist(frame) .. MatchGroup.deprecatedCategory
 end
 
--- Deprecated
+---@deprecated
 function MatchGroup.luaMatchlist(_, args)
 	return MatchGroup.TemplateMatchlist(args) .. MatchGroup.deprecatedCategory
 end
 
 -- Entry point from Template:ShowBracket and direct #invoke
--- Deprecated
+---@deprecated
 function MatchGroup.Display(frame)
 	return tostring(MatchGroup.TemplateShowBracket(frame)) .. MatchGroup.deprecatedCategory
 end
 
 -- Entry point from direct #invoke
--- Deprecated
+---@deprecated
 function MatchGroup.DisplayDev(frame)
 	local args = Arguments.getArgs(frame)
 	args.dev = true

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -92,13 +92,13 @@ function MatchGroupBase._checkBracketDuplicate(bracketId)
 	end
 end
 
--- Deprecated
+---@deprecated
 function MatchGroupBase.luaMatchlist(_, args)
 	local MatchGroup = Lua.import('Module:MatchGroup', {requireDevIfEnabled = true})
 	return MatchGroup.MatchList(args) .. MatchGroup.deprecatedCategory
 end
 
--- Deprecated
+---@deprecated
 function MatchGroupBase.luaBracket(_, args)
 	local MatchGroup = Lua.import('Module:MatchGroup', {requireDevIfEnabled = true})
 	return MatchGroup.Bracket(args) .. MatchGroup.deprecatedCategory

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -20,16 +20,14 @@ local DisplayHelper = {}
 local _NONBREAKING_SPACE = '&nbsp;'
 local _UTC = '<abbr data-tz="+0:00" title="Coordinated Universal Time (UTC)">UTC</abbr>'
 
---[[
-Deprecated. Use Opponent.typeIsParty
-]]
+---@deprecated
+---Use Opponent.typeIsParty
 function DisplayHelper.opponentTypeIsParty(opponentType)
 	return Opponent.typeIsParty(opponentType)
 end
 
---[[
-Deprecated. Use Opponent.isTbd
-]]
+---@deprecated
+---Use Opponent.isTbd
 function DisplayHelper.opponentIsTBD(opponent)
 	return Opponent.isTbd(opponent)
 end

--- a/components/match2/commons/starcraft_starcraft2/player_ext_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_ext_starcraft.lua
@@ -43,9 +43,8 @@ function StarcraftPlayerExt.readRace(race)
 	end
 end
 
---[[
-Deprecated. Use PlayerExt.extractFromLink instead
-]]
+---@deprecated
+---Use PlayerExt.extractFromLink instead
 StarcraftPlayerExt.extractFromLink = PlayerExt.extractFromLink
 
 --[[


### PR DESCRIPTION
## Summary

For functions where their function comment mentioning that they're deprecated, replace with a proper annotation for deprecation. Gives slight intellisense advantages.

As a result of this, 4 calls to deprecated functions have been indentified and can be resolved in future PRs.
![image](https://user-images.githubusercontent.com/3426850/179361723-d8f864bb-8422-4184-ad6a-e7aad129a711.png)


## How did you test this change?

N/A just a change in comments