### PR TITLE
In flags template fallback, lowercase the flag name

### DIFF
--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -55,10 +55,12 @@ function Flags.Icon(args, flagName)
 		end
 	elseif shouldLink then
 		mw.log('Unknown flag: ', flagName)
-		return Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. flagName) .. '[[Category:Pages with unknown flags]]'
+		return Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. flagName:lower()) ..
+				'[[Category:Pages with unknown flags]]'
 	else
 		mw.log('Unknown flag: ', flagName)
-		return Template.safeExpand(mw.getCurrentFrame(), 'FlagNoLink/' .. flagName) .. '[[Category:Pages with unknown flags]]'
+		return Template.safeExpand(mw.getCurrentFrame(), 'FlagNoLink/' .. flagName:lower()) ..
+				'[[Category:Pages with unknown flags]]'
 	end
 end
 


### PR DESCRIPTION
## Summary

On the wiki flag templates are always written with lowercase names.
Have the fallback scenario lowercase the flag name before calling the template.

## How did you test this change?

Tested on CS
