### PR TITLE
Remove cybergamer from Links

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -206,7 +206,6 @@ function Links.transform(links)
 		challonge3 = links.challonge3,
 		challonge4 = links.challonge4,
 		challonge5 = links.challonge5,
-		cybergamer = links.cybergamer,
 		datdota = links.datdota,
 		daumcafe = links.daumcafe,
 		discord = links.discord,


### PR DESCRIPTION
## Summary

CyberGamer was acquired by LPL and is already setup as an alias of LPL, it shouldn't be here.

## How did you test this change?
Live