### PR TITLE
Add cntft and lolchess to Module:Links

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -51,6 +51,7 @@ local PREFIXES = {
 		'',
 		player = 'https://challonge.com/users/',
 	},
+	cntft = {'https://lol.qq.com/tft/#/masterDetail/'},
 	datdota = {
 		'https://www.datdota.com/leagues/',
 		player = 'https://www.datdota.com/players/',
@@ -113,6 +114,7 @@ local PREFIXES = {
 	kuaishou = {'https://live.kuaishou.com/u/'},
 	letsplaylive = {'https://letsplay.live/profile/'},
 	loco = {'https://loco.gg/streamers/'},
+	lolchess = {'https://lolchess.gg/profile/'},
 	matcherino = {'https://matcherino.com/tournaments/'},
 	matcherinolink = {'https://matcherino.com/t/'},
 	mildom = {'https://www.mildom.com/'},
@@ -196,6 +198,7 @@ local PREFIXES = {
 PREFIXES = Table.merge(PREFIXES, CustomData.prefixes or {})
 
 local SUFFIXES = {
+	cntft = {'/1'},
 	facebook = {
 		'',
 		stream = '/live',


### PR DESCRIPTION
## Summary
Missing link entries for lolchess and cntft

## How did you test this change?
/dev
cntft (last)
![image](https://user-images.githubusercontent.com/16326643/220421964-c011d842-a755-4591-ac65-d61c763c89c2.png)
lolchess (last)
![image](https://user-images.githubusercontent.com/16326643/220421977-e97438e0-5ff1-48b3-a613-d0cb8faa550c.png)

