### PR TITLE
Use OpponentDisplay for rending squad tables

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -9,7 +9,9 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Flags = require('Module:Flags')
-local Player = require('Module:Player')
+local OpponentLib = require('Module:OpponentLibraries')
+local Opponent = OpponentLib.Opponent
+local OpponentDisplay = OpponentLib.OpponentDisplay
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local String = require('Module:StringUtils')
 local Template = require('Module:Template')
@@ -65,9 +67,8 @@ function SquadRow:id(args)
 	local cell = mw.html.create('td')
 	cell:addClass('ID')
 
-	args['noclean'] = true
-	cell:wikitext('<b>' .. Player._player(args) .. '</b>')
-	args['noclean'] = nil
+	local opponent = Opponent.readOpponentArgs(Table.merge(args, {type = Opponent.solo}))
+	cell:tag('b'):node(OpponentDisplay.BlockOpponent{opponent = Opponent.resolve(opponent, nil, {syncPlayer = true})})
 
 	if String.isNotEmpty(args.captain) then
 		cell:wikitext('&nbsp;' .. _ICON_CAPTAIN)


### PR DESCRIPTION
## Summary
Use Opponent/OpponentDisplay to render the Player Id in Squad Tables, instead of the super deprecated `Module:Player`.

Added side bonus is that `flag` input is now automatically retrieved, if not provided, from the player's page.

Before:
![image](https://user-images.githubusercontent.com/3426850/214371467-7270bad1-ba83-4fd9-9ead-a4ecd4fccf72.png)

After:
![image](https://user-images.githubusercontent.com/3426850/214371447-ae0632c9-de12-4343-8c08-7e8a10434063.png)


## How did you test this change?
Dev module