### PR TITLE
Avoid showing empty player syntax in PlayerDisplay

### DIFF
--- a/components/match2/commons/player_display.lua
+++ b/components/match2/commons/player_display.lua
@@ -46,7 +46,7 @@ function PlayerDisplay.BlockPlayer(props)
 	local zeroWidthSpace = '&#8203;'
 	local nameNode = mw.html.create(props.dq and 's' or 'span'):addClass('name')
 		:wikitext(props.abbreviateTbd and Opponent.playerIsTbd(player) and TBD_ABBREVIATION
-			or props.showLink ~= false and player.pageName
+			or props.showLink ~= false and Logic.isNotEmpty(player.pageName)
 			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
 			or Logic.emptyOr(player.displayName, zeroWidthSpace)
 		)


### PR DESCRIPTION
## Summary

Avoids showing `[[|]]` when no player is specified in `PlayerDisplay`

| Before:                                                                                                          | After:                                                                                                          |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/42142350/209376984-bac81663-f4cf-491f-be42-00ffb2da1286.png) | ![After](https://user-images.githubusercontent.com/42142350/209377086-83a0e3d4-3598-461c-ac65-7f70ab581ce1.png) |

## How did you test this change?

/dev module
