### PR TITLE
AoE: Infobox player bugfixes

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -359,7 +359,7 @@ function CustomPlayer._getLatestPlacement(game)
 end
 
 function CustomPlayer._buildPlacementConditions()
-	local person = _args.id or _player.pagename
+	local person = _player.pagename
 
 	local opponentConditions = ConditionTree(BooleanOperator.any)
 
@@ -374,7 +374,7 @@ function CustomPlayer._buildPlacementConditions()
 end
 
 function CustomPlayer._getBroadcastGames()
-	local person = _args.id or _player.pagename
+	local person = _player.pagename
 	local personCondition = ConditionNode(ColumnName('page'), Comparator.eq, person)
 	local games = {}
 

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -354,7 +354,6 @@ function CustomPlayer._getLatestPlacement(game)
 		CustomPlayer._buildPlacementConditions(),
 		ConditionNode(ColumnName('game'), Comparator.eq, game)
 	}
-	mw.log(conditions:toString())
 	local data = mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = conditions:toString(),
 		query = 'date',

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -359,13 +359,14 @@ function CustomPlayer._getLatestPlacement(game)
 end
 
 function CustomPlayer._buildPlacementConditions()
-	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id):gsub(' ', '_')
+	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
 	local opponentConditions = ConditionTree(BooleanOperator.any)
 
 	local prefix = 'p'
 	for playerIndex = 1, MAX_NUMBER_OF_PLAYERS do
 		opponentConditions:add{
 			ConditionNode(ColumnName('opponentplayers_' .. prefix .. playerIndex), Comparator.eq, person),
+			ConditionNode(ColumnName('opponentplayers_' .. prefix .. playerIndex), Comparator.eq, person:gsub(' ', '_')),
 		}
 	end
 
@@ -373,8 +374,12 @@ function CustomPlayer._buildPlacementConditions()
 end
 
 function CustomPlayer._getBroadcastGames()
-	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id):gsub(' ', '_')
-	local personCondition = ConditionNode(ColumnName('page'), Comparator.eq, person)
+	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
+	local personCondition = ConditionTree(BooleanOperator.any)
+		:add{
+			ConditionNode(ColumnName('page'), Comparator.eq, person),
+			ConditionNode(ColumnName('page'), Comparator.eq, person:gsub(' ', '_')),
+		}
 	local games = {}
 
 	for _, gameInfo in pairs(Info.games) do

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -359,7 +359,7 @@ function CustomPlayer._getLatestPlacement(game)
 end
 
 function CustomPlayer._buildPlacementConditions()
-	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
+	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id):gsub(' ', '_')
 	local opponentConditions = ConditionTree(BooleanOperator.any)
 
 	local prefix = 'p'
@@ -373,7 +373,7 @@ function CustomPlayer._buildPlacementConditions()
 end
 
 function CustomPlayer._getBroadcastGames()
-	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
+	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id):gsub(' ', '_')
 	local personCondition = ConditionNode(ColumnName('page'), Comparator.eq, person)
 	local games = {}
 

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -359,8 +359,7 @@ function CustomPlayer._getLatestPlacement(game)
 end
 
 function CustomPlayer._buildPlacementConditions()
-	local person = _player.pagename
-
+	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
 	local opponentConditions = ConditionTree(BooleanOperator.any)
 
 	local prefix = 'p'
@@ -374,7 +373,7 @@ function CustomPlayer._buildPlacementConditions()
 end
 
 function CustomPlayer._getBroadcastGames()
-	local person = _player.pagename
+	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
 	local personCondition = ConditionNode(ColumnName('page'), Comparator.eq, person)
 	local games = {}
 


### PR DESCRIPTION
## Summary
Without resolved ID, querying would fail for lowercased IDs.
Removing the pagename as that doesn't work in userspace and ID is mandatory anyways.
Added optional query for pagenames with underscores instead of spaces.

Also changed the array merge to do one after another (otherwise, games might be added multiple times)

## How did you test this change?
/dev
