### PR TITLE
Add option to link to LIS template on the wikis in LIS generators

### DIFF
--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -231,7 +231,8 @@ function LeagueIcon._buildLinkToTemplate(args)
 		return ''
 	end
 
-	return '<br><b>Link to the template page:</b> [[' .. args.wiki .. ':Template:LeagueIconSmall/' .. args.templateName:lower() .. ']]'
+	return '<br><b>Link to the template page:</b> [[' .. args.wiki ..
+		':Template:LeagueIconSmall/' .. args.templateName:lower() .. ']]'
 end
 
 

--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -171,6 +171,7 @@ function LeagueIcon.generate(args)
 		'--><span class="league-icon-small-image darkmode">' ..
 		'[[File:' .. iconDark .. imageOptions .. '</span><!--\n' ..
 		'--><noinclude>[[Category:Small League Icon Templates]]</noinclude>') .. '</pre>'
+		.. LeagueIcon._buildLinkToTemplate(args)
 end
 
 --generate copy paste code for new historical LeagueIconSmall templates
@@ -222,7 +223,17 @@ function LeagueIcon.generateHistorical(args)
 
 	return '<pre class="selectall" width=50%>' .. mw.text.nowiki(
 			defineTime .. comparisons .. '--><noinclude>[[Category:Historical Small League Icon template]]</noinclude>'
-		) .. '</pre>'
+		) .. '</pre>' .. LeagueIcon._buildLinkToTemplate(args)
 end
+
+function LeagueIcon._buildLinkToTemplate(args)
+	if String.isEmpty(args.templateName) or String.isEmpty(args.wiki) then
+		return ''
+	end
+
+	return '<br><b>Link to the template page:</b> [[' .. args.wiki .. ':Template:LeagueIconSmall/' .. args.templateName:lower() .. ']]'
+end
+
+
 
 return Class.export(LeagueIcon, { frameOnly = true })

--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -235,6 +235,4 @@ function LeagueIcon._buildLinkToTemplate(args)
 		':Template:LeagueIconSmall/' .. args.templateName:lower() .. ']]'
 end
 
-
-
 return Class.export(LeagueIcon, { frameOnly = true })


### PR DESCRIPTION
## Summary
Add option to link to LIS template on the wikis in LIS generators

After merge the forms need adjusting by undoing:
- https://liquipedia.net/commons/index.php?title=Form%3ALeagueIconSmall&type=revision&diff=475604&oldid=475603
- https://liquipedia.net/commons/index.php?title=Form%3AHistoricalLeagueIconSmall&type=revision&diff=475620&oldid=475611

requested by @Hesketh2 
https://discord.com/channels/93055209017729024/874304000718172200/1071746318411772007

## How did you test this change?
dev