### PR TITLE
Allow cancelled tournament to be set before Infobox

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -379,7 +379,7 @@ function League:_definePageVariables(args)
 	]]
 
 	Variables.varDefine('tournament_type', args.type)
-	Variables.varDefine('tournament_status', args.status)
+	Variables.varDefine('tournament_status', args.status or Variables.varDefault('tournament_status'))
 
 	Variables.varDefine('tournament_region', args.region)
 	Variables.varDefine('tournament_country', args.country)
@@ -445,7 +445,7 @@ function League:_setLpdbData(args, links)
 		prizepool = Variables.varDefault('tournament_prizepoolusd', 0),
 		liquipediatier = Variables.varDefault('tournament_liquipediatier'),
 		liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype'),
-		status = args.status,
+		status = Variables.varDefault('tournament_status'),
 		format = TextSanitizer.stripHTML(args.format),
 		sponsors = mw.ext.LiquipediaDB.lpdb_create_json(
 			League:_getNamedTableofAllArgsForBase(args, 'sponsor')


### PR DESCRIPTION
## Summary
Allow cancelled tournament (via Template:Cancelled Tournament) to be set both before and after Infobox instead of just after

## How did you test this change?
dev