### PR TITLE
Split input of alternate ids and display with dots

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -144,7 +144,10 @@ function Person:createInfobox()
 				}}
 			end}
 		}},
-		Cell{name = 'Alternate IDs', content = {args.ids or args.alternateids}},
+		Cell{name = 'Alternate IDs', content = {
+				table.concat(mw.text.split(args.ids or args.alternateids or '', ',%s?'), ' &#8226; ')
+			}
+		},
 		Cell{name = 'Nicknames', content = {args.nicknames}},
 		Builder{
 			builder = function()


### PR DESCRIPTION
## Summary
Some wikis used to split the input of `ids` or `alternateids` by `,%s?`, which allowed input without spaces.
With the standard infobox, this produces bad output, as there are no possibilities to break lines:
![image](https://user-images.githubusercontent.com/16326643/219942984-3c200382-fe6b-4f71-96d4-4396e5b699f9.png)
This splits the input by and concats again for display with dots instead:
![image](https://user-images.githubusercontent.com/16326643/219943018-f93f74a1-6468-4ebb-bfce-d079e4458b18.png)

On pages/wikis where ids are input with spaces, this will change the display:
New:
![image](https://user-images.githubusercontent.com/16326643/219943337-716073d1-d442-4fda-b489-e1daf00a46e4.png)
Old:
![image](https://user-images.githubusercontent.com/16326643/219943340-e7d9660a-59d5-458e-96db-0ac1b58b9afc.png)


## How did you test this change?
Tested/checked on AoE, dota2, valorant, cs

