### PR TITLE
Store the same data on BW team pages as on sc2

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_team_custom.lua
@@ -20,6 +20,7 @@ local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Opponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -41,8 +42,7 @@ local CustomTeam = Class.new()
 local CustomInjector = Class.new(Injector)
 local _LANGUAGE = mw.language.new('en')
 
-local _earnings = 0
-local _EARNINGS_MODES = {team = 'team'}
+local _EARNINGS_MODES = {team = Opponent.team}
 local _ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local _PLAYER_EARNINGS_ABBREVIATION = '<abbr title="Earnings of players while on the team">Player earnings</abbr>'
 
@@ -57,7 +57,6 @@ function CustomTeam.run(frame)
 	team.getWikiCategories = CustomTeam.getWikiCategories
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
-
 	return team:createInfobox(frame)
 end
 
@@ -66,23 +65,19 @@ function CustomInjector:addCustomCells(widgets)
 		name = 'Gaming Director',
 		content = {_args['gaming director']}
 	})
-
 	return widgets
 end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'earnings' then
-		local earningsWhileOnTeam
-		_earnings, earningsWhileOnTeam = CustomTeam.calculateEarnings(_args)
+		CustomTeam.calculateEarnings(_args)
 		local earningsDisplay
-		if _earnings == 0 then
-			earningsDisplay = nil
-		else
-			earningsDisplay = '$' .. _LANGUAGE:formatNum(_earnings)
+		if _team.totalEarnings > 0 then
+			earningsDisplay = '$' .. _LANGUAGE:formatNum(_team.totalEarnings)
 		end
 		local earningsFromPlayersDisplay
-		if earningsWhileOnTeam > 0 then
-			earningsFromPlayersDisplay = '$' .. _LANGUAGE:formatNum(earningsWhileOnTeam)
+		if _team.totalEarningsWhileOnTeam > 0 then
+			earningsFromPlayersDisplay = '$' .. _LANGUAGE:formatNum(_team.totalEarningsWhileOnTeam)
 		end
 		return {
 			Cell{name = 'Approx. Total Winnings', content = {earningsDisplay}},
@@ -116,9 +111,14 @@ function CustomTeam:createWidgetInjector()
 end
 
 function CustomTeam:addToLpdb(lpdbData)
-	lpdbData.earnings = _earnings
 	lpdbData.region = nil
 	lpdbData.extradata.subteams = CustomTeam._listSubTeams()
+
+	lpdbData.extradata.playerearnings = _team.totalEarningsWhileOnTeam
+	for year, playerEarningsOfYear  in pairs(_team.earningsWhileOnTeam or {}) do
+		lpdbData.extradata['playerearningsin' .. year] = playerEarningsOfYear
+	end
+
 	return lpdbData
 end
 
@@ -127,7 +127,6 @@ function CustomTeam.getWikiCategories()
 	if String.isNotEmpty(_args.disbanded) then
 		table.insert(categories, 'Disbanded Teams')
 	end
-
 	return categories
 end
 
@@ -179,6 +178,12 @@ function CustomTeam.playerBreakDown(args)
 end
 
 function CustomTeam.calculateEarnings(args)
+	-- set default values for the non query case
+	_team.earnings = {}
+	_team.totalEarnings = 0
+	_team.earningsWhileOnTeam = {}
+	_team.totalEarningsWhileOnTeam = 0
+
 	if
 		Logic.readBool(args.disable_smw) or
 		Logic.readBool(args.disable_lpdb) or
@@ -186,26 +191,22 @@ function CustomTeam.calculateEarnings(args)
 		Logic.readBool(Variables.varDefault('disable_SMW_storage')) or
 		(not Namespace.isMain())
 	then
-			doStore = false
-			Variables.varDefine('disable_SMW_storage', 'true')
+		doStore = false
+		Variables.varDefine('disable_SMW_storage', 'true')
 	else
-		local earnings, earningsWhileOnTeam = CustomTeam.getEarningsAndMedalsData()
-		Variables.varDefine('earnings', earnings)
-
-		return earnings, earningsWhileOnTeam
+		CustomTeam.getEarningsAndMedalsData(_team.pagename)
+		Variables.varDefine('earnings', _team.totalEarnings)
 	end
-
-	return 0, 0
 end
 
-function CustomTeam.getEarningsAndMedalsData()
-	local team = _team.pagename
-	local query = 'liquipediatier, liquipediatiertype, placement, date, individualprizemoney, prizemoney, players'
+function CustomTeam.getEarningsAndMedalsData(team)
+	local query = 'liquipediatier, liquipediatiertype, placement, date, '
+		.. 'individualprizemoney, prizemoney, opponentplayers, opponenttype'
 
 	local playerTeamConditions = ConditionTree(BooleanOperator.any)
 	for playerIndex = 1, Info.maximumNumberOfPlayersInPlacements do
 		playerTeamConditions:add{
-			ConditionNode(ColumnName('players_p' .. playerIndex .. 'team'), Comparator.eq, team),
+			ConditionNode(ColumnName('opponentplayers_p' .. playerIndex .. 'team'), Comparator.eq, team),
 		}
 	end
 
@@ -223,15 +224,15 @@ function CustomTeam.getEarningsAndMedalsData()
 		ConditionTree(BooleanOperator.any):add{
 			ConditionNode(ColumnName('prizemoney'), Comparator.gt, '0'),
 			ConditionTree(BooleanOperator.all):add{
-				ConditionNode(ColumnName('players_type'), Comparator.eq, 'team'),
-				ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
+				ConditionNode(ColumnName('opponenttype'), Comparator.eq, Opponent.team),
+				ConditionNode(ColumnName('opponentname'), Comparator.eq, team),
 				placementConditions,
 			},
 		},
 		ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
+			ConditionNode(ColumnName('opponentname'), Comparator.eq, team),
 			ConditionTree(BooleanOperator.all):add{
-				ConditionNode(ColumnName('players_type'), Comparator.neq, 'team'),
+				ConditionNode(ColumnName('opponenttype'), Comparator.neq, Opponent.team),
 				playerTeamConditions
 			},
 		},
