### PR TITLE
Change Smash 64 to string key instead of number

### DIFF
--- a/standard/info/wikis/smash/info.lua
+++ b/standard/info/wikis/smash/info.lua
@@ -76,7 +76,7 @@ return {
 				lightMode = 'Smash default lightmode.png',
 			},
 		},
-		[64] = {
+		['64'] = {
 			abbreviation = '64',
 			name = 'Super Smash Bros.',
 			link = 'Super Smash Bros.',


### PR DESCRIPTION
## Summary

String expected for index, not number

## How did you test this change?

It's live. Numbers break existing implementations expecting strings.
