### PR TITLE
Fix `|link=` in manual squad tables on League

### DIFF
--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -88,6 +88,7 @@ function CustomSquad.runAuto(playerList, squadType)
 		player.leavedate = (player.leavedatedisplay or player.leavedate) .. ' ' .. leaveReference
 		player.inactivedate = player.leavedate
 
+		player.link = player.page
 		player.role = player.thisTeam.role
 		player.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
 
@@ -107,7 +108,7 @@ function CustomSquad._playerRow(player, squadType)
 	row:id({
 		(player.idleavedate or player.id),
 		flag = player.flag,
-		link = player.page,
+		link = player.link,
 		captain = player.captain,
 		role = player.role,
 		team = player.team,


### PR DESCRIPTION
## Summary

The current link code expects `|page=`, due to the property is called `page` in the automatic squad table. The manual table should still accept `|link=`. This PR changes the fields the row looks for from `page` to `link`, and maps the auto tables `page` to `link`.

## How did you test this change?
Live since last night