### PR TITLE
Add `|female=` BW infobox league

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -301,14 +301,14 @@ function CustomLeague:addToLpdb(lpdbData)
 	-- hence they need to not RR them
 	lpdbData.series = _args.series
 
-	lpdbData.extradata.isfemaleonly = Logic.readBool(_args.female)
+	lpdbData.extradata.female = Logic.readBool(_args.female)
 
 	return lpdbData
 end
 
 function CustomLeague:getWikiCategories(args)
 	if Logic.readBool(args.female) then
-		return {'Female-only Tournaments'}
+		return {'Female-only Tournaments, Female Tournaments'}
 	end
 
 	return {}

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -308,7 +308,7 @@ end
 
 function CustomLeague:getWikiCategories(args)
 	if Logic.readBool(args.female) then
-		return {'Female-only Tournaments, Female Tournaments'}
+		return {'Female-only Tournaments', 'Female Tournaments'}
 	end
 
 	return {}

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -301,13 +301,13 @@ function CustomLeague:addToLpdb(lpdbData)
 	-- hence they need to not RR them
 	lpdbData.series = _args.series
 
-	lpdbData.extradata.isfemaleonly = Logic.readBool(_args.isFemaleOnly)
+	lpdbData.extradata.isfemaleonly = Logic.readBool(_args.female)
 
 	return lpdbData
 end
 
 function CustomLeague:getWikiCategories(args)
-	if Logic.readBool(args.isFemaleOnly) then
+	if Logic.readBool(args.female) then
 		return {'Female-only Tournaments'}
 	end
 

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -42,6 +42,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.shouldStore = CustomLeague.shouldStore
+	league.getWikiCategories = CustomLeague.getWikiCategories
 
 	return league:createInfobox(frame)
 end
@@ -300,7 +301,17 @@ function CustomLeague:addToLpdb(lpdbData)
 	-- hence they need to not RR them
 	lpdbData.series = _args.series
 
+	lpdbData.extradata.isfemaleonly = Logic.readBool(_args.isFemaleOnly)
+
 	return lpdbData
+end
+
+function CustomLeague:getWikiCategories(args)
+	if Logic.readBool(args.isFemaleOnly) then
+		return {'Female-only Tournaments'}
+	end
+
+	return {}
 end
 
 function CustomLeague:_concatArgs(base)


### PR DESCRIPTION
## Summary
If `|female=` is set to true (readBool) then add
- indicator into lpdb_tournament_extradata
- according category

fwiw #2277 is needed for this to have any effect on the extradeata storage as currently the ppt overwrites it again

## How did you test this change?
/dev