### PR TITLE
SEO Tags for Infobox League

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -237,11 +237,6 @@ function League:addToLpdb(lpdbData, args)
 end
 
 --- Allows for overriding this functionality
-function League:seoImage(args)
-	return args.image
-end
-
---- Allows for overriding this functionality
 function League:seoText(args)
 	return MetadataGenerator.tournament(args)
 end
@@ -415,11 +410,6 @@ function League:_setLpdbData(args, links)
 end
 
 function League:_setSeoTags(args)
-	local image = self:seoImage(args)
-	if image then
-		mw.ext.SearchEngineOptimization.metaimage(image)
-	end
-
 	local desc = self:seoText(args)
 	if desc then
 		mw.ext.SearchEngineOptimization.metadescl(desc)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -215,6 +215,7 @@ function League:createInfobox()
 		end
 		self.infobox:categories(unpack(self:getWikiCategories(args)))
 		self:_setLpdbData(args, links)
+		self:_setSeoTags(args)
 	end
 
 	return tostring(builtInfobox) .. WarningBox.displayAll(League.warnings)
@@ -232,6 +233,50 @@ end
 --- Allows for overriding this functionality
 function League:addToLpdb(lpdbData, args)
 	return lpdbData
+end
+
+--- Allows for overriding this functionality
+function League:seoImage(args)
+	return args.image
+end
+
+--- Allows for overriding this functionality
+function League:seoText(args)
+	local name = self.name
+	local tournamentType = args.type
+	local location = Localisation.getLocalisation({displayNoError = true}, args.country)
+	local game = args.game -- TODO Remove or improved via wiki custom
+	local tier = args.tier -- TODO Resolve to name
+	local tierType = args.tiertype or 'tournament'
+	local organizers = {
+		args['organizer-name'] or args.organizer,
+		args['organizer2-name'] or args.organizer2,
+		args['organizer3-name'] or args.organizer3
+	}
+
+	local intro = ''
+
+	intro = intro .. name .. ' is a'
+	if String.isNotEmpty(tournamentType) then
+		intro = intro .. 'n ' .. tournamentType
+	end
+	if String.isNotEmpty(location) then
+		intro = intro .. ' ' .. location
+	end
+	if String.isNotEmpty(game) then
+		intro = intro .. ' ' .. game
+	end
+
+	intro = intro .. ' ' .. tierType
+
+	if Table.isNotEmpty(organizers) then
+		intro = intro .. ' organized by ' .. mw.text.listToText(organizers)
+	end
+
+	local details = ''
+	-- TODO
+
+	return intro .. '. ' .. details
 end
 
 --- Allows for overriding this functionality
@@ -397,6 +442,11 @@ function League:_setLpdbData(args, links)
 	lpdbData = self:addToLpdb(lpdbData, args)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
 	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. self.name, lpdbData)
+end
+
+function League:_setSeoTags(args)
+	mw.ext.SearchEngineOptimization.metaimage(self:seoImage(args))
+	mw.ext.SearchEngineOptimization.metadescl(self:seoText(args))
 end
 
 function League:_getNamedTableofAllArgsForBase(args, base)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -245,26 +245,31 @@ function League:seoText(args)
 	local name = self.name
 	local tournamentType = args.type
 	local location = Localisation.getLocalisation({displayNoError = true}, args.country)
-	local game = args.game -- TODO Remove or improved via wiki custom
-	local tier = args.tier -- TODO Resolve to name
-	local tierType = args.tiertype or 'tournament'
+	local date, dateVerb -- TODO
+	local teamCount, playerCount = args.team_number, args.player_number
+	local prizePool = self:_createPrizepool(args)
+	local tierType = args.liquipediatiertype or 'tournament'
 	local organizers = {
 		args['organizer-name'] or args.organizer,
 		args['organizer2-name'] or args.organizer2,
 		args['organizer3-name'] or args.organizer3
 	}
