### PR TITLE
Store `textlesslogo` from infobox team

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -239,9 +239,11 @@ function Team:_setLpdbData(args, links)
 
 	local team = args.teamtemplate or self.pagename
 	local teamTemplate
+	local textlessImage, textlessImageDark
 	if team and mw.ext.TeamTemplate.teamexists(team) then
 		local teamRaw = mw.ext.TeamTemplate.raw(team)
 		teamTemplate = teamRaw.historicaltemplate or teamRaw.templatename
+		textlessImage, textlessImageDark = teamRaw.image, teamRaw.imagedark
 	end
 
 	local lpdbData = {
@@ -250,10 +252,10 @@ function Team:_setLpdbData(args, links)
 		location2 = self:getStandardLocationValue(args.location2),
 		region = args.region,
 		locations = Locale.formatLocations(args),
-		logo = args.image,
-		logodark = args.imagedark or args.imagedarkmode,
-		textlesslogo = args.teamcardimage,
-		textlesslogodark = args.teamcardimagedark,
+		logo = args.image or textlessImage,
+		logodark = args.imagedark or args.imagedarkmode or textlessImageDark,
+		textlesslogo = textlessImage or args.teamcardimage,
+		textlesslogodark = textlessImageDark or args.teamcardimagedark,
 		earnings = earnings,
 		createdate = args.created,
 		disbanddate = ReferenceCleaner.clean(args.disbanded),

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -252,6 +252,8 @@ function Team:_setLpdbData(args, links)
 		locations = Locale.formatLocations(args),
 		logo = args.image,
 		logodark = args.imagedark or args.imagedarkmode,
+		textlesslogo = args.teamcardimage,
+		textlesslogodark = args.teamcardimagedark,
 		earnings = earnings,
 		createdate = args.created,
 		disbanddate = ReferenceCleaner.clean(args.disbanded),


### PR DESCRIPTION
## Summary
Step in the solution of #1337 

#1337 allows us to unify the storage across the wikis in the short-term (see #2158), and making sure that that the version with text is available. Currently what's stored in `logo`:
* half the wikis don't store the text based logo at all, making it unavailable for consumers of LPDB, if there's a textless version
* The other half always store the text-version

The field `textlesslogo` should be seen as deprecated, and the purpose of it's introduction is standardized and enriched the `logo` field.
Once team templates have been switched away from `std`'s, `textlesslogo` can be removed all together.

## How did you test this change?
Tested with /dev module