### PR TITLE
Adjust mvp storage + dependencies

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -400,7 +400,7 @@ function MatchGroupInput.getCommonTournamentVars(obj)
 end
 
 function MatchGroupInput.readMvp(match)
-	if not match.mvp then return nil end
+	if not match.mvp then return end
 	local mvppoints = match.mvppoints or 1
 
 	-- Split the input

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -412,7 +412,7 @@ function MatchGroupInput.readMvp(match)
 		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
 			for _, lookUpPlayer in pairs(opponent.match2players) do
 				if link == lookUpPlayer.name then
-					return Table.merge(lookUpPlayer, {team = opponent.template})
+					return Table.merge(lookUpPlayer, {team = opponent.name, template = opponent.template})
 				end
 			end
 		end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -399,4 +399,26 @@ function MatchGroupInput.getCommonTournamentVars(obj)
 	return obj
 end
 
+function MatchGroupInput.readMvp(match)
+	if not match.mvp then return nil end
+	local mvppoints = match.mvppoints or 1
+
+	-- Split the input
+	local players = mw.text.split(match.mvp, ',')
+
+	-- parse the players to get their information
+	local parsedPlayers = Table.mapValues(players, function(player)
+		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(mw.text.split(player, '|')[1]):gsub(' ', '_')
+		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
+			for _, lookUpPlayer in pairs(opponent.match2players) do
+				if link == lookUpPlayer.name then
+					return Table.merge(lookUpPlayer, {team = opponent.template})
+				end
+			end
+		end
+	end)
+
+	return {players = parsedPlayers, points = mvppoints}
+end
+
 return MatchGroupInput

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -134,7 +134,11 @@ local Mvp = Class.new(
 )
 
 function Mvp:addPlayer(player)
-	if not Logic.isEmpty(player) then
+	if Logic.isEmpty(player) then
+		return self
+	elseif type(player) == 'table' then
+		table.insert(self.players, player.name .. '|' .. player.displayname)
+	else
 		table.insert(self.players, player)
 	end
 	return self

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -388,12 +388,19 @@ function matchFunctions.getMVP(match)
 	-- Split the input
 	local players = mw.text.split(match.mvp, ',')
 
-	-- Trim the input
-	for index, player in pairs(players) do
-		players[index] = mw.text.trim(player)
-	end
+	-- parse the players to get their information
+	local parsedPlayers = Table.mapValues(players, function(player)
+		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(mw.text.split(player, '|')[1]):gsub(' ', '_')
+		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
+			for _, lookUpPlayer in pairs(opponent.match2players) do
+				if link == lookUpPlayer.name then
+					return Table.merge(lookUpPlayer, {team = opponent.template})
+				end
+			end
+		end
+	end)
 
-	return {players = players, points = mvppoints}
+	return {players = parsedPlayers, points = mvppoints}
 end
 
 function matchFunctions.getOpponents(match)

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -376,31 +376,10 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		mvp = matchFunctions.getMVP(match),
+		mvp = MatchGroupInput.readMvp(match),
 	}
+
 	return match
-end
-
-function matchFunctions.getMVP(match)
-	if not match.mvp then return nil end
-	local mvppoints = match.mvppoints or 1
-
-	-- Split the input
-	local players = mw.text.split(match.mvp, ',')
-
-	-- parse the players to get their information
-	local parsedPlayers = Table.mapValues(players, function(player)
-		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(mw.text.split(player, '|')[1]):gsub(' ', '_')
-		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
-			for _, lookUpPlayer in pairs(opponent.match2players) do
-				if link == lookUpPlayer.name then
-					return Table.merge(lookUpPlayer, {team = opponent.template})
-				end
-			end
-		end
-	end)
-
-	return {players = parsedPlayers, points = mvppoints}
 end
 
 function matchFunctions.getOpponents(match)

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -65,12 +65,8 @@ function MatchLegacy._convertParameters(match2)
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
 		local players = {}
-		if type(mvp.players[1]) == 'string' then
-			players = mvp.players
-		else
-			for _, player in ipairs(mvp.players) do
-				table.insert(players, player.name .. '|' .. player.displayname)
-			end
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
 		end
 		match.extradata.mvp = table.concat(players, ',')
 		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
@@ -215,15 +211,7 @@ function MatchLegacy.storeMatchSMW(match, match2)
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
 		for index, player in ipairs(mvp.players) do
