### PR TITLE
LPA-2465: Use Bracket Name in Match Summaries

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -59,7 +59,7 @@ function Header:createOpponent(opponent, side)
 		opponent = opponent,
 		showLink = showLink,
 		overflow = 'wrap',
-		teamStyle = 'short',
+		teamStyle = 'bracket',
 	}
 end
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -58,7 +58,7 @@ function Header:createOpponent(opponent, side)
 		flip = side == 'left',
 		opponent = opponent,
 		showLink = showLink,
-		overflow = 'wrap',
+		overflow = 'ellipsis',
 		teamStyle = 'bracket',
 	}
 end

--- a/components/match2/commons/match_summary_ffa.lua
+++ b/components/match2/commons/match_summary_ffa.lua
@@ -499,7 +499,7 @@ function FfaMatchSummary.Opponent(props)
 	local contentNode = OpponentDisplay.BlockOpponent({
 		opponent = props.opponent,
 		overflow = props.opponent.type == 'team' and 'hidden' or 'ellipsis',
-		teamStyle = 'short',
+		teamStyle = 'bracket',
 	})
 	return mw.html.create('div')
 		:addClass('ffa-match-summary-cell ffa-match-summary-opponent')

--- a/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_ffa_starcraft.lua
@@ -48,7 +48,7 @@ function CustomFfaMatchSummary.Opponent(props)
 	local contentNode = StarcraftOpponentDisplay.BlockOpponent({
 		opponent = props.opponent,
 		overflow = props.opponent.type == 'team' and 'hidden' or 'ellipsis',
-		teamStyle = 'short',
+		teamStyle = 'bracket',
 	})
 		:addClass('ffa-match-summary-cell-content')
 	return mw.html.create('div')

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -35,7 +35,7 @@ function CustomMatchSummary.getByMatchId(args)
 		return OpponentDisplay.BlockOpponent({
 			flip = opponentIndex == 1,
 			opponent = match.opponents[opponentIndex],
-			overflow = 'wrap',
+			overflow = 'ellipsis',
 			teamStyle = 'bracket',
 		})
 			:addClass(match.opponents[opponentIndex].type ~= 'solo'

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -36,7 +36,7 @@ function CustomMatchSummary.getByMatchId(args)
 			flip = opponentIndex == 1,
 			opponent = match.opponents[opponentIndex],
 			overflow = 'wrap',
-			teamStyle = 'short',
+			teamStyle = 'bracket',
 		})
 			:addClass(match.opponents[opponentIndex].type ~= 'solo'
 				and 'brkts-popup-header-opponent'

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -170,7 +170,7 @@ function Header:createOpponent(opponent, opponentIndex)
 		flip = opponentIndex == 1,
 		opponent = opponent,
 		overflow = 'wrap',
-		teamStyle = 'short',
+		teamStyle = 'bracket',
 	})
 		:addClass(opponent.type ~= 'solo'
 			and 'brkts-popup-header-opponent'

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -169,7 +169,7 @@ function Header:createOpponent(opponent, opponentIndex)
 	return OpponentDisplay.BlockOpponent({
 		flip = opponentIndex == 1,
 		opponent = opponent,
-		overflow = 'wrap',
+		overflow = 'ellipsis',
 		teamStyle = 'bracket',
 	})
 		:addClass(opponent.type ~= 'solo'


### PR DESCRIPTION
## Summary
Use Bracket Name instead of Short Name in Match Summary.

Changed the overflow to ellipsis since wrap looks quite bad. 

Fixed CSS to allow overflow to work at all (https://liquipedia.net/commons/index.php?title=MediaWiki:Common.css/Brackets.css&diff=prev&oldid=447943) 

## How did you test this change?
Tested with dev module