### PR TITLE
Remove (additional) sectionHeader from sc2 resultstable

### DIFF
--- a/components/results_table/wikis/starcraft2/results_table_custom.lua
+++ b/components/results_table/wikis/starcraft2/results_table_custom.lua
@@ -75,12 +75,7 @@ function CustomResultsTable.awards(frame)
 	awardsTable.tierDisplay = CustomResultsTable.tierDisplay
 	awardsTable.rowHighlight = CustomResultsTable.rowHighlight
 
-	local sectionHeader = ''
-	if Logic.readBool(args.achievements) then
-		sectionHeader = '\n=====Notable Awards=====\n'
-	end
-
-	return sectionHeader .. tostring(awardsTable:create():build())
+	return awardsTable:create():build()
 end
 
 function CustomResultsTable:tierDisplay(placement)


### PR DESCRIPTION
## Summary
Remove (additional) sectionHeader from sc2 resultstable
Decided to display it a bit different, hence not needed anymore

## How did you test this change?
dev to live