### PR TITLE
Store Mode into LPDB from Infobox League

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -379,6 +379,7 @@ function League:_setLpdbData(args, links)
 		next = mw.ext.TeamLiquidIntegration.resolve_redirect(self:_getPageNameFromChronology(args.next)),
 		next2 = mw.ext.TeamLiquidIntegration.resolve_redirect(self:_getPageNameFromChronology(args.next2)),
 		game = string.lower(args.game or ''),
+		mode = Variables.varDefault('tournament_mode', ''),
 		patch = args.patch,
 		endpatch = args.endpatch or args.epatch,
 		type = args.type,


### PR DESCRIPTION
## Summary

#1265 added the field `mode` to LPDB Tournament.

Have Infobox League store it by default, by using the standard (wiki-custom) wiki-variable `tournament_mode`.
## How did you test this change?

Dev module
![image](https://user-images.githubusercontent.com/3426850/181640263-baa80f40-159c-468e-901a-db9e44f24c56.png)
