### PR TITLE
Improvements for MatchSummary in Trackmania

### DIFF
--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -404,8 +404,7 @@ function mapFunctions.getScoresAndWinner(map)
 			break
 		end
 	end
-	local isFinished = Logic.readBool(map.finished)
-	if isFinished and not Logic.isEmpty(indexedScores) then
+	if not Logic.isEmpty(indexedScores) then
 		map.winner = mapFunctions.getWinner(indexedScores)
 	end
 

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -287,14 +287,14 @@ function CustomMatchSummary._createGame(game)
 
 	row:addElement(CustomMatchSummary._iconDisplay(
 		GREEN_CHECK,
-		game.winner == 1,
+		(game.scores[1] or 0) > (game.scores[2] or 0),
 		game.scores[1],
 		1
 	))
 	row:addElement(centerNode)
 	row:addElement(CustomMatchSummary._iconDisplay(
 		GREEN_CHECK,
-		game.winner == 2,
+		(game.scores[1] or 0) < (game.scores[2] or 0),
 		game.scores[2],
 		2
 	))

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -283,7 +283,7 @@ function CustomMatchSummary._createGame(game)
 
 	local centerNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
-		:node(mw.html.create('div'):node('[[' .. game.map .. ']]'))
+		:node(mw.html.create('div'):node(game.map))
 
 	row:addElement(CustomMatchSummary._iconDisplay(
 		GREEN_CHECK,

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -287,14 +287,14 @@ function CustomMatchSummary._createGame(game)
 
 	row:addElement(CustomMatchSummary._iconDisplay(
 		GREEN_CHECK,
-		(game.scores[1] or 0) > (game.scores[2] or 0),
+		game.winner == 1,
 		game.scores[1],
 		1
 	))
 	row:addElement(centerNode)
 	row:addElement(CustomMatchSummary._iconDisplay(
 		GREEN_CHECK,
-		(game.scores[1] or 0) < (game.scores[2] or 0),
+		game.winner == 2,
 		game.scores[2],
 		2
 	))


### PR DESCRIPTION
## Summary
There are two changes in this PR :
* Map names no longer redirects to a link, because of how map system is in Trackmania, we can't make a page for every single one of them
* Green checks when a map score is added now appears automatically, comparing the two scores entered and applying the green check to the highest score. It also takes into an account if a map has no scores (you'll see in examples that I did not catch a result in Upper Bracket Finals, and it does not brake)

## How did you test this change?
All of my changes have been tested on [this page](https://liquipedia.net/trackmania/User:Sigeth/RegionalsTest)
You can see the differences with the [page with current MatchSummary](https://liquipedia.net/trackmania/Trackmania_World_Tour/2023/Stage_1/Regionals/Middle-East_%26_Africa/Regional_1).

You will see these changes in the Results section, as it is only MatchSummary related.
