### PR TITLE
Do not save player pageVars for TBD in Opponent.resolve

### DIFF
--- a/components/match2/commons/opponent.lua
+++ b/components/match2/commons/opponent.lua
@@ -250,7 +250,7 @@ function Opponent.resolve(opponent, date, options)
 	elseif Opponent.typeIsParty(opponent.type) then
 		for _, player in ipairs(opponent.players) do
 			if options.syncPlayer then
-				PlayerExt.syncPlayer(player)
+				PlayerExt.syncPlayer(player, {savePageVar = not Opponent.playerIsTbd(player)})
 			else
 				PlayerExt.populatePageName(player)
 			end

--- a/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -127,7 +127,7 @@ function StarcraftOpponent.resolve(opponent, date, options)
 		for _, player in ipairs(opponent.players) do
 			if options.syncPlayer then
 				local hasRace = String.isNotEmpty(player.race)
-				StarcraftPlayerExt.syncPlayer(player)
+				StarcraftPlayerExt.syncPlayer(player, {savePageVar = not Opponent.playerIsTbd(player)})
 				if not player.team then
 					player.team = PlayerExt.syncTeam(player.pageName, nil, {date = date})
 				end


### PR DESCRIPTION
## Summary
Do not save player pageVars for TBD in Opponent.resolve when syncing

can cause issues on pages due to flags and races wrongly being assigned to TBD stuff
also causes issues in prize pool when setting manual flag/race data for a player that data gets used for tbd opponents further down in the prize pool

## How did you test this change?
/dev