### PR TITLE
Add head-to-head to RL's match summary

### DIFF
--- a/components/hidden_data_box/wikis/rocketleague/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/rocketleague/hidden_data_box_custom.lua
@@ -11,6 +11,7 @@ local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
 local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox', {requireDevIfEnabled = true})
+local CustomLeague = Lua.import('Module:Infobox/League/Custom', {requireDevIfEnabled = true})
 local CustomHiddenDataBox = {}
 
 function CustomHiddenDataBox.run(args)
@@ -27,6 +28,7 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	)
 	Variables.varDefine('tournament_icon_dark', Variables.varDefault('tournament_icondark'))
 	Variables.varDefine('tournament_parent_name', Variables.varDefault('tournament_parentname'))
+	Variables.varDefine('showh2h', CustomLeague:parseShowHeadToHead(args))
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/hidden_data_box/wikis/rocketleague/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/rocketleague/hidden_data_box_custom.lua
@@ -28,7 +28,7 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	)
 	Variables.varDefine('tournament_icon_dark', Variables.varDefault('tournament_icondark'))
 	Variables.varDefine('tournament_parent_name', Variables.varDefault('tournament_parentname'))
-	Variables.varDefine('showh2h', CustomLeague:parseShowHeadToHead(args))
+	Variables.varDefine('showh2h', CustomLeague.parseShowHeadToHead(args))
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -169,7 +169,7 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('showh2h',
 		Logic.emptyOr(
 			args.showh2h,
-			tostring(tonumber(args.liquipediatier or _H2H_TIER_THRESHOLD) < _H2H_TIER_THRESHOLD)
+			tostring(tonumber(args.liquipediatier) or _H2H_TIER_THRESHOLD < _H2H_TIER_THRESHOLD)
 		)
 	)
 end

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -31,6 +31,8 @@ local _MODE_2v2 = '2v2'
 local _GAME_ROCKET_LEAGUE = 'rl'
 local _GAME_SARPBC = 'sarpbc'
 
+local _H2H_TIER_THRESHOLD = 4
+
 local _league
 
 function CustomLeague.run(frame)
