### PR TITLE
Adjust `fetchMatchForBracketDisplay`

### DIFF
--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -45,7 +45,7 @@ function SingleMatchDisplay.SingleMatchContainer(props)
 
 	local bracketId, _ = MatchGroupUtil.splitMatchId(props.matchId)
 
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, props.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, props.matchId, _)
 	return match
 		and SingleMatchDisplay.SingleMatch({
 			config = props.config,

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -328,17 +328,19 @@ Returns a match struct for use in a bracket display or match summary popup. The
 bracket display and match summary popup expects that the finals match also
 include results from the bracket reset match.
 ]]
-function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId)
+function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, config)
+	config = config or {}
 	local bracket = MatchGroupUtil.fetchMatchGroup(bracketId)
 	local match = bracket.matchesById[matchId]
 
 	local bracketResetMatch = match
 		and match.bracketData.bracketResetMatchId
 		and bracket.matchesById[match.bracketData.bracketResetMatchId]
-	if bracketResetMatch then
+
+	if bracketResetMatch and not config.seperateBracketResetMatch then
 		return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
 	else
-		return match
+		return match, bracketResetMatch
 	end
 end
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
@@ -17,11 +17,7 @@ local StarcraftSingleMatchDisplay = {propTypes = {}}
 
 function StarcraftSingleMatchDisplay.SingleMatchContainer(props)
 	local bracketId, _ = MatchGroupUtil.splitMatchId(props.matchId)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(
-		bracketId,
-		props.matchId,
-		{seperateBracketResetMatch = true}
-	)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, props.matchId, _)
 
 	return match
 		and StarcraftSingleMatchDisplay.SingleMatch{

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
@@ -17,7 +17,7 @@ local StarcraftSingleMatchDisplay = {propTypes = {}}
 
 function StarcraftSingleMatchDisplay.SingleMatchContainer(props)
 	local bracketId, _ = MatchGroupUtil.splitMatchId(props.matchId)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, props.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, props.matchId, _)
 
 	return match
 		and StarcraftSingleMatchDisplay.SingleMatch{

--- a/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_display_singlematch_starcraft.lua
@@ -17,7 +17,11 @@ local StarcraftSingleMatchDisplay = {propTypes = {}}
 
 function StarcraftSingleMatchDisplay.SingleMatchContainer(props)
 	local bracketId, _ = MatchGroupUtil.splitMatchId(props.matchId)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, props.matchId, _)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(
+		bracketId,
+		props.matchId,
+		{seperateBracketResetMatch = true}
+	)
 
 	return match
 		and StarcraftSingleMatchDisplay.SingleMatch{

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -70,7 +70,7 @@ end
 
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init('420px')
 

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -124,7 +124,7 @@ function Brawler:create()
 end
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init()
 

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -89,7 +89,7 @@ end
 
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init('400px')
 	matchSummary.root:css('flex-wrap', 'unset')

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -25,7 +25,7 @@ local _GREEN_CHECK = '<i class="fa fa-check forest-green-text" style="width: 14p
 local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local wrapper = htmlCreate('div')
 		:addClass('brkts-popup')

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -80,7 +80,7 @@ end
 
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init('400px')
 	matchSummary.root:css('flex-wrap', 'unset')

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -70,7 +70,7 @@ end
 
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init('420px')
 

--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -47,7 +47,7 @@ local _LINK_DATA = {
 local CustomMatchSummary = {}
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init()
 

--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -311,7 +311,7 @@ local CustomMatchSummary = {}
 
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init()
 	matchSummary.root:css('flex-wrap', 'unset') -- temporary workaround to fix height, taken from RL

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -190,7 +190,7 @@ end
 local CustomMatchSummary = {}
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init()
 

--- a/components/match2/wikis/splitgate/match_summary.lua
+++ b/components/match2/wikis/splitgate/match_summary.lua
@@ -34,7 +34,7 @@ local _LINK_DATA = {
 local CustomMatchSummary = {}
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init()
 

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -243,7 +243,7 @@ end
 local CustomMatchSummary = {}
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 	local frame = mw.getCurrentFrame()
 
 	local matchSummary = MatchSummary():init('480px')

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -70,7 +70,7 @@ end
 
 
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, _)
 
 	local matchSummary = MatchSummary():init('420px')
 


### PR DESCRIPTION
## Summary
Adjust `fetchMatchForBracketDisplay`
only real change is in components/match2/commons/match_group_util.lua
the rest is just adding `, _` to the calls for the plugin in IDEs

## How did you test this change?
/dev module (not the adding of `, _`)