### PR TITLE
Make use of #2392 and #2394 in the sc/sc2 opponent modules

### DIFF
--- a/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -17,9 +17,7 @@ local StarcraftOpponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfE
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
 local StarcraftPlayerDisplay = Lua.import('Module:Player/Display/Starcraft', {requireDevIfEnabled = true})
-local RaceIcon = Lua.requireIfExists('Module:RaceIcon') or {
-	getBigIcon = function(_) end,
-}
+local Race = Lua.import('Module:Race', {requireDevIfEnabled = true})
 
 local html = mw.html
 
@@ -183,9 +181,7 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 		return playerNodes[1]
 
 	elseif showRace and opponent.isArchon then
-		local raceIcon = DisplayUtil.removeLinkFromWikiLink(
-			RaceIcon.getBigIcon({opponent.players[1].race})
-		)
+		local raceIcon = Race.Icon{size = 'large', showLink = false, showTitle = false, race = opponent.players[1].race}
 		return StarcraftOpponentDisplay.BlockArchon({
 			flip = props.flip,
 			playerNodes = playerNodes,
@@ -200,9 +196,7 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 		for archonIx = 1, #opponent.players / 2 do
 			local primaryRace = opponent.players[2 * archonIx - 1].race
 			local secondaryRace = opponent.players[2 * archonIx].race
-			local primaryIcon = DisplayUtil.removeLinkFromWikiLink(
-				RaceIcon.getBigIcon({primaryRace})
-			)
+			local primaryIcon = Race.Icon{size = 'large', showLink = false, showTitle = false, race = primaryRace}
 			local secondaryIcon
 			if primaryRace ~= secondaryRace then
 				secondaryIcon = html.create('div')

--- a/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -13,11 +13,11 @@ local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
-local StarcraftOpponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
+local Faction = Lua.import('Module:Faction', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
 local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
+local StarcraftOpponent = Lua.import('Module:Opponent/Starcraft', {requireDevIfEnabled = true})
 local StarcraftPlayerDisplay = Lua.import('Module:Player/Display/Starcraft', {requireDevIfEnabled = true})
-local Race = Lua.import('Module:Race', {requireDevIfEnabled = true})
 
 local html = mw.html
 
@@ -181,7 +181,7 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 		return playerNodes[1]
 
 	elseif showRace and opponent.isArchon then
-		local raceIcon = Race.Icon{size = 'large', showLink = false, showTitle = false, race = opponent.players[1].race}
+		local raceIcon = Faction.Icon{size = 'large', showLink = false, showTitle = false, faction = opponent.players[1].race}
 		return StarcraftOpponentDisplay.BlockArchon({
 			flip = props.flip,
 			playerNodes = playerNodes,
@@ -196,7 +196,7 @@ function StarcraftOpponentDisplay.PlayerBlockOpponent(props)
 		for archonIx = 1, #opponent.players / 2 do
 			local primaryRace = opponent.players[2 * archonIx - 1].race
 			local secondaryRace = opponent.players[2 * archonIx].race
-			local primaryIcon = Race.Icon{size = 'large', showLink = false, showTitle = false, race = primaryRace}
+			local primaryIcon = Faction.Icon{size = 'large', showLink = false, showTitle = false, faction = primaryRace}
 			local secondaryIcon
 			if primaryRace ~= secondaryRace then
 				secondaryIcon = html.create('div')

--- a/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -8,7 +8,7 @@
 
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
-local StarcraftRace = require('Module:Race/Starcraft')
+local StarcraftRace = require('Module:Race')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TeamTemplate = require('Module:TeamTemplate')

--- a/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -6,9 +6,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Faction = require('Module:Faction')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
-local StarcraftRace = require('Module:Race')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TeamTemplate = require('Module:TeamTemplate')
@@ -48,18 +48,18 @@ function StarcraftOpponent.readOpponentArgs(args)
 	local partySize = Opponent.partySize((opponent or {}).type)
 
 	if partySize == 1 then
-		opponent.players[1].race = StarcraftRace.read(args.race)
+		opponent.players[1].race = Faction.read(args.race)
 
 	elseif partySize then
 		opponent.isArchon = Logic.readBool(args.isarchon)
 		if opponent.isArchon then
-			local archonRace = StarcraftRace.read(args.race)
+			local archonRace = Faction.read(args.race)
 			for _, player in ipairs(opponent.players) do
 				player.race = archonRace
 			end
 		else
 			for playerIx, player in ipairs(opponent.players) do
-				player.race = StarcraftRace.read(args['p' .. playerIx .. 'race'])
+				player.race = Faction.read(args['p' .. playerIx .. 'race'])
 			end
 		end
 	end
@@ -73,7 +73,7 @@ function StarcraftOpponent.fromMatch2Record(record)
 	if Opponent.typeIsParty(opponent.type) then
 		for playerIx, player in ipairs(opponent.players) do
 			local playerRecord = record.match2players[playerIx]
-			player.race = StarcraftRace.read(playerRecord.extradata.faction) or StarcraftRace.defaultRace
+			player.race = Faction.read(playerRecord.extradata.faction) or Faction.defaultFaction
 		end
 		opponent.isArchon = Logic.readBool((record.extradata or {}).isarchon)
 	end
@@ -131,7 +131,7 @@ function StarcraftOpponent.resolve(opponent, date, options)
 				if not player.team then
 					player.team = PlayerExt.syncTeam(player.pageName, nil, {date = date})
 				end
-				player.race = (hasRace or player.race ~= StarcraftRace.defaultRace) and player.race or nil
+				player.race = (hasRace or player.race ~= Faction.defaultFaction) and player.race or nil
 			else
 				PlayerExt.populatePageName(player)
 			end


### PR DESCRIPTION
depends on #2392 and #2394

## Summary
Make use of #2392 and #2394 in the sc/sc2 opponent modules
(20 more git modules and a several non git modules to follow in the upcoming days/weeks)

## How did you test this change?
dev together with #2392 and #2394