### PR TITLE
LPA-6245 Split venue/venue-link in LPDB

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -62,6 +62,18 @@ function League:createInfobox()
 	args.abbreviation = self:_fetchAbbreviation()
 	local links
 
+	-- Split venue from legacy format to new format.
+	-- Legacy format is a wiki-code string that can include an external link
+	-- New format has |venue= and |venuelink= as different parameters.
+	-- This should be removed once there's been a bot run to change this.
+	if not args.venuelink and args.venue and args.venue:sub(1, 1) == '[' then
+		-- Remove [] and split on space
+		local splitVenue = mw.text.split(args.venue:gsub('%[', ''):gsub('%]', ''), ' ')
+		args.venuelink = splitVenue[1]
+		table.remove(splitVenue, 1)
+		args.venue = table.concat(splitVenue, ' ')
+	end
+
 	-- set Variables here already so they are available in functions
 	-- we call from here on, e.g. _createPrizepool
 	self:_definePageVariables(args)
@@ -156,7 +168,12 @@ function League:createInfobox()
 				self:_createLocation(args)
 			}
 		},
-		Cell{name = 'Venue', content = {args.venue}},
+		Cell{
+			name = 'Venue',
+			content = {
+				Page.makeExternalLink(args.venue, args.venuelink) or args.venue
+			}
+		},
 		Cell{name = 'Format', content = {args.format}},
 		Customizable{id = 'prizepool', children = {
 			Cell{

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -50,6 +50,18 @@ function Series:createInfobox(frame)
 	-- define this here so we can use it in lpdb data and the display
 	local links = Links.transform(args)
 
+	-- Split venue from legacy format to new format.
+	-- Legacy format is a wiki-code string that can include an external link
+	-- New format has |venue= and |venuelink= as different parameters.
+	-- This should be removed once there's been a bot run to change this.
+	if not args.venuelink and args.venue and args.venue:sub(1, 1) == '[' then
+		-- Remove [] and split on space
+		local splitVenue = mw.text.split(args.venue:gsub('%[', ''):gsub('%]', ''), ' ')
+		args.venuelink = splitVenue[1]
+		table.remove(splitVenue, 1)
+		args.venue = table.concat(splitVenue, ' ')
+	end
+
 	local widgets = {
 		Header{
 			name = args.name,
@@ -91,7 +103,7 @@ function Series:createInfobox(frame)
 		Cell{
 			name = 'Venue',
 			content = {
-				args.venue
+				Page.makeExternalLink(args.venue, args.venuelink) or args.venue
 			}
 		},
 		Cell{

--- a/standard/locale.lua
+++ b/standard/locale.lua
@@ -44,16 +44,24 @@ function Locale.formatLocation(args)
 end
 
 function Locale.formatLocations(args)
-	local LOCATION_KEYS = {'venue', 'city', 'country', 'region'}
+	local LOCATION_KEYS = {
+		'venue${index}',
+		'venue${index}link',
+		'city${index}',
+		'country${index}',
+		'region${index}'
+	}
 	local locations = Array.mapIndexes(function(index)
-		local getLocationData = function(_, parameter)
-			return parameter, args[parameter .. index]
+		local getLocationData = function(_, rawParameter)
+			local parameter = String.interpolate(rawParameter, {index = index})
+			return parameter, args[parameter]
 		end
 
 		local location = Table.mapValues(Table.map(LOCATION_KEYS, getLocationData), String.nilIfEmpty)
 
 		if index == 1 then
-			local getLocationDataIndexless = function(_, parameter)
+			local getLocationDataIndexless = function(_, rawParameter)
+				local parameter = String.interpolate(rawParameter, {index = ''})
 				return parameter, location[parameter] or args[parameter]
 			end
 


### PR DESCRIPTION
## Summary
Add support for `|venuelink=` in addition to `|venue=`.
Split the external link from the display one in current method if in `|venue=` as a first step before doing bot runs that can be done later.

Old:
![image](https://user-images.githubusercontent.com/3426850/186455347-3a9c97bd-7292-43d9-a4b1-9bf15dafb5ab.png)

New:
![image](https://user-images.githubusercontent.com/3426850/186455125-91895c2e-bd0b-42ca-bc73-39cd4c9430e5.png)

## How did you test this change?

/dev module