### PR TITLE
Fix broken condition when adjusting score

### DIFF
--- a/components/notability/wikis/ageofempires/notability_checker_config.lua
+++ b/components/notability/wikis/ageofempires/notability_checker_config.lua
@@ -210,7 +210,7 @@ end
 -- want to decrease the points given for a certain mode
 function Config.adjustScoreForMode(score, mode)
 	local modeMod = 1
-	if mode == "team" then
+	if mode == 'team' then
 		modeMod = 0.5
 	end
 	return score * modeMod

--- a/components/notability/wikis/ageofempires/notability_checker_config.lua
+++ b/components/notability/wikis/ageofempires/notability_checker_config.lua
@@ -210,7 +210,7 @@ end
 -- want to decrease the points given for a certain mode
 function Config.adjustScoreForMode(score, mode)
 	local modeMod = 1
-	if mode == "2v2" or "3v3" or "4v4" then
+	if mode == "team" then
 		modeMod = 0.5
 	end
 	return score * modeMod


### PR DESCRIPTION
## Summary
The previous implementation would always evaluate to true and half the calculated score therefore.
It was also based on by now unused values of the mode field.
This fixes it by using a valid condition and the correct field value, `team`.

Discovered in #2250.

## How did you test this change?
Calculate scores with updated config to verify 1v1 results are now doubled compared to the old results.
