### PR TITLE
Prepare CS matchSummary footer for darkmode

### DIFF
--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -104,7 +104,8 @@ return {
 	},
 	{
 		name = 'sostronk',
-		icon = 'SoStronk icon.png',
+		icon = 'SoStronk lightmode.png',
+		iconDark = 'SoStronk darkmode.png',
 		prefixLink = 'https://www.sostronk.com/match/',
 		label = 'Matchpage and Stats on SoStronk',
 		isMapStats = true

--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -31,7 +31,8 @@ return {
 	},
 	{
 		name = 'esl',
-		icon = 'ESL icon.png',
+		icon = 'ESL 2019 icon lightmode.png',
+		iconDark = 'ESL 2019 icon darkmode.png',
 		prefixLink = 'https://play.eslgaming.com/match/',
 		label = 'Matchpage and Stats on ESL Play',
 		isMapStats = true
@@ -83,20 +84,21 @@ return {
 	},
 	{
 		name = 'pinger',
-		icon = 'Pinger icon.png',
+		icon = 'Pinger icon lightmode.png',
+		iconDark = 'Pinger icon darkmode.png',
 		prefixLink = 'https://pinger.kz/matches/csgo/',
 		label = 'Matchpage and Stats on Pinger',
 	},
 	{
 		name = '99damage',
-		icon = '99DMG-icon.png',
+		icon = '99Damage_2021_allmode.png',
 		prefixLink = 'https://csgo.99damage.de/de/matches/',
 		label = '99Damage Matchpage',
 		stats = {'99liga'}
 	},
 	{
 		name = '99liga',
-		icon = '99DMG-icon.png',
+		icon = '99Damage_2021_allmode.png',
 		prefixLink = 'https://liga.99damage.de/de/leagues/matches/',
 		label = 'Matchpage and Stats on 99Liga',
 	},
@@ -165,21 +167,24 @@ return {
 	},
 	{
 		name = 'draft5',
-		icon = 'Draft5 icon.png',
+		icon = 'Draft5 icon lightmode.png',
+		iconDark = 'Draft5 icon darkmode.png',
 		prefixLink = 'https://draft5.gg/partida/',
 		label = 'Draft5 Matchpage',
 		stats = {'gamersclub', 'gamersclublobby', 'coliseum'}
 	},
 	{
 		name = 'gamersclub',
-		icon = 'Gamersclub.png',
+		icon = 'Gamers Club icon lightmode.png',
+		iconDark = 'Gamers Club icon darkmode.png',
 		prefixLink = 'https://csgo.gamersclub.gg/tournaments/csgo/',
 		label = 'Matchpage and Stats on Gamers Club',
 		isMapStats = true
 	},
 	{
 		name = 'gamersclublobby',
-		icon = 'Gamersclub.png',
+		icon = 'Gamers Club icon lightmode.png',
+		iconDark = 'Gamers Club icon darkmode.png',
 		prefixLink = 'https://csgo.gamersclub.gg/lobby/partida/',
 		label = 'Matchpage and Stats on Gamers Club',
 		isMapStats = true

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 
@@ -299,7 +300,7 @@ function CustomMatchSummary._createFooter(match, vods)
 
 	local separator = '<b>·</b>'
 
-	local function createFooterLink(icon, url, label, index)
+	local function createFooterLink(icon, iconDark, url, label, index)
 		if icon == 'stats' then
 			icon = index ~= 0 and 'Match Info Stats' .. index .. '.png' or 'Match Info Stats.png'
 		end
@@ -307,7 +308,11 @@ function CustomMatchSummary._createFooter(match, vods)
 			label = label .. ' for Game ' .. index
 		end
 
-		return '[[FILE:' .. icon .. '|link=' .. url .. '|15px|' .. label .. '|alt=' .. url .. ']]'
+		if String.isEmpty(iconDark) then
+			return '[[FILE:' .. icon .. '|link=' .. url .. '|15px|' .. label .. '|alt=' .. url .. ']]'
+		end
+		return '[[FILE:' .. icon .. '|link=' .. url .. '|15px|' .. label .. '|alt=' .. url .. '|class=show-when-light-mode]]'
+			.. '[[FILE:' .. iconDark .. '|link=' .. url .. '|15px|' .. label .. '|alt=' .. url .. '|class=show-when-dark-mode]]'
 	end
 
 	-- Match vod
@@ -354,11 +359,12 @@ function CustomMatchSummary._createFooter(match, vods)
 				end
 
 				local icon = platform.icon
+				local iconDark = platform.iconDark
 				local label = platform.label
 				local addGameLabel = platform.isMapStats and match.bestof and match.bestof > 1
 
 				for _, val in ipairs(link) do
-					footer:addElement(createFooterLink(icon, val[1], label,
+					footer:addElement(createFooterLink(icon, iconDark, val[1], label,
 														addGameLabel and val[2] or 0))
 					iconsInserted = iconsInserted + 1
 				end

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -300,7 +300,7 @@ function CustomMatchSummary._createFooter(match, vods)
 
 	local separator = '<b>·</b>'
 
-	local function createFooterLink(icon, iconDark, url, label, index)
+	local function addFooterLink(icon, iconDark, url, label, index)
 		if icon == 'stats' then
 			icon = index ~= 0 and 'Match Info Stats' .. index .. '.png' or 'Match Info Stats.png'
 		end
@@ -308,11 +308,12 @@ function CustomMatchSummary._createFooter(match, vods)
 			label = label .. ' for Game ' .. index
 		end
 
-		if String.isEmpty(iconDark) then
-			return '[[FILE:' .. icon .. '|link=' .. url .. '|15px|' .. label .. '|alt=' .. url .. ']]'
+		icon = 'File:' .. icon
+		if iconDark then
+			iconDark = 'File:' .. iconDark
 		end
-		return '[[FILE:' .. icon .. '|link=' .. url .. '|15px|' .. label .. '|alt=' .. url .. '|class=show-when-light-mode]]'
-			.. '[[FILE:' .. iconDark .. '|link=' .. url .. '|15px|' .. label .. '|alt=' .. url .. '|class=show-when-dark-mode]]'
+
+		footer:addLink(url, icon, iconDark, label)
 	end
 
 	-- Match vod
@@ -364,8 +365,7 @@ function CustomMatchSummary._createFooter(match, vods)
 				local addGameLabel = platform.isMapStats and match.bestof and match.bestof > 1
 
 				for _, val in ipairs(link) do
-					footer:addElement(createFooterLink(icon, iconDark, val[1], label,
-														addGameLabel and val[2] or 0))
+					addFooterLink(icon, iconDark, val[1], label, addGameLabel and val[2] or 0)
 					iconsInserted = iconsInserted + 1
 				end
 


### PR DESCRIPTION
depends on #1722

## Summary
enable darkmode support in match2 footers (together with https://github.com/Liquipedia/Lua-Modules/pull/1702 & https://github.com/Liquipedia/Lua-Modules/pull/1612)

## How did you test this change?
/dev

![Screenshot 2022-08-16 11 17 41](https://user-images.githubusercontent.com/75081997/184845514-49c14978-bbca-40e2-abe6-0bd9466208c2.png)

## ToDo
Get DarkMode Icon for:
- [x] https://liquipedia.net/commons/File:SoStronk_icon.png