### PR TITLE
Use `trackmania_id` for `trackmania.io` in Infobox player

### DIFF
--- a/components/infobox/wikis/trackmania/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/trackmania/infobox_person_player_custom.lua
@@ -25,6 +25,8 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_args = player.args
 
+	_args['trackmania-io'] = _args.trackmania_id
+
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	return player:createInfobox()


### PR DESCRIPTION
## Summary
Set alias in trackmania infobox player so that trackmania.io links work as intended

## How did you test this change?
dev into live