### PR TITLE
Rework earnings for sc2 infobox team

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -318,8 +318,6 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		end
 	end
 
-	mw.logObject(earnings)
-	
 	_team.totalEarnings = Table.extract(earnings.team or {}, 'total') or 0
 	_team.earnings = earnings.team or {}
 	_team.totalEarningsWhileOnTeam = Table.extract(earnings.other or {}, 'total') or 0

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -229,7 +229,8 @@ function CustomTeam.calculateEarnings(args)
 end
 
 function CustomTeam.getEarningsAndMedalsData(team)
-	local query = 'liquipediatier, liquipediatiertype, placement, date, individualprizemoney, prizemoney, opponentplayers, opponenttype'
+	local query = 'liquipediatier, liquipediatiertype, placement, date, '
+		.. 'individualprizemoney, prizemoney, opponentplayers, opponenttype'
 
 	local playerTeamConditions = ConditionTree(BooleanOperator.any)
 	for playerIndex = 1, _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS do

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -21,6 +21,7 @@ local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Opponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -43,8 +44,7 @@ local CustomTeam = Class.new()
 local CustomInjector = Class.new(Injector)
 local _LANGUAGE = mw.language.new('en')
 
-local _earnings = 0
-local _EARNINGS_MODES = {team = 'team'}
+local _EARNINGS_MODES = {team = Opponent.team}
 local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 20
 local _PLAYER_EARNINGS_ABBREVIATION = '<abbr title="Earnings of players while on the team">Player earnings</abbr>'
@@ -74,15 +74,14 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'earnings' then
-		local earningsWhileOnTeam
-		_earnings, earningsWhileOnTeam = CustomTeam.calculateEarnings(_args)
+		CustomTeam.calculateEarnings(_args)
 		local earningsDisplay
-		if _earnings > 0 then
-			earningsDisplay = '$' .. _LANGUAGE:formatNum(_earnings)
+		if _team.totalEarnings > 0 then
+			earningsDisplay = '$' .. _LANGUAGE:formatNum(_team.totalEarnings)
 		end
 		local earningsFromPlayersDisplay
-		if earningsWhileOnTeam > 0 then
-			earningsFromPlayersDisplay = '$' .. _LANGUAGE:formatNum(earningsWhileOnTeam)
+		if _team.totalEarningsWhileOnTeam > 0 then
+			earningsFromPlayersDisplay = '$' .. _LANGUAGE:formatNum(_team.totalEarningsWhileOnTeam)
 		end
 		return {
 			Cell{name = 'Approx. Total Winnings', content = {earningsDisplay}},
@@ -135,9 +134,14 @@ function CustomTeam:createBottomContent()
 end
 
 function CustomTeam:addToLpdb(lpdbData)
-	lpdbData.earnings = _earnings
 	lpdbData.region = nil
 	lpdbData.extradata.subteams = CustomTeam._listSubTeams()
+
+	lpdbData.extradata.playerearnings = _team.totalEarningsWhileOnTeam
+	for year, playerEarningsOfYear  in pairs(_team.earningsWhileOnTeam or {}) do
+		lpdbData.extradata['playerearningsin' .. year] = playerEarningsOfYear
+	end
+
 	return lpdbData
 end
 
@@ -204,6 +208,12 @@ function CustomTeam.getAutomatedAchievements(team)
 end
 
 function CustomTeam.calculateEarnings(args)
+	-- set default values for the non query case
+	_team.earnings = {}
+	_team.totalEarnings = 0
+	_team.earningsWhileOnTeam = {}
+	_team.totalEarningsWhileOnTeam = 0
+
 	if
 		Logic.readBool(args.disable_lpdb) or
 		Logic.readBool(args.disable_storage) or
@@ -213,21 +223,18 @@ function CustomTeam.calculateEarnings(args)
 		_doStore = false
 		Variables.varDefine('disable_LPDB_storage', 'true')
 	else
-		local earnings, earningsWhileOnTeam = CustomTeam.getEarningsAndMedalsData(_team.pagename)
-		Variables.varDefine('earnings', earnings)
-		return earnings, earningsWhileOnTeam
+		CustomTeam.getEarningsAndMedalsData(_team.pagename)
+		Variables.varDefine('earnings', _team.totalEarnings)
 	end
-
-	return 0, 0
 end
 
 function CustomTeam.getEarningsAndMedalsData(team)
-	local query = 'liquipediatier, liquipediatiertype, placement, date, individualprizemoney, prizemoney, players'
+	local query = 'liquipediatier, liquipediatiertype, placement, date, individualprizemoney, prizemoney, opponentplayers, opponenttype'
 
 	local playerTeamConditions = ConditionTree(BooleanOperator.any)
 	for playerIndex = 1, _MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS do
 		playerTeamConditions:add{
-			ConditionNode(ColumnName('players_p' .. playerIndex .. 'team'), Comparator.eq, team),
+			ConditionNode(ColumnName('opponentplayers_p' .. playerIndex .. 'team'), Comparator.eq, team),
 		}
 	end
 
@@ -245,15 +252,15 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		ConditionTree(BooleanOperator.any):add{
 			ConditionNode(ColumnName('prizemoney'), Comparator.gt, '0'),
 			ConditionTree(BooleanOperator.all):add{
-				ConditionNode(ColumnName('players_type'), Comparator.eq, 'team'),
-				ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
+				ConditionNode(ColumnName('opponenttype'), Comparator.eq, Opponent.team),
+				ConditionNode(ColumnName('opponentname'), Comparator.eq, team),
 				placementConditions,
 			},
 		},
 		ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
+			ConditionNode(ColumnName('opponentname'), Comparator.eq, team),
 			ConditionTree(BooleanOperator.all):add{
-				ConditionNode(ColumnName('players_type'), Comparator.neq, 'team'),
+				ConditionNode(ColumnName('opponenttype'), Comparator.neq, Opponent.team),
 				playerTeamConditions
 			},
 		},
