### PR TITLE
Fix mediawiki sorting for placements

### DIFF
--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -140,7 +140,7 @@ function Placement._placement(args)
 	local diff
 	if tonumber(placement[1]) == nil then
 		text = string.upper(placement[1])
-		diff = 1
+		diff = 0
 	elseif table.maxn(placement) == 2 then
 		if ordinalSuffix[placement[2]] then
 			text = placement[1] .. '&nbsp;-&nbsp;' .. placement[2] .. ordinalSuffix[placement[2]]
@@ -154,7 +154,7 @@ function Placement._placement(args)
 		else
 			text = placement[1] .. ordinalSuffix[string.sub(placement[1], -1)]
 		end
-		diff = 1
+		diff = 0
 	end
 
 	-- Cell color
@@ -198,7 +198,9 @@ function Placement._placement(args)
 	end
 
 	local sortPrefix2 --Sort key for second part
-	if tonumber(diff) <= 17 then
+	if tonumber(diff) == 0 then
+		sortPrefix2 = ''
+	elseif tonumber(diff) <= 17 then
 		sortPrefix2 = placeSortPrefix[tostring(diff)]
 	elseif tonumber(diff) <= 32 then
 		sortPrefix2 = 'R'

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -208,15 +208,11 @@ function Placement._placement(args)
 
 	if sortPrefix == nil then
 		mw.log('No placement found in Module:Placement: ' .. args.placement)
-		args.parent:tag('span')
-			:css('display', 'none')
-			:wikitext('ZZ')
+		args.parent:attr('data-sort-value', 'ZZ')
 		args.parent:tag('font')
 			:wikitext(args.placement .. ' [[Category:Pages with unknown placements]]')
 	else
-		args.parent:tag('span')
-			:css('display', 'none')
-			:wikitext(sortPrefix .. sortPrefix2)
+		args.parent:attr('data-sort-value', sortPrefix .. sortPrefix2)
 
 		-- Display text
 		args.parent:tag('font')


### PR DESCRIPTION
## Summary

Previously using `display:none` spans was potentially causing issues with how the javascript was sorting the tables. This is now switched to using the intended sorting value way that's described on the MediaWiki wiki.

## How did you test this change?

Tested live on CS wiki since `/dev` module was already in use for refactor and CS wiki uses `Module:Placement/Custom`
* https://liquipedia.net/counterstrike/User:IMarbot/placement_test
* https://liquipedia.net/counterstrike/Module:Placement