### PR TITLE
Add annotation to Lua.import

### DIFF
--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -42,14 +42,14 @@ function Lua.loadDataIfExists(name)
 	end
 end
 
---[[
-Imports a module by its name.
-
-options.requireDevIfEnabled:
-Requires the development version of a module (with /dev appended to name) if it
-exists and the dev feature flag is enabled. Otherwise requires the non-
-development module.
-]]
+---Imports a module by its name.
+---
+---options.requireDevIfEnabled:
+---Requires the development version of a module (with /dev appended to name) if it
+---exists and the dev feature flag is enabled. Otherwise requires the non-development module.
+---@param name string
+---@param options {requireDevIfEnabled: boolean}
+---@return unknown
 function Lua.import(name, options)
 	options = options or {}
 	if options.requireDevIfEnabled then


### PR DESCRIPTION
## Summary
Add proper annotations to Lua.import. Mainly to get the options table in intellisense.

## How did you test this change?
![image](https://user-images.githubusercontent.com/3426850/199244582-7444dd4b-5477-4831-8fcc-fa704511bc70.png)