### PR TITLE
Deprecated `Localisation.getCountryName`

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -498,7 +498,7 @@ function League:_createLocation(args)
 			content = content .. '[[Category:Unrecognised Country|' .. current .. ']]'
 
 		else
-			local countryName = Localisation.getCountryName(current)
+			local countryName = Flags.getCountryName(current)
 			local displayText = currentLocation or countryName
 			if displayText == '' then
 				displayText = current

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -497,7 +497,7 @@ function League:_createLocation(args)
 			content = content .. '[[Category:Unrecognised Country|' .. current .. ']]'
 
 		else
-			local countryName = Flags.getCountryName(current)
+			local countryName = Flags.CountryName(current)
 			local displayText = currentLocation or countryName
 			if displayText == '' then
 				displayText = current

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -24,7 +24,6 @@ local InfoboxPrizePool = Lua.import('Module:Infobox/Extensions/PrizePool', {requ
 local LeagueIcon = Lua.import('Module:LeagueIcon', {requireDevIfEnabled = true})
 local Links = Lua.import('Module:Links', {requireDevIfEnabled = true})
 local Locale = Lua.import('Module:Locale', {requireDevIfEnabled = true})
-local Localisation = Lua.import('Module:Localisation', {requireDevIfEnabled = true})
 local MetadataGenerator = Lua.import('Module:MetadataGenerator', {requireDevIfEnabled = true})
 local ReferenceCleaner = Lua.import('Module:ReferenceCleaner', {requireDevIfEnabled = true})
 local TextSanitizer = Lua.import('Module:TextSanitizer', {requireDevIfEnabled = true})

--- a/standard/localisation.lua
+++ b/standard/localisation.lua
@@ -11,6 +11,7 @@ local String = require('Module:StringUtils')
 
 local Localisation = {}
 
+---@deprecated
 function Localisation.getCountryName(country, noentry)
 	local data = mw.loadData('Module:Localisation/data/country')
 


### PR DESCRIPTION
## Summary
Deprecated `Localisation.getCountryName` and remove github uses of it. It's still widely used on none-git modules.

## How did you test this change?
Dev module
