### PR TITLE
Change the call order of match.getLinks

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -44,6 +44,7 @@ local CustomMatchGroupInput = {}
 function CustomMatchGroupInput.processMatch(_, match)
 	-- Count number of maps, check for empty maps to remove, and automatically count score
 	match = matchFunctions.getBestOf(match)
+	match = matchFunctions.getLinks(match)
 	match = matchFunctions.removeUnsetMaps(match)
 	match = matchFunctions.getScoreFromMapWinners(match)
 
@@ -54,7 +55,6 @@ function CustomMatchGroupInput.processMatch(_, match)
 	)
 	match = matchFunctions.getTournamentVars(match)
 	match = matchFunctions.getOpponents(match)
-	match = matchFunctions.getLinks(match)
 	match = matchFunctions.getExtraData(match)
 
 	return match


### PR DESCRIPTION
## Summary

Sometimes an external link for a map stats page can be set while the name of the map still empty. Usually, it happens in ESEA events where we know the map stats page before the map veto happens.

## How did you test this change?

Using `/dev` module.
