### PR TITLE
Create HDB for CounterStrike

### DIFF
--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -15,7 +15,9 @@ local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
-	args.liquipediatier = Tier.number[args.liquipediatier or '']
+	if args.liquipediatier then
+		args.liquipediatier = Tier.number[args.liquipediatier]
+	end
 	return BasicHiddenDataBox.run(args)
 end
 
@@ -28,13 +30,13 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('edate', Variables.varDefault('tournament_enddate'))
 	Variables.varDefine('date', Variables.varDefault('tournament_enddate'))
 
-	Variables.varDefine('tournament_tier', Tier.text[Variables.varDefault('tournament_liquipediatier', '')])
+	Variables.varDefine('tournament_tier', Tier.text[tostring(Variables.varDefault('tournament_liquipediatier', ''))])
 	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
-	Variables.varDefine('tournament_icon_dark', Variables.varDefault('tournament_icondark'))
+	Variables.varDefine('tournament_icon_darkmode', Variables.varDefault('tournament_icondark'))
 
 	Variables.varDefine('match_featured_override', args.featured)
-	Variables.varDefine('tournament_valve_major', args.valvemajor or args.valvetier == 'Major')
-	Variables.varDefine('tournament_valve_tier', args.valvetier)
+	Variables.varDefine('tournament_valve_major', args.valvemajor or (args.valvetier == 'Major' and 'true') or 'false')
+	BasicHiddenDataBox.checkAndAssign('tournament_valve_tier', args.valvetier, queryResult.publishertier)
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Tier = mw.loadData('Module:Tier')
 local Variables = require('Module:Variables')
 
@@ -15,7 +16,7 @@ local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
-	if args.liquipediatier and not Logic.isNumeric then
+	if args.liquipediatier and not Logic.isNumeric(args.liquipediatier) then
 		args.liquipediatier = Tier.number[args.liquipediatier]
 	end
 	return BasicHiddenDataBox.run(args)

--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -15,7 +15,7 @@ local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
-	if args.liquipediatier then
+	if args.liquipediatier and not Logic.isNumeric then
 		args.liquipediatier = Tier.number[args.liquipediatier]
 	end
 	return BasicHiddenDataBox.run(args)

--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -1,0 +1,40 @@
+---
+-- @Liquipedia
+-- wiki=counterstrike
+-- page=Module:HiddenDataBox/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Tier = mw.loadData('Module:Tier')
+local Variables = require('Module:Variables')
+
+local BasicHiddenDataBox = require('Module:HiddenDataBox')
+local CustomHiddenDataBox = {}
+
+function CustomHiddenDataBox.run(args)
+	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+	args.liquipediatier = Tier.number[args.liquipediatier or '']
+	return BasicHiddenDataBox.run(args)
+end
+
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate'))
+
+	Variables.varDefine('sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('date', Variables.varDefault('tournament_enddate'))
+
+	Variables.varDefine('tournament_tier', Tier.text[Variables.varDefault('tournament_liquipediatier', '')])
+	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
+	Variables.varDefine('tournament_icon_dark', Variables.varDefault('tournament_icondark'))
+
+	Variables.varDefine('match_featured_override', args.featured)
+	Variables.varDefine('tournament_valve_major', args.valvemajor or args.valvetier == 'Major')
+	Variables.varDefine('tournament_valve_tier', args.valvetier)
+end
+
+return Class.export(CustomHiddenDataBox)


### PR DESCRIPTION
## Summary

Have removed the usage on CS where they, in match1, uses wiki-arrays (changed into wiki-vars). This simplifies TC and HDB, especially the latter.

## How did you test this change?
Tested with dev module on Antwerp Major
