### PR TITLE
Fix `expected` vs `actual` in Reference Cleaner Tests

### DIFF
--- a/standard/test/reference_cleaner_test.lua
+++ b/standard/test/reference_cleaner_test.lua
@@ -12,9 +12,9 @@ local ScribuntoUnit = require('Module:ScribuntoUnit')
 local suite = ScribuntoUnit:new()
 
 function suite:testClass()
-	self:assertEquals(ReferenceCleaner.clean('2021-07-05'), '2021-07-05')
-	self:assertEquals(ReferenceCleaner.clean('2011-05-??'), '2011-05-01')
-	self:assertEquals(ReferenceCleaner.clean('2011-??-05'), '2011-01-05')
+	self:assertEquals('2021-07-05', ReferenceCleaner.clean('2021-07-05'))
+	self:assertEquals('2011-05-01', ReferenceCleaner.clean('2011-05-??'))
+	self:assertEquals('2011-01-05', ReferenceCleaner.clean('2011-??-05'))
 end
 
 return suite


### PR DESCRIPTION
## Summary
Per documentation, the first parameter is expected, while the second is actual. (https://liquipedia.net/commons/Module:ScribuntoUnit#assertEquals) 
Update the code the reflect that.

## How did you test this change?
N/A