### PR TITLE
PrizePool: Add extradata fields to lpdb.placement storage

### DIFF
--- a/components/prize_pool/wikis/apexlegends/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/apexlegends/prize_pool_custom.lua
@@ -43,6 +43,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+	lpdbData.extradata.location = Variables.varDefault('tournament_location', '')
+	lpdbData.extradata['is ea major'] = Variables.varDefault('tournament_ea_major', '')
 	return lpdbData
 end
 


### PR DESCRIPTION

## Summary

Added extradata fields passed from lpdb.tournament to lpdb.placement for use in other modules. 


## How did you test this change?

Tested here using dev module:
https://liquipedia.net/apexlegends/Dark_meluca/PointsPrizePoolTest
