### PR TITLE
Stash instead of store in lua of smw data (incl. injector)

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -97,12 +97,6 @@ PrizePool.config = {
 	storeSmw = {
 		default = true,
 	},
-	stashSmw = {
-		default = false,
-		read = function(args)
-			return Logic.readBoolOrNil(args.stashsmw)
-		end
-	},
 	storeLpdb = {
 		default = true,
 	},
@@ -864,10 +858,7 @@ function PrizePool:_storeData()
 	end
 
 	for _, lpdbEntry in ipairs(lpdbData) do
-		lpdbEntry.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.players or {})
-		lpdbEntry.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.extradata or {})
-
-		if self.options.storeSmw and self.options.stashSmw then
+		if self.options.storeSmw then
 			local smwEntry = self:_lpdbToSmw(lpdbEntry)
 
 			if self._smwInjector then
@@ -879,9 +870,10 @@ function PrizePool:_storeData()
 			tournamentVars:set('smwRecords.count', count + 1)
 			tournamentVars:set('smwRecords.' .. count .. '.id', Table.extract(smwEntry, 'objectName'))
 			tournamentVars:set('smwRecords.' .. count .. '.data', Json.stringify(smwEntry))
-		elseif self.options.storeSmw then
-			Template.safeExpand(mw.getCurrentFrame(), 'PrizePoolSmwStorage', lpdbEntry)
 		end
+
+		lpdbEntry.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.players or {})
+		lpdbEntry.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.extradata or {})
 
 		if self.options.storeLpdb then
 			mw.ext.LiquipediaDB.lpdb_placement(

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -17,6 +17,7 @@ local Lua = require('Module:Lua')
 local MatchPlacement = require('Module:Match/Placement')
 local Math = require('Module:Math')
 local Ordinal = require('Module:Ordinal')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
 local PlacementInfo = require('Module:Placement')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -24,6 +25,7 @@ local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local SmwInjector = Lua.import('Module:Smw/Injector', {requireDevIfEnabled = true})
 local WidgetInjector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
 ---Note: This can be overwritten
@@ -35,6 +37,8 @@ local WidgetFactory = require('Module:Infobox/Widget/Factory')
 local WidgetTable = require('Module:Widget/Table')
 local TableRow = require('Module:Widget/Table/Row')
 local TableCell = require('Module:Widget/Table/Cell')
+
+local tournamentVars = PageVariableNamespace('Tournament')
 
 --- @class PrizePool
 local PrizePool = Class.new(function(self, ...) self:init(...) end)
@@ -92,6 +96,12 @@ PrizePool.config = {
 	},
 	storeSmw = {
 		default = true,
+	},
+	stashSmw = {
+		default = false,
+		read = function(args)
+			return Logic.readBoolOrNil(args.stashsmw)
+		end
 	},
 	storeLpdb = {
 		default = true,
@@ -816,6 +826,14 @@ function PrizePool:setLpdbInjector(lpdbInjector)
 	return self
 end
 
+--- Set the SmwInjector.
+-- @param smwInjector SmwInjector An instance of a class that implements the SmwInjector interface
+function PrizePool:setSmwInjector(smwInjector)
+	assert(smwInjector:is_a(SmwInjector), "setSmwInjector: Not an SMW Injector")
+	self._smwInjector = smwInjector
+	return self
+end
+
 function PrizePool:_storeData()
 	local prizePoolIndex = (tonumber(Variables.varDefault('prizepool_index')) or 0) + 1
 	Variables.varDefine('prizepool_index', prizePoolIndex)
@@ -849,19 +867,72 @@ function PrizePool:_storeData()
 		lpdbEntry.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.players or {})
 		lpdbEntry.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.extradata or {})
 
+		if self.options.storeSmw and self.options.stashSmw then
+			local smwEntry = self:_lpdbToSmw(lpdbEntry)
+
+			if self._smwInjector then
+				smwEntry = self.parent._smwInjector:adjust(smwEntry, lpdbEntry)
+			end
+
+			local count = tonumber(tournamentVars:get('smwRecords.count')) or 0
+			count = count + 1
+			tournamentVars:set('smwRecords.count', count + 1)
+			tournamentVars:set('smwRecords.' .. count .. '.id', Table.extract(smwEntry, 'objectName'))
+			tournamentVars:set('smwRecords.' .. count .. '.data', Json.stringify(smwEntry))
+		elseif self.options.storeSmw then
+			Template.safeExpand(mw.getCurrentFrame(), 'PrizePoolSmwStorage', lpdbEntry)
+		end
+
 		if self.options.storeLpdb then
 			mw.ext.LiquipediaDB.lpdb_placement(
 				PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, self.options.lpdbPrefix),
 				lpdbEntry
 			)
 		end
-
-		if self.options.storeSmw then
-			Template.safeExpand(mw.getCurrentFrame(), 'PrizePoolSmwStorage', lpdbEntry)
-		end
 	end
 
 	return self
