### PR TITLE
Add fallback for `tournament_parentname` variable setting

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -343,7 +343,7 @@ function League:_definePageVariables(args)
 	local parent = args.parent or mw.title.getCurrentTitle().prefixedText
 	parent = string.gsub(parent, ' ', '_')
 	Variables.varDefine('tournament_parent', parent)
-	Variables.varDefine('tournament_parentname', args.parentname)
+	Variables.varDefine('tournament_parentname', args.parentname or args.name)
 	Variables.varDefine('tournament_subpage', args.subpage)
 
 	Variables.varDefine('tournament_startdate',


### PR DESCRIPTION
## Summary
Add fallback for `tournament_parentname` variable setting analogous to how HDB sets the variable
https://github.com/Liquipedia/Lua-Modules/blob/main/components/hidden_data_box/commons/hidden_data_box.lua#L61

## How did you test this change?
todo, atm PR for discussion only