### PR TITLE
Temporary literal opponent handling as team for match1

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -11,7 +11,9 @@ local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+local TextSanitizer = require('Module:TextSanitizer')
 local Variables = require('Module:Variables')
+
 
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 
@@ -109,11 +111,19 @@ function MatchLegacy.convertParameters(match2)
 		local prefix = 'opponent' .. index
 		local opponent = match2.match2opponents[index] or {}
 		local opponentmatch2players = opponent.match2players or {}
-		if opponent.type == Opponent.team then
-			if mw.ext.TeamTemplate.teamexists(opponent.template) then
-				match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
+		if opponent.type == Opponent.team or opponent.type == Opponent.literal then
+			if opponent.type == Opponent.team then
+				if mw.ext.TeamTemplate.teamexists(opponent.template) then
+					match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
+				else
+					match[prefix] = opponent.template
+				end
 			else
-				match[prefix] = opponent.template
+				if TextSanitizer.stripHTML(opponent.name) ~= opponent.name then
+					match[prefix] = 'TBD'
+				else
+					match[prefix] = opponent.name
+				end
 			end
 			--When a match is overturned winner get score needed to win bestofx while loser gets score = 0
 			if isOverturned then
@@ -149,8 +159,6 @@ function MatchLegacy.convertParameters(match2)
 			match[prefix] = player.name
 			match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix .. 'flag'] = player.flag
-		elseif opponent.type == Opponent.literal then
-			match[prefix] = 'TBD'
 		end
 	end
 


### PR DESCRIPTION
## Summary
Previously literal opponents on CS were stored as TBD always. Now, if the team name doesn't contain HTML (i.e., `<sup></sup>` for placeholder names in brackets), it will use the literal name for match1 opponent names.

![image](https://user-images.githubusercontent.com/5881994/213567867-db407a79-4cea-44c7-8b11-4a1144024014.png)
![image](https://user-images.githubusercontent.com/5881994/213567983-b172b64d-d891-4252-8e1a-f2c0be0b2996.png)


## How did you test this change?

![image](https://user-images.githubusercontent.com/5881994/213567988-d7ad53a4-8ded-44d6-92cd-0862afd1f9f7.png)
`/dev` module on CS wiki.
https://liquipedia.net/counterstrike/International_Gaming_League/2016/Summer/Qualifier#Group_A

And `TBD` still kept here: https://liquipedia.net/counterstrike/Special:LiquipediaDB/User:IMarbot/IEM#match