### PR TITLE
Add Opponent Display for Fortnite

### DIFF
--- a/components/match2/wikis/fortnite/opponent_display_custom.lua
+++ b/components/match2/wikis/fortnite/opponent_display_custom.lua
@@ -1,0 +1,137 @@
+---
+-- @Liquipedia
+-- wiki=fortnite
+-- page=Module:OpponentDisplay/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
+
+local html = mw.html
+
+--[[
+Display components for opponents used by the Fortnite wiki
+]]
+local FortniteOpponentDisplay = {propTypes = {}, types={}}
+
+--[[
+Displays an opponent as an inline element. Useful for describing opponents in
+prose.
+]]
+function FortniteOpponentDisplay.InlineOpponent(props)
+	DisplayUtil.assertPropTypes(props, OpponentDisplay.propTypes.InlineOpponent)
+	local opponent = props.opponent
+
+	if opponent.type == 'team' then
+		return OpponentDisplay.InlineTeamContainer({
+			flip = props.flip,
+			showLink = props.showLink,
+			style = props.teamStyle,
+			team = opponent.team,
+			template = opponent.template or 'tbd',
+		})
+	elseif opponent.type == 'literal' then
+		return OpponentDisplay.InlineOpponent(props)
+	else -- opponent.type == 'solo' 'duo' 'trio' 'quad'
+		return FortniteOpponentDisplay.PlayerInlineOpponent(props)
+	end
+end
+
+--[[
+Displays an opponent as a block element. The width of the component is
+determined by its layout context, and not of the opponent.
+]]
+function FortniteOpponentDisplay.BlockOpponent(props)
+	DisplayUtil.assertPropTypes(props, OpponentDisplay.propTypes.BlockOpponent)
+	local opponent = props.opponent
+	opponent.extradata = opponent.extradata or {}
+	-- Default TBDs to not show links
+	local showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
+
+	if opponent.type == 'team' then
+		return OpponentDisplay.BlockTeamContainer({
+			flip = props.flip,
+			overflow = props.overflow,
+			showLink = showLink,
+			style = props.teamStyle,
+			team = opponent.team,
+			template = opponent.template or 'tbd',
+		})
+	elseif opponent.type == 'literal' and opponent.extradata.hasRaceOrFlag then
+		return FortniteOpponentDisplay.PlayerBlockOpponent(
+			Table.merge(props, {showLink = showLink})
+		)
+	elseif opponent.type == 'literal' then
+		return OpponentDisplay.BlockOpponent(props)
+	else -- opponent.type == 'solo' 'duo' 'trio' 'quad'
+		return FortniteOpponentDisplay.PlayerBlockOpponent(
+			Table.merge(props, {showLink = showLink})
+		)
+	end
+end
+
+--[[
+Displays a player opponent (solo, duo, trio, or quad) as an inline element.
+]]
+function FortniteOpponentDisplay.PlayerInlineOpponent(props)
+	local opponent = props.opponent
+
+	local playerTexts = Array.map(opponent.players, function(player)
+		local node = PlayerDisplay.InlinePlayer({
+			flip = props.flip,
+			player = player,
+			showFlag = props.showFlag,
+			showLink = props.showLink,
+		})
+		return tostring(node)
+	end)
+	if props.flip then
+		playerTexts = Array.reverse(playerTexts)
+	end
+end
+
+--[[
+Displays a player opponent (solo, duo, trio, or quad) as a block element.
+]]
+function FortniteOpponentDisplay.PlayerBlockOpponent(props)
+	local opponent = props.opponent
+
+	local playerNodes = Array.map(opponent.players, function(player)
+		return PlayerDisplay.BlockPlayer({
+			flip = props.flip,
+			overflow = props.overflow,
+			player = player,
+			showFlag = props.showFlag,
+			showLink = props.showLink,
+			showPlayerTeam = props.showPlayerTeam,
+			team = player.team,
+			abbreviateTbd = props.abbreviateTbd,
+		})
+			:addClass(props.playerClass)
+	end)
+
+	if #opponent.players == 1 then
+		return playerNodes[1]
+
+	else
+		local playersNode = html.create('div')
+			:addClass(props.showPlayerTeam and 'player-has-team' or nil)
+		for _, playerNode in ipairs(playerNodes) do
+			playersNode:node(playerNode)
+		end
+		return playersNode
+	end
+end
+
+return FortniteOpponentDisplay

--- a/components/match2/wikis/fortnite/opponent_display_custom.lua
+++ b/components/match2/wikis/fortnite/opponent_display_custom.lua
@@ -11,11 +11,9 @@ local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
-local TypeUtil = require('Module:TypeUtil')
 
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
-local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
 
 local html = mw.html

--- a/components/match2/wikis/fortnite/opponent_display_custom.lua
+++ b/components/match2/wikis/fortnite/opponent_display_custom.lua
@@ -66,10 +66,6 @@ function FortniteOpponentDisplay.BlockOpponent(props)
 			team = opponent.team,
 			template = opponent.template or 'tbd',
 		})
-	elseif opponent.type == 'literal' and opponent.extradata.hasRaceOrFlag then
-		return FortniteOpponentDisplay.PlayerBlockOpponent(
-			Table.merge(props, {showLink = showLink})
-		)
 	elseif opponent.type == 'literal' then
 		return OpponentDisplay.BlockOpponent(props)
 	else -- opponent.type == 'solo' 'duo' 'trio' 'quad'
@@ -97,6 +93,9 @@ function FortniteOpponentDisplay.PlayerInlineOpponent(props)
 	if props.flip then
 		playerTexts = Array.reverse(playerTexts)
 	end
+
+	return html.create('span')
+		:node(table.concat(playerTexts, ' / '))
 end
 
 --[[


### PR DESCRIPTION
## Summary
To introduce, Fortnite is a Battle Royale wiki and has no submatches. 

These related module (3 that will be put on PR) are currently served for only one purpose and that is **to make the **TournamentPortalList** that was used on Starcraft2 to be functional on Fortnite** (as they allowed duos and trios result display)

But also just in case if these poses future usage for BR Match2 (whenever it happens) as well
https://liquipedia.net/fortnite/index.php?title=Template:TournamentPortalList&action=edit
https://liquipedia.net/commons/index.php?title=Module:Tournament/PortalList/Fortnite&action=edit

## How did you test this change?
https://liquipedia.net/fortnite/B-Tier_Tournaments
(Goal is only to get this portal displayed, and both solo/team/duos/trios winners-runnerups are shown)