### PR TITLE
Fix annotation in Results Table

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -18,7 +18,7 @@ local BaseResultsTable = Lua.import('Module:ResultsTable/Base', {requireDevIfEna
 
 local Opponent = require('Module:OpponentLibraries').Opponent
 
---- @class ResultsTable
+--- @class ResultsTable: BaseResultsTable
 local ResultsTable = Class.new(BaseResultsTable)
 
 function ResultsTable:buildHeader()


### PR DESCRIPTION
## Summary

Missing information in the annotation that this call is inheriting from another.

## How did you test this change?
Warnings went away