### PR TITLE
Add "individual" to tournament_extradata

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -139,7 +139,12 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_series2', _args.series2 or '')
 	Variables.varDefine('tournament_publisher', _args['ea-sponsored'] or '')
 	Variables.varDefine('tournament_pro_circuit_tier', _args.pctier or '')
-	Variables.varDefine('tournament_individual', _args.individual or '')
+	
+	local isIndividual = ''
+	if String.isNotEmpty(_args.player_number) then
+		isIndividual = 'true'
+	end
+	Variables.varDefine('tournament_individual', isIndividual')
 
 	local eaMajor = _args.eamajor
 	if String.isEmpty(eaMajor) then

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -144,7 +144,7 @@ function CustomLeague:defineCustomPageVariables()
 	if String.isNotEmpty(_args.player_number) then
 		isIndividual = 'true'
 	end
-	Variables.varDefine('tournament_individual', isIndividual')
+	Variables.varDefine('tournament_individual', isIndividual)
 
 	local eaMajor = _args.eamajor
 	if String.isEmpty(eaMajor) then

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -168,7 +168,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.publishertier = _args.pctier
 	lpdbData.extradata = {
 		['is ea major'] = Variables.varDefault('tournament_ea_major', '')
-		['individual'] = Variables.varDefault('tournament_individual', '')
+		individual = Variables.varDefault('tournament_individual', ''),
 	}
 
 	--retrieve sponsors from _args.sponsors if sponsorX, X=1,...,3, is empty

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -167,7 +167,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.participantsnumber = _args.team_number
 	lpdbData.publishertier = _args.pctier
 	lpdbData.extradata = {
-		['is ea major'] = Variables.varDefault('tournament_ea_major', '')
+		['is ea major'] = Variables.varDefault('tournament_ea_major', ''),
 		individual = Variables.varDefault('tournament_individual', ''),
 	}
 

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -139,6 +139,7 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_series2', _args.series2 or '')
 	Variables.varDefine('tournament_publisher', _args['ea-sponsored'] or '')
 	Variables.varDefine('tournament_pro_circuit_tier', _args.pctier or '')
+	Variables.varDefine('tournament_individual', _args.individual or '')
 
 	local eaMajor = _args.eamajor
 	if String.isEmpty(eaMajor) then
@@ -162,6 +163,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.publishertier = _args.pctier
 	lpdbData.extradata = {
 		['is ea major'] = Variables.varDefault('tournament_ea_major', '')
+		['individual'] = Variables.varDefault('tournament_individual', '')
 	}
 
 	--retrieve sponsors from _args.sponsors if sponsorX, X=1,...,3, is empty

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -139,7 +139,7 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_series2', _args.series2 or '')
 	Variables.varDefine('tournament_publisher', _args['ea-sponsored'] or '')
 	Variables.varDefine('tournament_pro_circuit_tier', _args.pctier or '')
-	
+
 	local isIndividual = ''
 	if String.isNotEmpty(_args.player_number) then
 		isIndividual = 'true'


### PR DESCRIPTION
## Summary

<!--
Solo tournaments are not being displayed correctly and are displaying players as team templates, as the extradata argument for "individual=true" is currently not supported.
-->

## How did you test this change?

<!--
I have not 
-->
