### PR TITLE
Fix timezone var in WC infobox league

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -328,7 +328,7 @@ function CustomLeague:defineCustomPageVariables()
 
 		Variables.varDefine('tournament_starttime', startTime)
 		Variables.varDefine('start_time', startTime)
-		local timeZone = _args.starttime:match('data-tz="(.*)"')
+		local timeZone = _args.starttime:match('data%-tz="(.-)"')
 		if timeZone then
 			Variables.varDefine('tournament_timezone', timeZone)
 		end


### PR DESCRIPTION
## Summary
Fix timezone var in WC infobox league
- escape the `-` (i.e. use `%-` over `-`)
- match non greedy (i.e. use `-` over `*`)

## How did you test this change?
dev into live