### PR TITLE
FACEIT link suffix update

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -174,7 +174,8 @@ _PREFIXES = Table.merge(_PREFIXES, CustomData.prefixes or {})
 
 local _SUFFIXES = {
 	iccup = '.html',
-	['faceit-c'] = '/event',
+	['faceit-c'] = '/',
+	['faceit-hub'] = '/',
 }
 
 _SUFFIXES = Table.merge(_SUFFIXES, CustomData.suffixes or {})


### PR DESCRIPTION
## Summary

FACEIT "championship" links now work with just a `/`. Also, hub links need a `/` at the end to function

## How did you test this change?

- https://www.faceit.com/en/championship/8ef9edaf-5e83-4cd6-9c01-fda8c948fafb/ works
- https://www.faceit.com/en/hub/fcd8dabb-31e2-4447-87df-3bfb79dc9546/ works
- https://www.faceit.com/en/hub/fcd8dabb-31e2-4447-87df-3bfb79dc9546 doesn't work
