### PR TITLE
Add option in PrizePool/Placement to not call `readOpponentArgs`

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -409,7 +409,7 @@ function PrizePool:init(args)
 	self.placements = {}
 
 	-- needed by Module:PrizePool/Placement
-	self.prizeTypes = PrizePool.prizeTypes
+	self.prizeTypes = Table.deepCopy(PrizePool.prizeTypes)
 
 	self.usedAutoConvertedCurrency = false
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -348,46 +348,6 @@ PrizePool.prizeTypes = {
 	}
 }
 
-PrizePool.additionalData = {
-	GROUPSCORE = {
-		field = 'wdl',
-		parse = function (placement, input, context)
-			return input
-		end
-	},
-	LASTVS = {
-		field = 'lastvs',
-		parse = function (placement, input, context)
-			return placement:_parseOpponentArgs(input, context.date)
-		end
-	},
-	LASTVSSCORE = {
-		field = 'lastvsscore',
-		parse = function (placement, input, context)
-			local forceValidScore = function(score)
-				if Table.includes(SPECIAL_SCORES, score:upper()) then
-					return score:upper()
-				end
-				return tonumber(score)
-			end
-
-			-- split the lastvsscore entry by '-', but allow negative scores
-			local rawScores = Table.mapValues(mw.text.split(input, '-'), mw.text.trim)
-			local scores = {}
-			for index, rawScore in ipairs(rawScores) do
-				if String.isEmpty(rawScore) and String.isNotEmpty(rawScores[index + 1]) then
-					rawScores[index + 1] = '-' .. rawScores[index + 1]
-				else
-					table.insert(scores, rawScore)
-				end
-			end
-
-			scores = Table.mapValues(scores, forceValidScore)
-			return {score = scores[1], vsscore = scores[2]}
-		end
-	},
-}
-
 
 
 function PrizePool:init(args)

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -394,7 +394,7 @@ function PrizePool:init(args)
 	self.args = self:_parseArgs(args)
 
 	self.pagename = mw.title.getCurrentTitle().text
-	self.date = self:getTournamentDate()
+	self.date = PrizePool._getTournamentDate()
 	self.opponentType = self.args.type
 	if self.args.opponentLibrary then
 		Opponent = Lua.import('Module:'.. self.args.opponentLibrary, {requireDevIfEnabled = true})
@@ -660,7 +660,7 @@ end
 function PrizePool._CurrencyConvertionText(prize)
 	local exchangeRate = Math.round{
 		PrizePool.prizeTypes[PRIZE_TYPE_LOCAL_CURRENCY].convertToUsd(
-			prize.data, 1, self:getTournamentDate()
+			prize.data, 1, PrizePool._getTournamentDate()
 		)
 		,5
 	}
@@ -954,7 +954,7 @@ function PrizePool._getTournamentInfo(pageName)
 end
 
 --- Returns the default date based on wiki-variables set in the Infobox League
-function PrizePool:getTournamentDate()
+function PrizePool._getTournamentDate()
 	return Variables.varDefaultMulti('tournament_enddate', 'tournament_edate', 'edate', TODAY)
 end
 

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -54,9 +54,6 @@ local PRIZE_TYPE_QUALIFIES = 'QUALIFIES'
 local PRIZE_TYPE_POINTS = 'POINTS'
 local PRIZE_TYPE_FREETEXT = 'FREETEXT'
 
