### PR TITLE
Add `qualified` to Overwatch PPT

### DIFF
--- a/components/prize_pool/wikis/overwatch/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/overwatch/prize_pool_custom.lua
@@ -44,6 +44,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+	
+	lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, 'QUALIFIES1') and 1 or 0
 
 	if Opponent.isTbd(opponent.opponentData) then
 		Variables.varDefine('minimum_secured', lpdbData.extradata.prizepoints)

--- a/components/prize_pool/wikis/overwatch/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/overwatch/prize_pool_custom.lua
@@ -44,7 +44,6 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
-	
 	lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, 'QUALIFIES1') and 1 or 0
 
 	if Opponent.isTbd(opponent.opponentData) then


### PR DESCRIPTION
## Summary

To allow for teams to appear in [Template:Tournaments list](https://liquipedia.net/overwatch/Qualifier_Tournaments/2023).

## How did you test this change?

[Here](https://liquipedia.net/overwatch/Special:LiquipediaDB/User:Moonshot/sandbox2#placement).
