### PR TITLE
Remove aggressive category setting

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -226,10 +226,6 @@ end
 
 function LegacyPrizePool.handleSeed(storeTo, input, slotSize)
 	local links = LegacyPrizePool.parseWikiLink(input)
-	if Table.isEmpty(links) then
-		-- Tracking category
-		mw.ext.TeamLiquidIntegration.add_category('Pages with missing qualifier link')
-	end
 	for _, linkData in ipairs(links) do
 		local link = linkData.link
 


### PR DESCRIPTION
## Summary
In case of `points=seed`, a category was added for missing links, which also happened when there was a slot without any indication that there is actually a missing link.

It would be possible to add `and input` to the condition to catch pages where there is input but no link can be parsed, e.g. there is only html that gets cleaned or something.

## How did you test this change?
via /dev
