### PR TITLE
Add `Module:Infobox/Extensions/PrizePool`

### DIFF
--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -92,4 +92,18 @@ function Currency.formatMoney(value)
 	return LANG:formatNum(integer) .. string.format('%.2f', decimal):sub(2)
 end
 
+function Currency.getExchangeRate(props)
+	local setVariables = Logic.readBool(props.setVariables)
+	local currencyRate = tonumber(props.currencyRate)
+	if not currencyRate then
+		currencyRate = mw.ext.CurrencyExchange.currencyexchange(1, props.currency:upper(), USD, props.date)
+	end
+
+	if setVariables and String.isNotEmpty(currencyRate) then
+		Variables.varDefine(props.currency .. '_rate', currencyRate)
+	end
+
+	return tonumber(currencyRate)
+end
+
 return Currency


### PR DESCRIPTION
## Summary
* Add `Module:Infobox/Extensions/PrizePool`, a cleaned up version of https://liquipedia.net/commons/Module:Prize_pool_currency
* Add `getExchangeRate` function to `Module:Currency`
--> usable in infobox league/series via the other module that gets added
--> usable for Prize pools to get the exchange rate if it isn't yet set by (to solve #1631 in a later PR)

## How did you test this change?
to be done, but an initial review is appreciated