### PR TITLE
Infobox League for CrossFire

### DIFF
--- a/components/infobox/wikis/crossfire/infobox_league_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_league_custom.lua
@@ -19,7 +19,6 @@ local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
-local _game
 
 local _GAME = mw.loadData('Module:GameVersion')
 
@@ -68,7 +67,7 @@ function CustomLeague:liquipediaTierHighlighted()
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.game = _game or args.game
+	lpdbData.game = CustomLeague._getGameVersion() or args.game
 	lpdbData.publishertier = args.cfpremier
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.extradata = {
@@ -79,7 +78,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 end
 
 function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_game', _game or _args.game)
+	Variables.varDefine('tournament_game', CustomLeague._getGameVersion() or _args.game)
 	Variables.varDefine('tournament_publishertier', _args.cfpremier)
 	--Legacy Vars:
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
@@ -87,9 +86,7 @@ function CustomLeague:defineCustomPageVariables()
 end
 
 function CustomLeague._getGameVersion()
-	local game = string.lower(_args.game or '')
-	_game = _GAME[game]
-	return _game
+	return _GAME[string.lower(_args.game or '')]
 end
 
 return CustomLeague

--- a/components/infobox/wikis/crossfire/infobox_league_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_league_custom.lua
@@ -1,0 +1,95 @@
+---
+-- @Liquipedia
+-- wiki=crossfire
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local League = require('Module:Infobox/League')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Title = require('Module:Infobox/Widget/Title')
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _game
+
+local _GAME = mw.loadData('Module:GameVersion')
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_args = league.args
+
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'sponsors' then
+		table.insert(widgets, Cell{name = 'Official Device', content = {_args.device}})
+	elseif id == 'gamesettings' then
+		return {
+			Cell{name = 'Game version', content = {
+					CustomLeague._getGameVersion()
+				}},
+			}
+	elseif id == 'customcontent' then
+		if _args.player_number then
+			table.insert(widgets, Title{name = 'Players'})
+			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
+		end
+
+		--teams section
+		if _args.team_number then
+			table.insert(widgets, Title{name = 'Teams'})
+			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+		end
+	end
+	return widgets
+end
+
+function CustomLeague:liquipediaTierHighlighted()
+	return Logic.readBool(_args.cfpremier)
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.game = _game or args.game
+	lpdbData.publishertier = args.cfpremier
+	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.extradata = {
+		individual = String.isNotEmpty(args.player_number) and 'true' or '',
+	}
+
+	return lpdbData
+end
+
+function CustomLeague:defineCustomPageVariables()
+	Variables.varDefine('tournament_game', _game or _args.game)
+	Variables.varDefine('tournament_publishertier', _args.cfpremier)
+	--Legacy Vars:
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+end
+
+function CustomLeague._getGameVersion()
+	local game = string.lower(_args.game or '')
+	_game = _GAME[game]
+	return _game
+end
+
+return CustomLeague


### PR DESCRIPTION
## Summary
Infobox League for CrossFire, loosely based from Arena of Valor ( #1000 ). Since CrossFire does contain multiple game versions for the wiki. The rest are some touchups for the wiki (e.g. highlighted tiers)

## How did you test this change?
LIVE:

Some of the pages
https://liquipedia.net/crossfire/Special:LiquipediaDB/CrossFire_Pro_League/Season_20
https://liquipedia.net/crossfire/Special:LiquipediaDB/CrossFire_Stars_Summer_Championship/2022/Vietnam

##Side Note
- Should this be merged before  1774 (venueX) so that this one gets updated later on? 
(Crossfire has a good range of multiple venue cases.)

- CF will only have Player and League in Github aside from Match2
(Teams, Squad, Series works fine through the /base aka commons)