### PR TITLE
Fix Module:Opponent/Starcraft

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -82,11 +82,11 @@ function StarcraftOpponent.toLpdbStruct(opponent)
 
 	if Opponent.typeIsParty(opponent.type) then
 		if opponent.isArchon then
-			storageStruct.players.isArchon = true
-			storageStruct.players.faction = opponent.players[1].race
+			storageStruct.opponentplayers.isArchon = true
+			storageStruct.opponentplayers.faction = opponent.players[1].race
 		else
 			for playerIndex, player in pairs(opponent.players) do
-				storageStruct.players['p' .. playerIndex .. 'faction'] = player.race
+				storageStruct.opponentplayers['p' .. playerIndex .. 'faction'] = player.race
 			end
 		end
 	end
@@ -98,9 +98,9 @@ function StarcraftOpponent.fromLpdbStruct(storageStruct)
 	local opponent = Opponent.fromLpdbStruct(storageStruct)
 
 	if Opponent.partySize(storageStruct.opponenttype) then
-		opponent.isArchon = storageStruct.players.isArchon
+		opponent.isArchon = storageStruct.opponentplayers.isArchon
 		for playerIndex, player in pairs(opponent.players) do
-			player.race = storageStruct['p' .. playerIndex .. 'faction']
+			player.race = storageStruct.opponentplayers['p' .. playerIndex .. 'faction']
 				or storageStruct.faction
 		end
 	end

--- a/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -101,7 +101,7 @@ function StarcraftOpponent.fromLpdbStruct(storageStruct)
 		opponent.isArchon = storageStruct.opponentplayers.isArchon
 		for playerIndex, player in pairs(opponent.players) do
 			player.race = storageStruct.opponentplayers['p' .. playerIndex .. 'faction']
-				or storageStruct.faction
+				or storageStruct.opponentplayers.faction
 		end
 	end
 


### PR DESCRIPTION
## Summary
- rename stuff according to renames in `Module:Opponent`
- add a missing key during indexing

## How did you test this change?
/dev modules in combination with testing for adding standardized storage of standings via sc/sc2 group table league