### PR TITLE
Add input for Voice Actors in MLBB Hero Infobox

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local ClassIcon = require('Module:ClassIcon')
+local Flags = require('Module:Flags')
 local Lua = require('Module:Lua')
 local HeroWL = require('Module:HeroWL')
 local Math = require('Module:Math')
@@ -34,6 +35,22 @@ local _pagename = mw.title.getCurrentTitle().text
 local _BATTLE_POINTS_ICON = '[[File:Mobile_Legends_BP_icon.png|x16px|Battle Points|link=Battle Point]]'
 local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Diamonds|x16px|link=Diamond]]'
 
+local NON_BREAKING_SPACE  = '&nbsp;'
+
+function CustomHero._voiceActors()
+	local voiceActors = {}
+
+	for voiceActorKey, voiceActor in Table.iter.pairsByPrefix(_args, 'voice') do
+		local flag = _args[voiceActorKey .. 'flag']
+		if flag then
+			voiceActor = Flags.Icon{flag = flag} .. NON_BREAKING_SPACE .. voiceActor
+		end
+		table.insert(voiceActors, voiceActor)
+	end
+
+	return voiceActors
+end
+
 function CustomHero.run(frame)
 	local unit = Unit(frame)
 	_args = unit.args
@@ -56,7 +73,7 @@ function CustomInjector:addCustomCells()
 		Cell{name = 'Secondary Bar', content = {_args.secondarybar}},
 		Cell{name = 'Secondary Attributes', content = {_args.secondaryattributes1}},
 		Cell{name = 'Release Date', content = {_args.releasedate}},
-		Cell{name = 'Voice Actor(s)', content = {_args.voice}},
+		Cell{name = 'Voice Actor(s)', content = CustomHero._voiceActors()},
 	}
 
 	local statisticsCells = {

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -137,6 +137,9 @@ function CustomInjector:parse(id, widgets)
 		}
 	end
 
+	return widgets
+end
+
 function CustomHero._voiceActors()
 	local voiceActors = {}
 
@@ -149,9 +152,6 @@ function CustomHero._voiceActors()
 	end
 
 	return voiceActors
-end
-
-	return widgets
 end
 
 function CustomHero:createWidgetInjector()

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -56,6 +56,7 @@ function CustomInjector:addCustomCells()
 		Cell{name = 'Secondary Bar', content = {_args.secondarybar}},
 		Cell{name = 'Secondary Attributes', content = {_args.secondaryattributes1}},
 		Cell{name = 'Release Date', content = {_args.releasedate}},
+		Cell{name = 'Voice Actor(s)', content = {_args.voice}},
 	}
 
 	local statisticsCells = {

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -37,20 +37,6 @@ local _DIAMONDS_ICON = '[[File:Mobile_Legends_Diamond_icon.png|Diamonds|x16px|li
 
 local NON_BREAKING_SPACE  = '&nbsp;'
 
-function CustomHero._voiceActors()
-	local voiceActors = {}
-
-	for voiceActorKey, voiceActor in Table.iter.pairsByPrefix(_args, 'voice') do
-		local flag = _args[voiceActorKey .. 'flag']
-		if flag then
-			voiceActor = Flags.Icon{flag = flag} .. NON_BREAKING_SPACE .. voiceActor
-		end
-		table.insert(voiceActors, voiceActor)
-	end
-
-	return voiceActors
-end
-
 function CustomHero.run(frame)
 	local unit = Unit(frame)
 	_args = unit.args
@@ -150,6 +136,20 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Price', content = {table.concat(costs, '&emsp;&ensp;')}},
 		}
 	end
+
+function CustomHero._voiceActors()
+	local voiceActors = {}
+
+	for voiceActorKey, voiceActor in Table.iter.pairsByPrefix(_args, 'voice') do
+		local flag = _args[voiceActorKey .. 'flag']
+		if flag then
+			voiceActor = Flags.Icon{flag = flag} .. NON_BREAKING_SPACE .. voiceActor
+		end
+		table.insert(voiceActors, voiceActor)
+	end
+
+	return voiceActors
+end
 
 	return widgets
 end


### PR DESCRIPTION
## Summary
The editors wanted to listed the voice actors for heroes on their respective page through Hero Infoboxes (as it appears such info were provided in the game)

## Input Need Change, I think

Right now the input is like the old venue/sponsors so 

```|parameter=X  <br> Y <br> Z```

I wanted to switch to be similar as the current venue input but I have no idea how. Hence why this revision is just a custom cells since it's the only method I know

Goal is like this if  based on the example pic
```|voice1=NO1 |voice1flag=jp```
```|voice2=NO2 |voice2flag=uk```
```|voice3=NO3 |voice3flag=id```

## How did you test this change?
DEV - https://liquipedia.net/mobilelegends/User:Hesketh2/Test2
![image](https://user-images.githubusercontent.com/88981446/206709337-f88b21b1-7807-4ea8-810e-2152d6ec3672.png)

https://liquipedia.net/mobilelegends/Module:Infobox/Unit/Hero/dev