### PR TITLE
Fix missing override in Team infobox

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -37,6 +37,7 @@ function CustomTeam.run(frame)
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
+	team.getWikiCategories = CustomTeam.getWikiCategories
 
 	return team:createInfobox(frame)
 end


### PR DESCRIPTION
## Summary

Missed to overwrite the standard function, making the custom not called.



## How did you test this change?
Live