### PR TITLE
Allow overwrite of lpdbTournamentData in prizePools

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -840,7 +840,7 @@ function PrizePool:_storeData()
 	for _, placement in ipairs(self.placements) do
 		local lpdbEntries = placement:_getLpdbData()
 
-		Array.forEach(lpdbEntries, function(lpdbEntry) Table.mergeInto(lpdbEntry, lpdbTournamentData) end)
+		Array.forEach(lpdbEntries, function(lpdbEntry) Table.mergeInto(lpdbTournamentData, lpdbEntry) end)
 
 		Array.extendWith(lpdbData, lpdbEntries)
 	end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -840,7 +840,7 @@ function PrizePool:_storeData()
 	for _, placement in ipairs(self.placements) do
 		local lpdbEntries = placement:_getLpdbData()
 
-		Array.forEach(lpdbEntries, function(lpdbEntry) Table.mergeInto(lpdbTournamentData, lpdbEntry) end)
+		Array.forEach(lpdbEntries, function(lpdbEntry) Table.merge(lpdbTournamentData, lpdbEntry) end)
 
 		Array.extendWith(lpdbData, lpdbEntries)
 	end


### PR DESCRIPTION
## Summary
Allow overwrite of lpdbTournamentData in prizePools.
SC/SC2 need it for ovwerwriting `mode` and `tournament`

## How did you test this change?
/dev