### PR TITLE
Add `PrizePool/Custom` for trackmania

### DIFF
--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -1,0 +1,61 @@
+---
+-- @Liquipedia
+-- wiki=trackmania
+-- page=Module:PrizePool/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+
+local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local CustomLpdbInjector = Class.new(LpdbInjector)
+
+local CustomPrizePool = {}
+
+local TIER_VALUE = {8, 4, 2}
+local TYPE_MODIFIER = {Online = 0.65}
+
+-- Template entry point
+function CustomPrizePool.run(frame)
+	local args = Arguments.getArgs(frame)
+	
+	args.opponentLibrary = 'Opponent'
+	args.opponentDisplayLibrary = 'OpponentDisplay/Custom'
+	args.syncPlayers = true
+	
+	local prizePool = PrizePool(args):create()
+
+	prizePool:setLpdbInjector(CustomLpdbInjector())
+
+	return prizePool:build()
+end
+
+function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
+	lpdbData.weight = CustomPrizePool.calculateWeight(
+		lpdbData.prizemoney,
+		Variables.varDefault('tournament_liquipediatier'),
+		placement.placeStart,
+		Variables.varDefault('tournament_type')
+	)
+
+	return lpdbData
+end
+
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
+	if String.isEmpty(tier) then
+		return 0
+	end
+
+	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier) or ''] or 1
+
+	return tierValue * ( prizeMoney * 1000 + 1000 - place) / place * (TYPE_MODIFIER[type] or 1)
+end
+
+return CustomPrizePool

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -53,7 +53,7 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
 
 	local tierValue = TIER_VALUE[tonumber(tier)] or 1
 
-	return tierValue * ( prizeMoney * 1000 + 1000 - place) / place * (TYPE_MODIFIER[type] or 1)
+	return tierValue * (prizeMoney * 1000 + 1000 - place) / place * (TYPE_MODIFIER[type] or 1)
 end
 
 return CustomPrizePool

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -25,9 +25,9 @@ local TYPE_MODIFIER = {Online = 0.65}
 -- Template entry point
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
-	
+
 	args.syncPlayers = true
-	
+
 	local prizePool = PrizePool(args):create()
 
 	prizePool:setLpdbInjector(CustomLpdbInjector())

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -26,8 +26,6 @@ local TYPE_MODIFIER = {Online = 0.65}
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
 	
-	args.opponentLibrary = 'Opponent'
-	args.opponentDisplayLibrary = 'OpponentDisplay/Custom'
 	args.syncPlayers = true
 	
 	local prizePool = PrizePool(args):create()

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -51,7 +51,7 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
 		return 0
 	end
 
-	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier) or ''] or 1
+	local tierValue = TIER_VALUE[tonumber(tier)] or 1
 
 	return tierValue * ( prizeMoney * 1000 + 1000 - place) / place * (TYPE_MODIFIER[type] or 1)
 end


### PR DESCRIPTION
## Summary

As we want to use the match2 PrizePool template, we need PrizePool/Custom. Everything seems to work now and stores the same values in LPDB and SMW Properties as the previous prize pool templates.

## How did you test this change?

Changes have been tested by using two pages in my userspace.

* Old (previous prize pool templates)
* * [Page](https://liquipedia.net/trackmania/User:Sigeth/Trackmania_World_Tour/2023/Stage_1/Grand_League)
* * [SMW Properties](https://liquipedia.net/trackmania/Special:Browse/:User:Sigeth-2FTrackmania-5FWorld-5FTour-2F2023-2FStage-5F1-2FGrand-5FLeague)
* * [SMW Properties for a ranked team](https://liquipedia.net/trackmania/Special:Browse/:User:Sigeth-2FTrackmania-20World-20Tour-2F2023-2FStage-201-2FGrand-20League-23ranking-5Fsolary)
* * [LPDB Data](https://liquipedia.net/trackmania/Special:LiquipediaDB/User:Sigeth/Trackmania_World_Tour/2023/Stage_1/Grand_League#placement)
* New (PrizePool using PrizePool/Custom)
* * [Page](https://liquipedia.net/trackmania/User:Sigeth/Trackmania_World_Tour/2023/Stage_1/All_Stars_Championship)
* * [SMW Properties](https://liquipedia.net/trackmania/Special:Browse/:User:Sigeth-2FTrackmania-5FWorld-5FTour-2F2023-2FStage-5F1-2FAll-5FStars-5FChampionship)
* * [SMW Properties for a ranked team](https://liquipedia.net/trackmania/Special:Browse/:User:Sigeth-2FTrackmania-20World-20Tour-2F2023-2FStage-201-2FAll-20Stars-20Championship-23ranking-5Fsolary)
* * [LPDB Data](https://liquipedia.net/trackmania/Special:LiquipediaDB/User:Sigeth/Trackmania_World_Tour/2023/Stage_1/All_Stars_Championship#placement)
