### PR TITLE
Set up Custom Player Module for Wild Rift

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -89,11 +89,6 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'status' then
-		local status = _args.status
-		if String.isNotEmpty(status) then
-			status = mw.getContentLanguage():ucfirst(status)
-		end
-
 		return {
 			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true},
 						_args.status) or _args.status}},

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -89,9 +89,14 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'status' then
+		local status = _args.status
+		if String.isNotEmpty(status) then
+			status = mw.getContentLanguage():ucfirst(status)
+		end
+
 		return {
 			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true},
-						_args.status) or _args.status}},
+						status) or status}},
 		}
 	elseif id == 'role' then
 		return {

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -1,0 +1,193 @@
+---
+-- @Liquipedia
+-- wiki=wildrift
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local ChampionIcon = require('Module:ChampionIcon')
+local Page = require('Module:Page')
+local Player = require('Module:Infobox/Person')
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
+local String = require('Module:StringUtils')
+local Team = require('Module:Team')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Variables = require('Module:Variables')
+local Template = require('Module:Template')
+
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+
+local _ROLES = {
+	-- Players
+	['baron'] = {category = 'Baron Lane players', variable = 'Baron', isplayer = true},
+	['support'] = {category = 'Support players', variable = 'Support', isplayer = true},
+	['jungle'] = {category = 'Jungle players', variable = 'Jungle', isplayer = true},
+	['mid'] = {category = 'Mid Lane players', variable = 'Mid', isplayer = true},
+	['dragon'] = {category = 'Dragon Lane players', variable = 'Dragon', isplayer = true},
+
+	-- Staff and Talents
+	['analyst'] = {category = 'Analysts', variable = 'Analyst', isplayer = false},
+	['observer'] = {category = 'Observers', variable = 'Observer', isplayer = false},
+	['host'] = {category = 'Hosts', variable = 'Host', isplayer = false},
+	['journalist'] = {category = 'Journalists', variable = 'Journalist', isplayer = false},
+	['expert'] = {category = 'Experts', variable = 'Expert', isplayer = false},
+	['coach'] = {category = 'Coaches', variable = 'Coach', isplayer = false},
+	['caster'] = {category = 'Casters', variable = 'Caster', isplayer = false},
+	['talent'] = {category = 'Talents', variable = 'Talent', isplayer = false},
+	['manager'] = {category = 'Managers', variable = 'Manager', isplayer = false},
+	['producer'] = {category = 'Producers', variable = 'Producer', isplayer = false},
+	['admin'] = {category = 'Admins', variable = 'Admin', isplayer = false},
+}
+_ROLES['assistant coach'] = _ROLES.coach
+_ROLES['strategic coach'] = _ROLES.coach
+_ROLES['positional coach'] = _ROLES.coach
+_ROLES['head coach'] = _ROLES.coach
+_ROLES['jgl'] = _ROLES.jungle
+_ROLES['solomiddle'] = _ROLES.mid
+_ROLES['carry'] = _ROLES.dragon
+_ROLES['adc'] = _ROLES.dragon
+_ROLES['bot'] = _ROLES.dragon
+_ROLES['ad carry'] = _ROLES.dragon
+_ROLES['sup'] = _ROLES.support
+
+local _SIZE_CHAMPION = '25x25px'
+
+local CustomPlayer = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+function CustomPlayer.run(frame)
+	local player = Player(frame)
+
+	if String.isEmpty(player.args.team) then
+		player.args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+
+	if String.isEmpty(player.args.team2) then
+		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
+	end
+
+	if String.isEmpty(player.args.history) then
+		player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata='true'})
+	end
+
+	player.adjustLPDB = CustomPlayer.adjustLPDB
+	player.createBottomContent = CustomPlayer.createBottomContent
+	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+	player.defineCustomPageVariables = CustomPlayer.defineCustomPageVariables
+
+	_args = player.args
+
+	return player:createInfobox(frame)
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'status' then
+		return {
+			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true},
+						_args.status) or _args.status}},
+		}
+	elseif id == 'role' then
+		return {
+			Cell{name = 'Role', content = {
+				CustomPlayer._createRole('role', _args.role),
+				CustomPlayer._createRole('role2', _args.role2)
+			}},
+		}
+	elseif id == 'history' then
+		table.insert(widgets, Cell{
+			name = 'Retired',
+			content = {_args.retired}
+		})
+	end
+	return widgets
+end
+
+function CustomInjector:addCustomCells(widgets)
+	-- Signature Champion
+	local championIcons = Array.map(Player:getAllArgsForBase(_args, 'champion'),
+		function(champion, _)
+			return ChampionIcon.getImage{champion, size = _SIZE_CHAMPION}
+		end
+	)
+	return {Cell{
+		name = #championIcons > 1 and 'Signature Champions' or 'Signature Champions',
+		content = {
+			table.concat(championIcons, '&nbsp;')
+		}
+	}}
+end
+
+function CustomPlayer:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomPlayer:adjustLPDB(lpdbData)
+	lpdbData.extradata.role = Variables.varDefault('role')
+	lpdbData.extradata.role2 = Variables.varDefault('role2')
+
+	lpdbData.extradata.signatureChampion1 = _args.champion1 or _args.champion
+	lpdbData.extradata.signatureChampion2 = _args.champion2
+	lpdbData.extradata.signatureChampion3 = _args.champion3
+	lpdbData.extradata.signatureChampion4 = _args.champion4
+	lpdbData.extradata.signatureChampion5 = _args.champion5
+	lpdbData.type = Variables.varDefault('isplayer') == 'true' and 'player' or 'staff'
+
+	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {_args.country})
+
+	if String.isNotEmpty(_args.team2) then
+		lpdbData.extradata.team2 = mw.ext.TeamTemplate.raw(_args.team2).page
+	end
+
+	return lpdbData
+end
+
+function CustomPlayer:createBottomContent(infobox)
+	if Player:shouldStoreData(_args) and String.isNotEmpty(_args.team) then
+		local teamPage = Team.page(mw.getCurrentFrame(),_args.team)
+		return
+			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing matches of', {team = teamPage}) ..
+			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
+	end
+end
+
+function CustomPlayer._createRole(key, role)
+	if String.isEmpty(role) then
+		return nil
+	end
+
+	local roleData = _ROLES[role:lower()]
+	if not roleData then
+		return nil
+	end
+	if Player:shouldStoreData(_args) then
+		local categoryCoreText = 'Category:' .. roleData.category
+
+		return '[[' .. categoryCoreText .. ']]' .. '[[:' .. categoryCoreText .. '|' ..
+			Variables.varDefineEcho(key or 'role', roleData.variable) .. ']]'
+	else
+		return Variables.varDefineEcho(key or 'role', roleData.variable)
+	end
+end
+
+function CustomPlayer:defineCustomPageVariables(args)
+	-- isplayer needed for SMW
+	local roleData
+	if String.isNotEmpty(args.role) then
+		roleData = _ROLES[args.role:lower()]
+	end
+	-- If the role is missing, assume it is a player
+	if roleData and roleData.isplayer == false then
+		Variables.varDefine('isplayer', 'false')
+	else
+		Variables.varDefine('isplayer', 'true')
+	end
+end
+
+return CustomPlayer

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -89,6 +89,11 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'status' then
+		local status = _args.status
+		if String.isNotEmpty(status) then
+			status = mw.getContentLanguage():ucfirst(status)
+		end
+
 		return {
 			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true},
 						_args.status) or _args.status}},


### PR DESCRIPTION
## Summary
Since the League of Legends player infobox was standardized, the Wild Rift module can easily be moved over as well as the wikis are set up in the same way.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested on the following page:
https://liquipedia.net/wildrift/Guyler

PlayerIntroduction has been updated along to fix the one issue with PlayerTeamAuto initially not working.

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
