### PR TITLE
RL:  Add years-active to more roles

### DIFF
--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -83,10 +83,7 @@ function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLi
 	local conditionTree = ConditionTree(BooleanOperator.all):add({
 		playerConditionTree,
 		ConditionNode(ColumnName('date'), Comparator.neq, _DEFAULT_DATE),
-		ConditionTree(BooleanOperator.any):add({
-			ConditionNode(ColumnName('date_year'), Comparator.gt, ActiveYears.startYear),
-			ConditionNode(ColumnName('date_year'), Comparator.eq, ActiveYears.startYear),
-		}),
+		ConditionNode(ColumnName('date_year'), Comparator.gt, ActiveYears.startYear - 1),
 	})
 
 	if String.isNotEmpty(mode) then

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -30,6 +30,7 @@ local _CURRENT_YEAR = tonumber(os.date('%Y'))
 ActiveYears.startYear = Info.startYear
 ActiveYears.defaultNumberOfStoredPlayersPerPlacement = 10
 ActiveYears.additionalConditions = ''
+ActiveYears.noResultsText = 'Player has no results.'
 
 ---
 -- Entry point
@@ -105,7 +106,7 @@ function ActiveYears._calculate(conditions)
 	-- Get years
 	local years = ActiveYears._getYears(conditions)
 	if Table.isEmpty(years) then
-		return 'Player has no results.'
+		return ActiveYears.noResultsText
 	end
 
 	return ActiveYears._displayYears(years)

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -62,9 +62,16 @@ function ActiveYears.display(args)
 		error('"playerPositionLimit" has to be >= 1')
 	end
 
+	-- Build conditions
 	local conditions = ActiveYears._buildConditions(player, playerAsPageName, playerPositionLimit, prefix, args.mode)
 
-	return ActiveYears._calculate(conditions)
+	-- Get years
+	local years = ActiveYears._getYears(conditions)
+	if Table.isEmpty(years) then
+		return 'Player has no results.'
+	end
+
+	return ActiveYears._calculate(years)
 end
 
 function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLimit, prefix, mode)
@@ -97,13 +104,7 @@ function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLi
 	return conditionTree:toString() .. ActiveYears.additionalConditions
 end
 
-function ActiveYears._calculate(conditions)
-	local years = ActiveYears._getYears(conditions)
-
-	if Table.isEmpty(years) then
-		return 'Player has no results.'
-	end
-
+function ActiveYears._calculate(years)
 	-- Sort years chronologically
 	table.sort(years)
 

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -65,13 +65,7 @@ function ActiveYears.display(args)
 	-- Build conditions
 	local conditions = ActiveYears._buildConditions(player, playerAsPageName, playerPositionLimit, prefix, args.mode)
 
-	-- Get years
-	local years = ActiveYears._getYears(conditions)
-	if Table.isEmpty(years) then
-		return 'Player has no results.'
-	end
-
-	return ActiveYears._calculate(years)
+	return ActiveYears._calculate(conditions)
 end
 
 function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLimit, prefix, mode)
@@ -104,7 +98,17 @@ function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLi
 	return conditionTree:toString() .. ActiveYears.additionalConditions
 end
 
-function ActiveYears._calculate(years)
+function ActiveYears._calculate(conditions)
+	-- Get years
+	local years = ActiveYears._getYears(conditions)
+	if Table.isEmpty(years) then
+		return 'Player has no results.'
+	end
+
+	return ActiveYears._displayYears(years)
+end
+
+function ActiveYears._displayYears(years)
 	-- Sort years chronologically
 	table.sort(years)
 

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -69,10 +69,13 @@ function ActiveYears.display(args)
 end
 
 function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLimit, prefix, mode)
