### PR TITLE
Catch cases where identifier is not a name or abbreviation

### DIFF
--- a/standard/game.lua
+++ b/standard/game.lua
@@ -49,6 +49,8 @@ function Game.toIdentifier(args)
 
 	return Game.getIdentifierByAbbreviation()[gameInput]
 		or Game.getIdentifierByName()[gameInput]
+		or GamesData[gameInput] and gameInput
+		or nil
 end
 
 ---Check if a given game is a valid game.


### PR DESCRIPTION
## Summary
Catch cases in Game.toIdentifier where identifier is not a name or abbreviation

## How did you test this change?
live, module not in use except for test pages