### PR TITLE
Handle score2 in map and draw

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -162,7 +162,7 @@ end
 function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match is marked as finished.
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
-	if Logic.readBool(data.finished) and (not Logic.isEmpty(indexedScores)) then
+	if Logic.readBool(data.finished) then
 		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'


### PR DESCRIPTION
## Summary

- Setting `|score2`in map wouldn't work as expected.
![image](https://user-images.githubusercontent.com/43279191/189412566-dac7b96d-a387-4ff1-8996-066997ed2eec.png)
- Avoid the calculation of a draw when there are less than 2 opponents.
- Only calculate the winner when scores are set for both opponents.

## How did you test this change?

`dev`module.
