### PR TITLE
BrktsSpecific for Splatoon

### DIFF
--- a/components/match2/wikis/splatoon/brkts_wiki_specific.lua
+++ b/components/match2/wikis/splatoon/brkts_wiki_specific.lua
@@ -1,0 +1,24 @@
+---
+-- @Liquipedia
+-- wiki=splatoon
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
+
+function WikiSpecific.matchHasDetails(match)
+	return match.dateIsExact
+		or match.date ~= DateExt.epochZero
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.games
+end
+
+return WikiSpecific


### PR DESCRIPTION
## Summary
**Splatoon Match2** (Explanation were done in the match modules already)

## How did you test this change?
LIVE

https://liquipedia.net/splatoon/Splatoon_2_World_Championship/2019#Results
![image](https://user-images.githubusercontent.com/88981446/193472739-b7214396-abfa-4068-ad28-81134bd09e68.png)

## Side Note
I thought adding BrktsSpecific up just for now, since it has the UNIX TIME changes that were related.
Legacy werent really related to the UNIX changes so I can wait until merge then PR that one later

