### PR TITLE
Change 'teams' to 'participants' in the prizepool prizenote

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -492,7 +492,7 @@ function PrizePool:_getPrizeSummaryText()
 		table.insert(displayText, ')')
 	end
 
-	table.insert(displayText, ' are spread among the teams as seen below:')
+	table.insert(displayText, ' are spread among the participants as seen below:')
 	table.insert(displayText, '<br>')
 
 	return table.concat(displayText)


### PR DESCRIPTION
## Summary
Changes the word `teams` to `participants` in the prizenote, matching the column header and fitting all wikis.

## How did you test this change?
N/A