### PR TITLE
Update `|female=` handling on BW

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -301,7 +301,7 @@ function CustomLeague:addToLpdb(lpdbData)
 	-- hence they need to not RR them
 	lpdbData.series = _args.series
 
-	lpdbData.extradata.female = Logic.readBool(_args.female)
+	lpdbData.extradata.female = Logic.readBool(_args.female) or nil
 
 	return lpdbData
 end

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -308,7 +308,7 @@ end
 
 function CustomLeague:getWikiCategories(args)
 	if Logic.readBool(args.female) then
-		return {'Female-only Tournaments', 'Female Tournaments'}
+		return {'Female Tournaments'}
 	end
 
 	return {}


### PR DESCRIPTION

## Summary
- Kick Legacy Category --> usages have been adjusted
- minor adjust in lpdb storage: unset female instead of storing `false` so that extradata is kept smaller

## How did you test this change?
/dev