### PR TITLE
Add `hasdraw` and `hasovertime` params as standard extradata for standings storage

### DIFF
--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -55,6 +55,8 @@ function StandingsStorage.table(data)
 	local cleanedTitle = title:gsub('<.->.-</.->', '')
 
 	local extradata = {
+		hasdraw = data.hasdraw,
+		hasovertime = data.hasovertime,
 		roundcount = data.roundcount,
 		stagename = data.stagename or Variables.varDefault('bracket_header'),
 	}


### PR DESCRIPTION
## Summary
Add `hasdraw` and `hasovertime` params as standard extradata for standings storage

## How did you test this change?
/dev together with https://liquipedia.net/rainbowsix/Module:GroupTableLeague/sandbox and https://liquipedia.net/commons/Module:GroupTableLeague/next/downstream