### PR TITLE
Add SC2/SC Legacy Wrapper for Standings Storage

### DIFF
--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -29,6 +29,7 @@ local Wrapper = {}
 
 function Wrapper.table(frame)
 	local args = Arguments.getArgs(frame)
+	-- option to disable storage in case of transclusions etc
 	if not Logic.readBool(Logic.emptyOr(args.store, true)) then
 		return
 	end

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -11,6 +11,7 @@ local Array = require('Module:Array')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
@@ -91,11 +92,15 @@ function Wrapper._processOpponent(args)
 	if not opponentType then
 		return
 	end
-	opponentArgs.type = opponentType
 
 	for playerIndex, playerInput in ipairs(playerInputs) do
 		Wrapper._processPlayer(playerInput, opponentArgs, 'p' .. playerIndex)
 	end
+
+	if Table.isEmpty(opponentArgs) then
+		return
+	end
+	opponentArgs.type = opponentType
 
 	-- archon handling gets ignored here
 	-- due to the input patern for them being inconsistent it is unfeasible to regex them

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -18,12 +18,9 @@ local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local StandingsStorage = Lua.import('Module:Standings/Storage', {requireDevIfEnabled = true})
 
 local LEAGUE_TYPE = 'league'
-local TYPE_FROM_NUMBER = {
-	Opponent.solo,
-	Opponent.duo,
-	Opponent.trio,
-	Opponent.quad,
-}
+local TYPE_FROM_NUMBER = FnUtil.memoize(function ()
+	Table.map(Opponent.partySizes, function(key, code) return code, key end)
+end)
 local INVALID_OPPONENT_CATEGORY = '[[Category:Pages with invalid opponent '
 	.. 'parsing in legacy group tables]]'
 

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -29,12 +29,6 @@ local INVALID_OPPONENT_CATEGORY = '[[Category:Pages with invalid opponent '
 local Wrapper = {}
 
 function Wrapper.table(frame)
-	local args = Arguments.getArgs(frame)
-	-- option to disable storage in case of transclusions etc
-	if not Logic.readBool(Logic.emptyOr(args.store, true)) then
-		return
-	end
-
 	return StandingsStorage.fromTemplateHeader(frame)
 end
 

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -79,6 +79,9 @@ function Wrapper._processOpponent(args)
 	-- case team opponent
 	if opponentInput:match('class="team%-template') then
 		local teamPage = opponentInput:match('%[%[([^|]-)|[^|]-%]%]')
