### PR TITLE
Kick TournamentUtil  usage from Player/Ext and Player/Ext/Starcraft

### DIFF
--- a/components/match2/commons/player_ext.lua
+++ b/components/match2/commons/player_ext.lua
@@ -14,7 +14,6 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TeamTemplate = require('Module:TeamTemplate')
-local TournamentUtil = require('Module:Tournament/Util')
 
 local globalVars = PageVariableNamespace({cached = true})
 local playerVars = PageVariableNamespace({namespace = 'Player', cached = true})
@@ -98,7 +97,7 @@ teamhistory data point.
 For specific uses only.
 ]]
 function PlayerExt.fetchTeamHistoryEntry(resolvedPageName, date)
-	date = date or TournamentUtil.getContextualDateOrNow()
+	date = date or PlayerExt.getContextualDateOrNow()
 
 	local conditions = {
 		'[[type::teamhistory]]',
@@ -227,7 +226,7 @@ PlayerExt.syncTeam. Enabled by default.
 ]]
 function PlayerExt.syncTeam(pageName, template, options)
 	options = options or {}
-	local date = options.date or TournamentUtil.getContextualDateOrNow()
+	local date = options.date or PlayerExt.getContextualDateOrNow()
 
 	local historyVar = playerVars:get(pageName .. '.teamHistory')
 	local history = historyVar and Json.parse(historyVar) or {}
@@ -269,6 +268,12 @@ team to page variables.
 ]]
 function PlayerExt.populateTeam(pageName, template, options)
 	return PlayerExt.syncTeam(pageName, template, Table.merge(options, {savePageVar = false}))
+end
+
+-- copy of a function (2 merged into 1) from Module:Tournament/Util to avoid a require loop
+function PlayerExt.getContextualDateOrNow()
+	return globalVars:get('tournament_enddate')
+		or os.date('%F')
 end
 
 return PlayerExt

--- a/components/match2/commons/starcraft_starcraft2/player_ext_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_ext_starcraft.lua
@@ -13,7 +13,6 @@ local Logic = require('Module:Logic')
 local PlayerExt = require('Module:Player/Ext')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local TournamentUtil = require('Module:Tournament/Util')
 
 local globalVars = PlayerExt.globalVars
 
@@ -78,7 +77,7 @@ For specific uses only.
 function StarcraftPlayerExt.fetchPlayerRace(resolvedPageName, date)
 	local lpdbPlayer = StarcraftPlayerExt.fetchPlayer(resolvedPageName)
 	if lpdbPlayer and lpdbPlayer.raceHistory then
-		date = date or TournamentUtil.getContextualDateOrNow()
+		date = date or PlayerExt.getContextualDateOrNow()
 		local entry = Array.find(lpdbPlayer.raceHistory, function(entry) return date <= entry.endDate end)
 		return entry and StarcraftPlayerExt.readRace(entry.race)
 	else


### PR DESCRIPTION
## Summary
Kick TournamentUtil  usage from Player/Ext and Player/Ext/Starcraft.
Reason: Need to use Opponent Module in TournamentUtil so it would create a require loop and since this is a tiny function it is way easier to do it this way instead of writing a new module that merges both.

## How did you test this change?
/dev then pushed live to see if require loop is solved