### PR TITLE
Fix issue when using LF with our Plugin

### DIFF
--- a/plugins/sumneko_plugin.lua
+++ b/plugins/sumneko_plugin.lua
@@ -28,7 +28,7 @@ end
 
 function importFunctions.annotate(text, funcName, diffs)
     for module, positionEndOfRow in text:gmatch(funcName .. '%s*%(?%s*[\'"](.-)[\'"]%s*%)?.-()\r?\n') do
-        table.insert(diffs, {start = positionEndOfRow, finish = positionEndOfRow, text = importFunctions._row(module)})
+        table.insert(diffs, {start = positionEndOfRow, finish = positionEndOfRow - 1, text = importFunctions._row(module)})
     end
 end
 

--- a/plugins/sumneko_plugin.lua
+++ b/plugins/sumneko_plugin.lua
@@ -28,7 +28,9 @@ end
 
 function importFunctions.annotate(text, funcName, diffs)
     for module, positionEndOfRow in text:gmatch(funcName .. '%s*%(?%s*[\'"](.-)[\'"]%s*%)?.-()\r?\n') do
-        table.insert(diffs, {start = positionEndOfRow, finish = positionEndOfRow - 1, text = importFunctions._row(module)})
+        table.insert(diffs,
+            {start = positionEndOfRow, finish = positionEndOfRow - 1, text = importFunctions._row(module)}
+        )
     end
 end
 


### PR DESCRIPTION
## Summary
When using LF lua files in combination with our Sumneko Lua plugin, the line break would be removed. This is because there's an off by one error in the code.  (See examples, https://github.com/sumneko/lua-language-server/wiki/Plugins & https://github.com/sumneko/sample-plugin/blob/master/.vscode/plugin.lua#L7).
The reason is worked on CRLF is that the CR would be removed, which had no impact on the Language Server. Howevewr on LF, the LF would be removed, causing multiple lines be merged (and effectively commented out).

## How did you test this change?
Chcked the `diffed` files in my VSCode (CRLF) and Martins VSCode (LF).