### PR TITLE
Check opponenttype in the correct table when determining mode

### DIFF
--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
@@ -163,7 +163,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.extradata = Table.mergeInto(lpdbData.extradata, extradata)
 
 	-- remove the following line once the consumers have been updated
-	lpdbData.mode = CustomPrizePool._getMode(opponent.opponenttype, opponent.opponentData)
+	lpdbData.mode = CustomPrizePool._getMode(lpdbData.opponenttype, opponent.opponentData)
 
 	lpdbData.tournament = _tournament_name
 	lpdbData.series = _series


### PR DESCRIPTION
## Summary
Fix var name when getting opponenttype for legacy mode

## How did you test this change?
/dev into live