### PR TITLE
Remove unnecessary injectors and `frame` creating from All Infoboxes

### DIFF
--- a/components/infobox/commons/custom/infobox_character_custom.lua
+++ b/components/infobox/commons/custom/infobox_character_custom.lua
@@ -13,7 +13,7 @@ local Character = Lua.import('Module:Infobox/Character', {requireDevIfEnabled = 
 local CustomCharacter = {}
 
 function CustomCharacter.run(frame)
-	return Character(frame):createInfobox(frame)
+	return Character(frame):createInfobox()
 end
 
 return CustomCharacter

--- a/components/infobox/commons/custom/infobox_company_custom.lua
+++ b/components/infobox/commons/custom/infobox_company_custom.lua
@@ -14,7 +14,7 @@ local CustomCompany = {}
 
 function CustomCompany.run(frame)
 	local company = Company(frame)
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 return CustomCompany

--- a/components/infobox/commons/custom/infobox_game_custom.lua
+++ b/components/infobox/commons/custom/infobox_game_custom.lua
@@ -10,24 +10,12 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
 local Game = Lua.import('Module:Infobox/Game', {requireDevIfEnabled = true})
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
 local CustomGame = Class.new()
 
-local CustomInjector = Class.new(Injector)
-
 function CustomGame.run(frame)
 	local customGame = Game(frame)
-	customGame.createWidgetInjector = CustomGame.createWidgetInjector
-	return customGame:createInfobox(frame)
-end
-
-function CustomGame:createWidgetInjector()
-	return CustomInjector()
-end
-
-function CustomInjector:addCustomCells(widgets)
-	return widgets
+	return customGame:createInfobox()
 end
 
 return CustomGame

--- a/components/infobox/commons/custom/infobox_league_custom.lua
+++ b/components/infobox/commons/custom/infobox_league_custom.lua
@@ -14,7 +14,7 @@ local CustomLeague = {}
 
 function CustomLeague.run(frame)
 	local league = League(frame)
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 return CustomLeague

--- a/components/infobox/commons/custom/infobox_patch_custom.lua
+++ b/components/infobox/commons/custom/infobox_patch_custom.lua
@@ -10,20 +10,12 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
 local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
 local CustomPatch = Class.new()
 
-local CustomInjector = Class.new(Injector)
-
 function CustomPatch.run(frame)
 	local customPatch = Patch(frame)
-	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
-	return customPatch:createInfobox(frame)
-end
-
-function CustomPatch:createWidgetInjector()
-	return CustomInjector()
+	return customPatch:createInfobox()
 end
 
 return CustomPatch

--- a/components/infobox/commons/custom/infobox_person_user_custom.lua
+++ b/components/infobox/commons/custom/infobox_person_user_custom.lua
@@ -35,7 +35,7 @@ function CustomUser.run(frame)
 
 	user.createWidgetInjector = CustomUser.createWidgetInjector
 
-	return user:createInfobox(frame)
+	return user:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/commons/custom/infobox_series_custom.lua
+++ b/components/infobox/commons/custom/infobox_series_custom.lua
@@ -14,7 +14,7 @@ local CustomSeries = {}
 
 function CustomSeries.run(frame)
 	local series = Series(frame)
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 return CustomSeries

--- a/components/infobox/commons/custom/infobox_show_custom.lua
+++ b/components/infobox/commons/custom/infobox_show_custom.lua
@@ -10,20 +10,12 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
 local Show = Lua.import('Module:Infobox/Show', {requireDevIfEnabled = true})
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
 local CustomShow = Class.new()
 
-local CustomInjector = Class.new(Injector)
-
 function CustomShow.run(frame)
 	local customShow = Show(frame)
-	customShow.createWidgetInjector = CustomShow.createWidgetInjector
-	return customShow:createInfobox(frame)
-end
-
-function CustomShow:createWidgetInjector()
-	return CustomInjector()
+	return customShow:createInfobox()
 end
 
 return CustomShow

--- a/components/infobox/commons/custom/infobox_strategy_custom.lua
+++ b/components/infobox/commons/custom/infobox_strategy_custom.lua
@@ -10,20 +10,12 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
 local Strategy = Lua.import('Module:Infobox/Strategy', {requireDevIfEnabled = true})
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 
 local CustomStrategy = Class.new()
 
-local CustomInjector = Class.new(Injector)
-
 function CustomStrategy.run(frame)
 	local customStrategy = Strategy(frame)
-	customStrategy.createWidgetInjector = CustomStrategy.createWidgetInjector
-	return customStrategy:createInfobox(frame)
-end
-
-function CustomStrategy:createWidgetInjector()
-	return CustomInjector()
+	return customStrategy:createInfobox()
 end
 
 return CustomStrategy

--- a/components/infobox/commons/custom/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/commons/custom/infobox_unofficial_world_champion_custom.lua
@@ -15,7 +15,7 @@ local CustomUnofficialWorldChampion = Class.new()
 
 function CustomUnofficialWorldChampion.run(frame)
 	local unofficialWorldChampion = UnofficialWorldChampion(frame)
-	return unofficialWorldChampion:createInfobox(frame)
+	return unofficialWorldChampion:createInfobox()
 end
 
 return CustomUnofficialWorldChampion

--- a/components/infobox/commons/custom/infobox_weapon_custom.lua
+++ b/components/infobox/commons/custom/infobox_weapon_custom.lua
@@ -14,7 +14,7 @@ local CustomWeapon = {}
 
 function CustomWeapon.run(frame)
 	local weapon = Weapon(frame)
-	return weapon:createInfobox(frame)
+	return weapon:createInfobox()
 end
 
 return CustomWeapon

--- a/components/infobox/commons/custom/infobox_website_custom.lua
+++ b/components/infobox/commons/custom/infobox_website_custom.lua
@@ -15,7 +15,7 @@ local CustomWebsite = Class.new()
 
 function CustomWebsite.run(frame)
 	local website = Website(frame)
-	return website:createInfobox(frame)
+	return website:createInfobox()
 end
 
 return CustomWebsite

--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -33,7 +33,7 @@ local _COMPANY_TYPE_ORGANIZER = 'ORGANIZER'
 
 function Company.run(frame)
 	local company = Company(frame)
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function Company:createInfobox()

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -23,10 +23,10 @@ local Map = Class.new(BasicInfobox)
 
 function Map.run(frame)
 	local map = Map(frame)
-	return map:createInfobox(frame)
+	return map:createInfobox()
 end
 
-function Map:createInfobox(frame)
+function Map:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
 

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -41,10 +41,10 @@ Series.warnings = {}
 
 function Series.run(frame)
 	local series = Series(frame)
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
-function Series:createInfobox(frame)
+function Series:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
 
@@ -224,7 +224,7 @@ function Series:createInfobox(frame)
 				Links.makeFullLinksForTableItems(links or {})
 			),
 		}
