### PR TITLE
Add Legacy PPT for Arena of Valor

### DIFF
--- a/components/prize_pool/wikis/arenaofvalor/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/arenaofvalor/prize_pool_legacy_custom.lua
@@ -1,0 +1,43 @@
+---
+-- @Liquipedia
+-- wiki=arenaofvalor
+-- page=Module:PrizePool/Legacy/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
+
+local CustomLegacyPrizePool = {}
+
+-- Template entry point
+function CustomLegacyPrizePool.run()
+	return PrizePoolLegacy.run(CustomLegacyPrizePool)
+end
+
+function CustomLegacyPrizePool.customOpponent(opponentData, CACHED_DATA, slot, opponentIndex)
+	-- AoV has use case of same placement but has different earnings
+
+	if slot['usdprize' .. opponentIndex] then
+		opponentData.usdprize = slot['usdprize' .. opponentIndex]
+	end
+
+	if slot['localprize' .. opponentIndex] then
+		local param = CACHED_DATA.inputToId['localprize']
+		CustomLegacyPrizePool._setOpponentReward(opponentData, param, slot['localprize' .. opponentIndex])
+	end
+
+	return opponentData
+end
+
+function CustomLegacyPrizePool._setOpponentReward(opponentData, param, value)
+	if param == 'seed' then
+		PrizePoolLegacy.handleSeed(opponentData, value, 1)
+	else
+		opponentData[param] = value
+	end
+end
+
+return CustomLegacyPrizePool


### PR DESCRIPTION
## Summary
New Prize Pool for Arena of Valor
these are clean ports of Mobile Legends PPT

Since both wikis use the same old non-standard **Module:Prize Pool Slot** before the new PPT. So it's kinda identical

Also same to ML, This wiki also had cases of **usdprize1** or same placement but with two different money earned.

## How did you test this change?
LIVE

USD (no seed): https://liquipedia.net/arenaofvalor/Arena_of_Valor_International_Championship/2022#Prize_Pool

Local (seed): https://liquipedia.net/arenaofvalor/Arena_of_Valor_International_Championship/2022/Europe

Beside these, Player/Team earnings are unaffected and both remain functional as it is before. (As I mentioned, both ML and This wiki has the same old prize module)