### PR TITLE
Improve column sorting of Prizes

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -455,7 +455,9 @@ end
 
 --- Compares the sort value of two prize entries
 function PrizePool._comparePrizes(x, y)
-	return PrizePool.prizeTypes[x.type].sortOrder < PrizePool.prizeTypes[y.type].sortOrder
+	local sortX = PrizePool.prizeTypes[x.type].sortOrder
+	local sortY = PrizePool.prizeTypes[y.type].sortOrder
+	return sortX == sortY and x.index < y.index or sortX < sortY
 end
 
 function PrizePool:build()


### PR DESCRIPTION
## Summary

The PPT currently sorts columns based on prize types. However for two prizes that change that same type the order is arbitrary. This PR will add a secondary sort based on the index (ie POINTS1 will be sorted to be before POINTS2).

## How did you test this change?

dev module