### PR TITLE
Create Legacy Custom for dota2

### DIFF
--- a/components/prize_pool/wikis/dota2/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/dota2/prize_pool_legacy_custom.lua
@@ -1,0 +1,34 @@
+---
+-- @Liquipedia
+-- wiki=dota2
+-- page=Module:PrizePool/Legacy/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
+
+local CustomLegacyPrizePool = {}
+
+-- Template entry point
+function CustomLegacyPrizePool.run()
+	return PrizePoolLegacy.run(CustomLegacyPrizePool)
+end
+
+function CustomLegacyPrizePool.customHeader(newArgs, data, header)
+	newArgs.prizesummary = header.prizenote and true or newArgs.prizesummary
+
+	local localCurrency = Variables.varDefault('currency')
+	if not newArgs.localcurrency and localCurrency then
+		newArgs.localcurrency = localCurrency
+		data.inputToId.localprize = 'localprize'
+	end
+
+	return newArgs
+end
+
+return CustomLegacyPrizePool

--- a/components/prize_pool/wikis/dota2/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/dota2/prize_pool_legacy_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})


### PR DESCRIPTION
## Summary

Dota2 has some of same variations that Valorant has, specifically the wiki variable to set local currency and that the prizesummary is called prizenote.

## How did you test this change?
![image](https://user-images.githubusercontent.com/3426850/180169517-52e4f7f5-5ad1-444b-81bc-c250112c3efc.png)
Gives -> (PrizeNote is correctly mapped to Prizesummary and the currency is set from the Infobox)
![image](https://user-images.githubusercontent.com/3426850/180169471-c82af364-7fdb-440e-bf00-f7a93a31739c.png)
