### PR TITLE
Do not have 1/2/3/4 bg color for special statuses

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -406,7 +406,7 @@ Placement.specialStatuses = {
 		display = function ()
 			return 'W'
 		end,
-		lpdb = 'win',
+		lpdb = 1,
 	},
 	D = {
 		active = function (args)
@@ -415,7 +415,7 @@ Placement.specialStatuses = {
 		display = function ()
 			return 'D'
 		end,
-		lpdb = 'draw',
+		lpdb = 1,
 	},
 	L = {
 		active = function (args)
@@ -424,7 +424,7 @@ Placement.specialStatuses = {
 		display = function ()
 			return 'L'
 		end,
-		lpdb = 'loss',
+		lpdb = 2,
 	},
 }
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -399,6 +399,33 @@ Placement.specialStatuses = {
 		end,
 		lpdb = 'dnp',
 	},
+	W = {
+		active = function (args)
+			return Logic.readBool(args.w)
+		end,
+		display = function ()
+			return 'W'
+		end,
+		lpdb = 'win',
+	},
+	D = {
+		active = function (args)
+			return Logic.readBool(args.d)
+		end,
+		display = function ()
+			return 'D'
+		end,
+		lpdb = 'draw',
+	},
+	L = {
+		active = function (args)
+			return Logic.readBool(args.l)
+		end,
+		display = function ()
+			return 'L'
+		end,
+		lpdb = 'loss',
+	},
 }
 
 function PrizePool:init(args)
@@ -1161,8 +1188,10 @@ function Placement:_displayPlace()
 end
 
 function Placement:getBackground()
-	if Placement.specialStatuses.DQ.active(self.args) then
-		return 'background-color-disqualified'
+	for statusName, status in pairs(Placement.specialStatuses) do
+		if status.active(self.args) and PlacementInfo.getBgClass(statusName:lower())  then
+			return PlacementInfo.getBgClass(statusName:lower())
+		end
 	end
 
 	return PlacementInfo.getBgClass(self.placeStart)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1189,7 +1189,7 @@ end
 
 function Placement:getBackground()
 	for statusName, status in pairs(Placement.specialStatuses) do
-		if status.active(self.args) and PlacementInfo.getBgClass(statusName:lower())  then
+		if status.active(self.args) then
 			return PlacementInfo.getBgClass(statusName:lower())
 		end
 	end

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -106,9 +106,7 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 	end
 
 	local newData = {}
-	if LETTER_PLACE_TO_NUMBER[slot.place:lower()] then
-		newData.place = LETTER_PLACE_TO_NUMBER[slot.place:lower()]
-	elseif SPECIAL_PLACES[slot.place:lower()] then
+	if SPECIAL_PLACES[slot.place:lower()] then
 		newData[SPECIAL_PLACES[slot.place:lower()]] = true
 	else
 		newData.place = slot.place

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -21,8 +21,7 @@ local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabl
 
 local LegacyPrizePool = {}
 
-local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp'}
-local LETTER_PLACE_TO_NUMBER = {w = 1, d = 1, l = 2}
+local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp', w = 'w', d = 'd', l = 'l'}
 
 local CACHED_DATA = {
 	next = {points = 1, qual = 1, freetext = 1},


### PR DESCRIPTION
stacked on #1778

refers to https://github.com/Liquipedia/Lua-Modules/pull/1778#discussion_r958212605

## Summary
Do not have 1/2/3/4 bg color for special statuses

## How did you test this change?
/dev module