+		if not teamPage then
+			return
+		end
 		return {type = Opponent.team, template = teamPage:lower()}
 	end
 

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -1,0 +1,132 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Standings/Storage/StarcraftLegacy
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local StandingsStorage = Lua.import('Module:Standings/Storage', {requireDevIfEnabled = true})
+
+local LEAGUE_TYPE = 'league'
+local TYPE_FROM_NUMBER = {
+	Opponent.solo,
+	Opponent.duo,
+	Opponent.trio,
+	Opponent.quad,
+}
+local INVALID_OPPONENT_CATEGORY = '[[Category:Pages with invalid opponent '
+	.. 'parsing in legacy group tables]]'
+
+local Wrapper = {}
+
+function Wrapper.table(frame)
+	local args = Arguments.getArgs(frame)
+	if not Logic.readBool(Logic.emptyOr(args.store, true)) then
+		return
+	end
+
+	return StandingsStorage.fromTemplateHeader(frame)
+end
+
+function Wrapper.entry(frame)
+	local args = Arguments.getArgs(frame)
+	if not Logic.readBool(Logic.emptyOr(args.store, true)) then
+		return
+	end
+
+	local opponent = Wrapper._processOpponent(args)
+	if not opponent then
+		mw.log('Unable to parse opponent for group slot with the following arguments:')
+		mw.logObject(args, 'args')
+		return INVALID_OPPONENT_CATEGORY
+	end
+
+	local storageArgs = {
+		opponentLibrary = 'Opponent/Starcraft',
+		opponent = opponent,
+		title = Variables.varDefault('standings_title'),
+		tournament = Variables.varDefault('tournament_name', mw.title.getCurrentTitle().text),
+		type = args.type or LEAGUE_TYPE,
+		placement = args.place,
+		definitestatus = args.bg,
+		currentstatus = args.pbg or args.bg,
+		diff = args.diff,
+		win_m = args.win_m,
+		tie_m = args.tie_m,
+		lose_m = args.lose_m,
+		win_g = args.win_g,
+		tie_g = args.tie_g,
+		lose_g = args.lose_g,
+		points = points,
+		roundindex = 1,
+		standingsindex = Variables.varDefault('standingsindex'),
+	}
+
+	return StandingsStorage.fromTemplateEntry(storageArgs)
+end
+
+function Wrapper._processOpponent(args)
+	local opponentInput = args[1] or ''
+	-- case team opponent
+	if opponentInput:match('class="team%-template') then
+		local teamPage = opponentInput:match('%[%[([^|]-)|[^|]-%]%]')
+		return {type = Opponent.team, template = teamPage:lower()}
+	end
+
+	local opponentArgs = {}
+	--split the value into 
+	local playerInputs = mw.text.split(opponentInput, '<span class="starcraft%-inline%-player ?f?l?i?p?p?e?d?">')
+	playerInputs = Wrapper._removeEmpty(playerInputs)
+
+	local opponentType = TYPE_FROM_NUMBER[#playerInputs]
+	if not opponentType then
+		return
+	end
+	opponentArgs.type = opponentType
+
+	for playerIndex, playerInput in ipairs(playerInputs) do
+		local prefix = 'p' .. playerIndex
+		-- parse the single player and add them to the opponentArgs
+		local link, name = playerInput:match('%[%[([^|]-)|([^|]-)%]%]')
+		if String.isEmpty(link) or String.isEmpty(link) then
+			-- invalid input
+			return
+		end
+		opponentArgs[prefix] = name
+		opponentArgs[prefix .. 'link'] = link
+		opponentArgs[prefix .. 'flag'] = playerInput:match('<span class="flag">%[%[File:[^|]-%.png|([^|]-)|')
+
+		-- get the race
+		-- first remove the flag so that only 1 image is left
+		playerInput = playerInput:gsub('<span class="flag">.-</span>', '')
+		-- now read the race from the remaining file
+		opponentArgs[prefix .. 'race'] = playerInput:match('&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
+	end
+
+	-- archon handling gets ignored here
+	-- due to the input patern for them being inconsistent it is unfeasible to regex them
+	-- hence they will be manually converted to use the automated GroupTableLeague
+
+	return opponentArgs
+end
+
+function Wrapper._removeEmpty(tbl)
+	local newTable = {}
+	for _, item in ipairs(tbl) do
+		if String.isNotEmpty(item) then
+			table.insert(newTable, item)
+		end
+	end
+
+	return newTable
+end
+
+return Wrapper

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -108,17 +108,6 @@ function Wrapper._processOpponent(args)
 	return opponentArgs
 end
 
-function Wrapper._removeEmpty(tbl)
-	local newTable = {}
-	for _, item in ipairs(tbl) do
-		if String.isNotEmpty(item) then
-			table.insert(newTable, item)
-		end
-	end
-
-	return newTable
-end
-
 function Wrapper._processPlayer(playerInput, opponentArgs, prefix)
 	-- parse the single player and add them to the opponentArgs
 	local link, name = playerInput:match('%[%[([^|]-)|([^|]-)%]%]')

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -73,6 +73,7 @@ function Wrapper._processOpponent(args)
 	local opponentInput = args[1] or ''
 	-- case team opponent
 	if opponentInput:match('class="team%-template') then
+		-- attempts to find [[teamPage|teamDisplay]] and skips images (images have multiple |)
 		local teamPage = opponentInput:match('%[%[([^|]-)|[^|]-%]%]')
 		if not teamPage then
 			return
@@ -107,8 +108,9 @@ function Wrapper._processOpponent(args)
 	return opponentArgs
 end
 
+-- parse the single player and add them to the opponentArgs
 function Wrapper._processPlayer(playerInput, opponentArgs, prefix)
-	-- parse the single player and add them to the opponentArgs
+	-- attempts to find [[link|displayName]] and skips images (images have multiple |)
 	local link, name = playerInput:match('%[%[([^|]-)|([^|]-)%]%]')
 	if String.isEmpty(link) or String.isEmpty(name) then
 		-- invalid input

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -105,7 +105,7 @@ function Wrapper._processOpponent(args)
 
 	-- archon handling gets ignored here
 	-- due to the input patern for them being inconsistent it is unfeasible to regex them
-	-- hence they will be manually converted to use the automated GroupTableLeague
+	-- hence they already got manually converted to use the automated GroupTableLeague
 
 	return opponentArgs
 end

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -7,6 +7,7 @@
 --
 
 local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -29,6 +29,7 @@ local INVALID_OPPONENT_CATEGORY = '[[Category:Pages with invalid opponent '
 local Wrapper = {}
 
 function Wrapper.table(frame)
+	frame.args.roundcount = 1
 	return StandingsStorage.fromTemplateHeader(frame)
 end
 

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -65,7 +65,7 @@ function Wrapper.entry(frame)
 		win_g = args.win_g,
 		tie_g = args.tie_g,
 		lose_g = args.lose_g,
-		points = points,
+		points = args.points,
 		roundindex = 1,
 		standingsindex = Variables.varDefault('standingsindex'),
 	}
@@ -82,8 +82,9 @@ function Wrapper._processOpponent(args)
 	end
 
 	local opponentArgs = {}
-	--split the value into 
-	local playerInputs = mw.text.split(opponentInput, '<span class="starcraft%-inline%-player ?f?l?i?p?p?e?d?">')
+	-- split the opponentInput into the sep. playerInputs
+	local playerInputs = mw.text.split(opponentInput, '<span class="starcraft%-inline%-player')
+	-- since the split can add empty strings we need to remove them again
 	playerInputs = Wrapper._removeEmpty(playerInputs)
 
 	local opponentType = TYPE_FROM_NUMBER[#playerInputs]
@@ -93,22 +94,7 @@ function Wrapper._processOpponent(args)
 	opponentArgs.type = opponentType
 
 	for playerIndex, playerInput in ipairs(playerInputs) do
-		local prefix = 'p' .. playerIndex
-		-- parse the single player and add them to the opponentArgs
-		local link, name = playerInput:match('%[%[([^|]-)|([^|]-)%]%]')
-		if String.isEmpty(link) or String.isEmpty(link) then
-			-- invalid input
-			return
-		end
-		opponentArgs[prefix] = name
-		opponentArgs[prefix .. 'link'] = link
-		opponentArgs[prefix .. 'flag'] = playerInput:match('<span class="flag">%[%[File:[^|]-%.png|([^|]-)|')
-
-		-- get the race
-		-- first remove the flag so that only 1 image is left
-		playerInput = playerInput:gsub('<span class="flag">.-</span>', '')
-		-- now read the race from the remaining file
-		opponentArgs[prefix .. 'race'] = playerInput:match('&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
+		Wrapper._processPlayer(playerInput, opponentArgs, 'p' .. playerIndex)
 	end
 
 	-- archon handling gets ignored here
@@ -127,6 +113,24 @@ function Wrapper._removeEmpty(tbl)
 	end
 
 	return newTable
+end
+
+function Wrapper._processPlayer(playerInput, opponentArgs, prefix)
+	-- parse the single player and add them to the opponentArgs
+	local link, name = playerInput:match('%[%[([^|]-)|([^|]-)%]%]')
+	if String.isEmpty(link) or String.isEmpty(name) then
+		-- invalid input
+		return
+	end
+	opponentArgs[prefix] = name
+	opponentArgs[prefix .. 'link'] = link
+	opponentArgs[prefix .. 'flag'] = playerInput:match('<span class="flag">%[%[File:[^|]-%.png|([^|]-)|')
+
+	-- get the race
+	-- first remove the flag so that only 1 image is left
+	playerInput = playerInput:gsub('<span class="flag">.-</span>', '')
+	-- now read the race from the remaining file
+	opponentArgs[prefix .. 'race'] = playerInput:match('&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
 end
 
 return Wrapper

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -89,7 +89,7 @@ function Wrapper._processOpponent(args)
 	-- split the opponentInput into the sep. playerInputs
 	local playerInputs = mw.text.split(opponentInput, '<span class="starcraft%-inline%-player')
 	-- since the split can add empty strings we need to remove them again
-	playerInputs = Wrapper._removeEmpty(playerInputs)
+	playerInputs = Array.filter(playerInputs, String.isNotEmpty)
 
 	local opponentType = TYPE_FROM_NUMBER[#playerInputs]
 	if not opponentType then

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -8,6 +8,7 @@
 
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
+local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -111,7 +111,7 @@ end
 
 -- parse the single player and add them to the opponentArgs
 function Wrapper._processPlayer(playerInput, opponentArgs, prefix)
-	-- attempts to find [[link|displayName]] and skips images (images have multiple |)
+	-- attempts to find [[link|name]] and skips images (images have multiple |)
 	local link, name = playerInput:match('%[%[([^|]-)|([^|]-)%]%]')
 	if String.isEmpty(link) or String.isEmpty(name) then
 		-- invalid input

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -54,6 +54,7 @@ function Wrapper.entry(frame)
 		tournament = Variables.varDefault('tournament_name', mw.title.getCurrentTitle().text),
 		type = args.type or LEAGUE_TYPE,
 		placement = args.place,
+		placerange = {tonumber(args.place), tonumber(args.place)},
 		definitestatus = args.bg,
 		currentstatus = args.pbg or args.bg,
 		diff = args.diff,


### PR DESCRIPTION
## Summary
Add SC2/SC Legacy Wrapper for Standings Storage
* supports parsing opponents as input into `args[1]`
* determines opponentType (if supported) automatically
* supports team, solo, duo, trio, quad opponents
* due to targeting sc/sc2 specific classes for the player split this is only applicable for sc/sc2
* archon gets ignored (for reason see comment in the code)

## How did you test this change?
live (new module)