### PR TITLE
LoL League Infobox

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -1,0 +1,139 @@
+---
+-- @Liquipedia
+-- wiki=rainbowsix
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+local Tier = require('Module:Tier')
+local Class = require('Module:Class')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local Center = require('Module:Infobox/Widget/Center')
+local PageLink = require('Module:Page')
+
+local _args
+local _league
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _DEFAULT_TIERTYPE = 'General'
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_league = league
+	_args = _league.args
+
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.addToLpdb = CustomLeague.addToLpdb
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:addCustomCells(widgets)
+	local args = _args
+	table.insert(widgets, Cell{
+		name = 'Teams',
+		content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}
+	})
+	table.insert(widgets, Cell{
+		name = 'Players',
+		content = {args.player_number}
+	})
+
+	return widgets
+end
+
+function CustomInjector:parse(id, widgets)
+	local args = _args
+	if id == 'liquipediatier' then
+		if CustomLeague:_validPublisherTier(args.riottier) then
+			table.insert(widgets,
+				Cell{
+					name = 'Riot Tier',
+					content = {'[[Worlds' .. riottier']]'},
+					classes = {'valvepremier-highlighted'}
+				}
+			)
+		end
+	end
+	return widgets
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	if CustomLeague:_validPublisherTier(args.riottier) then
+		lpdbData.publishertier = args.riottier:lower()
+	end
+	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.liquipediatiertype = Tier.text.types[string.lower(args.liquipediatiertype or '')] or _DEFAULT_TIERTYPE
+	lpdbData.extradata = {
+		individual = String.isNotEmpty(args.player_number) and 'true' or '',
+		startdatetext = CustomLeague:_standardiseRawDate(args.sdate or args.date),
+		enddatetext = CustomLeague:_standardiseRawDate(args.edate or args.date),
+	}
+
+	return lpdbData
+end
+
+function CustomLeague:_validPublisherTier(publishertier)
+	return String.isNotEmpty(publishertier) and _RIOT_TIERS[publishertier:lower()]
+end
+
+function CustomLeague:_standardiseRawDate(dateString)
+	-- Length 7 = YYYY-MM
+	-- Length 10 = YYYY-MM-??
+	if String.isEmpty(dateString) or (#dateString ~= 7 and #dateString ~= 10) then
+		return ''
+	end
+
+	if #dateString == 7 then
+		dateString = dateString .. '-??'
+	end
+	dateString = dateString:gsub('%-XX', '-??')
+	return dateString
+end
+
+function CustomLeague:defineCustomPageVariables()
+	-- Variables with different handling compared to commons
+	Variables.varDefine(
+		'tournament_liquipediatiertype',
+		Tier.text.types[string.lower(_args.liquipediatiertype or '')] or _DEFAULT_TIERTYPE
+	)
+
+	--Legacy vars
+	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
+	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
+	Variables.varDefine('tournament_tier_type', Variables.varDefault('tournament_liquipediatiertype'))
+	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
+	Variables.varDefine('tournament_mode', _args.mode or '')
+
+	--Legacy date vars
+	local sdate = Variables.varDefault('tournament_startdate', '')
+	local edate = Variables.varDefault('tournament_enddate', '')
+	Variables.varDefine('tournament_sdate', sdate)
+	Variables.varDefine('tournament_edate', edate)
+	Variables.varDefine('tournament_date', edate)
+	Variables.varDefine('date', edate)
+	Variables.varDefine('sdate', sdate)
+	Variables.varDefine('edate', edate)
+end
+
+function CustomLeague:_createNoWrappingSpan(content)
+	local span = mw.html.create('span')
+		:css('white-space', 'nowrap')
+		:node(content)
+	return span
+end
+
+return CustomLeague

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -55,11 +55,12 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = _args
 	if id == 'liquipediatier' then
-		if CustomLeague:_validPublisherTier(args.riottier) then
+		local riotTier = _args.riotTier
+		if String.isNotEmpty(riotTier) then
 			table.insert(widgets,
 				Cell{
 					name = 'Riot Tier',
-					content = {'[[Worlds' .. riottier']]'},
+					content = {'[[Worlds' .. riotTier']]'},
 					classes = {'valvepremier-highlighted'}
 				}
 			)

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -9,7 +9,6 @@
 local League = require('Module:Infobox/League')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
-local Tier = require('Module:Tier')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Injector = require('Module:Infobox/Widget/Injector')
@@ -66,7 +65,6 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	
 	if Logic.readBool(args.riotpremier) then
 		lpdbData.publishertier = 'major'
 	elseif Logic.readBool(args['riot-sponsored']) then

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -11,6 +11,7 @@ local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 local Tier = require('Module:Tier')
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 
@@ -30,6 +31,7 @@ function CustomLeague.run(frame)
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
 	return league:createInfobox(frame)
 end
@@ -54,12 +56,12 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'liquipediatier' then
-		local riotTier = _args.riotTier
-		if String.isNotEmpty(riotTier) then
+		if _args.pctier and _args.liquipediatiertype ~= 'Qualifier' then
+			local riotIcon = ''
 			table.insert(widgets,
 				Cell{
-					name = 'Riot Tier',
-					content = {'[[Worlds' .. riotTier']]'},
+					name = 'Worlds',
+					content = {'[[World Championship|' .. _args.riotTier .. ']] ' .. riotIcon},
 					classes = {'valvepremier-highlighted'}
 				}
 			)
@@ -68,8 +70,12 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+function CustomLeague:liquipediaTierHighlighted()
+	return Logic.readBool(_args.riotpremier)
+end
+
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = args.riottier:lower()
+	lpdbData.publishertier = args.pctier
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.liquipediatiertype = Tier.text.types[string.lower(args.liquipediatiertype or '')] or _DEFAULT_TIERTYPE
 	lpdbData.extradata = {
@@ -96,11 +102,10 @@ function CustomLeague:_standardiseRawDate(dateString)
 end
 
 function CustomLeague:defineCustomPageVariables()
-	-- Variables with different handling compared to commons
-	Variables.varDefine(
-		'tournament_liquipediatiertype',
-		Tier.text.types[string.lower(_args.liquipediatiertype or '')] or _DEFAULT_TIERTYPE
-	)
+	-- Custom Vars
+	Variables.varDefine('tournament_riot_premier', _args.riotpremier)
+	Variables.varDefine('tournament_publisher_major', _args.riotpremier)
+	Variables.varDefine('tournament_publishertier', _args.pctier)
 
 	--Legacy vars
 	Variables.varDefine('tournament_ticker_name', _args.tickername or '')

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -65,8 +65,9 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.participants_number or args.team_number
+	lpdbData.publishertier = Logic.readBool(args.riotpremier) and '1' or ''
 	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.participants_number) or 
+		individual = String.isNotEmpty(args.participants_number) or
 			String.isNotEmpty(args.individual) and 'true' or '',
 		['is riot premier'] = String.isNotEmpty(args.riotpremier) and 'true' or '',
 	}
