### PR TITLE
Sync playerTeam if syncing player in StarcraftOpponent.resolve

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -126,6 +126,9 @@ function StarcraftOpponent.resolve(opponent, date, options)
 		for _, player in ipairs(opponent.players) do
 			if options.syncPlayer then
 				StarcraftPlayerExt.syncPlayer(player)
+				if not player.team then
+					player.team = PlayerExt.syncTeam(player.pageName, nil, {date = date})
+				end
 			else
 				PlayerExt.populatePageName(player)
 			end


### PR DESCRIPTION
## Summary
Sync playerTeam if syncing player in StarcraftOpponent.resolve.
Intended so i can kick the _populatePlayerTeams function from the PrizePool/Import/Custom (the placement calls inside /Import will already do it)

## How did you test this change?
/dev