### PR TITLE
Use pairs over ipairs in Table.includes

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -36,7 +36,7 @@ end
 ---@param value any
 ---@return boolean
 function Table.includes(tbl, value)
-	for _, entry in ipairs(tbl) do
+	for _, entry in pairs(tbl) do
 		if entry == value then
 			return true
 		end

--- a/standard/test/table_test.lua
+++ b/standard/test/table_test.lua
@@ -106,4 +106,14 @@ function suite:testExtract()
 	self:assertEquals(1, b)
 end
 
+function suite:testIncludes()
+	local a = {'testValue', 'testValue2', 'testValue3'}
+	local b = {key1 = 'testValue', key2 = 'testValue2', 'testValue3'}
+	self:assertTrue(Table.includes(a, 'testValue'))
+	self:assertTrue(Table.includes(b, 'testValue'))
+	self:assertTrue(Table.includes(b, 'testValue3'))
+	self:assertFalse(Table.includes(a, 'testValue4'))
+	self:assertFalse(Table.includes(b, 'testValue4'))
+end
+
 return suite


### PR DESCRIPTION
## Summary
Use pairs over ipairs in Table.includes

## How did you test this change?
/dev module in combination with a few modules
\+ checking the code all (non dev/sanbox) modules that use it if there are cases where it depends on ipairs

## ToDo
- [x] check all git modules if there are cases that could cause issues
- [x] check non git modules if there are cases that could cause issues
- [x] add testcase for it
![FFAC480B-F4A5-492B-B85E-2653BAE9059C](https://user-images.githubusercontent.com/75081997/201516967-b2cf5bdb-c0f9-4a4f-a4bf-d4066191e3b6.png)

