### PR TITLE
Support Literals in PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -988,7 +988,7 @@ function Placement:_parseOpponentArgs(input, date)
 
 	local opponentData = Opponent.readOpponentArgs(opponentArgs)
 
-	if not opponentData or (opponentData.type ~= Opponent.literal and Opponent.isTbd(opponentData)) then
+	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
 		opponentData = Opponent.tbd(opponentArgs.type)
 	end
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -988,7 +988,7 @@ function Placement:_parseOpponentArgs(input, date)
 
 	local opponentData = Opponent.readOpponentArgs(opponentArgs)
 
-	if not opponentData or Opponent.isTbd(opponentData) then
+	if not opponentData or (opponentData.type ~= Opponent.literal and Opponent.isTbd(opponentData)) then
 		opponentData = Opponent.tbd(opponentArgs.type)
 	end
 

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -120,6 +120,7 @@ function LegacyPrizePool.mapSlot(slot)
 
 	Table.mergeInto(newData, LegacyPrizePool.mapOpponents(slot))
 
+	mw.logObject(newData)
 	return newData
 end
 
@@ -131,6 +132,7 @@ function LegacyPrizePool.mapOpponents(slot)
 
 		local opponentData = {
 			[1] = slot[opponentIndex],
+			type = slot['literal' .. opponentIndex] and Opponent.literal or nil,
 			date = slot['date' .. opponentIndex],
 			link = slot['link' .. opponentIndex],
 			wdl = slot['wdl' .. opponentIndex],

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -120,7 +120,6 @@ function LegacyPrizePool.mapSlot(slot)
 
 	Table.mergeInto(newData, LegacyPrizePool.mapOpponents(slot))
 
-	mw.logObject(newData)
 	return newData
 end
 


### PR DESCRIPTION
## Summary

Currently `Placement:_parseOpponentArgs` will discard any Literals as `Opponent.isTbd` will return true for any and all literals.
This PR adds allows literals not to be automatically discarded and used as is instead. The PR also adds handling of `|literalX=` in legacy PPTs.

![image](https://user-images.githubusercontent.com/3426850/184095723-d3acde49-9271-47c4-86f4-b0805acc0d88.png)
![image](https://user-images.githubusercontent.com/3426850/184095750-304e33b5-6478-4e3d-b3e2-2a5eb8d7b9c2.png)

![image](https://user-images.githubusercontent.com/3426850/184095816-2a8884e8-c44f-4e69-b5de-09688153d5ba.png)
![image](https://user-images.githubusercontent.com/3426850/184095874-eb2ff2e2-3acd-47ff-b625-b10fe3055474.png)


## How did you test this change?

Dev module