### PR TITLE
pubgmobile: Call bottom content method for player infobox

### DIFF
--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -61,6 +61,7 @@ function CustomPlayer.run(frame)
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+	player.createBottomContent = CustomPlayer.createBottomContent
 	player.defineCustomPageVariables = CustomPlayer.defineCustomPageVariables
 
 	_args = player.args


### PR DESCRIPTION
## Summary

Removed the template call in the infobox template and pushed it to the custom module method.

## How did you test this change?

/dev
