### PR TITLE
Fix typo in dota2 matchsummary

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -40,7 +40,7 @@ local _LINK_DATA = {
 -- Auto generated links from Publisher ID
 local _AUTO_LINKS = {
 	{icon = 'File:DOTABUFF-icon.png', url = 'https://www.dotabuff.com/matches/', name = 'DOTABUFF'},
-	{icon = 'File:DatDota-icon.png', url = 'https://www.datdota.com/matches//', name = 'datDota'},
+	{icon = 'File:DatDota-icon.png', url = 'https://www.datdota.com/matches/', name = 'datDota'},
 	{icon = 'File:Stratz-icon.png', url = 'https://stratz.com/en-us/match/', name = 'Stratz'},
 }
 


### PR DESCRIPTION
## Summary
Fix typo in dota2 matchsummary
requested by trev: https://discord.com/channels/93055209017729024/372075546231832576/1006057649852391445

## How did you test this change?
N/A