### PR TITLE
Create Timezone library

### DIFF
--- a/standard/timezone.lua
+++ b/standard/timezone.lua
@@ -15,7 +15,7 @@ local OUTPUT_FORMAT = '<abbr data-tz="${tzDataLong}" title="${tzTitle} (UTC${tzD
 
 local Timezone = {}
 
-function Timezone._getTimezoneData(timezone)
+function Timezone.getTimezoneData(timezone)
 	if String.isEmpty(timezone) then
 		return
 	end
@@ -34,7 +34,7 @@ function Timezone._getTimezoneData(timezone)
 end
 
 function Timezone.getTimezoneString(timezone)
-	local timezoneData = Timezone._getTimezoneData(timezone)
+	local timezoneData = Timezone.getTimezoneData(timezone)
 	if not timezoneData then
 		return
 	end

--- a/standard/timezone.lua
+++ b/standard/timezone.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 local TimezoneData = mw.loadData('Module:Timezone/Data')
 
 local OUTPUT_FORMAT = '<abbr data-tz="${tzDataLong}" title="${tzTitle} (UTC${tzDataShort})">${tzNameShort}</abbr>'
@@ -24,6 +25,7 @@ function Timezone._getTimezoneData(timezone)
 		return
 	end
 
+	timezoneData = Table.copy(timezoneData)
 	if not timezoneData.abbr then
 		timezoneData.abbr = timezone:upper()
 	end

--- a/standard/timezone.lua
+++ b/standard/timezone.lua
@@ -1,0 +1,54 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Timezone
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local String = require('Module:StringUtils')
+local TimezoneData = mw.loadData('Module:Timezone/Data')
+
+local OUTPUT_FORMAT = '<abbr data-tz="${tzDataLong}" title="${tzTitle} (UTC${tzDataShort})">${tzNameShort}</abbr>'
+
+local Timezone = {}
+
+function Timezone._getTimezoneData(timezone)
+	if String.isEmpty(timezone) then
+		return
+	end
+
+	local timezoneData = TimezoneData[timezone:upper()]
+	if not timezoneData then
+		return
+	end
+
+	if not timezoneData.abbr then
+		timezoneData.abbr = timezone:upper()
+	end
+
+	return timezoneData
+end
+
+function Timezone.getTimezoneString(timezone)
+	local timezoneData = Timezone._getTimezoneData(timezone)
+	if not timezoneData then
+		return
+	end
+
+	local dataLong = string.format('%+03d', timezoneData.offset[1]) .. string.format(':%02d', timezoneData.offset[2])
+	local dataShort = string.format('%+d', timezoneData.offset[1])
+	if timezoneData.offset[2] > 0 then
+		dataShort = dataShort .. string.format(':%02d', timezoneData.offset[2])
+	end
+
+	return String.interpolate(OUTPUT_FORMAT, {
+		tzTitle = timezoneData.name,
+		tzNameShort = timezoneData.abbr,
+		tzDataLong = dataLong,
+		tzDataShort = dataShort
+	})
+end
+
+return Class.export(Timezone)

