### PR TITLE
Add `MatchSummary` for trackmania

### DIFF
--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -58,22 +58,12 @@ function Casters:create()
 end
 
 -- Custom Header Class
-local Header = Class.new(
-	function(self)
-		self.root = mw.html.create('div')
-		self.root:addClass('brkts-popup-header')
-	end
-)
+local Header = Class.new(MatchSummary.Header)
 
 function Header:scoreBoard(content)
 	self.scoreBoard = content
 	return self
 end
-
-Header.leftOpponent = MatchSummary.Header.leftOpponent
-
-Header.rightOpponent = MatchSummary.Header.rightOpponent
-
 function Header:createScoreDisplay(opponent1, opponent2)
 	local function getScore(opponent)
 		local scoreText
@@ -136,16 +126,6 @@ function Header:createScoreBoard(score, bestof, isNotFinished)
 
 	return scoreBoardNode:node(score)
 end
-
-function Header:createOpponent(opponent, opponentIndex)
-	return OpponentDisplay.BlockOpponent({
-		flip = opponentIndex == 1,
-		opponent = opponent,
-		overflow = 'ellipsis',
-		teamStyle = 'short',
-	})
-end
-
 function Header:create()
 	self.root:tag('div'):addClass('brkts-popup-header-opponent'):addClass('brkts-popup-header-opponent-left')
 		:node(self.leftElementAdditional)
@@ -246,7 +226,7 @@ function CustomMatchSummary._createHeader(match)
 	local header = Header()
 
 	header
