### PR TITLE
Allow specifying column count for CellWidget

### DIFF
--- a/components/infobox/commons/infobox_widget_cell.lua
+++ b/components/infobox/commons/infobox_widget_cell.lua
@@ -15,15 +15,17 @@ local Cell = Class.new(Widget,
 	function(self, input)
 		self.name = self:assertExistsAndCopy(input.name)
 		self.content = input.content
-		self.options = input.options
+		self.options = input.options or {}
 		self.classes = input.classes
 	end
 )
 
 function Cell:_new(description)
+	local columns = self.options.columns or 2
+
 	self.root = mw.html.create('div')
 	self.description = mw.html.create('div')
-	self.description:addClass('infobox-cell-2')
+	self.description:addClass('infobox-cell-'.. columns)
 					:addClass('infobox-description')
 					:wikitext(description .. ':')
 	self.contentDiv = nil
@@ -60,7 +62,7 @@ function Cell:_content(...)
 			break
 		end
 
-		if self.options ~= nil and self.options.makeLink == true then
+		if self.options.makeLink == true then
 			self.contentDiv:wikitext('[[' .. item .. ']]')
 		else
 			self.contentDiv:wikitext(item)

--- a/components/infobox/commons/infobox_widget_cell.lua
+++ b/components/infobox/commons/infobox_widget_cell.lua
@@ -17,15 +17,15 @@ local Cell = Class.new(Widget,
 		self.content = input.content
 		self.options = input.options or {}
 		self.classes = input.classes
+
+		self.options.columns = self.options.columns or 2
 	end
 )
 
 function Cell:_new(description)
-	local columns = self.options.columns or 2
-
 	self.root = mw.html.create('div')
 	self.description = mw.html.create('div')
-	self.description:addClass('infobox-cell-'.. columns)
+	self.description:addClass('infobox-cell-'.. self.options.columns)
 					:addClass('infobox-description')
 					:wikitext(description .. ':')
 	self.contentDiv = nil
@@ -52,7 +52,7 @@ function Cell:_content(...)
 	end
 
 	self.contentDiv = mw.html.create('div')
-	self.contentDiv:addClass('infobox-cell-2')
+	self.contentDiv:css('width', (100 * (self.options.columns - 1) / self.options.columns) .. '%') -- 66.66% for col = 3
 	for i = 1, select('#', ...) do
 		if i > 1 then
 			self.contentDiv:wikitext('<br/>')


### PR DESCRIPTION
## Summary
Add support in the Widget Cell for multiple columns. This is primarily to make the descrption a smaller part as the implement here makes the description always use 1 column, and the content use the remaining columns

See Achievements here:
![image](https://user-images.githubusercontent.com/3426850/218490375-67ebc042-2c44-4e6e-b154-b4a6c9a36d63.png)


## How did you test this change?
dev module