### PR TITLE
LPA-6895: Set dateexact to false for cancelled or postponed games

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -503,6 +503,7 @@ function matchFunctions.getOpponents(match)
 		match.resulttype = 'np'
 		match.status = match.finished
 		match.finished = false
+		match.dateexact = false
 	else
 		-- see if match should actually be finished if score is set
 		if isScoreSet and not Logic.readBool(match.finished) and match.hasDate then


### PR DESCRIPTION
## Summary
The easiest way to check if a match should be included in live or upcoming matches, `dateexact` is currently used. In order to not build additional complexities for around postponed and cancelled matches and tournaments, setting `dateexact` to `false` would be an easy and simple solution, which is technically correct as well (as the match will no longer take place at said time).

## How did you test this change?
Tested with dev module
