### PR TITLE
Remove StringUtils.explode

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -272,7 +272,7 @@ function MatchGroupInput.readDate(dateString)
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>
 	local timezoneOffset = dateString:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
 	local timezoneId = dateString:match('>(%a-)<')
-	local matchDate = String.explode(dateString, '<', 0):gsub('-', '')
+	local matchDate = mw.text.split(dateString, '<', true)[1]:gsub('-', '')
 	local isDateExact = String.contains(matchDate .. (timezoneOffset or ''), '[%+%-]')
 	local date = getContentLanguage():formatDate('c', matchDate .. (timezoneOffset or ''))
 	return {

--- a/standard/string_utils.lua
+++ b/standard/string_utils.lua
@@ -76,12 +76,6 @@ function String.isNotEmpty(str)
 	return str ~= nil and str ~= ''
 end
 
--- index counts up from 0
----@deprecated
-function String.explode(str, delimiter, index)
-	return String.split(str, delimiter)[index + 1] or ''
-end
-
 ---transforms a wiki code list:
 ---
 --- * text


### PR DESCRIPTION
## Summary
`StringUtils.explode(..., ..., X)` works the same way as `mw.text.split(..., ...)[X+1]`, ie unnecessary.

The following non-git modules needs updating:

- [x] https://liquipedia.net/starcraft2/Module:Match_maps
- [x] https://liquipedia.net/rocketleague/Module:EventsTable
- [x] https://liquipedia.net/starcraft2/Module:GroupTableStart
- [x] https://liquipedia.net/starcraft/Module:Temp
- [x] https://liquipedia.net/trackmania/Module:Match_maps
- [x] https://liquipedia.net/halo/Module:GroupTableLeague/new
- [x] https://liquipedia.net/commons/Module:LuaUtils

## How did you test this change?
Tested using /dev module
