### PR TITLE
Add support for `|place=Q`

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -431,7 +431,7 @@ Placement.specialStatuses = {
 			return Logic.readBool(args.q)
 		end,
 		display = function ()
-			return 'Q'
+			return Abbreviation.make('Q', 'Qualified Automatically')
 		end,
 		lpdb = 1,
 	},

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -426,6 +426,15 @@ Placement.specialStatuses = {
 		end,
 		lpdb = 2,
 	},
+	Q = {
+		active = function (args)
+			return Logic.readBool(args.q)
+		end,
+		display = function ()
+			return 'Q'
+		end,
+		lpdb = 1,
+	},
 }
 
 function PrizePool:init(args)

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -21,7 +21,7 @@ local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabl
 
 local LegacyPrizePool = {}
 
-local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp', w = 'w', d = 'd', l = 'l'}
+local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp', w = 'w', d = 'd', l = 'l', q = 'q'}
 
 local CACHED_DATA = {
 	next = {points = 1, qual = 1, freetext = 1},


### PR DESCRIPTION
## Summary

Add support for `|place=Q`, used on a few places on CS. If possible, we should look in the future at removing this if can be replaced with something better.

Resolves #1781

![image](https://user-images.githubusercontent.com/3426850/187656647-57b2e87d-e8d9-47e6-8e69-d2ef879cf448.png)


## How did you test this change?
/dev module