### PR TITLE
Add support for points1/2/... for Qualifiers on CS Legacy

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -119,17 +119,7 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 	Table.iter.forEachPair(CACHED_DATA.inputToId, function(parameter, newParameter)
 		local input = slot[parameter]
 		if newParameter == 'seed' then
-			local links = LegacyPrizePool.parseWikiLink(input)
-			for _, linkData in ipairs(links) do
-				local link = linkData.link
-
-				if not CACHED_DATA.qualifiers[link] then
-					CACHED_DATA.qualifiers[link] = {id = CACHED_DATA.next.qual, name = linkData.name}
-					CACHED_DATA.next.qual = CACHED_DATA.next.qual + 1
-				end
-
-				newData['qualified' .. CACHED_DATA.qualifiers[link].id] = true
-			end
+			LegacyPrizePool.handleSeed(newData, input)
 
 		elseif input and tonumber(input) ~= 0 then
 			-- Handle the legacy checkmarks, they were set in value = 'q'
@@ -159,6 +149,20 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 		return newSlot
 	end
 	return newData
+end
+
+function LegacyPrizePool.handleSeed(storeTo, input)
+	local links = LegacyPrizePool.parseWikiLink(input)
+	for _, linkData in ipairs(links) do
+		local link = linkData.link
+
+		if not CACHED_DATA.qualifiers[link] then
+			CACHED_DATA.qualifiers[link] = {id = CACHED_DATA.next.qual, name = linkData.name}
+			CACHED_DATA.next.qual = CACHED_DATA.next.qual + 1
+		end
+
+		storeTo['qualified' .. CACHED_DATA.qualifiers[link].id] = true
+	end
 end
 
 function LegacyPrizePool.mapOpponents(slot, newData, mergeSlots)

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -44,15 +44,23 @@ function CustomLegacyPrizePool.customOpponent(opponentData, CACHED_DATA, slot, o
 
 	if slot['points' .. opponentIndex] then
 		local param = CACHED_DATA.inputToId['points']
-		opponentData[param] = slot['points' .. opponentIndex]
+		CustomLegacyPrizePool._setOpponentReward(opponentData, param, slot['points' .. opponentIndex])
 	end
 
 	if slot['localprize' .. opponentIndex] then
 		local param = CACHED_DATA.inputToId['localprize']
-		opponentData[param] = slot['localprize' .. opponentIndex]
+		CustomLegacyPrizePool._setOpponentReward(opponentData, param, slot['localprize' .. opponentIndex])
 	end
 
 	return opponentData
+end
+
+function CustomLegacyPrizePool._setOpponentReward(opponentData, param, value)
+	if param == 'seed' then
+		PrizePoolLegacy.handleSeed(opponentData, value)
+	else
+		opponentData[param] = value
+	end
 end
 
 return CustomLegacyPrizePool


### PR DESCRIPTION
## Summary
Resolves #1782

CounterStrike used `points2` to indicate points for the second opponent instead of a second column of points. The current implementation in legacy handles for all cases expect Qualifiers (Seed). This PR adds support for Qualifiers as well.

![image](https://user-images.githubusercontent.com/3426850/187692013-90c82520-ed75-425b-a8b9-2e698eaa9aa3.png)

Before:
![image](https://user-images.githubusercontent.com/3426850/187692070-ac121c63-2920-4c0c-b951-44b5756a35f7.png)

After:
![image](https://user-images.githubusercontent.com/3426850/187692100-076142d2-62ee-4357-b73c-db07e357e8e6.png)


## How did you test this change?

Dev modules