### PR TITLE
Create a Template Engine

### DIFF
--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 ---Return true if the input is a table in array format

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -8,7 +8,7 @@
 
 local Table = require('Module:Table')
 
----@class TemplateEngine 
+---@class TemplateEngine
 ---Subset implementation of `{{mustache}} templates`.
 ---https://mustache.github.io/mustache.5.html
 local TemplateEngine = {}

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -6,11 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 ---@class TemplateEngine 
----Subset implementation of `{{mustache}} templates`
+---Subset implementation of `{{mustache}} templates`.
 ---https://mustache.github.io/mustache.5.html
 local TemplateEngine = {}
 

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -35,9 +35,12 @@ local VARIABLE = '[%w%. ]-'
 local SELF_REF = '.'
 local TABLE_SPLIT_CHAR = '.'
 
-local REGEX_SECTION = '{{'.. PREFIX_SECTION_START ..'('.. VARIABLE ..')}}('.. TEXT ..'){{'.. PREFIX_SECTION_END .. '%1}}'
-local REGEX_INVERTED_SECTION = '{{'.. PREFIX_INVERTED_SECTION ..'('.. VARIABLE ..')}}('.. TEXT ..'){{'.. PREFIX_SECTION_END .. '%1}}'
-local REGEX_VARIABLE = '{{(['.. PREFIX_COMMENT .. PREFIX_UNESCAPE ..']?)('.. VARIABLE ..')}}'
+local REGEX_SECTION =
+	'{{'.. PREFIX_SECTION_START ..'('.. VARIABLE ..')}}('.. TEXT ..'){{'.. PREFIX_SECTION_END .. '%1}}'
+local REGEX_INVERTED_SECTION =
+	'{{'.. PREFIX_INVERTED_SECTION ..'('.. VARIABLE ..')}}('.. TEXT ..'){{'.. PREFIX_SECTION_END .. '%1}}'
+local REGEX_VARIABLE =
+	'{{(['.. PREFIX_COMMENT .. PREFIX_UNESCAPE ..']?)('.. VARIABLE ..')}}'
 
 ---@class TemplateEngineContext
 local Context = Class.new(function(self, ...) self:init(...) end)

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local Logic = require('Module:Logic')
 local Table = require('Module:Table')
 
 ---@class TemplateEngine
@@ -24,7 +23,10 @@ function TemplateEngine.render(template, model)
 end
 
 ---Handles mustache `sections`
----A section start has two possible inputs. Either 
+---A section start has is a key in the model.
+---If it's an array then the contnet within will be displayed once for each element in the array
+---If it's a function, the function will be called
+---Otherwise, if the value is truthy then it will be rendered
 ---@param template string
 ---@param model table
 ---@return string

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -80,13 +80,13 @@ end
 ---@param context TemplateEngineContext
 ---@return string
 function TemplateEngine:_variable(template, context)
-	return (
-		template:gsub('{{([%w%.]-)}}',
-			function(variable)
-				return context:find(variable) or variable
-			end
-		)
-	)
+	return (template:gsub('{{([%w%.]-)}}', function(variable)
+		local value = context:find(variable)
+		if type(value) == 'function' then
+			value = value(context)
+		end
+		return value or variable
+	end))
 end
 
 function Context:init(model, parent)

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -83,7 +83,7 @@ function TemplateEngine:_variable(template, context)
 	return (template:gsub('{{([%w%.]-)}}', function(variable)
 		local value = context:find(variable)
 		if type(value) == 'function' then
-			value = value(context)
+			value = value(context.model)
 		end
 		return value or variable
 	end))

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -10,16 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Table = require('Module:Table')
 
----Return true if the input is a table in array format
----@param array any
----@return boolean
-local function isArray(array)
-	if type(array) ~= 'table' then
-		return false
-	end
-	return Table.size(array) == #array
-end
-
 ---@class TemplateEngine
 ---Subset implementation of `{{mustache}} templates`.
 ---https://mustache.github.io/mustache.5.html
