### PR TITLE
Change WDLQ placements in LPDB

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -70,7 +70,7 @@ Placement.specialStatuses = {
 		display = function ()
 			return 'W'
 		end,
-		lpdb = 1,
+		lpdb = 'w',
 	},
 	D = {
 		active = function (args)
@@ -79,7 +79,7 @@ Placement.specialStatuses = {
 		display = function ()
 			return 'D'
 		end,
-		lpdb = 1,
+		lpdb = 'd',
 	},
 	L = {
 		active = function (args)
@@ -88,7 +88,7 @@ Placement.specialStatuses = {
 		display = function ()
 			return 'L'
 		end,
-		lpdb = 2,
+		lpdb = 'l',
 	},
 	Q = {
 		active = function (args)
@@ -97,7 +97,7 @@ Placement.specialStatuses = {
 		display = function ()
 			return Abbreviation.make('Q', 'Qualified Automatically')
 		end,
-		lpdb = 1,
+		lpdb = 'q',
 	},
 }
 


### PR DESCRIPTION
## Summary

Changing storage of special placements to literal letters rather than inferred placement numbers. Discussed with Rathoz on discord. Can revert if causing issues down the road.

## How did you test this change?

`/dev` wiki.
