### PR TITLE
Add all missing games in the Simracing Info

### DIFF
--- a/standard/info/wikis/simracing/info.lua
+++ b/standard/info/wikis/simracing/info.lua
@@ -336,19 +336,6 @@ return {
 				lightMode = 'Gran Turismo default allmode.png',
 			},
 		},
-		['gt4'] = {
-			abbreviation = 'GT4',
-			name = 'Gran Turismo 4',
-			link = 'Gran Turismo 4',
-			logo = {
-				darkMode = 'Gran Turismo default allmode.png',
-				lightMode = 'Gran Turismo default allmode.png',
-			},
-			defaultTeamLogo = {
-				darkMode = 'Gran Turismo default allmode.png',
-				lightMode = 'Gran Turismo default allmode.png',
-			},
-		},
 		['gt5'] = {
 			abbreviation = 'GT5',
 			name = 'Gran Turismo 5',
@@ -427,7 +414,7 @@ return {
 				lightMode = 'Dirt Rally default allmode.png',
 			},
 		},
-		['dr'] = {
+		['dr2'] = {
 			abbreviation = 'DR2',
 			name = 'DiRT Rally 2.0',
 			link = 'DiRT Rally 2.0',

--- a/standard/info/wikis/simracing/info.lua
+++ b/standard/info/wikis/simracing/info.lua
@@ -24,6 +24,721 @@ return {
 				lightMode = 'Sim Racing default lightmode.png',
 			},
 		},
+		multi = {
+			abbreviation = 'Multi',
+			name = 'Various Games',
+			link = 'Various Games',
+			logo = {
+				darkMode = 'Sim Racing default darkmode.png',
+				lightMode = 'Sim Racing default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Sim Racing default darkmode.png',
+				lightMode = 'Sim Racing default lightmode.png',
+			},
+		},
+		iracing = {
+			abbreviation = 'iR',
+			name = 'iRacing',
+			link = 'iRacing',
+			logo = {
+				darkMode = 'IRacing default allmode.png',
+				lightMode = 'IRacing default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'IRacing default allmode.png',
+				lightMode = 'IRacing default allmode.png',
+			},
+		},
+		rennsport = {
+			abbreviation = 'Rennsport',
+			name = 'Rennsport',
+			link = 'Rennsport',
+			logo = {
+				darkMode = 'Rennsport default allmode.png',
+				lightMode = 'Rennsport default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Rennsport default allmode.png',
+				lightMode = 'Rennsport default allmode.png',
+			},
+		},
+		f1c = {
+			abbreviation = 'F1C',
+			name = 'F1 Challenge 99-02',
+			link = 'F1 Challenge 99-02',
+			logo = {
+				darkMode = 'F1 Challenge default allmode.png',
+				lightMode = 'F1 Challenge default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 Challenge default allmode.png',
+				lightMode = 'F1 Challenge default allmode.png',
+			},
+		},
+		gp3 = {
+			abbreviation = 'Gp3',
+			name = 'Grand Prix 3',
+			link = 'Grand Prix 3',
+			logo = {
+				darkMode = 'Grand Prix 3 default allmode.png',
+				lightMode = 'Grand Prix 3 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Grand Prix 3 default allmode.png',
+				lightMode = 'Grand Prix 3 default allmode.png',
+			},
+		},
+		['f1 2002'] = {
+			abbreviation = 'F1 2002',
+			name = 'F1 2002',
+			link = 'F1 2002',
+			logo = {
+				darkMode = 'F1 2002 default allmode.png',
+				lightMode = 'F1 2002 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 2002 default allmode.png',
+				lightMode = 'F1 2002 default allmode.png',
+			},
+		},
+		['f1 2017'] = {
+			abbreviation = 'F1 17',
+			name = 'F1 2017',
+			link = 'F1 2017',
+			logo = {
+				darkMode = 'F1 1994 darkmode.png',
+				lightMode = 'F1 1994 lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 1994 darkmode.png',
+				lightMode = 'F1 1994 lightmode.png',
+			},
+		},
+		['f1 2018'] = {
+			abbreviation = 'F1 18',
+			name = 'F1 2018',
+			link = 'F1 2018',
+			logo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+		},
+		['f1 2019'] = {
+			abbreviation = 'F1 19',
+			name = 'F1 2019',
+			link = 'F1 2019',
+			logo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+		},
+		['f1 2020'] = {
+			abbreviation = 'F1 20',
+			name = 'F1 2020',
+			link = 'F1 2020',
+			logo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+		},
+		['f1 2021'] = {
+			abbreviation = 'F1 21',
+			name = 'F1 2021',
+			link = 'F1 2021',
+			logo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+		},
+		['f1 2022'] = {
+			abbreviation = 'F1 22',
+			name = 'F1 2022',
+			link = 'F1 2022',
+			logo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+		},
+		['f1 2023'] = {
+			abbreviation = 'F1 23',
+			name = 'F1 2023',
+			link = 'F1 2023',
+			logo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'F1 2018 allmode.png',
+				lightMode = 'F1 2018 allmode.png',
+			},
+		},
+		['heat3'] = {
+			abbreviation = 'Heat 3',
+			name = 'NASCAR Heat 3',
+			link = 'NASCAR Heat 3',
+			logo = {
+				darkMode = 'Nascar Heat default allmode.png',
+				lightMode = 'Nascar Heat default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Nascar Heat default allmode.png',
+				lightMode = 'Nascar Heat default allmode.png',
+			},
+		},
+		['heat4'] = {
+			abbreviation = 'Heat 4',
+			name = 'NASCAR Heat 4',
+			link = 'NASCAR Heat 4',
+			logo = {
+				darkMode = 'Nascar Heat default allmode.png',
+				lightMode = 'Nascar Heat default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Nascar Heat default allmode.png',
+				lightMode = 'Nascar Heat default allmode.png',
+			},
+		},
+		['rf2'] = {
+			abbreviation = 'rF2',
+			name = 'rFactor 2',
+			link = 'rFactor 2',
+			logo = {
+				darkMode = 'RFactor 2 default allmode.png',
+				lightMode = 'RFactor 2 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'RFactor 2 default allmode.png',
+				lightMode = 'RFactor 2 default allmode.png',
+			},
+		},
+		['rf1'] = {
+			abbreviation = 'rF1',
+			name = 'rFactor',
+			link = 'rFactor',
+			logo = {
+				darkMode = 'RFactor 1 default allmode.png',
+				lightMode = 'RFactor 1 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'RFactor 1 default allmode.png',
+				lightMode = 'RFactor 1 default allmode.png',
+			},
+		},
+		['pc1'] = {
+			abbreviation = 'PCARS',
+			name = 'Project CARS',
+			link = 'Project CARS',
+			logo = {
+				darkMode = 'Project CARS default allmode.png',
+				lightMode = 'Project CARS default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Project CARS default allmode.png',
+				lightMode = 'Project CARS default allmode.png',
+			},
+		},
+		['pc2'] = {
+			abbreviation = 'PCARS 2',
+			name = 'Project CARS 2',
+			link = 'Project CARS 2',
+			logo = {
+				darkMode = 'Project CARS default allmode.png',
+				lightMode = 'Project CARS default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Project CARS default allmode.png',
+				lightMode = 'Project CARS default allmode.png',
+			},
+		},
+		ac = {
+			abbreviation = 'AC',
+			name = 'Assetto Corsa',
+			link = 'Assetto Corsa',
+			logo = {
+				darkMode = 'Assetto Corsa default darkmode.png',
+				lightMode = 'Assetto Corsa default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Assetto Corsa default darkmode.png',
+				lightMode = 'Assetto Corsa default lightmode.png',
+			},
+		},
+		acc = {
+			abbreviation = 'ACC',
+			name = 'Assetto Corsa Competizione',
+			link = 'Assetto Corsa Competizione',
+			logo = {
+				darkMode = 'Assetto Corsa default darkmode.png',
+				lightMode = 'Assetto Corsa default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Assetto Corsa default darkmode.png',
+				lightMode = 'Assetto Corsa default lightmode.png',
+			},
+		},
+		rr = {
+			abbreviation = 'RR',
+			name = 'RaceRoom',
+			link = 'RaceRoom',
+			logo = {
+				darkMode = 'Raceroom default darkmode.png',
+				lightMode = 'Raceroom default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Raceroom default darkmode.png',
+				lightMode = 'Raceroom default lightmode.png',
+			},
+		},
+		lfs = {
+			abbreviation = 'LFS',
+			name = 'Live For Speed',
+			link = 'Live For Speed',
+			logo = {
+				darkMode = 'Live For Speed default allmode.png',
+				lightMode = 'Live For Speed default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Live For Speed default allmode.png',
+				lightMode = 'Live For Speed default allmode.png',
+			},
+		},
+		['gt4'] = {
+			abbreviation = 'GT4',
+			name = 'Gran Turismo 4',
+			link = 'Gran Turismo 4',
+			logo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+		},
+		['gt4'] = {
+			abbreviation = 'GT4',
+			name = 'Gran Turismo 4',
+			link = 'Gran Turismo 4',
+			logo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+		},
+		['gt5'] = {
+			abbreviation = 'GT5',
+			name = 'Gran Turismo 5',
+			link = 'Gran Turismo 5',
+			logo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+		},
+		['gt6'] = {
+			abbreviation = 'GT6',
+			name = 'Gran Turismo 6',
+			link = 'Gran Turismo 6',
+			logo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+		},
+		['gt7'] = {
+			abbreviation = 'GT7',
+			name = 'Gran Turismo 7',
+			link = 'Gran Turismo 7',
+			logo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+		},
+		['gt sport'] = {
+			abbreviation = 'GT Sport',
+			name = 'Gran Turismo Sport',
+			link = 'Gran Turismo SPort',
+			logo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Gran Turismo default allmode.png',
+				lightMode = 'Gran Turismo default allmode.png',
+			},
+		},
+		['dirt4'] = {
+			abbreviation = 'D4',
+			name = 'DiRT 4',
+			link = 'DiRT 4',
+			logo = {
+				darkMode = 'Dirt 4 default allmode.png',
+				lightMode = 'Dirt 4 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Dirt 4 default allmode.png',
+				lightMode = 'Dirt 4 default allmode.png',
+			},
+		},
+		['dr'] = {
+			abbreviation = 'DR',
+			name = 'DiRT Rally',
+			link = 'DiRT Rally',
+			logo = {
+				darkMode = 'Dirt Rally default allmode.png',
+				lightMode = 'Dirt Rally default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Dirt Rally default allmode.png',
+				lightMode = 'Dirt Rally default allmode.png',
+			},
+		},
+		['dr'] = {
+			abbreviation = 'DR2',
+			name = 'DiRT Rally 2.0',
+			link = 'DiRT Rally 2.0',
+			logo = {
+				darkMode = 'Dirt Rally 2 default allmode.png',
+				lightMode = 'Dirt Rally 2 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Dirt Rally 2 default allmode.png',
+				lightMode = 'Dirt Rally 2 default allmode.png',
+			},
+		},
+		['motogp17'] = {
+			abbreviation = 'MotoGP 17',
+			name = 'MotoGP 17',
+			link = 'MotoGP 17',
+			logo = {
+				darkMode = 'Motogp17 default allmode.png',
+				lightMode = 'Motogp17 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Motogp17 default allmode.png',
+				lightMode = 'Motogp17 default allmode.png',
+			},
+		},
+		['motogp18'] = {
+			abbreviation = 'MotoGP 18',
+			name = 'MotoGP 18',
+			link = 'MotoGP 18',
+			logo = {
+				darkMode = 'Motogp18 default allmode.png',
+				lightMode = 'Motogp18 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Motogp18 default allmode.png',
+				lightMode = 'Motogp18 default allmode.png',
+			},
+		},
+		['motogp19'] = {
+			abbreviation = 'MotoGP 19',
+			name = 'MotoGP 19',
+			link = 'MotoGP 19',
+			logo = {
+				darkMode = 'Motogp19 default allmode.png',
+				lightMode = 'Motogp19 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Motogp19 default allmode.png',
+				lightMode = 'Motogp19 default allmode.png',
+			},
+		},
+		['motogp20'] = {
+			abbreviation = 'MotoGP 20',
+			name = 'MotoGP 20',
+			link = 'MotoGP 20',
+			logo = {
+				darkMode = 'Motogp20 default allmode.png',
+				lightMode = 'Motogp20 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Motogp20 default allmode.png',
+				lightMode = 'Motogp20 default allmode.png',
+			},
+		},
+		['motogp21'] = {
+			abbreviation = 'MotoGP 21',
+			name = 'MotoGP 21',
+			link = 'MotoGP 21',
+			logo = {
+				darkMode = 'Motogp21 default allmode.png',
+				lightMode = 'Motogp21 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Motogp21 default allmode.png',
+				lightMode = 'Motogp21 default allmode.png',
+			},
+		},
+		['motogp22'] = {
+			abbreviation = 'MotoGP 22',
+			name = 'MotoGP 22',
+			link = 'MotoGP 22',
+			logo = {
+				darkMode = 'Motogp22 default allmode.png',
+				lightMode = 'Motogp22 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Motogp22 default allmode.png',
+				lightMode = 'Motogp22 default allmode.png',
+			},
+		},
+		['motogp23'] = {
+			abbreviation = 'MotoGP 23',
+			name = 'MotoGP 23',
+			link = 'MotoGP 23',
+			logo = {
+				darkMode = 'Motogp23 default allmode.png',
+				lightMode = 'Motogp23 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Motogp23 default allmode.png',
+				lightMode = 'Motogp23 default allmode.png',
+			},
+		},
+		['forza 2'] = {
+			abbreviation = 'FM2',
+			name = 'Forza Motorsport 2',
+			link = 'Forza Motorsport 2',
+			logo = {
+				darkMode = 'Forza 2 default allmode.png',
+				lightMode = 'Forza 2 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Forza 2 default allmode.png',
+				lightMode = 'Forza 2 default allmode.png',
+			},
+		},
+		['forza 3'] = {
+			abbreviation = 'FM3',
+			name = 'Forza Motorsport 3',
+			link = 'Forza Motorsport 3',
+			logo = {
+				darkMode = 'Forza 3 default allmode.png',
+				lightMode = 'Forza 3 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Forza 3 default allmode.png',
+				lightMode = 'Forza 3 default allmode.png',
+			},
+		},
+		['forza 4'] = {
+			abbreviation = 'FM4',
+			name = 'Forza Motorsport 4',
+			link = 'Forza Motorsport 4',
+			logo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+		},
+		['forza 5'] = {
+			abbreviation = 'FM5',
+			name = 'Forza Motorsport 5',
+			link = 'Forza Motorsport 5',
+			logo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+		},
+		['forza 6'] = {
+			abbreviation = 'FM6',
+			name = 'Forza Motorsport 6',
+			link = 'Forza Motorsport 6',
+			logo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+		},
+		['forza 7'] = {
+			abbreviation = 'FM7',
+			name = 'Forza Motorsport 7',
+			link = 'Forza Motorsport 7',
+			logo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+		},
+		['forza 2023'] = {
+			abbreviation = 'FM (2023)',
+			name = 'Forza Motorsport (2023)',
+			link = 'Forza Motorsport (2023)',
+			logo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Forza Motorsports default darkmode.png',
+				lightMode = 'Forza Motorsports default lightmode.png',
+			},
+		},
+		['pgr2'] = {
+			abbreviation = 'PGR 2',
+			name = 'Project Gotham Racing 2',
+			link = 'Project Gotham Racing 2',
+			logo = {
+				darkMode = 'PGR2 default allmode.png',
+				lightMode = 'PGR2 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'PGR2 default allmode.png',
+				lightMode = 'PGR2 default allmode.png',
+			},
+		},
+		['pgr3'] = {
+			abbreviation = 'PGR 3',
+			name = 'Project Gotham Racing 3',
+			link = 'Project Gotham Racing 3',
+			logo = {
+				darkMode = 'PGR default darkmode.png',
+				lightMode = 'PGR default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'PGR default darkmode.png',
+				lightMode = 'PGR default lightmode.png',
+			},
+		},
+		['pgr4'] = {
+			abbreviation = 'PGR 4',
+			name = 'Project Gotham Racing 4',
+			link = 'Project Gotham Racing 4',
+			logo = {
+				darkMode = 'PGR default darkmode.png',
+				lightMode = 'PGR default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'PGR default darkmode.png',
+				lightMode = 'PGR default lightmode.png',
+			},
+		},
+		['ug1'] = {
+			abbreviation = 'UG1',
+			name = 'Need for Speed: Underground',
+			link = 'Need for Speed: Underground',
+			logo = {
+				darkMode = 'NFS Underground default allmode.png',
+				lightMode = 'NFS Underground default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'NFS Underground default allmode.png',
+				lightMode = 'NFS Underground default allmode.png',
+			},
+		},
+		['ug2'] = {
+			abbreviation = 'UG2',
+			name = 'Need for Speed: Underground 2',
+			link = 'Need for Speed: Underground 2',
+			logo = {
+				darkMode = 'NFS Underground default allmode.png',
+				lightMode = 'NFS Underground default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'NFS Underground default allmode.png',
+				lightMode = 'NFS Underground default allmode.png',
+			},
+		},
+		['mw05'] = {
+			abbreviation = 'MW',
+			name = 'Need for Speed: Most Wanted',
+			link = 'Need for Speed: Most Wanted',
+			logo = {
+				darkMode = 'NFS MW05 default allmode.png',
+				lightMode = 'NFS MW05 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'NFS MW05 default allmode.png',
+				lightMode = 'NFS MW05 default allmode.png',
+			},
+		},
+		['carbon'] = {
+			abbreviation = 'CB',
+			name = 'Need for Speed: Carbon',
+			link = 'Need for Speed: Carbon',
+			logo = {
+				darkMode = 'NFS Carbon default allmode.png',
+				lightMode = 'NFS Carbon default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'NFS Carbon default allmode.png',
+				lightMode = 'NFS Carbon default allmode.png',
+			},
+		},
+		['prostreet'] = {
+			abbreviation = 'PS',
+			name = 'Need for Speed: ProStreet',
+			link = 'Need for Speed: ProStreet',
+			logo = {
+				darkMode = 'NFS Prostreet default allmode.png',
+				lightMode = 'NFS Prostreet default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'NFS Prostreet default allmode.png',
+				lightMode = 'NFS Prostreet default allmode.png',
+			},
+		},
+		['shift'] = {
+			abbreviation = 'Shift',
+			name = 'Need for Speed: Shift',
+			link = 'Need for Speed: Shift',
+			logo = {
+				darkMode = 'NFS default darkmode.png',
+				lightMode = 'NFS default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'NFS default darkmode.png',
+				lightMode = 'NFS default lightmode.png',
+			},
+		},
 	},
 	defaultGame = 'sr',
 	defaultTeamLogo = 'Sim Racing default lightmode.png', ---@deprecated

