### PR TITLE
feat: add extradata storage for LoL squads

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -190,7 +190,7 @@ function SquadRow:setType(type)
 end
 
 function SquadRow:setExtradata(extradata)
-	self.lpdbData.extradata = extradata
+	self.lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(extradata)
 	return self
 end
 

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -189,6 +189,11 @@ function SquadRow:setType(type)
 	return self
 end
 
+function SquadRow:setExtradata(extradata)
+	self.lpdbData.extradata = extradata
+	return self
+end
+
 function SquadRow:addToLpdb(lpdbData)
 	return lpdbData
 end

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -130,6 +130,8 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
+	row:setExtradata{status = squadType}
+
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')


### PR DESCRIPTION
## Summary
Resolves #2315

Create function to set extradata, and have LoL store `status` (TableType) into there.

## How did you test this change?
dev module