### PR TITLE
fix HDB nil error with no args present on cs

### DIFF
--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -11,10 +11,11 @@ local Logic = require('Module:Logic')
 local Tier = mw.loadData('Module:Tier')
 local Variables = require('Module:Variables')
 
-local BasicHiddenDataBox = require('Module:HiddenDataBox')
+local BasicHiddenDataBox = require('Module:HiddenDataBox/dev')
 local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
+	args = args or {}
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
 	if args.liquipediatier and not Logic.isNumeric(args.liquipediatier) then
 		args.liquipediatier = Tier.number[args.liquipediatier]

--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -11,7 +11,7 @@ local Logic = require('Module:Logic')
 local Tier = mw.loadData('Module:Tier')
 local Variables = require('Module:Variables')
 
-local BasicHiddenDataBox = require('Module:HiddenDataBox/dev')
+local BasicHiddenDataBox = require('Module:HiddenDataBox')
 local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)


### PR DESCRIPTION
## Summary

Fix if the template is called without any args.
![image](https://user-images.githubusercontent.com/5881994/187033531-c1569139-a7c8-401e-86c1-60209eadde38.png)


## How did you test this change?

Code for fix was copied from commons module. Tested on `/dev`.
![image](https://user-images.githubusercontent.com/5881994/187033555-c6f72833-83f1-4919-8dff-4fab0a4b9977.png)

