### PR TITLE
Catch case in `PlayerExt.syncTeam` with `pageVarEntry` has no `template` property

### DIFF
--- a/components/match2/commons/player_ext.lua
+++ b/components/match2/commons/player_ext.lua
@@ -239,6 +239,12 @@ function PlayerExt.syncTeam(pageName, template, options)
 		template = template ~= 'noteam' and template or nil,
 	}
 
+	-- catch some edge cases for pageVarEntry
+	if pageVarEntry and not pageVarEntry.template then
+		pageVarEntry.template = pageVarEntry.team
+		pageVarEntry.isResolved = nil
+	end
+
 	local entry = timelessEntry
 		or pageVarEntry
 		or options.fetchPlayer ~= false and PlayerExt.fetchTeamHistoryEntry(pageName, options.date)

--- a/components/match2/commons/player_ext.lua
+++ b/components/match2/commons/player_ext.lua
@@ -239,7 +239,9 @@ function PlayerExt.syncTeam(pageName, template, options)
 		template = template ~= 'noteam' and template or nil,
 	}
 
-	-- catch some edge cases for pageVarEntry
+	-- catch some edge cases for pageVarEntry where pageVarEntry.team
+	-- (unresolved team template or lowercased underscore replaced pagename of the team)
+	-- is set while pageVarEntry.template is not set
 	if pageVarEntry and not pageVarEntry.template then
 		pageVarEntry.template = pageVarEntry.team
 		pageVarEntry.isResolved = nil

--- a/components/match2/commons/player_ext.lua
+++ b/components/match2/commons/player_ext.lua
@@ -239,9 +239,8 @@ function PlayerExt.syncTeam(pageName, template, options)
 		template = template ~= 'noteam' and template or nil,
 	}
 
-	-- catch some edge cases for pageVarEntry where pageVarEntry.team
-	-- (unresolved team template or lowercased underscore replaced pagename of the team)
-	-- is set while pageVarEntry.template is not set
+	-- Catch an edge case where pageVarEntry.team is set while pageVarEntry.template is not set
+	-- (pageVarEntry.team being an unresolved team template or lowercased underscore replaced pagename of the team)
 	if pageVarEntry and not pageVarEntry.template then
 		pageVarEntry.template = pageVarEntry.team
 		pageVarEntry.isResolved = nil


### PR DESCRIPTION
## Summary
Catch some edge cases for `pageVarEntry` in `PlayerExt.syncTeam`
where pageVarEntry.team (unresolved team template or lowercased underscore replaced pagename of the team) is set while pageVarEntry.template is not set

## How did you test this change?
/dev