### PR TITLE
Adjustments for AoV Infobox - Publisher TIer

### DIFF
--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -68,13 +68,13 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args.aovpremier)
+	return Logic.readBool(_args.publisherpremier)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.publishertier = Logic.readBool(_args.aovpremier) and 'true' or nil
+	lpdbData.publishertier = Logic.readBool(_args.publisherpremier) and 'true' or nil
 	lpdbData.extradata = {
 		individual = String.isNotEmpty(args.player_number) and 'true' or '',
 	}
@@ -84,7 +84,7 @@ end
 
 function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args.aovpremier or '')
+	Variables.varDefine('tournament_publishertier', _args.publisherpremier or '')
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -68,13 +68,13 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args['aovpremier'])
+	return Logic.readBool(_args.aovpremier)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.publishertier = _args['aovpremier'] == 'true' and 'true' or nil
+	lpdbData.publishertier = Logic.readBool(_args.aovpremier) and 'true' or nil
 	lpdbData.extradata = {
 		individual = String.isNotEmpty(args.player_number) and 'true' or '',
 	}
@@ -84,7 +84,7 @@ end
 
 function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args['aovpremier'])
+	Variables.varDefine('tournament_publishertier', _args.aovpremier or '')
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -84,7 +84,7 @@ end
 
 function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args.publisherpremier
+	Variables.varDefine('tournament_publishertier', _args.publisherpremier)
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -68,12 +68,13 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args['garena-sponsored'])
+	return Logic.readBool(_args['aovpremier'])
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.publishertier = _args['aovpremier'] == 'true' and 'true' or nil
 	lpdbData.extradata = {
 		individual = String.isNotEmpty(args.player_number) and 'true' or '',
 	}
@@ -83,7 +84,7 @@ end
 
 function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args['garena-sponsored'])
+	Variables.varDefine('tournament_publishertier', _args['aovpremier'])
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -84,7 +84,7 @@ end
 
 function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args.publisherpremier or '')
+	Variables.varDefine('tournament_publishertier', _args.publisherpremier
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end


### PR DESCRIPTION
## Summary
It's related with https://github.com/Liquipedia/Lua-Modules/pull/2096 

1. change **garena-sponsored** to **aovpremier** for a better standard name (as aov refer to the wiki, even though we cover two games on this wiki: **aov** and **hok**)
2. there is a missing **addToLPDB** line that it wouldnt stored publisher tier to the LPDB Datas of InfoLeague at all

3. Actual goal is so that highlights are actually shown, current one isnt because nothing was stored in **publisher tier**
![image](https://user-images.githubusercontent.com/88981446/196498149-1061e606-4643-4202-b11c-4beefe2ea803.png)

## How did you test this change?
Dev Modules
