### PR TITLE
HDB for AoV

### DIFF
--- a/components/hidden_data_box/wikis/arenaofvalor/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/arenaofvalor/hidden_data_box_custom.lua
@@ -29,7 +29,7 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
 
 	BasicHiddenDataBox.checkAndAssign('tournament_patch', args.patch, queryResult.patch)
-	BasicHiddenDataBox.checkAndAssign('tournament_publishertier', args.aovpremier, queryResult.publishertier)
+	BasicHiddenDataBox.checkAndAssign('tournament_publishertier', args.publisherpremier, queryResult.publishertier)
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/hidden_data_box/wikis/arenaofvalor/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/arenaofvalor/hidden_data_box_custom.lua
@@ -29,7 +29,7 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
 
 	BasicHiddenDataBox.checkAndAssign('tournament_patch', args.patch, queryResult.patch)
-	BasicHiddenDataBox.checkAndAssign('tournament_publishertier', args['aovpremier'], queryResult.publishertier)
+	BasicHiddenDataBox.checkAndAssign('tournament_publishertier', args.aovpremier, queryResult.publishertier)
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/hidden_data_box/wikis/arenaofvalor/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/arenaofvalor/hidden_data_box_custom.lua
@@ -1,0 +1,35 @@
+---
+-- @Liquipedia
+-- wiki=arenaofvalor
+-- page=Module:HiddenDataBox/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Variables = require('Module:Variables')
+
+local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox', {requireDevIfEnabled = true})
+local CustomHiddenDataBox = {}
+
+function CustomHiddenDataBox.run(args)
+	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+	return BasicHiddenDataBox.run(args)
+end
+
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	queryResult.extradata = queryResult.extradata or {}
+
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier'))
+	Variables.varDefine('tournament_tier_type', Variables.varDefault('tournament_liquipediatiertype'))
+	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
+
+	BasicHiddenDataBox.checkAndAssign('tournament_patch', args.patch, queryResult.patch)
+	BasicHiddenDataBox.checkAndAssign('tournament_publishertier', args['aovpremier'], queryResult.publishertier)
+end
+
+return Class.export(CustomHiddenDataBox)


### PR DESCRIPTION
## Summary
Towards app readiness, ported from ML

Key parts of this are the **aovpremier** publisher tier line, as I need this to trigger the highlights for the Match Tickers, and actually the field name for this is originally **garena-sponsored** but i'm going to change it to **aovpremier** to be more standard 

(as there was prev. case with HoK Contributors wrongly assumed that theres another param for Honor of Kings, the other game we cover on this same wiki. This **aovpremier** should help as aov is refer to just the wiki. Better field name anyways)
 
## How did you test this change?
LIVE

## Side Note
Infobox League will have a PR to changed **garena-sponsored** to **aovpremier**
https://github.com/Liquipedia/Lua-Modules/pull/2097