### PR TITLE
Add support for steam2

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -272,6 +272,7 @@ function Links.transform(links)
 		sostronk = links.sostronk,
 		['start-gg'] = links.startgg or links.smashgg,
 		steam = links.steam,
+		steam2 = links.steam2,
 		steamalternative = links.steamalternative,
 		stratz = links.stratz,
 		stream = links.stream,


### PR DESCRIPTION
## Summary
CS requests an addtional steam input (`|steam2=`)

Side Note: In the future should rewrite the Links.transform to make use of pairsByPrefix so we can have an arbitrary amount of each

## How did you test this change?
N/A data