### PR TITLE
Add missing `"` in Abbreviation Module

### DIFF
--- a/standard/abbreviation.lua
+++ b/standard/abbreviation.lua
@@ -15,7 +15,7 @@ function Abbreviation.make(text, title)
 	if String.isEmpty(title) or String.isEmpty(text) then
 		return nil
 	end
-	return '<abbr title="' .. title .. '>' .. text .. '</abbr>'
+	return '<abbr title="' .. title .. '">' .. text .. '</abbr>'
 end
 
 return Class.export(Abbreviation)


### PR DESCRIPTION
## Summary
While doing #2035 I noticed that the Abbreviation Module is missing a `"` in its return. Mediawiki parser seems to currently automatically correct it, but we should return correct html.

## How did you test this change?
Tested using dev module
