### PR TITLE
In Infobox Team, make Staff a customizable.

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -79,11 +79,16 @@ function Team:createInfobox()
 				},
 			}
 		},
-		Cell{name = 'Coaches', content = {args.coaches}},
-		Cell{name = 'Coach', content = {args.coach}},
-		Cell{name = 'Director', content = {args.director}},
-		Cell{name = 'Manager', content = {args.manager}},
-		Cell{name = 'Team Captain', content = {args.captain}},
+		Customizable{
+			id = 'staff',
+			children = {
+				Cell{name = 'Coaches', content = {args.coaches}},
+				Cell{name = 'Coach', content = {args.coach}},
+				Cell{name = 'Director', content = {args.director}},
+				Cell{name = 'Manager', content = {args.manager}},
+				Cell{name = 'Team Captain', content = {args.captain}},
+			}
+		},
 		Customizable{
 			id = 'earnings',
 			children = {


### PR DESCRIPTION
## Summary

Many wikis, such as Valorant and Counter strike have additional staff roles added to the infobox.

This PR makes the entire section with staff roles a customizable, allowing for wikis to add new roles in the same section as the current roles.

## How did you test this change?
Tested using dev module
![image](https://user-images.githubusercontent.com/3426850/180408122-e39cd6c4-694e-4ca8-98c2-d905e16ecd41.png)
