### PR TITLE
Fix Swiss prize pool import

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -147,7 +147,6 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 	local placementIndexes = {}
 
 	local lastEntry, lastPlacement
-	local lastPlacement = nil
 	for _, record in ipairs(standingRecords) do
 		if options.isFinalStage or Table.includes(options.groupElimStatuses, record.currentstatus) then
 			-- Only discriminate placement in Swiss by series score.

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -146,7 +146,7 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 	local placementEntries = {}
 	local placementIndexes = {}
 
-	local lastEntry = nil
+	local lastEntry, lastPlacement
 	local lastPlacement = nil
 	for _, record in ipairs(standingRecords) do
 		if options.isFinalStage or Table.includes(options.groupElimStatuses, record.currentstatus) then

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -150,15 +150,13 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 	local lastPlacement = nil
 	for _, record in ipairs(standingRecords) do
 		if options.isFinalStage or Table.includes(options.groupElimStatuses, record.currentstatus) then
-			local placement = record.placement
-
 			-- Only discriminate placement in Swiss by series score.
 			if isSwiss then
 				-- We use the previous teams placement, if we have the same series score.
-				placement = (lastEntry and lastEntry.scoreBoard
+				record.placement = (lastEntry and lastEntry.scoreBoard
 					and Table.deepEquals(record.scoreboard.match, lastEntry.scoreBoard.match))
 					and lastPlacement
-					or placement
+					or record.placement
 			end
 
 			local entry = {
@@ -168,7 +166,7 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 			}
 
 			if not record.extradata.placeRange and Logic.readBool(record.extradata.finished) then
-				record.extradata.placeRange = {placement, placement}
+				record.extradata.placeRange = {record.placement, record.placement}
 			end
 			if record.extradata.placeRange and record.extradata.placeRange[1] == record.extradata.placeRange[2] then
 				Table.mergeInto(entry, {
@@ -183,15 +181,15 @@ function Import._computeGroupTablePlacementEntries(standingRecords, options)
 			entry.needsLastVs = needsLastVs
 			entry.matches = record.matches
 
-			if not placementIndexes[placement] then
+			if not placementIndexes[record.placement] then
 				table.insert(placementEntries, {entry})
-				placementIndexes[placement] = #placementEntries
+				placementIndexes[record.placement] = #placementEntries
 			else
-				table.insert(placementEntries[placementIndexes[placement]], entry)
+				table.insert(placementEntries[placementIndexes[record.placement]], entry)
 			end
 
 			lastEntry = entry
-			lastPlacement = placement
+			lastPlacement = record.placement
 		end
 	end
 


### PR DESCRIPTION
## Summary

Fix Swiss prize pool import. Placements should only be separated by series score.
I removed the functionality that add more rows when the placements overflow, the reason I did this is because an empty Swiss table simply places a team in each row, I wasn't sure how else to go about remedying this, but I'd like to know if anyone has another solution?

## How did you test this change?

/dev module
I couldn't test this on a midway-through Swiss, since the Swiss table only works on mainspace