### PR TITLE
Both `hltv` and `hltvlegacy` can have `stats`and `legacystats` as map stats

### DIFF
--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -203,14 +203,7 @@ return {
 		icon = 'HLTV icon.png',
 		prefixLink = 'https://www.hltv.org/legacy/match/',
 		label = 'HLTV Matchpage',
-		stats = {'legacystats'}
-	},
-	{
-		name = 'legacystats',
-		icon = 'stats',
-		prefixLink = 'https://www.hltv.org/legacystats/match/mapstatsid/',
-		label = 'Stats on HLTV',
-		isMapStats = true
+		stats = {'legacystats', 'stats'}
 	},
 	{
 		name = 'hltv',
@@ -219,7 +212,14 @@ return {
 		suffixLink = '/match',
 		label = 'HLTV Matchpage',
 		max = 2,
-		stats = {'stats'}
+		stats = {'legacystats', 'stats'}
+	},
+	{
+		name = 'legacystats',
+		icon = 'stats',
+		prefixLink = 'https://www.hltv.org/legacystats/match/mapstatsid/',
+		label = 'Stats on HLTV',
+		isMapStats = true
 	},
 	{
 		name = 'stats',


### PR DESCRIPTION
## Summary

Both `hltv` and `hltvlegacy` can have `stats`and `legacystats` as map stats.

## How did you test this change?

Live.

- (OLD) `hltv` and `legacystats`
![image](https://user-images.githubusercontent.com/43279191/194299124-0e03cf53-aa83-468e-9444-1fbe94ab7b84.png)

- (NEW) `hltv` and `legacystats`
![image](https://user-images.githubusercontent.com/43279191/194299252-05fc3b5a-0a48-4643-9c9d-373085f2f534.png)

