### PR TITLE
Create Legacy Custom for Valorant PPT

### DIFF
--- a/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
@@ -1,0 +1,26 @@
+---
+-- @Liquipedia
+-- wiki=valorant
+-- page=Module:PrizePool/Legacy/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
+
+local CustomLegacyPrizePool = {}
+
+-- Template entry point
+function CustomLegacyPrizePool.run()
+	return PrizePoolLegacy.run(CustomLegacyPrizePool)
+end
+
+function CustomLegacyPrizePool.customHeader(newArgs, data, header)
+    newArgs.prizesummary = header.prizenote and true or newArgs.prizesummary
+
+    return newArgs
+end
+
+return CustomLegacyPrizePool


### PR DESCRIPTION
## Summary

Valorant Legacy has a slightly different naming scheme to enable the prize summary. 
Made a short custom to handle their way.

## How did you test this change?
Without Custom:
![image](https://user-images.githubusercontent.com/3426850/179953702-05e70bfe-fad9-459b-a262-0367fb397e56.png)

With Custom:
![image](https://user-images.githubusercontent.com/3426850/179953587-c9c123ee-0760-4a64-95a6-1ca5f82cf9dd.png)
