### PR TITLE
Add catch for winner or loser in match1 TBD filter

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -121,7 +121,7 @@ function MatchLegacy.convertParameters(match2)
 					match[prefix] = opponent.template
 				end
 			else
-				if String.isEmpty(opponent.name) or TextSanitizer.stripHTML(opponent.name) ~= opponent.name then
+				if String.isEmpty(opponent.name) or (TextSanitizer.stripHTML(opponent.name) ~= opponent.name) or String.contains(opponent.name, 'winner') or String.contains(opponent.name, 'loser') then
 					match[prefix] = 'TBD'
 				else
 					match[prefix] = opponent.name

--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -121,7 +121,9 @@ function MatchLegacy.convertParameters(match2)
 					match[prefix] = opponent.template
 				end
 			else
-				if String.isEmpty(opponent.name) or (TextSanitizer.stripHTML(opponent.name) ~= opponent.name) or String.contains(opponent.name, 'winner') or String.contains(opponent.name, 'loser') then
+				if String.isEmpty(opponent.name) or (TextSanitizer.stripHTML(opponent.name) ~= opponent.name)
+					or String.contains(opponent.name, 'winner') or String.contains(opponent.name, 'loser')
+				then
 					match[prefix] = 'TBD'
 				else
 					match[prefix] = opponent.name


### PR DESCRIPTION
## Summary

Fix storage of placeholder names which often container winner or loser as string.

![image](https://user-images.githubusercontent.com/5881994/222926069-edf35053-cd37-4645-b1c1-b003a5842521.png)
![image](https://user-images.githubusercontent.com/5881994/222926071-0dce084a-a684-4082-9064-aaf3fd0bb7b4.png)


## How did you test this change?

`/dev` followed by live on wiki due to important to fix matchticker bug.

![image](https://user-images.githubusercontent.com/5881994/222926088-d77c9f62-9c8a-4d1a-8fdd-4b70275828b7.png)
