### PR TITLE
Fix CS' PPT weight calculations

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -118,7 +118,8 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
 
 	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier)] or 1
 
-	return tierValue * math.max(prizeMoney, 0.1) * (TYPE_MODIFIER[type:lower()] or TYPE_MODIFIER.default) / (prizeMoney > 0 and place or 1)
+	return tierValue * math.max(prizeMoney, 0.1) * (TYPE_MODIFIER[type:lower()] or TYPE_MODIFIER.default)
+		/ (prizeMoney > 0 and place or 1)
 end
 
 return CustomPrizePool

--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -22,7 +22,7 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 
 local CustomPrizePool = {}
 
-local TIER_VALUE = {10, 6, 4, 2}
+local TIER_VALUE = {10, 6, 4, 2, 1, 2}
 local TYPE_MODIFIER = {offline = 1, ['offline/online'] = 0.75, ['online/offline'] = 0.75, default = 0.65}
 
 local HEADER_DATA = {}
@@ -118,7 +118,7 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
 
 	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier)] or 1
 
-	return tierValue * math.max(prizeMoney, 0.1) * (TYPE_MODIFIER[type:lower()] or TYPE_MODIFIER.default) / place
+	return tierValue * math.max(prizeMoney, 0.1) * (TYPE_MODIFIER[type:lower()] or TYPE_MODIFIER.default) / (prizeMoney > 0 and place or 1)
 end
 
 return CustomPrizePool

--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -118,8 +118,8 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
 
 	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier)] or 1
 
-	return tierValue * math.max(prizeMoney, 0.1) * (TYPE_MODIFIER[type:lower()] or TYPE_MODIFIER.default)
-		/ (prizeMoney > 0 and place or 1)
+	return tierValue * math.max(prizeMoney, 0.1) * (TYPE_MODIFIER[type:lower()] or TYPE_MODIFIER.default) /
+		(prizeMoney > 0 and place or 1)
 end
 
 return CustomPrizePool


### PR DESCRIPTION
## Summary

Before moving to new PPT, the calculation was slightly different. If prize money was 0, then the weight was not divided by placement. This addresses that difference by bringing back the old way.

## How did you test this change?

`/dev` module on CS wiki.

**Before dev changes**
![image](https://user-images.githubusercontent.com/5881994/213572450-6309dba9-eae9-46df-ade4-41f0c281413d.png)

**After dev changes**
![image](https://user-images.githubusercontent.com/5881994/213572488-09df90fd-6cb2-4062-884c-f8efe5d82f12.png)

