### PR TITLE
refactor: fix incorrect IDE warnings in test for game

### DIFF
--- a/standard/test/game_test.lua
+++ b/standard/test/game_test.lua
@@ -10,11 +10,12 @@ local Lua = require('Module:Lua')
 local ScribuntoUnit = require('Module:ScribuntoUnit')
 
 local Game = Lua.import('Module:Game', {requireDevIfEnabled = true})
+local Info = Lua.import('Module:Info', {requireDevIfEnabled = true})
 
 local suite = ScribuntoUnit:new()
 
 local COMMONS_IDENTIFIER = 'commons'
-local COMMONS_DATA = Lua.import('Module:Info', {requireDevIfEnabled = true}).games.commons
+local COMMONS_DATA = Info.games.commons
 local COMMONS_ICON = mw.text.decode('[[File:Liquipedia logo.png|link=lpcommons:Main Page|class=|25x25px]]')
 local GAME_TO_THROW = 'please throw'
 


### PR DESCRIPTION
## Summary
The plugin doesn't handle imports correctly when not directly assigned to a variable.

This PR fixes this by moving the import to its own variable.
## How did you test this change?
Testcase:
https://liquipedia.net/commons/Module_talk:Game/testcases

IDE Before:
![image](https://user-images.githubusercontent.com/3426850/216586342-34afe427-0152-48fe-9be3-e0a94eea1491.png)

IDE After:
![image](https://user-images.githubusercontent.com/3426850/216585609-e7e8434d-8366-4dbb-a451-46f2b5cf54e1.png)
