### PR TITLE
refactor: move warnings to infobox core

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
+local WarningBox = require('Module:WarningBox')
 
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory', {requireDevIfEnabled = true})
 
@@ -29,6 +30,7 @@ function Infobox:create(frame, gameName, forceDarkMode)
 	end
 
 	self.injector = nil
+	self.warnings = {}
 	return self
 end
 
@@ -73,7 +75,7 @@ function Infobox:build(widgets)
 		self.root:node(self.bottomContent)
 	end
 
-	return self.root
+	return mw.html.create():node(self.root):node(WarningBox.displayAll(self.warnings))
 end
 
 return Infobox

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -16,7 +16,6 @@ local Table = require('Module:Table')
 local Template = require('Module:Template')
 local Tier = require('Module:Tier') -- loadData?
 local Variables = require('Module:Variables')
-local WarningBox = require('Module:WarningBox')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
 local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
@@ -44,8 +43,6 @@ local Builder = Widgets.Builder
 local Chronology = Widgets.Chronology
 
 local League = Class.new(BasicInfobox)
-
-League.warnings = {}
 
 function League.run(frame)
 	local league = League(frame)
@@ -263,7 +260,7 @@ function League:createInfobox()
 		self:_setSeoTags(args)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayAll(League.warnings)
+	return tostring(builtInfobox)
 end
 
 --- Allows for overriding this functionality
@@ -316,7 +313,7 @@ function League:createLiquipediaTierDisplay(args)
 		if not tierText then
 			tierMode = tierMode == _TIER_MODE_TYPES and 'Tiertype' or 'Tier'
 			table.insert(
-				self.warnings,
+				self.infobox.warnings,
 				String.interpolate(_INVALID_TIER_WARNING, {tierString = tierString, tierMode = tierMode})
 			)
 			return ''
@@ -575,7 +572,7 @@ function League:_setIconVariable(iconSmallTemplate, manualIcon, manualIconDark)
 
 	if String.isNotEmpty(trackingCategory) then
 		table.insert(
-			self.warnings,
+			self.infobox.warnings,
 			'Missing icon while icondark is set.'
 		)
 	end

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -15,7 +15,6 @@ local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
-local WarningBox = require('Module:WarningBox')
 
 local AgeCalculation = Lua.import('Module:AgeCalculation', {requireDevIfEnabled = true})
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
@@ -33,8 +32,6 @@ local Builder = Widgets.Builder
 local Customizable = Widgets.Customizable
 
 local Person = Class.new(BasicInfobox)
-
-Person.warnings = {}
 
 local Language = mw.language.new('en')
 local _LINK_VARIANT = 'player'
@@ -225,7 +222,7 @@ function Person:createInfobox()
 		)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayAll(self.warnings)
+	return tostring(builtInfobox)
 end
 
 function Person:_definePageVariables(args)
@@ -300,7 +297,7 @@ function Person:getStandardNationalityValue(nationality)
 
 	if String.isEmpty(nationalityToStore) then
 		table.insert(
-			self.warnings,
+			self.infobox.warnings,
 			'"' .. nationality .. '" is not supported as a value for nationalities'
 		)
 		nationalityToStore = nil

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -13,7 +13,6 @@ local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tier = require('Module:Tier')
-local WarningBox = require('Module:WarningBox')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
 local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
@@ -36,8 +35,6 @@ local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
 
 local Series = Class.new(BasicInfobox)
-
-Series.warnings = {}
 
 function Series.run(frame)
 	local series = Series(frame)
@@ -227,7 +224,6 @@ function Series:createInfobox()
 	end
 
 	return tostring(builtInfobox)
-		.. WarningBox.displayAll(Series.warnings)
 end
 
 --- Allows for overriding this functionality
@@ -252,7 +248,7 @@ function Series:createLiquipediaTierDisplay(args)
 		if not tierText then
 			tierMode = tierMode == _TIER_MODE_TYPES and 'Tiertype' or 'Tier'
 			table.insert(
-				self.warnings,
+				self.infobox.warnings,
 				String.interpolate(_INVALID_TIER_WARNING, {tierString = tierString, tierMode = tierMode})
 			)
 			return ''
