### PR TITLE
Refactor `USD` to `BASE_CURRENCY` in PrizePool

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -49,7 +49,7 @@ local DASH = '&#045;'
 local NON_BREAKING_SPACE = '&nbsp;'
 local BASE_CURRENCY = 'USD'
 
-local PRIZE_TYPE_USD = 'USD'
+local PRIZE_TYPE_BASE_CURRENCY = 'BASE_CURRENCY'
 local PRIZE_TYPE_LOCAL_CURRENCY = 'LOCAL_CURRENCY'
 local PRIZE_TYPE_QUALIFIES = 'QUALIFIES'
 local PRIZE_TYPE_POINTS = 'POINTS'
@@ -61,13 +61,13 @@ local FORFEIT_SCORE = 'FF'
 local SPECIAL_SCORES = {WALKOVER_SCORE, FORFEIT_SCORE , 'L', 'DQ', 'D'}
 
 PrizePool.config = {
-	showUSD = {
+	showBaseCurrency = {
 		default = false
 	},
-	autoUSD = {
+	autoExchange = {
 		default = true,
 		read = function(args)
-			return Logic.readBoolOrNil(args.autousd)
+			return Logic.readBoolOrNil(args.autoexchange or args.autousd)
 		end
 	},
 	prizeSummary = {
@@ -145,7 +145,7 @@ PrizePool.config = {
 }
 
 PrizePool.prizeTypes = {
-	[PRIZE_TYPE_USD] = {
+	[PRIZE_TYPE_BASE_CURRENCY] = {
 		sortOrder = 10,
 
 		headerDisplay = function (data)
@@ -153,13 +153,16 @@ PrizePool.prizeTypes = {
 			return TableCell{content = {{currencyText}}}
 		end,
 
-		row = 'usdprize',
+		row = BASE_CURRENCY:lower() .. 'prize',
 		rowParse = function (placement, input, context, index)
 			return PrizePool._parseInteger(input)
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {{'$', Currency.formatMoney(data, headerData.roundPrecision)}}}
+				return TableCell{content = {
+					Currency.display(BASE_CURRENCY, data,
+						{formatValue = true, formatPrecision = headerData.roundPrecision, abbreviation = false})
+				}}
 			end
 		end,
 	},
@@ -197,11 +200,12 @@ PrizePool.prizeTypes = {
 			if data > 0 then
 				return TableCell{content = {
 					Currency.display(headerData.currency, data,
-					{formatValue = true, formatPrecision = headerData.roundPrecision, abbreviation = false})}}
+					{formatValue = true, formatPrecision = headerData.roundPrecision, abbreviation = false})
+				}}
 			end
 		end,
 
-		convertToUsd = function (headerData, data, date, perOpponent)
+		convertToBaseCurrency = function (headerData, data, date, perOpponent)
 			local rate = headerData.rate
 
 			if perOpponent then
@@ -390,17 +394,17 @@ function PrizePool:create()
 	self.placements = self:_readPlacements(self.args)
 	self.placements = Import.run(self)
 
-	if self:_hasUsdPrizePool() then
-		self:setConfig('showUSD', true)
-		self:addPrize(PRIZE_TYPE_USD, 1, {roundPrecision = self.options.currencyRoundPrecision})
+	if self:_hasBaseCurrency() then
+		self:setConfig('showBaseCurrency', true)
+		self:addPrize(PRIZE_TYPE_BASE_CURRENCY, 1, {roundPrecision = self.options.currencyRoundPrecision})
 
-		if self.options.autoUSD then
+		if self.options.autoExchange then
 			local canConvertCurrency = function(prize)
 				return prize.type == PRIZE_TYPE_LOCAL_CURRENCY
 			end
 
 			for _, placement in ipairs(self.placements) do
-				placement:_setUsdFromRewards(Array.filter(self.prizes, canConvertCurrency), PrizePool.prizeTypes)
+				placement:_setBaseFromRewards(Array.filter(self.prizes, canConvertCurrency), PrizePool.prizeTypes)
 			end
 		end
 	end
@@ -454,7 +458,7 @@ end
 function PrizePool:_getPrizeSummaryText()
 	local tba = Abbreviation.make('TBA', 'To Be Announced')
 	local tournamentCurrency = Variables.varDefault('tournament_currency')
-	local baseMoneyRaw = Variables.varDefault('tournament_prizepool_usd', tba)
+	local baseMoneyRaw = Variables.varDefault('tournament_prizepool_' .. BASE_CURRENCY:lower(), tba)
 	local baseMoneyDisplay = Currency.display(BASE_CURRENCY, baseMoneyRaw, {formatValue = true})
 
 	local displayText = {baseMoneyDisplay}
@@ -610,7 +614,7 @@ function PrizePool:_currencyExchangeInfo()
 		wrapper:wikitext('Converted ' .. currencyText .. ' prizes are ')
 		wrapper:wikitext('based on the ' .. exchangeProvider ..' on ' .. exchangeDateText .. ': ')
 		wrapper:wikitext(table.concat(Array.map(Array.filter(self.prizes, function (prize)
-			return PrizePool.prizeTypes[prize.type].convertToUsd
+			return PrizePool.prizeTypes[prize.type].convertToBaseCurrency
 		end), PrizePool._CurrencyConvertionText), ', '))
 		wrapper:wikitext(')\'\'')
 
@@ -620,7 +624,7 @@ end
 
 function PrizePool._CurrencyConvertionText(prize)
 	local exchangeRate = Math.round{
-		PrizePool.prizeTypes[PRIZE_TYPE_LOCAL_CURRENCY].convertToUsd(
+		PrizePool.prizeTypes[PRIZE_TYPE_LOCAL_CURRENCY].convertToBaseCurrency(
 			prize.data, 1, PrizePool._getTournamentDate()
 		)
 		,5
@@ -890,13 +894,13 @@ function PrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, lpdbPrefix)
 	return objectName .. prizePoolIndex .. '_' .. lpdbEntry.participant
 end
 
---- Returns true if this prizePool has a US Dollar reward.
--- This is true if any placement has a dollar input,
+--- Returns true if this PrizePool has a Base Currency money reward.
+-- This is true if any placement has a Base Currency input,
 -- or if there is a money reward in another currency whilst currency conversion is active
-function PrizePool:_hasUsdPrizePool()
+function PrizePool:_hasBaseCurrency()
 	return (Array.any(self.placements, function (placement)
-		return placement.hasUSD
-	end)) or (self.options.autoUSD and Array.any(self.prizes, function (prize)
+		return placement.hasBaseCurrency
+	end)) or (self.options.autoExchange and Array.any(self.prizes, function (prize)
 		return prize.type == PRIZE_TYPE_LOCAL_CURRENCY
 	end))
 end

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -35,6 +35,8 @@ local CUSTOM_HANDLER
 
 local IS_SOLO = false
 
+LegacyPrizePool.BASE_CURRENCY = 'USD'
+
 function LegacyPrizePool.run(dependency)
 	local args = Template.retrieveReturnValues('LegacyPrizePool')
 	local header = Array.sub(args, 1, 1)[1]
@@ -159,8 +161,10 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 		newData.place = slot.place
 	end
 
+	local baseCurrencyPrize = LegacyPrizePool.BASE_CURRENCY:lower() .. 'prize'
+
 	newData.date = slot.date
-	newData.usdprize = (slot.usdprize and slot.usdprize ~= '0') and slot.usdprize or nil
+	newData[baseCurrencyPrize] = (slot[baseCurrencyPrize] and slot[baseCurrencyPrize] ~= '0') and slot[baseCurrencyPrize] or nil
 
 	local opponentsInSlot = #slot
 	Table.iter.forEachPair(CACHED_DATA.inputToId, function(parameter, newParameter)

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -164,7 +164,8 @@ function LegacyPrizePool.mapSlot(slot, mergeSlots)
 	local baseCurrencyPrize = LegacyPrizePool.BASE_CURRENCY:lower() .. 'prize'
 
 	newData.date = slot.date
-	newData[baseCurrencyPrize] = (slot[baseCurrencyPrize] and slot[baseCurrencyPrize] ~= '0') and slot[baseCurrencyPrize] or nil
+	newData[baseCurrencyPrize] = (slot[baseCurrencyPrize] and slot[baseCurrencyPrize] ~= '0') and slot[baseCurrencyPrize]
+		or nil
 
 	local opponentsInSlot = #slot
 	Table.iter.forEachPair(CACHED_DATA.inputToId, function(parameter, newParameter)

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -25,6 +25,7 @@ local StarcraftLegacyPrizePool = {}
 
 local AUTOMATION_START_DATE = '2022-01-14'
 local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp', w = 'w', d = 'd', l = 'l', q = 'q'}
+local BASE_CURRENCY_PRIZE = LegacyPrizePool.BASE_CURRENCY:lower() .. 'prize'
 
 local CACHED_DATA = {
 	next = {points = 1, qual = 1, freetext = 1},
@@ -200,7 +201,8 @@ function StarcraftLegacyPrizePool._mapSlot(slot)
 	end
 
 	newData.date = slot.date
-	newData.usdprize = (slot.usdprize and slot.usdprize ~= '0') and slot.usdprize or nil
+	newData[BASE_CURRENCY_PRIZE] = (slot[BASE_CURRENCY_PRIZE] and slot[BASE_CURRENCY_PRIZE] ~= '0') and slot[BASE_CURRENCY_PRIZE]
+		or nil
 
 	local slotInputSize = math.min(StarcraftLegacyPrizePool._slotSize(slot) or math.huge, #slot)
 	local opponentsInSlot = tonumber(slot.count) or math.max(slotInputSize, 1)
@@ -215,9 +217,9 @@ function StarcraftLegacyPrizePool._mapSlot(slot)
 		end
 	end)
 
-	if newData.usdprize then
-		if newData.usdprize:match('[^,%.%d]') then
-			error('Unexpected value in usdprize for place=' .. slot.place)
+	if newData[BASE_CURRENCY_PRIZE] then
+		if newData[BASE_CURRENCY_PRIZE]:match('[^,%.%d]') then
+			error('Unexpected value in ' .. newData[BASE_CURRENCY_PRIZE] .. ' for place=' .. slot.place)
 		end
 	end
 
@@ -349,8 +351,8 @@ function StarcraftLegacyPrizePool._mapOpponents(slot, newData, opponentsInSlot)
 			StarcraftLegacyPrizePool._setOpponentReward(opponentData, param, points2)
 		end
 
-		if slot['usdprize' .. opponentIndex] then
-			opponentData.usdprize = slot['usdprize' .. opponentIndex]
+		if slot[BASE_CURRENCY_PRIZE .. opponentIndex] then
+			opponentData[BASE_CURRENCY_PRIZE] = slot[BASE_CURRENCY_PRIZE .. opponentIndex]
 		end
 
 		if slot['localprize' .. opponentIndex] then

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -201,8 +201,8 @@ function StarcraftLegacyPrizePool._mapSlot(slot)
 	end
 
 	newData.date = slot.date
-	newData[BASE_CURRENCY_PRIZE] = (slot[BASE_CURRENCY_PRIZE] and slot[BASE_CURRENCY_PRIZE] ~= '0') and slot[BASE_CURRENCY_PRIZE]
-		or nil
+	newData[BASE_CURRENCY_PRIZE] = (slot[BASE_CURRENCY_PRIZE] and slot[BASE_CURRENCY_PRIZE] ~= '0')
+		and slot[BASE_CURRENCY_PRIZE] or nil
 
 	local slotInputSize = math.min(StarcraftLegacyPrizePool._slotSize(slot) or math.huge, #slot)
 	local opponentsInSlot = tonumber(slot.count) or math.max(slotInputSize, 1)

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -201,8 +201,8 @@ function StarcraftLegacyPrizePool._mapSlot(slot)
 	end
 
 	newData.date = slot.date
-	newData[BASE_CURRENCY_PRIZE] = (slot[BASE_CURRENCY_PRIZE] and slot[BASE_CURRENCY_PRIZE] ~= '0')
-		and slot[BASE_CURRENCY_PRIZE] or nil
+	newData[BASE_CURRENCY_PRIZE] = (slot[BASE_CURRENCY_PRIZE] and slot[BASE_CURRENCY_PRIZE] ~= '0') and
+		slot[BASE_CURRENCY_PRIZE] or nil
 
 	local slotInputSize = math.min(StarcraftLegacyPrizePool._slotSize(slot) or math.huge, #slot)
 	local opponentsInSlot = tonumber(slot.count) or math.max(slotInputSize, 1)

--- a/components/prize_pool/test/prize_pool_test.lua
+++ b/components/prize_pool/test/prize_pool_test.lua
@@ -37,7 +37,7 @@ function suite:testHeaderInput()
 
 	self:assertDeepEquals(
 		{
-			{id = 'USD1', type = 'USD', index = 1, data = {roundPrecision = 3}},
+			{id = 'BASE_CURRENCY1', type = 'BASE_CURRENCY', index = 1, data = {roundPrecision = 3}},
 			{id = 'LOCAL_CURRENCY1', type = 'LOCAL_CURRENCY', index = 1, data =
 				{
 					rate = 0.97821993318758, roundPrecision = 3,
@@ -62,7 +62,7 @@ function suite:testHeaderInput()
 	self:assertDeepEquals(
 		{
 			abbreviateTbd = true,
-			autoUSD = true,
+			autoExchange = true,
 			currencyRatePerOpponent = false,
 			currencyRoundPrecision = 3,
 			cutafter = 4,
@@ -71,7 +71,7 @@ function suite:testHeaderInput()
 			lpdbPrefix = 'abc',
 			prizeSummary = true,
 			resolveRedirect = false,
-			showUSD = true,
+			showBaseCurrency = true,
 			storeLpdb = true,
 			storeSmw = true,
 			syncPlayers = false,

--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -35,7 +35,7 @@ function CustomPrizePool.run(frame)
 
 	-- Turn off automations
 	prizePool:setConfigDefault('prizeSummary', false)
-	prizePool:setConfigDefault('autoUSD', false)
+	prizePool:setConfigDefault('autoExchange', false)
 	prizePool:setConfigDefault('exchangeInfo', false)
 
 	prizePool:create()

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -44,8 +44,9 @@ end
 function CustomLegacyPrizePool.customOpponent(opponentData, CACHED_DATA, slot, opponentIndex)
 	-- CS didn't support multiple points (etc), however they supported points (etc) per opponent
 
-	if slot['usdprize' .. opponentIndex] then
-		opponentData.usdprize = slot['usdprize' .. opponentIndex]
+	local baseCurrencyPrize = PrizePoolLegacy.BASE_CURRENCY:lower() .. 'prize'
+	if slot[baseCurrencyPrize .. opponentIndex] then
+		opponentData[baseCurrencyPrize] = slot[baseCurrencyPrize .. opponentIndex]
 	end
 
 	if slot['points' .. opponentIndex] then

--- a/components/prize_pool/wikis/mobilelegends/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/mobilelegends/prize_pool_legacy_custom.lua
@@ -20,8 +20,9 @@ end
 function CustomLegacyPrizePool.customOpponent(opponentData, CACHED_DATA, slot, opponentIndex)
 	-- ML has use case of same placement but has different earnings
 
-	if slot['usdprize' .. opponentIndex] then
-		opponentData.usdprize = slot['usdprize' .. opponentIndex]
+	local baseCurrencyPrize = PrizePoolLegacy.BASE_CURRENCY:lower() .. 'prize'
+	if slot[baseCurrencyPrize .. opponentIndex] then
+		opponentData[baseCurrencyPrize] = slot[baseCurrencyPrize .. opponentIndex]
 	end
 
 	if slot['localprize' .. opponentIndex] then


### PR DESCRIPTION
## Summary

There was conflicting use of `USD` and `BASE_CURRENCY` across the PPT modules. This PR addressed that by renaming everything to `BASE_CURRENCY`.

## How did you test this change?

Tested using `/dev` modules on commons, and with CS and ML wikis.