+	local tierText -- TODO: Extract to function
+	if args.liquipediatier then
+		if not Tier.text[_TIER_MODE_TIERS] then -- allow legacy tier modules
+			tierText = Tier.text[args.liquipediatier]
+		else -- default case, i.e. tier module with intended format
+			tierText = Tier.text[_TIER_MODE_TIERS][args.liquipediatier:lower()]
+		end
+	end
 
 	local intro = ''
-
 	intro = intro .. name .. ' is a'
 	if String.isNotEmpty(tournamentType) then
 		intro = intro .. 'n ' .. tournamentType
 	end
 	if String.isNotEmpty(location) then
 		intro = intro .. ' ' .. location
-	end
-	if String.isNotEmpty(game) then
-		intro = intro .. ' ' .. game
 	end
 
 	intro = intro .. ' ' .. tierType
@@ -274,9 +279,33 @@ function League:seoText(args)
 	end
 
 	local details = ''
-	-- TODO
+	details = details .. 'This'
+	if String.isNotEmpty(tierText) then
+		details = details .. ' ' .. tierText
+	end
+	details = details .. ' ' .. tierType
 
-	return intro .. '. ' .. details
+	if date and dateVerb then
+		details = details .. ' ' .. dateVerb .. ' ' .. date
+	end
+
+	if teamCount or playerCount then
+		details = details .. ' features '
+		if teamCount then
+			details = details .. teamCount .. ' teams'
+		elseif playerCount then
+			details = details .. playerCount .. ' players'
+		end
+	end
+
+	if String.isNotEmpty(prizePool) then
+		if teamCount or playerCount then
+			details = details .. ' competing over'
+		end
+		details = details .. ' a total of ' .. prizePool
+	end
+
+	return intro .. '. ' .. details .. '.'
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -252,14 +252,15 @@ function League:seoText(args)
 		local sYear, sMonth, sDay = sdate:match('(%d%d%d%d)-?([%d%?]?[%d%?]?)-?([%d%?][%d%?]?)$')
 		local eYear, eMonth, eDay = edate:match('(%d%d%d%d)-?([%d%?]?[%d%?]?)-?([%d%?][%d%?]?)$')
 
-		if not tonumber(sMonth) then
+		if not tonumber(sYear) or not tonumber(eYear) or not tonumber(sMonth) then
 			return
 		end
 
 		local eMonthExact = tonumber(eMonth) and true
 		local sDayExact, eDayExact = tonumber(sDay) and true, tonumber(eDay) and true
 
-		local sTimestamp, eTimestamp = Date.readTimestamp(sdate), Date.readTimestamp(edate)
+		local sTimestamp = Date.readTimestamp(sdate:gsub('%?%?', '01'))
+		local eTimestamp = Date.readTimestamp(edate:gsub('%?%?', '01'))
 		local currentTimestamp = os.time()
 
 		if currentTimestamp < sTimestamp then

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -258,10 +258,14 @@ function League:seoText(args)
 		args['organizer2-name'] or args.organizer2,
 		args['organizer3-name'] or args.organizer3
 	}
-	local tierType = args.liquipediatiertype and self:_getTierText(args.liquipediatiertype, _TIER_MODE_TYPES) or 'tournament'
-	local tierText = args.liquipediatier and self:_getTierText(args.liquipediatier, _TIER_MODE_TIERS) or nil
+	local tierType = args.liquipediatiertype
+		and self:_getTierText(args.liquipediatiertype, _TIER_MODE_TYPES)
+		or 'tournament'
+	local tierText = args.liquipediatier
+		and self:_getTierText(args.liquipediatier, _TIER_MODE_TIERS)
+		or nil
 
-	-- FooBar Season 4 is an offline American Qualifier orangized by X and Y. 
+	-- FooBar Season 4 is an offline American Qualifier orangized by X and Y.
 	local intro = name .. ' is a'
 	if String.isNotEmpty(tournamentType) then
 		intro = intro .. 'n ' .. tournamentType:lower()

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -576,8 +576,15 @@ function League:_setLpdbData(args, links)
 end
 
 function League:_setSeoTags(args)
