### PR TITLE
Fix inline issue with Squad Table Display

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -66,8 +66,11 @@ function SquadRow:id(args)
 	local cell = mw.html.create('td')
 	cell:addClass('ID')
 
-	local opponent = Opponent.readOpponentArgs(Table.merge(args, {type = Opponent.solo}))
-	cell:tag('b'):node(OpponentDisplay.BlockOpponent{opponent = Opponent.resolve(opponent, nil, {syncPlayer = true})})
+	local opponent = Opponent.resolve(
+		Opponent.readOpponentArgs(Table.merge(args, {type = Opponent.solo}),
+		nil, {syncPlayer = true})
+	)
+	cell:tag('b'):node(OpponentDisplay.InlineOpponent{opponent = opponent})
 
 	if String.isNotEmpty(args.captain) then
 		cell:wikitext('&nbsp;' .. _ICON_CAPTAIN)


### PR DESCRIPTION
## Summary
The Coach and Sub logos put on a new line instead of the same line due to using `BlockOpponent` instead of `InlineOpponent`.

Introduced in #2412

**Block:**
![image](https://user-images.githubusercontent.com/3426850/214558815-dbe11f7c-1c8a-46ab-a75e-7bbc3c67f776.png)


**Inline:**
![image](https://user-images.githubusercontent.com/3426850/214558777-0752669c-673c-41fc-b7f2-3e8a13e5672c.png)


## How did you test this change?
dev module
