### PR TITLE
Adjust old prize pool call in case of awards

### DIFF
--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -37,7 +37,7 @@ function StarcraftLegacyPrizePool.run(frame)
 	local header = Array.sub(args, 1, 1)[1]
 
 	if Logic.readBool(header.award) then
-		OldStarcraftPrizePool.TemplatePrizePoolEnd()
+		return OldStarcraftPrizePool.PrizePoolEnd(args)
 	end
 
 	local slots = Array.sub(args, 2)


### PR DESCRIPTION
please merge #2018 first

## Summary
The `local args = Template.retrieveReturnValues('PrizePool')` (line 36) empties the wiki vars, hence the old prize pool can not retrieve them anymore.
Changed the old prize pool to accept passed args, this way we can now pass the retrieved args to the old module

## How did you test this change?
live