### PR TITLE
Have match2-to-match1 respect store flags.

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_legacy.lua
+++ b/components/match2/wikis/arenaofvalor/match_legacy.lua
@@ -20,7 +20,7 @@ local _GAME_EXTRADATA_CONVERTER = {
 }
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/arenaofvalor/match_legacy.lua
+++ b/components/match2/wikis/arenaofvalor/match_legacy.lua
@@ -19,17 +19,21 @@ local _GAME_EXTRADATA_CONVERTER = {
 	champion = 'h',
 }
 
-function MatchLegacy.storeMatch(match2)
-	local match = MatchLegacy._convertParameters(match2)
+function MatchLegacy.storeMatch(match2, options)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy._convertParameters(match2)

--- a/components/match2/wikis/brawlstars/match_legacy.lua
+++ b/components/match2/wikis/brawlstars/match_legacy.lua
@@ -17,17 +17,21 @@ local Variables = require('Module:Variables')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function MatchLegacy.storeMatch(match2)
+function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/brawlstars/match_legacy.lua
+++ b/components/match2/wikis/brawlstars/match_legacy.lua
@@ -18,7 +18,7 @@ local Variables = require('Module:Variables')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)
@@ -122,7 +122,7 @@ function MatchLegacy.storeGames(match, match2)
 	return games
 end
 
-function MatchLegacy.convertParameters(match2)
+function MatchLegacy._convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, 'match2') then

--- a/components/match2/wikis/dota2/match_legacy.lua
+++ b/components/match2/wikis/dota2/match_legacy.lua
@@ -20,7 +20,7 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDev
 local _NUMBER_OF_PLAYERS_TO_STORE = 10
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/dota2/match_legacy.lua
+++ b/components/match2/wikis/dota2/match_legacy.lua
@@ -19,18 +19,21 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDev
 
 local _NUMBER_OF_PLAYERS_TO_STORE = 10
 
+function MatchLegacy.storeMatch(match2, options)
+	local match = MatchLegacy.convertParameters(match2)
 
-function MatchLegacy.storeMatch(match2)
-	local match = MatchLegacy._convertParameters(match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	MatchLegacy.storeMatchSMW(match, match2)
-
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy._convertParameters(match2)

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -20,7 +20,7 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDev
 local _NUMBER_OF_PLAYERS_TO_STORE = 10
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -19,18 +19,21 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDev
 
 local _NUMBER_OF_PLAYERS_TO_STORE = 10
 
+function MatchLegacy.storeMatch(match2, options)
+	local match = MatchLegacy.convertParameters(match2)
 
-function MatchLegacy.storeMatch(match2)
-	local match = MatchLegacy._convertParameters(match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	MatchLegacy.storeMatchSMW(match, match2)
-
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy._convertParameters(match2)

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -20,7 +20,7 @@ local _GAME_EXTRADATA_CONVERTER = {
 }
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -19,17 +19,21 @@ local _GAME_EXTRADATA_CONVERTER = {
 	champion = 'h',
 }
 
-function MatchLegacy.storeMatch(match2)
-	local match = MatchLegacy._convertParameters(match2)
+function MatchLegacy.storeMatch(match2, options)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy._convertParameters(match2)

--- a/components/match2/wikis/overwatch/match_legacy.lua
+++ b/components/match2/wikis/overwatch/match_legacy.lua
@@ -18,7 +18,7 @@ local Variables = require('Module:Variables')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)
@@ -89,7 +89,7 @@ function MatchLegacy.storeGames(match, match2)
 	return games
 end
 
-function MatchLegacy.convertParameters(match2)
+function MatchLegacy._convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, 'match2') then

--- a/components/match2/wikis/overwatch/match_legacy.lua
+++ b/components/match2/wikis/overwatch/match_legacy.lua
@@ -17,17 +17,21 @@ local Variables = require('Module:Variables')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function MatchLegacy.storeMatch(match2)
+function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -18,7 +18,7 @@ local Variables = require("Module:Variables")
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)
@@ -128,7 +128,7 @@ function MatchLegacy.storeGames(match, match2)
 	return games
 end
 
