### PR TITLE
Fix case sensitivity of seed in Prize Pool Legacy

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -156,7 +156,7 @@ function LegacyPrizePool.assignType(assignTo, input, slotParam)
 		CACHED_DATA.inputToId[slotParam] = 'points' .. index
 		CACHED_DATA.next.points = index + 1
 
-	elseif input == 'seed' then
+	elseif input and input:lower() == 'seed' then
 		CACHED_DATA.inputToId[slotParam] = 'seed'
 
 	elseif String.isNotEmpty(input) then


### PR DESCRIPTION
## Summary

Currently, `|points=seed` will work, but not `|points=Seed` when detecting a qualifier. Fix this by lowercasing the input before checking.

## How did you test this change?
Tested using dev module

Before:
![image](https://user-images.githubusercontent.com/3426850/179395858-088fb00f-0f91-474b-83ed-2aef95ddcca4.png)

After:
![image](https://user-images.githubusercontent.com/3426850/179395854-78ddc925-3a81-4c68-87a4-7084cad5ac9b.png)
