### PR TITLE
Support darkmode team card images

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -63,8 +63,9 @@ end
 function CustomTeam:addToLpdb(lpdbData, args)
 	if not String.isEmpty(args.teamcardimage) then
 		lpdbData.logo = args.teamcardimage
-	elseif not String.isEmpty(args.image) then
-		lpdbData.logo = args.image
+	end
+	if not String.isEmpty(args.teamcardimagedark) then
+		lpdbData.logodark = args.teamcardimagedark
 	end
 
 	lpdbData.extradata.rating = Variables.varDefault('rating')


### PR DESCRIPTION
## Summary

Adds support for darkmode team card images, this most notably allows them to be supported in team navboxes

## How did you test this change?

/dev module
