### PR TITLE
Make the cell inside `earnings` customizable

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -107,11 +107,15 @@ function Team:createInfobox()
 							totalEarningsDisplay = '$' .. Language:formatNum(self.totalEarnings)
 						end
 						return {
-							Cell{name = Abbreviation.make(
-									'Approx. Total Winnings',
-									'Includes individual player earnings won&#10;while representing this team'
-								),
-								content = {totalEarningsDisplay}}
+							Customizable{id = 'earningscell',
+								children = {
+									Cell{name = Abbreviation.make(
+										'Approx. Total Winnings',
+										'Includes individual player earnings won&#10;while representing this team'
+									),
+									content = {totalEarningsDisplay}}
+								}
+							}
 						}
 					end
 				}


### PR DESCRIPTION
## Summary
Have the built cell in Earnings be customizable. This allows a wiki to make use of its calculated values, whilst customizing parts.

## How did you test this change?
Dev module