### PR TITLE
Support multiple `venue` with similiar wikicode format to `organizer`

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -170,7 +170,7 @@ function League:createInfobox()
 				local venues = {}
 				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
 					-- TODO: Description
-					local description
+					local description = ''
 					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -169,7 +169,9 @@ function League:createInfobox()
 
 				local venues = {}
 				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
-					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], args[prefix .. 'desc']))
+					-- TODO: Description
+					local description
+					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 
 				return Cell{

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -174,10 +174,10 @@ function League:createInfobox()
 					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 
-				return Cell{
+				return {Cell{
 					name = 'Venue',
-					content = {venues}
-				}
+					content = venues
+				}}
 			end
 		},
 		Cell{name = 'Format', content = {args.format}},

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -161,11 +161,22 @@ function League:createInfobox()
 				self:_createLocation(args)
 			}
 		},
-		Cell{
-			name = 'Venue',
-			content = {
-				Page.makeExternalLink(args.venue, args.venuelink) or args.venue
-			}
+		Builder{
+			builder = function()
+				args.venue1 = args.venue1 or args.venue
+				args.venue1link = args.venue1link or args.venuelink
+				args.venue1desc = args.venue1desc or args.venuedesc
+
+				local venues = {}
+				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
+					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], args[prefix .. 'desc']))
+				end
+
+				return Cell{
+					name = 'Venue',
+					content = {venues}
+				}
+			end
 		},
 		Cell{name = 'Format', content = {args.format}},
 		Customizable{id = 'prizepool', children = {
@@ -553,36 +564,36 @@ function League:_setIconVariable(iconSmallTemplate, manualIcon, manualIconDark)
 	end
 end
 
-function League:_createOrganizer(organizer, name, link, reference)
-	if String.isEmpty(organizer) then
+function League:_createLink(id, name, link, desc)
+	if String.isEmpty(id) then
 		return nil
 	end
 
 	local output
 
-	if Page.exists(organizer) then
-		output = '[[' .. organizer .. '|'
+	if Page.exists(id) then
+		output = '[[' .. id .. '|'
 		if String.isEmpty(name) then
-			output = output .. organizer .. ']]'
+			output = output .. id .. ']]'
 		else
 			output = output .. name .. ']]'
 		end
 
 	elseif not String.isEmpty(link) then
 		if String.isEmpty(name) then
-			output = '[' .. link .. ' ' .. organizer .. ']'
+			output = '[' .. link .. ' ' .. id .. ']'
 		else
 			output = '[' .. link .. ' ' .. name .. ']'
 
 		end
 	elseif String.isEmpty(name) then
-		output = organizer
+		output = id
 	else
 		output = name
 	end
 
-	if not String.isEmpty(reference) then
-		output = output .. reference
+	if not String.isEmpty(desc) then
+		output = output .. desc
 	end
 
 	return output
@@ -590,7 +601,7 @@ end
 
 function League:_createOrganizers(args)
 	local organizers = {
-		League:_createOrganizer(
+		League:_createLink(
 			args.organizer, args['organizer-name'], args['organizer-link'], args.organizerref),
 	}
 
@@ -599,7 +610,7 @@ function League:_createOrganizers(args)
 	while not String.isEmpty(args['organizer' .. index]) do
 		table.insert(
 			organizers,
-			League:_createOrganizer(
+			League:_createLink(
 				args['organizer' .. index],
 				args['organizer' .. index .. '-name'],
 				args['organizer' .. index .. '-link'],

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -100,11 +100,22 @@ function Series:createInfobox(frame)
 				},
 			}
 		},
-		Cell{
-			name = 'Venue',
-			content = {
-				Page.makeExternalLink(args.venue, args.venuelink) or args.venue
-			}
+		Builder{
+			builder = function()
+				args.venue1 = args.venue1 or args.venue
+				args.venue1link = args.venue1link or args.venuelink
+				args.venue1desc = args.venue1desc or args.venuedesc
+
+				local venues = {}
+				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
+					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], args[prefix .. 'desc']))
+				end
+
+				return Cell{
+					name = 'Venue',
+					content = {venues}
+				}
+			end
 		},
 		Cell{
 			name = 'Date',
@@ -309,36 +320,36 @@ function Series:_createLocation(country, city)
 	return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' .. (city or country)
 end
 
-function Series:_createOrganizer(organizer, name, link, reference)
-	if String.isEmpty(organizer) then
+function Series:_createLink(id, name, link, desc)
+	if String.isEmpty(id) then
 		return nil
 	end
 
 	local output
 
-	if Page.exists(organizer) then
-		output = '[[' .. organizer .. '|'
+	if Page.exists(id) then
+		output = '[[' .. id .. '|'
 		if String.isEmpty(name) then
-			output = output .. organizer .. ']]'
+			output = output .. id .. ']]'
 		else
 			output = output .. name .. ']]'
 		end
 
 	elseif not String.isEmpty(link) then
 		if String.isEmpty(name) then
-			output = '[' .. link .. ' ' .. organizer .. ']'
+			output = '[' .. link .. ' ' .. id .. ']'
 		else
 			output = '[' .. link .. ' ' .. name .. ']'
 
 		end
 	elseif String.isEmpty(name) then
-		output = organizer
+		output = id
 	else
 		output = name
 	end
 
-	if not String.isEmpty(reference) then
-		output = output .. reference
+	if not String.isEmpty(desc) then
+		output = output .. desc
 	end
 
 	return output
@@ -346,7 +357,7 @@ end
 
 function Series:_createOrganizers(args)
 	local organizers = {
-		Series:_createOrganizer(
+		Series:_createLink(
 			args.organizer, args['organizer-name'], args['organizer-link'], args.organizerref),
 	}
 
@@ -355,7 +366,7 @@ function Series:_createOrganizers(args)
 	while not String.isEmpty(args['organizer' .. index]) do
 		table.insert(
 			organizers,
-			Series:_createOrganizer(
+			Series:_createLink(
 				args['organizer' .. index],
 				args['organizer' .. index .. '-name'],
 				args['organizer' .. index .. '-link'],

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -113,10 +113,10 @@ function Series:createInfobox(frame)
 					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 
-				return Cell{
+				return {Cell{
 					name = 'Venue',
-					content = {venues}
-				}
+					content = venues
+				}}
 			end
 		},
 		Cell{

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -109,7 +109,7 @@ function Series:createInfobox(frame)
 				local venues = {}
 				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
 					-- TODO: Description
-					local description
+					local description = ''
 					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -108,7 +108,9 @@ function Series:createInfobox(frame)
 
 				local venues = {}
 				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
-					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], args[prefix .. 'desc']))
+					-- TODO: Description
+					local description
+					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 
 				return Cell{


### PR DESCRIPTION
## Summary

Add support in infobox league and series to display multiple `venue`s with separate wikicode input. This would replace the freetext `|venue=` overtime. 

Wikicode would be:
* `|venueX=` (just `|venue=` would be an alias for `|venue1=`)
* `|venueXlink=` (internal or external link to a page)
* ~~`|venueXdesc=` (description to append at the end of the venue)~~

![image](https://user-images.githubusercontent.com/3426850/187191335-f03d9cbd-4679-43d4-b849-f1b509f9d0a1.png)
Gives
![image](https://user-images.githubusercontent.com/3426850/187191301-8e6bd738-4d1d-45f5-8eef-cd0746429715.png)


## How did you test this change?
/dev module