### PR TITLE
Handle winner and resulttype in match legacy

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -15,6 +15,7 @@ local Variables = require('Module:Variables')
 
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 
+local DRAW = 'draw'
 local LOSER_STATUSES = {'FF', 'DQ', 'L'}
 
 local MatchLegacy = {}
@@ -44,7 +45,7 @@ function MatchLegacy.convertParameters(match2)
 		end
 	end
 
-	if match.resulttype == 'draw' then
+	if match.resulttype == DRAW then
 		match.winner = 'draw'
 	end
 

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -47,6 +47,8 @@ function MatchLegacy.convertParameters(match2)
 	if match.winner == 0 then
 		match.winner = 'draw'
 	end
+	
+	match.resulttype = nil
 
 	if match.walkover == 'ff' or match.walkover == 'dq' then
 		match.walkover = match.winner

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -47,7 +47,7 @@ function MatchLegacy.convertParameters(match2)
 	if match.winner == 0 then
 		match.winner = 'draw'
 	end
-	
+
 	match.resulttype = nil
 
 	if match.walkover == 'ff' or match.walkover == 'dq' then

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -44,7 +44,7 @@ function MatchLegacy.convertParameters(match2)
 		end
 	end
 
-	if match.winner == 0 then
+	if match.resulttype == 'draw' then
 		match.winner = 'draw'
 	end
 

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -44,6 +44,10 @@ function MatchLegacy.convertParameters(match2)
 		end
 	end
 
+	if match.winner == 0 then
+		match.winner = 'draw'
+	end
+
 	if match.walkover == 'ff' or match.walkover == 'dq' then
 		match.walkover = match.winner
 	else


### PR DESCRIPTION
## Summary

Match1 stores a draw as `draw`instead of `0`. Also, the resulttype is only set if a `opponent.score` is contained in `{'FF', 'DQ', 'L'}` or if the match is overturned, the resulttype its equal to `ff`.

## How did you test this change?

Live.

### LPDB
- Before
![image](https://user-images.githubusercontent.com/43279191/189339998-c0210e97-16c6-4b57-9c80-4405c946c4a1.png)
- After:
![image](https://user-images.githubusercontent.com/43279191/189339705-dc90914b-8255-4b18-b98a-8ab5645a92e3.png)

## After merge

Undo [Recent games/row](https://liquipedia.net/counterstrike/index.php?title=Template%3ARecent_games%2Frow&type=revision&diff=2345127&oldid=2338932)

