### PR TITLE
Create Infobox League for Teamfight Tactics

### DIFF
--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -1,0 +1,107 @@
+---
+-- @Liquipedia
+-- wiki=tft
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+local Class = require('Module:Class')
+
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+
+local _args
+local _league
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _GAME_MODE = mw.loadData('Module:GameMode')
+local _RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	
+	_league = league
+	_args = _league.args
+	
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
+	
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:addCustomCells(widgets)
+	local args = _args
+	table.insert(widgets, Cell{
+		name = 'Teams',
+		content = {args.team_number}
+	})
+	table.insert(widgets, Cell{
+		name = 'Players',
+		content = {args.participants_number}
+	})
+	return widgets
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'gamesettings' then
+		table.insert(widgets, Cell{
+			name = 'Patch',
+			content = {CustomLeague:_createPatchCell(_args)}
+		})
+		table.insert(widgets, Cell{
+			name = 'Game mode',
+			content = {CustomLeague._getGameMode()}
+		})
+	end
+
+	return widgets
+end
+
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args['riot-sponsored'])
+end
+
+function CustomLeague:appendLiquipediatierDisplay()
+	if Logic.readBool(_args['riot-sponsored']) then
+		return ' ' .. _RIOT_ICON
+	end
+	return ''
+end
+
+function CustomLeague:_createPatchCell(args)
+	if String.isEmpty(args.patch) then
+		return nil
+	end
+	local content
+
+	if String.isEmpty(args.epatch) then
+		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]'
+	else
+		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. ' &ndash; ' ..
+		'[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
+	end
+
+	return content
+end
+
+function CustomLeague._getGameMode()
+	local gameMode = _args.mode
+	if String.isEmpty(gameMode) then
+		return nil
+	end
+	gameMode = string.lower(gameMode)
+	return _GAME_MODE[gameMode] or _GAME_MODE['default']
+end
+
+return CustomLeague

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -22,7 +22,20 @@ local _args
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
-local GAME_MODE = mw.loadData('Module:GameMode')
+local GAME_MODE = {
+	solo = 'solos',
+	solos = 'solos',
+	duo = 'suos',
+	duos = 'suos',
+	squad = 'squads',
+	squads = 'squads',
+}
+local MODE_CATEGORIES = {
+	solos = 'Solos [[Category:Solos Mode Tournaments]]',
+	duos = 'Duos [[Category:Duos Mode Tournaments]]',
+	squads = 'Squads [[Category:Squads Mode Tournaments]]',
+	default = '[[Category:Unknown Mode Tournaments]]',
+}
 local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
 
 function CustomLeague.run(frame)
@@ -81,7 +94,7 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_mode', string.lower(_args.mode or ''))
+	Variables.varDefine('tournament_mode', GAME_MODE[string.lower(_args.mode or '')])
 end
 
 function CustomLeague:_createPatchCell(args)
@@ -99,10 +112,7 @@ function CustomLeague:_createPatchCell(args)
 end
 
 function CustomLeague._getGameMode()
-	if String.isEmpty(_args.mode) then
-		return nil
-	end
-	return GAME_MODE[string.lower(_args.mode)] or GAME_MODE['default']
+	return MODE_CATEGORIES[GAME_MODE[string.lower(_args.mode or '')]]
 end
 
 return CustomLeague

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -87,7 +87,7 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_mode', GAME_MODE[string.lower(_args.mode or '')])
+	Variables.varDefine('tournament_mode', CustomLeague._getGameMode())
 end
 
 function CustomLeague:_createPatchCell(args)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -25,9 +25,9 @@ local CustomInjector = Class.new(Injector)
 local GAME_MODES = {
 	solo = 'Solos',
 	duo = 'Duos',
-	squad = 'Squads',',
+	squad = 'Squads',
 }
-local UNKNOWN_MODE = Unknown
+local UNKNOWN_MODE = 'Unknown'
 local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
 
 function CustomLeague.run(frame)
@@ -110,4 +110,5 @@ end
 
 function CustomLeague.getWikiCategories(args)
 	return {(CustomLeague._getGameMode() or UNKNOWN_MODE) .. ' Mode Tournaments'}
+end
 return CustomLeague

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -33,6 +33,7 @@ local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournam
 function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
