### PR TITLE
Infobox League: store `shortname2` in CS custom

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -338,6 +338,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		startdate_raw = Variables.varDefault('raw_sdate', ''),
 		enddate_raw = Variables.varDefault('raw_edate', ''),
 		series2 = mw.ext.TeamLiquidIntegration.resolve_redirect(args.series2 or ''),
+		shortname2 = args.shortname2,
 	}
 
 	return lpdbData


### PR DESCRIPTION
## Summary

Needed for tournament table lists, as with `series2`.

## How did you test this change?

Tested on `dev` on CS wiki.
