### PR TITLE
Recalculate PPT slot `count` for legacy PPTs

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -283,7 +283,7 @@ function LegacyPrizePool.mapOpponents(slot, newData, mergeSlots)
 			team = slot['team' .. opponentIndex],
 			lastvs = {
 				slot['lastvs' .. opponentIndex],
-				link = slot['lastvs' .. opponentIndex .. 'link'] or slot['lastvs' .. opponentIndex .. 'page'],
+				link = slot['lastvs' .. opponentIndex .. 'link'] or slot['lastvspage' .. opponentIndex],
 				flag = slot['lastvsflag' .. opponentIndex],
 			},
 			lastvsscore = (slot['lastscore' .. opponentIndex] or '') ..

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -94,6 +94,7 @@ function LegacyPrizePool.run(dependency)
 			newSlotIndex = newSlotIndex + 1
 			newArgs[newSlotIndex] = tempSlot
 		end
+		newArgs[newSlotIndex].count = #newArgs[newSlotIndex].opponents
 	end
 
 	-- iterate over slots and merge opponents into the slots directly
@@ -282,7 +283,7 @@ function LegacyPrizePool.mapOpponents(slot, newData, mergeSlots)
 			team = slot['team' .. opponentIndex],
 			lastvs = {
 				slot['lastvs' .. opponentIndex],
-				link = slot['lastvs' .. opponentIndex .. 'link'] or slot['lastvspage' .. opponentIndex],
+				link = slot['lastvs' .. opponentIndex .. 'link'] or slot['lastvs' .. opponentIndex .. 'page'],
 				flag = slot['lastvsflag' .. opponentIndex],
 			},
 			lastvsscore = (slot['lastscore' .. opponentIndex] or '') ..


### PR DESCRIPTION
## Summary

When `mergeSlots` is disabled, slots that have larger placement widths than their pseudo count become broken as such.
![image](https://user-images.githubusercontent.com/5881994/215279866-04b09d25-2ad7-4c6c-8ed8-4fc5730de298.png)

This change recalculates and add s arg `count` for each slot after it is generated and/or merged into.

**This PR requires the following PR's to be merged first or will cause errors:**
- [x] #2477

## How did you test this change?

`/dev` with this page: https://liquipedia.net/counterstrike/ESL/Masters_Espa%C3%B1a/Season_8
![image](https://user-images.githubusercontent.com/5881994/215279977-a47714a4-beca-4ce0-b08a-ebee1e900c03.png)

## Better solutions?

For me, this isn't the ideal solution based on how #2369 and #2431 currently behave since it's remapping them to 3rd and 4th when they should ideally be 3-4th both. A different fix is probably possible in the handling of how the expand/collapse row is handled (i.e., check follow placement too before placing the toggle row), but this seemed more correct way to fix it. Although if the remapping is kept to 3rd and 4th, then maybe that other solution will be better.

Also, enabling `mergeSlots` on the CS wiki would also fix the issue, but currently I don't recall why it's disabled.

For now, leaving this as draft as depends on #2431 anyway.