### PR TITLE
Refine `getPersonType()` for Coaches and Talent

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
@@ -237,11 +237,11 @@ function CustomPlayer:getPersonType(args)
 	local roleData = _ROLES[(args.role or ''):lower()]
 	if roleData then
 		if roleData.coach then
-			return { store = 'Staff', category = 'Coache' }
+			return { store = 'Coach', category = 'Coache' }
 		elseif roleData.management then
 			return { store = 'Staff', category = 'Manager' }
 		elseif roleData.talent then
-			return { store = '', category = 'Talent' }
+			return { store = 'Talent', category = 'Talent' }
 		end
 	end
 	return { store = 'Player', category = 'Player' }


### PR DESCRIPTION
## Summary

Players get tagged as `Player` but that leaves coaches and talent in weird limbo. Can't easily query just coaches cos they get stored as `Staff` and talent don't get anything. This addresses that issue.

## How did you test this change?

`/dev` on cs wiki.
