### PR TITLE
Set OpponentIndex in Data Storage

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1069,6 +1069,8 @@ function Placement:_getLpdbData()
 			opponenttype = opponentType,
 			players = players,
 			placement = self:_lpdbValue(),
+			placestart = self.placeStart, -- Needed in SMW
+			placeend = self.placeEnd, -- Needed in SMW
 			prizemoney = prizeMoney,
 			individualprizemoney = (playerCount > 0) and (prizeMoney / playerCount) or 0,
 			lastvs = Opponent.toName(opponent.additionalData.LASTVS or {}),

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1032,7 +1032,7 @@ end
 
 function Placement:_getLpdbData()
 	local entries = {}
-	for _, opponent in ipairs(self.opponents) do
+	for opponentIndex, opponent in ipairs(self.opponents) do
 		local participant, image, imageDark, players
 		local playerCount = 0
 		local opponentType = opponent.opponentData.type
@@ -1066,11 +1066,10 @@ function Placement:_getLpdbData()
 			participantlink = Opponent.toName(opponent.opponentData),
 			participantflag = opponentType == Opponent.solo and players.p1flag or nil,
 			participanttemplate = opponent.opponentData.template,
+			opponentindex = opponentIndex, -- Needed in SMW
 			opponenttype = opponentType,
 			players = players,
 			placement = self:_lpdbValue(),
-			placestart = self.placeStart, -- Needed in SMW
-			placeend = self.placeEnd, -- Needed in SMW
 			prizemoney = prizeMoney,
 			individualprizemoney = (playerCount > 0) and (prizeMoney / playerCount) or 0,
 			lastvs = Opponent.toName(opponent.additionalData.LASTVS or {}),


### PR DESCRIPTION
## Summary
This information is needed by SMW Storage  to the set `has firstX page` when there are multiple participants sharing the same placement.

## How did you test this change?
See https://github.com/Liquipedia/Lua-Modules/pull/1727#issuecomment-1222469115