### PR TITLE
Fix `MatchGroupCoordinates.computeRawCounts` for double qual

### DIFF
--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -347,7 +347,7 @@ function MatchGroupCoordinates.computeRawCounts(bracket)
 			countsBySection[sectionIndex] = countsBySection[sectionIndex] + count
 
 			-- Loser of match drops down
-			if sectionIndex + 1 <= #bracket.sections and coordinates.semanticDepth ~= 0 then
+			if sectionIndex + 1 <= #bracket.sections and coordinates.semanticDepth ~= 0 and not bracketData.qualLose then
 				countsBySection[sectionIndex + 1] = countsBySection[sectionIndex + 1] - 1
 			end
 		end


### PR DESCRIPTION
## Summary
Fix `MatchGroupCoordinates.computeRawCounts` for double qual

This is mainly used by the PPT import

fixes import at https://liquipedia.net/counterstrike/BLAST/Major/2023/Paris/Europe/Qualifier/Open/1

## How did you test this change?
dev