### PR TITLE
Add `Module:Info` on commons

### DIFF
--- a/standard/info/commons/info.lua
+++ b/standard/info/commons/info.lua
@@ -11,6 +11,4 @@ return {
 	name = 'Commons',
 	defaultTeamLogo = 'Liquipedia_logo.png',
 	defaultTeamLogoDark = 'Liquipedia_logo.png',
-	opponentLibrary = 'Opponent',
-	opponentDisplayLibrary = 'OpponentDisplay',
 }

--- a/standard/info/commons/info.lua
+++ b/standard/info/commons/info.lua
@@ -1,0 +1,16 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Info
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	wikiName = 'commons',
+	name = 'Commons',
+	defaultTeamLogo = 'Liquipedia_logo.png',
+	defaultTeamLogoDark = 'Liquipedia_logo.png',
+	opponentLibrary = 'Opponent',
+	opponentDisplayLibrary = 'OpponentDisplay',
+}


### PR DESCRIPTION
## Summary
Add `Module:Info` on commons for it to not be missing when requiring it

## How did you test this change?
N/A