### PR TITLE
Sort Legacy Qualifiers 

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -93,9 +93,16 @@ function LegacyPrizePool.run(dependency)
 		newArgs[slotIndex].opponents = nil
 	end
 
-	for link, linkData in pairs(CACHED_DATA.qualifiers) do
-		newArgs['qualifies' .. linkData.id] = link
-		newArgs['qualifies' .. linkData.id .. 'name'] = linkData.name
+	local qualifiers = Array.extractValues(CACHED_DATA.qualifiers)
+	local qualifiersSortValue = function (qualifier1, qualifier2)
+		return qualifier1.occurance == qualifier2.occurance and qualifier1.id < qualifier2.id
+			or qualifier1.occurance < qualifier2.occurance
+	end
+	table.sort(qualifiers, qualifiersSortValue)
+
+	for index, linkData in ipairs(qualifiers) do
+		newArgs['qualifies' .. index] = linkData.link
+		newArgs['qualifies' .. index .. 'name'] = linkData.name
 	end
 
 	return CustomPrizePool.run(newArgs)
@@ -124,10 +131,11 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 				local link = linkData.link
 
 				if not CACHED_DATA.qualifiers[link] then
-					CACHED_DATA.qualifiers[link] = {id = CACHED_DATA.next.qual, name = linkData.name}
+					CACHED_DATA.qualifiers[link] = {id = CACHED_DATA.next.qual, name = linkData.name, link = link, occurance = 0}
 					CACHED_DATA.next.qual = CACHED_DATA.next.qual + 1
 				end
 
+				CACHED_DATA.qualifiers[link].occurance = CACHED_DATA.qualifiers[link].occurance + 1
 				newData['qualified' .. CACHED_DATA.qualifiers[link].id] = true
 			end
 

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -155,10 +155,11 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 	newData.date = slot.date
 	newData.usdprize = (slot.usdprize and slot.usdprize ~= '0') and slot.usdprize or nil
 
+	local opponentsInSlot = #slot
 	Table.iter.forEachPair(CACHED_DATA.inputToId, function(parameter, newParameter)
 		local input = slot[parameter]
 		if newParameter == 'seed' then
-			LegacyPrizePool.handleSeed(newData, input)
+			LegacyPrizePool.handleSeed(newData, input, opponentsInSlot)
 
 		elseif input and tonumber(input) ~= 0 then
 			-- Handle the legacy checkmarks, they were set in value = 'q'
@@ -190,7 +191,7 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 	return newData
 end
 
-function LegacyPrizePool.handleSeed(storeTo, input)
+function LegacyPrizePool.handleSeed(storeTo, input, slotSize)
 	local links = LegacyPrizePool.parseWikiLink(input)
 	for _, linkData in ipairs(links) do
 		local link = linkData.link
@@ -200,7 +201,7 @@ function LegacyPrizePool.handleSeed(storeTo, input)
 			CACHED_DATA.next.qual = CACHED_DATA.next.qual + 1
 		end
 
-		CACHED_DATA.qualifiers[link].occurance = CACHED_DATA.qualifiers[link].occurance + 1
+		CACHED_DATA.qualifiers[link].occurance = CACHED_DATA.qualifiers[link].occurance + slotSize
 		storeTo['qualified' .. CACHED_DATA.qualifiers[link].id] = true
 	end
 end

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -63,7 +63,7 @@ end
 
 function CustomLegacyPrizePool._setOpponentReward(opponentData, param, value)
 	if param == 'seed' then
-		PrizePoolLegacy.handleSeed(opponentData, value)
+		PrizePoolLegacy.handleSeed(opponentData, value, 1)
 	else
 		opponentData[param] = value
 	end


### PR DESCRIPTION
## Summary

Resolves #1784 

Sort the Qualifiers IDs (1, 2, 3 etc) based on the following logic:
* Lowest number of Slots qualifying to this position (@iMarbot should this be changed to Lowest number of Opponents instead?)
* If tied, fall back to the one that was spotted first (ie first occurrence further up in the table)

Before:
![image](https://user-images.githubusercontent.com/3426850/187709336-cfea8aa3-b9de-47d3-a5f3-f3fc2c71d19e.png)
![image](https://user-images.githubusercontent.com/3426850/187709503-58a53a7e-cc62-40fb-bbf9-d214d9520cdd.png)


After:
![image](https://user-images.githubusercontent.com/3426850/187709398-94515581-cc8f-4941-8ea3-cf2fa4acf50c.png)
![image](https://user-images.githubusercontent.com/3426850/187709534-bc6bec69-b19b-485e-ab5a-7cfae81f0004.png)

## How did you test this change?
/dev module