### PR TITLE
hltv is always at www.hltv.org

### DIFF
--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -201,7 +201,7 @@ return {
 	{
 		name = 'hltvlegacy',
 		icon = 'HLTV icon.png',
-		prefixLink = 'https://hltv.org/legacy/match/',
+		prefixLink = 'https://www.hltv.org/legacy/match/',
 		label = 'HLTV Matchpage',
 		stats = {'legacystats'}
 	},
@@ -215,7 +215,7 @@ return {
 	{
 		name = 'hltv',
 		icon = 'HLTV icon.png',
-		prefixLink = 'https://hltv.org/matches/',
+		prefixLink = 'https://www.hltv.org/matches/',
 		suffixLink = '/match',
 		label = 'HLTV Matchpage',
 		max = 2,


### PR DESCRIPTION
## Summary
Updating the link so it's one less redirect

## How did you test this change?
Went to the HLTV website and saw it redirected me
