### PR TITLE
Adding team count support in Heroes League infobox

### DIFF
--- a/components/infobox/wikis/heroes/infobox_league_custom.lua
+++ b/components/infobox/wikis/heroes/infobox_league_custom.lua
@@ -64,7 +64,7 @@ end
 function CustomInjector:addCustomCells(widgets)
 	table.insert(widgets, Cell{
 		name = 'Teams',
-		content = {(_league.args.team_number or '')}
+		content = {(_league.args.team_number)}
 	})
 	return widgets
 end

--- a/components/infobox/wikis/heroes/infobox_league_custom.lua
+++ b/components/infobox/wikis/heroes/infobox_league_custom.lua
@@ -30,6 +30,7 @@ function CustomLeague.run(frame)
 	_league = league
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.addToLpdb = CustomLeague.addToLpdb
 
 	return league:createInfobox()
 end
@@ -58,6 +59,19 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	return widgets
+end
+
+function CustomInjector:addCustomCells(widgets)
+	table.insert(widgets, Cell{
+		name = 'Teams',
+		content = {(_league.args.team_number or '') .. (_league.args.team_slots and ('/' .. _league.args.team_slots) or '')}
+	})
+	return widgets
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.participantsnumber = args.team_number
+	return lpdbData
 end
 
 function CustomLeague:_createNoWrappingSpan(content)

--- a/components/infobox/wikis/heroes/infobox_league_custom.lua
+++ b/components/infobox/wikis/heroes/infobox_league_custom.lua
@@ -64,7 +64,7 @@ end
 function CustomInjector:addCustomCells(widgets)
 	table.insert(widgets, Cell{
 		name = 'Teams',
-		content = {(_league.args.team_number or '') .. (_league.args.team_slots and ('/' .. _league.args.team_slots) or '')}
+		content = {(_league.args.team_number or '')}
 	})
 	return widgets
 end


### PR DESCRIPTION
## Summary
Adds support for team count via request by Rennalla in the Discord chat. Having confirmed with Rennalla, there are no individual events that need accounting for
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Currently live on this [page](https://liquipedia.net/heroes/META_Madness/7). LPBD saving was also enabled and saving correctly. 
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
