### PR TITLE
Store Opponent Structure in PrizePool

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -343,7 +343,7 @@ function Placement:_getLpdbData(...)
 			-- lastvs match2 opponent (json?)
 		}
 
-		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(opponent))
+		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(opponent.opponentData))
 
 		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
 

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -323,7 +323,6 @@ function Placement:_getLpdbData(...)
 			participantflag = opponentType == Opponent.solo and players.p1flag or nil,
 			participanttemplate = opponent.opponentData.template,
 			opponentindex = opponentIndex, -- Needed in SMW
-			opponenttype = opponentType,
 			players = players,
 			placement = self:_lpdbValue(),
 			prizemoney = prizeMoney,

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -338,13 +338,13 @@ function Placement:_getLpdbData(...)
 									and Opponent.toName{template = players.p1team, type = 'team'}
 									or nil,
 			}
-
 			-- TODO: We need to create additional LPDB Fields
-			-- match2 opponents (opponentname, opponenttemplate, opponentplayers, opponenttype)
 			-- Qualified To struct (json?)
 			-- Points struct (json?)
 			-- lastvs match2 opponent (json?)
 		}
+
+		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(opponent))
 
 		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
 


### PR DESCRIPTION
## Summary
Store the opponent structure (`opponentname`, `opponenttemplate`, `opponenttype` and `opponentplayers`) into Placements.

## How did you test this change?
dev module
![image](https://user-images.githubusercontent.com/3426850/192776144-67a2065f-b7b2-4402-b66f-a9acc4981289.png)
![image](https://user-images.githubusercontent.com/3426850/192776168-359e9a58-7942-4b65-89ac-7f77df483a37.png)
![image](https://user-images.githubusercontent.com/3426850/192776187-611795f7-6bfb-404c-b3f2-4ee68c59db7e.png)

