### PR TITLE
Added link support for Infobox/Game

### DIFF
--- a/components/infobox/commons/infobox_game.lua
+++ b/components/infobox/commons/infobox_game.lua
@@ -9,8 +9,10 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')
+local Table = require('Module:Table')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
+local Links = Lua.import('Module:Links', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -18,6 +20,7 @@ local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
 local Customizable = Widgets.Customizable
+local Builder = Widgets.Builder
 
 local Game = Class.new(BasicInfobox)
 
@@ -29,6 +32,7 @@ end
 function Game:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
+	local links = Links.transform(args)
 
 	local widgets = {
 		Header{
@@ -43,6 +47,16 @@ function Game:createInfobox()
 		Cell{name = 'Release Date(s)', content = self:getAllArgsForBase(args, 'releasedate')},
 		Cell{name = 'Platforms', content = self:getAllArgsForBase(args, 'platform')},
 		Customizable{id = 'custom', children = {}},
+		Builder{
+			builder = function()
+				if not Table.isEmpty(links) then
+					return {
+						Title{name = 'Links'},
+						Widgets.Links{content = links}
+					}
+				end
+			end
+		},
 		Center{content = {args.footnotes}},
 	}
 


### PR DESCRIPTION
## Summary

As per discussion in discord yesterday, I have added support for social links at the bottom of Infobox/Game.

## How did you test this change?

Tested here: - https://liquipedia.net/pubgmobile/User:Dark_meluca/GameTest
with /dev here : - https://liquipedia.net/commons/Module:Infobox/Game/dev

the /dev version differs slightly in that it uses 
"local Links = require('Module:Links')"
 instead of 
"Lua.import('Module:Links', {requireDevIfEnabled = true}"
for testing purposes. However the commit pushed here uses Lua.import

