### PR TITLE
Remove $ sign from prize pool inputs

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -436,6 +436,7 @@ function CustomLeague:_cleanPrizeValue(value, currency, oldHasPlus, oldHasText)
 	value = string.gsub(value, '%s', '')
 	value = string.gsub(value, '&nbsp;', '')
 	value = string.gsub(value, ',', '')
+	value = string.gsub(value, '%$', '')
 
 	--check if it has a '+' at the end
 	local hasPlus = string.match(value, '%+$')


### PR DESCRIPTION
## Summary
Automatically remove $ sign from prize pool inputs

## How did you test this change?
/dev into live