### PR TITLE
Create HDB for Valorant

### DIFF
--- a/components/hidden_data_box/wikis/valorant/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/valorant/hidden_data_box_custom.lua
@@ -45,10 +45,7 @@ function CustomHiddenDataBox.setWikiVariableForParticipantKey(participant, parti
 
 	-- Used in match1, remove once legacy is convert to match2 is done
 	local frame = mw.getCurrentFrame()
-	mw.log(key)
-	mw.log(key:sub(1,1) == 'p' and key:len() == 2)
 	if key:sub(1,1) == 'p' and key:len() == 2 then
-		mw.log(participant, value)
 		-- Skipping Flag, this was 100% broken in the before now anyway
 		frame:callParserFunction{name = '#arraydefine:temp_player_info', args = {value .. ','}}
 		if String.isEmpty(frame:callParserFunction{name = '#arrayprint:' .. participant .. '_players_info'}) then

--- a/components/hidden_data_box/wikis/valorant/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/valorant/hidden_data_box_custom.lua
@@ -1,0 +1,69 @@
+---
+-- @Liquipedia
+-- wiki=valorant
+-- page=Module:HiddenDataBox/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local String = require('Module:StringUtils')
+local Tier = mw.loadData('Module:Tier')
+local Variables = require('Module:Variables')
+
+local BasicHiddenDataBox = require('Module:HiddenDataBox')
+local CustomHiddenDataBox = {}
+
+function CustomHiddenDataBox.run(args)
+	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+	BasicHiddenDataBox.setWikiVariableForParticipantKey = CustomHiddenDataBox.setWikiVariableForParticipantKey
+	args.liquipediatier = Tier.number[args.liquipediatier]
+	return BasicHiddenDataBox.run(args)
+end
+
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	Variables.varDefine('tournament_parent_name', Variables.varDefault('tournament_parentname'))
+	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier'))
+	Variables.varDefine('tournament_tiertype', Variables.varDefault('tournament_liquipediatiertype'))
+	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
+	Variables.varDefine('tournament_icon_darkmode', Variables.varDefault('tournament_icondark'))
+	Variables.varDefine('mode', Variables.varDefault('tournament_mode', 'team'))
+	Variables.varDefine('female', queryResult.extradata.female or args.female and 'true' or 'false')
+	BasicHiddenDataBox.checkAndAssign('patch', args.patch, queryResult.patch)
+	BasicHiddenDataBox.checkAndAssign('tournament_riot_premier', queryResult.tournament_riot_premier, args.riotpremier)
+end
+
+function CustomHiddenDataBox.setWikiVariableForParticipantKey(participant, participantResolved, key, value)
+	Variables.varDefine(participant .. '_' .. key, value)
+	if participant ~= participantResolved then
+		Variables.varDefine(participantResolved .. key, value)
+	end
+
+	-- Used in match1, remove once legacy is convert to match2 is done
+	local frame = mw.getCurrentFrame()
+	mw.log(key)
+	mw.log(key:sub(1,1) == 'p' and key:len() == 2)
+	if key:sub(1,1) == 'p' and key:len() == 2 then
+		mw.log(participant, value)
+		-- Skipping Flag, this was 100% broken in the before now anyway
+		frame:callParserFunction{name = '#arraydefine:temp_player_info', args = {value .. ','}}
+		if String.isEmpty(frame:callParserFunction{name = '#arrayprint:' .. participant .. '_players_info'}) then
+
+			frame:callParserFunction{
+				name = '#arraymerge:' .. participant .. '_players_info',
+				args = {'temp_player_info'}
+			}
+		else
+			frame:callParserFunction{
+				name = '#arraymerge:' .. participant .. '_players_info',
+				args = {participant .. '_players_info', 'temp_player_info'}
+			}
+		end
+	end
+end
+
+return Class.export(CustomHiddenDataBox)


### PR DESCRIPTION
## Summary

Create HDB custom for Valorant, setting the custom wiki vars that Valorant are setting in their current template based HDB.
Also fixed match1 players being broken, opted to not include flags atm (since they were broken before anyway and it would complicate stuff).

## How did you test this change?

Dev template and compared the data in LPDB on a test page.