### PR TITLE
Remove images in points in Valorant's legacy PPT

### DIFF
--- a/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Lua = require('Module:Lua')
+local Table = require('Module:Table')
 
 local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
 
@@ -21,6 +22,21 @@ function CustomLegacyPrizePool.customHeader(newArgs, data, header)
     newArgs.prizesummary = header.prizenote and true or newArgs.prizesummary
 
     return newArgs
+end
+
+function CustomLegacyPrizePool.customSlot(newData, data, slot)
+	-- Remove points with only image
+    -- Table.filter doesn't work on Tables (only Arrays)... Let's use Table.map instead
+	newData = Table.map(newData, function(key, value)
+        if key == 'points1' or key == 'points2' or key == 'points3' then
+            if string.sub(value, 0, 2) == '[[' then
+                return key, nil
+            end
+        end
+        return key, value
+    end)
+
+    return newData
 end
 
 return CustomLegacyPrizePool

--- a/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
@@ -19,24 +19,24 @@ function CustomLegacyPrizePool.run()
 end
 
 function CustomLegacyPrizePool.customHeader(newArgs, data, header)
-    newArgs.prizesummary = header.prizenote and true or newArgs.prizesummary
+	newArgs.prizesummary = header.prizenote and true or newArgs.prizesummary
 
-    return newArgs
+	return newArgs
 end
 
 function CustomLegacyPrizePool.customSlot(newData, data, slot)
 	-- Remove points with only image
-    -- Table.filter doesn't work on Tables (only Arrays)... Let's use Table.map instead
+	-- Table.filter doesn't work on Tables (only Arrays)... Let's use Table.map instead
 	newData = Table.map(newData, function(key, value)
-        if key == 'points1' or key == 'points2' or key == 'points3' then
-            if string.sub(value, 0, 2) == '[[' then
-                return key, nil
-            end
-        end
-        return key, value
-    end)
+		if key == 'points1' or key == 'points2' or key == 'points3' then
+			if string.sub(value, 0, 2) == '[[' then
+				return key, nil
+			end
+		end
+		return key, value
+	end)
 
-    return newData
+	return newData
 end
 
 return CustomLegacyPrizePool


### PR DESCRIPTION
## Summary
Valorant inserts tournament logos as points on occasion. 
![image](https://user-images.githubusercontent.com/3426850/180015820-580bdf46-8b29-44e7-8ded-230b1caa749d.png)

In the current handling, it gives the following effect (the PPT tries it's best to find a number in there)
![image](https://user-images.githubusercontent.com/3426850/180015849-1fcbb3ce-74b3-4285-b507-d4e516080552.png)

After a discussion on the Valorant Discord channel, it was decided to at least temporary hide it until a final decision has been made once more Editors are online

![image](https://user-images.githubusercontent.com/3426850/180017663-079b32d8-ce69-4f35-8d06-516d6ee9e622.png)


## How did you test this change?
Live