### PR TITLE
MatchSummary for Tetris

### DIFF
--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -12,7 +12,7 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
-local MatchSummary = Lua.import('Module:MatchSummary/Base/temp', {requireDevIfEnabled = true})
+local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
 
 local Opponent = require('Module:OpponentLibraries').Opponent
 

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -10,13 +10,9 @@ local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
-local Table = require('Module:Table')
-local VodLink = require('Module:VodLink')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
-local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
+local MatchSummary = Lua.import('Module:MatchSummary/Base/temp', {requireDevIfEnabled = true})
 
 local Opponent = require('Module:OpponentLibraries').Opponent
 
@@ -25,62 +21,15 @@ local NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 local CustomMatchSummary = {}
 
+---@param args table
+---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
-
-	local matchSummary = MatchSummary():init()
-	matchSummary.root:css('flex-wrap', 'unset')
-
-	matchSummary:header(CustomMatchSummary._createHeader(match))
-				:body(CustomMatchSummary._createBody(match))
-
-	if match.comment then
-		local comment = MatchSummary.Comment():content(match.comment)
-		matchSummary:comment(comment)
-	end
-
-	local vods = {}
-	for index, game in ipairs(match.games) do
-		if not Logic.isEmpty(game.vod) then
-			vods[index] = game.vod
-		end
-	end
-
-	if not Table.isEmpty(vods) or String.isNotEmpty(match.vod) then
-		local footer = MatchSummary.Footer()
-
-		if match.vod then
-			footer:addElement(VodLink.display{
-				vod = match.vod,
-			})
-		end
-
-		-- Game Vods
-		for index, vod in pairs(vods) do
-			footer:addElement(VodLink.display{
-				gamenum = index,
-				vod = vod,
-			})
-		end
-
-		matchSummary:footer(footer)
-	end
-
-	return matchSummary:create()
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
-function CustomMatchSummary._createHeader(match)
-	local header = MatchSummary.Header()
-
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
-		:leftScore(header:createScore(match.opponents[1]))
-		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
-
-	return header
-end
-
-function CustomMatchSummary._createBody(match)
+---@param match MatchGroupUtilMatch
+---@return MatchSummaryBody
+function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
 	if match.dateIsExact or (match.timestamp ~= DateExt.epochZero) then
@@ -105,6 +54,8 @@ function CustomMatchSummary._createBody(match)
 	return body
 end
 
+---@param game MatchGroupUtilGame
+---@return MatchSummaryRow
 function CustomMatchSummary._createGame(game)
 	local row = MatchSummary.Row()
 
@@ -131,6 +82,8 @@ function CustomMatchSummary._createGame(game)
 	return row
 end
 
+---@param isWinner boolean?
+---@return Html
 function CustomMatchSummary._createCheckMark(isWinner)
 	local container = mw.html.create('div')
 		:addClass('brkts-popup-body-element-vertical-centered')

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -17,8 +17,7 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDev
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = require('Module:OpponentLibraries').Opponent
 
 local GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
@@ -53,14 +52,6 @@ function CustomMatchSummary.getByMatchId(args)
 		-- Match Vod + other links
 		local buildLink = function (link, icon, text)
 			return '[['..icon..'|link='..link..'|15px|'..text..']]'
