### PR TITLE
Allow wiki spec. categories in infobox map

### DIFF
--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -51,7 +51,7 @@ function Map:createInfobox(frame)
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Maps')
+		infobox:categories('Maps', unpack(self:getWikiCategories(args)))
 		self:_setLpdbData(args)
 	end
 
@@ -61,6 +61,11 @@ end
 --- Allows for overriding this functionality
 function Map:getNameDisplay(args)
 	return args.name
+end
+
+--- Allows for overriding this functionality
+function Map:getWikiCategories(args)
+	return {}
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/wikis/starcraft2/infobox_map_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_map_custom.lua
@@ -27,7 +27,7 @@ local _args
 function CustomMap.run(frame)
 	local customMap = Map(frame)
 	customMap.createWidgetInjector = CustomMap.createWidgetInjector
-	customMap.getCategories = CustomMap.getCategories
+	customMap.getWikiCategories = CustomMap.getWikiCategories
 	_args = customMap.args
 	return customMap:createInfobox(frame)
 end
@@ -141,6 +141,19 @@ end
 function CustomMap:_tlpdMap(id, query)
 	if not id then return nil end
 	return Template.safeExpand(mw.getCurrentFrame(), 'Tlpd map', { id, query })
+end
+
+function CustomMap:getWikiCategories(args)
+	local players = args.players
+	if String.isEmpty(players) then
+		players = CustomMap:_tlpdMap(args.id, 'players')
+	end
+
+	if String.isEmpty(players) then
+		return {}
+	end
+
+	return {'Maps (' .. players .. ' Players)'}
 end
 
 return CustomMap


### PR DESCRIPTION
## Summary
- Allow wiki spec. categories in infobox map
- set wiki specific categories based on max number of players on the map for sc2

## How did you test this change?
/dev