### PR TITLE
CS Match2: Fix 5E Arena link to new URL

### DIFF
--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -127,7 +127,7 @@ return {
 	{
 		name = '5earena',
 		icon = '5E Arena icon.png',
-		prefixLink = 'https://client1.5earenacdn.com/data/match/',
+		prefixLink = 'https://www.5earena.com/gamedata/matchboard/',
 		label = 'Stats on 5E Arena',
 		isMapStats = true
 	},


### PR DESCRIPTION
## Summary

Old URLs are now 404, they moved them all to this new URL.

## How did you test this change?

Just data. Also, live on wiki.