### PR TITLE
Make all characters acceptable in LPDB Mock for values

### DIFF
--- a/standard/mock/mock_lpdb.lua
+++ b/standard/mock/mock_lpdb.lua
@@ -16,7 +16,7 @@ local TypeUtil = require('Module:TypeUtil')
 
 -- Parses a single condition into it's three components,
 -- Eg. `[[field::!value]]` is parsed into `field`, `!`, `value`
-local CONDITION_REGEX = '%[%[(%a+)::([!><]?)([%a%s%d]+)]]'
+local CONDITION_REGEX = '%[%[(%a+)::([!><]?)(.-)]]'
 
 local mockLpdb = {}
 


### PR DESCRIPTION
## Summary
The current regex doesn't allow for special characters. Setup with a lazy any character instead of the current char-set.

## How did you test this change?
dev module