### PR TITLE
Resolve Redirect Tournament Links

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -164,7 +164,7 @@ PrizePool.prizeTypes = {
 
 		header = 'qualifies',
 		headerParse = function (prizePool, input, context, index)
-			local link = input:gsub(' ', '_')
+			local link = mw.ext.TeamLiquidIntegration.resolve_redirect(input):gsub(' ', '_')
 			local data = {link = link}
 
 			-- Automatically retrieve information from the Tournament


### PR DESCRIPTION
## Summary

Tournament Pags can be moved, and then the `|qualifies=` link can become invalid, even though there's a redirect in place.
This PR solves this by doing a resolve redirect on the tournament links.

## How did you test this change?

Dev module

Before:
![image](https://user-images.githubusercontent.com/3426850/179949998-8d48c8c1-f3ef-4fda-936d-3ffc84898bb4.png)

After:
![image](https://user-images.githubusercontent.com/3426850/179949968-8c3b8d58-4555-4c40-8c23-f66ed2d27719.png)

