### PR TITLE
Add basic (common) match2 extradata lpdb storage

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -321,8 +321,22 @@ function Match._prepareMatchRecordForStore(match)
 	match.match2bracketid = match.match2bracketid or match.bracketid
 	match.match2id = match.match2id or match.bracketid .. '_' .. match.matchid
 	match.section = Match._getSection()
+	match.extradata = Match._addCommonMatchExtradata(match)
 	Match.clampFields(match, Match.matchFields)
 end
+
+function Match._addCommonMatchExtradata(match)
+	local commonExtradata = {
+		comment = match.comment,
+		matchsection = Variables.varDefault('matchsection'),
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
+	}
+
+	return Table.merge(commonExtradata, match.extradata or {})
+end
+
+
 
 function Match._getSection()
 	local cleanHtml = function(rawString)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -267,10 +267,11 @@ end
 function MatchGroupInput.readDate(dateString)
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>
 	local timezoneOffset = dateString:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
+	local timezoneId = dateString:match('>(%a-)<')
 	local matchDate = String.explode(dateString, '<', 0):gsub('-', '')
 	local isDateExact = String.contains(matchDate .. (timezoneOffset or ''), '[%+%-]')
 	local date = getContentLanguage():formatDate('c', matchDate .. (timezoneOffset or ''))
-	return {date = date, dateexact = isDateExact}
+	return {date = date, dateexact = isDateExact, timezoneId = timezoneId, timezoneOffset = timezoneOffset}
 end
 
 function MatchGroupInput.getInexactDate(suggestedDate)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -167,11 +167,7 @@ function StarcraftMatchGroupInput._getExtraData(match)
 		extradata = getStarcraftFfaInputModule().getExtraData(match)
 	else
 		extradata = {
-			timezoneid = match.timezoneId,
-			timezoneoffset = match.timezoneOffset,
 			noQuery = match.noQuery,
-			matchsection = Variables.varDefault('matchsection'),
-			comment = match.comment,
 			featured = match.featured,
 			casters = match.casters,
 			headtohead = match.headtohead,

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -167,8 +167,8 @@ function StarcraftMatchGroupInput._getExtraData(match)
 		extradata = getStarcraftFfaInputModule().getExtraData(match)
 	else
 		extradata = {
-			timezoneid = timezoneId,
-			timezoneoffset = timezoneOffset,
+			timezoneid = match.timezoneId,
+			timezoneoffset = match.timezoneOffset,
 			noQuery = match.noQuery,
 			matchsection = Variables.varDefault('matchsection'),
 			comment = match.comment,

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -167,6 +167,8 @@ function StarcraftMatchGroupInput._getExtraData(match)
 		extradata = getStarcraftFfaInputModule().getExtraData(match)
 	else
 		extradata = {
+			timezoneid = timezoneId,
+			timezoneoffset = timezoneOffset,
 			noQuery = match.noQuery,
 			matchsection = Variables.varDefault('matchsection'),
 			comment = match.comment,

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -132,8 +132,6 @@ end
 --function to get extradata for storage
 function StarcraftFfaInput.getExtraData(match)
 	local extradata = {
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		featured = match.featured,
 		veto1by = String.nilIfEmpty(match.vetoplayer1) or match.vetoopponent1,
 		veto1 = match.veto1,

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -10,7 +10,6 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local Variables = require('Module:Variables')
 
 local StarcraftMatchGroupInput = Lua.import('Module:MatchGroup/Input/Starcraft', {requireDevIfEnabled = true})
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})

--- a/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
@@ -336,6 +336,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		mvp = match.mvp,

--- a/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/matchgroup_input_custom.lua
@@ -336,10 +336,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		mvp = match.mvp,
 		mvpteam = match.mvpteam or match.winner
 	}

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -162,6 +162,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		mvp = match.mvp,

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -162,10 +162,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		mvp = match.mvp,
 	}
 	return match

--- a/components/match2/wikis/dota2/matchgroup_input_custom.lua
+++ b/components/match2/wikis/dota2/matchgroup_input_custom.lua
@@ -391,6 +391,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		featured = Logic.emptyOr(

--- a/components/match2/wikis/dota2/matchgroup_input_custom.lua
+++ b/components/match2/wikis/dota2/matchgroup_input_custom.lua
@@ -391,10 +391,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		featured = Logic.emptyOr(
 			match.featured,
 			matchFunctions.isFeatured(match)

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -325,6 +325,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		mvp = matchFunctions.getMVP(match),

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -325,10 +325,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		mvp = matchFunctions.getMVP(match),
 		isconverted = 0
 	}

--- a/components/match2/wikis/leagueoflegends/matchgroup_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/matchgroup_input_custom.lua
@@ -387,10 +387,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		mvp = matchFunctions.getMVP(match),
 	}
 	return match

