### PR TITLE
SMW: Do not set score and opponent score in case of special scores

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -65,6 +65,8 @@ local PRIZE_TYPE_FREETEXT = 'FREETEXT'
 
 -- Allowed none-numeric score values.
 local SPECIAL_SCORES = {'W', 'FF', 'L', 'DQ', 'D'}
+local WALKOVER_SCORE = 'W'
+local FORFEIT_SCORE = 'FF'
 
 PrizePool.config = {
 	showUSD = {
@@ -942,6 +944,20 @@ function PrizePool:_lpdbToSmw(lpdbData)
 		}
 	end
 
+	local scoreData = {
+		['has last wdl'] = lpdbData.groupscore,
+	}
+	if Table.includes(SPECIAL_SCORES, lpdbData.lastscore) then
+		if lpdbData.lastscore == WALKOVER_SCORE then
+			scoreData['has walkover from'] = lpdbData.lastvs
+		else if lpdbData.lastscore == FORFEIT_SCORE then
+			scoreData['has walkover to'] = lpdbData.lastvs
+		end
+	else
+		scoreData['has last score'] = lpdbData.lastscore
+		scoreData['has last opponent score'] = lpdbData.lastvsscore
+	end
+
 	return Table.mergeInto({
 			objectName = lpdbData.objectName,
 
@@ -957,12 +973,10 @@ function PrizePool:_lpdbToSmw(lpdbData)
 			['has placement'] = lpdbData.placement,
 			['has prizemoney'] = lpdbData.prizemoney,
 			['has last opponent'] = lpdbData.lastvs,
-			['has last score'] = lpdbData.lastscore,
-			['has last opponent score'] = lpdbData.lastvsscore,
-			['has last wdl'] = lpdbData.groupscore,
 			['has weight'] = lpdbData.weight,
 		},
-		smwOpponentData
+		smwOpponentData,
+		scoreData
 	)
 end
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -64,9 +64,9 @@ local PRIZE_TYPE_POINTS = 'POINTS'
 local PRIZE_TYPE_FREETEXT = 'FREETEXT'
 
 -- Allowed none-numeric score values.
-local SPECIAL_SCORES = {'W', 'FF', 'L', 'DQ', 'D'}
 local WALKOVER_SCORE = 'W'
 local FORFEIT_SCORE = 'FF'
+local SPECIAL_SCORES = {WALKOVER_SCORE, FORFEIT_SCORE , 'L', 'DQ', 'D'}
 
 PrizePool.config = {
 	showUSD = {

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -950,7 +950,7 @@ function PrizePool:_lpdbToSmw(lpdbData)
 	if Table.includes(SPECIAL_SCORES, lpdbData.lastscore) then
 		if lpdbData.lastscore == WALKOVER_SCORE then
 			scoreData['has walkover from'] = lpdbData.lastvs
-		else if lpdbData.lastscore == FORFEIT_SCORE then
+		elseif lpdbData.lastscore == FORFEIT_SCORE then
 			scoreData['has walkover to'] = lpdbData.lastvs
 		end
 	else


### PR DESCRIPTION
## Summary
Prevents setting the SMW properties for scores in case of Special Scores (non-numeric), since those properties are expected to be Numbers.
Sets walkover properties if necessary.

Will work for Legacy PPT once #1838 is merged.

## How did you test this change?
TBD (changes only done in Github Web)
- [x] AoE
- [x] [CS](https://liquipedia.net/counterstrike/GAM3RS_X/EU_Champions/2022/Fall/Europe/Qualifier)
- [x] RL (changes storage from W/FF in score properties to walkover properties)
