### PR TITLE
Always set bestofx in match legacy

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -109,7 +109,7 @@ function MatchLegacy.convertParameters(match2)
 				else
 					match[prefix .. 'score'] = 0
 				end
-				match.extradata[prefix .. 'rounds'] = 0
+				match.extradata[prefix .. 'rounds'] = '0'
 			elseif opponent.status == 'W' then
 				match[prefix .. 'score'] = math.floor(match2.bestof /2) + 1
 			else

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -63,6 +63,7 @@ function MatchLegacy.convertParameters(match2)
 		timezone = extradata.timezoneoffset or '',
 		timezoneID = extradata.timezoneid or '',
 		matchsection = extradata.matchsection or '',
+		bestofx = tostring(match2.bestof),
 		overturned = Logic.readBool(extradata.overturned) and '1' or '',
 		hidden = Logic.readBool(extradata.hidden) and '1' or '0',
 		featured = Logic.readBool(extradata.featured) and '1' or '0',
@@ -93,10 +94,6 @@ function MatchLegacy.convertParameters(match2)
 	match.extradata.opponent1rounds = tostring(opponent1Rounds)
 	match.extradata.opponent2rounds = tostring(opponent2Rounds)
 	match.extradata.maps = table.concat(maps, ',')
-
-	if #maps > 0 then
-		match.extradata.bestofx = tostring(match2.bestof)
-	end
 
 	-- Handle Opponents
 	local handleOpponent = function (index)


### PR DESCRIPTION
## Summary

Always set `match.extradata.bestofx`. Doing this previously was messing the `SwissTableLeague` that only relied on the field being set to display either map or score in swiss cell.

## How did you test this change?

Tested on Live pages using both `SwissTableLeague` and match2.
