### PR TITLE
Move `placement:_displayPlace()` call to the display part

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1061,7 +1061,8 @@ function Placement:init(args, parent, lastPlacement)
 		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
 	end
 
-	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart, 'Placement: Too many opponents')
+	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
+		'Placement: Too many opponents in place ' .. self.placeStart .. '-' .. self.placeStart)
 
 	self.placeDisplay = self:_displayPlace()
 end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -623,7 +623,7 @@ function PrizePool:_buildRows()
 
 			if opponentIndex == 1 then
 				local placeCell = TableCell{
-					content = {{placement:getMedal() or '' , NON_BREAKING_SPACE, placement.placeDisplay}},
+					content = {{placement:getMedal() or '' , NON_BREAKING_SPACE, placement:_displayPlace()}},
 					css = {['font-weight'] = 'bolder'},
 				}
 				placeCell.rowSpan = #placement.opponents
@@ -1061,10 +1061,8 @@ function Placement:init(args, parent, lastPlacement)
 		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
 	end
 
-	self.placeDisplay = self:_displayPlace()
-
 	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
-		'Placement: Too many opponents in place ' .. self.placeDisplay:gsub('&#045;', '-'))
+		'Placement: Too many opponents in place ' .. self:_displayPlace():gsub('&#045;', '-'))
 end
 
 function Placement:_parseArgs(args)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1062,8 +1062,7 @@ function Placement:init(args, parent, lastPlacement)
 	end
 
 	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
-		'Placement: Too many opponents in place ' .. self.placeStart
-		.. (self.placeStart ~= self.placeEnd and ('-' .. self.placeEnd) or ''))
+		'Placement: Too many opponents in place ' .. self.placeDisplay:gsub('&#045;', '-'))
 
 	self.placeDisplay = self:_displayPlace()
 end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1061,10 +1061,10 @@ function Placement:init(args, parent, lastPlacement)
 		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
 	end
 
+	self.placeDisplay = self:_displayPlace()
+
 	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
 		'Placement: Too many opponents in place ' .. self.placeDisplay:gsub('&#045;', '-'))
-
-	self.placeDisplay = self:_displayPlace()
 end
 
 function Placement:_parseArgs(args)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -1062,7 +1062,8 @@ function Placement:init(args, parent, lastPlacement)
 	end
 
 	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
-		'Placement: Too many opponents in place ' .. self.placeStart .. '-' .. self.placeStart)
+		'Placement: Too many opponents in place ' .. self.placeStart
+		.. (self.placeStart ~= self.placeEnd and ('-' .. self.placeEnd) or ''))
 
 	self.placeDisplay = self:_displayPlace()
 end


### PR DESCRIPTION
#stacked on #1836 due to altering stuff that gets changed there

## Summary
Move `placement:_displayPlace()` call to the display part so it can be used on importet placements that had no manual input

## How did you test this change?
/dev