### PR TITLE
Wiki InfoboxLeague customs should not overwrite extradata

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -256,12 +256,11 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	-- whereas voobly is used to denote non-official version played via voobly
 	lpdbData['patch'] = args.patch or args.voobly
 	lpdbData['participantsnumber'] = args.team_number or args.player_number
-	lpdbData['extradata'] = {
-		region = args.region,
-		deadline = DateClean._clean(args.deadline or ''),
-		gamemode = table.concat(CustomLeague:_getGameModes(args, false), ','),
-		gameversion = args.version
-	}
+
+	lpdbData.extradata.region = args.region
+	lpdbData.extradata.deadline = DateClean._clean(args.deadline or '')
+	lpdbData.extradata.gamemode = table.concat(CustomLeague:_getGameModes(args, false), ',')
+	lpdbData.extradata.gameversion = args.version
 
 	return lpdbData
 end

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -173,10 +173,9 @@ end
 function CustomLeague:addToLpdb(lpdbData)
 	lpdbData.participantsnumber = _args.team_number
 	lpdbData.publishertier = _args.pctier
-	lpdbData.extradata = {
-		['is ea major'] = Variables.varDefault('tournament_ea_major', ''),
-		individual = Variables.varDefault('tournament_individual', ''),
-	}
+
+	lpdbData.extradata['is ea major'] = Variables.varDefault('tournament_ea_major', '')
+	lpdbData.extradata.individual = Variables.varDefault('tournament_individual', '')
 
 	--retrieve sponsors from _args.sponsors if sponsorX, X=1,...,3, is empty
 	if

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -75,9 +75,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = Logic.readBool(_args.publisherpremier) and 'true' or nil
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-	}
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/brawlhalla/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlhalla/infobox_league_custom.lua
@@ -74,10 +74,8 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData['patch'] = args.patch
 	lpdbData['participantsnumber'] = args.team_number or args.player_number
-	lpdbData['extradata'] = {
-		region = args.region,
-		mode = args.mode,
-	}
+	lpdbData.extradata.region = args.region
+	lpdbData.extradata.mode = args.mode
 
 	return lpdbData
 end

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -337,7 +337,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.prizepoollocal = Variables.varDefault('prizepoollocal', '')
 	lpdbData.extradata.startdate_raw = Variables.varDefault('raw_sdate', '')
 	lpdbData.extradata.enddate_raw = Variables.varDefault('raw_edate', '')
-	lpdbData.extradata.series2 = mw.ext.TeamLiquidIntegration.resolve_redirect(args.series2 or '')
 	lpdbData.extradata.shortname2 = args.shortname2
 
 	return lpdbData

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -333,13 +333,12 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(League:getAllArgsForBase(args, 'map'), ';')
 	lpdbData.participantsnumber = args.team_number or args.player_number
 	lpdbData.sortdate = args.sort_date or lpdbData.enddate
-	lpdbData.extradata = {
-		prizepoollocal = Variables.varDefault('prizepoollocal', ''),
-		startdate_raw = Variables.varDefault('raw_sdate', ''),
-		enddate_raw = Variables.varDefault('raw_edate', ''),
-		series2 = mw.ext.TeamLiquidIntegration.resolve_redirect(args.series2 or ''),
-		shortname2 = args.shortname2,
-	}
+
+	lpdbData.extradata.prizepoollocal = Variables.varDefault('prizepoollocal', '')
+	lpdbData.extradata.startdate_raw = Variables.varDefault('raw_sdate', '')
+	lpdbData.extradata.enddate_raw = Variables.varDefault('raw_edate', '')
+	lpdbData.extradata.series2 = mw.ext.TeamLiquidIntegration.resolve_redirect(args.series2 or '')
+	lpdbData.extradata.shortname2 = args.shortname2
 
 	return lpdbData
 end

--- a/components/infobox/wikis/crossfire/infobox_league_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_league_custom.lua
@@ -74,9 +74,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = CustomLeague._getGameVersion() or args.game
 	lpdbData.publishertier = args.cfpremier
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-	}
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -123,7 +123,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.valvepremier = String.isNotEmpty(args.valvepremier) and '1' or '0'
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 	lpdbData.extradata.dpcpoints = String.isNotEmpty(args.points) or ''
-	lpdbData.extradata.series2 = String.isNotEmpty(args.series2) or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -119,12 +119,11 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = string.lower(args.game or 'dota2')
 	lpdbData.publishertier = args.pctier
 	lpdbData.participantsnumber = args.team_number or args.player_number
