### PR TITLE
Store player's additional teams in extradata

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -133,10 +133,10 @@ function Person:createInfobox()
 			Builder{builder = function()
 				local teams = {
 					self:_createTeam(args.team, args.teamlink),
-					self:_createTeam(args.team2, args.teamlink2),
-					self:_createTeam(args.team3, args.teamlink3),
-					self:_createTeam(args.team4, args.teamlink4),
-					self:_createTeam(args.team5, args.teamlink5)
+					self:_createTeam(args.team2, args.team2link),
+					self:_createTeam(args.team3, args.team3link),
+					self:_createTeam(args.team4, args.team4link),
+					self:_createTeam(args.team5, args.team5link)
 				}
 				return {Cell{
 					name = #teams > 1 and 'Teams' or 'Team',
@@ -265,6 +265,11 @@ function Person:_setLpdbData(args, links, status, personType)
 
 	for year, earningsOfYear in pairs(self.earningsPerYear or {}) do
 		lpdbData.extradata['earningsin' .. year] = earningsOfYear
+	end
+
+	args.team1 = team
+	for key, team in Table.iter.pairsByPrefix(args, 'team') do
+		lpdbData.extradata[key] = args[key .. 'link'] or team
 	end
 
 	lpdbData = self:adjustLPDB(lpdbData, args, personType)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -268,8 +268,8 @@ function Person:_setLpdbData(args, links, status, personType)
 	end
 
 	args.team1 = team
-	for key, otherTeam in Table.iter.pairsByPrefix(args, 'team') do
-		lpdbData.extradata[key] = args[key .. 'link'] or otherTeam
+	for teamKey, otherTeam in Table.iter.pairsByPrefix(args, 'team') do
+		lpdbData.extradata[teamKey] = args[teamKey .. 'link'] or otherTeam
 	end
 
 	lpdbData = self:adjustLPDB(lpdbData, args, personType)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -268,8 +268,8 @@ function Person:_setLpdbData(args, links, status, personType)
 	end
 
 	args.team1 = team
-	for key, team in Table.iter.pairsByPrefix(args, 'team') do
-		lpdbData.extradata[key] = args[key .. 'link'] or team
+	for key, otherTeam in Table.iter.pairsByPrefix(args, 'team') do
+		lpdbData.extradata[key] = args[key .. 'link'] or otherTeam
 	end
 
 	lpdbData = self:adjustLPDB(lpdbData, args, personType)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -268,9 +268,11 @@ function Person:_setLpdbData(args, links, status, personType)
 	end
 
 	args.team1 = team
-	for teamKey, otherTeam in Table.iter.pairsByPrefix(args, 'team') do
-		otherTeam = args[teamKey .. 'link'] or otherTeam
-		lpdbData.extradata[teamKey] = (mw.ext.TeamTemplate.raw(otherTeam) or {}).templatename
+	for teamKey, otherTeam, teamIndex in Table.iter.pairsByPrefix(args, 'team') do
+		if teamIndex > 1 then
+			otherTeam = args[teamKey .. 'link'] or otherTeam
+			lpdbData.extradata[teamKey] = (mw.ext.TeamTemplate.raw(otherTeam) or {}).templatename
+		end
 	end
 
 	lpdbData = self:adjustLPDB(lpdbData, args, personType)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -269,7 +269,8 @@ function Person:_setLpdbData(args, links, status, personType)
 
 	args.team1 = team
 	for teamKey, otherTeam in Table.iter.pairsByPrefix(args, 'team') do
-		lpdbData.extradata[teamKey] = args[teamKey .. 'link'] or otherTeam
+		otherTeam = args[teamKey .. 'link'] or otherTeam
+		lpdbData.extradata[teamKey] = (mw.ext.TeamTemplate.raw(otherTeam) or {}).templatename
 	end
 
 	lpdbData = self:adjustLPDB(lpdbData, args, personType)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -267,6 +267,7 @@ function Person:_setLpdbData(args, links, status, personType)
 		lpdbData.extradata['earningsin' .. year] = earningsOfYear
 	end
 
+	-- Store additional team-templates in extradata
 	args.team1 = team
 	for teamKey, otherTeam, teamIndex in Table.iter.pairsByPrefix(args, 'team') do
 		if teamIndex > 1 then


### PR DESCRIPTION
## Summary

Expose player's additional teams in extradata.

Fix mistake in which `teamlinkX` was being used in one part of the code instead of `teamXlink`, `teamlinkX` is not used on any wiki.

## How did you test this change?

/dev module