### PR TITLE
Correctly handle link `|site=`

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -124,7 +124,6 @@ local PREFIXES = {
 		team = 'https://siege.gg/teams/',
 		player = 'https://siege.gg/players/',
 	},
-	site = {''},
 	sk = {'https://sk-gaming.com/member/'},
 	snapchat = {'https://www.snapchat.com/add/'},
 	sostronk = {'https://www.sostronk.com/tournament/'},


### PR DESCRIPTION
## Summary
`|site=` is setup as a both an alias to `|home=` and it's own. This PR solve this by removing as it's own and only having it as an alias.

## How did you test this change?
Live
