### PR TITLE
Add support for venue description in Infobox

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -171,8 +171,8 @@ function League:createInfobox()
 				local venues = {}
 				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
 					local description
-					if String.isNotEmpty(args.venuedesc) then
-						description = String.interpolate(VENUE_DESCRIPTION, {desc = args.venuedesc})
+					if String.isNotEmpty(args[prefix .. 'desc']) then
+						description = String.interpolate(VENUE_DESCRIPTION, {desc = args[prefix .. 'desc']})
 					end
 
 					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -31,6 +31,7 @@ local _TIER_MODE_TYPES = 'types'
 local _TIER_MODE_TIERS = 'tiers'
 local _INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
 	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
+local VENUE_DESCRIPTION = "<br><small><small>${desc}</small></small>"
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -169,8 +170,11 @@ function League:createInfobox()
 
 				local venues = {}
 				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
-					-- TODO: Description
-					local description = ''
+					local description
+					if String.isNotEmpty(args.venuedesc) then
+						String.interpolate(VENUE_DESCRIPTION, {desc = args.venuedesc})
+					end
+
 					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -172,7 +172,7 @@ function League:createInfobox()
 				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue') do
 					local description
 					if String.isNotEmpty(args.venuedesc) then
-						String.interpolate(VENUE_DESCRIPTION, {desc = args.venuedesc})
+						description = String.interpolate(VENUE_DESCRIPTION, {desc = args.venuedesc})
 					end
 
 					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -31,7 +31,7 @@ local _TIER_MODE_TYPES = 'types'
 local _TIER_MODE_TIERS = 'tiers'
 local _INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
 	.. '${tierMode}[[Category:Pages with invalid ${tierMode}]]'
-local VENUE_DESCRIPTION = "<br><small><small>${desc}</small></small>"
+local VENUE_DESCRIPTION = "<br><small><small>(${desc})</small></small>"
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell


### PR DESCRIPTION
## Summary
Add support to display description with the venue.

Wikicode:
![image](https://user-images.githubusercontent.com/3426850/188087201-cbc670c8-edac-497d-bde5-cbc849e18248.png)

Display:
![image](https://user-images.githubusercontent.com/3426850/188087155-a5574f5b-c865-4d81-85e4-07c4d5afc82a.png)
LPDB:
![image](https://user-images.githubusercontent.com/3426850/188087320-55435144-de40-49d5-abbd-0a21a60aed5a.png)



## How did you test this change?
/dev module