### PR TITLE
Change name of aoe1 to include roman number

### DIFF
--- a/standard/info/wikis/ageofempires/info.lua
+++ b/standard/info/wikis/ageofempires/info.lua
@@ -14,7 +14,7 @@ return {
 	games = {
 		aoe1 = {
 			abbreviation = 'AoE1',
-			name = 'Age of Empires',
+			name = 'Age of Empires I',
 			link = 'Age of Empires I',
 			logo = {
 				darkMode = 'AoE1 Icon.png',


### PR DESCRIPTION
## Summary
All current modules expect variables/storage of games to be `Age of Empires I`, as specified in [Module:Games](https://liquipedia.net/ageofempires/Module:Games).
Therefore this should be also the name that's used here.

## How did you test this change?
n/a
