### PR TITLE
Update edit summary for weekly auto re-deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,14 +9,15 @@ pat='\-\-\-\
 \-\- page=([^
 ]*)\
 '
-gitCommitSubject=$(git log -1 --pretty='%h %s')
 
 declare -A loggedin
 
 if [[ -n "$1" ]]; then
   luaFiles=$1
+  gitDeployReason="\"$(git log -1 --pretty='%h %s')\""
 else
   luaFiles=$(find . -type f -name '*.lua')
+  gitDeployReason='Automated Weekly Re-Sync'
 fi
 
 for luaFile in $luaFiles
@@ -105,7 +106,7 @@ do
         -c "$ckf" \
         --data-urlencode "title=${page}" \
         --data-urlencode "text=${fileContents}" \
-        --data-urlencode "summary=Git: \"${gitCommitSubject}\"" \
+        --data-urlencode "summary=Git: ${gitDeployReason}" \
         --data-urlencode "bot=true" \
         --data-urlencode "recreate=true" \
         --data-urlencode "token=${editToken}" \


### PR DESCRIPTION
## Summary

Instead of using the latest git commit message on the automated weekly re-sync deploy, it will now use _(Git: Automated Weekly Re-Sync)_.

## How did you test this change?

Tested on dev wiki using my fork of the repo. Both normal deploy and re-sync work as before, except with new message for re-sync.
