### PR TITLE
Remove css class that causes issues

### DIFF
--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -304,7 +304,6 @@ function OpponentDisplay.BlockTeam(props)
 	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
 
 	return mw.html.create('div'):addClass('block-team')
-		:addClass(props.showLink == false and 'block-team-hide-link' or nil)
 		:addClass(props.flip and 'flipped' or nil)
 		:node(props.icon)
 		:node(nameNode)


### PR DESCRIPTION
## Summary

This css-class stops the ability for mouse pointer to change while hoovering over items. The biggest issue with this is that abbr's don't work while this is set. It brings no real advantage, and starcraft2 has already remove its usage from their implementations.  Hence suggesting we remove it from the common library as well.

## How did you test this change?

CSS Preview mode, removing the class there and made sure nothing breaks.
