### PR TITLE
Adjust mvp storage + dependencies for Wild Rift

### DIFF
--- a/components/match2/wikis/wildrift/match_legacy.lua
+++ b/components/match2/wikis/wildrift/match_legacy.lua
@@ -178,7 +178,6 @@ function MatchLegacy.storeMatchSMW(match, match2)
 		'Has teams name=' .. (match.opponent2 or ''),
 		'Has calendar description=- ' .. match.opponent1 .. ' vs ' .. match.opponent2 .. ' on ' .. match.date,
 	}
-	
 	local extradata = Json.parseIfString(match2.extradata) or {}
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
@@ -187,7 +186,6 @@ function MatchLegacy.storeMatchSMW(match, match2)
 			table.insert(data, 'Has mvp ' .. index .. '=' .. mvpString)
 		end
 	end
-	
 	local streams = match.stream or {}
 	streams = Json.parseIfString(streams)
 	for key, item in pairs(streams) do
@@ -197,31 +195,11 @@ function MatchLegacy.storeMatchSMW(match, match2)
 		)
 	end
 
-	local extradata = match.extradata or {}
-	extradata = Json.parseIfString(extradata)
 	for key, item in pairs(extradata) do
 		if String.startsWith(key, 'vodgame') then
 			table.insert(
 				data,
 				'Has match ' .. key .. '=' .. item
-			)
-		end
-	end
-
-	local mvpTable = mw.text.split(extradata.mvp or '', ',')
-	local mvpTeamsTable = mw.text.split(extradata.mvpteam or '', ',')
-	if String.isNotEmpty(mvpTable[1]) then
-		for key, item in pairs(mvpTable) do
-			local mvp = mw.text.trim(item)
-			local mvpTeam = mw.text.trim(mvpTeamsTable[key] or '')
-			if Logic.isNumeric(mvpTeam) then
-				mvpTeam = match['opponent' .. mvpTeam]
-			else
-				mvpTeam = mvpTeam or ''
-			end
-			table.insert(
-				data,
-				'Has mvp ' .. key .. '=' .. mvp .. '§§§§' .. mvpTeam .. '§§§§0'
 			)
 		end
 	end

--- a/components/match2/wikis/wildrift/match_legacy.lua
+++ b/components/match2/wikis/wildrift/match_legacy.lua
@@ -25,7 +25,7 @@ function MatchLegacy.storeMatch(match2, options)
 		match.games = MatchLegacy.storeGames(match, match2)
 
 		return mw.ext.LiquipediaDB.lpdb_match(
-			"legacymatch_" .. match2.match2id,
+			'legacymatch_' .. match2.match2id,
 			match
 		)
 	end
@@ -52,7 +52,15 @@ function MatchLegacy._convertParameters(match2)
 	local extradata = Json.parseIfString(match2.extradata)
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.mvpteam = extradata.mvpteam
-	match.extradata.mvp = extradata.mvp
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
 	match.extradata.comment = extradata.comment
 
 	local opponents = match2.match2opponents or {}
@@ -170,7 +178,16 @@ function MatchLegacy.storeMatchSMW(match, match2)
 		'Has teams name=' .. (match.opponent2 or ''),
 		'Has calendar description=- ' .. match.opponent1 .. ' vs ' .. match.opponent2 .. ' on ' .. match.date,
 	}
-
+	
+	local extradata = Json.parseIfString(match2.extradata) or {}
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		for index, player in ipairs(mvp.players) do
+			local mvpString = player.name .. '§§§§'.. (player.team or '') ..'§§§§0'
+			table.insert(data, 'Has mvp ' .. index .. '=' .. mvpString)
+		end
+	end
+	
 	local streams = match.stream or {}
 	streams = Json.parseIfString(streams)
 	for key, item in pairs(streams) do

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -140,20 +140,14 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	local mvpInput = match.extradata.mvp
-	if mvpInput then
-		local mvpData = mw.text.split(mvpInput or '', ',')
-		if String.isNotEmpty(mvpData[1]) then
-			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData) do
-				if String.isNotEmpty(player) then
-					mvp:addPlayer(player)
-				end
-			end
-
-			body:addRow(mvp)
+	local mvpData = match.extradata.mvp
+	if mvpData and mvpData.players and mvpData.players[1]  then
+		local mvp = MatchSummary.Mvp()
+		for _, player in ipairs(mvpData.players) do
+			mvp:addPlayer(player)
 		end
 
+		body:addRow(mvp)
 	end
 
 	-- Pre-Process Champion Ban Data


### PR DESCRIPTION
## Summary
This is to allow new Match2 MVP Table to be working (it does not before)

## How did you test this change?
/dev https://liquipedia.net/wildrift/User:Hesketh2/MVP

Tournament with Dev enabled https://liquipedia.net/wildrift/Icons_Global_Championship/2022/Knockout_Stage

## Side Note
summary and matchgroup will be include in same PR