### PR TITLE
LPA-5998: Have `Misc` as an alias for Tier `-1` on R6

### DIFF
--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -55,6 +55,11 @@ function CustomLeague.run(frame)
 	_league = league
 	_args = _league.args
 
+	-- Temp solution until a commons solution is made
+	if _args.liquipediatier == 'Misc' then
+		_args.liquipediatier = '-1'
+	end
+
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb


### PR DESCRIPTION
## Summary

To allow for a clean moving over to `-1` as storage value for Misc, will do this in wiki customs at first, one by one. 

Module:Tier and other Modules using this info has been updated
https://liquipedia.net/rainbowsix/index.php?title=Module%3ATier&type=revision&diff=483234&oldid=448331

## How did you test this change?

Live