### PR TITLE
Re-add missing bracket around newteamrole

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -168,7 +168,7 @@ function SquadRow:newteam(args)
 			end
 
 			if String.isNotEmpty(args.newteamrole) then
-				cell:wikitext('&nbsp;'):tag('i'):tag('small'):wikitext(args.newteamrole)
+				cell:wikitext('&nbsp;'):tag('i'):tag('small'):wikitext('(' .. args.newteamrole .. ')')
 			end
 		elseif not self.options.useTemplatesForSpecialTeams and String.isNotEmpty(args.newteamrole) then
 			cell:tag('div'):addClass('NewTeamRole'):wikitext(args.newteamrole)


### PR DESCRIPTION
## Summary

In #2411 the newTeamRole brackets were incorrectly removed. This PR re-adds them

Before:
![image](https://user-images.githubusercontent.com/3426850/214561949-d851ce22-cc07-4bb3-a879-c742cbe51f8a.png)


After:
![image](https://user-images.githubusercontent.com/3426850/214561919-94673d26-f292-4223-9dc7-e6de967a6f3d.png)


## How did you test this change?
dev module