@@ -77,7 +78,8 @@ end
 function CustomLeague:defineCustomPageVariables()
 	-- Custom Vars
 	Variables.varDefine('tournament_riot_premier', _args.riotpremier)
-	Variables.varDefine('tournament_publishertier', _args.riotpremier)
+	Variables.varDefine('tournament_publisher_major', _args.riotpremier)
+	Variables.varDefine('tournament_publishertier', Logic.readBool(_args.riotpremier) and '1' or nil)
 
 	--Legacy vars
 	Variables.varDefine('tournament_ticker_name', _args.tickername or '')

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -88,7 +88,7 @@ function CustomLeague:_standardiseRawDate(dateString)
 end
 
 function CustomLeague:defineCustomPageVariables()
-	-- Custom Vars	
+	-- Custom Vars
 	Variables.varDefine('tournament_riot_premier', _args.riotpremier)
 	Variables.varDefine('tournament_publishertier', _args.riotpremier)
 

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -13,14 +13,13 @@ local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
+local Template = require('Module:Template')
 
 local _args
 local _league
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
-
-local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
 
 function CustomLeague.run(frame)
 	local league = League(frame)
@@ -53,24 +52,18 @@ function CustomInjector:addCustomCells(widgets)
 	return widgets
 end
 
-function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args['riot-sponsored'])
-end
-
 function CustomLeague:appendLiquipediatierDisplay()