-	mw.ext.SearchEngineOptimization.metaimage(self:seoImage(args))
-	mw.ext.SearchEngineOptimization.metadescl(self:seoText(args))
+	local image = self:seoImage(args)
+	if image then
+		mw.ext.SearchEngineOptimization.metaimage(image)
+	end
+
+	local desc = self:seoText(args)
+	if desc then
+		mw.ext.SearchEngineOptimization.metadescl(desc)
+	end
 end
 
 function League:_getNamedTableofAllArgsForBase(args, base)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -282,7 +282,7 @@ function League:seoText(args)
 		elseif sYear == eYear then
 			sFormat = '%b'
 		else
-			eFormat = '%b %Y'
+			sFormat = '%b %Y'
 		end
 
 		if eDayExact and sMonth == eMonth then

--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -34,6 +34,10 @@ function Header:make()
 		)
 	}
 
+	if self.image then
+		mw.ext.SearchEngineOptimization.metaimage(self.image)
+	end
+
 	local subHeader = Header:_subHeader(self.subHeader)
 	if subHeader then
 		table.insert(header, 2, subHeader)
@@ -100,7 +104,7 @@ function Header:_makeSizedImage(imageName, fileName, size, mode)
 	end
 
 	local fullFileName = '[[File:' .. imageName .. '|center|' .. size .. ']]'
-	infoboxImage:wikitext(mw.getCurrentFrame():preprocess('{{#metaimage:' .. (fileName or '') .. '}}') .. fullFileName)
+	infoboxImage:wikitext(fullFileName)
 
 	return infoboxImage
 end

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -64,7 +64,8 @@ function MetadataGenerator.tournament(args)
 	local players = args.player_number
 
 	local game
-	if type(Games.abbr) == 'function' and args.primarygame and String.isNotEmpty(args.game) and args.game == args.primarygame then
+	if type(Games.abbr) == 'function' and args.primarygame and String.isNotEmpty(args.game)
+			and args.game == args.primarygame then
 		game = Games.abbr[args.game]
 	end
 

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -64,7 +64,7 @@ function MetadataGenerator.tournament(args)
 	local players = args.player_number
 
 	local game
-	if type(Games.abbr) == 'function' and args.primarygame and String.isNotEmpty(args.game)
+	if type(Games.abbr) == 'table' and args.primarygame and String.isNotEmpty(args.game)
 		and args.game == args.primarygame then
 
 		game = Games.abbr[args.game]

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -15,12 +15,15 @@ local StringUtils = require('Module:StringUtils')
 local Class = require('Module:Class')
 local AnOrA = require('Module:A or an')
 local Tier = mw.loadData('Module:Tier')
+local Table = mw.loadData('Module:Table')
 
 local MetadataGenerator = {}
 
 local TIME_FUTURE = 1
 local TIME_ONGOING = 0
 local TIME_PAST = -1
+
+local TYPES_TO_DISPLAY = {'qualifier', 'showmatch', 'show match'}
 
 function MetadataGenerator.tournament(args)
 	local output
@@ -46,7 +49,7 @@ function MetadataGenerator.tournament(args)
 	local tierType = 'tournament'
 	if args.liquipediatiertype then
 		local tierTypeLower = args.liquipediatiertype:lower()
-		if tierTypeLower == 'qualifier' or tierTypeLower == 'showmatch' then
+		if Table.includes(TYPES_TO_DISPLAY, tierTypeLower) then
 			tierType = tierTypeLower
 		end
 	end
@@ -61,7 +64,7 @@ function MetadataGenerator.tournament(args)
 	local players = args.player_number
 
 	local game
