### PR TITLE
Update non team opponent display in prize pools

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -86,6 +86,7 @@ MatchGroupUtil.types.Player = TypeUtil.struct({
 	displayName = 'string?',
 	flag = 'string?',
 	pageName = 'string?',
+	team = 'string?',
 })
 
 MatchGroupUtil.types.Opponent = TypeUtil.struct({

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -181,7 +181,7 @@ function OpponentDisplay.BlockOpponent(props)
 			showFlag = props.showFlag,
 			showLink = showLink,
 			showPlayerTeam = props.showPlayerTeam,
-			team = player.team,
+			team = opponent.players[1].team,
 		})
 	else
 		error('Unrecognized opponent.type ' .. opponent.type)

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -181,7 +181,6 @@ function OpponentDisplay.BlockOpponent(props)
 			showFlag = props.showFlag,
 			showLink = showLink,
 			showPlayerTeam = props.showPlayerTeam,
-			team = opponent.players[1].team,
 		})
 	else
 		error('Unrecognized opponent.type ' .. opponent.type)

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -145,6 +145,7 @@ OpponentDisplay.propTypes.BlockOpponent = {
 	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
 	showFlag = 'boolean?',
 	showLink = 'boolean?',
+	showPlayerTeam = 'boolean?',
 	teamStyle = TypeUtil.optional(OpponentDisplay.types.TeamStyle),
 }
 
@@ -179,6 +180,8 @@ function OpponentDisplay.BlockOpponent(props)
 			player = opponent.players[1],
 			showFlag = props.showFlag,
 			showLink = showLink,
+			showPlayerTeam = props.showPlayerTeam,
+			team = player.team,
 		})
 	else
 		error('Unrecognized opponent.type ' .. opponent.type)

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -28,7 +28,6 @@ PlayerDisplay.propTypes.BlockPlayer = {
 	showFlag = 'boolean?',
 	showLink = 'boolean?',
 	showPlayerTeam = 'boolean?',
-	team = 'string?',
 }
 
 --[[
@@ -53,10 +52,10 @@ function PlayerDisplay.BlockPlayer(props)
 	end
 
 	local teamNode
-	if props.showPlayerTeam and props.team and props.team:lower() ~= 'tbd' then
+	if props.showPlayerTeam and player.team and player.team:lower() ~= 'tbd' then
 		teamNode = mw.html.create('span')
 			:wikitext('&nbsp;')
-			:node(mw.ext.TeamTemplate.teampart(props.team))
+			:node(mw.ext.TeamTemplate.teampart(player.team))
 	end
 
 	return mw.html.create('div'):addClass('block-player')

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -61,7 +61,7 @@ function PlayerDisplay.BlockPlayer(props)
 
 	return mw.html.create('div'):addClass('block-player')
 		:addClass(props.flip and 'flipped' or nil)
-		:addClass(props.showPlayerTeam and 'hast-team' or nil)
+		:addClass(props.showPlayerTeam and 'has-team' or nil)
 		:node(flagNode)
 		:node(nameNode)
 		:node(teamNode)

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -54,7 +54,7 @@ function PlayerDisplay.BlockPlayer(props)
 
 	local teamNode
 	if props.showPlayerTeam and props.team and props.team:lower() ~= 'tbd' then
-		teamNode = html.create('span')
+		teamNode = mw.html.create('span')
 			:wikitext('&nbsp;')
 			:node(mw.ext.TeamTemplate.teampart(props.team))
 	end

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -27,6 +27,8 @@ PlayerDisplay.propTypes.BlockPlayer = {
 	player = MatchGroupUtil.types.Player,
 	showFlag = 'boolean?',
 	showLink = 'boolean?',
+	showPlayerTeam = 'boolean?',
+	team = 'string?',
 }
 
 --[[
@@ -50,10 +52,20 @@ function PlayerDisplay.BlockPlayer(props)
 		flagNode = PlayerDisplay.Flag(player.flag)
 	end
 
+	local teamNode
+	if props.showPlayerTeam and props.team and props.team:lower() ~= 'tbd' then
+		teamNode = html.create('span')
+			:wikitext('&nbsp;')
+			:node(mw.ext.TeamTemplate.teampart(props.team))
+	end
+
 	return mw.html.create('div'):addClass('block-player')
 		:addClass(props.flip and 'flipped' or nil)
+		:addClass(props.showPlayerTeam and 'block-player-with-team' or nil)
+		:cssText(props.showPlayerTeam and 'width: 100%' or nil)--move into above class
 		:node(flagNode)
 		:node(nameNode)
+		:node(teamNode)
 end
 
 PlayerDisplay.propTypes.InlinePlayer = {

--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -61,8 +61,7 @@ function PlayerDisplay.BlockPlayer(props)
 
 	return mw.html.create('div'):addClass('block-player')
 		:addClass(props.flip and 'flipped' or nil)
-		:addClass(props.showPlayerTeam and 'block-player-with-team' or nil)
-		:cssText(props.showPlayerTeam and 'width: 100%' or nil)--move into above class
+		:addClass(props.showPlayerTeam and 'hast-team' or nil)
 		:node(flagNode)
 		:node(nameNode)
 		:node(teamNode)

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -171,7 +171,6 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 			showLink = props.showLink,
 			showPlayerTeam = props.showPlayerTeam,
 			showRace = showRace and not opponent.isArchon and not opponent.isSpecialArchon,
-			team = player.team,
 		})
 			:addClass(props.playerClass)
 	end)

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -188,14 +188,12 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 			playerNodes = playerNodes,
 			raceNode = html.create('div'):wikitext(raceIcon),
 		})
