### PR TITLE
Store series2 in tournament extradata

### DIFF
--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -114,6 +114,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		startdate_raw = args.sdate or args.date,
 		enddate_raw = args.edate or args.date,
 		female = args.female or 'false',
+		series2 = args.series2 and mw.ext.TeamLiquidIntegration.resolve_redirect(args.series2) or nil,
 	}
 
 	return lpdbData


### PR DESCRIPTION
## Summary
Store series2 in tournament extradata on valorant wiki

## How did you test this change?
/dev