@@ -165,7 +167,10 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_participants', '(')
 	Variables.varDefine('tournament_teamplayers', args.mode == _MODE_2v2 and 2 or 3)
 	Variables.varDefine('showh2h',
-		Logic.emptyOr(args.showh2h, tostring(tonumber(args.liquipediatier) < 5))
+		Logic.emptyOr(
+			args.showh2h,
+			tostring(tonumber(args.liquipediatier or 0) <= _H2H_TIER_THRESHOLD)
+		)
 	)
 end
 

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -12,6 +12,7 @@ local String = require('Module:StringUtils')
 local Template = require('Module:Template')
 local TournamentNotability = require('Module:TournamentNotability')
 local Variables = require('Module:Variables')
+local Logic = require('Module:Logic')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
@@ -163,6 +164,9 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_participant_number', 0)
 	Variables.varDefine('tournament_participants', '(')
 	Variables.varDefine('tournament_teamplayers', args.mode == _MODE_2v2 and 2 or 3)
+	Variables.varDefine('showheadtohead',
+		Logic.emptyOr(args.showheadtohead, tostring(tonumber(args.liquipediatier) < 5))
+	)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -7,12 +7,12 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Template = require('Module:Template')
 local TournamentNotability = require('Module:TournamentNotability')
 local Variables = require('Module:Variables')
-local Logic = require('Module:Logic')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -166,10 +166,10 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_participant_number', 0)
 	Variables.varDefine('tournament_participants', '(')
 	Variables.varDefine('tournament_teamplayers', args.mode == _MODE_2v2 and 2 or 3)
-	Variables.varDefine('showh2h', CustomLeague:parseShowHeadToHead(args))
+	Variables.varDefine('showh2h', CustomLeague.parseShowHeadToHead(args))
 end
 
-function CustomLeague:parseShowHeadToHead(args)
+function CustomLeague.parseShowHeadToHead(args)
 	return Logic.emptyOr(
 		args.showh2h,
 		tostring((tonumber(args.liquipediatier) or _H2H_TIER_THRESHOLD) < _H2H_TIER_THRESHOLD)

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -169,7 +169,7 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('showh2h',
 		Logic.emptyOr(
 			args.showh2h,
-			tostring(tonumber(args.liquipediatier) or _H2H_TIER_THRESHOLD < _H2H_TIER_THRESHOLD)
+			tostring((tonumber(args.liquipediatier) or _H2H_TIER_THRESHOLD) < _H2H_TIER_THRESHOLD)
 		)
 	)
 end

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -164,8 +164,8 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_participant_number', 0)
 	Variables.varDefine('tournament_participants', '(')
 	Variables.varDefine('tournament_teamplayers', args.mode == _MODE_2v2 and 2 or 3)
-	Variables.varDefine('showheadtohead',
-		Logic.emptyOr(args.showheadtohead, tostring(tonumber(args.liquipediatier) < 5))
+	Variables.varDefine('showh2h',
+		Logic.emptyOr(args.showh2h, tostring(tonumber(args.liquipediatier) < 5))
 	)
 end
 

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -169,7 +169,7 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('showh2h',
 		Logic.emptyOr(
 			args.showh2h,
-			tostring(tonumber(args.liquipediatier or 0) <= _H2H_TIER_THRESHOLD)
+			tostring(tonumber(args.liquipediatier or _H2H_TIER_THRESHOLD + 1) <= _H2H_TIER_THRESHOLD)
 		)
 	)
 end

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -166,11 +166,13 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_participant_number', 0)
 	Variables.varDefine('tournament_participants', '(')
 	Variables.varDefine('tournament_teamplayers', args.mode == _MODE_2v2 and 2 or 3)
-	Variables.varDefine('showh2h',
-		Logic.emptyOr(
-			args.showh2h,
-			tostring((tonumber(args.liquipediatier) or _H2H_TIER_THRESHOLD) < _H2H_TIER_THRESHOLD)
-		)
+	Variables.varDefine('showh2h', CustomLeague:parseShowHeadToHead(args))
+end
+
+function CustomLeague:parseShowHeadToHead(args)
+	return Logic.emptyOr(
+		args.showh2h,
+		tostring((tonumber(args.liquipediatier) or _H2H_TIER_THRESHOLD) < _H2H_TIER_THRESHOLD)
 	)
 end
 

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -31,7 +31,7 @@ local _MODE_2v2 = '2v2'
 local _GAME_ROCKET_LEAGUE = 'rl'
 local _GAME_SARPBC = 'sarpbc'
 
-local _H2H_TIER_THRESHOLD = 4
+local _H2H_TIER_THRESHOLD = 5
 
 local _league
 
@@ -169,7 +169,7 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('showh2h',
 		Logic.emptyOr(
 			args.showh2h,
-			tostring(tonumber(args.liquipediatier or _H2H_TIER_THRESHOLD + 1) <= _H2H_TIER_THRESHOLD)
+			tostring(tonumber(args.liquipediatier or _H2H_TIER_THRESHOLD) < _H2H_TIER_THRESHOLD)
 		)
 	)
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -150,7 +150,7 @@ end
 
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', '3v3'))
-	match.showheadtohead = Variables.varDefault('showheadtohead')
+	match.showheadtohead = Logic.emptyOr(match.showheadtohead, Variables.varDefault('showheadtohead'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 
@@ -189,7 +189,7 @@ function matchFunctions.getExtraData(match)
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
 		isconverted = 0,
-		showheadtohead = match.showheadtohead == 'true',
+		showheadtohead = match.showheadtohead ~= 'false',
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -184,12 +184,16 @@ function matchFunctions.getExtraData(match)
 	end
 	table.sort(casters, function(c1, c2) return c1.displayName:lower() < c2.displayName:lower() end)
 
+	local showh2h = Logic.readBool(match.showh2h)
+		and opponent1.type == Opponent.team
+		and opponent2.type == Opponent.team
+
 	match.extradata = {
 		team1icon = getIconName(opponent1.template or ''),
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
 		isconverted = 0,
-		showh2h = Logic.readBool(match.showh2h),
+		showh2h = showh2h,
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -150,6 +150,7 @@ end
 
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', '3v3'))
+	match.showheadtohead = Variables.varDefault('showheadtohead')
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 
@@ -188,6 +189,7 @@ function matchFunctions.getExtraData(match)
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
 		isconverted = 0,
+		showheadtohead = match.showheadtohead == 'true',
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -150,7 +150,7 @@ end
 
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', '3v3'))
-	match.showheadtohead = Logic.emptyOr(match.showheadtohead, Variables.varDefault('showheadtohead'))
+	match.showh2h = Logic.emptyOr(match.showh2h, Variables.varDefault('showh2h'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 
@@ -189,7 +189,7 @@ function matchFunctions.getExtraData(match)
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
 		isconverted = 0,
-		showheadtohead = Logic.readBool(match.showheadtohead),
+		showh2h = Logic.readBool(match.showh2h),
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -189,7 +189,7 @@ function matchFunctions.getExtraData(match)
 		team2icon = getIconName(opponent2.template or ''),
 		lastgame = Variables.varDefault('last_game'),
 		isconverted = 0,
-		showheadtohead = match.showheadtohead ~= 'false',
+		showheadtohead = Logic.readBool(match.showheadtohead),
 		isfeatured = matchFunctions.isFeatured(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -15,7 +15,7 @@ local Json = require('Module:Json')
 local Abbreviation = require('Module:Abbreviation')
 local String = require('Module:StringUtils')
 local Flags = require('Module:Flags')
-local Page = require('Module:Page')
+local Opponent = require('Module:Opponent')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
@@ -198,12 +198,6 @@ local CustomMatchSummary = {}
 function CustomMatchSummary._getHeadToHead(opponents)
 	if opponents[1].type ~= Opponent.team or opponents[2].type ~= Opponent.team then
 		return
-	end
-
-	for _, team in pairs(opponents) do
-		if not Page.exists(mw.ext.TeamTemplate.teampage(team.template)) then
-			return
-		end
 	end
 
 	local team1, team2 = mw.uri.encode(opponents[1].name), mw.uri.encode(opponents[2].name)

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -196,7 +196,7 @@ end
 local CustomMatchSummary = {}
 
 function CustomMatchSummary._getHeadToHead(opponents)
-	if opponents[1].type ~= 'team' or opponents[2].type ~= 'team' then
+	if opponents[1].type ~= Opponent.team or opponents[2].type ~= Opponent.team then
 		return
 	end
 

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -198,10 +198,6 @@ end
 local CustomMatchSummary = {}
 
 function CustomMatchSummary._getHeadToHead(match)
-	if not match.extradata.showheadtohead then
-		return
-	end
-
 	local opponents = match.opponents
 	if opponents[1].type ~= Opponent.team or opponents[2].type ~= Opponent.team then
 		return
@@ -235,7 +231,8 @@ function CustomMatchSummary.getByMatchId(args)
 		end
 	end
 
-	local headToHead = CustomMatchSummary._getHeadToHead(match)
+	local headToHead = match.extradata.showheadtohead and
+		CustomMatchSummary._getHeadToHead(match) or nil
 
 	if
 		Table.isNotEmpty(vods) or

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -197,7 +197,7 @@ local CustomMatchSummary = {}
 
 function CustomMatchSummary._getHeadToHead(opponents)
 	if opponents[1].type ~= 'team' or opponents[2].type ~= 'team' then
-		return nil
+		return
 	end
 
 	for _, team in pairs(opponents) do

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -15,7 +15,6 @@ local Json = require('Module:Json')
 local Abbreviation = require('Module:Abbreviation')
 local String = require('Module:StringUtils')
 local Flags = require('Module:Flags')
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
@@ -197,12 +196,7 @@ end
 
 local CustomMatchSummary = {}
 
-function CustomMatchSummary._getHeadToHead(match)
-	local opponents = match.opponents
-	if opponents[1].type ~= Opponent.team or opponents[2].type ~= Opponent.team then
-		return
-	end
-
+function CustomMatchSummary._getHeadToHead(opponents)
 	local team1, team2 = mw.uri.encode(opponents[1].name), mw.uri.encode(opponents[2].name)
 	local link = tostring(mw.uri.fullUrl('Special:RunQuery/Head2head'))
 		.. '?RunQuery=Run&pfRunQueryFormName=Head2head&Headtohead%5Bteam1%5D='
@@ -232,7 +226,7 @@ function CustomMatchSummary.getByMatchId(args)
 	end
 
 	local headToHead = match.extradata.showh2h and
-		CustomMatchSummary._getHeadToHead(match) or nil
+		CustomMatchSummary._getHeadToHead(match.opponents) or nil
 
 	if
 		Table.isNotEmpty(vods) or

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -231,7 +231,7 @@ function CustomMatchSummary.getByMatchId(args)
 		end
 	end
 
-	local headToHead = match.extradata.showheadtohead and
+	local headToHead = match.extradata.showh2h and
 		CustomMatchSummary._getHeadToHead(match) or nil
 
 	if

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -15,7 +15,7 @@ local Json = require('Module:Json')
 local Abbreviation = require('Module:Abbreviation')
 local String = require('Module:StringUtils')
 local Flags = require('Module:Flags')
-local Opponent = require('Module:Opponent')
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -202,7 +202,7 @@ function CustomMatchSummary._getHeadToHead(opponents)
 
 	for _, team in pairs(opponents) do
 		if not Page.exists(mw.ext.TeamTemplate.teampage(team.template)) then
-			return nil
+			return
 		end
 	end
 

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -195,11 +195,11 @@ end
 
 local CustomMatchSummary = {}
 
-function getHeadToHead(opponents)
+function CustomMatchSummary._getHeadToHead(opponents)
 	if opponents[1].type ~= 'team' or opponents[2].type ~= 'team' then
 		return nil
 	end
-	
+
 	for _, team in pairs(opponents) do
 		if not Page.exists(mw.ext.TeamTemplate.teampage(team.template)) then
 			return nil
@@ -234,7 +234,7 @@ function CustomMatchSummary.getByMatchId(args)
 		end
 	end
 
-	local headToHead = getHeadToHead(match.opponents)
+	local headToHead = CustomMatchSummary._getHeadToHead(match.opponents)
 
 	if
 		Table.isNotEmpty(vods) or
@@ -268,7 +268,7 @@ function CustomMatchSummary.getByMatchId(args)
 				vod = vod,
 			})
 		end
-		
+
 		-- Head-to-head
 		if headToHead then
 			footer:addElement(headToHead)

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -30,6 +30,8 @@ local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link='
 local _OCTANE_SUFFIX = '|Octane matchpage]]'
 local _BALLCHASING_PREFIX = '[[File:Ballchasing icon.png|14x14px|link='
 local _BALLCHASING_SUFFIX = '|Ballchasing replays]]'
+local _HEADTOHEAD_PREFIX = '[[File:Match Info Stats.png|14x14px|link='
+local _HEADTOHEAD_SUFFIX = '|Head to Head history]]'
 
 local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
 
@@ -209,7 +211,7 @@ function CustomMatchSummary._getHeadToHead(match)
 	local link = tostring(mw.uri.fullUrl('Special:RunQuery/Head2head'))
 		.. '?RunQuery=Run&pfRunQueryFormName=Head2head&Headtohead%5Bteam1%5D='
 		.. team1 .. '&Headtohead%5Bteam2%5D=' .. team2
-	return '[[File:Match Info Stats.png|14x14px|link=' .. link .. '|Head to Head history]]'
+	return _HEADTOHEAD_PREFIX .. link .. _HEADTOHEAD_SUFFIX
 end
 
 function CustomMatchSummary.getByMatchId(args)

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -195,7 +195,12 @@ end
 
 local CustomMatchSummary = {}
 
-function CustomMatchSummary._getHeadToHead(opponents)
+function CustomMatchSummary._getHeadToHead(match)
+	if not match.extradata.showheadtohead then
+		return
+	end
+
+	local opponents = match.opponents
 	if opponents[1].type ~= Opponent.team or opponents[2].type ~= Opponent.team then
 		return
 	end
@@ -228,7 +233,7 @@ function CustomMatchSummary.getByMatchId(args)
 		end
 	end
 
-	local headToHead = CustomMatchSummary._getHeadToHead(match.opponents)
+	local headToHead = CustomMatchSummary._getHeadToHead(match)
 
 	if
 		Table.isNotEmpty(vods) or


### PR DESCRIPTION
## Summary

Adds a button to match summaries in order to make the head-to-head pages more quickly and easily accessible for upcoming and past matchups.
The button only appears for matchups in which both teams have pages, since they are more likely to have a history.

I was unsure whether this logic should be in the summary, or the input.

## How did you test this change?

/dev module