### PR TITLE
Adjust participants number handling in WC infobox league

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -173,6 +173,19 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+function CustomLeague._displayParticipantNumber(number)
+	local numberOfReplacements
+	number, numberOfReplacements = string.gsub(number, '%+', '')
+
+	if numberOfReplacements > 0 then
+		return tostring(mw.html.create()
+			:node(mw.html.create('small'):wikitext('more than '))
+			:wikitext(number))
+	end
+
+	return number
+end
+
 function CustomLeague._displayStartDateTime()
 	return Countdown._create{
 		date = Variables.varDefault('tournament_starttimeraw'),

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -140,6 +140,8 @@ function CustomInjector:parse(id, widgets)
 
 			-- clean var of '+' suffix
 			playerNumber = string.gsub(playerNumber, '%+', '')
+			--make playerNumber available for commons category check
+			_args.player_number = playerNumber
 		end
 		if _args.team_number then
 			table.insert(widgets, Cell{name = 'Number of teams',
@@ -148,9 +150,6 @@ function CustomInjector:parse(id, widgets)
 			-- clean var of '+' suffix
 			_args.team_number = string.gsub(_args.team_number, '%+', '')
 		end
-
-		--make playerNumber available for commons category check
-		_args.player_number = playerNumber
 
 		Variables.varDefine('player_number', playerNumber or 0)
 

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -128,21 +128,29 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'customcontent' then
 		--player breakdown
 		local playerRaceBreakDown = CustomLeague._playerRaceBreakDown() or {}
-		--make playerNumber available for commons category check
-		_args.player_number = playerRaceBreakDown.playerNumber
-		local playerNumber = _args.player_number or 0
-		Variables.varDefine('player_number', playerNumber)
-		if playerNumber > 0 or _args.team_number then
+		local playerNumber = playerRaceBreakDown.playerNumber or _args.player_number
+		if playerNumber or _args.team_number then
 			table.insert(widgets, Title{name = 'Participants breakdown'})
 		end
 
-		if playerNumber > 0 then
-			table.insert(widgets, Cell{name = 'Number of players', content = {playerNumber}})
+		if playerNumber then
+			table.insert(widgets, Cell{name = 'Number of players', content = {CustomLeague._displayParticipantNumber(playerNumber)}})
 			table.insert(widgets, Breakdown{content = playerRaceBreakDown.display, classes = {'infobox-center'}})
+
+			-- clean var of '+' suffix
+			playerNumber = string.gsub(playerNumber, '%+', '')
 		end
 		if _args.team_number then
-			table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+			table.insert(widgets, Cell{name = 'Number of teams', content = {CustomLeague._displayParticipantNumber(_args.team_number)}})
+
+			-- clean var of '+' suffix
+			_args.team_number = string.gsub(_args.team_number, '%+', '')
 		end
+
+		--make playerNumber available for commons category check
+		_args.player_number = playerNumber
+
+		Variables.varDefine('player_number', playerNumber or 0)
 
 		--maps
 		if String.isNotEmpty(_args.map1) then

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -134,14 +134,16 @@ function CustomInjector:parse(id, widgets)
 		end
 
 		if playerNumber then
-			table.insert(widgets, Cell{name = 'Number of players', content = {CustomLeague._displayParticipantNumber(playerNumber)}})
+			table.insert(widgets, Cell{name = 'Number of players',
+				content = {CustomLeague._displayParticipantNumber(playerNumber)}})
 			table.insert(widgets, Breakdown{content = playerRaceBreakDown.display, classes = {'infobox-center'}})
 
 			-- clean var of '+' suffix
 			playerNumber = string.gsub(playerNumber, '%+', '')
 		end
 		if _args.team_number then
-			table.insert(widgets, Cell{name = 'Number of teams', content = {CustomLeague._displayParticipantNumber(_args.team_number)}})
+			table.insert(widgets, Cell{name = 'Number of teams',
+				content = {CustomLeague._displayParticipantNumber(_args.team_number)}})
 
 			-- clean var of '+' suffix
 			_args.team_number = string.gsub(_args.team_number, '%+', '')

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -151,6 +151,8 @@ function CustomInjector:parse(id, widgets)
 			_args.team_number = string.gsub(_args.team_number, '%+', '')
 		end
 
+		-- Variable only needed for storage in SMW via Infobox league template
+		-- to be removed once SMW is removed
 		Variables.varDefine('player_number', playerNumber or 0)
 
 		--maps


### PR DESCRIPTION
## Summary
Adjust participants number handling in WC infobox league
- Warcraft wants to be able to enter stuff like `|player_number=8+`, i.e. a `'+'` suffix
- It is to be stored without the suffix
- It is to be displayed as `<small>more than </small> .. cleanedNumber`

## How did you test this change?
dev