### PR TITLE
Support "Publisher" in Infobox/Game

### DIFF
--- a/components/infobox/commons/infobox_game.lua
+++ b/components/infobox/commons/infobox_game.lua
@@ -44,6 +44,7 @@ function Game:createInfobox()
 		Center{content = {args.caption}},
 		Title{name = 'Game Information'},
 		Cell{name = 'Developer', content = self:getAllArgsForBase(args, 'developer')},
+		Cell{name = 'Publisher', content = self:getAllArgsForBase(args, 'publisher')},
 		Cell{name = 'Release Date(s)', content = self:getAllArgsForBase(args, 'releasedate')},
 		Cell{name = 'Platforms', content = self:getAllArgsForBase(args, 'platform')},
 		Customizable{id = 'custom', children = {}},


### PR DESCRIPTION

## Summary

Added support in the same fashion as "Developer", so that multiple publishers can be added if needed.

## How did you test this change?

https://liquipedia.net/pubgmobile/PUBG_Mobile

Tested using dev version