### PR TITLE
Player Infobox - Uppercase first letter in status

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -89,9 +89,11 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'status' then
+		local status = _args.status
+		status = status:gsub("^%l", string.upper)
 		return {
 			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true},
-						_args.status) or _args.status}},
+						status) or status}},
 		}
 	elseif id == 'role' then
 		return {

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -90,7 +90,10 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'status' then
 		local status = _args.status
-		status = status:gsub("^%l", string.upper)
+		if String.isNotEmpty(status) then
+			status = mw.language:ucfirst(status)
+		end
+
 		return {
 			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true},
 						status) or status}},

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -91,7 +91,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'status' then
 		local status = _args.status
 		if String.isNotEmpty(status) then
-			status = mw.language:ucfirst(status)
+			status = mw.getContentLanguage():ucfirst(string)
 		end
 
 		return {

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -91,7 +91,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'status' then
 		local status = _args.status
 		if String.isNotEmpty(status) then
-			status = mw.getContentLanguage():ucfirst(string)
+			status = mw.getContentLanguage():ucfirst(status)
 		end
 
 		return {


### PR DESCRIPTION
Forces any input that is has an alphabetical character as its first character to be capitalized for the status input. 
This reduces the need of a bot run to correct instances of ``|status=active`` to ``|status=Active``. Most of the input was already capitalized, this standardizes it

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested live via a /dev module
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
