### PR TITLE
Placement: Fix skipShadowCell and remove unnecessary CSS

### DIFF
--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -218,10 +218,7 @@ function Placement._placement(args)
 
 		-- Display text
 		args.parent:tag('font')
-			:addClass('placement-text')
-			-- luacheck: ignore
-			-- line length
-			:css('text-shadow', (skipShadowCell and 'none' or '1px 1px rgba(64, 64, 64, 0.4), 1px -1px rgba(64, 64, 64, 0.4), -1px -1px rgba(64, 64, 64, 0.4), -1px 1px rgba(64, 64, 64, 0.4)'))
+			:addClass(skipShadowCell and '' or 'placement-text')
 			:css('font-weight', 'bold')
 			:css('color', textColorCell)
 			:wikitext(text .. (args.text and ' ' .. args.text or ''))

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -218,7 +218,7 @@ function Placement._placement(args)
 
 		-- Display text
 		args.parent:tag('font')
-			:addClass(skipShadowCell and '' or 'placement-text')
+			:addClass(not skipShadowCell and 'placement-text' or nil)
 			:css('font-weight', 'bold')
 			:css('color', textColorCell)
 			:wikitext(text .. (args.text and ' ' .. args.text or ''))


### PR DESCRIPTION
## Summary

Basically, the code did nothing before because the css class `placement-text` already applied that identical CSS shadow stuff. Now it uses the boolean to determine whether to add the class or not, which achieves the wanted behaviour. Also, less hardcoded CSS, more darkmode fun, and less includes size memes.

## How did you test this change?

Live on CS wiki.