### PR TITLE
Have Imports of `Brkts/WikiSpec` use DevFlag if Enabled

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -19,7 +19,7 @@ local TypeUtil = require('Module:TypeUtil')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local matchHasDetailsWikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true}).matchHasDetails
+local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local OpponentDisplay = require('Module:OpponentLibraries').OpponentDisplay
 
@@ -105,7 +105,7 @@ function BracketDisplay.Bracket(props)
 		headerMargin = propsConfig.headerMargin or defaultConfig.headerMargin,
 		hideRoundTitles = propsConfig.hideRoundTitles or false,
 		lineWidth = propsConfig.lineWidth or defaultConfig.lineWidth,
-		matchHasDetails = propsConfig.matchHasDetails or matchHasDetailsWikiSpecific or DisplayHelper.defaultMatchHasDetails,
+		matchHasDetails = propsConfig.matchHasDetails or WikiSpecific.matchHasDetails or DisplayHelper.defaultMatchHasDetails,
 		matchMargin = propsConfig.matchMargin or math.floor(defaultConfig.opponentHeight / 4),
 		matchWidth = propsConfig.matchWidth or defaultConfig.matchWidth,
 		matchWidthMobile = propsConfig.matchWidthMobile or defaultConfig.matchWidthMobile,

--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -16,10 +16,10 @@ local MathUtil = require('Module:MathUtil')
 local StringUtils = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
-local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local matchHasDetailsWikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true}).matchHasDetails
 
 local OpponentDisplay = require('Module:OpponentLibraries').OpponentDisplay
 

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -15,7 +15,7 @@ local TypeUtil = require('Module:TypeUtil')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local matchHasDetailsWikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true}).matchHasDetails
+local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local OpponentDisplay = require('Module:OpponentLibraries').OpponentDisplay
 
@@ -81,7 +81,7 @@ function MatchlistDisplay.Matchlist(props)
 		attached = propsConfig.attached or false,
 		collapsed = propsConfig.collapsed or false,
 		collapsible = Logic.nilOr(propsConfig.collapsible, true),
-		matchHasDetails = propsConfig.matchHasDetails or matchHasDetailsWikiSpecific or DisplayHelper.defaultMatchHasDetails,
+		matchHasDetails = propsConfig.matchHasDetails or WikiSpecific.matchHasDetails or DisplayHelper.defaultMatchHasDetails,
 		width = propsConfig.width or 300,
 	}
 

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -12,10 +12,10 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
-local matchHasDetailsWikiSpecific = require('Module:Brkts/WikiSpecific').matchHasDetails
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local matchHasDetailsWikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true}).matchHasDetails
 
 local OpponentDisplay = require('Module:OpponentLibraries').OpponentDisplay
 

--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -14,11 +14,11 @@ local MatchGroup = require('Module:MatchGroup')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
-local WikiSpecific = require('Module:Brkts/WikiSpecific')
 local getArgs = require('Module:Arguments').getArgs
 local getDefaultMapping = require('Module:MatchGroup/Legacy/Default').get
 local json = require('Module:Json')
 
+local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 local MatchSubobjects = Lua.import('Module:Match/Subobjects', {requireDevIfEnabled = true})
 
 local _IS_USERSPACE = false

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -12,7 +12,7 @@ local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
-local wikiSpec = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
+local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local MatchSubobjects = {}
 
@@ -26,7 +26,7 @@ function MatchSubobjects.luaGetMap(args)
 	if Logic.isEmpty(args.map) then
 		return nil
 	else
-		args = wikiSpec.processMap(args)
+		args = WikiSpecific.processMap(args)
 
 		args.participants = args.participants or {}
 		for key, item in pairs(args.participants) do
@@ -56,7 +56,7 @@ function MatchSubobjects.getPlayer(frame)
 end
 
 function MatchSubobjects.luaGetPlayer(args)
-	return wikiSpec.processPlayer(args)
+	return WikiSpecific.processPlayer(args)
 end
 
 local _ENTRY_POINT_NAMES = {'getMap', 'getPlayer', 'getRound'}

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -11,7 +11,8 @@ local FeatureFlag = require('Module:FeatureFlag')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local wikiSpec = require('Module:Brkts/WikiSpecific')
+
+local wikiSpec = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local MatchSubobjects = {}
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -718,7 +718,7 @@ function StarcraftMatchGroupInput.ProcessTeamOpponentInput(opponent, date)
 
 	if customTeam then
 		if not defaultIcon then
-			defaultIcon = require('Module:Brkts/WikiSpecific').defaultIcon
+			defaultIcon = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true}).defaultIcon
 		end
 		opponent.template = 'default'
 		icon = defaultIcon


### PR DESCRIPTION
## Summary
Most, but not all, uses of `Brkts/WikiSpecific` is imported with requireDev, but not all. This PR makes the remaining uses import with requireDev.

## How did you test this change?
Tested with dev modules
