### PR TITLE
Map CS Steam to SteamAlternative

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
@@ -67,6 +67,8 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 
 	player.args.history = player.args.team_history
+	player.args.steamalternative = player.args.steam
+	player.args.steam = nil
 
 	player.args.informationType = player.args.informationType or 'Player'
 


### PR DESCRIPTION
## Summary

CS uses `|steam=` input for what would be `link.steamalternative`. Map the input accordingly.

## How did you test this change?
Live
