### PR TITLE
Migrate uses of deprecated `Localisation.getLocalisation`

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -492,7 +492,7 @@ function League:_createLocation(args)
 	local currentLocation = args['city'] or args['location']
 
 	while not String.isEmpty(current) do
-		local nationality = Localisation.getLocalisation({displayNoError = true}, current)
+		local nationality = Flags.getLocalisation(current)
 
 		if String.isEmpty(nationality) then
 			content = content .. '[[Category:Unrecognised Country|' .. current .. ']]'

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -401,7 +401,7 @@ function Person:_createLocation(country, location, personType)
 		return nil
 	end
 	local countryDisplay = Flags.CountryName(country)
-	local demonym = Localisation.getLocalisation(countryDisplay)
+	local demonym = Flags.getLocalisation(countryDisplay) or ''
 
 	local category = ''
 	if Namespace.isMain() then

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -20,7 +20,6 @@ local AgeCalculation = Lua.import('Module:AgeCalculation', {requireDevIfEnabled 
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
 local Earnings = Lua.import('Module:Earnings', {requireDevIfEnabled = true})
 local Links = Lua.import('Module:Links', {requireDevIfEnabled = true})
-local Localisation = Lua.import('Module:Localisation', {requireDevIfEnabled = true})
 local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
 local Region = Lua.import('Module:Region', {requireDevIfEnabled = true})
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -15,7 +15,6 @@ local Variables = require('Module:Variables')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
 local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
-local Localisation = Lua.import('Module:Localisation', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -84,9 +83,9 @@ function Scene:createNameDisplay(args)
 	local name = args.name
 	local country = Flags.CountryName(args.country or args.scene)
 	if not name then
-		local localised = Localisation.getLocalisation(country)
+		local localised, errorText = Flags.getLocalisation(country)
 		local flag = Flags.Icon({flag = country, shouldLink = true})
-		name = flag .. '&nbsp;' .. localised .. ((' ' .. args.gamenamedisplay) or '') .. ' scene'
+		name = flag .. '&nbsp;' .. (localised or errorText) .. ((' ' .. args.gamenamedisplay) or '') .. ' scene'
 	end
 
 	Variables.varDefine('country', country)

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -20,7 +20,6 @@ local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
 local LeagueIcon = Lua.import('Module:LeagueIcon', {requireDevIfEnabled = true})
 local Links = Lua.import('Module:Links', {requireDevIfEnabled = true})
 local Locale = Lua.import('Module:Locale', {requireDevIfEnabled = true})
-local Localisation = Lua.import('Module:Localisation', {requireDevIfEnabled = true})
 local ReferenceCleaner = Lua.import('Module:ReferenceCleaner', {requireDevIfEnabled = true})
 
 local _TIER_MODE_TYPES = 'types'
@@ -383,12 +382,12 @@ function Series:_createOrganizers(args)
 end
 
 function Series:_setCountryCategories(country)
-	if country == nil or country == '' then
+	if String.isEmpty(country) then
 		return ''
 	end
 
-	local countryAdjective = Localisation.getLocalisation({ shouldReturnSimpleError = true }, country)
-	if countryAdjective == 'error' then
+	local countryAdjective = Flags.getLocalisation(country)
+	if not countryAdjective then
 		return 'Unrecognised Country||' .. country
 	end
 

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -20,7 +20,6 @@ local Earnings = Lua.import('Module:Earnings', {requireDevIfEnabled = true})
 local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
 local Links = Lua.import('Module:Links', {requireDevIfEnabled = true})
 local Locale = Lua.import('Module:Locale', {requireDevIfEnabled = true})
-local Localisation = Lua.import('Module:Localisation', {requireDevIfEnabled = true})
 local ReferenceCleaner = Lua.import('Module:ReferenceCleaner', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -202,7 +201,7 @@ function Team:_createLocation(location)
 	local locationDisplay = self:getStandardLocationValue(location)
 	local demonym
 	if String.isNotEmpty(locationDisplay) then
-		demonym = Localisation.getLocalisation(locationDisplay)
+		demonym = Flags.getLocalisation(locationDisplay)
 		locationDisplay = '[[:Category:' .. locationDisplay
 			.. '|' .. locationDisplay .. ']]'
 	end

--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -8,7 +8,7 @@
 
 local String = require('Module:StringUtils')
 local Date = require('Module:Date/Ext')
-local Localisation = require('Module:Localisation')
+local Flags = require('Module:Flags')
 local Games = mw.loadData('Module:Games')
 local Variables = require('Module:Variables')
 local StringUtils = require('Module:StringUtils')
@@ -31,7 +31,7 @@ function MetadataGenerator.tournament(args)
 	local name = not String.isEmpty(args.name) and (args.name):gsub('&nbsp;', ' ') or mw.title.getCurrentTitle().text
 
 	local tournamentType = args.type
-	local locality = Localisation.getLocalisation({displayNoError = true}, args.country)
+	local locality = Flags.getLocalisation(args.country)
 
 	local organizers = {
 		args['organizer-name'] or args.organizer,

--- a/components/infobox/extensions/test/metadata_generator_test.lua
+++ b/components/infobox/extensions/test/metadata_generator_test.lua
@@ -6,14 +6,16 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local MetadataGenerator = require('Module:MetadataGenerator')
-local Arguments = require('Module:Arguments')
+local Lua = require('Module:Lua')
 local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local Arguments = require('Module:Arguments')
+local MetadataGenerator = Lua.import('Module:MetadataGenerator', {requireDevIfEnabled = true})
 
 local suite = ScribuntoUnit:new()
 
 local _EXPECTED_RESULT = 'Intel Extreme Masters XVI - Cologne is an offline German tournament organized by ESL.' ..
-	' This [[Template:TierDisplay]] tournament took place from Jul 06 to Jul 18 2021 featuring 24 teams competing' ..
+	' This Unknown Tier tournament took place from Jul 06 to 18 2021 featuring 24 teams competing' ..
 	' over a total prize pool of $1,000,000 USD.'
 
 function suite:testGenerator()

--- a/components/infobox/wikis/dota2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_player_custom.lua
@@ -19,7 +19,6 @@ local Variables = require('Module:Variables')
 local YearsActive = require('Module:YearsActive')
 
 local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
-local Localisation = Lua.import('Module:Localisation', {requireDevIfEnabled = true})
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
 
@@ -241,7 +240,7 @@ function CustomPlayer._createLocation(country)
 		return nil
 	end
 	local countryDisplay = Flags.CountryName(country)
-	local demonym = Localisation.getLocalisation(countryDisplay)
+	local demonym = Flags.getLocalisation(countryDisplay) or ''
 	countryDisplay = '[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]'
 
 	local roleCategory = _ROLES_CATEGORY[_args.role or ''] or 'Players'

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -11,7 +11,6 @@ local Flags = require('Module:Flags')
 local Lua = require('Module:Lua')
 local Matches = require('Module:Matches_Player')
 local Namespace = require('Module:Namespace')
-local Localisation = require('Module:Localisation')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
@@ -295,7 +294,7 @@ function CustomPlayer:_createLocation(country)
 		return nil
 	end
 	local countryDisplay = Flags.CountryName(country)
-	local demonym = Localisation.getLocalisation(countryDisplay)
+	local demonym = Flags.getLocalisation(countryDisplay) or ''
 
 	return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' ..
 				'[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]'

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -12,11 +12,11 @@ local AllowedServers = require('Module:Server')
 local Autopatch = require('Module:Automated Patch')
 local Class = require('Module:Class')
 local Currency = require('Module:Currency')
+local Flags = require('Module:Flags')
 local Json = require('Module:Json')
 local LeagueIcon = require('Module:LeagueIcon')
 local Links = require('Module:Links')
 local Locale = require('Module:Locale')
-local Localisation = require('Module:Localisation')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')
 local String = require('Module:StringUtils')
@@ -122,7 +122,7 @@ function HiddenInfoboxLeague._getCountryCategories()
 	local current = _args.country
 
 	while not String.isEmpty(current) do
-		local nationality = Localisation.getLocalisation({displayNoError = true}, current)
+		local nationality = Flags.getLocalisation(current)
 
 		if String.isEmpty(nationality) then
 			table.insert(countryCategories, 'Unrecognised Country')


### PR DESCRIPTION
## Summary
Localisation.getLocalisation was deprecated in favor of Flags.getLocalisation in #1058.

This PR removes all uses of `Localisation.getLocalisation` in favor of `Flags.getLocalisation`. Since the parameters and return values are slightly different, some logic around has been changed (eg ` or ''` where necessary).

None-git modules have already been changed.

## How did you test this change?
Dev modules.

Metadata generator tested here https://liquipedia.net/commons/Module_talk:MetadataGenerator/testcases
Rest of random pages that use it