### PR TITLE
Use Json.Stringify for standings matches

### DIFF
--- a/components/standings/standings_storage.lua
+++ b/components/standings/standings_storage.lua
@@ -68,7 +68,7 @@ function StandingsStorage.table(data)
 			title = mw.text.trim(cleanedTitle),
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),
 			type = data.type,
-			matches = mw.ext.LiquipediaDB.lpdb_create_json(data.matches or {}),
+			matches = Json.stringify(data.matches or {}),
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, data.extradata)),
 		}
 	)


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

Currently the standingstable.matches  value is 
```
"matches": {
        "1": "2Uem5SbOHQ_0001",
        "2": "2Uem5SbOHQ_0002",
        "3": "2Uem5SbOHQ_0003" 
},
```
AND when empty it is 
```"matches": [],```

Change this to be 1 type:
Array of string 
```"matches":["2Uem5SbOHQ_0001","2Uem5SbOHQ_0002","2Uem5SbOHQ_0003"]```
when empty
```"matches":[]```

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
Live