### PR TITLE
PPT CS: Option to force LPDB field `qualified` and add legacy support

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -90,7 +90,11 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.tournament = HEADER_DATA.tournamentName or lpdbData.tournament
 	lpdbData.publishertier = Variables.varDefault('tournament_valve_tier', '')
 
-	lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, "QUALIFIES1") and 1 or 0
+	if placement.args.forceQualified ~= nil then
+		lpdbData.qualified = Logic.readBool(placement.args.forceQualified) and 1 or 0
+	else
+		lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, "QUALIFIES1") and 1 or 0
+	end
 
 	if lpdbData.opponenttype == Opponent.solo then
 		lpdbData.extradata.participantteam = lpdbData.players.p1team

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
@@ -31,6 +32,11 @@ function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
 			error('Unexpected value in localprize for place=' .. slot.place)
 		end
 	end
+
+	if Logic.readBoolOrNil(slot.noqual) ~= nil then
+		slot.qualified = not Logic.readBool(slot.noqual)
+	end
+	newData.forceQualified = Logic.readBoolOrNil(slot.qualified)
 
 	return newData
 end

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -34,9 +34,9 @@ function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
 	end
 
 	if Logic.readBoolOrNil(slot.noqual) ~= nil then
-		slot.qualified = not Logic.readBool(slot.noqual)
+		slot.qual = not Logic.readBool(slot.noqual)
 	end
-	newData.forceQualified = Logic.readBoolOrNil(slot.qualified)
+	newData.forceQualified = Logic.readBoolOrNil(slot.qual)
 
 	return newData
 end


### PR DESCRIPTION
## Summary

Resolves #1783

CS uses the LPDB field `qualified` for their tournament lists. Due to its complicated usage, the automatic handling frequently fails and need manual input. This PR adds support in the new prizepool for `|forceQualified=` for a slot and adds support for the legacy methods of `|qual=true`, `|qual=false` & `|noqual=true`.

## How did you test this change?
/dev module