### PR TITLE
Prepare match footer icons for darkmode

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -202,7 +202,7 @@ local Footer = Class.new(
 		self.root = mw.html.create('div')
 		self.root:addClass('brkts-popup-footer')
 		self.inner = mw.html.create('div')
-		self.inner:addClass('brkts-popup-spaced')
+		self.inner:addClass('brkts-popup-spaced vodlink')
 	end
 )
 


### PR DESCRIPTION
## Summary
Prepare match footer icons for darkmode
analogous to #1611

## How did you test this change?
to be done

## To-Do
- [x] check customs if there are non icons in footers
- [x] check customs where this class is not used and adjust them too
- [x] test it
- [x] option for the non standard icons to also switch to darkmode (needs these icons as darkmode versions ...)