### PR TITLE
Add WT Points integration in prize pools

### DIFF
--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -74,17 +74,4 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
 	return tierValue * (prizeMoney * 1000 + 1000 - place) / place * (TYPE_MODIFIER[type] or 1)
 end
 
-function CustomPrizePool.addWTDatapoint(data, wtPoints)
-	local pageName = mw.title.getCurrentTitle().fullText
-	mw.ext.LiquipediaDB.lpdb_datapoint('wt_points_' .. pageName .. '_' .. data.placement .. '_' .. data.participant, {
-		type = 'wt_points',
-		name = data.participant,
-		date = data.date,
-		information = wtPoints,
-		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
-			placement = data.placement,
-		})
-	})
-end
-
 return CustomPrizePool

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -54,7 +54,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end)[1]
 
 	if worldTourPoints then
-		CustomPrizePool.addWTDatapoint(lpdbData, placement:getPrizeRewardForOpponent(opponent, worldTourPoints.id))
+		lpdbData.extradata.prizepoints = placement:getPrizeRewardForOpponent(opponent, worldTourPoints.id)
+		lpdbData.extradata.prizepointsTitle = 'wt_points'
 	end
 
 	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -59,6 +59,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end
 
 	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(lpdbData.participant:lower() .. '_prizepointsTitle', lpdbData.extradata.prizepointsTitle)
 
 	return lpdbData
 end

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -21,7 +21,7 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 local CustomPrizePool = {}
 
 local PRIZE_TYPE_POINTS = 'POINTS'
-local PRIZE_TITLE_WORD_TOUR = 'WT'
+local PRIZE_TITLE_WORLD_TOUR = 'WT'
 
 local TIER_VALUE = {8, 4, 2}
 local TYPE_MODIFIER = {Online = 0.65}
@@ -48,7 +48,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	)
 
 	local worldTourPoints = Array.filter(placement.parent.prizes, function (prize)
-		if prize.type == PRIZE_TYPE_POINTS and prize.data.title == PRIZE_TITLE_WORD_TOUR then
+		if prize.type == PRIZE_TYPE_POINTS and prize.data.title == PRIZE_TITLE_WORLD_TOUR then
 			return true
 		end
 	end)[1]


### PR DESCRIPTION
## Summary
With the current Trackmania World Tour, we need automated counter for the Global Points Ranking, on which the competition and World Cup are based on.
It begins with PrizePool storing in LPDB those World Tour points. This is what this PR is about

## How did you test this change?
I've tested this change on [this page](https://liquipedia.net/trackmania/User:Sigeth/RegionalsTest).
You can see that LPDB has been changed [here](https://liquipedia.net/trackmania/Special:LiquipediaDB/User:Sigeth/RegionalsTest#datapoint)
