### PR TITLE
Fix PrizePool Table Crash

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -535,7 +535,7 @@ function PrizePool:_buildRows()
 					Array.extendWith(lastCellOfType.content, cell.content)
 					lastCellOfType.css['flex-direction'] = 'column'
 
-					return
+					return nil
 				end
 
 				previousOfPrizeType[prize.type] = cell

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -56,14 +56,11 @@ function Array.sub(tbl, startIndex, endIndex)
 	return subArray
 end
 
---[[
-Applies a function to each element in an array and places the results in a
-new array.
-
-Example:
-Array.map({1, 2, 3}, function(x) return 2 * x end)
--- returns {2, 4, 6}
-]]
+---@comment Applies a function to each element in an array and places the results in a new array.
+---@generic V, T
+---@param elements V[]
+---@param funct fun(value: V, argument?: integer): T
+---@return T[]
 function Array.map(elements, funct)
 	local mappedArray = {}
 	for index, element in ipairs(elements) do

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -59,7 +59,7 @@ end
 ---@comment Applies a function to each element in an array and places the results in a new array.
 ---@generic V, T
 ---@param elements V[]
----@param funct fun(value: V, argument?: integer): T
+---@param funct fun(element: V,  index?: integer): T
 ---@return T[]
 function Array.map(elements, funct)
 	local mappedArray = {}


### PR DESCRIPTION
## Summary
In #2340, there was a critical issue, where `return nil` within an `Array.map` was changed to just `return`. This caused the table.insert to critically fail, due to expectation of two parameters.

As a short term solution, I've added Annotation to `Array.map()`. This will in the IDE catch a this issue before it arises.
`return` 
![image](https://user-images.githubusercontent.com/3426850/212374228-0d10a88e-78b5-4000-b0a7-ca50b4400c3f.png)

`return nil`
![image](https://user-images.githubusercontent.com/3426850/212374306-18881297-ef64-4431-9dec-6e5e3e5bb6a9.png)


## How did you test this change?
Live