### PR TITLE
Dropped `p` as internal name in match2 to match1

### DIFF
--- a/components/match2/wikis/brawlstars/match_legacy.lua
+++ b/components/match2/wikis/brawlstars/match_legacy.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchLegacy = {}
 
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -17,12 +17,12 @@ local Variables = require('Module:Variables')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function p.storeMatch(match2)
-	local match = p.convertParameters(match2)
+function MatchLegacy.storeMatch(match2)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = p.storeGames(match, match2)
+	match.games = MatchLegacy.storeGames(match, match2)
 
-	p.storeMatchSMW(match, match2)
+	MatchLegacy.storeMatchSMW(match, match2)
 
 	return mw.ext.LiquipediaDB.lpdb_match(
 		'legacymatch_' .. match2.match2id,
@@ -30,7 +30,7 @@ function p.storeMatch(match2)
 	)
 end
 
-function p.storeMatchSMW(match, match2)
+function MatchLegacy.storeMatchSMW(match, match2)
 	local streams = Json.parseIfString(match.stream or {})
 	local icon = Variables.varDefault('tournament_icon')
 	local opponents = match2.match2opponents
@@ -89,7 +89,7 @@ function p.storeMatchSMW(match, match2)
 	mw.smw.subobject(subObjectTable)
 end
 
-function p.storeGames(match, match2)
+function MatchLegacy.storeGames(match, match2)
 	local games = ''
 	for gameIndex, game2 in ipairs(match2.match2games or {}) do
 		local game = Table.deepCopy(game2)
@@ -118,7 +118,7 @@ function p.storeGames(match, match2)
 	return games
 end
 
-function p.convertParameters(match2)
+function MatchLegacy.convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, 'match2') then
@@ -205,4 +205,4 @@ function p.convertParameters(match2)
 	return match
 end
 
-return p
+return MatchLegacy

--- a/components/match2/wikis/overwatch/match_legacy.lua
+++ b/components/match2/wikis/overwatch/match_legacy.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchLegacy = {}
 
 local json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -17,12 +17,12 @@ local Variables = require('Module:Variables')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function p.storeMatch(match2)
-	local match = p.convertParameters(match2)
+function MatchLegacy.storeMatch(match2)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = p.storeGames(match, match2)
+	match.games = MatchLegacy.storeGames(match, match2)
 
-	p.storeMatchSMW(match, match2)
+	MatchLegacy.storeMatchSMW(match, match2)
 
 	return mw.ext.LiquipediaDB.lpdb_match(
 		'legacymatch_' .. match2.match2id,
@@ -30,7 +30,7 @@ function p.storeMatch(match2)
 	)
 end
 
-function p.storeMatchSMW(match, match2)
+function MatchLegacy.storeMatchSMW(match, match2)
 	local streams = json.parseIfString(match.stream or {})
 	local icon = Variables.varDefault('tournament_icon')
 	mw.smw.subobject({
@@ -56,7 +56,7 @@ function p.storeMatchSMW(match, match2)
 	 })
 end
 
-function p.storeGames(match, match2)
+function MatchLegacy.storeGames(match, match2)
 	local games = ''
 	for gameIndex, game2 in ipairs(match2.match2games or {}) do
 		local game = Table.deepCopy(game2)
@@ -85,7 +85,7 @@ function p.storeGames(match, match2)
 	return games
 end
 
-function p.convertParameters(match2)
+function MatchLegacy.convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, 'match2') then
@@ -154,4 +154,4 @@ function p.convertParameters(match2)
 	return match
 end
 
-return p
+return MatchLegacy

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchLegacy = {}
 
 local json = require("Module:Json")
 local Logic = require("Module:Logic")
@@ -17,12 +17,12 @@ local Variables = require("Module:Variables")
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function p.storeMatch(match2)
-	local match = p.convertParameters(match2)
+function MatchLegacy.storeMatch(match2)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = p.storeGames(match, match2)
+	match.games = MatchLegacy.storeGames(match, match2)
 
-	p.storeMatchSMW(match, match2)
+	MatchLegacy.storeMatchSMW(match, match2)
 
 	return mw.ext.LiquipediaDB.lpdb_match(
 		"legacymatch_" .. match2.match2id,
@@ -30,7 +30,7 @@ function p.storeMatch(match2)
 	)
 end
 
-function p.storeMatchSMW(match, match2)
+function MatchLegacy.storeMatchSMW(match, match2)
 	local streams = json.parseIfString(match.stream or {})
 	local links = json.parseIfString(match.links or {})
 	local icon = Variables.varDefault("tournament_icon")
@@ -59,7 +59,7 @@ function p.storeMatchSMW(match, match2)
 	 })
 end
 
