### PR TITLE
Create Team Infobox for CS

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -45,30 +45,35 @@ function CustomTeam:createWidgetInjector()
 	return CustomInjector()
 end
 
+function CustomInjector:parse(id, widgets)
+	if id == 'staff' then
+		table.insert(widgets, Cell{
+			name = 'Founders',
+			content = {_team.args.founders}
+		})
+		table.insert(widgets, Cell{
+			name = 'CEO',
+			content = {_team.args.ceo}
+		})
+		table.insert(widgets, Cell{
+			name = 'In-Game Leader',
+			content = {_team.args.igl}
+		})
+		table.insert(widgets, Cell{
+			name = 'Analysts',
+			content = {_team.args.analysts}
+		})
+	end
+	return widgets
+end
+
 function CustomInjector:addCustomCells(widgets)
-	table.insert(widgets, Cell{
-		name = 'Founders',
-		content = {_team.args.founders}
-	})
-	table.insert(widgets, Cell{
-		name = 'CEO',
-		content = {_team.args.ceo}
-	})
-	table.insert(widgets, Cell{
-		name = 'In-Game Leader',
-		content = {_team.args.igl}
-	})
-	table.insert(widgets, Cell{
-		name = 'Analysts',
-		content = {_team.args.analysts}
-	})
-	table.insert(widgets, Cell{
+	return {Cell{
 		name = 'Games',
 		content = Array.map(CustomTeam.getGames(), function (gameData)
 			return Page.makeInternalLink({}, gameData.name, gameData.link)
 		end)
-	})
-	return widgets
+	}}
 end
 
 function CustomTeam.getGames()

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -48,26 +48,26 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'staff' then
 		return {
-			[1] = Cell{
+			Cell{
 				name = 'Founders',
 				content = {_team.args.founders}
 			},
-			[2] = Cell{
+			Cell{
 				name = 'CEO',
 				content = {_team.args.ceo}
 			},
-			[3] = Cell{
+			Cell{
 				name = 'Gaming Director',
 				content = {_team.args['gaming director']}
 			},
-			[4] = widgets[4], -- Manager
-			[5] = widgets[5], -- Captain
-			[6] = Cell{
+			widgets[4], -- Manager
+			widgets[5], -- Captain
+			Cell{
 				name = 'In-Game Leader',
 				content = {_team.args.igl}
 			},
-			[7] = widgets[1], -- Coaches
-			[8] = Cell{
+			widgets[1], -- Coaches
+			Cell{
 				name = 'Analysts',
 				content = {_team.args.analysts}
 			},

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -1,0 +1,133 @@
+---
+-- @Liquipedia
+-- wiki=counterstrike
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Class = require('Module:Class')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Page = require('Module:Page')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Team = require('Module:Infobox/Team')
+local Template = require('Module:Template')
+local Variables = require('Module:Variables')
+
+local CustomTeam = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local GAMES = {
+	cs = {name = 'Counter-Strike', link = 'Counter-Strike', category = 'CS Teams'},
+	cscz = {name = 'Condition Zero', link = 'Counter-Strike: Condition Zero', category = 'CSCZ Teams'},
+	css = {name = 'Source', link = 'Counter-Strike: Source', category = 'CSS Teams'},
+	cso = {name = 'Online', link = 'Counter-Strike Online', category = 'CSO Teams'},
+	csgo = {name = 'Global Offensive', link = 'Counter-Strike: Global Offensive', category = 'CSGO Teams'},
+}
+
+local _team
+
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	_team = team
+
+	team.createWidgetInjector = CustomTeam.createWidgetInjector
+	team.createBottomContent = CustomTeam.createBottomContent
+	team.addToLpdb = CustomTeam.addToLpdb
+
+	return team:createInfobox(frame)
+end
+
+function CustomTeam:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:addCustomCells(widgets)
+	table.insert(widgets, Cell{
+		name = 'Founders',
+		content = {_team.args.founders}
+	})
+	table.insert(widgets, Cell{
+		name = 'CEO',
+		content = {_team.args.ceo}
+	})
+	table.insert(widgets, Cell{
+		name = 'In-Game Leader',
+		content = {_team.args.igl}
+	})
+	table.insert(widgets, Cell{
+		name = 'Analysts',
+		content = {_team.args.analysts}
+	})
+	table.insert(widgets, Cell{
+		name = 'Games',
+		content = Array.map(CustomTeam.getGames(), function (gameData)
+			return Page.makeInternalLink({}, gameData.name, gameData.link)
+		end)
+	})
+	return widgets
+end
+
+function CustomTeam.getGames()
+	return Array.extractValues(Table.map(GAMES, function (key, data)
+		if _team.args[key] then
+			return key, data
+		end
+		return key, nil
+	end))
+end
+
+function CustomTeam:createBottomContent()
+	if not _team.args.disbanded and mw.ext.TeamTemplate.teamexists(_team.pagename) then
+		local teamPage = mw.ext.TeamTemplate.teampage(_team.pagename)
+
+		return Template.expandTemplate(
+			mw.getCurrentFrame(),
+			'Upcoming and ongoing matches of',
+			{team = _team.lpdbname or teamPage}
+		) .. Template.expandTemplate(
+			mw.getCurrentFrame(),
+			'Upcoming and ongoing tournaments of',
+			{team = _team.lpdbname or teamPage}
+		)
+	end
+end
+
+function CustomTeam:addToLpdb(lpdbData, args)
+	if not String.isEmpty(args.teamcardimage) then
+		lpdbData.logo = args.teamcardimage
+	elseif not String.isEmpty(args.image) then
+		lpdbData.logo = args.image
+	end
+
+	lpdbData.region = Variables.varDefault('region', '')
+
+	return lpdbData
+end
+
+function CustomTeam:getWikiCategories(args)
+	local categories = {}
+
+	Array.extendWith(categories, Array.map(CustomTeam.getGames(), function (gameData)
+		return gameData.category
+	end))
+
+	if args.teamcardimage then
+		table.insert(categories, 'Teams using TeamCardImage')
+	end
+
+	if not args.region then
+		table.insert(categories, 'Teams without a region')
+	end
+
+	if args.nationalteam then
+		table.insert(categories, 'National Teams')
+	end
+
+	return categories
+end
+
+return CustomTeam

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -47,22 +47,31 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'staff' then
-		table.insert(widgets, Cell{
-			name = 'Founders',
-			content = {_team.args.founders}
-		})
-		table.insert(widgets, Cell{
-			name = 'CEO',
-			content = {_team.args.ceo}
-		})
-		table.insert(widgets, Cell{
-			name = 'In-Game Leader',
-			content = {_team.args.igl}
-		})
-		table.insert(widgets, Cell{
-			name = 'Analysts',
-			content = {_team.args.analysts}
-		})
+		return {
+			[1] = Cell{
+				name = 'Founders',
+				content = {_team.args.founders}
+			},
+			[2] = Cell{
+				name = 'CEO',
+				content = {_team.args.ceo}
+			},
+			[3] = Cell{
+				name = 'Gaming Director',
+				content = {_team.args['gaming director']}
+			},
+			[4] = widgets[4], -- Manager
+			[5] = widgets[5], -- Captain
+			[6] = Cell{
+				name = 'In-Game Leader',
+				content = {_team.args.igl}
+			},
+			[7] = widgets[1], -- Coaches
+			[8] = Cell{
+				name = 'Analysts',
+				content = {_team.args.analysts}
+			},
+ 		}
 	end
 	return widgets
 end

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -71,7 +71,7 @@ function CustomInjector:parse(id, widgets)
 				name = 'Analysts',
 				content = {_team.args.analysts}
 			},
- 		}
+		}
 	end
 	return widgets
 end

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -48,29 +48,14 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'staff' then
 		return {
-			Cell{
-				name = 'Founders',
-				content = {_team.args.founders}
-			},
-			Cell{
-				name = 'CEO',
-				content = {_team.args.ceo}
-			},
-			Cell{
-				name = 'Gaming Director',
-				content = {_team.args['gaming director']}
-			},
+			Cell{name = 'Founders',	content = {_team.args.founders}},
+			Cell{name = 'CEO', content = {_team.args.ceo}},
+			Cell{name = 'Gaming Director', content = {_team.args['gaming director']}},
 			widgets[4], -- Manager
 			widgets[5], -- Captain
-			Cell{
-				name = 'In-Game Leader',
-				content = {_team.args.igl}
-			},
+			Cell{name = 'In-Game Leader', content = {_team.args.igl}},
 			widgets[1], -- Coaches
-			Cell{
-				name = 'Analysts',
-				content = {_team.args.analysts}
-			},
+			Cell{name = 'Analysts', content = {_team.args.analysts}},
 		}
 	end
 	return widgets


### PR DESCRIPTION
## Summary

Create the Customizable for Team Infobox on Counter Strike.

Template based:
![image](https://user-images.githubusercontent.com/3426850/180427928-a0dfad81-ab16-46c5-8214-38aa3d2484c7.png)

New Module:
![image](https://user-images.githubusercontent.com/3426850/180427888-1b1e8c92-1af7-4b84-b72b-0e5a90ef20f2.png)

LPDB Before:
![image](https://user-images.githubusercontent.com/3426850/180429036-e79456d9-ef32-4a99-bc85-c36e970632d2.png)

LPDB After:
![image](https://user-images.githubusercontent.com/3426850/180429606-e155624d-4d52-473a-8398-a343c186ef80.png)


## How did you test this change?

Tested using dev module on Navi's page