### PR TITLE
Treat `award_individual` as `individual` when it comes to earnings

### DIFF
--- a/components/earnings/commons/earnings_base.lua
+++ b/components/earnings/commons/earnings_base.lua
@@ -213,7 +213,7 @@ function Earnings.divisionFactorPlayer(mode)
 		return 3
 	elseif mode == '2v2' then
 		return 2
-	elseif mode == '1v1' or mode == 'individual' then
+	elseif mode == '1v1' or mode == 'individual' or mode == 'award_individual' then
 		return 1
 	end
 


### PR DESCRIPTION
## Summary
As a stop-gap solution to distinguish award placements from normal placement, all award places will have their `mode` set to either `award_individual` or `award_team`. 
This PR make sure we treat `award_individual` in Earnings the same way as `individual`.

## How did you test this change?
N/A
