### PR TITLE
Add `role` as part of the SquadPlayer objectname

### DIFF
--- a/components/squad/wikis/ageofempires/squad_custom.lua
+++ b/components/squad/wikis/ageofempires/squad_custom.lua
@@ -69,7 +69,10 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. player.joindate)
+	return row:create(
+		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. player.joindate
+		.. (player.role and '_' .. player.role or '')
+	)
 end
 
 return CustomSquad

--- a/components/squad/wikis/apexlegends/squad_custom.lua
+++ b/components/squad/wikis/apexlegends/squad_custom.lua
@@ -103,6 +103,7 @@ function CustomSquad.run(frame)
 			mw.title.getCurrentTitle().prefixedText) ..
 				'_' .. player.id .. '_' ..
 				ReferenceCleaner.clean(player.joindate)
+				.. (player.role and '_' .. player.role or '')
 		))
 
 		index = index + 1

--- a/components/squad/wikis/arenaofvalor/squad_custom.lua
+++ b/components/squad/wikis/arenaofvalor/squad_custom.lua
@@ -163,6 +163,7 @@ function CustomSquad._playerRow(player, squadType)
 
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+		.. (player.role and '_' .. player.role or '')
 	)
 end
 

--- a/components/squad/wikis/counterstrike/squad_custom.lua
+++ b/components/squad/wikis/counterstrike/squad_custom.lua
@@ -101,8 +101,9 @@ function CustomSquad.run(frame)
 		squad:row(row:create(
 			Variables.varDefault('squad_name',
 			mw.title.getCurrentTitle().prefixedText) ..
-				'_' .. player.id .. '_' ..
-				ReferenceCleaner.clean(player.joindate)
+			'_' .. player.id .. '_' ..
+			ReferenceCleaner.clean(player.joindate) ..
+			(player.role and '_' .. player.role or '')
 		))
 
 		index = index + 1

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -138,10 +138,10 @@ function CustomSquad.run(frame)
 		end
 
 		squad:row(row:create(
-			Variables.varDefault('squad_name',
-			mw.title.getCurrentTitle().prefixedText) ..
-				'_' .. player.id .. '_' ..
-				ReferenceCleaner.clean(player.joindate)
+			Variables.varDefault('squad_name', mw.title.getCurrentTitle().prefixedText)
+			.. '_' .. player.id .. '_'
+			.. ReferenceCleaner.clean(player.joindate)
+			.. (player.role and '_' .. player.role or '')
 		))
 
 		index = index + 1

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -132,6 +132,7 @@ function CustomSquad._playerRow(player, squadType)
 
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+		.. (player.role and '_' .. player.role or '')
 	)
 end
 

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -163,6 +163,7 @@ function CustomSquad._playerRow(player, squadType)
 
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+		.. (player.role and '_' .. player.role or '')
 	)
 end
 

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -201,6 +201,7 @@ function CustomSquad._playerRow(player, squadType)
 
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+		.. (player.role and '_' .. player.role or '')
 	)
 end
 

--- a/components/squad/wikis/pubg/squad_custom.lua
+++ b/components/squad/wikis/pubg/squad_custom.lua
@@ -51,6 +51,7 @@ function CustomSquad.run(frame)
 		squad:row(row:create(
 			Variables.varDefault('squad_name',
 			mw.title.getCurrentTitle().prefixedText) .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+			.. (player.role and '_' .. player.role or '')
 		))
 
 		index = index + 1

--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -69,7 +69,10 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. player.joindate)
+	return row:create(
+		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_'
+		.. player.joindate .. (player.role and '_' .. player.role or '')
+	)
 end
 
 return CustomSquad

--- a/components/squad/wikis/rocketleague/squad_custom.lua
+++ b/components/squad/wikis/rocketleague/squad_custom.lua
@@ -52,6 +52,7 @@ function CustomSquad.run(frame)
 		squad:row(row:create(
 			Variables.varDefault('squad_name',
 			mw.title.getCurrentTitle().prefixedText) .. '_' .. link .. '_' .. ReferenceCleaner.clean(player.joindate)
+			.. (player.role and '_' .. player.role or '')
 		))
 
 		index = index + 1

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -99,6 +99,7 @@ function CustomSquad.run(frame)
 
 		squad:row(row:create(
 			squadName .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+			.. (player.role and '_' .. player.role or '')
 		))
 
 		index = index + 1

--- a/components/squad/wikis/trackmania/squad_custom.lua
+++ b/components/squad/wikis/trackmania/squad_custom.lua
@@ -51,6 +51,7 @@ function CustomSquad.run(frame)
 		squad:row(row:create(
 			Variables.varDefault('squad_name',
 			mw.title.getCurrentTitle().prefixedText) .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+			.. (player.role and '_' .. player.role or '')
 		))
 
 		index = index + 1

--- a/components/squad/wikis/valorant/squad_custom.lua
+++ b/components/squad/wikis/valorant/squad_custom.lua
@@ -155,6 +155,7 @@ function CustomSquad._playerRow(player, squadType)
 		)
 		.. '_' .. player.id .. '_'
 		.. ReferenceCleaner.clean(player.joindate)
+		.. (player.role and '_' .. player.role or '')
 	)
 end
 

--- a/components/squad/wikis/wildrift/squad_custom.lua
+++ b/components/squad/wikis/wildrift/squad_custom.lua
@@ -163,6 +163,7 @@ function CustomSquad._playerRow(player, squadType)
 
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
+		.. (player.role and '_' .. player.role or '')
 	)
 end
 


### PR DESCRIPTION
## Summary
Resolves #2314

Eg. Incase a person joins both the active squad and as a streamer, add role suffix to the objectname.

## How did you test this change?
Dev module on LoL