### PR TITLE
Rework SC/SC2 matchSummary display for bracketResets

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -22,6 +22,8 @@ local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 
 local html = mw.html
 
+local RESET_MATCH = 'RxMBR'
+
 --[[
 Display component for the match summary used by the starcraft and stacraft2
 wikis. Shows details of a StarCraft match, including opponents, maps,

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -11,6 +11,7 @@ local DisplayUtil = require('Module:DisplayUtil')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
+local TypeUtil = require('Module:TypeUtil')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
@@ -49,6 +50,7 @@ function StarcraftMatchSummary.MatchSummaryContainer(props)
 end
 
 StarcraftMatchSummary.propTypes.MatchSummary = {
+	bracketResetMatch = TypeUtil.optional(StarcraftMatchGroupUtil.types.Match),
 	match = StarcraftMatchGroupUtil.types.Match,
 	config = 'table',
 }
@@ -57,9 +59,6 @@ function StarcraftMatchSummary.MatchSummary(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.MatchSummary)
 	local match = props.match
 	local bracketResetMatch = props.bracketResetMatch
-	if bracketResetMatch then
-		DisplayUtil.assertPropTypes(bracketResetMatch, StarcraftMatchGroupUtil.types.Match)
-	end
 
 	local propsConfig = props.config or {}
 	local config = {

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -22,8 +22,6 @@ local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 
 local html = mw.html
 
-local RESET_MATCH = 'RxMBR'
-
 --[[
 Display component for the match summary used by the starcraft and stacraft2
 wikis. Shows details of a StarCraft match, including opponents, maps,
@@ -41,7 +39,7 @@ function StarcraftMatchSummary.MatchSummaryContainer(props)
 	local options = {mergeBracketResetMatch = false}
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId, options)
 	local bracketResetMatch = match and match.bracketData.bracketResetMatchId
-		and MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.bracketId .. '_' .. RESET_MATCH, options)
+		and MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, match.bracketData.bracketResetMatchId, options)
 
 	local MatchSummary = match.isFfa
 		and Lua.import('Module:MatchSummary/Ffa/Starcraft', {requireDevIfEnabled = true}).FfaMatchSummary

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -36,12 +36,13 @@ StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
 }
 
 function StarcraftMatchSummary.MatchSummaryContainer(props)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
-	match.submatches = StarcraftMatchGroupUtil.mergeResetSubmatches(match, props.bracketId)
+	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId, {seperateBracketResetMatch = true})
+
 	local MatchSummary = match.isFfa
 		and Lua.import('Module:MatchSummary/Ffa/Starcraft', {requireDevIfEnabled = true}).FfaMatchSummary
 		or StarcraftMatchSummary.MatchSummary
