### PR TITLE
Use prizepoolusd if set

### DIFF
--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -109,7 +109,7 @@ function PrizePoolCurrency._exchange(props)
 		return prizepool, prizepoolUsd, currencyRate, errorMessage
 	end
 
-	if Logic.isNumeric(prizepool) and currencyRate ~= math.huge then
+	if Logic.isNumeric(prizepool) and currencyRate ~= math.huge and not Logic.isNumeric(prizepoolUsd) then
 		prizepoolUsd = tonumber(prizepool) * currencyRate
 	end
 


### PR DESCRIPTION
## Summary
If both `|prizepool=` (+ `|currency=`) and `|prizepoolusd=` is set, don't auto convert from local currency to USD, use the manual input.
## How did you test this change?
dev module