### PR TITLE
Allow for space on either side of the `/` in br/hr in Legacy PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -234,7 +234,7 @@ function LegacyPrizePool.parseWikiLink(input)
 
 	local inputWithoutHtml = input:gsub('<.->.-</.->', '')
 
-	for inputSection in mw.text.gsplit(inputWithoutHtml, '< *[hb]r/? *>') do
+	for inputSection in mw.text.gsplit(inputWithoutHtml, '< *[hb]r */? *>') do
 		-- Does this contain a wiki link?
 		if string.find(inputSection, '%[') then
 			local cleanedInput = inputSection:gsub('^.-%[+', ''):gsub('%].-$', '')


### PR DESCRIPTION
## Summary

Allow for space in the `<br>` or `<hr>` on either side of a potential `/`.

## How did you test this change?
Tested with /dev module
