### PR TITLE
MatchGroup/Input/Custom for Critical Ops

### DIFF
--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -90,8 +90,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		or Opponent.blank()
 
 	-- Convert byes to literals
-	if opponent.type == Opponent.team and opponent.template:lower() == 'bye'
-		or opponent.type == Opponent.solo and opponent.name:lower() == 'bye' then
+	if Opponent.isBye(opponent) then
 		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -306,9 +306,9 @@ function matchFunctions.getScoreFromMapWinners(match)
 			local winner = tonumber(map.winner)
 			foundScores = true
 			-- Only two opponents in C-OPS
-				if winner and winner > 0 and winner <= 2 then
-					newScores[winner] = (newScores[winner] or 0) + 1
-				end
+			if winner and winner > 0 and winner <= 2 then
+				newScores[winner] = (newScores[winner] or 0) + 1
+			end
 		end
 	end
 	if not opponent1.score and foundScores then

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -338,7 +338,6 @@ end
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_valve_tier'))
-	match.status = Logic.emptyOr(match.status, Variables.varDefault('tournamentSTATUS'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -279,7 +279,7 @@ function matchFunctions.removeUnsetMaps(match)
 	for mapKey, map in Table.iter.pairsByPrefix(match, 'map') do
 		if map.map == DUMMY_MAP_NAME then
 			match[mapKey] = nil
-			end
+		end
 	end
 	return match
 end

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -337,7 +337,6 @@ end
 
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
-	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_valve_tier'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -182,7 +182,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	if Logic.readBool(data.finished) then
 		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
 			data.winner = 0
-			data.resulttype = 'draw'
+			data.resulttype = DRAW_RESULT_TYPE
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 1)
 		elseif CustomMatchGroupInput.placementCheckSpecialStatus(indexedScores) then
 			data.winner = CustomMatchGroupInput.getDefaultWinner(indexedScores)

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -576,8 +576,8 @@ function mapFunctions.getScoresAndWinner(map)
 		end
 	end
 
-	if Table.includes(NOT_PLAYED_MATCH_STATUSES, match.resulttype) then
-		return match.resulttype
+	if Table.includes(NOT_PLAYED_MATCH_STATUSES, map.finished) then
+		map.resulttype = 'skip'
 	else
 		map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
 	end

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -19,8 +19,6 @@ local Streams = require('Module:Links/Stream')
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
-local args = require('Module:Arguments')
-
 local SIDE_DEF = 'ct'
 local SIDE_ATK = 't'
 local STATUS_SCORE = 'S'
@@ -264,7 +262,7 @@ end
 --
 function matchFunctions.getBestOf(match)
 	local mapCount = 0
-	for _, _, mapIndex in Table.iter.pairsByPrefix(args, 'map') do
+	for _, _, mapIndex in Table.iter.pairsByPrefix(match, 'map') do
 		mapCount = mapIndex
 	end
 	match.bestof = mapCount
@@ -276,7 +274,7 @@ end
 -- The discardMap function will check if a map should be removed
 -- Remove all maps that should be removed.
 function matchFunctions.removeUnsetMaps(match)
-	for mapKey, map in Table.iter.pairsByPrefix(args, 'map') do
+	for mapKey, map in Table.iter.pairsByPrefix(match, 'map') do
 			if map.map == DUMMY_MAP_NAME then
 				match[mapKey] = nil
 			end
@@ -302,17 +300,9 @@ function matchFunctions.getScoreFromMapWinners(match)
 			foundScores = true
 		end
 	else -- For best of >1, disply the map wins
-		for _, _, mapIndex in Table.iter.pairsByPrefix(args, 'map') do
-			if match['map' .. i] then
-				local winner = tonumber(match['map' .. i].winner)
+		for _, map in Table.iter.pairsByPrefix(match, 'map') do
+				local winner = tonumber(map.winner)
 				foundScores = true
-				-- Only two opponents in CS
-				if winner and winner > 0 and winner <= 2 then
-					newScores[winner] = (newScores[winner] or 0) + 1
-				end
-			else
-				break
-			end
 		end
 	end
 	if not opponent1.score and foundScores then

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -347,11 +347,6 @@ end
 function matchFunctions.getVodStuff(match)
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
-
-	match.links = {}
-	local links = match.links
-	if match.reddit then links.reddit = match.reddit end
-
 	return match
 end
 

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -89,7 +89,8 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		or Opponent.blank()
 
 	-- Convert byes to literals
-	if opponent.type == (Opponent.team or Opponent.individual) and opponent.template:lower() == 'bye' then
+	if opponent.type == Opponent.team and opponent.template:lower() == 'bye'
+		or opponent.type == Opponent.solo and opponent.name:lower() == 'bye' then
 		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -47,9 +47,6 @@ local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
 local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 local TODAY = os.date('%Y-%m-%d')
 
-local args 
-local match
-
 -- containers for process helper functions
 local matchFunctions = {}
 local mapFunctions = {}

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -37,6 +37,7 @@ local ALLOWED_STATUSES = {
 local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban'}
 local NOT_PLAYED_MATCH_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
 local NOT_PLAYED_RESULT_TYPE = 'np'
+local DRAW_RESULT_TYPE = 'draw'
 local NOW = os.time(os.date('!*t'))
 local NOT_PLAYED_SCORE = -1
 local NO_WINNER = -1
@@ -182,7 +183,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	if Logic.readBool(data.finished) then
 		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
 			data.winner = 0
-			data.resulttype = STATUS_DRAW
+			data.resulttype = 'draw'
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 1)
 		elseif CustomMatchGroupInput.placementCheckSpecialStatus(indexedScores) then
 			data.winner = CustomMatchGroupInput.getDefaultWinner(indexedScores)
@@ -209,7 +210,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 		--If a manual winner is set use it
 		if winner and data.resulttype ~= DEFAULT_RESULT_TYPE then
 			if winner == 0 then
-				data.resulttype = STATUS_DRAW
+				data.resulttype = DRAW_RESULT_TYPE
 			else
 				data.resulttype = nil
 			end

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -303,6 +303,10 @@ function matchFunctions.getScoreFromMapWinners(match)
 		for _, map in Table.iter.pairsByPrefix(match, 'map') do
 				local winner = tonumber(map.winner)
 				foundScores = true
+			-- Only two opponents in C-OPS
+				if winner and winner > 0 and winner <= 2 then
+					newScores[winner] = (newScores[winner] or 0) + 1
+				end
 		end
 	end
 	if not opponent1.score and foundScores then

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -1,0 +1,683 @@
+---
+-- @Liquipedia
+-- wiki=criticalops
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local MathUtil = require('Module:MathUtil')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+local Variables = require('Module:Variables')
+local Streams = require('Module:Links/Stream')
+local EarningsOf = require('Module:Earnings of')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
+
+local ALLOWED_STATUSES = {'W', 'FF', 'DQ', 'L', 'D'}
+local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban'}
+local NP_MATCH_STATUS = {'cancelled','canceled', 'postponed'}
+local MAX_NUM_OPPONENTS = 2
+local MAX_NUM_PLAYERS = 10
+local MAX_NUM_MAPS = 9
+local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
+
+local FEATURED_TIERS = {1, 2}
+local MIN_EARNINGS_FOR_FEATURED = 200000
+
+local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+local TODAY = os.date('%Y-%m-%d')
+
+-- containers for process helper functions
+local matchFunctions = {}
+local mapFunctions = {}
+local opponentFunctions = {}
+
+local CustomMatchGroupInput = {}
+
+-- called from Module:MatchGroup
+function CustomMatchGroupInput.processMatch(match)
+	-- Count number of maps, check for empty maps to remove, and automatically count score
+	match = matchFunctions.getBestOf(match)
+	match = matchFunctions.getLinks(match)
+	match = matchFunctions.removeUnsetMaps(match)
+	match = matchFunctions.getScoreFromMapWinners(match)
+
+	-- process match
+	Table.mergeInto(
+		match,
+		matchFunctions.readDate(match)
+	)
+	match = matchFunctions.getTournamentVars(match)
+	match = matchFunctions.getOpponents(match)
+	match = matchFunctions.getExtraData(match)
+
+	return match
+end
+
+-- called from Module:Match/Subobjects
+function CustomMatchGroupInput.processMap(map)
+	map = mapFunctions.getTournamentVars(map)
+	map = mapFunctions.getExtraData(map)
+	map = mapFunctions.getScoresAndWinner(map)
+
+	return map
+end
+
+function CustomMatchGroupInput.processOpponent(record, date)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	-- Convert byes to literals
+	if opponent.type == Opponent.team and opponent.template:lower() == 'bye' then
+		opponent = {type = Opponent.literal, name = 'BYE'}
+	end
+
+	local teamTemplateDate = date
+	-- If date is epoch, resolve using tournament dates instead
+	-- Epoch indicates that the match is missing a date
+	-- In order to get correct child team template, we will use an approximately date and not 1970-01-01
+	if teamTemplateDate == EPOCH_TIME_EXTENDED then
+		teamTemplateDate = Variables.varDefaultMulti(
+			'tournament_enddate',
+			'tournament_startdate',
+			TODAY
+		)
+	end
+
+	Opponent.resolve(opponent, teamTemplateDate)
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+end
+
+-- called from Module:Match/Subobjects
+function CustomMatchGroupInput.processPlayer(player)
+	return player
+end
+
+--
+--
+-- function to check for draws
+function CustomMatchGroupInput.placementCheckDraw(table)
+	if #table < MAX_NUM_OPPONENTS then
+		return false
+	end
+
+	local last
+	for _, scoreInfo in pairs(table) do
+		if scoreInfo.status ~= 'S' and scoreInfo.status ~= 'D' then
+			return false
+		end
+		if last and last ~= scoreInfo.score then
+			return false
+		else
+			last = scoreInfo.score
+		end
+	end
+
+	return true
+end
+
+-- Set the field 'placement' for the two participants in the opponenets list.
+-- Set the placementWinner field to the winner, and placementLoser to the other team
+-- Special cases:
+-- If Winner = 0, that means draw, and placementLoser isn't used. Both teams will get placementWinner
+-- If Winner = -1, that mean no team won, and placementWinner isn't used. Both teams will gt placementLoser
+function CustomMatchGroupInput.setPlacement(opponents, winner, placementWinner, placementLoser)
+	if opponents and #opponents == 2 then
+		local loserIdx
+		local winnerIdx
+		if winner == 1 then
+			winnerIdx = 1
+			loserIdx = 2
+		elseif winner == 2 then
+			winnerIdx = 2
+			loserIdx = 1
+		elseif winner == 0 then
+			-- Draw; idx of winner/loser doesn't matter
+			-- since loser and winner gets the same placement
+			placementLoser = placementWinner
+			winnerIdx = 1
+			loserIdx = 2
+		elseif winner == -1 then
+			-- No Winner (both loses). For example if both teams DQ.
+			-- idx's doesn't matter
+			placementWinner = placementLoser
+			winnerIdx = 1
+			loserIdx = 2
+		else
+			error('setPlacement: Unexpected winner')
+			return opponents
+		end
+		opponents[winnerIdx].placement = placementWinner
+		opponents[loserIdx].placement = placementLoser
+	end
+	return opponents
+end
+
+function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
+	-- Map or Match is marked as finished.
+	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
+	local winner = tonumber(data.winner)
+	if Logic.readBool(data.finished) then
+		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
+			data.winner = 0
+			data.resulttype = 'draw'
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 1)
+		elseif CustomMatchGroupInput.placementCheckSpecialStatus(indexedScores) then
+			data.winner = CustomMatchGroupInput.getDefaultWinner(indexedScores)
+			data.resulttype = 'default'
+			if CustomMatchGroupInput.placementCheckFF(indexedScores) then
+				data.walkover = 'ff'
+			elseif CustomMatchGroupInput.placementCheckDQ(indexedScores) then
+				data.walkover = 'dq'
+			elseif CustomMatchGroupInput.placementCheckWL(indexedScores) then
+				data.walkover = 'l'
+			end
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
+		elseif CustomMatchGroupInput.placementCheckScoresSet(indexedScores) then
+			--CS only has exactly 2 opponents, neither more or less
+			if #indexedScores == MAX_NUM_OPPONENTS then
+				if tonumber(indexedScores[1].score) > tonumber(indexedScores[2].score) then
+					data.winner = 1
+				else
+					data.winner = 2
+				end
+				indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
+			end
+		end
+		--If a manual winner is set use it
+		if winner and data.resulttype ~= 'default' then
+			if winner == 0 then
+				data.resulttype = 'draw'
+			else
+				data.resulttype = nil
+			end
+			data.winner = winner
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, winner, 1, 2)
+		end
+	end
+	return data, indexedScores
+end
+
+
+-- Check if any team has a none-standard status
+function CustomMatchGroupInput.placementCheckSpecialStatus(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status and scoreinfo.status ~= 'S' end)
+end
+
+-- function to check for forfeits
+function CustomMatchGroupInput.placementCheckFF(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'FF' end)
+end
+
+-- function to check for DQ's
+function CustomMatchGroupInput.placementCheckDQ(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'DQ' end)
+end
+
+-- function to check for W/L
+function CustomMatchGroupInput.placementCheckWL(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'L' end)
+end
+
+-- Get the winner when resulttype=default
+function CustomMatchGroupInput.getDefaultWinner(table)
+	for index, scoreInfo in pairs(table) do
+		if scoreInfo.status == 'W' then
+			return index
+		end
+	end
+	return -1
+end
+
+function CustomMatchGroupInput.placementCheckScoresSet(table)
+	return Table.all(table, function (_, scoreinfo) return scoreinfo.status == 'S' end)
+end
+
+--
+-- match related functions
+--
+function matchFunctions.getBestOf(match)
+	local mapCount = 0
+	for i = 1, MAX_NUM_MAPS do
+		if match['map' .. i] then
+			mapCount = mapCount + 1
+		else
+			break
+		end
+	end
+	match.bestof = mapCount
+	return match
+end
+
+-- Template:Map sets a default map name so we can count the number of maps.
+-- These maps however shouldn't be stored in lpdb, nor displayed
+-- The discardMap function will check if a map should be removed
+-- Remove all maps that should be removed.
+function matchFunctions.removeUnsetMaps(match)
+	for i = 1, MAX_NUM_MAPS do
+		if match['map' .. i] then
+			if mapFunctions.discardMap(match['map' .. i]) then
+				match['map' .. i] = nil
+			end
+		else
+			break
+		end
+	end
+	return match
+end
+
+-- Calculate the match scores based on the map results.
+-- If it's a Best of 1, we'll take the exact score of that map
+-- If it's not a Best of 1, we should count the map wins
+-- Only update a teams result if it's
+-- 1) Not manually added
+-- 2) At least one map has a winner
+function matchFunctions.getScoreFromMapWinners(match)
+	-- For best of 1, display the results of the single map
+	local opponent1 = match.opponent1
+	local opponent2 = match.opponent2
+	local newScores = {}
+	local foundScores = false
+	if match.bestof == 1 then
+		if match.map1 then
+			newScores = match.map1.scores
+			foundScores = true
+		end
+	else -- For best of >1, disply the map wins
+		for i = 1, MAX_NUM_MAPS do
+			if match['map' .. i] then
+				local winner = tonumber(match['map' .. i].winner)
+				foundScores = true
+				-- Only two opponents in CS
+				if winner and winner > 0 and winner <= 2 then
+					newScores[winner] = (newScores[winner] or 0) + 1
+				end
+			else
+				break
+			end
+		end
+	end
+	if not opponent1.score and foundScores then
+		opponent1.score = newScores[1] or 0
+	end
+	if not opponent2.score and foundScores then
+		opponent2.score = newScores[2] or 0
+	end
+	match.opponent1 = opponent1
+	match.opponent2 = opponent2
+	return match
+end
+
+function matchFunctions.readDate(matchArgs)
+	if matchArgs.date then
+		local dateProps = MatchGroupInput.readDate(matchArgs.date)
+		dateProps.hasDate = true
+		return dateProps
+	else
+		return {
+			date = EPOCH_TIME_EXTENDED,
+			dateexact = false,
+		}
+	end
+end
+
+function matchFunctions.getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_valve_tier'))
+	match.status = Logic.emptyOr(match.status, Variables.varDefault('tournament_status'))
+	return MatchGroupInput.getCommonTournamentVars(match)
+end
+
+function matchFunctions.getLinks(match)
+	match.stream = Streams.processStreams(match)
+	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
+	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))
+
+	match.links = {}
+
+	local links = match.links
+
+	local platforms = mw.loadData('Module:MatchExternalLinks')
+	table.insert(platforms, {name = 'vod2', isMapStats = true})
+
+	for _, platform in ipairs(platforms) do
+		-- Stat external links inserted in {{Map}}
+		if Logic.isNotEmpty(platform) then
+			local platformLinks = {}
+			local name = platform.name
+			local prefixLink = platform.prefixLink or ''
+			local suffixLink = platform.suffixLink or ''
+
+			if match[name] then
+				table.insert(platformLinks, {prefixLink .. match[name] .. suffixLink, 0})
+				match[name] = nil
+			end
+
+			if platform.isMapStats then
+				for i = 1, match.bestof do
+					local map = match['map' .. i]
+					if map and map[platform.name] then
+						table.insert(platformLinks, {prefixLink .. match['map' .. i][name] .. suffixLink, i})
+						match['map' .. i][platform.name] = nil
+					end
+				end
+			else
+				if platform.max then
+					for i = 2, platform.max, 1 do
+						if match[platform.name .. i] then
+							table.insert(platformLinks, {prefixLink .. match[name .. i] .. suffixLink, i})
+							match[platform.name .. i] = nil
+						end
+					end
+				end
+			end
+
+			if #platformLinks > 0 then
+				links[name] = platformLinks
+			end
+		end
+	end
+
+	return match
+end
+
+function matchFunctions.getMatchStatus(match)
+	if match.resulttype == 'np' then
+		return match.status
+	else
+		return nil
+	end
+end
+
+function matchFunctions.getEarnings(name, year)
+	if Logic.isEmpty(name) then
+		return 0
+	end
+
+	return tonumber(EarningsOf._team(name, {sdate = (year-1) .. '-01-01', edate = year .. '-12-31'}))
+end
+
+function matchFunctions.isFeatured(match)
+	if Table.includes(FEATURED_TIERS, tonumber(match.liquipediatier)) then
+		return true
+	end
+	if Logic.isNotEmpty(match.publishertier) then
+		return true
+	end
+
+	if not match.hasDate then
+		return false
+	end
+
+	local opponent1, opponent2 = match.opponent1, match.opponent2
+	local year = os.date('%Y')
+
+	if
+		opponent1.type == Opponent.team and
+		matchFunctions.getEarnings(opponent1.name, year) >= MIN_EARNINGS_FOR_FEATURED
+	or
+		opponent2.type == Opponent.team and
+		matchFunctions.getEarnings(opponent2.name, year) >= MIN_EARNINGS_FOR_FEATURED
+	then
+		return true
+	end
+
+	return false
+end
+
+function matchFunctions.getExtraData(match)
+	match.extradata = {
+		mapveto = matchFunctions.getMapVeto(match),
+		status = matchFunctions.getMatchStatus(match),
+		overturned = Logic.isNotEmpty(match.overturned),
+		featured = matchFunctions.isFeatured(match),
+		hidden = Logic.readBool(Variables.varDefault('match_hidden'))
+	}
+	return match
+end
+
+-- Parse the mapVeto input
+function matchFunctions.getMapVeto(match)
+	if not match.mapveto then return nil end
+
+	match.mapveto = Json.parseIfString(match.mapveto)
+
+	local vetotypes = mw.text.split(match.mapveto.types or '', ',')
+	local deciders = mw.text.split(match.mapveto.decider or '', ',')
+	local vetostart = match.mapveto.firstpick or ''
+	local deciderIndex = 1
+
+	local data = {}
+	for index, vetoType in ipairs(vetotypes) do
+		vetoType = mw.text.trim(vetoType):lower()
+		if not Table.includes(ALLOWED_VETOES, vetoType) then
+			return nil -- Any invalid input will not store (ie hide) all vetoes.
+		end
+		if vetoType == 'decider' then
+			table.insert(data, {type = vetoType, decider = deciders[deciderIndex]})
+			deciderIndex = deciderIndex + 1
+		else
+			table.insert(data, {type = vetoType, team1 = match.mapveto['t1map' .. index],
+									team2 = match.mapveto['t2map' .. index]})
+		end
+	end
+	if data[1] then
+		data[1].vetostart = vetostart
+	end
+	return data
+end
+
+function matchFunctions.getOpponents(match)
+	-- read opponents and ignore empty ones
+	local opponents = {}
+	local isScoreSet = false
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		-- read opponent
+		local opponent = match['opponent' .. opponentIndex]
+		if not Logic.isEmpty(opponent) then
+			CustomMatchGroupInput.processOpponent(opponent, match.date)
+
+			-- Retrieve icon for team
+			if opponent.type == Opponent.team then
+				opponent.icon, opponent.icondark = opponentFunctions.getIcon(opponent.template)
+			end
+
+			-- apply status
+			if TypeUtil.isNumeric(opponent.score) then
+				opponent.status = 'S'
+				isScoreSet = true
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
+				opponent.status = opponent.score
+				opponent.score = -1
+			end
+			opponents[opponentIndex] = opponent
+
+			-- get players from vars for teams
+			if opponent.type == Opponent.team and not Logic.isEmpty(opponent.name) then
+				match = matchFunctions.getPlayers(match, opponentIndex, opponent.name)
+			end
+		end
+	end
+
+	-- Handle tournament status for unfinished matches
+	if (not Logic.readBool(match.finished)) and Logic.isNotEmpty(match.status) then
+		match.finished = match.status
+	end
+
+	if Table.includes(NP_MATCH_STATUS, match.finished) then
+		match.resulttype = 'np'
+		match.status = match.finished
+		match.finished = false
+		match.dateexact = false
+	else
+		-- see if match should actually be finished if score is set
+		if isScoreSet and not Logic.readBool(match.finished) and match.hasDate then
+			local currentUnixTime = os.time(os.date('!*t'))
+			local lang = mw.getContentLanguage()
+			local matchUnixTime = tonumber(lang:formatDate('U', match.date))
+			local threshold = match.dateexact and 30800 or 86400
+			if matchUnixTime + threshold < currentUnixTime then
+				match.finished = true
+			end
+		end
+
+		if Logic.readBool(match.finished) then
+			match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
+		end
+	end
+
+	-- Update all opponents with new values
+	for opponentIndex, opponent in pairs(opponents) do
+		match['opponent' .. opponentIndex] = opponent
+	end
+	return match
+end
+
+-- Get Playerdata from Vars (get's set in TeamCards)
+function matchFunctions.getPlayers(match, opponentIndex, teamName)
+	-- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
+	local count = 1
+	for playerIndex = 1, MAX_NUM_PLAYERS do
+		-- parse player
+		local player = match['opponent' .. opponentIndex .. '_p' .. playerIndex] or {}
+		player = Json.parseIfString(player)
+		local playerPrefix = teamName .. '_p' .. playerIndex
+		player.name = player.name or Variables.varDefault(playerPrefix)
+		player.flag = player.flag or Variables.varDefault(playerPrefix .. 'flag')
+		player.displayname = player.displayname or Variables.varDefault(playerPrefix .. 'dn')
+		if not Table.isEmpty(player) then
+			match['opponent' .. opponentIndex .. '_p' .. count] = player
+			count = count + 1
+		end
+	end
+	return match
+end
+
+--
+-- map related functions
+--
+
+-- Check if a map should be discarded due to being redundant
+-- DUMMY_MAP_NAME needs the match the default value in Template:Map
+function mapFunctions.discardMap(map)
+	if map.map == DUMMY_MAP_NAME then
+		return true
+	else
+		return false
+	end
+end
+
+-- Parse extradata information
+function mapFunctions.getExtraData(map)
+	map.extradata = {
+		comment = map.comment,
+	}
+	return map
+end
+
+function mapFunctions._getHalfScores(map)
+	map.extradata['t1sides'] = {}
+	map.extradata['t2sides'] = {}
+	map.extradata['t1halfs'] = {}
+	map.extradata['t2halfs'] = {}
+
+	local key = ''
+	local overtimes = 0
+
+	local function getOpossiteSide(side)
+		return side == 'ct' and 't' or 'ct'
+	end
+
+	while true do
+		local t1Side = map[key .. 't1firstside']
+		if Logic.isEmpty(t1Side) or (t1Side ~= 'ct' and t1Side ~= 't') then
+			break
+		end
+		local t2Side = getOpossiteSide(t1Side)
+
+		-- Iterate over two Halfs (In regular time a half is 15 rounds, after that sides switch)
+		for _ = 1, 2, 1 do
+			if(map[key .. 't1' .. t1Side] and map[key .. 't2' .. t2Side]) then
+				table.insert(map.extradata['t1sides'], t1Side)
+				table.insert(map.extradata['t2sides'], t2Side)
+				table.insert(map.extradata['t1halfs'], tonumber(map[key .. 't1' .. t1Side]) or 0)
+				table.insert(map.extradata['t2halfs'], tonumber(map[key .. 't2' .. t2Side]) or 0)
+				map[key .. 't1' .. t1Side] = nil
+				map[key .. 't2' .. t2Side] = nil
+				-- second half (sides switch)
+				t1Side, t2Side = t2Side, t1Side
+			end
+		end
+
+		overtimes = overtimes + 1
+		key = 'o' .. overtimes
+	end
+
+	return map
+end
+
+-- Calculate Score and Winner of the map
+-- Use the half information if available
+function mapFunctions.getScoresAndWinner(map)
+	map.scores = {}
+	local indexedScores = {}
+
+	map = mapFunctions._getHalfScores(map)
+
+	for scoreIndex = 1, MAX_NUM_OPPONENTS do
+		-- read scores
+		local score
+		if Table.includes(ALLOWED_STATUSES, map['score' .. scoreIndex]) then
+			score = map['score' .. scoreIndex]
+		elseif Logic.isNotEmpty(map.extradata['t' .. scoreIndex .. 'halfs']) then
+			score = MathUtil.sum(map.extradata['t' .. scoreIndex .. 'halfs'])
+		else
+			score = tonumber(map['score' .. scoreIndex])
+		end
+		local obj = {}
+		if not Logic.isEmpty(score) then
+			if TypeUtil.isNumeric(score) then
+				obj.status = 'S'
+				obj.score = score
+			elseif Table.includes(ALLOWED_STATUSES, score) then
+				obj.status = score
+				obj.score = -1
+			end
+			map.scores[scoreIndex] = score
+			indexedScores[scoreIndex] = obj
+		end
+	end
+
+	if map.finished == 'skip' then
+		map.resulttype = 'np'
+	else
+		map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
+	end
+
+	return map
+end
+
+function mapFunctions.getTournamentVars(map)
+	map.mode = Logic.emptyOr(map.mode, Variables.varDefault('tournament_mode', 'team'))
+	return MatchGroupInput.getCommonTournamentVars(map)
+end
+
+--
+-- opponent related functions
+--
+function opponentFunctions.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	if raw then
+		local icon = Logic.emptyOr(raw.image, raw.legacyimage)
+		local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
+		return icon, iconDark
+	end
+end
+
+return CustomMatchGroupInput

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -89,7 +89,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		or Opponent.blank()
 
 	-- Convert byes to literals
-	if opponent.type == Opponent.team and opponent.template:lower() == 'bye' then
+	if opponent.type == (Opponent.team or Opponent.individual) and opponent.template:lower() == 'bye' then
 		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
@@ -195,7 +195,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 			end
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
 		elseif CustomMatchGroupInput.placementCheckScoresSet(indexedScores) then
-			--CS only has exactly 2 opponents, neither more or less
+			--C-OPS only has exactly 2 opponents, neither more or less
 			if #indexedScores == MAX_NUM_OPPONENTS then
 				if tonumber(indexedScores[1].score) > tonumber(indexedScores[2].score) then
 					data.winner = 1

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -19,6 +19,8 @@ local Streams = require('Module:Links/Stream')
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
+local args = require('Module:Arguments')
+
 local SIDE_DEF = 'ct'
 local SIDE_ATK = 't'
 local STATUS_SCORE = 'S'

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -36,6 +36,7 @@ local ALLOWED_STATUSES = {
 }
 local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban'}
 local NOT_PLAYED_MATCH_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
+local NOT_PLAYED_RESULT_TYPE = 'np'
 local NOW = os.time(os.date('!*t'))
 local NOT_PLAYED_SCORE = -1
 local NO_WINNER = -1
@@ -275,8 +276,8 @@ end
 -- Remove all maps that should be removed.
 function matchFunctions.removeUnsetMaps(match)
 	for mapKey, map in Table.iter.pairsByPrefix(match, 'map') do
-			if map.map == DUMMY_MAP_NAME then
-				match[mapKey] = nil
+		if map.map == DUMMY_MAP_NAME then
+			match[mapKey] = nil
 			end
 	end
 	return match
@@ -301,8 +302,8 @@ function matchFunctions.getScoreFromMapWinners(match)
 		end
 	else -- For best of >1, disply the map wins
 		for _, map in Table.iter.pairsByPrefix(match, 'map') do
-				local winner = tonumber(map.winner)
-				foundScores = true
+			local winner = tonumber(map.winner)
+			foundScores = true
 			-- Only two opponents in C-OPS
 				if winner and winner > 0 and winner <= 2 then
 					newScores[winner] = (newScores[winner] or 0) + 1
@@ -347,7 +348,7 @@ function matchFunctions.getVodStuff(match)
 end
 
 function matchFunctions.getMatchStatus(match)
-	if Table.includes(NOT_PLAYED_MATCH_STATUSES, match.resulttype) then
+	if match.resulttype == NOT_PLAYED_RESULT_TYPE then
 		return match.status
 	else
 		return nil
@@ -568,7 +569,7 @@ function mapFunctions.getScoresAndWinner(map)
 	end
 
 	if Table.includes(NOT_PLAYED_MATCH_STATUSES, map.finished) then
-		map.resulttype = 'skip'
+		map.resulttype = NOT_PLAYED_RESULT_TYPE
 	else
 		map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
 	end

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -41,12 +41,14 @@ local NOT_PLAYED_SCORE = -1
 local NO_WINNER = -1
 local MAX_NUM_OPPONENTS = 2
 local MAX_NUM_PLAYERS = 10
-local MAX_NUM_MAPS = 9
 local DEFAULT_RESULT_TYPE = 'default'
 local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
 
 local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
 local TODAY = os.date('%Y-%m-%d')
+
+local args 
+local match
 
 -- containers for process helper functions
 local matchFunctions = {}
@@ -251,7 +253,7 @@ function CustomMatchGroupInput.getDefaultWinner(table)
 			return index
 		end
 	end
-	return _NO_WINNER
+	return NO_WINNER
 end
 
 function CustomMatchGroupInput.placementCheckScoresSet(table)
@@ -424,7 +426,7 @@ function matchFunctions.getOpponents(match)
 				isScoreSet = true
 			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
 				opponent.status = opponent.score
-				opponent.score = _NOT_PLAYED_SCORE
+				opponent.score = NOT_PLAYED_SCORE
 			end
 			opponents[opponentIndex] = opponent
 
@@ -570,7 +572,7 @@ function mapFunctions.getScoresAndWinner(map)
 				obj.score = score
 			elseif Table.includes(ALLOWED_STATUSES, score) then
 				obj.status = score
-				obj.score = _NOT_PLAYED_SCORE
+				obj.score = NOT_PLAYED_SCORE
 			end
 			map.scores[scoreIndex] = score
 			indexedScores[scoreIndex] = obj

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -19,28 +19,28 @@ local Streams = require('Module:Links/Stream')
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
-local _STATUS_SCORE = 'S'
-local _STATUS_DRAW = 'D'
-local _STATUS_DEFAULT_WIN = 'W'
-local _STATUS_FORFEIT = 'FF'
-local _STATUS_DISQUALIFIED = 'DQ'
-local _STATUS_DEFAULT_LOSS = 'L'
-local _ALLOWED_STATUSES = {
-	_STATUS_DRAW,
-	_STATUS_DEFAULT_WIN,
-	_STATUS_FORFEIT,
-	_STATUS_DISQUALIFIED,
-	_STATUS_DEFAULT_LOSS,
+local STATUS_SCORE = 'S'
+local STATUS_DRAW = 'D'
+local STATUS_DEFAULT_WIN = 'W'
+local STATUS_FORFEIT = 'FF'
+local STATUS_DISQUALIFIED = 'DQ'
+local STATUS_DEFAULT_LOSS = 'L'
+local ALLOWED_STATUSES = {
+	STATUS_DRAW,
+	STATUS_DEFAULT_WIN,
+	STATUS_FORFEIT,
+	STATUS_DISQUALIFIED,
+	STATUS_DEFAULT_LOSS,
 }
 local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban'}
-local NP_MATCH_STATUS = {'skip', 'np', 'canceled', 'cancelled'}
+local NP_MATCHSTATUS = {'skip', 'np', 'canceled', 'cancelled'}
 local NOW = os.time(os.date('!*t'))
 local _NOT_PLAYED_SCORE = -1
 local _NO_WINNER = -1
 local MAX_NUM_OPPONENTS = 2
 local MAX_NUM_PLAYERS = 10
 local MAX_NUM_MAPS = 9
-local _DEFAULT_RESULT_TYPE = 'default'
+local DEFAULT_RESULT_TYPE = 'default'
 local DUMMY_MAP_NAME = 'null' -- Is set in Template:Map when |map= is empty.
 
 local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
@@ -122,7 +122,7 @@ function CustomMatchGroupInput.placementCheckDraw(table)
 
 	local last
 	for _, scoreInfo in pairs(table) do
-		if scoreInfo.status ~= _STATUS_SCORE and scoreInfo.status ~= _STATUS_DRAW then
+		if scoreInfo.status ~= STATUS_SCORE and scoreInfo.status ~= STATUS_DRAW then
 			return false
 		end
 		if last and last ~= scoreInfo.score then
@@ -179,17 +179,17 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	if Logic.readBool(data.finished) then
 		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
 			data.winner = 0
-			data.resulttype = _STATUS_DRAW
+			data.resulttype = STATUS_DRAW
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 1)
 		elseif CustomMatchGroupInput.placementCheckSpecialStatus(indexedScores) then
 			data.winner = CustomMatchGroupInput.getDefaultWinner(indexedScores)
-			data.resulttype = _DEFAULT_RESULT_TYPE
+			data.resulttype = DEFAULT_RESULT_TYPE
 			if CustomMatchGroupInput.placementCheckFF(indexedScores) then
-				data.walkover = _STATUS_FORFEIT
+				data.walkover = STATUS_FORFEIT
 			elseif CustomMatchGroupInput.placementCheckDQ(indexedScores) then
-				data.walkover = _STATUS_DISQUALIFIED
+				data.walkover = STATUS_DISQUALIFIED
 			elseif CustomMatchGroupInput.placementCheckWL(indexedScores) then
-				data.walkover = _STATUS_DEFAULT_LOSS
+				data.walkover = STATUS_DEFAULT_LOSS
 			end
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
 		elseif CustomMatchGroupInput.placementCheckScoresSet(indexedScores) then
@@ -222,30 +222,30 @@ end
 function CustomMatchGroupInput.placementCheckSpecialStatus(table)
 	return Table.any(table,
 		function (_, scoreinfo)
-			return scoreinfo.status ~= _STATUS_SCORE and String.isNotEmpty(scoreinfo.status)
+			return scoreinfo.status ~= STATUS_SCORE and String.isNotEmpty(scoreinfo.status)
 		end
 	)
 end
 
 -- function to check for forfeits
 function CustomMatchGroupInput.placementCheckFF(table)
-	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ==  _STATUS_FORFEIT end)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ==  STATUS_FORFEIT end)
 end
 
 -- function to check for DQ's
 function CustomMatchGroupInput.placementCheckDQ(table)
