### PR TITLE
Change `getContextualDate` to `getContextualDateOrNow` in `_enableImport`

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -69,7 +69,7 @@ function Import._getConfig(args, placements)
 end
 
 function Import._enableImport(importInput)
-	local date = TournamentUtil.getContextualDate()
+	local date = TournamentUtil.getContextualDateOrNow()
 	return Logic.nilOr(
 		Logic.readBoolOrNil(importInput),
 		not date or date >= AUTOMATION_START_DATE


### PR DESCRIPTION
## Summary
Change `getContextualDate` to `getContextualDateOrNow` in `_enableImport`.
This is so that it assumes todays date if no tournament_enddate nor tournament_startdate is set

## How did you test this change?
to be done