### PR TITLE
Add Participant Fetching & Cleaning the code

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -110,13 +110,15 @@ function HiddenDataBox._fetchParticipants(parent)
 		query = 'players, participant',
 	})
 
-	return Table.map(placements, function(_, placement)
-		if String.isEmpty(placement.participant) or placement.participant:lower() == 'tbd' then
-			return placement.participant, nil
-		end
-
-		return placement.participant, placement.players
-	end)
+	return
+		Table.map(
+			Table.filter(placements, function(placement)
+				return String.isNotEmpty(placement.participant) and placement.participant:lower() ~= 'tbd'
+			end),
+			function(_, placement)
+				return placement.participant, placement.players
+			end
+		)
 end
 
 -- overridable so that wikis can add custom vars

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -7,7 +7,7 @@
 --
 
 local Class = require('Module:Class')
-local Logic = require('Module:Logc')
+local Logic = require('Module:Logic')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -112,7 +112,7 @@ function HiddenDataBox._fetchParticipants(parent)
 
 	return Table.map(placements, function(_, placement)
 		if String.isEmpty(placement.participant) or placement.participant:lower() == 'tbd' then
-			return
+			return placement.participant, nil
 		end
 
 		return placement.participant, placement.players
@@ -125,7 +125,7 @@ end
 
 -- overridable so that wikis can add custom vars
 function HiddenDataBox.setWikiVariableForParticipantKey(participant, participantResolved, key, value)
-	Variables.varDefine(participant .. key, value)
+	Variables.varDefine(participant .. '_' .. key, value)
 	if participant ~= participantResolved then
 		Variables.varDefine(participantResolved .. key, value)
 	end

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -152,7 +152,7 @@ function HiddenDataBox.validateTier(tierString, tierMode)
 		)
 	end
 
-	-- For types we want to normalized value
+	-- For types we want to return the normalized value
 	-- For tiers we want to return the input
 	tierValue = tierMode == TIER_MODE_TYPES and tierValue or tierString
 

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 local Tier = require('Module:Tier')
 local Variables = require('Module:Variables')
 local WarningBox = require('Module:WarningBox')
@@ -16,11 +17,14 @@ local WarningBox = require('Module:WarningBox')
 local HiddenDataBox = {}
 local INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
 	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
+local INVALID_PARENT = '${parent} is not a Liquipedia Tournament'
 local TIER_MODE_TYPES = 'types'
 local TIER_MODE_TIERS = 'tiers'
 
+---Entry point
 function HiddenDataBox.run(args)
 	args = args or {}
+	args.participantGrabber = args.participantGrabber or true
 
 	local warnings = {}
 	local warning
@@ -31,71 +35,111 @@ function HiddenDataBox.run(args)
 		= HiddenDataBox.validateTier(args.liquipediatiertype, TIER_MODE_TYPES)
 	table.insert(warnings, warning)
 
-	local parent = args.tournament or tostring(mw.title.getCurrentTitle().basePageTitle)
+	local parent = args.parent or args.tournament or tostring(mw.title.getCurrentTitle().basePageTitle)
 	parent = parent:gsub(' ', '_')
 
 	local queryResult = mw.ext.LiquipediaDB.lpdb('tournament', {
 		conditions = '[[pagename::' .. parent .. ']]',
 		limit = 1,
-		order = 'pagename asc',
 	})
-	queryResult = queryResult[1] or {}
+	queryResult = queryResult[1]
 
-	local startDate = HiddenDataBox:cleanDate(args.sdate, args.date)
-	local endDate = HiddenDataBox:cleanDate(args.edate, args.date)
-	HiddenDataBox:checkAndAssign('tournament_startdate', startDate, queryResult.startdate)
-	HiddenDataBox:checkAndAssign('tournament_enddate', endDate, queryResult.enddate)
+	if not queryResult then
+		table.insert(warnings, String.interpolate(INVALID_PARENT, {parent = parent}))
+		queryResult = {}
+	elseif args.participantGrabber then
+		local participants = HiddenDataBox._fetchParticipants(parent)
 
