### PR TITLE
Allow places to autofill from PrizePool

### DIFF
--- a/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
 
 local CustomLegacyPrizePool = {}
-local CLEAN_PLACE = false
+local REMOVE_PLACE = false
 -- Template entry point
 function CustomLegacyPrizePool.run()
 	return PrizePoolLegacy.run(CustomLegacyPrizePool)
@@ -22,12 +22,12 @@ function CustomLegacyPrizePool.customHeader(newArgs, data, header)
 	if Logic.readBool(header.seed) then
 		PrizePoolLegacy.assignType(newArgs, 'seed', 'seed')
 	end
-	CLEAN_PLACE = Logic.readBool(header.cleanplace)
+	REMOVE_PLACE = Logic.readBool(header.removeplace)
 	return newArgs
 end
 
 function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
-	if CLEAN_PLACE then
+	if REMOVE_PLACE then
 		newData["place"] = nil
 	end
 	return newData

--- a/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
@@ -27,7 +27,7 @@ function CustomLegacyPrizePool.customHeader(newArgs, data, header)
 end
 
 function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
-	if Logic.readBool(CLEAN_PLACE) then
+	if CLEAN_PLACE then
 		newData["place"] = nil
 	end
 	return newData

--- a/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
@@ -26,4 +26,9 @@ function CustomLegacyPrizePool.customHeader(newArgs, data, header)
 	return newArgs
 end
 
+function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
+	newData["place"] = nil
+	return newData
+end
+
 return CustomLegacyPrizePool

--- a/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/apexlegends/prize_pool_legacy_custom.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
 
 local CustomLegacyPrizePool = {}
-
+local CLEAN_PLACE = false
 -- Template entry point
 function CustomLegacyPrizePool.run()
 	return PrizePoolLegacy.run(CustomLegacyPrizePool)
@@ -22,13 +22,14 @@ function CustomLegacyPrizePool.customHeader(newArgs, data, header)
 	if Logic.readBool(header.seed) then
 		PrizePoolLegacy.assignType(newArgs, 'seed', 'seed')
 	end
-
+	CLEAN_PLACE = Logic.readBool(header.cleanplace)
 	return newArgs
 end
 
 function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
-	newData["place"] = nil
+	if Logic.readBool(CLEAN_PLACE) then
+		newData["place"] = nil
+	end
 	return newData
 end
-
 return CustomLegacyPrizePool


### PR DESCRIPTION
## Summary

Currently a lot of prizepools which call the legacy modules which have many teams in 1 place slot. This allows the PrizePool module to autoassign any slot with the correct sequential order

## How did you test this change?

Tested with/dev here
https://liquipedia.net/apexlegends/User:Dark_meluca/PrizePoolMappingTest
