### PR TITLE
Adjust sc2 results table custom

### DIFF
--- a/components/results_table/wikis/starcraft2/results_table_custom.lua
+++ b/components/results_table/wikis/starcraft2/results_table_custom.lua
@@ -35,7 +35,7 @@ local MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = 20
 local CustomResultsTable = {}
 
 -- Template entry point
-function CustomResultsTable.run(frame)
+function CustomResultsTable.results(frame)
 	local args = Arguments.getArgs(frame)
 	args.playerLimit = MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS
 
@@ -105,18 +105,6 @@ function CustomResultsTable:rowHighlight(placement)
 	if Logic.readBool(placement.publishertier) then
 		return 'sc2premier-highlighted'
 	end
-end
-
-function CustomResultsTable:processLegacyVsData(placement)
-	if Table.isEmpty(placement.lastvsdata) then
-		local opponent = (placement.extradata or {}).vsOpponent or {}
-		placement.lastvsdata = Table.merge(
-			Opponent.toLpdbStruct(opponent or {}),
-			{groupscore = placement.groupscore, score = placement.lastvsscore}
-		)
-	end
-
-	return placement
 end
 
 -- all kill rows are manual inputs of all kill chievements

--- a/components/results_table/wikis/starcraft2/results_table_custom.lua
+++ b/components/results_table/wikis/starcraft2/results_table_custom.lua
@@ -60,7 +60,9 @@ function CustomResultsTable.results(frame)
 	return buildTable
 end
 
-function CustomResultsTable.awards(args)
+function CustomResultsTable.awards(frame)
+	local args = Arguments.getArgs(frame)
+
 	args.data = Json.parseIfTable(Variables.varDefault('awardAchievements'))
 
 	if Logic.readBool(args.achievements) and Table.isEmpty(args.data) then


### PR DESCRIPTION
## Summary
- kick legacy lastvs since PPTs store into the new field (purge run done)
- rename main function from `run` to `results` to match commons
- correctly use frame over args in awards table

## How did you test this change?
Live, module not yet in use