### PR TITLE
Refactor category setting in Infoboxes

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -6,8 +6,11 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory', {requireDevIfEnabled = true})
@@ -29,16 +32,18 @@ function Infobox:create(frame, gameName, forceDarkMode)
 		self.root:addClass('infobox-darkmodeforced')
 	end
 
+	self.categories = {}
+
 	self.injector = nil
 	return self
 end
 
-function Infobox:categories(...)
-	local input = {...}
-	for i = 1, #input do
+function Infobox:addCategories(...)
+	local input = Table.pack(...)
+	for i = 1, input.n do
 		local category = input[i]
-		if category ~= nil and category ~= '' then
-			self.root:wikitext('[[Category:' .. category .. ']]')
+		if String.isNotEmpty(category) then
+			table.insert(self.categories, category)
 		end
 	end
 	return self
@@ -79,6 +84,8 @@ function Infobox:build(widgets)
 	if self.bottomContent ~= nil then
 		self.root:node(self.bottomContent)
 	end
+
+	Array.forEach(self.categories, mw.ext.TeamLiquidIntegration.add_category)
 
 	return self.root
 end

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -9,8 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
-local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory', {requireDevIfEnabled = true})
@@ -39,13 +37,7 @@ function Infobox:create(frame, gameName, forceDarkMode)
 end
 
 function Infobox:addCategories(...)
-	local input = Table.pack(...)
-	for i = 1, input.n do
-		local category = input[i]
-		if String.isNotEmpty(category) then
-			table.insert(self.categories, category)
-		end
-	end
+	Array.extendWith(self.categories, ...)
 	return self
 end
 

--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -90,16 +90,13 @@ function Building:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	infobox:addCategories('Buildings')
-	infobox:addCategories(unpack(self:getWikiCategories(args)))
-
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if Namespace.isMain() then
+		infobox:addCategories('Buildings')
+		infobox:addCategories(unpack(self:getWikiCategories(args)))
 		self:setLpdbData(args)
 	end
 
-	return builtInfobox
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 function Building:getWikiCategories(args)

--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -90,8 +90,8 @@ function Building:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	infobox:categories('Buildings')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:addCategories('Buildings')
+	infobox:addCategories(unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_campaign.lua
+++ b/components/infobox/commons/infobox_campaign.lua
@@ -36,7 +36,7 @@ function Campaign:createInfobox()
 		Center{content = {args.caption}},
 	}
 
-	infobox:categories('Campaign')
+	infobox:addCategories('Campaign')
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end

--- a/components/infobox/commons/infobox_campaign_mission.lua
+++ b/components/infobox/commons/infobox_campaign_mission.lua
@@ -52,8 +52,8 @@ function Mission:createInfobox()
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Missions', 'Campaign')
-		infobox:categories(unpack(self:getWikiCategories(args)))
+		infobox:addCategories('Missions', 'Campaign')
+		infobox:addCategories(unpack(self:getWikiCategories(args)))
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -86,15 +86,13 @@ function Character:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if Namespace.isMain() then
 		infobox:addCategories(args.informationType or 'Character')
 		infobox:addCategories(unpack(self:getWikiCategories(args)))
 		self:setLpdbData(args)
 	end
 
-	return builtInfobox
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 function Character:_createLocation(location)

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -89,8 +89,8 @@ function Character:createInfobox()
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	if Namespace.isMain() then
-		infobox:categories(args.informationType or 'Character')
-		infobox:categories(unpack(self:getWikiCategories(args)))
+		infobox:addCategories(args.informationType or 'Character')
+		infobox:addCategories(unpack(self:getWikiCategories(args)))
 		self:setLpdbData(args)
 	end
 

--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -72,7 +72,7 @@ function Company:createInfobox()
 		Builder{
 			builder = function()
 				if not String.isEmpty(args.companytype) and args.companytype == _COMPANY_TYPE_ORGANIZER then
-					infobox:categories('Tournament organizers')
+					infobox:addCategories('Tournament organizers')
 					return {
 						Cell{
 							name = 'Total Prize Money',
@@ -120,7 +120,7 @@ function Company:createInfobox()
 		})
 	})
 
