### PR TITLE
Fix condition when deciding notability

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -41,16 +41,14 @@ function NotabilityChecker.run(args)
 
 	output = output .. '===Summary===\n'
 	output = output .. '<b>Final weight:</b> ' .. tostring(weight) .. '\n\n'
+	output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person')
 
-	if weight < Config.NOTABILITY_THRESHOLD_NOTABLE and weight > Config.NOTABILITY_THRESHOLD_MIN then
-		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person') ..
-		' is <b>OPEN FOR DISCUSSION</b>\n'
-	elseif weight < Config.NOTABILITY_THRESHOLD_MIN then
-		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person') ..
-		' is <b>NOT NOTABLE</b>\n'
+	if weight >= Config.NOTABILITY_THRESHOLD_NOTABLE then
+		output = output .. ' is <b>NOTABLE</b>\n'
+	elseif weight >= Config.NOTABILITY_THRESHOLD_MIN then
+		output = output .. ' is <b>OPEN FOR DISCUSSION</b>\n'
 	else
-		output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person') ..
-		' is <b>NOTABLE</b>\n'
+		output = output .. ' is <b>NOT NOTABLE</b>\n'
 	end
 
 	return output

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -40,8 +40,8 @@ function NotabilityChecker.run(args)
 	end
 
 	output = output .. '===Summary===\n'
-	output = output .. '<b>Final weight:</b> ' .. tostring(weight) .. '\n\n'
-	output = output .. 'This means this ' .. (isTeamResult and 'team' or 'person')
+		.. '<b>Final weight:</b> ' .. tostring(weight) .. '\n\n'
+		.. 'This means this ' .. (isTeamResult and 'team' or 'person')
 
 	if weight >= Config.NOTABILITY_THRESHOLD_NOTABLE then
 		output = output .. ' is <b>NOTABLE</b>\n'


### PR DESCRIPTION
## Summary
The old condition failed when calculated weight was exactly on the MIN_THRESHOLD:
![image](https://user-images.githubusercontent.com/16326643/217780044-33c9699f-c770-4a39-a852-556f8eb77e2e.png)

This removes some duplicate code and reorders the condition to work again.
It also changes the thresholds to be inclusive, so a weight of exactly NOTABILITY_THRESHOLD_NOTABLE is treated as notable (same for NOTABILITY_THRESHOLD_MIN)

## How did you test this change?
via /dev
![image](https://user-images.githubusercontent.com/16326643/217780267-919530f0-014d-433a-a86e-edd49779db64.png)
