### PR TITLE
Change so all categories are only set in mainspace

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -448,7 +448,7 @@ function League:_createLocation(args)
 		if String.isEmpty(nationality) then
 			content = content .. '[[Category:Unrecognised Country|' .. current .. ']]'
 
-		elseif String.isNotEmpty(nationality) then
+		else
 			local countryName = Localisation.getCountryName(current)
 			local displayText = currentLocation or countryName
 			if displayText == '' then

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -445,23 +445,26 @@ function League:_createLocation(args)
 	while not String.isEmpty(current) do
 		local nationality = Localisation.getLocalisation({displayNoError = true}, current)
 
-		if String.isEmpty(nationality) then
-				content = content .. '[[Category:Unrecognised Country|' .. current .. ']]<br>'
-		else
+		if String.isNotEmpty(nationality) then
 			local countryName = Localisation.getCountryName(current)
 			local displayText = currentLocation or countryName
 			if displayText == '' then
 				displayText = current
 			end
 
-			content = content .. Flags.Icon{flag = current, shouldLink = true} .. '&nbsp;' ..
-					displayText .. '[[Category:' .. nationality .. ' Tournaments]]<br>'
+			if self:shouldStore(args) then
+				content = content .. '[[Category:' .. nationality .. ' Tournaments]]'
+			end
+			content = content .. Flags.Icon{flag = current, shouldLink = true} .. '&nbsp;' .. displayText .. '<br>'
+
+		elseif self:shouldStore(args) and String.isEmpty(nationality) then
+			content = content .. '[[Category:Unrecognised Country|' .. current .. ']]'
 		end
 
 		index = index + 1
 		current = args['country' .. index]
 		currentLocation = args['city' .. index] or args['location' .. index]
-		end
+	end
 	return content
 end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -445,7 +445,10 @@ function League:_createLocation(args)
 	while not String.isEmpty(current) do
 		local nationality = Localisation.getLocalisation({displayNoError = true}, current)
 
-		if String.isNotEmpty(nationality) then
+		if String.isEmpty(nationality) then
+			content = content .. '[[Category:Unrecognised Country|' .. current .. ']]'
+
+		elseif String.isNotEmpty(nationality) then
 			local countryName = Localisation.getCountryName(current)
 			local displayText = currentLocation or countryName
 			if displayText == '' then
@@ -456,9 +459,6 @@ function League:_createLocation(args)
 				content = content .. '[[Category:' .. nationality .. ' Tournaments]]'
 			end
 			content = content .. Flags.Icon{flag = current, shouldLink = true} .. '&nbsp;' .. displayText .. '<br>'
-
-		elseif self:shouldStore(args) and String.isEmpty(nationality) then
-			content = content .. '[[Category:Unrecognised Country|' .. current .. ']]'
 		end
 
 		index = index + 1

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -168,14 +168,14 @@ function Team:createInfobox()
 	}
 	infobox:bottom(self:createBottomContent())
 
-	if Namespace.isMain() then
+	if self:shouldStore(args) then
 		infobox:categories('Teams')
 		infobox:categories(unpack(self:getWikiCategories(args)))
 	end
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
-	if Namespace.isMain() then
+	if self:shouldStore(args) then
 		self:_setLpdbData(args, links)
 		self:defineCustomPageVariables(args)
 	end
@@ -204,9 +204,14 @@ function Team:_createLocation(location)
 			.. '|' .. locationDisplay .. ']]'
 	end
 
+	local category
+	if String.isNotEmpty(demonym) and self:shouldStore(self.args) then
+		category = '[[Category:' .. demonym .. ' Teams]]'
+	end
+
 	return Flags.Icon({flag = location, shouldLink = true}) ..
 			'&nbsp;' ..
-			(String.isNotEmpty(demonym) and '[[Category:' .. demonym .. ' Teams]]' or '') ..
+			(category or '') ..
 			(locationDisplay or '')
 end
 
@@ -282,6 +287,10 @@ end
 
 function Team:addToLpdb(lpdbData, args)
 	return lpdbData
+end
+
+function Team:shouldStore(args)
+	return Namespace.isMain()
 end
 
 return Team


### PR DESCRIPTION
## Summary

Currently the categories why `Country Tournaments` and `Country Teams` are set in Userspace. No other category, except for warning/error categories, are set in mainspace by default. This PR solves this issue.

## How did you test this change?

Tested with dev modules