### PR TITLE
Use OpponentLibraries in some match2 modules

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -20,7 +20,8 @@ local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHa
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+
+local OpponentDisplay = require('Module:OpponentLibraries').OpponentDisplay
 
 local html = mw.html
 local _NON_BREAKING_SPACE = '&nbsp;'

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -16,7 +16,8 @@ local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHa
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+
+local OpponentDisplay = require('Module:OpponentLibraries').OpponentDisplay
 
 local MatchlistDisplay = {propTypes = {}, types = {}}
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -7,12 +7,12 @@
 --
 
 local Class = require('Module:Class')
-local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
-local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local Break = Class.new(
 	function(self)


### PR DESCRIPTION
## Summary
Adjust 
Module:MatchGroup/Display/Bracket 
Module:MatchGroup/Display/Matchlist 
Module:MatchSummary/Base

to use **OpponentLibraries** on OpponentDisplay local calls

## How did you test this change?
/Dev

## Side Note 
all file changes in this PR