### PR TITLE
Remove uses of `p` in favor of better names

### DIFF
--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -19,12 +19,12 @@ local htmlCreate = mw.html.create
 
 local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
 
-local p = {}
+local CustomMatchSummary = {}
 
 local _GREEN_CHECK = '<i class="fa fa-check forest-green-text" style="width: 14px; text-align: center" ></i>'
 local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 
-function p.getByMatchId(args)
+function CustomMatchSummary.getByMatchId(args)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
 
 	local wrapper = htmlCreate('div')
@@ -63,11 +63,11 @@ function p.getByMatchId(args)
 		:node(renderOpponent(1))
 		:node(renderOpponent(2))
 		:node(renderSoloOpponentTeam(2))
-	wrapper:node(header):node(p._breakNode())
+	wrapper:node(header):node(CustomMatchSummary._breakNode())
 
 	-- body
 	local body = htmlCreate('div'):addClass('brkts-popup-body')
-	body = p._addFlexRow(body, {DisplayHelper.MatchCountdownBlock(match)})
+	body = CustomMatchSummary._addFlexRow(body, {DisplayHelper.MatchCountdownBlock(match)})
 	for _, game in ipairs(match.games) do
 		if game.map then
 			local mapDisplay = '[[' .. game.map .. ']]'
@@ -96,7 +96,7 @@ function p.getByMatchId(args)
 
 			local gameHeader = game.header or ''
 			if gameHeader ~= '' then
-				table.insert(gameElements, 1, p._breakNode())
+				table.insert(gameElements, 1, CustomMatchSummary._breakNode())
 				table.insert(gameElements, 1, htmlCreate('div')
 					:node(gameHeader)
 					:css('font-weight','bold')
@@ -104,17 +104,17 @@ function p.getByMatchId(args)
 					:css('margin','auto'))
 			end
 			if game.comment then
-				table.insert(gameElements, p._breakNode())
+				table.insert(gameElements, CustomMatchSummary._breakNode())
 				table.insert(gameElements, htmlCreate('div')
 					:node(game.comment)
 					:css('margin','auto')
 					:css('max-width', '60%'))
 			end
-			body = p._addFlexRow(body, gameElements, 'brkts-popup-body-game')
+			body = CustomMatchSummary._addFlexRow(body, gameElements, 'brkts-popup-body-game')
 		end
 	end
 
-	wrapper:node(body):node(p._breakNode())
+	wrapper:node(body):node(CustomMatchSummary._breakNode())
 
 	-- comment
 	if match.comment then
@@ -123,7 +123,7 @@ function p.getByMatchId(args)
 			:css('white-space','normal')
 			:css('font-size','85%')
 			:node(match.comment)
-		wrapper:node(comment):node(p._breakNode())
+		wrapper:node(comment):node(CustomMatchSummary._breakNode())
 	end
 
 	-- footer
@@ -159,7 +159,7 @@ function p.getByMatchId(args)
 	return wrapper
 end
 
-function p._addFlexRow(wrapper, contentElements, class, style)
+function CustomMatchSummary._addFlexRow(wrapper, contentElements, class, style)
 	local node = htmlCreate('div'):addClass('brkts-popup-body-element')
 	if not Logic.isEmpty(class) then
 		node:addClass(class)
@@ -173,9 +173,9 @@ function p._addFlexRow(wrapper, contentElements, class, style)
 	return wrapper:node(node)
 end
 
-function p._breakNode()
+function CustomMatchSummary._breakNode()
 	return htmlCreate('div')
 		:addClass('brkts-popup-break')
 end
 
-return p
+return CustomMatchSummary

--- a/components/match2/wikis/rocketleague/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/rocketleague/legacy/match_group_legacy_default.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchGroupLegacyDefault = {}
 
 local String = require("Module:StringUtils")
 local Logic = require("Module:Logic")
@@ -14,7 +14,7 @@ local Logic = require("Module:Logic")
 local MAX_NUM_MAPS = 20
 
 local roundData
-function p.get(templateid, bracketType)
+function MatchGroupLegacyDefault.get(templateid, bracketType)
 	local lowerHeader = {}
 	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateid)
 
@@ -23,7 +23,8 @@ function p.get(templateid, bracketType)
 	roundData = roundData or {}
 	local lastRound = 0
 	for _, match in ipairs(matches) do
-		bracketData, lastRound, lowerHeader = p._getMatchMapping(match, bracketData, bracketType, lowerHeader)
+		bracketData, lastRound, lowerHeader =
+			MatchGroupLegacyDefault._getMatchMapping(match, bracketData, bracketType, lowerHeader)
 	end
 
 	-- add reference for map mappings
