### PR TITLE
Adjust some icons to use darkmode friendly versions

### DIFF
--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -34,8 +34,8 @@ local _ICONS = {
 local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 local _LINK_DATA = {
 	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
-	preview = {icon = 'File:Preview Icon.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport.png', text = 'LiveReport.png'},
+	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
+	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 }
 
 

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -31,9 +31,9 @@ local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 -- Normal links, from input/lpdb
 local _LINK_DATA = {
 	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
-	preview = {icon = 'File:Preview Icon.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport.png', text = 'Live Report Thread'},
-	recap = {icon = 'File:Writers Icon.png', text = 'Recap'},
+	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
+	lrthread = {icon = 'File:LiveReport32.png', text = 'Live Report Thread'},
+	recap = {icon = 'File:Reviews32.png', text = 'Recap'},
 	headtohead = {icon = 'File:Match Info Stats.png', text = 'Head-to-head statistics'},
 	faceit = {icon = 'File:FACEIT-icon.png', text = 'FACEIT match room'},
 }

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -30,9 +30,9 @@ local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 -- Normal links, from input/lpdb
 local _LINK_DATA = {
 	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
-	preview = {icon = 'File:Preview Icon.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport.png', text = 'Live Report Thread'},
-	recap = {icon = 'File:Writers Icon.png', text = 'Recap'},
+	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
+	lrthread = {icon = 'File:LiveReport32.png', text = 'Live Report Thread'},
+	recap = {icon = 'File:Reviews32.png', text = 'Recap'},
 	reddit = {icon = 'File:Reddit-icon.png', text = 'Head-to-head statistics'},
 	gol = {icon = 'File:Gol.gg_allmode.png', text = 'GolGG Match Report'},
 }

--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -30,8 +30,8 @@ local _ICONS = {
 
 local _LINK_DATA = {
 	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
-	preview = {icon = 'File:Preview Icon.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport.png', text = 'LiveReport.png'},
+	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
+	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 	esl = {icon = 'File:ESL icon.png', text = 'Match page on ESL'},
 	owl = {icon = 'File:Overwatch League allmode.png', text = 'Overwatch League matchpage'},
 	owc = {icon = 'File:OWC-BMS icon.png', text = 'OW Contenders matchpage'},

--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -32,8 +32,8 @@ local _ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]
 local _ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
 local _LINK_DATA = {
 	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
-	preview = {icon = 'File:Preview Icon.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport.png', text = 'LiveReport.png'},
+	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
+	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 	siegegg = {icon = 'File:SiegeGG icon.png', text = 'SiegeGG Match Page'},
 	opl = {icon = 'File:OPL Icon.png', text = 'OPL Match Page'},
 	esl = {icon = 'File:ESL icon.png', text = 'Match page on ESL'},

--- a/components/match2/wikis/splitgate/match_summary.lua
+++ b/components/match2/wikis/splitgate/match_summary.lua
@@ -27,8 +27,8 @@ local _ICONS = {
 local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 local _LINK_DATA = {
 	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
-	preview = {icon = 'File:Preview Icon.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport.png', text = 'LiveReport.png'},
+	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
+	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 }
 
 local CustomMatchSummary = {}


### PR DESCRIPTION
## Summary
Adjust some icons to use darkmode friendly versions
`LiveReport.png` --> `LiveReport32.png`
`Preview Icon.png` --> `Preview Icon32.png`
`Writers Icon.png` --> `Reviews32.png`

## How did you test this change?
n/a, just switching file targets