### PR TITLE
Fix `[h]` link when template only exists on commons

### DIFF
--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -123,16 +123,19 @@ function Header:_createInfoboxButtons()
 
 	local buttons = mw.html.create('span')
 	buttons:addClass('infobox-buttons')
+
+	-- Quick edit link
 	buttons:node(
 		mw.text.nowiki('[') .. '[' .. mw.site.server ..
 		tostring(mw.uri.localUrl( mw.title.getCurrentTitle().prefixedText, 'action=edit&section=0' )) ..
 		' e]' .. mw.text.nowiki(']')
 	)
-	buttons:node(
-		mw.text.nowiki('[') ..
-		'[[' .. moduleTitle ..
-		'|h]]' .. mw.text.nowiki(']')
-	)
+
+	-- Quick help link (links to template)
+	if not mw.title.new(moduleTitle).exists then
+		moduleTitle = 'lpcommons:'.. moduleTitle
+	end
+	buttons:node(mw.text.nowiki('[') .. '[[' .. moduleTitle ..'|h]]' .. mw.text.nowiki(']'))
 
 	return buttons
 end


### PR DESCRIPTION
## Summary
If a wiki doesn't have an Infobox Template, rather using one from commons, the following happens today
![image](https://user-images.githubusercontent.com/3426850/217545199-09fc1526-45ff-48ae-b7d5-f43a08d15547.png)

With this change it will correctly work
![image](https://user-images.githubusercontent.com/3426850/217545275-75eb1564-a418-403a-bd9e-48ae2b22234e.png)


## How did you test this change?
dev module. Verified on Valorant that having a template on the wiki still has the expected behavior.