### PR TITLE
Allow comments per mvp player in mvp display in matchSummary

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -418,7 +418,7 @@ function MatchGroupInput.readMvp(match)
 		end
 	end)
 
-	return {players = parsedPlayers, points = mvppoints}
+	return {players = parsedPlayers, points = mvppoints, freetext = match.mvpfreetext}
 end
 
 return MatchGroupInput

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -407,7 +407,7 @@ function MatchGroupInput.readMvp(match)
 	local players = mw.text.split(match.mvp, ',')
 
 	-- parse the players to get their information
-	local parsedPlayers = Table.map(players, function(playerIndex, player)
+	local parsedPlayers = Array.map(players, function(player, playerIndex)
 		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(mw.text.split(player, '|')[1]):gsub(' ', '_')
 		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
 			for _, lookUpPlayer in pairs(opponent.match2players) do

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -407,18 +407,19 @@ function MatchGroupInput.readMvp(match)
 	local players = mw.text.split(match.mvp, ',')
 
 	-- parse the players to get their information
-	local parsedPlayers = Table.mapValues(players, function(player)
+	local parsedPlayers = Table.map(players, function(playerIndex, player)
 		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(mw.text.split(player, '|')[1]):gsub(' ', '_')
 		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
 			for _, lookUpPlayer in pairs(opponent.match2players) do
 				if link == lookUpPlayer.name then
-					return Table.merge(lookUpPlayer, {team = opponent.name, template = opponent.template})
+					return playerIndex, Table.merge(lookUpPlayer,
+						{team = opponent.name, template = opponent.template, comment = match['mvp' .. playerIndex .. 'comment']})
 				end
 			end
 		end
 	end)
 
-	return {players = parsedPlayers, points = mvppoints, freetext = match.mvpfreetext}
+	return {players = parsedPlayers, points = mvppoints}
 end
 
 return MatchGroupInput

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -134,13 +134,20 @@ local Mvp = Class.new(
 )
 
 function Mvp:addPlayer(player)
+	local playerDisplay
 	if Logic.isEmpty(player) then
 		return self
 	elseif type(player) == 'table' then
-		table.insert(self.players, player.name .. '|' .. player.displayname)
+		playerDisplay = '[[' .. player.name .. '|' .. player.displayname .. ']]'
+		if player.comment then
+			playerDisplay = playerDisplay .. ' (' .. player.comment .. ')'
+		end
 	else
-		table.insert(self.players, player)
+		playerDisplay = '[[' .. player .. ']]'
 	end
+
+	table.insert(self.players, playerDisplay)
+
 	return self
 end
 
@@ -151,27 +158,12 @@ function Mvp:setPoints(points)
 	return self
 end
 
-function Mvp:addFreeText(freeText)
-	if String.isNotEmpty(freeText) then
-		self.freeText = freeText
-	end
-	return self
-end
-
 function Mvp:create()
 	local span = mw.html.create('span')
 	span:wikitext(#self.players > 1 and 'MVPs: ' or 'MVP: ')
-	for index, player in ipairs(self.players) do
-		if index > 1 then
-			span:wikitext(', ')
-		end
-		span:wikitext('[['..player..']]')
-	end
+		:wikitext(table.concat(self.players, ', '))
 	if self.points and self.points ~= 1 then
 		span:wikitext(' ('.. self.points ..'pts)')
-	end
-	if self.freeText then
-		span:wikitext(' ('.. self.freeText ..')')
 	end
 	self.root:node(span)
 	return self.root

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -151,6 +151,13 @@ function Mvp:setPoints(points)
 	return self
 end
 
+function Mvp:addFreeText(freeText)
+	if String.isNotEmpty(freeText) then
+		self.freeText = freeText
+	end
+	return self
+end
+
 function Mvp:create()
 	local span = mw.html.create('span')
 	span:wikitext(#self.players > 1 and 'MVPs: ' or 'MVP: ')
@@ -162,6 +169,9 @@ function Mvp:create()
 	end
 	if self.points and self.points ~= 1 then
 		span:wikitext(' ('.. self.points ..'pts)')
+	end
+	if self.freeText then
+		span:wikitext(' ('.. self.freeText ..')')
 	end
 	self.root:node(span)
 	return self.root

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -170,7 +170,6 @@ function CustomMatchSummary._createBody(match)
 				mvp:addPlayer(player)
 			end
 			mvp:setPoints(mvpData.points)
-			mvp:addFreeText(mvpData.freetext)
 
 			body:addRow(mvp)
 		end

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -170,6 +170,7 @@ function CustomMatchSummary._createBody(match)
 				mvp:addPlayer(player)
 			end
 			mvp:setPoints(mvpData.points)
+			mvp:addFreeText(mvpData.freetext)
 
 			body:addRow(mvp)
 		end


### PR DESCRIPTION
## Summary
Allow comments per mvp player in mvp display in matchSummary

## How did you test this change?
/dev

![Screenshot 2022-10-31 11 42 43](https://user-images.githubusercontent.com/75081997/198990259-2f104f6e-e3ce-4f4c-b633-37c92247e082.png)

