### PR TITLE
Catch empty lastvs table to avoid storing tbd opponents in lastvsdata

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -290,6 +290,11 @@ function LegacyPrizePool.mapOpponents(slot, newData, mergeSlots)
 				(slot['lastvsscore' .. opponentIndex] or ''),
 		}
 
+		-- catch empty lastvs table to avoid storing tbd opponents in lastvsdata
+		if Table.isEmpty(opponentData.lastvs) then
+			opponentData.lastvs = nil
+		end
+
 		if not opponentData.link and IS_SOLO then
 			local splitPlayer = mw.text.split(opponentData[1], '|')
 			opponentData.link = splitPlayer[1]


### PR DESCRIPTION
## Summary
Catch empty lastvs table to avoid storing tbd opponents in lastvsdata

reported by @DMeluca : https://discord.com/channels/93055209017729024/268719633366777856/1070327549609123891

## How did you test this change?
/dev