### PR TITLE
Allow partial input for non literal/team Opponents

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -279,7 +279,7 @@ function Placement:_parseOpponentArgs(input, date)
 	local opponentData = Opponent.readOpponentArgs(opponentArgs)
 
 	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
-		opponentData = Table.deepMergeInto(Opponent.tbd(opponentArgs.type), opponentData)
+		opponentData = Table.deepMergeInto(Opponent.tbd(opponentArgs.type), opponentData or {})
 	end
 
 	return Opponent.resolve(opponentData, date, {syncPlayer = self.parent.options.syncPlayers})

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -279,7 +279,7 @@ function Placement:_parseOpponentArgs(input, date)
 	local opponentData = Opponent.readOpponentArgs(opponentArgs)
 
 	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
-		opponentData = Opponent.tbd(opponentArgs.type)
+		opponentData = Table.deepMergeInto(Opponent.tbd(opponentArgs.type), opponentData)
 	end
 
 	return Opponent.resolve(opponentData, date, {syncPlayer = self.parent.options.syncPlayers})


### PR DESCRIPTION
## Summary
Allow partial input for non literal/team Opponents.
E.g. if the nationality (or race/faction) of the first/... is already known

required for sc/sc2 legacy handling

## How did you test this change?
/dev