### PR TITLE
Make sc2 infobox player a bit faster

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -362,19 +362,22 @@ function CustomPlayer._getEarningsMedalsData(player)
 		})
 	end
 
-	local conditions = ConditionTree(BooleanOperator.all):add({
-		playerConditions,
+	local conditions = ConditionTree(BooleanOperator.all):add{
+		ConditionTree(BooleanOperator.any):add{
+			ConditionNode(ColumnName('participantlink'), Comparator.eq, player),
+			playerConditions,
+		},
 		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
 		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
-		ConditionTree(BooleanOperator.any):add({
+		ConditionTree(BooleanOperator.any):add{
 			ConditionNode(ColumnName('individualprizemoney'), Comparator.gt, '0'),
 			ConditionNode(ColumnName('extradata_award'), Comparator.neq, ''),
-			ConditionTree(BooleanOperator.all):add({
+			ConditionTree(BooleanOperator.all):add{
 				ConditionNode(ColumnName('players_type'), Comparator.gt, Opponent.solo),
 				placementConditions,
-			}),
-		}),
-	})
+			},
+		},
+	}
 
 	local earnings = {}
 	local medals = {}


### PR DESCRIPTION
## Summary
* use `participantlink` as an additional query condition (or) so for solo opponents in placements it doesn't have to check the json
--> this speeds up infobox player by ~4%
* cleanup: remove redundant brackets in the ConditionTree building

## How did you test this change?
/dev, but pushed live now
