### PR TITLE
Add `pagename` as a custom type

### DIFF
--- a/standard/mock/mock_lpdb.lua
+++ b/standard/mock/mock_lpdb.lua
@@ -45,7 +45,7 @@ end
 
 local dbStructure = {}
 dbStructure.standingstable = {
-	parent = 'page',
+	parent = 'pagename',
 	standingsindex = 'number',
 	title = 'string',
 	tournament = 'string',
@@ -55,7 +55,7 @@ dbStructure.standingstable = {
 	extradata = 'struct?',
 }
 dbStructure.standingsentry = {
-	parent = 'page',
+	parent = 'pagename',
 	standingsindex = 'number',
 	opponenttype = 'string',
 	opponentname = 'string',

--- a/standard/type_util.lua
+++ b/standard/type_util.lua
@@ -93,6 +93,9 @@ function TypeUtil.valueIsTypeNoTable (value, typeSpec)
 			or typeSpec == 'table'
 			or typeSpec == 'nil' then
 			return type(value) == typeSpec
+		elseif typeSpec == 'pagename' then
+			-- A pagename is a string, with first letter capitalized and may not contains spaces
+			return type(value) == 'string' and value:find('^%u') and not value:find(' ')
 		elseif require('Module:StringUtils').endsWith(typeSpec, '?') then
 			return value == nil or TypeUtil.valueIsTypeNoTable(value, typeSpec:sub(1, -2))
 		elseif typeSpec == 'any' then


### PR DESCRIPTION
## Summary
Add the custom type `pagename` to our Type Checking. 
`pagename` is a `string` with two additional criteria, first letter must be uppercase and it may not contain any spaces. 

Also update Lpdb specification to use this field where applicable, instead of the non-existing type `page`.

## How did you test this change?
Tested with dev module
