### PR TITLE
Update handling of Team Nane in Match Summary

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -52,14 +52,14 @@ function Header:rightOpponent(content)
 	return self
 end
 
-function Header:createOpponent(opponent, side)
+function Header:createOpponent(opponent, side, style)
 	local showLink = not Opponent.isTbd(opponent) and true or false
 	return OpponentDisplay.BlockOpponent{
 		flip = side == 'left',
 		opponent = opponent,
 		showLink = showLink,
 		overflow = 'ellipsis',
-		teamStyle = 'bracket',
+		teamStyle = style or 'short',
 	}
 end
 
@@ -134,11 +134,7 @@ local Mvp = Class.new(
 )
 
 function Mvp:addPlayer(player)
-	if Logic.isEmpty(player) then
-		return self
-	elseif type(player) == 'table' then
-		table.insert(self.players, player.name .. '|' .. player.displayname)
-	else
+	if not Logic.isEmpty(player) then
 		table.insert(self.players, player)
 	end
 	return self

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -134,7 +134,11 @@ local Mvp = Class.new(
 )
 
 function Mvp:addPlayer(player)
-	if not Logic.isEmpty(player) then
+	if Logic.isEmpty(player) then
+		return self
+	elseif type(player) == 'table' then
+		table.insert(self.players, player.name .. '|' .. player.displayname)
+	else
 		table.insert(self.players, player)
 	end
 	return self

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -112,10 +112,10 @@ end
 function CustomMatchSummary._createHeader(match)
 	local header = MatchSummary.Header()
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
 
 	return header
 end

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -160,10 +160,10 @@ end
 function CustomMatchSummary._createHeader(match)
 	local header = MatchSummary.Header()
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
 
 	return header
 end

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -36,7 +36,7 @@ function CustomMatchSummary.getByMatchId(args)
 			flip = opponentIndex == 1,
 			opponent = match.opponents[opponentIndex],
 			overflow = 'ellipsis',
-			teamStyle = 'bracket',
+			teamStyle = 'short',
 		})
 			:addClass(match.opponents[opponentIndex].type ~= 'solo'
 				and 'brkts-popup-header-opponent'

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -136,10 +136,10 @@ end
 function CustomMatchSummary._createHeader(match)
 	local header = MatchSummary.Header()
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
 
 	return header
 end

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -112,10 +112,10 @@ end
 function CustomMatchSummary._createHeader(match)
 	local header = MatchSummary.Header()
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
 
 	return header
 end

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -113,10 +113,10 @@ end
 function CustomMatchSummary._createHeader(match)
 	local header = MatchSummary.Header()
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
 
 	return header
 end

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -170,7 +170,7 @@ function Header:createOpponent(opponent, opponentIndex)
 		flip = opponentIndex == 1,
 		opponent = opponent,
 		overflow = 'ellipsis',
-		teamStyle = 'bracket',
+		teamStyle = 'short',
 	})
 		:addClass(opponent.type ~= 'solo'
 			and 'brkts-popup-header-opponent'

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -292,10 +292,10 @@ end
 function CustomMatchSummary._createHeader(frame, match)
 	local header = MatchSummary.Header()
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
 
 	return header
 end

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -112,10 +112,10 @@ end
 function CustomMatchSummary._createHeader(match)
 	local header = MatchSummary.Header()
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
 
 	return header
 end


### PR DESCRIPTION
## Summary
In match summary:
* Add option to override display style
* Set default style to `short`
* Set wikis with match summary widths >= 400px to `bracket`

Recommend to start the review with `match_summary_base.lua`.

## How did you test this change?

dev module

Counterstrike (width = 330px, using default)
![image](https://user-images.githubusercontent.com/3426850/190170932-dedbe921-07b4-4d89-a9d3-3683f1ca7a9b.png)

dota2 (width = 400px, using override)
![image](https://user-images.githubusercontent.com/3426850/190171266-50e5846d-2460-445d-8c64-59b7b932641e.png)
