### PR TITLE
Fix bug in match2 Countdown

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -97,7 +97,7 @@ function DisplayHelper.MatchCountdownBlock(match)
 	DisplayUtil.assertPropTypes(match, MatchGroupUtil.types.Match.struct)
 	local dateString
 	if match.dateIsExact == true then
-		dateString = mw.getContentLanguage():formatDate('F j, Y - H:i', match.date) .. _NONBREAKING_SPACE .. _UTC
+		dateString = mw.getContentLanguage():formatDate('F j, Y - H:i', match.date) .. ' ' .. _UTC
 	else
 		dateString = mw.getContentLanguage():formatDate('F j, Y', match.date)
 	end


### PR DESCRIPTION
## Summary

Due to insufficient testing in #1393, a bug slipped through in one of the cases. Fix was immediately put on the live server but no PR was opened (due to none-working hours). nbsp isn't read by the countdown JS as a space, and hence it cannot parse the date. Switch it intoa normal space.

## How did you test this change?

Live since Friday.