### PR TITLE
Add additional text label for ML Hero Infobox

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -46,6 +46,8 @@ end
 function CustomInjector:addCustomCells()
 	local widgets = {
 		Cell{name = 'Specialty', content = {_args.specialty}},
+		Cell{name = 'Region', content = {_args.region}},
+		Cell{name = 'City', content = {_args.city}},
 		Cell{name = 'Attack Type', content = {_args.attacktype}},
 		Cell{name = 'Resource Bar', content = {_args.resourcebar}},
 		Cell{name = 'Secondary Bar', content = {_args.secondarybar}},


### PR DESCRIPTION
## Summary
The MLBB Editors were requesting **Region and City** text labels, since this is bit different from LoL that Region/City do not  contain its own icon so they need only just Text Label. The rest were untouched, just two more text labels

## How did you test this change?
/Dev
![image](https://user-images.githubusercontent.com/88981446/185066366-55c1fcbf-51d4-4234-9b9e-41380bf4ed2c.png)
from: <https://liquipedia.net/mobilelegends/Tigreal>
<https://liquipedia.net/mobilelegends/Module:Infobox/Unit/Hero/dev>

## Side Note
- I remember that Rathoz is on Vacation, so I have add both Rath and Jasper (Vogan) for this case.
- I'm looking to push ML to Full Wiki this week or so (as I want to timed it with a competitive scene-related announcement this week) so If I can get this merged before we reach Saturday would be a great timing
