### PR TITLE
Add option for map date countdowns on dota

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -175,12 +175,19 @@ function CustomMatchSummary._createBody(match)
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not epoch=0, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(
-			DisplayHelper.MatchCountdownBlock(match)
+			DisplayHelper.MatchCountdownBlock(Table.merge(match,
+				{finished = match.finished or match.extradata.dateheaderfinished}))
 		))
 	end
 
 	-- Iterate each map
 	for gameIndex, game in ipairs(match.games) do
+		if game.extradata.dateheader then
+			body:addRow(MatchSummary.Row():addElement(
+				DisplayHelper.MatchCountdownBlock(Table.merge(game,
+					{finished = game.extradata.finished, dateIsExact = game.extradata.dateexact}))
+			))
+		end
 		local rowDisplay = CustomMatchSummary._createGame(game, gameIndex)
 		body:addRow(rowDisplay)
 	end


### PR DESCRIPTION
depends on #1898

## Summary
Add option for map date countdowns on dota

requested by steventcyh:
https://discord.com/channels/93055209017729024/268719633366777856/1020551840338821130
(CS is interested too)

## How did you test this change?
/dev

![Screenshot 2022-09-17 14 56 15](https://user-images.githubusercontent.com/75081997/190857963-8311cd10-e3f2-45ea-a4d9-8ff091eaa3ff.png)


if you have better names for the params i am more than happy to adjust