### PR TITLE
Fix incorrect annotations in Variables and Placement

### DIFF
--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -120,7 +120,7 @@ function Placement.raw(placement)
 end
 
 ---Takes a table of placement numbers and makes them ordinal.
----@param placement table
+---@param placement number[]
 ---@return table
 function Placement._makeOrdinal(placement)
 	return Table.mapValues(placement,
@@ -133,8 +133,7 @@ end
 
 ---Takes parent mw html object and childs a placement.
 ---Expected args fields are `parent` and `placement`.
----@param placement table?
----@return nil
+---@param args table?
 function Placement._placement(args)
 	if not (type(args) == 'table' and type(args.parent) == 'table') then
 		return
@@ -149,7 +148,7 @@ function Placement._placement(args)
 end
 
 ---Converts a placement table into a ordinal string.
----@param placement table
+---@param range number[]
 ---@return string
 function Placement.RangeLabel(range)
 	local ordinal = Placement._makeOrdinal(range)

--- a/standard/variables.lua
+++ b/standard/variables.lua
@@ -11,16 +11,16 @@ local Class = require('Module:Class')
 local Variables = {}
 
 ---Stores a wiki-variable and returns the empty string
----@param name string Key of the wiki-variable
----@param value any? Value of the wiki-variable. Must have a __tostring metamethod.
+---@param name string|number Key of the wiki-variable
+---@param value string|number|nil Value of the wiki-variable
 ---@return string #always the empty string
 function Variables.varDefine(name, value)
 	return mw.ext.VariablesLua.vardefine(name, value)
 end
 
 ---Stores a wiki-variable and returns the stored value
----@param name string Key of the wiki-variable
----@param value any? Value of the wiki-variable. Must have a __tostring metamethod.
+---@param name string|number Key of the wiki-variable
+---@param value string|number|nil Value of the wiki-variable
 ---@return string
 function Variables.varDefineEcho(name, value)
 	return mw.ext.VariablesLua.vardefineecho(name, value)
@@ -28,17 +28,17 @@ end
 
 ---Gets the stored value of a wiki-variable
 ---@generic T
----@param name string Key of the wiki-variable
+---@param name string|number Key of the wiki-variable
 ---@param default T fallback value if wiki-variable is not defined
 ---@return string|T
----@overload fun(name: string):string?
+---@overload fun(name: string|number):string?
 function Variables.varDefault(name, default)
 	local val = mw.ext.VariablesLua.var(name)
 	return (val ~= '' and val ~= nil) and val or default
 end
 
 ---
----@param ... string wiki-variable keys
+---@param ... string|number wiki-variable keys
 ---@return string
 function Variables.varDefaultMulti(...)
 	--pack varargs

--- a/standard/variables.lua
+++ b/standard/variables.lua
@@ -12,7 +12,7 @@ local Variables = {}
 
 ---Stores a wiki-variable and returns the empty string
 ---@param name string Key of the wiki-variable
----@param value string Value of the wiki-variable
+---@param value any? Value of the wiki-variable. Must have a __tostring metamethod.
 ---@return string #always the empty string
 function Variables.varDefine(name, value)
 	return mw.ext.VariablesLua.vardefine(name, value)
@@ -20,7 +20,7 @@ end
 
 ---Stores a wiki-variable and returns the stored value
 ---@param name string Key of the wiki-variable
----@param value string Value of the wiki-variable
+---@param value any? Value of the wiki-variable. Must have a __tostring metamethod.
 ---@return string
 function Variables.varDefineEcho(name, value)
 	return mw.ext.VariablesLua.vardefineecho(name, value)

--- a/standard/variables.lua
+++ b/standard/variables.lua
@@ -10,17 +10,20 @@ local Class = require('Module:Class')
 
 local Variables = {}
 
+---@alias wikiVaribleKey string|number
+---@alias wikiVariableValue string|number|nil
+
 ---Stores a wiki-variable and returns the empty string
----@param name string|number Key of the wiki-variable
----@param value string|number|nil Value of the wiki-variable
+---@param name wikiVaribleKey Key of the wiki-variable
+---@param value wikiVariableValue Value of the wiki-variable
 ---@return string #always the empty string
 function Variables.varDefine(name, value)
 	return mw.ext.VariablesLua.vardefine(name, value)
 end
 
 ---Stores a wiki-variable and returns the stored value
----@param name string|number Key of the wiki-variable
----@param value string|number|nil Value of the wiki-variable
+---@param name wikiVaribleKey Key of the wiki-variable
+---@param value wikiVariableValue Value of the wiki-variable
 ---@return string
 function Variables.varDefineEcho(name, value)
 	return mw.ext.VariablesLua.vardefineecho(name, value)
@@ -28,17 +31,17 @@ end
 
 ---Gets the stored value of a wiki-variable
 ---@generic T
----@param name string|number Key of the wiki-variable
+---@param name wikiVaribleKey Key of the wiki-variable
 ---@param default T fallback value if wiki-variable is not defined
 ---@return string|T
----@overload fun(name: string|number):string?
+---@overload fun(name: wikiVaribleKey):string?
 function Variables.varDefault(name, default)
 	local val = mw.ext.VariablesLua.var(name)
 	return (val ~= '' and val ~= nil) and val or default
 end
 
 ---
----@param ... string|number wiki-variable keys
+---@param ... wikiVaribleKey wiki-variable keys
 ---@return string
 function Variables.varDefaultMulti(...)
 	--pack varargs


### PR DESCRIPTION
## Summary
In placement:
* Fixed two parameter names being incorrect
* Changed two `table` to `number[]` 

In variables:
* Changed from `string` to `any?` for the varDefine methods, as it will accept anything that has a tostring,

## How did you test this change?

Just Annotations
