### PR TITLE
Create isArray standard function

### DIFF
--- a/standard/array.lua
+++ b/standard/array.lua
@@ -20,6 +20,13 @@ function Array.randomize(tbl)
 	return Table.randomize(tbl)
 end
 
+---Return true if the input is a table in array format
+---@param tbl any
+---@return boolean
+function Array.isArray(tbl)
+	return type(tbl) == 'table' and Table.size(tbl) == #tbl
+end
+
 -- Creates a copy of an array with the same elements.
 function Array.copy(tbl)
 	local copy = {}

--- a/standard/test/array_test.lua
+++ b/standard/test/array_test.lua
@@ -13,6 +13,13 @@ local Array = Lua.import('Module:Array', {requireDevIfEnabled = true})
 
 local suite = ScribuntoUnit:new()
 
+function suite:testIsArray()
+	self:assertTrue(Array.isArray{})
+	self:assertTrue(Array.isArray{5, 2, 3})
+	self:assertFalse(Array.isArray{a = 1, [3] = 2, c = 3})
+	self:assertFalse(Array.isArray{5, 2, c = 3})
+end
+
 function suite:testCopy()
 	local a, b, c = {1, 2, 3}, {}, {{5}}
 	self:assertDeepEquals(a, Array.copy(a))


### PR DESCRIPTION
## Summary
This PR created a function that checks if an input is an array (ie table with all keys in ascending, consecutive order). Because the `#` only works on arrays, comparing the return value of that compared to the number of elements, is a clean and simple way to check (but not most performative, as the array is iterated twice).

## How did you test this change?
Attached testcases
https://liquipedia.net/commons/Module_talk:Array/testcases