### PR TITLE
Strip the `format` field of HTML in lpdb_tournament

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -446,7 +446,7 @@ function League:_setLpdbData(args, links)
 		liquipediatier = Variables.varDefault('tournament_liquipediatier'),
 		liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype'),
 		status = args.status,
-		format = args.format,
+		format = TextSanitizer.stripHTML(args.format),
 		sponsors = mw.ext.LiquipediaDB.lpdb_create_json(
 			League:_getNamedTableofAllArgsForBase(args, 'sponsor')
 		),


### PR DESCRIPTION
## Summary
HtmlStrip the `format` field before inserting it into lpdb_tournament

## How did you test this change?
Dev module
**Before:** 
![image](https://user-images.githubusercontent.com/3426850/213696352-136677ed-7c88-4d15-9e29-aac7b2372d0e.png)

**After:**
![image](https://user-images.githubusercontent.com/3426850/213696334-267e9d0b-d8f1-470a-a02f-19195b43dd17.png)
