### PR TITLE
Add option to push header params up top in match2 copy paste

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste.lua
+++ b/components/match2/commons/get_match_group_copy_paste.lua
@@ -125,7 +125,7 @@ function copyPaste.bracket(frame, args)
 	local bestof = tonumber(args.bestof) or 3
 	local opponents = tonumber(args.opponents) or 2
 	local mode = WikiSpecific.getMode(args.mode)
-	local headersUpTop = Logic.readBool(args.headersUpTop)
+	local headersUpTop = Logic.readBool(Logic.emptyOr(args.headersUpTop, true))
 
 	local bracketDataList = copyPaste._getBracketData(templateid)
 

--- a/components/match2/wikis/counterstrike/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/counterstrike/get_match_group_copy_paste_wiki.lua
@@ -107,6 +107,7 @@ end
 
 function wikiCopyPaste.getStart(template, id, modus, args)
 	args.namedMatchParams = false
+	args.headersUpTop = Logic.readBool(Logic.emptyOr(args.headersUpTop, true))
 	local out = '{{' .. (
 		(modus == 'bracket' and
 			('Bracket|Bracket/' .. template)


### PR DESCRIPTION
## Summary
Add option to push header params up top in match2 copy paste

as requested by CS (Zaykor)
--> https://discord.com/channels/93055209017729024/874304000718172200/1009206326628454521

## How did you test this change?
/dev

![Screenshot 2022-08-22 10 02 46](https://user-images.githubusercontent.com/75081997/185870999-83095aa0-bd55-456d-916f-bbf8f915dc8a.png)
![Screenshot 2022-08-22 10 03 09](https://user-images.githubusercontent.com/75081997/185871006-82f6cb0f-249a-479e-aa43-b22f8ec2cc29.png)

