### PR TITLE
Use init statement in PPT header to add TableRow class instead

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -471,8 +471,7 @@ function PrizePool:_getPrizeSummaryText()
 end
 
 function PrizePool:_buildHeader()
-	local headerRow = TableRow{css = {['font-weight'] = 'bold'}}
-	headerRow:addClass('prizepooltable-header')
+	local headerRow = TableRow{classes = {'prizepooltable-header'}, css = {['font-weight'] = 'bold'}}
 
 	headerRow:addCell(TableCell{content = {'Place'}, css = {['min-width'] = '80px'}})
 


### PR DESCRIPTION
## Summary

Uses this functionality instead
https://github.com/Liquipedia/Lua-Modules/blob/db0ae9f05a2c63d10d841276d7113ea188e81040/components/widget/widget_table_row.lua#L17

## How did you test this change?

I didn't test it due to only doing this really quickly at 2am. I can test later if needed before merge.
