### PR TITLE
Update deploy actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 2
 
       - id: changed-files
-        uses: tj-actions/changed-files@v29
+        uses: tj-actions/changed-files@v32
         with:
           files: |
             components/**/*.lua
@@ -37,12 +37,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
       - id: changed-files
-        uses: tj-actions/changed-files@v29
+        uses: tj-actions/changed-files@v32
         with:
           files: |
             components/**/*.lua


### PR DESCRIPTION
## Summary

Some actions were still using Node 12 which is being deprecated next year.

![image](https://user-images.githubusercontent.com/5881994/196249185-a933fb72-dbf7-4229-ba0e-cf4ce0bf2e24.png)

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

## How did you test this change?

As before on my fork of the repo. Seems to be working fine and I didn't see any breaking changes from v29 to v32 that affect us in the changelogs.