-		lpdbData = self:_getIconFromLeagueIconSmall(frame, lpdbData)
+		lpdbData = self:_getIconFromLeagueIconSmall(lpdbData)
 
 		lpdbData = self:addToLpdb(lpdbData)
 		mw.ext.LiquipediaDB.lpdb_series('series_' .. self.name, lpdbData)
@@ -285,7 +285,7 @@ function Series:appendLiquipediatierDisplay()
 	return ''
 end
 
-function Series:_getIconFromLeagueIconSmall(frame, lpdbData)
+function Series:_getIconFromLeagueIconSmall(lpdbData)
 	local icon = lpdbData.icon
 	local iconDark = lpdbData.icondark
 	local iconSmallTemplate = LeagueIcon.display{

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -45,7 +45,7 @@ function CustomLeague.run(frame)
 	league.getWikiCategories = CustomLeague.getWikiCategories
 	league.createLiquipediaTierDisplay = CustomLeague.createLiquipediaTierDisplay
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/ageofempires/infobox_series_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_series_custom.lua
@@ -26,7 +26,7 @@ function CustomSeries.run(frame)
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 	_series = series
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -33,7 +33,7 @@ function CustomTeam.run(frame)
 
 	_args = team.args
 
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/apexlegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_character_custom.lua
@@ -26,7 +26,7 @@ function CustomCharacter.run(frame)
 	_args = character.args
 	character.addToLpdb = CustomCharacter.addToLpdb
 	character.createWidgetInjector = CustomCharacter.createWidgetInjector
-	return character:createInfobox(frame)
+	return character:createInfobox()
 end
 
 function CustomCharacter:createWidgetInjector()

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -45,7 +45,7 @@ function CustomLeague.run(frame)
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/apexlegends/infobox_map_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_map_custom.lua
@@ -32,7 +32,7 @@ function CustomMap.run(frame)
 	_args = map.args
 	map.addToLpdb = CustomMap.addToLpdb
 	map.createWidgetInjector = CustomMap.createWidgetInjector
-	return map:createInfobox(frame)
+	return map:createInfobox()
 end
 
 function CustomMap:createWidgetInjector()

--- a/components/infobox/wikis/apexlegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_person_player_custom.lua
@@ -71,7 +71,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/apexlegends/infobox_team_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_team_custom.lua
@@ -28,7 +28,7 @@ function CustomTeam.run(frame)
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/apexlegends/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_weapon_custom.lua
@@ -52,7 +52,7 @@ function CustomWeapon.run(frame)
 	_args = _weapon.args
 	weapon.addToLpdb = CustomWeapon.addToLpdb
 	weapon.createWidgetInjector = CustomWeapon.createWidgetInjector
-	return weapon:createInfobox(frame)
+	return weapon:createInfobox()
 end
 
 function CustomWeapon:createWidgetInjector()

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -36,7 +36,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -39,7 +39,7 @@ function CustomPlayer.run(frame)
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/arenaofvalor/infobox_team_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_team_custom.lua
@@ -27,7 +27,7 @@ function CustomTeam.run(frame)
 
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createBottomContent()

--- a/components/infobox/wikis/brawlhalla/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlhalla/infobox_league_custom.lua
@@ -33,7 +33,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/brawlhalla/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlhalla/infobox_person_player_custom.lua
@@ -54,7 +54,7 @@ function CustomPlayer.run(frame)
 
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/brawlhalla/infobox_team_custom.lua
+++ b/components/infobox/wikis/brawlhalla/infobox_team_custom.lua
@@ -18,7 +18,7 @@ function CustomTeam.run(frame)
 	local team = Team(frame)
 	team.addToLpdb = CustomTeam.addToLpdb
 
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:addToLpdb(lpdbData, args)

--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -36,7 +36,7 @@ function CustomLeague.run(frame)
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -55,7 +55,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	local builtInfobox = player:createInfobox(frame)
+	local builtInfobox = player:createInfobox()
 
 	local autoPlayerIntro = ''
 	if Logic.readBool((_args.autoPI or ''):lower()) then

--- a/components/infobox/wikis/brawlstars/infobox_unit_brawler.lua
+++ b/components/infobox/wikis/brawlstars/infobox_unit_brawler.lua
@@ -35,7 +35,7 @@ function CustomUnit.run(frame)
 	unit.setLpdbData = CustomUnit.setLpdbData
 	unit.getWikiCategories = CustomUnit.getWikiCategories
 	unit.createWidgetInjector = CustomUnit.createWidgetInjector
-	return unit:createInfobox(frame)
+	return unit:createInfobox()
 end
 
 function CustomInjector:addCustomCells()

--- a/components/infobox/wikis/counterstrike/infobox_company_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_company_custom.lua
@@ -27,7 +27,7 @@ function CustomCompany.run(frame)
 
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -108,7 +108,7 @@ function CustomLeague.run(frame)
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
 	league.shouldStore = CustomLeague.shouldStore
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:shouldStore(args)

--- a/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
@@ -83,7 +83,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/counterstrike/infobox_series_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_series_custom.lua
@@ -42,7 +42,7 @@ function CustomSeries.run(frame)
 
 	_args.liquipediatier = Tier.number[_args.liquipediatier]
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -42,7 +42,7 @@ function CustomTeam.run(frame)
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.getWikiCategories = CustomTeam.getWikiCategories
 
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/crossfire/infobox_league_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_league_custom.lua
@@ -35,7 +35,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/dota2/infobox_company_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_company_custom.lua
@@ -27,7 +27,7 @@ function CustomCompany.run(frame)
 
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -47,7 +47,7 @@ function CustomLeague.run(frame)
 	_league = league
 	_args = _league.args
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/dota2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_player_custom.lua
@@ -87,7 +87,7 @@ function CustomPlayer.run(frame)
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 	player.defineCustomPageVariables = CustomPlayer.defineCustomPageVariables
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/dota2/infobox_person_user_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_user_custom.lua
@@ -36,7 +36,7 @@ function CustomUser.run(frame)
 
 	user.createWidgetInjector = CustomUser.createWidgetInjector
 
-	return user:createInfobox(frame)
+	return user:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/dota2/infobox_series_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_series_custom.lua
@@ -28,7 +28,7 @@ function CustomSeries.run(frame)
 	_args = series.args
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/dota2/infobox_team_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_team_custom.lua
@@ -34,7 +34,7 @@ function CustomTeam.run(frame)
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
 
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createBottomContent()

--- a/components/infobox/wikis/fifa/infobox_company_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_company_custom.lua
@@ -27,7 +27,7 @@ function CustomCompany.run(frame)
 
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -45,7 +45,7 @@ function CustomPlayer.run(frame)
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/fortnite/infobox_series_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_series_custom.lua
@@ -31,7 +31,7 @@ function CustomSeries.run(frame)
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 	_series = series
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/fortnite/infobox_team_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_team_custom.lua
@@ -46,7 +46,7 @@ function CustomTeam.run(frame)
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:addToLpdb(lpdbData)

--- a/components/infobox/wikis/freefire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/freefire/infobox_person_player_custom.lua
@@ -62,7 +62,7 @@ function CustomPlayer.run(frame)
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/freefire/infobox_team_custom.lua
+++ b/components/infobox/wikis/freefire/infobox_team_custom.lua
@@ -28,7 +28,7 @@ function CustomTeam.run(frame)
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/halo/infobox_league_custom.lua
+++ b/components/infobox/wikis/halo/infobox_league_custom.lua
@@ -42,7 +42,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/halo/infobox_map_custom.lua
+++ b/components/infobox/wikis/halo/infobox_map_custom.lua
@@ -32,7 +32,7 @@ function CustomMap.run(frame)
 	customMap.getCategories = CustomMap.getCategories
 	customMap.addToLpdb = CustomMap.addToLpdb
 	_args = customMap.args
-	return customMap:createInfobox(frame)
+	return customMap:createInfobox()
 end
 
 function CustomMap:createWidgetInjector()

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -28,7 +28,7 @@ function CustomPatch.run(frame)
 	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
 	customPatch.getChronologyData = CustomPatch.getChronologyData
 	customPatch.addToLpdb = CustomPatch.addToLpdb
-	return customPatch:createInfobox(frame)
+	return customPatch:createInfobox()
 end
 
 function CustomPatch:createWidgetInjector()

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -50,7 +50,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/halo/infobox_team_custom.lua
+++ b/components/infobox/wikis/halo/infobox_team_custom.lua
@@ -29,7 +29,7 @@ function CustomTeam.run(frame)
 	_team = team
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/hearthstone/infobox_company_custom.lua
+++ b/components/infobox/wikis/hearthstone/infobox_company_custom.lua
@@ -27,7 +27,7 @@ function CustomCompany.run(frame)
 
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/heroes/infobox_team_custom.lua
+++ b/components/infobox/wikis/heroes/infobox_team_custom.lua
@@ -22,7 +22,7 @@ function CustomTeam.run(frame)
 	team.args.manager = Template.expandTemplate(frame, 'Manager of')
 	team.args.captain = Template.expandTemplate(frame, 'Captain of')
 
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 return CustomTeam

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -38,7 +38,7 @@ function CustomLeague.run(frame)
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -92,7 +92,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
@@ -38,7 +38,7 @@ function CustomTeam.run(frame)
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.getWikiCategories = CustomTeam.getWikiCategories
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -46,7 +46,7 @@ function CustomHero.run(frame)
 	unit.setLpdbData = CustomHero.setLpdbData
 	unit.createWidgetInjector = CustomHero.createWidgetInjector
 
-	return unit:createInfobox(frame)
+	return unit:createInfobox()
 end
 
 function CustomInjector:addCustomCells()

--- a/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
@@ -49,7 +49,7 @@ function CustomItem.run(frame)
 	item.getWikiCategories = CustomItem.getWikiCategories
 	item.createWidgetInjector = CustomItem.createWidgetInjector
 
-	return item:createInfobox(frame)
+	return item:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
@@ -34,7 +34,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -46,7 +46,7 @@ function CustomPlayer.run(frame)
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -35,7 +35,7 @@ function CustomLeague.run(frame)
 	_args = league.args
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/naraka/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_person_player_custom.lua
@@ -67,7 +67,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -46,7 +46,7 @@ function CustomLeague.run(frame)
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.getWikiCategories = CustomLeague.getWikiCategories
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/overwatch/infobox_map_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_map_custom.lua
@@ -29,7 +29,7 @@ function CustomMap.run(frame)
 	customMap.createWidgetInjector = CustomMap.createWidgetInjector
 	customMap.addToLpdb = CustomMap.addToLpdb
 	_args = customMap.args
-	return customMap:createInfobox(frame)
+	return customMap:createInfobox()
 end
 
 function CustomMap:createWidgetInjector()

--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -64,7 +64,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomPlayer:createWidgetInjector()

--- a/components/infobox/wikis/overwatch/infobox_person_user_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_user_custom.lua
@@ -36,7 +36,7 @@ function CustomUser.run(frame)
 
 	user.createWidgetInjector = CustomUser.createWidgetInjector
 
-	return user:createInfobox(frame)
+	return user:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/overwatch/infobox_team_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_team_custom.lua
@@ -24,7 +24,7 @@ function CustomTeam.run(frame)
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.getWikiCategories = CustomTeam.getWikiCategories
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createBottomContent()

--- a/components/infobox/wikis/overwatch/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_unofficial_world_champion_custom.lua
@@ -29,7 +29,7 @@ function CustomUnofficialWorldChampion.run(frame)
 	local unofficialWorldChampion = UnofficialWorldChampion(frame)
 	_args = unofficialWorldChampion.args
 	unofficialWorldChampion.createWidgetInjector = CustomUnofficialWorldChampion.createWidgetInjector
-	return unofficialWorldChampion:createInfobox(frame)
+	return unofficialWorldChampion:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/pokemon/infobox_league_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_league_custom.lua
@@ -38,7 +38,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -40,7 +40,7 @@ function CustomPlayer.run(frame)
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/pubg/infobox_company_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_company_custom.lua
@@ -33,7 +33,7 @@ function CustomCompany.run(frame)
 	local company = Company(frame)
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 	_args = company.args
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomCompany:createWidgetInjector()

--- a/components/infobox/wikis/pubg/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_league_custom.lua
@@ -73,7 +73,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/pubg/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_weapon_custom.lua
@@ -30,7 +30,7 @@ function CustomWeapon.run(frame)
 	_weapon = weapon
 	_args = _weapon.args
 	weapon.createWidgetInjector = CustomWeapon.createWidgetInjector
-	return weapon:createInfobox(frame)
+	return weapon:createInfobox()
 end
 
 function CustomWeapon:createWidgetInjector()

--- a/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
@@ -69,7 +69,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -65,7 +65,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -70,7 +70,7 @@ function CustomLeague.run(frame)
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.getWikiCategories = CustomLeague.getWikiCategories
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
@@ -26,7 +26,7 @@ function CustomPatch.run(frame)
 	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
 	customPatch.getChronologyData = CustomPatch.getChronologyData
 	customPatch.addToLpdb = CustomPatch.addToLpdb
-	return customPatch:createInfobox(frame)
+	return customPatch:createInfobox()
 end
 
 function CustomPatch:createWidgetInjector()

--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -84,7 +84,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/rainbowsix/infobox_team_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_team_custom.lua
@@ -23,7 +23,7 @@ function CustomTeam.run(frame)
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.defineCustomPageVariables = CustomTeam.defineCustomPageVariables
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createBottomContent()

--- a/components/infobox/wikis/rainbowsix/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_weapon_custom.lua
@@ -30,7 +30,7 @@ function CustomWeapon.run(frame)
 
 	weapon.addToLpdb = CustomWeapon.addToLpdb
 	weapon.createWidgetInjector = CustomWeapon.createWidgetInjector
-	return weapon:createInfobox(frame)
+	return weapon:createInfobox()
 end
 
 function CustomWeapon:createWidgetInjector()

--- a/components/infobox/wikis/rocketleague/infobox_company_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_company_custom.lua
@@ -33,7 +33,7 @@ function CustomCompany.run(frame)
 	local company = Company(frame)
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 	_args = company.args
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomCompany:createWidgetInjector()

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -48,7 +48,7 @@ function CustomLeague.run(frame)
 	league.createLiquipediaTierDisplay = CustomLeague.createLiquipediaTierDisplay
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -49,7 +49,7 @@ function CustomPlayer.run(frame)
 	player.getCategories = CustomPlayer.getCategories
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/rocketleague/infobox_series_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_series_custom.lua
@@ -31,7 +31,7 @@ function CustomSeries.run(frame)
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 	_series = series
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -28,7 +28,7 @@ function CustomTeam.run(frame)
 	_team = team
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/rocketleague/infobox_unit_car.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unit_car.lua
@@ -29,7 +29,7 @@ function CustomUnit.run(frame)
 	unit.setLpdbData = CustomUnit.setLpdbData
 	unit.getWikiCategories = CustomUnit.getWikiCategories
 	unit.createWidgetInjector = CustomUnit.createWidgetInjector
-	return unit:createInfobox(frame)
+	return unit:createInfobox()
 end
 
 function CustomInjector:addCustomCells()

--- a/components/infobox/wikis/smash/infobox_series_custom.lua
+++ b/components/infobox/wikis/smash/infobox_series_custom.lua
@@ -27,7 +27,7 @@ function CustomSeries.run(frame)
 	_series.createWidgetInjector = CustomSeries.createWidgetInjector
 	_series.addToLpdb = CustomSeries.addToLpdb
 
-	return _series:createInfobox(frame)
+	return _series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/splatoon/infobox_league_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_league_custom.lua
@@ -33,7 +33,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
@@ -43,7 +43,7 @@ function CustomPlayer.run(frame)
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -44,7 +44,7 @@ function CustomLeague.run(frame)
 	league.shouldStore = CustomLeague.shouldStore
 	league.getWikiCategories = CustomLeague.getWikiCategories
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/starcraft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_person_player_custom.lua
@@ -89,7 +89,7 @@ function CustomPlayer.run(frame)
 	player.getWikiCategories = CustomPlayer.getWikiCategories
 	player.getPersonType = CustomPlayer.getPersonType
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/starcraft/infobox_series_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_series_custom.lua
@@ -39,7 +39,7 @@ function CustomSeries.run(frame)
 
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/starcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_team_custom.lua
@@ -57,7 +57,7 @@ function CustomTeam.run(frame)
 	team.getWikiCategories = CustomTeam.getWikiCategories
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/starcraft2/infobox_building_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_building_custom.lua
@@ -42,7 +42,7 @@ function CustomBuilding.run(frame)
 	building.nameDisplay = CustomBuilding.nameDisplay
 	building.setLpdbData = CustomBuilding.setLpdbData
 	building.createWidgetInjector = CustomBuilding.createWidgetInjector
-	return building:createInfobox(frame)
+	return building:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/starcraft2/infobox_campaign_mission_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_campaign_mission_custom.lua
@@ -37,7 +37,7 @@ function CustomMission.run(frame)
 	_args = mission.args
 	mission.createWidgetInjector = CustomMission.createWidgetInjector
 	mission.getWikiCategories = CustomMission.getWikiCategories
-	return mission:createInfobox(frame)
+	return mission:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -73,7 +73,7 @@ function CustomLeague.run(frame)
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.shouldStore = CustomLeague.shouldStore
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/starcraft2/infobox_map_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_map_custom.lua
@@ -29,7 +29,7 @@ function CustomMap.run(frame)
 	customMap.createWidgetInjector = CustomMap.createWidgetInjector
 	customMap.getWikiCategories = CustomMap.getWikiCategories
 	_args = customMap.args
-	return customMap:createInfobox(frame)
+	return customMap:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_patch_custom.lua
@@ -29,7 +29,7 @@ function CustomPatch.run(frame)
 	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
 	customPatch.getChronologyData = CustomPatch.getChronologyData
 	customPatch.addToLpdb = CustomPatch.addToLpdb
-	return customPatch:createInfobox(frame)
+	return customPatch:createInfobox()
 end
 
 function CustomPatch:createWidgetInjector()

--- a/components/infobox/wikis/starcraft2/infobox_person_map_maker_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_map_maker_custom.lua
@@ -39,7 +39,7 @@ function CustomMapMaker.run(frame)
 	player.createBottomContent = CustomMapMaker.createBottomContent
 	player.createWidgetInjector = CustomMapMaker.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -89,7 +89,7 @@ function CustomPlayer.run(frame)
 	player.createBottomContent = CustomPlayer.createBottomContent
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/starcraft2/infobox_person_user.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_user.lua
@@ -66,7 +66,7 @@ function CustomUser.run(frame)
 	user.nameDisplay = CustomUser.nameDisplay
 	user.createWidgetInjector = CustomUser.createWidgetInjector
 
-	return user:createInfobox(frame)
+	return user:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/starcraft2/infobox_series_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_series_custom.lua
@@ -57,7 +57,7 @@ function CustomSeries.run(frame)
 
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/starcraft2/infobox_show_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_show_custom.lua
@@ -28,7 +28,7 @@ function CustomShow.run(frame)
 	_show = customShow
 	_args = customShow.args
 	customShow.createWidgetInjector = CustomShow.createWidgetInjector
-	return customShow:createInfobox(frame)
+	return customShow:createInfobox()
 end
 
 function CustomShow:createWidgetInjector()

--- a/components/infobox/wikis/starcraft2/infobox_skill_ability.lua
+++ b/components/infobox/wikis/starcraft2/infobox_skill_ability.lua
@@ -35,7 +35,7 @@ function Ability.run(frame)
 	ability.createWidgetInjector = Ability.createWidgetInjector
 	ability.getCategories = Ability.getCategories
 	_args = ability.args
-	return ability:createInfobox(frame)
+	return ability:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/starcraft2/infobox_skill_spell.lua
+++ b/components/infobox/wikis/starcraft2/infobox_skill_spell.lua
@@ -35,7 +35,7 @@ function Spell.run(frame)
 	spell.createWidgetInjector = Spell.createWidgetInjector
 	spell.getCategories = Spell.getCategories
 	_args = spell.args
-	return spell:createInfobox(frame)
+	return spell:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/starcraft2/infobox_strategy_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_strategy_custom.lua
@@ -38,7 +38,7 @@ function CustomStrategy.run(frame)
 	_strategy = customStrategy
 	_args = customStrategy.args
 	customStrategy.createWidgetInjector = CustomStrategy.createWidgetInjector
-	return customStrategy:createInfobox(frame)
+	return customStrategy:createInfobox()
 end
 
 function CustomStrategy:createWidgetInjector()

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -61,7 +61,7 @@ function CustomTeam.run(frame)
 	team.getWikiCategories = CustomTeam.getWikiCategories
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/starcraft2/infobox_unit_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_unit_custom.lua
@@ -43,7 +43,7 @@ function CustomUnit.run(frame)
 	unit.nameDisplay = CustomUnit.nameDisplay
 	unit.setLpdbData = CustomUnit.setLpdbData
 	unit.createWidgetInjector = CustomUnit.createWidgetInjector
-	return unit:createInfobox(frame)
+	return unit:createInfobox()
 end
 
 function CustomInjector:addCustomCells()

--- a/components/infobox/wikis/starcraft2/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_unofficial_world_champion_custom.lua
@@ -30,7 +30,7 @@ function CustomUnofficialWorldChampion.run(frame)
 	local unofficialWorldChampion = UnofficialWorldChampion(frame)
 	_args = unofficialWorldChampion.args
 	unofficialWorldChampion.createWidgetInjector = CustomUnofficialWorldChampion.createWidgetInjector
-	return unofficialWorldChampion:createInfobox(frame)
+	return unofficialWorldChampion:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)

