### PR TITLE
LPA-5872 match2 on web: Gameline breaks on < 450px on Dota2 and LoL(LPA-5875)

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -348,6 +348,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	end
 
 	local display = mw.html.create('div')
+	    :addClass('brkts-popup-body-element-thumbs')
 	for _, item in ipairs(opponentHeroesDisplay) do
 		display:node(item)
 	end

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -348,7 +348,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	end
 
 	local display = mw.html.create('div')
-	    :addClass('brkts-popup-body-element-thumbs')
+		:addClass('brkts-popup-body-element-thumbs')
 	for _, item in ipairs(opponentHeroesDisplay) do
 		display:node(item)
 	end

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -321,6 +321,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	end
 
 	local display = mw.html.create('div')
+		:addClass('brkts-popup-body-element-thumbs')
 	if isBan then
 		--display:addClass('brkts-popup-side-shade-out')
 		display:css('padding-' .. (flip and 'right' or 'left'), '4px')


### PR DESCRIPTION
- Added a class to the div that groups the thumbs. 
- Added 
`.brkts-popup-body-element-thumbs {
	flex: 1;
}`
to the [brackets.css](https://liquipedia.net/commons/MediaWiki:Common.css/Brackets.css). This allows the group thumbs to go to the next line if needed:
![image](https://user-images.githubusercontent.com/105433238/184903462-d98c11de-1df1-45e5-847d-d291b6c058e7.png)

