### PR TITLE
Prepare sc2 infobox league (+ hidden) for placement cleanup

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -617,7 +617,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
 	lpdbData.publishertier = Variables.varDefault('featured')
 
-	lpdbData.extradata.seriesnumber = Variables.varDefault('tournament_series_number'),
+	lpdbData.extradata.seriesnumber = Variables.varDefault('tournament_series_number')
 	lpdbData.extradata.featured = Variables.varDefault('featured')
 
 	return lpdbData

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -614,7 +614,12 @@ function CustomLeague:addToLpdb(lpdbData)
 	end
 	lpdbData.participantsnumber = participantsNumber
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
-	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
+	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous)) 
+	lpdbData.publishertier = Variables.varDefault('featured')
+	lpdbData.extradata = {
+		seriesnumber = Variables.varDefault('tournament_series_number'),
+		featured = Variables.varDefault('featured')
+	}
 
 	return lpdbData
 end

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -616,10 +616,9 @@ function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
 	lpdbData.publishertier = Variables.varDefault('featured')
-	lpdbData.extradata = {
-		seriesnumber = Variables.varDefault('tournament_series_number'),
-		featured = Variables.varDefault('featured')
-	}
+
+	lpdbData.extradata.seriesnumber = Variables.varDefault('tournament_series_number'),
+	lpdbData.extradata.featured = Variables.varDefault('featured')
 
 	return lpdbData
 end

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -614,7 +614,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	end
 	lpdbData.participantsnumber = participantsNumber
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
-	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous)) 
+	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
 	lpdbData.publishertier = Variables.varDefault('featured')
 	lpdbData.extradata = {
 		seriesnumber = Variables.varDefault('tournament_series_number'),

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -416,7 +416,9 @@ function HiddenInfoboxLeague._setLpdbData()
 		),
 		maps = Variables.varDefault('tournament_maps'),
 		participantsnumber = participantsNumber,
-		extradata = mw.ext.LiquipediaDB.lpdb_create_json{seriesnumber = Variables.varDefault('tournament_series_number')}
+		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
+			seriesnumber = Variables.varDefault('tournament_series_number')
+		}
 	}
 
 	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. lpdbData.name, lpdbData)

--- a/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_hidden.lua
@@ -416,6 +416,7 @@ function HiddenInfoboxLeague._setLpdbData()
 		),
 		maps = Variables.varDefault('tournament_maps'),
 		participantsnumber = participantsNumber,
+		extradata = mw.ext.LiquipediaDB.lpdb_create_json{seriesnumber = Variables.varDefault('tournament_series_number')}
 	}
 
 	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. lpdbData.name, lpdbData)


### PR DESCRIPTION
depends on #2162

## Summary
Prepare sc2 infobox league (+ hidden) for placement cleanup
- the stuff set into extradata is currently set into extradata via the prize poools when they add the top4
- featured is not applicable for hidden infobox league, so skipped there

Currently it has no real effect, but after the sc/sc2 placement cleanup it will be needed.

## How did you test this change?
/dev