### PR TITLE
Legacy PPT for PUBG Mobile

### DIFF
--- a/components/prize_pool/wikis/pubgmobile/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/pubgmobile/prize_pool_legacy_custom.lua
@@ -1,0 +1,41 @@
+---
+-- @Liquipedia
+-- wiki=pubgmobile
+-- page=Module:PrizePool/Legacy/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Currency = require('Module:Currency')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local PrizePoolLegacy = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
+
+local CustomLegacyPrizePool = {}
+-- Template entry point
+function CustomLegacyPrizePool.run()
+	return PrizePoolLegacy.run(CustomLegacyPrizePool)
+end
+
+function CustomLegacyPrizePool.customHeader(newArgs, data, header)
+	if Logic.readBool(header.seed) then
+		PrizePoolLegacy.assignType(newArgs, 'seed', 'seed')
+	end
+
+	-- no manual localcurrency input, so fall back to wiki variable set by infobox league
+	if String.isEmpty(header.localcurrency) and String.isNotEmpty(Variables.varDefault('tournament_currency')) then
+		local localCurrency = Variables.varDefault('tournament_currency')
+		-- only allow valid currencies
+		if Currency.raw(localCurrency) then
+			newArgs.localcurrency = localCurrency
+			data.inputToId.localprize = 'localprize'
+		end
+	end
+
+	return newArgs
+end
+
+return CustomLegacyPrizePool


### PR DESCRIPTION
## Summary
Ported from Apex Legends.

Previously editors have voiced request on bringing new PPT for PUBGM as there is a lot of cases for "Shifted columns" that involves a now unused parameter **nopoints=true** that cause a lot of events to have an offset column. 

So I eventually ported this right away
 
One of the changes added both in new and legacy module is ability to allow the PPT to trigger and define the local currency automatically without needing to define through **|localcurrency=X**

this is due to old PPT/InfoLeague has set it this way and a lot of event pages setup it in that way (E.G : https://liquipedia.net/pubgmobile/Piala_Presiden_Esports/2021#Prize_Pool)

## How did you test this change?
LIVE

Some of the pages: 
https://liquipedia.net/pubgmobile/Peacekeeper_Elite_League/2022/Summer
https://liquipedia.net/pubgmobile/PUBG_Mobile_Global_Championship/2021/Grand_Finals

## For Solo and Duos events
Solos will be manually converted to the **SoloPrizePool** input

while for Duos I go with using the old PPT, set indiv and give each placement as two numbers instead (e.g. https://liquipedia.net/pubgmobile/index.php?title=PUBG_Mobile/Winter_War&action=edit&section=4 
_Maybe DuosPrizePool in future?_)
