### PR TITLE
Adjust interview icon for sc/sc2 match2 external links

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_external_links_starcraft.lua
@@ -68,7 +68,7 @@ function StarcraftMatchExternalLinks.ExternalLink(props)
 	end
 
 	if props.type == 'interview' then
-		return '[[File:Int_Icon.png|link=' .. props.url .. '|16px|Interview]] '
+		return '[[File:Interview32.png|link=' .. props.url .. '|16px|Interview]] '
 	end
 
 	if props.type == 'recap' then


### PR DESCRIPTION
## Summary
Adjust interview icon for sc/sc2 match2 external links
Advantages:
- use standard icon other wikis use also
- since it is black only it can be adjusted via css for darkmode and we do not need an additional icon

## How did you test this change?
N/A
just icon file change
