### PR TITLE
Fix OpponentLibraries module

### DIFF
--- a/components/opponent/commons/opponent_libraries.lua
+++ b/components/opponent/commons/opponent_libraries.lua
@@ -9,8 +9,8 @@
 local Info = require('Module:Info')
 local Lua = require('Module:Lua')
 
-local Opponent = Lua.import('Module:'.. (Info.opponentLibrary or 'Opponent'), {requireDevIfEnabled = true})
-local OpponentDisplay = Lua.import('Module:'.. (Info.opponentDisplayLibrary or 'OpponentDisplay'),
-	{requireDevIfEnabled = true})
-
-return Opponent, OpponentDisplay
+return {
+	Opponent = Lua.import('Module:'.. (Info.opponentLibrary or 'Opponent'), {requireDevIfEnabled = true}),
+	OpponentDisplay = Lua.import('Module:'.. (Info.opponentDisplayLibrary or 'OpponentDisplay'),
+		{requireDevIfEnabled = true})
+}


### PR DESCRIPTION
## Summary
When requiring a module only the first return value is returned, hence the OpponentDisplay library is currently never returned.
This PR changes the return value to be a table (with named keys) of the libraries, hence returning bot libraries.
This allows to require as follows:
```lua
local OpponentLibraries = require('Module:OpponentLibraries')
local Opponent = OpponentLibraries.Opponent
local OpponentDisplay = OpponentLibraries.OpponentDisplay
```

The bug was introduced via #2145
The module is not yet in use anywhere.

## How did you test this change?
dev modules

