### PR TITLE
RL Squads: Set objectname based on `link`

### DIFF
--- a/components/squad/wikis/rocketleague/squad_custom.lua
+++ b/components/squad/wikis/rocketleague/squad_custom.lua
@@ -48,9 +48,10 @@ function CustomSquad.run(frame)
 			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 		end
 
+		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(player.link or player.id)
 		squad:row(row:create(
 			Variables.varDefault('squad_name',
-			mw.title.getCurrentTitle().prefixedText) .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+			mw.title.getCurrentTitle().prefixedText) .. '_' .. link .. '_' .. ReferenceCleaner.clean(player.joindate)
 		))
 
 		index = index + 1


### PR DESCRIPTION
## Summary
Rocket League lists and stores previous Squads into LPDB. Earlier tables on the page contain full or partial information, which is stored. For entries that only have partial info, it's important that the entries are merged when more information comes further down on the page. This is currently not working for players had changed their `id` between the tables.

This PR sets objectname based on `link` instead of `id`. This allows merging of players with pages at least.

## How did you test this change?
Tested with dev module. LPDB Entries now merge as expected
