### PR TITLE
Prepare sc2 match footer icons for darkmode

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -436,7 +436,7 @@ function StarcraftMatchSummary.Footer(props)
 	if hasFooter then
 		local linksNode = StarcraftMatchExternalLinks.MatchExternalLinks({links = links})
 			:node(headToHeadNode)
-			:addClass('brkts-popup-sc-footer-links')
+			:addClass('brkts-popup-sc-footer-links vodlink')
 		return html.create('div')
 			:addClass('brkts-popup-footer')
 			:addClass('brkts-popup-sc-footer')


### PR DESCRIPTION
## Summary
Prepare sc2 match footer icons for darkmode

before:
![Screenshot 2022-08-04 08 59 08](https://user-images.githubusercontent.com/75081997/182784165-867f1721-b9fb-40a6-bde9-a05392fe4e95.png)

after:
![Screenshot 2022-08-04 08 58 56](https://user-images.githubusercontent.com/75081997/182784161-1de0225a-2dad-4ffa-9a2f-6d434a0b04bc.png)

Remark: Currently that only affects dark-reader extension
for the proper darkmode the css has to be slightly adjusted once match2 has darkmode support
![IMG_4123](https://user-images.githubusercontent.com/75081997/182784450-424f3cc8-b8c4-43ca-bde5-770cb6c177f9.jpg)

see also https://discord.com/channels/93055209017729024/268719633366777856/1004604490068000908 and the messages thereafter

## How did you test this change?
/dev module