### PR TITLE
Do not store legacy standings from non main space

### DIFF
--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -26,12 +26,13 @@ local INVALID_OPPONENT_CATEGORY = '[[Category:Pages with invalid opponent '
 local Wrapper = {}
 
 function Wrapper.table(frame)
-	if not Wrapper._shouldStore(frame.args) then
+	local args = Arguments.getArgs(frame)
+	if not Wrapper._shouldStore(args) then
 		return
 	end
 
-	frame.args.roundcount = 1
-	return StandingsStorage.fromTemplateHeader(frame)
+	args.roundcount = 1
+	return StandingsStorage.fromTemplateHeader(args)
 end
 
 function Wrapper.entry(frame)

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -37,7 +37,7 @@ end
 
 function Wrapper.entry(frame)
 	local args = Arguments.getArgs(frame)
-	if not Wrapper._shouldStore(frame.args) then
+	if not Wrapper._shouldStore(args) then
 		return
 	end
 

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -26,16 +26,17 @@ local INVALID_OPPONENT_CATEGORY = '[[Category:Pages with invalid opponent '
 local Wrapper = {}
 
 function Wrapper.table(frame)
-	if not Logic.readBool(Logic.emptyOr(frame.args.store, Namespace.isMain())) then
+	if not Wrapper._shouldStore(frame.args) then
 		return
 	end
+
 	frame.args.roundcount = 1
 	return StandingsStorage.fromTemplateHeader(frame)
 end
 
 function Wrapper.entry(frame)
 	local args = Arguments.getArgs(frame)
-	if not Logic.readBool(Logic.emptyOr(args.store, Namespace.isMain())) then
+	if not Wrapper._shouldStore(frame.args) then
 		return
 	end
 
@@ -127,6 +128,10 @@ function Wrapper._processPlayer(playerInput, opponentArgs, prefix)
 	playerInput = playerInput:gsub('<span class="flag">.-</span>', '')
 	-- now read the race from the remaining file
 	opponentArgs[prefix .. 'race'] = playerInput:match('&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
+end
+
+function Wrapper._shouldStore(args)
+	return Logic.readBool(Logic.emptyOr(args.store, Namespace.isMain()))
 end
 
 return Wrapper

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -10,6 +10,7 @@ local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Namespace = require('Module:Namespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
@@ -25,13 +26,16 @@ local INVALID_OPPONENT_CATEGORY = '[[Category:Pages with invalid opponent '
 local Wrapper = {}
 
 function Wrapper.table(frame)
+	if not Logic.readBool(Logic.emptyOr(frame.args.store, Namespace.isMain())) then
+		return
+	end
 	frame.args.roundcount = 1
 	return StandingsStorage.fromTemplateHeader(frame)
 end
 
 function Wrapper.entry(frame)
 	local args = Arguments.getArgs(frame)
-	if not Logic.readBool(Logic.emptyOr(args.store, true)) then
+	if not Logic.readBool(Logic.emptyOr(args.store, Namespace.isMain())) then
 		return
 	end
 


### PR DESCRIPTION
## Summary
By default do not store Standings from old manual group table templates from non main space.
The data causes issues on some old user space pages with the ppt import.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev into live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