-	HiddenDataBox:checkAndAssign('tournament_name', args.name, queryResult.name)
-	HiddenDataBox:checkAndAssign('tournament_series', args.series, queryResult.series)
-	HiddenDataBox:checkAndAssign('tournament_shortname', args.shortname, queryResult.shortname)
-	HiddenDataBox:checkAndAssign('tournament_tickername', args.tickername, queryResult.tickername)
-	HiddenDataBox:checkAndAssign('tournament_icon', args.icon, queryResult.icon)
-	HiddenDataBox:checkAndAssign('tournament_icondark', args.icondark or args.icondarkmode, queryResult.icondark)
-	HiddenDataBox:checkAndAssign('tournament_liquipediatier', args.liquipediatier, queryResult.liquipediatier)
-	HiddenDataBox:checkAndAssign('tournament_liquipediatiertype', args.liquipediatiertype, queryResult.liquipediatiertype)
-	HiddenDataBox:checkAndAssign('tournament_type', args.type, queryResult.type)
-	HiddenDataBox:checkAndAssign('tournament_status', args.status, queryResult.status)
-	HiddenDataBox:checkAndAssign('tournament_game', args.game, queryResult.game)
-	HiddenDataBox:checkAndAssign('tournament_parent', args.parent, parent)
-	HiddenDataBox:checkAndAssign('tournament_parentname', args.parentname, queryResult.name)
+		Table.iter.forEachPair(participants, function (participant, players)
+			-- TODO: An improvement would be called TeamCard module for this
+			-- Would need a rework for the function that does it however
+			local participantResolved = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
 
-	HiddenDataBox:addCustomVariables(args, queryResult)
+			Table.iter.forEachPair(players, function(key, value)
+				HiddenDataBox.setWikiVariableForParticipantKey(participant, participantResolved, key, value)
+			end)
+		end)
+	end
+
+	HiddenDataBox.checkAndAssign('tournament_name', args.name, queryResult.name)
+	HiddenDataBox.checkAndAssign('tournament_shortname', args.shortname, queryResult.shortname)
+	HiddenDataBox.checkAndAssign('tournament_tickername', args.tickername, queryResult.tickername)
+	HiddenDataBox.checkAndAssign('tournament_icon', args.icon, queryResult.icon)
+	HiddenDataBox.checkAndAssign('tournament_icondark', args.icondark or args.icondarkmode, queryResult.icondark)
+	HiddenDataBox.checkAndAssign('tournament_series', args.series, queryResult.series)
+
+	HiddenDataBox.checkAndAssign('tournament_liquipediatier', args.liquipediatier, queryResult.liquipediatier)
+	HiddenDataBox.checkAndAssign('tournament_liquipediatiertype', args.liquipediatiertype, queryResult.liquipediatiertype)
+
+	HiddenDataBox.checkAndAssign('tournament_type', args.type, queryResult.type)
+	HiddenDataBox.checkAndAssign('tournament_status', args.status, queryResult.status)
+	HiddenDataBox.checkAndAssign('tournament_mode', args.mode, queryResult.mode)
+
+	HiddenDataBox.checkAndAssign('tournament_game', args.game, queryResult.game)
+	HiddenDataBox.checkAndAssign('tournament_parent', args.parent, parent)
+	HiddenDataBox.checkAndAssign('tournament_parentname', args.parentname, queryResult.name)
+
+	local startDate = HiddenDataBox.cleanDate(args.sdate, args.date)
+	local endDate = HiddenDataBox.cleanDate(args.edate, args.date)
+	HiddenDataBox.checkAndAssign('tournament_startdate', startDate, queryResult.startdate)
+	HiddenDataBox.checkAndAssign('tournament_enddate', endDate, queryResult.enddate)
+
+	HiddenDataBox.addCustomVariables(args, queryResult)
 
 	return WarningBox.displayAll(warnings)
 end
 
