### PR TITLE
Fix OW prize pool deploy

### DIFF
--- a/components/prize_pool/wikis/overwatch/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/overwatch/prize_pool_custom.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=Overwatch
+-- wiki=overwatch
 -- page=Module:PrizePool/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute


### PR DESCRIPTION
## Summary

`Overwatch` should be lowercase `overwatch` :p 

![image](https://user-images.githubusercontent.com/5881994/192543880-b526225e-4580-4d90-9aeb-215ea94c84f0.png)


## How did you test this change?

I didn't but surely it will be fine.
