### PR TITLE
Handle opponentscore in Bestof 1 (Match Legacy)

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -117,11 +117,13 @@ function MatchLegacy.convertParameters(match2)
 				match.extradata[prefix .. 'rounds'] = '0'
 			elseif opponent.status == 'W' then
 				match[prefix .. 'score'] = math.floor(match2.bestof /2) + 1
-			elseif match.winner == DRAW then
-				match[prefix .. 'score'] = 0
 			else
 				if match2.bestof == 1 then
-					match[prefix .. 'score'] = tonumber(match.winner) == index and 1 or 0
+					if match.winner == DRAW then
+						match[prefix .. 'score'] = 0
+					else
+						match[prefix .. 'score'] = tonumber(match.winner) == index and 1 or 0
+					end
 				else
 					match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 				end

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -113,16 +113,18 @@ function MatchLegacy.convertParameters(match2)
 			match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
 			--When a match is overturned winner get score needed to win bestofx while loser gets score = 0
 			if isOverturned then
-				if tonumber(match.winner) == index then
-					match[prefix .. 'score'] = math.floor(match2.bestof /2) + 1
-				else
-					match[prefix .. 'score'] = 0
-				end
+				match[prefix .. 'score'] = tonumber(match.winner) == index and (math.floor(match2.bestof /2) + 1) or 0
 				match.extradata[prefix .. 'rounds'] = '0'
 			elseif opponent.status == 'W' then
 				match[prefix .. 'score'] = math.floor(match2.bestof /2) + 1
+			elseif match.winner == DRAW then
+				match[prefix .. 'score'] = 0
 			else
-				match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
+				if match2.bestof == 1 then
+					match[prefix .. 'score'] = tonumber(match.winner) == index and 1 or 0
+				else
+					match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
+				end
 			end
 
 			if Table.includes(LOSER_STATUSES, opponent.status) then


### PR DESCRIPTION
## Summary

In match legacy, the `opponentXscore` in a best of 1 is equal to 1 if the opponent is the winner or 0 if it is the loser.

## How did you test this change?

Live
