### PR TITLE
Only display errors in luacheck junit CI run

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -22,7 +22,7 @@ jobs:
       - name: test
         run: |
           luacheck ./ |
-          luacheck ./ --quiet --formatter=JUnit > report.xml
+          luacheck ./ --formatter=JUnit > report.xml
 
       - name: junit
         uses: mikepenz/action-junit-report@v3
@@ -30,4 +30,5 @@ jobs:
         with:
           report_paths: 'report.xml'
           check_name: 'junit-report'
+          job_summary: false
 

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -22,7 +22,7 @@ jobs:
       - name: test
         run: |
           luacheck ./ |
-          luacheck ./ --formatter=JUnit > report.xml
+          luacheck ./ --quiet --formatter=JUnit > report.xml
 
       - name: junit
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           report_paths: 'report.xml'
           check_name: 'junit-report'
-          job_summary: false
+          annotate_notice: false
 

--- a/components/earnings/wikis/rocketleague/earnings.lua
+++ b/components/earnings/wikis/rocketleague/earnings.lua
@@ -15,7 +15,7 @@ CustomEarnings.defaultNumberOfPlayersInTeam = 3
 
 -- Legacy entry points
 function CustomEarnings.calc_player(input)
-    	local args = input.args
+    local args = input.args
 
     return CustomEarnings.calculateForPlayer(args)
 end

--- a/components/earnings/wikis/rocketleague/earnings.lua
+++ b/components/earnings/wikis/rocketleague/earnings.lua
@@ -15,7 +15,7 @@ CustomEarnings.defaultNumberOfPlayersInTeam = 3
 
 -- Legacy entry points
 function CustomEarnings.calc_player(input)
-    local args = input.args
+        local args = input.args
 
     return CustomEarnings.calculateForPlayer(args)
 end

--- a/components/earnings/wikis/rocketleague/earnings.lua
+++ b/components/earnings/wikis/rocketleague/earnings.lua
@@ -15,7 +15,7 @@ CustomEarnings.defaultNumberOfPlayersInTeam = 3
 
 -- Legacy entry points
 function CustomEarnings.calc_player(input)
-        local args = input.args
+    	local args = input.args
 
     return CustomEarnings.calculateForPlayer(args)
 end


### PR DESCRIPTION
## Summary
With the latest release of https://github.com/mikepenz/action-junit-report `annotate_notice` must be set to `false` to only show warnings and errors.

## How did you test this change?
I tested it locally on a PC
