### PR TITLE
Remove unused & deprecated `Localisation.getLocalisation`

### DIFF
--- a/standard/localisation.lua
+++ b/standard/localisation.lua
@@ -7,9 +7,9 @@
 --
 
 local Class = require('Module:Class')
-local Localisation = {}
 local String = require('Module:StringUtils')
-local Logic = require('Module:Logic')
+
+local Localisation = {}
 
 function Localisation.getCountryName(country, noentry)
 	local data = mw.loadData('Module:Localisation/data/country')
@@ -33,51 +33,6 @@ function Localisation.getCountryName(country, noentry)
 	end
 
 	return countryname
-end
-
--- use Module:Flags instead
----@deprecated
-function Localisation.getLocalisation(options, country)
-	--in case no options are entered the country is the first var
-	--so we need to adjust for that
-	--in that case it will be a string so we catch it via this
-	--it also catches cases where country and options are switched
-	if type(options) == 'string' then
-		local tempForSwitch = country
-		country = options
-		options = tempForSwitch
-	end
-
-	--avoid indexing nil
-	options = options or {}
-
-	local displayNoError = Logic.readBool(options.displayNoError)
-	local shouldReturnSimpleError = Logic.readBool(options.shouldReturnSimpleError)
-
-	local dataModuleName = 'Module:Localisation/data/localised'
-	local data = mw.loadData(dataModuleName)
-
-	-- clean the entered country value
-	country = Localisation._cleanCountry(country)
-
-	-- First try to look it up
-	local localised = data[country]
-
-	-- Return message if none is found
-	if localised == nil then
-		mw.log('No country found in ' .. dataModuleName .. ': ' .. country)
-		-- set category unless second argument is set
-		if displayNoError then
-			localised = ''
-		elseif shouldReturnSimpleError then
-			localised = 'error'
-		else
-			localised = 'Unknown country "[[lpcommons:' .. dataModuleName ..
-				'|' .. country .. ']][[Category:Pages with unknown countries]]'
-		end
-	end
-
-	return localised
 end
 
 function Localisation._cleanCountry(country)


### PR DESCRIPTION
## Summary
Once #1968 is merged, this function will be unused.

## How did you test this change?
Checked twice with Wiki-wide search & github search that this function is unused (After merge of #1968)
