### PR TITLE
Proper date storage in MatchGroup/Input/Custom in OW

### DIFF
--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -9,6 +9,7 @@
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Streams = require('Module:Links/Stream')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -25,7 +26,7 @@ local _MAX_NUM_MAPS = 9
 local _DEFAULT_BESTOF = 3
 local _NO_SCORE = -99
 
-local _EPOCH_TIME = '1970-01-01 00:00:00'
+local globalVars = PageVariableNamespace()
 
 -- containers for process helper functions
 local matchFunctions = {}
@@ -263,7 +264,7 @@ function matchFunctions.readDate(matchArgs)
 		return dateProps
 	else
 		return {
-			date = mw.getContentLanguage():formatDate('c', _EPOCH_TIME),
+			date = MatchGroupInput.getInexactDate(globalVars:get('tournament_enddate')),
 			dateexact = false,
 		}
 	end


### PR DESCRIPTION


## Summary

Currently, matches without |date= defined in {{Match}} default to 1970-01-01 and thus original team templates.

## How did you test this change?

[Testing](https://liquipedia.net/overwatch/index.php?title=User:Moonshot/sandbox2&diff=719678&oldid=719677) versus [current example](https://liquipedia.net/overwatch/GameBattles_Overwatch_2_Online_Tournament/EU/13).
