### PR TITLE
Set `allGroupsUseWdl` as `true` for R6, RL and lol

### DIFF
--- a/components/prize_pool/wikis/leagueoflegends/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/leagueoflegends/prize_pool_custom.lua
@@ -24,6 +24,7 @@ local TIER_VALUE = {8, 4, 2}
 -- Template entry point
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
+	args.allGroupsUseWdl = true
 	local prizePool = PrizePool(args):create()
 
 	prizePool:setLpdbInjector(CustomLpdbInjector())

--- a/components/prize_pool/wikis/rainbowsix/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/rainbowsix/prize_pool_custom.lua
@@ -28,6 +28,7 @@ local TYPE_MODIFIER = {Online = 0.65}
 -- Template entry point
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
+	args.allGroupsUseWdl = true
 	local prizePool = PrizePool(args):create()
 
 	prizePool:setLpdbInjector(CustomLpdbInjector())

--- a/components/prize_pool/wikis/rocketleague/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/rocketleague/prize_pool_custom.lua
@@ -26,6 +26,7 @@ local TYPE_MODIFIER = {Online = 0.65}
 -- Template entry point
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
+	args.allGroupsUseWdl = true
 	local prizePool = PrizePool(args):create()
 
 	prizePool:setLpdbInjector(CustomLpdbInjector())


### PR DESCRIPTION
## Summary
As per the discord conversation on september 3rd R6 uses WDL for GSL style groups:
https://discord.com/channels/93055209017729024/315607343331278848/1015435649710559373

As per the discord conversation on september 3rd RL uses WDL for GSL style groups:
https://discord.com/channels/93055209017729024/202524980146208768/1015435677531373578

As per the discord conversation on september 3rd lol uses WDL for GSL style groups:
https://discord.com/channels/93055209017729024/276340346831765504/1015435528797171792

## How did you test this change?
N/A