-		:leftOpponent(header:createOpponent(match.opponents[1], 1))
+		:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
 		:scoreBoard(header:createScoreBoard(
 			header:createScoreDisplay(
 				match.opponents[1],
@@ -255,7 +235,7 @@ function CustomMatchSummary._createHeader(match)
 			match.bestof,
 			not match.finished
 		))
-		:rightOpponent(header:createOpponent(match.opponents[2], 2))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
 
 	return header
 end

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -61,7 +61,7 @@ end
 local Header = Class.new(
 	function(self)
 		self.root = mw.html.create('div')
-		self.root:addClass('brkts-popup-header-dev')
+		self.root:addClass('brkts-popup-header')
 	end
 )
 

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -1,0 +1,386 @@
+---
+-- @Liquipedia
+-- wiki=trackmania
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local VodLink = require('Module:VodLink')
+local Json = require('Module:Json')
+local Abbreviation = require('Module:Abbreviation')
+local String = require('Module:StringUtils')
+local Flags = require('Module:Flags')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local OpponentDisplayCustom = Lua.import('Module:OpponentDisplay/Custom', {requireDevIfEnabled = true})
+
+local _GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
+local _NO_CHECK = '[[File:NoCheck.png|link=]]'
+local _OVERTIME = '[[File:Cooldown_Clock.png|14x14px|link=]]'
+
+local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link='
+local _OCTANE_SUFFIX = '|Octane matchpage]]'
+local _BALLCHASING_PREFIX = '[[File:Ballchasing icon.png|14x14px|link='
+local _BALLCHASING_SUFFIX = '|Ballchasing replays]]'
+local _HEADTOHEAD_PREFIX = '[[File:Match Info Stats.png|14x14px|link='
+local _HEADTOHEAD_SUFFIX = '|Head to Head history]]'
+
+local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
+
+-- Custom Caster Class
+local Casters = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+			:addClass('brkts-popup-comment')
+			:css('white-space','normal')
+			:css('font-size','85%')
+		self.casters = {}
+	end
+)
+
+function Casters:addCaster(caster)
+	if Logic.isNotEmpty(caster) then
+		local nameDisplay = '[[' .. caster.name .. '|' .. caster.displayName .. ']]'
+		if caster.flag then
+			table.insert(self.casters, Flags.Icon(caster['flag']) .. ' ' .. nameDisplay)
+		else
+			table.insert(self.casters, nameDisplay)
+		end
+	end
+	return self
+end
+
+function Casters:create()
+	return self.root
+		:wikitext('Caster' .. (#self.casters > 1 and 's' or '') .. ': ')
+		:wikitext(table.concat(self.casters, #self.casters > 2 and ', ' or ' & '))
+end
+
+-- Custom Header Class
+local Header = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+		self.root:addClass('brkts-popup-header-dev')
+	end
+)
+
+function Header:leftOpponentTeam(content)
+	self.leftElementAdditional = content
+	return self
+end
+
+function Header:rightOpponentTeam(content)
+	self.rightElementAdditional = content
+	return self
+end
+
+function Header:scoreBoard(content)
+	self.scoreBoard = content
+	return self
+end
+
+function Header:leftOpponent(content)
+	self.leftElement = content
+	return self
+end
+
+function Header:rightOpponent(content)
+	self.rightElement = content
+	return self
+end
+
+function Header:createScoreDisplay(opponent1, opponent2)
+	local function getScore(opponent)
+		local scoreText
+		local isWinner = opponent.placement == 1 or opponent.advances
+		if opponent.placement2 then
+			-- Bracket Reset, show W/L
+			if opponent.placement2 == 1 then
+				isWinner = true
+				scoreText = 'W'
+			else
+				isWinner = false
+				scoreText = 'L'
+			end
+		elseif opponent.extradata and opponent.extradata.additionalScores then
+			-- Match Series (Sets), show the series score
+			scoreText = (opponent.extradata.set1win and 1 or 0)
+					+ (opponent.extradata.set2win and 1 or 0)
+					+ (opponent.extradata.set3win and 1 or 0)
+		else
+			scoreText = OpponentDisplay.InlineScore(opponent)
+		end
+		return OpponentDisplay.BlockScore{
+			isWinner = isWinner,
+			scoreText = scoreText,
+		}
+	end
+
+	return mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(
+			getScore(opponent1)
+				:css('margin-right', 0)
+		)
+		:node(' : ')
+		:node(getScore(opponent2))
+end
+
+function Header:createScoreBoard(score, bestof, isNotFinished)
+	local scoreBoardNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+
+	if String.isNotEmpty(bestof) and bestof > 0 and isNotFinished then
+		return scoreBoardNode
+			:node(mw.html.create('span')
+				:css('line-height', '1.1')
+				:css('width', '100%')
+				:css('text-align', 'center')
+				:node(score)
+			)
+			:node('<br>')
+			:node(mw.html.create('span')
+				:wikitext('(')
+				:node(Abbreviation.make(
+					'Bo' .. bestof,
+					'Best of ' .. bestof
+				))
+				:wikitext(')')
+			)
+	end
+
+	return scoreBoardNode:node(score)
+end
+
+function Header:soloOpponentTeam(opponent, date)
+	if opponent.type == 'solo' then
+		local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
+		local display = teamExists
+			and mw.ext.TeamTemplate.teamicon(opponent.template, date)
+			or _TBD_ICON
+		return mw.html.create('div'):wikitext(display)
+			:addClass('brkts-popup-header-opponent-solo-team')
+		end
+end
+
+function Header:createOpponent(opponent, opponentIndex)
+	return OpponentDisplayCustom.BlockOpponent({
+		flip = opponentIndex == 1,
+		opponent = opponent,
+		overflow = 'ellipsis',
+		teamStyle = 'short',
+	})
+		:addClass(opponent.type ~= 'solo'
+			and 'brkts-popup-header-opponent'
+			or 'brkts-popup-header-opponent-solo-with-team')
+end
+
+function Header:create()
+	self.root:tag('div'):addClass('brkts-popup-header-opponent'):addClass('brkts-popup-header-opponent-left')
+		:node(self.leftElementAdditional)
+		:node(self.leftElement)
+	self.root:node(self.scoreBoard)
+	self.root:tag('div'):addClass('brkts-popup-header-opponent'):addClass('brkts-popup-header-opponent-right')
+		:node(self.rightElement)
+		:node(self.rightElementAdditional)
+	return self.root
+end
+
+
+local CustomMatchSummary = {}
+
+function CustomMatchSummary._getHeadToHead(opponents)
+	local team1, team2 = mw.uri.encode(opponents[1].name), mw.uri.encode(opponents[2].name)
+	local link = tostring(mw.uri.fullUrl('Special:RunQuery/Head2head'))
+		.. '?RunQuery=Run&pfRunQueryFormName=Head2head&Headtohead%5Bteam1%5D='
+		.. team1 .. '&Headtohead%5Bteam2%5D=' .. team2
+	return _HEADTOHEAD_PREFIX .. link .. _HEADTOHEAD_SUFFIX
+end
+
+function CustomMatchSummary.getByMatchId(args)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+
+	local matchSummary = MatchSummary():init()
+
+	matchSummary:header(CustomMatchSummary._createHeader(match))
+				:body(CustomMatchSummary._createBody(match))
+
+	if match.comment then
+		local comment = MatchSummary.Comment():content(match.comment)
+		matchSummary:comment(comment)
+	end
+
+	-- footer
+	local vods = {}
+	for index, game in ipairs(match.games) do
+		if game.vod then
+			vods[index] = game.vod
+		end
+	end
+
+	local headToHead = match.extradata.showh2h and
+		CustomMatchSummary._getHeadToHead(match.opponents) or nil
+
+	if
+		Table.isNotEmpty(vods) or
+		String.isNotEmpty(match.vod) or
+		Table.isNotEmpty(match.links) or
+		headToHead
+	then
+		local footer = MatchSummary.Footer()
+
+		-- Match Vod
+		if String.isNotEmpty(match.vod) then
+			footer:addElement(VodLink.display{
+				vod = match.vod,
+			})
+		end
+
+		-- Game Vods
+		for index, vod in pairs(vods) do
+			footer:addElement(VodLink.display{
+				gamenum = index,
+				vod = vod,
+			})
+		end
+
+		-- Head-to-head
+		if headToHead then
+			footer:addElement(headToHead)
+		end
+
+		matchSummary:footer(footer)
+	end
+
+	return matchSummary:create()
+end
+
+function CustomMatchSummary._createHeader(match)
+	local header = Header()
+
+	header
+		:leftOpponentTeam(header:soloOpponentTeam(match.opponents[1], match.date))
+		:leftOpponent(header:createOpponent(match.opponents[1], 1))
+		:scoreBoard(header:createScoreBoard(
+			header:createScoreDisplay(
+				match.opponents[1],
+				match.opponents[2]
+			),
+			match.bestof,
+			not match.finished
+		))
+		:rightOpponent(header:createOpponent(match.opponents[2], 2))
+		:rightOpponentTeam(header:soloOpponentTeam(match.opponents[2], match.date))
+
+	return header
+end
+
+function CustomMatchSummary._createBody(match)
+	local body = MatchSummary.Body()
+
+	body:addRow(MatchSummary.Row():addElement(DisplayHelper.MatchCountdownBlock(match)))
+
+	-- Iterate each map
+	for _, game in ipairs(match.games) do
+		if game.map then
+			local rowDisplay = CustomMatchSummary._createGame(game)
+			body:addRow(rowDisplay)
+		end
+	end
+
+	-- casters
+	if String.isNotEmpty(match.extradata.casters) then
+		local casters = Json.parseIfString(match.extradata.casters)
+		local casterRow = Casters()
+		for _, caster in pairs(casters) do
+			casterRow:addCaster(caster)
+		end
+
+		body:addRow(casterRow)
+	end
+
+	return body
+end
+
+function CustomMatchSummary._createGame(game)
+	local row = MatchSummary.Row()
+		:addClass('brkts-popup-body-game')
+	local extradata = game.extradata or {}
+
+	if String.isNotEmpty(game.header) then
+		local gameHeader = mw.html.create('div')
+			:css('font-weight','bold')
+			:css('font-size','85%')
+			:css('margin','auto')
+			:node(game.header)
+
+		row:addElement(gameHeader)
+		row:addElement(MatchSummary.Break():create())
+	end
+
+	local centerNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(mw.html.create('div'):node('[[' .. game.map .. ']]'))
+
+	row:addElement(CustomMatchSummary._iconDisplay(
+		_GREEN_CHECK,
+		game.winner == 1,
+		game.scores[1],
+		1
+	))
+	row:addElement(centerNode)
+	row:addElement(CustomMatchSummary._iconDisplay(
+		_GREEN_CHECK,
+		game.winner == 2,
+		game.scores[2],
+		2
+	))
+
+	if extradata.overtime then
+		local overtimes = Json.parseIfString(extradata.overtime)
+		row:addElement(MatchSummary.Break():create())
+		row:addElement(CustomMatchSummary._iconDisplay(
+			_OVERTIME,
+			Table.includes(overtimes, 1)
+		))
+		row:addElement(mw.html.create('div')
+			:addClass('brkts-popup-spaced')
+			:node(mw.html.create('div'):node('Overtime'))
+		)
+		row:addElement(CustomMatchSummary._iconDisplay(
+			_OVERTIME,
+			Table.includes(overtimes, 2)
+		))
+	end
+
+	if String.isNotEmpty(game.comment) then
+		row:addElement(MatchSummary.Break():create())
+
+		row:addElement(mw.html.create('div')
+			:css('margin','auto')
+			:css('max-width', '60%')
+			:node(game.comment)
+		)
+	end
+
+	return row
+end
+
+function CustomMatchSummary._iconDisplay(icon, shouldDisplay, additionalElement, side)
+	local flip = side == 2
+	return mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(additionalElement and flip and mw.html.create('div'):node(additionalElement) or nil)
+		:node(shouldDisplay and icon or _NO_CHECK)
+		:node(additionalElement and (not flip) and mw.html.create('div'):node(additionalElement) or nil)
+end
+
+return CustomMatchSummary

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -19,8 +19,7 @@ local Flags = require('Module:Flags')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
-local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
-local OpponentDisplayCustom = Lua.import('Module:OpponentDisplay/Custom', {requireDevIfEnabled = true})
+local OpponentDisplay = require('Module:OpponentLibraries').OpponentDisplay
 
 local GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
@@ -168,7 +167,7 @@ function Header:soloOpponentTeam(opponent, date)
 end
 
 function Header:createOpponent(opponent, opponentIndex)
-	return OpponentDisplayCustom.BlockOpponent({
+	return OpponentDisplay.BlockOpponent({
 		flip = opponentIndex == 1,
 		opponent = opponent,
 		overflow = 'ellipsis',

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -65,16 +65,6 @@ local Header = Class.new(
 	end
 )
 
-function Header:leftOpponentTeam(content)
-	self.leftElementAdditional = content
-	return self
-end
-
-function Header:rightOpponentTeam(content)
-	self.rightElementAdditional = content
-	return self
-end
-
 function Header:scoreBoard(content)
 	self.scoreBoard = content
 	return self

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -22,18 +22,14 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 local OpponentDisplayCustom = Lua.import('Module:OpponentDisplay/Custom', {requireDevIfEnabled = true})
 
-local _GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
-local _NO_CHECK = '[[File:NoCheck.png|link=]]'
-local _OVERTIME = '[[File:Cooldown_Clock.png|14x14px|link=]]'
+local GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
+local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local OVERTIME = '[[File:Cooldown_Clock.png|14x14px|link=]]'
 
-local _OCTANE_PREFIX = '[[File:Octane_gg.png|14x14px|link='
-local _OCTANE_SUFFIX = '|Octane matchpage]]'
-local _BALLCHASING_PREFIX = '[[File:Ballchasing icon.png|14x14px|link='
-local _BALLCHASING_SUFFIX = '|Ballchasing replays]]'
-local _HEADTOHEAD_PREFIX = '[[File:Match Info Stats.png|14x14px|link='
-local _HEADTOHEAD_SUFFIX = '|Head to Head history]]'
+local HEADTOHEAD_PREFIX = '[[File:Match Info Stats.png|14x14px|link='
+local HEADTOHEAD_SUFFIX = '|Head to Head history]]'
 
-local _TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
+local TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
 
 -- Custom Caster Class
 local Casters = Class.new(
@@ -165,7 +161,7 @@ function Header:soloOpponentTeam(opponent, date)
 		local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
 		local display = teamExists
 			and mw.ext.TeamTemplate.teamicon(opponent.template, date)
-			or _TBD_ICON
+			or TBD_ICON
 		return mw.html.create('div'):wikitext(display)
 			:addClass('brkts-popup-header-opponent-solo-team')
 		end
@@ -202,7 +198,7 @@ function CustomMatchSummary._getHeadToHead(opponents)
 	local link = tostring(mw.uri.fullUrl('Special:RunQuery/Head2head'))
 		.. '?RunQuery=Run&pfRunQueryFormName=Head2head&Headtohead%5Bteam1%5D='
 		.. team1 .. '&Headtohead%5Bteam2%5D=' .. team2
-	return _HEADTOHEAD_PREFIX .. link .. _HEADTOHEAD_SUFFIX
+	return HEADTOHEAD_PREFIX .. link .. HEADTOHEAD_SUFFIX
 end
 
 function CustomMatchSummary.getByMatchId(args)
@@ -331,14 +327,14 @@ function CustomMatchSummary._createGame(game)
 		:node(mw.html.create('div'):node('[[' .. game.map .. ']]'))
 
 	row:addElement(CustomMatchSummary._iconDisplay(
-		_GREEN_CHECK,
+		GREEN_CHECK,
 		game.winner == 1,
 		game.scores[1],
 		1
 	))
 	row:addElement(centerNode)
 	row:addElement(CustomMatchSummary._iconDisplay(
-		_GREEN_CHECK,
+		GREEN_CHECK,
 		game.winner == 2,
 		game.scores[2],
 		2
@@ -348,7 +344,7 @@ function CustomMatchSummary._createGame(game)
 		local overtimes = Json.parseIfString(extradata.overtime)
 		row:addElement(MatchSummary.Break():create())
 		row:addElement(CustomMatchSummary._iconDisplay(
-			_OVERTIME,
+			OVERTIME,
 			Table.includes(overtimes, 1)
 		))
 		row:addElement(mw.html.create('div')
@@ -356,7 +352,7 @@ function CustomMatchSummary._createGame(game)
 			:node(mw.html.create('div'):node('Overtime'))
 		)
 		row:addElement(CustomMatchSummary._iconDisplay(
-			_OVERTIME,
+			OVERTIME,
 			Table.includes(overtimes, 2)
 		))
 	end
@@ -379,7 +375,7 @@ function CustomMatchSummary._iconDisplay(icon, shouldDisplay, additionalElement,
 	return mw.html.create('div')
 		:addClass('brkts-popup-spaced')
 		:node(additionalElement and flip and mw.html.create('div'):node(additionalElement) or nil)
-		:node(shouldDisplay and icon or _NO_CHECK)
+		:node(shouldDisplay and icon or NO_CHECK)
 		:node(additionalElement and (not flip) and mw.html.create('div'):node(additionalElement) or nil)
 end
 

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -25,8 +25,7 @@ local GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 local OVERTIME = '[[File:Cooldown_Clock.png|14x14px|link=]]'
 
-local HEADTOHEAD_PREFIX = '[[File:Match Info Stats.png|14x14px|link='
-local HEADTOHEAD_SUFFIX = '|Head to Head history]]'
+local HEADTOHEAD = '[[File:Match Info Stats.png|14x14px|link=%s|Head to Head history]]'
 
 -- Custom Caster Class
 local Casters = Class.new(
@@ -161,7 +160,7 @@ function CustomMatchSummary._getHeadToHead(match)
 	}
 
 	local link = buildQueryFormLink('Head2head', 'Headtohead', headtoheadArgs)
-	return HEADTOHEAD_PREFIX .. link .. HEADTOHEAD_SUFFIX
+	return HEADTOHEAD:format(link)
 end
 
 function CustomMatchSummary.getByMatchId(args)

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -162,9 +162,6 @@ function Header:createOpponent(opponent, opponentIndex)
 		overflow = 'ellipsis',
 		teamStyle = 'short',
 	})
-		:addClass(opponent.type ~= 'solo'
-			and 'brkts-popup-header-opponent'
-			or 'brkts-popup-header-opponent-solo-with-team')
 end
 
 function Header:create()

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -70,15 +70,9 @@ function Header:scoreBoard(content)
 	return self
 end
 
-function Header:leftOpponent(content)
-	self.leftElement = content
-	return self
-end
+Header.leftOpponent = MatchSummary.Header.leftOpponent
 
-function Header:rightOpponent(content)
-	self.rightElement = content
-	return self
-end
+Header.rightOpponent = MatchSummary.Header.rightOpponent
 
 function Header:createScoreDisplay(opponent1, opponent2)
 	local function getScore(opponent)

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -28,8 +28,6 @@ local OVERTIME = '[[File:Cooldown_Clock.png|14x14px|link=]]'
 local HEADTOHEAD_PREFIX = '[[File:Match Info Stats.png|14x14px|link='
 local HEADTOHEAD_SUFFIX = '|Head to Head history]]'
 
-local TBD_ICON = mw.ext.TeamTemplate.teamicon('tbd')
-
 -- Custom Caster Class
 local Casters = Class.new(
 	function(self)

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -155,17 +155,6 @@ function Header:createScoreBoard(score, bestof, isNotFinished)
 	return scoreBoardNode:node(score)
 end
 
-function Header:soloOpponentTeam(opponent, date)
-	if opponent.type == 'solo' then
-		local teamExists = mw.ext.TeamTemplate.teamexists(opponent.template or '')
-		local display = teamExists
-			and mw.ext.TeamTemplate.teamicon(opponent.template, date)
-			or TBD_ICON
-		return mw.html.create('div'):wikitext(display)
-			:addClass('brkts-popup-header-opponent-solo-team')
-		end
-end
-
 function Header:createOpponent(opponent, opponentIndex)
 	return OpponentDisplay.BlockOpponent({
 		flip = opponentIndex == 1,
@@ -262,7 +251,6 @@ function CustomMatchSummary._createHeader(match)
 	local header = Header()
 
 	header
-		:leftOpponentTeam(header:soloOpponentTeam(match.opponents[1], match.date))
 		:leftOpponent(header:createOpponent(match.opponents[1], 1))
 		:scoreBoard(header:createScoreBoard(
 			header:createScoreDisplay(
@@ -273,7 +261,6 @@ function CustomMatchSummary._createHeader(match)
 			not match.finished
 		))
 		:rightOpponent(header:createOpponent(match.opponents[2], 2))
-		:rightOpponentTeam(header:soloOpponentTeam(match.opponents[2], match.date))
 
 	return header
 end

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -105,7 +105,7 @@ function Header:createScoreBoard(score, bestof, isNotFinished)
 	local scoreBoardNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
 
-	if String.isNotEmpty(bestof) and bestof > 0 and isNotFinished then
+	if bestof > 0 and isNotFinished then
 		return scoreBoardNode
 			:node(mw.html.create('span')
 				:css('line-height', '1.1')

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -166,11 +166,27 @@ end
 
 local CustomMatchSummary = {}
 
-function CustomMatchSummary._getHeadToHead(opponents)
+function CustomMatchSummary._getHeadToHead(match)
+	local opponents = match.opponents
 	local team1, team2 = mw.uri.encode(opponents[1].name), mw.uri.encode(opponents[2].name)
-	local link = tostring(mw.uri.fullUrl('Special:RunQuery/Head2head'))
-		.. '?RunQuery=Run&pfRunQueryFormName=Head2head&Headtohead%5Bteam1%5D='
-		.. team1 .. '&Headtohead%5Bteam2%5D=' .. team2
+	local buildQueryFormLink = function(form, template, arguments)
+		return tostring(mw.uri.fullUrl('Special:RunQuery/' .. form,
+			mw.uri.buildQueryString(Table.map(arguments, function(key, value) return template .. key, value end))
+			.. '&_run'
+		))
+	end
+
+	local headtoheadArgs = {
+		['[team1]'] = team1,
+		['[team2]'] = team2,
+		['[games][is_list]'] = 1,
+		['[tiers][is_list]'] = 1,
+		['[fromdate][day]'] = '01',
+		['[fromdate][month]'] = '01',
+		['[fromdate][year]'] = string.sub(match.date,1,4)
+	}
+
+	local link = buildQueryFormLink('Head2head', 'Headtohead', headtoheadArgs)
 	return HEADTOHEAD_PREFIX .. link .. HEADTOHEAD_SUFFIX
 end
 
@@ -196,7 +212,7 @@ function CustomMatchSummary.getByMatchId(args)
 	end
 
 	local headToHead = match.extradata.showh2h and
-		CustomMatchSummary._getHeadToHead(match.opponents) or nil
+		CustomMatchSummary._getHeadToHead(match) or nil
 
 	if
 		Table.isNotEmpty(vods) or

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -54,7 +54,7 @@ end
 function Casters:create()
 	return self.root
 		:wikitext('Caster' .. (#self.casters > 1 and 's' or '') .. ': ')
-		:wikitext(table.concat(self.casters, #self.casters > 2 and ', ' or ' & '))
+		:wikitext(mw.text.listToText(self.casters, ', ', ' & '))
 end
 
 -- Custom Header Class

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -274,8 +274,7 @@ function CustomMatchSummary._createBody(match)
 	-- Iterate each map
 	for _, game in ipairs(match.games) do
 		if game.map then
-			local rowDisplay = CustomMatchSummary._createGame(game)
-			body:addRow(rowDisplay)
+			body:addRow(CustomMatchSummary._createGame(game))
 		end
 	end
 


### PR DESCRIPTION
## Summary

This PR is the last mandatory module to be added for match2 implementation on Trackmania wiki. MatchSummary is displaying BOs (like BO5 or BO7 for a match) and should display correctly any informations related to the match.

## How did you test this change?

This module has been tested mainly on [User:Sigeth/BracketsShenanigans](https://liquipedia.net/trackmania/User:Sigeth/BracketsShenanigans) and on [User:Sigeth/......./Regional_1](https://liquipedia.net/trackmania/User:Sigeth/Trackmania_World_Tour/2023/Stage_1/Regionals/Europe/Regional_1)
