### PR TITLE
Set `lastvs` on walkover to/from in PPT Legacy

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -213,13 +213,17 @@ function LegacyPrizePool.mapOpponents(slot, newData, mergeSlots)
 		end
 
 		-- Map Legacy WO flags into score
-		if slot['walkoverfrom' .. opponentIndex] or slot['wofrom' .. opponentIndex] then
+		local walkoverFrom = slot['walkoverfrom' .. opponentIndex] or slot['wofrom' .. opponentIndex]
+		local walkoverTo = slot['walkoverto' .. opponentIndex] or slot['woto' .. opponentIndex]
+		if walkoverFrom then
 			slot['lastscore' .. opponentIndex] = 'W'
 			slot['lastvsscore' .. opponentIndex] = 'FF'
+			slot['lastvs' .. opponentIndex] = slot['lastvs' .. opponentIndex] or walkoverFrom
 
-		elseif slot['walkoverto' .. opponentIndex] or slot['woto' .. opponentIndex] then
+		elseif walkoverTo then
 			slot['lastscore' .. opponentIndex] = 'FF'
 			slot['lastvsscore' .. opponentIndex] = 'W'
+			slot['lastvs' .. opponentIndex] = slot['lastvs' .. opponentIndex] or walkoverTo
 		end
 
 		local opponentData = {


### PR DESCRIPTION
## Summary
For walkover in legacy PPT, the `lastvs` field wasn't set rather the walkover to/from contained the opponent. This PR ensure that the opponent information is properly maintained into the normal PPT.

## How did you test this change?

Tested with /dev