### PR TITLE
Add Import Module for PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -48,7 +48,9 @@ function Import.run(placements, args)
 end
 
 function Import._getConfig(args, placements)
-	if String.isEmpty(args.matchGroupId1) and String.isEmpty(args.tournament1) and not Logic.readBool(args.import) then
+	if String.isEmpty(args.matchGroupId1) and String.isEmpty(args.tournament1)
+		and not Import._enableImport(args.import, args.importEnableStartDate) then
+
 		return {}
 	end
 
@@ -63,6 +65,14 @@ function Import._getConfig(args, placements)
 		groupScoreDelimiter = args.groupScoreDelimiter or GROUPSCORE_DELIMITER,
 		allGroupsUseWdl = Logic.readBool(args.allGroupsUseWdl),
 	}
+end
+
+function Import._enableImport(importInput, importEnableStartDate)
+	local date = TournamentUtil.getContextualDate()
+	return Logic.nilOr(
+		Logic.readBoolOrNil(importInput),
+		importEnableStartDate and (not date or date >= importEnableStartDate)
+	)
 end
 
 function Import._importLimit(importLimitInput, placements)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -139,6 +139,8 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 		if options.isFinalStage or Table.includes(options.groupElimStatuses, record.currentstatus) then
 			local entry = {
 				date = record.extradata.endTime and DateExt.toYmdInUtc(record.extradata.endTime),
+				hasDraw = record.hasDraw,
+				hasOvertime = record.hasOvertime,
 			}
 
 			if not record.extradata.placeRange then
@@ -450,13 +452,13 @@ function Import._formatGroupScore(lpdbEntry)
 
 	local matches = lpdbEntry.scoreBoard.match
 	local overtime = lpdbEntry.scoreBoard.overtime
-	local wdl
-	if String.isNotEmpty(matches.d) then
-		wdl = {matches.w or '', matches.d or '', matches.l or ''}
-	elseif (overtime.w or 0) ~= 0 or (overtime.l or 0) ~= 0 then
-		wdl = {matches.w or '', overtime.w or '', overtime.l or '', matches.l or ''}
-	else
-		wdl = {matches.w or '', matches.l or ''}
+	local wdl = {matches.w or '', matches.l or ''}
+	if lpdbEntry.hasDraw then
+		table.insert(wdl, 2, matches.d or '')
+	end
+	if lpdbEntry.hasOvertime then
+		table.insert(wdl, 2, overtime.w or '')
+		table.insert(wdl, -1, overtime.l or '')
 	end
 
 	return table.concat(wdl, Import.config.groupScoreDelimiter)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -324,6 +324,8 @@ function Import.mergePlacement(lpdbEntries, placement)
 		)
 	end
 
+	assert(#placement.opponents <= 1 + placement.placeEnd - placement.placeStart, 'Import: Too many opponents queried for placement range ' .. placement.placeDisplay)
+
 	return placement
 end
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -345,24 +345,20 @@ function Import._emptyPlacement(priorPlacement, placementSize)
 	priorPlacement = priorPlacement or {}
 	local placement = Table.deepCopy(priorPlacement, {copyMetatable = true})
 
-	local placeStart = (priorPlacement.placeEnd or 0) + 1
-	local placeEnd = (priorPlacement.placeEnd or 0) + placementSize
-
 	return Table.mergeInto(placement, {
 			args = {},
 			hasUSD = false,
 			opponents = {},
 			prizeRewards = {},
-			placeStart = placeStart,
-			placeEnd = placeEnd,
-			placeDisplay = Import._getPlaceDisplay(placeStart, placeEnd),
+			placeStart = (priorPlacement.placeEnd or 0) + 1,
+			placeEnd = (priorPlacement.placeEnd or 0) + placementSize,
 		})
 end
 
 function Import._getPlaceDisplay(placeStart, placeEnd)
 	local display = Ordinal._ordinal(placeStart)
 	if placeEnd > placeStart then
-		return display .. DASH .. Ordinal._ordinal(placeEnd)
+		return display .. '-' .. Ordinal._ordinal(placeEnd)
 	end
 
 	return display
@@ -377,9 +373,11 @@ function Import._mergePlacement(lpdbEntries, placement)
 		)
 	end
 
+mw.logObject(placement)
 	assert(
 		#placement.opponents <= 1 + placement.placeEnd - placement.placeStart,
-		'Import: Too many opponents returned from query for placement range ' .. placement.placeDisplay
+		'Import: Too many opponents returned from query for placement range '
+			.. Import._getPlaceDisplay(placement.placeStart, placement.placeEnd)
 	)
 
 	return placement
@@ -414,19 +412,19 @@ function Import._entryToOpponent(lpdbEntry)
 	return {
 		additionalData = additionalData or {
 			GROUPSCORE = Import._makeGroupScore(lpdbEntry),
-			LASTVS = Import._kickIfTbd(lpdbEntry.vsOpponent),
+			LASTVS = Import._removeIfTbd(lpdbEntry.vsOpponent),
 			LASTVSSCORE = {
 				score = Import._getScore(lpdbEntry.opponent),
 				vsscore = Import._getScore(lpdbEntry.vsOpponent),
 			},
 		},
 		date = lpdbEntry.date,
-		opponentData = Import._kickIfTbd(lpdbEntry.opponent),
+		opponentData = Import._removeIfTbd(lpdbEntry.opponent),
 		prizeRewards = {},
 	}
 end
 
-function Import._kickIfTbd(opponent)
+function Import._removeIfTbd(opponent)
 	return (Table.isEmpty(opponent) or Opponent.isTbd(opponent))
 		and {} or opponent
 end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -48,6 +48,7 @@ end
 
 function Import._getConfig(args, placements)
 	if String.isEmpty(args.matchGroupId1) and String.isEmpty(args.tournament1)
+		and String.isEmpty(args.matchGroupId) and String.isEmpty(args.tournament)
 		and not Import._enableImport(args.import, args.importEnableStartDate) then
 
 		return {}
@@ -96,10 +97,12 @@ function Import._importPlacements(inputPlacements)
 
 	-- Apply importLimit if set
 	if Import.config.importLimit then
