### PR TITLE
Adjust a game key in arenafps module info

### DIFF
--- a/standard/info/wikis/arenafps/info.lua
+++ b/standard/info/wikis/arenafps/info.lua
@@ -388,8 +388,8 @@ return {
 				lightMode = 'Warsow logo.png',
 			},
 		},
-		xon = {
-			abbreviation = 'xon',
+		xo = {
+			abbreviation = 'xo',
 			name = 'Xonotic',
 			link = 'Xonotic',
 			logo = {


### PR DESCRIPTION
changed xon to xo for Xonotic.

Results for players show "?" for the Xonotic game.