### PR TITLE
Complete rewrite of placements (fix #1535)

### DIFF
--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -12,7 +12,7 @@ local Table = require('Module:Table')
 
 local Placement = {}
 
-local placementClasses = {
+local PLACEMENT_CLASSES = {
 	['1'] = 'placement-1',
 	['2'] = 'placement-2',
 	['3'] = 'placement-3',
@@ -43,12 +43,12 @@ local placementClasses = {
 	['div'] = 'placement-darkgrey',
 }
 
-local customSorts = {
+local CUSTOM_SORTS = {
 	['w'] = '1025',
 	['proceeded'] = '1026',
 	['q'] = '1027',
 	['d'] = '1028',
-	['stay'] = '2019',
+	['stay'] = '1029',
 	['l'] = '1030',
 	['relegated'] = '1031',
 	['dnp'] = '1032',

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -173,7 +173,7 @@ end
 ---@return string
 function Placement.get(placement, customText)
 	local raw = Placement.raw(placement)
-	return 'class="' .. (raw.backgroundClass or '') .. '" data-sort-value="' .. raw.sort .. '"' ..
+	return 'class="text-center ' .. (raw.backgroundClass or '') .. '" data-sort-value="' .. raw.sort .. '"' ..
 		'|<b' .. (raw.blackText and '' or ' class="placement-text"') .. '>' .. (customText or raw.display) .. '</b>'
 end
 

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Ordinal = require('Module:Ordinal')
 local Table = require('Module:Table')
 
@@ -87,16 +88,16 @@ function Placement.raw(placement)
 		raw.backgroundClass = PLACEMENT_CLASSES['d']
 	elseif PLACEMENT_CLASSES[raw.placement[1]] then
 		raw.backgroundClass = PLACEMENT_CLASSES[raw.placement[1]]
-	elseif tonumber(raw.placement[1]) and tonumber(raw.placement[1]) <= 128 then
+	elseif Logic.isNumeric(raw.placement[1]) and tonumber(raw.placement[1]) <= 128 then
 		raw.backgroundClass = PLACEMENT_CLASSES['17']
-	elseif tonumber(raw.placement[1]) then
+	elseif Logic.isNumeric(raw.placement[1]) then
 		raw.backgroundClass = PLACEMENT_CLASSES['129']
 	else
 		raw.unknown = true
 	end
 
 	-- Intercept non-numeric placements for sorting and ordinal creation
-	if not tonumber(raw.placement[1]) then
+	if not Logic.isNumeric(raw.placement[1]) then
 		raw.sort = CUSTOM_SORTS[raw.placement[1]] or CUSTOM_SORTS['']
 		raw.ordinal = mw.text.split(string.upper(placement or ''), '-', true)
 	else

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -12,6 +12,9 @@ local Table = require('Module:Table')
 
 local Placement = {}
 
+local ZERO_WIDTH_SPACE = '&#8203;'
+local EN_DASH = '–'
+
 local PLACEMENT_CLASSES = {
 	['1'] = 'placement-1',
 	['2'] = 'placement-2',
@@ -81,20 +84,20 @@ function Placement.raw(placement)
 
 	-- Identify appropriate background class
 	if raw.placement[1] == '3' and raw.placement[2] then
-		raw.backgroundClass = placementClasses['d']
-	elseif placementClasses[raw.placement[1]] then
-		raw.backgroundClass = placementClasses[raw.placement[1]]
-	elseif tonumber(raw.placement[1]) <= 128 then
-		raw.backgroundClass = placementClasses['17']
+		raw.backgroundClass = PLACEMENT_CLASSES['d']
+	elseif PLACEMENT_CLASSES[raw.placement[1]] then
+		raw.backgroundClass = PLACEMENT_CLASSES[raw.placement[1]]
+	elseif tonumber(raw.placement[1]) and tonumber(raw.placement[1]) <= 128 then
+		raw.backgroundClass = PLACEMENT_CLASSES['17']
 	elseif tonumber(raw.placement[1]) then
-		raw.backgroundClass = placementClasses['129']
+		raw.backgroundClass = PLACEMENT_CLASSES['129']
 	else
 		raw.unknown = true
 	end
 
 	-- Intercept non-numeric placements for sorting and ordinal creation
 	if not tonumber(raw.placement[1]) then
-		raw.sort = customSorts[raw.placement[1]] or customSorts['']
+		raw.sort = CUSTOM_SORTS[raw.placement[1]] or CUSTOM_SORTS['']
 		raw.ordinal = mw.text.split(string.upper(placement or ''), '-', true)
 	else
 		raw.sort = raw.placement[1] .. (raw.placement[2] and ('-' .. raw.placement[2]) or '')
@@ -136,7 +139,7 @@ function Placement._placement(args)
 		return
 	end
 	local raw = Placement.raw(args.placement or '')
-	args.parent:attr('align', 'center')
+	args.parent:css('text-align', 'center')
 			   :attr('data-sort-value', raw.sort)
 			   :addClass(raw.backgroundClass)
 			   :tag('b')
@@ -150,12 +153,10 @@ end
 ---@return string
 function Placement.RangeLabel(range)
 	local ordinal = Placement._makeOrdinal(range)
-	local zeroWidthSpace = '&#8203;'
-	local enDash = '–'
 	return table.concat({
 		ordinal[1],
 		range[1] < range[2] and ordinal[2] or nil,
-	}, zeroWidthSpace .. enDash .. zeroWidthSpace)
+	}, ZERO_WIDTH_SPACE .. EN_DASH .. ZERO_WIDTH_SPACE)
 end
 
 ---Takes string place value and returns prize pool color class.

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -6,94 +6,13 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Ordinal = require('Module:Ordinal')
+local Table = require('Module:Table')
 
 local Placement = {}
 
---[[
-Returns a text label for a range of placements.
-
-Example:
-Placement.RangeLabel({1, 2})
--- Returns 1st–2nd
-]]
-function Placement.RangeLabel(range)
-	local zeroWidthSpace = '&#8203;'
-	local enDash = '–'
-	return table.concat({
-		Ordinal._ordinal(range[1]),
-		range[1] < range[2] and Ordinal._ordinal(range[2]) or nil,
-	}, zeroWidthSpace .. enDash .. zeroWidthSpace)
-end
-
-Placement.placementClasses = {
-	'background-color-first-place',
-	'background-color-second-place',
-	'background-color-third-place',
-	'background-color-fourth-place',
-	w = 'bg-win',
-	d = 'bg-draw',
-	l = 'bg-lose',
-	dq = 'bg-dq',
-}
-
---[[
-Converts a placement to a css class that sets its background.
-
-Example:
-Placement.getBgClass(2)
--- returns 'background-color-second-place'
-]]
-function Placement.getBgClass(placement)
-	return Placement.placementClasses[placement]
-end
-
-local ordinalSuffix = {
-	['1'] = 'st',
-	['2'] = 'nd',
-	['3'] = 'rd',
-	['4'] = 'th',
-	['5'] = 'th',
-	['6'] = 'th',
-	['7'] = 'th',
-	['8'] = 'th',
-	['9'] = 'th',
-	['0'] = 'th',
-	['11'] = 'th',
-	['12'] = 'th',
-	['13'] = 'th',
-}
-
-local placeSortPrefix = {
-	['1'] = 'A',
-	['2'] = 'B',
-	['3'] = 'C',
-	['4'] = 'D',
-	['5'] = 'E',
-	['6'] = 'F',
-	['7'] = 'G',
-	['8'] = 'H',
-	['9'] = 'I',
-	['10'] = 'J',
-	['11'] = 'K',
-	['12'] = 'L',
-	['13'] = 'M',
-	['14'] = 'N',
-	['15'] = 'O',
-	['16'] = 'P',
-	['17'] = 'Q',
-	['w'] = 'T1',
-	['l'] = 'T2',
-	['dq'] = 'T3',
-	['dnp'] = 'V',
-	['proceeded'] = 'W1',
-	['stay'] = 'W2',
-	['relegated'] = 'W3',
-}
-
-local placeColorClass = {
+local placementClasses = {
 	['1'] = 'placement-1',
 	['2'] = 'placement-2',
 	['3'] = 'placement-3',
@@ -110,127 +29,152 @@ local placeColorClass = {
 	['14'] = 'placement-blue',
 	['15'] = 'placement-blue',
 	['16'] = 'placement-blue',
-	['32'] = 'placement-darkblue',
-	['256'] = 'placement-darkgrey',
+	['17'] = 'placement-darkblue',
+	['129'] = 'placement-darkgrey',
+	['q'] = 'placement-win',
 	['w'] = 'placement-win',
+	['d'] = 'placement-draw',
 	['l'] = 'placement-lose',
 	['dq'] = 'placement-lose',
 	['dnp'] = 'placement-dnp',
 	['proceeded'] = 'placement-up',
 	['stay'] = 'placement-stay',
 	['relegated'] = 'placement-down',
+	['div'] = 'placement-darkgrey',
 }
 
-local textColor = {
-	-- White is the default color. Only overrides will need to be entered here.
-	['dnp'] = 'black',
+local customSorts = {
+	['w'] = '1025',
+	['proceeded'] = '1026',
+	['q'] = '1027',
+	['d'] = '1028',
+	['stay'] = '2019',
+	['l'] = '1030',
+	['relegated'] = '1031',
+	['dnp'] = '1032',
+	['dq'] = '1033',
+	['div'] = '1034',
+	[''] = '1035',
 }
 
-local skipShadow = {
-	-- Default is false
-	['dnp'] = true,
+local prizepoolClasses = {
+	'background-color-first-place',
+	'background-color-second-place',
+	'background-color-third-place',
+	'background-color-fourth-place',
+	w = 'bg-win',
+	q = 'bg-win',
+	d = 'bg-draw',
+	l = 'bg-lose',
+	dq = 'bg-dq',
 }
 
-function Placement._placement(args)
-	-- Defaults
-	local textColorCell = 'white'
-	local skipShadowCell = false
+---Processes a placement text input into raw data.
+---Returned table will not always contain every key.
+---@param placement string?
+---@return table
+function Placement.raw(placement)
+	local raw = {}
 
-	-- Attempt to split the placement into two parts and store it in a table
-	local placement = mw.text.split(tostring(args.placement), '-', true)
+	-- Nil check on input and split placement if joint
+	raw.placement = mw.text.split(string.lower(placement or ''), '-', true)
 
-	-- If the table has 2 parts, the placement has a start and end number
-	local text
-	local diff
-	if tonumber(placement[1]) == nil then
-		text = string.upper(placement[1])
-		diff = 0
-	elseif table.maxn(placement) == 2 then
-		if ordinalSuffix[placement[2]] then
-			text = placement[1] .. '&nbsp;-&nbsp;' .. placement[2] .. ordinalSuffix[placement[2]]
-		else
-			text = placement[1] .. '&nbsp;-&nbsp;' .. placement[2] .. ordinalSuffix[string.sub(placement[2], -1)]
-		end
-		diff = (tonumber(placement[2]) or 1000) - tonumber(placement[1])
+	-- Identify appropriate background class
+	if raw.placement[1] == '3' and raw.placement[2] then
+		raw.backgroundClass = placementClasses['d']
+	elseif placementClasses[raw.placement[1]] then
+		raw.backgroundClass = placementClasses[raw.placement[1]]
+	elseif tonumber(raw.placement[1]) <= 128 then
+		raw.backgroundClass = placementClasses['17']
+	elseif tonumber(raw.placement[1]) then
+		raw.backgroundClass = placementClasses['129']
 	else
-		if ordinalSuffix[placement[1]] then
-			text = placement[1] .. ordinalSuffix[placement[1]]
-		else
-			text = placement[1] .. ordinalSuffix[string.sub(placement[1], -1)]
-		end
-		diff = 0
+		raw.unknown = true
 	end
 
-	-- Cell color
-	if tonumber(placement[1]) ~= nil then
-		if tonumber(placement[1]) <= 16 then
-			args.parent:addClass(placeColorClass[placement[1]])
-			textColorCell = textColor[placement[1]] or textColorCell
-			skipShadowCell = skipShadow[placement[1]] or skipShadowCell
-		elseif tonumber(placement[1]) <= 32 then
-			args.parent:addClass(placeColorClass['32'])
-			textColorCell = textColor['32'] or textColorCell
-			skipShadowCell = skipShadow['32'] or skipShadowCell
-		else
-			args.parent:addClass(placeColorClass['256'])
-			textColorCell = textColor['256'] or textColorCell
-			skipShadowCell = skipShadow['256'] or skipShadowCell
-		end
+	-- Intercept non-numeric placements for sorting and ordinal creation
+	if not tonumber(raw.placement[1]) then
+		raw.sort = customSorts[raw.placement[1]] or customSorts['']
+		raw.ordinal = mw.text.split(string.upper(placement or ''), '-', true)
 	else
-		args.parent:addClass(placeColorClass[placement[1]])
-		textColorCell = textColor[placement[1]] or textColorCell
-		skipShadowCell = skipShadow[placement[1]] or skipShadowCell
+		raw.sort = raw.placement[1] .. (raw.placement[2] and ('-' .. raw.placement[2]) or '')
+		raw.ordinal = Placement._makeOrdinal(raw.placement)
 	end
 
-	-- Parent attributes
-	args.parent:attr('align', 'center')
-
-	-- HiddenSort
-	local sortPrefix --Sort key for first part
-	if tonumber(placement[1]) ~= nil then
-		if tonumber(placement[1]) <= 17 then
-			sortPrefix = placeSortPrefix[placement[1]]
-		elseif tonumber(placement[1]) <= 32 then
-			sortPrefix = 'R'
-		else
-			sortPrefix = 'S'
-		end
-	elseif placement[1] ~= nil then
-		sortPrefix = placeSortPrefix[placement[1]]
+	-- Create placement display from ordinal (or not) variants
+	if not raw.unknown then
+		raw.display = raw.ordinal[1] .. (raw.ordinal[2] and ('&nbsp;-&nbsp;' .. raw.ordinal[2]) or '')
 	else
-		sortPrefix = 'Z'
+		mw.log('No placement found in Module:Placement: ' .. placement)
+		raw.display = placement .. '[[Category:Pages with unknown placements]]'
 	end
 
-	local sortPrefix2 --Sort key for second part
-	if tonumber(diff) == 0 then
-		sortPrefix2 = ''
-	elseif tonumber(diff) <= 17 then
-		sortPrefix2 = placeSortPrefix[tostring(diff)]
-	elseif tonumber(diff) <= 32 then
-		sortPrefix2 = 'R'
-	else
-		sortPrefix2 = 'S'
-	end
+	-- Determine any black text placements
+	raw.blackText = (raw.placement[1] == 'dnp')
 
-	if sortPrefix == nil then
-		mw.log('No placement found in Module:Placement: ' .. args.placement)
-		args.parent:attr('data-sort-value', 'ZZ')
-		args.parent:tag('font')
-			:wikitext(args.placement .. ' [[Category:Pages with unknown placements]]')
-	else
-		args.parent:attr('data-sort-value', sortPrefix .. sortPrefix2)
-
-		-- Display text
-		args.parent:tag('font')
-			:addClass(not skipShadowCell and 'placement-text' or nil)
-			:css('font-weight', 'bold')
-			:css('color', textColorCell)
-			:wikitext(text .. (args.text and ' ' .. args.text or ''))
-	end
+	return raw
 end
 
-function Placement.placement(frame)
-	return Placement._placement(Arguments.getArgs(frame))
+---Takes a table of placement numbers and makes them ordinal.
+---@param placement table
+---@return table
+function Placement._makeOrdinal(placement)
+	return Table.mapValues(placement,
+		function(place)
+			return Ordinal._ordinal(place)
+		end
+	)
+end
+
+
+---Takes parent mw html object and childs a placement.
+---Expected args fields are `parent` and `placement`.
+---@param placement table?
+---@return nil
+function Placement._placement(args)
+	if not (type(args) == 'table' and type(args.parent) == 'table') then
+		return
+	end
+	local raw = Placement.raw(args.placement or '')
+	args.parent:attr('align', 'center')
+			   :attr('data-sort-value', raw.sort)
+			   :addClass(raw.backgroundClass)
+			   :tag('b')
+			   :addClass(not raw.blackText and 'placement-text' or nil)
+			   :wikitext(raw.display)
+
+end
+
+---Converts a placement table into a ordinal string.
+---@param placement table
+---@return string
+function Placement.RangeLabel(range)
+	local ordinal = Placement._makeOrdinal(range)
+	local zeroWidthSpace = '&#8203;'
+	local enDash = '–'
+	return table.concat({
+		ordinal[1],
+		range[1] < range[2] and ordinal[2] or nil,
+	}, zeroWidthSpace .. enDash .. zeroWidthSpace)
+end
+
+---Takes string place value and returns prize pool color class.
+---May return `nil` if no color is registered.
+---@param placement string
+---@return string?
+function Placement.getBgClass(placement)
+	return prizepoolClasses[placement]
+end
+
+---Produces wikicode table code for a placement for use in wikitables.
+---Can optionally take a `customText` input for custom display text.
+---@param placement string
+---@param customText string?
+---@return string
+function Placement.get(placement, customText)
+	local raw = Placement.raw(placement)
+	return 'class="' .. (raw.backgroundClass or '') .. '" data-sort-value="' .. raw.sort .. '"' ..
+		'|<b' .. (raw.blackText and '' or ' class="placement-text"') .. '>' .. (customText or raw.display) .. '</b>'
 end
 
 return Class.export(Placement)


### PR DESCRIPTION
## Summary

As discussed with hjpa on discord, we felt that this module could benefit from a complete rewrite. Complete refactor of `Module:Placement`. Also adds support for CS `/Custom` needs. Essentially closes #1535.

Also makes a little progress towards addressing #1781.

## Things of note

* Unsure where/if `Placement.RangeLabel()` is used. I had thought it was used in prize pools but it's not. If it's not needed we can drop it.
* Which placement starts to use `placement-darkgrey` after top 32 may need discussion. CS never really used it for anything before, for example.
* Was unsure of correct way to do documentation for functions, I did what I saw in other module replacing what was currently in used in this one. If this incorrect, then will adjust accordingly or restore old comments.
* Function names and variable names can be changed if I didn't follow correct styling or if you think others would be better.

## How did you test this change?

Tested on `/dev` on CS wiki. https://liquipedia.net/counterstrike/Module:Placement/dev
