### PR TITLE
Add stage `importLimits`, `importWinners`, & `groupElimStatuses` to PPT Import

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -118,15 +118,15 @@ function Import._importPlacements(inputPlacements)
 	local stages = TournamentUtil.fetchStages(Import.config.matchGroupsSpec)
 
 	local placementEntries = Array.flatten(Array.map(Array.reverse(stages), function(stage, reverseStageIndex)
-		local stageIndex = #stages + 1 - reverseStageIndex
-		return Import._computeStagePlacementEntries(stage, {
-				importWinners = Import.config.stageImportWinners[stageIndex] or
-					(Import.config.stageImportWinners[stageIndex] == nil and reverseStageIndex == 1),
-				groupElimStatuses = Import.config.stageGroupElimStatuses[stageIndex] or
-					Import.config.groupElimStatuses,
-				importLimit = Import.config.stageImportLimits[stageIndex] or 0,
-			})
-	end))
+				local stageIndex = #stages + 1 - reverseStageIndex
+				return Import._computeStagePlacementEntries(stage, {
+						importWinners = Import.config.stageImportWinners[stageIndex] or
+							(Import.config.stageImportWinners[stageIndex] == nil and reverseStageIndex == 1),
+						groupElimStatuses = Import.config.stageGroupElimStatuses[stageIndex] or
+							Import.config.groupElimStatuses,
+						importLimit = Import.config.stageImportLimits[stageIndex] or 0,
+					})
+			end))
 
 	-- Apply importLimit if set
 	if Import.config.importLimit then

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -120,8 +120,10 @@ function Import._importPlacements(inputPlacements)
 	local placementEntries = Array.flatten(Array.map(Array.reverse(stages), function(stage, reverseStageIndex)
 		local stageIndex = #stages + 1 - reverseStageIndex
 		return Import._computeStagePlacementEntries(stage, {
-				importWinners = Import.config.stageImportWinners[stageIndex] or (Import.config.stageImportWinners[stageIndex] == nil and reverseStageIndex == 1),
-				groupElimStatuses = Import.config.stageGroupElimStatuses[stageIndex] or Import.config.groupElimStatuses,
+				importWinners = Import.config.stageImportWinners[stageIndex] or
+					(Import.config.stageImportWinners[stageIndex] == nil and reverseStageIndex == 1),
+				groupElimStatuses = Import.config.stageGroupElimStatuses[stageIndex] or
+					Import.config.groupElimStatuses,
 				importLimit = Import.config.stageImportLimits[stageIndex] or 0,
 			})
 	end))


### PR DESCRIPTION
## Summary
Add more options to PPT Import, namely:
* (optional) `importLimit` per stage.
![Screenshot 2023-01-13 08 28 43](https://user-images.githubusercontent.com/75081997/212691356-0a679419-da2a-4e32-aa8d-00c39d164646.png)
---
* (optional) `importWinners` per stage to override importing of non-eliminated opponents in a stage (by default only in the last stage the non-eliminated opponents are also imported. This change gives the option to do it in earlier stages or disable it entirely for a stage.
![image](https://user-images.githubusercontent.com/5881994/213889186-c4cdf7f6-b34d-4ae0-861d-80f06db44496.png)
---
* (optional) `groupElimStatuses` per stage. Defaults to global `groupElimStatuses` then to `DEFAULT_ELIMINATION_STATUS`.
![image](https://user-images.githubusercontent.com/5881994/213889208-4d2face3-560a-4edf-84b8-0724b5cd2b3a.png)
With above two images, can see that `seedup` is ignored as not present in stage's `groupElimStatuses`.
---

example usage for those changes: https://liquipedia.net/counterstrike/User:IMarbot/BLAST and https://liquipedia.net/counterstrike/User:IMarbot/temp

## How did you test this change?
`/dev` testing on CS wiki.

## todo
- [ ] update /docs after merge