### PR TITLE
Adjust `fetchMatchForBracketDisplay `

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -328,8 +328,8 @@ Returns a match struct for use in a bracket display or match summary popup. The
 bracket display and match summary popup expects that the finals match also
 include results from the bracket reset match.
 ]]
-function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, config)
-	config = config or {}
+function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, options)
+	options = options or {}
 	local bracket = MatchGroupUtil.fetchMatchGroup(bracketId)
 	local match = bracket.matchesById[matchId]
 
@@ -337,10 +337,10 @@ function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, config)
 		and match.bracketData.bracketResetMatchId
 		and bracket.matchesById[match.bracketData.bracketResetMatchId]
 
-	if bracketResetMatch and not config.seperateBracketResetMatch then
+	if bracketResetMatch and options.mergeBracketResetMatch ~= false then
 		return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
 	else
-		return match, bracketResetMatch
+		return match
 	end
 end
 

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -333,17 +333,16 @@ function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, options)
 	local bracket = MatchGroupUtil.fetchMatchGroup(bracketId)
 	local match = bracket.matchesById[matchId]
 
-	if not Logic.nilOr(options.mergeBracketResetMatch, true) then
-		return match
+	if Logic.nilOr(options.mergeBracketResetMatch, true) then
+		local bracketResetMatch = match
+			and match.bracketData.bracketResetMatchId
+			and bracket.matchesById[match.bracketData.bracketResetMatchId]
+
+		if bracketResetMatch then
+			return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
+		end
 	end
 
-	local bracketResetMatch = match
-		and match.bracketData.bracketResetMatchId
-		and bracket.matchesById[match.bracketData.bracketResetMatchId]
-
-	if bracketResetMatch then
-		return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
-	end
 	return match
 end
 

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -328,17 +328,19 @@ Returns a match struct for use in a bracket display or match summary popup. The
 bracket display and match summary popup expects that the finals match also
 include results from the bracket reset match.
 ]]
-function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId)
+function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, config)
+	config = config or {}
 	local bracket = MatchGroupUtil.fetchMatchGroup(bracketId)
 	local match = bracket.matchesById[matchId]
 
 	local bracketResetMatch = match
 		and match.bracketData.bracketResetMatchId
 		and bracket.matchesById[match.bracketData.bracketResetMatchId]
-	if bracketResetMatch then
+
+	if bracketResetMatch and not config.seperateBracketResetMatch then
 		return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
 	else
-		return match
+		return match, bracketResetMatch
 	end
 end
 

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -337,7 +337,7 @@ function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, options)
 		and match.bracketData.bracketResetMatchId
 		and bracket.matchesById[match.bracketData.bracketResetMatchId]
 
-	if bracketResetMatch and options.mergeBracketResetMatch ~= false then
+	if bracketResetMatch and Logic.nilOr(options.mergeBracketResetMatch, true) then
 		return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
 	else
 		return match

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -333,15 +333,18 @@ function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, options)
 	local bracket = MatchGroupUtil.fetchMatchGroup(bracketId)
 	local match = bracket.matchesById[matchId]
 
+	if not Logic.nilOr(options.mergeBracketResetMatch, true) then
+		return match
+	end
+
 	local bracketResetMatch = match
 		and match.bracketData.bracketResetMatchId
 		and bracket.matchesById[match.bracketData.bracketResetMatchId]
 
-	if bracketResetMatch and Logic.nilOr(options.mergeBracketResetMatch, true) then
+	if bracketResetMatch then
 		return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
-	else
-		return match
 	end
+	return match
 end
 
 --[[


### PR DESCRIPTION
## Summary
Adjust `fetchMatchForBracketDisplay `
->  add option to not combine match and bracketResetMatch but instead return them seperately
usecase see: #1566

## How did you test this change?
/dev module