@@ -256,10 +257,10 @@ function CustomTeam.getEarningsAndMedalsData()
 		earnings, playerEarnings = CustomTeam._addPlacementToEarnings(earnings, playerEarnings, placement)
 
 		--handle medals
-		local mode = (placement.players or {}).type
-		if mode == 'solo' then
+		local mode = placement.opponenttype
+		if mode == Opponent.solo then
 			medals = CustomTeam._addPlacementToMedals(medals, placement)
-		elseif mode == 'team' then
+		elseif mode == Opponent.team then
 			teamMedals = CustomTeam._addPlacementToMedals(teamMedals, placement)
 		end
 	end
@@ -274,6 +275,7 @@ function CustomTeam.getEarningsAndMedalsData()
 		earnings.team = {}
 	end
 
+	-- to be removed after a purge run + consumer updates
 	if doStore then
 		mw.ext.LiquipediaDB.lpdb_datapoint('total_earnings_players_while_on_team_' .. team, {
 				type = 'total_earnings_players_while_on_team',
@@ -282,16 +284,25 @@ function CustomTeam.getEarningsAndMedalsData()
 		})
 	end
 
-	return Math.round{earnings.team.total or 0}, Math.round{playerEarnings or 0}
+	for _, earningsTable in pairs(earnings) do
+		for key, value in pairs(earningsTable) do
+			earningsTable[key] = Math.round{value}
+		end
+	end
+
+	_team.totalEarnings = Table.extract(earnings.team or {}, 'total') or 0
+	_team.earnings = earnings.team or {}
+	_team.totalEarningsWhileOnTeam = Table.extract(earnings.other or {}, 'total') or 0
+	_team.earningsWhileOnTeam = earnings.other or {}
 end
 
 function CustomTeam._addPlacementToEarnings(earnings, playerEarnings, data)
 	local prizeMoney = data.prizemoney
-	data.players = data.players or {}
-	local mode = data.players.type
+	data.opponentplayers = data.opponentplayers or {}
+	local mode = data.opponenttype
 	mode = _EARNINGS_MODES[mode]
 	if not mode then
-		prizeMoney = data.individualprizemoney * CustomTeam._amountOfTeamPlayersInPlacement(data.players)
+		prizeMoney = data.individualprizemoney * CustomTeam._amountOfTeamPlayersInPlacement(data.opponentplayers)
 		playerEarnings = playerEarnings + prizeMoney
 		mode = 'other'
 	end
@@ -338,8 +349,6 @@ function CustomTeam._placements(value)
 	elseif value == '3' then
 		return 'sf'
 	end
-
-	return nil
 end
 
 function CustomTeam._amountOfTeamPlayersInPlacement(players)


### PR DESCRIPTION
## Summary

1. Store the same (extra)data on BW team pages as on sc2
- playerearningsinXXXX
- playerearnings
- earningsinXXXX (via passing to commons)

2. Switch to using standardized keys in placement query and data processing
3. Replace some hardcoded `'solo'`/`'team'` to using `Opponent.solo`/`Opponent.team`

## How did you test this change?
/dev into live (99% copy paste from sc2)