### PR TITLE
Set parent instead of copying it

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -353,8 +353,7 @@ function Import._emptyPlacement(priorPlacement, placementSize)
 	local placeStart = (priorPlacement.placeEnd or 0) + 1
 	local placeEnd = (priorPlacement.placeEnd or 0) + placementSize
 
-	local parent = Table.deepCopy(priorPlacement.parent, {copyMetatable = true})
-	parent.placements = nil
+	local parent = priorPlacement.parent
 
 	return Placement(
 		{placeStart = placeStart, placeEnd = placeEnd},


### PR DESCRIPTION
## Summary
Currently PPT Import does not copy the lpdb/smw injectors from parent
This PR changes the parent setting from deepCopy (incl. metatable) to just playing setting it as the parent
Hence the injectors are available in for the importet placements that have no manual import whatsoever

example:
```
{{TeamPrizePool
	|{{Slot|place=1|usdprize=5,000}}
	|{{Slot|place=2|usdprize=3,000}}
	|{{Slot|place=3|usdprize=2,000}}
}}
```
on a page with a 4de bracket would import the 4th place
The injectors are apllied to placements 1-3 but not 4

With the changes of this PR the injectors also get applied to the 4th place

## How did you test this change?
/dev