### PR TITLE
Add Prize Pool for FIFA

### DIFF
--- a/components/prize_pool/wikis/fifa/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/fifa/prize_pool_custom.lua
@@ -1,0 +1,64 @@
+---
+-- @Liquipedia
+-- wiki=fifa
+-- page=Module:PrizePool/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+
+local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local CustomLpdbInjector = Class.new(LpdbInjector)
+
+local CustomPrizePool = {}
+
+local TIER_VALUE = {8, 4, 2}
+
+-- Template entry point
+function CustomPrizePool.run(frame)
+	local args = Arguments.getArgs(frame)
+	args.opponentLibrary = 'Opponent/Custom'
+	args.syncPlayers = true
+	local prizePool = PrizePool(args):create()
+
+	prizePool:setLpdbInjector(CustomLpdbInjector())
+
+	return prizePool:build()
+end
+
+function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
+	lpdbData.weight = CustomPrizePool.calculateWeight(
+		lpdbData.prizemoney,
+		Variables.varDefault('tournament_liquipediatier'),
+		placement.placeStart
+	)
+
+	local participants = lpdbData.opponentname or ''
+	local lpdbPrefix = placement.parent.options.lpdbPrefix
+
+	Variables.varDefine('enddate_' .. lpdbPrefix .. participants, lpdbData.date)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participants:lower()) ..
+		'_pointprize', lpdbData.extradata.prizepoints
+	)
+
+	return lpdbData
+end
+
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place)
+	if String.isEmpty(tier) then
+		return 0
+	end
+
+	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier)] or 1
+
+	return tierValue * math.max(prizeMoney, 1) / place
+end
+
+return CustomPrizePool

--- a/components/prize_pool/wikis/fifa/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/fifa/prize_pool_custom.lua
@@ -24,9 +24,9 @@ local TIER_VALUE = {8, 4, 2}
 -- Template entry point
 function CustomPrizePool.run(frame)
 	local args = Arguments.getArgs(frame)
-	args.opponentLibrary = 'Opponent/Custom'
-	args.syncPlayers = true
-	local prizePool = PrizePool(args):create()
+	local prizePool = PrizePool(args)
+	prizePool:setConfigDefault('syncPlayers', true)
+	prizePool:create()
 
 	prizePool:setLpdbInjector(CustomLpdbInjector())
 
@@ -40,11 +40,11 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		placement.placeStart
 	)
 
-	local participants = lpdbData.opponentname or ''
+	local participant = lpdbData.opponentname or ''
 	local lpdbPrefix = placement.parent.options.lpdbPrefix
 
-	Variables.varDefine('enddate_' .. lpdbPrefix .. participants, lpdbData.date)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participants:lower()) ..
+	Variables.varDefine('enddate_' .. lpdbPrefix .. participant, lpdbData.date)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participant:lower()) ..
 		'_pointprize', lpdbData.extradata.prizepoints
 	)
 


### PR DESCRIPTION
## Summary
new Standard Prize Pool for FIFA Wiki, this is based on the merged prize pool from Tetris
and add calls to use **Opponent/Custom** ( related to #2625 ) to Sync teams in addition to the already existing SyncPlayers by default

For old prize pool with template start/end those have been moved over to used the Commons PrizePool/Legacy/Custom already, currently I have no plans to make a local Legacy Custom because it doesnt seem to need a local one and works all good

## How did you test this change?
LIVE - https://liquipedia.net/fifa/FIFA_23/Global_Series/North_Asia/2
This page includes utilizing a /dev Match2 for Import, and also the syncteam stuff (this is why I wanted, if possible to have match2 merged like soon as possible)
