### PR TITLE
One function call was not updated in #1510

### DIFF
--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -205,7 +205,7 @@ function Legacy._convertSingle(realKey, val, match, mapping, flattened, source)
 			if String.startsWith(realKey, 'opponent') then
 				match[realKey] = nestedArgs
 			elseif String.startsWith(realKey, 'map') then
-				match[realKey] = MatchSubobjects.luaGetMap(_frame, nestedArgs)
+				match[realKey] = MatchSubobjects.luaGetMap(nestedArgs)
 			else
 				match[realKey] = nestedArgs
 			end

--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -27,7 +27,6 @@ local _RESET_MATCH = 'RxMBR'
 local _THIRD_PLACE_MATCH = 'RxMTP'
 local _args
 local _type
-local _frame
 
 function Legacy.get(frame)
 	_args = getArgs(frame)
@@ -80,7 +79,6 @@ end
 
 function Legacy.getTemplate(frame)
 	_args = getArgs(frame)
-	_frame = frame
 
 	local templateid = _args['template']
 	if Logic.isEmpty(templateid) then


### PR DESCRIPTION
## Summary
In #1510, one function call to `luaGetMap` was not updated. This PR updates said function call.
It was missed due to only used in match1->match2 conversion on RL and R6. We should look at adding better tests for match2.

## How did you test this change?
Live