--- a/components/infobox/wikis/teamfortress/infobox_company_custom.lua
+++ b/components/infobox/wikis/teamfortress/infobox_company_custom.lua
@@ -27,7 +27,7 @@ function CustomCompany.run(frame)
 
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/teamfortress/infobox_team_custom.lua
+++ b/components/infobox/wikis/teamfortress/infobox_team_custom.lua
@@ -22,7 +22,7 @@ function CustomTeam.run(frame)
 	team.args.manager = Template.expandTemplate(frame, 'Manager of')
 	team.args.captain = Template.expandTemplate(frame, 'Captain of')
 
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 return CustomTeam

--- a/components/infobox/wikis/trackmania/infobox_league_custom.lua
+++ b/components/infobox/wikis/trackmania/infobox_league_custom.lua
@@ -43,7 +43,7 @@ function CustomLeague.run(frame)
 	league.getWikiCategories = CustomLeague.getWikiCategories
 	league.addToLpdb = CustomLeague.addToLpdb
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague.createWidgetInjector()

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -45,7 +45,7 @@ function CustomLeague.run(frame)
 
 	_args.liquipediatier = Tier.number[_args.liquipediatier]
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -62,7 +62,7 @@ function CustomPlayer.run(frame)
 	_args = player.args
 	_player = player
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/valorant/infobox_series_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_series_custom.lua
@@ -31,7 +31,7 @@ function CustomSeries.run(frame)
 	_args = series.args
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -28,7 +28,7 @@ function CustomTeam.run(frame)
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/warcraft/infobox_company_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_company_custom.lua
@@ -27,7 +27,7 @@ function CustomCompany.run(frame)
 
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/warcraft/infobox_series_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_series_custom.lua
@@ -32,7 +32,7 @@ function CustomSeries.run(frame)
 	series.createWidgetInjector = CustomSeries.createWidgetInjector
 	_series = series
 
