### PR TITLE
Set default for `fillPlaceRange` in Legacy PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -45,6 +45,7 @@ function LegacyPrizePool.run(dependency)
 	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
 	newArgs.cutafter = header.cutafter
 	newArgs.lpdb_prefix = header.lpdb_prefix or header.smw_prefix
+	newArgs.fillPlaceRange = Logic.readBoolOrNil(eader.fillPlaceRange) or false
 
 	if Currency.raw(header.localcurrency) then
 		-- If the localcurrency is a valid currency, handle it like currency

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -45,7 +45,7 @@ function LegacyPrizePool.run(dependency)
 	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
 	newArgs.cutafter = header.cutafter
 	newArgs.lpdb_prefix = header.lpdb_prefix or header.smw_prefix
-	newArgs.fillPlaceRange = Logic.readBoolOrNil(eader.fillPlaceRange) or false
+	newArgs.fillPlaceRange = Logic.readBool(header.fillPlaceRange) or false
 
 	if Currency.raw(header.localcurrency) then
 		-- If the localcurrency is a valid currency, handle it like currency


### PR DESCRIPTION
depends on #1867

## Summary
Set default for `fillPlaceRange` in Legacy PPT
Since apparently most wikis have cases where placeranges were not filled we imo should set it like this as default for Legacy PPTs.
For new PPTs we should not set `false` as the default since for automation (which i assume most wikis will like) needs the filled place ranges for the merging process.
(For SC/SC2 (who already have automation with the old PPT) the Legacy (#1828) is different anyways so not affected by this PR)

## How did you test this change?
/dev