-function MatchLegacy.convertParameters(match2)
+function MatchLegacy._convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, "match2") then

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -17,17 +17,21 @@ local Variables = require("Module:Variables")
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function MatchLegacy.storeMatch(match2)
+function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		"legacymatch_" .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/rocketleague/match_legacy.lua
+++ b/components/match2/wikis/rocketleague/match_legacy.lua
@@ -15,7 +15,7 @@ local Table = require("Module:Table")
 local Variables = require("Module:Variables")
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/rocketleague/match_legacy.lua
+++ b/components/match2/wikis/rocketleague/match_legacy.lua
@@ -14,17 +14,21 @@ local String = require("Module:StringUtils")
 local Table = require("Module:Table")
 local Variables = require("Module:Variables")
 
-function MatchLegacy.storeMatch(match2)
-	local match = MatchLegacy._convertParameters(match2)
+function MatchLegacy.storeMatch(match2, options)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		"legacymatch_" .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/starcraft/match_legacy.lua
+++ b/components/match2/wikis/starcraft/match_legacy.lua
@@ -20,7 +20,7 @@ local Template = require('Module:Template')
 
 local _MODES = { ['solo'] = '1v1', ['team'] = 'team' }
 
-function MatchLegacy.storeMatch(match2)
+function MatchLegacy.storeMatch(match2, options)
 	local match, do_store = MatchLegacy._convertParameters(match2)
 
 	if do_store then

--- a/components/match2/wikis/starcraft2/match_legacy.lua
+++ b/components/match2/wikis/starcraft2/match_legacy.lua
@@ -19,7 +19,7 @@ local _UNKNOWNREASON_DEFAULT_LOSS = 'L'
 
 local MODES = { ['solo'] = '1v1', ['team'] = 'team' }
 
-function MatchLegacy.storeMatch(match2)
+function MatchLegacy.storeMatch(match2, options)
 	local match, do_store = MatchLegacy.convertParameters(match2)
 
 	if do_store then

--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -18,7 +18,7 @@ local Variables = require("Module:Variables")
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)
@@ -146,7 +146,7 @@ function MatchLegacy.storeGames(match, match2)
 	return games
 end
 
-function MatchLegacy.convertParameters(match2)
+function MatchLegacy._convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do
 		if String.startsWith(key, "match2") then

--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -17,17 +17,21 @@ local Variables = require("Module:Variables")
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 
-function MatchLegacy.storeMatch(match2)
+function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		"legacymatch_" .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy.storeMatchSMW(match, match2)

--- a/components/match2/wikis/wildrift/match_legacy.lua
+++ b/components/match2/wikis/wildrift/match_legacy.lua
@@ -14,17 +14,21 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
-function MatchLegacy.storeMatch(match2)
-	local match = MatchLegacy._convertParameters(match2)
+function MatchLegacy.storeMatch(match2, options)
+	local match = MatchLegacy.convertParameters(match2)
 
-	match.games = MatchLegacy.storeGames(match, match2)
+	if options.storeSmw then
+		MatchLegacy.storeMatchSMW(match, match2)
+	end
 
-	MatchLegacy.storeMatchSMW(match, match2)
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
 
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		match
-	)
+		return mw.ext.LiquipediaDB.lpdb_match(
+			"legacymatch_" .. match2.match2id,
+			match
+		)
+	end
 end
 
 function MatchLegacy._convertParameters(match2)

--- a/components/match2/wikis/wildrift/match_legacy.lua
+++ b/components/match2/wikis/wildrift/match_legacy.lua
@@ -15,7 +15,7 @@ local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy.convertParameters(match2)
+	local match = MatchLegacy._convertParameters(match2)
 
 	if options.storeSmw then
 		MatchLegacy.storeMatchSMW(match, match2)


### PR DESCRIPTION
## Summary

**Not added for SC1 and SC2** - they were doing a bunch of extra stuff and I think it's better if @hjpalpha does it instead just so the business logic gets correct.

Module:Match sends a second parameter in its call to Module:Match/Legacy, `options`, with info if it should be converted to match1 and/or smw. None of the current implementations respect those. Updated so they do.

## How did you test this change?

Tested on R6 with dev modules