### PR TITLE
Add `Module:OpponentLibraries`

### DIFF
--- a/components/opponent/commons/opponent_libraries.lua
+++ b/components/opponent/commons/opponent_libraries.lua
@@ -1,0 +1,15 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:OpponentLibraries 
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Info = require('Module:Info')
+local Lua = require('Module:Lua')
+
+local Opponent = Lua.import('Module:'.. Info.opponentLibrary or 'Opponent', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:'.. Info.opponentDisplayLibrary or 'OpponentDisplay', {requireDevIfEnabled = true})
+
+return Opponent, OpponentDisplay

--- a/components/opponent/commons/opponent_libraries.lua
+++ b/components/opponent/commons/opponent_libraries.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:OpponentLibraries 
+-- page=Module:OpponentLibraries
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -9,7 +9,8 @@
 local Info = require('Module:Info')
 local Lua = require('Module:Lua')
 
-local Opponent = Lua.import('Module:'.. Info.opponentLibrary or 'Opponent', {requireDevIfEnabled = true})
-local OpponentDisplay = Lua.import('Module:'.. Info.opponentDisplayLibrary or 'OpponentDisplay', {requireDevIfEnabled = true})
+local Opponent = Lua.import('Module:'.. (Info.opponentLibrary or 'Opponent'), {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:'.. (Info.opponentDisplayLibrary or 'OpponentDisplay'),
+	{requireDevIfEnabled = true})
 
 return Opponent, OpponentDisplay


### PR DESCRIPTION
## Summary
Add `Module:OpponentLibraries` for easily fetching the wanted opponent library and opponent display library

## How did you test this change?
created the module and tested it with the Results table i am currently building in my sandboxes (simulate the case of non sc2 with temp removing the opponent libs from module:Info)
<https://liquipedia.net/starcraft2/index.php?title=Module%3AHjpalpha%2Fsandbox30&type=revision&diff=2297928&oldid=2297924>
