### PR TITLE
Create Custom Company Infobox for CS

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_company_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_company_custom.lua
@@ -1,0 +1,51 @@
+---
+-- @Liquipedia
+-- wiki=counterstrike
+-- page=Module:Infobox/Company/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Company = Lua.import('Module:Infobox/Company', {requireDevIfEnabled = true})
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+local CustomCompany = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+function CustomCompany.run(frame)
+	local company = Company(frame)
+	_args = company.args
+
+	company.createWidgetInjector = CustomCompany.createWidgetInjector
+
+	return company:createInfobox(frame)
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'parent' then
+		table.insert(widgets, Cell{name = 'Sister Company', content = {_args.sister}})
+		table.insert(widgets, Cell{name = 'Subsidiaries', content = {_args.subsidiaries}})
+		table.insert(widgets, Cell{name = 'Industry', content = {_args.industry}})
+	elseif id == 'dates' then
+		table.insert(widgets, Cell{name = 'Fate', content = {_args.fate}})
+	elseif id == 'employees' then
+		table.insert(widgets, Cell{name = 'People', content = {_args.people}})
+	end
+
+	return widgets
+end
+
+function CustomCompany:createWidgetInjector()
+	return CustomInjector()
+end
+
+return CustomCompany

--- a/components/infobox/wikis/counterstrike/infobox_company_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_company_custom.lua
@@ -44,6 +44,14 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+function CustomInjector:addCustomCells(widgets)
+	table.insert(widgets, Cell({
+		name = 'Series',
+		content = {_args.series}
+	}))
+	return widgets
+end
+
 function CustomCompany:createWidgetInjector()
 	return CustomInjector()
 end

--- a/components/infobox/wikis/counterstrike/infobox_company_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_company_custom.lua
@@ -34,7 +34,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'parent' then
 		table.insert(widgets, Cell{name = 'Sister Company', content = {_args.sister}})
 		table.insert(widgets, Cell{name = 'Subsidiaries', content = {_args.subsidiaries}})
-		table.insert(widgets, Cell{name = 'Industry', content = {_args.industry}})
+		table.insert(widgets, Cell{name = 'Focus', content = {_args.focus or _args.industry}})
 	elseif id == 'dates' then
 		table.insert(widgets, Cell{name = 'Fate', content = {_args.fate}})
 	elseif id == 'employees' then

--- a/components/infobox/wikis/counterstrike/infobox_company_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_company_custom.lua
@@ -38,7 +38,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'dates' then
 		table.insert(widgets, Cell{name = 'Fate', content = {_args.fate}})
 	elseif id == 'employees' then
-		table.insert(widgets, Cell{name = 'People', content = {_args.people}})
+		table.insert(widgets, Cell{name = 'Key People', content = {_args.people}})
 	end
 
 	return widgets


### PR DESCRIPTION
## Summary
Removed 1 field that is in use, `events`. Checked with Zaykor who was fine with it, since it's out of date on most and there are dynamic event lists in the content of the page. The input `|series=` has been added as an optional field.

Few fields have changed location. For instance `Location` is now next to `HQ` instead of on the top. `Industry` is renamed `Focus` is now directly after Parent/Sister/Subsisdiary instead of just before. `People` has been renamed `Key People`.

Before:
![image](https://user-images.githubusercontent.com/3426850/210855850-e257cc16-bc68-43a6-8bf4-73b10296d683.png)
After:
![image](https://user-images.githubusercontent.com/3426850/211580647-ee1c4bb7-3462-4dd9-b248-d437bbf27ad4.png)


## How did you test this change?
"Live" Module (in preview)