### PR TITLE
Add Infobox Player for Zula

### DIFF
--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -33,7 +33,7 @@ local _args
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
-	
+
 	if String.isEmpty(player.args.team) then
 		player.args.team = PlayerTeamAuto._main{team = 'team'}
 	end

--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -58,7 +58,7 @@ function CustomInjector:parse(id, widgets)
 		local automatedHistory = TeamHistoryAuto._results({
 			convertrole = 'true',
 			player = _pagename
-		}) or ''
+		})
 		automatedHistory = tostring(automatedHistory)
 		if automatedHistory == _EMPTY_AUTO_HISTORY then
 			automatedHistory = nil

--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -1,0 +1,88 @@
+---
+-- @Liquipedia
+-- wiki=zula
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Role = require('Module:Role')
+local String = require('Module:StringUtils')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Title = Widgets.Title
+local Center = Widgets.Center
+
+local _pagename = mw.title.getCurrentTitle().prefixedText
+local _role
+local _role2
+local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
+
+local CustomPlayer = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+function CustomPlayer.run(frame)
+	local player = Player(frame)
+	
+	if String.isEmpty(player.args.team) then
+		player.args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+
+	if String.isEmpty(player.args.team2) then
+		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
+	end
+
+	player.adjustLPDB = CustomPlayer.adjustLPDB
+	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+
+	_args = player.args
+	_role = Role.run({role = _args.role})
+	_role2 = Role.run({role = _args.role2})
+
+	return player:createInfobox(frame)
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'history' then
+		local manualHistory = _args.history
+		local automatedHistory = TeamHistoryAuto._results({
+			convertrole = 'true',
+			player = _pagename
+		}) or ''
+		automatedHistory = tostring(automatedHistory)
+		if automatedHistory == _EMPTY_AUTO_HISTORY then
+			automatedHistory = nil
+		end
+
+		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+			return {
+				Title{name = 'History'},
+				Center{content = {manualHistory}},
+				Center{content = {automatedHistory}},
+			}
+			end
+		end
+	return widgets
+end
+
+function CustomPlayer:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomPlayer:adjustLPDB(lpdbData)
+	lpdbData.extradata.role = _role.role
+	lpdbData.extradata.role2 = _role2.role
+	return lpdbData
+end
+
+return CustomPlayer


### PR DESCRIPTION
## Summary
Zula is a CS:GO type of game. 

Outside of Info Player the rest is a port of either CS or VAL

But the Infobox Player has Tetris base to include the role changes (moved to run function). However I've added the feature to have Team History and Player's current team **(|team=)** to be automated like how LoL and APEX has this feature

## How did you test this change?
LIVE, Because this is the only player page on wiki : https://liquipedia.net/zula/Doxiu
