### PR TITLE
Fix Typo in Wiki-Variable name

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -143,7 +143,7 @@ end
 function HiddenDataBox.setWikiVariableForParticipantKey(participant, participantResolved, key, value)
 	Variables.varDefine(participant .. '_' .. key, value)
 	if participant ~= participantResolved then
-		Variables.varDefine(participantResolved .. key, value)
+		Variables.varDefine(participantResolved .. '_' .. key, value)
 	end
 end
 


### PR DESCRIPTION
## Summary
Fix Typo in `.setWikiVariableForParticipantKey` function.
THe wiki-var names for resolved and unresolved have a different format.

## How did you test this change?
/dev