### PR TITLE
Add default header support for GSL style matchlists

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -42,7 +42,6 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 	local gslGroupStyle = (args.gsl or ''):lower()
 	if Table.includes(VALID_GSL_GROUP_STYLES, gslGroupStyle) then
 		for matchIndex, header in pairs(GSL_GROUP_STYLE_DEFAULT_HEADERS) do
-			--args.M1header = args.M1header or 'Opening Matches'
 			args['M' .. matchIndex .. 'header'] = Logic.emptyOr(
 				args['M' .. matchIndex .. 'header'],
 				header[gslGroupStyle],

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -24,8 +24,32 @@ local globalVars = PageVariableNamespace({cached = true})
 
 local MatchGroupInput = {}
 
+local GSL_GROUP_STYLE_DEFAULT_HEADERS = {
+	{default = 'Opening Matches'},
+	{},
+	{winnersfirst = 'Winners Match', losersfirst = 'Elimination Match'},
+	{winnersfirst = 'Elimination Match', losersfirst = 'Winners Match'},
+	{default = 'Decider Match'},
+}
+local VALID_GSL_GROUP_STYLES = {
+	'winnersfirst',
+	'losersfirst',
+}
+
 function MatchGroupInput.readMatchlist(bracketId, args)
 	local matchKeys = Table.mapArgumentsByPrefix(args, {'M'}, FnUtil.identity)
+
+	local gslGroupStyle = (args.gsl or ''):lower()
+	if Table.includes(VALID_GSL_GROUP_STYLES, gslGroupStyle) then
+		for matchIndex, header in pairs(GSL_GROUP_STYLE_DEFAULT_HEADERS) do
+			--args.M1header = args.M1header or 'Opening Matches'
+			args['M' .. matchIndex .. 'header'] = Logic.emptyOr(
+				args['M' .. matchIndex .. 'header'],
+				header[gslGroupStyle],
+				header.default
+			)
+		end
+	end
 
 	return Array.map(matchKeys, function(matchKey, matchIndex)
 			local matchId = MatchGroupInput._matchlistMatchIdFromIndex(matchIndex)


### PR DESCRIPTION
## Summary
Add default header support for GSL style matchlists

![Screenshot 2022-08-04 08 13 28](https://user-images.githubusercontent.com/75081997/182776967-71c28c9f-9343-4833-8faf-c6b7aa8626f8.png)
![Screenshot 2022-08-04 08 13 43](https://user-images.githubusercontent.com/75081997/182776973-fc19992c-0ff6-4945-b024-b96573b6ed17.png)
![Screenshot 2022-08-04 08 14 54](https://user-images.githubusercontent.com/75081997/182776974-e539edce-4bd0-491f-bcda-ebbdc0b18dd8.png)


suggested by CS, but imo a net gain for all wikis, as that format is quite common across wikis

## How did you test this change?
/dev module