### PR TITLE
Fix MatchGroup Input Custom crashing if opponent.template does not exist

### DIFF
--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -65,8 +65,10 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		or Opponent.blank()
 
 	-- Convert byes to literals
-	if opponent.template:lower() == BYE_OPPONENT_NAME then
-		opponent = {type = Opponent.literal, name = 'BYE'}
+	if opponent.template then
+		if opponent.template:lower() == BYE_OPPONENT_NAME then
+			opponent = {type = Opponent.literal, name = 'BYE'}
+		end
 	end
 
 	Opponent.resolve(opponent, date)

--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -65,10 +65,8 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		or Opponent.blank()
 
 	-- Convert byes to literals
-	if opponent.template then
-		if opponent.template:lower() == BYE_OPPONENT_NAME then
-			opponent = {type = Opponent.literal, name = 'BYE'}
-		end
+	if (opponent.template or ''):lower() == BYE_OPPONENT_NAME then
+		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
 	Opponent.resolve(opponent, date)


### PR DESCRIPTION


## Summary
Before this fix, nil values of opponent.template will cause to crash the module, notably when Opponent was not filled (empty field).

## How did you test this change?

This change was tested on Brackets of [this page](https://liquipedia.net/trackmania/User:Sigeth/Trackmania_World_Tour/2023/Stage_1/Regionals/Europe/Regional_1)
