### PR TITLE
Fix issue on Rocket League match2 with Goal displays

### DIFF
--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -383,7 +383,7 @@ end
 
 function CustomMatchSummary._goalDisaplay(goalesValue, side)
 	local goalsDisplay = mw.html.create('div')
-		:cssText(side == 2 and 'float:right; margin-right:10px;')
+		:cssText(side == 2 and 'float:right; margin-right:10px;' or nil)
 		:node(Abbreviation.make(
 			goalesValue,
 			'Team ' .. side .. ' Goaltimes')


### PR DESCRIPTION
## Summary
Spotted error on an old Rocket League bracket
`Module:MatchSummary:386: bad argument #1 to 'cssText' (string, number or nil expected, got boolean)`
https://liquipedia.net/rocketleague/Rocket_League_Championship_Series/Season_1/North_America/Qualifier_2#Playoffs

This PR fixes this issue by ensure a boolean is never returned by the ternary. 

## How did you test this change?
Dev module
![image](https://user-images.githubusercontent.com/3426850/199431824-28772b8e-b74b-4d98-a264-7e12e0563fa4.png)

