### PR TITLE
Set the match1 `walkover` field correctly

### DIFF
--- a/components/match2/wikis/rocketleague/match_legacy.lua
+++ b/components/match2/wikis/rocketleague/match_legacy.lua
@@ -142,9 +142,14 @@ function MatchLegacy._convertParameters(match2)
 			and opponent2.score or 0
 		match.opponent2flag = player.flag
 	end
+
 	if match2.walkover then
 		match.resulttype = match2.walkover
-		match.walkover = nil
+		if match2.walkover == "ff" or match2.walkover == "dq" then
+			match.walkover = match.winner
+		else
+			match.walkover = nil
+		end
 	end
 
 	return match


### PR DESCRIPTION
## Summary
RocketLeague's match1 compatibility is not setting the `walkover` field according the the logic that RL-Match1 was using. See for instance https://liquipedia.net/rocketleague/index.php?title=Template:MatchMaps&action=edit#mw-ce-l158

This caused issues with using some commons functionality, most notably `played matches`.

## How did you test this change?
test with /dev