### PR TITLE
Add support for non standard opponent types to prize pool display

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -35,8 +35,6 @@ local WidgetTable = require('Module:Widget/Table')
 local TableRow = require('Module:Widget/Table/Row')
 local TableCell = require('Module:Widget/Table/Cell')
 
-local EMPTY_TEAM = '[[File:Logo_filler_std.png|link=]]'
-
 --- @class PrizePool
 local PrizePool = Class.new(function(self, ...) self:init(...) end)
 
@@ -53,6 +51,7 @@ local LANG = mw.language.getContentLanguage()
 local DASH = '&#045;'
 local NON_BREAKING_SPACE = '&nbsp;'
 local BASE_CURRENCY = 'USD'
+local EMPTY_TEAM = mw.html.create('div'):css('text-align', 'center'):wikitext(DASH)
 
 local PRIZE_TYPE_USD = 'USD'
 local PRIZE_TYPE_LOCAL_CURRENCY = 'LOCAL_CURRENCY'

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1016,8 +1016,9 @@ function Placement:_getLpdbData()
 	for _, opponent in ipairs(self.opponents) do
 		local participant, image, imageDark, players
 		local playerCount = 0
+		local opponentType = opponent.opponentData.type
 
-		if opponent.opponentData.type == Opponent.team then
+		if opponentType == Opponent.team then
 			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template)
 
 			participant = teamTemplate and teamTemplate.page or ''
@@ -1027,7 +1028,7 @@ function Placement:_getLpdbData()
 
 			image = teamTemplate.image
 			imageDark = teamTemplate.imagedark
-		elseif opponent.opponentData.type == Opponent.solo then
+		elseif opponentType == Opponent.solo then
 			participant = Opponent.toName(opponent.opponentData)
 			local p1 = opponent.opponentData.players[1]
 			players = {p1 = p1.pageName, p1dn = p1.displayName, p1flag = p1.flag, p1team = p1.team}
@@ -1038,7 +1039,6 @@ function Placement:_getLpdbData()
 
 		local prizeMoney = tonumber(self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_USD .. 1)) or 0
 		local pointsReward = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
-		local opponentType = opponent.opponentData.type
 		local lpdbData = {
 			image = image,
 			imagedark = imageDark,

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1045,7 +1045,7 @@ function Placement:_getLpdbData()
 			date = opponent.date,
 			participant = participant,
 			participantlink = Opponent.toName(opponent.opponentData),
-			participantflag = opponentType == Opponent.solo and (players or {}).p1flag or nil,
+			participantflag = opponentType == Opponent.solo and players.p1flag or nil,
 			participanttemplate = opponent.opponentData.template,
 			opponenttype = opponentType,
 			players = players,


### PR DESCRIPTION
## Summary
Add support for non standard opponent types to prize pool display, namely
- duo
- trio
- quad
- archon (subtype of duo on sc2)

if those opponent types are supported by the opponent/opponentdisplay modules

also slightly adjust participantflag (deprecated) storage for those opponent types (i.e. onyl store into that field for solo opponents)

## How did you test this change?
/dev

## Remark
the `EMPTY_TEAM` is needed due to spacing

https://liquipedia.net/starcraft2/User:Hjpalpha/PPT#EUL