### PR TITLE
Add Squad/Custom with SquadAuto support for ageofempires

### DIFF
--- a/components/squad/wikis/ageofempires/squad_custom.lua
+++ b/components/squad/wikis/ageofempires/squad_custom.lua
@@ -1,0 +1,75 @@
+---
+-- @Liquipedia
+-- wiki=ageofempires
+-- page=Module:Squad/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Squad = require('Module:Squad')
+local SquadRow = require('Module:Squad/Row')
+local SquadAutoRefs = require('Module:SquadAuto/References')
+local Table = require('Module:Table')
+
+local CustomSquad = {}
+
+function CustomSquad.run(frame)
+	error("AoE wiki doesn't support manual Squad Tables")
+end
+
+function CustomSquad.runAuto(playerList, squadType)
+	if Table.isEmpty(playerList) then
+		return
+	end
+
+	local squad = Squad()
+	squad:init(mw.getCurrentFrame())
+
+	squad.type = squadType
+
+	squad:title():header()
+
+	for _, player in pairs(playerList) do
+		squad:row(CustomSquad._playerRow(player, squad.type))
+	end
+
+	return squad:create()
+end
+
+function CustomSquad._playerRow(player, squadType)
+	--Get Reference(s)
+	local joinReference = SquadAutoRefs.useReferences(player.joindateRef, player.joindate)
+	local leaveReference = SquadAutoRefs.useReferences(player.leavedateRef, player.leavedate)
+
+	local joinText = (player.joindatedisplay or player.joindate) .. ' ' .. joinReference
+	local leaveText = (player.leavedatedisplay or player.leavedate) .. ' ' .. leaveReference
+
+	local row = SquadRow(mw.getCurrentFrame(), player.thisTeam.role)
+	row:id({
+		(player.idleavedate or player.id),
+		flag = player.flag,
+		link = player.page,
+		captain = player.captain,
+		role = player.thisTeam.role,
+		team = player.thisTeam.role == 'Loan' and player.oldTeam.team,
+	})
+	row:name({name = player.name})
+	row:role({role = player.thisTeam.role})
+	row:date(joinText, 'Join Date:&nbsp;', 'joindate')
+	
+	if squadType == Squad.TYPE_FORMER then
+		row:date(leaveText, 'Leave Date:&nbsp;', 'leavedate')
+		row:newteam({
+			newteam = player.newTeam.team,
+			newteamrole = player.newTeam.role,
+			newteamdate = player.newTeam.date,
+			leavedate = player.newTeam.date
+		})
+	elseif squadType == Squad.TYPE_INACTIVE then
+		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
+	end
+
+	return row:create(mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. player.joindate)
+end
+
+return CustomSquad

--- a/components/squad/wikis/ageofempires/squad_custom.lua
+++ b/components/squad/wikis/ageofempires/squad_custom.lua
@@ -56,7 +56,7 @@ function CustomSquad._playerRow(player, squadType)
 	row:name({name = player.name})
 	row:role({role = player.thisTeam.role})
 	row:date(joinText, 'Join Date:&nbsp;', 'joindate')
-	
+
 	if squadType == Squad.TYPE_FORMER then
 		row:date(leaveText, 'Leave Date:&nbsp;', 'leavedate')
 		row:newteam({


### PR DESCRIPTION
## Summary
This enables the combination of SquadAuto and Squad already in use on R6.
Therefore data on rosters will be stored in LPDB SquadPlayer instead of datapoints, enabling the future use of `Module:NavboxGenerator`.

## How did you test this change?
Tested by enabling the flag on some team pages and verifying the display works and data can be pulled correctly on player's pages.

