### PR TITLE
Add Opponent Custom for Fortnite

### DIFF
--- a/components/match2/wikis/opponent_custom.lua
+++ b/components/match2/wikis/opponent_custom.lua
@@ -1,0 +1,29 @@
+---
+-- @Liquipedia
+-- wiki=fortnite
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local PlayerExt = Lua.import('Module:Player/Ext/Custom', {requireDevIfEnabled = true})
+
+local CustomOpponent = Table.deepCopy(Opponent)
+
+function CustomOpponent.resolve(opponent, date, options)
+	Opponent.resolve(opponent, date, options)
+	if Opponent.typeIsParty(opponent.type) then
+		for _, player in ipairs(opponent.players) do
+			if not player.team and options.syncPlayer then
+				player.team = PlayerExt.syncTeam(player.pageName, nil)
+			end
+		end
+	end
+	return opponent
+end
+
+return CustomOpponent


### PR DESCRIPTION
## Summary
To introduce, Fortnite is a Battle Royale wiki and has no submatches. 

These related module (3 that will be put on PR) are currently served for only one purpose and that is **to make the **TournamentPortalList** that was used on Starcraft2 to be functional on Fortnite** (as they allowed duos and trios result display)

But also just in case if these poses future usage for BR Match2 (whenever it happens) as well
https://liquipedia.net/fortnite/index.php?title=Template:TournamentPortalList&action=edit
https://liquipedia.net/commons/index.php?title=Module:Tournament/PortalList/Fortnite&action=edit

## How did you test this change?
https://liquipedia.net/fortnite/B-Tier_Tournaments
(Goal is only to get this portal displayed, and both solo/team/duos/trios winners-runnerups are shown)

## Side Note
**While the rest based on SC2 with adjustments made, this one is a clean port from AoE**