@@ -83,7 +73,7 @@ function TemplateEngine:_section(template, context)
 	return (template:gsub(REGEX_SECTION, function (varible, text)
 		local value = context:find(varible)
 		if type(value) == 'table' then
-			if isArray(value) then
+			if Array.isArray(value) then
 				return table.concat(Array.map(value, function (val)
 					return self:_subRender(text, Context(val, context))
 				end))
@@ -110,7 +100,7 @@ end
 function TemplateEngine:_invertedSection(template, context)
 	return (template:gsub(REGEX_INVERTED_SECTION, function (varible, text)
 		local value = context:find(varible)
-		if not value or (type(value) == 'table' and isArray(value) and #value == 0) then
+		if not value or (type(value) == 'table' and Array.isArray(value) and #value == 0) then
 			return self:_subRender(text, context)
 		end
 		return ''

--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -1,0 +1,61 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:TemplateEngine
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local TemplateEngine = {}
+
+---Created the html output from a given template string and table input.
+---@param template string
+---@param tbl table
+---@return string
+function TemplateEngine.eval(template, tbl)
+	return TemplateEngine._interpolate(TemplateEngine._foreach(template, tbl), tbl)
+end
+
+---Handles foreach loops by replacing
+---```*{foreach x in y}${x}*{end}```
+---with `${y.foo}${y.bar}` given that key `y` in `tbl` input is a table with two keys, `foo` and `bar`.
+---@param template string
+---@param tbl table
+---@return string
+function TemplateEngine._foreach(template, tbl)
+	local function createReplacement(list, value)
+		return '${' .. String.interpolate('${list}.${val}', {list = list, val = value}) .. '}'
+	end
+	return (template:gsub('*{foreach (.-) in (.-)}(.-)*{end}', function (var, list, text)
+		local str = ''
+		for value in pairs(tbl[list]) do
+			str = str .. TemplateEngine._interpolate(text, {[var] = createReplacement(list, value)})
+		end
+		return str
+	end))
+end
+
+---Interpolates a template using string interpolation. Can handle nested tables.
+---@param template string
+---@param tbl table
+---@return string
+function TemplateEngine._interpolate(template, tbl)
+	local function toNumberIfNumeric(number)
+		return tonumber(number) or number
+	end
+	return (
+		template:gsub('($%b{})',
+			function(w)
+				local path = Table.mapValues(mw.text.split(w:sub(3, -2), '.', true), toNumberIfNumeric)
+				local key = Table.extract(path, #path)
+				local finalTbl =  Table.getByPath(tbl, path)
+				return finalTbl and finalTbl[key] or w
+			end
+		)
+	)
+end
+
+return TemplateEngine

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -13,11 +13,18 @@ local TemplateEngine = Lua.import('Module:TemplateEngine', {requireDevIfEnabled 
 
 local suite = ScribuntoUnit:new()
 
-function suite:testEngine()
-	self:assertEquals(
-		'2foo bar baz',
-		TemplateEngine.render('{{b}}{{a.b}}{{#bar}} {{.}}{{/bar}}', {a = {b = 'foo'}, b = 2, bar = {'bar', 'baz'}})
-	)
+local TEST_DATA = {a = {b = 'foo'}, b = 2, foo = {'bar', 'baz'}}
+
+function suite:testVariables()
+	self:assertEquals('2foo', TemplateEngine.render('{{b}}{{a.b}}', TEST_DATA))
+end
+
+function suite:testLoops()
+	self:assertEquals(' bar baz', TemplateEngine.render('{{#foo}} {{.}}{{/foo}}', TEST_DATA))
+end
+
+function suite:testIf()
+	self:assertEquals('HAI', TemplateEngine.render('{{#b}}HAI{{/b}}{{#c}}BAI{{/c}}', TEST_DATA))
 end
 
 return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -27,4 +27,8 @@ function suite:testIf()
 	self:assertEquals('HAI', TemplateEngine.render('{{#b}}HAI{{/b}}{{#c}}BAI{{/c}}', TEST_DATA))
 end
 
+function suite:testNotIf()
+	self:assertEquals('BAI', TemplateEngine.render('{{^foo}}HAI1{{/foo}}{{^b}}HAI2{{/b}}{{^c}}BAI{{/c}}', TEST_DATA))
+end
+
 return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -1,0 +1,20 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:TemplateEngine/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local TemplateEngine = Lua.import('Module:TemplateEngine', {requireDevIfEnabled = true})
+
+local suite = ScribuntoUnit:new()
+
+function suite:testEngine()
+	self:assertEquals('foo bar baz', TemplateEngine.eval('${a.b}*{foreach foo in bar} ${foo}*{end}', {a = {b = 'foo'}, bar = {'bar', 'baz'}}))
+end
+
+return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -13,26 +13,49 @@ local TemplateEngine = Lua.import('Module:TemplateEngine', {requireDevIfEnabled 
 
 local suite = ScribuntoUnit:new()
 
-local TEST_DATA = {a = {b = 'foo'}, b = 2, foo = {'bar', 'baz'}}
+local TEST_DATA = {a = {a = 'baz', b = 'foo'}, b = 2, foo = {'bar', 'baz'}, d = {},
+	math = function (self) return self.b + 5 end,
+	bold = function (text, render) return '<b>' .. render(text) .. '</b>' end,
+	locations = {
+		{country = 'Sweden', city = 'Stockholm'},
+		{country = 'The Netherlands', city = 'Utrecht'},
+		{country = 'USA', city = 'Santa Monica'},
+	}
+}
 
 function suite:testVariables()
 	self:assertEquals('2foo', TemplateEngine:render('{{b}}{{a.b}}', TEST_DATA))
 end
 
-function suite:testLoops()
-	self:assertEquals(' bar baz', TemplateEngine:render('{{#foo}} {{.}}{{/foo}}', TEST_DATA))
+function suite:testVariableFunction()
+	self:assertEquals('7', TemplateEngine:render('{{math}}', TEST_DATA))
 end
 
-function suite:testIf()
+function suite:testSectionArrays()
+	self:assertEquals('*bar*baz', TemplateEngine:render('{{#foo}}*{{.}}{{/foo}}', TEST_DATA))
+end
+
+function suite:testSectionTables()
+	self:assertEquals('Stockholm, Sweden\nUtrecht, The Netherlands\nSanta Monica, USA\n', TemplateEngine:render('{{#locations}}{{city}}, {{country}}\n{{/locations}}', TEST_DATA))
+end
+
+function suite:testSectionIf()
 	self:assertEquals('HAI', TemplateEngine:render('{{#b}}HAI{{/b}}{{#c}}BAI{{/c}}', TEST_DATA))
 end
 
-function suite:testNotIf()
-	self:assertEquals('BAI', TemplateEngine:render('{{^foo}}HAI1{{/foo}}{{^b}}HAI2{{/b}}{{^c}}BAI{{/c}}', TEST_DATA))
+function suite:testSectionFunction()
+	self:assertEquals('<b>foo</b>', TemplateEngine:render('{{#bold}}{{a.b}}{{/bold}}', TEST_DATA))
 end
 
 function suite:testNestedSections()
 	self:assertEquals('HAI', TemplateEngine:render('{{#a.b}}HAI{{/a.b}}', TEST_DATA))
+end
+
+function suite:testInvertedSection()
+	self:assertEquals('BAIKAI',
+		TemplateEngine:render('{{^foo}}HAI1{{/foo}}{{^b}}HAI2{{/b}}{{^a}}HAI2{{/a}}{{^c}}BAI{{/c}}{{^d}}KAI{{/d}}',
+		TEST_DATA)
+	)
 end
 
 return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -31,4 +31,8 @@ function suite:testNotIf()
 	self:assertEquals('BAI', TemplateEngine:render('{{^foo}}HAI1{{/foo}}{{^b}}HAI2{{/b}}{{^c}}BAI{{/c}}', TEST_DATA))
 end
 
+function suite:testNestedSections()
+	self:assertEquals('HAI', TemplateEngine:render('{{#a.b}}HAI{{/a.b}}', TEST_DATA))
+end
+
 return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -14,7 +14,7 @@ local TemplateEngine = Lua.import('Module:TemplateEngine', {requireDevIfEnabled 
 local suite = ScribuntoUnit:new()
 
 function suite:testEngine()
-	self:assertEquals('foo bar baz', TemplateEngine.eval('${a.b}*{foreach foo in bar} ${foo}*{end}', {a = {b = 'foo'}, bar = {'bar', 'baz'}}))
+	self:assertEquals('2foo bar baz', TemplateEngine.render('{{b}}{{a.b}}{{#bar}} {{.}}{{/bar}}', {a = {b = 'foo'}, b = 2, bar = {'bar', 'baz'}}))
 end
 
 return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -14,7 +14,10 @@ local TemplateEngine = Lua.import('Module:TemplateEngine', {requireDevIfEnabled 
 local suite = ScribuntoUnit:new()
 
 function suite:testEngine()
-	self:assertEquals('2foo bar baz', TemplateEngine.render('{{b}}{{a.b}}{{#bar}} {{.}}{{/bar}}', {a = {b = 'foo'}, b = 2, bar = {'bar', 'baz'}}))
+	self:assertEquals(
+		'2foo bar baz',
+		TemplateEngine.render('{{b}}{{a.b}}{{#bar}} {{.}}{{/bar}}', {a = {b = 'foo'}, b = 2, bar = {'bar', 'baz'}})
+	)
 end
 
 return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -45,7 +45,10 @@ function suite:testSectionArrays()
 end
 
 function suite:testSectionTables()
-	self:assertEquals('Stockholm, Sweden\nUtrecht, The Netherlands\nSanta Monica, USA\n', TemplateEngine:render('{{#locations}}{{city}}, {{country}}\n{{/locations}}', TEST_DATA))
+	self:assertEquals(
+		'Stockholm, Sweden\nUtrecht, The Netherlands\nSanta Monica, USA\n',
+		TemplateEngine:render('{{#locations}}{{city}}, {{country}}\n{{/locations}}', TEST_DATA)
+	)
 end
 
 function suite:testSectionIf()

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -16,19 +16,19 @@ local suite = ScribuntoUnit:new()
 local TEST_DATA = {a = {b = 'foo'}, b = 2, foo = {'bar', 'baz'}}
 
 function suite:testVariables()
-	self:assertEquals('2foo', TemplateEngine.render('{{b}}{{a.b}}', TEST_DATA))
+	self:assertEquals('2foo', TemplateEngine:render('{{b}}{{a.b}}', TEST_DATA))
 end
 
 function suite:testLoops()
-	self:assertEquals(' bar baz', TemplateEngine.render('{{#foo}} {{.}}{{/foo}}', TEST_DATA))
+	self:assertEquals(' bar baz', TemplateEngine:render('{{#foo}} {{.}}{{/foo}}', TEST_DATA))
 end
 
 function suite:testIf()
-	self:assertEquals('HAI', TemplateEngine.render('{{#b}}HAI{{/b}}{{#c}}BAI{{/c}}', TEST_DATA))
+	self:assertEquals('HAI', TemplateEngine:render('{{#b}}HAI{{/b}}{{#c}}BAI{{/c}}', TEST_DATA))
 end
 
 function suite:testNotIf()
-	self:assertEquals('BAI', TemplateEngine.render('{{^foo}}HAI1{{/foo}}{{^b}}HAI2{{/b}}{{^c}}BAI{{/c}}', TEST_DATA))
+	self:assertEquals('BAI', TemplateEngine:render('{{^foo}}HAI1{{/foo}}{{^b}}HAI2{{/b}}{{^c}}BAI{{/c}}', TEST_DATA))
 end
 
 return suite

--- a/standard/test/template_engine_test.lua
+++ b/standard/test/template_engine_test.lua
@@ -20,7 +20,8 @@ local TEST_DATA = {a = {a = 'baz', b = 'foo'}, b = 2, foo = {'bar', 'baz'}, d = 
 		{country = 'Sweden', city = 'Stockholm'},
 		{country = 'The Netherlands', city = 'Utrecht'},
 		{country = 'USA', city = 'Santa Monica'},
-	}
+	},
+	html = '<b>a</b>'
 }
 
 function suite:testVariables()
@@ -29,6 +30,14 @@ end
 
 function suite:testVariableFunction()
 	self:assertEquals('7', TemplateEngine:render('{{math}}', TEST_DATA))
+end
+
+function suite:testVariableEscape()
+	self:assertEquals('<b>a</b>&#60;b&#62;a&#60;/b&#62;', TemplateEngine:render('{{&html}}{{html}}', TEST_DATA))
+end
+
+function suite:testComments()
+	self:assertEquals('', TemplateEngine:render('{{!A Comment}}', TEST_DATA))
 end
 
 function suite:testSectionArrays()


### PR DESCRIPTION
## Summary
This PR aims to create a Template Engine for our Lua environment.

The syntax follows [{{mustache}}](https://mustache.github.io/mustache.5.html). Most functionality in {{mustache}} is supported.
What is **not** supported is:
* `{{{variable}}}` (use `{{&variable}}` instead for unescape functionality). _Code complexity for no new functionality gain._
* [Partials](http://mustache.github.io/mustache.5.html#Partials). _Not useful yet, would be easy implementation_
* Sections within section and inverted section within sections. _This requires proper tokenization instead of just string manipulation_
* Delimiter setting. _Unlikely to be implemented in the future_

## How did you test this change?
Attached testcase