### PR TITLE
Update StaticID on mobas to match other wikis

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_legacy.lua
+++ b/components/match2/wikis/arenaofvalor/match_legacy.lua
@@ -50,7 +50,7 @@ function MatchLegacy._convertParameters(match2)
 		match.walkover = match.winner
 	end
 
-	match.staticid = 'Legacy_' .. match2.match2id
+	match.staticid = match2.match2id
 
 	-- Handle extradata fields
 	match.extradata = {}

--- a/components/match2/wikis/dota2/match_legacy.lua
+++ b/components/match2/wikis/dota2/match_legacy.lua
@@ -50,7 +50,7 @@ function MatchLegacy._convertParameters(match2)
 		match.walkover = match.winner
 	end
 
-	match.staticid = 'Legacy_' .. match2.match2id
+	match.staticid = match2.match2id
 
 	-- Handle extradata fields
 	match.extradata = {}

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -55,7 +55,7 @@ function MatchLegacy._convertParameters(match2)
 		match.winner = 'draw'
 	end
 
-	match.staticid = 'Legacy_' .. match2.match2id
+	match.staticid = match2.match2id
 
 	-- Handle extradata fields
 	match.extradata = {}

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -50,7 +50,7 @@ function MatchLegacy._convertParameters(match2)
 		match.walkover = match.winner
 	end
 
-	match.staticid = 'Legacy_' .. match2.match2id
+	match.staticid = match2.match2id
 
 	-- Handle extradata fields
 	match.extradata = {}

--- a/components/match2/wikis/wildrift/match_legacy.lua
+++ b/components/match2/wikis/wildrift/match_legacy.lua
@@ -45,7 +45,7 @@ function MatchLegacy._convertParameters(match2)
 		match.walkover = match.winner
 	end
 
-	match.staticid = 'Legacy_' .. match2.match2id
+	match.staticid = match2.match2id
 
 	-- Handle extradata fields
 	match.extradata = {}


### PR DESCRIPTION
## Summary

These five MOBAs prefix their match1 static id's with `Legacy_`.
None of the other wikis does this it and there seems to be no reason for it. Additionally it causes issues when trying to work with a combination of match1 and match2 (as we have to do for now), as the direct link is broken.

## How did you test this change?
Tested live on dota2