### PR TITLE
Adjust sc2 infobox league (+hidden) to use `Module:Currency`

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -376,7 +376,7 @@ function CustomLeague:_currencyConversion(localPrize, currency, exchangeDate)
 	local usdPrize
 	local currencyRate = Currency.getExchangeRate{
 		currency = currency,
-		date = exchangeDate
+		date = exchangeDate,
 		setVariables = true,
 	}
 	if currencyRate then

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -307,7 +307,7 @@ function HiddenInfoboxLeague._currencyConversion(localPrize, currency, exchangeD
 	local usdPrize
 	local currencyRate = Currency.getExchangeRate{
 		currency = currency,
-		date = exchangeDate
+		date = exchangeDate,
 		setVariables = true,
 	}
 	if currencyRate then

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -9,6 +9,7 @@
 --this "infobox" has no display and only stores into LPDB, sets wiki vars and categories
 
 local Class = require('Module:Class')
+local Currency = require('Module:Currency')
 local Template = require('Module:Template')
 local Namespace = require('Module:Namespace')
 local String = require('Module:StringUtils')

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -303,21 +303,17 @@ function HiddenInfoboxLeague._cleanPrizeValue(value)
 end
 
 function HiddenInfoboxLeague._currencyConversion(localPrize, currency, exchangeDate)
-	if exchangeDate and currency and currency ~= 'USD' then
-		if localPrize then
-			local usdPrize = mw.ext.CurrencyExchange.currencyexchange(
-				localPrize,
-				currency,
-				'USD',
-				exchangeDate
-			)
-			if type(usdPrize) == 'number' then
-				return usdPrize
-			end
-		end
+	local usdPrize
+	local currencyRate = Currency.getExchangeRate{
+		currency = currency,
+		date = exchangeDate
+		setVariables = true,
+	}
+	if currencyRate then
+		usdPrize = currencyRate * localPrize
 	end
 
-	return nil
+	return usdPrize
 end
 
 function HiddenInfoboxLeague._getPatch()


### PR DESCRIPTION
depends on #1638

## Summary
Adjust sc2 infobox league (+hidden) to use `Module:Currency`

## How did you test this change?
/dev modules