### PR TITLE
LPA-5869 Update operator icons on Rainbow 6

### DIFF
--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -525,7 +525,7 @@ function CustomMatchSummary._createMap(game)
 		row:addElement(comment)
 	end
 
-	row:addClass('brkts-popup-body-game'):css('font-size', '85%'):css('overflow', 'hidden')
+	row:addClass('brkts-popup-body-game'):css('font-size', '85%')
 
 	-- Winner/Loser backgrounds
 	if game.winner == 1 then


### PR DESCRIPTION
Issue: Operator Icons are cut off at the popup's edge.

Solved this by removing `overflow: hidden` from brkts-popup-body-game.

I also wrapped the hover styling in a `@media (hover: hover)`media feature (https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover) on https://liquipedia.net/commons/MediaWiki:Common.css/Brackets.css 
