### PR TITLE
Add `|count=` support in slots

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -161,11 +161,8 @@ function Placement:init(args, parent, lastPlacement)
 	-- Implicit place range has been given (|place= is not set)
 	-- Use the last known place and set the place range based on the entered args.count
 	-- or the number of entered opponents
-	if not self.placeStart then
+	if not self.placeStart and not self.placeEnd then
 		self.placeStart = lastPlacement + 1
-	end
-
-	if not self.placeEnd then
 		self.placeEnd = lastPlacement + (self.count or math.max(#self.opponents, 1))
 	end
 

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -151,6 +151,7 @@ function Placement:init(args, parent, lastPlacement)
 	self.date = self.args.date or parent.date
 	self.placeStart = self.args.placeStart
 	self.placeEnd = self.args.placeEnd
+	self.count = self.args.count
 	self.hasBaseCurrency = false
 
 	self.prizeRewards = self:_readPrizeRewards(self.args)
@@ -158,21 +159,30 @@ function Placement:init(args, parent, lastPlacement)
 	self.opponents = self:_parseOpponents(self.args)
 
 	-- Implicit place range has been given (|place= is not set)
-	-- Use the last known place and set the place range based on the entered number of opponents
-	if not self.placeStart and not self.placeEnd then
+	-- Use the last known place and set the place range based on the entered args.count
+	-- or the number of entered opponents
+	if not self.placeStart then
 		self.placeStart = lastPlacement + 1
-		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
 	end
 
-	assert(#self.opponents <= 1 + self.placeEnd - self.placeStart,
+	if not self.placeEnd then
+		self.placeEnd = lastPlacement + (self.count or math.max(#self.opponents, 1))
+	end
+
+	self.count = self.placeEnd + 1 - self.placeStart
+
+	assert(#self.opponents <= self.count,
 		'Placement: Too many opponents in place ' .. self:_displayPlace():gsub('&#045;', '-'))
 end
 
 function Placement:_parseArgs(args)
 	local parsedArgs = Table.deepCopy(args)
 
+	-- count (number of opponents in the slot) has been given explicitly
+	if args.count then
+		parsedArgs.count = tonumber(args.count)
 	-- Explicit place range has been given
-	if args.place then
+	elseif args.place then
 		local places = Table.mapValues(mw.text.split(args.place, '-'), tonumber)
 		parsedArgs.placeStart = places[1]
 		parsedArgs.placeEnd = places[2] or places[1]


### PR DESCRIPTION
## Summary
Add `|count=` support in slots
`count` gives the size/width of the slot, i.e. the number of participants expec ted in the slot

requested by @iMarbot 

## How did you test this change?
dev + preview pages (both pages using import and pages not using import)