### PR TITLE
Update field used for Position in `RunAuto` in Squads

### DIFF
--- a/components/squad/wikis/arenaofvalor/squad_custom.lua
+++ b/components/squad/wikis/arenaofvalor/squad_custom.lua
@@ -121,6 +121,7 @@ function CustomSquad.runAuto(playerList, squadType)
 
 		player.link = player.page
 		player.role = player.thisTeam.role
+		player.position = player.thisTeam.position
 		player.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
 
 		player.newteam = player.newTeam.team

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -90,6 +90,7 @@ function CustomSquad.runAuto(playerList, squadType)
 
 		player.link = player.page
 		player.role = player.thisTeam.role
+		player.position = player.thisTeam.position
 		player.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
 
 		player.newteam = player.newTeam.team

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -121,6 +121,7 @@ function CustomSquad.runAuto(playerList, squadType)
 
 		player.link = player.page
 		player.role = player.thisTeam.role
+		player.position = player.thisTeam.position
 		player.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
 
 		player.newteam = player.newTeam.team

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -156,6 +156,7 @@ function CustomSquad.runAuto(playerList, squadType)
 
 		player.link = player.page
 		player.role = player.thisTeam.role
+		player.position = player.thisTeam.position
 		player.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
 
 		player.newteam = player.newTeam.team

--- a/components/squad/wikis/wildrift/squad_custom.lua
+++ b/components/squad/wikis/wildrift/squad_custom.lua
@@ -121,6 +121,7 @@ function CustomSquad.runAuto(playerList, squadType)
 
 		player.link = player.page
 		player.role = player.thisTeam.role
+		player.position = player.thisTeam.position
 		player.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
 
 		player.newteam = player.newTeam.team


### PR DESCRIPTION
## Summary
`Transfer` & `SquadAuto` had a data structure change, where there can be more than one position per transfer. This is to allow position transfers (in addition to role transfer). As a result of this the old field `player.position` no longer exists, rather there is now `player.oldTeam.position`,  `player.newTeam.position` and `player.thisTeam.position`. 

This PR adjust the Squad Custom for the wiki using Position combined with SquadAuto.

## How did you test this change?
LIVE
