### PR TITLE
Add all missing games in Fighters Info

### DIFF
--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -14,18 +14,1604 @@ return {
 		fighters = {
 			abbreviation = 'Fighters',
 			name = 'Fighters',
-			link = 'Fighters',
+			link = 'Main Page',
 			logo = {
-				darkMode = 'Fistlogo std.png', --not dark mode friendly
-				lightMode = 'Fistlogo std.png',
+				darkMode = 'Fighters default darkmode.png',
+				lightMode = 'Fighters default lightmode.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Fistlogo std.png', --not dark mode friendly
-				lightMode = 'Fistlogo std.png',
+				darkMode = 'Fighters default darkmode.png',
+				lightMode = 'Fighters default lightmode.png',
+			},
+		},
+		multiple = {
+			abbreviation = 'Multiple',
+			name = 'Multiple Games',
+			link = 'Main Page',
+			logo = {
+				darkMode = 'Fighters default darkmode.png',
+				lightMode = 'Fighters default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Fighters default darkmode.png',
+				lightMode = 'Fighters default lightmode.png',
+			},
+		},
+		abk = {
+			abbreviation = 'ABK',
+			name = 'Akatsuki Blitzkampf',
+			link = 'Akatsuki Blitzkampf',
+			logo = {
+				darkMode = 'ABK Ausf Achse Logo.png',
+				lightMode = 'ABK Ausf Achse Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'ABK Ausf Achse Logo.png',
+				lightMode = 'ABK Ausf Achse Logo.png',
+			},
+		},
+		ah3 = {
+			abbreviation = 'AH3',
+			name = 'Arcana Heart 3',
+			link = 'Arcana Heart 3',
+			logo = {
+				darkMode = 'Arcana Heart 3 default allmode.png',
+				lightMode = 'Arcana Heart 3 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Arcana Heart 3 default allmode.png',
+				lightMode = 'Arcana Heart 3 default allmode.png',
+			},
+		},
+		ah3x = {
+			abbreviation = 'AH3X',
+			name = 'Arcana Heart 3: Love Max Six Stars Xtend',
+			link = 'Arcana Heart 3: Love Max Six Stars Xtend',
+			logo = {
+				darkMode = 'AH3 Xtend Logo.png',
+				lightMode = 'AH3 Xtend Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'AH3 Xtend Logo.png',
+				lightMode = 'AH3 Xtend Logo.png',
+			},
+		},
+		arms = {
+			abbreviation = 'ARMS',
+			name = 'ARMS',
+			link = 'ARMS',
+			logo = {
+				darkMode = 'ARMS default allmode.png',
+				lightMode = 'ARMS default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'ARMS default allmode.png',
+				lightMode = 'ARMS default allmode.png',
+			},
+		},
+		bbcf = {
+			abbreviation = 'BBCF',
+			name = 'BlazBlue: Central Fiction',
+			link = 'BlazBlue: Central Fiction',
+			logo = {
+				darkMode = 'BBCF Logo.png',
+				lightMode = 'BBCF Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'BBCF Logo.png',
+				lightMode = 'BBCF Logo.png',
+			},
+		},
+		bbcp = {
+			abbreviation = 'BBCP',
+			name = 'BlazBlue: Chrono Phantasma',
+			link = 'BlazBlue: Chrono Phantasma',
+			logo = {
+				darkMode = 'BBCP Logo.png',
+				lightMode = 'BBCP Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'BBCP Logo.png',
+				lightMode = 'BBCP Logo.png',
+			},
+		},
+		bbcpe = {
+			abbreviation = 'BBCPE',
+			name = 'BlazBlue: Chrono Phantasma Extend',
+			link = 'BlazBlue: Chrono Phantasma Extend',
+			logo = {
+				darkMode = 'BBCPE logo.png',
+				lightMode = 'BBCPE logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'BBCPE logo.png',
+				lightMode = 'BBCPE logo.png',
+			},
+		},
+		bbctb = {
+			abbreviation = 'BBCTB',
+			name = 'BlazBlue: Cross Tag Battle',
+			link = 'BlazBlue: Cross Tag Battle',
+			logo = {
+				darkMode = 'BBCTB Logo.png',
+				lightMode = 'BBCTB Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'BBCTB Logo.png',
+				lightMode = 'BBCTB Logo.png',
+			},
+		},
+		bbct = {
+			abbreviation = 'BBCT',
+			name = 'BlazBlue: Calamity Trigger',
+			link = 'BlazBlue: Calamity Trigger',
+			logo = {
+				darkMode = 'BBCT Logo.png',
+				lightMode = 'BBCT Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'BBCT Logo.png',
+				lightMode = 'BBCT Logo.png',
+			},
+		},
+		bbcs = {
+			abbreviation = 'BBCS',
+			name = 'BlazBlue: Continuum Shift',
+			link = 'BlazBlue: Continuum Shift',
+			logo = {
+				darkMode = 'BBCT Logo.png',
+				lightMode = 'BBCT Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'BBCT Logo.png',
+				lightMode = 'BBCT Logo.png',
+			},
+		},
+		bbcs2 = {
+			abbreviation = 'BBCS 2',
+			name = 'BlazBlue: Continuum Shift II',
+			link = 'BlazBlue: Continuum Shift II',
+			logo = {
+				darkMode = 'BlazBlue Continuum Shift II Logo.png',
+				lightMode = 'BlazBlue Continuum Shift II Logo.png ',
+			},
+			defaultTeamLogo = {
+				darkMode = 'BlazBlue Continuum Shift II Logo.png',
+				lightMode = 'BlazBlue Continuum Shift II Logo.png ',
+			},
+		},
+		bftg = {
+			abbreviation = 'BFTG',
+			name = 'Power Rangers: Battle for the Grid',
+			link = 'Power Rangers: Battle for the Grid',
+			logo = {
+				darkMode = 'Power Rangers default allmode.png',
+				lightMode = 'Power Rangers default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Power Rangers default allmode.png',
+				lightMode = 'Power Rangers default allmode.png',
+			},
+		},
+		brpf = {
+			abbreviation = 'BRPF',
+			name = 'Bloody Roar: Primal Fury',
+			link = 'Bloody Roar: Primal Fury',
+			logo = {
+				darkMode = 'Bloody Roar Primal Fury logo.png',
+				lightMode = 'Bloody Roar Primal Fury logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Bloody Roar Primal Fury logo.png',
+				lightMode = 'Bloody Roar Primal Fury logo.png',
+			},
+		},
+		cvs = {
+			abbreviation = 'CVS',
+			name = 'Capcom vs SNK',
+			link = 'Capcom vs SNK',
+			logo = {
+				darkMode = 'Capcom vs SNK Logo.png',
+				lightMode = 'Capcom vs SNK Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Capcom vs SNK Logo.png',
+				lightMode = 'Capcom vs SNK Logo.png',
+			},
+		},
+		cvs2 = {
+			abbreviation = 'CVS2',
+			name = 'Capcom vs SNK 2',
+			link = 'Capcom vs SNK 2',
+			logo = {
+				darkMode = 'Capcom vs SNK 2logo.png',
+				lightMode = 'Capcom vs SNK 2logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Capcom vs SNK 2logo.png',
+				lightMode = 'Capcom vs SNK 2logo.png',
+			},
+		},
+		svc = {
+			abbreviation = 'SVC Chaos',
+			name = 'SNK vs. Capcom: SVC Chaos',
+			link = 'SNK vs. Capcom: SVC Chaos',
+			logo = {
+				darkMode = 'SVC Chaos default allmode.png',
+				lightMode = 'SVC Chaos default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SVC Chaos default allmode.png',
+				lightMode = 'SVC Chaos default allmode.png',
+			},
+		},
+		dbfz = {
+			abbreviation = 'DBFZ',
+			name = 'Dragon Ball FighterZ',
+			link = 'Dragon Ball FighterZ',
+			logo = {
+				darkMode = 'DBFZ Logo.png',
+				lightMode = 'DBFZ Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'DBFZ Logo.png',
+				lightMode = 'DBFZ Logo.png',
+			},
+		},
+		dfc = {
+			abbreviation = 'DBFC',
+			name = 'Dengeki Bunko Fighting Climax',
+			link = 'Dengeki Bunko Fighting Climax',
+			logo = {
+				darkMode = 'DBFC Logo.png',
+				lightMode = 'DBFC Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'DBFC Logo.png',
+				lightMode = 'DBFC Logo.png',
+			},
+		},
+		divekick = {
+			abbreviation = 'DiveKick',
+			name = 'DiveKick',
+			link = 'DiveKick',
+			logo = {
+				darkMode = 'DiveKick.png',
+				lightMode = 'DiveKick.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'DiveKick.png',
+				lightMode = 'DiveKick.png',
+			},
+		},
+		dnfduel = {
+			abbreviation = 'DNF Duel',
+			name = 'DNF Duel',
+			link = 'DNF Duel',
+			logo = {
+				darkMode = 'DNF Duel Logo.png',
+				lightMode = 'DNF Duel Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'DNF Duel Logo.png',
+				lightMode = 'DNF Duel Logo.png',
+			},
+		},
+		doa4 = {
+			abbreviation = 'DOA 4',
+			name = 'Dead or Alive 4',
+			link = 'Dead or Alive 4',
+			logo = {
+				darkMode = 'DOA4 default allmode.png',
+				lightMode = 'DOA4 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'DOA4 default allmode.png',
+				lightMode = 'DOA4 default allmode.png',
+			},
+		},
+		doa5 = {
+			abbreviation = 'DOA 5',
+			name = 'Dead or Alive 5',
+			link = 'Dead or Alive 5',
+			logo = {
+				darkMode = 'DOA5 default allmode.png',
+				lightMode = 'DOA5 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'DOA5 default allmode.png',
+				lightMode = 'DOA 5default allmode.png',
+			},
+		},
+		doa6 = {
+			abbreviation = 'DOA 6',
+			name = 'Dead or Alive 6',
+			link = 'Dead or Alive 6',
+			logo = {
+				darkMode = 'DOA6 default allmode.png',
+				lightMode = 'DOA6 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'DOA6 default allmode.png',
+				lightMode = 'DOA6 default allmode.png',
+			},
+		},
+		efz = {
+			abbreviation = 'EFZ',
+			name = 'Eternal Fighter Zero',
+			link = 'Eternal Fighter Zero',
+			logo = {
+				darkMode = 'Eternal Fighter Zero Logo.png',
+				lightMode = 'Eternal Fighter Zero Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Eternal Fighter Zero Logo.png',
+				lightMode = 'Eternal Fighter Zero Logo.png',
+			},
+		},
+		fexl = {
+			abbreviation = 'FEXL',
+			name = 'Fighting EX Layer',
+			link = 'Fighting EX Layer',
+			logo = {
+				darkMode = 'FEXL.png',
+				lightMode = 'FEXL.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'FEXL.png',
+				lightMode = 'FEXL.png',
+			},
+		},
+		fhd = {
+			abbreviation = 'FHD',
+			name = 'Fighters History Dynamite',
+			link = 'Fighters History Dynamite',
+			logo = {
+				darkMode = 'Fighters History Dynamite logo.png',
+				lightMode = 'Fighters History Dynamite logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Fighters History Dynamite logo.png',
+				lightMode = 'Fighters History Dynamite logo.png',
+			},
+		},
+		fs = {
+			abbreviation = 'FS',
+			name = 'Fantasy Strike',
+			link = 'Fantasy Strike',
+			logo = {
+				darkMode = 'FS Logo.png',
+				lightMode = 'FS Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'FS Logo.png',
+				lightMode = 'FS Logo.png',
+			},
+		},
+		foa = {
+			abbreviation = 'FoA',
+			name = 'Fight of Animals',
+			link = 'Fight of Animals',
+			logo = {
+				darkMode = 'Fight of Animals Logo.png',
+				lightMode = 'Fight of Animals Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Fight of Animals Logo.png',
+				lightMode = 'Fight of Animals Logo.png',
+			},
+		},
+		gbvs = {
+			abbreviation = 'GBFVS',
+			name = 'Granblue Fantasy: Versus',
+			link = 'Granblue Fantasy: Versus',
+			logo = {
+				darkMode = 'GBFVS Logo.png',
+				lightMode = 'GBFVS Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GBFVS Logo.png',
+				lightMode = 'GBFVS Logo.png',
+			},
+		},
+		gbvsr = {
+			abbreviation = 'GBVS:R',
+			name = 'Granblue Fantasy Versus: Rising',
+			link = 'Granblue Fantasy Versus: Rising',
+			logo = {
+				darkMode = 'GBVS Rising Logo.png',
+				lightMode = 'GBVS Rising Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GBVS Rising Logo.png',
+				lightMode = 'GBVS Rising Logo.png',
+			},
+		},
+		gevsmbon = {
+			abbreviation = 'EXVS:MBON',
+			name = 'Mobile Suit Gundam EXTREME VS. Maxi Boost ON',
+			link = 'Mobile Suit Gundam EXTREME VS. Maxi Boost ON',
+			logo = {
+				darkMode = 'Gundam EXVS Maxiboost ON default allmode.png',
+				lightMode = 'Gundam EXVS Maxiboost ON default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Gundam EXVS Maxiboost ON default allmode.png',
+				lightMode = 'Gundam EXVS Maxiboost ON default allmode.png',
+			},
+		},
+		gg = {
+			abbreviation = 'gg',
+			name = 'Guilty Gear',
+			link = 'Guilty Gear',
+			logo = {
+				darkMode = 'Guilty Gear logo.png',
+				lightMode = 'Guilty Gear logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Guilty Gear logo.png',
+				lightMode = 'Guilty Gear logo.png',
+			},
+		},
+		ggxx = {
+			abbreviation = 'GG XX',
+			name = 'Guilty Gear XX',
+			link = 'Guilty Gear XX',
+			logo = {
+				darkMode = 'Guilty Gear XX Logo.png',
+				lightMode = 'Guilty Gear XX Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Guilty Gear XX Logo.png',
+				lightMode = 'Guilty Gear XX Logo.png',
+			},
+		},
+		ggxxacp = {
+			abbreviation = 'GGXX ACP',
+			name = 'Guilty Gear XX Accent Core Plus',
+			link = 'Guilty Gear XX Accent Core Plus',
+			logo = {
+				darkMode = 'GGXXAC+ Logo.png',
+				lightMode = 'GGXXAC+ Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXXAC+ Logo.png',
+				lightMode = 'GGXXAC+ Logo.png',
+			},
+		},
+		ggxxacpr = {
+			abbreviation = 'GGXX ACP R',
+			name = 'Guilty Gear XX Accent Core Plus R',
+			link = 'Guilty Gear XX Accent Core Plus R',
+			logo = {
+				darkMode = 'GGXXACPR-logo.png',
+				lightMode = 'GGXXACPR-logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXXACPR-logo.png',
+				lightMode = 'GGXXACPR-logo.png',
+			},
+		},
+		ggxrd = {
+			abbreviation = 'GG XRD',
+			name = 'Guilty Gear Xrd -SIGN-',
+			link = 'Guilty Gear Xrd -SIGN-',
+			logo = {
+				darkMode = 'GGXrdSign Logo.png',
+				lightMode = 'GGXrdSign Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXrdSign Logo.png',
+				lightMode = 'GGXrdSign Logo.png',
+			},
+		},
+		ggx2r = {
+			abbreviation = 'GG X2R',
+			name = 'Guilty Gear X2 Reload',
+			link = 'Guilty Gear X2 Reload',
+			logo = {
+				darkMode = 'GGXX2R Logo.png',
+				lightMode = 'GGXX2R Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXX2R Logo.png',
+				lightMode = 'v',
+			},
+		},
+		ggxxs = {
+			abbreviation = 'GG XXS',
+			name = 'Guilty Gear XX Slash',
+			link = 'Guilty Gear XX Slash',
+			logo = {
+				darkMode = 'GGXXS Logo.png',
+				lightMode = 'GGXXS Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXXS Logo.png',
+				lightMode = 'GGXXS Logo.png',
+			},
+		},
+		ggxrdr = {
+			abbreviation = 'GG XRD R',
+			name = 'Guilty Gear Xrd -Revelator-',
+			link = 'Guilty Gear Xrd -Revelator-',
+			logo = {
+				darkMode = 'GGXrdR.png',
+				lightMode = 'GGXrdR.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXrdR.png',
+				lightMode = 'GGXrdR.png',
+			},
+		},
+		ggxrdr2 = {
+			abbreviation = 'GG XRD R2',
+			name = 'GUILTY GEAR Xrd REV 2',
+			link = 'GUILTY GEAR Xrd REV 2',
+			logo = {
+				darkMode = 'GGXrdR2 Logo.png',
+				lightMode = 'GGXrdR2 Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXrdR2 Logo.png',
+				lightMode = 'GGXrdR2 Logo.png',
+			},
+		},
+		ggst = {
+			abbreviation = 'GGST',
+			name = 'GUILTY GEAR -STRIVE-',
+			link = 'GUILTY GEAR -STRIVE-',
+			logo = {
+				darkMode = 'Guilty Gear Strive default darkmode.png',
+				lightMode = 'Guilty Gear Strive default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Guilty Gear Strive default darkmode.png',
+				lightMode = 'Guilty Gear Strive default lightmode.png',
+			},
+		},
+		gmotw = {
+			abbreviation = 'Garou 1',
+			name = 'Garou: Mark of the Wolves',
+			link = 'Garou: Mark of the Wolves',
+			logo = {
+				darkMode = 'GMOTW Logo.png',
+				lightMode = 'GMOTW Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GMOTW Logo.png',
+				lightMode = 'GMOTW Logo.png',
+			},
+		},
+		hsfii = {
+			abbreviation = 'HSFII',
+			name = 'Hyper Street Fighter II',
+			link = 'Hyper Street Fighter II',
+			logo = {
+				darkMode = 'HSFII Logo.png',
+				lightMode = 'HSFII Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'HSFII Logo.png',
+				lightMode = 'HSFII Logo.png',
+			},
+		},
+		igau = {
+			abbreviation = 'Injustice 1',
+			name = 'Injustice: Gods Among Us',
+			link = 'Injustice: Gods Among Us',
+			logo = {
+				darkMode = 'Injustice Logo.png',
+				lightMode = 'Injustice Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Injustice Logo.png',
+				lightMode = 'Injustice Logo.png',
+			},
+		},
+		i2 = {
+			abbreviation = 'Injustice 2',
+			name = 'Injustice 2',
+			link = 'Injustice 2',
+			logo = {
+				darkMode = 'Injustice 2 default darkmode.png',
+				lightMode = 'Injustice 2 default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Injustice 2 default darkmode.png',
+				lightMode = 'Injustice 2 default lightmode.png',
+			},
+		},
+		ki = {
+			abbreviation = 'KI',
+			name = 'Killer Instinct',
+			link = 'Killer Instinct',
+			logo = {
+				darkMode = 'Killer Instinct default allmode.png',
+				lightMode = 'Killer Instinct default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Killer Instinct default allmode.png',
+				lightMode = 'Killer Instinct default allmode.png',
+			},
+		},
+		klkif = {
+			abbreviation = 'KLK - IF',
+			name = 'KILL la KILL - IF',
+			link = 'KILL la KILL - IF',
+			logo = {
+				darkMode = 'KILL la KILL - IF default allmode.png',
+				lightMode = 'KILL la KILL - IF default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KILL la KILL - IF default allmode.png',
+				lightMode = 'KILL la KILL - IF default allmode.png',
+			},
+		},
+		hnk = {
+			abbreviation = 'HNK',
+			name = 'Hokuto no Ken',
+			link = 'Hokuto no Ken',
+			logo = {
+				darkMode = 'Hokuto no Ken logo.png',
+				lightMode = 'Hokuto no Ken logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Hokuto no Ken logo.png',
+				lightMode = 'Hokuto no Ken logo.png',
+			},
+		},
+		llb = {
+			abbreviation = 'LL Blaze',
+			name = 'Lethal League Blaze',
+			link = 'Lethal League Blaze',
+			logo = {
+				darkMode = 'Lethal League Blaze default allmode.png',
+				lightMode = 'Lethal League Blaze default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Lethal League Blaze default allmode.png',
+				lightMode = 'Lethal League Blaze default allmode.png',
+			},
+		},
+		kof98 = {
+			abbreviation = 'KOF98',
+			name = 'The King of Fighters 98',
+			link = 'The King of Fighters 98',
+			logo = {
+				darkMode = 'KOF 98 default darkmode.png',
+				lightMode = 'KOF 98 default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KOF 98 default darkmode.png',
+				lightMode = 'KOF 98 default lightmode.png',
+			},
+		},
+		kof98um = {
+			abbreviation = 'KOF98 UM',
+			name = 'The King of Fighters 98 Ultimate Match',
+			link = 'The King of Fighters 98 Ultimate Match',
+			logo = {
+				darkMode = 'KOF 98 UM default allmode.png',
+				lightMode = 'KOF 98 UM default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KOF 98 UM default allmode.png',
+				lightMode = 'KOF 98 UM default allmode.png',
+			},
+		},
+		kof2002um = {
+			abbreviation = 'KOF02 UM',
+			name = 'The King of Fighters 2002 Unlimited Match',
+			link = 'The King of Fighters 2002 Unlimited Match',
+			logo = {
+				darkMode = 'KOF 2002 UM default darkmode.png',
+				lightMode = 'KOF 2002 UM default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KOF 2002 UM default darkmode.png',
+				lightMode = 'KOF 2002 UM default lightmode.png',
+			},
+		},
+		kof2002 = {
+			abbreviation = 'KOF02',
+			name = 'The King of Fighters 2002',
+			link = 'The King of Fighters 2002',
+			logo = {
+				darkMode = 'KOF 2002 default allmode.png',
+				lightMode = 'KOF 2002 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KOF 2002 default allmode.png',
+				lightMode = 'KOF 2002 default allmode.png',
+			},
+		},
+		kofxiii = {
+			abbreviation = 'KOF XIII',
+			name = 'The King of Fighters XIII',
+			link = 'The King of Fighters XIII',
+			logo = {
+				darkMode = 'KOF13 Logo.png',
+				lightMode = 'KOF13 Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KOF13 Logo.png',
+				lightMode = 'KOF13 Logo.png',
+			},
+		},
+		kofxiv = {
+			abbreviation = 'KOF XIV',
+			name = 'The King of Fighters XIV',
+			link = 'The King of Fighters XIV',
+			logo = {
+				darkMode = 'King of Fighters XIV.png',
+				lightMode = 'King of Fighters XIV.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'King of Fighters XIV.png',
+				lightMode = 'King of Fighters XIV.png',
+			},
+		},
+		kofxv = {
+			abbreviation = 'KOF XV',
+			name = 'The King of Fighters XV',
+			link = 'The King of Fighters XV',
+			logo = {
+				darkMode = 'KoFXV Logo.png',
+				lightMode = 'KoFXV Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KoFXV Logo.png',
+				lightMode = 'KoFXV Logo.png',
+			},
+		},
+		jojohftf = {
+			abbreviation = 'JoJo HFTF',
+			name = 'JoJo\'s Bizarre Adventure: Heritage for the Future',
+			link = 'JoJo\'s Bizarre Adventure: Heritage for the Future',
+			logo = {
+				darkMode = 'JoJo\'s Bizarre Adventure Heritage for the Future logo.png',
+				lightMode = 'JoJo\'s Bizarre Adventure Heritage for the Future logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'JoJo\'s Bizarre Adventure Heritage for the Future logo.png',
+				lightMode = 'JoJo\'s Bizarre Adventure Heritage for the Future logo.png',
+			},
+		},
+		jojoasb = {
+			abbreviation = 'JoJo ASB',
+			name = 'JoJo\'s Bizarre Adventure: All-Star Battle',
+			link = 'JoJo\'s Bizarre Adventure: All-Star Battle',
+			logo = {
+				darkMode = 'JoJo\'s Bizarre Adventure All-Star Battle logo.png',
+				lightMode = 'JoJo\'s Bizarre Adventure All-Star Battle logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'JoJo\'s Bizarre Adventure All-Star Battle logo.png',
+				lightMode = 'JoJo\'s Bizarre Adventure All-Star Battle logo.png',
+			},
+		},
+		maab = {
+			abbreviation = 'MAAB',
+			name = 'Million Arthur Arcana Blood',
+			link = 'Million Arthur Arcana Blood',
+			logo = {
+				darkMode = 'Million Arthur Arcana Blood Logo.png',
+				lightMode = 'Million Arthur Arcana Blood Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Million Arthur Arcana Blood Logo.png',
+				lightMode = 'Million Arthur Arcana Blood Logo.png',
+			},
+		},
+		mbaa = {
+			abbreviation = 'MBAA',
+			name = 'Melty Blood: Actress Again',
+			link = 'Melty Blood: Actress Again',
+			logo = {
+				darkMode = 'MBAA Logo.png',
+				lightMode = 'MBAA Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'MBAA Logo.png',
+				lightMode = 'MBAA Logo.png',
+			},
+		},
+		mbaacc = {
+			abbreviation = 'MBAACC',
+			name = 'Melty Blood: Actress Again Current Code',
+			link = 'Melty Blood: Actress Again Current Code',
+			logo = {
+				darkMode = 'MBAACC Logo.png',
+				lightMode = 'MBAACC Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'MBAACC Logo.png',
+				lightMode = 'MBAACC Logo.png',
+			},
+		},
+		mbtl = {
+			abbreviation = 'MBTL',
+			name = 'Melty Blood: Type Lumina',
+			link = 'Melty Blood: Type Lumina',
+			logo = {
+				darkMode = 'Melty Blood Type Lumina Logo.png',
+				lightMode = 'Melty Blood Type Lumina Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Melty Blood Type Lumina Logo.png',
+				lightMode = 'Melty Blood Type Lumina Logo.png',
+			},
+		},
+		mk9 = {
+			abbreviation = 'MK9',
+			name = 'Mortal Kombat (2011)',
+			link = 'Mortal Kombat (2011)',
+			logo = {
+				darkMode = 'Mortal Kombat 9 default allmode.png',
+				lightMode = 'Mortal Kombat 9 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Mortal Kombat 9 default allmode.png',
+				lightMode = 'Mortal Kombat 9 default allmode.png',
+			},
+		},
+		mkx = {
+			abbreviation = 'MKX',
+			name = 'Mortal Kombat X',
+			link = 'Mortal Kombat X',
+			logo = {
+				darkMode = 'Mortal Kombat X default darkmode.png',
+				lightMode = 'Mortal Kombat X default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Mortal Kombat X default darkmode.png',
+				lightMode = 'Mortal Kombat X default lightmode.png',
+			},
+		},
+		mk11 = {
+			abbreviation = 'MK11',
+			name = 'Mortal Kombat 11',
+			link = 'Mortal Kombat 11',
+			logo = {
+				darkMode = 'Mortal Kombat 11 default allmode.png',
+				lightMode = 'Mortal Kombat 11 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Mortal Kombat 11 default allmode.png',
+				lightMode = 'Mortal Kombat 11 default allmode.png',
+			},
+		},
+		mvc2 = {
+			abbreviation = 'MvC 2',
+			name = 'Marvel vs. Capcom 2',
+			link = 'Marvel vs. Capcom 2',
+			logo = {
+				darkMode = 'MVC2 Logo.png',
+				lightMode = 'MVC2 Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'MVC2 Logo.png',
+				lightMode = 'MVC2 Logo.png',
+			},
+		},
+		mvc3 = {
+			abbreviation = 'MvC 3',
+			name = 'Marvel vs. Capcom 3',
+			link = 'Marvel vs. Capcom 3',
+			logo = {
+				darkMode = 'MVC3 default allmode.png',
+				lightMode = 'MVC3 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'MVC3 default allmode.png',
+				lightMode = 'MVC3 default allmode.png',
+			},
+		},
+		umvc3 = {
+			abbreviation = 'UMvC 3',
+			name = 'Ultimate Marvel vs. Capcom 3',
+			link = 'Ultimate Marvel vs. Capcom 3',
+			logo = {
+				darkMode = 'UMVC3 default allmode.png',
+				lightMode = 'UMVC3 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'UMVC3 default allmode.png',
+				lightMode = 'UMVC3 default allmode.png',
+			},
+		},
+		mvc3 = {
+			abbreviation = 'MvCI',
+			name = 'Marvel vs. Capcom: Infinite',
+			link = 'Marvel vs. Capcom: Infinite',
+			logo = {
+				darkMode = 'MVCI Logo.png',
+				lightMode = 'MVCI Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'MVCI Logo.png',
+				lightMode = 'MVCI Logo.png',
+			},
+		},
+		p4a = {
+			abbreviation = 'P4A',
+			name = 'Persona 4 Arena',
+			link = 'Persona 4 Arena',
+			logo = {
+				darkMode = 'P4A Logo.png',
+				lightMode = 'P4A Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'P4A Logo.png',
+				lightMode = 'P4A Logo.png',
+			},
+		},
+		p4au = {
+			abbreviation = 'P4AU',
+			name = 'Persona 4 Arena Ultimax',
+			link = 'Persona 4 Arena Ultimax',
+			logo = {
+				darkMode = 'P4AU Logo.png',
+				lightMode = 'P4AU Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'P4AU Logo.png',
+				lightMode = 'P4AU Logo.png',
+			},
+		},
+		pokken = {
+			abbreviation = 'Pokkén',
+			name = 'Pokkén Tournament',
+			link = 'Pokkén Tournament',
+			logo = {
+				darkMode = 'Pokken Tournament.png',
+				lightMode = 'Pokken Tournament.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Pokken Tournament.png',
+				lightMode = 'Pokken Tournament.png',
+			},
+		},
+		pokkendx = {
+			abbreviation = 'Pokkén DX',
+			name = 'Pokkén Tournament DX',
+			link = 'Pokkén Tournament DX',
+			logo = {
+				darkMode = 'PokkenDX Logo.png',
+				lightMode = 'PokkenDX Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'PokkenDX Logo.png',
+				lightMode = 'PokkenDX Logo.png',
+			},
+		},
+		pj = {
+			abbreviation = 'PJ',
+			name = 'Project Justice',
+			link = 'Project Justice',
+			logo = {
+				darkMode = 'Project Justice logo.png',
+				lightMode = 'Project Justice logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Project Justice logo.png',
+				lightMode = 'Project Justice logo.png',
+			},
+		},
+		pocketbravery = {
+			abbreviation = 'PB',
+			name = 'Pocket Bravery',
+			link = 'Pocket Bravery',
+			logo = {
+				darkMode = 'Pocket Bravery Logo.png',
+				lightMode = 'Pocket Bravery Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Pocket Bravery Logo.png',
+				lightMode = 'Pocket Bravery Logo.png',
+			},
+		},
+		sailormoon = {
+			abbreviation = 'SMS',
+			name = 'Sailor Moon S',
+			link = 'Sailor Moon S',
+			logo = {
+				darkMode = 'Sailor Moon S Logo.png',
+				lightMode = 'Sailor Moon S Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Sailor Moon S Logo.png',
+				lightMode = 'Sailor Moon S Logo.png',
+			},
+		},
+		skullgirls = {
+			abbreviation = 'SKG',
+			name = 'Skullgirls',
+			link = 'Skullgirls',
+			logo = {
+				darkMode = 'Skullgirls.png',
+				lightMode = 'Skullgirls.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Skullgirls.png',
+				lightMode = 'Skullgirls.png',
+			},
+		},
+		ssii = {
+			abbreviation = 'SSII',
+			name = 'Samurai Shodown II',
+			link = 'Samurai Shodown II',
+			logo = {
+				darkMode = 'Samurai Shodown II Logo.png',
+				lightMode = 'Samurai Shodown II Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Samurai Shodown II Logo.png',
+				lightMode = 'Samurai Shodown II Logo.png',
+			},
+		},
+		ssvs = {
+			abbreviation = 'SSVS',
+			name = 'Samurai Shodown V Special',
+			link = 'Samurai Shodown V Special',
+			logo = {
+				darkMode = 'Samurai Shodown V Special Logo.png',
+				lightMode = 'Samurai Shodown V Special Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Samurai Shodown V Special Logo.png',
+				lightMode = 'Samurai Shodown V Special Logo.png',
+			},
+		},
+		ss2019 = {
+			abbreviation = 'SS 2019',
+			name = 'Samurai Shodown (2019)',
+			link = 'Samurai Shodown (2019)',
+			logo = {
+				darkMode = 'Samurai Shodown 2019 default allmode.png',
+				lightMode = 'Samurai Shodown 2019 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Samurai Shodown 2019 default allmode.png',
+				lightMode = 'Samurai Shodown 2019 default allmode.png',
+			},
+		},
+		scii = {
+			abbreviation = 'SCII',
+			name = 'Soulcalibur II',
+			link = 'Soulcalibur II',
+			logo = {
+				darkMode = 'SCII Logo.png',
+				lightMode = 'SCII Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SCII Logo.png',
+				lightMode = 'SCII Logo.png',
+			},
+		},
+		sciv = {
+			abbreviation = 'SCIV',
+			name = 'Soulcalibur IV',
+			link = 'Soulcalibur IV',
+			logo = {
+				darkMode = 'Soulcalibur IV default allmode.png',
+				lightMode = 'Soulcalibur IV default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Soulcalibur IV default allmode.png',
+				lightMode = 'Soulcalibur IV default allmode.png',
+			},
+		},
+		scv = {
+			abbreviation = 'SCV',
+			name = 'Soulcalibur V',
+			link = 'Soulcalibur V',
+			logo = {
+				darkMode = 'Soulcalibur V default allmode.png',
+				lightMode = 'Soulcalibur V default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Soulcalibur V default allmode.png',
+				lightMode = 'Soulcalibur V default allmode.png',
+			},
+		},
+		scvi = {
+			abbreviation = 'SCVI',
+			name = 'Soulcalibur VI',
+			link = 'Soulcalibur VI',
+			logo = {
+				darkMode = 'Soulcalibur VI default darkmode.png',
+				lightMode = 'Soulcalibur VI default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Soulcalibur VI default darkmode.png',
+				lightMode = 'Soulcalibur VI default lightmode.png',
+			},
+		},
+		sfii = {
+			abbreviation = 'SFII',
+			name = 'Street Fighter II',
+			link = 'Street Fighter II',
+			logo = {
+				darkMode = 'SFII default allmode.png',
+				lightMode = 'SFII default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFII default allmode.png',
+				lightMode = 'SFII default allmode.png',
+			},
+		},
+		sfiii = {
+			abbreviation = 'SFIII',
+			name = 'Street Fighter III',
+			link = 'Street Fighter III',
+			logo = {
+				darkMode = 'SFIII Logo.png',
+				lightMode = 'SFIII Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFIII Logo.png',
+				lightMode = 'SFIII Logo.png',
+			},
+		},
+		sfiiis = {
+			abbreviation = '3rd Strike',
+			name = 'Street Fighter III 3rd Strike',
+			link = 'Street Fighter III 3rd Strike',
+			logo = {
+				darkMode = 'SFIII 3rd Strike.png',
+				lightMode = 'SFIII 3rd Strike.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFIII 3rd Strike.png',
+				lightMode = 'SFIII 3rd Strike.png',
+			},
+		},
+		ssfiit = {
+			abbreviation = 'SSFII Turbo',
+			name = 'Super Street Fighter II Turbo',
+			link = 'Super Street Fighter II Turbo',
+			logo = {
+				darkMode = 'SSF2T.png',
+				lightMode = 'SSF2T.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SSF2T.png',
+				lightMode = 'SSF2T.png',
+			},
+		},
+		ssfiithdr = {
+			abbreviation = 'SSFII Turbo HDR',
+			name = 'Super Street Fighter II Turbo HD Remix',
+			link = 'Super Street Fighter II Turbo HD Remix',
+			logo = {
+				darkMode = 'SSFIITHDR Logo.png',
+				lightMode = 'SSFIITHDR Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SSFIITHDR Logo.png',
+				lightMode = 'SSFIITHDR Logo.png',
+			},
+		},
+		sfa2 = {
+			abbreviation = 'SFA 2',
+			name = 'Street Fighter Alpha 2',
+			link = 'Street Fighter Alpha 2',
+			logo = {
+				darkMode = 'SFA2 Logo.png',
+				lightMode = 'SFA2 Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFA2 Logo.png',
+				lightMode = 'SFA2 Logo.png',
+			},
+		},
+		sfa3 = {
+			abbreviation = 'SFA 3',
+			name = 'Street Fighter Alpha 3',
+			link = 'Street Fighter Alpha 3',
+			logo = {
+				darkMode = 'SFA3 Logo.png',
+				lightMode = 'SFA3 Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFA3 Logo.png',
+				lightMode = 'SFA3 Logo.png',
+			},
+		},
+		sfiv = {
+			abbreviation = 'SFIV',
+			name = 'Street Fighter IV',
+			link = 'Street Fighter IV',
+			logo = {
+				darkMode = 'SFIV default allmode.png',
+				lightMode = 'SFIV default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFIV default allmode.png',
+				lightMode = 'SFIV default allmode.png',
+			},
+		},
+		ssfiv = {
+			abbreviation = 'SSFIV',
+			name = 'Super Street Fighter IV',
+			link = 'Super Street Fighter IV',
+			logo = {
+				darkMode = 'SSFIV Logo.png',
+				lightMode = 'SSFIV Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SSFIV Logo.png',
+				lightMode = 'SSFIV Logo.png',
+			},
+		},
+		ssfivae = {
+			abbreviation = 'SSFIV Arcade',
+			name = 'Super Street Fighter IV: Arcade Edition',
+			link = 'Super Street Fighter IV: Arcade Edition',
+			logo = {
+				darkMode = 'SSFIVAE Logo.png',
+				lightMode = 'SSFIVAE Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SSFIVAE Logo.png',
+				lightMode = 'SSFIVAE Logo.png',
+			},
+		},
+		usfiv = {
+			abbreviation = 'USFIV',
+			name = 'Ultra Street Fighter IV',
+			link = 'Ultra Street Fighter IV',
+			logo = {
+				darkMode = 'USFIV Logo.png',
+				lightMode = 'USFIV Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'USFIV Logo.png',
+				lightMode = 'USFIV Logo.png',
+			},
+		},
+		sfvae = {
+			abbreviation = 'SFV Arcade',
+			name = 'Street Fighter V: Arcade Edition',
+			link = 'Street Fighter V: Arcade Edition',
+			logo = {
+				darkMode = 'SFVAE Logo.png',
+				lightMode = 'SFVAE Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFVAE Logo.png',
+				lightMode = 'SFVAE Logo.png',
+			},
+		},
+		sfv = {
+			abbreviation = 'SFV',
+			name = 'Street Fighter V',
+			link = 'Street Fighter V',
+			logo = {
+				darkMode = 'SFV Logo.png',
+				lightMode = 'SFV Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFV Logo.png',
+				lightMode = 'SFV Logo.png',
+			},
+		},
+		sfvce = {
+			abbreviation = 'SFV Champion',
+			name = 'Street Fighter V: Champion Edition',
+			link = 'Street Fighter V: Champion Edition',
+			logo = {
+				darkMode = 'SFVCE Logo.png',
+				lightMode = 'SFVCE Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFVCE Logo.png',
+				lightMode = 'SFVCE Logo.png',
+			},
+		},
+		sf6 = {
+			abbreviation = 'SF6',
+			name = 'Street Fighter 6',
+			link = 'Street Fighter 6',
+			logo = {
+				darkMode = 'SF6 default darkmode.png',
+				lightMode = 'SF6 default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SF6 default darkmode.png',
+				lightMode = 'SF6 default lightmode.png',
+			},
+		},
+		t4 = {
+			abbreviation = 'TK4',
+			name = 'Tekken 4',
+			link = 'Tekken 4',
+			logo = {
+				darkMode = 'Tekken 4 default allmode.png',
+				lightMode = 'Tekken 4 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tekken 4 default allmode.png',
+				lightMode = 'Tekken 4 default allmode.png',
+			},
+		},
+		t5 = {
+			abbreviation = 'TK5',
+			name = 'Tekken 5',
+			link = 'Tekken 5',
+			logo = {
+				darkMode = 'Tekken 5 default allmode.png',
+				lightMode = 'Tekken 5 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tekken 5 default allmode.png',
+				lightMode = 'Tekken 5 default allmode.png',
+			},
+		},
+		t5dr = {
+			abbreviation = 'TK5 DR',
+			name = 'Tekken 5: Dark Resurrection',
+			link = 'Tekken 5: Dark Resurrection',
+			logo = {
+				darkMode = 'Tekken 5 Dark Resurrection default allmode.png',
+				lightMode = 'Tekken 5 Dark Resurrection default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tekken 5 Dark Resurrection default allmode.png',
+				lightMode = 'Tekken 5 Dark Resurrection default allmode.png',
+			},
+		},
+		t6 = {
+			abbreviation = 'TK6',
+			name = 'Tekken 6',
+			link = 'Tekken 6',
+			logo = {
+				darkMode = 'Tekken 6 default allmode.png',
+				lightMode = 'Tekken 6 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tekken 6 default allmode.png',
+				lightMode = 'Tekken 6 default allmode.png',
+			},
+		},
+		t7 = {
+			abbreviation = 'TK7',
+			name = 'TEKKEN 7',
+			link = 'TEKKEN 7',
+			logo = {
+				darkMode = 'Tekken 7 default allmode.png',
+				lightMode = 'Tekken 7 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tekken 7 default allmode.png',
+				lightMode = 'Tekken 7 default allmode.png',
+			},
+		},
+		t8 = {
+			abbreviation = 'TK8',
+			name = 'TEKKEN 8',
+			link = 'TEKKEN 8',
+			logo = {
+				darkMode = 'Tekken 8 default allmode.png',
+				lightMode = 'Tekken 8 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tekken 8 default allmode.png',
+				lightMode = 'Tekken 8 default allmode.png',
+			},
+		},
+		ttt = {
+			abbreviation = 'TTT',
+			name = 'Tekken Tag Tournament',
+			link = 'Tekken Tag Tournament',
+			logo = {
+				darkMode = 'Tekken Tag Tournament Logo.png',
+				lightMode = 'Tekken Tag Tournament Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tekken Tag Tournament Logo.png',
+				lightMode = 'Tekken Tag Tournament Logo.png',
+			},
+		},
+		ttt2 = {
+			abbreviation = 'TTT2',
+			name = 'Tekken Tag Tournament 2',
+			link = 'Tekken Tag Tournament 2',
+			logo = {
+				darkMode = 'TTT2 Logo.png',
+				lightMode = 'TTT2 Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'TTT2 Logo.png',
+				lightMode = 'TTT2 Logo.png',
+			},
+		},
+		sfxt = {
+			abbreviation = 'SFxT',
+			name = 'Street Fighter X Tekken',
+			link = 'Street Fighter X Tekken',
+			logo = {
+				darkMode = 'SFxT Logo.png',
+				lightMode = 'SFxT Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SFxT Logo.png',
+				lightMode = 'SFxT Logo.png',
+			},
+		},
+		tvc = {
+			abbreviation = 'TvC',
+			name = 'Tatsunoko vs. Capcom: Ultimate All-Stars',
+			link = 'Tatsunoko vs. Capcom: Ultimate All-Stars',
+			logo = {
+				darkMode = 'TVCUAS Logo.png',
+				lightMode = 'TVCUAS Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'TVCUAS Logo.png',
+				lightMode = 'TVCUAS Logo.png',
+			},
+		},
+		tfh = {
+			abbreviation = 'TFH',
+			name = 'Them\'s Fightin\' Herds',
+			link = 'Them\'s Fightin\' Herds',
+			logo = {
+				darkMode = 'Them\'s Fightin\' Herds logo.png',
+				lightMode = 'Them\'s Fightin\' Herds logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Them\'s Fightin\' Herds logo.png',
+				lightMode = 'Them\'s Fightin\' Herds logo.png',
+			},
+		},
+		th123 = {
+			abbreviation = 'TH123',
+			name = 'Touhou Hisoutensoku',
+			link = 'Touhou Hisoutensoku',
+			logo = {
+				darkMode = 'TH123 Logo.png',
+				lightMode = 'TH123 Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'TH123 Logo.png',
+				lightMode = 'TH123 Logo.png',
+			},
+		},
+		vsav = {
+			abbreviation = 'VS',
+			name = 'Vampire Savior',
+			link = 'Vampire Savior (Darkstalkers 3)',
+			logo = {
+				darkMode = 'Vampire Savior Logo.png',
+				lightMode = 'Vampire Savior Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Vampire Savior Logo.png',
+				lightMode = 'Vampire Savior Logo.png',
+			},
+		},
+		vf4 = {
+			abbreviation = 'VF4',
+			name = 'Virtua Fighter 4',
+			link = 'Virtua Fighter 4',
+			logo = {
+				darkMode = 'VF4 default allmode.png',
+				lightMode = 'VF4 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'VF4 default allmode.png',
+				lightMode = 'VF4 default allmode.png',
+			},
+		},
+		vf4e = {
+			abbreviation = 'VF4 Evolution',
+			name = 'Virtua Fighter 4: Evolution',
+			link = 'Virtua Fighter 4: Evolution',
+			logo = {
+				darkMode = 'VF4E default allmode.png',
+				lightMode = 'VF4E default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'VF4E default allmode.png',
+				lightMode = 'VF4E default allmode.png',
+			},
+		},
+		vf5 = {
+			abbreviation = 'VF5',
+			name = 'Virtua Fighter 5',
+			link = 'Virtua Fighter 5',
+			logo = {
+				darkMode = 'VF5 default allmode.png',
+				lightMode = 'VF5 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'VF5 default allmode.png',
+				lightMode = 'VF5 default allmode.png',
+			},
+		},
+		vf5us = {
+			abbreviation = 'VF5 US',
+			name = 'Virtua Fighter 5: Ultimate Showdown',
+			link = 'Virtua Fighter 5: Ultimate Showdown',
+			logo = {
+				darkMode = 'VF5US default allmode.png',
+				lightMode = 'VF5US default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'VF5US default allmode.png',
+				lightMode = 'VF5US default allmode.png',
+			},
+		},
+		uniclr = {
+			abbreviation = 'UNICLR',
+			name = 'Under Night In-Birth EXE:Late cl-r',
+			link = 'Under Night In-Birth EXE:Late cl-r',
+			logo = {
+				darkMode = 'UNICLR Logo.png',
+				lightMode = 'UNICLR Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'UNICLR Logo.png',
+				lightMode = 'UNICLR Logo.png',
+			},
+		},
+		uniel = {
+			abbreviation = 'UNIEL',
+			name = 'Under Night In-Birth EXE:Late',
+			link = 'Under Night In-Birth EXE:Late',
+			logo = {
+				darkMode = 'UNIEL Logo.png',
+				lightMode = 'UNIEL Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'UNIEL Logo.png',
+				lightMode = 'UNIEL Logo.png',
+			},
+		},
+		unist = {
+			abbreviation = 'UNIST',
+			name = 'Under Night In-Birth EXE:Late ST',
+			link = 'Under Night In-Birth EXE:Late ST',
+			logo = {
+				darkMode = 'UNIST Logo.png',
+				lightMode = 'UNIST Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'UNIST Logo.png',
+				lightMode = 'UNIST Logo.png',
+			},
+		},
+		unib = {
+			abbreviation = 'UNIB',
+			name = 'Under Night In-Birth',
+			link = 'Under Night In-Birth',
+			logo = {
+				darkMode = 'UNIEL Logo.png',
+				lightMode = 'UNIEL Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'UNIEL Logo.png',
+				lightMode = 'UNIEL Logo.png',
+			},
+		},
+		['project l'] = {
+			abbreviation = 'Project L',
+			name = 'Project L',
+			link = 'Project L',
+			logo = {
+				darkMode = 'League of Legends allmode.png',
+				lightMode = 'League of Legends allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'League of Legends allmode.png',
+				lightMode = 'League of Legends allmode.png',
 			},
 		},
 	},
 	defaultGame = 'fighters',
-	defaultTeamLogo = 'Fistlogo std.png', ---@deprecated
-	defaultTeamLogoDark = 'Fistlogo std.png', ---@deprecated
+	defaultTeamLogo = 'Fighters default lightmode.png', ---@deprecated
+	defaultTeamLogoDark = 'Fighters default darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -921,7 +921,7 @@ return {
 				lightMode = 'UMVC3 default allmode.png',
 			},
 		},
-		mvc3 = {
+		mvci = {
 			abbreviation = 'MvCI',
 			name = 'Marvel vs. Capcom: Infinite',
 			link = 'Marvel vs. Capcom: Infinite',


### PR DESCRIPTION
## Summary
Title.  Total of 123 Games including the default Fighters entry 

This include at least every entry in the old infobox league plus many new addition being a game with **Template:Game/** that doesnt had in the list and some of the newer games.

The file name inconsistency is due to 
1. The Logo.png or such is files that already existed, I had no plans to moved file names yet
2. all/dark/lightmodes are newly uploaded

## Side Note 
At this time of PR around 1.5 dozen of logos not yet uploaded
^^^ This is done.
