### PR TITLE
Fix query to use pagename if in mainspace

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -13,6 +13,7 @@ local Game = require('Module:Game')
 local Info = require('Module:Info')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Namespace = require('Module:Namespace')
 local Page = require('Module:Page')
 local PlayerIntroduction = require('Module:PlayerIntroduction')
 local Region = require('Module:Region')
@@ -368,7 +369,7 @@ function CustomPlayer._getLatestPlacement(game)
 end
 
 function CustomPlayer._buildPlacementConditions()
-	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
+	local person = CustomPlayer._getPersonQuery()
 
 	local opponentConditions = ConditionTree(BooleanOperator.any)
 
@@ -384,7 +385,7 @@ function CustomPlayer._buildPlacementConditions()
 end
 
 function CustomPlayer._getBroadcastGames()
-	local person = mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
+	local person = CustomPlayer._getPersonQuery()
 	local personCondition = ConditionTree(BooleanOperator.any)
 		:add{
 			ConditionNode(ColumnName('page'), Comparator.eq, person),
@@ -414,6 +415,14 @@ function CustomPlayer._getBroadcastGames()
 		end
 	end
 	return games
+end
+
+function CustomPlayer._getPersonQuery()
+	if Namespace.isMain() then
+		return _player.pagename
+	else
+		return mw.ext.TeamLiquidIntegration.resolve_redirect(_args.id)
+	end
 end
 
 return CustomPlayer


### PR DESCRIPTION
## Summary
In case of name clashes, IDs don't match page names, so querying by ID does not work. This fixes the problem by using the pagename if in mainspace.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
/dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
