### PR TITLE
Fix wrong name in magic comment

### DIFF
--- a/standard/tournaments_summary_table/wikis/trackmania/tournaments_summary_table_custom.lua
+++ b/standard/tournaments_summary_table/wikis/trackmania/tournaments_summary_table_custom.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=trackmania
--- page=Module:CustomTournamentsSummaryTable/Custom
+-- page=Module:TournamentsSummaryTable/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --


### PR DESCRIPTION
## Summary
Removes the additional `Custom` in the magic comment.
Correct URL is https://liquipedia.net/trackmania/Module:TournamentsSummaryTable/Custom

## How did you test this change?
N/A