-		local sums = MathUtil.partialSums(Array.map(placementEntries, function(entries) return #entries end))
-		local index = ArrayExt.findIndex(sums, function(sum) return Import.config.importLimit <= sum end)
-		if index ~= 0 then
-			placementEntries = Array.sub(placementEntries, 1, index - 1)
+		-- array of partial sums of the number of entries until a given placement/slot
+		local importedEntriesSums = MathUtil.partialSums(Array.map(placementEntries, function(entries) return #entries end))
+		-- slotIndex of the slot until which we want to import based on importLimit
+		local slotIndex = ArrayExt.findIndex(importedEntriesSums, function(sum) return Import.config.importLimit <= sum end)
+		if slotIndex ~= 0 then
+			placementEntries = Array.sub(placementEntries, 1, slotIndex - 1)
 		end
 	end
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -395,14 +395,12 @@ function Import._removeTbdIdentifiers(opponent)
 	if Table.isEmpty(opponent) then
 		return {}
 	elseif not Opponent.isTbd(opponent) then
-		opponent.isAlreadyParsed = true
 		return opponent
 	-- Entry is a TBD Opponent, but could contain data (e.g. flag or faction) for party opponents
 	elseif not opponent.type or not Opponent.typeIsParty(opponent.type) then
 		return {}
 	end
 
-	opponent.isAlreadyParsed = true
 	opponent.type = nil
 	for _, player in pairs(opponent.players or {}) do
 		if Opponent.playerIsTbd(player) then
@@ -429,12 +427,20 @@ function Import._entryToOpponent(lpdbEntry, placement)
 	end
 
 	return placement:_parseOpponents{{
-		Import._removeTbdIdentifiers(lpdbEntry.opponent),
+		Import._checkIfParsed(Import._removeTbdIdentifiers(lpdbEntry.opponent)),
 		wdl = (not lpdbEntry.needsLastVs) and Import._formatGroupScore(lpdbEntry) or nil,
-		lastvs = {additionalData.lastVs or Import._removeTbdIdentifiers(lpdbEntry.vsOpponent)},
+		lastvs = {additionalData.lastVs or Import._checkIfParsed(Import._removeTbdIdentifiers(lpdbEntry.vsOpponent))},
 		lastvsscore = additionalData.score or lastVsScore,
 		date = lpdbEntry.date,
 	}}[1]
+end
+
+function Import._checkIfParsed(opponent)
+	if Table.isNotEmpty(opponent) then
+		opponent.isAlreadyParsed = true
+	end
+
+	return opponent
 end
 
 function Import._formatGroupScore(lpdbEntry)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -384,7 +384,27 @@ function Import._mergeEntry(lpdbEntry, entry, placement)
 		return entry
 	end
 
-	return Table.deepMergeInto(entry, Import._entryToOpponent(lpdbEntry, placement))
+	return Table.deepMergeInto(Import._entryToOpponent(lpdbEntry, placement), Import._removeTbd(entry))
+end
+
+function Import._removeTbd(entry)
+	-- if we get here we know entry is a TBD Opponent
+	-- but it still might hold data (e.g. flag or race of players) for non party opponents
+	local opponent = entry.opponentData
+	if not Opponent.typeIsParty(opponent.type) then
+		-- TBD opponents of non party types do not hold additional data
+		entry.opponentData = {}
+	else
+		for _, player in pairs(opponent.players or {}) do
+			if Opponent.playerIsTbd(player) then
+				player.displayName = nil
+				player.pageIsResolved = nil
+				player.pageName = nil
+			end
+		end
+	end
+
+	return entry
 end
 
 function Import._entryToOpponent(lpdbEntry, placement)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -382,7 +382,7 @@ function Import.entryToOpponent(lpdbEntry)
 end
 
 -- export for usage in /Custom
-function ImportkickIfTbd(opponent)
+function Import.kickIfTbd(opponent)
 	return (Table.isEmpty(opponent) or Opponent.isTbd(opponent))
 		and {} or opponent
 end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -1,0 +1,392 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:PrizePool/Import
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Array = require('Module:Array')
+local ArrayExt = require('Module:Array/Ext')
+local DateExt = require('Module:Date/Ext')
+local Logic = require('Module:Logic')
+local MathUtil = require('Module:MathUtil')
+local Ordinal = require('Module:Ordinal')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local TournamentUtil = Lua.import('Module:Tournament/Util', {requireDevIfEnabled = true})
+
+local GROUPSCORE_DELIMITER = '-'
+local SCORE_STATUS = 'S'
+local DASH = '&#045;'
+
+local Import = {}
+
+function Import.run(placements, args)
+	local config = Import.getConfig(args, placements)
+
+	if not config.matchGroupsSpec then
+		return placements
+	end
+
+	return Import.importPlacements(placements, config)
+end
+
+function Import.getConfig(args, placements)
+	local doImport = Logic.nilOr(Logic.readBoolOrNil(args.import), true)
+
+	return {
+		importLimit = Import._importLimit(args.importLimit, placements),
+		matchGroupsSpec = TournamentUtil.readMatchGroupsSpec(args)
+			or doImport and TournamentUtil.currentPageSpec(),
+	}
+end
+
+function Import._importLimit(importLimitInput, placements)
+	local importLimit = tonumber(importLimitInput)
+	if not importLimit then 
+		return
+	end
+
+	-- if the number of entered entries is higher use that instead
+	return math.max(placements[#placements].placeEnd or 0, importLimit)
+end
+
+-- fills in placements and opponents using data fetched from LPDB
+function Import.importPlacements(inputPlacements, config)
+	local stages = TournamentUtil.fetchStages(config.matchGroupsSpec)
+	local placementEntries = Array.flatMap(Array.reverse(stages), function(stage, reverseStageIndex)
+		return Import.computeStagePlacementEntries(stage, {isFinalStage = reverseStageIndex == 1})
+	end)
+
+	-- Apply config.importLimit
+	local placementEntryCounts = Array.map(placementEntries, function(entries) return #entries end)
+	if config.importLimit then
+		local sums = MathUtil.partialSums(placementEntryCounts)
+		local index = ArrayExt.findIndex(sums, function(sum) return config.importLimit <= sum end)
+		if index ~= 0 then
+			placementEntryCounts = Array.sub(placementEntryCounts, 1, index - 1)
+			placementEntries = Array.sub(placementEntries, 1, index - 1)
+		end
+	end
+
+	local merged = Import.mergePlacements(placementEntries, inputPlacements)
+mw.logObject(merged)
+
+	-- todo
+	-- add player teams ?!?!
+	--> custom?!
+
+	-- return the input to not break stuff for now
+	return merged
+end
+
+-- Compute placements and their entries of all brackets or all group tables in a
+-- tournament stage. The placements are ordered from high placement to low.
+function Import.computeStagePlacementEntries(stage, options)
+	local groupPlacementEntries = Array.map(stage, function(matchGroup)
+		return TournamentUtil.isGroupTable(matchGroup)
+			and Import.computeGroupTablePlacementEntries(matchGroup, options)
+			or Import.computeBracketPlacementEntries(matchGroup, options)
+	end)
+
+	local maxPlacementCount = Array.max(Array.map(groupPlacementEntries, function(placementEntries) return #placementEntries end))
+	return Array.map(Array.range(1, maxPlacementCount or 0), function(placementIx)
+		return Array.flatMap(groupPlacementEntries, function(placementEntries)
+			return placementEntries[placementIx]
+		end)
+	end)
+end
+
+-- Compute placements and their entries from a GroupTableLeague record.
+function Import.computeGroupTablePlacementEntries(standingRecords, options)
+	local placementEntries = {}
+	for _, record in ipairs(standingRecords) do
+		if options.isFinalStage or record.currentstatus == 'down' then
+			local entry = {
+				date = record.extradata.endTime and DateExt.toYmdInUtc(record.extradata.endTime),
+				showMatchDraws = record.extradata.showMatchDraws or false,
+			}
+
+			if record.extradata.placeRange[1] == record.extradata.placeRange[2] then
+				Table.mergeInto(entry, {
+					matchScore = record.scoreboard.match,
+					opponent = record.extradata.opponent,
+				})
+				if entry.opponent.template then
+					entry.opponent.name = entry.opponent.template
+				else
+					entry.opponent.isResolved = true
+				end
+			end
+
+			table.insert(placementEntries, {entry})
+		end
+	end
+
+	return placementEntries
+end
+
+-- Compute placements and their entries from the match records of a bracket.
+function Import.computeBracketPlacementEntries(matchRecords, options)
+	local bracket = MatchGroupUtil.makeBracketFromRecords(matchRecords)
+	return Array.map(
+		Import.computeBracketPlacementGroups(bracket, options),
+		function(group)
+			return Array.map(group, function(placementEntry)
+				local match = bracket.matchesById[placementEntry.matchId]
+				return Import.makeEntryFromMatch(placementEntry, match)
+			end)
+		end
+	)
+end
+
+function Import.makeEntryFromMatch(placementEntry, match)
+	local entry = {
+		date = match.date:match('^[%d-]+'),
+	}
+
+	if match.winner and 1 <= match.winner and #match.opponents == 2 then
+		local entryOpponentIx = placementEntry.matchPlacement == 1
+			and match.winner
+			or #match.opponents - match.winner + 1
+		local opponent = match.opponents[entryOpponentIx]
+		local vsOpponent = match.opponents[#match.opponents - entryOpponentIx + 1]
+		opponent.isResolved = true
+		vsOpponent.isResolved = true
+
+		Table.mergeInto(entry, {
+			lastGameScore = {opponent.score, 0, vsOpponent.score},
+			lastStatuses = {opponent.status, vsOpponent.status},
+			opponent = opponent,
+			vsOpponent = vsOpponent,
+		})
+	end
+
+	return entry
+end
+
+-- Computes the placement placements of a LPDB bracket
+-- @options.isFinalStage: If on the last stage, then include placement placements for
+-- winners of final matches.
+function Import.computeBracketPlacementGroups(bracket, options)
+	local firstDeRoundIx = Import.findDeRoundIndex(bracket)
+	local preTiebreakMatchIds = Import.getPreTiebreakMatchIds(bracket)
+
+	local function getGroupKeys(matchId)
+		local coordinates = bracket.coordinatesByMatchId[matchId]
+
+		-- Winners and losers of grand finals
+		if coordinates.semanticDepth == 0 then
+			return Array.append({},
+				options.isFinalStage and {1, coordinates.sectionIndex, 1} or nil,
+				{1, coordinates.sectionIndex, 2}
+			)
+
+		-- Third place match
+		elseif String.endsWith(matchId, 'RxMTP') then
+			return {
+				{2, coordinates.depth + 0.5, 1},
+				{2, coordinates.depth + 0.5, 2},
+			}
+
+		-- Semifinals into third place match
+		elseif preTiebreakMatchIds[matchId] then
+			return {}
+
+		else
+			local groupKeys = {}
+
+			-- Winners of root matches
+			if coordinates.depth == 0 and options.isFinalStage then
+				table.insert(groupKeys, {0, coordinates.sectionIndex, 1})
+			end
+
+			-- Opponents knocked out from sole section (se) or lower bracket (de)
+			if coordinates.sectionIndex == #bracket.sections
+
+				-- Include opponents directly knocked out from the upper bracket
+				or firstDeRoundIx and coordinates.roundIndex < firstDeRoundIx then
+
+				table.insert(groupKeys, {2, coordinates.depth, 2})
+			end
+
+			return groupKeys
+		end
+	end
+
+	local placementEntries = {}
+	for matchId in MatchGroupCoordinates.dfs(bracket) do
+		for _, groupKey in ipairs(getGroupKeys(matchId)) do
+			table.insert(placementEntries, {
+				groupKey = groupKey,
+				matchId = matchId,
+				matchPlacement = groupKey[3],
+			})
+		end
+	end
+
+	Array.sortInPlaceBy(placementEntries, function(entry)
+		return Array.extend(
+			entry.groupKey,
+			bracket.coordinatesByMatchId[entry.matchId].matchIndexInRound
+		)
+	end)
+
+	return Array.groupBy(placementEntries, function(entry)
+		return table.concat(entry.groupKey, '.')
+	end)
+end
+
+-- Returns the semifinals match IDs of a bracket if the losers also play in a
+-- third place match to determine placement.
+function Import.getPreTiebreakMatchIds(bracket)
+	local firstBracketData = bracket.bracketDatasById[bracket.rootMatchIds[1]]
+	local thirdPlaceMatchId = firstBracketData.thirdPlaceMatchId
+
+	local sfMatchIds = {}
+	if thirdPlaceMatchId and bracket.matchesById[thirdPlaceMatchId] then
+		for _, lowerMatchId in ipairs(firstBracketData.lowerMatchIds) do
+			sfMatchIds[lowerMatchId] = true
+		end
+	end
+	return sfMatchIds
+end
+
+-- Finds the first round in where upper bracket opponents drop to the lower
+-- bracket. Returns nil if it cannot be determined unambiguously, or if the
+-- bracket is not double elimination.
+function Import.findDeRoundIndex(bracket)
+	if #bracket.sections ~= 2 then
+		return nil
+	end
+	local countsByRound = MatchGroupCoordinates.computeRawCounts(bracket)
+
+	for roundIx = 1, #bracket.rounds do
+		local lbCount = countsByRound[roundIx][2]
+		if lbCount == 0 then
+			return roundIx
+		elseif lbCount > 0 then
+			return nil
+		end
+	end
+end
+
+function Import.mergePlacements(lpdbEntries, placements)
+	for placementIndex, lpdbPlacement in ipairs(lpdbEntries) do
+		placements[placementIndex] = Import.mergePlacement(
+			lpdbPlacement,
+			placements[placementIndex] or Import._emptyPlacement(placements[placementIndex - 1], #lpdbPlacement)
+		)
+	end
+
+	return placements
+end
+
+function Import._emptyPlacement(priorPlacement, placementSize)
+	priorPlacement = priorPlacement or {}
+	local placement = Table.deepCopy(priorPlacement, {copyMetatable = true})
+
+	local placeStart = (priorPlacement.placeEnd or 0) + 1
+	local placeEnd = (priorPlacement.placeEnd or 0) + placementSize
+
+	return Table.mergeInto(placement, {
+			args = {},
+			hasUSD = false,
+			opponents = {},
+			prizeRewards = {},
+			placeStart = placeStart,
+			placeEnd = placeEnd,
+			placeDisplay = Import._getPlaceDisplay(placeStart, placeEnd),
+		})
+end
+
+function Import._getPlaceDisplay(placeStart, placeEnd)
+	local display = Ordinal._ordinal(placeStart)
+	if placeEnd > placeStart then
+		return display .. DASH .. Ordinal._ordinal(placeEnd)
+	end
+
+	return display
+end
+
+function Import.mergePlacement(lpdbEntries, placement)
+	local defaultOpponentType = (placement.parent or {}).opponentType
+	for opponentIndex, opponent in ipairs(lpdbEntries) do
+		placement.opponents[opponentIndex] = Import.mergeEntry(
+			opponent,
+			Table.mergeInto(Import._emptyOpponent(defaultOpponentType), placement.opponents[opponentIndex])
+		)
+	end
+
+	return placement
+end
+
+function Import._emptyOpponent(opponentType)
+	return {
+		opponentData = Opponent.tbd(opponentType),
+		additionalData = {},
+		prizeRewards = {},
+	}
+end
+
+function Import.mergeEntry(lpdbEntry, entry)
+	if
+		not Opponent.isTbd(entry.opponentData)
+		or Table.isEmpty(lpdbEntry.opponent)
+		or Opponent.isTbd(lpdbEntry.opponent)
+	then
+		return entry
+	end
+
+	return Table.deepMergeInto(entry, Import.entryToOpponent(lpdbEntry))
+end
+
+function Import.entryToOpponent(lpdbEntry)
+	return {
+		additionalData = {
+			GROUPSCORE = Import.makeGroupScore(lpdbEntry),
+			LASTVS = Import._kickIfTbd(lpdbEntry.vsOpponent),
+			LASTVSSCORE = {
+				score = Import._getScore(lpdbEntry.opponent),
+				vsscore = Import._getScore(lpdbEntry.vsOpponent),
+			},
+		},
+		date = date,
+		opponentData = Import._kickIfTbd(lpdbEntry.opponent),
+		prizeRewards = {},
+	}
+end
+
+function Import._kickIfTbd(opponent)
+	return (Table.isEmpty(opponent) or Opponent.isTbd(opponent))
+		and {} or opponent
+end
+
+function Import.makeGroupScore(lpdbEntry)
+	if not lpdbEntry.matchScore then
+		return
+	end
+
+	if not lpdbEntry.showMatchDraws then
+		table.remove(lpdbEntry.matchScore, 2)
+	end
+
+	return table.concat(lpdbEntry.matchScore, GROUPSCORE_DELIMITER)
+end
+
+function Import._getScore(opponentData)
+	if not opponentData then
+		return
+	end
+
+	return opponentData.status == SCORE_STATUS and opponentData.score
+		or opponentData.status
+end
+
+return Import

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -397,11 +397,11 @@ function Import._removeTbdIdentifiers(opponent)
 	elseif not Opponent.isTbd(opponent) then
 		opponent.isAlreadyParsed = true
 		return opponent
+	-- Entry is a TBD Opponent, but could contain data (e.g. flag or faction) for party opponents
 	elseif not opponent.type or not Opponent.typeIsParty(opponent.type) then
 		return {}
 	end
 
-	-- Entry is a TBD Opponent, but could contain data (e.g. flag or faction) for party opponents
 	opponent.isAlreadyParsed = true
 	opponent.type = nil
 	for _, player in pairs(opponent.players or {}) do

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -330,7 +330,7 @@ function Import._findDeRoundIndex(bracket)
 		if lbCount == 0 then
 			return roundIndex
 		elseif lbCount > 0 then
-			return nil
+			return
 		end
 	end
 end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -346,7 +346,12 @@ function Import._emptyPlacement(priorPlacement, placementSize)
 	local placeStart = (priorPlacement.placeEnd or 0) + 1
 	local placeEnd = (priorPlacement.placeEnd or 0) + placementSize
 
-	return Placement({placeStart = placeStart, placeEnd = placeEnd}, priorPlacement.parent, priorPlacement.placeEnd or 0)
+	return Placement(
+		{placeStart = placeStart, placeEnd = placeEnd},
+		priorPlacement.parent,
+		priorPlacement.placeEnd or 0,
+		priorPlacement.prizeTypes
+	)
 end
 
 function Import._getPlaceDisplay(placeStart, placeEnd)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -113,6 +113,9 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 				showMatchDraws = record.extradata.showMatchDraws or false,
 			}
 
+			if not record.extradata.placeRange then
+				record.extradata.placeRange = {record.placement, record.placement}
+			end
 			if record.extradata.placeRange[1] == record.extradata.placeRange[2] then
 				Table.mergeInto(entry, {
 					matchScore = record.scoreboard.match,

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -75,13 +75,7 @@ function Import.importPlacements(inputPlacements, config)
 	end
 
 	local merged = Import.mergePlacements(placementEntries, inputPlacements)
-mw.logObject(merged)
 
-	-- todo
-	-- add player teams ?!?!
-	--> custom?!
-
-	-- return the input to not break stuff for now
 	return merged
 end
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -358,15 +358,6 @@ function Import._emptyPlacement(priorPlacement, placementSize)
 	)
 end
 
-function Import._getPlaceDisplay(placeStart, placeEnd)
-	local display = Ordinal._ordinal(placeStart)
-	if placeEnd > placeStart then
-		return display .. '-' .. Ordinal._ordinal(placeEnd)
-	end
-
-	return display
-end
-
 function Import._mergePlacement(lpdbEntries, placement)
 	for opponentIndex, opponent in ipairs(lpdbEntries) do
 		placement.opponents[opponentIndex] = Import._mergeEntry(
@@ -379,7 +370,7 @@ function Import._mergePlacement(lpdbEntries, placement)
 	assert(
 		#placement.opponents <= 1 + placement.placeEnd - placement.placeStart,
 		'Import: Too many opponents returned from query for placement range '
-			.. Import._getPlaceDisplay(placement.placeStart, placement.placeEnd)
+			.. placement:_displayPlace():gsub('&#045;', '-')
 	)
 
 	return placement
@@ -403,8 +394,8 @@ function Import._entryToOpponent(lpdbEntry, placement)
 		additionalData = Import._groupLastVsAdditionalData(lpdbEntry)
 	end
 
-	local score = Import._getScore(lpdbEntry.opponent)
-	local vsScore = Import._getScore(lpdbEntry.vsOpponent)
+	local score = additionalData.score or Import._getScore(lpdbEntry.opponent)
+	local vsScore = additionalData.vsScore or Import._getScore(lpdbEntry.vsOpponent)
 	local lastVsScore
 	if score or vsScore then
 		lastVsScore = (score or '') .. '-' .. (vsScore or '')
@@ -484,14 +475,10 @@ function Import._makeAdditionalDataFromMatch(opponentName, match)
 		end
 	end
 
-	local lastVsScore
-	if score or vsScore then
-		lastVsScore = (score or '') .. '-' .. (vsScore or '')
-	end
-
 	return {
 		lastVs = lastVs,
-		score = lastVsScore,
+		score = score,
+		vsScore = vsScore,
 	}
 end
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -148,6 +148,7 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 			end
 
 			entry.isGslStyleGroup = isGslStyleGroup
+			entry.matches = record.matches
 
 			table.insert(placementEntries, {entry})
 		end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -394,15 +394,13 @@ function Import._mergeEntry(lpdbEntry, entry)
 end
 
 function Import._entryToOpponent(lpdbEntry)
+	local additionalData
 	if lpdbEntry.isGslStyleGroup then
-		local returnValue = Import._gslEntryToOpponent(lpdbEntry)
-		if returnValue.additionalData then
-			return returnValue
-		end
+		additionalData = Import._gslEntryToAdditionalData(lpdbEntry)
 	end
 
 	return {
-		additionalData = {
+		additionalData = additionalData or {
 			GROUPSCORE = Import._makeGroupScore(lpdbEntry),
 			LASTVS = Import._kickIfTbd(lpdbEntry.vsOpponent),
 			LASTVSSCORE = {
@@ -442,7 +440,7 @@ function Import._getScore(opponentData)
 		or opponentData.status
 end
 
-function Import._gslEntryToOpponent(lpdbEntry)
+function Import._gslEntryToAdditionalData(lpdbEntry)
 	local opponentName = Opponent.toName(lpdbEntry.opponent)
 	local matchConditions = {}
 	for _, matchId in pairs(lpdbEntry.matches) do
@@ -457,15 +455,10 @@ function Import._gslEntryToOpponent(lpdbEntry)
 	})
 
 	if not type(matchData) == 'table' or not matchData[1] then
-		return {}
+		return
 	end
 
-	return {
-		additionalData = Import._makeAdditionalDataFromGslMatch(opponentName, matchData[1]),
-		date = lpdbEntry.date,
-		opponentData = Import._kickIfTbd(lpdbEntry.opponent),
-		prizeRewards = {},
-	}
+	return Import._makeAdditionalDataFromGslMatch(opponentName, matchData[1])
 end
 
 function Import._makeAdditionalDataFromGslMatch(opponentName, match)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -12,7 +12,6 @@ local ArrayExt = require('Module:Array/Ext')
 local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local MathUtil = require('Module:MathUtil')
-local Ordinal = require('Module:Ordinal')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -451,7 +451,7 @@ function Import._formatGroupScore(lpdbEntry)
 	local matches = lpdbEntry.scoreBoard.match
 	local overtime = lpdbEntry.scoreBoard.overtime
 	local wdl
-	if (matches.d or 0) ~= 0 then
+	if String.isNotEmpty(matches.d) then
 		wdl = {matches.w or '', matches.d or '', matches.l or ''}
 	elseif (overtime.w or 0) ~= 0 or (overtime.l or 0) ~= 0 then
 		wdl = {matches.w or '', overtime.w or '', overtime.l or '', matches.l or ''}

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -19,6 +19,7 @@ local Table = require('Module:Table')
 local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local Placement = Lua.import('Module:PrizePool/Placement', {requireDevIfEnabled = true})
 local TournamentUtil = Lua.import('Module:Tournament/Util', {requireDevIfEnabled = true})
 
 local GROUPSCORE_DELIMITER = '-'
@@ -342,16 +343,10 @@ end
 
 function Import._emptyPlacement(priorPlacement, placementSize)
 	priorPlacement = priorPlacement or {}
-	local placement = Table.deepCopy(priorPlacement, {copyMetatable = true})
+	local placeStart = (priorPlacement.placeEnd or 0) + 1
+	local placeEnd = (priorPlacement.placeEnd or 0) + placementSize
 
-	return Table.mergeInto(placement, {
-			args = {},
-			hasUSD = false,
-			opponents = {},
-			prizeRewards = {},
-			placeStart = (priorPlacement.placeEnd or 0) + 1,
-			placeEnd = (priorPlacement.placeEnd or 0) + placementSize,
-		})
+	return Placement({placeStart = placeStart, placeEnd = placeEnd}, priorPlacement.parent, priorPlacement.placeEnd or 0)
 end
 
 function Import._getPlaceDisplay(placeStart, placeEnd)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -321,7 +321,7 @@ end
 -- bracket is not double elimination.
 function Import._findDeRoundIndex(bracket)
 	if #bracket.sections ~= 2 then
-		return nil
+		return
 	end
 	local countsByRound = MatchGroupCoordinates.computeRawCounts(bracket)
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -354,37 +354,40 @@ end
 
 function Import._mergeEntry(lpdbEntry, entry)
 	if
-		not Opponent.isTbd(entry.opponentData)
-		or Table.isEmpty(lpdbEntry.opponent)
+		not Opponent.isTbd(entry.opponentData) -- valid manual input
+		or Table.isEmpty(lpdbEntry.opponent) -- irrelevant lpdbEntry
 		or Opponent.isTbd(lpdbEntry.opponent)
 	then
 		return entry
 	end
 
-	return Table.deepMergeInto(entry, Import._entryToOpponent(lpdbEntry))
+	return Table.deepMergeInto(entry, Import.entryToOpponent(lpdbEntry))
 end
 
-function Import._entryToOpponent(lpdbEntry)
+-- overwritable so wikis can adjust to their needs
+function Import.entryToOpponent(lpdbEntry)
 	return {
 		additionalData = {
 			GROUPSCORE = Import.makeGroupScore(lpdbEntry),
-			LASTVS = Import._kickIfTbd(lpdbEntry.vsOpponent),
+			LASTVS = Import.kickIfTbd(lpdbEntry.vsOpponent),
 			LASTVSSCORE = {
-				score = Import._getScore(lpdbEntry.opponent),
-				vsscore = Import._getScore(lpdbEntry.vsOpponent),
+				score = Import.getScore(lpdbEntry.opponent),
+				vsscore = Import.getScore(lpdbEntry.vsOpponent),
 			},
 		},
 		date = lpdbEntry.date,
-		opponentData = Import._kickIfTbd(lpdbEntry.opponent),
+		opponentData = Import.kickIfTbd(lpdbEntry.opponent),
 		prizeRewards = {},
 	}
 end
 
-function Import._kickIfTbd(opponent)
+-- export for usage in /Custom
+function ImportkickIfTbd(opponent)
 	return (Table.isEmpty(opponent) or Opponent.isTbd(opponent))
 		and {} or opponent
 end
 
+-- overwritable so e.g. the delimiter can be changed
 function Import.makeGroupScore(lpdbEntry)
 	if not lpdbEntry.matchScore then
 		return
@@ -397,7 +400,8 @@ function Import.makeGroupScore(lpdbEntry)
 	return table.concat(lpdbEntry.matchScore, GROUPSCORE_DELIMITER)
 end
 
-function Import._getScore(opponentData)
+-- export for usage in /Custom
+function Import.getScore(opponentData)
 	if not opponentData then
 		return
 	end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -324,7 +324,10 @@ function Import._mergePlacement(lpdbEntries, placement)
 		)
 	end
 
-	assert(#placement.opponents <= 1 + placement.placeEnd - placement.placeStart, 'Import: Too many opponents queried for placement range ' .. placement.placeDisplay)
+	assert(
+		#placement.opponents <= 1 + placement.placeEnd - placement.placeStart,
+		'Import: Too many opponents queried for placement range ' .. placement.placeDisplay
+	)
 
 	return placement
 end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -25,6 +25,7 @@ local GROUPSCORE_DELIMITER = '-'
 local SCORE_STATUS = 'S'
 local DASH = '&#045;'
 local DEFAULT_ELIMINATION_STATUS = 'down'
+local THIRD_PLACE_MATCH_ID = 'RxMTP'
 
 local Import = {}
 
@@ -200,7 +201,7 @@ function Import._computeBracketPlacementGroups(bracket, options)
 			)
 
 		-- Third place match
-		elseif String.endsWith(matchId, 'RxMTP') then
+		elseif String.endsWith(matchId, THIRD_PLACE_MATCH_ID) then
 			return {
 				{2, coordinates.depth + 0.5, 1},
 				{2, coordinates.depth + 0.5, 2},
@@ -337,7 +338,7 @@ function Import._mergePlacement(lpdbEntries, placement)
 
 	assert(
 		#placement.opponents <= 1 + placement.placeEnd - placement.placeStart,
-		'Import: Too many opponents queried for placement range ' .. placement.placeDisplay
+		'Import: Too many opponents returned from query for placement range ' .. placement.placeDisplay
 	)
 
 	return placement

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -30,7 +30,7 @@ local Import = {}
 function Import.run(placements, args)
 	local config = Import.getConfig(args, placements)
 
-	if not config.matchGroupsSpec then
+	if config.importLimit == 0 or not config.matchGroupsSpec then
 		return placements
 	end
 
@@ -38,12 +38,18 @@ function Import.run(placements, args)
 end
 
 function Import.getConfig(args, placements)
-	local doImport = Logic.nilOr(Logic.readBoolOrNil(args.import), true)
+	local doImport = Logic.readBool(args.import)
+		or String.isNotEmpty(args.matchGroupId1)
+		or String.isNotEmpty(args.tournament1)
+
+	if not doImport then
+		return {}
+	end
 
 	return {
 		importLimit = Import._importLimit(args.importLimit, placements),
 		matchGroupsSpec = TournamentUtil.readMatchGroupsSpec(args)
-			or doImport and TournamentUtil.currentPageSpec(),
+			or TournamentUtil.currentPageSpec(),
 	}
 end
 
@@ -74,9 +80,7 @@ function Import.importPlacements(inputPlacements, config)
 		end
 	end
 
-	local merged = Import.mergePlacements(placementEntries, inputPlacements)
-
-	return merged
+	return Import.mergePlacements(placementEntries, inputPlacements)
 end
 
 -- Compute placements and their entries of all brackets or all group tables in a

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -126,6 +126,8 @@ end
 function Import._computeGroupTablePlacementEntries(standingRecords, options)
 	local needsLastVs = Import._needsLastVs(standingRecords)
 	local placementEntries = {}
+	local placementIndexes = {}
+
 	for _, record in ipairs(standingRecords) do
 		if options.isFinalStage or Table.includes(options.groupElimStatuses, record.currentstatus) then
 			local entry = {
@@ -151,7 +153,12 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 			entry.needsLastVs = needsLastVs
 			entry.matches = record.matches
 
-			table.insert(placementEntries, {entry})
+			if not placementIndexes[record.placement] then
+				table.insert(placementEntries, {entry})
+				placementIndexes[record.placement] = #placementEntries
+			else
+				table.insert(placementEntries[placementIndexes[record.placement]], entry)
+			end
 		end
 	end
 
@@ -161,7 +168,7 @@ end
 function Import._needsLastVs(standingRecords)
 	if Import.config.allGroupsUseWdl then
 		return false
-	elseif standingRecords.type == SWISS_GROUP_TYPE then
+	elseif (standingRecords[1] or {}).type == SWISS_GROUP_TYPE then
 		return true
 	elseif #standingRecords ~= GSL_GROUP_OPPONENT_NUMBER then
 		return false

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -21,6 +21,7 @@ local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local Placement = Lua.import('Module:PrizePool/Placement', {requireDevIfEnabled = true})
 local TournamentUtil = Lua.import('Module:Tournament/Util', {requireDevIfEnabled = true})
 
+local AUTOMATION_START_DATE = '2023-01-01'
 local GROUPSCORE_DELIMITER = '-'
 local SCORE_STATUS = 'S'
 local DEFAULT_ELIMINATION_STATUS = 'down'
@@ -49,7 +50,7 @@ end
 function Import._getConfig(args, placements)
 	if String.isEmpty(args.matchGroupId1) and String.isEmpty(args.tournament1)
 		and String.isEmpty(args.matchGroupId) and String.isEmpty(args.tournament)
-		and not Import._enableImport(args.import, args.importEnableStartDate) then
+		and not Import._enableImport(args.import) then
 
 		return {}
 	end
@@ -67,11 +68,11 @@ function Import._getConfig(args, placements)
 	}
 end
 
-function Import._enableImport(importInput, importEnableStartDate)
+function Import._enableImport(importInput)
 	local date = TournamentUtil.getContextualDate()
 	return Logic.nilOr(
 		Logic.readBoolOrNil(importInput),
-		importEnableStartDate and (not date or date >= importEnableStartDate)
+		not date or date >= AUTOMATION_START_DATE
 	)
 end
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -423,7 +423,7 @@ function Import._entryToOpponent(lpdbEntry, placement)
 
 	return placement:_parseOpponents{{
 		Import._removeIfTbd(lpdbEntry.opponent),
-		wdl = (not lpdbEntry.needsLastVs) and Import._makeGroupScore(lpdbEntry) or nil,
+		wdl = (not lpdbEntry.needsLastVs) and Import._formatGroupScore(lpdbEntry) or nil,
 		lastvs = additionalData.lastVs or Import._removeIfTbd(lpdbEntry.vsOpponent),
 		lastvsscore = additionalData.score or lastVsScore,
 		date = lpdbEntry.date,
@@ -436,7 +436,7 @@ function Import._removeIfTbd(opponent)
 		and {} or Table.merge(opponent, {isAlreadyParsed = true})
 end
 
-function Import._makeGroupScore(lpdbEntry)
+function Import._formatGroupScore(lpdbEntry)
 	if not lpdbEntry.scoreBoard then
 		return
 	end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -23,7 +23,6 @@ local TournamentUtil = Lua.import('Module:Tournament/Util', {requireDevIfEnabled
 
 local GROUPSCORE_DELIMITER = '-'
 local SCORE_STATUS = 'S'
-local DASH = '&#045;'
 local DEFAULT_ELIMINATION_STATUS = 'down'
 local THIRD_PLACE_MATCH_ID = 'RxMTP'
 local GSL_GROUP_OPPONENT_NUMBER = 4

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -443,7 +443,7 @@ function Import._makeGroupScore(lpdbEntry)
 
 	local matches = lpdbEntry.scoreBoard.match
 	local overtime = lpdbEntry.scoreBoard.overtime
-	local wdl = {}
+	local wdl
 	if (matches.d or 0) ~= 0 then
 		wdl = {matches.w or '', matches.d or '', matches.l or ''}
 	elseif (overtime.w or 0) ~= 0 or (overtime.l or 0) ~= 0 then

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -49,7 +49,7 @@ end
 
 function Import._importLimit(importLimitInput, placements)
 	local importLimit = tonumber(importLimitInput)
-	if not importLimit then 
+	if not importLimit then
 		return
 	end
 
@@ -70,7 +70,6 @@ function Import.importPlacements(inputPlacements, config)
 		local sums = MathUtil.partialSums(placementEntryCounts)
 		local index = ArrayExt.findIndex(sums, function(sum) return config.importLimit <= sum end)
 		if index ~= 0 then
-			placementEntryCounts = Array.sub(placementEntryCounts, 1, index - 1)
 			placementEntries = Array.sub(placementEntries, 1, index - 1)
 		end
 	end
@@ -95,10 +94,13 @@ function Import.computeStagePlacementEntries(stage, options)
 			or Import.computeBracketPlacementEntries(matchGroup, options)
 	end)
 
-	local maxPlacementCount = Array.max(Array.map(groupPlacementEntries, function(placementEntries) return #placementEntries end))
-	return Array.map(Array.range(1, maxPlacementCount or 0), function(placementIx)
+	local maxPlacementCount = Array.max(Array.map(
+			groupPlacementEntries,
+			function(placementEntries) return #placementEntries end
+		))
+	return Array.map(Array.range(1, maxPlacementCount or 0), function(placementIndex)
 		return Array.flatMap(groupPlacementEntries, function(placementEntries)
-			return placementEntries[placementIx]
+			return placementEntries[placementIndex]
 		end)
 	end)
 end
@@ -152,11 +154,11 @@ function Import.makeEntryFromMatch(placementEntry, match)
 	}
 
 	if match.winner and 1 <= match.winner and #match.opponents == 2 then
-		local entryOpponentIx = placementEntry.matchPlacement == 1
+		local entryOpponentIndex = placementEntry.matchPlacement == 1
 			and match.winner
 			or #match.opponents - match.winner + 1
-		local opponent = match.opponents[entryOpponentIx]
-		local vsOpponent = match.opponents[#match.opponents - entryOpponentIx + 1]
+		local opponent = match.opponents[entryOpponentIndex]
+		local vsOpponent = match.opponents[#match.opponents - entryOpponentIndex + 1]
 		opponent.isResolved = true
 		vsOpponent.isResolved = true
 
@@ -175,7 +177,7 @@ end
 -- @options.isFinalStage: If on the last stage, then include placement placements for
 -- winners of final matches.
 function Import.computeBracketPlacementGroups(bracket, options)
-	local firstDeRoundIx = Import.findDeRoundIndex(bracket)
+	local firstDeRoundIndex = Import.findDeRoundIndex(bracket)
 	local preTiebreakMatchIds = Import.getPreTiebreakMatchIds(bracket)
 
 	local function getGroupKeys(matchId)
@@ -211,7 +213,7 @@ function Import.computeBracketPlacementGroups(bracket, options)
 			if coordinates.sectionIndex == #bracket.sections
 
 				-- Include opponents directly knocked out from the upper bracket
-				or firstDeRoundIx and coordinates.roundIndex < firstDeRoundIx then
+				or firstDeRoundIndex and coordinates.roundIndex < firstDeRoundIndex then
 
 				table.insert(groupKeys, {2, coordinates.depth, 2})
 			end
@@ -267,10 +269,10 @@ function Import.findDeRoundIndex(bracket)
 	end
 	local countsByRound = MatchGroupCoordinates.computeRawCounts(bracket)
 
-	for roundIx = 1, #bracket.rounds do
-		local lbCount = countsByRound[roundIx][2]
+	for roundIndex = 1, #bracket.rounds do
+		local lbCount = countsByRound[roundIndex][2]
 		if lbCount == 0 then
-			return roundIx
+			return roundIndex
 		elseif lbCount > 0 then
 			return nil
 		end
@@ -357,7 +359,7 @@ function Import.entryToOpponent(lpdbEntry)
 				vsscore = Import._getScore(lpdbEntry.vsOpponent),
 			},
 		},
-		date = date,
+		date = lpdbEntry.date,
 		opponentData = Import._kickIfTbd(lpdbEntry.opponent),
 		prizeRewards = {},
 	}

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -56,7 +56,8 @@ function Import._getConfig(args, placements)
 			mw.text.split(args.groupElimStatuses or DEFAULT_ELIMINATION_STATUS, ','),
 			mw.text.trim
 		),
-		gslStyleGroupAsWdl = Logic.readBool(args.gslStyleGroupAsWdl)
+		groupScoreDelimiter = args.groupScoreDelimiter or GROUPSCORE_DELIMITER,
+		gslStyleGroupAsWdl = Logic.readBool(args.gslStyleGroupAsWdl),
 	}
 end
 
@@ -368,7 +369,7 @@ end
 function Import._entryToOpponent(lpdbEntry)
 	return {
 		additionalData = {
-			GROUPSCORE = Import.makeGroupScore(lpdbEntry),
+			GROUPSCORE = Import._makeGroupScore(lpdbEntry),
 			LASTVS = Import._kickIfTbd(lpdbEntry.vsOpponent),
 			LASTVSSCORE = {
 				score = Import._getScore(lpdbEntry.opponent),
@@ -386,7 +387,7 @@ function Import._kickIfTbd(opponent)
 		and {} or opponent
 end
 
-function Import.makeGroupScore(lpdbEntry)
+function Import._makeGroupScore(lpdbEntry)
 	if not lpdbEntry.matchScore then
 		return
 	end
@@ -395,7 +396,7 @@ function Import.makeGroupScore(lpdbEntry)
 		table.remove(lpdbEntry.matchScore, 2)
 	end
 
-	return table.concat(lpdbEntry.matchScore, GROUPSCORE_DELIMITER)
+	return table.concat(lpdbEntry.matchScore, Import.config.groupScoreDelimiter)
 end
 
 function Import._getScore(opponentData)

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -42,6 +42,9 @@ function LegacyPrizePool.run(dependency)
 
 	local newArgs = {}
 
+	-- disable import legacy prize pools
+	newArgs.import = false
+
 	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
 	newArgs.cutafter = header.cutafter
 	newArgs.lpdb_prefix = header.lpdb_prefix or header.smw_prefix


### PR DESCRIPTION
depends on #1851

## Summary
Add Import Module for PPT

## How did you test this change?
new module, tested together with /dev of the prize pool module and a test /Custom of the prize pool module on sc2

sc2 testing page (new pp not live, PrizePool/Custom not really set up):
https://liquipedia.net/starcraft2/User:Hjpalpha/PPT

for other wikis see screenshots below

## What this does not support
If the placements in prize pool don't technically match what is in the swiss table, i.e. swiss might have all placements as 1 to 16 (1, 2, 3, etc, rather than 1-2, 3-5, etc.) but prize pools still has 1-2, 3-5, etc. regardless.
Issue with this is that the standings table doesn't hold that data, so the import module can not know that those are to be pushed into the same placement.
Possibly at a later date we can come up with a solution for this via storing additional data in standings entries that indicate the appropriate data but for now due to the limitations described above this case is out of scope of the semi-automation of prize pools.