### PR TITLE
Updating Mobile Legends Squad modules

### DIFF
--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -17,6 +17,36 @@ local Table = require('Module:Table')
 
 local CustomSquad = {}
 
+function CustomSquad.header(self)
+	local makeHeader = function(wikiText)
+		local headerCell = mw.html.create('th')
+
+		if wikiText == nil then
+			return headerCell
+		end
+
+		return headerCell:wikitext(wikiText):addClass('divCell')
+	end
+
+	local headerRow = mw.html.create('tr'):addClass('HeaderRow')
+
+		headerRow	:node(makeHeader('ID'))
+					:node(makeHeader())
+					:node(makeHeader('Name'))
+					:node(makeHeader('Position'))
+					:node(makeHeader('Join Date'))
+	if self.type == Squad.TYPE_FORMER then
+		headerRow	:node(makeHeader('Leave Date'))
+					:node(makeHeader('New Team'))
+	elseif self.type == Squad.TYPE_INACTIVE then
+		headerRow:node(makeHeader('Inactive Date'))
+	end
+
+	self.content:node(headerRow)
+
+	return self
+end
+
 local ExtendedSquadRow = Class.new(SquadRow)
 
 function ExtendedSquadRow:position(args)

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -106,6 +106,7 @@ function CustomSquad.runAuto(playerList, squadType)
 
 	squad.type = squadType
 
+	squad.header = CustomSquad.header
 	squad:title():header()
 
 	for _, player in pairs(playerList) do


### PR DESCRIPTION
## Summary
Towards app readiness (as **newStorageDisplay** isnt compatible with the old module):

 This one is just a clean port of LoL's squad for now (adjustments if needed) 

and at the same time I wanted to adjust the **Position** text to be just non-italic and without brackets (in which LoL fits the description), so all these are happening on one go

## How did you test this change?
/dev calls on test pages - https://liquipedia.net/mobilelegends/User:Hesketh2/Test

Old Version (Already merged in the github)
![image](https://user-images.githubusercontent.com/88981446/187725334-f88f8711-dee8-4ca4-ae4e-1a8aa1db1f50.png)

Ported Version
![image](https://user-images.githubusercontent.com/88981446/187725010-77d749c8-dcbc-4030-b9b9-1fc6819f0047.png)

## Side Note
The **Position** header is absent and empty, any possible way we could bring it back? (unless it is supposed to be that way)

