### PR TITLE
Handle reset matches in PPT import

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -200,6 +200,10 @@ function Import._computeBracketPlacementEntries(matchRecords, options)
 		function(group)
 			return Array.map(group, function(placementEntry)
 				local match = bracket.matchesById[placementEntry.matchId]
+				if match.bracketData.bracketResetMatchId then
+					local resetMatchId = match.bracketData.bracketResetMatchId
+					match = bracket.matchesById[resetMatchId] or match
+				end
 				return Import._makeEntryFromMatch(placementEntry, match)
 			end)
 		end


### PR DESCRIPTION
## Summary
Currently Reset matches are ignored by PPT import (as one of the limitations of the MVP for it).
This PR makes the import use the reset match if present to determine the 1st/2nd place (instead of using the grandfinal match)

## How did you test this change?
/dev

![Screenshot 2022-10-20 14 24 26](https://user-images.githubusercontent.com/75081997/196948621-c375ad14-25b1-4335-87c6-ef0322971dda.png)
![Screenshot 2022-10-20 14 29 53](https://user-images.githubusercontent.com/75081997/196948930-83ef374b-3d63-46d3-be30-1e6d5a6f030c.png)

## Open Questions:
how should we handle scores in this case?
should we use the scores of the reset match or are there other suggestions?