### PR TITLE
Fix another `placement.lua` annotation issue

### DIFF
--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -160,7 +160,7 @@ end
 
 ---Takes string place value and returns prize pool color class.
 ---May return `nil` if no color is registered.
----@param placement string
+---@param placement string|number
 ---@return string?
 function Placement.getBgClass(placement)
 	return prizepoolClasses[placement]


### PR DESCRIPTION
## Summary
This function should accept both integers and strings. Since integers are not in native lua until 5.3 (and we're using modified 5.1), let's do number instead.

## How did you test this change?
In VSCode