### PR TITLE
Adjust `Table.mapArguments`

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -298,7 +298,7 @@ end
 ---@generic K, V, T, I
 ---@param args {[K] : V}
 ---@param indexFromKey fun(key?: K): integer
----@param f fun(key?: K, index?: I, ...?: any): T
+---@param f fun(key?: K, index?: integer, ...?: any): T
 ---@param noInterleave boolean?
 ---@return {[I] : T}
 function Table.mapArguments(args, indexFromKey, f, noInterleave)

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -289,14 +289,19 @@ function Table.mapArgumentsByPrefix(args, prefixes, f)
 	return Table.mapArguments(args, indexFromKey, f)
 end
 
---[[
-Extracts keys based on a passed `indexFromKey` function interleaved with numeric indexes
-from an arguments table, and applies a transform to each key or index.
-
-Most common use-case will be `Table.mapArgumentsByPrefix` where
-the `indexFromKey` function retrieves keys based on a prefix.
-]]
-function Table.mapArguments(args, indexFromKey, f)
+--- Extracts keys based on a passed `indexFromKey` function interleaved with numeric indexes
+-- from an arguments table, and applies a transform to each key or index.
+--
+-- Most common use-case will be `Table.mapArgumentsByPrefix` where
+-- the `indexFromKey` function retrieves keys based on a prefix.
+--
+---@generic K, V, T, I
+---@param args {[K] : V}
+---@param indexFromKey fun(key?: K): integer
+---@param f fun(key?: K, index?: I, ...?: any): T
+---@param noInterleave boolean?
+---@return {[I] : T}
+function Table.mapArguments(args, indexFromKey, f, noInterleave)
 	local entriesByIndex = {}
 
 	-- Non-numeric args
@@ -311,7 +316,11 @@ function Table.mapArguments(args, indexFromKey, f)
 		end
 	end
 
-	-- Numeric index entries fills in gaps of prefixN= entries
+	if noInterleave then
+		return entriesByIndex
+	end
+
+	-- Numeric index entries fills in gaps of prefixN= entries if not disabled
 	local entryIndex = 1
 	for argIndex = 1, math.huge do
 		if not args[argIndex] then

--- a/standard/test/table_test.lua
+++ b/standard/test/table_test.lua
@@ -72,6 +72,26 @@ function suite:testMap()
 	end))
 end
 
+function suite:testMapArguments()
+	local args = {a1a = 1, a3a = 3, a4a = 4, 2, 5}
+
+	local function indexFromKey(key)
+		local index = key:match('^a(%d+)a$')
+		if index then
+			return tonumber(index)
+		else
+			return nil
+		end
+	end
+
+	local function mapFunction(key)
+		return args[key] * 2
+	end
+
+	self:assertDeepEquals({2, 4, 6, 8, 10}, Table.mapArguments(args, indexFromKey, mapFunction))
+	self:assertDeepEquals({2, [3] = 6, [4] = 8}, Table.mapArguments(args, indexFromKey, mapFunction, true))
+end
+
 function suite:testMapValues()
 	local a = {1, 2, 3}
 	self:assertDeepEquals({2, 4, 6}, Table.mapValues(a, function(x)


### PR DESCRIPTION
## Summary
Adjust `Table.mapArguments`
- add option to not use interleave stuff
- add annotations

intentional usecase is for adjusting PPT Import to:
- be able to have a importLimit per stage in addition to the overall importLimit
- be able to have a switch for a stages last match importing winner too (currently it only does so for the last stage, with the planned adjusts it could do so for earlier stages too if the according switch is set to true for that stage

see #2352

for both the interleave fillup would make this function not (easily) usable

## How did you test this change?
/dev + test suite

## todo
- [x] add test cases