### PR TITLE
refactor: remove redundant parameters of the SquadRow Constructor

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -27,25 +27,9 @@ local _ICON_CAPTAIN = '[[File:Captain Icon.png|18px|baseline|Captain|link=Catego
 local _ICON_SUBSTITUTE = '[[File:Substitution.png|18px|baseline|Sub|link=|alt=Substitution|class=player-role-icon]]'
 
 local SquadRow = Class.new(
-	function(self, frame, role, options)
-		self.frame = frame
+	function(self, options)
 		self.content = mw.html.create('tr'):addClass('Player')
 		self.options = options or {}
-
-		role = string.lower(role or '')
-
-		if role == 'sub' then
-			self.content:addClass('sub')
-		elseif role == 'coach' then
-			self.content:addClass('coach')
-			self.content:addClass('roster-coach')
-		elseif role == 'coach/manager' then
-			self.content:addClass('coach/manager')
-			self.content:addClass('roster-coach')
-		elseif role == 'coach/substitute' then
-			self.content:addClass('coach/substitute')
-			self.content:addClass('roster-coach')
-		end
 
 		self.lpdbData = {}
 		self.lpdbData.type = _DEFAULT_TYPE
@@ -123,6 +107,22 @@ function SquadRow:role(args)
 	self.content:node(cell)
 
 	self.lpdbData['role'] = args.role
+
+	-- Set row background for certain roles
+	local role = string.lower(args.role or '')
+
+	if role == 'sub' then
+		self.content:addClass('sub')
+	elseif role == 'coach' then
+		self.content:addClass('coach')
+		self.content:addClass('roster-coach')
+	elseif role == 'coach/manager' then
+		self.content:addClass('coach/manager')
+		self.content:addClass('roster-coach')
+	elseif role == 'coach/substitute' then
+		self.content:addClass('coach/substitute')
+		self.content:addClass('roster-coach')
+	end
 
 	return self
 end

--- a/components/squad/wikis/ageofempires/squad_custom.lua
+++ b/components/squad/wikis/ageofempires/squad_custom.lua
@@ -44,7 +44,7 @@ function CustomSquad._playerRow(player, squadType)
 	local joinText = (player.joindatedisplay or player.joindate) .. ' ' .. joinReference
 	local leaveText = (player.leavedatedisplay or player.leavedate) .. ' ' .. leaveReference
 
-	local row = SquadRow(mw.getCurrentFrame(), player.thisTeam.role)
+	local row = SquadRow()
 	row:id({
 		(player.idleavedate or player.id),
 		flag = player.flag,

--- a/components/squad/wikis/apexlegends/squad_custom.lua
+++ b/components/squad/wikis/apexlegends/squad_custom.lua
@@ -71,7 +71,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] ~= nil or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
+		local row = SquadRow{useTemplatesForSpecialTeams = true}
 		row	:id{
 				player.id,
 				flag = player.flag,

--- a/components/squad/wikis/arenaofvalor/squad_custom.lua
+++ b/components/squad/wikis/arenaofvalor/squad_custom.lua
@@ -135,7 +135,7 @@ function CustomSquad.runAuto(playerList, squadType)
 end
 
 function CustomSquad._playerRow(player, squadType)
-	local row = ExtendedSquadRow(mw.getCurrentFrame(), player.role)
+	local row = ExtendedSquadRow()
 
 	row:id({
 		(player.idleavedate or player.id),

--- a/components/squad/wikis/counterstrike/squad_custom.lua
+++ b/components/squad/wikis/counterstrike/squad_custom.lua
@@ -71,7 +71,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
+		local row = SquadRow{useTemplatesForSpecialTeams = true}
 		row	:id{
 				player.id,
 				flag = player.flag,

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -105,7 +105,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] ~= nil or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = ExtendedSquadRow(frame, player.role)
+		local row = ExtendedSquadRow()
 		row	:id{
 				player.id,
 				flag = player.flag,

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -104,7 +104,7 @@ function CustomSquad.runAuto(playerList, squadType)
 end
 
 function CustomSquad._playerRow(player, squadType)
-	local row = ExtendedSquadRow(mw.getCurrentFrame(), player.role)
+	local row = ExtendedSquadRow()
 
 	row:id({
 		(player.idleavedate or player.id),

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -135,7 +135,7 @@ function CustomSquad.runAuto(playerList, squadType)
 end
 
 function CustomSquad._playerRow(player, squadType)
-	local row = ExtendedSquadRow(mw.getCurrentFrame(), player.role)
+	local row = ExtendedSquadRow()
 
 	row:id({
 		(player.idleavedate or player.id),

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -170,7 +170,7 @@ function CustomSquad.runAuto(playerList, squadType)
 end
 
 function CustomSquad._playerRow(player, squadType)
-	local row = ExtendedSquadRow(mw.getCurrentFrame(), player.role, player.number)
+	local row = ExtendedSquadRow()
 
 	row:id({
 		(player.idleavedate or player.id),

--- a/components/squad/wikis/pubg/squad_custom.lua
+++ b/components/squad/wikis/pubg/squad_custom.lua
@@ -23,7 +23,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] ~= nil or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
+		local row = SquadRow{useTemplatesForSpecialTeams = true}
 		row	:id({
 				player.id,
 				flag = player.flag,

--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -44,7 +44,7 @@ function CustomSquad._playerRow(player, squadType)
 	local joinText = (player.joindatedisplay or player.joindate) .. ' ' .. joinReference
 	local leaveText = (player.leavedatedisplay or player.leavedate) .. ' ' .. leaveReference
 
-	local row = SquadRow(mw.getCurrentFrame(), player.thisTeam.role)
+	local row = SquadRow()
 	row:id({
 		(player.idleavedate or player.id),
 		flag = player.flag,

--- a/components/squad/wikis/rocketleague/squad_custom.lua
+++ b/components/squad/wikis/rocketleague/squad_custom.lua
@@ -23,7 +23,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] ~= nil or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
+		local row = SquadRow{useTemplatesForSpecialTeams = true}
 		row	:id({
 				player.id,
 				flag = player.flag,

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -56,7 +56,7 @@ function CustomSquad.run(frame)
 		local player = Json.parseIfString(args['p' .. index] or args[index])
 		player.race = string.lower(player.race)
 		player.race = CleanRace[player.race] or player.race
-		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
+		local row = SquadRow{useTemplatesForSpecialTeams = true}
 		row	:id({
 				player.id,
 				flag = player.flag,

--- a/components/squad/wikis/trackmania/squad_custom.lua
+++ b/components/squad/wikis/trackmania/squad_custom.lua
@@ -23,7 +23,7 @@ function CustomSquad.run(frame)
 	local index = 1
 	while args['p' .. index] or args[index] do
 		local player = Json.parseIfString(args['p' .. index] or args[index])
-		local row = SquadRow(frame, player.role, {useTemplatesForSpecialTeams = true})
+		local row = SquadRow{useTemplatesForSpecialTeams = true}
 		row	:id({
 				player.id,
 				flag = player.flag,

--- a/components/squad/wikis/valorant/squad_custom.lua
+++ b/components/squad/wikis/valorant/squad_custom.lua
@@ -119,7 +119,7 @@ function CustomSquad.runAuto(playerList, squadType)
 end
 
 function CustomSquad._playerRow(player, squadType)
-	local row = SquadRow(mw.getCurrentFrame(), player.role, {useTemplatesForSpecialTeams = true})
+	local row = SquadRow{useTemplatesForSpecialTeams = true}
 
 	row:id{
 		player.id,

--- a/components/squad/wikis/wildrift/squad_custom.lua
+++ b/components/squad/wikis/wildrift/squad_custom.lua
@@ -135,7 +135,7 @@ function CustomSquad.runAuto(playerList, squadType)
 end
 
 function CustomSquad._playerRow(player, squadType)
-	local row = ExtendedSquadRow(mw.getCurrentFrame(), player.role)
+	local row = ExtendedSquadRow()
 
 	row:id({
 		(player.idleavedate or player.id),


### PR DESCRIPTION
## Summary
SquadRow constuctor expects `frame` and `role` inputs. Frame is enough unused, and `role` handling should be in the `:role(...)` method.

## How did you test this change?
Dev module with RL
Before:
![image](https://user-images.githubusercontent.com/3426850/214548570-c576ce55-9737-4000-b7d5-0d14ff8f6ada.png)

After:
![image](https://user-images.githubusercontent.com/3426850/214548607-aca2fe1b-67b5-47d3-a457-b67f1a7bfa94.png)
