### PR TITLE
Improve Squad Table display on mobile

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -134,9 +134,8 @@ function SquadRow:date(dateValue, cellTitle, lpdbColumn)
 	local cell = mw.html.create('td')
 	cell:addClass('Date')
 
-	cell:tag('div'):addClass('MobileStuffDate'):wikitext(cellTitle)
-
 	if String.isNotEmpty(dateValue) then
+		cell:tag('div'):addClass('MobileStuffDate'):wikitext(cellTitle)
 		cell:tag('div'):addClass('Date'):tag('i'):wikitext(dateValue)
 	end
 	self.content:node(cell)


### PR DESCRIPTION
## Summary
Currently, if a Squad entry is missing a date, the display get messed up on mobile.
![image](https://user-images.githubusercontent.com/3426850/217760304-8e747a37-2d76-438a-be3e-287c99ffafd7.png) (missing inactive date on both entries)

With this change missing a date will instead look like
![image](https://user-images.githubusercontent.com/3426850/217760459-00c317e9-bee7-476f-9a2f-06af2c471c2b.png)


## How did you test this change?
dev module