### PR TITLE
Allow penalty as param in sc/sc2 opponents in match2

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -295,7 +295,7 @@ function StarcraftMatchGroupInput._matchWinnerProcessing(match)
 				end
 			else
 				opponent.status = 'S'
-				opponent.score = tonumber(opponent.score or '') or
+				opponent.score = tonumber(opponent.score) or
 					tonumber(opponent.sumscore) or -1
 				if opponent.score > bestof / 2 then
 					match.finished = Logic.emptyOr(match.finished, 'true')
@@ -470,7 +470,7 @@ function StarcraftMatchGroupInput._opponentInput(match)
 
 		--set initial opponent sumscore
 		opponent.sumscore =
-			tonumber(opponent.extradata.advantage) or tonumber('-' .. (opponent.extradata.penalty or '')) or ''
+			tonumber(opponent.extradata.advantage) or tonumber('-' .. (opponent.extradata.penalty or ''))
 
 		local mode = _OPPONENT_MODE_TO_PARTIAL_MATCH_MODE[opponent.type]
 		if mode == '2' and Logic.readBool(opponent.extradata.isarchon) then

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -434,6 +434,7 @@ function StarcraftMatchGroupInput._opponentInput(match)
 		-- Sort out extradata
 		opponent.extradata = {
 			advantage = opponent.advantage,
+			penalty = opponent.penalty,
 			score2 = opponent.score2,
 			isarchon = opponent.isarchon
 		}
@@ -469,7 +470,7 @@ function StarcraftMatchGroupInput._opponentInput(match)
 
 		--set initial opponent sumscore
 		opponent.sumscore =
-			tonumber(opponent.extradata.advantage or '') or ''
+			tonumber(opponent.extradata.advantage) or tonumber('-' .. (opponent.extradata.penalty or '')) or ''
 
 		local mode = _OPPONENT_MODE_TO_PARTIAL_MATCH_MODE[opponent.type]
 		if mode == '2' and Logic.readBool(opponent.extradata.isarchon) then

--- a/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -284,6 +284,11 @@ function StarcraftOpponentDisplay.InlineScore(opponent)
 			local title = 'Advantage of ' .. advantage .. ' game' .. (advantage > 1 and 's' or '')
 			return '<abbr title="' .. title .. '">' .. opponent.score .. '</abbr>'
 		end
+		local penalty = tonumber(opponent.extradata.penalty) or 0
+		if penalty > 0 then
+			local title = 'Penalty of ' .. penalty .. ' game' .. (penalty > 1 and 's' or '')
+			return '<abbr title="' .. title .. '">' .. opponent.score .. '</abbr>'
+		end
 	end
 
 	if Logic.readBool(opponent.extradata.noscore) then


### PR DESCRIPTION
## Summary
Allow penalty as param in sc/sc2 opponents in match2.
Used for cases where opponents are awarded penalty maps (i.e. start with a negative score)

## How did you test this change?
/dev