### PR TITLE
Add support for multiple links to RL's match summary

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -201,10 +201,24 @@ function matchFunctions.getExtraData(match)
 end
 
 function matchFunctions.getLinks(match)
-	match.links = {
-		octane = match.octane and ('https://octane.gg/matches/' .. match.octane) or nil,
-		ballchasing = match.ballchasing and ('https://ballchasing.com/group/' .. match.ballchasing) or nil
-	}
+	match.links = {}
+
+	-- Octane
+	match.links.octane = {}
+	match.octane1 = match.octane1 or match.octane
+	for _, octane in Table.iter.pairsByPrefix(match, 'octane') do
+		table.insert(match.links.octane, 'https://octane.gg/matches/' .. octane)
+	end
+	match.links.octane = Table.isNotEmpty(match.links.octane) and match.links.octane or nil
+
+	-- Ballchasing
+	match.links.ballchasing = {}
+	match.ballchasing1 = match.ballchasing1 or match.ballchasing
+	for _, ballchasing in Table.iter.pairsByPrefix(match, 'ballchasing') do
+		table.insert(match.links.ballchasing, 'https://ballchasing.com/group/' .. ballchasing)
+	end
+	match.links.ballchasing = Table.isNotEmpty(match.links.ballchasing) and match.links.ballchasing or nil
+
 	return match
 end
 

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -204,20 +204,16 @@ function matchFunctions.getLinks(match)
 	match.links = {}
 
 	-- Octane
-	match.links.octane = {}
 	match.octane1 = match.octane1 or match.octane
-	for _, octane in Table.iter.pairsByPrefix(match, 'octane') do
-		table.insert(match.links.octane, 'https://octane.gg/matches/' .. octane)
+	for key, octane in Table.iter.pairsByPrefix(match, 'octane') do
+		match.links[key] = 'https://octane.gg/matches/' .. octane
 	end
-	match.links.octane = Table.isNotEmpty(match.links.octane) and match.links.octane or nil
 
 	-- Ballchasing
-	match.links.ballchasing = {}
 	match.ballchasing1 = match.ballchasing1 or match.ballchasing
-	for _, ballchasing in Table.iter.pairsByPrefix(match, 'ballchasing') do
-		table.insert(match.links.ballchasing, 'https://ballchasing.com/group/' .. ballchasing)
+	for key, ballchasing in Table.iter.pairsByPrefix(match, 'ballchasing') do
+		match.links[key] = 'https://ballchasing.com/group/' .. ballchasing
 	end
-	match.links.ballchasing = Table.isNotEmpty(match.links.ballchasing) and match.links.ballchasing or nil
 
 	return match
 end

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -237,13 +237,13 @@ function CustomMatchSummary.getByMatchId(args)
 		local footer = MatchSummary.Footer()
 
 		-- Octane
-		if Logic.isNotEmpty(match.links.octane) then
-			footer:addElement(_OCTANE_PREFIX .. match.links.octane .. _OCTANE_SUFFIX)
+		for _, octane in ipairs(match.links.octane or {}) do
+			footer:addElement(_OCTANE_PREFIX .. octane .. _OCTANE_SUFFIX)
 		end
 
 		-- Ballchasing
-		if Logic.isNotEmpty(match.links.ballchasing) then
-			footer:addElement(_BALLCHASING_PREFIX .. match.links.ballchasing .. _BALLCHASING_SUFFIX)
+		for _, ballchasing in ipairs(match.links.ballchasing or {}) do
+			footer:addElement(_BALLCHASING_PREFIX .. ballchasing .. _BALLCHASING_SUFFIX)
 		end
 
 		-- Match Vod

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -237,12 +237,12 @@ function CustomMatchSummary.getByMatchId(args)
 		local footer = MatchSummary.Footer()
 
 		-- Octane
-		for _, octane in ipairs(match.links.octane or {}) do
+		for _, octane in Table.iter.pairsByPrefix(match.links, 'octane') do
 			footer:addElement(_OCTANE_PREFIX .. octane .. _OCTANE_SUFFIX)
 		end
 
 		-- Ballchasing
-		for _, ballchasing in ipairs(match.links.ballchasing or {}) do
+		for _, ballchasing in Table.iter.pairsByPrefix(match.links, 'ballchasing') do
 			footer:addElement(_BALLCHASING_PREFIX .. ballchasing .. _BALLCHASING_SUFFIX)
 		end
 


### PR DESCRIPTION
## Summary

Grand finals that have bracket resets are made up of two series, meaning 2 Octane and 2 Ballchasing links are needed.
Match summary supposedly once supported multiple Octane links, or at least they are written in multiple pages.

## How did you test this change?

/dev module
The `links.octane` and `links.ballchasing` are now tables in LPDB, but nothing is affected by this as nothing uses them.

![Example](https://user-images.githubusercontent.com/42142350/201991378-06d87627-7897-441c-b0cd-6a6990f4d271.png)