### PR TITLE
Adjust achievements processing in sc2 infobox player

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -365,7 +365,6 @@ function CustomPlayer._getEarningsMedalsData(player)
 		})
 	end
 
-mw.logObject(player)
 	local conditions = ConditionTree(BooleanOperator.all):add{
 		ConditionTree(BooleanOperator.any):add{
 			ConditionNode(ColumnName('opponentname'), Comparator.eq, player),
@@ -392,7 +391,7 @@ mw.logObject(player)
 
 	local queryParameters = {
 		conditions = conditions:toString(),
-		order = 'liquipediatier asc, placement asc, weight desc',
+		order = 'liquipediatier asc, weight desc, placement asc',
 	}
 
 	local processPlacement = function(placement)
@@ -407,8 +406,10 @@ mw.logObject(player)
 
 	-- if < MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS achievements fill them up
 	if #_player.achievements < MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then
-		_player.achievements = Array.extendWith(_player.achievements, _player.achievementsFallBack)
-		_player.achievements = Array.sub(_player.achievements, 1, MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS)
+		Array.extendWith(
+			_player.achievements,
+			Array.sub(_player.achievementsFallBack, 1, MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS - #_player.achievements)
+		)
 	end
 	if #_player.achievements > 0 then
 		Variables.varDefine('achievements', Json.stringify(_player.achievements))


### PR DESCRIPTION
## Summary
Adjust achievements processing in sc2 infobox player
- kick log (added with #2080 by accident)
- adjust sort order in the lpdb call (weight before placement)
- change order of `Array.sub` and `Array.extendWith` calls to be a tiny bit more efficient and not loose order
--> (i do not get why but when doing it the other way around it doesn't take the first objects from the 2nd table but random ones although `Array.extendWith` uses ipairs afaik)
--> this only affects player pages who have < 10 real achievements

## How did you test this change?
/dev