### PR TITLE
Adjust parent handling in PPT import

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -397,7 +397,7 @@ function PrizePool:create()
 	self.options = self:_readConfig(self.args)
 	self.prizes = self:_readPrizes(self.args)
 	self.placements = self:_readPlacements(self.args)
-	self.placements = Import.run(self.placements, self.args)
+	self.placements = Import.run(self)
 
 	if self:_hasUsdPrizePool() then
 		self:setConfig('showUSD', true)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -36,16 +36,20 @@ local GSL_STYLE_SCORES = {
 }
 local BYE_OPPONENT_NAME = 'bye'
 
+local _parent
+
 local Import = {}
 
-function Import.run(placements, args)
-	Import.config = Import._getConfig(args, placements)
+function Import.run(parent)
+	_parent = parent
+
+	Import.config = Import._getConfig(parent.args, parent.placements)
 
 	if Import.config.importLimit == 0 or not Import.config.matchGroupsSpec then
-		return placements
+		return parent.placements
 	end
 
-	return Import._importPlacements(placements)
+	return Import._importPlacements(parent.placements)
 end
 
 function Import._getConfig(args, placements)
@@ -368,11 +372,9 @@ function Import._emptyPlacement(priorPlacement, placementSize)
 	local placeStart = (priorPlacement.placeEnd or 0) + 1
 	local placeEnd = (priorPlacement.placeEnd or 0) + placementSize
 
-	local parent = priorPlacement.parent
-
 	return Placement(
 		{placeStart = placeStart, placeEnd = placeEnd},
-		parent,
+		_parent,
 		priorPlacement.placeEnd or 0
 	)
 end


### PR DESCRIPTION
## Summary
Adjust parent handling in PPT import
- pass self from `Module:PrizePool` instead of placements and args
- use the so passed parent (above passed self) in the `_emptyPlacement` fucntion

Advantages:
- can call prizepool now without initial slot (very rare as it automatically means no prizes specified)
![Screenshot 2022-10-20 15 21 40](https://user-images.githubusercontent.com/75081997/196960289-e37f3860-4c9e-4c4d-8626-d085c0ede0be.png)
- prep for #2003

## How did you test this change?
/dev