### PR TITLE
Add Faction.readMultiFaction

### DIFF
--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -85,7 +85,7 @@ function Faction.readMultiFaction(input, options)
 	options = options or {}
 
 	local singleFaction = Faction.read(input, options)
-	if factionsingleFaction then return singleFaction end
+	if singleFaction then return singleFaction end
 
 	local inputArray = Array.map(
 		mw.text.split(input, options.sep or '', true),

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -88,10 +88,13 @@ function Faction.readMultiFaction(input, options)
 		return {Faction.read(input, options)}
 	end
 
-	local inputArray = Array.map(mw.text.split(input, options.sep or '', true), mw.text.trim)
+	local inputArray = Array.map(mw.text.split(input, options.sep or '', true),
+		function(faction) return mw.text.trim(faction) end)
 
 	local factions = Array.map(inputArray, function(faction) return Faction.read(faction, options) end)
+
 	assert(#factions == #inputArray, 'Invalid multi-faction specifier ' .. input)
+
 	return factions
 end
 

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -53,6 +53,7 @@ end
 
 --- Parses a faction from input. Returns the factions short handle/identifier.
 -- Returns nil if not a valid faction.
+-- If `options.alias` is set to false the function will not look in the aliases provided via the data module.
 ---@param faction string
 ---@param options {alias: boolean?}?
 ---@return string?
@@ -73,8 +74,8 @@ end
 --- Parses multiple factions from input.
 -- Returns a table of the found factions short handle/identifier.
 -- Returns empty table if no input is specified.
----@props input: string
----@props options: {sep: string?, alias: boolean?}?
+---@param input: string
+---@param options: {sep: string?, alias: boolean?}?
 ---@return table
 function Faction.readMultiFaction(input, options)
 	if String.isEmpty(input) then
@@ -87,14 +88,7 @@ function Faction.readMultiFaction(input, options)
 		return {Faction.read(input, options)}
 	end
 
-	local inputArray = {}
-	if String.isNotEmpty(options.sep) then
-		inputArray = Array.map(mw.text.split(input, options.sep, true), mw.text.trim)
-	else
-		for char in input:gmatch('(.)') do
-			table.insert(inputArray, char)
-		end
-	end
+	local inputArray = Array.map(mw.text.split(input, options.sep or '', true), mw.text.trim)
 
 	local factions = Array.map(inputArray, function(faction) return Faction.read(faction, options) end)
 	assert(#factions == #inputArray, 'Invalid multi-faction specifier ' .. input)
@@ -125,7 +119,7 @@ local namedSizes = {
 }
 
 --- Returns the icon of an entered faction identifier
----@props props {faction: string, size: string|number|nil, showLink: boolean?, showTitle: boolean?, title: string?}
+---@param props {faction: string, size: string|number|nil, showLink: boolean?, showTitle: boolean?, title: string?}
 ---@return string?
 function Faction.Icon(props)
 	local faction = Faction.read(props.faction)

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -84,9 +84,8 @@ function Faction.readMultiFaction(input, options)
 
 	options = options or {}
 
-	if Faction.read(input, options) then
-		return {Faction.read(input, options)}
-	end
+	local faction = Faction.read(input, options)
+	if faction then return faction end
 
 	local inputArray = Array.map(mw.text.split(input, options.sep or '', true),
 		function(faction) return mw.text.trim(faction) end)

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -72,7 +72,7 @@ function Faction.read(faction, options)
 end
 
 --- Parses multiple factions from input.
--- Returns a table of the found factions short handle/identifier.
+-- Returns an array of faction identifiers.
 -- Returns empty table if no input is specified.
 ---@param input: string
 ---@param options: {sep: string?, alias: boolean?}?

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -54,7 +54,7 @@ end
 --- Parses a faction from input. Returns the factions short handle/identifier.
 -- Returns nil if not a valid faction.
 ---@param faction string
----@param options {noAliasing: boolean?}?
+---@param options {alias: boolean?}?
 ---@return string?
 function Faction.read(faction, options)
 	if type(faction) ~= 'string' then
@@ -66,7 +66,7 @@ function Faction.read(faction, options)
 	faction = faction:lower()
 	return Faction.isValid(faction) and faction
 		or byLowerName[faction]
-		or (not options.noAliasing) and Faction.aliases[faction]
+		or (options.alias ~= false and Faction.aliases[faction])
 		or nil
 end
 
@@ -74,7 +74,7 @@ end
 -- Returns a table of the found factions short handle/identifier.
 -- Returns empty table if no input is specified.
 ---@props input: string
----@props options: {sep: string?, noAliasing: boolean?}?
+---@props options: {sep: string?, alias: boolean?}?
 ---@return table?
 function Faction.readMultiFaction(input, options)
 	if String.isEmpty(input) then

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -84,8 +84,8 @@ function Faction.readMultiFaction(input, options)
 
 	options = options or {}
 
-	local faction = Faction.read(input, options)
-	if faction then return faction end
+	local singleFaction = Faction.read(input, options)
+	if factionsingleFaction then return singleFaction end
 
 	local inputArray = Array.map(mw.text.split(input, options.sep or '', true),
 		function(faction) return mw.text.trim(faction) end)

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -6,8 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Data = mw.loadData('Module:Faction/Data')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 
@@ -62,6 +64,36 @@ function Faction.read(faction)
 	return Faction.isValid(faction) and faction
 		or byLowerName[faction]
 		or Faction.aliases[faction]
+end
+
+--- Parses multiple factions from input.
+-- Returns a table of the found factions short handle/identifier.
+-- Returns empty table if no input is specified.
+---@props props {input: string, sep: string?}
+---@return table
+function Faction.readMultiFaction(props)
+	if String.isEmpty(props.input) then
+		return {}
+	end
+
+	if Faction.read(props.input) then
+		return {Faction.read(props.input)}
+	end
+
+	local input = {}
+	if String.isNotEmpty(props.sep) then
+		input = Array.map(mw.text.split(props.input, props.sep, true), mw.text.trim)
+	else
+		for char in props.input:gmatch('(.)') do
+			table.insert(input, char)
+		end
+	end
+
+	return Array.map(input, function(factionInput)
+		local faction = Faction.read(factionInput)
+		assert(faction, 'Invalid faction "' .. factionInput .. '"')
+		return faction
+	end)
 end
 
 --- Returns the name of an entered faction identifier

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -73,7 +73,7 @@ end
 
 --- Parses multiple factions from input.
 -- Returns an array of faction identifiers.
--- Returns an empty array for nil input. Throws upon invalid inputs,
+-- Returns an empty array for nil input. Throws upon invalid inputs.
 ---@param input: string
 ---@param options: {sep: string?, alias: boolean?}?
 ---@return table

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -73,27 +73,29 @@ end
 --- Parses a faction from input. Returns the factions short handle/identifier.
 -- Returns nil if not a valid faction.
 ---@props input: string
----@props sep: string?
+---@props options: {sep: string?, noAliasing: boolean?}?
 ---@return table?
-function Faction.readMultiFaction(input, sep)
+function Faction.readMultiFaction(input, options)
 	if String.isEmpty(input) then
 		return {}
 	end
 
-	if Faction.read(input, {noAliasing = true}) then
-		return {Faction.read(input, {noAliasing = true})}
+	options = options or {}
+
+	if Faction.read(input, options) then
+		return {Faction.read(input, options)}
 	end
 
 	local inputArray = {}
-	if String.isNotEmpty(sep) then
-		inputArray = Array.map(mw.text.split(input, sep, true), mw.text.trim)
+	if String.isNotEmpty(options.sep) then
+		inputArray = Array.map(mw.text.split(input, options.sep, true), mw.text.trim)
 	else
 		for char in input:gmatch('(.)') do
 			table.insert(inputArray, char)
 		end
 	end
 
-	local factions = Array.map(inputArray, function(faction) return Faction.read(faction) end)
+	local factions = Array.map(inputArray, function(faction) return Faction.read(faction, options) end)
 	assert(#factions == #inputArray, 'Invalid multi-faction specifier ' .. input)
 	return factions
 end

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -70,8 +70,9 @@ function Faction.read(faction, options)
 		or nil
 end
 
---- Parses a faction from input. Returns the factions short handle/identifier.
--- Returns nil if not a valid faction.
+--- Parses multiple factions from input.
+-- Returns a table of the found factions short handle/identifier.
+-- Returns empty table if no input is specified.
 ---@props input: string
 ---@props options: {sep: string?, noAliasing: boolean?}?
 ---@return table?

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -75,7 +75,7 @@ end
 -- Returns empty table if no input is specified.
 ---@props input: string
 ---@props options: {sep: string?, alias: boolean?}?
----@return table?
+---@return table
 function Faction.readMultiFaction(input, options)
 	if String.isEmpty(input) then
 		return {}

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -87,8 +87,10 @@ function Faction.readMultiFaction(input, options)
 	local singleFaction = Faction.read(input, options)
 	if factionsingleFaction then return singleFaction end
 
-	local inputArray = Array.map(mw.text.split(input, options.sep or '', true),
-		function(faction) return mw.text.trim(faction) end)
+	local inputArray = Array.map(
+		mw.text.split(input, options.sep or '', true),
+		function(faction) return mw.text.trim(faction) end
+	)
 
 	local factions = Array.map(inputArray, function(faction) return Faction.read(faction, options) end)
 

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -89,11 +89,9 @@ function Faction.readMultiFaction(props)
 		end
 	end
 
-	return Array.map(input, function(factionInput)
-		local faction = Faction.read(factionInput)
-		assert(faction, 'Invalid faction "' .. factionInput .. '"')
-		return faction
-	end)
+	local factions = Array.map(input, Faction.read)
+	assert(#factions == #input, 'Invalid multi-faction specifier ' .. props.input)
+	return factions
 end
 
 --- Returns the name of an entered faction identifier

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -73,7 +73,7 @@ end
 
 --- Parses multiple factions from input.
 -- Returns an array of faction identifiers.
--- Returns empty table if no input is specified.
+-- Returns an empty array for nil input. Throws upon invalid inputs,
 ---@param input: string
 ---@param options: {sep: string?, alias: boolean?}?
 ---@return table


### PR DESCRIPTION
## Summary
Add Faction.readMultiFaction

Needed for reading input of multiple factions in the same string.
optionally with sep. otherwise going char by char

usecase will be person infoboxes on sc, sc2 (and at a later date warcraft)

example (used in testing the function on sc2):
```lua
Faction.readMultiFaction{input = 'ptz'} = {'p', 't', 'z'}

Faction.readMultiFaction{input = 'protoss'} = {'p'}

Faction.readMultiFaction{input = 'p'} = {'p'}

Faction.readMultiFaction{input = 'protoss,zerg', sep = ','} = {'p', 'z'}

Faction.readMultiFaction{input = 'pghjn'} —> intentional error
```

note that adding testcases on commons could not be evaluated on commons as the data is not available on commons

## How did you test this change?
/dev