### PR TITLE
TM: Use individualprizemoney for earnings calculation

### DIFF
--- a/components/earnings/wikis/trackmania/earnings.lua
+++ b/components/earnings/wikis/trackmania/earnings.lua
@@ -1,0 +1,17 @@
+---
+-- @Liquipedia
+-- wiki=trackmania
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+-- Use placement field individualprizemoney in case of player earnings
+CustomEarnings.divisionFactorPlayer = nil
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
## Summary
Default earnings was dividing earnings by 5.
This now uses individualprizemoney to leave the division to teamcards.
Could be removed with #2476 ?

## How did you test this change?
New module, so live
