### PR TITLE
Ensure non-nil in BracketOpponentEntry

### DIFF
--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -46,6 +46,7 @@ OpponentDisplay.BracketOpponentEntry = Class.new(
 )
 
 function OpponentDisplay.BracketOpponentEntry:createTeam(template, options)
+	options = options or {}
 	local forceShortName = options.forceShortName
 
 	local bracketStyleNode = OpponentDisplay.BlockTeamContainer({


### PR DESCRIPTION
## Summary

Introduced in #1739.

Custom OpponentEntry was the reason of this bug.

## How did you test this change?

Live