### PR TITLE
Fix Siege.gg infobox links

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -119,7 +119,7 @@ local PREFIXES = {
 	royaleapi = {'https://royaleapi.com/player/'},
 	rules = {''},
 	shift = {'https://www.shiftrle.gg/events/'},
-	['siege-gg'] = {
+	siegegg = {
 		'https://siege.gg/competitions/',
 		team = 'https://siege.gg/teams/',
 		player = 'https://siege.gg/players/',


### PR DESCRIPTION
## Summary
https://github.com/Liquipedia/Lua-Modules/pull/2334/files#diff-3b3ed830e3f8f975bc4df4542d6a3610a3a6f786902ab7bfebb4efd3935c792cL268

The input was `|siegegg=`, whilst after the PR #2334 it become `|siege-gg=`. This PR changes it back to `|siegegg=`.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
