### PR TITLE
Remove Icon Link if links should be removed in Team Display

### DIFF
--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -302,11 +302,16 @@ function OpponentDisplay.BlockTeam(props)
 			and '[[' .. props.team.pageName .. '|' .. displayName .. ']]'
 			or displayName
 		)
+
+	local icon = props.showLink
+		and props.icon
+		or DisplayUtil.removeLinkFromWikiLink(props.icon)
+
 	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
 
 	return mw.html.create('div'):addClass('block-team')
 		:addClass(props.flip and 'flipped' or nil)
-		:node(props.icon)
+		:node(icon)
 		:node(nameNode)
 end
 


### PR DESCRIPTION
## Summary

Taken from OpponentDisplay/downstreams.

Remove the link from the icon in addition to the actual link, if links should not be given.

Slight known issue: the alignment change done around the same time this PR was opened assumes the <a> is in place. After this PR is merged, the alignment change will be tweaked to reflect the new situation.

## How did you test this change?

/dev module