### PR TITLE
LPA-5874: Update paddings on LOL's match summary

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -63,7 +63,7 @@ end
 function HeroBan:banRow(banData, gameNumber, numberOfBans)
 	self.table:tag('tr')
 		:tag('td'):css('float', 'left')
-			:node(CustomMatchSummary._opponentHeroesDisplay(banData[1], numberOfBans, true, true, self.date))
+			:node(CustomMatchSummary._opponentHeroesDisplay(banData[1], numberOfBans, true, self.date))
 		:tag('td'):css('font-size', '80%'):node(mw.html.create('div')
 			:wikitext(CustomMatchSummary._createAbbreviation{
 				title = 'Bans in game ' .. gameNumber,
@@ -71,7 +71,7 @@ function HeroBan:banRow(banData, gameNumber, numberOfBans)
 			})
 		)
 		:tag('td'):css('float', 'right')
-			:node(CustomMatchSummary._opponentHeroesDisplay(banData[2], numberOfBans, true, true, self.date))
+			:node(CustomMatchSummary._opponentHeroesDisplay(banData[2], numberOfBans, true, self.date))
 	return self
 end
 
@@ -242,8 +242,7 @@ function CustomMatchSummary._createGame(game, gameIndex)
 
 	row:addClass('brkts-popup-body-game')
 		:css('font-size', '80%')
-		:css('padding-left', '5px')
-		:css('padding-right', '5px')
+		:css('padding', '4px')
 		:css('min-height', '32px')
 
 	row:addElement(CustomMatchSummary._opponentHeroesDisplay(heroesData[1], numberOfHeroes, false))
@@ -290,7 +289,7 @@ function CustomMatchSummary._createAbbreviation(args)
 	return '<i><abbr title="' .. args.title .. '">' .. args.text .. '</abbr></i>'
 end
 
-function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfHeroes, flip, isBan, date)
+function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfHeroes, flip, date)
 	local opponentHeroesDisplay = {}
 	local color = opponentHeroesData.side or ''
 
@@ -300,12 +299,6 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 			:addClass('brkts-champion-icon')
 			:css('float', flip and 'right' or 'left')
 			:node(HeroIcon._getImage{opponentHeroesData[index], date = date})
-		if index == 1 then
-			heroDisplay:css('padding-left', '2px')
-		end
-		if index == numberOfHeroes then
-			heroDisplay:css('padding-right', '2px')
-		end
 		if numberOfHeroes == _NUM_HEROES_PICK_SOLO then
 			if flip then
 				heroDisplay:css('margin-right', '70px')
@@ -322,10 +315,6 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 
 	local display = mw.html.create('div')
 		:addClass('brkts-popup-body-element-thumbs')
-	if isBan then
-		--display:addClass('brkts-popup-side-shade-out')
-		display:css('padding-' .. (flip and 'right' or 'left'), '4px')
-	end
 
 	for _, item in ipairs(opponentHeroesDisplay) do
 		display:node(item)


### PR DESCRIPTION
## Summary
Padding is inconsistent between game rows and ban rows. Changes match PR #1208.

Live:
![image](https://user-images.githubusercontent.com/3426850/187160051-827f11e2-90a4-4f3a-abf1-2f302a8b5538.png)

With PR:
![image](https://user-images.githubusercontent.com/3426850/187160394-dffad82c-e994-48a4-826e-3f4e0da706b2.png)


## How did you test this change?

Dev module