### PR TITLE
Halo: Add Head2Head link to Match Summary 

### DIFF
--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -19,6 +19,7 @@ local VodLink = require('Module:VodLink')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 
 local _EPOCH_TIME = '1970-01-01 00:00:00'
 local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
@@ -37,6 +38,7 @@ local _LINK_DATA = {
 	},
 	faceit = {icon = 'File:FACEIT-icon.png', text = 'Match page on FACEIT'},
 	halodatahive = {icon = 'File:Halo Data Hive allmode.png',text = 'Match page on Halo Data Hive'},
+	headtohead = {icon = 'File:Match Info Stats.png', text = 'Head-to-head statistics'},
 	stats = {icon = 'File:Match_Info_Stats.png', text = 'Match Statistics'},
 }
 
@@ -95,6 +97,16 @@ function CustomMatchSummary.getByMatchId(args)
 
 	match.links.lrthread = match.lrthread
 	match.links.vod = match.vod
+	if
+		--Logic.readBool(match.extradata.headtohead) and
+		match.opponents[1].type == Opponent.team and
+		match.opponents[2].type == Opponent.team
+	then
+		local team1, team2 = string.gsub(match.opponents[1].name, ' ', '_'), string.gsub(match.opponents[2].name, ' ', '_')
+		match.links.headtohead = tostring(mw.uri.fullUrl('Special:RunQuery/Head2head')) ..
+		'?pfRunQueryFormName=Match+history&Head_to_head_query%5Bplayer%5D=' .. team1 ..
+		'&Head_to_head_query%5Bopponent%5D=' .. team2 .. '&wpRunQuery=Run+query'
+	end
 	if Table.isNotEmpty(vods) or Table.isNotEmpty(match.links) then
 		local footer = MatchSummary.Footer()
 

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -98,7 +98,6 @@ function CustomMatchSummary.getByMatchId(args)
 	match.links.lrthread = match.lrthread
 	match.links.vod = match.vod
 	if
-		--Logic.readBool(match.extradata.headtohead) and
 		match.opponents[1].type == Opponent.team and
 		match.opponents[2].type == Opponent.team
 	then


### PR DESCRIPTION
## Summary
Wanted to add a Head2Head link in the Match Summary for every match as Halo Data Hive had to pause their product due to costs. It is set to always be on, as there is no other statistics site to provide this sort of information, and I believe should be easy to access from any match.


<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
/dev in Userspace
[https://liquipedia.net/halo/User:OxWeaselDee/BracketTest#Results](https://liquipedia.net/halo/User:OxWeaselDee/BracketTest#Results)
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
