### PR TITLE
Remove the /doc part of the link when linking to template

### DIFF
--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -129,7 +129,7 @@ function Header:_createInfoboxButtons()
 	buttons:node(
 		mw.text.nowiki('[') ..
 		'[[' .. moduleTitle ..
-		'/doc|h]]' .. mw.text.nowiki(']')
+		'|h]]' .. mw.text.nowiki(']')
 	)
 
 	return buttons


### PR DESCRIPTION
## Summary

The old template infobox's linked directly to the template (which shows the documentation as well), not to the doc page.
Let's change the behavior the match that of old. The current behavior wasn't something that was actively decided on based on this discsussion.
![image](https://user-images.githubusercontent.com/3426850/180450333-230228e4-08f2-4bd3-b149-d40120641eb8.png)


## How did you test this change?

Tested using dev module.