### PR TITLE
Adressing lack of consistent capitalization (fix #1323)

### DIFF
--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -48,7 +48,7 @@ function Company:createInfobox()
 		Center{content = {args.caption}},
 		Title{name = 'Company Information'},
 		Cell{
-			name = 'Parent company',
+			name = 'Parent Company',
 			content = self:getAllArgsForBase(args, 'parent', {makeLink = true}),
 		},
 		Cell{name = 'Founded', content = {args.foundeddate},},
@@ -59,7 +59,7 @@ function Company:createInfobox()
 		},
 		Cell{name = 'Headquarters', content = {args.headquarters}},
 		Cell{name = 'Employees', content = {args.employees}},
-		Cell{name = 'Traded as', content = {args.tradedas}},
+		Cell{name = 'Trades as', content = {args.tradedas}},
 		Customizable{id = 'custom', children = {}},
 		Builder{
 			builder = function()
@@ -67,7 +67,7 @@ function Company:createInfobox()
 					infobox:categories('Tournament organizers')
 					return {
 						Cell{
-							name = 'Total prize money',
+							name = 'Total Prize Money',
 							content = {self:_getOrganizerPrizepools()}
 						}
 					}

--- a/components/infobox/commons/infobox_game.lua
+++ b/components/infobox/commons/infobox_game.lua
@@ -38,7 +38,7 @@ function Game:createInfobox()
 		Center{content = {args.caption}},
 		Title{name = 'Game Information'},
 		Cell{name = 'Developer', content = self:getAllArgsForBase(args, 'developer')},
-		Cell{name = 'Release Dates', content = self:getAllArgsForBase(args, 'releasedate')},
+		Cell{name = 'Release Date(s)', content = self:getAllArgsForBase(args, 'releasedate')},
 		Cell{name = 'Platforms', content = self:getAllArgsForBase(args, 'platform')},
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -152,7 +152,7 @@ function League:createInfobox()
 		Cell{name = 'Format', content = {args.format}},
 		Customizable{id = 'prizepool', children = {
 			Cell{
-					name = 'Prize pool',
+					name = 'Prize Pool',
 					content = {self:_createPrizepool(args)},
 				},
 			},
@@ -163,7 +163,7 @@ function League:createInfobox()
 		Customizable{id = 'custom', children = {}},
 		Customizable{id = 'liquipediatier', children = {
 				Cell{
-					name = 'Liquipedia tier',
+					name = 'Liquipedia Tier',
 					content = {self:createLiquipediaTierDisplay(args)},
 					classes = {self:liquipediaTierHighlighted(args) and 'valvepremier-highlighted' or ''},
 				},

--- a/components/infobox/commons/infobox_person_user_custom.lua
+++ b/components/infobox/commons/infobox_person_user_custom.lua
@@ -53,12 +53,12 @@ function CustomInjector:addCustomCells()
 	local widgets = {
 		Cell{name = 'Gender', content = {_args.gender}},
 		Cell{name = 'Languages', content = {_args.languages}},
-		Cell{name = 'Favorite players', content = CustomUser:_getArgsfromBaseDefault('fav-player', 'fav-players')},
-		Cell{name = 'Favorite casters', content = CustomUser:_getArgsfromBaseDefault('fav-caster', 'fav-casters')},
-		Cell{name = 'Favorite teams', content = {_args['fav-teams']}}
+		Cell{name = 'Favorite Players', content = CustomUser:_getArgsfromBaseDefault('fav-player', 'fav-players')},
+		Cell{name = 'Favorite Casters', content = CustomUser:_getArgsfromBaseDefault('fav-caster', 'fav-casters')},
+		Cell{name = 'Favorite Teams', content = {_args['fav-teams']}}
 	}
 	if not String.isEmpty(_args['fav-team-1']) then
-		table.insert(widgets, Title{name = 'Favorite teams'})
+		table.insert(widgets, Title{name = 'Favorite Teams'})
 		table.insert(widgets, Center{content = {CustomUser:_getFavouriteTeams()}})
 	end
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -44,7 +44,7 @@ function Scene:createInfobox()
 		Center{content = {args.caption}},
 		Title{name = 'Scene Information'},
 		Cell{name = 'Region', content = {args.region}},
-		Cell{name = 'National team', content = {args.nationalteam}, options = {makeLink = true}},
+		Cell{name = 'National Team', content = {args.nationalteam}, options = {makeLink = true}},
 		Cell{name = 'Events', content = self:getAllArgsForBase(args, 'event', {makeLink = true})},
 		Cell{name = 'Size', content = {args.size}},
 		Customizable{id = 'custom', children = {}},

--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -59,7 +59,7 @@ function Unit:createInfobox()
 			}
 		},
 		Cell{name = 'Description', content = {args.description}},
-		Cell{name = 'Built from', content = {args.builtfrom}},
+		Cell{name = 'Built From', content = {args.builtfrom}},
 		Customizable{
 			id = 'requirements',
 			children = {

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -52,7 +52,7 @@ function UnofficialWorldChampion:createInfobox()
 						contentCell = ' vs ' .. args['gained against']
 					end
 					return {
-						Title{name = 'Title gained'},
+						Title{name = 'Title Gained'},
 						Cell{
 							name = args['gained date'],
 							content = { contentCell },
@@ -61,7 +61,7 @@ function UnofficialWorldChampion:createInfobox()
 				end
 			end
 		},
-		Title{name = 'Most defences'},
+		Title{name = 'Most Defences'},
 		Cell{
 			name = (args['most defences no'] or '?') .. ' Matches',
 			content = { args['most defences'] },

--- a/components/infobox/commons/infobox_website.lua
+++ b/components/infobox/commons/infobox_website.lua
@@ -40,10 +40,10 @@ function Website:createInfobox()
 		Center{content = {args.caption}},
 		Title{name = 'Website Information'},
 		Cell{name = 'Type', content = {args.type}},
-		Cell{name = 'Available language(s)', content = self:getAllArgsForBase(args, 'language')},
-		Cell{name = 'Content license', content = {args.content_license}},
+		Cell{name = 'Available Language(s)', content = self:getAllArgsForBase(args, 'language')},
+		Cell{name = 'Content License', content = {args.content_license}},
 		Cell{name = 'Launched', content = {args.date_of_launch}},
-		Cell{name = 'Current status', content = {args.current_status}},
+		Cell{name = 'Current Status', content = {args.current_status}},
 		Customizable{id = 'custom', children = {}},
 		Builder{
 			builder = function()


### PR DESCRIPTION
Most of the stuff I changed was just text fields addressing #1323. The only code change made was adding dynamic organizer row singular/plural support. Was copied from infobox_league.lua so it should work. But tested anyway here: https://liquipedia.net/counterstrike/User:IMarbot/test_series_infobox (working as intended).

![image](https://user-images.githubusercontent.com/5881994/181589200-28604e8d-281d-4f0a-b782-d76cd36b114c.png)
<img width="278" alt="image" src="https://user-images.githubusercontent.com/5881994/181589229-1d576afa-ef8c-44c7-b989-84fb921aa1c1.png">
<img width="269" alt="image" src="https://user-images.githubusercontent.com/5881994/181589252-87daa039-a792-486a-b3c3-f95040700e6d.png">
