### PR TITLE
Adjust default `MatchHasDetails` behavior

### DIFF
--- a/components/match2/commons/brkts_wiki_specific.lua
+++ b/components/match2/commons/brkts_wiki_specific.lua
@@ -1,0 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+return Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true})

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -77,7 +77,7 @@ components.
 ]]
 function DisplayHelper.defaultMatchHasDetails(match)
 	return match.dateIsExact
-		or (match.timestamp and match.timestamp ~= DateExt.epochZero)
+		or (match.timestamp and match.timestamp ~= Date.epochZero)
 		or match.vod
 		or not Table.isEmpty(match.links)
 		or match.comment

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -77,6 +77,7 @@ components.
 ]]
 function DisplayHelper.defaultMatchHasDetails(match)
 	return match.dateIsExact
+		or (match.timestamp and match.timestamp ~= DateExt.epochZero)
 		or match.vod
 		or not Table.isEmpty(match.links)
 		or match.comment


### PR DESCRIPTION
## Summary
As discussed yesterday in our module talk the idea behind this PR is to add functionality to remove several `Brkts/WikiSpecific` modules because the commons one already exists.

- Add commons Version of `Module:Brkts/WikiSpecific` that only "redirects" to `Module:Brkts/WikiSpecific/Base`
- Adjust `defaultMatchHasDetails` in `Module:MatchGroup/Display/Helper` to check for `match.timestamp ~= DateExt.epochZero` IF `match.timestamp` exists

The second point mirrors what most wikis already do without hurting the wikis that
- overwrite the `matchHasDetails` function or
- used the current default (as for them match.timestamp is not set)

## How did you test this change?
/dev (via R6 & SC2 & RL)
