### PR TITLE
AoE: Restructure player ratings

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -40,7 +40,11 @@ local CustomInjector = Class.new(Injector)
 local RATINGCONFIG = {
 	aoe2 = {
 		{text = 'RM [[Age of Empires II/Definitive Edition|DE]]', id = 'aoe2net_id', game = 'aoe2de'},
-		{text = Page.makeExternalLink('Tournament', 'https://aoe-elo.com/players'), id = 'aoe-elo.com_id', game = 'aoe-elo.com'},
+		{
+			text = Page.makeExternalLink('Tournament', 'https://aoe-elo.com/players'),
+			id = 'aoe-elo.com_id',
+			game = 'aoe-elo.com'
+		},
 		{text = 'RM [[Voobly]]', id = 'voobly_elo'},
 	},
 	aoe3 = {


### PR DESCRIPTION
## Summary
Groups the rating config based on game, and displays the game when showing ratings.

## How did you test this change?
[Sandbox](https://liquipedia.net/ageofempires/User:SyntacticSalt/Sandbox/1)
