### PR TITLE
fix ppt exchange info italics

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -621,7 +621,7 @@ function PrizePool:_currencyExchangeInfo()
 		wrapper:wikitext(table.concat(Array.map(Array.filter(self.prizes, function (prize)
 			return PrizePool.prizeTypes[prize.type].convertToUsd
 		end), PrizePool._CurrencyConvertionText), ', '))
-		wrapper:wikitext('\'\')')
+		wrapper:wikitext(')\'\'')
 
 		return tostring(wrapper)
 	end


### PR DESCRIPTION
## Summary

The `)` was outside of the italics when the `(` was inside. So, I moved the `)` to be inside too, otherwise it looked bad.

## How did you test this change?

`/dev`

**before**
![image](https://user-images.githubusercontent.com/5881994/197304181-3b6bd7db-24a8-4616-ab63-190047366971.png)
**after**
![image](https://user-images.githubusercontent.com/5881994/197304183-9b042b94-b7ff-47c3-96d9-cff3a41bb81a.png)