+end
+
+function PrizePool:_lpdbToSmw(lpdbData)
+	local smwOpponentData = {}
+	if lpdbData.opponenttype == Opponent.team then
+		smwOpponentData['has team page'] = lpdbData.participant
+	elseif lpdbData.opponenttype == Opponent.literal then
+		smwOpponentData['has literal team'] = lpdbData.participant
+	elseif lpdbData.opponenttype == Opponent.solo then
+		local playersData = Json.parseIfString(lpdbData.players) or {}
+		smwOpponentData = {
+			['has player id'] = lpdbData.participant,
+			['has player page'] = lpdbData.participantlink,
+			['has flag'] = lpdbData.participantflag,
+			['has team page'] = playersData.p1team,
+			['has team'] = playersData.p1team,
+		}
+	end
+
+	return Table.mergeInto({
+			objectName = lpdbData.objectName,
+
+			['has tournament page'] = lpdbData.parent,
+			['has tournament name'] = lpdbData.tournament,
+			['has tournament type'] = lpdbData.type,
+			['has tournament series'] = lpdbData.series,
+			['has icon'] = lpdbData.icon,
+			['is result type'] = lpdbData.mode,
+			['has game'] = lpdbData.game,
+			['has date'] = lpdbData.date,
+			['is tier'] = lpdbData.liquipediatier,
+			['has placement'] = lpdbData.placement,
+			['has prizemoney'] = lpdbData.prizemoney,
+			['has last opponent'] = lpdbData.lastvs,
+			['has last score'] = lpdbData.lastscore,
+			['has last opponent score'] = lpdbData.lastvsscore,
+			['has last wdl'] = lpdbData.groupscore,
+			['has weight'] = lpdbData.weight,
+		},
+		smwOpponentData
+	)
 end
 
 -- get the lpdbObjectName depending on opponenttype

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -874,6 +874,10 @@ function PrizePool:_storeData()
 		end
 	end
 
+	if Table.isNotEmpty(smwTournamentStash) then
+		tournamentVars:set('smwRecords.tournament', Json.stringify(smwTournamentStash))
+	end
+
 	return self
 end
 
@@ -903,7 +907,6 @@ function PrizePool:_storeSmw(lpdbEntry, smwTournamentStash)
 		key = key .. ' place page'
 
 		smwTournamentStash[key] = lpdbEntry.participant
-		tournamentVars:set('smwRecords.tournament', Json.stringify(smwTournamentStash))
 	end
 
 	return smwTournamentStash

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -860,35 +860,7 @@ function PrizePool:_storeData()
 	local smwTournamentStash = {}
 	for _, lpdbEntry in ipairs(lpdbData) do
 		if self.options.storeSmw then
-			local smwEntry = self:_lpdbToSmw(lpdbEntry)
-
-			if self._smwInjector then
-				smwEntry = self._smwInjector:adjust(smwEntry, lpdbEntry)
-			end
-
-			local count = tonumber(tournamentVars:get('smwRecords.count')) or 0
-			count = count + 1
-			tournamentVars:set('smwRecords.count', count + 1)
-			tournamentVars:set('smwRecords.' .. count .. '.id', Table.extract(smwEntry, 'objectName'))
-			tournamentVars:set('smwRecords.' .. count .. '.data', Json.stringify(smwEntry))
-
-			local place = smwEntry['has placement']
-			if place and not Placement.specialStatuses[string.upper(place)] then
-				local key = 'has '
-				if String.isNotEmpty(self.options.lpdbPrefix) then
-					key = key .. self.options.lpdbPrefix .. ' '
-				end
-				place = mw.text.split(place, '-')[1]
-				key = key .. Template.safeExpand(mw.getCurrentFrame(), 'OrdinalWritten/' .. place, {}, '')
-				if lpdbEntry.opponentindex ~= 1 then
-					key = key .. lpdbEntry.opponentindex
-				end
-				key = key .. ' place page'
-
-				smwTournamentStash[key] = lpdbEntry.participant
-
-				tournamentVars:set('smwRecords.tournament', Json.stringify(smwTournamentStash))
-			end
+			smwTournamentStash = self:_storeSmw(lpdbEntry, smwTournamentStash)
 		end
 
 		lpdbEntry.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.players or {})
@@ -903,6 +875,39 @@ function PrizePool:_storeData()
 	end
 
 	return self
