### PR TITLE
Improve lpdb_prefix support

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -831,7 +831,7 @@ end
 function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, lpdbPrefix)
 	local objectName = 'ranking_'
 	if lpdbEntry.opponenttype == Opponent.team then
-		return objectName .. lpdbPrefix .. mw.ustring.lower(lpdbEntry.participant)
+		return objectName .. lpdbPrefix .. '_' .. mw.ustring.lower(lpdbEntry.participant)
 	end
 	-- for non team opponents the pagename can be case sensitive
 	-- so objectname needs to be case sensitive to avoid edge cases

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -813,7 +813,10 @@ function PrizePool:_storeData()
 		lpdbEntry.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.extradata or {})
 
 		if self.options.storeLpdb then
-			mw.ext.LiquipediaDB.lpdb_placement(PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, self.options.smwPrefix), lpdbEntry)
+			mw.ext.LiquipediaDB.lpdb_placement(
+				PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, self.options.smwPrefix),
+				lpdbEntry
+			)
 		end
 
 		if self.options.storeSmw then

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -831,7 +831,10 @@ end
 function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, lpdbPrefix)
 	local objectName = 'ranking_'
 	if lpdbEntry.opponenttype == Opponent.team then
-		return objectName .. lpdbPrefix .. '_' .. mw.ustring.lower(lpdbEntry.participant)
+		if String.isNotEmpty(lpdbPrefix) then
+			objectName = objectName .. '_' .. lpdbPrefix
+		end
+		return objectName .. '_' .. mw.ustring.lower(lpdbEntry.participant)
 	end
 	-- for non team opponents the pagename can be case sensitive
 	-- so objectname needs to be case sensitive to avoid edge cases

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -832,7 +832,7 @@ function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, lpdbPrefix)
 	local objectName = 'ranking_'
 	if lpdbEntry.opponenttype == Opponent.team then
 		if String.isNotEmpty(lpdbPrefix) then
-			objectName = objectName .. '_' .. lpdbPrefix
+			objectName = objectName .. lpdbPrefix
 		end
 		return objectName .. '_' .. mw.ustring.lower(lpdbEntry.participant)
 	end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -116,6 +116,12 @@ PrizePool.config = {
 			return tonumber(args.currencyroundprecision)
 		end
 	},
+	smwPrefix = {
+		default = '',
+		read = function(args)
+			return args.smw_prefix or Variables.varDefault('smw_prefix')
+		end
+	},
 }
 
 PrizePool.prizeTypes = {
@@ -807,7 +813,7 @@ function PrizePool:_storeData()
 		lpdbEntry.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.extradata or {})
 
 		if self.options.storeLpdb then
-			mw.ext.LiquipediaDB.lpdb_placement(PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex), lpdbEntry)
+			mw.ext.LiquipediaDB.lpdb_placement(PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, self.options.smwPrefix), lpdbEntry)
 		end
 
 		if self.options.storeSmw then
@@ -819,15 +825,14 @@ function PrizePool:_storeData()
 end
 
 -- get the lpdbObjectName depending on opponenttype
-function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex)
+function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, smwPrefix)
 	local objectName = 'ranking_'
 	if lpdbEntry.opponenttype == Opponent.team then
-		local smwPrefix = Variables.varDefault('smw_prefix', '')
 		return objectName .. smwPrefix .. mw.ustring.lower(lpdbEntry.participant)
 	end
 	-- for non team opponents the pagename can be case sensitive
 	-- so objectname needs to be case sensitive to avoid edge cases
-	return objectName .. prizePoolIndex .. '_' .. lpdbEntry.participant
+	return objectName .. smwPrefix .. prizePoolIndex .. '_' .. lpdbEntry.participant
 end
 
 --- Returns true if this prizePool has a US Dollar reward.

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -116,10 +116,10 @@ PrizePool.config = {
 			return tonumber(args.currencyroundprecision)
 		end
 	},
-	smwPrefix = {
+	lpdbPrefix = {
 		default = '',
 		read = function(args)
-			return args.smw_prefix or Variables.varDefault('smw_prefix')
+			return args.lpdb_prefix or Variables.varDefault('lpdb_prefix') or Variables.varDefault('smw_prefix')
 		end
 	},
 }
