### PR TITLE
Update query conditions for SC's tournaments summary table

### DIFF
--- a/standard/tournaments_summary_table/wikis/starcraft2/tournaments_summary_table_custom.lua
+++ b/standard/tournaments_summary_table/wikis/starcraft2/tournaments_summary_table_custom.lua
@@ -45,8 +45,7 @@ function CustomTournamentsSummaryTable.dateConditions(type)
 					ConditionNode(ColumnName('enddate'), Comparator.eq, today),
 				}),
 				ConditionTree(BooleanOperator.any):add({
-					ConditionNode(ColumnName('extradata_winner'), Comparator.eq, 'TBD'),
-					ConditionNode(ColumnName('extradata_winner'), Comparator.eq, 'tbd'),
+					ConditionNode(ColumnName('status'), Comparator.neq, 'finished'),
 					ConditionNode(ColumnName('enddate'), Comparator.gt, today),
 				}),
 			})
@@ -61,8 +60,7 @@ function CustomTournamentsSummaryTable.dateConditions(type)
 				ConditionTree(BooleanOperator.any):add({
 					ConditionTree(BooleanOperator.all):add({
 						ConditionNode(ColumnName('enddate'), Comparator.lt, today),
-						ConditionNode(ColumnName('extradata_winner'), Comparator.neq, 'TBD'),
-						ConditionNode(ColumnName('extradata_winner'), Comparator.neq, 'tbd'),
+						ConditionNode(ColumnName('status'), Comparator.eq, 'finished'),
 					}),
 					ConditionNode(ColumnName('enddate'), Comparator.gt, today),
 				}),


### PR DESCRIPTION
## Summary
Adjust sc2 conditions in tournaments summary table due to ppt not storing into tournament_extradata anymore (missed that when updating all consumers)

## How did you test this change?
dev into live