### PR TITLE
Don't override whole row when points are used

### DIFF
--- a/components/mvp_table/commons/mvp_table.lua
+++ b/components/mvp_table/commons/mvp_table.lua
@@ -155,8 +155,7 @@ function MvpTable._row(item, args)
 		:tag('td'):wikitext(item.mvp):done()
 
 	if args.points then
-		row = mw.html.create('tr')
-			:tag('td'):wikitext(item.points):done()
+		row:tag('td'):wikitext(item.points):done()
 	end
 
 	return row:done()


### PR DESCRIPTION
## Summary
When `args.points` is used, the complete row was overriden instead of just adding a cell.
![image](https://user-images.githubusercontent.com/16326643/216408781-eedb841e-a16e-43cc-98a2-8a7ab83656b0.png)

## How did you test this change?
/dev (and then live for bugfix)
![image](https://user-images.githubusercontent.com/16326643/216408736-0a1f1987-e0e4-490c-96e6-904b7c86b52b.png)

