### PR TITLE
Fix typo regarding `location` in League Infobox

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -157,12 +157,12 @@ function League:createInfobox()
 				}
 			}
 		},
-		Customizable{id = 'location', children = Cell{
+		Customizable{id = 'location', children = {Cell{
 			name = 'Location',
 			content = {
 				self:_createLocation(args)
 			}
-		}},
+		}}},
 		Builder{
 			builder = function()
 				args.venue1 = args.venue1 or args.venue


### PR DESCRIPTION
## Summary
Introduced in #2525, where only the happy path was tested. Due to missing table, the field will never be shown.

## How did you test this change?
Live