### PR TITLE
Add FIFA Opponent/Custom

### DIFF
--- a/components/opponent/wikis/fifa/opponent_custom.lua
+++ b/components/opponent/wikis/fifa/opponent_custom.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- wiki=fifa
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local PlayerExt = Lua.import('Module:Player/Ext', {requireDevIfEnabled = true})
+
+local CustomOpponent = Table.deepCopy(Opponent)
+
+function CustomOpponent.resolve(opponent, date, options)
+	options = options or {}
+	Opponent.resolve(opponent, date, options)
+	if Opponent.typeIsParty(opponent.type) then
+		for _, player in ipairs(opponent.players) do
+			if not player.team and options.syncPlayer then
+				player.team = PlayerExt.syncTeam(player.pageName, nil)
+			end
+		end
+	end
+	return opponent
+end
+
+return CustomOpponent

--- a/components/opponent/wikis/fifa/opponent_custom.lua
+++ b/components/opponent/wikis/fifa/opponent_custom.lua
@@ -20,7 +20,7 @@ function CustomOpponent.resolve(opponent, date, options)
 	if Opponent.typeIsParty(opponent.type) then
 		for _, player in ipairs(opponent.players) do
 			if not player.team and options.syncPlayer then
-				player.team = PlayerExt.syncTeam(player.pageName, nil)
+				player.team = PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), nil)
 			end
 		end
 	end

--- a/standard/info/wikis/fifa/info.lua
+++ b/standard/info/wikis/fifa/info.lua
@@ -392,4 +392,5 @@ return {
 	defaultGame = 'fifa',
 	defaultTeamLogo = 'FIFA lightmode logo.png', ---@deprecated
 	defaultTeamLogoDark = 'FIFA darkmode logo.png', ---@deprecated
+	opponentLibrary = 'Opponent/Custom',
 }


### PR DESCRIPTION
## Summary
The Goal of this is related to implementing New Prize Pool for FIFA, but add features to allow Teams and Flags to be retrieved automatically from either the player page which already have data points set 

or a Hidden {{OpponentList}} (similar to Clash Royale)

**Includes both Info and Opponent/Custom, the latter is a clean port of Clash Royale**

## Side Note 
**PrizePool/Custom** will come later maybe tmr or something.