-		end
-
-		for linkType, link in pairs(match.links) do
-			if not LINK_DATA[linkType] then
-				mw.log('Unknown link: ' .. linkType)
-			else
-				footer:addElement(buildLink(link, LINK_DATA[linkType].icon, LINK_DATA[linkType].text))
-			end
 		end
 
 		-- Game Vods

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
@@ -20,7 +19,6 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled
 
 local OpponentLibraries = require('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
 local NO_CHECK = '[[File:NoCheck.png|link=]]'

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -50,7 +50,7 @@ function CustomMatchSummary.getByMatchId(args)
 
 		if match.vod then
 			footer:addElement(VodLink.display{
-				vod = vod,
+				vod = match.vod,
 			})
 		end
 
@@ -79,7 +79,7 @@ function CustomMatchSummary._createHeader(match)
 	return header
 end
 
-function CustomMatchSummary._createBody(match, matchId)
+function CustomMatchSummary._createBody(match)
 	local body = MatchSummary.Body()
 
 	if match.dateIsExact or (match.timestamp ~= DateExt.epochZero) then
@@ -93,18 +93,18 @@ function CustomMatchSummary._createBody(match, matchId)
 	if Array.any(match.opponents, function(opponent) return opponent.type == Opponent.team end) then
 		error('Team matches not yet supported')
 		-- todo (in sep PR): team match submatch support
-		--return CustomMatchSummary._createTeamMatchBody(body, match, matchId)
+		--return CustomMatchSummary._createTeamMatchBody(body, match)
 	end
 
 	-- Iterate each map
 	for gameIndex, game in ipairs(match.games) do
-		body:addRow(CustomMatchSummary._createGame(game, gameIndex, match.date))
+		body:addRow(CustomMatchSummary._createGame(game))
 	end
 
 	return body
 end
 
-function CustomMatchSummary._createGame(game, gameIndex, date)
+function CustomMatchSummary._createGame(game)
 	local row = MatchSummary.Row()
 
 	row:addClass('brkts-popup-body-game')
@@ -114,7 +114,7 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))
 	row:addElement(mw.html.create('div')
 		:addClass('brkts-popup-body-element-vertical-centered')
-		:wikitext('Game ' .. gameIndex)
+		:wikitext(game.map)
 	)
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 2))
 

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -1,0 +1,161 @@
+---
+-- @Liquipedia
+-- wiki=tetris
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Abbreviation = require('Module:Abbreviation')
+local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local VodLink = require('Module:VodLink')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
+local GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
+local NO_CHECK = '[[File:NoCheck.png|link=]]'
+
+local CustomMatchSummary = {}
+
+function CustomMatchSummary.getByMatchId(args)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+
+	local matchSummary = MatchSummary():init('360px')
+	matchSummary.root:css('flex-wrap', 'unset')
+
+	matchSummary:header(CustomMatchSummary._createHeader(match))
+				:body(CustomMatchSummary._createBody(match, args.matchId))
+
+	if match.comment then
+		local comment = MatchSummary.Comment():content(match.comment)
+		matchSummary:comment(comment)
+	end
+
+	local vods = {}
+	for index, game in ipairs(match.games) do
+		if not Logic.isEmpty(game.vod) then
+			vods[index] = game.vod
+		end
+	end
+	match.links.vod = match.vod
+
+	if not Table.isEmpty(vods) or not Table.isEmpty(match.links) then
+		local footer = MatchSummary.Footer()
+
+		-- Match Vod + other links
+		local buildLink = function (link, icon, text)
+			return '[['..icon..'|link='..link..'|15px|'..text..']]'
+		end
+
+		for linkType, link in pairs(match.links) do
+			if not LINK_DATA[linkType] then
+				mw.log('Unknown link: ' .. linkType)
+			else
+				footer:addElement(buildLink(link, LINK_DATA[linkType].icon, LINK_DATA[linkType].text))
+			end
+		end
+
+		-- Game Vods
+		for index, vod in pairs(vods) do
+			footer:addElement(VodLink.display{
+				gamenum = index,
+				vod = vod,
+				source = vod.url
+			})
+		end
+
+		matchSummary:footer(footer)
+	end
+
+	return matchSummary:create()
+end
+
+function CustomMatchSummary._createHeader(match)
+	local header = MatchSummary.Header()
+
+	header:leftOpponent(header:createOpponent(match.opponents[1], 'left', 'bracket'))
+		:leftScore(header:createScore(match.opponents[1]))
+		:rightScore(header:createScore(match.opponents[2]))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', 'bracket'))
+
+	return header
+end
+
+function CustomMatchSummary._createBody(match, matchId)
+	local body = MatchSummary.Body()
+
+	if match.dateIsExact or (match.timestamp ~= DateExt.epochZero) then
+		-- dateIsExact means we have both date and time. Show countdown
+		-- if match is not epoch=0, we have a date, so display the date
+		body:addRow(MatchSummary.Row():addElement(
+			DisplayHelper.MatchCountdownBlock(match)
+		))
+	end
+
+	if Array.any(match.opponents, function(opponent) return opponent.type == Opponent.team end) then
+		error('Team matches not yet supported')
+		-- todo (in sep PR): team match submatch support
+		--return CustomMatchSummary._createTeamMatchBody(body, match, matchId)
+	end
+
+	-- Iterate each map
+	for gameIndex, game in ipairs(match.games) do
+		body:addRow(CustomMatchSummary._createGame(game, gameIndex, match.date))
+	end
+
+	return body
+end
+
+function CustomMatchSummary._createGame(game, gameIndex, date)
+	local row = MatchSummary.Row()
+
+	row:addClass('brkts-popup-body-game')
+		:css('font-size', '80%')
+		:css('padding', '4px')
+		:css('min-height', '32px')
+	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))
+	row:addElement(mw.html.create('div')
+		:addClass('brkts-popup-body-element-vertical-centered')
+		:wikitext('Game ' .. gameIndex)
+	)
+	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 2))
+
+	-- Add Comment
+	if not Logic.isEmpty(game.comment) then
+		row:addElement(MatchSummary.Break():create())
+		row:addElement(mw.html.create('div')
+			:wikitext(game.comment)
+			:css('margin', 'auto')
+		)
+	end
+
+	return row
+end
+
+function CustomMatchSummary._createCheckMark(isWinner)
+	local container = mw.html.create('div')
+		:addClass('brkts-popup-body-element-vertical-centered')
+		:css('line-height', '17px')
+		:css('margin-left', '1%')
+		:css('margin-right', '1%')
+
+	if Logic.readBool(isWinner) then
+		container:node(GREEN_CHECK)
+	else
+		container:node(NO_CHECK)
+	end
+
+	return container
+end
+
+return CustomMatchSummary

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -97,7 +97,7 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Iterate each map
-	for gameIndex, game in ipairs(match.games) do
+	for _, game in ipairs(match.games) do
 		body:addRow(CustomMatchSummary._createGame(game))
 	end
 
