### PR TITLE
Remove redundant lpdb_datapoint storage in SC2 team infobox

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -304,15 +304,6 @@ function CustomTeam.getEarningsAndMedalsData(team)
 		earnings.team = {}
 	end
 
-	-- to be removed after a purge run + consumer updates
-	if _doStore then
-		mw.ext.LiquipediaDB.lpdb_datapoint('total_earnings_players_while_on_team_' .. team, {
-				type = 'total_earnings_players_while_on_team',
-				name = _team.pagename,
-				information = playerEarnings,
-		})
-	end
-
 	for _, earningsTable in pairs(earnings) do
 		for key, value in pairs(earningsTable) do
 			earningsTable[key] = Math.round{value}


### PR DESCRIPTION
## Summary
Remove extra datapoint storage in sc2 infobox team
- it is stored in lpdb_team_extradata
- all team pages have been purged
- all consumers have been updated

## How did you test this change?
/dev