### PR TITLE
TBD prizepool entries now differ in their object name, using their placement (Trackmania)

### DIFF
--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -47,6 +47,10 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		Variables.varDefault('tournament_type')
 	)
 
+	if lpdbData.objectName == 'ranking_tbd' then
+		lpdbData.objectName = 'ranking_tbd_' .. lpdbData.placement
+	end
+
 	local worldTourPoints = Array.filter(placement.parent.prizes, function (prize)
 		if prize.type == PRIZE_TYPE_POINTS and prize.data.title == PRIZE_TITLE_WORLD_TOUR then
 			return true

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -63,8 +63,10 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		lpdbData.extradata.prizepointsTitle = 'wt_points'
 	end
 
-	Variables.varDefine(lpdbData.placement .. '_' .. lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)
-	Variables.varDefine(lpdbData.placement .. '_' .. lpdbData.participant:lower() .. '_prizepointsTitle', lpdbData.extradata.prizepointsTitle)
+	Variables.varDefine(lpdbData.placement .. '_' .. lpdbData.participant:lower()
+							.. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(lpdbData.placement .. '_' .. lpdbData.participant:lower()
+							.. '_prizepointsTitle', lpdbData.extradata.prizepointsTitle)
 
 	return lpdbData
 end

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -63,8 +63,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		lpdbData.extradata.prizepointsTitle = 'wt_points'
 	end
 
-	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)
-	Variables.varDefine(lpdbData.participant:lower() .. '_prizepointsTitle', lpdbData.extradata.prizepointsTitle)
+	Variables.varDefine(lpdbData.placement .. '_' .. lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(lpdbData.placement .. '_' .. lpdbData.participant:lower() .. '_prizepointsTitle', lpdbData.extradata.prizepointsTitle)
 
 	return lpdbData
 end

--- a/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/trackmania/prize_pool_custom.lua
@@ -14,6 +14,7 @@ local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 
 local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+local Opponent = require('Module:OpponentLibraries').Opponent
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
 local CustomLpdbInjector = Class.new(LpdbInjector)
@@ -47,8 +48,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		Variables.varDefault('tournament_type')
 	)
 
-	if lpdbData.objectName == 'ranking_tbd' then
-		lpdbData.objectName = 'ranking_tbd_' .. lpdbData.placement
+	if Opponent.isTbd(opponent.opponentData) then
+		lpdbData.objectName = lpdbData.objectName .. '_' .. lpdbData.placement
 	end
 
 	local worldTourPoints = Array.filter(placement.parent.prizes, function (prize)


### PR DESCRIPTION
## Summary
For counting automatically points for TM World Tour, I need informations of every prize pool entries. However, it is currently not possible because we can only have the last placement informations, because all of the TBD entries get overwritten, apart from the last one.
This PR fixes this problem, modifying TBD rankings' object name according to their placement, without modifying anything else.

## How did you test this change?
This change have been tested on [this page](https://liquipedia.net/trackmania/User:Sigeth/RegionalsTestEmpty)
You can see [page's LPDB data](https://liquipedia.net/trackmania/Special:LiquipediaDB/User:Sigeth/RegionalsTestEmpty#placement)
