### PR TITLE
Infobox League CS: Always set USD Prize Pool wiki-var

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -260,6 +260,8 @@ function CustomLeague:_createPrizepool(args)
 
 	if String.isNotEmpty(prizepoolInUsd) then
 		Variables.varDefine('tournament_prizepoolusd', prizepoolInUsd:gsub(',', ''):gsub('$', ''))
+	else
+		Variables.varDefine('tournament_prizepoolusd', 0)
 	end
 
 	return content


### PR DESCRIPTION
## Summary

Currently the `tournament_prizepoolusd` is being set by the default handling of PrizePool in Infobox Leauge on CS wiki. Whilst mostly fine, for tournaments without a prize pool set in usd, `tournament_prizepoolusd` will not be updated by the CS custom. This has the side effect of storing an auto converted prize pool from local to usd into LPDB (but not displaying it anywhere on the page). This causes consumers of this LPDB data (Tournament Lists) to get the auto converted USD prize. 

## How did you test this change?

Live on CS.