### PR TITLE
Store map info as Json in Infobox league

### DIFF
--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 local Class = require('Module:Class')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -52,6 +53,17 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 
 	--gamemode
 	BasicHiddenDataBox.checkAndAssign('tournament_gamemode', args.gamemode, queryResult.gamemode)
+
+	--maps
+	Variables.varDefine('tournament_maps', queryResult.maps)
+
+	-- legacy variables, to be removed with match2
+	local maps, failure = Json.parse(queryResult.maps)
+	if not failure then
+		for _, map in ipairs(maps) do
+			Variables.varDefine('tournament_map_'.. map.displayName, map.link)
+		end
+	end
 end
 
 function CustomHiddenDataBox.validateTier(tierString, tierMode)

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -61,7 +61,7 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	local maps, failure = Json.parse(queryResult.maps)
 	if not failure then
 		for _, map in ipairs(maps) do
-			Variables.varDefine('tournament_map_'.. map.displayName, map.link)
+			Variables.varDefine('tournament_map_'.. (map.name or map.link), map.link)
 		end
 	end
 end

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -373,6 +373,7 @@ function CustomLeague:_getMaps()
 
 		if String.isNotEmpty(args[prefix .. 'link']) then
 			link = args[prefix .. 'link']
+			display = mapInput[1]
 		else
 			link = mapInput[1]
 			display = mapInput[2]

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -236,7 +236,7 @@ function CustomLeague:defineCustomPageVariables(args)
 	local maps = CustomLeague:_getMaps()
 	Variables.varDefine('tournament_maps', Json.stringify(maps))
 	for _, map in ipairs(maps) do
-		Variables.varDefine('tournament_map_'.. map.displayName, map.link)
+		Variables.varDefine('tournament_map_'.. (map.name or map.link), map.link)
 	end
 end
 
@@ -366,21 +366,20 @@ function CustomLeague:_getMaps()
 	local args = _league.args
 	local maps = {}
 	for prefix, mapInput in Table.iter.pairsByPrefix(args, 'map') do
-		local mode = String.isNotEmpty(args[prefix .. 'mode']) and MapMode.get({args[prefix .. 'mode']}) or ''
+		local mode = String.isNotEmpty(args[prefix .. 'mode']) and MapMode.get({args[prefix .. 'mode']}) or nil
 
 		mapInput = mw.text.split(mapInput, '|', true)
 		local display, link
 
 		if String.isNotEmpty(args[prefix .. 'link']) then
 			link = args[prefix .. 'link']
-			display = mapInput[1]
 		else
 			link = mapInput[1]
-			display = mapInput[2] or mapInput[1]
+			display = mapInput[2]
 		end
 		link = mw.ext.TeamLiquidIntegration.resolve_redirect(link)
 
-		table.insert(maps, {link = link, displayName = display, mode = mode, image = args[prefix .. 'image']})
+		table.insert(maps, {link = link, name = display, mode = mode, image = args[prefix .. 'image']})
 	end
 
 	_league.maps = maps
@@ -391,7 +390,7 @@ end
 function CustomLeague:_displayMaps(maps)
 	local mapDisplay = function(map)
 		return tostring(CustomLeague:_createNoWrappingSpan(
-			Page.makeInternalLink({}, map.displayName .. map.mode, map.link)
+			Page.makeInternalLink({}, (map.displayName or map.link) .. (map.mode and map.mode or ''), map.link)
 		))
 	end
 

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -390,7 +390,7 @@ end
 function CustomLeague:_displayMaps(maps)
 	local mapDisplay = function(map)
 		return tostring(CustomLeague:_createNoWrappingSpan(
-			Page.makeInternalLink({}, (map.displayName or map.link) .. (map.mode and map.mode or ''), map.link)
+			Page.makeInternalLink({}, (map.name or map.link) .. (map.mode and map.mode or ''), map.link)
 		))
 	end
 

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -251,7 +251,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 
 	lpdbData['sponsors'] = args.sponsors
 
-	lpdbData['maps'] = Variables.varDefault('tournament_maps')
+	lpdbData.maps = Variables.varDefault('tournament_maps')
 
 	lpdbData['game'] = GameLookup.getName({args.game})
 	-- Currently, args.patch shall be used for official patches,


### PR DESCRIPTION
## Summary
Stores map info entered in Infobox league as stringified JSON instead of CSV.
Allows fetch of structured information, including link and image overrides, in consumer modules (HDB, Maplist, Map occurences, Matches)

## How did you test this change?
via /dev
Consumers of LPDB field maps have been updated to try to parse JSON and default to old CSV if parsing fails.