### PR TITLE
Fix capitalisation typo in mapmaker category check

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
@@ -192,7 +192,7 @@ function CustomPerson.getPersonType()
 	role = string.lower(role or '')
 	local category = _ROLES[role]
 	local store = category or _CLEAN_OTHER_ROLES[role] or _args.defaultPersonType
-	if category == 'Map maker' then
+	if category == _ROLES['map maker'] then
 		category = 'Mapmaker'
 	end
 

--- a/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_custom_shared.lua
@@ -192,7 +192,7 @@ function CustomPerson.getPersonType()
 	role = string.lower(role or '')
 	local category = _ROLES[role]
 	local store = category or _CLEAN_OTHER_ROLES[role] or _args.defaultPersonType
-	if category == 'Map Maker' then
+	if category == 'Map maker' then
 		category = 'Mapmaker'
 	end
 


### PR DESCRIPTION
## Summary
Fix capitalisation typo in mapmaker category check

## How did you test this change?
live