### PR TITLE
LoL League: Fallback tickername to shortname

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -25,6 +25,9 @@ function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
 
+	_args.tickername = _args.tickername or _args.shortname
+
+
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb


### PR DESCRIPTION
## Summary

Fallback tickername to shortname on LoL's Infobox League.

Requested by Admins.

## How did you test this change?
Live