### PR TITLE
Fix TBD handling for Party Opponents

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -989,7 +989,13 @@ function Placement:_parseOpponentArgs(input, date)
 	local opponentArgs = Json.parseIfTable(input) or (type(input) == 'table' and input or {input})
 	opponentArgs.type = opponentArgs.type or self.parent.opponentType
 	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
-	local opponentData = Opponent.readOpponentArgs(opponentArgs) or Opponent.tbd(opponentArgs.type)
+
+	local opponentData = Opponent.readOpponentArgs(opponentArgs)
+
+	if not opponentData or Opponent.isTbd(opponentData) then
+		opponentData = Opponent.tbd(opponentArgs.type)
+	end
+
 	return Opponent.resolve(opponentData, date)
 end
 


### PR DESCRIPTION
## Summary

`Opponent.readOpponentArgs` only returns nil for missing team templates. This PR adds support to detect other types of TBDs and set them to the TBD Opponent.

Before:
![image](https://user-images.githubusercontent.com/3426850/180425059-293a0cd9-bc79-43fa-990f-7b495df043bd.png)
After:
![image](https://user-images.githubusercontent.com/3426850/180425079-db6dc527-a452-43d1-976c-4f1a13eebab8.png)


## How did you test this change?
Tested using dev module