-	return MatchSummary({match = match, config = props.config})
+
+	return MatchSummary{match = match, bracketResetMatch = bracketResetMatch, config = props.config}
 end
 
 StarcraftMatchSummary.propTypes.MatchSummary = {
@@ -52,6 +53,10 @@ StarcraftMatchSummary.propTypes.MatchSummary = {
 function StarcraftMatchSummary.MatchSummary(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.MatchSummary)
 	local match = props.match
+	local bracketResetMatch = props.bracketResetMatch
+	if bracketResetMatch then
+		DisplayUtil.assertPropTypes(bracketResetMatch, StarcraftMatchGroupUtil.types.Match)
+	end
 
 	local propsConfig = props.config or {}
 	local config = {
@@ -59,21 +64,19 @@ function StarcraftMatchSummary.MatchSummary(props)
 	}
 
 	-- Compute offraces
-	if match.opponentMode == 'uniform' then
-		StarcraftMatchSummary.computeMatchOffraces(match)
-	else
-		for _, submatch in pairs(match.submatches) do
-			StarcraftMatchSummary.computeMatchOffraces(submatch)
-		end
+	StarcraftMatchSummary.computeOffraces(match)
+	if bracketResetMatch then
+		StarcraftMatchSummary.computeOffraces(bracketResetMatch)
 	end
 
 	return html.create('div')
 		:addClass('brkts-popup')
 		:addClass('brkts-popup-sc')
 		:addClass(match.opponentMode == 'uniform' and 'brkts-popup-sc-uniform-match' or 'brkts-popup-sc-team-match')
-		:node(StarcraftMatchSummary.Header({match = match, config = config}))
-		:node(StarcraftMatchSummary.Body({match = match}))
-		:node(StarcraftMatchSummary.Footer({match = match, showHeadToHead = match.headToHead}))
+		:node(StarcraftMatchSummary.Header{match = match, config = config})
+		:node(StarcraftMatchSummary.Body{match = match})
+		:node(bracketResetMatch and StarcraftMatchSummary.Body{match = bracketResetMatch, config = {isReset = true}} or nil)
+		:node(StarcraftMatchSummary.Footer{match = match, showHeadToHead = match.headToHead})
 end
 
 StarcraftMatchSummary.propTypes.Header = {
@@ -131,15 +134,21 @@ end
 
 StarcraftMatchSummary.propTypes.Body = {
 	match = StarcraftMatchGroupUtil.types.Match,
+	config = 'table?',
 }
 
 function StarcraftMatchSummary.Body(props)
 	DisplayUtil.assertPropTypes(props, StarcraftMatchSummary.propTypes.Body)
+	local config = props.config or {}
 	local match = props.match
 
 	local body = html.create('div')
 		:addClass('brkts-popup-body')
 		:addClass('brkts-popup-sc-body')
+
+	if config.isReset then
+		body:node(StarcraftMatchSummary.ResetHeader())
+	end
 
 	-- Stream, date, and countdown
 	if match.dateIsExact then
@@ -355,6 +364,13 @@ function StarcraftMatchSummary.GameHeader(props)
 		:wikitext(props.header)
 end
 
+function StarcraftMatchSummary.ResetHeader()
+	return html.create('div')
+		:addClass('brkts-popup-body-element brkts-popup-sc-veto-center')
+		:css('font-weight', 'bold')
+		:wikitext('Reset match')
+end
+
 StarcraftMatchSummary.propTypes.VetoHeader = {
 	header = 'string',
 }
@@ -453,6 +469,16 @@ function StarcraftMatchSummary.OffraceIcons(races)
 	end
 
 	return racesNode
+end
+
+function StarcraftMatchSummary.computeOffraces(match)
+	if match.opponentMode == 'uniform' then
+		StarcraftMatchSummary.computeMatchOffraces(match)
+	else
+		for _, submatch in pairs(match.submatches) do
+			StarcraftMatchSummary.computeMatchOffraces(submatch)
+		end
+	end
 end
 
 --[[

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -36,7 +36,11 @@ StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
 }
 
 function StarcraftMatchSummary.MatchSummaryContainer(props)
-	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId, {seperateBracketResetMatch = true})
+	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(
+		props.bracketId,
+		props.matchId,
+		{seperateBracketResetMatch = true}
+	)
 
 	local MatchSummary = match.isFfa
 		and Lua.import('Module:MatchSummary/Ffa/Starcraft', {requireDevIfEnabled = true}).FfaMatchSummary

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -36,11 +36,10 @@ StarcraftMatchSummary.propTypes.MatchSummaryContainer = {
 }
 
 function StarcraftMatchSummary.MatchSummaryContainer(props)
-	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(
-		props.bracketId,
-		props.matchId,
-		{seperateBracketResetMatch = true}
-	)
+	local options = {mergeBracketResetMatch = false}
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId, options)
+	local bracketResetMatch = match and match.bracketData.bracketResetMatchId
+		and MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.bracketId .. '_' .. RESET_MATCH, options)
 
 	local MatchSummary = match.isFfa
 		and Lua.import('Module:MatchSummary/Ffa/Starcraft', {requireDevIfEnabled = true}).FfaMatchSummary


### PR DESCRIPTION
Depends on #1569

## Summary
Rework SC/SC2 matchSummary display for bracketResets.

before:
![Screenshot 2022-07-25 17 11 32](https://user-images.githubusercontent.com/75081997/180813734-bd0035d0-d488-4141-ba44-7df9cb5efdcb.png)

after:
![Screenshot 2022-07-25 17 11 14](https://user-images.githubusercontent.com/75081997/180813765-ca4ef93a-4d3f-4059-b715-b643b45c5608.png)


## How did you test this change?
/dev modules