### PR TITLE
MatchGroup/Input/Custom for Tetris

### DIFF
--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -85,7 +85,6 @@ function CustomMatchGroupInput._getVodStuff(match)
 end
 
 function CustomMatchGroupInput._getExtraData(match)
-	local casters = {}
 	match.extradata = {
 		casters = MatchGroupInput.readCasters(match, {noSort = true}),
 	}

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -425,6 +425,7 @@ function CustomMatchGroupInput._processPlayerMapData(map, match)
 				participants
 			)
 		elseif opponent.type == Opponent.team then
+			error('Team opponents are currently not yet supported on tetris wiki')
 			--[[ todo in a sep PR:
 			CustomMatchGroupInput._processTeamPlayerMapData(
 				opponent.match2players or {},

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
+--local Flags = require('Module:Flags')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
-local Flags = require('Module:Flags')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -134,7 +133,7 @@ function CustomMatchGroupInput._adjustData(match)
 	if CustomMatchGroupInput._hasTeamOpponent(match) then
 		error('Team opponents are currently not yet supported on tetris wiki')
 		-- todo (sep PR):
-		-- Each set contains various 1v1 matches with different players, when a team wins 3 1v1s matches they win the set 
+		-- Each set contains various 1v1 matches with different players, when a team wins 3 1v1s matches they win the set
 		-- First team to get 2 set, wins the complete series
 		-- match = CustomMatchGroupInput._subMatchStructure(match)
 	end

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -1,0 +1,560 @@
+---
+-- @Liquipedia
+-- wiki=tetris
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
+local Flags = require('Module:Flags')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
+local Streams = Lua.import('Module:Links/Stream', {requireDevIfEnabled = true})
+
+local Opponent = require('Module:OpponentLibraries').Opponent
+
+local UNKNOWN_REASON_LOSS_STATUS = 'L'
+local DEFAULT_WIN_STATUS = 'W'
+local DEFAULT_WIN_RESULTTYPE = 'default'
+local NO_SCORE = -1
+local SCORE_STATUS = 'S'
+local ALLOWED_STATUSES = {DEFAULT_WIN_STATUS, 'FF', 'DQ', UNKNOWN_REASON_LOSS_STATUS}
+local MAX_NUM_OPPONENTS = 2
+local DEFAULT_BEST_OF = 99
+local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+local NOW = os.time(os.date('!*t'))
+--local MAX_NUM_PLAYERS_PER_MAP = 2
+--local TBD = 'tbd'
+--local TBA = 'tba'
+local BYE = 'bye'
+local MAX_NUM_MAPS = 30
+
+local CustomMatchGroupInput = {}
+
+CustomMatchGroupInput.walkoverProcessing = {}
+local walkoverProcessing = CustomMatchGroupInput.walkoverProcessing
+
+-- called from Module:MatchGroup
+function CustomMatchGroupInput.processMatch(match)
+	if Logic.readBool(match.ffa) then
+		error('FFA matches are not yet supported')
+		-- later call ffa processing from here
+	elseif match['opponent' .. (MAX_NUM_OPPONENTS + 1)] then
+		error('Unexpected number of opponents in a non-FFA match')
+	end
+
+	Table.mergeInto(
+		match,
+		CustomMatchGroupInput._readDate(match)
+	)
+	match = CustomMatchGroupInput._getExtraData(match)
+	match = CustomMatchGroupInput._getTournamentVars(match)
+	match = CustomMatchGroupInput._adjustData(match)
+	match = CustomMatchGroupInput._getVodStuff(match)
+
+	return match
+end
+
+function CustomMatchGroupInput._readDate(matchArgs)
+	if matchArgs.date then
+		return MatchGroupInput.readDate(matchArgs.date)
+	else
+		return {
+			date = EPOCH_TIME_EXTENDED,
+			dateexact = false,
+			timestamp = DateExt.epochZero,
+		}
+	end
+end
+
+function CustomMatchGroupInput._getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'solo'))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
+	return MatchGroupInput.getCommonTournamentVars(match)
+end
+
+function CustomMatchGroupInput._getVodStuff(match)
+	match.stream = Streams.processStreams(match)
+	match.vod = Logic.emptyOr(match.vod)
+
+	return match
+end
+
+function CustomMatchGroupInput._getExtraData(match)
+	local casters = {}
+	for key, name in Table.iter.pairsByPrefix(match, 'caster') do
+		table.insert(casters, CustomMatchGroupInput._getCasterInformation(
+			name,
+			match[key .. 'flag'],
+			match[key .. 'name']
+		))
+	end
+
+	match.extradata = {
+		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil
+	}
+
+	for subGroupIndex = 1, MAX_NUM_MAPS do
+		local prefix = 'subgroup' .. subGroupIndex
+
+		match.extradata[prefix .. 'header'] = CustomMatchGroupInput._getSubGroupHeader(subGroupIndex, match)
+	end
+
+	return match
+end
+
+function CustomMatchGroupInput._getSubGroupHeader(subGroupIndex, match)
+	local header = match['set' .. subGroupIndex .. 'header']
+
+	return String.isNotEmpty(header) and header or nil
+end
+
+function CustomMatchGroupInput._adjustData(match)
+	--parse opponents + set base sumscores
+	match = CustomMatchGroupInput._opponentInput(match)
+
+	--main processing done here
+	local subGroupIndex = 0
+	for _, _, mapIndex in Table.iter.pairsByPrefix(match, 'map') do
+		match, subGroupIndex = CustomMatchGroupInput._mapInput(match, mapIndex, subGroupIndex)
+	end
+
+	match = CustomMatchGroupInput._matchWinnerProcessing(match)
+
+	CustomMatchGroupInput._setPlacements(match)
+
+	if CustomMatchGroupInput._hasTeamOpponent(match) then
+		error('Team opponents are currently not yet supported on tetris wiki')
+		-- todo (sep PR):
+		-- Each set contains various 1v1 matches with different players, when a team wins 3 1v1s matches they win the set 
+		-- First team to get 2 set, wins the complete series
+		-- match = CustomMatchGroupInput._subMatchStructure(match)
+	end
+
+	if Logic.isNumeric(match.winner) then
+		match.finished = true
+	end
+
+	return match
+end
+
+function CustomMatchGroupInput._matchWinnerProcessing(match)
+	local bestof = tonumber(match.bestof) or Variables.varDefault('bestof', DEFAULT_BEST_OF)
+	match.bestof = bestof
+	Variables.varDefine('bestof', bestof)
+
+	local scores = Array.map(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
+		local opponent = match['opponent' .. opponentIndex]
+		if not opponent then
+			return NO_SCORE
+		end
+
+		-- set the score either from manual input or sumscore
+		opponent.score = Table.includes(ALLOWED_STATUSES, string.upper(opponent.score or ''))
+			and opponent.score:upper()
+			or tonumber(opponent.score) or tonumber(opponent.sumscore) or NO_SCORE
+
+		return opponent.score
+	end)
+
+	walkoverProcessing.walkover(match, scores)
+
+	if match.resulttype == DEFAULT_WIN_RESULTTYPE then
+		walkoverProcessing.applyMatchWalkoverToOpponents(match)
+		return match
+	end
+
+	if match.winner == 'draw' then
+		match.winner = 0
+	end
+
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local opponent = match['opponent' .. opponentIndex]
+		if Logic.isNotEmpty(opponent) then
+			opponent.status = SCORE_STATUS
+			if opponent.score > bestof / 2 then
+				match.finished = Logic.emptyOr(match.finished, true)
+				match.winner = tonumber(match.winner) or opponentIndex
+			elseif match.winner == 0 or (opponent.score == bestof / 2 and match.opponent1.score == match.opponent2.score) then
+				match.finished = Logic.emptyOr(match.finished, true)
+				match.winner = 0
+				match.resulttype = 'draw'
+			end
+		end
+	end
+
+	match.winner = tonumber(match.winner)
+
+	CustomMatchGroupInput._checkFinished(match)
+
+	if match.finished and not match.winner then
+		CustomMatchGroupInput._determineWinnerIfMissing(match, scores)
+	end
+
+	return match
+end
+
+function CustomMatchGroupInput._checkFinished(match)
+	if Logic.readBoolOrNil(match.finished) == false then
+		match.finished = false
+	elseif Logic.readBool(match.finished) or match.winner then
+		match.finished = true
+	end
+
+	-- Match is automatically marked finished upon page edit after a
+	-- certain amount of time (depending on whether the date is exact)
+	if not match.finished and match.timestamp > DateExt.epochZero then
+		local threshold = match.dateexact and 30800 or 86400
+		if match.timestamp + threshold < NOW then
+			match.finished = true
+		end
+	end
+end
+
+function CustomMatchGroupInput._determineWinnerIfMissing(match, scores)
+	local maxScore = math.max(unpack(scores) or 0)
+	-- if we have a positive score and the match is finished we also have a winner
+	if maxScore > 0 then
+		if Array.all(scores, function(score) return score == maxScore end) then
+			match.winner = 0
+			return
+		end
+
+		for opponentIndex, score in pairs(scores) do
+			if score == maxScore then
+				match.winner = opponentIndex
+				return
+			end
+		end
+	end
+end
+
+function CustomMatchGroupInput._setPlacements(match)
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local opponent = match['opponent' .. opponentIndex]
+
+		if match.winner == opponentIndex or match.winner == 0 then
+			opponent.placement = 1
+		elseif match.winner then
+			opponent.placement = 2
+		end
+	end
+end
+
+--[[
+
+OpponentInput functions
+
+]]--
+function CustomMatchGroupInput._opponentInput(match)
+	local opponentIndex = 1
+	local opponent = match['opponent' .. opponentIndex]
+
+	while opponentIndex <= MAX_NUM_OPPONENTS and Logic.isNotEmpty(opponent) do
+		opponent = Json.parseIfString(opponent) or Opponent.blank()
+
+		-- Convert byes to literals
+		if
+			string.lower(opponent.template or '') == BYE
+			or string.lower(opponent.name or '') == BYE
+		then
+			opponent = {type = Opponent.literal, name = BYE:upper()}
+		end
+
+		--process input
+		if opponent.type == Opponent.team or opponent.type == Opponent.solo or
+			opponent.type == Opponent.literal then
+
+			opponent = CustomMatchGroupInput.processOpponent(opponent, match.timestamp)
+		else
+			error('Unsupported Opponent Type')
+		end
+
+		--set initial opponent sumscore
+		opponent.sumscore = 0
+
+		match['opponent' .. opponentIndex] = opponent
+
+		opponentIndex = opponentIndex + 1
+		opponent = match['opponent' .. opponentIndex]
+	end
+
+	return match
+end
+
+function CustomMatchGroupInput.processOpponent(record, timestamp)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	local teamTemplateDate = timestamp
+	-- If date is epoch, resolve using tournament dates instead
+	-- Epoch indicates that the match is missing a date
+	-- In order to get correct child team template, we will use an approximately date and not 1970-01-01
+	if teamTemplateDate == DateExt.epochZero then
+		teamTemplateDate = Variables.varDefaultMulti(
+			'tournament_enddate',
+			'tournament_startdate',
+			NOW
+		)
+	end
+
+	Opponent.resolve(opponent, teamTemplateDate)
+
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+
+	if record.type == Opponent.team then
+		record.icon, record.icondark = CustomMatchGroupInput.getIcon(opponent.template)
+		-- todo in sep pr:
+		--record.match2players = CustomMatchGroupInput._readTeamPlayers(record, record.players)
+	end
+
+	return record
+end
+
+--[[
+
+MapInput functions
+
+]]--
+function CustomMatchGroupInput._mapInput(match, mapIndex, subGroupIndex)
+	local map = Json.parseIfString(match['map' .. mapIndex])
+
+	if Table.isEmpty(map) then
+		match['map' .. mapIndex] = nil
+		return match, subGroupIndex
+	end
+
+	-- Tetris has no map names, use generic one instead
+	map.map = 'Game ' .. mapIndex
+
+	-- set initial extradata for maps
+	map.extradata = {
+		comment = map.comment,
+	}
+
+	-- inherit stuff from match data
+	map.type = Logic.emptyOr(map.type, match.type)
+	map.liquipediatier = match.liquipediatier
+	map.liquipediatiertype = match.liquipediatiertype
+	map.game = Logic.emptyOr(map.game, match.game)
+	map.date = Logic.emptyOr(map.date, match.date)
+
+	-- determine score, resulttype, walkover and winner
+	map = CustomMatchGroupInput._mapWinnerProcessing(map)
+
+	-- get participants data for the map + get map mode
+	map = CustomMatchGroupInput._processPlayerMapData(map, match)
+
+	-- set sumscore to 0 if it isn't a number
+	if String.isEmpty(match.opponent1.sumscore) then
+		match.opponent1.sumscore = 0
+	end
+	if String.isEmpty(match.opponent2.sumscore) then
+		match.opponent2.sumscore = 0
+	end
+
+	--adjust sumscore for winner opponent
+	if (tonumber(map.winner) or 0) > 0 then
+		match['opponent' .. map.winner].sumscore =
+			match['opponent' .. map.winner].sumscore + 1
+	end
+
+	match['map' .. mapIndex] = map
+
+	return match, subGroupIndex
+end
+
+function CustomMatchGroupInput._mapWinnerProcessing(map)
+	if map.winner == 'skip' then
+		map.scores = {NO_SCORE, NO_SCORE}
+		map.resulttype = 'np'
+
+		return map
+	end
+
+	map.scores = {}
+	local hasManualScores = false
+
+	local scores = Array.map(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
+		local score = map['score' .. opponentIndex]
+		map.scores[opponentIndex] = tonumber(score) or NO_SCORE
+
+		if String.isNotEmpty(score) then
+			hasManualScores = true
+		end
+
+		return Table.includes(ALLOWED_STATUSES, string.upper(score or ''))
+			and score:upper()
+			or map.scores[opponentIndex]
+	end)
+
+	if not hasManualScores then
+		local winnerInput = tonumber(map.winner)
+		if winnerInput == 1 then
+			map.scores = {1, 0}
+		elseif winnerInput == 2 then
+			map.scores = {0, 1}
+		end
+
+		return map
+	end
+
+	walkoverProcessing.walkover(map, scores)
+
+	return map
+end
+
+function CustomMatchGroupInput._processPlayerMapData(map, match)
+	local participants = {}
+
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local opponent = match['opponent' .. opponentIndex]
+		if Opponent.typeIsParty(opponent.type) then
+			CustomMatchGroupInput._processDefaultPlayerMapData(
+				opponent.match2players or {},
+				opponentIndex,
+				map,
+				participants
+			)
+		elseif opponent.type == Opponent.team then
+			--[[ todo in a sep PR:
+			CustomMatchGroupInput._processTeamPlayerMapData(
+				opponent.match2players or {},
+				opponentIndex,
+				map,
+				participants
+			)
+			]]
+		end
+	end
+
+	map.mode = Opponent.toMode(match.opponent1.type, match.opponent2.type)
+
+	map.participants = participants
+
+	return map
+end
+
+function CustomMatchGroupInput._processDefaultPlayerMapData(players, opponentIndex, map, participants)
+	for playerIndex = 1, #players do
+		participants[opponentIndex .. '_' .. playerIndex] = {
+			played = true,
+		}
+	end
+end
+
+function CustomMatchGroupInput.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	if raw then
+		local icon = Logic.emptyOr(raw.image, raw.legacyimage)
+		local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
+		return icon, iconDark
+	end
+end
+
+function CustomMatchGroupInput._hasTeamOpponent(match)
+	return match.opponent1.type == Opponent.team or match.opponent2.type == Opponent.team
+end
+
+function walkoverProcessing.walkover(obj, scores)
+	local walkover = obj.walkover
+
+	if Logic.isNumeric(walkover) then
+		walkoverProcessing.numericWalkover(obj, walkover)
+	elseif walkover then
+		walkoverProcessing.nonNumericWalkover(obj, walkover)
+	elseif #scores ~=2 then -- since we always have 2 opponents outside of ffa
+		error('Unexpected number of opponents when calculating winner')
+	elseif Array.all(scores, function(score)
+			return Table.includes(ALLOWED_STATUSES, score) and score ~= DEFAULT_WIN_STATUS
+		end) then
+
+		walkoverProcessing.scoreDoubleWalkover(obj, scores)
+	elseif Array.any(scores, function(score) return Table.includes(ALLOWED_STATUSES, score) end) then
+		walkoverProcessing.scoreWalkover(obj, scores)
+	end
+end
+
+function walkoverProcessing.numericWalkover(obj, walkover)
+	local winner = tonumber(walkover)
+
+	obj.winner = winner
+	obj.finished = true
+	obj.walkover = UNKNOWN_REASON_LOSS_STATUS
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.nonNumericWalkover(obj, walkover)
+	if not Table.includes(ALLOWED_STATUSES, string.upper(walkover)) then
+		error('Invalid walkover "' .. walkover .. '"')
+	elseif not Logic.isNumeric(obj.winner) then
+		error('Walkover without winner specified')
+	end
+
+	obj.winner = tonumber(obj.winner)
+	obj.finished = true
+	obj.walkover = walkover:upper()
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.scoreDoubleWalkover(obj, scores)
+	obj.winner = -1
+	obj.finished = true
+	obj.walkover = scores[1]
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.scoreWalkover(obj, scores)
+	local winner, status
+
+	for scoreIndex, score in pairs(scores) do
+		score = string.upper(score)
+		if score == DEFAULT_WIN_STATUS then
+			winner = scoreIndex
+		elseif Table.includes(ALLOWED_STATUSES, score) then
+			status = score
+		else
+			status = UNKNOWN_REASON_LOSS_STATUS
+		end
+	end
+
+	if not winner then
+		error('Invalid score combination "{' .. scores[1] .. ', ' .. scores[2] .. '}"')
+	end
+
+	obj.winner = winner
+	obj.finished = true
+	obj.walkover = status
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.applyMatchWalkoverToOpponents(match)
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local score = match['opponent' .. opponentIndex].score
+
+		if Logic.isNumeric(score) or String.isEmpty(score) then
+			match['opponent' .. opponentIndex].score = String.isNotEmpty(score) and score or NO_SCORE
+			match['opponent' .. opponentIndex].status = match.walkover
+		elseif score and Table.includes(ALLOWED_STATUSES, score:upper()) then
+			match['opponent' .. opponentIndex].score = NO_SCORE
+			match['opponent' .. opponentIndex].status = score
+		else
+			error('Invalid score "' .. score .. '"')
+		end
+	end
+
+	-- neither match.opponent0 nor match['opponent-1'] does exist hence the if
+	if match['opponent' .. match.winner] then
+		match['opponent' .. match.winner].status = DEFAULT_WIN_STATUS
+	end
+end
+
+return CustomMatchGroupInput

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -310,6 +310,14 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 
+	for _, player in pairs(record.players or {}) do
+		player.name = player.name:gsub(' ', '_')
+	end
+
+	if record.name then
+		record.name = record.name:gsub(' ', '_')
+	end
+
 	if record.type == Opponent.team then
 		record.icon, record.icondark = CustomMatchGroupInput.getIcon(opponent.template)
 		-- todo in sep pr:


### PR DESCRIPTION
## Summary
**Part of Match2 Implementation**

PRs starts with non-team stuff. When merged, a 2nd PR which contain team stuff is then up
(This also applies to **MatchSummary**)

## How did you test this change?
For Part 1 (non-team stuff) = LIVE
(e.g. https://liquipedia.net/tetris/CTWC/2022)