### PR TITLE
Add fortnite results table custom

### DIFF
--- a/components/results_table/wikis/fortnite/results_table_custom.lua
+++ b/components/results_table/wikis/fortnite/results_table_custom.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tier = require('Module:Tier')
 
@@ -28,6 +29,7 @@ function CustomResultsTable.results(args)
 	-- overwrite functions
 	resultsTable.tierDisplay = CustomResultsTable.tierDisplay
 	resultsTable.processLegacyVsData = CustomResultsTable.processLegacyVsData
+	resultsTable.processVsData = CustomResultsTable.processVsData
 
 	return resultsTable:create():build()
 end
@@ -72,6 +74,17 @@ function CustomResultsTable:processLegacyVsData(placement)
 	end
 
 	return placement
+end
+
+function CustomResultsTable:processVsData(placement)
+	local lastVs = placement.lastvsdata
+
+	if String.isNotEmpty(lastVs.groupscore) then
+		return placement.groupscore, Abbreviation.make('Grp S.', 'Group Stage')
+	end
+
+	-- return empty strings for non group scores since it is a BattleRoyale wiki
+	return '', ''
 end
 
 return Class.export(CustomResultsTable)

--- a/components/results_table/wikis/fortnite/results_table_custom.lua
+++ b/components/results_table/wikis/fortnite/results_table_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Class = require('Module:Class')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local Table = require('Module:Table')

--- a/components/results_table/wikis/fortnite/results_table_custom.lua
+++ b/components/results_table/wikis/fortnite/results_table_custom.lua
@@ -1,0 +1,78 @@
+---
+-- @Liquipedia
+-- wiki=fortnite
+-- page=Module:ResultsTable/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local Table = require('Module:Table')
+local Tier = require('Module:Tier')
+
+local ResultsTable = Lua.import('Module:ResultsTable', {requireDevIfEnabled = true})
+local AwardsTable = Lua.import('Module:ResultsTable/Award', {requireDevIfEnabled = true})
+
+local Opponent = require('Module:OpponentLibraries').Opponent
+
+local UNDEFINED_TIER = 'undefined'
+
+local CustomResultsTable = {}
+
+-- Template entry point
+function CustomResultsTable.results(args)
+	local resultsTable = ResultsTable(args)
+
+	-- overwrite functions
+	resultsTable.tierDisplay = CustomResultsTable.tierDisplay
+	resultsTable.processLegacyVsData = CustomResultsTable.processLegacyVsData
+
+	return resultsTable:create():build()
+end
+
+function CustomResultsTable.awards(args)
+	local awardsTable = AwardsTable(args)
+
+	-- overwrite functions
+	awardsTable.tierDisplay = CustomResultsTable.tierDisplay
+
+	return awardsTable:create():build()
+end
+
+-- to be replaced with a call to Module:Tier/Utils once that module is on git
+function CustomResultsTable:tierDisplay(placement)
+	local tierDisplay = Tier.text.tiers[placement.liquipediatier] or UNDEFINED_TIER
+
+	tierDisplay = Page.makeInternalLink(
+		{},
+		tierDisplay,
+		tierDisplay .. ' Tournaments'
+	)
+
+	local tierTypeDisplay = Tier.text.typesShort[(placement.liquipediatiertype or ''):lower()]
+
+	local sortValue = placement.liquipediatier .. (tierTypeDisplay or '')
+
+	if not tierTypeDisplay then
+		return tierDisplay, sortValue
+	end
+
+	return tierDisplay .. ' (' .. tierTypeDisplay .. ')', sortValue
+end
+
+function CustomResultsTable:processLegacyVsData(placement)
+	if Table.isEmpty(placement.lastvsdata) then
+		local opponent = (placement.extradata or {}).vsOpponent or {}
+		placement.lastvsdata = Table.merge(
+			Opponent.toLpdbStruct(opponent or {}),
+			{groupscore = placement.groupscore, score = placement.lastvsscore}
+		)
+	end
+
+	return placement
+end
+
+return Class.export(CustomResultsTable)

--- a/components/results_table/wikis/fortnite/results_table_custom.lua
+++ b/components/results_table/wikis/fortnite/results_table_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Abbreviation = require('Module:Abbreviation')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')


### PR DESCRIPTION
## Summary
Add fortnite results table custom

Please note:
- Although Fortnite is not yet on the new prize pool they use the (deprecated) base of what we used for the sc2 prize pools. Hence they store opponentData already correctly.
- They do not store lastvs data though (since it is a battle royale)

## How did you test this change?
dev