@@ -814,7 +814,7 @@ function PrizePool:_storeData()
 
 		if self.options.storeLpdb then
 			mw.ext.LiquipediaDB.lpdb_placement(
-				PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, self.options.smwPrefix),
+				PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, self.options.lpdbPrefix),
 				lpdbEntry
 			)
 		end
@@ -828,14 +828,14 @@ function PrizePool:_storeData()
 end
 
 -- get the lpdbObjectName depending on opponenttype
-function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, smwPrefix)
+function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, lpdbPrefix)
 	local objectName = 'ranking_'
 	if lpdbEntry.opponenttype == Opponent.team then
-		return objectName .. smwPrefix .. mw.ustring.lower(lpdbEntry.participant)
+		return objectName .. lpdbPrefix .. mw.ustring.lower(lpdbEntry.participant)
 	end
 	-- for non team opponents the pagename can be case sensitive
 	-- so objectname needs to be case sensitive to avoid edge cases
-	return objectName .. smwPrefix .. prizePoolIndex .. '_' .. lpdbEntry.participant
+	return objectName .. lpdbPrefix .. prizePoolIndex .. '_' .. lpdbEntry.participant
 end
 
 --- Returns true if this prizePool has a US Dollar reward.

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -829,16 +829,16 @@ end
 
 -- get the lpdbObjectName depending on opponenttype
 function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, lpdbPrefix)
-	local objectName = 'ranking_'
+	local objectName = 'ranking'
+	if String.isNotEmpty(lpdbPrefix) then
+		objectName = objectName .. '_' .. lpdbPrefix
+	end
 	if lpdbEntry.opponenttype == Opponent.team then
-		if String.isNotEmpty(lpdbPrefix) then
-			objectName = objectName .. lpdbPrefix
-		end
 		return objectName .. '_' .. mw.ustring.lower(lpdbEntry.participant)
 	end
 	-- for non team opponents the pagename can be case sensitive
 	-- so objectname needs to be case sensitive to avoid edge cases
-	return objectName .. lpdbPrefix .. prizePoolIndex .. '_' .. lpdbEntry.participant
+	return objectName .. prizePoolIndex .. '_' .. lpdbEntry.participant
 end
 
 --- Returns true if this prizePool has a US Dollar reward.

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -15,6 +15,7 @@ local Points = mw.loadData('Module:Points/data')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
+local Variables = require('Module:Variables')
 
 local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabled = true})
 
@@ -44,7 +45,7 @@ function LegacyPrizePool.run(dependency)
 
 	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
 	newArgs.cutafter = header.cutafter
-	newArgs.smw_prefix = header.smw_prefix
+	newArgs.lpdb_prefix = header.lpdb_prefix or header.smw_prefix or Variables.varDefault('smw_prefix')
 
 	if Currency.raw(header.localcurrency) then
 		-- If the localcurrency is a valid currency, handle it like currency

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -44,6 +44,7 @@ function LegacyPrizePool.run(dependency)
 
 	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
 	newArgs.cutafter = header.cutafter
+	newArgs.smw_prefix = header.smw_prefix
 
 	if Currency.raw(header.localcurrency) then
 		-- If the localcurrency is a valid currency, handle it like currency

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -15,7 +15,6 @@ local Points = mw.loadData('Module:Points/data')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
-local Variables = require('Module:Variables')
 
 local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabled = true})
 
@@ -45,7 +44,7 @@ function LegacyPrizePool.run(dependency)
 
 	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
 	newArgs.cutafter = header.cutafter
-	newArgs.lpdb_prefix = header.lpdb_prefix or header.smw_prefix or Variables.varDefault('smw_prefix')
+	newArgs.lpdb_prefix = header.lpdb_prefix or header.smw_prefix
 
 	if Currency.raw(header.localcurrency) then
 		-- If the localcurrency is a valid currency, handle it like currency

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -26,8 +26,8 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		end
 	end
 
-	local lpdbPrefix = args.lpdb_prefix or Variables.varDefault('lpdb_prefix')
-		or args.smw_prefix or Variables.varDefault('smw_prefix') or ''
+	local lpdbPrefix = args.lpdb_prefix or args.smw_prefix
+		or Variables.varDefault('lpdb_prefix') or Variables.varDefault('smw_prefix') or ''
 
 	-- Setup LPDB Data
 	local lpdbData = {}

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -26,31 +26,32 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		end
 	end
 
