### PR TITLE
Default extradata before usage in HDB Customs

### DIFF
--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -27,6 +27,8 @@ function CustomHiddenDataBox.run(args)
 end
 
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	queryResult.extradata = queryResult.extradata or {}
+
 	--legacy variables
 	Variables.varDefine('tournament_parent_name', Variables.varDefault('tournament_parentname', ''))
 	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier', ''))

--- a/components/hidden_data_box/wikis/dota2/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/dota2/hidden_data_box_custom.lua
@@ -18,6 +18,8 @@ function CustomHiddenDataBox.run(args)
 end
 
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	queryResult.extradata = queryResult.extradata or {}
+
 	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate'))
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))

--- a/components/hidden_data_box/wikis/leagueoflegends/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/leagueoflegends/hidden_data_box_custom.lua
@@ -19,6 +19,8 @@ function CustomHiddenDataBox.run(args)
 end
 
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	queryResult.extradata = queryResult.extradata or {}
+
 	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate'))
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))

--- a/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/starcraft2/hidden_data_box_custom.lua
@@ -23,6 +23,8 @@ function CustomHiddenDataBox.run(args)
 end
 
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	queryResult.extradata = queryResult.extradata or {}
+
 	--legacy variables
 	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier', ''))
 	Variables.varDefine('tournament_tiertype', Variables.varDefault('tournament_liquipediatiertype', ''))
@@ -41,7 +43,7 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	BasicHiddenDataBox.checkAndAssign(
 		'featured',
 		args.featured,
-		(queryResult.extradata or {}).featured
+		queryResult.extradata.featured
 	)
 	if args.team_number then
 		Variables.varDefine('is_team_tournament', 1)

--- a/components/hidden_data_box/wikis/valorant/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/valorant/hidden_data_box_custom.lua
@@ -22,6 +22,8 @@ function CustomHiddenDataBox.run(args)
 end
 
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	queryResult.extradata = queryResult.extradata or {}
+
 	Variables.varDefine('tournament_parent_name', Variables.varDefault('tournament_parentname'))
 	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier'))
 	Variables.varDefine('tournament_tiertype', Variables.varDefault('tournament_liquipediatiertype'))


### PR DESCRIPTION
## Summary

If the parent doesn't exist, `queryResult`will be an empty table when given to `addCustomVariables`. In wikis going into the `extradata`, ensure that it exists.

## How did you test this change?

Live on league of legends since last night.