### PR TITLE
Fix Date Validation in Prize Pool

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -826,7 +826,7 @@ function PrizePool._isValidDateFormat(date)
 	if type(date) ~= 'string' or String.isEmpty(date) then
 		return false
 	end
-	return date:match('%d%d%d%d-%d%d-%d%d') and true or false
+	return date:match('%d%d%d%d%-%d%d%-%d%d') and true or false
 end
 
 --- Asserts that an Opponent Struct is valid and has a valid type


### PR DESCRIPTION
## Summary

Incorrect lua regex (`-` needs to be `%` escaped in lua...). 

## How did you test this change?

```lua
mw.log(string.match('2022-05-20', '%d%d%d%d-%d%d-%d%d'))
-- nil
mw.log(string.match('2022-05-20', '%d%d%d%d%-%d%d%-%d%d'))
-- 2022-05-20
mw.log(string.match('not a date', '%d%d%d%d%-%d%d%-%d%d'))
-- nil
```