--- Allowed none-numeric score values.
-local SPECIAL_SCORES = {'W', 'FF', 'L', 'DQ', 'D'}
-
 PrizePool.config = {
 	showUSD = {
 		default = false

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -14,17 +14,15 @@ local LeagueIcon = require('Module:LeagueIcon')
 local Currency = require('Module:Currency')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchPlacement = require('Module:Match/Placement')
 local Math = require('Module:Math')
-local Ordinal = require('Module:Ordinal')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
-local PlacementInfo = require('Module:Placement')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local Placement = Lua.import('Module:PrizePool/Placement', {requireDevIfEnabled = true})
 local SmwInjector = Lua.import('Module:Smw/Injector', {requireDevIfEnabled = true})
 local WidgetInjector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
@@ -38,17 +36,10 @@ local WidgetTable = require('Module:Widget/Table')
 local TableRow = require('Module:Widget/Table/Row')
 local TableCell = require('Module:Widget/Table/Cell')
 
-local tournamentVars = PageVariableNamespace('Tournament')
-
 --- @class PrizePool
 local PrizePool = Class.new(function(self, ...) self:init(...) end)
 
---- @class Placement
---- A Placement is a set of opponents who all share the same final place in the tournament.
---- Its input is generally a table created by `Template:Placement`.
---- It has a range from placeStart to placeEnd, for example 5 to 8
---- and is expected to have the same amount of opponents as the range allows (4 is the 5-8 example).
-local Placement = Class.new(function(self, ...) self:init(...) end)
+local tournamentVars = PageVariableNamespace('Tournament')
 
 local TODAY = os.date('%Y-%m-%d')
 
@@ -397,80 +388,17 @@ PrizePool.additionalData = {
 	},
 }
 
-Placement.specialStatuses = {
-	DQ = {
-		active = function (args)
-			return Logic.readBool(args.dq)
-		end,
-		display = function ()
-			return Abbreviation.make('DQ', 'Disqualified')
-		end,
-		lpdb = 'dq',
-	},
-	DNF = {
-		active = function (args)
-			return Logic.readBool(args.dnf)
-		end,
-		display = function ()
-			return Abbreviation.make('DNF', 'Did not finish')
-		end,
-		lpdb = 'dnf',
-	},
-	DNP = {
-		active = function (args)
-			return Logic.readBool(args.dnp)
-		end,
-		display = function ()
-			return Abbreviation.make('DNP', 'Did not participate')
-		end,
-		lpdb = 'dnp',
-	},
-	W = {
-		active = function (args)
-			return Logic.readBool(args.w)
-		end,
-		display = function ()
-			return 'W'
-		end,
-		lpdb = 1,
-	},
-	D = {
-		active = function (args)
-			return Logic.readBool(args.d)
-		end,
-		display = function ()
-			return 'D'
-		end,
-		lpdb = 1,
-	},
-	L = {
-		active = function (args)
-			return Logic.readBool(args.l)
-		end,
-		display = function ()
-			return 'L'
-		end,
-		lpdb = 2,
-	},
-	Q = {
-		active = function (args)
-			return Logic.readBool(args.q)
-		end,
-		display = function ()
-			return Abbreviation.make('Q', 'Qualified Automatically')
-		end,
-		lpdb = 1,
-	},
-}
+
 
 function PrizePool:init(args)
 	self.args = self:_parseArgs(args)
 
 	self.pagename = mw.title.getCurrentTitle().text
-	self.date = PrizePool._getTournamentDate()
+	self.date = self:getTournamentDate()
 	self.opponentType = self.args.type
 	if self.args.opponentLibrary then
 		Opponent = Lua.import('Module:'.. self.args.opponentLibrary, {requireDevIfEnabled = true})
+		self.opponentLibrary = Opponent
 	end
 	if self.args.opponentDisplayLibrary then
 		OpponentDisplay = Lua.import('Module:'.. self.args.opponentDisplayLibrary, {requireDevIfEnabled = true})
@@ -479,6 +407,9 @@ function PrizePool:init(args)
 	self.options = {}
 	self.prizes = {}
 	self.placements = {}
+
+	-- needed by Module:PrizePool/Placement
+	self.prizeTypes = PrizePool.prizeTypes
 
 	self.usedAutoConvertedCurrency = false
 
@@ -489,7 +420,7 @@ function PrizePool:_parseArgs(args)
 	local parsedArgs = Table.deepCopy(args)
 	local typeStruct = Json.parseIfString(args.type)
 
-	PrizePool._assertOpponentStructType(typeStruct)
+	self:assertOpponentStructType(typeStruct)
 
 	parsedArgs.type = typeStruct.type
 
@@ -732,7 +663,7 @@ end
 function PrizePool._CurrencyConvertionText(prize)
 	local exchangeRate = Math.round{
 		PrizePool.prizeTypes[PRIZE_TYPE_LOCAL_CURRENCY].convertToUsd(
-			prize.data, 1, PrizePool._getTournamentDate()
+			prize.data, 1, self:getTournamentDate()
 		)
 		,5
 	}
@@ -1006,16 +937,8 @@ function PrizePool._parseInteger(input)
 	end
 end
 
---- Returns true if the input matches the format of a date
-function PrizePool._isValidDateFormat(date)
-	if type(date) ~= 'string' or String.isEmpty(date) then
-		return false
-	end
-	return date:match('%d%d%d%d%-%d%d%-%d%d') and true or false
-end
-
 --- Asserts that an Opponent Struct is valid and has a valid type
-function PrizePool._assertOpponentStructType(typeStruct)
+function PrizePool:assertOpponentStructType(typeStruct)
 	if not typeStruct then
 		error('Please provide a type!')
 	elseif type(typeStruct) ~= 'table' or not typeStruct.type then
@@ -1034,306 +957,8 @@ function PrizePool._getTournamentInfo(pageName)
 end
 
 --- Returns the default date based on wiki-variables set in the Infobox League
-function PrizePool._getTournamentDate()
+function PrizePool:getTournamentDate()
 	return Variables.varDefaultMulti('tournament_enddate', 'tournament_edate', 'edate', TODAY)
-end
-
---- @class Placement
---- @param args table Input information
---- @param parent PrizePool The PrizePool this Placement is part of
---- @param lastPlacement integer The previous placement's end
-function Placement:init(args, parent, lastPlacement)
-	self.args = self:_parseArgs(args)
-	self.date = self.args.date or PrizePool._getTournamentDate()
-	self.placeStart = self.args.placeStart
-	self.placeEnd = self.args.placeEnd
-	self.parent = parent
-	self.hasUSD = false
-
-	self.prizeRewards = self:_readPrizeRewards(self.args)
-
-	self.opponents = self:_parseOpponents(self.args)
-
-	-- Implicit place range has been given (|place= is not set)
-	-- Use the last known place and set the place range based on the entered number of opponents
-	if not self.placeStart and not self.placeEnd then
-		self.placeStart = lastPlacement + 1
-		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
-	end
-
-	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
-		'Placement: Too many opponents in place ' .. self:_displayPlace():gsub('&#045;', '-'))
-end
-
-function Placement:_parseArgs(args)
-	local parsedArgs = Table.deepCopy(args)
-
-	-- Explicit place range has been given
-	if args.place then
-		local places = Table.mapValues(mw.text.split(args.place, '-'), tonumber)
-		parsedArgs.placeStart = places[1]
-		parsedArgs.placeEnd = places[2] or places[1]
-		assert(parsedArgs.placeStart and parsedArgs.placeEnd, 'Placement: Invalid |place= provided.')
-	end
-
-	return parsedArgs
-end
-
---- Parse the input for available rewards of prizes, for instance how much money a team would win.
---- This also checks if the Placement instance has a dollar reward and assigns a variable if so.
-function Placement:_readPrizeRewards(args)
-	local rewards = {}
-
-	-- Loop through all prizes that have been defined in the header
-	Array.forEach(self.parent.prizes, function (prize)
-		local prizeData = self.parent.prizeTypes[prize.type]
-		local fieldName = prizeData.row
-		if not fieldName then
-			return
-		end
-
-		local prizeIndex = prize.index
-		local reward = args[fieldName .. prizeIndex]
-		if prizeIndex == 1 then
-			reward = reward or args[fieldName]
-		end
-		if not reward then
-			return
-		end
-
-		rewards[prize.id] = prizeData.rowParse(self, reward, args, prizeIndex)
-	end)
-
-	-- Special case for USD, as it's not defined in the header.
-	local usdType = self.parent.prizeTypes[PRIZE_TYPE_USD]
-	if usdType.row and args[usdType.row] then
-		self.hasUSD = true
-		rewards[PRIZE_TYPE_USD .. 1] = usdType.rowParse(self, args[usdType.row], args, 1)
-	end
-
-	return rewards
-end
-
---- Parse and set additional data fields for opponents.
--- This includes fields such as group stage score (wdl) and last versus (lastvs).
-function Placement:_readAdditionalData(args)
-	local data = {}
-
-	for prizeType, typeData in pairs(self.parent.additionalData) do
-		local fieldName = typeData.field
-		if args[fieldName] then
-			data[prizeType] = typeData.parse(self, args[fieldName], args)
-		end
-	end
-
-	return data
-end
-
-function Placement:_parseOpponents(args)
-	return Array.mapIndexes(function(opponentIndex)
-		local opponentInput = Json.parseIfString(args[opponentIndex])
-		local opponent = {opponentData = {}, prizeRewards = {}, additionalData = {}}
-		if not opponentInput then
-			-- If given a range of opponents, add them all, even if they're missing from the input
-			if not args.place or self.placeStart + opponentIndex > self.placeEnd + 1 then
-				return
-			else
-				opponent.opponentData = Opponent.tbd(self.parent.opponentType)
-			end
-		else
-			-- Set the date
-			if not PrizePool._isValidDateFormat(opponentInput.date) then
-				opponentInput.date = self.date
-			end
-
-			-- Parse Opponent Data
-			if opponentInput.type then
-				PrizePool._assertOpponentStructType(opponentInput)
-			else
-				opponentInput.type = self.parent.opponentType
-			end
-			opponent.opponentData = self:_parseOpponentArgs(opponentInput, opponentInput.date)
-
-			opponent.prizeRewards = self:_readPrizeRewards(opponentInput)
-			opponent.additionalData = self:_readAdditionalData(opponentInput)
-
-			-- Set date
-			opponent.date = opponentInput.date
-		end
-		return opponent
-	end)
-end
-
-function Placement:_parseOpponentArgs(input, date)
-	-- Allow for lua-table, json-table and just raw string input
-	local opponentArgs = Json.parseIfTable(input) or (type(input) == 'table' and input or {input})
-	opponentArgs.type = opponentArgs.type or self.parent.opponentType
-	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
-
-	local opponentData = Opponent.readOpponentArgs(opponentArgs)
-
-	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
-		opponentData = Opponent.tbd(opponentArgs.type)
-	end
-
-	return Opponent.resolve(opponentData, date, {syncPlayer = self.parent.options.syncPlayers})
-end
-
-function Placement:_getLpdbData(...)
-	local entries = {}
-	for opponentIndex, opponent in ipairs(self.opponents) do
-		local participant, image, imageDark, players
-		local playerCount = 0
-		local opponentType = opponent.opponentData.type
-
-		if opponentType == Opponent.team then
-			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template) or {}
-
-			participant = teamTemplate.page or ''
-			if self.parent.options.resolveRedirect then
-				participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
-			end
-
-			image = teamTemplate.image
-			imageDark = teamTemplate.imagedark
-		elseif opponentType == Opponent.solo then
-			participant = Opponent.toName(opponent.opponentData)
-			local p1 = opponent.opponentData.players[1]
-			players = {p1 = p1.pageName, p1dn = p1.displayName, p1flag = p1.flag, p1team = p1.team}
-			playerCount = 1
-		else
-			participant = Opponent.toName(opponent.opponentData)
-		end
-
-		local prizeMoney = tonumber(self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_USD .. 1)) or 0
-		local pointsReward = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
-		local lpdbData = {
-			image = image,
-			imagedark = imageDark,
-			date = opponent.date,
-			participant = participant,
-			participantlink = Opponent.toName(opponent.opponentData),
-			participantflag = opponentType == Opponent.solo and players.p1flag or nil,
-			participanttemplate = opponent.opponentData.template,
-			opponentindex = opponentIndex, -- Needed in SMW
-			opponenttype = opponentType,
-			players = players,
-			placement = self:_lpdbValue(),
-			prizemoney = prizeMoney,
-			individualprizemoney = (playerCount > 0) and (prizeMoney / playerCount) or 0,
-			lastvs = Opponent.toName(opponent.additionalData.LASTVS or {}),
-			lastscore = (opponent.additionalData.LASTVSSCORE or {}).score,
-			lastvsscore = (opponent.additionalData.LASTVSSCORE or {}).vsscore,
-			groupscore = opponent.additionalData.GROUPSCORE,
-			extradata = {
-				prizepoints = tostring(pointsReward or ''),
-				participantteam = (opponentType == Opponent.solo and players.p1team)
-									and Opponent.toName{template = players.p1team, type = 'team'}
-									or nil,
-			}
-
-			-- TODO: We need to create additional LPDB Fields
-			-- match2 opponents (opponentname, opponenttemplate, opponentplayers, opponenttype)
-			-- Qualified To struct (json?)
-			-- Points struct (json?)
-			-- lastvs match2 opponent (json?)
-		}
-
-		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
-
-		if self.parent._lpdbInjector then
-			lpdbData = self.parent._lpdbInjector:adjust(lpdbData, self, opponent)
-		end
-
-		table.insert(entries, lpdbData)
-	end
-
-	return entries
-end
-
-function Placement:getPrizeRewardForOpponent(opponent, prize)
-	return opponent.prizeRewards[prize] or self.prizeRewards[prize]
-end
-
-function Placement:_setUsdFromRewards(prizesToUse, prizeTypes)
-	Array.forEach(self.opponents, function(opponent)
-		if opponent.prizeRewards[PRIZE_TYPE_USD .. 1] or self.prizeRewards[PRIZE_TYPE_USD .. 1] then
-			return
-		end
-
-		local usdReward = 0
-		Array.forEach(prizesToUse, function(prize)
-			local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id]
-
-			if not localMoney or localMoney <= 0 then
-				return
-			end
-
-			usdReward = usdReward + prizeTypes[prize.type].convertToUsd(
-				prize.data,
-				localMoney,
-				opponent.date,
-				self.parent.options.currencyRatePerOpponent
-			)
-			self.parent.usedAutoConvertedCurrency = true
-		end)
-
-		opponent.prizeRewards[PRIZE_TYPE_USD .. 1] = usdReward
-	end)
-end
-
-function Placement:_lpdbValue()
-	for _, status in pairs(Placement.specialStatuses) do
-		if status.active(self.args) then
-			return status.lpdb
-		end
-	end
-
-	if self.placeEnd > self.placeStart then
-		return self.placeStart .. '-' .. self.placeEnd
-	end
-
-	return self.placeStart
-end
-
-function Placement:_displayPlace()
-	for _, status in pairs(Placement.specialStatuses) do
-		if status.active(self.args) then
-			return status.display()
-		end
-	end
-
-	local start = Ordinal._ordinal(self.placeStart)
-	if self.placeEnd > self.placeStart then
-		return start .. DASH .. Ordinal._ordinal(self.placeEnd)
-	end
-
-	return start
-end
-
-function Placement:getBackground()
-	for statusName, status in pairs(Placement.specialStatuses) do
-		if status.active(self.args) then
-			return PlacementInfo.getBgClass(statusName:lower())
-		end
-	end
-
-	return PlacementInfo.getBgClass(self.placeStart)
-end
-
-function Placement:getMedal()
-	if self:hasSpecialStatus() then
-		return
-	end
-
-	local medal = MatchPlacement.MedalIcon{range = {self.placeStart, self.placeEnd}}
-	if medal then
-		return tostring(medal)
-	end
-end
-
-function Placement:hasSpecialStatus()
-	return Table.any(Placement.specialStatuses, function(_, status) return status.active(self.args) end)
 end
 
 return PrizePool

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -520,7 +520,7 @@ function PrizePool:_buildHeader()
 
 	local previousOfType = {}
 	for _, prize in ipairs(self.prizes) do
