### PR TITLE
Store Player Displaynames on Valorant match2

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -447,6 +447,7 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
 		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
+		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
 			match['opponent' .. opponentIndex .. '_p' .. playerIndex] = player
 		end


### PR DESCRIPTION
## Summary
Valorant's match2 is not storing DisplayNames for players in lpdb. The PR fixes this issue.

## How did you test this change?
Dev module
![image](https://user-images.githubusercontent.com/3426850/205918894-03ad1b88-0fdc-4b3f-92f5-14300e99da30.png)
