### PR TITLE
Move `IGL` in Valorant's Infobox Team

### DIFF
--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -37,14 +37,12 @@ function CustomTeam:createWidgetInjector()
 end
 
 function CustomInjector:parse(id, widgets)
-	return widgets
-end
-
-function CustomInjector:addCustomCells(widgets)
-	table.insert(widgets, Cell{
-		name = 'In-Game Leader',
-		content = {_team.args.igl}
-	})
+	if id == 'staff' then
+		table.insert(widgets, Cell{
+			name = 'In-Game Leader',
+			content = {_team.args.igl}
+		})
+	end
 	return widgets
 end
 


### PR DESCRIPTION
## Summary
Valorant requested `IGL` to be shown together with the other roles.

## How did you test this change?
Tested with dev module
![image](https://user-images.githubusercontent.com/3426850/193635996-b1c2d1e7-8aac-462e-adec-e4936c4af3b7.png)
