### PR TITLE
Change Atlantic Daylight Time (ADT) to -3 instead of 4

### DIFF
--- a/standard/timezone_data.lua
+++ b/standard/timezone_data.lua
@@ -9,7 +9,7 @@
 return {
 	ADT = {
 		name ='Atlantic Daylight Time',
-		offset = {4, 0},
+		offset = {-3, 0},
 	},
 	AEDT = {
 		name = 'Australian Eastern Daylight Time',


### PR DESCRIPTION
## Summary
ADT uses UTC -3 as opposed to 4.

Source:
https://www.timeanddate.com/time/zones/adt
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
