### PR TITLE
Adjust category name for military stuff

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
@@ -48,10 +48,10 @@ local _CLEAN_OTHER_ROLES = {
 }
 
 local _MILITARY_DATA = {
-	starting = {category = 'People waiting for Military Duty', storeValue = 'pending'},
-	ongoing = {category = 'People on Military Duty', storeValue = 'ongoing'},
-	fulfilled = {category = 'People that completed their Military Duty', storeValue = 'fulfilled'},
-	exempted = {category = 'People exempted from Military Duty', storeValue = 'exempted'},
+	starting = {category = 'Persons waiting for Military Duty', storeValue = 'pending'},
+	ongoing = {category = 'Persons on Military Duty', storeValue = 'ongoing'},
+	fulfilled = {category = 'Persons that completed their Military Duty', storeValue = 'fulfilled'},
+	exempted = {category = 'Persons exempted from Military Duty', storeValue = 'exempted'},
 }
 _MILITARY_DATA.pending = _MILITARY_DATA.starting
 _MILITARY_DATA.started = _MILITARY_DATA.ongoing


### PR DESCRIPTION
## Summary
Adjust category name for military stuff in sc2 person infoboxes

## How did you test this change?
N/A, just category rename