### PR TITLE
Multiple fixes for `Module:Ordinal` plus error prevention in #1883

### DIFF
--- a/standard/ordinal/ordinal.lua
+++ b/standard/ordinal/ordinal.lua
@@ -162,7 +162,7 @@ function Ordinal.ordinal(frame)
 end
 
 function Ordinal._ordinal(value, _, superScript)
-	return Ordinal.suffix(value, {
+	return value .. Ordinal.suffix(value, {
 		superScript = superScript,
 	}) or ''
 end

--- a/standard/ordinal/ordinal.lua
+++ b/standard/ordinal/ordinal.lua
@@ -156,15 +156,23 @@ end
 function Ordinal.ordinal(frame)
 	local args = Arguments.getArgs(frame)
 
-	return Ordinal.suffix(args[1], {
+	if not args[1] then
+		return
+	end
+
+	return args[1] .. Ordinal.suffix(args[1], {
 		superScript = Logic.readBool(args.sup),
 	}) or ''
 end
 
 function Ordinal._ordinal(value, _, superScript)
-	return value .. Ordinal.suffix(value, {
+	if Logic.isEmpty(value) then
+		return
+	end
+
+	return value .. (Ordinal.suffix(value, {
 		superScript = superScript,
-	}) or ''
+	}) or '')
 end
 
 return Ordinal

--- a/standard/ordinal/ordinal.lua
+++ b/standard/ordinal/ordinal.lua
@@ -156,13 +156,7 @@ end
 function Ordinal.ordinal(frame)
 	local args = Arguments.getArgs(frame)
 
-	if not args[1] then
-		return
-	end
-
-	return args[1] .. (Ordinal.suffix(args[1], {
-		superScript = Logic.readBool(args.sup),
-	}) or '')
+	return Ordinal._ordinal(args[1], _, Logic.readBool(args['sup']))
 end
 
 function Ordinal._ordinal(value, _, superScript)

--- a/standard/ordinal/ordinal.lua
+++ b/standard/ordinal/ordinal.lua
@@ -160,9 +160,9 @@ function Ordinal.ordinal(frame)
 		return
 	end
 
-	return args[1] .. Ordinal.suffix(args[1], {
+	return args[1] .. (Ordinal.suffix(args[1], {
 		superScript = Logic.readBool(args.sup),
-	}) or ''
+	}) or '')
 end
 
 function Ordinal._ordinal(value, _, superScript)

--- a/standard/ordinal/ordinal.lua
+++ b/standard/ordinal/ordinal.lua
@@ -156,7 +156,7 @@ end
 function Ordinal.ordinal(frame)
 	local args = Arguments.getArgs(frame)
 
-	return Ordinal._ordinal(args[1], _, Logic.readBool(args['sup']))
+	return Ordinal._ordinal(args[1], nil, Logic.readBool(args['sup']))
 end
 
 function Ordinal._ordinal(value, _, superScript)

--- a/standard/ordinal/ordinal.lua
+++ b/standard/ordinal/ordinal.lua
@@ -137,9 +137,9 @@ function Ordinal.suffix(value, options)
 	local suffix
 	if residual10 == 1 and residual100 ~= 11 then
 		suffix = 'st'
-	elseif residual10 == 1 and residual100 ~= 12 then
+	elseif residual10 == 2 and residual100 ~= 12 then
 		suffix = 'nd'
-	elseif residual10 == 1 and residual100 ~= 13 then
+	elseif residual10 == 3 and residual100 ~= 13 then
 		suffix = 'rd'
 	else
 		suffix = 'th'


### PR DESCRIPTION
## Summary

`_ordinal()` previously returned the input + suffix, not just suffix. However, #1883 changed it to just suffix which broke reliance on the module.

![image](https://user-images.githubusercontent.com/5881994/190830421-be2ccf79-5340-410b-89ed-f4da460d6781.png)

The code here could also be changed as different way to fix this but all other uses of `_ordinal()` need to be modified too.
https://github.com/Liquipedia/Lua-Modules/blob/63fde24455eb9c0d04451b9a7e9eb20471c21ef0/components/prize_pool/commons/prize_pool_placement.lua#L413-L416

**Edit:** 2nd and 3rd not showing up as such is also fixed now.

**Edit 2:** Added some error prevention.

**Edit 3:** Refactored `ordinal()` to just call `_ordinal()` instead.

## How did you test this change?

Live on commons due to being applied as emergency fix.

![image](https://user-images.githubusercontent.com/5881994/190838466-8783138c-b6b5-4208-80c8-3521152fb8ea.png)

![image](https://user-images.githubusercontent.com/5881994/190838462-e36b1814-c4a1-47a2-85f4-d11a270f063f.png)
