### PR TITLE
Update Infobox Player to match #2643

### DIFF
--- a/components/infobox/wikis/smash/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/smash/infobox_person_player_custom.lua
@@ -28,7 +28,7 @@ local CustomPlayer = Class.new()
 
 local CustomInjector = Class.new(Injector)
 
-local GAME_ORDER = {64, 'melee', 'brawl', 'pm', 'wiiu', 'ultimate'}
+local GAME_ORDER = {'64', 'melee', 'brawl', 'pm', 'wiiu', 'ultimate'}
 
 local _args
 


### PR DESCRIPTION
## Summary

String expected for index, not number

## How did you test this change?

It's live. GAME_ORDER is used to iterate through indices, which are expected to be strings.
