### PR TITLE
Add Apex Legend Status support to Widget Links

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -47,6 +47,7 @@ local _PRIORITY_GROUPS = {
 		'5ewin',
 		'abiosgaming',
 		'aligulac',
+		'apexlegendsstatus',
 		'battlefy',
 		'b5csgo',
 		'challengermode',


### PR DESCRIPTION
## Summary
Apex Legends Status Public website that tracks accounts on Apex Legends. (Showing match histories, ranked leaderboards, character statistics)
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