-function HiddenDataBox:cleanDate(primaryDate, secondaryDate)
-	local date = ReferenceCleaner.clean(primaryDate)
-	if date == '' then
-		date = ReferenceCleaner.clean(secondaryDate)
-		if date == '' then
-			return nil
-		end
-	end
-
-	return date
+function HiddenDataBox.cleanDate(primaryDate, secondaryDate)
+	return String.nilIfEmpty(ReferenceCleaner.clean(primaryDate)) or
+		 	String.nilIfEmpty(ReferenceCleaner.clean(secondaryDate))
 end
 
-function HiddenDataBox:checkAndAssign(variableName, valueFromArgs, valueFromQuery)
-	if not String.isEmpty(valueFromArgs) then
+function HiddenDataBox.checkAndAssign(variableName, valueFromArgs, valueFromQuery)
+	if String.isNotEmpty(valueFromArgs) then
 		Variables.varDefine(variableName, valueFromArgs)
 	elseif String.isEmpty(Variables.varDefault(variableName)) then
 		Variables.varDefine(variableName, valueFromQuery or '')
 	end
 end
 
--- overridable so that wikis can add custom vars
-function HiddenDataBox:addCustomVariables(args, queryResult) end
+function HiddenDataBox._fetchParticipants(parent)
+	local placements = mw.ext.LiquipediaDB.lpdb('placement', {
+		conditions = '[[pagename::' .. parent .. ']]',
+		limit = 1000,
+		query = 'players, participant',
+	})
 
--- overridable so that wikis can adjust
--- according to their tier system
+	return Table.map(placements, function(_, placement)
+		if String.isEmpty(placement.participant) or placement.participant:lower() == 'tbd' then
+			return
+		end
+
+		return placement.participant, placement.players
+	end)
+end
+
+-- overridable so that wikis can add custom vars
+function HiddenDataBox.addCustomVariables(args, queryResult)
+end
+
+-- overridable so that wikis can add custom vars
+function HiddenDataBox.setWikiVariableForParticipantKey(participant, participantResolved, key, value)
+	Variables.varDefine(participant .. key, value)
+	if participant ~= participantResolved then
+		Variables.varDefine(participantResolved .. key, value)
+	end
+end
+
+-- overridable so that wikis can adjust according to their tier system
 function HiddenDataBox.validateTier(tierString, tierMode)
 	if String.isEmpty(tierString) then
-		return nil, nil
+		return
 	end
 	local warning
-	local tierValue = Tier.text[tierMode][tierString:lower()]
+	local tierValue = (Tier.text[tierMode] and
+						Tier.text[tierMode][tierString:lower()]) or
+					 	Tier.text[tierString]
+
 	if not tierValue then
 		tierValue = tierString
 		warning = String.interpolate(
@@ -107,6 +151,8 @@ function HiddenDataBox.validateTier(tierString, tierMode)
 		)
 	end
 
+	-- For types we want to normalized value
+	-- For tiers we want to return the input
 	tierValue = tierMode == TIER_MODE_TYPES and tierValue or tierString
 
 	return tierValue, warning

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -25,7 +25,7 @@ local TIER_MODE_TIERS = 'tiers'
 ---Entry point
 function HiddenDataBox.run(args)
 	args = args or {}
-	args.participantGrabber = Logic.readBoolOrNil(args.participantGrabber) or true
+	args.participantGrabber = Logic.nilOr(Logic.readBoolOrNil(args.participantGrabber), true)
 
 	local warnings = {}
 	local warning

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logc')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -24,7 +25,7 @@ local TIER_MODE_TIERS = 'tiers'
 ---Entry point
 function HiddenDataBox.run(args)
 	args = args or {}
