### PR TITLE
Adjust Featured match

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -391,7 +391,7 @@ function matchFunctions.getEarnings(name, year)
 		return 0
 	end
 
-	return tonumber(EarningsOf._team(name, {sdate = year .. '-01-01', edate = year .. '-12-31'}))
+	return tonumber(EarningsOf._team(name, {sdate = (year-1) .. '-01-01', edate = year .. '-12-31'}))
 end
 
 function matchFunctions.isFeatured(match)

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -27,7 +27,8 @@ local MAX_NUM_PLAYERS = 10
 local MAX_NUM_MAPS = 9
 local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
 
-local FEATURED_TIERS = {'S-Tier', 'A-Tier'}
+local S_TIER = 1
+local A_TIER = 2
 local MIN_EARNINGS_FOR_FEATURED = 200000
 
 local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
@@ -394,7 +395,10 @@ function matchFunctions.getEarnings(name, year)
 end
 
 function matchFunctions.isFeatured(match)
-	if Table.includes(FEATURED_TIERS, match.liquipediatier) then
+	if
+		tonumber(match.liquipediatier or '') == S_TIER
+		or tonumber(match.liquipediatier or '') == A_TIER
+	then
 		return true
 	end
 	if Logic.isNotEmpty(match.publishertier) then

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -27,8 +27,7 @@ local MAX_NUM_PLAYERS = 10
 local MAX_NUM_MAPS = 9
 local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
 
-local S_TIER = 1
-local A_TIER = 2
+local FEATURED_TIERS = {1, 2}
 local MIN_EARNINGS_FOR_FEATURED = 200000
 
 local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
@@ -395,10 +394,7 @@ function matchFunctions.getEarnings(name, year)
 end
 
 function matchFunctions.isFeatured(match)
-	if
-		tonumber(match.liquipediatier or '') == S_TIER
-		or tonumber(match.liquipediatier or '') == A_TIER
-	then
+	if Table.includes(FEATURED_TIERS, tonumber(match.liquipediatier)) then
 		return true
 	end
 	if Logic.isNotEmpty(match.publishertier) then


### PR DESCRIPTION
## Summary

match.liquipediatier is a number and was being compared agains string tier.
Earnings year also adjusted to retrieve earning from 2 years.

## How did you test this change?

Live
