### PR TITLE
Add `w`, `d`, `l`, `dq` classes to `Placement.placementClasses` for later usage in PPT

### DIFF
--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -33,6 +33,10 @@ Placement.placementClasses = {
 	'background-color-second-place',
 	'background-color-third-place',
 	'background-color-fourth-place',
+	w = 'bg-win',
+	d = 'bg-draw',
+	l = 'bg-lose',
+	dq = 'bg-dq',
 }
 
 --[[


### PR DESCRIPTION
## Summary
Add `w`, `d`, `l`, `dq` classes to Placement.placementClasses`

Idea is to adjust `Placement:getBackground()` to be able to read them from there
https://github.com/Liquipedia/Lua-Modules/blob/fde50c2ae82a4b92b76f6fb3adb4d0615f8e575b/components/prize_pool/commons/prize_pool.lua#L1163
maybe something like the following (only idea)
```lua
function Placement:getBackground()
	for statusName, status in pairs(Placement.specialStatuses) do
		if status.active(self.args) and PlacementInfo.getBgClass(statusName:lower())  then
			return PlacementInfo.getBgClass(statusName:lower())
		end
	end

	return PlacementInfo.getBgClass(self.placeStart)
end
```
this way we maybe could solve #1675 (together with adding w,d,l as special statuses)

## How did you test this change?
N/A