### PR TITLE
PPT: Add method to modify config defaults from custom

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -697,6 +697,15 @@ function PrizePool:setConfig(option, value)
 	return self
 end
 
+function PrizePool:changeConfigDefault(option, value)
+	if self.config[option] then
+		self.config[option].default = value
+	else
+		error('Invalid default config override!')
+	end
+	return self
+end
+
 function PrizePool:addCustomConfig(name, default, func)
 	self.config[name] = {
 		default = default,

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -697,7 +697,7 @@ function PrizePool:setConfig(option, value)
 	return self
 end
 
-function PrizePool:changeConfigDefault(option, value)
+function PrizePool:setConfigDefault(option, value)
 	if self.config[option] then
 		self.config[option].default = value
 	else


### PR DESCRIPTION
## Summary

Allow to modify default for a wiki while still allowing users to change the value with args. Before it was like
```lua
-- Turn off automations
args.prizesummary = false
args.autousd = false
args.exchangeInfo = false
```
This meant you couldn't use the args in wikicode to change the values. Could have added like args handling in custom but this felt better.

## How did you test this change?

`/dev`

```lua
-- Turn off automations
prizePool:changeConfigDefault('prizeSummary', false)
prizePool:changeConfigDefault('autoUSD', false)
prizePool:changeConfigDefault('exchangeInfo', false)
```

<https://liquipedia.net/counterstrike/index.php?title=Module%3APrizePool%2FCustom%2Fdev&type=revision&diff=2391352&oldid=2344059>
(Will submit as PR if/when this get's merged)

Live here for testing: <https://liquipedia.net/counterstrike/index.php?title=ESL/T%C3%BCrkiye_%C5%9Eampiyonas%C4%B1/2022/Summer&oldid=2391338>