-	local smwPrefix = args.smw_prefix or Variables.varDefault('smw_prefix') or ''
+	local lpdbPrefix = args.lpdb_prefix or Variables.varDefault('lpdb_prefix')
+		or args.smw_prefix or Variables.varDefault('smw_prefix') or ''
 
 	-- Setup LPDB Data
 	local lpdbData = {}
-	lpdbData = TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, smwPrefix)
+	lpdbData = TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, lpdbPrefix)
 	lpdbData.participanttemplate = teamTemplateName
 	lpdbData.players = players
 	lpdbData.individualprizemoney = playerPrize
 
 	-- If a custom override for LPDB exists, use it
-	lpdbData = Custom.adjustLpdb and Custom.adjustLpdb(lpdbData, team, args, smwPrefix) or lpdbData
+	lpdbData = Custom.adjustLpdb and Custom.adjustLpdb(lpdbData, team, args, lpdbPrefix) or lpdbData
 
 	-- Jsonify the json fields
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata)
 	lpdbData.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.players)
 
 	-- Name must match prize pool insertion
-	local storageName = Custom.getLpdbObjectName and Custom.getLpdbObjectName(team, smwPrefix)
-						or TeamCardStorage._getLpdbObjectName(team, smwPrefix)
+	local storageName = Custom.getLpdbObjectName and Custom.getLpdbObjectName(team, lpdbPrefix)
+						or TeamCardStorage._getLpdbObjectName(team, lpdbPrefix)
 
 	mw.ext.LiquipediaDB.lpdb_placement(storageName, lpdbData)
 end
 
 -- Adds basic lpdb fields
-function TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, smwPrefix)
+function TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, lpdbPrefix)
 	local title = mw.title.getCurrentTitle().text
 	local tournamentName = Variables.varDefault('tournament name pp') or Variables.varDefault('tournament_name')
 	local date = Variables.varDefault('tournament_date')
@@ -62,7 +63,7 @@ function TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, smwPrefix)
 	lpdbData.series = Variables.varDefault('tournament_series')
 	lpdbData.parent = Variables.varDefault('tournament_parent')
 	lpdbData.startdate = startDate
-	lpdbData.date = args.date or Variables.varDefault('enddate_' .. team .. smwPrefix .. '_date') or endDate
+	lpdbData.date = args.date or Variables.varDefault('enddate_' .. team .. lpdbPrefix .. '_date') or endDate
 	lpdbData.qualifier, lpdbData.qualifierpage, lpdbData.qualifierurl = Qualifier.parseQualifier(args.qualifier)
 
 	if team ~= 'TBD' then
@@ -83,10 +84,10 @@ function TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, smwPrefix)
 end
 
 -- Build the standard LPDB "Object Name", which is used as primary key in the DB record
-function TeamCardStorage._getLpdbObjectName(team, smwPrefix)
+function TeamCardStorage._getLpdbObjectName(team, lpdbPrefix)
 	local storageName = 'ranking'
-	if String.isNotEmpty(smwPrefix) then
-		storageName = storageName .. '_' .. smwPrefix
+	if String.isNotEmpty(lpdbPrefix) then
+		storageName = storageName .. '_' .. lpdbPrefix
 	end
 	storageName = storageName .. '_' ..  mw.ustring.lower(team)
 	if team == 'TBD' then

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -6,7 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Custom = require('Module:TeamCard/Custom')
+local Lua = require('Module:Lua')
+local Custom = Lua.import('Module:TeamCard/Custom', {requireDevIfEnabled = true})
 local String = require('Module:StringUtils')
 -- TODO: Once the Template calls are not needed (when RL has been moved to Module), deprecate Qualifier Module
 local Qualifier = require('Module:TeamCard/Qualifier')


### PR DESCRIPTION
## Summary
* Improve ~~smw~~lpdb_prefix support (+ rename stuff from smwPrefix to lpdbPrefix)
* Fix bug where smw prefix caused teamCard and prize pool object names not to match if smw/lpdb prefix was set
* Enable dev stuff for `team_card_storage.lua`

## How did you test this change?
/dev