### PR TITLE
Add Alias `night elf` in wc faction data

### DIFF
--- a/components/faction/wikis/warcraft/faction_data.lua
+++ b/components/faction/wikis/warcraft/faction_data.lua
@@ -62,5 +62,5 @@ return {
 	factions = {'h', 'o', 'n', 'u', 'r', 'a'},
 	knownFactions = {'h', 'o', 'n', 'u', 'r'},
 	coreFactions = {'h', 'o', 'n', 'u'},
-	aliases = {},
+	aliases = {['night elf'] = 'n'},
 }


### PR DESCRIPTION
## Summary
Add Alias `night elf` in wc faction data
Sometimes it is written with, sometimes without space to account for that add the alias to be able to read both

## How did you test this change?
live, just an alias