### PR TITLE
Improve counterstrike handling of match status (postponed/canceled)

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -499,7 +499,7 @@ function matchFunctions.getOpponents(match)
 	if Table.includes(NP_MATCH_STATUS, match.finished) then
 		match.resulttype = 'np'
 		match.status = match.finished
-		match.finished = true
+		match.finished = false
 	else
 		-- see if match should actually be finished if score is set
 		if isScoreSet and not Logic.readBool(match.finished) and match.hasDate then

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -247,6 +247,9 @@ function CustomMatchSummary._createBody(match)
 	local body = MatchSummary.Body()
 
 	if match.dateIsExact or (match.date ~= EPOCH_TIME_EXTENDED and match.date ~= EPOCH_TIME) then
+		if Logic.isNotEmpty(match.extradata.status) then
+			match.stream = {rawdatetime = true}
+		end
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not epoch=0, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(


### PR DESCRIPTION
## Summary

Avoid showing match countdown if a match is postponed or cancelled, and also don't set it as finished in these cases.

## How did you test this change?

* `/dev` modules.
* [VANYLO x SCL Summer Cup 2022](https://liquipedia.net/counterstrike/VANYLO_x_SCL_Cup/2022/Summer)

