### PR TITLE
Remove info around links in PPT Legacy

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -207,7 +207,7 @@ function LegacyPrizePool.parseWikiLink(input)
 	for inputSection in mw.text.gsplit(inputWithoutHtml, '< *[hb]r/? *>') do
 		-- Does this contain a wiki link?
 		if string.find(inputSection, '%[') then
-			local cleanedInput = inputSection:gsub('%[', ''):gsub('%]', '')
+			local cleanedInput = inputSection:gsub('^.-%[+', ''):gsub('%].-$', '')
 			local link, displayName
 			if cleanedInput:find('|') then
 				-- Link and Display


### PR DESCRIPTION
## Summary

If there's a legacy prizepool with the entry `''[[Link|Text]]''` then the outputted link would become `''Link`. This PR solves this by removing data outside the actual link. 


## How did you test this change?
Before:
<img width="593" alt="Screenshot 2022-08-22 at 17 43 23" src="https://user-images.githubusercontent.com/3426850/185962706-8e444d58-fd27-408a-92e2-b90dd9653489.png">

/dev module:
<img width="609" alt="Screenshot 2022-08-22 at 17 42 54" src="https://user-images.githubusercontent.com/3426850/185962673-0b2df20b-1e12-4eb5-b5dc-2002284c8e68.png">
