### PR TITLE
Limit queried keys to lower the used lua memory significantly

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -200,7 +200,25 @@ function CustomPlayer._getMatchupData(player)
 	player = string.gsub(player, '_', ' ')
 	local queryParameters = {
 		conditions = '[[opponent::' .. player .. ']] AND [[walkover::]] AND [[winner::>]]',
-		order = 'date desc'
+		order = 'date desc',
+		query = table.concat({
+				'match2opponents',
+				'winner',
+				'pagename',
+				'tournament',
+				'tickername',
+				'icon',
+				'date',
+				'publishertier',
+				'vod',
+				'stream',
+				'extradata',
+				'parent',
+				'finished',
+				'bestof',
+				'match2id',
+				'icondark',
+			}, ', '),
 	}
 
 	local years = {}


### PR DESCRIPTION
## Summary
Limit queried keys to lower the used lua memory significantly (on https://liquipedia.net/starcraft2/Bly from ~46 MB down to ~25MB; the page didn't load before the change)
mainly match2games takes up a significant chunk but is neither needed inside the infobox nor inside the matchticker to which the first 5 matches are passed

## How did you test this change?
live