### PR TITLE
Set `qualified` field if opponent has any qualifier

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
@@ -93,7 +94,14 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	if placement.args.forceQualified ~= nil then
 		lpdbData.qualified = Logic.readBool(placement.args.forceQualified) and 1 or 0
 	else
-		lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, "QUALIFIES1") and 1 or 0
+		local prizeIsQualifier = function(prize)
+			return prize.type == "QUALIFIES"
+		end
+		local opponentHasPrize = function (prize)
+			placement:getPrizeRewardForOpponent(opponent, prize.id)
+		end
+
+		lpdbData.qualified = Array.any(Array.filter(placement.parent.prizes, prizeIsQualifier), opponentHasPrize) and 1 or 0
 	end
 
 	if lpdbData.opponenttype == Opponent.solo then

--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -98,7 +98,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 			return prize.type == "QUALIFIES"
 		end
 		local opponentHasPrize = function (prize)
-			placement:getPrizeRewardForOpponent(opponent, prize.id)
+			return placement:getPrizeRewardForOpponent(opponent, prize.id)
 		end
 
 		lpdbData.qualified = Array.any(Array.filter(placement.parent.prizes, prizeIsQualifier), opponentHasPrize) and 1 or 0

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -35,6 +35,8 @@ function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
 
 	if Logic.readBoolOrNil(slot.noqual) ~= nil then
 		slot.qual = not Logic.readBool(slot.noqual)
+	elseif Logic.readBoolOrNil(slot.qualified) ~= nil then
+		slot.qual = Logic.readBool(slot.qualified)
 	end
 	newData.forceQualified = Logic.readBoolOrNil(slot.qual)
 


### PR DESCRIPTION
## Summary

Change the logic on CS Custom to set the LPDB field `qualified` to check for any qualifier for the opponent rather if they have specifically the first qualifier.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
