### PR TITLE
Add Match2 input processing for fifa

### DIFF
--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -355,14 +355,7 @@ function CustomMatchGroupInput._mapInput(match, mapIndex)
 		comment = map.comment,
 		penaltyscores = CustomMatchGroupInput._submatchPenaltyScores(match, map),
 	}
-
-	-- inherit stuff from match data
-	map.type = Logic.emptyOr(map.type, match.type)
-	map.liquipediatier = match.liquipediatier
-	map.liquipediatiertype = match.liquipediatiertype
-	map.game = Logic.emptyOr(map.game, match.game)
-	map.date = Logic.emptyOr(map.date, match.date)
-
+	
 	-- determine score, resulttype, walkover and winner
 	CustomMatchGroupInput._mapWinnerProcessing(map)
 

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -355,7 +355,6 @@ function CustomMatchGroupInput._mapInput(match, mapIndex)
 		comment = map.comment,
 		penaltyscores = CustomMatchGroupInput._submatchPenaltyScores(match, map),
 	}
-	
 	-- determine score, resulttype, walkover and winner
 	CustomMatchGroupInput._mapWinnerProcessing(map)
 

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -355,6 +355,10 @@ function CustomMatchGroupInput._mapInput(match, mapIndex)
 		comment = map.comment,
 		penaltyscores = CustomMatchGroupInput._submatchPenaltyScores(match, map),
 	}
