### PR TITLE
Store `participantteam` in extradata in PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1078,7 +1078,7 @@ function Placement:_getLpdbData()
 			groupscore = opponent.additionalData.GROUPSCORE,
 			extradata = {
 				prizepoints = tostring(pointsReward or ''),
-				participantteam = opponentType == Opponent.solo
+				participantteam = (opponentType == Opponent.solo and players.p1team)
 									and Opponent.toName{template = players.p1team, type = 'team'}
 									or nil,
 			}

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1078,6 +1078,7 @@ function Placement:_getLpdbData()
 			groupscore = opponent.additionalData.GROUPSCORE,
 			extradata = {
 				prizepoints = tostring(pointsReward or ''),
+				participantteam = opponentType == Opponent.solo and players.p1team or nil,
 			}
 
 			-- TODO: We need to create additional LPDB Fields

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1078,7 +1078,9 @@ function Placement:_getLpdbData()
 			groupscore = opponent.additionalData.GROUPSCORE,
 			extradata = {
 				prizepoints = tostring(pointsReward or ''),
-				participantteam = opponentType == Opponent.solo and players.p1team or nil,
+				participantteam = opponentType == Opponent.solo
+									and Opponent.toName{template = players.p1team, type = 'team'}
+									or nil,
 			}
 
 			-- TODO: We need to create additional LPDB Fields


### PR DESCRIPTION
## Summary
Resolves #1718

The participant structure (ie non-opponent structure) expects `participantteam` in the extradata. This is used by `earnings` for instance. This PR adds the saving of this extradata field.

## How did you test this change?

Tested with dev module