### PR TITLE
Fix localcurrency in Valorant Legacy

### DIFF
--- a/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/valorant/prize_pool_legacy_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Lua = require('Module:Lua')
+local Variables = require('Module:Variables')
 
 local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
 
@@ -18,9 +19,14 @@ function CustomLegacyPrizePool.run()
 end
 
 function CustomLegacyPrizePool.customHeader(newArgs, data, header)
-    newArgs.prizesummary = header.prizenote and true or newArgs.prizesummary
+	newArgs.prizesummary = header.prizenote and true or newArgs.prizesummary
+	local localCurrency = Variables.varDefault('currency')
+	if not newArgs.localcurrency and localCurrency then
+		newArgs.localcurrency = localCurrency
+		data.inputToId.localprize = 'localprize'
+	end
 
-    return newArgs
+	return newArgs
 end
 
 return CustomLegacyPrizePool


### PR DESCRIPTION
## Summary

Valorant can run thier local currency directly from the infobox into their prize pool table. 
This PR add support for this in their legacy handling.

In a future PR, should look at either adding support for this in Commons PPT alternatively in Valorant custom PPT.

## How did you test this change?

Live