### PR TITLE
Remove prefix website

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -165,7 +165,6 @@ local _PREFIXES = {
 		team = 'https://www.vlr.gg/team/',
 		player = 'https://www.vlr.gg/player/'
 	},
-	website = {''},
 	weibo = {'https://weibo.com/'},
 	youtube = {'https://www.youtube.com/'},
 	zhangyutv = {'http://www.zhangyu.tv/'},


### PR DESCRIPTION
## Summary
Inputs `website` and `website2` are already mapped to `home`, which is the functional icon.
`lp-website` is not an icon

## How did you test this change?
via /dev 
Wrong:
![image](https://user-images.githubusercontent.com/16326643/214637614-2544648e-6fbe-45c1-8096-6ced32aa3413.png)
Fixed:
![image](https://user-images.githubusercontent.com/16326643/214637637-716f83a5-1c87-4d8a-8533-394e921e4bb3.png)

