### PR TITLE
DeepCopy base opponent module into custom

### DIFF
--- a/components/opponent/wikis/rocketleague/opponent_display_custom.lua
+++ b/components/opponent/wikis/rocketleague/opponent_display_custom.lua
@@ -8,11 +8,12 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local Table = require('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 
-local CustomOpponentDisplay = {propTypes = {}, types = {}}
+local CustomOpponentDisplay = Table.deepCopy(OpponentDisplay)
 
 CustomOpponentDisplay.BracketOpponentEntry = Class.new(OpponentDisplay.BracketOpponentEntry, function(self) end)
 


### PR DESCRIPTION
## Summary
deepCopy base opponent module into custom instead of just holding the adjusted/added functions without the stuff from the base module
intoduced with #2247
https://discord.com/channels/93055209017729024/372075546231832576/1055811882683998229

## How did you test this change?
dev into live since bug fix
