### PR TITLE
Prevent resolving of redirects for arg.series

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -242,6 +242,10 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		lpdbData['tickername'] = args.name
 	end
 
+	-- Prevent resolving redirects for series
+	-- lpdbData.seriespage will still contain the resolved page
+	lpdbData['series'] = args.series
+
 	lpdbData['sponsors'] = args.sponsors
 
 	local mapPages = Table.mapValues(_league.maps, function(map) return map.link end)


### PR DESCRIPTION
## Summary
In AoE, series pages are often redirects, e.g. for multiple seasons of one big series.
Due to the infobox previously resolving redirects before storage, it wasn't possible to query for these different seasons using LPDB.
This prevents resolving of redirects for args.series, while still resolving redirects before storing seriespage.

## How did you test this change?
via /dev
