### PR TITLE
Create apexlegends earnings.lua

### DIFF
--- a/components/earnings/wikis/apexlegends/earnings.lua
+++ b/components/earnings/wikis/apexlegends/earnings.lua
@@ -1,0 +1,16 @@
+---
+-- @Liquipedia
+-- wiki=apexlegends
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+CustomEarnings.defaultNumberOfPlayersInTeam = 3
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
Currently tested on this page:

https://liquipedia.net/apexlegends/Hardecki

Missing earnings of solo tournaments atm, but the prizepool still needs to be updated.

## Summary

Adding earnings module to divide the apex earnings by 3

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

Currently checked on this (dev) page
https://liquipedia.net/apexlegends/Hardecki
Earnings are correct apart from missing Solo Tournament earnings. Prizepool still needs to be updated. 
  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
