### PR TITLE
Table.isEmpty() refactor

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -70,7 +70,7 @@ function Table.isEmpty(tbl)
 	if not tbl then
 		return true
 	end
-	return not next(tbl) and true or false
+	return not next(tbl)
 end
 
 ---Return true if table is neither empty nor nil

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -70,7 +70,7 @@ function Table.isEmpty(tbl)
 	if not tbl then
 		return true
 	end
-	return next(tbl) and false or true
+	return not next(tbl) and true or false
 end
 
 ---Return true if table is neither empty nor nil

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -70,7 +70,7 @@ function Table.isEmpty(tbl)
 	if not tbl then
 		return true
 	end
-	return next(tbl) and true or false
+	return next(tbl) and false or true
 end
 
 ---Return true if table is neither empty nor nil

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -67,16 +67,10 @@ end
 ---@param tbl table?
 ---@return boolean
 function Table.isEmpty(tbl)
-	if tbl == nil then
+	if not tbl then
 		return true
 	end
-	-- luacheck: push ignore
-	--it is intended that the loop is executed at most once
-	for _, _ in pairs(tbl) do
-		return false
-	end
-	-- luacheck: pop
-	return true
+	return next(tbl) and true or false
 end
 
 ---Return true if table is neither empty nor nil

--- a/standard/test/table_test.lua
+++ b/standard/test/table_test.lua
@@ -1,0 +1,36 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Table/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local Table = Lua.import('Module:Table', {requireDevIfEnabled = true})
+
+local suite = ScribuntoUnit:new()
+
+function suite:testSize()
+	self:assertEquals(Table.size({1,3,6}), 3)
+	self:assertEquals(Table.size({1}), 1)
+	self:assertEquals(Table.size({}), 0)
+end
+
+function suite:testIsEmpty()
+	self:assertEquals(Table.isEmpty({1,3,6}), false)
+	self:assertEquals(Table.isEmpty({1}), false)
+	self:assertEquals(Table.isEmpty({}), true)
+	self:assertEquals(Table.isEmpty(), true)
+end
+
+function suite:testIsNotEmpty()
+	self:assertEquals(Table.isNotEmpty({1,3,6}), true)
+	self:assertEquals(Table.isNotEmpty({1}), true)
+	self:assertEquals(Table.isNotEmpty({}), false)
+	self:assertEquals(Table.isNotEmpty(), false)
+end
+
+return suite


### PR DESCRIPTION
## Summary
Improve the logic of `Table.isEmpty(tbl)` so we no longer need the luacheck ignore.

## How did you test this change?
Test cases:
https://liquipedia.net/commons/Module_talk:Table/testcases
