### PR TITLE
pubgmobile: Fix incorrect function definition

### DIFF
--- a/components/infobox/wikis/pubgmobile/infobox_map_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_map_custom.lua
@@ -77,7 +77,7 @@ function CustomMap._getGameVersion()
 	return GAME[string.lower(_args.game or '')]
 end
 
-function CustomMap:_getGameMode()
+function CustomMap._getGameMode()
 	return MODES[string.lower(_args.mode or '')]
 end
 


### PR DESCRIPTION
## Summary

colon notation wasn't supposed to be there originally, updating to correct bug.
