### PR TITLE
Add `Non-representing` support to EPT Regions stuff

### DIFF
--- a/standard/region/extensions/ept_data.lua
+++ b/standard/region/extensions/ept_data.lua
@@ -18,6 +18,12 @@ https://cdn.eslgaming.com/misc/media/lo/ESL%20Pro%20Tour%20-%20CSGO%20General%20
 ]]
 return {
 	{
+		name = 'Others',
+		countries = {
+			'Non-representing',
+		},
+	},
+	{
 		name = 'Americas',
 		countries = {
 			'Anguilla',


### PR DESCRIPTION
## Summary
Add `Non-representing` support to EPT Regions stuff

## How did you test this change?
live

![Screenshot 2022-07-25 18 25 34](https://user-images.githubusercontent.com/75081997/180827867-d9b21b34-c650-49cd-a29c-6b4570866f7a.png)
before it did not display the `1` in the "Others" region, it displayed `NYD` instead:
https://cdn.discordapp.com/attachments/213614988647071744/1000907907178713239/unknown.png


![Screenshot 2022-07-25 18 25 37](https://user-images.githubusercontent.com/75081997/180827870-5b22808f-8eb5-494f-90f0-739b9ea31d38.png)
before it did not display the non-rep. flag in the "Others" region, it displayed it without region (transparent BG)

