### PR TITLE
Store lpdb field lastvsdata in PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -778,6 +778,8 @@ function PrizePool:_storeData()
 			smwTournamentStash = self:_storeSmw(lpdbEntry, smwTournamentStash)
 		end
 
+		lpdbEntry.lastvsdata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.lastvsdata or {})
+		lpdbEntry.opponentplayers = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.opponentplayers or {})
 		lpdbEntry.players = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.players or {})
 		lpdbEntry.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbEntry.extradata or {})
 

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -351,6 +351,13 @@ function Placement:_getLpdbData(...)
 			lastscore = (opponent.additionalData.LASTVSSCORE or {}).score,
 			lastvsscore = (opponent.additionalData.LASTVSSCORE or {}).vsscore,
 			groupscore = opponent.additionalData.GROUPSCORE,
+			lastvsdata = Table.merge(
+				opponent.additionalData.LASTVS and Opponent.toLpdbStruct(opponent.additionalData.LASTVS) or {},
+				{
+					score = (opponent.additionalData.LASTVSSCORE or {}).vsscore,
+					groupscore = opponent.additionalData.GROUPSCORE,
+				}
+			),
 			extradata = {
 				prizepoints = tostring(pointsReward or ''),
 				participantteam = (opponentType == Opponent.solo and players.p1team)
@@ -360,7 +367,6 @@ function Placement:_getLpdbData(...)
 			-- TODO: We need to create additional LPDB Fields
 			-- Qualified To struct (json?)
 			-- Points struct (json?)
-			-- lastvs match2 opponent (json?)
 		}
 
 		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(opponent.opponentData))


### PR DESCRIPTION
## Summary
Set lastvsdata in lpdbentries
The lpdb field does not yet exist but once it does this will make it so that it gets filled up

## How did you test this change?
/dev (together with the changes of PR 2218)
since the lpdb field does not exist yet checked via previews and logs of the lpdb data right before storage