### PR TITLE
Squad Tables: use darkmode icons

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -20,11 +20,8 @@ local _VALID_TYPES = {'player', 'staff'}
 local _DEFAULT_TYPE = 'player'
 
 
-local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain'
-			.. '|class=show-when-light-mode]][[File:Captain Icon darkmode.png|18px|baseline|Captain'
-			.. '|link=Category:Captains|alt=Captain|class=show-when-dark-mode]]'
-local _ICON_SUBSTITUTE = '[[File:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-light-mode]]'
-			.. '[[File:Substitution darkmode.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-dark-mode]]'
+local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=player-role-icon]]'
+local _ICON_SUBSTITUTE = '[[File:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=player-role-icon]]'
 
 local SquadRow = Class.new(
 	function(self, frame, role, options)

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -20,8 +20,10 @@ local _VALID_TYPES = {'player', 'staff'}
 local _DEFAULT_TYPE = 'player'
 
 
-local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain]]'
-local _ICON_SUBSTITUTE = '[[image:Substitution.svg|18px|baseline|Sub|link=|alt=Substitution]]'
+local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-light-mode]]'
+			.. '[[image:Captain Icon darkmode.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-dark-mode]]'
+local _ICON_SUBSTITUTE = '[[image:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-light-mode]]'
+			.. [[image:Substitution darkmode.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-dark-mode]]'
 
 local SquadRow = Class.new(
 	function(self, frame, role, options)

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -20,10 +20,10 @@ local _VALID_TYPES = {'player', 'staff'}
 local _DEFAULT_TYPE = 'player'
 
 
-local _ICON_CAPTAIN = '[[image:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-light-mode]]'
-			.. '[[image:Captain Icon darkmode.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-dark-mode]]'
-local _ICON_SUBSTITUTE = '[[image:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-light-mode]]'
-			.. [[image:Substitution darkmode.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-dark-mode]]'
+local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-light-mode]]'
+			.. '[[File:Captain Icon darkmode.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-dark-mode]]'
+local _ICON_SUBSTITUTE = '[[File:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-light-mode]]'
+			.. '[[File:Substitution darkmode.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-dark-mode]]'
 
 local SquadRow = Class.new(
 	function(self, frame, role, options)

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -20,8 +20,9 @@ local _VALID_TYPES = {'player', 'staff'}
 local _DEFAULT_TYPE = 'player'
 
 
-local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-light-mode]]'
-			.. '[[File:Captain Icon darkmode.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=show-when-dark-mode]]'
+local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain'
+			.. '|class=show-when-light-mode]][[File:Captain Icon darkmode.png|18px|baseline|Captain'
+			.. '|link=Category:Captains|alt=Captain|class=show-when-dark-mode]]'
 local _ICON_SUBSTITUTE = '[[File:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-light-mode]]'
 			.. '[[File:Substitution darkmode.png|18px|baseline|Sub|link=|alt=Substitution|class=show-when-dark-mode]]'
 

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -20,7 +20,8 @@ local _VALID_TYPES = {'player', 'staff'}
 local _DEFAULT_TYPE = 'player'
 
 
-local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain|class=player-role-icon]]'
+local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Category:Captains|alt=Captain'
+	.. '|class=player-role-icon]]'
 local _ICON_SUBSTITUTE = '[[File:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=player-role-icon]]'
 
 local SquadRow = Class.new(


### PR DESCRIPTION
## Summary

Lightmode logos are almost invisible in darkmode.

## How did you test this change?

Untested, I was unsure of how to test a commons change in userspace.
