### PR TITLE
Fix achievements in Infobox/Team for Dota 2

### DIFF
--- a/components/infobox/wikis/dota2/infobox_team_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_team_custom.lua
@@ -24,7 +24,7 @@ function CustomTeam.run(frame)
 	team.args.dotabuff = team.args.teamid
 
 	-- Automatic achievements
-	team.args.achievements = Template.expandTemplate(frame, 'Team achievements')
+	team.args.achievements = Template.expandTemplate(frame, 'Team achievements', {team.args.name})
 
 	-- Automatic org people
 	team.args.coach = Template.expandTemplate(frame, 'Coach of')


### PR DESCRIPTION
## Summary

Template `Team achievements` needs team name.

## How did you test this change?

/dev

## Before
![image](https://user-images.githubusercontent.com/42477808/198882324-ae73b4f9-cd46-4952-a4a0-07804856ab36.png)

## After
![image](https://user-images.githubusercontent.com/42477808/198882311-8283b020-5990-4e74-b884-65282bdd0695.png)
