### PR TITLE
Add Resolve Redirect on CS `series2`

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -334,7 +334,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		prizepoollocal = Variables.varDefault('prizepoollocal', ''),
 		startdate_raw = Variables.varDefault('raw_sdate', ''),
 		enddate_raw = Variables.varDefault('raw_edate', ''),
-		series2 = args.series2,
+		series2 = mw.ext.TeamLiquidIntegration.resolve_redirect(args.series2 or ''),
 	}
 
 	return lpdbData


### PR DESCRIPTION
## Summary
Resolve Redirect the extradata field `series2`, just like `series` is done in the commons league, on Counter Strike.

## How did you test this change?

/dev module
