### PR TITLE
Do not overwrite with nil

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -264,7 +264,7 @@ function CustomPlayer._getMatchupData(player)
 		CustomPlayer._setVarsForVS(vs)
 	end
 
-	_player.yearsActive = yearsActive
+	return yearsActive
 end
 
 function CustomPlayer._getYearsActive(years)


### PR DESCRIPTION
## Summary
Do not overwrite with nil.
Due to the call `player.yearsActive = CustomPlayer._getMatchupData(_PAGENAME)` overwriting `player.yearsActive` while the function does not return basically the calculated string gets overwritten with nil.
Change it so that the string is actually returned.

## How did you test this change?
live (bug fix)