--- a/components/match2/wikis/leagueoflegends/matchgroup_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/matchgroup_input_custom.lua
@@ -387,6 +387,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		mvp = matchFunctions.getMVP(match),

--- a/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
@@ -336,6 +336,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		mvp = match.mvp,

--- a/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/matchgroup_input_custom.lua
@@ -336,10 +336,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		mvp = match.mvp,
 		mvpteam = match.mvpteam or match.winner
 	}

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -345,6 +345,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		comment = match.comment,
 		mvp = matchFunctions.getMVP(match),
 	}

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -345,9 +345,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		comment = match.comment,
 		mvp = matchFunctions.getMVP(match),
 	}
 	return match

--- a/components/match2/wikis/pokemon/matchgroup_input_custom.lua
+++ b/components/match2/wikis/pokemon/matchgroup_input_custom.lua
@@ -336,6 +336,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		mvp = match.mvp,

--- a/components/match2/wikis/pokemon/matchgroup_input_custom.lua
+++ b/components/match2/wikis/pokemon/matchgroup_input_custom.lua
@@ -336,10 +336,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		mvp = match.mvp,
 		mvpteam = match.mvpteam or match.winner
 	}

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -352,6 +352,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		lastgame = Variables.varDefault('last_game'),
 		comment = match.comment,

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -352,11 +352,7 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
 		lastgame = Variables.varDefault('last_game'),
-		comment = match.comment,
 		mapveto = matchFunctions.getMapVeto(match),
 		mvp = matchFunctions.getMVP(match),
 		isconverted = 0

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -199,13 +199,9 @@ function matchFunctions.getExtraData(match)
 	table.sort(casters, function(c1, c2) return c1.displayName:lower() < c2.displayName:lower() end)
 
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
 		team1icon = getIconName(opponent1.template or ''),
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
-		comment = match.comment,
 		octane = match.octane,
 		isconverted = 0,
 		isfeatured = matchFunctions.isFeatured(match),

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -199,6 +199,8 @@ function matchFunctions.getExtraData(match)
 	table.sort(casters, function(c1, c2) return c1.displayName:lower() < c2.displayName:lower() end)
 
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		team1icon = getIconName(opponent1.template or ''),
 		team2icon = getIconName(opponent2.template or ''),

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -141,6 +141,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		isfeatured = matchFunctions.isFeatured(match)

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -141,10 +141,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		isfeatured = matchFunctions.isFeatured(match)
 	}
 	return match

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -331,9 +331,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		comment = match.comment,
 		mapveto = matchFunctions.getMapVeto(match),
 		mvp = matchFunctions.getMVP(match),
 		isconverted = 0

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -331,6 +331,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		comment = match.comment,
 		mapveto = matchFunctions.getMapVeto(match),
 		mvp = matchFunctions.getMVP(match),

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -340,12 +340,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
 		mapveto = matchFunctions.getMapVeto(match),
 		mvp = matchFunctions.getMVP(match),
-		comment = match.comment,
 	}
 	return match
 end

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -340,6 +340,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		mapveto = matchFunctions.getMapVeto(match),
 		mvp = matchFunctions.getMVP(match),

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -336,6 +336,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
+		timezoneid = match.timezoneId,
+		timezoneoffset = match.timezoneOffset,
 		matchsection = Variables.varDefault('matchsection'),
 		comment = match.comment,
 		mvp = match.mvp,

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -336,10 +336,6 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		timezoneid = match.timezoneId,
-		timezoneoffset = match.timezoneOffset,
-		matchsection = Variables.varDefault('matchsection'),
-		comment = match.comment,
 		mvp = match.mvp,
 		mvpteam = match.mvpteam or match.winner
 	}


### PR DESCRIPTION
## Summary
Add timeZone storage to match2 & move common extradata to commons

## How did you test this change?
/dev modules
![Screenshot 2022-08-05 14 20 54](https://user-images.githubusercontent.com/75081997/183076161-59661e1f-6b62-4b9e-a388-2915f3c28f52.png)

