### PR TITLE
Match prop definition and usage for OpponentDisplay.InlineOpponent

### DIFF
--- a/components/opponent/commons/opponent_display.lua
+++ b/components/opponent/commons/opponent_display.lua
@@ -126,6 +126,8 @@ function OpponentDisplay.InlineOpponent(props)
 			player = opponent.players[1],
 			flip = props.flip,
 			dq = props.dq,
+			showFlag = props.showFlag,
+			showLink = props.showLink
 		}
 
 	else

--- a/components/opponent/commons/opponent_display.lua
+++ b/components/opponent/commons/opponent_display.lua
@@ -98,9 +98,10 @@ end
 OpponentDisplay.propTypes.InlineOpponent = {
 	flip = 'boolean?',
 	opponent = MatchGroupUtil.types.GameOpponent,
-	showFlag = 'boolean?',
-	showLink = 'boolean?', -- does not affect opponent.type == 'team'
-	teamStyle = TypeUtil.optional(OpponentDisplay.types.TeamStyle),
+	showFlag = 'boolean?', -- only affects opponent.type == 'solo'
+	showLink = 'boolean?', -- only affects opponent.type == 'solo'
+	dq = 'boolean?', -- only affects opponent.type == 'solo'
+	teamStyle = TypeUtil.optional(OpponentDisplay.types.TeamStyle), -- only affects opponent.type == 'team'
 }
 
 --[[

--- a/standard/test/opponent_display_test.lua
+++ b/standard/test/opponent_display_test.lua
@@ -1,0 +1,60 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:OpponentDisplay/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+
+local suite = ScribuntoUnit:new()
+
+---
+-- InlineOpponent
+---
+function suite:testInlineOpponentSolo()
+	local opponent = {type = 'solo', players = {{displayName = 'test', pageName = 'link', flag = 'de'}}}
+	self:assertEquals(
+		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;[[link|test]]</span>',
+		tostring(OpponentDisplay.InlineOpponent{opponent = opponent}),
+		'Unexpected default display'
+	)
+	self:assertEquals(
+		'<span class="inline-player" style="white-space:pre">[[link|test]]</span>',
+		tostring(OpponentDisplay.InlineOpponent{showFlag = false, opponent = opponent}),
+		'Disabling flags did not work'
+	)
+	self:assertEquals(
+		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;[[link|test]]</span>',
+		tostring(OpponentDisplay.InlineOpponent{showFlag = true, opponent = opponent}),
+		'Showing flags did not work'
+	)
+	self:assertEquals(
+		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;test</span>',
+		tostring(OpponentDisplay.InlineOpponent{showLink = false, opponent = opponent}),
+		'Hiding links did not work'
+	)
+	self:assertEquals(
+		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;[[link|test]]</span>',
+		tostring(OpponentDisplay.InlineOpponent{showLink = true, opponent = opponent}),
+		'Hiding links did not work'
+	)
+	self.assertEquals(
+		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;<s>[[link|test]]</s></span>',
+		tostring(OpponentDisplay.InlineOpponent{dq = true, opponent = opponent}),
+		'Strikethrough/DQ did not work'
+	)
+
+	opponent.players[1].pageName = nil
+	self:assertEquals(
+		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;test</span>',
+		tostring(OpponentDisplay.InlineOpponent{showLink = true, opponent = opponent}),
+		'Unexpected display for missing links'
+	)
+end
+
+return suite

--- a/standard/test/opponent_display_test.lua
+++ b/standard/test/opponent_display_test.lua
@@ -19,7 +19,9 @@ local suite = ScribuntoUnit:new()
 function suite:testInlineOpponentSolo()
 	local opponent = {type = 'solo', players = {{displayName = 'test', pageName = 'link', flag = 'de'}}}
 	self:assertEquals(
-		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;[[link|test]]</span>',
+		'<span class="inline-player" style="white-space:pre">'
+			.. '<span class="flag">[[File:de_hd.png|Germany|link=]]</span>'
+			.. '&nbsp;[[link|test]]</span>',
 		tostring(OpponentDisplay.InlineOpponent{opponent = opponent}),
 		'Unexpected default display'
 	)
@@ -29,29 +31,39 @@ function suite:testInlineOpponentSolo()
 		'Disabling flags did not work'
 	)
 	self:assertEquals(
-		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;[[link|test]]</span>',
+		'<span class="inline-player" style="white-space:pre">'
+			.. '<span class="flag">[[File:de_hd.png|Germany|link=]]</span>'
+			.. '&nbsp;[[link|test]]</span>',
 		tostring(OpponentDisplay.InlineOpponent{showFlag = true, opponent = opponent}),
 		'Showing flags did not work'
 	)
 	self:assertEquals(
-		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;test</span>',
+		'<span class="inline-player" style="white-space:pre">'
+			.. '<span class="flag">[[File:de_hd.png|Germany|link=]]</span>'
+			.. '&nbsp;test</span>',
 		tostring(OpponentDisplay.InlineOpponent{showLink = false, opponent = opponent}),
 		'Hiding links did not work'
 	)
 	self:assertEquals(
-		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;[[link|test]]</span>',
+		'<span class="inline-player" style="white-space:pre">'
+			.. '<span class="flag">[[File:de_hd.png|Germany|link=]]</span>'
+			.. '&nbsp;[[link|test]]</span>',
 		tostring(OpponentDisplay.InlineOpponent{showLink = true, opponent = opponent}),
 		'Hiding links did not work'
 	)
-	self.assertEquals(
-		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;<s>[[link|test]]</s></span>',
+	self:assertEquals(
+		'<span class="inline-player" style="white-space:pre">'
+			.. '<span class="flag">[[File:de_hd.png|Germany|link=]]</span>'
+			.. '&nbsp;<s>[[link|test]]</s></span>',
 		tostring(OpponentDisplay.InlineOpponent{dq = true, opponent = opponent}),
 		'Strikethrough/DQ did not work'
 	)
 
 	opponent.players[1].pageName = nil
 	self:assertEquals(
-		'<span class="inline-player" style="white-space:pre"><span class="flag">[[File:de_hd.png|Germany|link=]]</span>&nbsp;test</span>',
+		'<span class="inline-player" style="white-space:pre">'
+			.. '<span class="flag">[[File:de_hd.png|Germany|link=]]</span>'
+			.. '&nbsp;test</span>',
 		tostring(OpponentDisplay.InlineOpponent{showLink = true, opponent = opponent}),
 		'Unexpected display for missing links'
 	)


### PR DESCRIPTION
## Summary
Props `showFlag` and `showLink` are allowed values in the props, but are not passed on to `PlayerDisplay.InlineOpponent`.

## How did you test this change?
via [Testsuite](https://liquipedia.net/commons/Module:OpponentDisplay/testcases)
![image](https://user-images.githubusercontent.com/16326643/210278014-ff4c4e8f-e89e-44ed-8b37-37b6d1722163.png)


