### PR TITLE
Fix player prefix for aoezone links

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -27,7 +27,10 @@ local PREFIXES = {
 		'http://afreecatv.com/',
 		stream = 'https://play.afreecatv.com/',
 	},
-	aoezone = {'https://aoezone.net/'},
+	aoezone = {
+		'https://aoezone.net/',
+		player = 'https://aoezone.net/members/'
+	},
 	['ask-fm'] = {'https://ask.fm/'},
 	b5csgo = {
 		'',


### PR DESCRIPTION
## Summary
Fixes the prefix used for variant player for aoezone links
![image](https://user-images.githubusercontent.com/16326643/219957064-a9b2a762-568c-4cfd-9a68-b5febe713863.png)


## How did you test this change?
dev