### PR TITLE
Silence the `rm` error in deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -127,4 +127,4 @@ do
   fi
 done
 
-rm cookie_*
+rm -f cookie_*


### PR DESCRIPTION
## Summary
After the change in #1945, if there are no changes to any dev wikis committed to main, the dev job will error (https://github.com/Liquipedia/Lua-Modules/actions/runs/3135441022/jobs/5091113088#step:4:15 ) on the `rm cookie_*` due to no cookies have been created. Providing `-f` should silence any such error.

```
 -f          Attempt to remove the files without prompting for confirma-
             tion, regardless of the file's permissions.  If the file does
             not exist, do not display a diagnostic message or modify the
             exit status to reflect an error.  The -f option overrides any
             previous -i options.
```

## How did you test this change?
Tested by Martin https://github.com/iMarbot/Lua-Modules/actions/runs/3135538041/jobs/5091332865