### PR TITLE
Convert `??` to valid date character for team's disband date

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Template = require('Module:Template')
 local Table = require('Module:Table')
 local Namespace = require('Module:Namespace')
@@ -254,7 +255,7 @@ function Team:_setLpdbData(args, links)
 		logodark = args.imagedark or args.imagedarkmode,
 		earnings = earnings,
 		createdate = args.created,
-		disbanddate = args.disbanded,
+		disbanddate = ReferenceCleaner.clean(args.disbanded),
 		coach = args.coaches,
 		manager = args.manager,
 		template = teamTemplate,


### PR DESCRIPTION
## Summary

Currently, if `|disbanded=<date>` contains any none-date characters, such as `??` (which is quite common), the entire date will be stored as Epoch 0 in the Database.
This PR resolves that issue by running the Cleaner on it. The cleaner will convert `??` into `01`, which is the most accurate we can be. This fixes issues with using LPDB for Portal Teams to determine if a team is disbanded or not.

Not doing this for `created`, as it often contains two dates, one for org-create and one for org joining the game.

## How did you test this change?
/dev module