### PR TITLE
Fix default history behaviour

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -78,7 +78,11 @@ function CustomPlayer.run(frame)
 	end
 
 	if String.isEmpty(player.args.history) then
-		player.args.history = tostring(TeamHistoryAuto._results{hiderole = 'true', iconModule = 'Module:PositionIcon/data', addlpdbdata='true'})
+		player.args.history = tostring(TeamHistoryAuto._results{
+			hiderole = 'true',
+			iconModule = 'Module:PositionIcon/data',
+			addlpdbdata='true'
+		})
 	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -78,7 +78,7 @@ function CustomPlayer.run(frame)
 	end
 
 	if String.isEmpty(player.args.history) then
-		player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata='true'})
+		player.args.history = tostring(TeamHistoryAuto._results{hiderole = 'true', iconModule = 'Module:PositionIcon/data', addlpdbdata='true'})
 	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB


### PR DESCRIPTION
change TeamHistoryAuto to use the proper default parameters as used in the main template (https://liquipedia.net/leagueoflegends/Template:TeamHistoryAuto)

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
