### PR TITLE
Handling points-link in CS Legacy PPT

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -17,6 +17,12 @@ function CustomLegacyPrizePool.run()
 	return PrizePoolLegacy.run(CustomLegacyPrizePool)
 end
 
+function CustomLegacyPrizePool.customHeader(newArgs, CACHED_DATA, header)
+	newArgs.points1link = header['points-link']
+
+	return newArgs
+end
+
 function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
 	-- 0 used to mean unset, so let's unset it
 	if newData.freetext1 == '0' then


### PR DESCRIPTION
## Summary

Forward the points link override that CS had in their legacy setup to the new PPT. The field was previously called `|points-link`. Only works for valid points setup in `Points/data`.

## How did you test this change?

/dev module