-		:css('width', '100%')
-		:addClass(props.showPlayerTeam and 'className' or nil)
+		:addClass(props.showPlayerTeam and 'player-has-team' or nil)
 
 	elseif showRace and opponent.isSpecialArchon then
 		local archonsNode = html.create('div')
 			:addClass('starcraft-special-archon-block-opponent')
-			:css('width', '100%')
-			:addClass(props.showPlayerTeam and 'className' or nil)
+			:addClass(props.showPlayerTeam and 'player-has-team' or nil)
 		for archonIx = 1, #opponent.players / 2 do
 			local primaryRace = opponent.players[2 * archonIx - 1].race
 			local secondaryRace = opponent.players[2 * archonIx].race
@@ -226,8 +224,7 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 
 	else
 		local playersNode = html.create('div')
-			:css('width', '100%')
-			:addClass(props.showPlayerTeam and 'className' or nil)
+			:addClass(props.showPlayerTeam and 'player-has-team' or nil)
 		for _, playerNode in ipairs(playerNodes) do
 			playersNode:node(playerNode)
 		end

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -66,6 +66,7 @@ StarcraftOpponentDisplay.propTypes.BlockOpponent = {
 	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
 	showFlag = 'boolean?',
 	showLink = 'boolean?',
+	showPlayerTeam = 'boolean?',
 	showRace = 'boolean?',
 	teamStyle = TypeUtil.optional(OpponentDisplay.types.TeamStyle),
 	playerClass = 'string?',
@@ -168,7 +169,9 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 			player = player,
 			showFlag = props.showFlag,
 			showLink = props.showLink,
+			showPlayerTeam = props.showPlayerTeam,
 			showRace = showRace and not opponent.isArchon and not opponent.isSpecialArchon,
+			team = player.team,
 		})
 			:addClass(props.playerClass)
 	end)
@@ -185,10 +188,14 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 			playerNodes = playerNodes,
 			raceNode = html.create('div'):wikitext(raceIcon),
 		})
+		:css('width', '100%')
+		:addClass(props.showPlayerTeam and 'className' or nil)
 
 	elseif showRace and opponent.isSpecialArchon then
 		local archonsNode = html.create('div')
 			:addClass('starcraft-special-archon-block-opponent')
+			:css('width', '100%')
+			:addClass(props.showPlayerTeam and 'className' or nil)
 		for archonIx = 1, #opponent.players / 2 do
 			local primaryRace = opponent.players[2 * archonIx - 1].race
 			local secondaryRace = opponent.players[2 * archonIx].race
@@ -219,6 +226,8 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 
 	else
 		local playersNode = html.create('div')
+			:css('width', '100%')
+			:addClass(props.showPlayerTeam and 'className' or nil)
 		for _, playerNode in ipairs(playerNodes) do
 			playersNode:node(playerNode)
 		end

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -75,7 +75,7 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 
 	return html.create('div'):addClass('block-player starcraft-block-player')
 		:addClass(props.flip and 'flipped' or nil)
-		:addClass(props.showPlayerTeam and 'hast-team' or nil)
+		:addClass(props.showPlayerTeam and 'has-team' or nil)
 		:node(flagNode)
 		:node(raceNode)
 		:node(nameNode)

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -32,8 +32,10 @@ StarcraftPlayerDisplay.propTypes.BlockPlayer = {
 	flip = 'boolean?',
 	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
 	player = StarcraftMatchGroupUtil.types.Player,
+	team = 'string?',
 	showFlag = 'boolean?',
 	showLink = 'boolean?',
+	showPlayerTeam = 'boolean?',
 	showRace = 'boolean?',
 }
 
