### PR TITLE
Fix inactivity fetching in AoE Infobox team

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -138,7 +138,7 @@ function CustomTeam._getLatestPlacement(game)
 end
 
 function CustomTeam._buildTeamPlacementConditions()
-	local team = _args.teamtemplate or _pagename
+	local team = _args.teamtemplate or _args.name or _pagename
 	local rawOpponentTemplate = TeamTemplates.queryRaw(team) or {}
 	local opponentTemplate = rawOpponentTemplate.historicaltemplate or rawOpponentTemplate.templatename
 	if not opponentTemplate then


### PR DESCRIPTION
## Summary
Previously, the functionality used a single lpdb query to fetch games a team competed in as well as the date of these placements.
Since `order` only applies after a `groupby`, this worked for some, but not all teams, as sometimes old placements and therefore dates would be returned.

In addition, fetching of games is decoupled from any manual input, and it uses `args.name` to query placements before it defaults to pagename.

## How did you test this change?
via /dev