### PR TITLE
Changes to single match display

### DIFF
--- a/components/match2/commons/match_group_display_singlematch.lua
+++ b/components/match2/commons/match_group_display_singlematch.lua
@@ -71,20 +71,15 @@ function SingleMatchDisplay.SingleMatch(props)
 		width = propsConfig.width or 400,
 	}
 
-	local singleMatchNode = mw.html.create('div'):addClass('brkts-popup brkts-match-info-popup')
-		:css('overflow', 'hidden')
-		:css('position', 'unset')
-		:css('max-height', 'unset')
-		:css('width', config.width .. 'px')
-
 	local matchNode = SingleMatchDisplay.Match{
 		MatchSummaryContainer = config.MatchSummaryContainer,
 		match = props.match,
 	}
 
-	singleMatchNode:node(matchNode:css('width', config.width .. 'px'))
+	matchNode:addClass('brkts-popup brkts-match-info-flat')
+		:css('width', config.width .. 'px')
 
-	return singleMatchNode
+	return matchNode
 end
 
 SingleMatchDisplay.propTypes.Match = {


### PR DESCRIPTION
## Summary

As was discussed a while back, It didn't make sense to display single matches (showmatches) as popups with shadows and stuff. This addresses that by changing the display to match bracket flat aesthetic. Also, it fixes an issue where there were two `brkts-popup` divs with one inside the other which is not the case with normal popups and was redundant.

![image](https://user-images.githubusercontent.com/5881994/192408219-b4f7d517-8947-499e-9e3d-13248e9799fd.png)

A new CSS class was created to move the display changes to it:
```css
.brkts-match-info-flat {
	border: 1px solid #aaaaaa;
	border-radius: 2px;
	position: static;
	overflow: hidden;
}
```

## How did you test this change?

Tested using `/dev` module on commons and CSS is live (although needs some for cache to expire).

Old aesthetic:
![image](https://user-images.githubusercontent.com/5881994/192408381-08f43979-bd1b-4a76-bd3a-0a3633fa091e.png)


New aesthetic:
![image](https://user-images.githubusercontent.com/5881994/192408334-b5c461b4-8571-4f13-96b9-79f29b47d06a.png)
