### PR TITLE
Fix issue with index being applied twice in `locaitons`

### DIFF
--- a/standard/locale.lua
+++ b/standard/locale.lua
@@ -53,16 +53,16 @@ function Locale.formatLocations(args)
 	}
 	local locations = Array.mapIndexes(function(index)
 		local getLocationData = function(_, rawParameter)
+			local parameterIndexless = String.interpolate(rawParameter, {index = ''})
 			local parameter = String.interpolate(rawParameter, {index = index})
-			return parameter, args[parameter]
+			return parameterIndexless, args[parameter]
 		end
 
 		local location = Table.mapValues(Table.map(LOCATION_KEYS, getLocationData), String.nilIfEmpty)
-
 		if index == 1 then
 			local getLocationDataIndexless = function(_, rawParameter)
-				local parameter = String.interpolate(rawParameter, {index = ''})
-				return parameter, location[parameter] or args[parameter]
+				local parameterIndexless = String.interpolate(rawParameter, {index = ''})
+				return parameterIndexless, location[parameterIndexless] or args[parameterIndexless]
 			end
 
 			location = Table.mapValues(Table.map(LOCATION_KEYS, getLocationDataIndexless), String.nilIfEmpty)


### PR DESCRIPTION
## Summary
Fixes #1753. Due to incorrect logic in `getLocationData` , the index would be applies twice, eg. `country1` would become `country11` and `country2` would become `country22`. The issue didn't affect `getLocationDataIndexless`, so `country` would become `country1` as intended. 
This PR fixes the return values of `getLocationData` and renames parameters in `getLocationDataIndexless` for commonality. 

## How did you test this change?

/dev module

```
mw.logObject(Locale.formatLocations{country='Sweden', country2='Norway'})
table#1 {
  ["country1"] = "se",
  ["country2"] = "no",
}
mw.logObject(Locale.formatLocations{country1='Sweden', country2='Norway'})
table#1 {
  ["country1"] = "se",
  ["country2"] = "no",
}
mw.logObject(Locale.formatLocations{country='Sweden', country2='Norway', country3='Finland'})
table#1 {
  ["country1"] = "se",
  ["country2"] = "no",
  ["country3"] = "fi",
}
```