### PR TITLE
Fortnite: Cleanup imports, require dev if dev-flag is on

### DIFF
--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -6,20 +6,23 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Player = require('Module:Infobox/Person')
 local Abbreviation = require('Module:Abbreviation')
-local String = require('Module:StringUtils')
-local Class = require('Module:Class')
-local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local ActiveYears = require('Module:YearsActive')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 local Role = require('Module:Role')
 local Region = require('Module:Region')
 local Math = require('Module:Math')
+local String = require('Module:StringUtils')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
-local Injector = require('Module:Infobox/Widget/Injector')
-local Cell = require('Module:Infobox/Widget/Cell')
-local Title = require('Module:Infobox/Widget/Title')
-local Center = require('Module:Infobox/Widget/Center')
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+local Center = Widgets.Center
 
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role

--- a/components/infobox/wikis/fortnite/infobox_series_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_series_custom.lua
@@ -6,10 +6,15 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Series = require('Module:Infobox/Series')
-local Injector = require('Module:Infobox/Widget/Injector')
-local Cell = require('Module:Infobox/Widget/Cell')
 local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Series = Lua.import('Module:Infobox/Series', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
 local Language = mw.language.new('en')
 
 local CustomSeries = {}

--- a/components/infobox/wikis/fortnite/infobox_team_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_team_custom.lua
@@ -6,15 +6,19 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Cell = require('Module:Infobox/Widget/Cell')
 local Class = require('Module:Class')
-local Injector = require('Module:Infobox/Widget/Injector')
 local Lpdb = require('Module:Lpdb')
+local Lua = require('Module:Lua')
 local Math = require('Module:Math')
 local Namespace = require('Module:Namespace')
 local Table = require('Module:Table')
-local Team = require('Module:Infobox/Team')
 local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
 
 local Condition = require('Module:Condition')
 local ConditionTree = Condition.Tree


### PR DESCRIPTION
## Summary

Setup Fortnite Infoboxes to use dev feature flag.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
