### PR TITLE
Remove Countries as Regions

### DIFF
--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -10,9 +10,6 @@ return {
 	aliases = {
 		europe = 'eu',
 
-		us = 'na',
-		usa = 'na',
-		['united states'] = 'na',
 		america = 'na',
 		americas = 'na',
 		['north america'] = 'na',
@@ -34,12 +31,6 @@ return {
 		anz = 'oce',
 		oceania = 'oce',
 
-		china = 'cn',
-		['south korea'] = 'kr',
-		sk = 'kr',
-
-		taiwan = 'tw',
-
 		['middle east'] = 'me',
 
 		africa = 'af',
@@ -47,12 +38,6 @@ return {
 		['asia pacific'] = 'apac',
 		['asia-pacific'] = 'apac',
 		ap = 'apac',
-
-		japan = 'jp',
-
-		brazil = 'br',
-
-		vietnam = 'vn',
 
 		['malaysia/singapore/philippines'] = 'msp',
 		['malaysia, singapore, philippines'] = 'msp',
@@ -95,18 +80,6 @@ return {
 		region = 'Oceania',
 		flag = 'anz',
 	},
-	cn = {
-		region = 'China',
-		flag = 'cn',
-	},
-	kr = {
-		region = 'Korea',
-		flag = 'kr',
-	},
-	tw = {
-		region = 'Taiwan',
-		flag = 'tw',
-	},
 	me = {
 		region = 'Middle East',
 		flag = 'middle east',
@@ -122,18 +95,6 @@ return {
 	apac = {
 		region = 'Asia Pacific',
 		flag = 'asia',
-	},
-	jp = {
-		region = 'Japan',
-		flag = 'jp',
-	},
-	br = {
-		region = 'Brazil',
-		flag = 'br',
-	},
-	vn = {
-		region = 'Vietnam',
-		flag = 'vn',
 	},
 	msp = {
 		region = 'MSP',

--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -25,9 +25,7 @@ return {
 
 		['southeast asia'] = 'sea',
 
-		australia = 'oce',
 		['australia/new zealand'] = 'oce',
-		['new zealand'] = 'oce',
 		anz = 'oce',
 		oceania = 'oce',
 


### PR DESCRIPTION
## Summary
In Region/Data, there are several countries listed as regions, or aliases to regions. For the latter case they should be set up in the wiki-specific `Module:Region/CountryData`. The former case should be avoided as it's redundant data (query country=XX instead).

## How did you test this change?
N/A
 Possible that there are regression on some wiki related to `player`'s region storage. 