-	infobox:categories('Companies')
+	infobox:addCategories('Companies')
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end

--- a/components/infobox/commons/infobox_game.lua
+++ b/components/infobox/commons/infobox_game.lua
@@ -61,7 +61,7 @@ function Game:createInfobox()
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Games')
+		infobox:addCategories('Games')
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_item.lua
+++ b/components/infobox/commons/infobox_item.lua
@@ -96,8 +96,8 @@ function Item:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	infobox:categories('Items')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:addCategories('Items')
+	infobox:addCategories(unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_item.lua
+++ b/components/infobox/commons/infobox_item.lua
@@ -99,13 +99,11 @@ function Item:createInfobox()
 	infobox:addCategories('Items')
 	infobox:addCategories(unpack(self:getWikiCategories(args)))
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if Namespace.isMain() then
 		self:setLpdbData(args)
 	end
 
-	return builtInfobox
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 function Item:getWikiCategories(args)

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -247,8 +247,6 @@ function League:createInfobox()
 
 	self.infobox:bottom(self:createBottomContent())
 
-	local builtInfobox = self.infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if self:shouldStore(args) then
 		self.infobox:addCategories('Tournaments')
 		if not String.isEmpty(args.team_number) then
@@ -261,6 +259,8 @@ function League:createInfobox()
 		self:_setLpdbData(args, links)
 		self:_setSeoTags(args)
 	end
+
+	local builtInfobox = self.infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	return tostring(builtInfobox) .. WarningBox.displayAll(League.warnings)
 end

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -133,13 +133,13 @@ function League:createInfobox()
 						local value = tostring(args.type):lower()
 						if self:shouldStore(args) then
 							if value == 'offline' then
-								self.infobox:categories('Offline Tournaments')
+								self.infobox:addCategories('Offline Tournaments')
 							elseif value == 'online' then
-								self.infobox:categories('Online Tournaments')
+								self.infobox:addCategories('Online Tournaments')
 							elseif value:match('online') and value:match('offline') then
-								self.infobox:categories('Online/Offline Tournaments')
+								self.infobox:addCategories('Online/Offline Tournaments')
 							else
-								self.infobox:categories('Unknown Type Tournaments')
+								self.infobox:addCategories('Unknown Type Tournaments')
 							end
 						end
 
@@ -250,14 +250,14 @@ function League:createInfobox()
 	local builtInfobox = self.infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	if self:shouldStore(args) then
-		self.infobox:categories('Tournaments')
+		self.infobox:addCategories('Tournaments')
 		if not String.isEmpty(args.team_number) then
-			self.infobox:categories('Team Tournaments')
+			self.infobox:addCategories('Team Tournaments')
 		end
 		if String.isNotEmpty(args.player_number) or String.isNotEmpty(args.individual) then
-			self.infobox:categories('Individual Tournaments')
+			self.infobox:addCategories('Individual Tournaments')
 		end
-		self.infobox:categories(unpack(self:getWikiCategories(args)))
+		self.infobox:addCategories(unpack(self:getWikiCategories(args)))
 		self:_setLpdbData(args, links)
 		self:_setSeoTags(args)
 	end
@@ -321,7 +321,7 @@ function League:createLiquipediaTierDisplay(args)
 			return ''
 		else
 			if self:shouldStore(self.args) then
-				self.infobox:categories(tierText .. ' Tournaments')
+				self.infobox:addCategories(tierText .. ' Tournaments')
 			end
 			local tierLink = tierText .. ' Tournaments'
 			if Tier.link and Tier.link[tierString] then

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -51,7 +51,7 @@ function Map:createInfobox(frame)
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Maps', unpack(self:getWikiCategories(args)))
+		infobox:addCategories('Maps', unpack(self:getWikiCategories(args)))
 		self:_setLpdbData(args)
 	end
 

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -78,7 +78,7 @@ function Patch:createInfobox()
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Patches')
+		infobox:addCategories('Patches')
 		self:addToLpdb(args)
 	end
 

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -206,8 +206,6 @@ function Person:createInfobox()
 				statusToStore
 			)))
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if _shouldStoreData then
 		self:_definePageVariables(args)
 		self:_setLpdbData(
@@ -217,6 +215,8 @@ function Person:createInfobox()
 			personType.store
 		)
 	end