-	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == _STATUS_DISQUALIFIED end)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == STATUS_DISQUALIFIED end)
 end
 
 -- function to check for W/L
 function CustomMatchGroupInput.placementCheckWL(table)
-	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ==  _STATUS_DEFAULT_LOSS end)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ==  STATUS_DEFAULT_LOSS end)
 end
 
 -- Get the winner when resulttype=default
 function CustomMatchGroupInput.getDefaultWinner(table)
 	for index, scoreInfo in pairs(table) do
-		if scoreInfo.status == _STATUS_DEFAULT_WIN then
+		if scoreInfo.status == STATUS_DEFAULT_WIN then
 			return index
 		end
 	end
@@ -253,7 +253,7 @@ function CustomMatchGroupInput.getDefaultWinner(table)
 end
 
 function CustomMatchGroupInput.placementCheckScoresSet(table)
-	return Table.all(table, function (_, scoreinfo) return scoreinfo.status == _STATUS_SCORE end)
+	return Table.all(table, function (_, scoreinfo) return scoreinfo.status == STATUS_SCORE end)
 end
 
 --
@@ -347,7 +347,7 @@ end
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_valve_tier'))
-	match.status = Logic.emptyOr(match.status, Variables.varDefault('tournament_status'))
+	match.status = Logic.emptyOr(match.status, Variables.varDefault('tournamentSTATUS'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 
@@ -384,8 +384,8 @@ function matchFunctions.getMapVeto(match)
 
 	match.mapveto = Json.parseIfString(match.mapveto)
 
-	local vetotypes = mw.text.split(match.mapveto.types or ',')
-	local deciders = mw.text.split(match.mapveto.decider or ',')
+	local vetotypes = mw.text.split(match.mapveto.types or '', ',')
+	local deciders = mw.text.split(match.mapveto.decider or '', ',')
 	local vetostart = match.mapveto.firstpick
 	local deciderIndex = 1
 
@@ -426,9 +426,9 @@ function matchFunctions.getOpponents(match)
 
 			-- apply status
 			if TypeUtil.isNumeric(opponent.score) then
-				opponent.status = _STATUS_SCORE
+				opponent.status = STATUS_SCORE
 				isScoreSet = true
-			elseif Table.includes(_ALLOWED_STATUSES, opponent.score) then
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
 				opponent.status = opponent.score
 				opponent.score = _NOT_PLAYED_SCORE
 			end
@@ -446,7 +446,7 @@ function matchFunctions.getOpponents(match)
 		match.finished = match.status
 	end
 
-	if Table.includes(NP_MATCH_STATUS, match.finished) then
+	if Table.includes(NP_MATCHSTATUS, match.finished) then
 		match.resulttype = _NOT_PLAYED_SCORE
 		match.status = match.finished
 		match.finished = false
@@ -499,11 +499,7 @@ end
 -- Check if a map should be discarded due to being redundant
 -- DUMMY_MAP_NAME needs the match the default value in Template:Map
 function mapFunctions.discardMap(map)
-	if map.map == DUMMY_MAP_NAME then
-		return true
-	else
-		return false
-	end
+	return map.map == DUMMY_MAP_NAME
 end
 
 -- Parse extradata information
@@ -566,7 +562,7 @@ function mapFunctions.getScoresAndWinner(map)
 	for scoreIndex = 1, MAX_NUM_OPPONENTS do
 		-- read scores
 		local score
-		if Table.includes(_ALLOWED_STATUSES, map['score' .. scoreIndex]) then
+		if Table.includes(ALLOWED_STATUSES, map['score' .. scoreIndex]) then
 			score = map['score' .. scoreIndex]
 		elseif Logic.isNotEmpty(map.extradata['t' .. scoreIndex .. 'halfs']) then
 			score = MathUtil.sum(map.extradata['t' .. scoreIndex .. 'halfs'])
@@ -576,9 +572,9 @@ function mapFunctions.getScoresAndWinner(map)
 		local obj = {}
 		if not Logic.isEmpty(score) then
 			if TypeUtil.isNumeric(score) then
-				obj.status = _STATUS_SCORE
+				obj.status = STATUS_SCORE
 				obj.score = score
-			elseif Table.includes(_ALLOWED_STATUSES, score) then
+			elseif Table.includes(ALLOWED_STATUSES, score) then
 				obj.status = score
 				obj.score = _NOT_PLAYED_SCORE
 			end
@@ -587,7 +583,7 @@ function mapFunctions.getScoresAndWinner(map)
 		end
 	end
 
-	if map.finished == NP_MATCH_STATUS then
+	if map.finished == NP_MATCHSTATUS then
 		map.resulttype = _NOT_PLAYED_SCORE
 	else
 		map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -19,6 +19,8 @@ local Streams = require('Module:Links/Stream')
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 
+local SIDE_DEF = 'ct'
+local SIDE_ATK = 't'
 local STATUS_SCORE = 'S'
 local STATUS_DRAW = 'D'
 local STATUS_DEFAULT_WIN = 'W'
@@ -363,7 +365,7 @@ function matchFunctions.getVodStuff(match)
 end
 
 function matchFunctions.getMatchStatus(match)
-	if match.resulttype == 'np' then
+	if match.resulttype == NP_MATCHSTATUS then
 		return match.status
 	else
 		return nil
@@ -519,16 +521,16 @@ function mapFunctions._getHalfScores(map)
 	local key = ''
 	local overtimes = 0
 
-	local function getOpossiteSide(side)
-		return side == 'ct' and 't' or 'ct'
+	local function getOppositeSide(side)
+		return side == SIDE_DEF and SIDE_ATK or SIDE_DEF
 	end
 
 	while true do
 		local t1Side = map[key .. 't1firstside']
-		if Logic.isEmpty(t1Side) or (t1Side ~= 'ct' and t1Side ~= 't') then
+		if Logic.isEmpty(t1Side) or (t1Side ~= SIDE_DEF and t1Side ~= SIDE_ATK) then
 			break
 		end
-		local t2Side = getOpossiteSide(t1Side)
+		local t2Side = getOppositeSide(t1Side)
 
 		-- Iterate over two Halfs (In regular time a half is 15 rounds, after that sides switch)
 		for _ = 1, 2, 1 do


### PR DESCRIPTION
## Summary
**Part of Critical Ops (very bottom of Pre-Alpha) Match2**

The entire game is a Counter-Strike clone on Mobile, I guess it doesnt required much explanation of match structure. 

The match2 starts with pure paste of CS:GO Match2 because it works instantly

## How did you test this change?
LIVE

https://liquipedia.net/criticalops/Critical_Ops_Circuit/Season_5/Asia/Finals

## Side Note
C-OPS has been on a WIP R6 Match2 for like 6-9months (before CS Match2 exist), but because the game barely has event until this year. I decide to re-visit this and paste the CSGO Match2 because it works out of the gate.