### PR TITLE
Allow standings to not store in legacy mode

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -44,7 +44,9 @@ function StandingsStorage.run(data, legacyData)
 
 	Array.forEach(data.entries, function (entry)
 		StandingsStorage.entry(entry, standingsIndex)
-		StandingsStorage.legacy(entry.slotindex, entry)
+		if not data.noLegacy then
+			StandingsStorage.legacy(entry.slotindex, entry)
+		end
 	end)
 end
 


### PR DESCRIPTION
## Summary
Allow standings to not store in legacy mode.
The legacy mode here is incompatible with what sc/sc2 currently store

## How did you test this change?
N/A