### PR TITLE
Add Esportal link, update icon for ESEA-D

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -22,7 +22,7 @@ local Links = Class.new(
 local _ICON_KEYS_TO_RENAME = {
 	['bilibili-stream'] = 'bilibili',
 	daumcafe = 'cafe-daum',
-	['esea-d'] = 'esea',
+	['esea-d'] = 'esea-league',
 	['faceit-c'] = 'faceit',
 	['faceit-c2'] = 'faceit',
 	matcherinolink = 'matcherino',
@@ -54,6 +54,7 @@ local _PRIORITY_GROUPS = {
 		'esea',
 		'esea-d',
 		'esl',
+		'esportal',
 		'faceit',
 		'gamersclub',
 		'halodatahive',

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -56,6 +56,7 @@ local _PREFIXES = {
 		team = 'https://play.eslgaming.com/team/',
 		player = 'https://play.eslgaming.com/player/',
 	},
+	esportal = {'https://esportal.com/tournament/'},
 	facebook = {'https://facebook.com/'},
 	['facebook-gaming'] = {'https://fb.gg/'},
 	faceit = {
@@ -210,6 +211,7 @@ function Links.transform(links)
 		esl3 = links.eslgaming3 or links.esl3,
 		esl4 = links.eslgaming4 or links.esl4,
 		esl5 = links.eslgaming5 or links.esl5,
+		esportal = links.esportal,
 		facebook = links.facebook,
 		facebook2 = links.facebook2,
 		['facebook-gaming'] = links['facebook-gaming'] or links.fbgg,


### PR DESCRIPTION
## Summary

Add link to Esportal.
Update link for ESEA-D (esea-division) to use esea-league icon instead of esea icon.
## How did you test this change?
N/A