-		local prizeTypeData = PrizePool.prizeTypes[prize.type]
+		local prizeTypeData = self.prizeTypes[prize.type]
 
 		if not prizeTypeData.mergeDisplayColumns or not previousOfType[prize.type] then
 			local cell = prizeTypeData.headerDisplay(prize.data)
@@ -560,7 +560,7 @@ function PrizePool:_buildRows()
 
 			local previousOfPrizeType = {}
 			local prizeCells = Array.map(self.prizes, function (prize)
-				local prizeTypeData = PrizePool.prizeTypes[prize.type]
+				local prizeTypeData = self.prizeTypes[prize.type]
 				local reward = opponent.prizeRewards[prize.id] or placement.prizeRewards[prize.id]
 
 				local cell
@@ -692,7 +692,7 @@ end
 
 --- Parse the input for available prize types overall.
 function PrizePool:_readPrizes(args)
-	for name, prizeData in pairs(PrizePool.prizeTypes) do
+	for name, prizeData in pairs(self.prizeTypes) do
 		local fieldName = prizeData.header
 		if fieldName then
 			args[fieldName .. '1'] = args[fieldName .. '1'] or args[fieldName]
@@ -714,7 +714,7 @@ function PrizePool:_readPlacements(args)
 		end
 
 		local placementInput = Json.parseIfString(args[placementIndex])
-		local placement = Placement(placementInput, self, currentPlace, PrizePool.prizeTypes)
+		local placement = Placement(placementInput, self, currentPlace)
 
 		currentPlace = placement.placeEnd
 
@@ -737,12 +737,12 @@ end
 
 --- Add a Custom Prize Type
 function PrizePool:addCustomPrizeType(prizeType, data)
-	PrizePool.prizeTypes[prizeType] = data
+	self.prizeTypes[prizeType] = data
 	return self
 end
 
 function PrizePool:addPrize(prizeType, index, data)
-	assert(PrizePool.prizeTypes[prizeType], 'addPrize: Not a valid prize!')
+	assert(self.prizeTypes[prizeType], 'addPrize: Not a valid prize!')
 	assert(Logic.isNumeric(index), 'addPrize: Index is not numeric!')
 	table.insert(self.prizes, {id = prizeType .. index, type = prizeType, index = index, data = data})
 	return self

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -408,9 +408,6 @@ function PrizePool:init(args)
 	self.prizes = {}
 	self.placements = {}
 
-	-- needed by Module:PrizePool/Placement
-	self.prizeTypes = Table.deepCopy(PrizePool.prizeTypes)
-
 	self.usedAutoConvertedCurrency = false
 
 	return self
@@ -523,7 +520,7 @@ function PrizePool:_buildHeader()
 
 	local previousOfType = {}
 	for _, prize in ipairs(self.prizes) do
-		local prizeTypeData = self.prizeTypes[prize.type]
+		local prizeTypeData = PrizePool.prizeTypes[prize.type]
 
 		if not prizeTypeData.mergeDisplayColumns or not previousOfType[prize.type] then
 			local cell = prizeTypeData.headerDisplay(prize.data)
@@ -563,7 +560,7 @@ function PrizePool:_buildRows()
 
 			local previousOfPrizeType = {}
 			local prizeCells = Array.map(self.prizes, function (prize)
-				local prizeTypeData = self.prizeTypes[prize.type]
+				local prizeTypeData = PrizePool.prizeTypes[prize.type]
 				local reward = opponent.prizeRewards[prize.id] or placement.prizeRewards[prize.id]
 
 				local cell
@@ -695,7 +692,7 @@ end
 
 --- Parse the input for available prize types overall.
 function PrizePool:_readPrizes(args)
-	for name, prizeData in pairs(self.prizeTypes) do
+	for name, prizeData in pairs(PrizePool.prizeTypes) do
 		local fieldName = prizeData.header
 		if fieldName then
 			args[fieldName .. '1'] = args[fieldName .. '1'] or args[fieldName]
@@ -717,7 +714,7 @@ function PrizePool:_readPlacements(args)
 		end
 
 		local placementInput = Json.parseIfString(args[placementIndex])
-		local placement = Placement(placementInput, self, currentPlace)
+		local placement = Placement(placementInput, self, currentPlace, PrizePool.prizeTypes)
 
 		currentPlace = placement.placeEnd
 
@@ -740,12 +737,12 @@ end
 
 --- Add a Custom Prize Type
 function PrizePool:addCustomPrizeType(prizeType, data)
-	self.prizeTypes[prizeType] = data
+	PrizePool.prizeTypes[prizeType] = data
 	return self
 end
 
 function PrizePool:addPrize(prizeType, index, data)
-	assert(self.prizeTypes[prizeType], 'addPrize: Not a valid prize!')
+	assert(PrizePool.prizeTypes[prizeType], 'addPrize: Not a valid prize!')
 	assert(Logic.isNumeric(index), 'addPrize: Index is not numeric!')
 	table.insert(self.prizes, {id = prizeType .. index, type = prizeType, index = index, data = data})
 	return self

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Json = require('Module:Json')
@@ -14,12 +15,10 @@ local Lua = require('Module:Lua')
 local MatchPlacement = require('Module:Match/Placement')
 local Ordinal = require('Module:Ordinal')
 local PlacementInfo = require('Module:Placement')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local Variables = require('Module:Variables')
 
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
-
-local TODAY = os.date('%Y-%m-%d')
 
 local DASH = '&#045;'
 

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -277,9 +277,9 @@ function Placement:_parseOpponentArgs(input, date)
 	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
 
 	local opponentData
-	if opponentArgs.isAlreadyParsed then
+	if type(opponentArgs[1]) == 'table' and opponentArgs[1].isAlreadyParsed then
 		opponentData = opponentArgs[1] or opponentArgs
-	else
+	elseif type(opponentArgs[1]) ~= 'table' then
 		opponentData = Opponent.readOpponentArgs(opponentArgs)
 	end
 

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -278,7 +278,7 @@ function Placement:_parseOpponentArgs(input, date)
 
 	local opponentData
 	if type(opponentArgs[1]) == 'table' and opponentArgs[1].isAlreadyParsed then
-		opponentData = opponentArgs[1] or opponentArgs
+		opponentData = opponentArgs[1]
 	elseif type(opponentArgs[1]) ~= 'table' then
 		opponentData = Opponent.readOpponentArgs(opponentArgs)
 	end

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -102,11 +102,11 @@ Placement.specialStatuses = {
 --- @param args table Input information
 --- @param parent PrizePool The PrizePool this Placement is part of
 --- @param lastPlacement integer The previous placement's end
-function Placement:init(args, parent, lastPlacement, prizeTypes)
+function Placement:init(args, parent, lastPlacement)
 	self.args = self:_parseArgs(args)
 	self.parent = parent
-	self.prizeTypes = prizeTypes
-	self.date = self.args.date or self.parent.date
+	self.prizeTypes = parent.prizeTypes
+	self.date = self.args.date or parent.date
 	self.placeStart = self.args.placeStart
 	self.placeEnd = self.args.placeEnd
 	self.hasUSD = false

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -276,7 +276,12 @@ function Placement:_parseOpponentArgs(input, date)
 	opponentArgs.type = opponentArgs.type or self.parent.opponentType
 	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
 
-	local opponentData = Opponent.readOpponentArgs(opponentArgs)
+	local opponentData
+	if opponentArgs.isAlreadyParsed then
+		opponentData = opponentArgs[1] or opponentArgs
+	else
+		opponentData = Opponent.readOpponentArgs(opponentArgs)
+	end
 
 	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
 		opponentData = Opponent.tbd(opponentArgs.type)

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -102,9 +102,10 @@ Placement.specialStatuses = {
 --- @param args table Input information
 --- @param parent PrizePool The PrizePool this Placement is part of
 --- @param lastPlacement integer The previous placement's end
-function Placement:init(args, parent, lastPlacement)
+function Placement:init(args, parent, lastPlacement, prizeTypes)
 	self.args = self:_parseArgs(args)
 	self.parent = parent
+	self.prizeTypes = prizeTypes
 	self.date = self.args.date or self.parent:getTournamentDate()
 	self.placeStart = self.args.placeStart
 	self.placeEnd = self.args.placeEnd
@@ -148,7 +149,7 @@ function Placement:_readPrizeRewards(args)
 
 	-- Loop through all prizes that have been defined in the header
 	Array.forEach(self.parent.prizes, function (prize)
-		local prizeData = self.parent.prizeTypes[prize.type]
+		local prizeData = self.prizeTypes[prize.type]
 		local fieldName = prizeData.row
 		if not fieldName then
 			return
@@ -167,8 +168,7 @@ function Placement:_readPrizeRewards(args)
 	end)
 
 	-- Special case for USD, as it's not defined in the header.
-	local usdType = self.parent.prizeTypes[PRIZE_TYPE_USD]
-mw.logObject(self.parent)
+	local usdType = self.prizeTypes[PRIZE_TYPE_USD]
 	if usdType.row and args[usdType.row] then
 		self.hasUSD = true
 		rewards[PRIZE_TYPE_USD .. 1] = usdType.rowParse(self, args[usdType.row], args, 1)

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -1,0 +1,411 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:PrizePool/Placement
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local MatchPlacement = require('Module:Match/Placement')
+local Ordinal = require('Module:Ordinal')
+local PlacementInfo = require('Module:Placement')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+
+local TODAY = os.date('%Y-%m-%d')
+
+local DASH = '&#045;'
+
+local PRIZE_TYPE_USD = 'USD'
+local PRIZE_TYPE_POINTS = 'POINTS'
+
+--- @class Placement
+--- A Placement is a set of opponents who all share the same final place in the tournament.
+--- Its input is generally a table created by `Template:Placement`.
+--- It has a range from placeStart to placeEnd, for example 5 to 8
+--- and is expected to have the same amount of opponents as the range allows (4 is the 5-8 example).
+local Placement = Class.new(function(self, ...) self:init(...) end)
+
+Placement.specialStatuses = {
+	DQ = {
+		active = function (args)
+			return Logic.readBool(args.dq)
+		end,
+		display = function ()
+			return Abbreviation.make('DQ', 'Disqualified')
+		end,
+		lpdb = 'dq',
+	},
+	DNF = {
+		active = function (args)
+			return Logic.readBool(args.dnf)
+		end,
+		display = function ()
+			return Abbreviation.make('DNF', 'Did not finish')
+		end,
+		lpdb = 'dnf',
+	},
+	DNP = {
+		active = function (args)
+			return Logic.readBool(args.dnp)
+		end,
+		display = function ()
+			return Abbreviation.make('DNP', 'Did not participate')
+		end,
+		lpdb = 'dnp',
+	},
+	W = {
+		active = function (args)
+			return Logic.readBool(args.w)
+		end,
+		display = function ()
+			return 'W'
+		end,
+		lpdb = 1,
+	},
+	D = {
+		active = function (args)
+			return Logic.readBool(args.d)
+		end,
+		display = function ()
+			return 'D'
+		end,
+		lpdb = 1,
+	},
+	L = {
+		active = function (args)
+			return Logic.readBool(args.l)
+		end,
+		display = function ()
+			return 'L'
+		end,
+		lpdb = 2,
+	},
+	Q = {
+		active = function (args)
+			return Logic.readBool(args.q)
+		end,
+		display = function ()
+			return Abbreviation.make('Q', 'Qualified Automatically')
+		end,
+		lpdb = 1,
+	},
+}
+
+--- @class Placement
+--- @param args table Input information
+--- @param parent PrizePool The PrizePool this Placement is part of
+--- @param lastPlacement integer The previous placement's end
+function Placement:init(args, parent, lastPlacement)
+	self.args = self:_parseArgs(args)
+	self.parent = parent
+	self.date = self.args.date or self.parent:getTournamentDate()
+	self.placeStart = self.args.placeStart
+	self.placeEnd = self.args.placeEnd
+	self.hasUSD = false
+
+	Opponent = self.parent.opponentLibrary or Opponent
+
+	self.prizeRewards = self:_readPrizeRewards(self.args)
+
+	self.opponents = self:_parseOpponents(self.args)
+
+	-- Implicit place range has been given (|place= is not set)
+	-- Use the last known place and set the place range based on the entered number of opponents
+	if not self.placeStart and not self.placeEnd then
+		self.placeStart = lastPlacement + 1
+		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
+	end
+
+	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
+		'Placement: Too many opponents in place ' .. self:_displayPlace():gsub('&#045;', '-'))
+end
+
+function Placement:_parseArgs(args)
+	local parsedArgs = Table.deepCopy(args)
+
+	-- Explicit place range has been given
+	if args.place then
+		local places = Table.mapValues(mw.text.split(args.place, '-'), tonumber)
+		parsedArgs.placeStart = places[1]
+		parsedArgs.placeEnd = places[2] or places[1]
+		assert(parsedArgs.placeStart and parsedArgs.placeEnd, 'Placement: Invalid |place= provided.')
+	end
+
+	return parsedArgs
+end
+
+--- Parse the input for available rewards of prizes, for instance how much money a team would win.
+--- This also checks if the Placement instance has a dollar reward and assigns a variable if so.
+function Placement:_readPrizeRewards(args)
+	local rewards = {}
+
+	-- Loop through all prizes that have been defined in the header
+	Array.forEach(self.parent.prizes, function (prize)
+		local prizeData = self.parent.prizeTypes[prize.type]
+		local fieldName = prizeData.row
+		if not fieldName then
+			return
+		end
+
+		local prizeIndex = prize.index
+		local reward = args[fieldName .. prizeIndex]
+		if prizeIndex == 1 then
+			reward = reward or args[fieldName]
+		end
+		if not reward then
+			return
+		end
+
+		rewards[prize.id] = prizeData.rowParse(self, reward, args, prizeIndex)
+	end)
+
+	-- Special case for USD, as it's not defined in the header.
+	local usdType = self.parent.prizeTypes[PRIZE_TYPE_USD]
+mw.logObject(self.parent)
+	if usdType.row and args[usdType.row] then
+		self.hasUSD = true
+		rewards[PRIZE_TYPE_USD .. 1] = usdType.rowParse(self, args[usdType.row], args, 1)
+	end
+
+	return rewards
+end
+
+--- Parse and set additional data fields for opponents.
+-- This includes fields such as group stage score (wdl) and last versus (lastvs).
+function Placement:_readAdditionalData(args)
+	local data = {}
+
+	for prizeType, typeData in pairs(self.parent.additionalData) do
+		local fieldName = typeData.field
+		if args[fieldName] then
+			data[prizeType] = typeData.parse(self, args[fieldName], args)
+		end
+	end
+
+	return data
+end
+
+function Placement:_parseOpponents(args)
+	return Array.mapIndexes(function(opponentIndex)
+		local opponentInput = Json.parseIfString(args[opponentIndex])
+		local opponent = {opponentData = {}, prizeRewards = {}, additionalData = {}}
+		if not opponentInput then
+			-- If given a range of opponents, add them all, even if they're missing from the input
+			if not args.place or self.placeStart + opponentIndex > self.placeEnd + 1 then
+				return
+			else
+				opponent.opponentData = Opponent.tbd(self.parent.opponentType)
+			end
+		else
+			-- Set the date
+			if not Placement._isValidDateFormat(opponentInput.date) then
+				opponentInput.date = self.date
+			end
+
+			-- Parse Opponent Data
+			if opponentInput.type then
+				self.parent:assertOpponentStructType(opponentInput)
+			else
+				opponentInput.type = self.parent.opponentType
+			end
+			opponent.opponentData = self:_parseOpponentArgs(opponentInput, opponentInput.date)
+
+			opponent.prizeRewards = self:_readPrizeRewards(opponentInput)
+			opponent.additionalData = self:_readAdditionalData(opponentInput)
+
+			-- Set date
+			opponent.date = opponentInput.date
+		end
+		return opponent
+	end)
+end
+
+function Placement:_parseOpponentArgs(input, date)
+	-- Allow for lua-table, json-table and just raw string input
+	local opponentArgs = Json.parseIfTable(input) or (type(input) == 'table' and input or {input})
+	opponentArgs.type = opponentArgs.type or self.parent.opponentType
+	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
+
+	local opponentData = Opponent.readOpponentArgs(opponentArgs)
+
+	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
+		opponentData = Opponent.tbd(opponentArgs.type)
+	end
+
+	return Opponent.resolve(opponentData, date, {syncPlayer = self.parent.options.syncPlayers})
+end
+
+function Placement:_getLpdbData(...)
+	local entries = {}
+	for opponentIndex, opponent in ipairs(self.opponents) do
+		local participant, image, imageDark, players
+		local playerCount = 0
+		local opponentType = opponent.opponentData.type
+
+		if opponentType == Opponent.team then
+			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template) or {}
+
+			participant = teamTemplate.page or ''
+			if self.parent.options.resolveRedirect then
+				participant = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
+			end
+
+			image = teamTemplate.image
+			imageDark = teamTemplate.imagedark
+		elseif opponentType == Opponent.solo then
+			participant = Opponent.toName(opponent.opponentData)
+			local p1 = opponent.opponentData.players[1]
+			players = {p1 = p1.pageName, p1dn = p1.displayName, p1flag = p1.flag, p1team = p1.team}
+			playerCount = 1
+		else
+			participant = Opponent.toName(opponent.opponentData)
+		end
+
+		local prizeMoney = tonumber(self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_USD .. 1)) or 0
+		local pointsReward = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
+		local lpdbData = {
+			image = image,
+			imagedark = imageDark,
+			date = opponent.date,
+			participant = participant,
+			participantlink = Opponent.toName(opponent.opponentData),
+			participantflag = opponentType == Opponent.solo and players.p1flag or nil,
+			participanttemplate = opponent.opponentData.template,
+			opponentindex = opponentIndex, -- Needed in SMW
+			opponenttype = opponentType,
+			players = players,
+			placement = self:_lpdbValue(),
+			prizemoney = prizeMoney,
+			individualprizemoney = (playerCount > 0) and (prizeMoney / playerCount) or 0,
+			lastvs = Opponent.toName(opponent.additionalData.LASTVS or {}),
+			lastscore = (opponent.additionalData.LASTVSSCORE or {}).score,
+			lastvsscore = (opponent.additionalData.LASTVSSCORE or {}).vsscore,
+			groupscore = opponent.additionalData.GROUPSCORE,
+			extradata = {
+				prizepoints = tostring(pointsReward or ''),
+				participantteam = (opponentType == Opponent.solo and players.p1team)
+									and Opponent.toName{template = players.p1team, type = 'team'}
+									or nil,
+			}
+
+			-- TODO: We need to create additional LPDB Fields
+			-- match2 opponents (opponentname, opponenttemplate, opponentplayers, opponenttype)
+			-- Qualified To struct (json?)
+			-- Points struct (json?)
+			-- lastvs match2 opponent (json?)
+		}
+
+		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
+
+		if self.parent._lpdbInjector then
+			lpdbData = self.parent._lpdbInjector:adjust(lpdbData, self, opponent)
+		end
+
+		table.insert(entries, lpdbData)
+	end
+
+	return entries
+end
+
+function Placement:getPrizeRewardForOpponent(opponent, prize)
+	return opponent.prizeRewards[prize] or self.prizeRewards[prize]
+end
+
+function Placement:_setUsdFromRewards(prizesToUse, prizeTypes)
+	Array.forEach(self.opponents, function(opponent)
+		if opponent.prizeRewards[PRIZE_TYPE_USD .. 1] or self.prizeRewards[PRIZE_TYPE_USD .. 1] then
+			return
+		end
+
+		local usdReward = 0
+		Array.forEach(prizesToUse, function(prize)
+			local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id]
+
+			if not localMoney or localMoney <= 0 then
+				return
+			end
+
+			usdReward = usdReward + prizeTypes[prize.type].convertToUsd(
+				prize.data,
+				localMoney,
+				opponent.date,
+				self.parent.options.currencyRatePerOpponent
+			)
+			self.parent.usedAutoConvertedCurrency = true
+		end)
+
+		opponent.prizeRewards[PRIZE_TYPE_USD .. 1] = usdReward
+	end)
+end
+
+function Placement:_lpdbValue()
+	for _, status in pairs(Placement.specialStatuses) do
+		if status.active(self.args) then
+			return status.lpdb
+		end
+	end
+
+	if self.placeEnd > self.placeStart then
+		return self.placeStart .. '-' .. self.placeEnd
+	end
+
+	return self.placeStart
+end
+
+function Placement:_displayPlace()
+	for _, status in pairs(Placement.specialStatuses) do
+		if status.active(self.args) then
+			return status.display()
+		end
+	end
+
+	local start = Ordinal._ordinal(self.placeStart)
+	if self.placeEnd > self.placeStart then
+		return start .. DASH .. Ordinal._ordinal(self.placeEnd)
+	end
+
+	return start
+end
+
+function Placement:getBackground()
+	for statusName, status in pairs(Placement.specialStatuses) do
+		if status.active(self.args) then
+			return PlacementInfo.getBgClass(statusName:lower())
+		end
+	end
+
+	return PlacementInfo.getBgClass(self.placeStart)
+end
+
+function Placement:getMedal()
+	if self:hasSpecialStatus() then
+		return
+	end
+
+	local medal = MatchPlacement.MedalIcon{range = {self.placeStart, self.placeEnd}}
+	if medal then
+		return tostring(medal)
+	end
+end
+
+function Placement:hasSpecialStatus()
+	return Table.any(Placement.specialStatuses, function(_, status) return status.active(self.args) end)
+end
+
+--- Returns true if the input matches the format of a date
+function Placement._isValidDateFormat(date)
+	if type(date) ~= 'string' or String.isEmpty(date) then
+		return false
+	end
+	return date:match('%d%d%d%d%-%d%d%-%d%d') and true or false
+end
+
+return Placement

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -106,7 +106,7 @@ function Placement:init(args, parent, lastPlacement, prizeTypes)
 	self.args = self:_parseArgs(args)
 	self.parent = parent
 	self.prizeTypes = prizeTypes
-	self.date = self.args.date or self.parent:getTournamentDate()
+	self.date = self.args.date or self.parent.date
 	self.placeStart = self.args.placeStart
 	self.placeEnd = self.args.placeEnd
 	self.hasUSD = false


### PR DESCRIPTION
stacked on #1850 due to that PR adding the Module that gets adjusted here

## Summary
Add option in PrizePool/Placement to not call `readOpponentArgs`.
This is needed for the automation/import stuff since the opponents coming from there are already in the format we need and do not possess the args that would be needed by `readOpponentArgs`

## How did you test this change?
live (new module not yet in use as of the start of this PR