### PR TITLE
Add additional extradata storage to warcraft infobox team

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_team_custom.lua
@@ -9,6 +9,7 @@
 local Achievements = require('Module:Achievements in infoboxes')
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Faction = require('Module:Faction')
 local Flags = require('Module:Flags')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -99,6 +100,7 @@ end
 function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.extradata.clantag = args.clantag
 	lpdbData.extradata.isnationalteam = tostring(CustomTeam._isNationalTeam(self.name))
+	lpdbData.extradata.isfactionteam = tostring(CustomTeam._isFactionTeam(self.name))
 
 	return lpdbData
 end
@@ -129,6 +131,11 @@ end
 
 function CustomTeam._isNationalTeam(name)
 	return Flags.getLocalisation(name) ~= nil
+end
+
+function CustomTeam._isFactionTeam(name)
+	local strippedName = name:gsub('^Team ', '')
+	return Faction.read(strippedName) ~= nil
 end
 
 return CustomTeam

--- a/components/infobox/wikis/warcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_team_custom.lua
@@ -98,6 +98,7 @@ end
 
 function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.extradata.clantag = args.clantag
+	lpdbData.extradata.isnationalteam = tostring(CustomTeam._isNationalTeam(self.name))
 
 	return lpdbData
 end
@@ -116,7 +117,7 @@ function CustomTeam:getWikiCategories(args)
 	local teamType, typeCategory = 'Esport team', 'Esport Teams'
 	if Table.includes({'Team Human', 'Team Orc', 'Team Undead', 'Team Night Elf'}, self.name) then
 		teamType, typeCategory = 'Race team', 'Race Teams'
-	elseif Flags.getLocalisation(self.name) then
+	elseif CustomTeam._isNationalTeam(self.name) then
 		teamType, typeCategory = 'National team', 'National Teams'
 	end
 
@@ -124,6 +125,10 @@ function CustomTeam:getWikiCategories(args)
 	Variables.varDefine('teamtype', teamType) -- for SMW
 
 	return categories
+end
+
+function CustomTeam._isNationalTeam(name)
+	return Flags.getLocalisation(name) ~= nil
 end
 
 return CustomTeam

--- a/components/infobox/wikis/warcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_team_custom.lua
@@ -117,7 +117,7 @@ function CustomTeam:getWikiCategories(args)
 	end
 
 	local teamType, typeCategory = 'Esport team', 'Esport Teams'
-	if Table.includes({'Team Human', 'Team Orc', 'Team Undead', 'Team Night Elf'}, self.name) then
+	if CustomTeam._isFactionTeam(self.name) then
 		teamType, typeCategory = 'Race team', 'Race Teams'
 	elseif CustomTeam._isNationalTeam(self.name) then
 		teamType, typeCategory = 'National team', 'National Teams'


### PR DESCRIPTION
## Summary
Add additional extradata storage to warcraft infobox team
- indicator if it is a national team
- indicator if it is a "race team"

Needed to condition on in some queries so we can replace some old smw shit

## How did you test this change?
dev