-	lpdbData.extradata = {
-		valvepremier = String.isNotEmpty(args.valvepremier) and '1' or '0',
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-		dpcpoints = String.isNotEmpty(args.points) or '',
-		series2 = String.isNotEmpty(args.series2) or '',
-	}
+
+	lpdbData.extradata.valvepremier = String.isNotEmpty(args.valvepremier) and '1' or '0'
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
+	lpdbData.extradata.dpcpoints = String.isNotEmpty(args.points) or ''
+	lpdbData.extradata.series2 = String.isNotEmpty(args.series2) or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/halo/infobox_league_custom.lua
+++ b/components/infobox/wikis/halo/infobox_league_custom.lua
@@ -100,10 +100,9 @@ function League:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.publishertier = args['hcs-sponsored']
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.extradata = {
-		maps = Json.stringify(maps),
-		individual = not String.isEmpty(args.player_number),
-	}
+
+	lpdbData.extradata.maps = Json.stringify(maps)
+	lpdbData.extradata.individual = not String.isEmpty(args.player_number)
 
 	return lpdbData
 end

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -73,11 +73,10 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.participants_number or args.team_number
 	lpdbData.publishertier = Logic.readBool(args.riotpremier) and '1' or ''
 
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.participants_number) or
-			String.isNotEmpty(args.individual) and 'true' or '',
-		['is riot premier'] = String.isNotEmpty(args.riotpremier) and 'true' or '',
-	}
+	lpdbData.extradata.individual = String.isNotEmpty(args.participants_number) or
+			String.isNotEmpty(args.individual) and 'true' or ''
+
+	lpdbData.extradata['is riot premier'] = String.isNotEmpty(args.riotpremier) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -66,9 +66,8 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = args.platform
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.narakapremier
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number)
-	}
+
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number)
 
 	return lpdbData
 end

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -108,9 +108,8 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	end
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.liquipediatiertype = args.liquipediatiertype
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-	}
+
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/pokemon/infobox_league_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_league_custom.lua
@@ -73,9 +73,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = CustomLeague._getGameVersion()
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.pokemonpremier
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-	}
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/pubg/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_league_custom.lua
@@ -115,9 +115,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.pubgpremier
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-	}
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
@@ -113,9 +113,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = args.platform
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.pubgpremier
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-	}
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -135,11 +135,10 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	end
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.liquipediatiertype = Tier.text.types[string.lower(args.liquipediatiertype or '')] or _DEFAULT_TIERTYPE
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-		startdatetext = CustomLeague:_standardiseRawDate(args.sdate or args.date),
-		enddatetext = CustomLeague:_standardiseRawDate(args.edate or args.date),
-	}
+
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
+	lpdbData.extradata.startdatetext = CustomLeague:_standardiseRawDate(args.sdate or args.date)
+	lpdbData.extradata.enddatetext = CustomLeague:_standardiseRawDate(args.edate or args.date)
 
 	return lpdbData
 end

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -169,17 +169,17 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData['game'] = 'rocket league'
 	lpdbData['patch'] = args.patch
 	lpdbData['participantsnumber'] = args.team_number or args.player_number
-	lpdbData['extradata'] = {
-		region = args.region,
-		mode = args.mode,
-		notabilitymod = args.notabilitymod,
-		liquipediatiertype2 = args.liquipediatiertype2,
-		participantsnumber =
-			not String.isEmpty(args.team_number) and args.team_number or args.player_number,
-		notabilitypercentage = args.edate ~= 'tba' and TournamentNotability.run() or ''
-	}
 
-	lpdbData['extradata']['is rlcs'] = Variables.varDefault('tournament_rlcs_premier', 0)
+	lpdbData.extradata.region = args.region
+	lpdbData.extradata.mode = args.mode
+	lpdbData.extradata.notabilitymod = args.notabilitymod
+	lpdbData.extradata.liquipediatiertype2 = args.liquipediatiertype2
+	lpdbData.extradata.notabilitypercentage = args.edate ~= 'tba' and TournamentNotability.run() or ''
+	lpdbData.extradata['is rlcs'] = Variables.varDefault('tournament_rlcs_premier', 0)
+	lpdbData.extradata.participantsnumber =
+			not String.isEmpty(args.team_number) and args.team_number or args.player_number
+
+
 	return lpdbData
 end
 

--- a/components/infobox/wikis/splatoon/infobox_league_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_league_custom.lua
@@ -71,9 +71,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = CustomLeague._getGameVersion()
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = Logic.readBool(_args.publisherpremier) or nil
-	lpdbData.extradata = {
-		individual = String.isNotEmpty(args.player_number) and 'true' or '',
-	}
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -109,12 +109,11 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	end
 
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.extradata = {
-		region = Template.safeExpand(mw.getCurrentFrame(), 'Template:Player region', {args.country}),
-		startdate_raw = args.sdate or args.date,
-		enddate_raw = args.edate or args.date,
-		female = args.female or 'false',
-	}
+
+	lpdbData.extradata.region = Template.safeExpand(mw.getCurrentFrame(), 'Template:Player region', {args.country})
+	lpdbData.extradata.startdate_raw = args.sdate or args.date
+	lpdbData.extradata.enddate_raw = args.edate or args.date
+	lpdbData.extradata.female = args.female or 'false'
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
With the introduction of #2162 and #2174, there's now extradata field provided with information from commons. This PR changes the wiki custom build upon this table instead of creating a new one.

## How did you test this change?
Sample testing (tested CS and dota2)