### PR TITLE
Remove Psyonix logo from RL League Infobox

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -36,7 +36,6 @@ local _TIER_1 = 1
 local _H2H_TIER_THRESHOLD = 5
 
 local _PSYONIX = 'Psyonix'
-local _PSYONIX_ICON = '[[File:Psyonix logo.svg|16px|link=Psyonix|Psyonix-%s event]]'
 
 local _league
 
@@ -138,13 +137,6 @@ function CustomLeague:createLiquipediaTierDisplay(args)
 	end
 
 	content = content .. '[[Category:' .. tierDisplay .. ' Tournaments]]'
-
-	-- Psyonix icon
-	if CustomLeague:containsPsyonix('organizer') then
-		content = content .. ' ' .. string.format(_PSYONIX_ICON, 'organized')
-	elseif CustomLeague:containsPsyonix('sponsor') then
-		content = content .. ' ' .. string.format(_PSYONIX_ICON, 'sponsored')
-	end
 
 	return content
 end


### PR DESCRIPTION
## Summary
Remove the Psyonix Logo from Infobox League for Psyonix sponsored and organized events. 

Based on request from RL Admins.

Before:
![image](https://user-images.githubusercontent.com/3426850/212705712-d5b282e8-73c4-4504-9b4c-744edc86f20d.png)

After:
![image](https://user-images.githubusercontent.com/3426850/212705784-da5298ab-d7bb-489d-a9d6-f5b0a2d27341.png)


## How did you test this change?
Dev module
