### PR TITLE
Store Prize Pool Index in Prize Pool Tables

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -746,7 +746,7 @@ function PrizePool:_storeData()
 		icon = Variables.varDefault('tournament_icon'),
 		icondark = Variables.varDefault('tournament_icondark'),
 		game = Variables.varDefault('tournament_game'),
-		-- TODO: Add PrizePoolIndex as a field?
+		prizepoolindex = prizePoolIndex,
 	}
 
 	local lpdbData = {}


### PR DESCRIPTION
## Summary

Store the new LPDB field `prizepoolindex` into lpdb placements.

## How did you test this change?
Tested using dev module