### PR TITLE
Remove class from infobox

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -20,10 +20,8 @@ function Infobox:create(frame, gameName, forceDarkMode)
 	self.frame = frame
 	self.root = mw.html.create('div')
 	self.adbox = mw.html.create('div')	:addClass('fo-nttax-infobox-adbox')
-										:addClass('wiki-bordercolor-light')
 										:node(self.frame:preprocess('<adbox />'))
 	self.content = mw.html.create('div')	:addClass('fo-nttax-infobox')
-											:addClass('wiki-bordercolor-light')
 	self.root	:addClass('fo-nttax-infobox-wrapper')
 				:addClass('infobox-' .. gameName:lower())
 	if forceDarkMode then


### PR DESCRIPTION
## Summary

I want to remove the class wiki-bordercolor-light because I added the border color to the selector itself and it's overwriting with the wrong color for skin LakesideView. I added fallback colors for skin Bruinen.
https://liquipedia.net/commons/index.php?title=MediaWiki:Common.css/Infobox.css&action=edit#mw-ce-l18
https://liquipedia.net/commons/index.php?title=MediaWiki:Common.css/Infobox.css&action=edit#mw-ce-l33
https://liquipedia.net/commons/index.php?title=MediaWiki:Common.css/Infobox.css&action=edit#mw-ce-l34

## How did you test this change?

Removing the class with devtools.
