### PR TITLE
Add unit tests for Squads

### DIFF
--- a/components/squad/test/squad_test.lua
+++ b/components/squad/test/squad_test.lua
@@ -1,0 +1,72 @@
+
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Squad/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local Squad = Lua.import('Module:Squad', {requireDevIfEnabled = true})
+local SquadRow = Lua.import('Module:Squad/Row', {requireDevIfEnabled = true})
+local LpdbMock = Lua.import('Module:Mock/Lpdb', {requireDevIfEnabled = true})
+
+local suite = ScribuntoUnit:new()
+
+function suite:testRow()
+	LpdbMock.setUp()
+
+	local row = SquadRow()
+	row	:id{'Baz', 'se'}
+		:name{'Foo Bar'}
+		:role{}
+		:date('2022-01-01', 'Join Date:&nbsp;', 'joindate')
+		:date('2022-03-03', 'Inactive Date:&nbsp;', 'inactivedate')
+		:date('2022-05-01', 'Leave Date:&nbsp;', 'leavedate')
+		:newteam{
+			newteam = 'Sweden',
+			leavedate = '2022-05-01'
+		}
+
+	local createdRow = row:create('object_name')
+
+	self:assertEquals(
+		'<tr class="Player"><td class="ID">\'\'\'<span style="white-space:pre">[[Baz]]</span>\'\'\'</td>' ..
+		'<td></td><td class="Name"><div class="MobileStuff">(</div><div class="MobileStuff">)</div></td>' ..
+		'<td class="Position"></td><td class="Date"><div class="MobileStuffDate">Join Date:&nbsp;</div>' ..
+		'<div class="Date">\'\'2022-01-01\'\'</div></td><td class="Date">' ..
+		'<div class="MobileStuffDate">Inactive Date:&nbsp;</div><div class="Date">\'\'2022-03-03\'\'</div></td>' ..
+		'<td class="Date"><div class="MobileStuffDate">Leave Date:&nbsp;</div>' ..
+		'<div class="Date">\'\'2022-05-01\'\'</div></td><td class="NewTeam"><div class="MobileStuff">' ..
+		'<i class="fa fa-long-arrow-right" aria-hidden="true"></i>&nbsp;</div>' ..
+		'<span data-highlightingclass="Team Sweden" class="team-template-team-standard">' ..
+		'<span class="team-template-image-icon team-template-lightmode">' ..
+		'[[File:Flag of Sweden 4 by 3.png|100x50px|middle|Team Sweden|link=Team Sweden]]</span>' ..
+		'<span class="team-template-image-icon team-template-darkmode">' ..
+		'[[File:Flag of Sweden 4 by 3.png|100x50px|middle|Team Sweden|link=Team Sweden]]</span> '..
+		'<span class="team-template-text">[[Team Sweden|Team Sweden]]</span></span></td></tr>',
+		tostring(createdRow)
+	)
+
+	LpdbMock.tearDown()
+end
+
+function suite:testHeader()
+	local squad = Squad():init{}:title():header():create()
+
+	self:assertEquals(
+		'<div class="table-responsive" style="margin-bottom:10px;padding-bottom:0px">' ..
+		'<table class="wikitable wikitable-striped roster-card">' ..
+		'<tr><th class="large-only" colspan="1">Active Squad</th>'..
+		'<th class="large-only roster-title-row2-border" colspan="10">Active Squad</th></tr>' ..
+		'<tr class="HeaderRow"><th class="divCell">ID</th><th></th><th class="divCell">Name</th><th>' ..
+		'</th><th class="divCell">Join Date</th></tr>' ..
+		'</table></div>',
+		tostring(squad)
+	)
+end
+
+return suite

--- a/standard/mock/mock_lpdb.lua
+++ b/standard/mock/mock_lpdb.lua
@@ -29,18 +29,21 @@ local _lpdb = {
 	lpdb = mw.ext.LiquipediaDB.lpdb,
 	lpdb_standingsentry = mw.ext.LiquipediaDB.lpdb_standingsentry,
 	lpdb_standingstable = mw.ext.LiquipediaDB.lpdb_standingstable,
+	lpdb_squadplayer = mw.ext.LiquipediaDB.lpdb_squadplayer,
 }
 
 function mockLpdb.setUp()
 	mw.ext.LiquipediaDB.lpdb = mockLpdb.lpdb
 	mw.ext.LiquipediaDB.lpdb_standingsentry = mockLpdb.lpdb_standingsentry
 	mw.ext.LiquipediaDB.lpdb_standingstable = mockLpdb.lpdb_standingstable
+	mw.ext.LiquipediaDB.lpdb_squadplayer = mockLpdb.lpdb_squadplayer
 end
 
 function mockLpdb.tearDown()
 	mw.ext.LiquipediaDB.lpdb = _lpdb.lpdb
 	mw.ext.LiquipediaDB.lpdb_standingsentry = _lpdb.lpdb_standingsentry
 	mw.ext.LiquipediaDB.lpdb_standingstable = _lpdb.lpdb_standingstable
+	mw.ext.LiquipediaDB.lpdb_squadplayer = _lpdb.lpdb_squadplayer
 end
 
 local dbStructure = {}
@@ -67,6 +70,26 @@ dbStructure.standingsentry = {
 	placementchange = 'number',
 	scoreboards = 'table', -- TODO
 	roundindex = 'number',
+	extradata = 'struct?',
+}
+dbStructure.squadplayer = {
+	id = 'string',
+	link = 'pagename',
+	name = 'string?',
+	nationality = 'string?',
+	image = 'string?',
+	position = 'string?',
+	role = 'string?',
+	type = TypeUtil.literalUnion('player', 'staff'),
+	newteam = 'string?',
+	teamtemplate = 'string?', -- TODO: TeamTemplate type?
+	newteamtemplate = 'string?', -- TODO: TeamTemplate type?
+	joindate = 'string?', -- TODO: Date type?
+	joindateref = 'string?',
+	leavedate = 'string?', -- TODO: Date type?
+	leavedateref = 'string?',
+	inactivedate = 'string?', -- TODO: Date type?
+	inactivedateref = 'string?',
 	extradata = 'struct?',
 }
 
@@ -196,6 +219,15 @@ function mockLpdb.lpdb_standingsentry(objectname, data)
 	data = Table.mapValues(data, mockLpdb._deserializeJson)
 	TypeUtil.assertValue(objectname, 'string')
 	TypeUtil.assertValue(data, TypeUtil.struct(dbStructure.standingsentry), { maxDepth = 3, name = 'StandingsEntry' })
+end
+
+---Stores data into LPDB SquadPlayer
+---@param objectname string
+---@param data table
+function mockLpdb.lpdb_squadplayer(objectname, data)
+	data = Table.mapValues(data, mockLpdb._deserializeJson)
+	TypeUtil.assertValue(objectname, 'string')
+	TypeUtil.assertValue(data, TypeUtil.struct(dbStructure.squadplayer), { maxDepth = 3, name = 'SquadPlayer' })
 end
 
 return mockLpdb


### PR DESCRIPTION
## Summary
Create unit tests for Squads.
Add LPDB storage mocking for SquadPlayer.

## How did you test this change?
https://liquipedia.net/commons/Module_talk:Squad/testcases
