### PR TITLE
Create a plugin for the sumenko extension

### DIFF
--- a/plugins/sumneko_plugin.lua
+++ b/plugins/sumneko_plugin.lua
@@ -5,8 +5,8 @@
 local liquipedia = {}
 
 local importFunctions = {}
-importFunctions.functions = { 'require', 'mw%.loadData', 'Lua%.import', 'Lua%.requireIfExists', 'Lua%.loadDataIfExists' }
-importFunctions.prefixModules = { table = 'standard.', math = 'standard.', string = 'standard.' }
+importFunctions.functions = {'require', 'mw%.loadData', 'Lua%.import', 'Lua%.requireIfExists', 'Lua%.loadDataIfExists'}
+importFunctions.prefixModules = {table = 'standard.', math = 'standard.', string = 'standard.'}
 
 function importFunctions._row(name)
     local normModuleName =
@@ -27,7 +27,7 @@ end
 
 function importFunctions.annotate(text, funcName, diffs)
     for module, positionEndOfRow in text:gmatch(funcName .. '%s*%(?%s*[\'"](.-)[\'"]%s*%)?.-()\r?\n') do
-        table.insert(diffs, { start = positionEndOfRow, finish = positionEndOfRow, text = importFunctions._row(module) })
+        table.insert(diffs, {start = positionEndOfRow, finish = positionEndOfRow, text = importFunctions._row(module)})
     end
 end
 
@@ -37,7 +37,10 @@ function liquipedia.annotate(text, diffs)
     end
 end
 
+-- luacheck: push ignore
+-- setting non-standard global variable 'OnSetText' (but it's mandatory)
 function OnSetText(uri, text)
+-- luacheck: pop ignore
     if text:sub(1, 3) ~= '---' then
         return nil
     end

--- a/plugins/sumneko_plugin.lua
+++ b/plugins/sumneko_plugin.lua
@@ -1,0 +1,50 @@
+--@Author Rath
+--Made for Liquipedia
+--For use with sumneko-lua vscode/neovim extension
+
+local liquipedia = {}
+
+local importFunctions = {}
+importFunctions.functions = { 'require', 'mw%.loadData', 'Lua%.import', 'Lua%.requireIfExists', 'Lua%.loadDataIfExists' }
+importFunctions.prefixModules = { table = 'standard.', math = 'standard.', string = 'standard.' }
+
+function importFunctions._row(name)
+    local normModuleName =
+        name
+            :gsub('Module:', '') -- Remove starting Module:
+            :gsub('^%u', string.lower) -- Lower case first letter
+            :gsub('%u', '_%0') -- Prefix uppercase letters with an underscore
+            :gsub('/', '_') -- Change slash to underscore
+            :gsub('__', '_') -- Never have two underscores in a row
+            :lower() -- Lowercase everything
+
+    if importFunctions.prefixModules[normModuleName] then
+        normModuleName = importFunctions.prefixModules[normModuleName] .. normModuleName
+    end
+
+    return ' ---@module \'' .. normModuleName ..'\''
+end
+
+function importFunctions.annotate(text, funcName, diffs)
+    for module, positionEndOfRow in text:gmatch(funcName .. '%s*%(?%s*[\'"](.-)[\'"]%s*%)?.-()\r?\n') do
+        table.insert(diffs, { start = positionEndOfRow, finish = positionEndOfRow, text = importFunctions._row(module) })
+    end
+end
+
+function liquipedia.annotate(text, diffs)
+    for _, funcName in pairs(importFunctions.functions) do
+        importFunctions.annotate(text, funcName, diffs)
+    end
+end
+
+function OnSetText(uri, text)
+    if text:sub(1, 3) ~= '---' then
+        return nil
+    end
+
+    local diffs = {}
+
+    liquipedia.annotate(text, diffs)
+
+    return diffs
+end

--- a/plugins/sumneko_plugin.lua
+++ b/plugins/sumneko_plugin.lua
@@ -1,6 +1,7 @@
---@Author Rath
---Made for Liquipedia
---For use with sumneko-lua vscode/neovim extension
+-- For use with sumneko-lua vscode/neovim extension.
+-- This file is automatically read assuming the extension is setup correctly.
+-- The setting "Lua.runtime.plugin" needs to be set to "plugins/sumneko_plugin.lua"
+-- See more at https://github.com/sumneko/lua-language-server/wiki/Plugin
 
 local liquipedia = {}
 


### PR DESCRIPTION
## Summary
Sumenko is the biggest lua extension for VSCode and Neovim. However much of the intellisense for the modules is unusable as the extension cannot map between our requires and the files in our repo (both the Module prefix and the different naming schemes causes the failure).

This PR implements a plugin that helps the intellisense to locate the correct file.

How it works it by automatically, under the hood, annotates all imports with `---module '...'` where `...` is a findable name for the intellisense engine. The annotation is not set in the lua code, but is set in the code read and consumed by the extension.


## How did you test this change?
![image](https://user-images.githubusercontent.com/3426850/179523859-2864a33a-f0c7-4668-b347-ff187b805d9d.png)
![image](https://user-images.githubusercontent.com/3426850/179523882-96c558a2-e53b-4468-90bf-56fac1440572.png)
![image](https://user-images.githubusercontent.com/3426850/179523922-681d9d60-64b2-43e8-a2f3-520c563ab913.png)
![image](https://user-images.githubusercontent.com/3426850/179523985-4f8aaecc-50a7-400b-af65-75cc31627843.png)
![image](https://user-images.githubusercontent.com/3426850/179524315-1631f0d6-48aa-49d9-a91f-24a8bf54a9eb.png)