+	_args.mode = _args.mode and GAME_MODES[string.lower(_args.mode):gsub('s$', '')] or nil -- Normalize Mode input
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -5,14 +5,17 @@
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
-
-local League = require('Module:Infobox/League')
-local Logic = require('Module:Logic')
-local String = require('Module:StringUtils')
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
 
-local Injector = require('Module:Infobox/Widget/Injector')
-local Cell = require('Module:Infobox/Widget/Cell')
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
 
 local _args
 
@@ -24,10 +27,10 @@ local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournam
 
 function CustomLeague.run(frame)
 	local league = League(frame)
-
 	_args = league.args
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
 
@@ -58,7 +61,7 @@ function CustomInjector:parse(id, widgets)
 			content = {CustomLeague:_createPatchCell(_args)}
 		})
 		table.insert(widgets, Cell{
-			name = 'Game mode',
+			name = 'Game Mode',
 			content = {CustomLeague._getGameMode()}
 		})
 	end
@@ -75,6 +78,10 @@ function CustomLeague:appendLiquipediatierDisplay()
 		return ' ' .. RIOT_ICON
 	end
 	return ''
+end
+
+function CustomLeague:defineCustomPageVariables()
+	Variables.varDefine('tournament_mode', string.lower(_args.mode) or '')
 end
 
 function CustomLeague:_createPatchCell(args)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -18,14 +18,15 @@ local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
 local _args
+local lang = mw.language.getContentLanguage()
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local GAME_MODES = {
-	solo = 'Solos',
-	duo = 'Duos',
-	squad = 'Squads',
+	solo = 'solos',
+	duo = 'duos',
+	squad = 'squads',
 }
 local UNKNOWN_MODE = 'Unknown'
 local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
@@ -68,7 +69,7 @@ function CustomInjector:parse(id, widgets)
 		})
 		table.insert(widgets, Cell{
 			name = 'Game Mode',
-			content = {CustomLeague._getGameMode()}
+			content = {lang:ucfirst(CustomLeague._getGameMode() or '')}
 		})
 	end
 

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -81,7 +81,7 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_mode', string.lower(_args.mode) or '')
+	Variables.varDefine('tournament_mode', string.lower(_args.mode or ''))
 end
 
 function CustomLeague:_createPatchCell(args)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -105,11 +105,7 @@ function CustomLeague:_createPatchCell(args)
 	return content .. ' &ndash; [[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
 end
 
-function CustomLeague._getGameMode()
-	return GAME_MODES[string.lower(_args.mode or ''):gsub('s$', '')]
-end
-
 function CustomLeague.getWikiCategories(args)
-	return {lang:ucfirst(CustomLeague._getGameMode() or UNKNOWN_MODE) .. ' Mode Tournaments'}
+	return {(_args.mode or UNKNOWN_MODE) .. ' Mode Tournaments'}
 end
 return CustomLeague

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -105,7 +105,7 @@ function CustomLeague:_createPatchCell(args)
 end
 
 function CustomLeague._getGameMode()
-	return MODE_CATEGORIES[GAME_MODE[string.lower(_args.mode or '')]]
+	return GAME_MODES[string.lower(_args.mode or ''):gsub('s$', '')]
 end
 
 function CustomLeague.getWikiCategories(args)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -30,12 +30,7 @@ local GAME_MODE = {
 	squad = 'squads',
 	squads = 'squads',
 }
-local MODE_CATEGORIES = {
-	solos = 'Solos [[Category:Solos Mode Tournaments]]',
-	duos = 'Duos [[Category:Duos Mode Tournaments]]',
-	squads = 'Squads [[Category:Squads Mode Tournaments]]',
-	default = '[[Category:Unknown Mode Tournaments]]',
-}
+local UNKNOWN_MODE = Unknown
 local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
 
 function CustomLeague.run(frame)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -23,9 +23,9 @@ local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local GAME_MODES = {
-	solo = 'solos',
-	duo = 'duos',
-	squad = 'squads',
+	solo = 'Solos',
+	duo = 'Duos',
+	squad = 'Squads',
 }
 local UNKNOWN_MODE = 'Unknown'
 local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -88,7 +88,7 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_mode', CustomLeague._getGameMode())
+	Variables.varDefine('tournament_mode', string.lower(_args.mode or ''))
 end
 
 function CustomLeague:_createPatchCell(args)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -24,13 +24,13 @@ local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournam
 
 function CustomLeague.run(frame)
 	local league = League(frame)
