### PR TITLE
Fix match legacy extradata values

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -60,15 +60,14 @@ function MatchLegacy.convertParameters(match2)
 	end
 
 	match.extradata = {
-		timezone = extradata.timezoneoffset,
-		timezoneID = extradata.timezoneid,
-		matchsection = extradata.matchsection,
-		opponent1rounds = 0,
-		opponent2rounds = 0,
+		timezone = extradata.timezoneoffset or '',
+		timezoneID = extradata.timezoneid or '',
+		matchsection = extradata.matchsection or '',
 		overturned = Logic.readBool(extradata.overturned) and '1' or '',
 		hidden = Logic.readBool(extradata.hidden) and '1' or '0',
 		featured = Logic.readBool(extradata.featured) and '1' or '0',
-		icondark = Variables.varDefault('tournament_icon_dark'),
+		cancelled = '',
+		icondark = match2.icondark,
 		team1icon = match2.match2opponents[1] and match2.match2opponents[1].icon or nil,
 		team2icon = match2.match2opponents[2] and match2.match2opponents[2].icon or nil,
 	}
@@ -76,22 +75,23 @@ function MatchLegacy.convertParameters(match2)
 	if extradata.status then
 		if extradata.status == 'cancelled' or extradata.status == 'canceled' then
 			match.extradata.cancelled = '1'
-		else
-			match.extradata.cancelled = ''
 		end
 	end
 
+	local opponent1Rounds, opponent2Rounds = 0, 0
 	local maps = {}
 	for gameIndex, game in ipairs(match2.match2games or {}) do
 		local scores = ''
 		if type(scores) == 'string' then
 			scores = Json.parse(game.scores)
 		end
-		match.extradata.opponent1rounds = match.extradata.opponent1rounds + (tonumber(scores[1] or '') or 0)
-		match.extradata.opponent2rounds = match.extradata.opponent2rounds + (tonumber(scores[2] or '') or 0)
+		opponent1Rounds = opponent1Rounds + (tonumber(scores[1] or '') or 0)
+		opponent2Rounds = opponent2Rounds + (tonumber(scores[2] or '') or 0)
 		match.extradata['vodgame' .. gameIndex] = game.vod
 		table.insert(maps, game.map)
 	end
+	match.extradata.opponent1rounds = tostring(opponent1Rounds)
+	match.extradata.opponent2rounds = tostring(opponent2Rounds)
 	match.extradata.maps = table.concat(maps, ',')
 
 	if #maps > 0 then
@@ -211,7 +211,7 @@ function MatchLegacy.storeMatchSMW(match)
 			['has tournament'] = mw.title.getCurrentTitle().prefixedText,
 			['has tournament tier'] =  Variables.varDefault('tournament_tier'), -- Legacy support Infobox
 			['has tournament tier number'] = match.liquipediatier, -- or this ^
-			['has tournament icon'] = Variables.varDefault('tournament_icon'),
+			['has tournament icon'] = match.icon,
 			['has tournament name'] = match.tickername,
 			['is part of tournament series'] = match.series,
 			['has match vod'] = match.vod or '',


### PR DESCRIPTION
## Summary

The icondark in `match.extradata` was being set using the wrong variable. After fixing that error, a new revision to extradata fields was made, to ensure they match exactly the fields set by match1, both in name and type.

## How did you test this change?
Compared the extradata fields from match, and match set via match2 input.

### Match
[ESEA Season 41: Advanced Division - Europe](https://liquipedia.net/counterstrike/Special:LiquipediaDB/ESEA/Season_41/Advanced/Europe)
`{"opponent1rounds":"33","maps":"Ancient,Mirage,Overpass","timezoneID":"CEST","featured":"0","hidden":"0","timezone":"+2:00","matchsection":"","overturned":"","bestofx":"3","opponent2rounds":"45","team1icon":"CSGO default lightmode.png","cancelled":"","icondark":"","team2icon":"Apeks 2021 lightmode.png"}`

### Match2
[FiReLEAGUE 2022: Argentinian League](https://liquipedia.net/counterstrike/Special:LiquipediaDB/FiReLEAGUE/2022/Argentina#match)
`{"opponent1rounds":"17","maps":"Nuke,Ancient,Mirage","timezoneID":"ART","featured":"0","hidden":"0","timezone":"-3:00","matchsection":"","overturned":"","bestofx":"3","opponent2rounds":"32","team1icon":"Arvum Esports allmode.png","cancelled":"","icondark":"Fire Logo icon.png","team2icon":"Windingo_Team_lightmode.png"}`
