### PR TITLE
Fix matchsection storage

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -328,7 +328,7 @@ end
 function Match._addCommonMatchExtradata(match)
 	local commonExtradata = {
 		comment = match.comment,
-		matchsection = Variables.varDefault('matchsection'),
+		matchsection = match.matchsection,
 		timezoneid = match.timezoneId,
 		timezoneoffset = match.timezoneOffset,
 	}


### PR DESCRIPTION
## Summary
Fix matchsection storage
—> the current way hits to late, the var at that point has the value of the last match instead of the match in question
—> set match.matchsection from context during matchlist processing so it can be accessed later again
—> access that instead of the variable later on

## How did you test this change?
/dev modules