### PR TITLE
Responsive display for teams in new brackets

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -122,6 +122,7 @@ function BracketDisplay.Bracket(props)
 		:css('--match-width-mobile', config.matchWidthMobile .. 'px')
 		:css('--score-width', config.scoreWidth .. 'px')
 		:css('--round-horizontal-margin', config.roundHorizontalMargin .. 'px')
+		:css('--opponent-height', config.opponentHeight .. 'px')
 
 	-- Draw all top level subtrees of the bracket. These are subtrees rooted
 	-- at matches that do not advance to higher rounds.

--- a/components/match2/commons/opponent_display.lua
+++ b/components/match2/commons/opponent_display.lua
@@ -51,7 +51,7 @@ function OpponentDisplay.BracketOpponentEntry:createTeam(template, options)
 
 	local opponentNode = OpponentDisplay.BlockTeamContainer({
 		showLink = false,
-		style = 'hybrid',
+		style = forceShortName and 'short' or 'hybrid',
 		template = template,
 	})
 


### PR DESCRIPTION
## Summary

I wasn't a fan of how teams were being displayed in the new brackets. i.e., two team templates depending on screen width. Also, they weren't responsive in regards to opponent height differences across wikis. Also, was really not a fan of the up-to-the-edge'ness of wide logos. And finally, in narrow mode, some logos just turned into unidentifiable blobs.
![image](https://user-images.githubusercontent.com/5881994/191112320-304d0515-3950-4041-af94-7e7508fced36.png)
![image](https://user-images.githubusercontent.com/5881994/191112328-3e4f159c-beda-4aeb-9fb6-3192555663bd.png)

So, I refactored `OpponentDisplay.BlockTeam()` to have a new style named `hybrid` which is similar to what `Module:Team` has for GTL for example. On wide views, the bracket name is displayed, and on narrow views, the short name is displayed.

The following CSS was also added/modified to allow for these changes:
```css
@media (max-width: 767px) {
	.brkts-bracket {
		--brkts-team-icon-width: 30px;
	}
}
.brkts-opponent-entry .team-template-image-icon,
.brkts-opponent-entry .team-template-image-legacy {
	height: calc(var(--opponent-height, 22px) - 4px);
	width: var(--brkts-team-icon-width, 44px);
	justify-content: center;
	display: inline-flex;
}
.brkts-opponent-entry .team-template-image-legacy img {
	max-width: 100%;
	height: auto;
	width: auto;
}
.brkts-opponent-entry img {
	max-height: 100%;
	max-width: 90%;
}
```

Functionality is also maintained with legacy TTs a swell which still use 120x50px files.

End result is this:
![image](https://user-images.githubusercontent.com/5881994/191118202-18c856f9-be7a-4507-9875-f1d99f66ccb1.png)
![image](https://user-images.githubusercontent.com/5881994/191118207-80be8bb2-c5a1-4dc8-bcae-6e7ab17cbb0b.png)

Logos are taller due to CS's taller opponent height, and also resize arguably better when on narrow displays. Wide logos also don't touch the sides of the bracket cells anymore which was ugly imo.


## How did you test this change?

`/dev` modules on commons and/or CS wiki.

https://liquipedia.net/counterstrike/User:IMarbot/m2teams
(top is new and bottom is old)

![video](https://i.gyazo.com/2a37138f06c7baddca891a3fa60fea22.gif)


## Things to note
⚠ **The CSS is currently not deployed on commons, so if this is something that will be merged, please let me know to see the CSS first before any merging is done. Thank you.**