### PR TITLE
Add another wiki-variable for Fighters' league

### DIFF
--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -135,6 +135,7 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('circuittier', _args.circuittier)
 	Variables.varDefine('circuitabbr', _args.circuitabbr)
 	Variables.varDefine('seriesabbr', _args.abbreviation)
+	Variables.varDefine('tournament_link', self.pagename)
 
 	-- Legacy vars
 	Variables.varDefine('tournament_tier', _args.liquipediatier or '')


### PR DESCRIPTION
## Summary
Missing wiki-variable during the migration.

## How did you test this change?
Live