### PR TITLE
[1/?] Prepare PrizePool/Placement for standardized Awards Prize Pools

### DIFF
--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -669,7 +669,7 @@ function PrizePool:_readPlacements(args)
 		end
 
 		local placementInput = Json.parseIfString(args[placementIndex])
-		local placement = Placement(placementInput, self, currentPlace)
+		local placement = Placement(placementInput, self):create(currentPlace)
 
 		currentPlace = placement.placeEnd
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -413,9 +413,8 @@ function Import._emptyPlacement(priorPlacement, placementSize)
 
 	return Placement(
 		{placeStart = placeStart, placeEnd = placeEnd, count = placementSize},
-		_parent,
-		priorPlacement.placeEnd or 0
-	)
+		_parent
+	):create(priorPlacement.placeEnd or 0)
 end
 
 function Import._mergePlacement(lpdbEntries, placement)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -422,7 +422,7 @@ function Import._mergePlacement(lpdbEntries, placement)
 	for opponentIndex, opponent in ipairs(lpdbEntries) do
 		placement.opponents[opponentIndex] = Import._mergeEntry(
 			opponent,
-			Table.mergeInto(placement:_parseOpponents{{}}[1], placement.opponents[opponentIndex]),
+			Table.mergeInto(placement:parseOpponents{{}}[1], placement.opponents[opponentIndex]),
 			placement
 		)
 	end
@@ -491,7 +491,7 @@ function Import._entryToOpponent(lpdbEntry, placement)
 
 	local lastVs = Import._checkIfParsed(additionalData.lastVs or Import._removeTbdIdentifiers(lpdbEntry.vsOpponent))
 
