### PR TITLE
Add space between flag and country name

### DIFF
--- a/components/infobox/wikis/heroes/infobox_league_custom.lua
+++ b/components/infobox/wikis/heroes/infobox_league_custom.lua
@@ -43,7 +43,7 @@ function CustomInjector:parse(id, widgets)
 		local server = _league.args.server
 		if server then
 			return {Cell{name = 'Server', content = {
-				Flags.Icon(server) .. Flags.CountryName(server)
+				Flags.Icon(server) .. '&nbsp;' .. Flags.CountryName(server)
 			}}}
 		end
 	elseif id == 'customcontent' then


### PR DESCRIPTION
## Summary
Adds a non-breaking space between flag and country name for server input to achieve the same display as for location.

## How did you test this change?
/dev
