### PR TITLE
Add `BrktsWikiSpecific` for Clash Royale

### DIFF
--- a/components/match2/wikis/clashroyale/brkts_wiki_specific.lua
+++ b/components/match2/wikis/clashroyale/brkts_wiki_specific.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- wiki=rainbowsix
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
+
+function WikiSpecific.matchHasDetails(match)
+	return match.dateIsExact
+		or match.date ~= DateExt.epochZero
+		or match.vod
+		or not Table.isEmpty(match.links)
+		or match.comment
+		or 0 < #match.games
+end
+
+function WikiSpecific.getMatchGroupContainer(matchGroupType)
+	return matchGroupType == 'matchlist'
+		and Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true}).MatchlistContainer
+		or Lua.import('Module:MatchGroup/Display/Bracket/Custom', {requireDevIfEnabled = true}).BracketContainer
+end
+
+return WikiSpecific

--- a/components/match2/wikis/clashroyale/brkts_wiki_specific.lua
+++ b/components/match2/wikis/clashroyale/brkts_wiki_specific.lua
@@ -14,7 +14,7 @@ local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {re
 
 function WikiSpecific.matchHasDetails(match)
 	return match.dateIsExact
-		or match.date ~= DateExt.epochZero
+		or match.timestamp ~= DateExt.epochZero
 		or match.vod
 		or not Table.isEmpty(match.links)
 		or match.comment


### PR DESCRIPTION
## Summary
Part of Match2 Implementation, largely based from Starcraft with large changes due to CR's niche game structure.

The game involves usage of both 1v1, 2v2 and Teams events
Alongside "Sets" (where a team match consists an array of 1v1 and 2v2 sets/subgroups) and the need of Card inputs (which is same manner as Characters in MOBA match2s)

## How did you test this change?
/Dev and Test Pages (https://liquipedia.net/clashroyale/User:Hesketh2/Mockup)
