### PR TITLE
Adjust placement condition in ResultsTable

### DIFF
--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -202,6 +202,7 @@ function BaseResultsTable:buildBaseConditions()
 		conditions:add{ConditionNode(ColumnName('mode'), Comparator.eq, 'award_individual')}
 	else
 		conditions:add{ConditionNode(ColumnName('mode'), Comparator.neq, 'award_individual')}
+		conditions:add{ConditionNode(ColumnName('placement'), Comparator.neq, '')}
 	end
 
 	if args.tier then


### PR DESCRIPTION
## Summary
Currently the ResultsTable also retrieves lpdb_placement data from placements that have no place set.
This PR changes that for the non awards queries.

## How did you test this change?
live (module not really in use yet)