### PR TITLE
Add warcraft link overwrite data

### DIFF
--- a/standard/links/wikis/warcraft/links_custom_data.lua
+++ b/standard/links/wikis/warcraft/links_custom_data.lua
@@ -1,0 +1,17 @@
+---
+-- @Liquipedia
+-- wiki=warcraft
+-- page=Module:Links/CustomData
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	prefixes = {
+		esl = {
+			'https://play.eslgaming.com/warcraft/',
+			team = 'https://play.eslgaming.com/team/',
+			player = 'https://play.eslgaming.com/player/',
+		}
+	},
+}


### PR DESCRIPTION
## Summary
Warcraft has a wiki specific prefix for esl/eslgaming links, this PR adds the customData to reflect that

## How did you test this change?
dev into live (new module)