### PR TITLE
Add Infobox Team for Wild Rift

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_team_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_team_custom.lua
@@ -46,21 +46,16 @@ function CustomTeam:createWidgetInjector()
 end
 
 function CustomTeam:createBottomContent()
-	if not _team.args.disbanded and mw.ext.TeamTemplate.teamexists(_team.pagename) then
-		local teamPage = mw.ext.TeamTemplate.teampage(_team.pagename)
-
+	if not _team.args.disbanded then
 		return Template.expandTemplate(
 			mw.getCurrentFrame(),
-			'Upcoming and ongoing matches of',
-			{team = _team.lpdbname or teamPage}
+			'Upcoming and ongoing matches of'
 		) .. Template.expandTemplate(
 			mw.getCurrentFrame(),
-			'Upcoming and ongoing tournaments of',
-			{team = _team.lpdbname or teamPage}
+			'Upcoming and ongoing tournaments of'
 		) .. Template.expandTemplate(
 			mw.getCurrentFrame(),
-			'Placement summary',
-			{team = _team.lpdbname or teamPage}
+			'Placement summary'
 		)
 	end
 end

--- a/components/infobox/wikis/wildrift/infobox_team_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_team_custom.lua
@@ -6,13 +6,17 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Team = require('Module:Infobox/Team')
-local Variables = require('Module:Variables')
 local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
-local Cell = require('Module:Infobox/Widget/Cell')
-local Injector = require('Module:Infobox/Widget/Injector')
 local Template = require('Module:Template')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
 
 local CustomTeam = Class.new()
 local CustomInjector = Class.new(Injector)

--- a/components/infobox/wikis/wildrift/infobox_team_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_team_custom.lua
@@ -29,11 +29,6 @@ function CustomTeam.run(frame)
 	_team = team
 	_args = _team.args
 
-	-- Automatic org people
-	team.args.coach = Template.expandTemplate(frame, 'Coach of')
-	team.args.manager = Template.expandTemplate(frame, 'Manager of')
-	team.args.captain = Template.expandTemplate(frame, 'Captain of')
-
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
@@ -53,6 +48,10 @@ function CustomTeam:createBottomContent()
 	) .. Template.expandTemplate(
 		mw.getCurrentFrame(),
 		'Upcoming and ongoing tournaments of',
+		{team = _team.name}
+	).. Template.expandTemplate(
+		mw.getCurrentFrame(),
+		'Placement summary',
 		{team = _team.name}
 	)
 end
@@ -76,23 +75,11 @@ function CustomTeam:addToLpdb(lpdbData, args)
 
 	lpdbData.region = Variables.varDefault('region', '')
 
-	if String.isNotEmpty(args.league) then
-		lpdbData.extradata.competesin = string.upper(args.league)
-	end
-
-	lpdbData.coach = Variables.varDefault('coachid') or args.coach or args.coaches
-	lpdbData.manager = Variables.varDefault('managerid') or args.manager
-
 	return lpdbData
 end
 
 function CustomTeam:getWikiCategories(args)
 	local categories = {}
-
-	if String.isNotEmpty(args.league) then
-		local division = string.upper(args.league)
-		table.insert(categories, division .. ' Teams')
-	end
 
 	return categories
 end

--- a/components/infobox/wikis/wildrift/infobox_team_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_team_custom.lua
@@ -41,19 +41,23 @@ function CustomTeam:createWidgetInjector()
 end
 
 function CustomTeam:createBottomContent()
-	return Template.expandTemplate(
-		mw.getCurrentFrame(),
-		'Upcoming and ongoing matches of',
-		{team = _team.name}
-	) .. Template.expandTemplate(
-		mw.getCurrentFrame(),
-		'Upcoming and ongoing tournaments of',
-		{team = _team.name}
-	).. Template.expandTemplate(
-		mw.getCurrentFrame(),
-		'Placement summary',
-		{team = _team.name}
-	)
+	if not _team.args.disbanded and mw.ext.TeamTemplate.teamexists(_team.pagename) then
+		local teamPage = mw.ext.TeamTemplate.teampage(_team.pagename)
+
+		return Template.expandTemplate(
+			mw.getCurrentFrame(),
+			'Upcoming and ongoing matches of',
+			{team = _team.lpdbname or teamPage}
+		) .. Template.expandTemplate(
+			mw.getCurrentFrame(),
+			'Upcoming and ongoing tournaments of',
+			{team = _team.lpdbname or teamPage}
+		) .. Template.expandTemplate(
+			mw.getCurrentFrame(),
+			'Placement summary',
+			{team = _team.lpdbname or teamPage}
+		)
+	end
 end
 
 function CustomInjector:addCustomCells(widgets)
