### PR TITLE
Use standardized lpdb_placement keys in BW infobox player earnings queries

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_person_player_custom.lua
@@ -352,10 +352,12 @@ function CustomPlayer:calculateEarnings()
 end
 
 function CustomPlayer._getEarningsMedalsData(player)
+	local playerWithUnderScores = player:gsub(' ', '_')
 	local playerConditions = ConditionTree(BooleanOperator.any)
 	for playerIndex = 1, Info.maximumNumberOfPlayersInPlacements do
 		playerConditions:add{
-			ConditionNode(ColumnName('players_p' .. playerIndex), Comparator.eq, player),
+			ConditionNode(ColumnName('opponentplayers_p' .. playerIndex), Comparator.eq, player),
+			ConditionNode(ColumnName('opponentplayers_p' .. playerIndex), Comparator.eq, playerWithUnderScores),
 		}
 	end
 
@@ -367,14 +369,18 @@ function CustomPlayer._getEarningsMedalsData(player)
 	end
 
 	local conditions = ConditionTree(BooleanOperator.all):add{
-		playerConditions,
+		ConditionTree(BooleanOperator.any):add{
+			ConditionNode(ColumnName('opponentname'), Comparator.eq, player),
+			ConditionNode(ColumnName('opponentname'), Comparator.eq, playerWithUnderScores),
+			playerConditions,
+		},
 		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
 		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
 		ConditionTree(BooleanOperator.any):add{
 			ConditionNode(ColumnName('individualprizemoney'), Comparator.gt, '0'),
 			ConditionNode(ColumnName('extradata_award'), Comparator.neq, ''),
 			ConditionTree(BooleanOperator.all):add{
-				ConditionNode(ColumnName('players_type'), Comparator.gt, Opponent.solo),
+				ConditionNode(ColumnName('opponenttype'), Comparator.gt, Opponent.solo),
 				placementConditions,
 			},
 		},
@@ -414,7 +420,7 @@ function CustomPlayer._getEarningsMedalsData(player)
 end
 
 function CustomPlayer._addPlacementToEarnings(earnings, earningsTotal, data)
-	local mode = _EARNING_MODES[(data.players or {}).type or ''] or _OTHER_MODE
+	local mode = _EARNING_MODES[data.opponenttype] or _OTHER_MODE
 	if not earnings[mode] then
 		earnings[mode] = {}
 	end
@@ -431,7 +437,7 @@ function CustomPlayer._addPlacementToMedals(medals, data)
 		local place = CustomPlayer._getPlacement(data.placement)
 		CustomPlayer._setAchievements(data, place)
 		if
-			(data.players or {}).type == Opponent.solo
+			data.opponenttype == Opponent.solo
 			and place and place <= 3
 		then
 			local tier = data.liquipediatier or 'undefined'


### PR DESCRIPTION
## Summary
- Use standardized lpdb_placement keys in BW infobox player earnings queries
- Condition on player name with and without underscore
- change the conditions slightly to drop the query runtime a bit

## How did you test this change?
/dev into live (basically the same change already done on sc2 some days/weeks ago)