### PR TITLE
Add abbreviation explaining team earnings

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Abbreviation = require('Module:Abbreviation')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')
@@ -106,7 +107,11 @@ function Team:createInfobox()
 							totalEarningsDisplay = '$' .. Language:formatNum(self.totalEarnings)
 						end
 						return {
-							Cell{name = 'Approx. Total Winnings', content = {totalEarningsDisplay}}
+							Cell{name = Abbreviation.make(
+									'Approx. Total Winnings',
+									'Includes individual player earnings won&#10;while representing this team'
+								),
+								content = {totalEarningsDisplay}}
 						}
 					end
 				}


### PR DESCRIPTION
## Summary
Adds an explanation about team earnings containing individual earnings.
![image](https://user-images.githubusercontent.com/16326643/206454315-f5e9988d-0aaa-4989-91bc-7972940368f5.png)

## How did you test this change?
via /dev
Checked that any custom implementations of Module:Earnings do not interfere (or the cell is also being overriden in a custom infobox)