### PR TITLE
Create BrktsWikiSpecific for COD

### DIFF
--- a/components/match2/wikis/callofduty/brkts_wiki_specific.lua
+++ b/components/match2/wikis/callofduty/brkts_wiki_specific.lua
@@ -6,15 +6,16 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+
+local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 
 local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
 
 function WikiSpecific.matchHasDetails(match)
 	return match.dateIsExact
-		or match.date ~= DateExt.epochZero
+		or match.date ~= _EPOCH_TIME_EXTENDED
 		or match.vod
 		or not Table.isEmpty(match.links)
 		or match.comment

--- a/components/match2/wikis/callofduty/brkts_wiki_specific.lua
+++ b/components/match2/wikis/callofduty/brkts_wiki_specific.lua
@@ -1,0 +1,24 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
+
+function WikiSpecific.matchHasDetails(match)
+	return match.dateIsExact
+		or match.date ~= DateExt.epochZero
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.games
+end
+
+return WikiSpecific


### PR DESCRIPTION
## Summary
**Match2 for Call of Duty**

This was ported from Splatoon instead since there's different in that the old WIP one on COD uses EPOCH TIME but the Splatoon assuming newer has moved to DateExt so I'm trying with that if it's the better go-to vs EPOCH

## How did you test this change?
LIVE

e.g. 
https://liquipedia.net/callofduty/Call_of_Duty_League/Season_4/Stage_1 (Matchlist)
https://liquipedia.net/callofduty/Fall_Invitational/2022/Knockout_Stage (Bracket)
