### PR TITLE
Fix WC PPT players data for duos

### DIFF
--- a/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
@@ -66,6 +66,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		seriesnumber = CustomPrizePool._seriesNumber()
 	})
 
+	lpdbData.players = lpdbData.opponentplayers
+
 	lpdbData.weight = Weight.calc(
 		lpdbData.individualprizemoney,
 		Variables.varDefault('tournament_liquipediatier'),


### PR DESCRIPTION
## Summary
The commons component does not set lpdbData.players for non solo/team opponents, hence we have to copy it over to lpdbData.players in that case.
Since for other cases (non duo) the additional data is no issue we can just copy it for all kinds of opponents.

The already deprecated lpdb_tournament.players field is currently still needed for earnings calculations.

## How did you test this change?
dev into live