@@ -52,7 +53,7 @@ end
 --the following variable gets mutaded by each p._getMatchMapping
 --it is needed as a basis for the next call
 local _lastRound
-function p._getMatchMapping(match, bracketData, bracketType, lowerHeader)
+function MatchGroupLegacyDefault._getMatchMapping(match, bracketData, bracketType, lowerHeader)
 	local id = String.split(match.match2id, "_")[2] or match.match2id
 	--remove 0's and dashes from the match param
 	--e.g. R01-M001 --> R1M1
@@ -187,7 +188,7 @@ function p._getMatchMapping(match, bracketData, bracketType, lowerHeader)
 		["$flatten$"] = { "R" .. round.R .. "G" .. round.G .. "details" }
 	}
 
-	bracketData[id] = p.addMaps(match)
+	bracketData[id] = MatchGroupLegacyDefault.addMaps(match)
 	_lastRound = round
 	roundData[round.R] = round
 
@@ -201,7 +202,7 @@ parameter format of the old bracket
 ]]--
 
 --this can be used for custom mappings too
-function p.addMaps(match)
+function MatchGroupLegacyDefault.addMaps(match)
 	for mapIndex = 1, MAX_NUM_MAPS do
 		match["map" .. mapIndex] = {
 			["$ref$"] = "map",
@@ -212,7 +213,7 @@ function p.addMaps(match)
 end
 
 --this is for custom mappings
-function p.matchMappingFromCustom(data, bracketType)
+function MatchGroupLegacyDefault.matchMappingFromCustom(data, bracketType)
 	--[[
 	data has the form {
 		opp1, -- e.g. R1D1
@@ -246,7 +247,7 @@ function p.matchMappingFromCustom(data, bracketType)
 			win = data.opp2 .. "win",
 			},
 	}
-	mapping = p.addMaps(mapping)
+	mapping = MatchGroupLegacyDefault.addMaps(mapping)
 
 	return mapping
 end
@@ -254,7 +255,7 @@ end
 --this is for custom mappings for Reset finals matches
 --it switches score2 into the place of score
 --and sets flatten to nil
-function p.matchResetMappingFromCustom(mapping)
+function MatchGroupLegacyDefault.matchResetMappingFromCustom(mapping)
 	local mappingReset = mw.clone(mapping)
 	mappingReset.opponent1.score = mapping.opponent1.score .. "2"
 	mappingReset.opponent2.score = mapping.opponent2.score .. "2"
@@ -262,4 +263,4 @@ function p.matchResetMappingFromCustom(mapping)
 	return mappingReset
 end
 
-return p
+return MatchGroupLegacyDefault

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = require('Module:Brkts/WikiSpecific/Base')
+local CustomMatchGroupInput = {}
 
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -43,7 +43,7 @@ local mapFunctions = {}
 local opponentFunctions = {}
 
 -- called from Module:MatchGroup
-function p.processMatch(frame, match)
+function CustomMatchGroupInput.processMatch(frame, match)
 	Table.mergeInto(
 		match,
 		matchFunctions.readDate(match)
@@ -57,7 +57,7 @@ function p.processMatch(frame, match)
 end
 
 -- called from Module:Match/Subobjects
-function p.processMap(frame, map)
+function CustomMatchGroupInput.processMap(frame, map)
 	map = mapFunctions.getExtraData(map)
 	map = mapFunctions.getScoresAndWinner(map)
 	map = mapFunctions.getTournamentVars(map)
@@ -66,7 +66,7 @@ function p.processMap(frame, map)
 	return map
 end
 
-function p.processOpponent(record, date)
+function CustomMatchGroupInput.processOpponent(record, date)
 	local opponent = Opponent.readOpponentArgs(record)
 		or Opponent.blank()
 
@@ -94,22 +94,22 @@ function p.processOpponent(record, date)
 end
 
 -- called from Module:Match/Subobjects
-function p.processPlayer(frame, player)
+function CustomMatchGroupInput.processPlayer(frame, player)
 	return player
 end
 
 --
 --
 -- function to sort out winner/placements
-function p._placementSortFunction(table, key1, key2)
+function CustomMatchGroupInput._placementSortFunction(table, key1, key2)
 	local op1 = table[key1]
 	local op2 = table[key2]
 	local op1norm = op1.status == _STATUS_HAS_SCORE
 	local op2norm = op2.status == _STATUS_HAS_SCORE
 	if op1norm then
 		if op2norm then
-			local op1setwins = p._getSetWins(op1)
-			local op2setwins = p._getSetWins(op2)
+			local op1setwins = CustomMatchGroupInput._getSetWins(op1)
+			local op2setwins = CustomMatchGroupInput._getSetWins(op2)
 			if op1setwins + op2setwins > 0 then
 				return op1setwins > op2setwins
 			else
@@ -126,7 +126,7 @@ function p._placementSortFunction(table, key1, key2)
 	end
 end
 
-function p._getSetWins(opp)
+function CustomMatchGroupInput._getSetWins(opp)
 	local extradata = opp.extradata or {}
 	local set1win = extradata.set1win and 1 or 0
 	local set2win = extradata.set2win and 1 or 0
@@ -190,7 +190,7 @@ function matchFunctions.getExtraData(match)
 
 	local casters = {}
 	for key, name in Table.iter.pairsByPrefix(match, 'caster') do
-		table.insert(casters, p._getCasterInformation(
+		table.insert(casters, CustomMatchGroupInput._getCasterInformation(
 			name,
 			match[key .. 'flag'],
 			match[key .. 'name']
@@ -212,7 +212,7 @@ function matchFunctions.getExtraData(match)
 	return match
 end
 
-function p._getCasterInformation(name, flag, displayName)
+function CustomMatchGroupInput._getCasterInformation(name, flag, displayName)
 	if String.isEmpty(flag) then
 		flag = Variables.varDefault(name .. '_flag')
 	end
@@ -300,7 +300,7 @@ function matchFunctions.getOpponents(args)
 		-- read opponent
 		local opponent = args['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
-			p.processOpponent(opponent, args.date)
+			CustomMatchGroupInput.processOpponent(opponent, args.date)
 
 			-- Retrieve icon and legacy name for team
 			if opponent.type == Opponent.team then
@@ -357,7 +357,7 @@ function matchFunctions.getOpponents(args)
 		local lastPlacement = 1
 		local lastStatus
 		-- luacheck: push ignore
-		for opponentIndex, opponent in Table.iter.spairs(opponents, p._placementSortFunction) do
+		for opponentIndex, opponent in Table.iter.spairs(opponents, CustomMatchGroupInput._placementSortFunction) do
 			if opponent.status ~= _STATUS_HAS_SCORE and opponent.status ~= _STATUS_DEFAULT_WIN and placement == 1 then
 				placement = 2
 			end
@@ -584,4 +584,4 @@ function opponentFunctions.getLegacyTeamIcon(template)
 	return icon, iconDark
 end
 
-return p
+return CustomMatchGroupInput

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = require('Module:Brkts/WikiSpecific/Base')
+local CustomMatchGroupInput = {}
 
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -39,7 +39,7 @@ local mapFunctions = {}
 local opponentFunctions = {}
 
 -- called from Module:MatchGroup
-function p.processMatch(frame, match)
+function CustomMatchGroupInput.processMatch(frame, match)
 	Table.mergeInto(
 		match,
 		matchFunctions.readDate(match)
@@ -53,7 +53,7 @@ function p.processMatch(frame, match)
 end
 
 -- called from Module:Match/Subobjects
-function p.processMap(frame, map)
+function CustomMatchGroupInput.processMap(frame, map)
 	map = mapFunctions.getExtraData(map)
 	map = mapFunctions.getScoresAndWinner(map)
 	map = mapFunctions.getTournamentVars(map)
@@ -63,7 +63,7 @@ function p.processMap(frame, map)
 end
 
 -- called from Module:Match/Subobjects
-function p.processOpponent(record, date)
+function CustomMatchGroupInput.processOpponent(record, date)
 	local opponent = Opponent.readOpponentArgs(record)
 		or Opponent.blank()
 
@@ -77,7 +77,7 @@ function p.processOpponent(record, date)
 end
 
 -- called from Module:Match/Subobjects
-function p.processPlayer(frame, player)
+function CustomMatchGroupInput.processPlayer(frame, player)
 	return player
 end
 
@@ -195,7 +195,7 @@ function matchFunctions.getOpponents(args)
 		-- read opponent
 		local opponent = args['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
-			p.processOpponent(opponent, args.date)
+			CustomMatchGroupInput.processOpponent(opponent, args.date)
 
 			-- Retrieve icon and legacy name for team
 			if opponent.type == Opponent.team then
@@ -431,4 +431,4 @@ function opponentFunctions.getTeamIcon(template)
 	return raw and Logic.emptyOr(raw.image, raw.legacyimage)
 end
 
-return p
+return CustomMatchGroupInput

--- a/components/match2/wikis/starcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/starcraft/legacy/match_group_legacy_default.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchGroupLegacyDefault = {}
 
 local Lua = require("Module:Lua")
 local Logic = require("Module:Logic")
@@ -16,7 +16,7 @@ local config = Lua.moduleExists("Module:Match/Config") and require("Module:Match
 local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
 
 local roundData
-function p.get(templateid, bracketType)
+function MatchGroupLegacyDefault.get(templateid, bracketType)
 	local LowerHeader = {}
 	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateid)
 
@@ -25,7 +25,7 @@ function p.get(templateid, bracketType)
 	roundData = roundData or {}
 	local lastround = 0
 	for _, match in ipairs(matches) do
-		bracketData, lastround, LowerHeader = p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+		bracketData, lastround, LowerHeader = MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 	end
 
 	-- add reference for map mappings
@@ -48,7 +48,7 @@ function p.get(templateid, bracketType)
 end
 
 local lastRound
-function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+function MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 	local id = String.split(match.match2id, "_")[2] or match.match2id
 	id = id:gsub("0*([1-9])", "%1"):gsub("%-", "")
 	local bd = match.match2bracketdata
@@ -157,4 +157,4 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 	return bracketData, round.R, LowerHeader
 end
 
-return p
+return MatchGroupLegacyDefault

--- a/components/match2/wikis/starcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/starcraft/legacy/match_group_legacy_default.lua
@@ -25,7 +25,8 @@ function MatchGroupLegacyDefault.get(templateid, bracketType)
 	roundData = roundData or {}
 	local lastround = 0
 	for _, match in ipairs(matches) do
-		bracketData, lastround, LowerHeader = MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+		bracketData, lastround, LowerHeader =
+			MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 	end
 
 	-- add reference for map mappings

--- a/components/match2/wikis/starcraft2/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_group_legacy_default.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local p = {}
+local MatchGroupLegacyDefault = {}
 
 local Lua = require("Module:Lua")
 local Logic = require("Module:Logic")
@@ -16,7 +16,7 @@ local config = Lua.moduleExists("Module:Match/Config") and require("Module:Match
 local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
 
 local roundData
-function p.get(templateid, bracketType)
+function MatchGroupLegacyDefault.get(templateid, bracketType)
 	local LowerHeader = {}
 	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateid)
 
@@ -25,7 +25,8 @@ function p.get(templateid, bracketType)
 	roundData = roundData or {}
 	local lastround = 0
 	for _, match in ipairs(matches) do
-		bracketData, lastround, LowerHeader = p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+		bracketData, lastround, LowerHeader =
+			MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 	end
 
 	-- add reference for map mappings
@@ -48,7 +49,7 @@ function p.get(templateid, bracketType)
 end
 
 local lastRound
-function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+function MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 	local id = String.split(match.match2id, "_")[2] or match.match2id
 	id = id:gsub("0*([1-9])", "%1"):gsub("%-", "")
 	local bd = match.match2bracketdata
@@ -143,7 +144,7 @@ function p.getMatchMapping(match, bracketData, bracketType, LowerHeader)
 		["$flatten$"] = { "R" .. round.R .. "G" .. round.G .. "details" }
 	}
 
-	bracketData[id] = p.addMaps(match)
+	bracketData[id] = MatchGroupLegacyDefault.addMaps(match)
 	lastRound = round
 	roundData[round.R] = round
 
@@ -157,7 +158,7 @@ parameter format of the old bracket
 ]]--
 
 --this can be used for custom mappings too
-function p.addMaps(match)
+function MatchGroupLegacyDefault.addMaps(match)
 	for mapIndex = 1, MAX_NUM_MAPS do
 		match["map" .. mapIndex] = {
 			["$ref$"] = "map",
@@ -168,7 +169,7 @@ function p.addMaps(match)
 end
 
 --this is for custom mappings
-function p.matchMappingFromCustom(data)
+function MatchGroupLegacyDefault.matchMappingFromCustom(data)
 	--[[
 	data has the form {
 		opp1,
@@ -203,7 +204,7 @@ function p.matchMappingFromCustom(data)
 	if data.match and data.header then
 		mapping[data.match .. 'header'] = data.header
 	end
-	mapping = p.addMaps(mapping)
+	mapping = MatchGroupLegacyDefault.addMaps(mapping)
 
 	return mapping
 end
@@ -211,7 +212,7 @@ end
 --this is for custom mappings for Reset finals matches
 --it switches score2 into the place of score
 --and sets flatten to nil
-function p.matchResetMappingFromCustom(mapping)
+function MatchGroupLegacyDefault.matchResetMappingFromCustom(mapping)
 	local mapping3rd = mw.clone(mapping)
 	mapping3rd.opponent1.score = mapping.opponent1.score .. '2'
 	mapping3rd.opponent2.score = mapping.opponent2.score .. '2'
@@ -219,4 +220,4 @@ function p.matchResetMappingFromCustom(mapping)
 	return mapping3rd
 end
 
-return p
+return MatchGroupLegacyDefault


### PR DESCRIPTION
## Summary

Remove remaining usages of `p` as internal module names in the code base.

## How did you test this change?

Tested the RL Input change with dev modules, as there's technically logic change there. Rest are just renames