### PR TITLE
Use `Faction.defaultFaction` instead of `'u'`

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/player_ext_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/player_ext_starcraft.lua
@@ -209,7 +209,7 @@ function StarcraftPlayerExt.syncPlayer(player, options)
 		or options.fetchPlayer ~= false and StarcraftPlayerExt.fetchPlayerRace(player.pageName, options.date)
 		or nonNotable() and nonNotable().race
 		or match2Player() and match2Player().race
-		or 'u'
+		or Faction.defaultFaction
 
 	if options.savePageVar ~= false then
 		StarcraftPlayerExt.saveToPageVars(player)


### PR DESCRIPTION
## Summary
Use `Faction.defaultFaction` instead of `'u'`

## How did you test this change?
dev to live