-	args.participantGrabber = args.participantGrabber or true
+	args.participantGrabber = Logic.readBoolOrNil(args.participantGrabber) or true
 
 	local warnings = {}
 	local warning

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -18,7 +18,7 @@ local WarningBox = require('Module:WarningBox')
 local HiddenDataBox = {}
 local INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
 	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
-local INVALID_PARENT = '${parent} is not a Liquipedia Tournament'
+local INVALID_PARENT = '${parent} is not a Liquipedia Tournament[[Category:Pages with invalid parent]]'
 local TIER_MODE_TYPES = 'types'
 local TIER_MODE_TIERS = 'tiers'
 

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -92,7 +92,7 @@ end
 
 function HiddenDataBox.cleanDate(primaryDate, secondaryDate)
 	return String.nilIfEmpty(ReferenceCleaner.clean(primaryDate)) or
-		 	String.nilIfEmpty(ReferenceCleaner.clean(secondaryDate))
+			String.nilIfEmpty(ReferenceCleaner.clean(secondaryDate))
 end
 
 function HiddenDataBox.checkAndAssign(variableName, valueFromArgs, valueFromQuery)
@@ -139,7 +139,7 @@ function HiddenDataBox.validateTier(tierString, tierMode)
 	local warning
 	local tierValue = (Tier.text[tierMode] and
 						Tier.text[tierMode][tierString:lower()]) or
-					 	Tier.text[tierString]
+						Tier.text[tierString]
 
 	if not tierValue then
 		tierValue = tierString

--- a/components/hidden_data_box/commons/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/commons/hidden_data_box_custom.lua
@@ -15,7 +15,7 @@ function CustomHiddenDataBox.run(args)
 	return BasicHiddenDataBox.run(args)
 end
 
-function CustomHiddenDataBox:addCustomVariables(args, queryResult)
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	--add your wiki specific vars here
 end
 

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -26,7 +26,7 @@ function CustomHiddenDataBox.run(args)
 	return BasicHiddenDataBox.run(args)
 end
 
-function CustomHiddenDataBox:addCustomVariables(args, queryResult)
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	--legacy variables
 	Variables.varDefine('tournament_parent_name', Variables.varDefault('tournament_parentname', ''))
 	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier', ''))
@@ -45,10 +45,10 @@ function CustomHiddenDataBox:addCustomVariables(args, queryResult)
 	Variables.varDefine('headtohead', args.headtohead)
 
 	-- tournament mode (1v1 or team)
-	BasicHiddenDataBox:checkAndAssign('tournament_mode', args.mode, queryResult.extradata.mode)
+	BasicHiddenDataBox.checkAndAssign('tournament_mode', args.mode, queryResult.extradata.mode)
 
 	--gamemode
-	BasicHiddenDataBox:checkAndAssign('tournament_gamemode', args.gamemode, queryResult.gamemode)
+	BasicHiddenDataBox.checkAndAssign('tournament_gamemode', args.gamemode, queryResult.gamemode)
 end
 
 function CustomHiddenDataBox.validateTier(tierString, tierMode)

--- a/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
@@ -18,7 +18,7 @@ function CustomHiddenDataBox.run(args)
 	if args.team_number or Logic.readBool(args.teamevent) then
 		args.participantGrabber = true
 	else
-		args.participantGrabber = true
+		args.participantGrabber = false
 	end
 	return BasicHiddenDataBox.run(args)
 end

--- a/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
@@ -14,12 +14,10 @@ local BasicHiddenDataBox = require('Module:HiddenDataBox')
 local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
+	args.participantGrabber = false
+
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
-	if args.team_number or Logic.readBool(args.teamevent) then
-		args.participantGrabber = true
-	else
-		args.participantGrabber = false
-	end
+
 	return BasicHiddenDataBox.run(args)
 end
 

--- a/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
@@ -14,6 +14,7 @@ local BasicHiddenDataBox = require('Module:HiddenDataBox')
 local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
+	args = args or {}
 	args.participantGrabber = false
 
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables

