### PR TITLE
Fix participantsnumber for team events

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -608,7 +608,11 @@ function CustomLeague:addToLpdb(lpdbData)
 		or Logic.readBool(Variables.varDefault('tournament_finished')) and 'finished'
 	lpdbData.status = status
 	lpdbData.maps = Variables.varDefault('tournament_maps')
-	lpdbData.participantsnumber = Variables.varDefault('tournament_playerNumber', _args.team_number or 0)
+	local participantsNumber = tonumber(Variables.varDefault('tournament_playerNumber')) or 0
+	if participantsNumber == 0 then
+		participantsNumber = _args.team_number or 0
+	end
+	lpdbData.participantsnumber = participantsNumber
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
 


### PR DESCRIPTION
## Summary
In infobox league fix participantsnumber for team events.

## How did you test this change?
dev into live