-	if args.primarygame and String.isNotEmpty(args.game) and args.game == args.primarygame then
+	if type(Games.abbr) == 'function' and args.primarygame and String.isNotEmpty(args.game) and args.game == args.primarygame then
 		game = Games.abbr[args.game]
 	end
 

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -7,27 +7,23 @@
 --
 
 local String = require('Module:StringUtils')
+local Date = require('Module:Date/Ext')
 local Localisation = require('Module:Localisation')
-local Template = require('Module:Template')
-local Games = require('Module:Games')
+local Games = mw.loadData('Module:Games')
 local Variables = require('Module:Variables')
 local StringUtils = require('Module:StringUtils')
 local Class = require('Module:Class')
 local AnOrA = require('Module:A or an')
+local Tier = mw.loadData('Module:Tier')
 
 local MetadataGenerator = {}
 
+local TIME_FUTURE = 1
+local TIME_ONGOING = 0
+local TIME_PAST = -1
+
 function MetadataGenerator.tournament(args)
-	if String.isEmpty(args.publisherdescription) then
-		error('You must provide the publisherdescription param!')
-	end
-
-	if String.isEmpty(args.primarygame) then
-		error('You must provide the primarygame param!')
-	end
-
 	local output
-	local frame = mw.getCurrentFrame()
 
 	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle()
 
@@ -40,24 +36,34 @@ function MetadataGenerator.tournament(args)
 		args['organizer3-name'] or args.organizer3,
 	}
 
-	local tier = args.liquipediatier and Template.safeExpand(frame, 'TierDisplay', {args.liquipediatier}) or nil
+	---@type string?
+	local tier = args.liquipediatier and MetadataGenerator.getTierText(args.liquipediatier) or nil
 
-	if tier then
-		tier = (tonumber(
-			Template.safeExpand(frame, 'TierDisplay/number', {args.liquipediatier})
-		) or 0) > 4 and tier:lower() or tier
-	else
+	if not tier then
 		tier = 'Unknown Tier'
 	end
 
-	local tierType = (tier == 'qualifier' or tier == 'showmatch') and tier or 'tournament'
-	local publisher = Variables.varDefault(args.publisherdescription, '')
-	local date, tense = MetadataGenerator.getDate(args.edate or args.date, args.sdate)
+	local tierType = 'tournament'
+	if args.liquipediatiertype then
+		local tierTypeLower = args.liquipediatiertype:lower()
+		if tierTypeLower == 'qualifier' or tierTypeLower == 'showmatch' then
+			tierType = tierTypeLower
+		end
+	end
+
+	local publisher
+	if args.publisherdescription then
+		publisher = Variables.varDefault(args.publisherdescription, '')
+	end
+	local date, tense = MetadataGenerator.getDate(args.sdate or args.date, args.edate or args.date)
 
 	local teams = args.team_number
 	local players = args.player_number
 
-	local game = (not String.isEmpty(args.game) and args.game ~= args.primarygame) and Games.abbr[args.game]
+	local game
+	if args.primarygame and String.isNotEmpty(args.game) and args.game == args.primarygame then
+		game = Games.abbr[args.game]
+	end
 
 	local prizepoolusd = args.prizepoolusd and ('$' .. args.prizepoolusd .. ' USD') or nil
 	local prizepool = prizepoolusd or (
@@ -68,10 +74,13 @@ function MetadataGenerator.tournament(args)
 		)
 	)
 	local charity = args.charity == 'true'
-	local dateVerb = (tense == 'past' and 'took place ') or (tense == 'future' and 'will take place ') or 'takes place '
+	local dateVerb = (tense == TIME_PAST and 'took place ')
+		or (tense == TIME_FUTURE and 'will take place ')
+		or 'takes place '
+
 	local dateVerbPublisher =
