### PR TITLE
Allow wikis to decide on the rounding precision in prize pool currency values

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -110,6 +110,12 @@ PrizePool.config = {
 			return Logic.readBoolOrNil(args.currencyrateperopponent)
 		end
 	},
+	currencyRoundPrecision = {
+		default = 2,
+		read = function(args)
+			return tonumber(args.currencyroundprecision)
+		end
+	},
 }
 
 PrizePool.prizeTypes = {
@@ -128,7 +134,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {{'$', Currency.formatMoney(data)}}}
+				return TableCell{content = {{'$', Currency.formatMoney(data, headerData.roundPrecision)}}}
 			end
 		end,
 	},
@@ -153,7 +159,7 @@ PrizePool.prizeTypes = {
 			return {
 				currency = currencyData.code, currencyText = currencyText,
 				symbol = currencyData.symbol, symbolFirst = not currencyData.isAfter,
-				rate = currencyRate or 0,
+				rate = currencyRate or 0, roundPrecision = prizePool.options.currencyRoundPrecision,
 			}
 		end,
 		headerDisplay = function (data)
@@ -166,7 +172,7 @@ PrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				local displayText = {Currency.formatMoney(data)}
+				local displayText = {Currency.formatMoney(data, headerData.roundPrecision)}
 
 				if headerData.symbolFirst then
 					table.insert(displayText, 1, headerData.symbol)
@@ -418,7 +424,7 @@ function PrizePool:create()
 
 	if self:_hasUsdPrizePool() then
 		self:setConfig('showUSD', true)
-		self:addPrize(PRIZE_TYPE_USD, 1)
+		self:addPrize(PRIZE_TYPE_USD, 1, {roundPrecision = self.options.currencyRoundPrecision})
 
 		if self.options.autoUSD then
 			local canConvertCurrency = function(prize)

--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -79,17 +79,18 @@ function Currency.raw(currencyCode)
 	return CurrencyData[currencyCode:lower()]
 end
 
-function Currency.formatMoney(value)
+function Currency.formatMoney(value, precision)
 	if not Logic.isNumeric(value) then
 		return 0
 	end
+	precision = tonumber(precision) or 2
 
-	local roundedValue = Math.round{value, 2}
+	local roundedValue = Math.round{value, precision}
 	local integer, decimal = math.modf(roundedValue)
 	if decimal == 0 then
 		return LANG:formatNum(integer)
 	end
-	return LANG:formatNum(integer) .. string.format('%.2f', decimal):sub(2)
+	return LANG:formatNum(integer) .. string.format('%.' .. precision .. 'f', decimal):sub(2)
 end
 
 function Currency.getExchangeRate(props)


### PR DESCRIPTION
## Summary
Allow wikis to decide on the rounding precision in prize pool currency values
- adjust PP
- adjust Currency.formatMoney

## How did you test this change?
/dev