### PR TITLE
Infobox Player for Pokemon

### DIFF
--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -52,7 +52,7 @@ function CustomInjector:parse(id, widgets)
 			automatedHistory = nil
 		end
 
-		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+		if String.isNotEmpty(manualHistory) and String.isNotEmpty(automatedHistory) then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -1,0 +1,99 @@
+---
+-- @Liquipedia
+-- wiki=pokemon
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Player = require('Module:Infobox/Person')
+local String = require('Module:StringUtils')
+local Class = require('Module:Class')
+local GameAppearances = require('Module:GetGameAppearances')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Role = require('Module:Role')
+local Region = require('Module:Region')
+
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+local Center = require('Module:Infobox/Widget/Center')
+
+local _pagename = mw.title.getCurrentTitle().prefixedText
+local _role
+local _role2
+local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
+
+local CustomPlayer = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+function CustomPlayer.run(frame)
+	local player = Player(frame)
+	_args = player.args
+
+	player.adjustLPDB = CustomPlayer.adjustLPDB
+	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+
+	return player:createInfobox(frame)
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'history' then
+		local manualHistory = _args.history
+		local automatedHistory = TeamHistoryAuto._results({
+			convertrole = 'true',
+			player = _pagename
+		}) or ''
+		automatedHistory = tostring(automatedHistory)
+		if automatedHistory == _EMPTY_AUTO_HISTORY then
+			automatedHistory = nil
+		end
+
+		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+			return {
+				Title{name = 'History'},
+				Center{content = {manualHistory}},
+				Center{content = {automatedHistory}},
+			}
+		end
+	elseif id == 'region' then return {}
+	elseif id == 'role' then
+		_role = Role.run({role = _args.role})
+		_role2 = Role.run({role = _args.role2})
+		return {
+			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
+		}
+	end
+	return widgets
+end
+
+function CustomInjector:addCustomCells(widgets)
+	return {
+		Cell{
+			name = 'Game Appearances',
+			content = GameAppearances.player({player = _pagename})
+		},
+	}
+end
+
+function CustomPlayer:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomPlayer:adjustLPDB(lpdbData)
+	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
+	lpdbData.extradata.role = _role.role
+	lpdbData.extradata.role2 = _role2.role
+
+	local region = Region.run({region = _args.region, country = _args.country})
+	if type(region) == 'table' then
+		lpdbData.region = region.region
+	end
+
+	return lpdbData
+end
+
+return CustomPlayer

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -52,7 +52,7 @@ function CustomInjector:parse(id, widgets)
 			automatedHistory = nil
 		end
 
-		if String.isNotEmpty(manualHistory) and String.isNotEmpty(automatedHistory) then
+		if String.isNotEmpty(manualHistory) or String.isNotEmpty(automatedHistory) then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},


### PR DESCRIPTION
## Summary
Infobox Player  for Pokemon, different from the MOBA ones that uses commons, this one is local for the wiki due to the need of "Game Appearances" display, so these are largely based on the Halo Infobox Player

## How did you test this change?
LIVE

Some of the pages:
https://liquipedia.net/pokemon/Wolfey / https://liquipedia.net/pokemon/Special:LiquipediaDB/Wolfey
https://liquipedia.net/pokemon/Tord_Reklev / https://liquipedia.net/pokemon/Special:LiquipediaDB/Tord_Reklev

## Side Note
Another wiki - Crossfire, will also share this same infobox as well once this is revised (if needed) and merged (since they need the game appearances as well)
