### PR TITLE
Remove redundant `rules2`, `rulebook` and `rulebook2`

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -117,7 +117,6 @@ local PREFIXES = {
 	playlist = {''},
 	reddit = {'https://www.reddit.com/user/'},
 	royaleapi = {'https://royaleapi.com/player/'},
-	rulebook = {''},
 	rules = {''},
 	shift = {'https://www.shiftrle.gg/events/'},
 	['siege-gg'] = {

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -118,9 +118,7 @@ local PREFIXES = {
 	reddit = {'https://www.reddit.com/user/'},
 	royaleapi = {'https://royaleapi.com/player/'},
 	rulebook = {''},
-	rulebook2 = {''},
 	rules = {''},
-	rules2 = {''},
 	shift = {'https://www.shiftrle.gg/events/'},
 	['siege-gg'] = {
 		'https://siege.gg/competitions/',


### PR DESCRIPTION
## Summary
Kick redundant `rules2`, `rulebook` and `rulebook2` in Links module

## How did you test this change?
N/A