### PR TITLE
PPT Legacy: Map `q` to checkmark

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Currency = require('Module:Currency')
 local Lua = require('Module:Lua')
 local Opponent = require('Module:Opponent')
+local Page = require('Module:Page')
 local Points = mw.loadData('Module:Points/data')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -27,6 +28,8 @@ local CACHED_DATA = {
 	inputToId = {},
 	qualifiers = {},
 }
+
+local CHECKMARK = '<div class="fa fa-check green-check" style="cursor: auto;"></div>'
 
 local CUSTOM_HANDLER
 
@@ -110,6 +113,12 @@ function LegacyPrizePool.mapSlot(slot)
 			end
 
 		elseif input and input ~= 0 then
+			-- Handle the legacy checkmarks, they were set in value = 'q'
+			-- If want, in the future this could be parsed as a Qualification instead of a freetext as now
+			if input == 'q' then
+				input = slot.link and Page.makeInternalLink(CHECKMARK, slot.link) or CHECKMARK
+			end
+
 			newData[newParameter] = input
 		end
 	end)

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -29,7 +29,7 @@ local CACHED_DATA = {
 	qualifiers = {},
 }
 
-local CHECKMARK = '<div class="fa fa-check green-check" style="cursor: auto;"></div>'
+local CHECKMARK = '<div class="fa fa-check green-check"></div>'
 
 local CUSTOM_HANDLER
 


### PR DESCRIPTION
## Summary
Handle the special case most wikis had in their Template based PPTs, which was `|points=q` to create a checkbox, with an optional `|link=`

![image](https://user-images.githubusercontent.com/3426850/184100071-030cbca5-cde0-49c7-a020-caf917bed3a7.png)

## How did you test this change?

Tested with dev module