### PR TITLE
Automate game display for teams

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -72,7 +72,7 @@ function CustomTeam._getGames()
 	return Table.mapValues(
 		Table.mapValues(mw.text.split(_args.games, ','), mw.text.trim),
 		function(game)
-			local game = GameLookup.getName(game)
+			game = GameLookup.getName(game)
 			return game .. (game ~= 'Unknown' and CustomTeam._getGameInactivity(game) or '')
 		end)
 end
@@ -80,14 +80,14 @@ end
 function CustomTeam._getGameInactivity(game)
 	local date = os.date('!*t')
 	date.year = date.year - 1
-	
+
 	
 	local conditions = ConditionTree(BooleanOperator.all):add{
 		CustomTeam._buildTeamPlacementConditions(),
 		ConditionNode(ColumnName('game'), Comparator.eq, game),
 		ConditionNode(ColumnName('date'), Comparator.gt, os.date('!%F', os.time(date)))
 	}
-	
+
 	local data = mw.ext.LiquipediaDB.lpdb('placement', {
 			conditions = conditions:toString(),
 			order = 'date desc',
@@ -98,14 +98,14 @@ function CustomTeam._getGameInactivity(game)
 	if type(data) ~= 'table' then
 		error(data)
 	end
-	
+
 	if data[1] then
 		return ''
 	else
 		return ' <i><small>(inactive)</small></i>'
 	end
 end
-	
+
 function CustomTeam._buildTeamPlacementConditions()
 	local team = _args.teamtemplate or _pagename
 	local rawOpponentTemplate = TeamTemplates.queryRaw(team) or {}
@@ -116,13 +116,13 @@ function CustomTeam._buildTeamPlacementConditions()
 
 	local opponentTeamTemplates = TeamTemplates.queryHistorical(opponentTemplate) or {opponentTemplate}
 
-	playerConditions = CustomTeam._buildPlayersOnTeamOpponentConditions(opponentTeamTemplates)
+	local playerConditions = CustomTeam._buildPlayersOnTeamOpponentConditions(opponentTeamTemplates)
 
 	local opponentConditions = ConditionTree(BooleanOperator.any)
 	for _, teamTemplate in pairs(opponentTeamTemplates) do
 		opponentConditions:add{ConditionNode(ColumnName('opponenttemplate'), Comparator.eq, teamTemplate)}
 	end
-		
+
 	local conditions = ConditionTree(BooleanOperator.any):add{
 		ConditionTree(BooleanOperator.all):add{
 			opponentConditions,

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -10,7 +10,9 @@ local Achievements = require('Module:Achievements in infoboxes')
 local Class = require('Module:Class')
 local GameLookup = require('Module:GameLookup')
 local Lua = require('Module:Lua')
+local Opponent = require('Module:OpponentLibraries').Opponent
 local Table = require('Module:Table')
+local TeamTemplates = require('Module:Team')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
@@ -18,10 +20,20 @@ local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
+local Condition = require('Module:Condition')
+local ConditionTree = Condition.Tree
+local ConditionNode = Condition.Node
+local Comparator = Condition.Comparator
+local BooleanOperator = Condition.BooleanOperator
+local ColumnName = Condition.ColumnName
+
 local CustomTeam = Class.new()
 local CustomInjector = Class.new(Injector)
 
+local MAX_NUMBER_OF_PLAYERS = 10
+
 local _args
+local _pagename
 
 function CustomTeam.run(frame)
 	local team = Team(frame)
@@ -32,6 +44,7 @@ function CustomTeam.run(frame)
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 
 	_args = team.args
+	_pagename = team.pagename
 
 	return team:createInfobox(frame)
 end
@@ -56,7 +69,86 @@ function CustomInjector:addCustomCells(widgets)
 end
 
 function CustomTeam._getGames()
-	return Table.mapValues(Table.mapValues(mw.text.split(_args.games, ','), mw.text.trim), GameLookup.getName)
+	return Table.mapValues(
+		Table.mapValues(mw.text.split(_args.games, ','), mw.text.trim),
+		function(game)
+			local game = GameLookup.getName(game)
+			return game .. (game ~= 'Unknown' and CustomTeam._getGameInactivity(game) or '')
+		end)
+end
+
+function CustomTeam._getGameInactivity(game)
+	local date = os.date('!*t')
+	date.year = date.year - 1
+	
+	
+	local conditions = ConditionTree(BooleanOperator.all):add{
+		CustomTeam._buildTeamPlacementConditions(),
+		ConditionNode(ColumnName('game'), Comparator.eq, game),
+		ConditionNode(ColumnName('date'), Comparator.gt, os.date('!%F', os.time(date)))
+	}
+	
+	local data = mw.ext.LiquipediaDB.lpdb('placement', {
+			conditions = conditions:toString(),
+			order = 'date desc',
+			query = 'date',
+			limit = 1
+		})
+
+	if type(data) ~= 'table' then
+		error(data)
+	end
+	
+	if data[1] then
+		return ''
+	else
+		return ' <i><small>(inactive)</small></i>'
+	end
+end
+	
+function CustomTeam._buildTeamPlacementConditions()
+	local team = _args.teamtemplate or _pagename
+	local rawOpponentTemplate = TeamTemplates.queryRaw(team) or {}
+	local opponentTemplate = rawOpponentTemplate.historicaltemplate or rawOpponentTemplate.templatename
+	if not opponentTemplate then
+		error('Missing team template for team: ' .. team)
+	end
+
+	local opponentTeamTemplates = TeamTemplates.queryHistorical(opponentTemplate) or {opponentTemplate}
+
+	playerConditions = CustomTeam._buildPlayersOnTeamOpponentConditions(opponentTeamTemplates)
+
+	local opponentConditions = ConditionTree(BooleanOperator.any)
+	for _, teamTemplate in pairs(opponentTeamTemplates) do
+		opponentConditions:add{ConditionNode(ColumnName('opponenttemplate'), Comparator.eq, teamTemplate)}
+	end
+		
+	local conditions = ConditionTree(BooleanOperator.any):add{
+		ConditionTree(BooleanOperator.all):add{
+			opponentConditions,
+			ConditionNode(ColumnName('opponenttype'), Comparator.eq, Opponent.team),
+		},
+		playerConditions
+	}
+	return conditions
+end
+
+function CustomTeam._buildPlayersOnTeamOpponentConditions(opponentTeamTemplates)
+	local opponentConditions = ConditionTree(BooleanOperator.any)
+
+	local prefix = 'p'
+	for _, teamTemplate in pairs(opponentTeamTemplates) do
+		for playerIndex = 1, MAX_NUMBER_OF_PLAYERS do
+			opponentConditions:add{
+				ConditionNode(ColumnName('opponentplayers_' .. prefix .. playerIndex .. 'template'), Comparator.eq, teamTemplate),
+			}
+		end
+	end
+
+	return ConditionTree(BooleanOperator.all):add{
+		opponentConditions,
+		ConditionNode(ColumnName('opponenttype'), Comparator.neq, Opponent.team),
+	}
 end
 
 return CustomTeam

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -12,7 +12,6 @@ local Class = require('Module:Class')
 local GameLookup = require('Module:GameLookup')
 local Lua = require('Module:Lua')
 local Opponent = require('Module:OpponentLibraries').Opponent
-local Table = require('Module:Table')
 local TeamTemplates = require('Module:Team')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -72,11 +71,11 @@ end
 
 function CustomTeam._getGames()
 	local games = Array.map(
-		mw.text.split(_args.games, ','), 
+		mw.text.split(_args.games, ','),
 		function(game)
 			return GameLookup.getName(mw.text.trim(game))
 		end)
-	
+
 	table.sort(games)
 
 	local activeGames = CustomTeam._getGameActivity()

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -78,12 +78,11 @@ function CustomTeam._getGames()
 			return {game = GameLookup.getName(mw.text.trim(game))}
 		end)
 
-	Array.forEach(manualGames,
+	Array.mergeInto(games, Array.filter(manualGames,
 		function(entry)
-			if not Array.find(games, function(e) return e.game == entry.game end) then
-				table.insert(games, entry)
-			end
-		end)
+			return not Array.any(games, function(e) return e.game == entry.game end)
+		end
+	))
 
 	Array.sortInPlaceBy(games, function(entry) return entry.game end)
 

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -78,7 +78,7 @@ function CustomTeam._getGames()
 			return {game = GameLookup.getName(mw.text.trim(game))}
 		end)
 
-	Array.mergeInto(games, Array.filter(manualGames,
+	Array.extendWith(games, Array.filter(manualGames,
 		function(entry)
 			return not Array.any(games, function(e) return e.game == entry.game end)
 		end

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -81,7 +81,6 @@ function CustomTeam._getGameInactivity(game)
 	local date = os.date('!*t')
 	date.year = date.year - 1
 
-	
 	local conditions = ConditionTree(BooleanOperator.all):add{
 		CustomTeam._buildTeamPlacementConditions(),
 		ConditionNode(ColumnName('game'), Comparator.eq, game),


### PR DESCRIPTION
## Summary
Automatically determine games for teams based on placements. Use latest placement date per game to determine inactivity.
Uses both team as well as player's placements.

## How did you test this change?
via /dev on various team pages
