### PR TITLE
Update info.lua for smash

### DIFF
--- a/standard/info/wikis/smash/info.lua
+++ b/standard/info/wikis/smash/info.lua
@@ -39,8 +39,8 @@ return {
 		},
 		wiiu = {
 			abbreviation = 'Wii U',
-			name = 'Super Smash Bros. Wii U',
-			link = 'Portal:Tournaments/All/Ultimate',
+			name = 'Super Smash Bros. for Wii U',
+			link = 'Super Smash Bros. for Wii U',
 			logo = {
 				darkMode = 'Smash default darkmode.png',
 				lightMode = 'Smash default lightmode.png',
@@ -78,7 +78,7 @@ return {
 		},
 		[64] = {
 			abbreviation = '64',
-			name = 'Super Smash Bros. 64',
+			name = 'Super Smash Bros.',
 			link = 'Super Smash Bros.',
 			logo = {
 				darkMode = 'Smash default darkmode.png',


### PR DESCRIPTION
## Summary

Incorrect game names. Wii U should not link to the Ultimate tournament portal.

## How did you test this change?

Matches existing usage.