--- a/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
@@ -7,16 +7,23 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Variables = require('Module:Variables')
+
 local BasicHiddenDataBox = require('Module:HiddenDataBox')
 local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+	if args.team_number or Logic.readBool(args.teamevent) then
+		args.participantGrabber = true
+	else
+		args.participantGrabber = true
+	end
 	return BasicHiddenDataBox.run(args)
 end
 
-function CustomHiddenDataBox:addCustomVariables(args, queryResult)
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	--legacy variables
 	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier', ''))
 	Variables.varDefine('tournament_tiertype', Variables.varDefault('tournament_liquipediatiertype', ''))
@@ -24,7 +31,7 @@ function CustomHiddenDataBox:addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate', ''))
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate', ''))
 	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername', ''))
-	BasicHiddenDataBox:checkAndAssign(
+	BasicHiddenDataBox.checkAndAssign(
 		'tournament_abbreviation',
 		args.abbreviation or args.shortname,
 		queryResult.shortname
@@ -32,7 +39,7 @@ function CustomHiddenDataBox:addCustomVariables(args, queryResult)
 
 	--custom stuff
 	Variables.varDefine('headtohead', args.headtohead)
-	BasicHiddenDataBox:checkAndAssign(
+	BasicHiddenDataBox.checkAndAssign(
 		'featured',
 		args.featured,
 		(queryResult.extradata or {}).featured
@@ -45,13 +52,13 @@ function CustomHiddenDataBox:addCustomVariables(args, queryResult)
 			'participants_number',
 			args.participants or args.participantsnumber or queryResult.participantsnumber
 		)
-		if args.teamevent == 'true' then
+		if Logic.readBool(args.teamevent) then
 			Variables.varDefine('is_team_tournament', 1)
 		end
 	end
 
 	--if specified also store in lpdb (custom for sc2)
-	if args.storage == 'true' then
+	if Logic.readBool(args.storage) then
 		local prizepool = CustomHiddenDataBox.cleanPrizePool(args.prizepool) or queryResult.prizepool
 		local lpdbData = {
 			name = Variables.varDefault('tournament_name'),

--- a/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
@@ -17,8 +17,8 @@ function CustomHiddenDataBox.run(args)
 	return BasicHiddenDataBox.run(args)
 end
 
-function CustomHiddenDataBox:addCustomVariables(args, queryResult)
-	BasicHiddenDataBox:checkAndAssign(
+function CustomHiddenDataBox.addCustomVariablesaddCustomVariables(args, queryResult)
+	BasicHiddenDataBox.checkAndAssign(
 		'tournament_publishertier',
 		args.riotpremier,
 		queryResult.publishertier

--- a/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/wildrift/hidden_data_box_custom.lua
@@ -17,7 +17,7 @@ function CustomHiddenDataBox.run(args)
 	return BasicHiddenDataBox.run(args)
 end
 
-function CustomHiddenDataBox.addCustomVariablesaddCustomVariables(args, queryResult)
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	BasicHiddenDataBox.checkAndAssign(
 		'tournament_publishertier',
 		args.riotpremier,


### PR DESCRIPTION
## Summary

Cleanup of HDB:
* Move from `:` to `.`, as no instance is ever being created
* Simplify `cleanDate` function
* Add support for legacy tier formatting in `validateTier`
* Change some `== 'true'` to `Logic.readBool()`
* Added warning for invalid parent

Participant Fetching:
* Add participant (player/staff of teams) fetcher. 
* * This information is retrieved from Placements LPDB, which is being set by the Team Cards.
* * The variables set can be overwritten by the wiki custom

## How did you test this change?

Tested on R6 so far with dev module. TCFetch seems to work. 
![image](https://user-images.githubusercontent.com/3426850/182577885-98476f50-6f6f-4034-8930-0f38c480db59.png)

Testing needs to be done on existing user of it. Some fields are not being set on R6, most likely because of lack of Custom var setting.