-			local playerString, team
-			if type(player) == 'table' then
-				playerString = player.name
-				team = player.team or ''
-			else
-				playerString = player
-				team = getTeamOfPlayer(playerString) or ''
-			end
-			local mvpString = playerString .. '§§§§'.. team ..'§§§§0'
+			local mvpString = player.name .. '§§§§'.. (player.team or '') ..'§§§§0'
 			table.insert(data, 'Has mvp ' .. index .. '=' .. mvpString)
 		end
 	end

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -30,7 +30,7 @@ function MatchLegacy.storeMatch(match2, options)
 		match.games = MatchLegacy.storeGames(match, match2)
 
 		return mw.ext.LiquipediaDB.lpdb_match(
-			"legacymatch_" .. match2.match2id,
+			'legacymatch_' .. match2.match2id,
 			match
 		)
 	end
@@ -64,22 +64,30 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.matchsection = extradata.matchsection
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
-		match.extradata.mvp = table.concat(mvp.players, ",")
-		match.extradata.mvp = match.extradata.mvp .. ";" .. mvp.points
+		local players = {}
+		if type(mvp.players[1]) == 'string' then
+			players = mvp.players
+		else
+			for _, player in ipairs(mvp.players) do
+				table.insert(players, player.name .. '|' .. player.displayname)
+			end
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
 	end
 
 	local bracketData = Json.parseIfString(match2.match2bracketdata)
-	if type(bracketData) == "table" and bracketData.type == "bracket" then
+	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
 		local headerName
 		if bracketData.header then
 			headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
 		end
 		if String.isEmpty(headerName) then
-			headerName = Variables.varDefault("match_legacy_header_name")
+			headerName = Variables.varDefault('match_legacy_header_name')
 		end
 		if String.isNotEmpty(headerName) then
 			match.extradata.matchsection = headerName
-			Variables.varDefine("match_legacy_header_name", headerName)
+			Variables.varDefine('match_legacy_header_name', headerName)
 		end
 	end
 
@@ -207,8 +215,14 @@ function MatchLegacy.storeMatchSMW(match, match2)
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
 		for index, player in ipairs(mvp.players) do
-			local team = getTeamOfPlayer(player) or ''
-			local mvpString = player .. '§§§§'.. team ..'§§§§0'
+			local playerString
+			if type(player) == 'table' then
+				playerString = player.name
+			else
+				playerString = player
+			end
+			local team = getTeamOfPlayer(playerString) or ''
+			local mvpString = playerString .. '§§§§'.. team ..'§§§§0'
 			table.insert(data, 'Has mvp ' .. index .. '=' .. mvpString)
 		end
 	end

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -215,13 +215,14 @@ function MatchLegacy.storeMatchSMW(match, match2)
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
 		for index, player in ipairs(mvp.players) do
-			local playerString
+			local playerString, team
 			if type(player) == 'table' then
 				playerString = player.name
+				team = player.team or ''
 			else
 				playerString = player
+				team = getTeamOfPlayer(playerString) or ''
 			end
-			local team = getTeamOfPlayer(playerString) or ''
 			local mvpString = playerString .. '§§§§'.. team ..'§§§§0'
 			table.insert(data, 'Has mvp ' .. index .. '=' .. mvpString)
 		end

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -198,15 +198,6 @@ function MatchLegacy.storeMatchSMW(match, match2)
 		'Has teams=' .. (match.opponent2 or ''),
 	}
 
-	local getTeamOfPlayer = function(playerName)
-		for _, opponent in ipairs(match2.match2opponents or {}) do
-			for _, player in ipairs(opponent.match2players or {}) do
-				if player.name == playerName then
-					return opponent.name
-				end
-			end
-		end
-	end
 	local extradata = Json.parseIfString(match2.extradata) or {}
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then


### PR DESCRIPTION
Should be manually deployed before merge due to it depending on each other and hence breaking stuff until merge bot run has updated all the modules

## Summary
Adjust mvp storage + dependencies on lol.
Testcase for doing it on all wikis that have mvp stuff with the same input as lol has (e.g. R6)
* move mvp read function to commons and adjust it to retrieve more data from match2players
* adjust matchsummary base to be able to handle both formats (temp until we have everything switched)
* adjust match/legacy on lol to fit the new mvp player format
* cleanup " vs ' in lol matchsummary

## How did you test this change?
/dev