--- a/standard/info/wikis/simracing/info.lua
+++ b/standard/info/wikis/simracing/info.lua
@@ -193,7 +193,7 @@ return {
 				lightMode = 'F1 2018 allmode.png',
 			},
 		},
-		['heat3'] = {
+		heat3 = {
 			abbreviation = 'Heat 3',
 			name = 'NASCAR Heat 3',
 			link = 'NASCAR Heat 3',
@@ -206,7 +206,7 @@ return {
 				lightMode = 'Nascar Heat default allmode.png',
 			},
 		},
-		['heat4'] = {
+		heat4 = {
 			abbreviation = 'Heat 4',
 			name = 'NASCAR Heat 4',
 			link = 'NASCAR Heat 4',
@@ -219,7 +219,7 @@ return {
 				lightMode = 'Nascar Heat default allmode.png',
 			},
 		},
-		['rf2'] = {
+		rf2 = {
 			abbreviation = 'rF2',
 			name = 'rFactor 2',
 			link = 'rFactor 2',
@@ -232,7 +232,7 @@ return {
 				lightMode = 'RFactor 2 default allmode.png',
 			},
 		},
-		['rf1'] = {
+		rf1 = {
 			abbreviation = 'rF1',
 			name = 'rFactor',
 			link = 'rFactor',
@@ -245,7 +245,7 @@ return {
 				lightMode = 'RFactor 1 default allmode.png',
 			},
 		},
-		['pc1'] = {
+		pc1 = {
 			abbreviation = 'PCARS',
 			name = 'Project CARS',
 			link = 'Project CARS',
@@ -258,7 +258,7 @@ return {
 				lightMode = 'Project CARS default allmode.png',
 			},
 		},
-		['pc2'] = {
+		pc2 = {
 			abbreviation = 'PCARS 2',
 			name = 'Project CARS 2',
 			link = 'Project CARS 2',
@@ -323,7 +323,7 @@ return {
 				lightMode = 'Live For Speed default allmode.png',
 			},
 		},
-		['gt4'] = {
+		gt4 = {
 			abbreviation = 'GT4',
 			name = 'Gran Turismo 4',
 			link = 'Gran Turismo 4',
@@ -336,7 +336,7 @@ return {
 				lightMode = 'Gran Turismo default allmode.png',
 			},
 		},
-		['gt5'] = {
+		gt5 = {
 			abbreviation = 'GT5',
 			name = 'Gran Turismo 5',
 			link = 'Gran Turismo 5',
@@ -349,7 +349,7 @@ return {
 				lightMode = 'Gran Turismo default allmode.png',
 			},
 		},
-		['gt6'] = {
+		gt6 = {
 			abbreviation = 'GT6',
 			name = 'Gran Turismo 6',
 			link = 'Gran Turismo 6',
@@ -362,7 +362,7 @@ return {
 				lightMode = 'Gran Turismo default allmode.png',
 			},
 		},
-		['gt7'] = {
+		gt7 = {
 			abbreviation = 'GT7',
 			name = 'Gran Turismo 7',
 			link = 'Gran Turismo 7',
@@ -388,7 +388,7 @@ return {
 				lightMode = 'Gran Turismo default allmode.png',
 			},
 		},
-		['dirt4'] = {
+		dirt4 = {
 			abbreviation = 'D4',
 			name = 'DiRT 4',
 			link = 'DiRT 4',
@@ -401,7 +401,7 @@ return {
 				lightMode = 'Dirt 4 default allmode.png',
 			},
 		},
-		['dr'] = {
+		dr = {
 			abbreviation = 'DR',
 			name = 'DiRT Rally',
 			link = 'DiRT Rally',
@@ -414,7 +414,7 @@ return {
 				lightMode = 'Dirt Rally default allmode.png',
 			},
 		},
-		['dr2'] = {
+		dr2 = {
 			abbreviation = 'DR2',
 			name = 'DiRT Rally 2.0',
 			link = 'DiRT Rally 2.0',
@@ -427,7 +427,7 @@ return {
 				lightMode = 'Dirt Rally 2 default allmode.png',
 			},
 		},
-		['motogp17'] = {
+		motogp17 = {
 			abbreviation = 'MotoGP 17',
 			name = 'MotoGP 17',
 			link = 'MotoGP 17',
@@ -440,7 +440,7 @@ return {
 				lightMode = 'Motogp17 default allmode.png',
 			},
 		},
-		['motogp18'] = {
+		motogp18 = {
 			abbreviation = 'MotoGP 18',
 			name = 'MotoGP 18',
 			link = 'MotoGP 18',
@@ -453,7 +453,7 @@ return {
 				lightMode = 'Motogp18 default allmode.png',
 			},
 		},
-		['motogp19'] = {
+		motogp19 = {
 			abbreviation = 'MotoGP 19',
 			name = 'MotoGP 19',
 			link = 'MotoGP 19',
@@ -466,7 +466,7 @@ return {
 				lightMode = 'Motogp19 default allmode.png',
 			},
 		},
-		['motogp20'] = {
+		motogp20 = {
 			abbreviation = 'MotoGP 20',
 			name = 'MotoGP 20',
 			link = 'MotoGP 20',
@@ -479,7 +479,7 @@ return {
 				lightMode = 'Motogp20 default allmode.png',
 			},
 		},
-		['motogp21'] = {
+		motogp21 = {
 			abbreviation = 'MotoGP 21',
 			name = 'MotoGP 21',
 			link = 'MotoGP 21',
@@ -492,7 +492,7 @@ return {
 				lightMode = 'Motogp21 default allmode.png',
 			},
 		},
-		['motogp22'] = {
+		motogp22 = {
 			abbreviation = 'MotoGP 22',
 			name = 'MotoGP 22',
 			link = 'MotoGP 22',
@@ -505,7 +505,7 @@ return {
 				lightMode = 'Motogp22 default allmode.png',
 			},
 		},
-		['motogp23'] = {
+		motogp23 = {
 			abbreviation = 'MotoGP 23',
 			name = 'MotoGP 23',
 			link = 'MotoGP 23',
@@ -609,7 +609,85 @@ return {
 				lightMode = 'Forza Motorsports default lightmode.png',
 			},
 		},
-		['pgr2'] = {
+		['wrc 5'] = {
+			abbreviation = 'WRC 5',
+			name = 'WRC 5',
+			link = 'WRC 5',
+			logo = {
+				darkMode = 'WRC 5 default allmode.png',
+				lightMode = 'WRC 5 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'WRC 5 default allmode.png',
+				lightMode = 'WRC 5 default allmode.png',
+			},
+		},
+		['wrc 6'] = {
+			abbreviation = 'WRC 6',
+			name = 'WRC 6',
+			link = 'WRC 6',
+			logo = {
+				darkMode = 'WRC 6 default allmode.png',
+				lightMode = 'WRC 6 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'WRC 6 default allmode.png',
+				lightMode = 'WRC 6 default allmode.png',
+			},
+		},
+		['wrc 7'] = {
+			abbreviation = 'WRC 7',
+			name = 'WRC 7',
+			link = 'WRC 7',
+			logo = {
+				darkMode = 'WRC 7 default darkmode.png',
+				lightMode = 'WRC 7 default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'WRC 7 default darkmode.png',
+				lightMode = 'WRC 7 default lightmode.png',
+			},
+		},
+		['wrc 8'] = {
+			abbreviation = 'WRC 8',
+			name = 'WRC 8',
+			link = 'WRC 8',
+			logo = {
+				darkMode = 'WRC 8 default darkmode.png',
+				lightMode = 'WRC 8 default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'WRC 8 default darkmode.png',
+				lightMode = 'WRC 8 default lightmode.png',
+			},
+		},
+		['wrc 9'] = {
+			abbreviation = 'WRC 9',
+			name = 'WRC 9',
+			link = 'WRC 9',
+			logo = {
+				darkMode = 'WRC 9 default darkmode.png',
+				lightMode = 'WRC 9 default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'WRC 9 default darkmode.png',
+				lightMode = 'WRC 9 default lightmode.png',
+			},
+		},
+		['wrc 10'] = {
+			abbreviation = 'WRC 10',
+			name = 'WRC 10',
+			link = 'WRC 10',
+			logo = {
+				darkMode = 'WRC 10 default darkmode.png',
+				lightMode = 'WRC 10 default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'WRC 10 default darkmode.png',
+				lightMode = 'WRC 10 default lightmode.png',
+			},
+		},
+		pgr2 = {
 			abbreviation = 'PGR 2',
 			name = 'Project Gotham Racing 2',
 			link = 'Project Gotham Racing 2',
@@ -622,7 +700,7 @@ return {
 				lightMode = 'PGR2 default allmode.png',
 			},
 		},
-		['pgr3'] = {
+		pgr3 = {
 			abbreviation = 'PGR 3',
 			name = 'Project Gotham Racing 3',
 			link = 'Project Gotham Racing 3',
@@ -635,7 +713,7 @@ return {
 				lightMode = 'PGR default lightmode.png',
 			},
 		},
-		['pgr4'] = {
+		pgr4 = {
 			abbreviation = 'PGR 4',
 			name = 'Project Gotham Racing 4',
 			link = 'Project Gotham Racing 4',
@@ -648,7 +726,7 @@ return {
 				lightMode = 'PGR default lightmode.png',
 			},
 		},
-		['ug1'] = {
+		ug1 = {
 			abbreviation = 'UG1',
 			name = 'Need for Speed: Underground',
 			link = 'Need for Speed: Underground',
@@ -661,7 +739,7 @@ return {
 				lightMode = 'NFS Underground default allmode.png',
 			},
 		},
-		['ug2'] = {
+		ug2 = {
 			abbreviation = 'UG2',
 			name = 'Need for Speed: Underground 2',
 			link = 'Need for Speed: Underground 2',
@@ -674,7 +752,7 @@ return {
 				lightMode = 'NFS Underground default allmode.png',
 			},
 		},
-		['mw05'] = {
+		mw05 = {
 			abbreviation = 'MW',
 			name = 'Need for Speed: Most Wanted',
 			link = 'Need for Speed: Most Wanted',
@@ -687,7 +765,7 @@ return {
 				lightMode = 'NFS MW05 default allmode.png',
 			},
 		},
-		['carbon'] = {
+		carbon = {
 			abbreviation = 'CB',
 			name = 'Need for Speed: Carbon',
 			link = 'Need for Speed: Carbon',
@@ -700,7 +778,7 @@ return {
 				lightMode = 'NFS Carbon default allmode.png',
 			},
 		},
-		['prostreet'] = {
+		prostreet = {
 			abbreviation = 'PS',
 			name = 'Need for Speed: ProStreet',
 			link = 'Need for Speed: ProStreet',
@@ -713,7 +791,7 @@ return {
 				lightMode = 'NFS Prostreet default allmode.png',
 			},
 		},
-		['shift'] = {
+		shift = {
 			abbreviation = 'Shift',
 			name = 'Need for Speed: Shift',
 			link = 'Need for Speed: Shift',


### PR DESCRIPTION
## Summary
Add all missing games based on https://liquipedia.net/simracing/index.php?title=Template:Infobox_league&action=edit&oldid=29649 plus including any missing games (due to I've stopped editing simracing in 2020 or something, a dozen was missing from that revision)

## How did you test this change?
![image](https://user-images.githubusercontent.com/88981446/219857790-7727a223-88ec-47a4-a8f1-bbde4817d6a2.png)
