### PR TITLE
Adjust handling of missing TTs in opponents

### DIFF
--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -243,7 +243,7 @@ options.syncPlayer: Whether to fetch player information from variables or LPDB. 
 function Opponent.resolve(opponent, date, options)
 	options = options or {}
 	if opponent.type == Opponent.team then
-		opponent.template = TeamTemplate.resolve(opponent.template, date) or 'tbd'
+		opponent.template = TeamTemplate.resolve(opponent.template, date) or opponent.template or 'tbd'
 	elseif Opponent.typeIsParty(opponent.type) then
 		local PlayerExt = require('Module:Player/Ext')
 		for _, player in ipairs(opponent.players) do

--- a/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -119,7 +119,7 @@ options.syncPlayer: Whether to fetch player information from variables or LPDB. 
 function StarcraftOpponent.resolve(opponent, date, options)
 	options = options or {}
 	if opponent.type == Opponent.team then
-		opponent.template = TeamTemplate.resolve(opponent.template, date) or 'tbd'
+		opponent.template = TeamTemplate.resolve(opponent.template, date) or opponent.template or 'tbd'
 	elseif Opponent.typeIsParty(opponent.type) then
 		for _, player in ipairs(opponent.players) do
 			if options.syncPlayer then

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1005,13 +1005,16 @@ function Placement:_getLpdbData()
 		if opponentType == Opponent.team then
 			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template)
 
-			participant = teamTemplate and teamTemplate.page or ''
-			if self.parent.options.resolveRedirect then
-				participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
-			end
+			participant = ''
+			if teamTemplate then
+				participant = teamTemplate.page
+				if self.parent.options.resolveRedirect then
+					participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
+				end
 
-			image = teamTemplate.image
-			imageDark = teamTemplate.imagedark
+				image = teamTemplate.image
+				imageDark = teamTemplate.imagedark
+			end
 		elseif opponentType == Opponent.solo then
 			participant = Opponent.toName(opponent.opponentData)
 			local p1 = opponent.opponentData.players[1]

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1003,18 +1003,15 @@ function Placement:_getLpdbData()
 		local opponentType = opponent.opponentData.type
 
 		if opponentType == Opponent.team then
-			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template)
+			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template) or {}
 
-			participant = ''
-			if teamTemplate then
-				participant = teamTemplate.page
-				if self.parent.options.resolveRedirect then
-					participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
-				end
-
-				image = teamTemplate.image
-				imageDark = teamTemplate.imagedark
+			participant = teamTemplate and teamTemplate.page or ''
+			if self.parent.options.resolveRedirect then
+				participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
 			end
+
+			image = teamTemplate.image
+			imageDark = teamTemplate.imagedark
 		elseif opponentType == Opponent.solo then
 			participant = Opponent.toName(opponent.opponentData)
 			local p1 = opponent.opponentData.players[1]

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1005,7 +1005,7 @@ function Placement:_getLpdbData()
 		if opponentType == Opponent.team then
 			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template) or {}
 
-			participant = teamTemplate and teamTemplate.page or ''
+			participant = teamTemplate.page or ''
 			if self.parent.options.resolveRedirect then
 				participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
 			end


### PR DESCRIPTION
## Summary
Adjust handling of missing TTs in opponents
Display the warning instead of using tbd as fallbacks

## How did you test this change?
/dev modules
- [x] tested with pp change applied in the pr
- [x] tested with sc/sc2 match2
- [x] tested with "normal" match2
- [x] tested in other places on sc2/sc

![Screenshot 2022-08-11 14 42 09](https://user-images.githubusercontent.com/75081997/184136051-8dcf29f7-d4ab-4990-a43e-a5d8c9f2433f.png)

![Screenshot 2022-08-11 14 42 07](https://user-images.githubusercontent.com/75081997/184136044-88aa1f75-dcd0-4e13-90d3-6fa4680ae17a.png)

![Screenshot 2022-08-11 14 50 53](https://user-images.githubusercontent.com/75081997/184137372-af3c3659-8efe-45da-9a7f-2ffc3e8ca403.png)

![Screenshot 2022-08-11 14 50 32](https://user-images.githubusercontent.com/75081997/184137363-c4253e74-9c8d-41c2-9e05-eb398dcc41b1.png)

