### PR TITLE
Remove Octane

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -207,7 +207,7 @@ function matchFunctions.getLinks(match)
 
 	-- Shift (formerly Octane)
 	match.shift1 = match.shift1 or match.shift
-	for key, shift in Table.iter.pairsByPrefix(match, 'ballchasing') do
+	for key, shift in Table.iter.pairsByPrefix(match, 'shift') do
 		match.links[key] = 'https://www.shiftrle.gg/matches/' .. shift
 	end
 

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -206,16 +206,9 @@ function matchFunctions.getLinks(match)
 	match.links = {}
 
 	-- Shift (formerly Octane)
-	local index = 1
-	match.shift1 = match.shift1 or match.shift or match.octane1 or match.octane
-	while true do
-		local key = 'shift' .. index
-		local slug = match[key] or match['octane' .. index]
-		if not slug then
-			break
-		end
-		match.links[key] = 'https://www.shiftrle.gg/matches/' .. slug
-		index = index + 1
+	match.shift1 = match.shift1 or match.shift
+	for key, shift in Table.iter.pairsByPrefix(match, 'ballchasing') do
+		match.links[key] = 'https://www.shiftrle.gg/matches/' .. shift
 	end
 
 	-- Ballchasing

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -265,7 +265,7 @@ function Links.transform(links)
 		royaleapi = links.royaleapi,
 		rules = links.rules or links.rulebook,
 		rules2 = links.rules2 or links.rulebook2,
-		shift = links.shift or links.octane,
+		shift = links.shift,
 		['siege-gg'] = links.siegegg,
 		snapchat = links.snapchat,
 		sk = links.sk,


### PR DESCRIPTION
## Summary
Followup to #2245, now that all `octane` params have been changed to `shift` instead.

## How did you test this change?
Dev module