### PR TITLE
Add organizer specific icons in BS infobox league

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -102,18 +102,23 @@ function League:createInfobox()
 				)
 			}
 		},
-		Builder{
-			builder = function()
-				local organizers = self:_createOrganizers(args)
-				local title = Table.size(organizers) == 1 and 'Organizer' or 'Organizers'
+		Customizable{
+			id = 'organizers',
+			children = {
+				Builder{
+					builder = function()
+						local organizers = self:_createOrganizers(args)
+						local title = Table.size(organizers) == 1 and 'Organizer' or 'Organizers'
 
-				return {
-					Cell{
-						name = title,
-						content = organizers
-					}
-				}
-			end
+						return {
+							Cell{
+								name = title,
+								content = organizers
+							}
+						}
+					end
+				},
+			},
 		},
 		Customizable{
 			id = 'sponsors',
@@ -176,7 +181,7 @@ function League:createInfobox()
 						description = String.interpolate(VENUE_DESCRIPTION, {desc = args[prefix .. 'desc']})
 					end
 
-					table.insert(venues, self:_createLink(venueName, nil, args[prefix .. 'link'], description))
+					table.insert(venues, self:createLink(venueName, nil, args[prefix .. 'link'], description))
 				end
 
 				return {Cell{
@@ -580,7 +585,7 @@ function League:_setIconVariable(iconSmallTemplate, manualIcon, manualIconDark)
 	end
 end
 
-function League:_createLink(id, name, link, desc)
+function League:createLink(id, name, link, desc)
 	if String.isEmpty(id) then
 		return nil
 	end
@@ -617,7 +622,7 @@ end
 
 function League:_createOrganizers(args)
 	local organizers = {
-		League:_createLink(
+		self:createLink(
 			args.organizer, args['organizer-name'], args['organizer-link'], args.organizerref),
 	}
 
@@ -626,7 +631,7 @@ function League:_createOrganizers(args)
 	while not String.isEmpty(args['organizer' .. index]) do
 		table.insert(
 			organizers,
-			League:_createLink(
+			self:createLink(
 				args['organizer' .. index],
 				args['organizer' .. index .. '-name'],
 				args['organizer' .. index .. '-link'],

--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -9,6 +9,8 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -18,6 +20,11 @@ local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
 local SUPERCELL_SPONSORED_ICON = '[[File:Supercell icon.png|x18px|link=Supercell|Tournament sponsored by Supercell.]]'
+
+local ORGANIZER_ICONS = {
+	Supercell = '[[File:Supercell icon.png|x18px|link=Supercell|Supercell]] ',
+	['Esports Engine'] = '[[File:Esports Engine icon allmode.png|x18px|link=Esports Engine|Esports Engine]] '
+}
 
 local _args
 local _league
@@ -44,6 +51,18 @@ function CustomLeague:createWidgetInjector()
 end
 
 function CustomInjector:parse(id, widgets)
+	if id == 'organizers' then
+		local organizers = CustomLeague._createOrganizers()
+		local title = Table.size(organizers) == 1 and 'Organizer' or 'Organizers'
+
+		return {
+			Cell{
+				name = title,
+				content = organizers
+			}
+		}
+	end
+
 	return widgets
 end
 
@@ -87,6 +106,29 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('date', edate)
 	Variables.varDefine('sdate', sdate)
 	Variables.varDefine('edate', edate)
+end
+
+function CustomLeague._createOrganizers()
+	local organizers = {
+		(ORGANIZER_ICONS[_args.organizer] or '') .. _league:createLink(
+			_args.organizer, _args['organizer-name'], _args['organizer-link'], _args.organizerref),
+	}
+
+	local index = 2
+	while not String.isEmpty(_args['organizer' .. index]) do
+		table.insert(
+			organizers,
+			(ORGANIZER_ICONS[_args['organizer' .. index]] or '') .. _league:createLink(
+				_args['organizer' .. index],
+				_args['organizer' .. index .. '-name'],
+				_args['organizer' .. index .. '-link'],
+				_args['organizerref' .. index])
+		)
+		index = index + 1
+	end
+
+	return organizers
+	
 end
 
 return CustomLeague

--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -128,7 +128,6 @@ function CustomLeague._createOrganizers()
 	end
 
 	return organizers
-	
 end
 
 return CustomLeague


### PR DESCRIPTION
## Summary
Add organizer specific icons in BS infobox league
- make organizers customizable in commons infobox league
- adjust the /Custom to adjust organizers display as wanted

requested by m4d0o3e

## How did you test this change?
dev

![Screenshot 2023-01-30 08 36 33](https://user-images.githubusercontent.com/75081997/215416501-455ba717-ec82-4883-a9e8-89f69a5d9b01.png)
