### PR TITLE
Set dateLossIgnored to true for every tier

### DIFF
--- a/components/notability/wikis/ageofempires/notability_checker_config.lua
+++ b/components/notability/wikis/ageofempires/notability_checker_config.lua
@@ -84,7 +84,7 @@ Config.weights = {
 	{
 		tier = 2,
 		options = {
-			dateLossIgnored = false,
+			dateLossIgnored = true,
 		},
 		tiertype = {
 			{
@@ -116,7 +116,7 @@ Config.weights = {
 	{
 		tier = 3,
 		options = {
-			dateLossIgnored = false,
+			dateLossIgnored = true,
 		},
 		tiertype = {
 			{
@@ -148,7 +148,7 @@ Config.weights = {
 	{
 		tier = 4,
 		options = {
-			dateLossIgnored = false,
+			dateLossIgnored = true,
 		},
 		tiertype = {
 			{
@@ -180,7 +180,7 @@ Config.weights = {
 	{
 		tier = 9,
 		options = {
-			dateLossIgnored = false,
+			dateLossIgnored = true,
 		},
 		tiertype = {
 			{


### PR DESCRIPTION
## Summary

Set dateLossIgnored to true to make every tournament receive the same value regardless of the date for all tiers (now only applies for tier 1)

## How did you test this change?

I made this same change in https://liquipedia.net/ageofempires/Module:NotabilityChecker/config without knowing that that change should've been done here. It was working until the bot made a rollback.

For example, running the notability checker right now for GlowWorm returns a score of 11: https://liquipedia.net/ageofempires/Special:RunQuery/Notability_Checker?title=Special%3ARunQuery%2FNotability_Checker&pfRunQueryFormName=Notability+Checker&Notability+checker%5Bplayer1%5D=GlowWorm&pf_free_text=&wpRunQuery=Run+query

With this change the score is/will be 250.

