### PR TITLE
Remove inline css overflow in matchsummary root

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -98,7 +98,6 @@ function CustomMatchSummary.getByMatchId(args)
 
 	local matchSummary = MatchSummary():init('400px')
 	matchSummary.root:css('flex-wrap', 'unset')
-	matchSummary.root:css('overflow', 'hidden')
 
 	matchSummary:header(CustomMatchSummary._createHeader(match))
 				:body(CustomMatchSummary._createBody(match))

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -85,7 +85,6 @@ function CustomMatchSummary.getByMatchId(args)
 
 	local matchSummary = MatchSummary():init('400px')
 	matchSummary.root:css('flex-wrap', 'unset')
-	matchSummary.root:css('overflow', 'unset')
 
 	matchSummary:header(CustomMatchSummary._createHeader(match))
 				:body(CustomMatchSummary._createBody(match))


### PR DESCRIPTION
## Summary

Remove CSS overflow changes in dota2/lol as improvements with overflow has been put in the CSS by Ely.

## How did you test this change?

Dev module