### PR TITLE
Setup earnings for AoE

### DIFF
--- a/components/earnings/wikis/ageofempires/earnings.lua
+++ b/components/earnings/wikis/ageofempires/earnings.lua
@@ -1,0 +1,19 @@
+---
+-- @Liquipedia
+-- wiki=ageofempires
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+CustomEarnings.defaultNumberOfStoredPlayersPerMatch = 15
+
+-- Use placement field individualprizemoney in case of player earnings
+CustomEarnings.divisionFactorPlayer = nil
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
## Summary
Sets up the commons Earnings module for use on the AoE wiki.

## How did you test this change?
via /dev, comparing various calculated earnings with new/old calculation
Also compared earnings listed on results pages via a spreadsheet
