### PR TITLE
Add support for using (Module:Tier).link to get set tier link

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -282,7 +282,12 @@ function League:createLiquipediaTierDisplay(args)
 			if self:shouldStore(self.args) then
 				self.infobox:categories(tierText .. ' Tournaments')
 			end
-			return '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
+			local tierLink = tierText .. ' Tournaments'
+			if Tier.link and Tier.link[tierString] then
+				tierLink = Tier.link[tierString]
+			end
+
+			return '[[' .. tierLink .. '|' .. tierText .. ']]'
 		end
 	end
 


### PR DESCRIPTION
## Summary

Currently we always use "TierDisplay Tournament" for the portal link. This PR allows wikis to have a Link table defined in Module:Tier (see CS for example) with specifically defined links for tiers.

## How did you test this change?

Dev Module, tested on CS (has link table) & R6 (does not have link table)