### PR TITLE
Catch Seeds that are plain text in Legacy

### DIFF
--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -146,6 +146,10 @@ function StarcraftLegacyPrizePool.run(frame)
 		newArgs['qualifies' .. linkData.id .. 'name'] = linkData.name
 	end
 
+	if CACHED_DATA.plainTextSeedsIndex then
+		newArgs['freetext' .. CACHED_DATA.plainTextSeedsIndex] = 'Seed'
+	end
+
 	return CustomPrizePool.run(newArgs)
 end
 
@@ -240,6 +244,11 @@ end
 
 function StarcraftLegacyPrizePool._handleSeed(storeTo, input, slotSize)
 	local links = LegacyPrizePool.parseWikiLink(input)
+
+	if Table.isEmpty(links) then
+		StarcraftLegacyPrizePool._handlePlainTextSeeds(storeTo, input)
+	end
+
 	for _, linkData in ipairs(links) do
 		local link = linkData.link
 
@@ -251,6 +260,22 @@ function StarcraftLegacyPrizePool._handleSeed(storeTo, input, slotSize)
 		CACHED_DATA.qualifiers[link].occurance = CACHED_DATA.qualifiers[link].occurance + slotSize
 		storeTo['qualified' .. CACHED_DATA.qualifiers[link].id] = true
 	end
+end
+
+function StarcraftLegacyPrizePool._handlePlainTextSeeds(storeTo, input)
+	if not input then
+		return
+	end
+
+	if not CACHED_DATA.plainTextSeedsIndex then
+		CACHED_DATA.plainTextSeedsIndex = CACHED_DATA.next.freetext
+		CACHED_DATA.next.freetext = CACHED_DATA.plainTextSeedsIndex + 1
+	end
+	local display = storeTo['freetext' .. CACHED_DATA.plainTextSeedsIndex] or ''
+	if String.isNotEmpty(display) then
+		display = display .. '<br>'
+	end
+	storeTo['freetext' .. CACHED_DATA.plainTextSeedsIndex] = display .. input
 end
 
 function StarcraftLegacyPrizePool._mapOpponents(slot, newData, opponentsInSlot)

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -271,11 +271,13 @@ function StarcraftLegacyPrizePool._handlePlainTextSeeds(storeTo, input)
 		CACHED_DATA.plainTextSeedsIndex = CACHED_DATA.next.freetext
 		CACHED_DATA.next.freetext = CACHED_DATA.plainTextSeedsIndex + 1
 	end
-	local display = storeTo['freetext' .. CACHED_DATA.plainTextSeedsIndex] or ''
-	if String.isNotEmpty(display) then
-		display = display .. '<br>'
+
+	local currentDisplay = storeTo['freetext' .. CACHED_DATA.plainTextSeedsIndex] or ''
+	if String.isNotEmpty(currentDisplay) then
+		currentDisplay = currentDisplay .. '<br>'
 	end
-	storeTo['freetext' .. CACHED_DATA.plainTextSeedsIndex] = display .. input
+	storeTo['freetext' .. CACHED_DATA.plainTextSeedsIndex] = currentDisplay .. input
+
 end
 
 function StarcraftLegacyPrizePool._mapOpponents(slot, newData, opponentsInSlot)


### PR DESCRIPTION
## Summary
Catch Seeds that are plain text.

SC2/SC has several old PrizePools that have plain text in columns that have the header Seed (be it from localcurrency or points).
Currently those are discarded due to them not having a link and hence `LegacyPrizePool.parseWikiLink` returning an empty table.
This PR catches those cases and converts them to `freetext` so they still get displayed.

## How did you test this change?
/dev into live

example: https://liquipedia.net/starcraft2/index.php?title=Gold_Series_International_2016/Qualifiers/Europe&action=edit&section=3
(the `Paid Trip` in seed column)