### PR TITLE
Store standings config values

### DIFF
--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -63,9 +63,9 @@ function StandingsStorage.table(data)
 	}
 
 	local config = {
-		draw = data.hasdraw,
-		overtime = data.hasovertime,
-		points = data.haspoints,
+		hasdraws = data.hasdraw,
+		hasovertimes = data.hasovertime,
+		haspoints = data.haspoints,
 	}
 
 	mw.ext.LiquipediaDB.lpdb_standingstable('standingsTable_' .. data.standingsindex,

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -62,6 +62,12 @@ function StandingsStorage.table(data)
 		stagename = data.stagename or Variables.varDefault('bracket_header'),
 	}
 
+	local config = {
+		draw = data.hasdraw,
+		overtime = data.hasovertime,
+		points = data.haspoints,
+	}
+
 	mw.ext.LiquipediaDB.lpdb_standingstable('standingsTable_' .. data.standingsindex,
 		{
 			tournament = Variables.varDefault('tournament_name', ''),
@@ -71,6 +77,7 @@ function StandingsStorage.table(data)
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),
 			type = data.type,
 			matches = Json.stringify(data.matches or {}),
+			config = mw.ext.LiquipediaDB.lpdb_create_json(config),
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, data.extradata)),
 		}
 	)

--- a/standard/mock/mock_lpdb.lua
+++ b/standard/mock/mock_lpdb.lua
@@ -58,6 +58,7 @@ dbStructure.standingstable = {
 	section = 'string',
 	type = TypeUtil.literalUnion('league', 'swiss'),
 	matches = TypeUtil.optional(TypeUtil.array('string')),
+	config = TypeUtil.table('string', 'boolean'),
 	extradata = 'struct?',
 }
 dbStructure.standingsentry = {


### PR DESCRIPTION
## Summary
LPDB field `config` was recently added to the StandingsTable.

As a first step in migrating away from the config values stored in extradata, store them into the new field.

## How did you test this change?
Dev module
![image](https://user-images.githubusercontent.com/3426850/216315044-35cd391a-0f35-4a87-9d17-5d2efdf8d129.png)
