### PR TITLE
Fix inconsistency in parent storage

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -84,7 +84,7 @@ function HiddenDataBox.run(args)
 	HiddenDataBox.checkAndAssign('tournament_mode', args.mode, queryResult.mode)
 
 	HiddenDataBox.checkAndAssign('tournament_game', args.game, queryResult.game)
-	HiddenDataBox.checkAndAssign('tournament_parent', args.parent, parent)
+	HiddenDataBox.checkAndAssign('tournament_parent', parent)
 	HiddenDataBox.checkAndAssign('tournament_parentname', args.parentname, queryResult.name)
 
 	local startDate = HiddenDataBox.cleanDate(args.sdate, args.date)


### PR DESCRIPTION
## Summary
Currently HDB sets the `tourtnament_parent` variable as `args.parent` if entered. This can cause the variable having spaces instead of underscores.
The local `parent` alsready has that cleaned up so just usse it instead

## How did you test this change?
/dev modules