### PR TITLE
Fix Halo's MatchSummary for Teams

### DIFF
--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -32,15 +32,12 @@ function CustomMatchSummary.getByMatchId(args)
 		:css('flex-wrap', 'unset') -- temporary workaround
 
 	local function renderOpponent(opponentIndex)
-		return OpponentDisplay.BlockOpponent({
+		return OpponentDisplay.BlockOpponent{
 			flip = opponentIndex == 1,
 			opponent = match.opponents[opponentIndex],
 			overflow = 'ellipsis',
 			teamStyle = 'short',
-		})
-			:addClass(match.opponents[opponentIndex].type ~= 'solo'
-				and 'brkts-popup-header-opponent'
-				or 'brkts-popup-header-opponent-solo-with-team')
+		}
 	end
 
 	local function renderSoloOpponentTeam(opponentIndex)
@@ -58,10 +55,19 @@ function CustomMatchSummary.getByMatchId(args)
 	end
 
 	-- header
+	local leftOpponent = mw.html.create('div')
+			:addClass('brkts-popup-header-opponent')
+			:addClass('brkts-popup-header-opponent-left')
+			:node(renderOpponent(1))
+	local rightOpponent = mw.html.create('div')
+			:addClass('brkts-popup-header-opponent')
+			:addClass('brkts-popup-header-opponent-right')
+			:node(renderOpponent(2))
+
 	local header = htmlCreate('div'):addClass('brkts-popup-header-dev')
 		:node(renderSoloOpponentTeam(1))
-		:node(renderOpponent(1))
-		:node(renderOpponent(2))
+		:node(leftOpponent)
+		:node(rightOpponent)
 		:node(renderSoloOpponentTeam(2))
 	wrapper:node(header):node(CustomMatchSummary._breakNode())
 


### PR DESCRIPTION
## Summary
Currently the team's in Halo's match summary are significantly misaligned.
![image](https://user-images.githubusercontent.com/3426850/192482544-add8fb5c-ac20-4ea0-989d-18da0dff0d9e.png)
This PR resolves this issue.
Any potential issue with Solo's are Out of Scope for this PR.

## How did you test this change?

Live
![image](https://user-images.githubusercontent.com/3426850/192482408-0cffee9c-898a-4017-aa27-1dfabe45d7aa.png)
