### PR TITLE
Require Dev version of Brkts/WikiSpecific if enabled

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -17,10 +17,10 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
-local WikiSpecific = require('Module:Brkts/WikiSpecific')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local globalVars = PageVariableNamespace({cached = true})
 


### PR DESCRIPTION
## Summary
To be able to use a dev version of `Module:Brkts/WikiSpecific`, that modules has to imported properly.
This PR adjusts the import into `Module:MatchGroup/Input` accordingly.

## How did you test this change?
via /dev, enabling the flag on various wikis using match2.
