### PR TITLE
Add missing games for Splatoon Info

### DIFF
--- a/standard/info/wikis/splatoon/info.lua
+++ b/standard/info/wikis/splatoon/info.lua
@@ -12,7 +12,7 @@ return {
 	name = 'Splatoon',
 	games = {
 		splatoon = {
-			abbreviation = 'Splatoon',
+			abbreviation = 'SP1',
 			name = 'Splatoon',
 			link = 'Splatoon',
 			logo = {
@@ -24,8 +24,34 @@ return {
 				lightMode = 'Splatoon default lightmode.png',
 			},
 		},
+		['2'] = {
+			abbreviation = 'SP2',
+			name = 'Splatoon 2',
+			link = 'Splatoon 2',
+			logo = {
+				darkMode = 'Splatoon 2 default allmode.png',
+				lightMode = 'Splatoon 2 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Splatoon 2 default allmode.png',
+				lightMode = 'Splatoon 2 default allmode.png',
+			},
+		},
+		['3'] = {
+			abbreviation = 'SP3',
+			name = 'Splatoon 3',
+			link = 'Splatoon 3',
+			logo = {
+				darkMode = 'Splatoon 3 default allmode.png',
+				lightMode = 'Splatoon 3 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Splatoon 3 default allmode.png',
+				lightMode = 'Splatoon 3 default allmode.png',
+			},
+		},
 	},
-	defaultGame = 'todo',
+	defaultGame = 'splatoon',
 	defaultTeamLogo = 'Splatoon default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Splatoon default darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/splatoon/info.lua
+++ b/standard/info/wikis/splatoon/info.lua
@@ -24,7 +24,7 @@ return {
 				lightMode = 'Splatoon default lightmode.png',
 			},
 		},
-		['2'] = {
+		['splatoon 2'] = {
 			abbreviation = 'SP2',
 			name = 'Splatoon 2',
 			link = 'Splatoon 2',
@@ -37,7 +37,7 @@ return {
 				lightMode = 'Splatoon 2 default allmode.png',
 			},
 		},
-		['3'] = {
+		['splatoon 3'] = {
 			abbreviation = 'SP3',
 			name = 'Splatoon 3',
 			link = 'Splatoon 3',

--- a/standard/info/wikis/splatoon/info.lua
+++ b/standard/info/wikis/splatoon/info.lua
@@ -51,7 +51,7 @@ return {
 			},
 		},
 	},
-	defaultGame = 'splatoon',
+	defaultGame = '1',
 	defaultTeamLogo = 'Splatoon default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Splatoon default darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/splatoon/info.lua
+++ b/standard/info/wikis/splatoon/info.lua
@@ -11,7 +11,7 @@ return {
 	wikiName = 'splatoon',
 	name = 'Splatoon',
 	games = {
-		splatoon = {
+		['1'] = {
 			abbreviation = 'SP1',
 			name = 'Splatoon',
 			link = 'Splatoon',
@@ -24,7 +24,7 @@ return {
 				lightMode = 'Splatoon default lightmode.png',
 			},
 		},
-		['splatoon 2'] = {
+		['2'] = {
 			abbreviation = 'SP2',
 			name = 'Splatoon 2',
 			link = 'Splatoon 2',
@@ -37,7 +37,7 @@ return {
 				lightMode = 'Splatoon 2 default allmode.png',
 			},
 		},
-		['splatoon 3'] = {
+		['3'] = {
 			abbreviation = 'SP3',
 			name = 'Splatoon 3',
 			link = 'Splatoon 3',


### PR DESCRIPTION
## Summary
Missing Games for Splatoon Info, which basically just two games. The original **splatoon** default entry actually works as the entry for the first game

in wikis the **game=** input only existed as **splatoon** / **2** / **3**