-function p.storeGames(match, match2)
+function MatchLegacy.storeGames(match, match2)
 	local games = ""
 	for gameIndex, game2 in ipairs(match2.match2games or {}) do
 		local game = Table.deepCopy(game2)
@@ -124,7 +124,7 @@ function p.storeGames(match, match2)
 	return games
 end
 
-function p.convertParameters(match2)
+function MatchLegacy.convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, "match2") then
@@ -217,4 +217,4 @@ function p.convertParameters(match2)
 	return match
 end
 
-return p
+return MatchLegacy

--- a/components/match2/wikis/rocketleague/match_legacy.lua
+++ b/components/match2/wikis/rocketleague/match_legacy.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchLegacy = {}
 
 local json = require("Module:Json")
 local Logic = require("Module:Logic")
@@ -14,12 +14,12 @@ local String = require("Module:StringUtils")
 local Table = require("Module:Table")
 local Variables = require("Module:Variables")
 
-function p.storeMatch(match2)
-	local match = p._convertParameters(match2)
+function MatchLegacy.storeMatch(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
-	match.games = p.storeGames(match, match2)
+	match.games = MatchLegacy.storeGames(match, match2)
 
-	p.storeMatchSMW(match, match2)
+	MatchLegacy.storeMatchSMW(match, match2)
 
 	return mw.ext.LiquipediaDB.lpdb_match(
 		"legacymatch_" .. match2.match2id,
@@ -27,7 +27,7 @@ function p.storeMatch(match2)
 	)
 end
 
-function p.storeMatchSMW(match, match2)
+function MatchLegacy.storeMatchSMW(match, match2)
 	local streams = match.stream or {}
 	if type(streams) == "string" then streams = json.parse(streams) end
 	local icon = Variables.varDefault("tournament_icon")
@@ -63,7 +63,7 @@ function p.storeMatchSMW(match, match2)
 	 })
 end
 
-function p.storeGames(match, match2)
+function MatchLegacy.storeGames(match, match2)
 	local games = ""
 	for gameIndex, game in ipairs(match2.match2games or {}) do
 		game = Table.deepCopy(game)
@@ -87,7 +87,7 @@ function p.storeGames(match, match2)
 	return games
 end
 
-function p._convertParameters(match2)
+function MatchLegacy._convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, "match2") then
@@ -146,4 +146,4 @@ function p._convertParameters(match2)
 	return match
 end
 
-return p
+return MatchLegacy

--- a/components/match2/wikis/starcraft/match_legacy.lua
+++ b/components/match2/wikis/starcraft/match_legacy.lua
@@ -11,7 +11,7 @@
 ***** ADJUST THIS FOR BROODWAR WIKI!!! *****
 ]]--
 
-local Legacy = {}
+local MatchLegacy = {}
 
 local json = require('Module:Json')
 local String = require('Module:StringUtils')
@@ -20,16 +20,16 @@ local Template = require('Module:Template')
 
 local _MODES = { ['solo'] = '1v1', ['team'] = 'team' }
 
-function Legacy.storeMatch(match2)
-	local match, do_store = Legacy._convertParameters(match2)
+function MatchLegacy.storeMatch(match2)
+	local match, do_store = MatchLegacy._convertParameters(match2)
 
 	if do_store then
-		match.games = Legacy._storeGames(match, match2)
+		match.games = MatchLegacy._storeGames(match, match2)
 
 		if (match2.match2opponents[1] or {}).type == 'team' then
-			Legacy._storeTeamMatchSMW(match, match2)
+			MatchLegacy._storeTeamMatchSMW(match, match2)
 		elseif (match2.match2opponents[1] or {}).type == 'solo' then
-			Legacy._storeSoloMatchSMW(match, match2)
+			MatchLegacy._storeSoloMatchSMW(match, match2)
 		end
 
 		return mw.ext.LiquipediaDB.lpdb_match(
@@ -41,7 +41,7 @@ function Legacy.storeMatch(match2)
 	end
 end
 
-function Legacy._storeGames(match, match2)
+function MatchLegacy._storeGames(match, match2)
 	local games = ''
 	for gameIndex, game in ipairs(match2.match2games or {}) do
 		game.extradata = json.parseIfString(game.extradata or '{}') or game.extradata
@@ -80,7 +80,7 @@ function Legacy._storeGames(match, match2)
 				game
 			)
 
-			Legacy._storeSoloMapSMW(game, gameIndex, match.tournament or '', match2.match2id)
+			MatchLegacy._storeSoloMapSMW(game, gameIndex, match.tournament or '', match2.match2id)
 
 			games = games .. res
 		elseif	game.mode == '1v1' then
