### PR TITLE
Add funcationity to get the `DisplayName` of a NameSpaceId

### DIFF
--- a/standard/namespace.lua
+++ b/standard/namespace.lua
@@ -24,4 +24,8 @@ function Namespace.idFromName(name)
 	return Namespace.getIdsByName()[name]
 end
 
+function Namespace.nameFromId(id)
+	return mw.site.namespaces[id].name
+end
+
 return Class.export(Namespace, {frameOnly = true})

--- a/standard/namespace.lua
+++ b/standard/namespace.lua
@@ -26,7 +26,7 @@ function Namespace.idFromName(name)
 end
 
 function Namespace.nameFromId(id)
-	return mw.site.namespaces[id].name
+	return (mw.site.namespaces[tonumber(id)] OR {}).name
 end
 
 function Namespace.prefixFromId(id)

--- a/standard/namespace.lua
+++ b/standard/namespace.lua
@@ -26,7 +26,7 @@ function Namespace.idFromName(name)
 end
 
 function Namespace.nameFromId(id)
-	return (mw.site.namespaces[tonumber(id)] OR {}).name
+	return (mw.site.namespaces[tonumber(id)] or {}).name
 end
 
 function Namespace.prefixFromId(id)

--- a/standard/namespace.lua
+++ b/standard/namespace.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local FnUtil = require('Module:FnUtil')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local Namespace = {}
@@ -26,6 +27,15 @@ end
 
 function Namespace.nameFromId(id)
 	return mw.site.namespaces[id].name
+end
+
+function Namespace.prefixFromId(id)
+	local name = Namespace.nameFromId(id)
+	if String.isNotEmpty(name) then
+		return name .. ':'
+	end
+
+	return name
 end
 
 return Class.export(Namespace, {frameOnly = true})

--- a/standard/test/namespace_test.lua
+++ b/standard/test/namespace_test.lua
@@ -14,9 +14,6 @@ local Namespace = Lua.import('Module:Namespace', {requireDevIfEnabled = true})
 local suite = ScribuntoUnit:new()
 
 function suite:testisMain()
-	-- can not really test much here due to the testcase page
-	-- not being in several name spaces at the same time
-
 	-- `Module:Namespace` treats Module talk space as main space
 	self:assertEquals(true, Namespace.isMain())
 end

--- a/standard/test/namespace_test.lua
+++ b/standard/test/namespace_test.lua
@@ -13,7 +13,7 @@ local Namespace = Lua.import('Module:Namespace', {requireDevIfEnabled = true})
 
 local suite = ScribuntoUnit:new()
 
-function suite:testIdFromName()
+function suite:testisMain()
 	-- can not really test much here due to the testcase page
 	-- not being in several name spaces at the same time
 

--- a/standard/test/namespace_test.lua
+++ b/standard/test/namespace_test.lua
@@ -13,7 +13,7 @@ local Namespace = Lua.import('Module:Namespace', {requireDevIfEnabled = true})
 
 local suite = ScribuntoUnit:new()
 
-function suite:testisMain()
+function suite:testIsMain()
 	-- `Module:Namespace` treats Module talk space as main space
 	self:assertEquals(true, Namespace.isMain())
 end

--- a/standard/test/namespace_test.lua
+++ b/standard/test/namespace_test.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Namespace/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local Namespace = Lua.import('Module:Namespace', {requireDevIfEnabled = true})
+
+local suite = ScribuntoUnit:new()
+
+function suite:testIdFromName()
+	-- can not really test much here due to the testcase page
+	-- not being in several name spaces at the same time
+
+	-- `Module:Namespace` treats Module talk space as main space
+	self:assertEquals(true, Namespace.isMain())
+end
+
+function suite:testIdFromName()
+	self:assertEquals(nil, Namespace.idFromName('bs'))
+	self:assertEquals(nil, Namespace.idFromName())
+	self:assertEquals(0, Namespace.idFromName(''))
+	self:assertEquals(2, Namespace.idFromName('User'))
+	self:assertEquals(4, Namespace.idFromName('Liquipedia'))
+	self:assertEquals(136, Namespace.idFromName('Data'))
+	self:assertEquals(829, Namespace.idFromName('Module talk'))
+end
+
+function suite:testNameFromId()
+	self:assertEquals(nil, Namespace.nameFromId('bs'))
+	self:assertEquals(nil, Namespace.nameFromId())
+	self:assertEquals('', Namespace.nameFromId(0))
+	self:assertEquals('', Namespace.nameFromId('0'))
+	self:assertEquals('User', Namespace.nameFromId(2))
+	self:assertEquals('User talk', Namespace.nameFromId(3))
+	self:assertEquals('Liquipedia', Namespace.nameFromId('4'))
+	self:assertEquals('Data', Namespace.nameFromId(136))
+	self:assertEquals('Module talk', Namespace.nameFromId('829'))
+end
+
+function suite:testPrefixFromId()
+	self:assertEquals(nil, Namespace.prefixFromId('bs'))
+	self:assertEquals(nil, Namespace.prefixFromId())
+	self:assertEquals('', Namespace.prefixFromId(0))
+	self:assertEquals('', Namespace.prefixFromId('0'))
+	self:assertEquals('User:', Namespace.prefixFromId(2))
+	self:assertEquals('User talk:', Namespace.prefixFromId(3))
+	self:assertEquals('Liquipedia:', Namespace.prefixFromId('4'))
+	self:assertEquals('Data:', Namespace.prefixFromId(136))
+	self:assertEquals('Module talk:', Namespace.prefixFromId('829'))
+end
+
+return suite


### PR DESCRIPTION
## Summary
Add 2 functions to module:Namespace
- `nameFromId` a function to retrieve NameSpace name from id
- `prefixFromId` a function to retrieve the NameSpace Prefix from id (usefull when building links)

## How did you test this change?
/dev