### PR TITLE
Fix faceit player & team links

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -61,8 +61,8 @@ local _PREFIXES = {
 	['facebook-gaming'] = {'https://fb.gg/'},
 	faceit = {
 		'',
-		team = 'https://www.faceit.com/teams/',
-		player = 'https://www.faceit.com/players/',
+		team = 'https://www.faceit.com/en/teams/',
+		player = 'https://www.faceit.com/en/players/',
 	},
 	['faceit-c'] = {'https://www.faceit.com/en/championship/'},
 	['faceit-hub'] = {'https://www.faceit.com/en/hub/'},

--- a/standard/links/wikis/counterstrike/links_custom_data.lua
+++ b/standard/links/wikis/counterstrike/links_custom_data.lua
@@ -10,8 +10,8 @@ return {
 	prefixes = {
 		faceit = {
 			'https://www.faceit.com/en/csgo/tournament/',
-			team = 'https://www.faceit.com/teams/',
-			player = 'https://www.faceit.com/players/',
+			team = 'https://www.faceit.com/en/teams/',
+			player = 'https://www.faceit.com/en/players/',
 		},
 		esl = {
 			'',

--- a/standard/links/wikis/rainbowsix/links_custom_data.lua
+++ b/standard/links/wikis/rainbowsix/links_custom_data.lua
@@ -10,8 +10,8 @@ return {
 	prefixes = {
 		faceit = {
 			'https://www.faceit.com/en/championship/',
-			team = 'https://www.faceit.com/teams/',
-			player = 'https://www.faceit.com/players/',
+			team = 'https://www.faceit.com/en/teams/',
+			player = 'https://www.faceit.com/en/players/',
 		}
 	},
 }


### PR DESCRIPTION
## Summary

Faceit links require the language code now days.
Add `/en`
https://www.faceit.com/players/Bennermaster
https://www.faceit.com/en/players/Bennermaster


## How did you test this change?
Live on CS