### PR TITLE
refactor: `|wiki=` fallbacks to info.wikiname in infobox

### DIFF
--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -10,21 +10,19 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Logic = require('Module:Logic')
-local getArgs = require('Module:Arguments').getArgs
+local Arguments = require('Module:Arguments')
 
+local Info = Lua.import('Module:Info', {requireDevIfEnabled = true})
 local Infobox = Lua.import('Module:Infobox', {requireDevIfEnabled = true})
 
 local BasicInfobox = Class.new(
 	function(self, frame)
-		self.args = getArgs(frame)
+		self.args = Arguments.getArgs(frame)
 		self.pagename = mw.title.getCurrentTitle().text
 		self.name = self.args.name or self.pagename
+		self.wiki = self.args.wiki or Info.wikiName
 
-		if self.args.wiki == nil then
-			return error('Please provide a wiki!')
-		end
-
-		self.infobox = Infobox:create(frame, self.args.wiki, Logic.readBool(self.args.darkmodeforced))
+		self.infobox = Infobox:create(frame, self.wiki, Logic.readBool(self.args.darkmodeforced))
 	end
 )
 

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -6,11 +6,11 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Logic = require('Module:Logic')
-local Arguments = require('Module:Arguments')
 
 local Info = Lua.import('Module:Info', {requireDevIfEnabled = true})
 local Infobox = Lua.import('Module:Infobox', {requireDevIfEnabled = true})


### PR DESCRIPTION
## Summary
Now with `Module:Info` up on 50/52 wikis, we can add a fallback for the Infoboxes to get the `|wiki=` param from that, if not provided in the call. 

This allows us to move basic Template's for infoboxes to commons (eg. Template:Infobox league) with most wikis not having a need to have them once SMW storage has been removed.

## How did you test this change?
Tested on WC3 (wiki that uses `|wiki=` and on Tetris (after removing `|wiki=` from their template). Both set the expected values (`tft` and `tetris` respectively).