### PR TITLE
Add FactorGG support (League match2, Links, Widget Sorting)

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -62,6 +62,7 @@ local _PRIORITY_GROUPS = {
 		'faceit-c',
 		'faceit-hub',
 		'faceit-org',
+		'factor',
 		'gamersclub',
 		'halodatahive',
 		'letsplaylive',

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -370,6 +370,7 @@ function matchFunctions.getLinks(match)
 	}
 	if match.reddit then match.links.reddit = 'https://redd.it/' .. match.reddit end
 	if match.gol then match.links.gol = 'https://gol.gg/game/stats/' .. match.gol .. '/page-game/' end
+	if match.factor then match.links.factor = 'https://www.factor.gg/match/' .. match.factor end
 	return match
 end
 

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -35,6 +35,7 @@ local _LINK_DATA = {
 	recap = {icon = 'File:Reviews32.png', text = 'Recap'},
 	reddit = {icon = 'File:Reddit-icon.png', text = 'Head-to-head statistics'},
 	gol = {icon = 'File:Gol.gg_allmode.png', text = 'GolGG Match Report'},
+	factor = {icon = 'File:factor.gg lightmode.png', text = 'FactorGG Match Report'},
 }
 
 local _EPOCH_TIME = '1970-01-01 00:00:00'

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -35,7 +35,7 @@ local _LINK_DATA = {
 	recap = {icon = 'File:Reviews32.png', text = 'Recap'},
 	reddit = {icon = 'File:Reddit-icon.png', text = 'Head-to-head statistics'},
 	gol = {icon = 'File:Gol.gg_allmode.png', text = 'GolGG Match Report'},
-	factor = {icon = 'File:factor.gg lightmode.png', text = 'FactorGG Match Report'},
+	factor = {icon = 'File:Factor.gg lightmode.png', text = 'FactorGG Match Report'},
 }
 
 local _EPOCH_TIME = '1970-01-01 00:00:00'

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -74,6 +74,11 @@ local _PREFIXES = {
 	['faceit-c'] = {'https://www.faceit.com/en/championship/'},
 	['faceit-hub'] = {'https://www.faceit.com/en/hub/'},
 	['faceit-org'] = {'https://www.faceit.com/en/organizers/'},
+	factor = {
+		'',
+		team = 'https://www.factor.gg/team/',
+		player = 'https://www.factor.gg/player/',
+	},
 	fanclub = {''},
 	gamersclub = {
 		'https://csgo.gamersclub.gg/campeonatos/csgo/',

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -235,6 +235,7 @@ function Links.transform(links)
 		['faceit-c2'] = links['faceit-c2'],
 		['faceit-hub'] = links['faceit-hub'],
 		['faceit-org'] = links['faceit-org'],
+		factor = links.factor,
 		fanclub = links.fanclub,
 		gamersclub = links.gamersclub,
 		gamersclub2 = links.gamersclub2,


### PR DESCRIPTION
## Summary

Add FactorGG (https://www.factor.gg/) support to:
* Match2 on League
* Player & Team Links (inc sorting).

## How did you test this change?

![image](https://user-images.githubusercontent.com/3426850/183845517-360263c3-0666-49c7-b74a-bf262be7e0ff.png)
