### PR TITLE
Squad's dota2: Use link for objectname

### DIFF
--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -139,9 +139,10 @@ function CustomSquad.run(frame)
 			}
 		end
 
+		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(player.link or player.id)
 		squad:row(row:create(
 			Variables.varDefault('squad_name', mw.title.getCurrentTitle().prefixedText)
-			.. '_' .. player.id .. '_'
+			.. '_' .. link .. '_'
 			.. ReferenceCleaner.clean(player.joindate)
 			.. (player.role and '_' .. player.role or '')
 		))


### PR DESCRIPTION
## Summary
Change the primary key to use link instead of id

## How did you test this change?
dev 