### PR TITLE
Remove redundant param

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -79,7 +79,7 @@ function StarcraftOpponent.fromMatch2Record(record)
 end
 
 function StarcraftOpponent.toLpdbStruct(opponent)
-	local storageStruct = Opponent.toLpdbStruct(opponent, true)
+	local storageStruct = Opponent.toLpdbStruct(opponent)
 
 	if Opponent.typeIsParty(opponent.type) then
 		if opponent.isArchon then


### PR DESCRIPTION
## Summary
Remove redundant param

## How did you test this change?
N/A the target function only eats 1 param anayways