### PR TITLE
fix: incorrect wiki-var used in TC Storage for PublisherTier

### DIFF
--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -83,7 +83,7 @@ function TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, lpdbPrefix
 	end
 
 	lpdbData.mode = Variables.varDefault('tournament_mode', 'team')
-	lpdbData.publishertier = Variables.varDefault('tournament_publisher_tier')
+	lpdbData.publishertier = Variables.varDefault('tournament_publishertier')
 	lpdbData.icon = Variables.varDefault('tournament_icon')
 	lpdbData.icondark = Variables.varDefault('tournament_icondark')
 	lpdbData.game = Variables.varDefault('tournament_game')


### PR DESCRIPTION
## Summary
The only place across the Wiki farm that sets `tournament_publisher_tier` wiki variable is https://liquipedia.net/commons/index.php?title=Template:TournamentVariables&action=edit#mw-ce-l23. This one also sets `tournament_publishertier`. The standard infobox league sets `tournament_publishertier`, so format should follow it.

## How did you test this change?
dev module