+
+	-- inherit stuff from match data
+	map = MatchGroupInput.getCommonTournamentVars(map, match)
+
 	-- determine score, resulttype, walkover and winner
 	CustomMatchGroupInput._mapWinnerProcessing(map)
 

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -1,0 +1,651 @@
+---
+-- @Liquipedia
+-- wiki=fifa
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
+local Flags = require('Module:Flags')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Ordinal = require('Module:Ordinal')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
+local Streams = Lua.import('Module:Links/Stream', {requireDevIfEnabled = true})
+
+local Opponent = require('Module:OpponentLibraries').Opponent
+
+local UNKNOWN_REASON_LOSS_STATUS = 'L'
+local DEFAULT_WIN_STATUS = 'W'
+local DEFAULT_WIN_RESULTTYPE = 'default'
+local NO_SCORE = -1
+local SCORE_STATUS = 'S'
+local ALLOWED_STATUSES = {DEFAULT_WIN_STATUS, 'FF', 'DQ', UNKNOWN_REASON_LOSS_STATUS}
+local MAX_NUM_OPPONENTS = 2
+local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+local NOW = os.time(os.date('!*t'))
+local TBD = 'tbd'
+local BYE = 'BYE'
+
+local CustomMatchGroupInput = {}
+
+CustomMatchGroupInput.walkoverProcessing = {}
+local walkoverProcessing = CustomMatchGroupInput.walkoverProcessing
+
+-- called from Module:MatchGroup
+function CustomMatchGroupInput.processMatch(match)
+	Table.mergeInto(
+		match,
+		CustomMatchGroupInput._readDate(match)
+	)
+	CustomMatchGroupInput._getExtraData(match)
+	CustomMatchGroupInput._getTournamentVars(match)
+	CustomMatchGroupInput._adjustData(match)
+	CustomMatchGroupInput._getVodStuff(match)
+
+	return match
+end
+
+function CustomMatchGroupInput._readDate(matchArgs)
+	if matchArgs.date then
+		return MatchGroupInput.readDate(matchArgs.date)
+	else
+		return {
+			date = EPOCH_TIME_EXTENDED,
+			dateexact = false,
+			timestamp = DateExt.epochZero,
+		}
+	end
+end
+
+function CustomMatchGroupInput._getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'solo'))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
+
+	MatchGroupInput.getCommonTournamentVars(match)
+end
+
+function CustomMatchGroupInput._getVodStuff(match)
+	match.stream = Streams.processStreams(match)
+	match.vod = Logic.emptyOr(match.vod)
+end
+
+function CustomMatchGroupInput._getExtraData(match)
+	local casters = {}
+	for key, name in Table.iter.pairsByPrefix(match, 'caster') do
+		table.insert(casters, CustomMatchGroupInput._getCasterInformation(
+			name,
+			match[key .. 'flag'],
+			match[key .. 'name']
+		))
+	end
+
+	match.extradata = {
+		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
+		hassubmatches = tostring(Logic.readBool(match.hasSubmatches)),
+	}
+end
+
+function CustomMatchGroupInput._adjustData(match)
+	CustomMatchGroupInput._opponentInput(match)
+
+	for _, _, mapIndex in Table.iter.pairsByPrefix(match, 'map') do
+		CustomMatchGroupInput._mapInput(match, mapIndex)
+	end
+
+	local scores = Array.map(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
+		local score = CustomMatchGroupInput._computeOpponentMatchScore(match, opponentIndex, true)
+		match['opponent' .. opponentIndex].score = score
+		if Logic.isNumeric(score) then
+			match['opponent' .. opponentIndex].status = SCORE_STATUS
+		end
+		return score
+	end)
+
+	CustomMatchGroupInput._winnerProcessing(match, scores, true)
+
+	CustomMatchGroupInput._setPlacements(match)
+end
+
+function CustomMatchGroupInput._winnerProcessing(obj, scores, isMatch)
+	walkoverProcessing.walkover(obj, scores)
+
+	if isMatch and obj.resulttype == DEFAULT_WIN_RESULTTYPE then
+		walkoverProcessing.applyMatchWalkoverToOpponents(obj)
+		return
+	end
+
+	if obj.winner == 'draw' then
+		obj.winner = 0
+		obj.resulttype = 'draw'
+		obj.finished = true
+	end
+
+	obj.finished = CustomMatchGroupInput._checkFinished(obj)
+
+	obj.winner = tonumber(obj.winner)
+
+	if obj.finished and not obj.winner then
+		obj.winner = CustomMatchGroupInput._determineWinnerIfMissing(scores)
+	end
+end
+
+function CustomMatchGroupInput._computeOpponentMatchScore(match, opponentIndex)
+	if not match['opponent' .. opponentIndex] then
+		return NO_SCORE
+	end
+
+	-- if valid manual input return that
+	local score = match['opponent' .. opponentIndex].score
+	if Logic.isNumeric(score) then
+		return tonumber(score)
+	elseif Table.includes(ALLOWED_STATUSES, (score or ''):upper()) then
+		return score:upper()
+	end
+
+	if not match.map1 or not match.map1.winner then
+		return NO_SCORE
+	end
+
+	local sumScore = 0
+
+	-- if submatches count submatch/map wins
+	if Logic.readBool(match.hasSubmatches) then
+		for _, map in Table.iter.pairsByPrefix(match, 'map') do
+			if map.winner == opponentIndex then
+				sumScore = sumScore + 1
+			end
+		end
+
+		return sumScore
+	end
+
+	-- if won in penalty shoot out return score of that shoot out
+	for _, map in Table.iter.pairsByPrefix(match, 'map') do
+		if Logic.readBool(map.penalty) then
+			return map.scores[opponentIndex]
+		end
+	end
+
+	-- sum up scores
+	for _, map in Table.iter.pairsByPrefix(match, 'map') do
+		local mapScore = map.scores[opponentIndex]
+		if mapScore ~= NO_SCORE then
+			sumScore = sumScore + mapScore
+		end
+	end
+
+	return sumScore
+end
+
+function CustomMatchGroupInput._checkFinished(obj)
+	if Logic.readBoolOrNil(obj.finished) == false then
+		return false
+	elseif Logic.readBool(obj.finished) or obj.winner then
+		return true
+	end
+
+	-- Match is automatically marked finished upon page edit after a
+	-- certain amount of time (depending on whether the date is exact)
+	if obj.timestamp and obj.timestamp > DateExt.epochZero then
+		local threshold = obj.dateexact and 30800 or 86400
+		if obj.timestamp + threshold < NOW then
+			return true
+		end
+	end
+end
+
+function CustomMatchGroupInput._determineWinnerIfMissing(scores)
+	local maxScore = math.max(unpack(scores or {0}))
+	-- if we have a positive score and the match is finished we also have a winner
+	if maxScore > 0 then
+		if Array.all(scores, function(score) return score == maxScore end) then
+			return 0
+		end
+
+		for opponentIndex, score in pairs(scores) do
+			if score == maxScore then
+				return opponentIndex
+			end
+		end
+	end
+end
+
+function CustomMatchGroupInput._setPlacements(match)
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local opponent = match['opponent' .. opponentIndex]
+
+		if match.winner == opponentIndex or match.winner == 0 then
+			opponent.placement = 1
+		elseif match.winner then
+			opponent.placement = 2
+		end
+	end
+end
+
+function CustomMatchGroupInput._subMatchStructure(match)
+	local subMatches = {}
+
+	local currentSubGroup = 0
+	for _, map in Table.iter.pairsByPrefix(match, 'map') do
+		local subMatchIndex = tonumber(map.set)
+		if subMatchIndex then
+			currentSubGroup = subMatchIndex
+		else
+			currentSubGroup = currentSubGroup + 1
+			subMatchIndex = currentSubGroup
+		end
+
+		map.subgroup = subMatchIndex
+
+		if not subMatches[subMatchIndex] then
+			subMatches[subMatchIndex] = {scores = {0, 0}}
+		end
+
+		local winner = tonumber(map.winner)
+		if winner and subMatches[subMatchIndex].scores[winner] then
+			subMatches[subMatchIndex].scores[winner] = subMatches[subMatchIndex].scores[winner] + 1
+		end
+	end
+
+	-- determine submatch winners & opponent sumscores
+	for subMatchIndex, subMatch in ipairs(subMatches) do
+		local winner = tonumber(match['set' .. subMatchIndex .. 'winner'])
+		if not winner or winner <= 0 or winner > MAX_NUM_OPPONENTS then
+			winner = nil
+			local bestof = tonumber(match['set' .. subMatchIndex .. 'bestof']) or DEFAULT_SUBMATCH_BESTOF
+			for opponentIndex = 1, MAX_NUM_OPPONENTS do
+				if subMatch.scores[opponentIndex] > (bestof / 2) then
+					winner = opponentIndex
+					break
+				end
+			end
+		end
+
+		subMatch.winner = winner
+
+		if winner then
+			match['opponent' .. winner].sumscore = match['opponent' .. winner].sumscore + 1
+		end
+	end
+end
+
+function CustomMatchGroupInput._opponentInput(match)
+	local opponentIndex = 1
+	local opponent = match['opponent' .. opponentIndex]
+
+	while opponentIndex <= MAX_NUM_OPPONENTS and Logic.isNotEmpty(opponent) do
+		opponent = Json.parseIfString(opponent) or Opponent.blank()
+
+		-- Convert byes to literals
+		if
+			string.upper(opponent.template or '') == BYE
+			or string.upper(opponent.name or '') == BYE
+		then
+			opponent = {type = Opponent.literal, name = BYE}
+		end
+
+		--process input
+		if opponent.type == Opponent.team or opponent.type == Opponent.solo or
+			opponent.type == Opponent.literal then
+
+			opponent = CustomMatchGroupInput.processOpponent(opponent, match.timestamp)
+		else
+			error('Unsupported Opponent Type')
+		end
+
+		match['opponent' .. opponentIndex] = opponent
+
+		opponentIndex = opponentIndex + 1
+		opponent = match['opponent' .. opponentIndex]
+	end
+end
+
+function CustomMatchGroupInput.processOpponent(record, timestamp)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	local teamTemplateDate = timestamp
+	-- If date is epoch, resolve using tournament dates instead
+	-- Epoch indicates that the match is missing a date
+	-- In order to get correct child team template, we will use an approximately date and not 1970-01-01
+	if teamTemplateDate == DateExt.epochZero then
+		teamTemplateDate = Variables.varDefaultMulti(
+			'tournament_enddate',
+			'tournament_startdate',
+			NOW
+		)
+	end
+
+	Opponent.resolve(opponent, teamTemplateDate)
+
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+
+	if record.type == Opponent.team then
+		record.icon, record.icondark = CustomMatchGroupInput.getIcon(opponent.template)
+		record.match2players = CustomMatchGroupInput._readTeamPlayers(record, record.players)
+	end
+
+	return record
+end
+
+function CustomMatchGroupInput._readTeamPlayers(opponent, playerData)
+	local players = CustomMatchGroupInput._getManuallyEnteredPlayers(playerData)
+
+	if Table.isEmpty(players) then
+		players = CustomMatchGroupInput._getPlayersFromVariables(opponent.name)
+	end
+
+	return players
+end
+
+function CustomMatchGroupInput._getManuallyEnteredPlayers(playerData)
+	local players = {}
+	playerData = Json.parseIfString(playerData) or {}
+
+	for prefix, displayName in Table.iter.pairsByPrefix(playerData, 'p') do
+		local name = mw.ext.TeamLiquidIntegration.resolve_redirect(Logic.emptyOr(
+			playerData[prefix .. 'link'],
+			displayName
+		))
+
+		table.insert(players, {
+			name = name,
+			displayname = displayName,
+			flag = Flags.CountryName(playerData[prefix .. 'flag']),
+		})
+	end
+
+	return players
+end
+
+function CustomMatchGroupInput._getPlayersFromVariables(teamName)
+	local players = {}
+
+	local playerIndex = 1
+	while true do
+		local prefix = teamName .. '_p' .. playerIndex
+		local playerName = Variables.varDefault(prefix)
+		if String.isEmpty(playerName) then
+			break
+		end
+		table.insert(players, {
+			name = playerName,
+			displayname = Variables.varDefault(prefix .. 'dn', playerName:gsub('_', ' ')),
+			flag = Flags.CountryName(Variables.varDefault(prefix .. 'flag')),
+		})
+		playerIndex = playerIndex + 1
+	end
+
+	return players
+end
+
+function CustomMatchGroupInput._mapInput(match, mapIndex)
+	local map = Json.parseIfString(match['map' .. mapIndex])
+
+	if Table.isEmpty(map) then
+		match['map' .. mapIndex] = nil
+		return match
+	end
+
+	if Logic.readBool(match.hasSubmatches) then
+		-- generic map name (not displayed)
+		map.map = 'Game ' .. mapIndex
+	elseif Logic.readBool(map.penalty) then
+		map.map = 'Penalties'
+	else
+		map.map = mapIndex .. Ordinal.suffix(mapIndex) .. ' Leg'
+	end
+
+	-- set initial extradata for maps
+	map.extradata = {
+		comment = map.comment,
+		penaltyscores = CustomMatchGroupInput._submatchPenaltyScores(match, map),
+	}
+
+	-- inherit stuff from match data
+	map.type = Logic.emptyOr(map.type, match.type)
+	map.liquipediatier = match.liquipediatier
+	map.liquipediatiertype = match.liquipediatiertype
+	map.game = Logic.emptyOr(map.game, match.game)
+	map.date = Logic.emptyOr(map.date, match.date)
+
+	-- determine score, resulttype, walkover and winner
+	CustomMatchGroupInput._mapWinnerProcessing(map)
+
+	-- get participants data for the map + get map mode
+	CustomMatchGroupInput._processPlayerMapData(map, match)
+
+	match['map' .. mapIndex] = map
+end
+
+function CustomMatchGroupInput._submatchPenaltyScores(match, map)
+	if not Logic.readBool(match.hasSubmatches) then
+		return
+	end
+
+	local hasPenalties = false
+	local scores = Array.map(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
+		local score = tonumber(map['penaltyScore' .. opponentIndex])
+		hasPenalties = hasPenalties or (score ~= nil)
+		return score or 0
+	end)
+
+	return hasPenalties and scores or nil
+end
+
+function CustomMatchGroupInput._mapWinnerProcessing(map)
+	if map.winner == 'skip' then
+		map.scores = {NO_SCORE, NO_SCORE}
+		map.resulttype = 'np'
+
+		return
+	end
+
+	map.scores = {}
+
+	local scores = Array.map(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
+		local score = map['score' .. opponentIndex]
+		map.scores[opponentIndex] = tonumber(score) or NO_SCORE
+
+		return Table.includes(ALLOWED_STATUSES, string.upper(score or ''))
+			and score:upper()
+			or map.scores[opponentIndex]
+	end)
+
+	CustomMatchGroupInput._winnerProcessing(map, scores)
+end
+
+function CustomMatchGroupInput._processPlayerMapData(map, match)
+	local participants = {}
+
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local opponent = match['opponent' .. opponentIndex]
+		if opponent.type == Opponent.solo then
+			CustomMatchGroupInput._processDefaultPlayerMapData(
+				opponent.match2players or {},
+				opponentIndex,
+				map,
+				participants
+			)
+		elseif opponent.type == Opponent.team then
+			CustomMatchGroupInput._processTeamPlayerMapData(
+				opponent.match2players or {},
+				opponentIndex,
+				map,
+				participants
+			)
+		end
+	end
+
+	map.mode = Opponent.toMode(match.opponent1.type, match.opponent2.type)
+
+	map.participants = participants
+end
+
+function CustomMatchGroupInput._processDefaultPlayerMapData(players, opponentIndex, map, participants)
+	for playerIndex = 1, #players do
+		participants[opponentIndex .. '_' .. playerIndex] = {
+			played = true,
+		}
+	end
+end
+
+function CustomMatchGroupInput._processTeamPlayerMapData(players, opponentIndex, map, participants)
+	local playerKey = 'p' .. opponentIndex
+	local player = map[playerKey .. 'link'] or map[playerKey]
+	if String.isEmpty(player) or player:lower() == TBD then
+		player = TBD
+	else
+		-- allows fetching the link of the player from preset wiki vars
+		player = mw.ext.TeamLiquidIntegration.resolve_redirect(
+			map[playerKey .. 'link'] or Variables.varDefault(map[playerKey] .. '_page') or map[playerKey]
+		)
+	end
+
+	local playerData = {
+		played = true,
+	}
+
+	local match2playerIndex = CustomMatchGroupInput._fetchMatch2PlayerIndexOfPlayer(players, player)
+
+	-- if we have the player not present in match2player add basic data here
+	if not match2playerIndex then
+		match2playerIndex = #players + 1
+		playerData = Table.merge(playerData, {name = player, displayname = map[playerKey] or player})
+	end
+
+	participants[opponentIndex .. '_' .. match2playerIndex] =  playerData
+end
+
+function CustomMatchGroupInput._fetchMatch2PlayerIndexOfPlayer(players, player)
+	local displayNameIndex
+	local displayNameFoundTwice = false
+	player = mw.ext.TeamLiquidIntegration.resolve_redirect(player)
+	local playerWithUnderscores = player:gsub(' ', '_')
+
+	for match2playerIndex, match2player in pairs(players) do
+		if match2player and match2player.name == playerWithUnderscores then
+			return match2playerIndex
+		elseif not displayNameIndex and match2player and match2player.displayname == player then
+			displayNameIndex = match2playerIndex
+		elseif match2player and match2player.displayname == player then
+			displayNameFoundTwice = true
+		end
+	end
+
+	if not displayNameFoundTwice then
+		return displayNameIndex
+	end
+end
+
+function CustomMatchGroupInput.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	if raw then
+		local icon = Logic.emptyOr(raw.image, raw.legacyimage)
+		local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
+		return icon, iconDark
+	end
+end
+
+function walkoverProcessing.walkover(obj, scores)
+	local walkover = obj.walkover
+
+	if Logic.isNumeric(walkover) then
+		walkoverProcessing.numericWalkover(obj, walkover)
+	elseif walkover then
+		walkoverProcessing.nonNumericWalkover(obj, walkover)
+	elseif #scores ~=2 then -- since we always have 2 opponents outside of ffa
+		error('Unexpected number of opponents when calculating winner')
+	elseif Array.all(scores, function(score)
+			return Table.includes(ALLOWED_STATUSES, score) and score ~= DEFAULT_WIN_STATUS
+		end) then
+
+		walkoverProcessing.scoreDoubleWalkover(obj, scores)
+	elseif Array.any(scores, function(score) return Table.includes(ALLOWED_STATUSES, score) end) then
+		walkoverProcessing.scoreWalkover(obj, scores)
+	end
+end
+
+function walkoverProcessing.numericWalkover(obj, walkover)
+	local winner = tonumber(walkover)
+
+	obj.winner = winner
+	obj.finished = true
+	obj.walkover = UNKNOWN_REASON_LOSS_STATUS
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.nonNumericWalkover(obj, walkover)
+	if not Table.includes(ALLOWED_STATUSES, string.upper(walkover)) then
+		error('Invalid walkover "' .. walkover .. '"')
+	elseif not Logic.isNumeric(obj.winner) then
+		error('Walkover without winner specified')
+	end
+
+	obj.winner = tonumber(obj.winner)
+	obj.finished = true
+	obj.walkover = walkover:upper()
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.scoreDoubleWalkover(obj, scores)
+	obj.winner = -1
+	obj.finished = true
+	obj.walkover = scores[1]
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.scoreWalkover(obj, scores)
+	local winner, status
+
+	for scoreIndex, score in pairs(scores) do
+		score = string.upper(score)
+		if score == DEFAULT_WIN_STATUS then
+			winner = scoreIndex
+		elseif Table.includes(ALLOWED_STATUSES, score) then
+			status = score
+		else
+			status = UNKNOWN_REASON_LOSS_STATUS
+		end
+	end
+
+	if not winner then
+		error('Invalid score combination "{' .. scores[1] .. ', ' .. scores[2] .. '}"')
+	end
+
+	obj.winner = winner
+	obj.finished = true
+	obj.walkover = status
+	obj.resulttype = DEFAULT_WIN_RESULTTYPE
+end
+
+function walkoverProcessing.applyMatchWalkoverToOpponents(match)
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local score = match['opponent' .. opponentIndex].score
+
+		if Logic.isNumeric(score) or String.isEmpty(score) then
+			match['opponent' .. opponentIndex].score = tonumber(score) or NO_SCORE
+			match['opponent' .. opponentIndex].status = match.walkover
+		elseif score and Table.includes(ALLOWED_STATUSES, score:upper()) then
+			match['opponent' .. opponentIndex].score = NO_SCORE
+			match['opponent' .. opponentIndex].status = score
+		else
+			error('Invalid score "' .. score .. '"')
+		end
+	end
+
+	-- neither match.opponent0 nor match['opponent-1'] does exist hence the if
+	if match['opponent' .. match.winner] then
+		match['opponent' .. match.winner].status = DEFAULT_WIN_STATUS
+	end
+end
+
+return CustomMatchGroupInput

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -475,11 +475,10 @@ function CustomMatchGroupInput._processTeamPlayerMapData(players, opponentIndex,
 	end
 
 	for playerKey, player in Table.iter.pairsByPrefix(map, prefix) do
-		local player = map[playerKey .. 'link'] or map[playerKey]
 		if player:lower() ~= TBD then
 			-- allows fetching the link of the player from preset wiki vars
 			player = mw.ext.TeamLiquidIntegration.resolve_redirect(
-				map[playerKey .. 'link'] or Variables.varDefault(map[playerKey] .. '_page') or map[playerKey]
+				map[playerKey .. 'link'] or Variables.varDefault(player .. '_page') or player
 			)
 		end
 

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -281,6 +281,14 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 
+	for _, player in pairs(record.players or {}) do
+		player.name = player.name:gsub(' ', '_')
+	end
+
+	if record.name then
+		record.name = record.name:gsub(' ', '_')
+	end
+
 	if record.type == Opponent.team then
 		record.icon, record.icondark = CustomMatchGroupInput.getIcon(opponent.template)
 		record.match2players = CustomMatchGroupInput._readTeamPlayers(record, record.players)
@@ -307,7 +315,7 @@ function CustomMatchGroupInput._getManuallyEnteredPlayers(playerData)
 		local name = mw.ext.TeamLiquidIntegration.resolve_redirect(Logic.emptyOr(
 			playerData[prefix .. 'link'],
 			displayName
-		))
+		)):gsub(' ', '_')
 
 		table.insert(players, {
 			name = name,
@@ -330,7 +338,7 @@ function CustomMatchGroupInput._getPlayersFromVariables(teamName)
 			break
 		end
 		table.insert(players, {
-			name = playerName,
+			name = playerName:gsub(' ', '_'),
 			displayname = Variables.varDefault(prefix .. 'dn', playerName:gsub('_', ' ')),
 			flag = Flags.CountryName(Variables.varDefault(prefix .. 'flag')),
 		})
@@ -472,7 +480,7 @@ function CustomMatchGroupInput._processTeamPlayerMapData(players, opponentIndex,
 	-- if we have the player not present in match2player add basic data here
 	if not match2playerIndex then
 		match2playerIndex = #players + 1
-		playerData = Table.merge(playerData, {name = player, displayname = map[playerKey] or player})
+		playerData = Table.merge(playerData, {name = player:gsub(' ', '_'), displayname = map[playerKey] or player})
 	end
 
 	participants[opponentIndex .. '_' .. match2playerIndex] =  playerData

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -287,7 +287,7 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 		end
 	end
 
-	if record.name then
+	if record.name and record.type ~= Opponent.literal then
 		record.name = record.name:gsub(' ', '_')
 	end
 

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -230,53 +230,6 @@ function CustomMatchGroupInput._setPlacements(match)
 	end
 end
 
-function CustomMatchGroupInput._subMatchStructure(match)
-	local subMatches = {}
-
-	local currentSubGroup = 0
-	for _, map in Table.iter.pairsByPrefix(match, 'map') do
-		local subMatchIndex = tonumber(map.set)
-		if subMatchIndex then
-			currentSubGroup = subMatchIndex
-		else
-			currentSubGroup = currentSubGroup + 1
-			subMatchIndex = currentSubGroup
-		end
-
-		map.subgroup = subMatchIndex
-
-		if not subMatches[subMatchIndex] then
-			subMatches[subMatchIndex] = {scores = {0, 0}}
-		end
-
-		local winner = tonumber(map.winner)
-		if winner and subMatches[subMatchIndex].scores[winner] then
-			subMatches[subMatchIndex].scores[winner] = subMatches[subMatchIndex].scores[winner] + 1
-		end
-	end
-
-	-- determine submatch winners & opponent sumscores
-	for subMatchIndex, subMatch in ipairs(subMatches) do
-		local winner = tonumber(match['set' .. subMatchIndex .. 'winner'])
-		if not winner or winner <= 0 or winner > MAX_NUM_OPPONENTS then
-			winner = nil
-			local bestof = tonumber(match['set' .. subMatchIndex .. 'bestof']) or DEFAULT_SUBMATCH_BESTOF
-			for opponentIndex = 1, MAX_NUM_OPPONENTS do
-				if subMatch.scores[opponentIndex] > (bestof / 2) then
-					winner = opponentIndex
-					break
-				end
-			end
-		end
-
-		subMatch.winner = winner
-
-		if winner then
-			match['opponent' .. winner].sumscore = match['opponent' .. winner].sumscore + 1
-		end
-	end
-end
-
 function CustomMatchGroupInput._opponentInput(match)
 	local opponentIndex = 1
 	local opponent = match['opponent' .. opponentIndex]


### PR DESCRIPTION
## Summary
Add Match2 input processing for fifa wiki.

They have 2 different match2 forms one for when no submatches are present and one for when submatches are present
Input processing wise they differ only slightly
- in the score calculation (sum up map/game scores (or in case of penalty shoot-out use that games scores) for the default case and sum up map/game wins in the submatch case)
- checking which player played in which map/game (`CustomMatchGroupInput._processTeamPlayerMapData` together with `CustomMatchGroupInput._fetchMatch2PlayerIndexOfPlayer`)

## How did you test this change?
test page: https://liquipedia.net/fifa/User:Hesketh2