### PR TITLE
Add 'icon' as valid TeamStyle in OpponentDisplay

### DIFF
--- a/components/opponent/commons/opponent_display.lua
+++ b/components/opponent/commons/opponent_display.lua
@@ -22,7 +22,7 @@ local zeroWidthSpace = '&#8203;'
 
 local OpponentDisplay = {propTypes = {}, types = {}}
 
-OpponentDisplay.types.TeamStyle = TypeUtil.literalUnion('standard', 'short', 'bracket', 'hybrid')
+OpponentDisplay.types.TeamStyle = TypeUtil.literalUnion('standard', 'short', 'bracket', 'hybrid', 'icon')
 
 --[[
 Display component for an opponent entry appearing in a bracket match.


### PR DESCRIPTION
## Summary
Add 'icon' as valid TeamStyle in OpponentDisplay
No need for any changes in the display as the display will add the icon and after that the name display based on the TeamStyle.
So since 'Icon' is not checked in the if cases no name display will get added.

## How did you test this change?
/dev