### PR TITLE
Add Ballchasing link to RL's match summary. Fix link storage on RL

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -196,8 +196,8 @@ end
 
 function matchFunctions.getLinks(match)
 	match.links = {
-		octane = match.octane,
-		ballchasing = match.ballchasing
+		octane = 'https://octane.gg/matches/' .. match.octane,
+		ballchasing = 'https://ballchasing.com/group/' .. match.ballchasing
 	}
 	return match
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -52,6 +52,7 @@ function CustomMatchGroupInput.processMatch(match)
 	match = matchFunctions.getTournamentVars(match)
 	match = matchFunctions.getVodStuff(match)
 	match = matchFunctions.getExtraData(match)
+	match = matchFunctions.getLinks(match)
 
 	return match
 end
@@ -186,11 +187,17 @@ function matchFunctions.getExtraData(match)
 		team1icon = getIconName(opponent1.template or ''),
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
-		octane = match.octane,
-		ballchasing = match.ballchasing,
 		isconverted = 0,
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
+	}
+	return match
+end
+
+function matchFunctions.getLinks(match)
+	match.links = {
+		octane = match.octane,
+		ballchasing = match.ballchasing
 	}
 	return match
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -187,6 +187,7 @@ function matchFunctions.getExtraData(match)
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
 		octane = match.octane,
+		ballchasing = match.ballchasing,
 		isconverted = 0,
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -217,19 +217,19 @@ function CustomMatchSummary.getByMatchId(args)
 	if
 		Table.isNotEmpty(vods) or
 		String.isNotEmpty(match.vod) or
-		Logic.isNotEmpty(match.extradata.octane) or
-		Logic.isNotEmpty(match.extradata.ballchasing)
+		Logic.isNotEmpty(match.links.octane) or
+		Logic.isNotEmpty(match.links.ballchasing)
 	then
 		local footer = MatchSummary.Footer()
 
 		-- Octane
-		if Logic.isNotEmpty(match.extradata.octane) then
-			footer:addElement(_OCTANE_PREFIX .. match.extradata.octane .. _OCTANE_SUFFIX)
+		if Logic.isNotEmpty(match.links.octane) then
+			footer:addElement(_OCTANE_PREFIX .. match.links.octane .. _OCTANE_SUFFIX)
 		end
 
 		-- Ballchasing
-		if Logic.isNotEmpty(match.extradata.ballchasing) then
-			footer:addElement(_BALLCHASING_PREFIX .. match.extradata.ballchasing .. _BALLCHASING_SUFFIX)
+		if Logic.isNotEmpty(match.links.ballchasing) then
+			footer:addElement(_BALLCHASING_PREFIX .. match.links.ballchasing .. _BALLCHASING_SUFFIX)
 		end
 
 		-- Match Vod

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -26,6 +26,8 @@ local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 local _TIMEOUT = '[[File:Cooldown_Clock.png|14x14px|link=]]'
 local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link=https://octane.gg/matches/'
 local _OCTANE_SUFFIX = '|Octane matchpage]]'
+local _BALLCHASING_PREFIX = '[[File:Ballchasing icon.png|14x14px|link=https://ballchasing.com/group/'
+local _BALLCHASING_SUFFIX = '|Ballchasing replays]]'
 
 local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
 
@@ -215,13 +217,19 @@ function CustomMatchSummary.getByMatchId(args)
 	if
 		Table.isNotEmpty(vods) or
 		String.isNotEmpty(match.vod) or
-		Logic.isNotEmpty(match.extradata.octane)
+		Logic.isNotEmpty(match.extradata.octane) or
+		Logic.isNotEmpty(match.extradata.ballchasing)
 	then
 		local footer = MatchSummary.Footer()
 
 		-- Octane
 		if Logic.isNotEmpty(match.extradata.octane) then
 			footer:addElement(_OCTANE_PREFIX .. match.extradata.octane .. _OCTANE_SUFFIX)
+		end
+
+		-- Ballchasing
+		if Logic.isNotEmpty(match.extradata.ballchasing) then
+			footer:addElement(_BALLCHASING_PREFIX .. match.extradata.ballchasing .. _BALLCHASING_SUFFIX)
 		end
 
 		-- Match Vod

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -24,9 +24,10 @@ local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnable
 local _GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
 local _NO_CHECK = '[[File:NoCheck.png|link=]]'
 local _TIMEOUT = '[[File:Cooldown_Clock.png|14x14px|link=]]'
-local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link=https://octane.gg/matches/'
+
+local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link='
 local _OCTANE_SUFFIX = '|Octane matchpage]]'
-local _BALLCHASING_PREFIX = '[[File:Ballchasing icon.png|14x14px|link=https://ballchasing.com/group/'
+local _BALLCHASING_PREFIX = '[[File:Ballchasing icon.png|14x14px|link='
 local _BALLCHASING_SUFFIX = '|Ballchasing replays]]'
 
 local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -218,8 +218,7 @@ function CustomMatchSummary.getByMatchId(args)
 	if
 		Table.isNotEmpty(vods) or
 		String.isNotEmpty(match.vod) or
-		Logic.isNotEmpty(match.links.octane) or
-		Logic.isNotEmpty(match.links.ballchasing)
+		Table.isNotEmpty(match.links)
 	then
 		local footer = MatchSummary.Footer()
 


### PR DESCRIPTION
Ballchasing is a website that hosts replays for Rocket League, all of the RLCS replays are hosted there. Liquipedia always has the link to the Ballchasing tournament page on the wiki tournament page, but with this pull-request it will be possible per match, so the user does not have to relocate the match they want to find the replays for.

## How did you test this change?

/dev module