### PR TITLE
Set variable for specific enddates entered in PPT

### DIFF
--- a/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
@@ -71,6 +71,9 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	lpdbData.qualified = Array.any(Array.filter(placement.parent.prizes, prizeIsQualifier), opponentHasPrize) and 1 or 0
 
+	-- Variable to communicate with TeamCards
+	Variables.varDefine('enddate_' .. lpdbData.participant, lpdbData.date)
+
 	return lpdbData
 end
 


### PR DESCRIPTION
## Summary
Current TeamCard overrides a placement's date with the default tournament enddate.
This change sets the wikivar to pass specific dates on to the TeamCard for each participant.

## How did you test this change?
via /dev