--- a/standard/timezone_data.lua
+++ b/standard/timezone_data.lua
@@ -1,0 +1,186 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Timezone/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	ADT = {
+		name ='Atlantic Daylight Time',
+		offset = {4, 0},
+	},
+	AEDT = {
+		name = 'Australian Eastern Daylight Time',
+		offset = {11, 0},
+	},
+	AEST = {
+		name = 'Australian Eastern Standard Time',
+		offset = {10, 0},
+	},
+	ART = {
+		name = 'Argentina Time',
+		offset = {-3, 0},
+	},
+	AST = {
+		name = 'Arabia Standard Time',
+		offset = {3, 0},
+	},
+	BOT = {
+		name = 'Bolivia Standard Time',
+		offset = {-4, 0},
+	},
+	BRST = {
+		name = 'Brasilia Summer Time',
+		offset = {-2, 0},
+	},
+	BRT = {
+		name = 'Brasilia Time',
+		offset = {-3, 0},
+	},
+	BST = {
+		name = 'British Summer Time',
+		offset = {1, 0},
+	},
+	CEST = {
+		name = 'Central European Summer Time',
+		offset = {2, 0},
+	},
+	CET = {
+		name = 'Central European Time',
+		offset = {1, 0},
+	},
+	COT = {
+		name = 'Colombia Time',
+		offset = {-5, 0},
+	},
+	CST = {
+		name = 'China Standard Time',
+		offset = {8, 0},
+	},
+	CST2 = {
+		abbr = 'CST',
+		name = 'Central Standard Time',
+		offset = {-6, 0},
+	},
+	CT = {
+		name = 'Central Standard Time',
+		offset = {-5, 0},
+	},
+	EDT = {
+		name = 'Eastern Daylight Time',
+		offset = {-4, 0},
+	},
+	EEST = {
+		name = 'Eastern European Summer Time',
+		offset = {3, 0},
+	},
+	EET = {
+		name = 'Eastern European Time',
+		offset = {2, 0},
+	},
+	EST = {
+		name = 'Eastern Standard Time',
+		offset = {-5, 0},
+	},
+	GMT = {
+		name = 'Greenwich Mean Time',
+		offset = {0, 0},
+	},
+	GST = {
+		name = 'Gulf Standard Time',
+		offset = {4, 0},
+	},
+	ICT = {
+		name = 'Indochina Time',
+		offset = {7, 0},
+	},
+	IRDT = {
+		name = 'Iran Daylight Time',
+		offset = {4, 30},
+	},
+	IST2 = {
+		abbr = 'IST',
+		name = 'Indian Standard Time',
+		offset = {5, 30},
+	},
+	JST = {
+		name = 'Japan Standard Time',
+		offset = {9, 0},
+	},
+	KST = {
+		name = 'Korea Standard Time',
+		offset = {9, 0},
+	},
+	MDT = {
+		name = 'Mountain Daylight Time',
+		offset = {-6, 0},
+	},
+	MMT = {
+		name = 'Myanmar Time',
+		offset = {6, 30},
+	},
+	MSK = {
+		name = 'Moscow Standard Time',
+		offset = {3, 0},
+	},
+	MST = {
+		name = 'Mountain Standard Time',
+		offset = {-7, 0},
+	},
+	MVT = {
+		name = 'Maldives Standard Time',
+		offset = {5, 0},
+	},
+	NPT = {
+		name = 'Nepal Time',
+		offset = {5, 45},
+	},
+	PDT = {
+		name = 'Pacific Daylight Time',
+		offset = {-7, 0},
+	},
+	PKT = {
+		name = 'Pakistan Standard Time',
+		offset = {5, 0},
+	},
+	PST = {
+		name = 'Pacific Standard Time',
+		offset = {-8, 0},
+	},
+	PYT = {
+		name = 'Paraguay Time',
+		offset = {-4, 0},
+	},
+	SAST = {
+		name = 'South Africa Standard Time',
+		offset = {2, 0},
+	},
+	SGT = {
+		name = 'Singapore Time',
+		offset = {8, 0},
+	},
+	THA = {
+		abbr = 'ICT',
+		name = 'Indochina Time',
+		offset = {7, 0},
+	},
+	TRT = {
+		name = 'Turkey Time',
+		offset = {3, 0},
+	},
+	UTC = {
+		name = 'Coordinated Universal Time',
+		offset = {0, 0},
+	},
+	VLAT = {
+		name = 'Vladivostok Time',
+		offset = {10, 0},
+	},
+	WIB = {
+		abbr = 'ICT',
+		name = 'Indochina Time',
+		offset = {7, 0},
+	},
+}

--- a/standard/timezone_data.lua
+++ b/standard/timezone_data.lua
@@ -59,11 +59,6 @@ return {
 		name = 'China Standard Time',
 		offset = {8, 0},
 	},
-	CST2 = {
-		abbr = 'CST',
-		name = 'Central Standard Time',
-		offset = {-6, 0},
-	},
 	CDT = {
 		name = 'Central Daylight Time',
 		offset = {-5, 0},
@@ -104,8 +99,7 @@ return {
 		name = 'Iran Daylight Time',
 		offset = {4, 30},
 	},
-	IST2 = {
-		abbr = 'IST',
+	IST = {
 		name = 'Indian Standard Time',
 		offset = {5, 30},
 	},

--- a/standard/timezone_data.lua
+++ b/standard/timezone_data.lua
@@ -64,9 +64,13 @@ return {
 		name = 'Central Standard Time',
 		offset = {-6, 0},
 	},
+	CDT = {
+		name = 'Central Daylight Time',
+		offset = {-5, 0},
+	},
 	CT = {
 		name = 'Central Standard Time',
-		offset = {-5, 0},
+		offset = {-6, 0},
 	},
 	EDT = {
 		name = 'Eastern Daylight Time',


### PR DESCRIPTION
## Summary

Create a Timezone Library and associative data package. 

The data is based on https://liquipedia.net/commons/Special:PrefixIndex?prefix=Abbr%2F&namespace=10

The TZ Library currently only builds the String of above templates. 

## How did you test this change?

```lua
mw.log(p.getTimezoneString('IST'))
--<abbr data-tz="+05:30" title="Indian Standard Time (UTC+5:30)">IST</abbr>
mw.log(p.getTimezoneString('CEST'))
--<abbr data-tz="+02:00" title="Central European Summer Time (UTC+2)">CEST</abbr>
mw.logObject(p.getTimezoneString('BAN'))
--nil
```