@@ -278,10 +285,10 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		earnings, playerEarnings = CustomTeam._addPlacementToEarnings(earnings, playerEarnings, placement)
 
 		--handle medals
-		local mode = (placement.players or {}).type
-		if mode == 'solo' then
+		local mode = placement.opponenttype
+		if mode == Opponent.solo then
 			medals = CustomTeam._addPlacementToMedals(medals, placement)
-		elseif mode == 'team' then
+		elseif mode == Opponent.team then
 			teamMedals = CustomTeam._addPlacementToMedals(teamMedals, placement)
 		end
 	end
@@ -296,6 +303,7 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		earnings.team = {}
 	end
 
+	-- to be removed after a purge run + consumer updates
 	if _doStore then
 		mw.ext.LiquipediaDB.lpdb_datapoint('total_earnings_players_while_on_team_' .. team, {
 				type = 'total_earnings_players_while_on_team',
@@ -304,16 +312,27 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		})
 	end
 
-	return Math.round{earnings.team.total or 0}, Math.round{playerEarnings or 0}
+	for _, earningsTable in pairs(earnings) do
+		for key, value in pairs(earningsTable) do
+			earningsTable[key] = Math.round{value}
+		end
+	end
+
+	mw.logObject(earnings)
+	
+	_team.totalEarnings = Table.extract(earnings.team or {}, 'total') or 0
+	_team.earnings = earnings.team or {}
+	_team.totalEarningsWhileOnTeam = Table.extract(earnings.other or {}, 'total') or 0
+	_team.earningsWhileOnTeam = earnings.other or {}
 end
 
 function CustomTeam._addPlacementToEarnings(earnings, playerEarnings, data)
 	local prizeMoney = data.prizemoney
-	data.players = data.players or {}
-	local mode = data.players.type
+	data.opponentplayers = data.opponentplayers or {}
+	local mode = data.opponenttype
 	mode = _EARNINGS_MODES[mode]
 	if not mode then
-		prizeMoney = data.individualprizemoney * CustomTeam._amountOfTeamPlayersInPlacement(data.players)
+		prizeMoney = data.individualprizemoney * CustomTeam._amountOfTeamPlayersInPlacement(data.opponentplayers)
 		playerEarnings = playerEarnings + prizeMoney
 		mode = 'other'
 	end


### PR DESCRIPTION
## Summary
- use new (standardized) keys from lpdb_placement
- store teamearnings per year into extradata (making use of #2045)
- store playerEarnings per year into extradata
- store playerearnings total into extradata
- norm those stored values to round with precision 0
- use module Opponent when checking on opponent types

## How did you test this change?
/dev