### PR TITLE
Use `lastVs.opponenttype` over the not existing `lastVs.type`

### DIFF
--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
@@ -156,7 +156,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 			lastVs = StarcraftOpponent.toLpdbStruct(lastVs) or {}
 			lpdbData.lastvs = Json.stringify(Table.merge(
 					lastVs.opponentplayers or {},
-					{type = lastVs.type}
+					{type = lastVs.opponenttype}
 				))
 		end
 	end


### PR DESCRIPTION
## Summary
Use `lastVs.opponenttype` over the not existing `lastVs.type` in lastVs handling in sc/sc2 PPT

## How did you test this change?
live
