### PR TITLE
Fix a bug with awards in sc2 infobox player

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -486,6 +486,8 @@ function CustomPlayer._setAchievements(data, place)
 
 	if CustomPlayer._isAwardAchievement(data, tier) then
 		table.insert(_player.awardAchievements, data)
+	elseif String.isNotEmpty((data.extradata or {}).award) then
+		return
 	elseif CustomPlayer._isAchievement(data, place, tier) then
 		table.insert(_player.achievements, data)
 	elseif (#_player.achievementsFallBack + #_player.achievements) < MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS then


### PR DESCRIPTION
## Summary
Fix a rare bug with awards in sc2 infobox player counting as a result if they are not an achievement.
Spotted so far on 1 page

This PR escapes that via an early return in case of a non achieve award

## How did you test this change?
dev into live