### PR TITLE
Add `Footer:addLinks` function to matchSummary/Base

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -220,7 +220,7 @@ function Footer:addLinks(LinkData, links)
 		return '[['..icon..'|link='..link..'|15px|'..text..'|class=show-when-light-mode]]'
 			.. '[['..iconDark..'|link='..link..'|15px|'..text..'|class=show-when-dark-mode]]'
 	end
-	
+
 	for linkType, link in pairs(links) do
 		local currentLinkData = LinkData[linkType]
 		if not currentLinkData then

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -10,6 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Opponent = require('Module:Opponent')
+local String = require('Module:StringUtils')
 
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
@@ -208,6 +209,27 @@ local Footer = Class.new(
 
 function Footer:addElement(element)
 	self.inner:node(element)
+	return self
+end
+
+function Footer:addLinks(LinkData, links)
+	local buildLink = function (link, icon, iconDark, text)
+		if String.isEmpty(iconDark) then
+			return '[['..icon..'|link='..link..'|15px|'..text..']]'
+		end
+		return '[['..icon..'|link='..link..'|15px|'..text..'|class=show-when-light-mode]]'
+			.. '[['..iconDark..'|link='..link..'|15px|'..text..'|class=show-when-dark-mode]]'
+	end
+	
+	for linkType, link in pairs(links) do
+		local currentLinkData = LinkData[linkType]
+		if not currentLinkData then
+			mw.log('Unknown link: ' .. linkType)
+		else
+			self.inner:node(buildLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text))
+		end
+	end
+
 	return self
 end
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -212,7 +212,7 @@ function Footer:addElement(element)
 	return self
 end
 
-function Footer:addLinks(LinkData, links)
+function Footer:addLinks(linkData, links)
 	local buildLink = function (link, icon, iconDark, text)
 		if String.isEmpty(iconDark) then
 			return '[['..icon..'|link='..link..'|15px|'..text..']]'
@@ -222,7 +222,7 @@ function Footer:addLinks(LinkData, links)
 	end
 
 	for linkType, link in pairs(links) do
-		local currentLinkData = LinkData[linkType]
+		local currentLinkData = linkData[linkType]
 		if not currentLinkData then
 			mw.log('Unknown link: ' .. linkType)
 		else


### PR DESCRIPTION
## Summary
Add `Footer:addLinks` function to matchSummary/Base
the function supports darkmode icons

examples & usecase see #

## How did you test this change?
/dev together with #