### PR TITLE
Support individualprizemoney for all party opponents

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -342,7 +342,7 @@ function Placement:_getLpdbData(...)
 			players = players,
 			placement = self:_lpdbValue(),
 			prizemoney = prizeMoney,
-			individualprizemoney = playerCount and (prizeMoney / playerCount) or 0,
+			individualprizemoney = Opponent.typeIsParty(opponentType) and (prizeMoney / Opponent.partySize(opponent.type)) or 0,
 			lastvs = Opponent.toName(opponent.additionalData.LASTVS or {}),
 			lastscore = (opponent.additionalData.LASTVSSCORE or {}).score,
 			lastvsscore = (opponent.additionalData.LASTVSSCORE or {}).vsscore,

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -310,8 +310,8 @@ function Placement:_getLpdbData(...)
 	local entries = {}
 	for opponentIndex, opponent in ipairs(self.opponents) do
 		local participant, image, imageDark, players
-		local playerCount = 0
 		local opponentType = opponent.opponentData.type
+		local playerCount = Opponent.partySize(opponentType)
 
 		if opponentType == Opponent.team then
 			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template) or {}
@@ -327,7 +327,6 @@ function Placement:_getLpdbData(...)
 			participant = Opponent.toName(opponent.opponentData)
 			local p1 = opponent.opponentData.players[1]
 			players = {p1 = p1.pageName, p1dn = p1.displayName, p1flag = p1.flag, p1team = p1.team}
-			playerCount = 1
 		else
 			participant = Opponent.toName(opponent.opponentData)
 		end
@@ -346,7 +345,7 @@ function Placement:_getLpdbData(...)
 			players = players,
 			placement = self:_lpdbValue(),
 			prizemoney = prizeMoney,
-			individualprizemoney = (playerCount > 0) and (prizeMoney / playerCount) or 0,
+			individualprizemoney = playerCount and (prizeMoney / playerCount) or 0,
 			lastvs = Opponent.toName(opponent.additionalData.LASTVS or {}),
 			lastscore = (opponent.additionalData.LASTVSSCORE or {}).score,
 			lastvsscore = (opponent.additionalData.LASTVSSCORE or {}).vsscore,

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -308,7 +308,6 @@ function Placement:_getLpdbData(...)
 	for opponentIndex, opponent in ipairs(self.opponents) do
 		local participant, image, imageDark, players
 		local opponentType = opponent.opponentData.type
-		local playerCount = Opponent.partySize(opponentType)
 
 		if opponentType == Opponent.team then
 			local teamTemplate = mw.ext.TeamTemplate.raw(opponent.opponentData.template) or {}

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
@@ -129,9 +129,6 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype')
 	lpdbData.type = Variables.varDefault('tournament_type')
 
-	local playerCount = StarcraftOpponent.partySize(lpdbData.opponenttype)
-	lpdbData.individualprizemoney = playerCount and (lpdbData.prizemoney / playerCount) or 0
-
 	lpdbData.weight = Weight.calc(
 		lpdbData.individualprizemoney,
 		lpdbData.liquipediatier,


### PR DESCRIPTION
## Summary
Currently the commons module only supports `individualprizemoney` for solo opponents.
This PR adds via a small tweak support for any opponentType except team opponents (i.e. for solo, duo, trio, quad).
(for team the `individualprizemoney` is intended to be handled via teamCards)

Since a few more wikis that have duo opponents want to switch to the standardized prize pool imo it is good to add support for it via commons, especially as the change makes it imo even better to read and more logical^^

## How did you test this change?
/dev (together with changes of PR 2218)