### PR TITLE
Add `OpponentDisplay/Custom` for trackmania

### DIFF
--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -19,6 +19,10 @@ local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled =
 
 local OpponentDisplayCustom = Table.deepCopy(OpponentDisplay)
 
+local SCORE_STATUS = 'S'
+local NO_SCORE = -1
+local ZERO_SCORE = 0
+
 --[[
 Display component for an opponent entry appearing in a bracket match.
 ]]
@@ -65,67 +69,41 @@ function OpponentDisplayCustom.BracketOpponentEntry:addScores(opponent)
 	if not extradata.additionalScores then
 		OpponentDisplay.BracketOpponentEntry.addScores(self, opponent)
 	else
-		local score1Node = OpponentDisplay.BracketScore({
+		self.root:node(OpponentDisplay.BracketScore{
 			isWinner = extradata.set1win,
-			scoreText = OpponentDisplay.InlineScore(opponent),
+			scoreText = OpponentDisplayCustom.InlineScore(opponent, ''),
 		})
-		self.root:node(score1Node)
-
-		local score2Node
 		if opponent.extradata.score2 or opponent.score2 then
-			score2Node = OpponentDisplay.BracketScore({
+			self.root:node(OpponentDisplay.BracketScore{
 				isWinner = extradata.set2win,
-				scoreText = OpponentDisplayCustom.InlineScore2(opponent),
+				scoreText = OpponentDisplayCustom.InlineScore(opponent, 2),
 			})
 		end
-		self.root:node(score2Node)
-
-		local score3Node
 		if opponent.extradata.score3 then
-			score3Node = OpponentDisplay.BracketScore({
+			self.root:node(OpponentDisplay.BracketScore{
 				isWinner = extradata.set3win,
-				scoreText = OpponentDisplayCustom.InlineScore3(opponent),
+				scoreText = OpponentDisplayCustom.InlineScore(opponent, 3)
 			})
 		end
-		self.root:node(score3Node)
-
 		if (opponent.placement2 or opponent.placement or 0) == 1
 			or opponent.advances then
 			self.content:addClass('brkts-opponent-win')
 		end
 	end
 end
-
---[[
-Displays the second score or status of the opponent, as a string.
-]]
-function OpponentDisplayCustom.InlineScore2(opponent)
-	local score2 = opponent.extradata.score2
-	if opponent.status2 == 'S' then
-		if opponent.score2 == 0 and Opponent.isTbd(opponent) then
+function OpponentDisplayCustom.InlineScore(opponent, scoreIndex)
+	scoreIndex = scoreIndex or ''
+	local status = opponent['status' .. scoreIndex] or opponent.extradata['status' .. scoreIndex] or ''
+	local score = opponent['score' .. scoreIndex] or opponent.extradata['score' .. scoreIndex] or 0
+	if status == SCORE_STATUS then
+		if (score == ZERO_SCORE and Opponent.isTbd(opponent)) or score == NO_SCORE then
 			return ''
 		else
-			return opponent.score2 ~= -1 and tostring(opponent.score2) or ''
+			return score ~= -1 and tostring(score) or ''
 		end
-	else
-		return opponent.status2 or score2 or ''
 	end
-end
-
---[[
-Displays the third score or status of the opponent, as a string.
-]]
-function OpponentDisplayCustom.InlineScore3(opponent)
-	local score3 = opponent.extradata.score3
-	if opponent.status3 == 'S' then
-		if opponent.score3 == 0 and Opponent.isTbd(opponent) then
-			return ''
-		else
-			return opponent.score3 ~= -1 and tostring(opponent.score3) or ''
-		end
-	else
-		return opponent.status3 or score3 or ''
-	end
+	
+	return score or status or ''
 end
 
 --[[

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -19,14 +19,12 @@ local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled =
 
 local OpponentDisplayCustom = Table.deepCopy(OpponentDisplay)
 
-local html = mw.html
-
 --[[
 Display component for an opponent entry appearing in a bracket match.
 ]]
 OpponentDisplayCustom.BracketOpponentEntry = Class.new(
 	function(self, opponent, options)
-		self.content = html.create('div'):addClass('brkts-opponent-entry-left')
+		self.content = mw.html.create('div'):addClass('brkts-opponent-entry-left')
 
 		if opponent.type == Opponent.team then
 			self:createTeam(opponent.template or 'tbd', options)
@@ -36,7 +34,7 @@ OpponentDisplayCustom.BracketOpponentEntry = Class.new(
 			self:createLiteral(opponent.name or '')
 		end
 
-		self.root = html.create('div'):addClass('brkts-opponent-entry')
+		self.root = mw.html.create('div'):addClass('brkts-opponent-entry')
 			:node(self.content)
 	end
 )
@@ -184,7 +182,7 @@ function OpponentDisplayCustom.PlayerInlineOpponent(props)
 
 	local playersNode = table.concat(playerTexts, ' / ')
 
-	return html.create('span')
+	return mw.html.create('span')
 		:node(playersNode)
 end
 
@@ -211,7 +209,7 @@ function OpponentDisplayCustom.PlayerBlockOpponent(props)
 	if #opponent.players == 1 then
 		return playerNodes[1]
 	else
-		local playersNode = html.create('div')
+		local playersNode = mw.html.create('div')
 			:addClass(props.showPlayerTeam and 'player-has-team' or nil)
 		for _, playerNode in ipairs(playerNodes) do
 			playersNode:node(playerNode)

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -102,7 +102,6 @@ function OpponentDisplayCustom.InlineScore(opponent, scoreIndex)
 			return score ~= -1 and tostring(score) or ''
 		end
 	end
-	
 	return score or status or ''
 end
 

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -12,9 +12,7 @@ local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
-local TypeUtil = require('Module:TypeUtil')
 
-local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
@@ -43,18 +41,7 @@ OpponentDisplayCustom.BracketOpponentEntry = Class.new(
 	end
 )
 
-function OpponentDisplayCustom.BracketOpponentEntry:createTeam(template, options)
-	options = options or {}
-	local forceShortName = options.forceShortName
-
-	local opponentNode = OpponentDisplay.BlockTeamContainer({
-		showLink = false,
-		style = forceShortName and 'short' or 'hybrid',
-		template = template,
-	})
-
-	self.content:node(opponentNode)
-end
+OpponentDisplayCustom.BracketOpponentEntry.createTeam = OpponentDisplay.BracketOpponentEntry.createTeam
 
 function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
 	local players = opponent.players
@@ -73,13 +60,7 @@ function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
 	end
 end
 
-function OpponentDisplayCustom.BracketOpponentEntry:createLiteral(name)
-	local literal = OpponentDisplay.BlockLiteral({
-		name = name,
-		overflow = 'ellipsis',
-	})
-	self.content:node(literal)
-end
+OpponentDisplayCustom.BracketOpponentEntry.createLiteral = OpponentDisplay.BracketOpponentEntry.createLiberal
 
 function OpponentDisplayCustom.BracketOpponentEntry:addScores(opponent)
 	local extradata = opponent.extradata or {}

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -50,7 +50,7 @@ OpponentDisplayCustom.BracketOpponentEntry.createLiteral = OpponentDisplay.Brack
 function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
 	if opponent.type == Opponent.solo then
 		local playerNode = PlayerDisplay.BlockPlayer({
-			player = players[1],
+			player = opponent.players[1],
 			overflow = 'ellipsis',
 		})
 		self.content:node(playerNode)

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -48,8 +48,7 @@ OpponentDisplayCustom.BracketOpponentEntry.createTeam = OpponentDisplay.BracketO
 OpponentDisplayCustom.BracketOpponentEntry.createLiteral = OpponentDisplay.BracketOpponentEntry.createLiteral
 
 function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
-	local players = opponent.players
-	if #players == 1 then
+	if opponent.type == Opponent.solo then
 		local playerNode = PlayerDisplay.BlockPlayer({
 			player = players[1],
 			overflow = 'ellipsis',

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -82,24 +82,70 @@ function OpponentDisplayCustom.BracketOpponentEntry:createLiteral(name)
 end
 
 function OpponentDisplayCustom.BracketOpponentEntry:addScores(opponent)
-	local score1Node = OpponentDisplay.BracketScore({
-		isWinner = opponent.placement == 1 or opponent.advances,
-		scoreText = OpponentDisplay.InlineScore(opponent),
-	})
-	self.root:node(score1Node)
-
-	local score2Node
-	if opponent.score2 then
-		score2Node = OpponentDisplay.BracketScore({
-			isWinner = opponent.placement2 == 1,
-			scoreText = OpponentDisplay.InlineScore2(opponent),
+	local extradata = opponent.extradata or {}
+	if not extradata.additionalScores then
+		OpponentDisplay.BracketOpponentEntry.addScores(self, opponent)
+	else
+		local score1Node = OpponentDisplay.BracketScore({
+			isWinner = extradata.set1win,
+			scoreText = OpponentDisplay.InlineScore(opponent),
 		})
-	end
-	self.root:node(score2Node)
+		self.root:node(score1Node)
 
-	if (opponent.placement2 or opponent.placement or 0) == 1
-		or opponent.advances then
-		self.content:addClass('brkts-opponent-win')
+		local score2Node
+		if opponent.extradata.score2 or opponent.score2 then
+			score2Node = OpponentDisplay.BracketScore({
+				isWinner = extradata.set2win,
+				scoreText = OpponentDisplayCustom.InlineScore2(opponent),
+			})
+		end
+		self.root:node(score2Node)
+
+		local score3Node
+		if opponent.extradata.score3 then
+			score3Node = OpponentDisplay.BracketScore({
+				isWinner = extradata.set3win,
+				scoreText = OpponentDisplayCustom.InlineScore3(opponent),
+			})
+		end
+		self.root:node(score3Node)
+
+		if (opponent.placement2 or opponent.placement or 0) == 1
+			or opponent.advances then
+			self.content:addClass('brkts-opponent-win')
+		end
+	end
+end
+
+--[[
+Displays the second score or status of the opponent, as a string.
+]]
+function OpponentDisplayCustom.InlineScore2(opponent)
+	local score2 = opponent.extradata.score2
+	if opponent.status2 == 'S' then
+		if opponent.score2 == 0 and Opponent.isTbd(opponent) then
+			return ''
+		else
+			return opponent.score2 ~= -1 and tostring(opponent.score2) or ''
+		end
+	else
+		return opponent.status2 or score2 or ''
+	end
+end
+
+--[[
+Displays the third score or status of the opponent, as a string.
+]]
+function OpponentDisplayCustom.InlineScore3(opponent)
+	local score3 = opponent.extradata.score3
+	if opponent.status3 == 'S' then
+		if opponent.score3 == 0 and Opponent.isTbd(opponent) then
+			return ''
+		else
+			return opponent.score3 ~= -1 and tostring(opponent.score3) or ''
+		end
+	else
+		return opponent.status3 or score3 or ''
 	end
 end
 

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -45,6 +45,8 @@ OpponentDisplayCustom.BracketOpponentEntry = Class.new(
 
 OpponentDisplayCustom.BracketOpponentEntry.createTeam = OpponentDisplay.BracketOpponentEntry.createTeam
 
+OpponentDisplayCustom.BracketOpponentEntry.createLiteral = OpponentDisplay.BracketOpponentEntry.createLiteral
+
 function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
 	local players = opponent.players
 	if #players == 1 then
@@ -61,8 +63,6 @@ function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
 		self.content:node(playersNode)
 	end
 end
-
-OpponentDisplayCustom.BracketOpponentEntry.createLiteral = OpponentDisplay.BracketOpponentEntry.createLiteral
 
 function OpponentDisplayCustom.BracketOpponentEntry:addScores(opponent)
 	local extradata = opponent.extradata or {}

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -169,7 +169,7 @@ function OpponentDisplayCustom.PlayerBlockOpponent(props)
 			:addClass(props.playerClass)
 	end)
 
-	if #opponent.players == 1 then
+	if opponent.type == Opponent.solo then
 		return playerNodes[1]
 	else
 		local playersNode = mw.html.create('div')

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -91,6 +91,7 @@ function OpponentDisplayCustom.BracketOpponentEntry:addScores(opponent)
 		end
 	end
 end
+
 function OpponentDisplayCustom.InlineScore(opponent, scoreIndex)
 	scoreIndex = scoreIndex or ''
 	local status = opponent['status' .. scoreIndex] or opponent.extradata['status' .. scoreIndex] or ''

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -1,0 +1,196 @@
+---
+-- @Liquipedia
+-- wiki=trackmania
+-- page=Module:OpponentDisplay/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
+
+local OpponentDisplayCustom = Table.deepCopy(OpponentDisplay)
+
+local html = mw.html
+
+--[[
+Display component for an opponent entry appearing in a bracket match.
+]]
+OpponentDisplayCustom.BracketOpponentEntry = Class.new(
+	function(self, opponent, options)
+		self.content = html.create('div'):addClass('brkts-opponent-entry-left')
+
+		if opponent.type == 'team' then
+			self:createTeam(opponent.template or 'tbd', options)
+		elseif opponent.type == 'solo' or opponent.type == 'duo' then
+			self:createPlayers(opponent)
+		elseif opponent.type == 'literal' then
+			self:createLiteral(opponent.name or '')
+		end
+
+		self.root = html.create('div'):addClass('brkts-opponent-entry')
+			:node(self.content)
+	end
+)
+
+function OpponentDisplayCustom.BracketOpponentEntry:createTeam(template, options)
+	options = options or {}
+	local forceShortName = options.forceShortName
+
+	local opponentNode = OpponentDisplay.BlockTeamContainer({
+		showLink = false,
+		style = forceShortName and 'short' or 'hybrid',
+		template = template,
+	})
+
+	self.content:node(opponentNode)
+end
+
+function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
+	local players = opponent.players
+	if #players == 1 then
+		local playerNode = PlayerDisplay.BlockPlayer({
+			player = players[1],
+			overflow = 'ellipsis',
+		})
+		self.content:node(playerNode)
+	else
+		local playersNode = OpponentDisplayCustom.PlayerInlineOpponent{
+			opponent = opponent
+		}
+
+		self.content:node(playersNode)
+	end
+end
+
+function OpponentDisplayCustom.BracketOpponentEntry:createLiteral(name)
+	local literal = OpponentDisplay.BlockLiteral({
+		name = name,
+		overflow = 'ellipsis',
+	})
+	self.content:node(literal)
+end
+
+function OpponentDisplayCustom.BracketOpponentEntry:addScores(opponent)
+	local score1Node = OpponentDisplay.BracketScore({
+		isWinner = opponent.placement == 1 or opponent.advances,
+		scoreText = OpponentDisplay.InlineScore(opponent),
+	})
+	self.root:node(score1Node)
+
+	local score2Node
+	if opponent.score2 then
+		score2Node = OpponentDisplay.BracketScore({
+			isWinner = opponent.placement2 == 1,
+			scoreText = OpponentDisplay.InlineScore2(opponent),
+		})
+	end
+	self.root:node(score2Node)
+
+	if (opponent.placement2 or opponent.placement or 0) == 1
+		or opponent.advances then
+		self.content:addClass('brkts-opponent-win')
+	end
+end
+
+--[[
+Displays an opponent as a block element. The width of the component is
+determined by its layout context, and not of the opponent.
+]]
+function OpponentDisplayCustom.BlockOpponent(props)
+	DisplayUtil.assertPropTypes(props, OpponentDisplay.propTypes.BlockOpponent, {maxDepth = 2})
+	local opponent = props.opponent
+	-- Default TBDs to not show links
+	local showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
+
+	if opponent.type == 'team' then
+		return OpponentDisplay.BlockTeamContainer({
+			flip = props.flip,
+			overflow = props.overflow,
+			showLink = showLink,
+			style = props.teamStyle,
+			template = opponent.template or 'tbd',
+		})
+	elseif opponent.type == 'literal' then
+		return OpponentDisplay.BlockLiteral({
+			flip = props.flip,
+			name = opponent.name or '',
+			overflow = props.overflow,
+		})
+	elseif opponent.type == 'solo' or opponent.type == 'duo' then
+		return OpponentDisplayCustom.PlayerBlockOpponent(
+			Table.merge(props, {showLink = showLink})
+		)
+	else
+		error('Unrecognized opponent.type ' .. opponent.type)
+	end
+end
+
+--[[
+Displays a player opponent (solo or duo) as an inline element.
+]]
+function OpponentDisplayCustom.PlayerInlineOpponent(props)
+	local opponent = props.opponent
+
+	local playerTexts = Array.map(opponent.players, function(player)
+		local node = PlayerDisplay.InlinePlayer({
+			flip = props.flip,
+			player = player,
+			showFlag = props.showFlag,
+			showLink = props.showLink
+		})
+		return tostring(node)
+	end)
+	if props.flip then
+		playerTexts = Array.reverse(playerTexts)
+	end
+
+	local playersNode = table.concat(playerTexts, ' / ')
+
+	return html.create('span')
+		:node(playersNode)
+end
+
+--[[
+Displays a player opponent (solo or duo) as a block element.
+]]
+function OpponentDisplayCustom.PlayerBlockOpponent(props)
+	local opponent = props.opponent
+
+	local playerNodes = Array.map(opponent.players, function(player)
+		return PlayerDisplay.BlockPlayer({
+			flip = props.flip,
+			overflow = props.overflow,
+			player = player,
+			showFlag = props.showFlag,
+			showLink = props.showLink,
+			showPlayerTeam = props.showPlayerTeam,
+			team = player.team,
+			abbreviateTbd = props.abbreviateTbd
+		})
+			:addClass(props.playerClass)
+	end)
+
+	if #opponent.players == 1 then
+		return playerNodes[1]
+	else
+		local playersNode = html.create('div')
+			:addClass(props.showPlayerTeam and 'player-has-team' or nil)
+		for _, playerNode in ipairs(playerNodes) do
+			playersNode:node(playerNode)
+		end
+		return playersNode
+	end
+end
+
+return Class.export(OpponentDisplayCustom)

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -112,30 +112,16 @@ determined by its layout context, and not of the opponent.
 function OpponentDisplayCustom.BlockOpponent(props)
 	DisplayUtil.assertPropTypes(props, OpponentDisplay.propTypes.BlockOpponent, {maxDepth = 2})
 	local opponent = props.opponent
-	-- Default TBDs to not show links
-	local showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
 
-	if opponent.type == Opponent.team then
-		return OpponentDisplay.BlockTeamContainer({
-			flip = props.flip,
-			overflow = props.overflow,
-			showLink = showLink,
-			style = props.teamStyle,
-			template = opponent.template or 'tbd',
-		})
-	elseif opponent.type == Opponent.literal then
-		return OpponentDisplay.BlockLiteral({
-			flip = props.flip,
-			name = opponent.name or '',
-			overflow = props.overflow,
-		})
-	elseif opponent.type == Opponent.solo or opponent.type == Opponent.duo then
+	if opponent.type == Opponent.solo or opponent.type == Opponent.duo then
+		-- Default TBDs to not show links
+		local showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
 		return OpponentDisplayCustom.PlayerBlockOpponent(
 			Table.merge(props, {showLink = showLink})
 		)
-	else
-		error('Unrecognized opponent.type ' .. opponent.type)
 	end
+
+	return OpponentDisplay.BlockOpponent(props)
 end
 
 --[[

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -28,11 +28,11 @@ OpponentDisplayCustom.BracketOpponentEntry = Class.new(
 	function(self, opponent, options)
 		self.content = html.create('div'):addClass('brkts-opponent-entry-left')
 
-		if opponent.type == 'team' then
+		if opponent.type == Opponent.team then
 			self:createTeam(opponent.template or 'tbd', options)
-		elseif opponent.type == 'solo' or opponent.type == 'duo' then
+		elseif opponent.type == Opponent.solo or opponent.type == Opponent.duo then
 			self:createPlayers(opponent)
-		elseif opponent.type == 'literal' then
+		elseif opponent.type == Opponent.literal then
 			self:createLiteral(opponent.name or '')
 		end
 
@@ -140,7 +140,7 @@ function OpponentDisplayCustom.BlockOpponent(props)
 	-- Default TBDs to not show links
 	local showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
 
-	if opponent.type == 'team' then
+	if opponent.type == Opponent.team then
 		return OpponentDisplay.BlockTeamContainer({
 			flip = props.flip,
 			overflow = props.overflow,
@@ -148,13 +148,13 @@ function OpponentDisplayCustom.BlockOpponent(props)
 			style = props.teamStyle,
 			template = opponent.template or 'tbd',
 		})
-	elseif opponent.type == 'literal' then
+	elseif opponent.type == Opponent.literal then
 		return OpponentDisplay.BlockLiteral({
 			flip = props.flip,
 			name = opponent.name or '',
 			overflow = props.overflow,
 		})
-	elseif opponent.type == 'solo' or opponent.type == 'duo' then
+	elseif opponent.type == Opponent.solo or opponent.type == Opponent.duo then
 		return OpponentDisplayCustom.PlayerBlockOpponent(
 			Table.merge(props, {showLink = showLink})
 		)

--- a/components/opponent/wikis/trackmania/opponent_display_custom.lua
+++ b/components/opponent/wikis/trackmania/opponent_display_custom.lua
@@ -60,7 +60,7 @@ function OpponentDisplayCustom.BracketOpponentEntry:createPlayers(opponent)
 	end
 end
 
-OpponentDisplayCustom.BracketOpponentEntry.createLiteral = OpponentDisplay.BracketOpponentEntry.createLiberal
+OpponentDisplayCustom.BracketOpponentEntry.createLiteral = OpponentDisplay.BracketOpponentEntry.createLiteral
 
 function OpponentDisplayCustom.BracketOpponentEntry:addScores(opponent)
 	local extradata = opponent.extradata or {}


### PR DESCRIPTION
## Summary

I want to make the migration to match2 for Trackmania wiki. OpponentDisplay has to be custom because we need 2v2 opponent, and we also needs score2 and score3, because TM Esports now have several games to be played in the official leagues of the game. This PR is a split of an initial PR that added every modules. I will add every modules with new PRs in the next days.

## How did you test this change?

Lots of my changes are tested on [User:Sigeth/BracketsShenanigans](https://liquipedia.net/trackmania/User:Sigeth/BracketsShenanigans) and, for 2v2, on [User:Sigeth/....../Regional_1](https://liquipedia.net/trackmania/User:Sigeth/Trackmania_World_Tour/2023/Stage_1/Regionals/Europe/Regional_1).
