### PR TITLE
Fix return value in the Annotation of `Table.map`

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -253,10 +253,10 @@ end
 --Returns `{6 = 'a', 8 = 'b', 10 = 'c'}`
 --
 --The return is not parsed correctly yet by extension, https://github.com/sumneko/lua-language-server/issues/1535
----@generic K, V, T
+---@generic K, V, U, T
 ---@param xTable {[K] : V}
----@param f fun(key?: K, value?: V): K, T
----@return {[K] : T}
+---@param f fun(key?: K, value?: V): U, T
+---@return {[U] : T}
 function Table.map(xTable, f)
 	local yTable = {}
 	for xKey, xValue in pairs(xTable) do


### PR DESCRIPTION
## Summary

The current annotation says that the Keys of the return table must be the same as the Keys of the input table. While this is correct for `Table.mapValues()`, it is not correct for `Table.map`. This PR fixes it.

## How did you test this change?
Ensured incorrect warnings are gone