### PR TITLE
Change default group score delimiter in PPT import

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -22,7 +22,7 @@ local Placement = Lua.import('Module:PrizePool/Placement', {requireDevIfEnabled 
 local TournamentUtil = Lua.import('Module:Tournament/Util', {requireDevIfEnabled = true})
 
 local AUTOMATION_START_DATE = '2023-01-01'
-local GROUPSCORE_DELIMITER = '-'
+local GROUPSCORE_DELIMITER = '/'
 local SCORE_STATUS = 'S'
 local DEFAULT_ELIMINATION_STATUS = 'down'
 local THIRD_PLACE_MATCH_ID = 'RxMTP'


### PR DESCRIPTION
## Summary
Change default group score delimiter in PPT import
Investigation https://github.com/Liquipedia/Lua-Modules/pull/1983#issuecomment-1264253532 showed that `/` is the commonly used delimiter

## How did you test this change?
/dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
