### PR TITLE
Add fallback for missing match2players in reading mvp

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -418,7 +418,6 @@ function MatchGroupInput.readMvp(match)
 			end
 		end
 
-
 		local nameComponents = mw.text.split(player, '|')
 		return playerIndex, {displayname = nameComponents[#nameComponents], name = link, comment = match['mvp' .. playerIndex .. 'comment']}
 	end)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -419,7 +419,11 @@ function MatchGroupInput.readMvp(match)
 		end
 
 		local nameComponents = mw.text.split(player, '|')
-		return playerIndex, {displayname = nameComponents[#nameComponents], name = link, comment = match['mvp' .. playerIndex .. 'comment']}
+		return playerIndex, {
+			displayname = nameComponents[#nameComponents],
+			name = link,
+			comment = match['mvp' .. playerIndex .. 'comment']
+		}
 	end)
 
 	return {players = parsedPlayers, points = mvppoints}

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -417,6 +417,10 @@ function MatchGroupInput.readMvp(match)
 				end
 			end
 		end
+
+
+		local nameComponents = mw.text.split(player, '|')
+		return playerIndex, {displayname = nameComponents[#nameComponents], name = link, comment = match['mvp' .. playerIndex .. 'comment']}
 	end)
 
 	return {players = parsedPlayers, points = mvppoints}

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -412,14 +412,14 @@ function MatchGroupInput.readMvp(match)
 		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
 			for _, lookUpPlayer in pairs(opponent.match2players) do
 				if link == lookUpPlayer.name then
-					return playerIndex, Table.merge(lookUpPlayer,
+					return Table.merge(lookUpPlayer,
 						{team = opponent.name, template = opponent.template, comment = match['mvp' .. playerIndex .. 'comment']})
 				end
 			end
 		end
 
 		local nameComponents = mw.text.split(player, '|')
-		return playerIndex, {
+		return {
 			displayname = nameComponents[#nameComponents],
 			name = link,
 			comment = match['mvp' .. playerIndex .. 'comment']


### PR DESCRIPTION
## Summary
Add fallback for missing match2players in reading mvp
Fixes preview "bug" where in section preview it would error due to the playerdata from TC/HDB not being present

"Bug" was introduced via #1862
"Bug" only shows on pages with bad data input or in preview

## How did you test this change?
/dev