@@ -134,7 +134,7 @@ function Legacy._storeGames(match, match2)
 	return games
 end
 
-function Legacy._convertParameters(match2)
+function MatchLegacy._convertParameters(match2)
 	local do_store = true
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
@@ -200,7 +200,7 @@ function Legacy._convertParameters(match2)
 	return match, do_store
 end
 
-function Legacy._storeTeamMatchSMW(match, match2)
+function MatchLegacy._storeTeamMatchSMW(match, match2)
 	local streams = match.stream or {}
 	if type(streams) == 'string' then streams = json.parse(streams) end
 	local extradata = match.extradata or {}
@@ -240,7 +240,7 @@ function Legacy._storeTeamMatchSMW(match, match2)
 	})
 end
 
-function Legacy._storeSoloMatchSMW(match, match2)
+function MatchLegacy._storeSoloMatchSMW(match, match2)
 	local streams = match.stream or {}
 	if type(streams) == 'string' then streams = json.parse(streams) end
 	local extradata = match.extradata or {}
@@ -277,7 +277,7 @@ function Legacy._storeSoloMatchSMW(match, match2)
 	})
 end
 
-function Legacy._storeSoloMapSMW(game, gameIndex, tournament, id)
+function MatchLegacy._storeSoloMapSMW(game, gameIndex, tournament, id)
 	game.extradata = json.parseIfString(game.extradata or '{}') or game.extradata
 	local object = 'Map ' .. (game.opponent1 or 'TBD') .. ' vs ' .. (game.opponent2 or 'TBD') .. ' at ' ..
 		(game.date or '') .. 'in Match TBD Map ' .. gameIndex .. ' on ' .. (game.map or '')
@@ -295,4 +295,4 @@ function Legacy._storeSoloMapSMW(game, gameIndex, tournament, id)
 	})
 end
 
-return Legacy
+return MatchLegacy

--- a/components/match2/wikis/starcraft2/match_legacy.lua
+++ b/components/match2/wikis/starcraft2/match_legacy.lua
@@ -10,7 +10,7 @@
 * Remove temp smw support (after lpdb api is available)
 ]]--
 
-local p = {}
+local MatchLegacy = {}
 
 local json = require('Module:Json')
 local String = require('Module:StringUtils')
@@ -19,16 +19,16 @@ local _UNKNOWNREASON_DEFAULT_LOSS = 'L'
 
 local MODES = { ['solo'] = '1v1', ['team'] = 'team' }
 
-function p.storeMatch(match2)
-	local match, do_store = p.convertParameters(match2)
+function MatchLegacy.storeMatch(match2)
+	local match, do_store = MatchLegacy.convertParameters(match2)
 
 	if do_store then
-		match.games = p.storeGames(match, match2)
+		match.games = MatchLegacy.storeGames(match, match2)
 
 		if (match2.match2opponents[1] or {}).type == 'team' then
-			p.storeTeamMatchSMW(match, match2)
+			MatchLegacy.storeTeamMatchSMW(match, match2)
 		elseif (match2.match2opponents[1] or {}).type == 'solo' then
-			p.storeSoloMatchSMW(match, match2)
+			MatchLegacy.storeSoloMatchSMW(match, match2)
 		end
 
 		return mw.ext.LiquipediaDB.lpdb_match(
@@ -40,7 +40,7 @@ function p.storeMatch(match2)
 	end
 end
 
-function p.storeGames(match, match2)
+function MatchLegacy.storeGames(match, match2)
 	local games = ''
 	for gameIndex, game in ipairs(match2.match2games or {}) do
 		game.extradata = json.parseIfString(game.extradata or '{}') or game.extradata
@@ -82,7 +82,7 @@ function p.storeGames(match, match2)
 				game
 			)
 
-			p.storeSoloMapSMW(game, gameIndex, match.tournament or '', match2.match2id)
+			MatchLegacy.storeSoloMapSMW(game, gameIndex, match.tournament or '', match2.match2id)
 
 			games = games .. res
 		end
@@ -90,7 +90,7 @@ function p.storeGames(match, match2)
 	return games
 end
 
-function p.convertParameters(match2)
+function MatchLegacy.convertParameters(match2)
 	local do_store = true
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
@@ -152,7 +152,7 @@ function p.convertParameters(match2)
 	return match, do_store
 end
 
-function p.storeTeamMatchSMW(match, match2)
+function MatchLegacy.storeTeamMatchSMW(match, match2)
 	local streams = match.stream or {}
 	if type(streams) == 'string' then streams = json.parse(streams) end
 	local extradata = match.extradata or {}
