### PR TITLE
Fix handling of double qualified in UB Finals(PPT Import)

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -289,6 +289,10 @@ function Import._computeBracketPlacementGroups(bracket, options)
 			-- Winners of root matches
 			if coordinates.depth == 0 and options.isFinalStage then
 				table.insert(groupKeys, {0, coordinates.sectionIndex, 1})
+				-- in case of qualLose also Loser of root match if not lower bracket (lower bracket gets handled below)
+				if bracket.bracketDatasById[matchId].qualLose and coordinates.sectionIndex ~= #bracket.sections then
+					table.insert(groupKeys, {0, coordinates.sectionIndex, 2})
+				end
 			end
 
 			-- Opponents knocked out from sole section (se) or lower bracket (de)


### PR DESCRIPTION
## Summary
Fix qualLose (loser also qualfies) handling for non single elim brackets
In the PPT Import currently the qualLose of a non lower bracket match (in non single elim) gets ignored from the ppt import.
This PR fixes that issue (#2313).

![Screenshot 2023-01-08 14 40 07](https://user-images.githubusercontent.com/75081997/211199320-750d3a84-bfbb-4e64-b1ef-187adea5d658.png)
![Screenshot 2023-01-08 14 41 38](https://user-images.githubusercontent.com/75081997/211199321-682076aa-1b39-4a0f-920e-08b5a071b02c.png)


## How did you test this change?
/dev module and then preview test (with dev enabled) on 20 (random) pages that do not have qualLose (but use import) and 2 pages that have qualLose
Cynical also checked a few pages with preview tests