### PR TITLE
Fix plural demonym in `Flags/MasterData`

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1143,7 +1143,7 @@ local data = {
 	},
 	['trinidadandtobago'] = {
 		flag = 'File:tt_hd.png',
-		localised = 'Trinidadian and Tobagonians',
+		localised = 'Trinidadian and Tobagonian',
 		name = 'Trinidad and Tobago',
 	},
 	['tristandacunha'] = {


### PR DESCRIPTION
## Summary

The demonym for Trinidad and Tobago is current plural, leading to [this](https://liquipedia.net/overwatch/Avani).

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
