### PR TITLE
Use match timezone instead of UTC

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -101,8 +101,8 @@ function DisplayHelper.MatchCountdownBlock(match)
 	local dateString
 	if match.dateIsExact == true then
 		local timestamp = Date.readTimestamp(match.date) + (Timezone.getOffset(match.extradata.timezoneid) or 0)
-		dateString = mw.getContentLanguage():formatDate('F j, Y - H:i', timestamp) .. ' '
-					.. (Timezone.getTimezoneString(match.extradata.timezoneid) or _UTC)
+		dateString = Date.formatTimestamp('F j, Y - H:i', timestamp) .. ' '
+				.. (Timezone.getTimezoneString(match.extradata.timezoneid) or _UTC)
 	else
 		dateString = mw.getContentLanguage():formatDate('F j, Y', match.date)
 	end

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -7,11 +7,13 @@
 --
 
 local Array = require('Module:Array')
+local Date = require('Module:Date/Ext')
 local DisplayUtil = require('Module:DisplayUtil')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+local Timezone = require('Module:Timezone')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
@@ -19,7 +21,7 @@ local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 
 local DisplayHelper = {}
 local _NONBREAKING_SPACE = '&nbsp;'
-local _UTC = '<abbr data-tz="+0:00" title="Coordinated Universal Time (UTC)">UTC</abbr>'
+local _UTC = Timezone.getTimezoneString('UTC')
 
 ---@deprecated
 ---Use Opponent.typeIsParty
@@ -98,7 +100,9 @@ function DisplayHelper.MatchCountdownBlock(match)
 	DisplayUtil.assertPropTypes(match, MatchGroupUtil.types.Match.struct)
 	local dateString
 	if match.dateIsExact == true then
-		dateString = mw.getContentLanguage():formatDate('F j, Y - H:i', match.date) .. ' ' .. _UTC
+		local timestamp = Date.readTimestamp(match.date) + (Timezone.getOffset(match.extradata.timezoneid) or 0)
+		dateString = mw.getContentLanguage():formatDate('F j, Y - H:i', timestamp) .. ' '
+					.. (Timezone.getTimezoneString(match.extradata.timezoneid) or _UTC)
 	else
 		dateString = mw.getContentLanguage():formatDate('F j, Y', match.date)
 	end


### PR DESCRIPTION
## Summary

Resolve #1750. Requires #1829.

User who have turned off TZ adjustment should be shown the match in the matches timezone instead of UTC.

With TZ adjustment turned off:
Before:
![image](https://user-images.githubusercontent.com/3426850/188671867-b3856cc6-cb8c-4021-9aed-17328a69267f.png)
After:
![image](https://user-images.githubusercontent.com/3426850/188671941-521b42cc-00b4-4968-995e-928c6c6cf29f.png)


## How did you test this change?

Dev module