### PR TITLE
LPA-6211: Sanitize tournament names before inserting into LPDB or Wiki-Variables

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -646,11 +646,14 @@ end
 
 ---Replaces a set of html entities with ansi characters. 
 ---Removes all html tags and their attributes.
----@param name string
----@return string
+---@param name string?
+---@return string?
 function League.sanitizeName(name)
-	local sanitizedName = name
+	if not name then
+		return
+	end
 
+	local sanitizedName = name
 	for search, replace in pairs(NAME_SANITIZER) do
 		sanitizedName = sanitizedName:gsub(search, replace)
 	end

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -31,6 +31,14 @@ local _TIER_MODE_TIERS = 'tiers'
 local _INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
 	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
 
+local NAME_SANITIZER = {
+	['<.->'] =  '', -- All html tags and their attributes
+	['&nbsp;'] = ' ', -- Non-breaking space
+	['&zwj;'] = '', -- Zero width joiner
+	['—'] = '-', -- Non-breaking hyphen
+	['&shy;'] = '', -- Soft hyphen
+}
+
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Header = Widgets.Header
@@ -634,6 +642,16 @@ function League:_fetchAbbreviation()
 	if type(seriesData) == 'table' and seriesData[1] then
 		return seriesData[1].abbreviation
 	end
+end
+
+function League:_sanitizeName(name)
+	local sanitizedName = name
+
+	for search, replace in pairs(NAME_SANITIZER) do
+		sanitizedName = sanitizedName:gsub(search, replace)
+	end
+
+	return sanitizedName
 end
 
 return League

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -327,9 +327,9 @@ function League:_createPrizepool(args)
 end
 
 function League:_definePageVariables(args)
-	Variables.varDefine('tournament_name', args.name)
-	Variables.varDefine('tournament_shortname', args.shortname or args.abbreviation)
-	Variables.varDefine('tournament_tickername', args.tickername)
+	Variables.varDefine('tournament_name', League.sanitizeName(args.name))
+	Variables.varDefine('tournament_shortname', League.sanitizeName(args.shortname or args.abbreviation))
+	Variables.varDefine('tournament_tickername', League.sanitizeName(args.tickername))
 	Variables.varDefine('tournament_icon', args.icon)
 	Variables.varDefine('tournament_icondark', args.icondark or args.icondarkmode)
 	Variables.varDefine('tournament_series', mw.ext.TeamLiquidIntegration.resolve_redirect(args.series or ''))
@@ -378,9 +378,9 @@ end
 
 function League:_setLpdbData(args, links)
 	local lpdbData = {
-		name = self.name,
-		tickername = args.tickername,
-		shortname = args.shortname or args.abbreviation,
+		name = League.sanitizeName(self.name),
+		tickername = League.sanitizeName(args.tickername),
+		shortname = League.sanitizeName(args.shortname or args.abbreviation),
 		banner = args.image,
 		bannerdark = args.imagedark or args.imagedarkmode,
 		icon = Variables.varDefault('tournament_icon'),
@@ -644,7 +644,11 @@ function League:_fetchAbbreviation()
 	end
 end
 
-function League:_sanitizeName(name)
+---Replaces a set of html entities with ansi characters. 
+---Removes all html tags and their attributes.
+---@param name string
+---@return string
+function League.sanitizeName(name)
 	local sanitizedName = name
 
 	for search, replace in pairs(NAME_SANITIZER) do

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -644,7 +644,7 @@ function League:_fetchAbbreviation()
 	end
 end
 
----Replaces a set of html entities with ansi characters. 
+---Replaces a set of html entities with ansi characters.
 ---Removes all html tags and their attributes.
 ---@param name string?
 ---@return string?


### PR DESCRIPTION
## Summary
Sanitize tournaments name, tickername and shortname before saving them into LPDB and Wiki-Variables.

Before:
![image](https://user-images.githubusercontent.com/3426850/186119898-5eb69ee3-a97d-4741-a1e1-f1f798b289f3.png)


After:
![image](https://user-images.githubusercontent.com/3426850/186119790-3ea1e95b-a7ce-4fab-8ed4-dc33faf694f4.png)


## How did you test this change?
/dev module