### PR TITLE
Error for missing standingsIndex

### DIFF
--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -32,12 +32,6 @@ function StandingsStorage.run(data)
 		Opponent = Lua.import('Module:'.. data.opponentLibrary, {requireDevIfEnabled = true})
 	end
 
-	local standingsIndex = tonumber(data.standingsindex)
-
-	if not standingsIndex then
-		error('No standingsindex specified')
-	end
-
 	data.roundcount = tonumber(data.roundcount) or Array.reduce(
 		Array.map(data.entries, function (entry) return tonumber (entry.roundindex) end),
 		math.max)

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -32,7 +32,11 @@ function StandingsStorage.run(data)
 		Opponent = Lua.import('Module:'.. data.opponentLibrary, {requireDevIfEnabled = true})
 	end
 
-	local standingsIndex = tonumber(data.standingsindex) or 0
+	local standingsIndex = tonumber(data.standingsindex)
+
+	if not standingsIndex then
+		error('No standingsindex specified')
+	end
 
 	data.roundcount = tonumber(data.roundcount) or Array.reduce(
 		Array.map(data.entries, function (entry) return tonumber (entry.roundindex) end),

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -58,6 +58,12 @@ function StandingsStorage.table(data)
 	local title = data.title or ''
 	local cleanedTitle = title:gsub('<.->.-</.->', '')
 
+	local standingsIndex = tonumber(data.standingsindex)
+
+	if not standingsIndex then
+		error('No standingsindex specified')
+	end
+
 	local extradata = {
 		enddate = data.enddate,
 		finished = data.finished,
@@ -71,7 +77,7 @@ function StandingsStorage.table(data)
 		{
 			tournament = Variables.varDefault('tournament_name', ''),
 			parent = Variables.varDefault('tournament_parent', ''),
-			standingsindex = tonumber(data.standingsindex),
+			standingsindex = standingsIndex,
 			title = mw.text.trim(cleanedTitle),
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),
 			type = data.type,
@@ -90,6 +96,7 @@ function StandingsStorage.entry(entry, standingsIndex)
 
 	local roundIndex = tonumber(entry.roundindex)
 	local slotIndex = tonumber(entry.slotindex)
+	standingsIndex = tonumber(standingsIndex)
 
 	if not standingsIndex or not roundIndex or not slotIndex then
 		return

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -39,7 +39,7 @@ function StandingsStorage.run(data)
 	StandingsStorage.table(data)
 
 	Array.forEach(data.entries, function (entry)
-		StandingsStorage.entry(entry, standingsIndex)
+		StandingsStorage.entry(entry, data.standingsindex)
 	end)
 end
 


### PR DESCRIPTION
## Summary
Throw intentional error in case of missing standings index.

Currently if standingsIndex is not set in several instances on the same page we get several standings on the same page with the same index, i.e. we get bad data and hence also possible issues for the app.

## How did you test this change?
/dev
