### PR TITLE
Fix logic issue in R6's hasDetails determination

### DIFF
--- a/components/match2/wikis/rainbowsix/brkts_wiki_specific.lua
+++ b/components/match2/wikis/rainbowsix/brkts_wiki_specific.lua
@@ -14,7 +14,7 @@ local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {re
 
 function WikiSpecific.matchHasDetails(match)
 	return match.dateIsExact
-		or match.date ~= DateExt.epochZero
+		or match.timestamp ~= DateExt.epochZero
 		or match.vod
 		or not Table.isEmpty(match.links)
 		or match.comment


### PR DESCRIPTION
## Summary
Comparing a string with a timestamp not correct.
This PR fixes this logic issue so it's comparing timestamp to timestamp,

## How did you test this change?
dev modules
Before:
![image](https://user-images.githubusercontent.com/3426850/210328292-700d6d65-bed0-42e4-8f2a-089bb2d32f96.png)

After:
![image](https://user-images.githubusercontent.com/3426850/210328340-14887768-c87d-4f55-bcc4-989b03af338b.png)

