### PR TITLE
Simplify match2 to match1 logic for `Header` field

### DIFF
--- a/components/match2/wikis/brawlstars/match_legacy.lua
+++ b/components/match2/wikis/brawlstars/match_legacy.lua
@@ -152,16 +152,8 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.matchsection = extradata.matchsection
 	local bracketData = Json.parseIfString(match2.match2bracketdata)
 	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
-		local headerName
-		if bracketData.header then
-			headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
-		end
-		if String.isEmpty(headerName) then
-			headerName = Variables.varDefault('match_legacy_header_name')
-		end
-		if String.isNotEmpty(headerName) then
-			match.header = headerName
-			Variables.varDefine('match_legacy_header_name', headerName)
+		if bracketData.inheritedheader then
+			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 	end
 

--- a/components/match2/wikis/dota2/match_legacy.lua
+++ b/components/match2/wikis/dota2/match_legacy.lua
@@ -62,17 +62,9 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.featured = tostring(extradata.featured)
 
 	local bracketData = Json.parseIfString(match2.match2bracketdata)
-	if type(bracketData) == "table" and bracketData.type == "bracket" then
-		local headerName
-		if bracketData.header then
-			headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
-		end
-		if String.isEmpty(headerName) then
-			headerName = Variables.varDefault("match_legacy_header_name")
-		end
-		if String.isNotEmpty(headerName) then
-			match.extradata.matchround = headerName
-			Variables.varDefine("match_legacy_header_name", headerName)
+	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
+		if bracketData.inheritedheader then
+			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 	end
 

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -74,16 +74,8 @@ function MatchLegacy._convertParameters(match2)
 
 	local bracketData = Json.parseIfString(match2.match2bracketdata)
 	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
-		local headerName
-		if bracketData.header then
-			headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
-		end
-		if String.isEmpty(headerName) then
-			headerName = Variables.varDefault('match_legacy_header_name')
-		end
-		if String.isNotEmpty(headerName) then
-			match.extradata.matchsection = headerName
-			Variables.varDefine('match_legacy_header_name', headerName)
+		if bracketData.inheritedheader then
+			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 	end
 

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -157,17 +157,9 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.bestofx = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	local bracketData = json.parseIfString(match2.match2bracketdata)
-	if type(bracketData) == "table" and bracketData.type == "bracket" then
-		local headerName
-		if bracketData.header then
-			headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
-		end
-		if String.isEmpty(headerName) then
-			headerName = Variables.varDefault("match_legacy_header_name")
-		end
-		if String.isNotEmpty(headerName) then
-			match.header = headerName
-			Variables.varDefine("match_legacy_header_name", headerName)
+	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
+		if bracketData.inheritedheader then
+			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 	end
 

--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -189,17 +189,9 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.opponent2rounds = opponent2score
 
 	local bracketData = json.parseIfString(match2.match2bracketdata)
-	if type(bracketData) == "table" and bracketData.type == "bracket" then
-		local headerName
-		if bracketData.header then
-			headerName = (DisplayHelper.expandHeader(bracketData.header) or {})[1]
-		end
-		if String.isEmpty(headerName) then
-			headerName = Variables.varDefault("match_legacy_header_name")
-		end
-		if String.isNotEmpty(headerName) then
-			match.header = headerName
-			Variables.varDefine("match_legacy_header_name", headerName)
+	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
+		if bracketData.inheritedheader then
+			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 	end
 


### PR DESCRIPTION
## Summary
Since inherited header was introduced in #1159, the complicated logic using Wiki Variables can be simplified. This was first done for OW in #1318
Apply the simplified logic to all wikis using the old logic.

## How did you test this change?
Verified on R6 as sample