@@ -64,11 +66,21 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 			:wikitext(StarcraftPlayerDisplay.Race(player.race))
 	end
 
+	local teamNode
+	if props.showPlayerTeam ~= false and props.team and props.team:lower() ~= 'tbd' then
+		teamNode = html.create('span')
+			:wikitext('&nbsp;')
+			:node(mw.ext.TeamTemplate.teampart(props.team))
+	end
+
 	return html.create('div'):addClass('block-player starcraft-block-player')
 		:addClass(props.flip and 'flipped' or nil)
+		:addClass(props.showPlayerTeam and 'block-player-with-team' or nil)
+		:cssText(props.showPlayerTeam and 'width: 100%' or nil)--move into above class
 		:node(flagNode)
 		:node(raceNode)
 		:node(nameNode)
+		:node(teamNode)
 end
 
 -- Called from Template:Player and Template:Player2

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -32,7 +32,6 @@ StarcraftPlayerDisplay.propTypes.BlockPlayer = {
 	flip = 'boolean?',
 	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
 	player = StarcraftMatchGroupUtil.types.Player,
-	team = 'string?',
 	showFlag = 'boolean?',
 	showLink = 'boolean?',
 	showPlayerTeam = 'boolean?',
@@ -67,10 +66,10 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 	end
 
 	local teamNode
-	if props.showPlayerTeam and props.team and props.team:lower() ~= 'tbd' then
+	if props.showPlayerTeam and player.team and player.team:lower() ~= 'tbd' then
 		teamNode = html.create('span')
 			:wikitext('&nbsp;')
-			:node(mw.ext.TeamTemplate.teampart(props.team))
+			:node(mw.ext.TeamTemplate.teampart(player.team))
 	end
 
 	return html.create('div'):addClass('block-player starcraft-block-player')

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -67,7 +67,7 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 	end
 
 	local teamNode
-	if props.showPlayerTeam ~= false and props.team and props.team:lower() ~= 'tbd' then
+	if props.showPlayerTeam and props.team and props.team:lower() ~= 'tbd' then
 		teamNode = html.create('span')
 			:wikitext('&nbsp;')
 			:node(mw.ext.TeamTemplate.teampart(props.team))

--- a/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -75,8 +75,7 @@ function StarcraftPlayerDisplay.BlockPlayer(props)
 
 	return html.create('div'):addClass('block-player starcraft-block-player')
 		:addClass(props.flip and 'flipped' or nil)
-		:addClass(props.showPlayerTeam and 'block-player-with-team' or nil)
-		:cssText(props.showPlayerTeam and 'width: 100%' or nil)--move into above class
+		:addClass(props.showPlayerTeam and 'hast-team' or nil)
 		:node(flagNode)
 		:node(raceNode)
 		:node(nameNode)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -548,7 +548,10 @@ function PrizePool:_buildRows()
 				end
 			end)
 
-			local opponentDisplay = tostring(OpponentDisplay.BlockOpponent{opponent = opponent.opponentData, showPlayerTeam = true})
+			local opponentDisplay = tostring(OpponentDisplay.BlockOpponent{
+				opponent = opponent.opponentData,
+				showPlayerTeam = true
+			})
 			local opponentCss = {['justify-content'] = 'start'}
 
 			row:addCell(TableCell{content = {opponentDisplay}, css = opponentCss})


### PR DESCRIPTION
## Summary
Update non team opponent display in prize pools
* support duo, trio, ... opponent types
* display playerTeam for non team opponents as an icon besides the players instead of in an extra column
this matches the display in participant tables (for solo opponents)
* adjust storage for non-solo non-team opponents a bit (participantflag)

![5D2C3A01-FEC0-46DD-A6E0-F28B13C9182E](https://user-images.githubusercontent.com/75081997/183299885-6f2e51bc-f3c9-4e55-a8cd-bafe60edfd4f.jpeg)

![Screenshot 2022-08-08 08 49 58](https://user-images.githubusercontent.com/75081997/183356856-3f40ba3c-7b84-4668-bcc6-ca750e321929.png)

## How did you test this change?
/dev modules

## Remark
This needed some slight css additions, so either needs a cache flush or waiting until cache expires^^

https://liquipedia.net/commons/index.php?title=MediaWiki%3ACommon.css%2FBrackets.css&type=revision&diff=442043&oldid=441187