### PR TITLE
Force PlayerTeamAuto on Halo in Player Infobox

### DIFF
--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -48,7 +48,6 @@ function CustomPlayer.run(frame)
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
-	player.defineCustomPageVariables = CustomPlayer.defineCustomPageVariables
 
 	_args = player.args
 

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -11,6 +11,7 @@ local GameAppearances = require('Module:GetGameAppearances')
 local Lua = require('Module:Lua')
 local Region = require('Module:Region')
 local Role = require('Module:Role')
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
@@ -35,10 +36,21 @@ local _args
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
-	_args = player.args
+
+	if String.isEmpty(player.args.team) then
+		player.args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+
+	if String.isEmpty(player.args.team2) then
+		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
+	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
+	player.createBottomContent = CustomPlayer.createBottomContent
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+	player.defineCustomPageVariables = CustomPlayer.defineCustomPageVariables
+
+	_args = player.args
 
 	return player:createInfobox(frame)
 end

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -46,7 +46,6 @@ function CustomPlayer.run(frame)
 	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
-	player.createBottomContent = CustomPlayer.createBottomContent
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args


### PR DESCRIPTION
## Summary
Added sypport for the PlayerTeamAuto Module on Halo's infobox.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested with a dev module on two player pages:
https://liquipedia.net/halo/Module:Infobox/Person/Player/Custom/Dev

https://liquipedia.net/halo/Kamado
https://liquipedia.net/halo/Penguin

Do note that playerintroduction was already broken before this
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
