### PR TITLE
pubgmobile: create infobox team custom

### DIFF
--- a/components/infobox/wikis/pubgmobile/infobox_team_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_team_custom.lua
@@ -22,7 +22,7 @@ function CustomTeam.run(frame)
 	_team = team
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
-  team.defineCustomPageVariables = CustomTeam.defineCustomPageVariables
+	team.defineCustomPageVariables = CustomTeam.defineCustomPageVariables
 	return team:createInfobox()
 end
 

--- a/components/infobox/wikis/pubgmobile/infobox_team_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_team_custom.lua
@@ -1,0 +1,49 @@
+---
+-- @Liquipedia
+-- wiki=pubgmobile
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Template = require('Module:Template')
+local Variables = require('Module:Variables')
+
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local CustomTeam = Class.new()
+
+local _team
+
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	_team = team
+	team.createBottomContent = CustomTeam.createBottomContent
+	team.addToLpdb = CustomTeam.addToLpdb
+  team.defineCustomPageVariables = CustomTeam.defineCustomPageVariables
+	return team:createInfobox()
+end
+
+function CustomTeam:createBottomContent()
+	return Template.expandTemplate(
+		mw.getCurrentFrame(),
+		'Upcoming and ongoing tournaments of',
+		{team = _team.name or _team.pagename}
+	) ..  Template.expandTemplate(
+		mw.getCurrentFrame(),
+		'Placement summary',
+		{team = _team.name or _team.pagename}
+	)
+end
+
+function CustomTeam:addToLpdb(lpdbData, args)
+	return lpdbData
+end
+
+function CustomTeam:defineCustomPageVariables(args)
+	Variables.varDefine('team_captain', args.captain)
+end
+
+return CustomTeam


### PR DESCRIPTION
## Summary

Moved bottom content out of template call and into custom and fixed the display of those sections. 
Added an extra page variable to be set

## How did you test this change?

https://liquipedia.net/pubgmobile/User:Dark_meluca/TeamTest
https://liquipedia.net/pubgmobile/Module:Infobox/Team/Custom/dev

current custom uses /dev versions of bottom content templates, so as not to disturb the current display of infoboxes