+end
+
+function PrizePool:_storeSmw(lpdbEntry, smwTournamentStash)
+	local smwEntry = self:_lpdbToSmw(lpdbEntry)
+
+	if self._smwInjector then
+		smwEntry = self._smwInjector:adjust(smwEntry, lpdbEntry)
+	end
+
+	local count = tonumber(tournamentVars:get('smwRecords.count')) or 0
+	count = count + 1
+	tournamentVars:set('smwRecords.count', count + 1)
+	tournamentVars:set('smwRecords.' .. count .. '.id', Table.extract(smwEntry, 'objectName'))
+	tournamentVars:set('smwRecords.' .. count .. '.data', Json.stringify(smwEntry))
+
+	local place = smwEntry['has placement']
+	if place and not Placement.specialStatuses[string.upper(place)] then
+		local key = 'has '
+		if String.isNotEmpty(self.options.lpdbPrefix) then
+			key = key .. self.options.lpdbPrefix .. ' '
+		end
+		place = mw.text.split(place, '-')[1]
+		key = key .. Template.safeExpand(mw.getCurrentFrame(), 'OrdinalWritten/' .. place, {}, '')
+		if lpdbEntry.opponentindex ~= 1 then
+			key = key .. lpdbEntry.opponentindex
+		end
+		key = key .. ' place page'
+
+		smwTournamentStash[key] = lpdbEntry.participant
+		tournamentVars:set('smwRecords.tournament', Json.stringify(smwTournamentStash))
+	end
+
+	return smwTournamentStash
 end
 
 function PrizePool:_lpdbToSmw(lpdbData)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -884,9 +884,8 @@ function PrizePool:_storeSmw(lpdbEntry, smwTournamentStash)
 		smwEntry = self._smwInjector:adjust(smwEntry, lpdbEntry)
 	end
 
-	local count = tonumber(tournamentVars:get('smwRecords.count')) or 0
-	count = count + 1
-	tournamentVars:set('smwRecords.count', count + 1)
+	local count = (tonumber(tournamentVars:get('smwRecords.count')) or 0) + 1
+	tournamentVars:set('smwRecords.count', count)
 	tournamentVars:set('smwRecords.' .. count .. '.id', Table.extract(smwEntry, 'objectName'))
 	tournamentVars:set('smwRecords.' .. count .. '.data', Json.stringify(smwEntry))
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -857,12 +857,13 @@ function PrizePool:_storeData()
 		Array.extendWith(lpdbData, lpdbEntries)
 	end
 
+	local smwTournamentStash = {}
 	for _, lpdbEntry in ipairs(lpdbData) do
 		if self.options.storeSmw then
 			local smwEntry = self:_lpdbToSmw(lpdbEntry)
 
 			if self._smwInjector then
-				smwEntry = self.parent._smwInjector:adjust(smwEntry, lpdbEntry)
+				smwEntry = self._smwInjector:adjust(smwEntry, lpdbEntry)
 			end
 
 			local count = tonumber(tournamentVars:get('smwRecords.count')) or 0
@@ -870,6 +871,24 @@ function PrizePool:_storeData()
 			tournamentVars:set('smwRecords.count', count + 1)
 			tournamentVars:set('smwRecords.' .. count .. '.id', Table.extract(smwEntry, 'objectName'))
 			tournamentVars:set('smwRecords.' .. count .. '.data', Json.stringify(smwEntry))
+
+			local place = smwEntry['has placement']
+			if place and not Placement.specialStatuses[string.upper(place)] then
+				local key = 'has '
+				if String.isNotEmpty(self.options.lpdbPrefix) then
+					key = key .. self.options.lpdbPrefix .. ' '
+				end
+				place = mw.text.split(place, '-')[1]
+				key = key .. Template.safeExpand(mw.getCurrentFrame(), 'OrdinalWritten/' .. place, {}, '')
+				if lpdbEntry.opponentindex ~= 1 then
+					key = key .. lpdbEntry.opponentindex
+				end
+				key = key .. ' place page'
+
+				smwTournamentStash[key] = lpdbEntry.participant
+
+				tournamentVars:set('smwRecords.tournament', Json.stringify(smwTournamentStash))
+			end
 		end
 
 		lpdbEntry.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.players or {})

--- a/standard/smw_injector.lua
+++ b/standard/smw_injector.lua
@@ -1,0 +1,17 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Smw/Injector
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+
+local Injector = Class.new()
+
+function Injector:adjust(smwData, ...)
+	return smwData
+end
+
+return Injector


### PR DESCRIPTION
## Summary
Stash instead of store smw (incl. injector)
* add `smw_injector.lua` (basically a copy of `lpdb_injector.lua`)
* set the smw data via the ppt module into a table and allow adjusting in /Custom via an injector
* then stash it into wiki vars so they can easily be stored into smw via a template (the template gets called in the prize pool templates, but OUTSIDE lua code, i.e. reduce lua run time significantly)

Advantages:
* easier adjusting of smw data, especially for non default opponents
* better performance
![Screenshot 2022-09-05 09 11 04](https://user-images.githubusercontent.com/75081997/188387420-f9ed69a5-33ac-48df-9a5e-d4fd834afa55.png)

## How did you test this change?
/dev module (smw inj. module is new, so live for that one)