### PR TITLE
Add option to disable query in HDB

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
+local Namespace = require('Module:Namespace')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -51,7 +52,7 @@ function HiddenDataBox.run(args)
 		queryResult = {}
 	end
 
-	if not queryResult then
+	if not queryResult and Namespace.isMain() then
 		table.insert(warnings, String.interpolate(INVALID_PARENT, {parent = parent}))
 		queryResult = {}
 	elseif doQuery and args.participantGrabber then

--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -26,6 +26,7 @@ local TIER_MODE_TIERS = 'tiers'
 function HiddenDataBox.run(args)
 	args = args or {}
 	args.participantGrabber = Logic.nilOr(Logic.readBoolOrNil(args.participantGrabber), true)
+	local doQuery = not Logic.readBool(args.noQuery)
 
 	local warnings = {}
 	local warning
@@ -39,16 +40,21 @@ function HiddenDataBox.run(args)
 	local parent = args.parent or args.tournament or tostring(mw.title.getCurrentTitle().basePageTitle)
 	parent = parent:gsub(' ', '_')
 
-	local queryResult = mw.ext.LiquipediaDB.lpdb('tournament', {
-		conditions = '[[pagename::' .. parent .. ']]',
-		limit = 1,
-	})
-	queryResult = queryResult[1]
+	local queryResult
+	if doQuery then
+		queryResult = mw.ext.LiquipediaDB.lpdb('tournament', {
+			conditions = '[[pagename::' .. parent .. ']]',
+			limit = 1,
+		})
+		queryResult = queryResult[1]
+	else
+		queryResult = {}
+	end
 
 	if not queryResult then
 		table.insert(warnings, String.interpolate(INVALID_PARENT, {parent = parent}))
 		queryResult = {}
-	elseif args.participantGrabber then
+	elseif doQuery and args.participantGrabber then
 		local participants = HiddenDataBox._fetchParticipants(parent)
 
 		Table.iter.forEachPair(participants, function (participant, players)


### PR DESCRIPTION
## Summary
* Add option to disable query and hence suppress the warning that the parent is invalid in HDB.
Use Case: SC2 Series subpages (12)
e.g. https://liquipedia.net/starcraft2/Alpha_Pro_Series_Showmatches/2018
the Parent is a Series page (hence lpdb_series is set but not lpdb_league), but still several variables need to get set.
Infobox League/hidden isn't an option as it creates a lpdb_tournament entry that is not wanted.
* Add the warning for invalid parent only in main space, so Pages that got moved to user space do not clutter the category

## How did you test this change?
/dev