@@ -192,7 +192,7 @@ function p.storeTeamMatchSMW(match, match2)
 	})
 end
 
-function p.storeSoloMatchSMW(match, match2)
+function MatchLegacy.storeSoloMatchSMW(match, match2)
 	local streams = match.stream or {}
 	if type(streams) == 'string' then streams = json.parse(streams) end
 	local extradata = match.extradata or {}
@@ -229,7 +229,7 @@ function p.storeSoloMatchSMW(match, match2)
 	})
 end
 
-function p.storeSoloMapSMW(game, gameIndex, tournament, id)
+function MatchLegacy.storeSoloMapSMW(game, gameIndex, tournament, id)
 	game.extradata = json.parseIfString(game.extradata or '{}') or game.extradata
 	local object = 'Map ' .. (game.opponent1 or 'TBD') .. ' vs ' .. (game.opponent2 or 'TBD') .. ' at ' ..
 		(game.date or '') .. 'in Match TBD Map ' .. gameIndex .. ' on ' .. (game.map or '')
@@ -242,4 +242,4 @@ function p.storeSoloMapSMW(game, gameIndex, tournament, id)
 	})
 end
 
-return p
+return MatchLegacy

--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchLegacy = {}
 
 local json = require("Module:Json")
 local Logic = require("Module:Logic")
@@ -17,12 +17,12 @@ local Variables = require("Module:Variables")
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function p.storeMatch(match2)
-	local match = p.convertParameters(match2)
+function MatchLegacy.storeMatch(match2)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = p.storeGames(match, match2)
+	match.games = MatchLegacy.storeGames(match, match2)
 
-	p.storeMatchSMW(match, match2)
+	MatchLegacy.storeMatchSMW(match, match2)
 
 	return mw.ext.LiquipediaDB.lpdb_match(
 		"legacymatch_" .. match2.match2id,
@@ -30,7 +30,7 @@ function p.storeMatch(match2)
 	)
 end
 
-function p.storeMatchSMW(match, match2)
+function MatchLegacy.storeMatchSMW(match, match2)
 	local streams = match.stream or {}
 	if type(streams) == "string" then streams = json.parse(streams) end
 	local icon = Variables.varDefault("tournament_icon")
@@ -59,7 +59,7 @@ function p.storeMatchSMW(match, match2)
 	 })
 end
 
-function p.storeGames(match, match2)
+function MatchLegacy.storeGames(match, match2)
 	local games = ""
 	for gameIndex, game2 in ipairs(match2.match2games or {}) do
 		local game = Table.deepCopy(game2)
@@ -142,7 +142,7 @@ function p.storeGames(match, match2)
 	return games
 end
 
-function p.convertParameters(match2)
+function MatchLegacy.convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, "match2") then
@@ -168,14 +168,14 @@ function p.convertParameters(match2)
 	match.extradata.hidden = Logic.readBool(Variables.varDefault('match_hidden')) and '1' or '0'
 	match.extradata.cancelled = Logic.readBool(Variables.varDefault('cancelled')) and '1' or '0'
 	match.extradata.bestofx = tostring(match2.bestof or '')
-	match.extradata.maps = table.concat(p._getAllInGames(match2, 'map'), ',')
-	for index, vod in ipairs(p._getAllInGames(match2, 'vod')) do
+	match.extradata.maps = table.concat(MatchLegacy._getAllInGames(match2, 'map'), ',')
+	for index, vod in ipairs(MatchLegacy._getAllInGames(match2, 'vod')) do
 		match.extradata['vodgame'..index] = vod
 	end
 
 	local opponent1score = 0
 	local opponent2score = 0
-	local scores = p._getAllInGames(match2, 'scores')
+	local scores = MatchLegacy._getAllInGames(match2, 'scores')
 	for _, stringScore in pairs(scores) do
 		local score = json.parseIfString(stringScore)
 		opponent1score = opponent1score + (tonumber(score[1]) or 0)
@@ -249,7 +249,7 @@ function p.convertParameters(match2)
 	return match
 end
 
-function p._getAllInGames(match2, field)
+function MatchLegacy._getAllInGames(match2, field)
 	local ret = {}
 	for _, game2 in ipairs(match2.match2games or {}) do
 		table.insert(ret, game2[field])
@@ -257,4 +257,4 @@ function p._getAllInGames(match2, field)
 	return ret
 end
 
-return p
+return MatchLegacy


### PR DESCRIPTION
## Summary

Half of the wiki custom for `Match/Legacy` (match2 to match1) is using `p` as the module table. Update these to a better name. 
Also changed BW from `Legacy` to `MatchLegacy` to have it more uniform across the board.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
