### PR TITLE
Import `Module:Info` via Lua.import in OpponentLibraries

### DIFF
--- a/components/opponent/commons/opponent_libraries.lua
+++ b/components/opponent/commons/opponent_libraries.lua
@@ -6,8 +6,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Info = require('Module:Info')
 local Lua = require('Module:Lua')
+
+local Info = Lua.import('Module:Info', {requireDevIfEnabled = true})
 
 return {
 	Opponent = Lua.import('Module:'.. (Info.opponentLibrary or 'Opponent'), {requireDevIfEnabled = true}),


### PR DESCRIPTION
## Summary
Allows to use a /dev version of Module:Info, to be able to adjust the opponent libraries during development.
As an alternative, i could also add a OpponentDisplay/Custom shim on the wiki, and change the Info module directly. (Since i then can work in OpponentDisplay/Custom/dev)

## How did you test this change?
Tested via dev:
![image](https://user-images.githubusercontent.com/16326643/215464428-7eaf3e25-85db-4568-9961-795b3d5fb1ff.png)
Info/dev:
![image](https://user-images.githubusercontent.com/16326643/215464463-0d924ff8-7181-4a8a-a348-135ccd4da5b0.png)

