### PR TITLE
Add option to override a point's link

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -260,8 +260,14 @@ PrizePool.prizeTypes = {
 
 		header = 'points',
 		headerParse = function (prizePool, input, context, index)
-			local pointsData = mw.loadData('Module:Points/data')
-			return pointsData[input] or {title = 'Points'}
+			local pointsData = Table.copy(mw.loadData('Module:Points/data')[input] or {})
+			pointsData.title = pointsData.title or 'Points'
+
+			-- Manual overrides
+			local prefix = 'points' .. index
+			pointsData.link = context[prefix .. 'link'] or pointsData.link
+
+			return pointsData
 		end,
 		headerDisplay = function (data)
 			local headerDisplay = {}


### PR DESCRIPTION
## Summary

Add option to add a manual (override) link to a points prize type similiar how data can be overriden in the Qualifier prize type.

## How did you test this change?
Dev module
