### PR TITLE
Fix typo'd wiki name in Module

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=leagueofledends
+-- wiki=leagueoflegends
 -- page=Module:Infobox/League/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute


### PR DESCRIPTION
## Summary

Fixed typo in wiki name

## How did you test this change?

N/A