### PR TITLE
Correct OpponentType on TBDs

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -951,7 +951,7 @@ function Placement:_parseOpponents(args)
 			if not args.place or self.placeStart + opponentIndex > self.placeEnd + 1 then
 				return
 			else
-				opponent.opponentData = Opponent.tbd()
+				opponent.opponentData = Opponent.tbd(self.parent.opponentType)
 			end
 		else
 			-- Set the date
@@ -986,7 +986,7 @@ function Placement:_parseOpponentArgs(input, date)
 	local opponentArgs = Json.parseIfTable(input) or (type(input) == 'table' and input or {input})
 	opponentArgs.type = opponentArgs.type or self.parent.opponentType
 	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
-	local opponentData = Opponent.readOpponentArgs(opponentArgs) or Opponent.tbd()
+	local opponentData = Opponent.readOpponentArgs(opponentArgs) or Opponent.tbd(opponentArgs.type)
 	return Opponent.resolve(opponentData, date)
 end
 


### PR DESCRIPTION
## Summary

Supply OpponentType information when it comes to TBDs. 
This has the intended side effect of adding (filler) icons to team TBDs.

![image](https://user-images.githubusercontent.com/3426850/179405308-eb853f64-85ef-4c3f-95fe-b05b608e78d7.png)


## How did you test this change?

/dev module