-	return series:createInfobox(frame)
+	return series:createInfobox()
 end
 
 function CustomSeries:createWidgetInjector()

--- a/components/infobox/wikis/wildrift/infobox_item_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_item_custom.lua
@@ -51,7 +51,7 @@ function CustomItem.run(frame)
 	--item.setLpdbData = CustomItem.setLpdbData--to be added later
 	item.createWidgetInjector = CustomItem.createWidgetInjector
 
-	return item:createInfobox(frame)
+	return item:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -34,7 +34,7 @@ function CustomLeague.run(frame)
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 function CustomLeague:createWidgetInjector()

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -87,7 +87,7 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 
-	return player:createInfobox(frame)
+	return player:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/wildrift/infobox_team_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_team_custom.lua
@@ -37,7 +37,7 @@ function CustomTeam.run(frame)
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.getWikiCategories = CustomTeam.getWikiCategories
-	return team:createInfobox(frame)
+	return team:createInfobox()
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/infobox/wikis/wildrift/infobox_unit_champion.lua
+++ b/components/infobox/wikis/wildrift/infobox_unit_champion.lua
@@ -46,7 +46,7 @@ function CustomChampion.run(frame)
 	unit.setLpdbData = CustomChampion.setLpdbData
 	unit.createWidgetInjector = CustomChampion.createWidgetInjector
 
-	return unit:createInfobox(frame)
+	return unit:createInfobox()
 end
 
 function CustomInjector:addCustomCells()

--- a/components/infobox/wikis/worldofwarcraft/infobox_company_custom.lua
+++ b/components/infobox/wikis/worldofwarcraft/infobox_company_custom.lua
@@ -27,7 +27,7 @@ function CustomCompany.run(frame)
 
 	company.createWidgetInjector = CustomCompany.createWidgetInjector
 
-	return company:createInfobox(frame)
+	return company:createInfobox()
 end
 
 function CustomInjector:parse(id, widgets)


### PR DESCRIPTION
## Summary
The `createInfobox()` functions in the Base Infoboxes doesn't have any parameters, yet many (most) Customs provides `frame` as a parameter. 
The only infobox base accepting a (frame) parameter is the Series and Map Infoboxes. However they have no need for it, and it has been removed as well.
This PR also removes some unused injectors from CommonCustoms.

## How did you test this change?
Sample testing has been done