### PR TITLE
Reduce include size

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -294,7 +294,6 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	for index = 1, numberOfHeroes do
 		local heroDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. color)
-			:addClass('brkts-champion-icon')
 			:css('float', flip and 'right' or 'left')
 			:node(HeroIcon._getImage{opponentHeroesData[index], date = date})
 		if numberOfHeroes == _NUM_HEROES_PICK_SOLO then
@@ -312,7 +311,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	end
 
 	local display = mw.html.create('div')
-		:addClass('brkts-popup-body-element-thumbs')
+		:addClass('brkts-popup-body-element-thumbs'):addClass('brkts-champion-icon')
 
 	for _, item in ipairs(opponentHeroesDisplay) do
 		display:node(item)

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -311,7 +311,8 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	end
 
 	local display = mw.html.create('div')
-		:addClass('brkts-popup-body-element-thumbs'):addClass('brkts-champion-icon')
+		:addClass('brkts-popup-body-element-thumbs')
+		:addClass('brkts-champion-icon')
 
 	for _, item in ipairs(opponentHeroesDisplay) do
 		display:node(item)


### PR DESCRIPTION
Moving the css class from children to parent reduced the Post-expand include size by about 3.5%. 

Tested on results section of https://liquipedia.net/leagueoflegends/Liga_Master/2022/Closing/Group_Stage

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
