### PR TITLE
Update notability thresholds for AoE

### DIFF
--- a/components/notability/wikis/ageofempires/notability_checker_config.lua
+++ b/components/notability/wikis/ageofempires/notability_checker_config.lua
@@ -34,8 +34,8 @@ Config.PLACEMENT_QUERY =
 	'liquipediatiertype, players, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
-Config.NOTABILITY_THRESHOLD_MIN = 400
-Config.NOTABILITY_THRESHOLD_NOTABLE = 600
+Config.NOTABILITY_THRESHOLD_MIN = 800
+Config.NOTABILITY_THRESHOLD_NOTABLE = 1600
 
 -- These are all the liquipediatiertypes which should be extra "penalised"
 -- for a lower placement, see also the placementDropOffFunction below.


### PR DESCRIPTION
## Summary
With the bugfix from #2258, most notability scores increased (pre-fix, the score for every result was halfed instead of only team results).
After discussion with other editors, this adjust the thresholds used to determine notability accordingly.

## How did you test this change?
N/A
