### PR TITLE
Add `coach` as valid input to lpdb in Team Infobox

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -268,7 +268,7 @@ function Team:_setLpdbData(args, links)
 		earnings = earnings,
 		createdate = args.created,
 		disbanddate = ReferenceCleaner.clean(args.disbanded),
-		coach = args.coaches,
+		coach = args.coaches or args.coach,
 		manager = args.manager,
 		template = teamTemplate,
 		links = mw.ext.LiquipediaDB.lpdb_create_json(


### PR DESCRIPTION
## Summary
`coach` is already a valid input to the Cells, but not to LPDB. This PR allows for for `coach` to be valid for LPDB in addition to `coaches`.

## How did you test this change?
Tested with dev module