### PR TITLE
Support Duos on PUBG (PC)

### DIFF
--- a/components/opponent/wikis/pubg/opponent_display_custom.lua
+++ b/components/opponent/wikis/pubg/opponent_display_custom.lua
@@ -1,0 +1,101 @@
+---
+-- @Liquipedia
+-- wiki=pubg
+-- page=Module:OpponentDisplay/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+-- needed for duo display
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+-- can not use Module:OpponentLibraries here due to circular requires
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
+
+local CustomOpponentDisplay = Table.copy(OpponentDisplay)
+
+CustomOpponentDisplay.BracketOpponentEntry = Class.new(OpponentDisplay.BracketOpponentEntry,
+	function(self, opponent, options)
+		if opponent.type == Opponent.duo then
+			self:createDuo(opponent)
+		end
+
+		self.root = mw.html.create('div'):addClass('brkts-opponent-entry')
+			:node(self.content)
+	end
+)
+
+function CustomOpponentDisplay.BracketOpponentEntry:createDuo(opponent)
+	local playerNode = CustomOpponentDisplay.BlockPlayers({
+		opponent = opponent,
+		overflow = 'ellipsis',
+		showLink = false,
+	})
+	self.content:node(playerNode)
+end
+
+function CustomOpponentDisplay.BlockOpponent(props)
+	DisplayUtil.assertPropTypes(props, CustomOpponentDisplay.propTypes.BlockOpponent, {maxDepth = 2})
+	local opponent = props.opponent
+
+	-- Default TBDs to not show links
+	props.showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
+
+	if opponent.type == Opponent.duo then
+		return CustomOpponentDisplay.BlockPlayers(props)
+	end
+
+	return OpponentDisplay.BlockOpponent(props)
+end
+
+function CustomOpponentDisplay.BlockPlayers(props)
+	local opponent = props.opponent
+
+	local playerNodes = Array.map(opponent.players, function(player)
+		return PlayerDisplay.BlockPlayer(Table.merge(props, {player = player, team = player.team}))
+	end)
+
+	local playersNode = mw.html.create('div')
+		:addClass(props.showPlayerTeam and 'player-has-team' or nil)
+	for _, playerNode in ipairs(playerNodes) do
+		playersNode:node(playerNode)
+	end
+
+	return playersNode
+end
+
+function CustomOpponentDisplay.InlineOpponent(props)
+	DisplayUtil.assertPropTypes(props, CustomOpponentDisplay.propTypes.InlineOpponent, {maxDepth = 2})
+	local opponent = props.opponent
+
+	if opponent.type == Opponent.duo then
+		return CustomOpponentDisplay.InlinePlayers(props)
+	end
+
+	return OpponentDisplay.InlineOpponent(props)
+end
+
+function CustomOpponentDisplay.InlinePlayers(props)
+	local opponent = props.opponent
+
+	local playerTexts = Array.map(opponent.players, function(player)
+		return tostring(PlayerDisplay.InlinePlayer(Table.merge(props, {player = player})))
+	end)
+
+	if props.flip then
+		playerTexts = Array.reverse(playerTexts)
+	end
+
+	return mw.html.create('span')
+		:node(table.concat(playerTexts, ' / '))
+end
+
+return Class.export(CustomOpponentDisplay)

--- a/standard/info/wikis/pubg/info.lua
+++ b/standard/info/wikis/pubg/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'pubg',
 	defaultTeamLogo = 'PUBG Default logo.png', ---@deprecated
 	defaultTeamLogoDark = 'PUBG Default logo.png', ---@deprecated
+	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }


### PR DESCRIPTION
## Summary
While this one does get used on Prize Pool, main goal is to allow results for tournaments under 2v2 prize pool worked and not return error through Module:ResultsTable/Custom (Results Table)

![image](https://user-images.githubusercontent.com/88981446/219086220-d3656811-eb28-4cb9-a21a-4fd8ad2c277b.png)

The module is a clean port of #2251 from Clash Royale with no edits on it yet

## How did you test this change?
LIVE
