### PR TITLE
Fix placement args.text being ingored

### DIFF
--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -145,8 +145,7 @@ function Placement._placement(args)
 				:addClass(raw.backgroundClass)
 				:tag('b')
 				:addClass(not raw.blackText and 'placement-text' or nil)
-				:wikitext(raw.display)
-
+				:wikitext(raw.display .. (Logic.isNotEmpty(args.text) and (' ' .. args.text) or ''))
 end
 
 ---Converts a placement table into a ordinal string.


### PR DESCRIPTION
## Summary

Due to oversight on my part, `args.text` was being ignored in refactored code. This PR addresses that.

## How did you test this change?

`/dev` on commons.

Before:
![image](https://user-images.githubusercontent.com/5881994/190447932-7e6edd4b-78a5-4e59-8a34-963f2ce831e2.png)
After:
![image](https://user-images.githubusercontent.com/5881994/190447954-1f96b1b2-febc-4bc3-a166-739b266ac6ca.png)

