### PR TITLE
LPA-6819: Resolve Redirect teampagename for LPDB Player

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -232,7 +232,7 @@ function Person:_setLpdbData(args, links, status, personType)
 	local team = args.teamlink or args.team
 	if team and mw.ext.TeamTemplate.teamexists(team) then
 		local teamRaw = mw.ext.TeamTemplate.raw(team)
-		teamLink = mw.ext.TeamLiquidIntegration.resolve_redirect(teamRaw.page)
+		teamLink = teamRaw.page
 		teamTemplate = teamRaw.templatename
 	end
 
@@ -250,7 +250,7 @@ function Person:_setLpdbData(args, links, status, personType)
 		image = args.image,
 		region = _region,
 		team = teamLink or team,
-		teampagename = (teamLink or team or ''):gsub(' ', '_'),
+		teampagename = mw.ext.TeamLiquidIntegration.resolve_redirect(teamLink or team or ''):gsub(' ', '_'),
 		teamtemplate = teamTemplate,
 		status = status,
 		type = personType,

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -232,7 +232,7 @@ function Person:_setLpdbData(args, links, status, personType)
 	local team = args.teamlink or args.team
 	if team and mw.ext.TeamTemplate.teamexists(team) then
 		local teamRaw = mw.ext.TeamTemplate.raw(team)
-		teamLink = teamRaw.page
+		teamLink = mw.ext.TeamLiquidIntegration.resolve_redirect(teamRaw.page)
 		teamTemplate = teamRaw.templatename
 	end
 


### PR DESCRIPTION
## Summary
For player with lowercase teams the `teampagename` field can contain a lowercase first letter. Let's do a resolve redirect so to ensure that the pagename is correctly capitalized. 

## How did you test this change?
/dev module
![image](https://user-images.githubusercontent.com/3426850/190173473-5fc3c527-51a9-4630-82d4-7e049034d9c5.png)

