### PR TITLE
Allow PrizePool to fetch flags for party opponents

### DIFF
--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -238,8 +238,7 @@ For team opponents, this resolves the team template to a particular date. For
 party opponents, this fills in players' pageNames using their displayNames,
 using data stored in page variables if present.
 
-options.loadFlag: Whether to fetch the flag from variables, match2 or LPDB. Disabled by default
-options.loadTeam: Whether to fetch the team from variables or LPDB. Disabled by default.
+options.syncPlayer: Whether to fetch player information from variables or LPDB. Disabled by default.
 ]]
 function Opponent.resolve(opponent, date, options)
 	options = options or {}
@@ -248,14 +247,13 @@ function Opponent.resolve(opponent, date, options)
 	elseif Opponent.typeIsParty(opponent.type) then
 		local PlayerExt = require('Module:Player/Ext')
 		for _, player in ipairs(opponent.players) do
-			PlayerExt.populatePageName(player)
-			if options.loadFlag then
+			if options.syncPlayer then
 				PlayerExt.syncPlayer(player)
+			else
+				PlayerExt.populatePageName(player)
 			end
 			if player.team then
 				player.team = TeamTemplate.resolve(player.team, date)
-			elseif options.loadTeam then
-				player.team = PlayerExt.syncTeam(player.pageName, nil)
 			end
 		end
 	end

--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -237,16 +237,25 @@ Resolves the identifiers of an opponent.
 For team opponents, this resolves the team template to a particular date. For
 party opponents, this fills in players' pageNames using their displayNames,
 using data stored in page variables if present.
+
+options.loadFlag: Whether to fetch the flag from variables, match2 or LPDB. Disabled by default
+options.loadTeam: Whether to fetch the team from variables or LPDB. Disabled by default.
 ]]
-function Opponent.resolve(opponent, date)
+function Opponent.resolve(opponent, date, options)
+	options = options or {}
 	if opponent.type == Opponent.team then
 		opponent.template = TeamTemplate.resolve(opponent.template, date) or 'tbd'
 	elseif Opponent.typeIsParty(opponent.type) then
 		local PlayerExt = require('Module:Player/Ext')
 		for _, player in ipairs(opponent.players) do
 			PlayerExt.populatePageName(player)
+			if options.loadFlag then
+				PlayerExt.syncPlayer(player)
+			end
 			if player.team then
 				player.team = TeamTemplate.resolve(player.team, date)
+			elseif options.loadTeam then
+				player.team = PlayerExt.syncTeam(player.pageName, nil)
 			end
 		end
 	end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1007,7 +1007,7 @@ function Placement:_parseOpponentArgs(input, date)
 	if not opponentData or Opponent.isTbd(opponentData) then
 		opponentData = Opponent.tbd(opponentArgs.type)
 	end
-	
+
 	local resolveOptions = {loadFlag = self.parent.options.loadFlags, loadTeam = self.parent.options.loadTeams}
 	return Opponent.resolve(opponentData, date, resolveOptions)
 end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -95,16 +95,10 @@ PrizePool.config = {
 	resolveRedirect = {
 		default = false,
 	},
-	loadFlags = {
+	syncPlayers = {
 		default = false,
 		read = function(args)
-			return Logic.readBoolOrNil(args.loadFlags)
-		end
-	},
-	loadTeams = {
-		default = false,
-		read = function(args)
-			return Logic.readBoolOrNil(args.loadTeams)
+			return Logic.readBoolOrNil(args.syncPlayers)
 		end
 	}
 }
@@ -1008,8 +1002,7 @@ function Placement:_parseOpponentArgs(input, date)
 		opponentData = Opponent.tbd(opponentArgs.type)
 	end
 
-	local resolveOptions = {loadFlag = self.parent.options.loadFlags, loadTeam = self.parent.options.loadTeams}
-	return Opponent.resolve(opponentData, date, resolveOptions)
+	return Opponent.resolve(opponentData, date, {syncPlayer = self.parent.options.syncPlayers})
 end
 
 function Placement:_getLpdbData()

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -94,6 +94,18 @@ PrizePool.config = {
 	},
 	resolveRedirect = {
 		default = false,
+	},
+	loadFlags = {
+		default = false,
+		read = function(args)
+			return Logic.readBoolOrNil(args.loadFlags)
+		end
+	},
+	loadTeams = {
+		default = false,
+		read = function(args)
+			return Logic.readBoolOrNil(args.loadTeams)
+		end
 	}
 }
 
@@ -995,8 +1007,9 @@ function Placement:_parseOpponentArgs(input, date)
 	if not opponentData or Opponent.isTbd(opponentData) then
 		opponentData = Opponent.tbd(opponentArgs.type)
 	end
-
-	return Opponent.resolve(opponentData, date)
+	
+	local resolveOptions = {loadFlag = self.parent.options.loadFlags, loadTeam = self.parent.options.loadTeams}
+	return Opponent.resolve(opponentData, date, resolveOptions)
 end
 
 function Placement:_getLpdbData()


### PR DESCRIPTION
## Summary
This modifies `Module:Opponent`, function `resolve` to optionally load flags and teams for players.
The data is fetched via `Module:Player/Ext`, so either comes from wikivars, match2 or lpdb.
According options are added to `Module:PrizePool`. The feature is disabled by default.

## How did you test this change?
Tested with [Opponent/dev](https://liquipedia.net/commons/Module:Opponent/dev), [PrizePool/dev](https://liquipedia.net/commons/Module:PrizePool/dev), and different configurations of [AoE:PrizePool/Custom](https://liquipedia.net/ageofempires/Module:PrizePool/Custom).

