### PR TITLE
Ignore `BYE` opponents during import

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -34,6 +34,7 @@ local GSL_STYLE_SCORES = {
 	{w = 1, d = 0, l = 2},
 	{w = 0, d = 0, l = 2},
 }
+local BYE_OPPONENT_NAME = 'bye'
 
 local Import = {}
 
@@ -195,7 +196,8 @@ end
 -- Compute placements and their entries from the match records of a bracket.
 function Import._computeBracketPlacementEntries(matchRecords, options)
 	local bracket = MatchGroupUtil.makeBracketFromRecords(matchRecords)
-	return Array.map(
+
+	local slots = Array.map(
 		Import._computeBracketPlacementGroups(bracket, options),
 		function(group)
 			return Array.map(group, function(placementEntry)
@@ -204,6 +206,18 @@ function Import._computeBracketPlacementEntries(matchRecords, options)
 			end)
 		end
 	)
+
+	for slotIndex, slotEntries in pairs(slots) do
+		slots[slotIndex] = Array.filter(slotEntries, function(entry)
+			return not (
+				entry.opponent
+				and entry.opponent.type == Opponent.literal -- in case we ever have a team/player with the id
+				and Opponent.toName(entry.opponent):lower() == BYE_OPPONENT_NAME
+			)
+		end)
+	end
+
+	return slots
 end
 
 function Import._makeEntryFromMatch(placementEntry, match)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -207,6 +207,7 @@ function Import._computeBracketPlacementEntries(matchRecords, options)
 		end
 	)
 
+	-- Remove `bye`s from slotentries
 	for slotIndex, slotEntries in pairs(slots) do
 		slots[slotIndex] = Array.filter(slotEntries, function(entry)
 			return not (

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -211,7 +211,7 @@ function Import._computeBracketPlacementEntries(matchRecords, options)
 		slots[slotIndex] = Array.filter(slotEntries, function(entry)
 			return not (
 				entry.opponent
-				and entry.opponent.type == Opponent.literal -- in case we ever have a team/player with the id
+				and entry.opponent.type == Opponent.literal
 				and Opponent.toName(entry.opponent):lower() == BYE_OPPONENT_NAME
 			)
 		end)


### PR DESCRIPTION
## Summary
Ignore `BYE` opponents during import
Limitations:
- matches have to be finished and the BYE Opponent has to be the loser
--> should not be a real limitation as matches with set winner should be finished anyways (unless overwritten and overwrite option available)

## How did you test this change?
/dev module + a few tests on sc, sc2, cs and r6