### PR TITLE
Fix 2 bugs in PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -955,10 +955,10 @@ function Placement:init(args, parent, lastPlacement)
 	-- Use the last known place and set the place range based on the entered number of opponents
 	if not self.placeStart and not self.placeEnd then
 		self.placeStart = lastPlacement + 1
-		self.placeEnd = lastPlacement + #self.opponents
+		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
 	end
 
-	assert(#self.opponents > self.placeEnd - self.placeStart, 'Placement: Too many opponents')
+	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart, 'Placement: Too many opponents')
 
 	self.placeDisplay = self:_displayPlace()
 end


### PR DESCRIPTION
## Summary
- if the first slot doesn't have an opponent nor a place set the 2nd place is declared as 1st place too
![Screenshot 2022-09-01 19 40 40](https://user-images.githubusercontent.com/75081997/187978453-182706a3-e23c-4a12-9789-e03a09ea55ff.png)
- fix the "Too many opponents" assert the logic was wrong (it checked if there were at least as many opponents as max possible)

## How did you test this change?
/dev