@@ -300,7 +296,7 @@ function Series:_getIconFromLeagueIconSmall(lpdbData)
 
 	if String.isNotEmpty(trackingCategory) then
 		table.insert(
-			self.warnings,
+			self.infobox.warnings,
 			'Missing icon while icondark is set.' .. trackingCategory
 		)
 	end

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -14,7 +14,6 @@ local Namespace = require('Module:Namespace')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 local String = require('Module:StringUtils')
-local WarningBox = require('Module:WarningBox')
 local Variables = require('Module:Variables')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
@@ -38,8 +37,6 @@ local _LINK_VARIANT = 'team'
 
 local Language = mw.language.new('en')
 local _defaultEarningsFunctionUsed = false
-
-local _warnings = {}
 
 function Team.run(frame)
 	local team = Team(frame)
@@ -205,7 +202,7 @@ function Team:createInfobox()
 		self:defineCustomPageVariables(args)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayAll(_warnings)
+	return tostring(builtInfobox)
 end
 
 function Team:_createRegion(region)
@@ -247,7 +244,7 @@ function Team:getStandardLocationValue(location)
 
 	if String.isEmpty(locationToStore) then
 		table.insert(
-			_warnings,
+			self.infobox.warnings,
 			'"' .. location .. '" is not supported as a value for locations'
 		)
 		return

--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -64,7 +64,7 @@ function CustomInjector:addCustomCells(widgets)
 				-- we have an invalid hero entry
 				-- add warning (including tracking category)
 				table.insert(
-					_player.warnings,
+					_player.infobox.warnings,
 					'Invalid hero input "' .. hero .. '"[[Category:Pages with invalid hero input]]'
 				)
 			end

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -100,7 +100,7 @@ function CustomInjector:addCustomCells(widgets)
 				-- we have an invalid hero entry
 				-- add warning (including tracking category)
 				table.insert(
-					_player.warnings,
+					_player.infobox.warnings,
 					'Invalid hero input "' .. hero .. '"[[Category:Pages with invalid hero input]]'
 				)
 			end

--- a/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
@@ -70,7 +70,7 @@ function CustomInjector:addCustomCells(widgets)
 				-- we have an invalid weapon entry
 				-- add warning (including tracking category)
 				table.insert(
-					_player.warnings,
+					_player.infobox.warnings,
 					'Invalid weapon input "' .. weapon .. '"[[Category:Pages with invalid weapon input]]'
 				)
 			end

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -235,7 +235,7 @@ function CustomLeague._createLiquipediaTierDisplay()
 		if not tierText then
 			tierMode = tierMode == TIER_MODE_TYPES and 'Tiertype' or 'Tier'
 			table.insert(
-				_league.warnings,
+				_league.infobox.warnings,
 				tierString .. ' is not a known Liquipedia ' .. tierMode
 					.. '[[Category:Pages with invalid ' .. tierMode .. ']]'
 			)

--- a/components/infobox/wikis/starcraft2/infobox_series_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_series_custom.lua
@@ -236,7 +236,7 @@ function CustomSeries.createLiquipediaTierDisplay()
 		if not tierText then
 			tierMode = tierMode == _TIER_MODE_TYPES and 'Tiertype' or 'Tier'
 			table.insert(
-				_series.warnings,
+				_series.infobox.warnings,
 				tierString .. ' is not a known Liquipedia ' .. tierMode
 					.. '[[Category:Pages with invalid ' .. tierMode .. ']]'
 			)

--- a/standard/warning_box.lua
+++ b/standard/warning_box.lua
@@ -20,12 +20,12 @@ function WarningBox.display(text)
 	return div:node(tbl)
 end
 
-function WarningBox.displayAll(tbl)
-	local display = ''
-	for _, text in pairs(tbl) do
-		display = display .. tostring(WarningBox.display(text))
+function WarningBox.displayAll(arr)
+	local wrapper = mw.html.create()
+	for _, text in ipairs(arr) do
+		wrapper:node(WarningBox.display(text))
 	end
-	return display
+	return wrapper
 end
 
 return Class.export(WarningBox)


### PR DESCRIPTION
## Summary
Recommend starting review with `infobox.lua` and `warnings_box.lua`.
On hold until the execution order is sorted out in the Infoboxes

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
