### PR TITLE
Added extradata functionality to notability checker

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -177,7 +177,9 @@ function NotabilityChecker.calculateTournament(tier, tierType, placement, date, 
 	return weight
 end
 
-function NotabilityChecker._calculateWeightForTournament(tier, tierType, placement, dateLoss, notabilityMod, mode, extradata)
+function NotabilityChecker._calculateWeightForTournament(
+		tier, tierType, placement, dateLoss, notabilityMod, mode, extradata
+	)
 	if String.isEmpty(tier) then
 		return 0
 	end

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -144,7 +144,7 @@ function NotabilityChecker._calculateWeight(placementData)
 
 			local weight = NotabilityChecker.calculateTournament(
 				placement.liquipediatier, placement.liquipediatiertype, placement.placement,
-				placement.date, placement.extradata, placement.mode
+				placement.date, placement.mode, placement.extradata
 			)
 			table.insert(weights, weight)
 		end
@@ -158,7 +158,7 @@ function NotabilityChecker._calculateWeight(placementData)
 	return finalWeight
 end
 
-function NotabilityChecker.calculateTournament(tier, tierType, placement, date, extradata, mode)
+function NotabilityChecker.calculateTournament(tier, tierType, placement, date, mode, extradata)
 	local dateLossModifier = NotabilityChecker._calculateDateLoss(date)
 	local notabilityModifier = NotabilityChecker._parseNotabilityMod(extradata.notabilitymod)
 	local parsedTier, parsedTierType = NotabilityChecker._parseTier(tier, tierType)

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -144,7 +144,7 @@ function NotabilityChecker._calculateWeight(placementData)
 
 			local weight = NotabilityChecker.calculateTournament(
 				placement.liquipediatier, placement.liquipediatiertype, placement.placement,
-				placement.date, placement.extradata.notabilitymod, placement.mode
+				placement.date, placement.extradata, placement.mode
 			)
 			table.insert(weights, weight)
 		end
@@ -158,13 +158,13 @@ function NotabilityChecker._calculateWeight(placementData)
 	return finalWeight
 end
 
-function NotabilityChecker.calculateTournament(tier, tierType, placement, date, notabilityMod, mode)
+function NotabilityChecker.calculateTournament(tier, tierType, placement, date, extradata, mode)
 	local dateLossModifier = NotabilityChecker._calculateDateLoss(date)
-	local notabilityModifier = NotabilityChecker._parseNotabilityMod(notabilityMod)
+	local notabilityModifier = NotabilityChecker._parseNotabilityMod(extradata.notabilitymod)
 	local parsedTier, parsedTierType = NotabilityChecker._parseTier(tier, tierType)
 
 	local weight = NotabilityChecker._calculateWeightForTournament(
-		parsedTier, parsedTierType, placement, dateLossModifier, notabilityModifier, mode
+		parsedTier, parsedTierType, placement, dateLossModifier, notabilityModifier, mode, extradata
 	)
 
 	if NotabilityChecker.LOGGING then
@@ -177,7 +177,7 @@ function NotabilityChecker.calculateTournament(tier, tierType, placement, date, 
 	return weight
 end
 
-function NotabilityChecker._calculateWeightForTournament(tier, tierType, placement, dateLoss, notabilityMod, mode)
+function NotabilityChecker._calculateWeightForTournament(tier, tierType, placement, dateLoss, notabilityMod, mode, extradata)
 	if String.isEmpty(tier) then
 		return 0
 	end
@@ -192,7 +192,7 @@ function NotabilityChecker._calculateWeightForTournament(tier, tierType, placeme
 			return pointsForType['name'] == (tierType or Config.TIER_TYPE_GENERAL)
 		end
 	)['points']
-	local placementDropOffFunction = Config.placementDropOffFunction(tier, tierType)
+	local placementDropOffFunction = Config.placementDropOffFunction(tier, tierType, extradata)
 
 	local placementValue = NotabilityChecker._preparePlacement(placement)
 


### PR DESCRIPTION
## Summary

As per the issue raised here
https://github.com/Liquipedia/Lua-Modules/issues/1879

extradata is now passed down through the function calls and eventually passed to the drop off function defined in the local /config file.  This allows for wiki's with specific criteria to better define notability with parameters saved in placement extradata.

Also cleared up the notability mod pass, since extradata is already being passed and can be used in line 163.

This is the version of the notability checker that has been running on Apex for the past few months


