### PR TITLE
Infobox Core: Require dev if feature flag is enable

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -7,8 +7,10 @@
 --
 
 local Class = require('Module:Class')
-local WidgetFactory = require('Module:Infobox/Widget/Factory')
+local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
+
+local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory', {requireDevIfEnabled = true})
 
 local Infobox = Class.new()
 

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -7,10 +7,12 @@
 --
 
 local Class = require('Module:Class')
-local Infobox = require('Module:Infobox')
+local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Logic = require('Module:Logic')
 local getArgs = require('Module:Arguments').getArgs
+
+local Infobox = Lua.import('Module:Infobox', {requireDevIfEnabled = true})
 
 local BasicInfobox = Class.new(
 	function(self, frame)

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -6,8 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 local Class = require('Module:Class')
-local Injector = require('Module:Infobox/Widget/Injector')
+local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
 local Widget = Class.new()
 

--- a/components/infobox/commons/infobox_widget_breakdown.lua
+++ b/components/infobox/commons/infobox_widget_breakdown.lua
@@ -7,7 +7,9 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Breakdown = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_builder.lua
+++ b/components/infobox/commons/infobox_widget_builder.lua
@@ -7,8 +7,10 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
-local WidgetFactory = require('Module:Infobox/Widget/Factory')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
+local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory', {requireDevIfEnabled = true})
 
 local Builder = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_cell.lua
+++ b/components/infobox/commons/infobox_widget_cell.lua
@@ -7,7 +7,9 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Cell = Class.new(Widget,
 	function(self, input)

--- a/components/infobox/commons/infobox_widget_center.lua
+++ b/components/infobox/commons/infobox_widget_center.lua
@@ -7,8 +7,10 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Center = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_chronology.lua
+++ b/components/infobox/commons/infobox_widget_chronology.lua
@@ -7,8 +7,10 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Chronology = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_customizable.lua
+++ b/components/infobox/commons/infobox_widget_customizable.lua
@@ -7,7 +7,9 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Customizable = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_error.lua
+++ b/components/infobox/commons/infobox_widget_error.lua
@@ -6,4 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-return require('Module:Infobox/Widget').Error
+local Lua = require('Module:Lua')
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
+
+return Widget.Error

--- a/components/infobox/commons/infobox_widget_factory.lua
+++ b/components/infobox/commons/infobox_widget_factory.lua
@@ -7,8 +7,10 @@
 --
 
 local Class = require('Module:Class')
-local Customizable = require('Module:Infobox/Widget/Customizable')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
+
+local Customizable = Lua.import('Module:Infobox/Widget/Customizable', {requireDevIfEnabled = true})
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local WidgetFactory = Class.new()
 

--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -7,7 +7,9 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Header = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_highlights.lua
+++ b/components/infobox/commons/infobox_widget_highlights.lua
@@ -7,8 +7,10 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Highlights = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -7,9 +7,11 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
-local UtilLinks = require('Module:Links')
+local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+
+local UtilLinks = Lua.import('Module:Links', {requireDevIfEnabled = true})
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Links = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widget_title.lua
+++ b/components/infobox/commons/infobox_widget_title.lua
@@ -7,7 +7,9 @@
 --
 
 local Class = require('Module:Class')
-local Widget = require('Module:Infobox/Widget')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
 
 local Title = Class.new(
 	Widget,

--- a/components/infobox/commons/infobox_widgets.lua
+++ b/components/infobox/commons/infobox_widgets.lua
@@ -8,15 +8,17 @@
 
 local Widgets = {}
 
-Widgets.Cell = require('Module:Infobox/Widget/Cell')
-Widgets.Header = require('Module:Infobox/Widget/Header')
-Widgets.Center = require('Module:Infobox/Widget/Center')
-Widgets.Title = require('Module:Infobox/Widget/Title')
-Widgets.Customizable = require('Module:Infobox/Widget/Customizable')
-Widgets.Links = require('Module:Infobox/Widget/Links')
-Widgets.Chronology = require('Module:Infobox/Widget/Chronology')
-Widgets.Builder = require('Module:Infobox/Widget/Builder')
-Widgets.Breakdown = require('Module:Infobox/Widget/Breakdown')
-Widgets.Error = require('Module:Infobox/Widget/Error')
+local Lua = require('Module:Lua')
+
+Widgets.Breakdown = Lua.import('Module:Infobox/Widget/Breakdown', {requireDevIfEnabled = true})
+Widgets.Builder = Lua.import('Module:Infobox/Widget/Builder', {requireDevIfEnabled = true})
+Widgets.Cell = Lua.import('Module:Infobox/Widget/Cell', {requireDevIfEnabled = true})
+Widgets.Center = Lua.import('Module:Infobox/Widget/Center', {requireDevIfEnabled = true})
+Widgets.Chronology = Lua.import('Module:Infobox/Widget/Chronology', {requireDevIfEnabled = true})
+Widgets.Customizable = Lua.import('Module:Infobox/Widget/Customizable', {requireDevIfEnabled = true})
+Widgets.Error = Lua.import('Module:Infobox/Widget/Error', {requireDevIfEnabled = true})
+Widgets.Header = Lua.import('Module:Infobox/Widget/Header', {requireDevIfEnabled = true})
+Widgets.Links = Lua.import('Module:Infobox/Widget/Links', {requireDevIfEnabled = true})
+Widgets.Title = Lua.import('Module:Infobox/Widget/Title', {requireDevIfEnabled = true})
 
 return Widgets


### PR DESCRIPTION
## Summary
In order to facilitate the efficient testing of new functionality in the Infobox, adding support for the Dev feature flag.
This PR only enables it on the shared infobox components, ie widgets and Infobox + Infobox Basic.

## How did you test this change?

Sample testing