### PR TITLE
Do not default to `u` for manual race input per map

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -987,11 +987,12 @@ function StarcraftMatchGroupInput._processDefaultPlayerMapData(players, map, opp
 end
 
 function StarcraftMatchGroupInput._processArchonPlayerMapData(players, map, opponentIndex, participants)
-	local faction = string.lower(Logic.emptyOr(
+	local faction = Logic.emptyOr(
 		map['opponent' .. opponentIndex .. 'race'],
 		map['race' .. opponentIndex],
-		players[1].extradata.faction or 'u'
-	))
+		players[1].extradata.faction
+	)
+	faction = string.lower(faction or '')
 	participants[opponentIndex .. '_1'] = {
 		faction = _FACTIONS[faction] or 'u',
 		player = players[1].name

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -965,17 +965,12 @@ function StarcraftMatchGroupInput._fetchOpponentMapRacesAndNames(participants)
 end
 
 function StarcraftMatchGroupInput._processDefaultPlayerMapData(players, map, opponentIndex, participants)
-	local faction = Logic.emptyOr(
+	map['t' .. opponentIndex .. 'p1race'] = Logic.emptyOr(
 		map['t' .. opponentIndex .. 'p1race'],
 		map['race' .. opponentIndex]
 	)
-	faction = string.lower(faction or '')
-	participants[opponentIndex .. '_1'] = {
-		faction = _FACTIONS[faction] or players[1].extradata.faction or 'u',
-		player = players[1].name
-	}
 
-	for playerIndex = 2, #players do
+	for playerIndex = 1, #players do
 		faction = string.lower(map['t' .. opponentIndex .. 'p' .. playerIndex .. 'race'] or '')
 		participants[opponentIndex .. '_' .. playerIndex] = {
 			faction = _FACTIONS[faction] or players[playerIndex].extradata.faction or 'u',

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -971,7 +971,7 @@ function StarcraftMatchGroupInput._processDefaultPlayerMapData(players, map, opp
 	)
 
 	for playerIndex = 1, #players do
-		faction = string.lower(map['t' .. opponentIndex .. 'p' .. playerIndex .. 'race'] or '')
+		local faction = string.lower(map['t' .. opponentIndex .. 'p' .. playerIndex .. 'race'] or '')
 		participants[opponentIndex .. '_' .. playerIndex] = {
 			faction = _FACTIONS[faction] or players[playerIndex].extradata.faction or 'u',
 			player = players[playerIndex].name

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -965,21 +965,18 @@ function StarcraftMatchGroupInput._fetchOpponentMapRacesAndNames(participants)
 end
 
 function StarcraftMatchGroupInput._processDefaultPlayerMapData(players, map, opponentIndex, participants)
-	local faction = string.lower(Logic.emptyOr(
+	local faction = Logic.emptyOr(
 		map['t' .. opponentIndex .. 'p1race'],
-		map['race' .. opponentIndex],
-		'u'
-	))
+		map['race' .. opponentIndex]
+	)
+	faction = string.lower(faction or '')
 	participants[opponentIndex .. '_1'] = {
 		faction = _FACTIONS[faction] or players[1].extradata.faction or 'u',
 		player = players[1].name
 	}
 
 	for playerIndex = 2, #players do
-		faction = string.lower(Logic.emptyOr(
-			map['t' .. opponentIndex .. 'p' .. playerIndex .. 'race'],
-			'u'
-		))
+		faction = string.lower(map['t' .. opponentIndex .. 'p' .. playerIndex .. 'race'] or '')
 		participants[opponentIndex .. '_' .. playerIndex] = {
 			faction = _FACTIONS[faction] or players[playerIndex].extradata.faction or 'u',
 			player = players[playerIndex].name


### PR DESCRIPTION
## Summary
Do not default to `u` for manual race input per map

## How did you test this change?
/dev & live (can't test for singlematch in /dev atm due to prep for #1154)