### PR TITLE
Have infobox league define LPDB `extradata`

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -450,10 +450,11 @@ function League:_setLpdbData(args, links)
 		links = mw.ext.LiquipediaDB.lpdb_create_json(
 			Links.makeFullLinksForTableItems(links or {})
 		),
+		extradata = {},
 	}
 
 	lpdbData = self:addToLpdb(lpdbData, args)
-	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
+	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata)
 	mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. self.name, lpdbData)
 end
 


### PR DESCRIPTION
## Summary
Change so commons Infobox League defines an empty extradata table. This is a step to unify is distinct patterns being used when it comes to LPDB extradata from commons. Other infoboxes using this pattern includes Infobox Team and Infobox Person.

The wikis are updated in #2163, but that's not a requirement for this PR, rather that PR changes the pattern to on the Custom side.

## How did you test this change?

Tested by hjp
