### PR TITLE
Add Years Active to Fighters

### DIFF
--- a/components/infobox/wikis/fighters/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_person_player_custom.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local GamesPlayed = require('Module:GamesPlayed')
 local Lua = require('Module:Lua')
+local YearsActive = require('Module:YearsActive') -- TODO Convert to use the commons YearsActive
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
@@ -41,6 +42,16 @@ end
 
 function CustomInjector:addCustomCells(widgets)
 	table.insert(widgets, Cell{name = 'Games', content = _games})
+
+	return widgets
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'status' then
+		table.insert(widgets,
+			Cell{name = 'Years Active', content = {YearsActive.get{player = mw.title.getCurrentTitle().baseText}}}
+		)
+	end
 
 	return widgets
 end


### PR DESCRIPTION
## Summary
Years Active was missed in the transition from legacy infobox to module based infobox for Fighters.

## How did you test this change?
Was put live