-	local playerConditionTree = ConditionTree(BooleanOperator.any):add({
-		ConditionNode(ColumnName('participant'), Comparator.eq, player),
-		ConditionNode(ColumnName('participant'), Comparator.eq, playerAsPageName),
-	})
+	local playerConditionTree = ConditionTree(BooleanOperator.any)
+	if prefix == 'p' then
+		playerConditionTree:add({
+			ConditionNode(ColumnName('participant'), Comparator.eq, player),
+			ConditionNode(ColumnName('participant'), Comparator.eq, playerAsPageName),
+		})
+	end
 	for playerIndex = 1, playerPositionLimit do
 		playerConditionTree:add({
 			ConditionNode(ColumnName('players_' .. prefix .. playerIndex), Comparator.eq, player),

--- a/components/infobox/extensions/commons/years_active_base.lua
+++ b/components/infobox/extensions/commons/years_active_base.lua
@@ -83,7 +83,10 @@ function ActiveYears._buildConditions(player, playerAsPageName, playerPositionLi
 	local conditionTree = ConditionTree(BooleanOperator.all):add({
 		playerConditionTree,
 		ConditionNode(ColumnName('date'), Comparator.neq, _DEFAULT_DATE),
-		ConditionNode(ColumnName('date_year'), Comparator.gt, ActiveYears.startYear - 1),
+		ConditionTree(BooleanOperator.any):add({
+			ConditionNode(ColumnName('date_year'), Comparator.gt, ActiveYears.startYear),
+			ConditionNode(ColumnName('date_year'), Comparator.eq, ActiveYears.startYear),
+		}),
 	})
 
 	if String.isNotEmpty(mode) then

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -37,12 +37,6 @@ local _TALENT_POSITIONS = {
 	'Stage Host',
 }
 
-local _OBSERVER_POSITIONS = {
-	'Observer',
-	'Observer/Producer',
-	'Producer/Observer',
-}
-
 -- legacy entry point
 function CustomActiveYears.get(input)
 	-- if invoked directly input == args
@@ -55,12 +49,6 @@ end
 function CustomActiveYears.getTalent(talent)
 	return CustomActiveYears._getBroadcaster(
 		CustomActiveYears._getBroadcastConditions(talent, _TALENT_POSITIONS)
-	)
-end
-
-function CustomActiveYears.getObserver(observer)
-	return CustomActiveYears._getBroadcaster(
-		CustomActiveYears._getBroadcastConditions(observer, _OBSERVER_POSITIONS)
 	)
 end
 

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -85,7 +85,7 @@ end
 function CustomActiveYears._getYearsBroadcast(conditions)
 	local years = Set{}
 	local checkYear = function(broadcast)
-		-- set the year in which the placement happened as true (i.e. active)
+		-- set the year in which the broadcast happened as true (i.e. active)
 		local year = tonumber(string.sub(broadcast.date, 1, 4))
 		years:add(year)
 	end

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -64,7 +64,7 @@ end
 
 function CustomActiveYears._getBroadcaster(conditions)
 	-- Get years
-	years = CustomActiveYears._getYearsBroadcast(conditions)
+	local years = CustomActiveYears._getYearsBroadcast(conditions)
 	if Table.isEmpty(years) then
 		return
 	end

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -41,7 +41,7 @@ function CustomActiveYears.getTalent(talent)
 end
 
 function CustomActiveYears._getBroadcastConditions(broadcaster, positions)
-	broadcaster = mw.ext.TeamLiquidIntegration.resolve_redirect(broadcaster)
+	broadcaster = mw.ext.TeamLiquidIntegration.resolve_redirect(broadcaster):gsub(' ', '_')
 
 	-- Add a condition for each broadcaster position
 	local positionTree

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -25,17 +25,7 @@ local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEna
 CustomActiveYears.defaultNumberOfStoredPlayersPerPlacement = 6
 CustomActiveYears.additionalConditions = ''
 
-local _TALENT_POSITIONS = {
-	'Analyst',
-	'Caster',
-	'Caster/Analyst',
-	'Commentator',
-	'Commentator/Analyst',
-	'Desk Host',
-	'Host',
-	'Reporter',
-	'Stage Host',
-}
+local _TALENT_POSITIONS = require('Module:BroadcastPositions').TalentPositions
 
 -- legacy entry point
 function CustomActiveYears.get(input)

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -25,8 +25,6 @@ local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEna
 CustomActiveYears.defaultNumberOfStoredPlayersPerPlacement = 6
 CustomActiveYears.additionalConditions = ''
 
-local _TALENT_POSITIONS = mw.loadData('Module:BroadcastPositions').TalentPositions
-
 -- legacy entry point
 function CustomActiveYears.get(input)
 	-- if invoked directly input == args
@@ -38,7 +36,7 @@ end
 
 function CustomActiveYears.getTalent(talent)
 	return CustomActiveYears._getBroadcaster(
-		CustomActiveYears._getBroadcastConditions(talent, _TALENT_POSITIONS)
+		CustomActiveYears._getBroadcastConditions(talent)
 	)
 end
 
@@ -46,11 +44,14 @@ function CustomActiveYears._getBroadcastConditions(broadcaster, positions)
 	broadcaster = mw.ext.TeamLiquidIntegration.resolve_redirect(broadcaster)
 
 	-- Add a condition for each broadcaster position
-	local positionTree = ConditionTree(BooleanOperator.any)
-	for _, position in pairs(positions) do
-		positionTree:add(
-			ConditionNode(ColumnName('position'), Comparator.eq, position)
-		)
+	local positionTree
+	if positions then
+		positionTree = ConditionTree(BooleanOperator.any)
+		for _, position in pairs(positions) do
+			positionTree:add(
+				ConditionNode(ColumnName('position'), Comparator.eq, position)
+			)
+		end
 	end
 
 	local tree = ConditionTree(BooleanOperator.all):add({

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -75,7 +75,7 @@ function CustomActiveYears._getBroadcaster(conditions)
 		return
 	end
 
-	return CustomActiveYears._calculate(years)
+	return CustomActiveYears._displayYears(years)
 end
 
 function CustomActiveYears._getYearsBroadcast(conditions)

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -25,7 +25,7 @@ local CustomActiveYears = Lua.import('Module:YearsActive/Base', {requireDevIfEna
 CustomActiveYears.defaultNumberOfStoredPlayersPerPlacement = 6
 CustomActiveYears.additionalConditions = ''
 
-local _TALENT_POSITIONS = require('Module:BroadcastPositions').TalentPositions
+local _TALENT_POSITIONS = mw.loadData('Module:BroadcastPositions').TalentPositions
 
 -- legacy entry point
 function CustomActiveYears.get(input)

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -43,7 +43,7 @@ function CustomActiveYears.get(input)
 	-- if passed from modules it might be a table that holds the args table
 	local args = input.args or input
 	local display = CustomActiveYears.display(args)
-	return display ~= 'Player has no results.' and display or nil
+	return display ~= CustomActiveYears.noResultsText and display or nil
 end
 
 function CustomActiveYears.getTalent(talent)

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -30,6 +30,12 @@ local _TALENT_POSITIONS = {
 	'Stage Host',
 }
 
+local _OBSERVER_POSITIONS = {
+	'Observer',
+	'Observer/Producer',
+	'Producer/Observer',
+}
+
 -- legacy entry point
 function CustomActiveYears.get(input)
 	-- if invoked directly input == args
@@ -45,7 +51,7 @@ function CustomActiveYears.getTalent(talent)
 end
 
 function CustomActiveYears.getObserver(observer)
-	local conditions = CustomActiveYears._getBroadcastConditions(observer, {'Observer'})
+	local conditions = CustomActiveYears._getBroadcastConditions(observer, _OBSERVER_POSITIONS)
 	return CustomActiveYears._getBroadcaster(conditions)
 end
 

--- a/components/infobox/extensions/wikis/rocketleague/years_active.lua
+++ b/components/infobox/extensions/wikis/rocketleague/years_active.lua
@@ -46,13 +46,15 @@ function CustomActiveYears.get(input)
 end
 
 function CustomActiveYears.getTalent(talent)
-	local conditions = CustomActiveYears._getBroadcastConditions(talent, _TALENT_POSITIONS)
-	return CustomActiveYears._getBroadcaster(conditions)
+	return CustomActiveYears._getBroadcaster(
+		CustomActiveYears._getBroadcastConditions(talent, _TALENT_POSITIONS)
+	)
 end
 
 function CustomActiveYears.getObserver(observer)
-	local conditions = CustomActiveYears._getBroadcastConditions(observer, _OBSERVER_POSITIONS)
-	return CustomActiveYears._getBroadcaster(conditions)
+	return CustomActiveYears._getBroadcaster(
+		CustomActiveYears._getBroadcastConditions(observer, _OBSERVER_POSITIONS)
+	)
 end
 
 function CustomActiveYears._getBroadcastConditions(broadcaster, positions)

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -55,7 +55,7 @@ end
 
 function CustomInjector:_parseActive(manualInput, varName, autoFunction, autoFunctionParam)
 	if String.isNotEmpty(manualInput) then
-		return manualInput:lower() ~= 'hide' and manualInput or nil
+		return manualInput:upper() ~= 'N/A' and manualInput or nil
 	end
 	return Logic.readBool(Variables.varDefault(varName)) and autoFunction(autoFunctionParam) or nil
 end

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -76,16 +76,12 @@ function CustomInjector:parse(id, widgets)
 		local yearsActiveTalent = CustomInjector:_parseActive(
 			_args.years_active_talent, YearsActive.getTalent, _base_page_name
 		)
-		local yearsActiveObserver = CustomInjector:_parseActive(
-			_args.years_active_observer, YearsActive.getObserver, _base_page_name
-		)
 
 		return {
 			Cell{name = 'Status', content = statusContents},
 			Cell{name = 'Years Active (Player)', content = {yearsActive}},
 			Cell{name = 'Years Active (Coach)', content = {yearsActiveCoach}},
 			Cell{name = 'Years Active (Talent)', content = {yearsActiveTalent}},
-			Cell{name = 'Years Active (Observer)', content = {yearsActiveObserver}},
 		}
 	elseif id == 'history' then
 		if not String.isEmpty(_args.history_iwo) then

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -14,10 +14,10 @@ local Namespace = require('Module:Namespace')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
-local YearsActive = Lua.import('Module:YearsActive', {requireDevIfEnabled = true})
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
+local YearsActive = Lua.import('Module:YearsActive', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -52,7 +52,7 @@ function CustomPlayer.run(frame)
 	return player:createInfobox()
 end
 
-function CustomInjector:_parseActive(yearsActive, getYearsActive, getYearsActiveArg)
+function CustomInjector:_parseActive(manualInput, autoFunction, autoFunctionParam)
 	if String.isEmpty(yearsActive) then
 		return getYearsActive(getYearsActiveArg)
 	elseif yearsActive:lower() == 'hide' then

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -56,7 +56,7 @@ function CustomInjector:_parseActive(manualInput, autoFunction, autoFunctionPara
 	if String.isEmpty(manualInput) then
 		return autoFunction(autoFunctionParam)
 	elseif manualInput:lower() == 'hide' then
-		return nil
+		return
 	else
 		return manualInput
 	end

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -52,9 +52,9 @@ function CustomPlayer.run(frame)
 	return player:createInfobox()
 end
 
-function CustomInjector:_parseActive(yearsActive, get, get_arg)
+function CustomInjector:_parseActive(yearsActive, get, getArg)
 	if String.isEmpty(yearsActive) then
-		return get(get_arg)
+		return get(getArg)
 	elseif yearsActive == 'hide' then
 		return nil
 	else

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -53,12 +53,12 @@ function CustomPlayer.run(frame)
 end
 
 function CustomInjector:_parseActive(manualInput, autoFunction, autoFunctionParam)
-	if String.isEmpty(yearsActive) then
-		return getYearsActive(getYearsActiveArg)
-	elseif yearsActive:lower() == 'hide' then
+	if String.isEmpty(manualInput) then
+		return autoFunction(autoFunctionParam)
+	elseif manualInput:lower() == 'hide' then
 		return nil
 	else
-		return yearsActive
+		return manualInput
 	end
 end
 

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -14,7 +14,7 @@ local Namespace = require('Module:Namespace')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
-local YearsActive = require('Module:YearsActive')
+local YearsActive = Lua.import('Module:YearsActive', {requireDevIfEnabled = true})
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
@@ -56,25 +56,52 @@ function CustomInjector:parse(id, widgets)
 	if id == 'status' then
 		local statusContents = CustomPlayer._getStatusContents()
 
+		-- Years Active (Player)
 		local yearsActive = _args.years_active
 		if String.isEmpty(yearsActive) then
 			yearsActive = YearsActive.get({player = _base_page_name})
+		elseif yearsActive == 'hide' then
+			yearsActive = nil
 		else
 			yearsActive = Page.makeInternalLink({onlyIfExists = true}, yearsActive)
 		end
 
-		local yearsActiveOrg = _args.years_active_manage
-		if not String.isEmpty(yearsActiveOrg) then
-			yearsActiveOrg = Page.makeInternalLink({onlyIfExists = true}, yearsActiveOrg)
+		-- Years Active (Coach)
+		local yearsActiveCoach = _args.years_active_coach
+		if String.isEmpty(yearsActiveCoach) then
+			yearsActiveCoach = YearsActive.get({player = _base_page_name, prefix = 'c'})
+		elseif yearsActiveCoach == 'hide' then
+			yearsActiveCoach = nil
+		else
+			yearsActiveCoach = Page.makeInternalLink({onlyIfExists = true}, yearsActiveCoach)
+		end
+
+		-- Years Active (Talent)
+		local yearsActiveTalent = _args.years_active_talent
+		if String.isEmpty(yearsActiveTalent) then
+			yearsActiveTalent = YearsActive.getTalent(_base_page_name)
+		elseif yearsActiveTalent == 'hide' then
+			yearsActiveTalent = nil
+		else
+			yearsActiveTalent = Page.makeInternalLink({onlyIfExists = true}, yearsActiveTalent)
+		end
+
+		-- Years Active (Observer)
+		local yearsActiveObserver = _args.years_active_observer
+		if String.isEmpty(yearsActiveObserver) then
+			yearsActiveObserver = YearsActive.getObserver(_base_page_name)
+		elseif yearsActiveObserver == 'hide' then
+			yearsActiveObserver = nil
+		else
+			yearsActiveObserver = Page.makeInternalLink({onlyIfExists = true}, yearsActiveObserver)
 		end
 
 		return {
 			Cell{name = 'Status', content = statusContents},
 			Cell{name = 'Years Active (Player)', content = {yearsActive}},
-			Cell{name = 'Years Active (Org)', content = {yearsActiveOrg}},
-			Cell{name = 'Years Active (Coach)', content = {_args.years_active_coach}},
-			Cell{name = 'Years Active (Analyst)', content = {_args.years_active_analyst}},
-			Cell{name = 'Years Active (Talent)', content = {_args.years_active_talent}},
+			Cell{name = 'Years Active (Coach)', content = {yearsActiveCoach}},
+			Cell{name = 'Years Active (Talent)', content = {yearsActiveTalent}},
+			Cell{name = 'Years Active (Observer)', content = {yearsActiveObserver}},
 		}
 	elseif id == 'history' then
 		if not String.isEmpty(_args.history_iwo) then

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -52,49 +52,25 @@ function CustomPlayer.run(frame)
 	return player:createInfobox()
 end
 
+function CustomInjector:_parseActive(yearsActive, get, get_arg)
+	if String.isEmpty(yearsActive) then
+		return get(get_arg)
+	elseif yearsActive == 'hide' then
+		return nil
+	else
+		return Page.makeInternalLink({onlyIfExists = true}, yearsActive)
+	end
+end
+
 function CustomInjector:parse(id, widgets)
 	if id == 'status' then
 		local statusContents = CustomPlayer._getStatusContents()
 
-		-- Years Active (Player)
-		local yearsActive = _args.years_active
-		if String.isEmpty(yearsActive) then
-			yearsActive = YearsActive.get({player = _base_page_name})
-		elseif yearsActive == 'hide' then
-			yearsActive = nil
-		else
-			yearsActive = Page.makeInternalLink({onlyIfExists = true}, yearsActive)
-		end
-
-		-- Years Active (Coach)
-		local yearsActiveCoach = _args.years_active_coach
-		if String.isEmpty(yearsActiveCoach) then
-			yearsActiveCoach = YearsActive.get({player = _base_page_name, prefix = 'c'})
-		elseif yearsActiveCoach == 'hide' then
-			yearsActiveCoach = nil
-		else
-			yearsActiveCoach = Page.makeInternalLink({onlyIfExists = true}, yearsActiveCoach)
-		end
-
-		-- Years Active (Talent)
-		local yearsActiveTalent = _args.years_active_talent
-		if String.isEmpty(yearsActiveTalent) then
-			yearsActiveTalent = YearsActive.getTalent(_base_page_name)
-		elseif yearsActiveTalent == 'hide' then
-			yearsActiveTalent = nil
-		else
-			yearsActiveTalent = Page.makeInternalLink({onlyIfExists = true}, yearsActiveTalent)
-		end
-
-		-- Years Active (Observer)
-		local yearsActiveObserver = _args.years_active_observer
-		if String.isEmpty(yearsActiveObserver) then
-			yearsActiveObserver = YearsActive.getObserver(_base_page_name)
-		elseif yearsActiveObserver == 'hide' then
-			yearsActiveObserver = nil
-		else
-			yearsActiveObserver = Page.makeInternalLink({onlyIfExists = true}, yearsActiveObserver)
-		end
+		-- Years active
+		local yearsActive = _parseActive(_args.years_active, YearsActive.get, {player = _base_page_name})
+		local yearsActiveCoach = _parseActive(_args.years_active_coach, YearsActive.get, {player = _base_page_name, prefix = 'c'})
+		local yearsActiveTalent = _parseActive(_args.years_active_talent, YearsActive.getTalent, _base_page_name)
+		local yearsActiveObserver = _parseActive(_args.years_active_observer, YearsActive.getObserver, _base_page_name)
 
 		return {
 			Cell{name = 'Status', content = statusContents},

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -67,10 +67,10 @@ function CustomInjector:parse(id, widgets)
 		local statusContents = CustomPlayer._getStatusContents()
 
 		-- Years active
-		local yearsActive = _parseActive(_args.years_active, YearsActive.get, {player = _base_page_name})
-		local yearsActiveCoach = _parseActive(_args.years_active_coach, YearsActive.get, {player = _base_page_name, prefix = 'c'})
-		local yearsActiveTalent = _parseActive(_args.years_active_talent, YearsActive.getTalent, _base_page_name)
-		local yearsActiveObserver = _parseActive(_args.years_active_observer, YearsActive.getObserver, _base_page_name)
+		local yearsActive = CustomInjector:_parseActive(_args.years_active, YearsActive.get, {player = _base_page_name})
+		local yearsActiveCoach = CustomInjector:_parseActive(_args.years_active_coach, YearsActive.get, {player = _base_page_name, prefix = 'c'})
+		local yearsActiveTalent = CustomInjector:_parseActive(_args.years_active_talent, YearsActive.getTalent, _base_page_name)
+		local yearsActiveObserver = CustomInjector:_parseActive(_args.years_active_observer, YearsActive.getObserver, _base_page_name)
 
 		return {
 			Cell{name = 'Status', content = statusContents},

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local Flags = require('Module:Flags')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Matches = require('Module:Matches_Player')
 local Namespace = require('Module:Namespace')
@@ -52,14 +53,11 @@ function CustomPlayer.run(frame)
 	return player:createInfobox()
 end
 
-function CustomInjector:_parseActive(manualInput, autoFunction, autoFunctionParam)
-	if String.isEmpty(manualInput) then
-		return autoFunction(autoFunctionParam)
-	elseif manualInput:lower() == 'hide' then
-		return
-	else
-		return manualInput
+function CustomInjector:_parseActive(manualInput, varName, autoFunction, autoFunctionParam)
+	if String.isNotEmpty(manualInput) then
+		return manualInput:lower() ~= 'hide' and manualInput or nil
 	end
+	return Logic.readBool(Variables.varDefault(varName)) and autoFunction(autoFunctionParam) or nil
 end
 
 function CustomInjector:parse(id, widgets)
@@ -68,13 +66,13 @@ function CustomInjector:parse(id, widgets)
 
 		-- Years active
 		local yearsActive = CustomInjector:_parseActive(
-			_args.years_active, YearsActive.get, {player = _base_page_name}
+			_args.years_active, 'role_player', YearsActive.get, {player = _args.id}
 		)
 		local yearsActiveCoach = CustomInjector:_parseActive(
-			_args.years_active_coach, YearsActive.get, {player = _base_page_name, prefix = 'c'}
+			_args.years_active_coach, 'role_coach', YearsActive.get, {player = _args.id, prefix = 'c'}
 		)
 		local yearsActiveTalent = CustomInjector:_parseActive(
-			_args.years_active_talent, YearsActive.getTalent, _base_page_name
+			_args.years_active_talent, 'role_talent', YearsActive.getTalent, _args.id
 		)
 
 		return {

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -67,10 +67,18 @@ function CustomInjector:parse(id, widgets)
 		local statusContents = CustomPlayer._getStatusContents()
 
 		-- Years active
-		local yearsActive = CustomInjector:_parseActive(_args.years_active, YearsActive.get, {player = _base_page_name})
-		local yearsActiveCoach = CustomInjector:_parseActive(_args.years_active_coach, YearsActive.get, {player = _base_page_name, prefix = 'c'})
-		local yearsActiveTalent = CustomInjector:_parseActive(_args.years_active_talent, YearsActive.getTalent, _base_page_name)
-		local yearsActiveObserver = CustomInjector:_parseActive(_args.years_active_observer, YearsActive.getObserver, _base_page_name)
+		local yearsActive = CustomInjector:_parseActive(
+			_args.years_active, YearsActive.get, {player = _base_page_name}
+		)
+		local yearsActiveCoach = CustomInjector:_parseActive(
+			_args.years_active_coach, YearsActive.get, {player = _base_page_name, prefix = 'c'}
+		)
+		local yearsActiveTalent = CustomInjector:_parseActive(
+			_args.years_active_talent, YearsActive.getTalent, _base_page_name
+		)
+		local yearsActiveObserver = CustomInjector:_parseActive(
+			_args.years_active_observer, YearsActive.getObserver, _base_page_name
+		)
 
 		return {
 			Cell{name = 'Status', content = statusContents},

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -52,13 +52,13 @@ function CustomPlayer.run(frame)
 	return player:createInfobox()
 end
 
-function CustomInjector:_parseActive(yearsActive, get, getArg)
+function CustomInjector:_parseActive(yearsActive, getYearsActive, getYearsActiveArg)
 	if String.isEmpty(yearsActive) then
-		return get(getArg)
-	elseif yearsActive == 'hide' then
+		return getYearsActive(getYearsActiveArg)
+	elseif yearsActive:lower() == 'hide' then
 		return nil
 	else
-		return Page.makeInternalLink({onlyIfExists = true}, yearsActive)
+		return yearsActive
 	end
 end
 

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -27,6 +27,8 @@ local Center = Widgets.Center
 
 local _BANNED = mw.loadData('Module:Banned')
 
+local _NOT_APPLICABLE = 'N/A'
+
 local _title = mw.title.getCurrentTitle()
 local _pagename = _title.prefixedText
 local _base_page_name = _title.baseText
@@ -53,9 +55,9 @@ function CustomPlayer.run(frame)
 	return player:createInfobox()
 end
 
-function CustomInjector:_parseActive(manualInput, varName, autoFunction, autoFunctionParam)
+function CustomPlayer:_parseActive(manualInput, varName, autoFunction, autoFunctionParam)
 	if String.isNotEmpty(manualInput) then
-		return manualInput:upper() ~= 'N/A' and manualInput or nil
+		return manualInput:upper() ~= _NOT_APPLICABLE and manualInput or nil
 	end
 	return Logic.readBool(Variables.varDefault(varName)) and autoFunction(autoFunctionParam) or nil
 end
@@ -65,14 +67,14 @@ function CustomInjector:parse(id, widgets)
 		local statusContents = CustomPlayer._getStatusContents()
 
 		-- Years active
-		local yearsActive = CustomInjector:_parseActive(
-			_args.years_active, 'role_player', YearsActive.get, {player = _args.id}
+		local yearsActive = CustomPlayer:_parseActive(
+			_args.years_active, 'role_player', YearsActive.get, {player = _base_page_name}
 		)
-		local yearsActiveCoach = CustomInjector:_parseActive(
-			_args.years_active_coach, 'role_coach', YearsActive.get, {player = _args.id, prefix = 'c'}
+		local yearsActiveCoach = CustomPlayer:_parseActive(
+			_args.years_active_coach, 'role_coach', YearsActive.get, {player = _base_page_name, prefix = 'c'}
 		)
-		local yearsActiveTalent = CustomInjector:_parseActive(
-			_args.years_active_talent, 'role_talent', YearsActive.getTalent, _args.id
+		local yearsActiveTalent = CustomPlayer:_parseActive(
+			_args.years_active_talent, 'role_talent', YearsActive.getTalent, _base_page_name
 		)
 
 		return {


### PR DESCRIPTION
## Summary

Rocket League currently uses the automatically calculated years-active for players, I extended this to coaches, talents, ~~and observers~~.

- Manual activity for coaches was not used on any page, neither were talents.
- ~~Observers previously did not have years-active, I thought this would be useful since there are observers with pages.~~
- Removed the completely-unused organisation years active, as well as analyst. It didn't seem fitting to keep them as it stands, as they can't automatically be updated (perhaps this could be done using `squadplayers`?).
- Added functionality to hide years active, example: `|years_active_talent=hide`. I think this could be useful for if a player was to cast or coach for a one-off event.
- Hid the `Player has no results.` text, since this text generally only appears on non-player pages.

## How did you test this change?

/dev module
`_base_page_name` has to be manually swapped out to work outside of the player's page

| Before:                                                                                                          | After:                                                                                                          |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/42142350/205751007-db54865d-2755-44b9-87ba-60df88839b67.png) | ![After](https://user-images.githubusercontent.com/42142350/205751467-70d56f33-a914-4dde-bb88-28ad8118f024.png) |

(Approx. winnings doesn't show outside of the player's page)
