### PR TITLE
Adjust filling up slots handling in SC/SC2 PPT Legacy

### DIFF
--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -170,7 +170,6 @@ function StarcraftLegacyPrizePool._fillerOpponent(lastOpponentData)
 		end
 	end
 
-	mw.logObject(fillerOpponent)
 	return fillerOpponent
 end
 

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -199,8 +199,7 @@ function StarcraftLegacyPrizePool._mapSlot(slot)
 	newData.date = slot.date
 	newData.usdprize = (slot.usdprize and slot.usdprize ~= '0') and slot.usdprize or nil
 
-	local opponentsInSlot = tonumber(slot.count)
-	opponentsInSlot = opponentsInSlot or math.max(#slot, 1)
+	local opponentsInSlot = tonumber(slot.count) or math.max(#slot, 1)
 
 	Table.iter.forEachPair(CACHED_DATA.inputToId, function(parameter, newParameter)
 		local input = slot[parameter]


### PR DESCRIPTION
## Summary
When using import do not fill up opponents until slot size while reading a slot. Instead first merge slots with the same place and fill them up afterwards. For filling up the last slot/opponent (without the opponent data (race, flag, link, displayname, wdl, lastvs, score)) is basically copied.

This is needed so when merging slots while import is enabled, we do not get too many opponents in a slot from reading the args.

basically it is for stuff like this:
```
{{prize pool slot|place=13-16|usdprize=1900|points=90}}
{{prize pool slot|place=13-16|usdprize=1775|points=90}}
{{prize pool slot|place=13-16|usdprize=1900|points=90|count=2}}
```

before it got 16 opponents now 4

but at the same time we also have such cases:
```
{{prize pool slot|place=13-16|usdprize=1900|points=90}}
```
here we need to copy the usdprize/points from the one opponent in the slot is assumes (to not fuck up the above) to the missing 3 opponents

## How did you test this change?
/dev into live