### PR TITLE
Fix: Customizable inside Builder failing

### DIFF
--- a/components/infobox/commons/infobox_widget_builder.lua
+++ b/components/infobox/commons/infobox_widget_builder.lua
@@ -23,6 +23,7 @@ function Builder:make()
 	local children = self.builder()
 	local widgets = {}
 	for _, child in ipairs(children or {}) do
+		child:setContext{injector = self.context.injector}
 		local childOutput = WidgetFactory.work(child, self.context.injector)
 		-- Our child might contain a list of children, so we need to iterate
 		for _, item in ipairs(childOutput) do


### PR DESCRIPTION
## Summary
Any type of widget that requires its `Context` set to work (currently only `Customizable` Widget) will fail inside a `Builder` Widget, because it doesn't set the context to it's children.

## How did you test this change?
Dev module