### PR TITLE
Have WC use `individualprizemoney` for Player Earnings

### DIFF
--- a/components/earnings/wikis/warcraft/earnings.lua
+++ b/components/earnings/wikis/warcraft/earnings.lua
@@ -1,0 +1,16 @@
+---
+-- @Liquipedia
+-- wiki=warcraft
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+CustomEarnings.divisionFactorPlayer = nil
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
## Summary
For correct player prize calculations for warcraft, have them use `individualprizemoney`.

## How did you test this change?
Live