### PR TITLE
Add CSS Class to header row of PPT

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -472,6 +472,7 @@ end
 
 function PrizePool:_buildHeader()
 	local headerRow = TableRow{css = {['font-weight'] = 'bold'}}
+	headerRow:addClass('prizepooltable-header')
 
 	headerRow:addCell(TableCell{content = {'Place'}, css = {['min-width'] = '80px'}})
 


### PR DESCRIPTION
## Summary

The header row needs a background color according to the design. By adding a class to this specific row I can set it with css.

## How did you test this change?

I tested it on my own wikidev environment to see if that class is being added, and that is the case:
![image](https://user-images.githubusercontent.com/105433238/211350319-ac545eae-e5db-431c-8674-fbf851168b55.png)
