### PR TITLE
Replace leftover `StarcraftPlayerDisplay.Race` call

### DIFF
--- a/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -146,7 +146,7 @@ function StarcraftOpponentDisplay.PlayerInlineOpponent(props)
 
 	local archonRaceNode
 	if showRace and opponent.isArchon then
-		archonRaceNode = StarcraftPlayerDisplay.Race(opponent.players[1].race)
+		archonRaceNode = Faction.Icon{faction = opponent.players[1].race}
 	end
 
 	return html.create('span')


### PR DESCRIPTION
## Summary
Replace leftover `StarcraftPlayerDisplay.Race` call
the function was removed via the race cleanup stuff, apparently i overlooked 1 usecase (did insource search and this is the only remaining case)

## How did you test this change?
dev into live