### PR TITLE
refactor: set categories with `add_category` instead of wikicode

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
@@ -34,13 +35,7 @@ function Infobox:create(frame, gameName, forceDarkMode)
 end
 
 function Infobox:categories(...)
-	local input = {...}
-	for i = 1, #input do
-		local category = input[i]
-		if category ~= nil and category ~= '' then
-			self.root:wikitext('[[Category:' .. category .. ']]')
-		end
-	end
+	Array.forEach({...}, mw.ext.TeamLiquidIntegration.add_category)
 	return self
 end
 


### PR DESCRIPTION
## Summary
Change infobox's standard way of setting categories from adding it in the wikitext `[[Category:FooBar]]` to using the dedicated lua function.

## How did you test this change?
Dev module, tested on R6 Infobox league, SC2 Infobox team and SC2 infobox player