### PR TITLE
Add option to force Short Names in match2 Brackets

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -29,6 +29,7 @@ local BracketDisplay = {propTypes = {}, types = {}}
 
 function BracketDisplay.configFromArgs(args)
 	return {
+		forceShortName = Logic.readBoolOrNil(args.forceShortName),
 		headerHeight = tonumber(args.headerHeight),
 		headerMargin = tonumber(args.headerMargin),
 		hideRoundTitles = Logic.readBoolOrNil(args.hideRoundTitles),
@@ -46,6 +47,7 @@ end
 BracketDisplay.types.BracketConfig = TypeUtil.struct({
 	MatchSummaryContainer = 'function',
 	OpponentEntry = 'function',
+	forceShortName = 'boolean',
 	headerHeight = 'number',
 	headerMargin = 'number',
 	hideRoundTitles = 'boolean',
@@ -97,6 +99,7 @@ function BracketDisplay.Bracket(props)
 	local config = {
 		MatchSummaryContainer = propsConfig.MatchSummaryContainer or DisplayHelper.DefaultMatchSummaryContainer,
 		OpponentEntry = propsConfig.OpponentEntry or BracketDisplay.OpponentEntry,
+		forceShortName = propsConfig.forceShortName or defaultConfig.forceShortName,
 		headerHeight = propsConfig.headerHeight or defaultConfig.headerHeight,
 		headerMargin = propsConfig.headerMargin or defaultConfig.headerMargin,
 		hideRoundTitles = propsConfig.hideRoundTitles or false,
@@ -441,6 +444,7 @@ function BracketDisplay.NodeBody(props)
 		MatchSummaryContainer = config.MatchSummaryContainer,
 		OpponentEntry = config.OpponentEntry,
 		match = match,
+		forceShortName = config.forceShortName,
 		matchHasDetails = config.matchHasDetails,
 		opponentHeight = config.opponentHeight,
 	})
@@ -464,6 +468,7 @@ function BracketDisplay.NodeBody(props)
 			MatchSummaryContainer = config.MatchSummaryContainer,
 			OpponentEntry = config.OpponentEntry,
 			match = thirdPlaceMatch,
+			forceShortName = config.forceShortName,
 			matchHasDetails = config.matchHasDetails,
 			opponentHeight = config.opponentHeight,
 		})
@@ -531,6 +536,7 @@ BracketDisplay.propTypes.Match = {
 	OpponentEntry = 'function',
 	MatchSummaryContainer = 'function',
 	match = MatchGroupUtil.types.Match,
+	forceShortName = 'boolean',
 	matchHasDetails = 'function',
 	opponentHeight = 'number',
 }
@@ -546,6 +552,7 @@ function BracketDisplay.Match(props)
 	for ix, opponent in ipairs(props.match.opponents) do
 		local opponentEntryNode = props.OpponentEntry({
 			displayType = 'bracket',
+			forceShortName = props.forceShortName,
 			height = props.opponentHeight,
 			opponent = opponent,
 		})
@@ -800,7 +807,7 @@ This is the default opponent entry component. Specific wikis may override this
 by passing in a different props.OpponentEntry in the Bracket component.
 ]]
 function BracketDisplay.OpponentEntry(props)
-	local opponentEntry = OpponentDisplay.BracketOpponentEntry(props.opponent)
+	local opponentEntry = OpponentDisplay.BracketOpponentEntry(props.opponent, {forceShortName = props.forceShortName})
 	if props.displayType == 'bracket' then
 		opponentEntry:addScores(props.opponent)
 	end

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -173,6 +173,7 @@ MediaWiki:BracketConfig.
 ]]
 DisplayHelper.getGlobalConfig = FnUtil.memoize(function()
 	local defaultConfig = {
+		forceShortName = false,
 		headerHeight = 25,
 		headerMargin = 8,
 		lineWidth = 2,

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -29,11 +29,11 @@ OpponentDisplay.types.TeamStyle = TypeUtil.literalUnion('standard', 'short', 'br
 Display component for an opponent entry appearing in a bracket match.
 ]]
 OpponentDisplay.BracketOpponentEntry = Class.new(
-	function(self, opponent)
+	function(self, opponent, options)
 		self.content = mw.html.create('div'):addClass('brkts-opponent-entry-left')
 
 		if opponent.type == 'team' then
-			self:createTeam(opponent.template or 'tbd')
+			self:createTeam(opponent.template or 'tbd', options)
 		elseif opponent.type == 'solo' then
 			self:createPlayer(opponent.players[1])
 		elseif opponent.type == 'literal' then
@@ -45,11 +45,13 @@ OpponentDisplay.BracketOpponentEntry = Class.new(
 	end
 )
 
-function OpponentDisplay.BracketOpponentEntry:createTeam(template)
+function OpponentDisplay.BracketOpponentEntry:createTeam(template, options)
+	local forceShortName = options.forceShortName
+
 	local bracketStyleNode = OpponentDisplay.BlockTeamContainer({
 		overflow = 'ellipsis',
 		showLink = false,
-		style = 'bracket',
+		style = forceShortName and 'short' or 'bracket',
 		template = template,
 	})
 		:addClass('hidden-xs')


### PR DESCRIPTION
## Summary
Solves #1699.
Add parameter to force a bracket to use short names instead of bracket names.
An improvement to this feature would be automatically determining the width that should be used. But that's left for the future.

## How did you test this change?

To be tested