### PR TITLE
Increase default height from 23->24px for opponent box in brackets

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -179,7 +179,7 @@ DisplayHelper.getGlobalConfig = FnUtil.memoize(function()
 		matchHeight = 44, -- deprecated
 		matchWidth = 150,
 		matchWidthMobile = 90,
-		opponentHeight = 26,
+		opponentHeight = 24,
 		roundHorizontalMargin = 20,
 		scoreWidth = 20,
 	}


### PR DESCRIPTION
## Summary

1) Moves to the 4px grid
2) Possible to center something with even dimensions.

## How did you test this change?
Before:
![image](https://user-images.githubusercontent.com/3426850/179812151-2bd617d2-67ff-46cb-8c5a-655b07084cf1.png)

After:
![image](https://user-images.githubusercontent.com/3426850/179811974-bda9e485-06a3-44a0-aa18-84341401b863.png)

