### PR TITLE
Create Squad Custom for League

### DIFF
--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -1,0 +1,136 @@
+---
+-- @Liquipedia
+-- wiki=rainbowsix
+-- page=Module:Squad/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Json = require('Module:Json')
+local ReferenceCleaner = require('Module:ReferenceCleaner')
+local Squad = require('Module:Squad')
+local SquadRow = require('Module:Squad/Row')
+local SquadAutoRefs = require('Module:SquadAuto/References')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local CustomSquad = {}
+
+local ExtendedSquadRow = Class.new(SquadRow)
+
+function ExtendedSquadRow:position(args)
+	local cell = mw.html.create('td')
+	cell:addClass('Position')
+
+	if String.isNotEmpty(args.position) or String.isNotEmpty(args.role) then
+		cell:node(mw.html.create('div'):addClass('MobileStuff'):wikitext('Position:&nbsp;'))
+
+		if String.isNotEmpty(args.position) then
+			cell:wikitext(args.position)
+			if String.isNotEmpty(args.role) then
+				cell:wikitext('&nbsp;(' .. args.role .. ')')
+			end
+		elseif String.isNotEmpty(args.role) then
+			cell:wikitext(args.role)
+		end
+	end
+
+	self.content:node(cell)
+
+	self.lpdbData.position = args.position
+	self.lpdbData.role = args.role
+
+	return self
+end
+
+function CustomSquad.run(frame)
+	local squad = Squad()
+
+	squad:init(frame):title()
+
+	local args = squad.args
+
+	squad.header = CustomSquad.header
+	squad:header()
+
+	local index = 1
+	while args['p' .. index] or args[index] do
+		local player = Json.parseIfString(args['p' .. index] or args[index])
+
+		squad:row(CustomSquad._playerRow(player, squad.type))
+
+		index = index + 1
+	end
+
+	return squad:create()
+end
+
+function CustomSquad.runAuto(playerList, squadType)
+	if Table.isEmpty(playerList) then
+		return
+	end
+
+	local squad = Squad()
+	squad:init(mw.getCurrentFrame())
+
+	squad.type = squadType
+
+	squad:title():header()
+
+	for _, player in pairs(playerList) do
+		--Get Reference(s)
+		local joinReference = SquadAutoRefs.useReferences(player.joindateRef, player.joindate)
+		local leaveReference = SquadAutoRefs.useReferences(player.leavedateRef, player.leavedate)
+
+		-- Map between formats
+		player.joindate = (player.joindatedisplay or player.joindate) .. ' ' .. joinReference
+		player.leavedate = (player.leavedatedisplay or player.leavedate) .. ' ' .. leaveReference
+		player.inactivedate = player.leavedate
+
+		player.role = player.thisTeam.role
+		player.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
+
+		player.newteam = player.newTeam.team
+		player.newteamrole = player.newTeam.role
+		player.newteamdate = player.newTeam.date
+
+		squad:row(CustomSquad._playerRow(player, squad.type))
+	end
+
+	return squad:create()
+end
+
+function CustomSquad._playerRow(player, squadType)
+	local row = ExtendedSquadRow(mw.getCurrentFrame(), player.role)
+
+	row:id({
+		(player.idleavedate or player.id),
+		flag = player.flag,
+		link = player.page,
+		captain = player.captain,
+		role = player.role,
+		team = player.team,
+	})
+	row:name{name = player.name}
+	row:role{role = player.role}
+	row:date(player.joindate, 'Join Date:&nbsp;', 'joindate')
+
+	if squadType == Squad.TYPE_FORMER then
+		row:date(player.leavedate, 'Leave Date:&nbsp;', 'leavedate')
+		row:newteam{
+			newteam = player.newteam,
+			newteamrole = player.newteamrole,
+			newteamdate = player.newteamdate,
+			leavedate = player.leavedate
+		}
+	elseif squadType == Squad.TYPE_INACTIVE then
+		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
+	end
+
+	return row:create(
+		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+	)
+end
+
+return CustomSquad


### PR DESCRIPTION
## Summary

Create Custom Squad implementation for League of Legends. It's a based of a mix of R6 (since League partially uses AutoSquadTables) and dota2 (since both League and dota2 has positions).

## How did you test this change?
Test scenarios:

**Squad Auto Active:**
Old: 
![image](https://user-images.githubusercontent.com/3426850/182834789-2bc5e7e9-644f-4fdc-96ad-27e9d7ac17c0.png)

New:
![image](https://user-images.githubusercontent.com/3426850/182834806-c8294202-43dc-4689-b3c9-b5f882acd232.png)

**Squad Auto Former:**
Old:
![image](https://user-images.githubusercontent.com/3426850/182835214-123d2196-2ebd-4379-b0b4-d199c37c9356.png)

New:
![image](https://user-images.githubusercontent.com/3426850/182835230-2fbcbda4-c810-4355-b92a-df75410f6540.png)

**Manual Active:**
Old:
![image](https://user-images.githubusercontent.com/3426850/182842111-6b2c4cd9-ea8b-447e-835e-a0d61a4aa269.png)

New:
![image](https://user-images.githubusercontent.com/3426850/182842136-cbad482f-4557-4356-8b88-b2f6cb415b88.png)

**Manual Former:**
Old:
![image](https://user-images.githubusercontent.com/3426850/182842331-bdcf7014-dcff-4e35-b0f7-146fc4f48b28.png)

New:
![image](https://user-images.githubusercontent.com/3426850/182842351-c232bc9b-5d84-47cc-a211-381757d24691.png)
