### PR TITLE
Fix CS match1 opponent names when missing TT

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -110,7 +110,11 @@ function MatchLegacy.convertParameters(match2)
 		local opponent = match2.match2opponents[index] or {}
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == Opponent.team then
-			match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
+			if mw.ext.TeamTemplate.teamexists(opponent.template) then
+				match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
+			else
+				match[prefix] = opponent.name
+			end
 			--When a match is overturned winner get score needed to win bestofx while loser gets score = 0
 			if isOverturned then
 				match[prefix .. 'score'] = tonumber(match.winner) == index and (math.floor(match2.bestof /2) + 1) or 0

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -113,7 +113,7 @@ function MatchLegacy.convertParameters(match2)
 			if mw.ext.TeamTemplate.teamexists(opponent.template) then
 				match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
 			else
-				match[prefix] = opponent.name
+				match[prefix] = opponent.template
 			end
 			--When a match is overturned winner get score needed to win bestofx while loser gets score = 0
 			if isOverturned then


### PR DESCRIPTION
## Summary
Fix issue with missing TTs and match1 mapping from match2

![image](https://user-images.githubusercontent.com/5881994/213525360-56b59f48-e178-4d0d-b59b-83d983890ea8.png)
![image](https://user-images.githubusercontent.com/5881994/213525378-ede9c408-6649-4596-ab78-6c4aa161e350.png)


## How did you test this change?

`/dev` on CS wiki.

![image](https://user-images.githubusercontent.com/5881994/213527962-a563fe36-16eb-4b36-9a86-defcf1e72461.png)
https://liquipedia.net/counterstrike/GDK/Season/8