### PR TITLE
Add BTN to Currency Data

### DIFF
--- a/standard/currency/currency_data.lua
+++ b/standard/currency/currency_data.lua
@@ -97,6 +97,15 @@ return {
 			text = 'R$',
 		},
 	},
+	btn = {
+		code = 'BTN',
+		name = 'Bhutanese ngultrum',
+		symbol = {
+			hasSpace = false,
+			isAfter = false,
+			text = 'Nu',
+		},
+	},
 	byn = {
 		code = 'BYN',
 		name = 'Belarusian Ruble',


### PR DESCRIPTION
Added support for Bhutanese ngultrum to currency/data module. 
A tournament on pubgmobile required it for prize pool.
Information on symbol taken from wikipedia. 