### PR TITLE
Fix TBD handling for CS match1

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -111,7 +111,9 @@ function MatchLegacy.convertParameters(match2)
 		local prefix = 'opponent' .. index
 		local opponent = match2.match2opponents[index] or {}
 		local opponentmatch2players = opponent.match2players or {}
-		if opponent.type == Opponent.team or opponent.type == Opponent.literal then
+		if String.isEmpty(opponent.template) then
+			match[prefix] = 'TBD'
+		elseif opponent.type == Opponent.team or opponent.type == Opponent.literal then
 			if opponent.type == Opponent.team then
 				if mw.ext.TeamTemplate.teamexists(opponent.template) then
 					match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -111,17 +111,17 @@ function MatchLegacy.convertParameters(match2)
 		local prefix = 'opponent' .. index
 		local opponent = match2.match2opponents[index] or {}
 		local opponentmatch2players = opponent.match2players or {}
-		if String.isEmpty(opponent.template) then
-			match[prefix] = 'TBD'
-		elseif opponent.type == Opponent.team or opponent.type == Opponent.literal then
+		if opponent.type == Opponent.team or opponent.type == Opponent.literal then
 			if opponent.type == Opponent.team then
-				if mw.ext.TeamTemplate.teamexists(opponent.template) then
+				if String.isEmpty(opponent.template) then
+					match[prefix] = 'TBD'
+				elseif mw.ext.TeamTemplate.teamexists(opponent.template) then
 					match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
 				else
 					match[prefix] = opponent.template
 				end
 			else
-				if TextSanitizer.stripHTML(opponent.name) ~= opponent.name then
+				if String.isEmpty(opponent.name) or TextSanitizer.stripHTML(opponent.name) ~= opponent.name then
 					match[prefix] = 'TBD'
 				else
 					match[prefix] = opponent.name
@@ -157,10 +157,14 @@ function MatchLegacy.convertParameters(match2)
 			end
 			match[prefix .. 'players'] = mw.ext.LiquipediaDB.lpdb_create_json(opponentplayers)
 		elseif opponent.type == Opponent.solo then
-			local player = opponentmatch2players[1] or {}
-			match[prefix] = player.name
-			match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
-			match[prefix .. 'flag'] = player.flag
+			if String.isEmpty(opponent.name) then
+				match[prefix] = 'TBD'
+			else
+				local player = opponentmatch2players[1] or {}
+				match[prefix] = player.name
+				match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
+				match[prefix .. 'flag'] = player.flag
+			end
 		end
 	end
 


### PR DESCRIPTION
## Summary

`TBD` handling was broken by #2374 and/or #2377 . This addresses that issue.

![image](https://user-images.githubusercontent.com/5881994/215213937-2371856b-2cba-4e51-b8e5-1a0ba9578670.png)

## How did you test this change?

Tested on `/dev`
![image](https://user-images.githubusercontent.com/5881994/215213973-b5862ed4-bce1-4abf-8584-46d803de71ef.png)

