### PR TITLE
Catch some empty cases in broodwar legacy handling

### DIFF
--- a/components/match2/wikis/starcraft/legacy/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft/legacy/match_group_legacy.lua
@@ -138,8 +138,10 @@ function Legacy._convert(mapping)
 			end
 
 			if not Logic.isEmpty(nested) then
-				local score1 = json.parseIfString(nested.opponent1 or {}).score or ''
-				local score2 = json.parseIfString(nested.opponent2 or {}).score or ''
+				nested.opponent1 = nested.opponent1 or {}
+				nested.opponent2 = nested.opponent2 or {}
+				local score1 = json.parseIfString(nested.opponent1).score or ''
+				local score2 = json.parseIfString(nested.opponent2).score or ''
 
 				--handle advantages that were bassed the old way
 				nested.opponent1 = Legacy.checkAdvantage(score1, nested.opponent1)


### PR DESCRIPTION
## Summary
Catch cases where in BW the old brackets had no opponents filled in but maps were filled in.
(Idk why they have it but it is the case on some pages ...)

## How did you test this change?
/dev, now live