-	if Logic.readBool(_args['riot-sponsored']) then
-		return ' ' .. RIOT_ICON
+	if String.isEmpty(_args.pctier) and Logic.readBool(_args.riotpremier) then
+		return ' ' .. Template.safeExpand(mw.getCurrentFrame(), 'Riot/infobox')
 	end
 	return ''
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)
-	if Logic.readBool(args.riotpremier) then
-		lpdbData.publishertier = 'major'
-	elseif Logic.readBool(args['riot-sponsored']) then
-		lpdbData.publishertier = 'Sponsored'
-	end
+function CustomLeague:liquipediaTierHighlighted()
+	return Logic.readBool(_args.riotpremier)
+end
 
+function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.extradata = {
 		individual = String.isNotEmpty(args.player_number) and 'true' or '',
@@ -95,10 +88,9 @@ function CustomLeague:_standardiseRawDate(dateString)
 end
 
 function CustomLeague:defineCustomPageVariables()
-	-- Custom Vars
-	Variables.varDefine('tournament_riot_premier', _args.riotpremier and 'true' or '')
-	Variables.varDefine('tournament_publisher_major', _args.riotpremier)
-	Variables.varDefine('tournament_publishertier', _args.pctier)
+	-- Custom Vars	
+	Variables.varDefine('tournament_riot_premier', _args.riotpremier)
+	Variables.varDefine('tournament_publishertier', _args.riotpremier)
 
 	--Legacy vars
 	Variables.varDefine('tournament_ticker_name', _args.tickername or '')

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -13,9 +13,10 @@ local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
-local Template = require('Module:Template')
 
 local _args
+
+local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Premier Tournament held by Riot Games]]'
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -52,7 +53,7 @@ end
 
 function CustomLeague:appendLiquipediatierDisplay()
 	if Logic.readBool(_args.riotpremier) then
-		return ' ' .. Template.safeExpand(mw.getCurrentFrame(), 'Riot/infobox')
+		return ' ' .. RIOT_ICON
 	end
 	return ''
 end
@@ -64,6 +65,7 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.participants_number or args.team_number
 	lpdbData.publishertier = Logic.readBool(args.riotpremier) and '1' or ''
+
 	lpdbData.extradata = {
 		individual = String.isNotEmpty(args.participants_number) or
 			String.isNotEmpty(args.individual) and 'true' or '',

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -53,7 +53,6 @@ function CustomInjector:addCustomCells(widgets)
 end
 
 function CustomInjector:parse(id, widgets)
-	local args = _args
 	if id == 'liquipediatier' then
 		local riotTier = _args.riotTier
 		if String.isNotEmpty(riotTier) then

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -44,11 +44,11 @@ function CustomInjector:addCustomCells(widgets)
 	local args = _args
 	table.insert(widgets, Cell{
 		name = 'Teams',
-		content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}
+		content = {(args.team_number or '')}
 	})
 	table.insert(widgets, Cell{
 		name = 'Players',
-		content = {args.player_number}
+		content = {args.participants_number}
 	})
 	return widgets
 end

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -16,15 +16,13 @@ local Cell = require('Module:Infobox/Widget/Cell')
 local Template = require('Module:Template')
 
 local _args
-local _league
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 function CustomLeague.run(frame)
 	local league = League(frame)
