### PR TITLE
Additional Formatting of tournament region data

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -17,6 +17,7 @@ local Injector = require('Module:Infobox/Widget/Injector')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Title = require('Module:Infobox/Widget/Title')
 local Center = require('Module:Infobox/Widget/Center')
+local Locale = require('Module:Locale')
 
 local _GAME_MODE = mw.loadData('Module:GameMode')
 local _EA_ICON = '&nbsp;[[File:EA icon.png|x15px|middle|link=Electronic Arts|'
@@ -161,6 +162,8 @@ function CustomLeague:defineCustomPageVariables()
 		end
 	end
 	Variables.varDefine('tournament_ea_major', eaMajor)
+	local regionData = Locale.formatLocations(_args)
+	Variables.varDefine('tournament_location_region', regionData.region1 or _args.country)
 end
 
 function CustomLeague:addToLpdb(lpdbData)

--- a/components/prize_pool/wikis/apexlegends/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/apexlegends/prize_pool_custom.lua
@@ -43,7 +43,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
-	lpdbData.extradata.location = Variables.varDefault('tournament_location', '')
+	lpdbData.extradata.location = Variables.varDefault('tournament_location_region', '')
 	lpdbData.extradata['is ea major'] = Variables.varDefault('tournament_ea_major', '')
 	return lpdbData
 end


### PR DESCRIPTION


## Summary

Storage of location data from `lpdb.tournament` into `lpdb.placement.extradata` with addtional formatting to store either the region or default to args.country. The formatted data is first stored as a custom variable in infobox league, and then is used in the prizepool module to assign it to the extradata of `lpdb.placement`.

## How did you test this change?

Tested here using dev module:
https://liquipedia.net/apexlegends/Dark_meluca/PointsPrizePoolTest
