### PR TITLE
Change vod link title and icon for a bestof 1

### DIFF
--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -326,8 +326,17 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 		footer:addLink(url, icon, iconDark, label)
 	end
 
-	local function addVodLink(gamenum, vod, htext)
+	local function addVodLink(gamenum, vod, part)
 		if vod then
+			gamenum = (gamenum and match.bestof > 1) and gamenum or nil
+			local htext
+			if part then
+				if gamenum then
+					htext = 'Watch Game ' .. gamenum .. ' (part ' .. part .. ')'
+				else
+					htext = 'Watch VOD (part ' .. part .. ')'
+				end
+			end
 			footer:addElement(VodLink.display{
 				gamenum = gamenum,
 				vod = vod,
@@ -338,8 +347,8 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 
 	-- Match vod
 	if secondVods[0] then
-		addVodLink(nil, match.vod, 'Watch VOD ' .. '(part 1)')
-		addVodLink(nil, secondVods[0], 'Watch VOD ' .. '(part 2)')
+		addVodLink(nil, match.vod, 1)
+		addVodLink(nil, secondVods[0], 2)
 	else
 		addVodLink(nil, match.vod, nil)
 	end
@@ -347,8 +356,8 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 	-- Game Vods
 	for index, vod in pairs(vods) do
 		if secondVods[index] then
-			addVodLink(index, vod, 'Watch Game ' .. index .. ' (part 1)')
-			addVodLink(index, secondVods[index], 'Watch Game ' .. index .. ' (part 2)')
+			addVodLink(index, vod, 1)
+			addVodLink(index, secondVods[index], 2)
 		else
 			addVodLink(index, vod, nil)
 		end


### PR DESCRIPTION
## Summary

Sometimes a vod is only set on the game, so for a best of 1, the title would be `Watch Game 1` instead of `Watch VOD`. The icon was also adjusted for a best of 1.

## How did you test this change?

`/dev`

### Before
![image](https://user-images.githubusercontent.com/43279191/197019204-5dabe370-395f-4080-8f35-9617172ef2e1.png)

### After
![image](https://user-images.githubusercontent.com/43279191/197019307-5c739081-6593-4fab-9339-b733a0a1aa9c.png)


