### PR TITLE
Make dates display customizable in infobox league

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -187,15 +187,18 @@ function League:createInfobox()
 		},
 		Cell{name = 'Format', content = {args.format}},
 		Customizable{id = 'prizepool', children = {
-			Cell{
+				Cell{
 					name = 'Prize Pool',
 					content = {self:_createPrizepool(args)},
 				},
 			},
 		},
-		Cell{name = 'Date', content = {args.date}},
-		Cell{name = 'Start Date', content = {args.sdate}},
-		Cell{name = 'End Date', content = {args.edate}},
+		Customizable{id = 'dates', children = {
+				Cell{name = 'Date', content = {args.date}},
+				Cell{name = 'Start Date', content = {args.sdate}},
+				Cell{name = 'End Date', content = {args.edate}},
+			},
+		},
 		Customizable{id = 'custom', children = {}},
 		Customizable{id = 'liquipediatier', children = {
 				Cell{


### PR DESCRIPTION
## Summary
Make dates display customizable in infobox league
Warcraft will need it.
They display a countdown with date/startDate if a starttime is given:
```wiki
-->{{#if:{{{date|}}}|<!--
	--><div><div class="infobox-cell-2 infobox-description">Date:</div><!--
		 --><div class="infobox-cell-2">{{#if:{{{starttime|}}}<!--
			-->|{{countdown|date={{#time:M j, Y - H:i|{{#var:start_time}}{{#var:tournament_timezone}}}}{{abbr/UTC}}|finished={{#var:tournament_finished}}}}<!--
			-->|{{{date}}}<!--
			-->}}</div><!--
	--></div><!--
-->}}<!--

-->{{#if:{{{sdate|}}}|<!--
	--><div><div class="infobox-cell-2 infobox-description">Start Date:</div><!--
		 --><div class="infobox-cell-2">{{#if:{{{starttime|}}}<!--
			-->|{{countdown|date={{#time:M j, Y - H:i|{{#var:start_time}}{{#var:tournament_timezone}}}}{{abbr/UTC}}|finished={{#ifexpr: {{#time:U|-4 hours}} < {{#time:U|{{#var:start_time}}{{#var:tournament_timezone}}}}|false|true}}}}<!--
			-->|{{{sdate}}}<!--
			-->}}</div><!--
	--></div><!--
-->}}<!--
```

## How did you test this change?
/dev
