### PR TITLE
Fix lastscore not working in Legacy Mapping

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -135,8 +135,9 @@ function LegacyPrizePool.mapOpponents(slot)
 			team = slot['team' .. opponentIndex],
 			lastvs = slot['lastvs' .. opponentIndex],
 			lastvsflag = slot['lastvsflag' .. opponentIndex],
-			lastscore = slot['lastscore' .. opponentIndex],
-			lastvsscore = slot['lastvsscore' .. opponentIndex],
+			lastvsscore = (slot['lastscore' .. opponentIndex] or '') ..
+				'-' ..
+				(slot['lastvsscore' .. opponentIndex] or ''),
 		}
 
 		if CUSTOM_HANDLER.customOpponent then


### PR DESCRIPTION
## Summary

The fields `lastscore` and `lastvscore` were merged in the new PPT. Update the legacy mapping to correctly reflect this

## How did you test this change?

Live