### PR TITLE
Add `advantage` comment in matchsummary

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -165,7 +165,9 @@ function StarcraftMatchSummary.Body(props)
 	for _, opponent in ipairs(match.opponents or {}) do
 		if Logic.isNumeric((opponent.extradata or {}).advantage) then
 			body:node(
-				html.create('div'):addClass('brkts-popup-sc-game-comment')
+				html.create('div')
+					:addClass('brkts-popup-body-element')
+					:addClass('brkts-popup-sc-game-center')
 					:node(StarcraftOpponentDisplay.InlineOpponent{
 						opponent = StarcraftOpponent.isTbd(opponent) and StarcraftOpponent.tbd() or opponent,
 						showFlag = false,

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -162,12 +162,14 @@ function StarcraftMatchSummary.Body(props)
 		body:node(countdownNode)
 	end
 
+	-- add a comment if there is a pre match map advantage
 	for _, opponent in ipairs(match.opponents or {}) do
+		-- if the opponent has a (numeric) pre match advantage build the comment
 		if Logic.isNumeric((opponent.extradata or {}).advantage) then
 			body:node(
 				html.create('div')
 					:addClass('brkts-popup-body-element')
-					:addClass('brkts-popup-sc-game-center')
+					:addClass('brkts-popup-sc-game-center') -- use this over comment class so it is shown in the height as maps
 					:node(StarcraftOpponentDisplay.InlineOpponent{
 						opponent = StarcraftOpponent.isTbd(opponent) and StarcraftOpponent.tbd() or opponent,
 						showFlag = false,

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local StarcraftMatchExternalLinks = require('Module:MatchExternalLinks/Starcraft')
@@ -16,6 +17,7 @@ local TypeUtil = require('Module:TypeUtil')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
+local StarcraftOpponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
 local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft', {requireDevIfEnabled = true})
 local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
 	getTinyIcon = function(_) end,
@@ -158,6 +160,22 @@ function StarcraftMatchSummary.Body(props)
 			:addClass('brkts-popup-body-element')
 			:addClass('brkts-popup-countdown')
 		body:node(countdownNode)
+	end
+
+	for _, opponent in ipairs(match.opponents or {}) do
+		if Logic.isNumeric((opponent.extradata or {}).advantage) then
+			body:node(
+				html.create('div'):addClass('brkts-popup-sc-game-comment')
+					:node(StarcraftOpponentDisplay.InlineOpponent{
+						opponent = StarcraftOpponent.isTbd(opponent) and StarcraftOpponent.tbd() or opponent,
+						showFlag = false,
+						showLink = true,
+						showRace = false,
+						teamStyle = 'short',
+					})
+					:wikitext(' starts with a ' .. opponent.extradata.advantage .. ' map advantage.')
+			)
+		end
 	end
 
 	if match.opponentMode == 'uniform' then


### PR DESCRIPTION
## Summary
Add `advantage` comment in matchsummary

On mobile the Abbr in the score display can not be hoovered and hence the user can not access that information.
This PR adds the information also to the matchSummary display. 

## How did you test this change?
/dev

![Screenshot 2022-11-27 15 12 22](https://user-images.githubusercontent.com/75081997/204139787-4eda2288-ff1b-4960-bfb8-bb18fecf8635.png)
