### PR TITLE
Use `scoreinfo.status` to check for score set

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -236,7 +236,7 @@ function CustomMatchGroupInput.getDefaultWinner(table)
 end
 
 function CustomMatchGroupInput.placementCheckScoresSet(table)
-	return Table.all(table, function (_, scoreinfo) return scoreinfo.score end)
+	return Table.all(table, function (_, scoreinfo) return scoreinfo.status == 'S' end)
 end
 
 --


### PR DESCRIPTION
## Summary

Related to (#2027). Using `scoreinfo.status == 'S'` guarantees that score is both set and numeric. This needs to be done to avoid weird scores inputs messing things up.

## How did you test this change?

/dev