-	return placement:_parseOpponents{{
+	return placement:parseOpponents{{
 		Import._checkIfParsed(Import._removeTbdIdentifiers(lpdbEntry.opponent)),
 		wdl = (not lpdbEntry.needsLastVs) and Import._formatGroupScore(lpdbEntry) or nil,
 		lastvs = Table.isNotEmpty(lastVs) and {lastVs} or nil,

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -200,22 +200,6 @@ function Placement:readAdditionalData(args)
 	return data
 end
 
-function Placement:shouldAddTbdOpponent(opponentIndex, place)
-	-- We want at least 1 opponent present for all placements
-	if opponentIndex == 1 then
-		return true
-	end
-	-- If the fillPlaceRange option is disabled or we do not have a give placeRange do not fill up further
-	if not self.parent.options.fillPlaceRange or not self.count then
-		return false
-	end
-	-- Only fill up further with TBD's if there is free space in the placeRange/slot
-	if opponentIndex <= self.count then
-		return true
-	end
-	return false
-end
-
 function Placement:_getLpdbData(...)
 	local entries = {}
 	for opponentIndex, opponent in ipairs(self.opponents) do

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -266,7 +266,7 @@ function Placement:_getLpdbData(...)
 		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
 		if Opponent.isTbd(opponent.opponentData) then
 			_tbd_index = _tbd_index + 1
-			lpdbData.objectName = lpdbData.objectName .. _tbd_index
+			lpdbData.objectName = lpdbData.objectName .. '_' .. _tbd_index
 		end
 
 		if self.parent._lpdbInjector then

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -11,13 +11,18 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchPlacement = require('Module:Match/Placement')
 local Ordinal = require('Module:Ordinal')
 local PlacementInfo = require('Module:Placement')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
+local BasePlacement = Lua.import('Module:PrizePool/Placement/Base', {requireDevIfEnabled = true})
+
 local Opponent = require('Module:OpponentLibraries').Opponent
+
+local _tbd_index = 0
 
 local DASH = '&#045;'
 
@@ -27,14 +32,12 @@ local PRIZE_TYPE_POINTS = 'POINTS'
 -- Allowed none-numeric score values.
 local SPECIAL_SCORES = {'W', 'FF' , 'L', 'DQ', 'D'}
 
-local _tbd_index = 0
-
 --- @class Placement
 --- A Placement is a set of opponents who all share the same final place in the tournament.
---- Its input is generally a table created by `Template:Placement`.
---- It has a range from placeStart to placeEnd, for example 5 to 8
---- and is expected to have the same amount of opponents as the range allows (4 is the 5-8 example).
-local Placement = Class.new(function(self, ...) self:init(...) end)
+--- Its input is generally a table created by `Template:Slot`.
+--- It has a range from placeStart to placeEnd, for example 5 to 8, or count (slotSize)
+--- and is expected to have at maximum the same amount of opponents as the range allows (4 is the 5-8 example).
+local Placement = Class.new(BasePlacement)
 
 Placement.specialStatuses = {
 	DQ = {
@@ -112,7 +115,7 @@ Placement.additionalData = {
 	LASTVS = {
 		field = 'lastvs',
 		parse = function (placement, input, context)
-			return placement:_parseOpponentArgs(input, context.date)
+			return placement:parseOpponentArgs(input, context.date)
 		end
 	},
 	LASTVSSCORE = {
@@ -142,23 +145,11 @@ Placement.additionalData = {
 	},
 }
 
---- @class Placement
---- @param args table Input information
---- @param parent PrizePool The PrizePool this Placement is part of
 --- @param lastPlacement integer The previous placement's end
-function Placement:init(args, parent, lastPlacement)
-	self.args = self:_parseArgs(args)
-	self.parent = parent
-	self.prizeTypes = parent.prizeTypes
-	self.date = self.args.date or parent.date
-	self.placeStart = self.args.placeStart
-	self.placeEnd = self.args.placeEnd
-	self.count = self.args.count
-	self.hasBaseCurrency = false
+function Placement:create(lastPlacement)
+	self:_parseArgs()
 
-	self.prizeRewards = self:_readPrizeRewards(self.args)
-
-	self.opponents = self:_parseOpponents(self.args)
+	self.opponents = self:parseOpponents(self.args)
 
 	self.count = self.count or math.max(#self.opponents, 1)
 
@@ -172,68 +163,33 @@ function Placement:init(args, parent, lastPlacement)
 
 	assert(#self.opponents <= self.count,
 		'Placement: Too many opponents in place ' .. self:_displayPlace():gsub('&#045;', '-'))
+
+	return self
 end
 
-function Placement:_parseArgs(args)
-	local parsedArgs = Table.deepCopy(args)
+function Placement:_parseArgs()
+	local args = self.args
 
-	parsedArgs.count = tonumber(args.count)
+	self.count = tonumber(args.count)
 
 	-- Explicit place range has been given
 	if args.place then
 		local places = Table.mapValues(mw.text.split(args.place, '-'), tonumber)
-		parsedArgs.placeStart = places[1]
-		parsedArgs.placeEnd = places[2] or places[1]
-		assert(parsedArgs.placeStart and parsedArgs.placeEnd, 'Placement: Invalid |place= provided.')
+		self.placeStart = places[1]
+		self.placeEnd = places[2] or places[1]
+		assert(self.placeStart and self.placeEnd, 'Placement: Invalid |place= provided.')
 
-		local calculatedCount = parsedArgs.placeEnd - parsedArgs.placeStart + 1
-		parsedArgs.count = parsedArgs.count or calculatedCount
+		local calculatedCount = self.placeEnd - self.placeStart + 1
+		self.count = self.count or calculatedCount
 
-		assert(parsedArgs.count <= calculatedCount,
-			'Placement: Invalid count (' .. parsedArgs.count .. ') and placement (' .. args.place .. ') combination')
+		assert(self.count <= calculatedCount,
+			'Placement: Invalid count (' .. args.count .. ') and placement (' .. args.place .. ') combination')
 	end
-
-	return parsedArgs
-end
-
---- Parse the input for available rewards of prizes, for instance how much money a team would win.
---- This also checks if the Placement instance has a dollar reward and assigns a variable if so.
-function Placement:_readPrizeRewards(args)
-	local rewards = {}
-
-	-- Loop through all prizes that have been defined in the header
-	Array.forEach(self.parent.prizes, function (prize)
-		local prizeData = self.prizeTypes[prize.type]
-		local fieldName = prizeData.row
-		if not fieldName then
-			return
-		end
-
-		local prizeIndex = prize.index
-		local reward = args[fieldName .. prizeIndex]
-		if prizeIndex == 1 then
-			reward = reward or args[fieldName]
-		end
-		if not reward then
-			return
-		end
-
-		rewards[prize.id] = prizeData.rowParse(self, reward, args, prizeIndex)
-	end)
-
-	-- Special case for Base Currency, as it's not defined in the header.
-	local baseType = self.prizeTypes[PRIZE_TYPE_BASE_CURRENCY]
-	if baseType.row and args[baseType.row] then
-		self.hasBaseCurrency = true
-		rewards[PRIZE_TYPE_BASE_CURRENCY .. 1] = baseType.rowParse(self, args[baseType.row], args, 1)
-	end
-
-	return rewards
 end
 
 --- Parse and set additional data fields for opponents.
 -- This includes fields such as group stage score (wdl) and last versus (lastvs).
-function Placement:_readAdditionalData(args)
+function Placement:readAdditionalData(args)
 	local data = {}
 
 	for prizeType, typeData in pairs(self.additionalData) do
@@ -246,41 +202,7 @@ function Placement:_readAdditionalData(args)
 	return data
 end
 
-function Placement:_parseOpponents(args)
-	return Array.mapIndexes(function(opponentIndex)
-		local opponentInput = Json.parseIfString(args[opponentIndex])
-		local opponent = {opponentData = {}, prizeRewards = {}, additionalData = {}}
-		if not opponentInput then
-			if self:_shouldAddTbdOpponent(opponentIndex) then
-				opponent.opponentData = Opponent.tbd(self.parent.opponentType)
-			else
-				return
-			end
-		else
-			-- Set the date
-			if not Placement._isValidDateFormat(opponentInput.date) then
-				opponentInput.date = self.date
-			end
-
-			-- Parse Opponent Data
-			if opponentInput.type then
-				self.parent:assertOpponentStructType(opponentInput)
-			else
-				opponentInput.type = self.parent.opponentType
-			end
-			opponent.opponentData = self:_parseOpponentArgs(opponentInput, opponentInput.date)
-
-			opponent.prizeRewards = self:_readPrizeRewards(opponentInput)
-			opponent.additionalData = self:_readAdditionalData(opponentInput)
-
-			-- Set date
-			opponent.date = opponentInput.date
-		end
-		return opponent
-	end)
-end
-
-function Placement:_shouldAddTbdOpponent(opponentIndex)
+function Placement:shouldAddTbdOpponent(opponentIndex, place)
 	-- We want at least 1 opponent present for all placements
 	if opponentIndex == 1 then
 		return true
@@ -294,26 +216,6 @@ function Placement:_shouldAddTbdOpponent(opponentIndex)
 		return true
 	end
 	return false
-end
-
-function Placement:_parseOpponentArgs(input, date)
-	-- Allow for lua-table, json-table and just raw string input
-	local opponentArgs = Json.parseIfTable(input) or (type(input) == 'table' and input or {input})
-	opponentArgs.type = opponentArgs.type or self.parent.opponentType
-	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
-
-	local opponentData
-	if type(opponentArgs[1]) == 'table' and opponentArgs[1].isAlreadyParsed then
-		opponentData = opponentArgs[1]
-	elseif type(opponentArgs[1]) ~= 'table' then
-		opponentData = Opponent.readOpponentArgs(opponentArgs)
-	end
-
-	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
-		opponentData = Table.deepMergeInto(Opponent.tbd(opponentArgs.type), opponentData or {})
-	end
-
-	return Opponent.resolve(opponentData, date, {syncPlayer = self.parent.options.syncPlayers})
 end
 
 function Placement:_getLpdbData(...)
@@ -382,7 +284,7 @@ function Placement:_getLpdbData(...)
 		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
 		if Opponent.isTbd(opponent.opponentData) then
 			_tbd_index = _tbd_index + 1
-			lpdbData.objectName = lpdbData.objectName .. '_' .. _tbd_index
+			lpdbData.objectName = lpdbData.objectName .. _tbd_index
 		end
 
 		if self.parent._lpdbInjector then
@@ -393,37 +295,6 @@ function Placement:_getLpdbData(...)
 	end
 
 	return entries
-end
-
-function Placement:getPrizeRewardForOpponent(opponent, prize)
-	return opponent.prizeRewards[prize] or self.prizeRewards[prize]
-end
-
-function Placement:_setBaseFromRewards(prizesToUse, prizeTypes)
-	Array.forEach(self.opponents, function(opponent)
-		if opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] or self.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] then
-			return
-		end
-
-		local baseReward = 0
-		Array.forEach(prizesToUse, function(prize)
-			local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id]
-
-			if not localMoney or localMoney <= 0 then
-				return
-			end
-
-			baseReward = baseReward + prizeTypes[prize.type].convertToBaseCurrency(
-				prize.data,
-				localMoney,
-				opponent.date,
-				self.parent.options.currencyRatePerOpponent
-			)
-			self.parent.usedAutoConvertedCurrency = true
-		end)
-
-		opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] = baseReward
-	end)
 end
 
 function Placement:_lpdbValue()
@@ -478,14 +349,6 @@ end
 
 function Placement:hasSpecialStatus()
 	return Table.any(Placement.specialStatuses, function(_, status) return status.active(self.args) end)
-end
-
---- Returns true if the input matches the format of a date
-function Placement._isValidDateFormat(date)
-	if type(date) ~= 'string' or String.isEmpty(date) then
-		return false
-	end
-	return date:match('%d%d%d%d%-%d%d%-%d%d') and true or false
 end
 
 return Placement

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -20,8 +20,6 @@ local BasePlacement = Lua.import('Module:PrizePool/Placement/Base', {requireDevI
 
 local Opponent = require('Module:OpponentLibraries').Opponent
 
-local _tbd_index = 0
-
 local DASH = '&#045;'
 
 local PRIZE_TYPE_BASE_CURRENCY = 'BASE_CURRENCY'
@@ -29,6 +27,8 @@ local PRIZE_TYPE_POINTS = 'POINTS'
 
 -- Allowed none-numeric score values.
 local SPECIAL_SCORES = {'W', 'FF' , 'L', 'DQ', 'D'}
+
+local _tbd_index = 0
 
 --- @class Placement
 --- A Placement is a set of opponents who all share the same final place in the tournament.

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -181,7 +181,7 @@ function Placement:_parseArgs()
 		self.count = self.count or calculatedCount
 
 		assert(self.count <= calculatedCount,
-			'Placement: Invalid count (' .. args.count .. ') and placement (' .. args.place .. ') combination')
+			'Placement: Invalid count (' .. self.count .. ') and placement (' .. args.place .. ') combination')
 	end
 end
 

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -7,9 +7,7 @@
 --
 
 local Abbreviation = require('Module:Abbreviation')
-local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MatchPlacement = require('Module:Match/Placement')

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -34,7 +34,7 @@ local _tbd_index = 0
 --- A Placement is a set of opponents who all share the same final place in the tournament.
 --- Its input is generally a table created by `Template:Slot`.
 --- It has a range from placeStart to placeEnd, for example 5 to 8, or count (slotSize)
---- and is expected to have at maximum the same amount of opponents as the range allows (4 is the 5-8 example).
+--- and is expected to have at maximum the same amount of opponents as the range allows (4 in the 5-8 example).
 local Placement = Class.new(BasePlacement)
 
 Placement.specialStatuses = {

--- a/components/prize_pool/commons/prize_pool_placement_base.lua
+++ b/components/prize_pool/commons/prize_pool_placement_base.lua
@@ -81,7 +81,7 @@ function Placement:parseOpponents(args)
 		local opponentInput = Json.parseIfString(args[opponentIndex])
 		local opponent = {opponentData = {}, prizeRewards = {}, additionalData = {}}
 		if not opponentInput then
-			if self:shouldAddTbdOpponent(opponentIndex) then
+			if self:_shouldAddTbdOpponent(opponentIndex) then
 				opponent.opponentData = Opponent.tbd(self.parent.opponentType)
 			else
 				return
@@ -110,8 +110,20 @@ function Placement:parseOpponents(args)
 	end)
 end
 
-function Placement:shouldAddTbdOpponent(args)
-	error('Function shouldAddTbdOpponent needs to be set via the module that requires "Module:PrizePool/Placement/Base"')
+function Placement:_shouldAddTbdOpponent(opponentIndex, place)
+	-- We want at least 1 opponent present for all placements
+	if opponentIndex == 1 then
+		return true
+	end
+	-- If the fillPlaceRange option is disabled or we do not have a give placeRange do not fill up further
+	if not self.parent.options.fillPlaceRange or not self.count then
+		return false
+	end
+	-- Only fill up further with TBD's if there is free space in the placeRange/slot
+	if opponentIndex <= self.count then
+		return true
+	end
+	return false
 end
 
 function Placement:readAdditionalData(args)

--- a/components/prize_pool/commons/prize_pool_placement_base.lua
+++ b/components/prize_pool/commons/prize_pool_placement_base.lua
@@ -37,10 +37,6 @@ function Placement:init(args, parent)
 	return self
 end
 
-function Placement:parseArgs(args)
-	error('This needs to be set via the module that requires "Module:PrizePool/Placement/Base"')
-end
-
 --- Parse the input for available rewards of prizes, for instance how much money a team would win.
 --- This also checks if the Placement instance has a dollar reward and assigns a variable if so.
 function Placement:_readPrizeRewards(args)

--- a/components/prize_pool/commons/prize_pool_placement_base.lua
+++ b/components/prize_pool/commons/prize_pool_placement_base.lua
@@ -123,7 +123,7 @@ function Placement:_shouldAddTbdOpponent(opponentIndex, place)
 end
 
 function Placement:readAdditionalData(args)
-	error('Function readAdditionalData needs to be set via the module that requires "Module:PrizePool/Placement/Base"')
+	error('Function readAdditionalData needs to be implemented by child class of `PrizePool/Placement/Base`')
 end
 
 function Placement:parseOpponentArgs(input, date)

--- a/components/prize_pool/commons/prize_pool_placement_base.lua
+++ b/components/prize_pool/commons/prize_pool_placement_base.lua
@@ -16,16 +16,15 @@ local Opponent = require('Module:OpponentLibraries').Opponent
 
 local PRIZE_TYPE_BASE_CURRENCY = 'BASE_CURRENCY'
 
---- @class Placement
---- A Placement is a set of opponents who all share the same final place/award in the tournament.
+--- @class BasePlacement
+--- A BasePlacement is a set of opponents who all share the same final place/award in the tournament.
 --- Its input is generally a table created by `Template:Slot`.
 --- It has a range from placeStart to placeEnd (e.g. 5 to 8) or a slotSize (count) or an award.
-local Placement = Class.new(function(self, ...) self:init(...) end)
+local BasePlacement = Class.new(function(self, ...) self:init(...) end)
 
---- @class Placement
 --- @param args table Input information
---- @param parent PrizePool The PrizePool this Placement is part of
-function Placement:init(args, parent)
+--- @param parent PrizePool The PrizePool this BasePlacement is part of
+function BasePlacement:init(args, parent)
 	self.args = Table.deepCopy(args)
 	self.parent = parent
 	self.prizeTypes = parent.prizeTypes
@@ -38,8 +37,8 @@ function Placement:init(args, parent)
 end
 
 --- Parse the input for available rewards of prizes, for instance how much money a team would win.
---- This also checks if the Placement instance has a dollar reward and assigns a variable if so.
-function Placement:_readPrizeRewards(args)
+--- This also checks if the BasePlacement instance has a dollar reward and assigns a variable if so.
+function BasePlacement:_readPrizeRewards(args)
 	local rewards = {}
 
 	-- Loop through all prizes that have been defined in the header
@@ -72,7 +71,7 @@ function Placement:_readPrizeRewards(args)
 	return rewards
 end
 
-function Placement:parseOpponents(args)
+function BasePlacement:parseOpponents(args)
 	return Array.mapIndexes(function(opponentIndex)
 		local opponentInput = Json.parseIfString(args[opponentIndex])
 		local opponent = {opponentData = {}, prizeRewards = {}, additionalData = {}}
@@ -84,7 +83,7 @@ function Placement:parseOpponents(args)
 			end
 		else
 			-- Set the date
-			if not Placement._isValidDateFormat(opponentInput.date) then
+			if not BasePlacement._isValidDateFormat(opponentInput.date) then
 				opponentInput.date = self.date
 			end
 
@@ -106,7 +105,7 @@ function Placement:parseOpponents(args)
 	end)
 end
 
-function Placement:_shouldAddTbdOpponent(opponentIndex, place)
+function BasePlacement:_shouldAddTbdOpponent(opponentIndex, place)
 	-- We want at least 1 opponent present for all placements
 	if opponentIndex == 1 then
 		return true
@@ -122,11 +121,11 @@ function Placement:_shouldAddTbdOpponent(opponentIndex, place)
 	return false
 end
 
-function Placement:readAdditionalData(args)
+function BasePlacement:readAdditionalData(args)
 	error('Function readAdditionalData needs to be implemented by child class of `PrizePool/Placement/Base`')
 end
 
-function Placement:parseOpponentArgs(input, date)
+function BasePlacement:parseOpponentArgs(input, date)
 	-- Allow for lua-table, json-table and just raw string input
 	local opponentArgs = Json.parseIfTable(input) or (type(input) == 'table' and input or {input})
 	opponentArgs.type = opponentArgs.type or self.parent.opponentType
@@ -147,11 +146,11 @@ function Placement:parseOpponentArgs(input, date)
 end
 
 
-function Placement:getPrizeRewardForOpponent(opponent, prize)
+function BasePlacement:getPrizeRewardForOpponent(opponent, prize)
 	return opponent.prizeRewards[prize] or self.prizeRewards[prize]
 end
 
-function Placement:_setBaseFromRewards(prizesToUse, prizeTypes)
+function BasePlacement:_setBaseFromRewards(prizesToUse, prizeTypes)
 	Array.forEach(self.opponents, function(opponent)
 		if opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] or self.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] then
 			return
@@ -179,11 +178,11 @@ function Placement:_setBaseFromRewards(prizesToUse, prizeTypes)
 end
 
 --- Returns true if the input matches the format of a date
-function Placement._isValidDateFormat(date)
+function BasePlacement._isValidDateFormat(date)
 	if type(date) ~= 'string' or String.isEmpty(date) then
 		return false
 	end
 	return date:match('%d%d%d%d%-%d%d%-%d%d') and true or false
 end
 
-return Placement
+return BasePlacement

--- a/components/prize_pool/commons/prize_pool_placement_base.lua
+++ b/components/prize_pool/commons/prize_pool_placement_base.lua
@@ -1,0 +1,181 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:PrizePool/Placement/Base
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Json = require('Module:Json')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local Opponent = require('Module:OpponentLibraries').Opponent
+
+local PRIZE_TYPE_BASE_CURRENCY = 'BASE_CURRENCY'
+
+--- @class Placement
+--- A Placement is a set of opponents who all share the same final place/award in the tournament.
+--- Its input is generally a table created by `Template:Slot`.
+--- It has a range from placeStart to placeEnd (e.g. 5 to 8) or a slotSize (count) or an award.
+local Placement = Class.new(function(self, ...) self:init(...) end)
+
+--- @class Placement
+--- @param args table Input information
+--- @param parent PrizePool The PrizePool this Placement is part of
+function Placement:init(args, parent)
+	self.args = Table.deepCopy(args)
+	self.parent = parent
+	self.prizeTypes = parent.prizeTypes
+	self.date = self.args.date or parent.date
+	self.hasBaseCurrency = false
+
+	self.prizeRewards = self:_readPrizeRewards(self.args)
+
+	return self
+end
+
+function Placement:parseArgs(args)
+	error('This needs to be set via the module that requires "Module:PrizePool/Placement/Base"')
+end
+
+--- Parse the input for available rewards of prizes, for instance how much money a team would win.
+--- This also checks if the Placement instance has a dollar reward and assigns a variable if so.
+function Placement:_readPrizeRewards(args)
+	local rewards = {}
+
+	-- Loop through all prizes that have been defined in the header
+	Array.forEach(self.parent.prizes, function (prize)
+		local prizeData = self.prizeTypes[prize.type]
+		local fieldName = prizeData.row
+		if not fieldName then
+			return
+		end
+
+		local prizeIndex = prize.index
+		local reward = args[fieldName .. prizeIndex]
+		if prizeIndex == 1 then
+			reward = reward or args[fieldName]
+		end
+		if not reward then
+			return
+		end
+
+		rewards[prize.id] = prizeData.rowParse(self, reward, args, prizeIndex)
+	end)
+
+	-- Special case for Base Currency, as it's not defined in the header.
+	local baseType = self.prizeTypes[PRIZE_TYPE_BASE_CURRENCY]
+	if baseType.row and args[baseType.row] then
+		self.hasBaseCurrency = true
+		rewards[PRIZE_TYPE_BASE_CURRENCY .. 1] = baseType.rowParse(self, args[baseType.row], args, 1)
+	end
+
+	return rewards
+end
+
+function Placement:parseOpponents(args)
+	return Array.mapIndexes(function(opponentIndex)
+		local opponentInput = Json.parseIfString(args[opponentIndex])
+		local opponent = {opponentData = {}, prizeRewards = {}, additionalData = {}}
+		if not opponentInput then
+			if self:shouldAddTbdOpponent(opponentIndex) then
+				opponent.opponentData = Opponent.tbd(self.parent.opponentType)
+			else
+				return
+			end
+		else
+			-- Set the date
+			if not Placement._isValidDateFormat(opponentInput.date) then
+				opponentInput.date = self.date
+			end
+
+			-- Parse Opponent Data
+			if opponentInput.type then
+				self.parent:assertOpponentStructType(opponentInput)
+			else
+				opponentInput.type = self.parent.opponentType
+			end
+			opponent.opponentData = self:parseOpponentArgs(opponentInput, opponentInput.date)
+
+			opponent.prizeRewards = self:_readPrizeRewards(opponentInput)
+			opponent.additionalData = self:readAdditionalData(opponentInput)
+
+			-- Set date
+			opponent.date = opponentInput.date
+		end
+		return opponent
+	end)
+end
+
+function Placement:shouldAddTbdOpponent(args)
+	error('Function shouldAddTbdOpponent needs to be set via the module that requires "Module:PrizePool/Placement/Base"')
+end
+
+function Placement:readAdditionalData(args)
+	error('Function readAdditionalData needs to be set via the module that requires "Module:PrizePool/Placement/Base"')
+end
+
+function Placement:parseOpponentArgs(input, date)
+	-- Allow for lua-table, json-table and just raw string input
+	local opponentArgs = Json.parseIfTable(input) or (type(input) == 'table' and input or {input})
+	opponentArgs.type = opponentArgs.type or self.parent.opponentType
+	assert(Opponent.isType(opponentArgs.type), 'Invalid type')
+
+	local opponentData
+	if type(opponentArgs[1]) == 'table' and opponentArgs[1].isAlreadyParsed then
+		opponentData = opponentArgs[1]
+	elseif type(opponentArgs[1]) ~= 'table' then
+		opponentData = Opponent.readOpponentArgs(opponentArgs)
+	end
+
+	if not opponentData or (Opponent.isTbd(opponentData) and opponentData.type ~= Opponent.literal) then
+		opponentData = Table.deepMergeInto(Opponent.tbd(opponentArgs.type), opponentData or {})
+	end
+
+	return Opponent.resolve(opponentData, date, {syncPlayer = self.parent.options.syncPlayers})
+end
+
+
+function Placement:getPrizeRewardForOpponent(opponent, prize)
+	return opponent.prizeRewards[prize] or self.prizeRewards[prize]
+end
+
+function Placement:_setBaseFromRewards(prizesToUse, prizeTypes)
+	Array.forEach(self.opponents, function(opponent)
+		if opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] or self.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] then
+			return
+		end
+
+		local baseReward = 0
+		Array.forEach(prizesToUse, function(prize)
+			local localMoney = opponent.prizeRewards[prize.id] or self.prizeRewards[prize.id]
+
+			if not localMoney or localMoney <= 0 then
+				return
+			end
+
+			baseReward = baseReward + prizeTypes[prize.type].convertToBaseCurrency(
+				prize.data,
+				localMoney,
+				opponent.date,
+				self.parent.options.currencyRatePerOpponent
+			)
+			self.parent.usedAutoConvertedCurrency = true
+		end)
+
+		opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] = baseReward
+	end)
+end
+
+--- Returns true if the input matches the format of a date
+function Placement._isValidDateFormat(date)
+	if type(date) ~= 'string' or String.isEmpty(date) then
+		return false
+	end
+	return date:match('%d%d%d%d%-%d%d%-%d%d') and true or false
+end
+
+return Placement


### PR DESCRIPTION
## Summary
Prepare PrizePool/Placement for standardized Awards Prize Pools with a refactor
-> split functions shareable between both normal and awards prize pool placements into a base module that gets used to init the placment class that then gets extended in `Module:PrizePool/Placement`

## How did you test this change?
dev

## Steps towards standardized Awards Table
1. Prepare PrizePool/Placement (split into base and specifics for non awards)
2. Prepare PrizePool (split into base and specifics for non awards)
   - https://liquipedia.net/commons/Module:PrizePool/refactor (replaces the current one)
   - https://liquipedia.net/commons/Module:PrizePool/Base (as base)
   - to avoid merge conflicts and rebases open PR after merge of this one
3. Build PrizePool/Awards and PrizePool/Award/Placement (sep. PRs)
   - https://liquipedia.net/commons/Module:PrizePool/Award
   - https://liquipedia.net/commons/Module:PrizePool/Award/Placement
4. Add /Customs (with a default on commons)
   - https://liquipedia.net/commons/Module:PrizePool/Award/Custom
   - https://liquipedia.net/commons/Module:PrizePool/Award/Starcraft
   - https://liquipedia.net/starcraft2/Module:PrizePool/Award/Custom
5. Look into legacy conversion (commons, sc/sc2, possibly customs?)
   - https://liquipedia.net/commons/index.php?title=Module%3APrizePool%2FLegacy%2Fdev&type=revision&diff=478942&oldid=474906
   - https://liquipedia.net/commons/index.php?title=Module%3APrizePool%2FLegacy%2FStarcraft%2Fdev&type=revision&diff=478941&oldid=471314
   - check if there are customs that need adjusting (unlikely except for warcraft)