+
+	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	return tostring(builtInfobox) .. WarningBox.displayAll(self.warnings)
 end

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -199,7 +199,7 @@ function Person:createInfobox()
 	infobox:bottom(self:createBottomContent())
 
 	local statusToStore = self:getStatusToStore(args)
-	infobox:categories(unpack(self:getCategories(
+	infobox:addCategories(unpack(self:getCategories(
 				args,
 				age.birth,
 				personType.category,

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -73,7 +73,7 @@ function Scene:createInfobox()
 		}
 	}
 
-	infobox:categories('Scene')
+	infobox:addCategories('Scene')
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -176,8 +176,6 @@ function Series:createInfobox(frame)
 		)
 	end
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if Namespace.isMain() then
 		local lpdbData = {
 			name = self.name,
@@ -229,6 +227,8 @@ function Series:createInfobox(frame)
 		lpdbData = self:addToLpdb(lpdbData)
 		mw.ext.LiquipediaDB.lpdb_series('series_' .. self.name, lpdbData)
 	end
+
+	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	return tostring(builtInfobox)
 		.. WarningBox.displayAll(Series.warnings)

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -166,7 +166,7 @@ function Series:createInfobox(frame)
 	}
 
 	if Namespace.isMain() then
-		infobox:categories(
+		infobox:addCategories(
 			'Tournament series',
 			self:_setCountryCategories(args.country),
 			self:_setCountryCategories(args.country2),
@@ -261,7 +261,7 @@ function Series:createLiquipediaTierDisplay(args)
 			)
 			return ''
 		else
-			self.infobox:categories(tierText .. ' Tournaments')
+			self.infobox:addCategories(tierText .. ' Tournaments')
 			return '[[' .. tierText .. ' Tournaments|' .. tierText .. ']]'
 		end
 	end

--- a/components/infobox/commons/infobox_show.lua
+++ b/components/infobox/commons/infobox_show.lua
@@ -73,7 +73,8 @@ function Show:createInfobox()
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Shows')
+		infobox:addCategories('Shows')
+		infobox:addCategories(unpack(self:getWikiCategories(args)))
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_skill.lua
+++ b/components/infobox/commons/infobox_skill.lua
@@ -90,7 +90,7 @@ function Skill:createInfobox()
 
 	if Namespace.isMain() then
 		local categories = self:getCategories(args)
-		infobox:categories(unpack(categories))
+		infobox:addCategories(unpack(categories))
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_strategy.lua
+++ b/components/infobox/commons/infobox_strategy.lua
@@ -57,7 +57,8 @@ function Strategy:createInfobox()
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Strategies')
+		infobox:addCategories('Strategies')
+		infobox:addCategories(unpack(self:getWikiCategories(args)))
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -182,12 +182,12 @@ function Team:createInfobox()
 		infobox:addCategories(unpack(self:getWikiCategories(args)))
 	end
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if self:shouldStore(args) then
 		self:_setLpdbData(args, links)
 		self:defineCustomPageVariables(args)
 	end
+
+	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
 end

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -178,8 +178,8 @@ function Team:createInfobox()
 	infobox:bottom(self:createBottomContent())
 
 	if self:shouldStore(args) then
-		infobox:categories('Teams')
-		infobox:categories(unpack(self:getWikiCategories(args)))
+		infobox:addCategories('Teams')
+		infobox:addCategories(unpack(self:getWikiCategories(args)))
 	end
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -96,8 +96,8 @@ function Unit:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	infobox:categories('Units')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:addCategories('Units')
+	infobox:addCategories(unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -99,13 +99,11 @@ function Unit:createInfobox()
 	infobox:addCategories('Units')
 	infobox:addCategories(unpack(self:getWikiCategories(args)))
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if Namespace.isMain() then
 		self:setLpdbData(args)
 	end
 
-	return builtInfobox
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 function Unit:getWikiCategories(args)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -105,13 +105,11 @@ function Weapon:createInfobox()
 	infobox:addCategories('Weapons')
 	infobox:addCategories(unpack(self:getWikiCategories(args)))
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if Namespace.isMain() then
 		self:setLpdbData(args)
 	end
 
-	return builtInfobox
+	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 end
 
 function Weapon:_createLocation(location)

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -102,8 +102,8 @@ function Weapon:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	infobox:categories('Weapons')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:addCategories('Weapons')
+	infobox:addCategories(unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/wikis/starcraft2/infobox_show_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_show_custom.lua
@@ -8,7 +8,6 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local Namespace = require('Module:Namespace')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Show = Lua.import('Module:Infobox/Show', {requireDevIfEnabled = true})
@@ -18,16 +17,15 @@ local Cell = Widgets.Cell
 
 local CustomShow = Class.new()
 
-local _show
 local _args
 
 local CustomInjector = Class.new(Injector)
 
 function CustomShow.run(frame)
 	local customShow = Show(frame)
-	_show = customShow
 	_args = customShow.args
 	customShow.createWidgetInjector = CustomShow.createWidgetInjector
+	customShow.getWikiCategories = CustomShow.getWikiCategories
 	return customShow:createInfobox(frame)
 end
 
@@ -45,16 +43,16 @@ function CustomInjector:addCustomCells(widgets)
 		content = {CustomShow:_getReleasePeriod(_args.sdate, _args.edate)}
 	})
 
-	if Namespace.isMain() and _args.edate == nil then
-		_show.infobox:categories('Active Shows')
-	end
-
 	return widgets
 end
 
 function CustomShow:_getReleasePeriod(sdate, edate)
 	if not sdate then return nil end
 	return sdate .. ' - ' .. (edate or '<b>Present</b>')
+end
+
+function CustomShow:getWikiCategories(args)
+	return _args.edate and {} or {'Active Shows'}
 end
 
 return CustomShow

--- a/components/infobox/wikis/starcraft2/infobox_strategy_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_strategy_custom.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local CleanRace = mw.loadData('Module:CleanRace2')
 local Lua = require('Module:Lua')
-local Namespace = require('Module:Namespace')
 local RaceIcon = require('Module:RaceIcon')
 local String = require('Module:StringUtils')
 
@@ -22,7 +21,6 @@ local Header = Widgets.Header
 
 local CustomStrategy = Class.new()
 
-local _strategy
 local _args
 
 local _RACE_MATCHUPS = {
@@ -35,9 +33,9 @@ local CustomInjector = Class.new(Injector)
 
 function CustomStrategy.run(frame)
 	local customStrategy = Strategy(frame)
-	_strategy = customStrategy
 	_args = customStrategy.args
 	customStrategy.createWidgetInjector = CustomStrategy.createWidgetInjector
+	customStrategy.getWikiCategories = CustomStrategy.getWikiCategories
 	return customStrategy:createInfobox(frame)
 end
 
@@ -67,11 +65,6 @@ function CustomInjector:addCustomCells(widgets)
 		name = 'TL-Article',
 		content = {CustomStrategy:_getTLarticle(_args.tlarticle)}
 	})
-
-	if Namespace.isMain() then
-		local categories = CustomStrategy:_getCategories(_args.race, _args.matchups)
-		_strategy.infobox:categories(unpack(categories))
-	end
 
 	return widgets
 end
@@ -126,6 +119,10 @@ function CustomStrategy:_getCategories(race, matchups)
 	end
 
 	return categories
+end
+
+function CustomStrategy:getWikiCategories(args)
+	return CustomStrategy:_getCategories(args.race, args.matchups)
 end
 
 return CustomStrategy


### PR DESCRIPTION
## Summary
One step in #1581. 

Refactor Categories in Infoboxes. The refactoring does:
1) Category setting is done during build instead of immediately. This allows in the future to remove/change added categories.
2) Set categories directly with Lua instead of via Wikicode
3) Renames the function `infobox:categories(...)` to `infobox:addCategories(...)` and refactored

Recommendation for review: Start with `infobox.lua`, do the rest of commons after, followed by customs.

## How did you test this change?
Tested changes on Infobox League