### PR TITLE
feat: Create infobox team for Warcraft

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -62,6 +62,7 @@ function Team:createInfobox()
 		},
 		Center{content = {args.caption}},
 		Title{name = 'Team Information'},
+		Customizable{id = 'topcustomcontent', children = {}},
 		Cell{
 			name = 'Location',
 			content = {

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -51,6 +51,9 @@ function Team:createInfobox()
 	-- Need links in LPDB, so declare them outside of display code
 	local links = Links.transform(args)
 
+	local team = args.teamtemplate or self.pagename
+	self.teamTemplate = mw.ext.TeamTemplate.teamexists(team) and mw.ext.TeamTemplate.raw(team) or {}
+
 	local widgets = {
 		Header{
 			name = args.name,
@@ -245,31 +248,22 @@ function Team:_setLpdbData(args, links)
 	local name = args.romanized_name or self.name
 	local earnings = self.totalEarnings
 
-	local team = args.teamtemplate or self.pagename
-	local teamTemplate
-	local textlessImage, textlessImageDark
-	if team and mw.ext.TeamTemplate.teamexists(team) then
-		local teamRaw = mw.ext.TeamTemplate.raw(team)
-		teamTemplate = teamRaw.historicaltemplate or teamRaw.templatename
-		textlessImage, textlessImageDark = teamRaw.image, teamRaw.imagedark
-	end
-
 	local lpdbData = {
 		name = name,
 		location = self:getStandardLocationValue(args.location),
 		location2 = self:getStandardLocationValue(args.location2),
 		region = args.region,
 		locations = Locale.formatLocations(args),
-		logo = args.image or textlessImage,
-		logodark = args.imagedark or args.imagedarkmode or args.image or textlessImageDark,
-		textlesslogo = textlessImage or args.teamcardimage,
-		textlesslogodark = textlessImageDark or args.teamcardimagedark or args.teamcardimage,
+		logo = args.image or self.teamTemplate.image,
+		logodark = args.imagedark or args.imagedarkmode or args.image or self.teamTemplate.imagedark,
+		textlesslogo = self.teamTemplate.image or args.teamcardimage,
+		textlesslogodark = self.teamTemplate.imagedark or args.teamcardimagedark or args.teamcardimage,
 		earnings = earnings,
 		createdate = args.created,
 		disbanddate = ReferenceCleaner.clean(args.disbanded),
 		coach = args.coaches or args.coach,
 		manager = args.manager,
-		template = teamTemplate,
+		template = self.teamTemplate.historicaltemplate or self.teamTemplate.templatename,
 		links = mw.ext.LiquipediaDB.lpdb_create_json(
 			Links.makeFullLinksForTableItems(links or {}, 'team')
 		),

--- a/components/infobox/wikis/warcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_team_custom.lua
@@ -1,0 +1,104 @@
+---
+-- @Liquipedia
+-- wiki=warcraft
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Achievements = require('Module:Achievements in infoboxes')
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Center = Widgets.Center
+local Title = Widgets.Title
+
+local CustomTeam = Class.new()
+local CustomInjector = Class.new(Injector)
+
+-- These should be converted to proper links at some point
+local PROFILE_DISPLAY =
+	'<span class="league-icon-small-image" style="margin-left:2px">[[File:${icon}|32px|link=${link}|${text}]]</span>'
+local PROFILES = {
+	w3iprofile = {
+		icon = 'War3.info icon.png',
+		link = 'https://warcraft3.info/league/clans/',
+		text = 'warcraft3.info ${name}\'s profile'
+	},
+	nwc3lprofile = {
+		icon = 'NWC3L-icon.png',
+		link = 'https://nwc3l.com/team/',
+		text = 'NWC3L ${name}\'s profile'
+	},
+	eslprofile = {
+		icon = 'ESL_2019_icon.png',
+		link = 'https://play.eslgaming.com/team/',
+		text = 'ESL ${name}\'s profile'
+	},
+}
+
+local _team
+
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	_team = team
+
+	-- Automatic achievements
+	team.args.achievements = Achievements.team{team = team.pagename}
+
+	team.createWidgetInjector = CustomTeam.createWidgetInjector
+	team.addToLpdb = CustomTeam.addToLpdb
+	return team:createInfobox()
+end
+
+function CustomTeam:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'topcustomcontent' then
+		table.insert(widgets, Cell{
+			name = 'Clan tag',
+			content = {_team.args.clantag}
+		})
+	elseif id == 'customcontent' then
+		local profiles = Array.extractValues(Table.map(PROFILES, function (param, profileData)
+			return param, CustomTeam._createProfile(profileData, _team.args[param])
+		end))
+		if not Table.isEmpty(profiles) then
+			table.insert(widgets, Title{name = 'Profiles'})
+			table.insert(widgets, Center{content = profiles})
+		end
+	end
+	return widgets
+end
+
+function CustomTeam._createProfile(profileData, profileValue)
+	if not profileValue then
+		return
+	end
+
+	return String.interpolate(PROFILE_DISPLAY, {
+		text = String.interpolate(profileData.text, {_team.name}),
+		link = profileData.link .. profileValue,
+		icon = profileData.icon,
+	})
+end
+
+function CustomTeam:addToLpdb(lpdbData, args)
+	lpdbData.extradata.clantag = args.clantag
+
+	return lpdbData
+end
+
+-- TODO: Categories
+
+return CustomTeam

--- a/components/infobox/wikis/warcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_team_custom.lua
@@ -9,9 +9,11 @@
 local Achievements = require('Module:Achievements in infoboxes')
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Flags = require('Module:Flags')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
@@ -56,6 +58,7 @@ function CustomTeam.run(frame)
 
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	team.addToLpdb = CustomTeam.addToLpdb
+	team.getWikiCategories = CustomTeam.getWikiCategories
 	return team:createInfobox()
 end
 
@@ -99,6 +102,28 @@ function CustomTeam:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
--- TODO: Categories
+function CustomTeam:getWikiCategories(args)
+	local categories = {}
+
+	if not args.image then
+		table.insert(categories, 'Team without image')
+	end
+
+	if not args.clantag then
+		table.insert(categories, 'Team without clan tag')
+	end
+
+	local teamType, typeCategory = 'Esport team', 'Esport Teams'
+	if Table.includes({'Team Human', 'Team Orc', 'Team Undead', 'Team Night Elf'}, self.name) then
+		teamType, typeCategory = 'Race team', 'Race Teams'
+	elseif Flags.getLocalisation(self.name) then
+		teamType, typeCategory = 'National team', 'National Teams'
+	end
+
+	table.insert(categories, typeCategory)
+	Variables.varDefine('teamtype', teamType) -- for SMW
+
+	return categories
+end
 
 return CustomTeam

--- a/components/infobox/wikis/warcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_team_custom.lua
@@ -90,7 +90,7 @@ function CustomTeam._createProfile(profileData, profileValue)
 	end
 
 	return String.interpolate(PROFILE_DISPLAY, {
-		text = String.interpolate(profileData.text, {_team.name}),
+		text = String.interpolate(profileData.text, {name = _team.name}),
 		link = profileData.link .. profileValue,
 		icon = profileData.icon,
 	})

--- a/components/infobox/wikis/warcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_team_custom.lua
@@ -70,7 +70,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'topcustomcontent' then
 		table.insert(widgets, Cell{
 			name = 'Clan tag',
-			content = {_team.args.clantag}
+			content = {_team.teamTemplate.shortname}
 		})
 	elseif id == 'customcontent' then
 		local profiles = Array.extractValues(Table.map(PROFILES, function (param, profileData)


### PR DESCRIPTION
## Summary
Create Team Infobox for Warcraft. Also fixes issue where achievements were broken due to incorrect SMW query since a few weeks back (now uses LPDB).

Before:
![image](https://user-images.githubusercontent.com/3426850/216610360-44e9fbfa-eea7-4bb8-9496-9d13a18b36b8.png)

After: 
![image](https://user-images.githubusercontent.com/3426850/216610386-f7eb6dc2-bb84-4c67-93d8-27a843586c14.png)


## How did you test this change?
Preview testing on WC. LPDB Testing (via dev) on other wiki to check the refactor.