### PR TITLE
Fix metadesc generator for no date, teams, and prizepool

### DIFF
--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -141,6 +141,10 @@ function MetadataGenerator.tournament(args)
 		})
 	end
 
+	if not (date or teams or players or prizepool) then
+		output = output .. 'is yet to take place'
+	end
+
 	output = output .. '.'
 
 	return output


### PR DESCRIPTION
## Summary

There was an issue when all three were missing the text generated would end abruptly.
![image](https://user-images.githubusercontent.com/5881994/186985528-757ab2ab-4631-43c7-b519-958c6cb84c62.png)


## How did you test this change?

Tested using `/dev`
![image](https://user-images.githubusercontent.com/5881994/186985550-11d534e4-1428-4638-abe9-6b58a311fd96.png)

