### PR TITLE
Add a nil check in BS infobox league for organizers

### DIFF
--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -109,6 +109,10 @@ function CustomLeague:defineCustomPageVariables()
 end
 
 function CustomLeague._createOrganizers()
+	if not _args.organizer then
+		return {}
+	end
+
 	local organizers = {
 		(ORGANIZER_ICONS[_args.organizer] or '') .. _league:createLink(
 			_args.organizer, _args['organizer-name'], _args['organizer-link'], _args.organizerref),


### PR DESCRIPTION
## Summary
Add a nil check in BS infobox league for organizers.
From #2475

## How did you test this change?
dev into live since bug fix