### PR TITLE
Always use individualprizemoney if available on the wiki

### DIFF
--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -174,7 +174,7 @@ function Earnings.calculatePerYear(conditions, divisionFactor)
 			local year = string.sub(item.date, 1, 4)
 			local prizeMoney = tonumber(item.individualprizemoney) or 0
 			if prizeMoney == 0 then
-				prizeMoney = Earnings._applyDivisionFactor(prizeMoney, divisionFactor, item.mode)
+				prizeMoney = Earnings._applyDivisionFactor(item.prizemoney, divisionFactor, item.mode)
 			end
 			earningsData[year] = (earningsData[year] or 0) + prizeMoney
 		end


### PR DESCRIPTION
## Summary

Current implementation of Player Earnings will only use `individualprizemoney` if the divisionFactor function is nil.
This PR changes the implementation to always use `individualprizemoney` as long as it's set. For wikis where it's not set, such as Counter Strike, it will fall back to `prizemoney`.

## How did you test this change?

Untested, idea so far