### PR TITLE
Metadata Generator - Fix typo in name fallback

### DIFF
--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -28,7 +28,7 @@ local TYPES_TO_DISPLAY = {'qualifier', 'showmatch', 'show match'}
 function MetadataGenerator.tournament(args)
 	local output
 
-	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle()
+	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle().text
 
 	local tournamentType = args.type
 	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)


### PR DESCRIPTION
## Summary

`mw.title.getCurrentTitle()` gets the title object. Need to have a string. Let's use `.text` (https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#Title_objects) 

## How did you test this change?

Live