### PR TITLE
Move tournament name sanitization

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -21,6 +21,7 @@ local Page = require('Module:Page')
 local LeagueIcon = require('Module:LeagueIcon')
 local WarningBox = require('Module:WarningBox')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
+local TextSanitizer = require('Module:TextSanitizer')
 local Tier = require('Module:Tier')
 local InfoboxPrizePool = require('Module:Infobox/Extensions/PrizePool')
 local Logic = require('Module:Logic')
@@ -30,14 +31,6 @@ local _TIER_MODE_TYPES = 'types'
 local _TIER_MODE_TIERS = 'tiers'
 local _INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
 	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
-
-local NAME_SANITIZER = {
-	['<.->'] =  '', -- All html tags and their attributes
-	['&nbsp;'] = ' ', -- Non-breaking space
-	['&zwj;'] = '', -- Zero width joiner
-	['—'] = '-', -- Non-breaking hyphen
-	['&shy;'] = '', -- Soft hyphen
-}
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -344,9 +337,9 @@ function League:_createPrizepool(args)
 end
 
 function League:_definePageVariables(args)
-	Variables.varDefine('tournament_name', League.sanitizeName(args.name))
-	Variables.varDefine('tournament_shortname', League.sanitizeName(args.shortname or args.abbreviation))
-	Variables.varDefine('tournament_tickername', League.sanitizeName(args.tickername))
+	Variables.varDefine('tournament_name', TextSanitizer.tournamentName(args.name))
+	Variables.varDefine('tournament_shortname', TextSanitizer.tournamentName(args.shortname or args.abbreviation))
+	Variables.varDefine('tournament_tickername', TextSanitizer.tournamentName(args.tickername))
 	Variables.varDefine('tournament_icon', args.icon)
 	Variables.varDefine('tournament_icondark', args.icondark or args.icondarkmode)
 	Variables.varDefine('tournament_series', mw.ext.TeamLiquidIntegration.resolve_redirect(args.series or ''))
@@ -395,9 +388,9 @@ end
 
 function League:_setLpdbData(args, links)
 	local lpdbData = {
-		name = League.sanitizeName(self.name),
-		tickername = League.sanitizeName(args.tickername),
-		shortname = League.sanitizeName(args.shortname or args.abbreviation),
+		name = TextSanitizer.tournamentName(self.name),
+		tickername = TextSanitizer.tournamentName(args.tickername),
+		shortname = TextSanitizer.tournamentName(args.shortname or args.abbreviation),
 		banner = args.image,
 		bannerdark = args.imagedark or args.imagedarkmode,
 		icon = Variables.varDefault('tournament_icon'),
@@ -441,7 +434,7 @@ function League:_setLpdbData(args, links)
 
 	lpdbData = self:addToLpdb(lpdbData, args)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
-	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. self.name, lpdbData)
+	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. TextSanitizer.tournamentName(self.name), lpdbData)
 end
 
 function League:_setSeoTags(args)
@@ -659,23 +652,6 @@ function League:_fetchAbbreviation()
 	if type(seriesData) == 'table' and seriesData[1] then
 		return seriesData[1].abbreviation
 	end
-end
-
----Replaces a set of html entities with ansi characters.
----Removes all html tags and their attributes.
----@param name string?
----@return string?
-function League.sanitizeName(name)
-	if not name then
-		return
-	end
-
-	local sanitizedName = name
-	for search, replace in pairs(NAME_SANITIZER) do
-		sanitizedName = sanitizedName:gsub(search, replace)
-	end
-
-	return sanitizedName
 end
 
 return League

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -221,7 +221,7 @@ function League:createInfobox()
 			}
 		},
 	}
-	
+
 	self.name = TextSanitizer.tournamentName(self.name)
 
 	self.infobox:bottom(self:createBottomContent())

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -221,6 +221,8 @@ function League:createInfobox()
 			}
 		},
 	}
+	
+	self.name = TextSanitizer.tournamentName(self.name)
 
 	self.infobox:bottom(self:createBottomContent())
 
@@ -388,7 +390,7 @@ end
 
 function League:_setLpdbData(args, links)
 	local lpdbData = {
-		name = TextSanitizer.tournamentName(self.name),
+		name = self.name,
 		tickername = TextSanitizer.tournamentName(args.tickername),
 		shortname = TextSanitizer.tournamentName(args.shortname or args.abbreviation),
 		banner = args.image,
@@ -434,7 +436,7 @@ function League:_setLpdbData(args, links)
 
 	lpdbData = self:addToLpdb(lpdbData, args)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
-	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. TextSanitizer.tournamentName(self.name), lpdbData)
+	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. self.name, lpdbData)
 end
 
 function League:_setSeoTags(args)

--- a/standard/text_sanitizer.lua
+++ b/standard/text_sanitizer.lua
@@ -1,0 +1,35 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:TextSanitizer
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+
+local TextSanitizer = {}
+
+local NAME_SANITIZER = {
+	['<.->'] =  '', -- All html tags and their attributes
+	['&nbsp;'] = ' ', -- Non-breaking space
+	['&zwj;'] = '', -- Zero width joiner
+	['—'] = '-', -- Non-breaking hyphen
+	['&shy;'] = '', -- Soft hyphen
+}
+
+---Replaces a set of html entities with ansi characters.
+---Removes all html tags and their attributes.
+---@param name string?
+---@return string?
+function TextSanitizer.tournamentName(name)
+	if not name then
+		return
+	end
+
+	local sanitizedName = name
+	for search, replace in pairs(NAME_SANITIZER) do
+		sanitizedName = sanitizedName:gsub(search, replace)
+	end
+
+	return sanitizedName
+end
+
+return TextSanitizer


### PR DESCRIPTION
## Summary

Move the sanitization code out of the infobox module for consistent use across other modules. Also fix objectname not being sanitizied. Allows for work on #1735.

## How did you test this change?

Tested on `/dev`.