### PR TITLE
Allow unnamed matchParams for matchlists in copy paste

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste.lua
+++ b/components/match2/commons/get_match_group_copy_paste.lua
@@ -171,13 +171,14 @@ function copyPaste.matchlist(frame, args)
 	local matches = tonumber(args.matches) or 5
 	local opponents = tonumber(args.opponents) or 2
 	local mode = WikiSpecific.getMode(args.mode)
+	local namedMatchParams = Logic.readBool(Logic.nilOr(args.namedMatchParams, true))
 
 	for index = 1, matches do
 		if customHeader then
 			out = out .. '\n|M' .. index .. 'header='
 		end
 
-		out = out .. '\n|M' .. index .. '=' ..
+		out = out .. '\n|' .. (namedMatchParams and ('M' .. index .. '=') or '') ..
 			(not empty and WikiSpecific.getMatchCode(bestof, mode, index, opponents, args) or '')
 	end
 

--- a/components/match2/wikis/counterstrike/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/counterstrike/get_match_group_copy_paste_wiki.lua
@@ -106,6 +106,7 @@ function wikiCopyPaste._ipairsSet(tbl)
 end
 
 function wikiCopyPaste.getStart(template, id, modus, args)
+	args.namedMatchParams = false
 	local out = '{{' .. (
 		(modus == 'bracket' and
 			('Bracket|Bracket/' .. template)


### PR DESCRIPTION
## Summary
Allow unnamed matchParams for matchlists in copy paste (requested by cs)

## How did you test this change?
/dev