### PR TITLE
Use `footer:addLinks` in R6 MatchSummary

### DIFF
--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -36,7 +36,11 @@ local _LINK_DATA = {
 	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 	siegegg = {icon = 'File:SiegeGG icon.png', text = 'SiegeGG Match Page'},
 	opl = {icon = 'File:OPL_icon_lightmode.png', iconDark = 'File:OPL_icon_darkmode.png', text = 'OPL Match Page'},
-	esl = {icon = 'File:ESL_2019_icon_lightmode.png', iconDark = 'File:ESL_2019_icon_darkmode.png', text = 'Match page on ESL'},
+	esl = {
+		icon = 'File:ESL_2019_icon_lightmode.png',
+		iconDark = 'File:ESL_2019_icon_darkmode.png',
+		text = 'Match page on ESL'
+	},
 	faceit = {icon = 'File:FACEIT-icon.png', text = 'Match page on FACEIT'},
 	lpl = {icon = 'File:LPL_Logo_lightmode.png', iconDark = 'File:LPL_Logo_darkmode.png', text = 'Match page on LPL Play'},
 	r6esports = {icon = 'File:Copa Elite Six icon.png', text = 'R6 Esports LATAM Match Page'},

--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -35,10 +35,10 @@ local _LINK_DATA = {
 	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
 	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 	siegegg = {icon = 'File:SiegeGG icon.png', text = 'SiegeGG Match Page'},
-	opl = {icon = 'File:OPL Icon.png', text = 'OPL Match Page'},
-	esl = {icon = 'File:ESL icon.png', text = 'Match page on ESL'},
+	opl = {icon = 'File:OPL_icon_lightmode.png', iconDark = 'File:OPL_icon_darkmode.png', text = 'OPL Match Page'},
+	esl = {icon = 'File:ESL_2019_icon_lightmode.png', iconDark = 'File:ESL_2019_icon_darkmode.png', text = 'Match page on ESL'},
 	faceit = {icon = 'File:FACEIT-icon.png', text = 'Match page on FACEIT'},
-	lpl = {icon = 'File:LPL Play icon.png', text = 'Match page on LPL Play'},
+	lpl = {icon = 'File:LPL_Logo_lightmode.png', iconDark = 'File:LPL_Logo_darkmode.png', text = 'Match page on LPL Play'},
 	r6esports = {icon = 'File:Copa Elite Six icon.png', text = 'R6 Esports LATAM Match Page'},
 	challengermode = {icon = 'File:Challengermode icon.png', text = 'Match page on Challengermode'},
 	stats = {icon = 'File:Match_Info_Stats.png', text = 'Match Statistics'},
@@ -346,15 +346,7 @@ function CustomMatchSummary.getByMatchId(args)
 			})
 		end
 
-		-- Match Vod + other links
-		local buildLink = function (linktype, link)
-			local icon, text = _LINK_DATA[linktype].icon, _LINK_DATA[linktype].text
-			return '[['..icon..'|link='..link..'|15px|'..text..']]'
-		end
-
-		for linktype, link in pairs(match.links) do
-			footer:addElement(buildLink(linktype,link))
-		end
+		footer:addLinks(_LINK_DATA, match.links)
 
 		matchSummary:footer(footer)
 	end


### PR DESCRIPTION
depending on #1702 

## Summary
Use `footer:addLinks` in R6 MatchSummary to enable darkmode support in match2 footers (together with #1702 & #1612)

## How did you test this change?
/dev

current:
![zz_current_dark](https://user-images.githubusercontent.com/75081997/184828659-c7abddc8-ce06-43aa-8979-fdb27501e35d.png)
![zz_current_light](https://user-images.githubusercontent.com/75081997/184828668-735d1214-5ee9-4bea-a8a0-d71e2f2a21b6.png)

proposed:
![zz_dev_dark](https://user-images.githubusercontent.com/75081997/184828672-3b5b9039-966b-4271-990d-4e1428d1023c.png)
![zz_dev_light](https://user-images.githubusercontent.com/75081997/184828674-a5646b89-87a5-40de-9593-dfccf7ef6344.png)

