### PR TITLE
Fix Bug caused by setting match.walkover in counterstrike

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -46,6 +46,8 @@ function MatchLegacy.convertParameters(match2)
 		match.walkover = match.winner
 	elseif match.walkover == 'l' then
 		match.walkover = nil
+	else
+		match.walkover = nil
 	end
 
 	match.staticid = match2.match2id

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -44,8 +44,6 @@ function MatchLegacy.convertParameters(match2)
 
 	if match.walkover == 'ff' or match.walkover == 'dq' then
 		match.walkover = match.winner
-	elseif match.walkover == 'l' then
-		match.walkover = nil
 	else
 		match.walkover = nil
 	end


### PR DESCRIPTION
## Summary

In counterstrike `|walkover=true` was set if a match was a forfeit, setting this prevented pages like https://liquipedia.net/counterstrike/Category:Pages_lacking_HLTV_stats from being populated. So this fix was created to avoid having match.walkover set with a random value, as this was causing a mess with [Module:CrossTableLeague ](https://liquipedia.net/counterstrike/Module:CrossTableLeague).

## How did you test this change?

Live.
* https://liquipedia.net/counterstrike/ESL/Challenger_League/Season_42/Asia-Pacific
* https://liquipedia.net/counterstrike/ESL/Challenger_League/Season_42/Asia-Pacific/Weeks_1_to_4

*edit (CrossTableLeague not GroupTableLeague)
