### PR TITLE
Fix missing `requireIndex=false`

### DIFF
--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -237,12 +237,12 @@ function CustomMatchSummary.getByMatchId(args)
 		local footer = MatchSummary.Footer()
 
 		-- Shift
-		for _, shift in Table.iter.pairsByPrefix(match.links, 'shift') do
+		for _, shift in Table.iter.pairsByPrefix(match.links, 'shift', {requireIndex = false}) do
 			footer:addElement(_SHIFT_PREFIX .. shift .. _SHIFT_SUFFIX)
 		end
 
 		-- Ballchasing
-		for _, ballchasing in Table.iter.pairsByPrefix(match.links, 'ballchasing') do
+		for _, ballchasing in Table.iter.pairsByPrefix(match.links, 'ballchasing', {requireIndex = false}) do
 			footer:addElement(_BALLCHASING_PREFIX .. ballchasing .. _BALLCHASING_SUFFIX)
 		end
 


### PR DESCRIPTION
## Summary
Introduced in #2408:
Keys don't match when a input was previously shifted manually, but now uses `requireIndex=false`

## How did you test this change?
Hotfix, live
