### PR TITLE
Adjust standings storage in preparation for sc/sc2

### DIFF
--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -90,9 +90,9 @@ function StandingsStorage.entry(entry, standingsIndex)
 		currentstatus = entry.currentstatus or entry.pbg,
 		placementchange = entry.placementchange or entry.change,
 		scoreboard = mw.ext.LiquipediaDB.lpdb_create_json{
-			match = StandingsStorage.toScoreBoardEntry(entry.match),
+			match = StandingsStorage.toScoreBoardEntry(entry.match, {isMandatory = true}),
 			overtime = StandingsStorage.toScoreBoardEntry(entry.overtime),
-			game = StandingsStorage.toScoreBoardEntry(entry.game),
+			game = StandingsStorage.toScoreBoardEntry(entry.game, {isMandatory = true}),
 			points = tonumber(entry.points),
 			diff = tonumber(entry.diff),
 			buchholz = tonumber(entry.buchholz),
@@ -109,8 +109,9 @@ end
 
 ---@param data table
 ---@return table
-function StandingsStorage.toScoreBoardEntry(data)
-	if Table.isEmpty(data) then
+function StandingsStorage.toScoreBoardEntry(data, options)
+	options = options or {}
+	if Table.isEmpty(data) and options.isMandatory then
 		return Table.copy(SCOREBOARD_FALLBACK)
 	end
 
@@ -147,7 +148,7 @@ function StandingsStorage.fromTemplateEntry(frame)
 	if not data.standingsindex or not data.roundindex or not data.placement then
 		return
 	end
-	if not data.team and not data.player then
+	if not data.team and not data.player and not data.opponent then
 		return
 	end
 

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -90,9 +90,9 @@ function StandingsStorage.entry(entry, standingsIndex)
 		currentstatus = entry.currentstatus or entry.pbg,
 		placementchange = entry.placementchange or entry.change,
 		scoreboard = mw.ext.LiquipediaDB.lpdb_create_json{
-			match = StandingsStorage.toScoreBoardEntry(entry.match, {isMandatory = true}),
+			match = StandingsStorage.toScoreBoardEntry(entry.match),
 			overtime = StandingsStorage.toScoreBoardEntry(entry.overtime),
-			game = StandingsStorage.toScoreBoardEntry(entry.game, {isMandatory = true}),
+			game = StandingsStorage.toScoreBoardEntry(entry.game),
 			points = tonumber(entry.points),
 			diff = tonumber(entry.diff),
 			buchholz = tonumber(entry.buchholz),
@@ -109,9 +109,8 @@ end
 
 ---@param data table
 ---@return table
-function StandingsStorage.toScoreBoardEntry(data, options)
-	options = options or {}
-	if Table.isEmpty(data) and options.isMandatory then
+function StandingsStorage.toScoreBoardEntry(data)
+	if Table.isEmpty(data) then
 		return Table.copy(SCOREBOARD_FALLBACK)
 	end
 


### PR DESCRIPTION
## Summary
Adjust standings storage in preparation for sc/sc2 for usage in deprecated group table slots
* allow direct opponent struct passing (sc/sc2 needs a wrapper for the opponent handling anyways (e.g. for archon, duo, ...))
* ~~do not store overtime in scoreboard if not set (—> discussion)~~
* move the file to match the directory structure of other components (and so the sc/sc2 wrapper can be added accordingly)

## How did you test this change?
/dev module