### PR TITLE
pubgmobile: add wikivars for extradata

### DIFF
--- a/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
@@ -9,7 +9,6 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 local Weight = require('Module:Weight')
 

--- a/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
@@ -40,6 +40,12 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		Variables.varDefault('tournament_liquipediatiertype')
 	)
 
+	local participantLower = mw.ustring.lower(lpdbData.participant)
+	local status = Variables.varDefault('placement_' .. participantLower) ~= '' and Variables.varDefault('tournament_status') or ''
+
+	Variables.varDefine(participantLower .. '_status', status)
+	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+
 	return lpdbData
 end
 

--- a/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
@@ -41,7 +41,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	)
 
 	local participantLower = mw.ustring.lower(lpdbData.participant)
-	local status = Variables.varDefault('placement_' .. participantLower) ~= '' and Variables.varDefault('tournament_status') or ''
+	local status = String.isNotEmpty(Variables.varDefault('placement_' .. participantLower))
+		and Variables.varDefault('tournament_status') or ''
 
 	Variables.varDefine(participantLower .. '_status', status)
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)

--- a/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
@@ -41,12 +41,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		Variables.varDefault('tournament_liquipediatiertype')
 	)
 
-	local participantLower = mw.ustring.lower(lpdbData.participant)
-	local status = String.isNotEmpty(Variables.varDefault('placement_' .. participantLower))
-		and Variables.varDefault('tournament_status') or ''
-
-	Variables.varDefine(participantLower .. '_status', status)
-	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints', lpdbData.extradata.prizepoints)
 
 	return lpdbData
 end

--- a/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/pubgmobile/prize_pool_custom.lua
@@ -9,6 +9,7 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 local Weight = require('Module:Weight')
 


### PR DESCRIPTION
## Summary

both prizepoints and status are defined to be stored in lpdb placement extradata

## How did you test this change?

Tested alongside teamcard/custom/dev here:
https://liquipedia.net/pubgmobile/User:Dark_meluca/PrizePoolTest