### PR TITLE
Treat namespace `Module Talk` as Mainspace

### DIFF
--- a/standard/namespace.lua
+++ b/standard/namespace.lua
@@ -13,7 +13,7 @@ local Table = require('Module:Table')
 local Namespace = {}
 
 function Namespace.isMain()
-	return mw.title.getCurrentTitle():inNamespace(0)
+	return mw.title.getCurrentTitle():inNamespace(0) or mw.title.getCurrentTitle():inNamespace(829)
 end
 
 Namespace.getIdsByName = FnUtil.memoize(function()


### PR DESCRIPTION
## Summary
Our unit tests runs on namespace `Module Talk` (id: 829), so it's important to treat it the same as Mainspace when it comes the logic. 
Hence adding it to `isMainspace()` function.

## How did you test this change?
/dev module