### PR TITLE
LPA-5995: Add mapping for 3166-2 to parent 3166-1 alpha2

### DIFF
--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -114,6 +114,7 @@ function Flags.CountryCode(flagName, format)
 		if format == 'alpha3' then
 			return Flags._getAlpha3CodesByKey()[flagKey] or Flags._getLanguage3LetterCodesByKey()[flagKey]
 		else
+			flagKey = MasterData.iso31662[flagKey] or flagKey
 			return Flags._getAlpha2CodesByKey()[flagKey] or Flags._getLanguageCodesByKey()[flagKey]
 		end
 	end

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1823,6 +1823,16 @@ local languageThreeLetter = {
 	['rus'] = 'russianspeaking',
 }
 
+-- This table includes
+-- ISO 3166-2 to the ISO 3166-1 country, that fulfill 
+-- https://liquipedia.net/commons/Liquipedia:Flag_and_Country_Policy#Countries
+local iso31662 = {
+	['wales'] = 'unitedkingdom',
+	['scotland'] = 'unitedkingdom',
+	['england'] = 'unitedkingdom',
+	['northernireland'] = 'unitedkingdom',
+}
+
 return {
 	data = data,
 	twoLetter = twoLetter,
@@ -1830,4 +1840,5 @@ return {
 	aliases = aliases,
 	languageTwoLetter = languageTwoLetter,
 	languageThreeLetter = languageThreeLetter,
+	iso31662 = iso31662,
 }

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1824,7 +1824,7 @@ local languageThreeLetter = {
 }
 
 -- This table includes
--- ISO 3166-2 to the ISO 3166-1 country, that fulfill 
+-- ISO 3166-2 to the ISO 3166-1 country, that fulfill
 -- https://liquipedia.net/commons/Liquipedia:Flag_and_Country_Policy#Countries
 local iso31662 = {
 	['wales'] = 'unitedkingdom',


### PR DESCRIPTION
## Summary

For areas that are allowed to be entered as countries (per LP Country Policy) whilst not having an ISO-3166-1 code, map their alpha2 codes to the parent 3166-1 alpha2.

For example, this will make `wales` alpha2 `gb` instead of not existing at all.

## How did you test this change?

/dev modules
![image](https://user-images.githubusercontent.com/3426850/186418159-bcf4d1a0-671f-406b-8d8f-e84844f0ef81.png)
![image](https://user-images.githubusercontent.com/3426850/186418127-618e7d4c-1631-48e1-80db-339bf5a4f95c.png)
