### PR TITLE
Catch unset winner for finished matches

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -70,7 +70,6 @@ function StarcraftMatchGroupInput.processMatch(match)
 		match = StarcraftMatchGroupInput._adjustData(match)
 	end
 	match = StarcraftMatchGroupInput._checkFinished(match)
-	match = StarcraftMatchGroupInput._determineWinnerIfMissing(match)
 	match = StarcraftMatchGroupInput._getVodStuff(match)
 	match = StarcraftMatchGroupInput._getLinks(match)
 	match = StarcraftMatchGroupInput._getExtraData(match)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -342,7 +342,7 @@ end
 
 function StarcraftMatchGroupInput._determineWinnerIfMissing(match)
 	if Logic.readBool(match.finished) and not match.winner then
-		local scores = Array.mapIndexes(function(opponentIndex) 
+		local scores = Array.mapIndexes(function(opponentIndex)
 			local opponent = match['opponent' .. opponentIndex]
 			if not opponent then
 				return nil


### PR DESCRIPTION
## Summary
Catch unset winner for finished matches in sc/sc2 match2 input.
- add business logic to determine the winner of a finished match where neither bestof nor winner are set
- change `true` string to bool when setting `match.finished`

## How did you test this change?
/dev