### PR TITLE
Add data callback functionality to LPDB Mock

### DIFF
--- a/standard/mock/mock_lpdb.lua
+++ b/standard/mock/mock_lpdb.lua
@@ -32,7 +32,7 @@ local _lpdb = {
 	lpdb_squadplayer = mw.ext.LiquipediaDB.lpdb_squadplayer,
 }
 
----@param callbackFunction fun(dbTable: string, objectName: string, storedData: table)
+---@param callbackFunction? fun(dbTable: string, objectName: string, storedData: table)
 function mockLpdb.setUp(callbackFunction)
 	mockLpdb.callback = callbackFunction
 	mw.ext.LiquipediaDB.lpdb = mockLpdb.lpdb

--- a/standard/mock/mock_lpdb.lua
+++ b/standard/mock/mock_lpdb.lua
@@ -32,7 +32,9 @@ local _lpdb = {
 	lpdb_squadplayer = mw.ext.LiquipediaDB.lpdb_squadplayer,
 }
 
-function mockLpdb.setUp()
+---@param callbackFunction fun(dbTable: string, objectName: string, storedData: table)
+function mockLpdb.setUp(callbackFunction)
+	mockLpdb.callback = callbackFunction
 	mw.ext.LiquipediaDB.lpdb = mockLpdb.lpdb
 	mw.ext.LiquipediaDB.lpdb_standingsentry = mockLpdb.lpdb_standingsentry
 	mw.ext.LiquipediaDB.lpdb_standingstable = mockLpdb.lpdb_standingstable
@@ -40,6 +42,7 @@ function mockLpdb.setUp()
 end
 
 function mockLpdb.tearDown()
+	mockLpdb.callback = nil
 	mw.ext.LiquipediaDB.lpdb = _lpdb.lpdb
 	mw.ext.LiquipediaDB.lpdb_standingsentry = _lpdb.lpdb_standingsentry
 	mw.ext.LiquipediaDB.lpdb_standingstable = _lpdb.lpdb_standingstable
@@ -203,31 +206,36 @@ function mockLpdb._deserializeJson(value)
 	return Json.parseIfTable(value) or value
 end
 
+function mockLpdb._verifyInsertion(dbTable, objectname, data)
+	local parsedData = Table.mapValues(data, mockLpdb._deserializeJson)
+
+	TypeUtil.assertValue(objectname, 'string')
+	TypeUtil.assertValue(parsedData, TypeUtil.struct(dbStructure[dbTable]), { maxDepth = 3, name = dbTable})
+
+	if mockLpdb.callback then
+		mockLpdb.callback(dbTable, objectname, parsedData)
+	end
+end
+
 ---Stores data into LPDB StandingsTable
 ---@param objectname string
 ---@param data table
 function mockLpdb.lpdb_standingstable(objectname, data)
-	data = Table.mapValues(data, mockLpdb._deserializeJson)
-	TypeUtil.assertValue(objectname, 'string')
-	TypeUtil.assertValue(data, TypeUtil.struct(dbStructure.standingstable), { maxDepth = 3, name = 'StandingsTable' })
+	mockLpdb._verifyInsertion('standingstable', objectname, data)
 end
 
 ---Stores data into LPDB StandingsEntry
 ---@param objectname string
 ---@param data table
 function mockLpdb.lpdb_standingsentry(objectname, data)
-	data = Table.mapValues(data, mockLpdb._deserializeJson)
-	TypeUtil.assertValue(objectname, 'string')
-	TypeUtil.assertValue(data, TypeUtil.struct(dbStructure.standingsentry), { maxDepth = 3, name = 'StandingsEntry' })
+	mockLpdb._verifyInsertion('standingsentry', objectname, data)
 end
 
 ---Stores data into LPDB SquadPlayer
 ---@param objectname string
 ---@param data table
 function mockLpdb.lpdb_squadplayer(objectname, data)
-	data = Table.mapValues(data, mockLpdb._deserializeJson)
-	TypeUtil.assertValue(objectname, 'string')
-	TypeUtil.assertValue(data, TypeUtil.struct(dbStructure.squadplayer), { maxDepth = 3, name = 'SquadPlayer' })
+	mockLpdb._verifyInsertion('squadplayer', objectname, data)
 end
 
 return mockLpdb


### PR DESCRIPTION
## Summary
Adding this functionality would allow tests to check and verify the exact data stored into LPDB. 
It is optional for a test to use it.

## How did you test this change?
/dev module and added little thing to a dev testcase `LpdbMock.setUp(function(...) mw.logObject(Table.pack(...)) end)` 
```
table#1 {
  "standingstable",
  "standingsTable_0",
  table#2 {
    ["extradata"] = table#3 {
    },
    ["matches"] = table#4 {
    },
    ["parent"] = "Module_talk:Standings/Storage/testcases",
    ["section"] = "",
    ["standingsindex"] = 0,
    ["title"] = "",
    ["tournament"] = "Test Tournament",
    ["type"] = "league",
  },
  ["n"] = 3,
}
```