### PR TITLE
Adjust cancelled_tournament handling in sc/sc2 match2

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -289,10 +289,6 @@ function StarcraftMatchGroupInput._matchWinnerProcessing(match)
 				opponent.score = -1
 				match.finished = 'true'
 				match.resulttype = 'default'
-			elseif Logic.readBool(match.cancelled) then
-				match.resulttype = 'np'
-				match.finished = 'true'
-				opponent.score = -1
 			elseif _CONVERT_STATUS_INPUT[string.upper(opponent.score or '')] then
 				if string.upper(opponent.score) == 'W' then
 					match.winner = opponentIndex
@@ -313,8 +309,16 @@ function StarcraftMatchGroupInput._matchWinnerProcessing(match)
 				opponent.score = tonumber(opponent.score or '') or
 					tonumber(opponent.sumscore) or -1
 				if opponent.score > bestof / 2 then
-					match.finished = Logic.nilOr(match.finished, 'true')
+					match.finished = Logic.emptyOr(match.finished, 'true')
 					match.winner = tonumber(match.winner or '') or opponentIndex
+				end
+			end
+
+			if Logic.readBool(match.cancelled) then
+				match.finished = 'true'
+				if String.isEmpty(match.resulttype) and String.isEmpty(opponent.score) then
+					match.resulttype = 'np'
+					opponent.score = opponent.score or -1
 				end
 			end
 		else


### PR DESCRIPTION
## Summary
Adjust cancelled_tournament handling in sc/sc2 match2
Namely still set scores and resulttypes based on score/map entered data, only if that is not available fall back to setting
resulttype as `'np'` and scores as `-1`

## How did you test this change?
/dev module