### PR TITLE
Tweaks to improve the display of Infobox person

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -14,6 +14,7 @@ local Variables = require('Module:Variables')
 local Namespace = require('Module:Namespace')
 local Localisation = require('Module:Localisation').getLocalisation
 local Flags = require('Module:Flags')
+local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Region = require('Module:Region')
 local AgeCalculation = require('Module:AgeCalculation')
@@ -125,16 +126,20 @@ function Person:createInfobox()
 			}
 		},
 		Customizable{id = 'teams', children = {
-			Cell{name = 'Team', content = {
-						self:_createTeam(args.team, args.teamlink),
-						self:_createTeam(args.team2, args.teamlink2),
-						self:_createTeam(args.team3, args.teamlink3),
-						self:_createTeam(args.team4, args.teamlink4),
-						self:_createTeam(args.team5, args.teamlink5)
-					}
+			Builder{builder = function()
+				local teams = {
+					self:_createTeam(args.team, args.teamlink),
+					self:_createTeam(args.team2, args.teamlink2),
+					self:_createTeam(args.team3, args.teamlink3),
+					self:_createTeam(args.team4, args.teamlink4),
+					self:_createTeam(args.team5, args.teamlink5)
 				}
-			}
-		},
+				return {Cell{
+					name = #teams > 1 and 'Teams' or 'Team',
+					content = teams
+				}}
+			end}
+		}},
 		Cell{name = 'Alternate IDs', content = {args.ids or args.alternateids}},
 		Cell{name = 'Nicknames', content = {args.nicknames}},
 		Builder{
@@ -406,10 +411,10 @@ function Person:_createTeam(team, link)
 
 	if mw.ext.TeamTemplate.teamexists(link) then
 		local data = mw.ext.TeamTemplate.raw(link)
-		return '[[' .. data.page .. '|' .. data.name .. ']]'
+		link, team = data.page, data.name
 	end
 
-	return '[[' .. link .. '|' .. team .. ']]'
+	return Page.makeInternalLink({onlyIfExists = true}, team, link) or team
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -18,7 +18,7 @@ local _MAXIMUM_DAYS_IN_FEBRUARY = 29
 local _MONTH_DECEMBER = 12
 local _CURRENT_YEAR = tonumber(mw.getContentLanguage():formatDate('Y'))
 
-local NONE_BREAKING_SPACE = '&nbsp;'
+local NON_BREAKING_SPACE = '&nbsp;'
 
 ---
 -- Represents a date
@@ -178,10 +178,10 @@ function Age:makeDisplay()
 
 	if age ~= nil then
 		if not self.deathDate.isEmpty then
-			result.death = self.deathDate:makeDisplay() .. NONE_BREAKING_SPACE .. '(aged ' .. age .. ')'
+			result.death = self.deathDate:makeDisplay() .. NON_BREAKING_SPACE .. '(aged ' .. age .. ')'
 			result.birth = self.birthDate:makeDisplay()
 		else
-			result.birth = self.birthDate:makeDisplay() .. NONE_BREAKING_SPACE .. '(age ' .. age .. ')'
+			result.birth = self.birthDate:makeDisplay() .. NON_BREAKING_SPACE .. '(age ' .. age .. ')'
 		end
 	else
 		result.death = self.deathDate:makeDisplay()

--- a/components/infobox/extensions/commons/age.lua
+++ b/components/infobox/extensions/commons/age.lua
@@ -18,6 +18,8 @@ local _MAXIMUM_DAYS_IN_FEBRUARY = 29
 local _MONTH_DECEMBER = 12
 local _CURRENT_YEAR = tonumber(mw.getContentLanguage():formatDate('Y'))
 
+local NONE_BREAKING_SPACE = '&nbsp;'
+
 ---
 -- Represents a date
 --
@@ -176,10 +178,10 @@ function Age:makeDisplay()
 
 	if age ~= nil then
 		if not self.deathDate.isEmpty then
-			result.death = self.deathDate:makeDisplay() .. ' (aged ' .. age .. ')'
+			result.death = self.deathDate:makeDisplay() .. NONE_BREAKING_SPACE .. '(aged ' .. age .. ')'
 			result.birth = self.birthDate:makeDisplay()
 		else
-			result.birth = self.birthDate:makeDisplay() .. ' (age ' .. age .. ')'
+			result.birth = self.birthDate:makeDisplay() .. NONE_BREAKING_SPACE .. '(age ' .. age .. ')'
 		end
 	else
 		result.death = self.deathDate:makeDisplay()


### PR DESCRIPTION
## Summary

- If the team of the player has no page, use plain text rather than a red link
- Change the space between age and the number to be non-breaking
- If multiple team input are set, use Teams rather than Team as Cell Name

Requested by CS Wiki

## How did you test this change?
To be tested