### PR TITLE
Use `Module:OpponentLibraries` in various ppt modules

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -27,10 +27,9 @@ local Placement = Lua.import('Module:PrizePool/Placement', {requireDevIfEnabled 
 local SmwInjector = Lua.import('Module:Smw/Injector', {requireDevIfEnabled = true})
 local WidgetInjector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
----Note: This can be overwritten
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
----Note: This can be overwritten
-local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local WidgetFactory = require('Module:Infobox/Widget/Factory')
 local WidgetTable = require('Module:Widget/Table')
@@ -356,13 +355,6 @@ function PrizePool:init(args)
 	self.pagename = mw.title.getCurrentTitle().text
 	self.date = PrizePool._getTournamentDate()
 	self.opponentType = self.args.type
-	if self.args.opponentLibrary then
-		Opponent = Lua.import('Module:'.. self.args.opponentLibrary, {requireDevIfEnabled = true})
-		self.opponentLibrary = Opponent
-	end
-	if self.args.opponentDisplayLibrary then
-		OpponentDisplay = Lua.import('Module:'.. self.args.opponentDisplayLibrary, {requireDevIfEnabled = true})
-	end
 
 	self.options = {}
 	self.prizes = {}

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -17,9 +17,10 @@ local Table = require('Module:Table')
 
 local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local Placement = Lua.import('Module:PrizePool/Placement', {requireDevIfEnabled = true})
 local TournamentUtil = Lua.import('Module:Tournament/Util', {requireDevIfEnabled = true})
+
+local Opponent = require('Module:OpponentLibraries').Opponent
 
 local AUTOMATION_START_DATE = '2023-01-01'
 local GROUPSCORE_DELIMITER = '/'

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -17,7 +17,8 @@ local Table = require('Module:Table')
 local Template = require('Module:Template')
 
 local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabled = true})
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+
+local Opponent = require('Module:OpponentLibraries').Opponent
 
 local LegacyPrizePool = {}
 

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -11,14 +11,13 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
-local Lua = require('Module:Lua')
 local MatchPlacement = require('Module:Match/Placement')
 local Ordinal = require('Module:Ordinal')
 local PlacementInfo = require('Module:Placement')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local Opponent = require('Module:OpponentLibraries').Opponent
 
 local DASH = '&#045;'
 
@@ -153,8 +152,6 @@ function Placement:init(args, parent, lastPlacement)
 	self.placeStart = self.args.placeStart
 	self.placeEnd = self.args.placeEnd
 	self.hasUSD = false
-
-	Opponent = self.parent.opponentLibrary or Opponent
 
 	self.prizeRewards = self:_readPrizeRewards(self.args)
 

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_legacy_starcraft.lua
@@ -19,7 +19,8 @@ local Variables = require('Module:Variables')
 local CustomPrizePool = Lua.import('Module:PrizePool/Custom', {requireDevIfEnabled = true})
 local LegacyPrizePool = Lua.import('Module:PrizePool/Legacy', {requireDevIfEnabled = true})
 local OldStarcraftPrizePool = Lua.import('Module:PrizePool/Starcraft/next', {requireDevIfEnabled = true})
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+
+local Opponent = require('Module:OpponentLibraries').Opponent
 
 local StarcraftLegacyPrizePool = {}
 

--- a/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
@@ -12,7 +12,8 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
-local Opponent = require('Module:Opponent/Custom')
+
+local Opponent = require('Module:OpponentLibraries').Opponent
 
 local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
 
@@ -27,7 +28,6 @@ local TIER_VALUE = {10, 6, 4, 2}
 -- Template entry point
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
-	args.opponentLibrary = 'Opponent/Custom'
 	args.syncPlayers = true
 
 	local prizePool = PrizePool(args)


### PR DESCRIPTION
## Summary
Use `Module:OpponentLibraries` in various ppt modules
- `Module:PrizePool`
- `Module:PrizePool/Placement`
- `Module:PrizePool/Import`
- `Module:PrizePool/Legacy`
- `Module:PrizePool/Starcraft`
- `Module:PrizePool/Legacy/Starcraft`
- `Module:PrizePool/Custom` on aoe (the only such module (except sc/sc2) that set a different opponent library)

this has the advantage that in the future we do not need to add the custom opponent libs in the `Module:PrizePool/Custom`s on the wikis if there are such custom opponent libs
(e.g. ClashRoyale and trackmania are in the process of getting stuff set up and both need custom opp libs)

## How did you test this change?
/dev (together with changes of PR 2218)