### PR TITLE
Forward `|qualifier=` in PPT Legacy for CS

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -17,6 +17,12 @@ function CustomLegacyPrizePool.run()
 	return PrizePoolLegacy.run(CustomLegacyPrizePool)
 end
 
+function CustomLegacyPrizePool.customHeader(newArgs, CACHED_DATA, header)
+	newArgs.qualifier = header.qualifier
+
+	return newArgs
+end
+
 function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
 	-- 0 used to mean unset, so let's unset it
 	if newData.freetext1 == '0' then


### PR DESCRIPTION
## Summary
Forward this parameter, used by the CS Custom to set a field into the tournament extradata.

## How did you test this change?

Tested with dev module