### PR TITLE
RequireDevIfEnavbled for ReferenceCleaner Testcases

### DIFF
--- a/standard/test/reference_cleaner_test copy.lua
+++ b/standard/test/reference_cleaner_test copy.lua
@@ -1,0 +1,22 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:ReferenceCleaner/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local ReferenceCleaner = Lua.import('Module:ReferenceCleaner', {requireDevIfEnabled = true})
+
+local suite = ScribuntoUnit:new()
+
+function suite:testClass()
+	self:assertEquals('2021-07-05', ReferenceCleaner.clean('2021-07-05'))
+	self:assertEquals('2011-05-01', ReferenceCleaner.clean('2011-05-??'))
+	self:assertEquals('2011-01-05', ReferenceCleaner.clean('2011-??-05'))
+end
+
+return suite


### PR DESCRIPTION
## Summary
Use LuaImport and RequireDevIfEnabled, to allow for [Template:RunTests](https://liquipedia.net/commons/Template:RunTests) to work.

## How did you test this change?
Live
https://liquipedia.net/commons/Module_talk:ReferenceCleaner/testcases