### PR TITLE
Add support for a second vod in map or match

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -335,6 +335,8 @@ function matchFunctions.getLinks(match)
 
 	local platforms = mw.loadData('Module:MatchExternalLinks')
 
+	table.insert(platforms, {name = 'vod2', isMapStats = true})
+
 	for _, platform in ipairs(platforms) do
 		-- Stat external links inserted in {{Map}}
 		if Logic.isNotEmpty(platform) then

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -334,7 +334,6 @@ function matchFunctions.getLinks(match)
 	local links = match.links
 
 	local platforms = mw.loadData('Module:MatchExternalLinks')
-
 	table.insert(platforms, {name = 'vod2', isMapStats = true})
 
 	for _, platform in ipairs(platforms) do

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -219,6 +219,11 @@ function CustomMatchSummary.getByMatchId(args)
 	end
 
 	local vods = {}
+	if Logic.isNotEmpty(match.links.vod2) then
+		for _, vodpart in ipairs(match.links.vod2) do
+			vods[vodpart[2] + 100] = vodpart[1]
+		end
+	end
 	for index, game in ipairs(match.games) do
 		if game.vod then
 			vods[index] = game.vod
@@ -318,22 +323,34 @@ function CustomMatchSummary._createFooter(match, vods)
 		footer:addLink(url, icon, iconDark, label)
 	end
 
+	local function addVodLink(gamenum, vod, htext)
+		if not Logic.isEmpty(vod) then
+			footer:addElement(VodLink.display{
+				gamenum = gamenum,
+				vod = vod,
+				htext = htext
+			})
+		end
+	end
+
 	-- Match vod
-	if not Logic.isEmpty(match.vod) then
-		footer:addElement(VodLink.display{
-			vod = match.vod,
-			source = match.vod.url
-		})
+	if vods[100] then
+		addVodLink(nil, match.vod, 'Watch VOD ' .. '(part 1)')
+		addVodLink(nil, vods[100], 'Watch VOD ' .. '(part 2)')
+	else
+		addVodLink(nil, match.vod, nil)
 	end
 
 	-- Game Vods
 	for index, vod in pairs(vods) do
-		-- TODO: Darkmode VodIcons
-		footer:addElement(VodLink.display{
-			gamenum = index,
-			vod = vod,
-			source = vod.url
-		})
+		if index < 100 then
+			if vods[index + 100] then
+				addVodLink(index, vod, 'Watch Game ' .. index .. ' (part 1)')
+				addVodLink(index, vods[index + 100], 'Watch Game ' .. index .. ' (part 2)')
+			else
+				addVodLink(index, vod, nil)
+			end
+		end
 	end
 
 	if Table.isNotEmpty(match.links) then

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -220,8 +220,8 @@ function CustomMatchSummary.getByMatchId(args)
 
 	local vods = {}
 	if Logic.isNotEmpty(match.links.vod2) then
-		for _, vodpart in ipairs(match.links.vod2) do
-			vods[vodpart[2] + 100] = vodpart[1]
+		for _, vod2 in ipairs(match.links.vod2) do
+			vods[vod2[2] + 100] = vod2[1]
 		end
 	end
 	for index, game in ipairs(match.games) do

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -324,7 +324,7 @@ function CustomMatchSummary._createFooter(match, vods)
 	end
 
 	local function addVodLink(gamenum, vod, htext)
-		if not Logic.isEmpty(vod) then
+		if vod then
 			footer:addElement(VodLink.display{
 				gamenum = gamenum,
 				vod = vod,

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -219,10 +219,12 @@ function CustomMatchSummary.getByMatchId(args)
 	end
 
 	local vods = {}
+	local secondVods = {}
 	if Logic.isNotEmpty(match.links.vod2) then
 		for _, vod2 in ipairs(match.links.vod2) do
-			vods[vod2[2] + 100] = vod2[1]
+			secondVods[vod2[2]] = vod2[1]
 		end
+		match.links.vod2 = nil
 	end
 	for index, game in ipairs(match.games) do
 		if game.vod then
@@ -231,7 +233,7 @@ function CustomMatchSummary.getByMatchId(args)
 	end
 
 	if not Table.isEmpty(vods) or not Table.isEmpty(match.links) or not Logic.isEmpty(match.vod) then
-		matchSummary:footer(CustomMatchSummary._createFooter(match, vods))
+		matchSummary:footer(CustomMatchSummary._createFooter(match, vods, secondVods))
 	end
 
 	return matchSummary:create()
@@ -302,7 +304,7 @@ function CustomMatchSummary._createBody(match)
 	return body
 end
 
-function CustomMatchSummary._createFooter(match, vods)
+function CustomMatchSummary._createFooter(match, vods, secondVods)
 	local footer = MatchSummary.Footer()
 
 	local separator = '<b>·</b>'
@@ -334,22 +336,20 @@ function CustomMatchSummary._createFooter(match, vods)
 	end
 
 	-- Match vod
-	if vods[100] then
+	if secondVods[0] then
 		addVodLink(nil, match.vod, 'Watch VOD ' .. '(part 1)')
-		addVodLink(nil, vods[100], 'Watch VOD ' .. '(part 2)')
+		addVodLink(nil, secondVods[0], 'Watch VOD ' .. '(part 2)')
 	else
 		addVodLink(nil, match.vod, nil)
 	end
 
 	-- Game Vods
 	for index, vod in pairs(vods) do
-		if index < 100 then
-			if vods[index + 100] then
-				addVodLink(index, vod, 'Watch Game ' .. index .. ' (part 1)')
-				addVodLink(index, vods[index + 100], 'Watch Game ' .. index .. ' (part 2)')
-			else
-				addVodLink(index, vod, nil)
-			end
+		if secondVods[index] then
+			addVodLink(index, vod, 'Watch Game ' .. index .. ' (part 1)')
+			addVodLink(index, secondVods[index], 'Watch Game ' .. index .. ' (part 2)')
+		else
+			addVodLink(index, vod, nil)
 		end
 	end
 

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -222,7 +222,8 @@ function CustomMatchSummary.getByMatchId(args)
 	local secondVods = {}
 	if Logic.isNotEmpty(match.links.vod2) then
 		for _, vod2 in ipairs(match.links.vod2) do
-			secondVods[vod2[2]] = vod2[1]
+			local link, gameIndex = unpack(vod2)
+			secondVods[gameIndex] = link
 		end
 		match.links.vod2 = nil
 	end


### PR DESCRIPTION
## Summary

Sometimes a vod doesn't contain the full match/map video, so a parameter to insert a second vod (part 2) is required.

## How did you test this change?
`dev`module and [Sandbox](https://liquipedia.net/counterstrike/User:LuckeLucky/Sandbox/2).

## Required changes
VodLink module should allow to set a custom title even if `gamenum` is numeric, or support some `part` parameter, with the objective to produce a title like `Watch VOD (part X)` or `Watch Game Y (part X)`.
