### PR TITLE
Add Opponent/Custom for Tetris

### DIFF
--- a/components/opponent/wikis/tetris/opponent_custom.lua
+++ b/components/opponent/wikis/tetris/opponent_custom.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- wiki=tetris
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local PlayerExt = Lua.import('Module:Player/Ext', {requireDevIfEnabled = true})
+
+local CustomOpponent = Table.deepCopy(Opponent)
+
+function CustomOpponent.resolve(opponent, date, options)
+	options = options or {}
+	Opponent.resolve(opponent, date, options)
+	if Opponent.typeIsParty(opponent.type) then
+		for _, player in ipairs(opponent.players) do
+			if not player.team and options.syncPlayer then
+				player.team = PlayerExt.syncTeam(player.pageName, nil)
+			end
+		end
+	end
+	return opponent
+end
+
+return CustomOpponent


### PR DESCRIPTION
## Summary
**Part of Tetris Match2 Implementation**

Tetris is a 1v1-centric in its game
while Team-based and 2v2 are very rare (unlike CR, this is actual rare). The PRs are planned to start with non-team stuff first

Custom Opponent modules are an adjusted port from Clash Royale (which was merged)

## How did you test this change?
/dev - https://liquipedia.net/tetris/User:Hesketh2/Test
