### PR TITLE
Add arg `qualified` to processing for CS Legacy PPT

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -35,6 +35,8 @@ function CustomLegacyPrizePool.customSlot(newData, CACHED_DATA, slot)
 
 	if Logic.readBoolOrNil(slot.noqual) ~= nil then
 		slot.qual = not Logic.readBool(slot.noqual)
+	elseif Logic.readBoolOrNil(slot.qualified) ~= nil then
+		slot.qual = Logic.readBool(slot.qualified)
 	end
 	newData.forceQualified = Logic.readBoolOrNil(slot.qual)
 


### PR DESCRIPTION
## Summary

Allow `qualified` to override the qualification status of teams in legacy PPTs.

## How did you test this change?

`/dev`
Before:
![image](https://user-images.githubusercontent.com/5881994/196050679-57982408-2bf6-4cc2-b6a9-b3774ee0d90e.png)
After:
![image](https://user-images.githubusercontent.com/5881994/196050687-635cc2ec-203d-457f-9a33-793d7f5cd7d0.png)

