### PR TITLE
Update parameters for `requireIfExists` and `loadDataIfExists`

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
-local CustomData = Lua.loadDataIfExists('Module:Links/CustomData', {})
+local CustomData = Lua.loadDataIfExists('Module:Links/CustomData') or {}
 
 local Links = {}
 

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -30,19 +30,15 @@ function Lua.moduleExists(name)
 	end
 end
 
-function Lua.requireIfExists(name, default)
+function Lua.requireIfExists(name, options)
 	if Lua.moduleExists(name) then
-		return require(name)
-	else
-		return default
+		return Lua.import(name, options)
 	end
 end
 
-function Lua.loadDataIfExists(name, default)
+function Lua.loadDataIfExists(name)
 	if Lua.moduleExists(name) then
 		return mw.loadData(name)
-	else
-		return default
 	end
 end
 

--- a/standard/region/commons/region.lua
+++ b/standard/region/commons/region.lua
@@ -13,7 +13,7 @@ local String = require('Module:StringUtils')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local regionData = mw.loadData('Module:Region/Data')
-local countryToRegionData = Lua.loadDataIfExists('Module:Region/CountryData', {})
+local countryToRegionData = Lua.loadDataIfExists('Module:Region/CountryData') or {}
 
 local noEntryFoundCategory = '[[Category:Pages using unsupported region values]]'
 


### PR DESCRIPTION
## Summary
For both `requireIfExists` and `loadDataIfExists`, the behavior behind the parameter `default` can be handled with a `or` instead, which is exactly what's done in the clear majority places using this function. 

This PR removes the `default` parameter from both function.

In addition this PR changes the logic of the `requireIfEixsts` from using `require` to `Lua.invoke`. This allows for combination of `requireIfExists` and `requireDevIfEnabled`. To allow for this, Lua.requireIfExists accepts an optional options table.

**Modules needing updating to use `or`:**
* https://liquipedia.net/commons/Module:LuaUtils (done)
* https://liquipedia.net/commons/Module:Head_to_head_match_stages (done)
* https://liquipedia.net/commons/Module:ResultTable/next (done)
* https://liquipedia.net/arenaofvalor/Module:BracketMatchSummary (done)
* https://liquipedia.net/halo/Module:Maps (done)
* https://liquipedia.net/paladins/Module:MatchMaps (done)
* https://liquipedia.net/leagueoflegends/Module:BracketMatchSummary (done)
* https://liquipedia.net/wildrift/Module:BracketMatchSummary (done)
* https://liquipedia.net/counterstrike/Module:Region (done)
* https://liquipedia.net/commons/Module:Region (done)
* https://liquipedia.net/commons/Module:Links (done)

## How did you test this change?
Tested with dev module