### PR TITLE
Check for dev in parent frames

### DIFF
--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -110,7 +110,18 @@ function Lua.invoke(frame)
 	frame.args.module = nil
 	frame.args.fn = nil
 
-	local flags = {dev = Logic.readBoolOrNil(frame.args.dev)}
+	local devEnabled = function(startFrame)
+		local currentFrame = startFrame
+		while currentFrame do
+			if Logic.readBoolOrNil(currentFrame.args.dev) ~= nil then
+				return Logic.readBool(currentFrame.args.dev)
+			end
+			currentFrame = currentFrame:getParent()
+		end
+		return false
+	end
+
+	local flags = {dev = devEnabled(frame)}
 	return require('Module:FeatureFlag').with(flags, function()
 		local module = Lua.import('Module:' .. moduleName, {requireDevIfEnabled = true})
 		return module[fnName](frame)


### PR DESCRIPTION
## Summary

This PR changes automatic pass-through of the `|dev=true` flag through template to modules called by directly or indirectly from that Template.

This allows for replacing
```
{{#vardefine:feature_dev|1}}
{{SomeTemplate|...}}
{{#vardefine:feature_dev|}}
```

with
`{{SomeTemplate|dev=true|...}}`
and achieve the same effect.

## How did you test this change?
Tested with dev module