### PR TITLE
VAL: Add category for Female Tournaments

### DIFF
--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -36,6 +36,7 @@ function CustomLeague.run(frame)
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
+	league.getWikiCategories = CustomLeague.getWikiCategories
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
 
@@ -83,6 +84,16 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	return widgets
+end
+
+function CustomLeague:getWikiCategories(args)
+	local categories = {}
+
+	if Logic.readBool(args.female) then
+		table.insert(categories, 'Female Tournaments')
+	end
+
+	return categories
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)


### PR DESCRIPTION
## Summary

Add category for Female Tournaments in Valorant's `Infobox league`.

## How did you test this change?

/dev Module
