### PR TITLE
Catch empty names in BroadcasterCard

### DIFF
--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -89,12 +89,19 @@ function BroadcasterCard.create(frame)
 	table.sort(casters, function(a, b) return a.sort < b.sort or (a.sort == b.sort and a.id < b.id) end)
 
 	for _, broadcaster in ipairs(casters) do
-		local displayName = broadcaster.displayName or broadcaster.name
-		outputList = outputList .. '\n**' .. Flags.Icon{flag = broadcaster.flag, shouldLink = true}
-			.. '&nbsp;[[' .. broadcaster.page .. '|'.. broadcaster.id .. ']]&nbsp;(' .. displayName ..')'
+		outputList = outputList .. BroadcasterCard._display(broadcaster)
 	end
 
 	return outputList
+end
+
+function BroadcasterCard._display(broadcaster)
+	local displayName = broadcaster.displayName or broadcaster.name
+	displayName = String.isEmpty(displayName) and '' or ('&nbsp;(' .. displayName ..')')
+
+	return '\n**' .. Flags.Icon{flag = broadcaster.flag, shouldLink = true}
+		.. '&nbsp;[[' .. broadcaster.page .. '|'.. broadcaster.id .. ']]'
+		.. displayName
 end
 
 function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)


### PR DESCRIPTION
## Summary
Catch empty names
Currently it still displays brackets if the name is empty

![](https://cdn.discordapp.com/attachments/268719633366777856/1080173379715346573/image.png)
reported by krola
https://discord.com/channels/93055209017729024/268719633366777856/1080173339802353704

introduced via #2646

## How did you test this change?
dev

![Screenshot 2023-02-28 18 18 22](https://user-images.githubusercontent.com/75081997/221928593-11d292a5-8daf-490c-a92b-d9580271fed4.png)