-	_league = league
-	_args = _league.args
+	_args = league.args
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
@@ -43,7 +41,7 @@ function CustomInjector:addCustomCells(widgets)
 	local args = _args
 	table.insert(widgets, Cell{
 		name = 'Teams',
-		content = {(args.team_number or '')}
+		content = {args.team_number}
 	})
 	table.insert(widgets, Cell{
 		name = 'Players',
@@ -53,7 +51,7 @@ function CustomInjector:addCustomCells(widgets)
 end
 
 function CustomLeague:appendLiquipediatierDisplay()
-	if String.isEmpty(_args.pctier) and Logic.readBool(_args.riotpremier) then
+	if Logic.readBool(_args.riotpremier) then
 		return ' ' .. Template.safeExpand(mw.getCurrentFrame(), 'Riot/infobox')
 	end
 	return ''
@@ -96,13 +94,6 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('date', edate)
 	Variables.varDefine('sdate', sdate)
 	Variables.varDefine('edate', edate)
-end
-
-function CustomLeague:_createNoWrappingSpan(content)
-	local span = mw.html.create('span')
-		:css('white-space', 'nowrap')
-		:node(content)
-	return span
 end
 
 return CustomLeague

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -64,27 +64,14 @@ function CustomLeague:liquipediaTierHighlighted()
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.participantsnumber = args.participants_number or args.team_number
 	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-		isriotpremier = String.isNotEmpty(args.riotpremier) and 'true' or '',
+		individual = String.isNotEmpty(args.participants_number) or 
+			String.isNotEmpty(args.individual) and 'true' or '',
+		['is riot premier'] = String.isNotEmpty(args.riotpremier) and 'true' or '',
 	}
 
 	return lpdbData
-end
-
-function CustomLeague:_standardiseRawDate(dateString)
-	-- Length 7 = YYYY-MM
-	-- Length 10 = YYYY-MM-??
-	if String.isEmpty(dateString) or (#dateString ~= 7 and #dateString ~= 10) then
-		return ''
-	end
-
-	if #dateString == 7 then
-		dateString = dateString .. '-??'
-	end
-	dateString = dateString:gsub('%-XX', '-??')
-	return dateString
 end
 
 function CustomLeague:defineCustomPageVariables()
@@ -96,7 +83,6 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
 	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
 	Variables.varDefine('tournament_tier_type', Variables.varDefault('tournament_liquipediatiertype'))
-	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
 	Variables.varDefine('tournament_mode', _args.mode or '')
 
 	--Legacy date vars

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -13,9 +13,6 @@ local Tier = require('Module:Tier')
 local Class = require('Module:Class')
 local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
-local Title = require('Module:Infobox/Widget/Title')
-local Center = require('Module:Infobox/Widget/Center')
-local PageLink = require('Module:Page')
 
 local _args
 local _league
@@ -72,9 +69,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	if CustomLeague:_validPublisherTier(args.riottier) then
-		lpdbData.publishertier = args.riottier:lower()
-	end
+	lpdbData.publishertier = args.riottier:lower()
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.liquipediatiertype = Tier.text.types[string.lower(args.liquipediatiertype or '')] or _DEFAULT_TIERTYPE
 	lpdbData.extradata = {
@@ -84,10 +79,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	}
 
 	return lpdbData
-end
-
-function CustomLeague:_validPublisherTier(publishertier)
-	return String.isNotEmpty(publishertier) and _RIOT_TIERS[publishertier:lower()]
 end
 
 function CustomLeague:_standardiseRawDate(dateString)

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=rainbowsix
+-- wiki=leagueofledends
 -- page=Module:Infobox/League/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -74,8 +74,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.extradata = {
 		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-		startdatetext = CustomLeague:_standardiseRawDate(args.sdate or args.date),
-		enddatetext = CustomLeague:_standardiseRawDate(args.edate or args.date),
+		isriotpremier = String.isNotEmpty(args.riotpremier) and 'true' or '',
 	}
 
 	return lpdbData


### PR DESCRIPTION
## Summary
Creates a new League Infobox for League of Legends

## How did you test this change?
[testing page](https://liquipedia.net/leagueoflegends/User:Fenrir.SPAZ/newleagues)

Tested using dev template on LCS 2022 Summar. Both Preview and LPDB looked fine, barring one thing. 
LPDB Organizers and Sponsors aren't saved properly, due to wikicode not matching (full links, all in one param). This needs to be botted or manually fixed on tournament after live)