### PR TITLE
Correcting error in Fortnite Infobox/Series

### DIFF
--- a/components/infobox/wikis/fortnite/infobox_series_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_series_custom.lua
@@ -45,7 +45,7 @@ end
 
 function CustomSeries._getSeriesPrizepools(series)
 	local prizemoney = mw.ext.LiquipediaDB.lpdb('tournament', {
-		conditions = '[[series::' .. series.name .. ']]',
+		conditions = '[[series::' .. series .. ']]',
 		query = 'sum::prizepool'
 	})
 


### PR DESCRIPTION
## Summary
Currently on Fortnite, the Infobox Series has a error for the Prize pool implementation (seen below)
![image](https://user-images.githubusercontent.com/58013431/195707989-ca822d65-7f52-4332-8fcc-6fcfe0dab3ba.png)

The current module queries for the ``series.name`` however this is nil. When logging ``series`` (as passed in by the function), the only parameter in the series is the data as saved in LPDB under the "name" field, thus making ``series`` the correct call here
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested with a /dev modul and results are shown here
![image](https://user-images.githubusercontent.com/58013431/195708374-c32359f7-b658-4cb1-b17b-659779638eb1.png)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
