### PR TITLE
Add Content Creator Role for WR Player Infobox

### DIFF
--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -40,6 +40,7 @@ local _ROLES = {
 	['expert'] = {category = 'Experts', variable = 'Expert', isplayer = false},
 	['coach'] = {category = 'Coaches', variable = 'Coach', isplayer = false},
 	['caster'] = {category = 'Casters', variable = 'Caster', isplayer = false},
+	['content creator'] = {category = 'Content Creators', variable = 'Content Creator', isplayer = false},
 	['talent'] = {category = 'Talents', variable = 'Talent', isplayer = false},
 	['manager'] = {category = 'Managers', variable = 'Manager', isplayer = false},
 	['producer'] = {category = 'Producers', variable = 'Producer', isplayer = false},


### PR DESCRIPTION
## Summary
originally **|role=Content Creator** dont displayed on WR Infobox player because the infobox didnt use Module:Role and instead set roles inside the infobox module

The PR is to add that, per this request
![image](https://user-images.githubusercontent.com/88981446/218796013-46cee8a7-d4e9-4087-86c2-87a6302ff23f.png)

## How did you test this change?
on LIVE briefly before bot rolls this back 
![image](https://user-images.githubusercontent.com/88981446/218796188-b2f961e7-d028-4f5e-a872-a58f1be03590.png)

