### PR TITLE
Lua.lua: Fix return value of `devEnabled`. It should have been `nil` not `false` as default

### DIFF
--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -114,7 +114,6 @@ function Lua.invoke(frame)
 			end
 			currentFrame = currentFrame:getParent()
 		end
-		return false
 	end
 
 	local flags = {dev = devEnabled(frame)}


### PR DESCRIPTION
## Summary
#1943 had the wrong return value in the inner function `devEnabled`. It should return `nil`, not `false` if the parameter is not found.

Test case should be created for to avoid it appending again. 
## How did you test this change?
dev module by hjp