### PR TITLE
Add Infobox League for Tetris

### DIFF
--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Game = require('Module:Game')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -23,7 +24,6 @@ local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
-local _GAME = mw.loadData('Module:GameVersion')
 
 function CustomLeague.run(frame)
 	local league = League(frame)
@@ -56,8 +56,7 @@ function CustomInjector:parse(id, widgets)
 		end
 
 		--teams section
-		if _args.team_number or (not String.isEmpty(_args.team1)) then
-			Variables.varDefine('is_team_tournament', 1)
+		if _args.team_number then
 			table.insert(widgets, Title{name = 'Teams'})
 		end
 		table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
@@ -80,18 +79,15 @@ function League:defineCustomPageVariables()
 	else
 		Variables.varDefine('tournament_mode', 'team')
 	end
-	Variables.varDefine('tournament_publishertier', _args['publisherpremier'])
-		--Legacy Vars:
-	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
-	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('tournament_publishertier', _args.publisherpremier)
 end
 
 function CustomLeague._getGameVersion()
-	return _GAME[string.lower(_args.game or '')]
+	return Game.name{game = _args.game}
 end
 
 function CustomLeague:liquipediaTierHighlighted(args)
-	return Logic.readBool(args['publisherpremier'])
+	return Logic.readBool(args.publisherpremier)
 end
 
 return CustomLeague

--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -41,6 +41,19 @@ function CustomLeague:createWidgetInjector()
 	return CustomInjector()
 end
 
+function CustomInjector:addCustomCells(widgets)
+	table.insert(widgets, Cell{
+		name = 'Teams',
+		content = {_args.team_number}
+	})
+	table.insert(widgets, Cell{
+		name = 'Players',
+		content = {_args.player_number}
+	})
+
+	return widgets
+end
+
 function CustomInjector:parse(id, widgets)
 	if id == 'gamesettings' then
 		return {
@@ -49,18 +62,7 @@ function CustomInjector:parse(id, widgets)
 				}
 			},
 		}
-	elseif id == 'customcontent' then
-		if _args.player_number then
-			table.insert(widgets, Title{name = 'Players'})
-			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
 		end
-
-		--teams section
-		if _args.team_number then
-			table.insert(widgets, Title{name = 'Teams'})
-		end
-		table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
-	end
 	return widgets
 end
 
@@ -74,10 +76,10 @@ function CustomLeague:addToLpdb(lpdbData, args)
 end
 
 function League:defineCustomPageVariables()
-	if _args.player_number then
-		Variables.varDefine('tournament_mode', 'individual')
-	else
+	if _args.team_number then
 		Variables.varDefine('tournament_mode', 'team')
+	else
+		Variables.varDefine('tournament_mode', 'individual')
 	end
 	Variables.varDefine('tournament_publishertier', _args.publisherpremier)
 end

--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -61,7 +61,7 @@ function CustomInjector:parse(id, widgets)
 				}
 			},
 		}
-		end
+	end
 	return widgets
 end
 

--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -1,0 +1,98 @@
+---
+-- @Liquipedia
+-- wiki=tetris
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local PageLink = require('Module:Page')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _GAME = mw.loadData('Module:GameVersion')
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_args = league.args
+
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+
+	return league:createInfobox(frame)
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'gamesettings' then
+		return {
+			Cell{name = 'Game version', content = {
+					CustomLeague._getGameVersion()
+				}
+			},
+		}
+	elseif id == 'customcontent' then
+		if _args.player_number then
+			table.insert(widgets, Title{name = 'Players'})
+			table.insert(widgets, Cell{name = 'Number of players', content = {_args.player_number}})
+		end
+
+		--teams section
+		if _args.team_number or (not String.isEmpty(_args.team1)) then
+			Variables.varDefine('is_team_tournament', 1)
+			table.insert(widgets, Title{name = 'Teams'})
+		end
+		table.insert(widgets, Cell{name = 'Number of teams', content = {_args.team_number}})
+	end
+	return widgets
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.game = CustomLeague._getGameVersion()
+	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.publishertier = args.publisherpremier
+	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
+
+	return lpdbData
+end
+
+function League:defineCustomPageVariables()
+	if _args.player_number then
+		Variables.varDefine('tournament_mode', 'individual')
+	else
+		Variables.varDefine('tournament_mode', 'team')
+	end
+	Variables.varDefine('tournament_publishertier', _args['publisherpremier'])
+		--Legacy Vars:
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+end
+
+function CustomLeague._getGameVersion()
+	return _GAME[string.lower(_args.game or '')]
+end
+
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args['publisherpremier'])
+end
+
+return CustomLeague

--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local PageLink = require('Module:Page')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 

--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -18,7 +18,6 @@ local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
-local Title = Widgets.Title
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)

--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -45,7 +45,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'gamesettings' then
 		return {
 			Cell{name = 'Game version', content = {
-					CustomLeague._getGameVersion()
+					Game.name{game = _args.game}
 				}
 			},
 		}
@@ -65,7 +65,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.game = CustomLeague._getGameVersion()
+	lpdbData.game = Game.name{game = _args.game}
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.publisherpremier
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
@@ -80,10 +80,6 @@ function League:defineCustomPageVariables()
 		Variables.varDefine('tournament_mode', 'team')
 	end
 	Variables.varDefine('tournament_publishertier', _args.publisherpremier)
-end
-
-function CustomLeague._getGameVersion()
-	return Game.name{game = _args.game}
 end
 
 function CustomLeague:liquipediaTierHighlighted(args)


### PR DESCRIPTION
## Summary
League Infobox for Tetris, while Tetris is mainly 1v1, **team_number=** still relevant due to some team events that will likely be covered in near future

## How did you test this change?
LIVE - https://liquipedia.net/tetris/CTWC/2022

## Fixes Needed
How do I edit the Infobox to instead of calling games from **Module:GameVersion** to called **Module:Info** instead with the Module:Game thingy?

I am going to assume its needed to be done anyway. So I will cut to the chase