@@ -108,7 +108,7 @@ function CustomMatchSummary._createGame(game)
 	local row = MatchSummary.Row()
 
 	row:addClass('brkts-popup-body-game')
-		:css('font-size', '80%')
+		:css('font-size', '84%')
 		:css('padding', '4px')
 		:css('min-height', '32px')
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 
@@ -45,7 +46,7 @@ function CustomMatchSummary.getByMatchId(args)
 		end
 	end
 
-	if not Table.isEmpty(vods) or not Table.isEmpty(match.links) then
+	if not Table.isEmpty(vods) or String.isNotEmpty(match.vod) then
 		local footer = MatchSummary.Footer()
 
 		if match.vod then

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -27,11 +27,11 @@ local CustomMatchSummary = {}
 function CustomMatchSummary.getByMatchId(args)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
 
-	local matchSummary = MatchSummary():init('360px')
+	local matchSummary = MatchSummary():init()
 	matchSummary.root:css('flex-wrap', 'unset')
 
 	matchSummary:header(CustomMatchSummary._createHeader(match))
-				:body(CustomMatchSummary._createBody(match, args.matchId))
+				:body(CustomMatchSummary._createBody(match))
 
 	if match.comment then
 		local comment = MatchSummary.Comment():content(match.comment)
@@ -44,14 +44,14 @@ function CustomMatchSummary.getByMatchId(args)
 			vods[index] = game.vod
 		end
 	end
-	match.links.vod = match.vod
 
 	if not Table.isEmpty(vods) or not Table.isEmpty(match.links) then
 		local footer = MatchSummary.Footer()
 
-		-- Match Vod + other links
-		local buildLink = function (link, icon, text)
-			return '[['..icon..'|link='..link..'|15px|'..text..']]'
+		if match.vod then
+			footer:addElement(VodLink.display{
+				vod = vod,
+			})
 		end
 
 		-- Game Vods
@@ -59,7 +59,6 @@ function CustomMatchSummary.getByMatchId(args)
 			footer:addElement(VodLink.display{
 				gamenum = index,
 				vod = vod,
-				source = vod.url
 			})
 		end
 


### PR DESCRIPTION
## Summary
**Part of Match2 Implementation**

PRs starts with non-team stuff. When merged, a 2nd PR which contain team stuff is then up
(This also applies to **MatchGroup**)

## How did you test this change?
For Part 1 (non-team stuff) = LIVE
(e.g. https://liquipedia.net/tetris/CTWC/2022)