-		(tense == 'past' and ' which took place ') or
-		(tense == 'future' and ' which will take place ') or
+		(tense == TIME_PAST and ' which took place ') or
+		(tense == TIME_FUTURE and ' which will take place ') or
 		' taking place '
 
 	output = StringUtils.interpolate('${name} is ${a}${type}${locality}${game}${charity}${tierType}${organizer}', {
@@ -129,48 +138,105 @@ function MetadataGenerator.tournament(args)
 	return output
 end
 
-function MetadataGenerator.getDate(date, sdate)
-	if String.isEmpty(date) then
-		return nil
+function MetadataGenerator.getTierText(tierString)
+	if not Tier.text.tiers then -- allow legacy tier modules
+		return Tier.text[tierString]
+	else -- default case, i.e. tier module with intended format
+		return Tier.text.tiers[tierString:lower()]
+	end
+end
+
+function MetadataGenerator.getDate(startDate, endDate)
+	if not startDate or not endDate then
+		return
 	end
 
-	local noStartDay, noEndDay, tense
-	local startRaw = (sdate or date):gsub('%-[?X]+', '')
-	local endRaw = date:gsub('%-[?X]+', '')
-	local currentU = tonumber(os.date("!%s"))
-	local startU = tonumber(mw.getContentLanguage():formatDate('U', startRaw))
-	local endU = tonumber(mw.getContentLanguage():formatDate('U', endRaw))
-	local startMD = startRaw:sub(6)
-	local endMD = endRaw:sub(6)
-
-	if tonumber(startMD) then
-		noStartDay = true
+	local dateStringToStruct = function (dateString)
+		local year, month, day = dateString:match('(%d%d%d%d)-?([%d%?]?[%d%?]?)-?([%d%?][%d%?]?)$')
+		if not year then return {} end
+		return {
+			year = year,
+			month = month,
+			day = day,
+			yearExact = tonumber(year) and true,
+			monthExact = tonumber(month) and true,
+			dayExact = tonumber(day) and true,
+			timestamp = Date.readTimestamp(dateString:gsub('%?%?', '01'))
+		}
 	end
 
-	if tonumber(endMD) then
-		noEndDay = true
+	local currentTimestamp = os.time()
+	local startTime = dateStringToStruct(startDate)
+	local endTime = dateStringToStruct(endDate)
+
+	if not startTime.yearExact or not endTime.yearExact or not startTime.monthExact then
+		return
 	end
 
-	if currentU > endU then
-		tense = 'past'
-	elseif currentU < startU then
-		tense = 'future'
-	elseif startU < currentU and currentU < endU then
-		tense = 'present'
-	end
+	local relativeTime = MetadataGenerator.getTimeRelativity(currentTimestamp, startTime, endTime)
 
-	if startU == endU then
-		return os.date("!on %b " .. (noStartDay and "??" or "%d") .. " %Y", endU), tense
-	elseif os.date("!%m, %Y", startU) == os.date("!%m %Y", endU) then
-		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' ..
-			os.date("!" .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
-	elseif os.date("!%Y", startU) == os.date("!%Y", endU) then
-		return os.date("!from %b " .. (noStartDay and "??" or "%d"), startU) .. ' to ' ..
-			os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+	local sFormat, eFormat = MetadataGenerator.getDateFormat(startTime, endTime)
+
+	local prefix
+	if startTime.timestamp == endTime.timestamp and endTime.dayExact then
+		prefix = 'on'
+		sFormat = '%b %d %Y'
+		eFormat = ''
+	elseif startTime.timestamp == endTime.timestamp and endTime.monthExact then
+		prefix = 'in'
+		sFormat = '%b %Y'
+		eFormat = ''
+	elseif not endTime.monthExact then
+		if relativeTime == TIME_FUTURE then
+			prefix = 'starting'
+		else
+			prefix = 'started'
+		end
+		eFormat = ''
 	else
-		return os.date("!from %b " .. (noStartDay and "??" or "%d") .. " %Y", startU) .. ' to ' ..
-			os.date("!%b " .. (noEndDay and "??" or "%d") .. " %Y", endU), tense
+		prefix = 'from'
 	end
+
+	local displayDate
+	displayDate = prefix .. ' ' .. os.date('!' .. sFormat, startTime.timestamp)
+	if String.isNotEmpty(eFormat) then
+		displayDate = displayDate .. ' to ' .. os.date('!' .. eFormat, endTime.timestamp)
+	end
+
+	return displayDate, relativeTime
+end
+
+function MetadataGenerator.getTimeRelativity(timeNow, startTime, endTime)
+	if timeNow < startTime.timestamp then
+		return TIME_FUTURE
+	elseif timeNow < endTime.timestamp then
+		return TIME_ONGOING
+	elseif timeNow > endTime.timestamp then
+		return TIME_PAST
+	end
+end
+
+function MetadataGenerator.getDateFormat(startTime, endTime)
+	local formatStart, formatEnd
+	if startTime.dayExact and startTime.year == endTime.year then
+		formatStart = '%b %d'
+	elseif startTime.dayExact then
+		formatStart = '%b %d %Y'
+	elseif startTime.year == endTime.year then
+		formatStart = '%b'
+	else
+		formatStart = '%b %Y'
+	end
+
+	if endTime.dayExact and startTime.month == endTime.month then
+		formatEnd = '%d %Y'
+	elseif endTime.dayExact then
+		formatEnd = '%b %d %Y'
+	else
+		formatEnd = '%b %Y'
+	end
+
+	return formatStart, formatEnd
 end
 
 return Class.export(MetadataGenerator)

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -15,7 +15,7 @@ local StringUtils = require('Module:StringUtils')
 local Class = require('Module:Class')
 local AnOrA = require('Module:A or an')
 local Tier = mw.loadData('Module:Tier')
-local Table = mw.loadData('Module:Table')
+local Table = require('Module:Table')
 
 local MetadataGenerator = {}
 
@@ -30,7 +30,7 @@ function MetadataGenerator.tournament(args)
 
 	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle()
 
-	local type = args.type
+	local tournamentType = args.type
 	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)
 
 	local organizers = {
@@ -90,8 +90,11 @@ function MetadataGenerator.tournament(args)
 
 	output = StringUtils.interpolate('${name} is ${a}${type}${locality}${game}${charity}${tierType}${organizer}', {
 		name = name,
-		a = AnOrA._main(type or locality or game or (charity and 'charity' or nil) or tierType) .. ' ',
-		type = type and (type:lower() .. ' ') or '',
+		a = AnOrA._main{
+			tournamentType or locality or game or (charity and 'charity' or nil) or tierType,
+			origStr = 'false' -- Ew (but has to be like this)
+		},
+		type = tournamentType and (tournamentType:lower() .. ' ') or '',
 		locality = locality and (locality .. ' ') or '',
 		game = game and (game .. ' ') or '',
 		charity = charity and 'charity ' or '',

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -65,7 +65,8 @@ function MetadataGenerator.tournament(args)
 
 	local game
 	if type(Games.abbr) == 'function' and args.primarygame and String.isNotEmpty(args.game)
-			and args.game == args.primarygame then
+		and args.game == args.primarygame then
+
 		game = Games.abbr[args.game]
 	end
 

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -17,7 +17,6 @@ local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
-local MetadataGenerator = require('Module:MetadataGenerator')
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -137,8 +136,6 @@ function CustomInjector:parse(id, widgets)
 			}
 		)
 	end
-
-	mw.getCurrentFrame():extensionTag{name = 'metadescl', MetadataGenerator.tournament(_league.args)}
 
 	return widgets
 end


### PR DESCRIPTION
## Summary
Set the metaImage and metaDescl tags allowing for embeds.
The image is set to the primary image of the league. 

## How did you test this change?
Dev modules initially then live on R6 to get a good sample size.
![image](https://user-images.githubusercontent.com/3426850/179709209-f918f44c-ad3f-4c92-ad83-2bda3b0cd313.png)
![image](https://user-images.githubusercontent.com/3426850/179721053-c03b3cb9-5796-4319-986c-cb82f8db121c.png)
