### PR TITLE
Have support for (unix) timestamp in match2

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -329,6 +329,7 @@ function Match._addCommonMatchExtradata(match)
 	local commonExtradata = {
 		comment = match.comment,
 		matchsection = match.matchsection,
+		timestamp = tonumber(match.timestamp),
 		timezoneid = match.timezoneId,
 		timezoneoffset = match.timezoneOffset,
 	}

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
 local FeatureFlag = require('Module:FeatureFlag')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
@@ -274,7 +275,13 @@ function MatchGroupInput.readDate(dateString)
 	local matchDate = String.explode(dateString, '<', 0):gsub('-', '')
 	local isDateExact = String.contains(matchDate .. (timezoneOffset or ''), '[%+%-]')
 	local date = getContentLanguage():formatDate('c', matchDate .. (timezoneOffset or ''))
-	return {date = date, dateexact = isDateExact, timezoneId = timezoneId, timezoneOffset = timezoneOffset}
+	return {
+		date = date,
+		dateexact = isDateExact,
+		timezoneId = timezoneId,
+		timezoneOffset = timezoneOffset,
+		timestamp = DateExt.readTimestamp(dateString),
+	}
 end
 
 function MatchGroupInput.getInexactDate(suggestedDate)

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -383,6 +383,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		opponents = opponents,
 		resultType = nilIfEmpty(record.resulttype),
 		stream = Json.parseIfString(record.stream) or {},
+		timestamp = tonumber(Table.extract(extradata, 'timestamp')) or 0,
 		type = nilIfEmpty(record.type) or 'literal',
 		vod = nilIfEmpty(record.vod),
 		walkover = nilIfEmpty(record.walkover),

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -21,6 +21,9 @@ DateExt.minTimestamp = -62167219200
 -- 9999-12-31 23:59:59
 DateExt.maxTimestamp = 253402300799
 
+-- 1970-01-01 00:00:00
+DateExt.epochZero = 0
+
 --[[
 Parses a date string into a timestamp, returning the number of seconds since
 UNIX epoch. The timezone offset is incorporated into the timestamp, and the


### PR DESCRIPTION
## Summary
Add support for unix timestamp in match2.
This PR adds support in parsing (`MatchGroupInput.readDate`), saving into LPDB (`Match._addCommonMatchExtradata`) & re-reading from LPDB (`MatchGroupUtil.matchFromRecord`).

## How did you test this change?
/dev module
