### PR TITLE
Add PPT for PUBG (PC Wiki)

### DIFF
--- a/components/prize_pool/wikis/pubg/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/pubg/prize_pool_custom.lua
@@ -1,0 +1,48 @@
+---
+-- @Liquipedia
+-- wiki=pubg
+-- page=Module:PrizePool/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Variables = require('Module:Variables')
+local Weight = require('Module:Weight')
+
+local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+
+local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local CustomLpdbInjector = Class.new(LpdbInjector)
+
+local CustomPrizePool = {}
+
+
+-- Template entry point
+function CustomPrizePool.run(frame)
+	local args = Arguments.getArgs(frame)
+	args.localcurrency = args.localcurrency or Variables.varDefault('tournament_currency')
+
+	local prizePool = PrizePool(args):create()
+	prizePool:setLpdbInjector(CustomLpdbInjector())
+
+	return prizePool:build()
+end
+
+function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
+	lpdbData.weight = Weight.calc(
+		lpdbData.prizemoney,
+		Variables.varDefault('tournament_liquipediatier'),
+		placement.placeStart,
+		Variables.varDefault('tournament_type'),
+		Variables.varDefault('tournament_liquipediatiertype')
+	)
+
+	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints', lpdbData.extradata.prizepoints)
+
+	return lpdbData
+end
+
+return CustomPrizePool


### PR DESCRIPTION
## Summary
This is the port of the #2138 (/Custom PPT from PUBG Mobile) (includes any subsequent changes that is done after this, because I paste from the pubgm wiki just today)

## How did you test this change?
since {{TeamPrizePool}} hasnt been used in past events before this, I converted it on past events

https://liquipedia.net/pubg/PUBG_Global_Championship/2022#Prize_Pool