@@ -76,12 +80,6 @@ function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.region = Variables.varDefault('region', '')
 
 	return lpdbData
-end
-
-function CustomTeam:getWikiCategories(args)
-	local categories = {}
-
-	return categories
 end
 
 return CustomTeam

--- a/components/infobox/wikis/wildrift/infobox_team_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_team_custom.lua
@@ -1,0 +1,96 @@
+---
+-- @Liquipedia
+-- wiki=wildrift
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Team = require('Module:Infobox/Team')
+local Variables = require('Module:Variables')
+local Class = require('Module:Class')
+local String = require('Module:StringUtils')
+local Cell = require('Module:Infobox/Widget/Cell')
+local Injector = require('Module:Infobox/Widget/Injector')
+local Template = require('Module:Template')
+
+local CustomTeam = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _team
+
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	_team = team
+	_args = _team.args
+
+	-- Automatic org people
+	team.args.coach = Template.expandTemplate(frame, 'Coach of')
+	team.args.manager = Template.expandTemplate(frame, 'Manager of')
+	team.args.captain = Template.expandTemplate(frame, 'Captain of')
+
+	team.createWidgetInjector = CustomTeam.createWidgetInjector
+	team.createBottomContent = CustomTeam.createBottomContent
+	team.addToLpdb = CustomTeam.addToLpdb
+	team.getWikiCategories = CustomTeam.getWikiCategories
+	return team:createInfobox(frame)
+end
+
+function CustomTeam:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomTeam:createBottomContent()
+	return Template.expandTemplate(
+		mw.getCurrentFrame(),
+		'Upcoming and ongoing matches of',
+		{team = _team.name}
+	) .. Template.expandTemplate(
+		mw.getCurrentFrame(),
+		'Upcoming and ongoing tournaments of',
+		{team = _team.name}
+	)
+end
+
+function CustomInjector:addCustomCells(widgets)
+	local args = _args
+	table.insert(widgets, Cell{
+		name = 'Abbreviation',
+		content = {args.abbreviation}
+	})
+
+	return widgets
+end
+
+function CustomTeam:addToLpdb(lpdbData, args)
+	if not String.isEmpty(args.teamcardimage) then
+		lpdbData.logo = args.teamcardimage
+	elseif not String.isEmpty(args.image) then
+		lpdbData.logo = args.image
+	end
+
+	lpdbData.region = Variables.varDefault('region', '')
+
+	if String.isNotEmpty(args.league) then
+		lpdbData.extradata.competesin = string.upper(args.league)
+	end
+
+	lpdbData.coach = Variables.varDefault('coachid') or args.coach or args.coaches
+	lpdbData.manager = Variables.varDefault('managerid') or args.manager
+
+	return lpdbData
+end
+
+function CustomTeam:getWikiCategories(args)
+	local categories = {}
+
+	if String.isNotEmpty(args.league) then
+		local division = string.upper(args.league)
+		table.insert(categories, division .. ' Teams')
+	end
+
+	return categories
+end
+
+return CustomTeam

--- a/components/infobox/wikis/wildrift/infobox_team_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_team_custom.lua
@@ -29,6 +29,11 @@ function CustomTeam.run(frame)
 	_team = team
 	_args = _team.args
 
+	-- Automatic org people
+	team.args.coach = Template.expandTemplate(frame, 'Coach of')
+	team.args.manager = Template.expandTemplate(frame, 'Manager of')
+	team.args.captain = Template.expandTemplate(frame, 'Captain of')
+
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb


### PR DESCRIPTION
## Summary
Part towards app readiness
_Clean Port of LoL team infobox_ so the coach and manager stuff  remains intact

## How did you test this change?
LIVE

https://liquipedia.net/wildrift/Nova_Esports_(Chinese_Team)
https://liquipedia.net/wildrift/Rex_Regum_Qeon

![image](https://user-images.githubusercontent.com/88981446/191796048-3b400922-ab29-435c-957a-e43936423951.png)

## Side Note
Prize Pool supposed to be first to get PR, however after testing with a /dev template called, the old infobox team loses recognition of earnings, but that was a non-module Team Infobox anyway.

(theres Teams, HDB, Prize and Squad left since standings gonna be using /dota2 anyway)

