### PR TITLE
Adjust Infobox League prize pool extension

### DIFF
--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -104,7 +104,9 @@ function PrizePoolCurrency._exchange(props)
 	local prizepoolUsd = props.prizepoolUsd
 	local currencyRate = Currency.getExchangeRate(props)
 
-	if not currencyRate then
+	if not currencyRate and Logic.isNumeric(prizepool) and Logic.isNumeric(prizepoolUsd) then
+		currencyRate = tonumber(prizepoolUsd) / tonumber(prizepool)
+	elseif not currencyRate then
 		local errorMessage = 'Need valid currency and exchange date or exchange rate'
 		return prizepool, prizepoolUsd, currencyRate, errorMessage
 	end


### PR DESCRIPTION
## Summary
Allow local value and usd value to calculate the currencyRate if it can not be determined via exchange.

Background: Currently on Warcraft several pages error for the infobox prizepool due to not retrieving a currencyRate while they have both (local) prizepool value and prizepoolusd value set.

## How did you test this change?
dev