### PR TITLE
Do not set lastVs if no lastVs is retrieved

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -429,10 +429,12 @@ function Import._entryToOpponent(lpdbEntry, placement)
 		lastVsScore = (score or '') .. '-' .. (vsScore or '')
 	end
 
+	local lastVs = additionalData.lastVs or Import._checkIfParsed(Import._removeTbdIdentifiers(lpdbEntry.vsOpponent))
+
 	return placement:_parseOpponents{{
 		Import._checkIfParsed(Import._removeTbdIdentifiers(lpdbEntry.opponent)),
 		wdl = (not lpdbEntry.needsLastVs) and Import._formatGroupScore(lpdbEntry) or nil,
-		lastvs = {additionalData.lastVs or Import._checkIfParsed(Import._removeTbdIdentifiers(lpdbEntry.vsOpponent))},
+		lastvs = Table.isNotEmpty(lastVs) and {lastVs} or nil,
 		lastvsscore = additionalData.score or lastVsScore,
 		date = lpdbEntry.date,
 	}}[1]


### PR DESCRIPTION
## Summary
Do not set lastVs if no lastVs is retrieved.
If we give the empty table in lastvs to `placement:_parseOpponents` it will think it is an tbd opponent
To avoid that add an IsEmpty check on the lastVs table and set lastvs as nil if lastVs is empty

## How did you test this change?
live (module not in use yet)