### PR TITLE
Create simracing PPT Custom

### DIFF
--- a/components/prize_pool/wikis/simracing/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/simracing/prize_pool_custom.lua
@@ -24,7 +24,9 @@ local TIER_VALUE = {8, 4, 2}
 -- Template entry point
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
-	local prizePool = PrizePool(args):create()
+	local prizePool = PrizePool(args)
+	prizePool:setConfigDefault('syncPlayers', true)
+	prizePool:create()
 
 	prizePool:setLpdbInjector(CustomLpdbInjector())
 

--- a/components/prize_pool/wikis/simracing/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/simracing/prize_pool_custom.lua
@@ -40,11 +40,11 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		placement.placeStart
 	)
 
-	local participants = lpdbData.opponentname or ''
+	local participant = lpdbData.opponentname or ''
 	local lpdbPrefix = placement.parent.options.lpdbPrefix
 
-	Variables.varDefine('enddate_' .. lpdbPrefix .. participants, lpdbData.date)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participants:lower()) ..
+	Variables.varDefine('enddate_' .. lpdbPrefix .. participant, lpdbData.date)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participant:lower()) ..
 		'_pointprize', lpdbData.extradata.prizepoints
 	)
 

--- a/components/prize_pool/wikis/simracing/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/simracing/prize_pool_custom.lua
@@ -1,0 +1,62 @@
+---
+-- @Liquipedia
+-- wiki=simracing
+-- page=Module:PrizePool/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+
+local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local CustomLpdbInjector = Class.new(LpdbInjector)
+
+local CustomPrizePool = {}
+
+local TIER_VALUE = {8, 4, 2}
+
+-- Template entry point
+function CustomPrizePool.run(frame)
+	local args = Arguments.getArgs(frame)
+	local prizePool = PrizePool(args):create()
+
+	prizePool:setLpdbInjector(CustomLpdbInjector())
+
+	return prizePool:build()
+end
+
+function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
+	lpdbData.weight = CustomPrizePool.calculateWeight(
+		lpdbData.prizemoney,
+		Variables.varDefault('tournament_liquipediatier'),
+		placement.placeStart
+	)
+
+	local participants = lpdbData.opponentname or ''
+	local lpdbPrefix = placement.parent.options.lpdbPrefix
+
+	Variables.varDefine('enddate_' .. lpdbPrefix .. participants, lpdbData.date)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participants:lower()) ..
+		'_pointprize', lpdbData.extradata.prizepoints
+	)
+
+	return lpdbData
+end
+
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place)
+	if String.isEmpty(tier) then
+		return 0
+	end
+
+	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier)] or 1
+
+	return tierValue * math.max(prizeMoney, 1) / place
+end
+
+return CustomPrizePool


### PR DESCRIPTION
Adding standardized prizepool to simracing wiki, as seen on page: https://liquipedia.net/simracing/ESL_R1/2023/Spring/Round_2 Works correctly both visually and when writing data (as seen on https://liquipedia.net/simracing/Special:LiquipediaDB/ESL_R1/2023/Spring/Round_2)

## Summary
The wiki is currently still using SMW for prize pools so in an effort to standardise the wiki I've started with the prizepools.

## How did you test this change?
Initially tested in userspace, later tested for data on page: https://liquipedia.net/simracing/ESL_R1/2023/Spring/Round_2 - Works correctly as data is written to LPDB and there are no visual issues showing up.