### PR TITLE
Fix match2 error when player.name is nil

### DIFF
--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -353,12 +353,15 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
-		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex, '')
+		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex)
 		player.displayname = player.displayname
-			or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn', player.name:gsub('_', ' '))
+			or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn', player.name and player.name:gsub('_', ' ') or nil)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		if not Table.isEmpty(player) then
+			player.name = player.name or ''
 			match['opponent' .. opponentIndex .. '_p' .. playerIndex] = player
+		else
+			break
 		end
 	end
 	return match

--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -353,7 +353,7 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
-		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex)
+		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex, '')
 		player.displayname = player.displayname
 			or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn', player.name:gsub('_', ' '))
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')

--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -358,7 +358,6 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 			or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn', player.name and player.name:gsub('_', ' ') or nil)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		if not Table.isEmpty(player) then
-			player.name = player.name or ''
 			match['opponent' .. opponentIndex .. '_p' .. playerIndex] = player
 		else
 			break


### PR DESCRIPTION
## Summary
Match2 threw an error when `player.name` was nil.
![image](https://user-images.githubusercontent.com/16326643/212541017-a7f905ea-cd3f-4141-8f78-98f49ac08d12.png)

This adds a default value of `''` to prevent a hard error.
In addition, it seems like the loop should be broken once no valid player can be found from match or the variables, to prevent listing empty players in LPDB data.

cc @Sigeth 

## How did you test this change?
Bugfix, so live
