### PR TITLE
Merge Grenade infobox into Weapon

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_weapon_custom.lua
@@ -133,9 +133,21 @@ function CustomInjector:addCustomCells(widgets)
 		})
 	end
 
+	if String.isNotEmpty(args.ammotype) then
+		table.insert(widgets, Cell{
+			name = 'Ammo Type',
+			content = {args.ammotypeicon .. ' ' .. args.ammotype}
+		})
+	end
+
 	table.insert(widgets, Cell{
-		name = 'Ammo Type',
-		content = {args.ammotypeicon .. ' ' .. args.ammotype}
+		name = 'Range',
+		content = {args.range}
+	})
+
+	table.insert(widgets, Cell{
+		name = 'Ignition Time',
+		content = {args.ignitiontime}
 	})
 
 	table.insert(widgets, Cell{

--- a/components/infobox/wikis/apexlegends/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_weapon_custom.lua
@@ -133,7 +133,7 @@ function CustomInjector:addCustomCells(widgets)
 		})
 	end
 
-	if String.isNotEmpty(args.ammotype) then
+	if String.isNotEmpty(args.ammotype) and String.isNotEmpty(args.ammotypeicon) then
 		table.insert(widgets, Cell{
 			name = 'Ammo Type',
 			content = {args.ammotypeicon .. ' ' .. args.ammotype}


### PR DESCRIPTION
## Summary

Removal of old infobox/grenade and incorporated relevant fields into infobox/weapon/custom. 
Added two extra fields relevant to grenade information, alongside adding a check for `ammotype` to avoid concat error when calling the module for a grenade (as there is no ammo type)

## How did you test this change?

Tested with `/dev`