### PR TITLE
Update the Earning's Cell Title on CS

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -19,7 +19,6 @@ local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
-local WidgetFactory = require('Module:Infobox/Widget/Factory')
 
 local CustomTeam = Class.new()
 local CustomInjector = Class.new(Injector)

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -19,6 +19,7 @@ local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
+local WidgetFactory = require('Module:Infobox/Widget/Factory')
 
 local CustomTeam = Class.new()
 local CustomInjector = Class.new(Injector)
@@ -61,6 +62,8 @@ function CustomInjector:parse(id, widgets)
 			widgets[1], -- Coaches
 			Cell{name = 'Analysts', content = {_team.args.analysts}},
 		}
+	elseif id == 'earningscell' then
+		widgets[1].name = 'Approx. Total Winnings'
 	end
 	return widgets
 end


### PR DESCRIPTION
## Summary
Resolves #2241.
CS doesn't wish the abbr to be displayed in the Team Infobox Earnings cell. This PR remove it.

## How did you test this change?
Dev module with #2306 (required bug fix) and #2307 (allows the customization)
![image](https://user-images.githubusercontent.com/3426850/210999687-55f8667f-0cc8-4b92-9bc4-cfcfa49b4e83.png)