-	
+
 	_args = league.args
-	
+
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
-	
+
 	return league:createInfobox(frame)
 end
 

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -110,6 +110,6 @@ function CustomLeague._getGameMode()
 end
 
 function CustomLeague.getWikiCategories(args)
-	return {(CustomLeague._getGameMode() or UNKNOWN_MODE) .. ' Mode Tournaments'}
+	return {lang:ucfirst(CustomLeague._getGameMode() or UNKNOWN_MODE) .. ' Mode Tournaments'}
 end
 return CustomLeague

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -18,7 +18,6 @@ local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
 local _args
-local lang = mw.language.getContentLanguage()
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -22,13 +22,10 @@ local _args
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
-local GAME_MODE = {
-	solo = 'solos',
-	solos = 'solos',
-	duo = 'suos',
-	duos = 'suos',
-	squad = 'squads',
-	squads = 'squads',
+local GAME_MODES = {
+	solo = 'Solos',
+	duo = 'Duos',
+	squad = 'Squads',',
 }
 local UNKNOWN_MODE = Unknown
 local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -108,4 +108,6 @@ function CustomLeague._getGameMode()
 	return MODE_CATEGORIES[GAME_MODE[string.lower(_args.mode or '')]]
 end
 
+function CustomLeague.getWikiCategories(args)
+	return {(CustomLeague._getGameMode() or UNKNOWN_MODE) .. ' Mode Tournaments'}
 return CustomLeague

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -41,6 +41,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
+	league.getWikiCategories= CustomLeague.getWikiCategories
 
 	return league:createInfobox(frame)
 end

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -69,7 +69,7 @@ function CustomInjector:parse(id, widgets)
 		})
 		table.insert(widgets, Cell{
 			name = 'Game Mode',
-			content = {lang:ucfirst(CustomLeague._getGameMode() or '')}
+			content = {_args.mode}
 		})
 	end
 

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -39,7 +39,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
-	league.getWikiCategories= CustomLeague.getWikiCategories
+	league.getWikiCategories = CustomLeague.getWikiCategories
 
 	return league:createInfobox(frame)
 end

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -15,19 +15,17 @@ local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 
 local _args
-local _league
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
-local _GAME_MODE = mw.loadData('Module:GameMode')
-local _RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
+local GAME_MODE = mw.loadData('Module:GameMode')
+local RIOT_ICON = '[[File:Riot Games Tier Icon.png|x12px|link=Riot Games|Tournament supported by Riot Games]]'
 
 function CustomLeague.run(frame)
 	local league = League(frame)
 	
-	_league = league
-	_args = _league.args
+	_args = league.args
 	
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
@@ -74,7 +72,7 @@ end
 
 function CustomLeague:appendLiquipediatierDisplay()
 	if Logic.readBool(_args['riot-sponsored']) then
-		return ' ' .. _RIOT_ICON
+		return ' ' .. RIOT_ICON
 	end
 	return ''
 end
@@ -83,25 +81,21 @@ function CustomLeague:_createPatchCell(args)
 	if String.isEmpty(args.patch) then
 		return nil
 	end
-	local content
+
+	local content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]'
 
 	if String.isEmpty(args.epatch) then
-		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]'
-	else
-		content = '[[Patch ' .. args.patch .. '|'.. args.patch .. ']]' .. ' &ndash; ' ..
-		'[[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
+		return content
 	end
 
-	return content
+	return content .. ' &ndash; [[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
 end
 
 function CustomLeague._getGameMode()
-	local gameMode = _args.mode
-	if String.isEmpty(gameMode) then
+	if String.isEmpty(_args.mode) then
 		return nil
 	end
-	gameMode = string.lower(gameMode)
-	return _GAME_MODE[gameMode] or _GAME_MODE['default']
+	return GAME_MODE[string.lower(_args.mode)] or GAME_MODE['default']
 end
 
 return CustomLeague


### PR DESCRIPTION
## Summary
I want to start adding some standardized templates to the tft wiki, I have started with the infobox league because it seemed the least complicated one
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
I have tested the changes on https://liquipedia.net/tft/Allie_Coin_Pro-Am/2021 and I have verified that the achievements do not disappear on the players page, for this I used the https://liquipedia.net/tft/Module:Infobox/League/Custom/dev and https://liquipedia.net/tft/Template:Infobox_league/dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
