### PR TITLE
Change `Info` module to use good Opponent and OpponentDisplay libraries

### DIFF
--- a/standard/info/wikis/trackmania/info.lua
+++ b/standard/info/wikis/trackmania/info.lua
@@ -12,4 +12,6 @@ return {
 	name = 'Trackmania',
 	defaultTeamLogo = 'Trackmania_logo_lightmode.png',
 	defaultTeamLogoDark = 'Trackmania_logo_darkmode.png',
+	opponentLibrary = 'Opponent',
+	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }


### PR DESCRIPTION
## Summary

As for PrizePool/Custom (that will be a PR later on) uses these libraries, we specify it in the Info module. This PR should be merged just after #2262 (OpponentDisplay custom module).

## How did you test this change?
as I tested OpponentDisplay/Custom, there should not be a problem
