### PR TITLE
Only reset iconsInserted if dot is inserted

### DIFF
--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -349,6 +349,7 @@ function CustomMatchSummary._createFooter(match, vods)
 			if link then
 				if insertDotNext then
 					insertDotNext = false
+					iconsInserted = 0
 					footer:addElement(separator)
 				end
 
@@ -373,7 +374,6 @@ function CustomMatchSummary._createFooter(match, vods)
 			end
 		else
 			insertDotNext = iconsInserted > 0 and true or false
-			iconsInserted = 0
 		end
 	end
 


### PR DESCRIPTION
## Summary

If match has `faceit`and `cstats`link there should be a dot in the middle.
![image](https://user-images.githubusercontent.com/43279191/184516626-92d9fa0c-c69b-4264-a82b-f29dd0ea0037.png)


## How did you test this change?

Using `/dev` module.
