### PR TITLE
Add Custom opponent Libs to info modules

### DIFF
--- a/standard/info/wikis/ageofempires/info.lua
+++ b/standard/info/wikis/ageofempires/info.lua
@@ -12,4 +12,5 @@ return {
 	name = 'Age of Empires',
 	defaultTeamLogo = 'Age_of_Empires_Default_Logo.png',
 	defaultTeamLogoDark = 'Age_of_Empires_Default_Logo.png',
+	opponentLibrary = 'Opponent/Custom',
 }

--- a/standard/info/wikis/fortnite/info.lua
+++ b/standard/info/wikis/fortnite/info.lua
@@ -12,4 +12,6 @@ return {
 	name = 'Fortnite',
 	defaultTeamLogo = 'Fortnite logo.png',
 	defaultTeamLogoDark = 'Fortnite logo.png',
+	opponentLibrary = 'Opponent/Custom',
+	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }

--- a/standard/info/wikis/rocketleague/info.lua
+++ b/standard/info/wikis/rocketleague/info.lua
@@ -12,4 +12,5 @@ return {
 	name = 'Rocket League',
 	defaultTeamLogo = 'Rocket_League.png',
 	defaultTeamLogoDark = 'Rocket_League.png',
+	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }

--- a/standard/info/wikis/starcraft/info.lua
+++ b/standard/info/wikis/starcraft/info.lua
@@ -13,4 +13,6 @@ return {
 	defaultTeamLogo = 'StarCraft_default_allmode.png',
 	defaultTeamLogoDark = 'StarCraft_default_allmode.png',
 	maximumNumberOfPlayersInPlacements = 35,
+	opponentLibrary = 'Opponent/Starcraft',
+	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
 }

--- a/standard/info/wikis/starcraft2/info.lua
+++ b/standard/info/wikis/starcraft2/info.lua
@@ -12,4 +12,6 @@ return {
 	name = 'StarCraft II',
 	defaultTeamLogo = 'StarCraft_2_Default_logo.png',
 	defaultTeamLogoDark = 'StarCraft_2_Default_logo.png',
+	opponentLibrary = 'Opponent/Starcraft',
+	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
 }


### PR DESCRIPTION
## Summary
Add Custom opponent Libs to info modules

Will allow to require the correct opponent libs via
```lua
local Info = require('Module:Info')
local Lua = require('Module:Lua')

local Opponent = Lua.import('Module:'.. Info.opponentLibrary or 'Opponent', {requireDevIfEnabled = true})
local OpponentDisplay = Lua.import('Module:'.. Info.opponentDisplayLibrary or 'OpponentDisplay', {requireDevIfEnabled = true})

```

## How did you test this change?
N/A, just adding data to info modules