### PR TITLE
Fix count handling in PPT Placement

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -163,7 +163,7 @@ function Placement:init(args, parent, lastPlacement)
 	-- or the number of entered opponents
 	if not self.placeStart and not self.placeEnd then
 		self.placeStart = lastPlacement + 1
-		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
+		self.placeEnd = lastPlacement + (self.count or math.max(#self.opponents, 1))
 	end
 
 	self.count = self.placeEnd + 1 - self.placeStart

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -156,11 +156,6 @@ function Placement:init(args, parent, lastPlacement)
 
 	self.prizeRewards = self:_readPrizeRewards(self.args)
 
-	if self.count then
-		self.placeStart = lastPlacement + 1
-		self.placeEnd = lastPlacement + self.count
-	end
-
 	self.opponents = self:_parseOpponents(self.args)
 
 	-- Implicit place range has been given (|place= is not set)
@@ -284,11 +279,11 @@ function Placement:_shouldAddTbdOpponent(opponentIndex, place)
 		return true
 	end
 	-- If the fillPlaceRange option is disabled or we do not have a give placeRange do not fill up further
-	if not self.parent.options.fillPlaceRange or not place then
+	if not self.parent.options.fillPlaceRange or (not place and not self.count) then
 		return false
 	end
 	-- Only fill up further with TBD's if there is free space in the placeRange/slot
-	local slotSize = self.placeEnd - self.placeStart + 1
+	local slotSize = self.count or (self.placeEnd - self.placeStart + 1)
 	if opponentIndex <= slotSize then
 		return true
 	end

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -156,6 +156,11 @@ function Placement:init(args, parent, lastPlacement)
 
 	self.prizeRewards = self:_readPrizeRewards(self.args)
 
+	if self.count then
+		self.placeStart = lastPlacement + 1
+		self.placeEnd = lastPlacement + self.count
+	end
+
 	self.opponents = self:_parseOpponents(self.args)
 
 	-- Implicit place range has been given (|place= is not set)
@@ -163,7 +168,7 @@ function Placement:init(args, parent, lastPlacement)
 	-- or the number of entered opponents
 	if not self.placeStart and not self.placeEnd then
 		self.placeStart = lastPlacement + 1
-		self.placeEnd = lastPlacement + (self.count or math.max(#self.opponents, 1))
+		self.placeEnd = lastPlacement + math.max(#self.opponents, 1)
 	end
 
 	self.count = self.placeEnd + 1 - self.placeStart


### PR DESCRIPTION
## Summary
Fix count handling in PPT Placement

Currently if count and place is entered then errors with `Lua error in Module:PrizePool/Placement at line 286: attempt to perform arithmetic on field 'placeEnd' (a nil value).`
With this PR this gets fixed.

introduced via #2369

## How did you test this change?
dev