### PR TITLE
Add PPT (Non-Legacy) for Mobile Legends

### DIFF
--- a/components/prize_pool/mobilelegends/prize_pool_custom.lua
+++ b/components/prize_pool/mobilelegends/prize_pool_custom.lua
@@ -1,0 +1,64 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:PrizePool/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+
+local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local CustomLpdbInjector = Class.new(LpdbInjector)
+
+local CustomPrizePool = {}
+
+local TIER_VALUE = {32, 16, 8, 4, 2}
+
+-- Template entry point
+function CustomPrizePool.run(frame)
+	local args = Arguments.getArgs(frame)
+	local prizePool = PrizePool(args):create()
+
+	prizePool:setLpdbInjector(CustomLpdbInjector())
+
+	return prizePool:build()
+end
+
+function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
+	lpdbData.weight = CustomPrizePool.calculateWeight(
+		lpdbData.prizemoney,
+		Variables.varDefault('tournament_liquipediatier'),
+		placement.placeStart
+	)
+
+	lpdbData.publishertier = Variables.varDefault('tournament_publishertier', '')
+	lpdbData.extradata.publisherpremier = Variables.varDefault('tournament_publisher_major') and 'true' or ''
+
+	local team = lpdbData.participant or ''
+	local smwPrefix = Variables.varDefault('smw_prefix', '')
+
+	Variables.varDefine('enddate_' .. smwPrefix .. team, lpdbData.date)
+	Variables.varDefine('ranking' .. smwPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+
+
+	return lpdbData
+end
+
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place)
+	if String.isEmpty(tier) then
+		return 0
+	end
+
+	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier) or ''] or 1
+
+	return tierValue * math.max(prizeMoney, 1) / place
+end
+
+return CustomPrizePool


### PR DESCRIPTION
## Summary
New Prize Module, this is very clean port of LoL, the only thing I've retouch is what was **tournament_riot_premier** , adjustments might be needed if theres more leftover than that

## How did you test this change?
**Non-Legacy (called by new template {{TeamPrizePool}}**

LIVE on Some pages 
Concluded (no points): https://liquipedia.net/mobilelegends/Top_Clans/2022/Summer_Invitational
Upcoming (with qualifies and seed): https://liquipedia.net/mobilelegends/MPL/Cambodia/2022/Autumn
Upcoming (no points): https://liquipedia.net/mobilelegends/IESF/World_Esports_Championships/2022
Upcoming (with local prize): https://liquipedia.net/mobilelegends/Turkiye_Sampiyonasi/2022

Basic checking of things such as does it affect player/team achievements table or not, or if it affects the tournament portal. All are in good state with no errors spotted
