### PR TITLE
Add option to merge slots with same place in legacy PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -86,7 +86,7 @@ function LegacyPrizePool.run(dependency)
 		end
 	end
 
-	-- itterate over slots and merge opponents into the slots directly
+	-- iterate over slots and merge opponents into the slots directly
 	local numberOfSlots = newSlotIndex
 	for slotIndex = 1, numberOfSlots do
 		Table.mergeInto(newArgs[slotIndex], newArgs[slotIndex].opponents)

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -146,6 +146,12 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 
 	newData.opponents = LegacyPrizePool.mapOpponents(slot, newData, mergeSlots)
 
+	if mergeSlots then
+		return {
+			opponents = newData.opponents,
+			place = newData.place
+		}
+	end
 	return newData
 end
 

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -75,7 +75,7 @@ function LegacyPrizePool.run(dependency)
 	for _, slot in ipairs(slots) do
 		-- retrieve the slot and push it into a temp var so it can be altered (to merge slots if need be)
 		local tempSlot = LegacyPrizePool.mapSlot(slot, mergeSlots)
-		-- if we want to merge slots and the slot we just retireved
+		-- if we want to merge slots and the slot we just retrieved
 		-- has the same place as the one before, then append the opponents
 		if mergeSlots and tempSlot.place and currentPlace == tempSlot.place then
 			Array.appendWith(newArgs[newSlotIndex].opponents, unpack(tempSlot.opponents))

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -72,7 +72,6 @@ function LegacyPrizePool.run(dependency)
 	local newSlotIndex = 0
 	local currentPlace
 	local mergeSlots = Logic.readBool(header.mergeSlots)
-	mw.logObject(mergeSlots)
 	for _, slot in ipairs(slots) do
 		local tempSlot = LegacyPrizePool.mapSlot(slot, mergeSlots)
 		if mergeSlots and tempSlot.place and currentPlace == tempSlot.place then

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -73,16 +73,20 @@ function LegacyPrizePool.run(dependency)
 	local currentPlace
 	local mergeSlots = Logic.readBool(header.mergeSlots)
 	for _, slot in ipairs(slots) do
+		-- retrieve the slot and push it into a temp var so it can be altered (to merge slots if need be)
 		local tempSlot = LegacyPrizePool.mapSlot(slot, mergeSlots)
+		-- if we want to merge slots and the slot we just retireved
+		-- has the same place as the one before, then append the opponents
 		if mergeSlots and tempSlot.place and currentPlace == tempSlot.place then
 			Array.appendWith(newArgs[newSlotIndex].opponents, unpack(tempSlot.opponents))
-		else
+		else -- regular case we do not need to merge
 			currentPlace = tempSlot.place
 			newSlotIndex = newSlotIndex + 1
 			newArgs[newSlotIndex] = tempSlot
 		end
 	end
 
+	-- itterate over slots and merge opponents into the slots directly
 	local numberOfSlots = newSlotIndex
 	for slotIndex = 1, numberOfSlots do
 		Table.mergeInto(newArgs[slotIndex], newArgs[slotIndex].opponents)


### PR DESCRIPTION
## Summary
Add option to merge slots with same place in legacy PPT

Why only as an option:
for wikis like CS that use `|points2=` to indicate that opponent 2 in this slot got those points the merge functionality doesn't work
but for wikis that do not have those the merge functionality ensures that legacy ppts look as intended

## How did you test this change?
/dev module

without merging (looks the same as pre PR):
![Screenshot 2022-08-13 17 13 01](https://user-images.githubusercontent.com/75081997/184500366-93a665d6-cdd7-4831-b75f-555f3cc8f9d2.png)

with merging:
![Screenshot 2022-08-14 15 26 02](https://user-images.githubusercontent.com/75081997/184539292-d9a8f7f9-36cd-4fa6-976d-44687bab23ac.png)