### PR TITLE
Add several custom tier data modules

### DIFF
--- a/standard/tier/wikis/arenafps/tier_data.lua
+++ b/standard/tier/wikis/arenafps/tier_data.lua
@@ -1,0 +1,143 @@
+---
+-- @Liquipedia
+-- wiki=arenafps
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until arenafps switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/arenaofvalor/tier_data.lua
+++ b/standard/tier/wikis/arenaofvalor/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=arenaofvalor
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/artifact/tier_data.lua
+++ b/standard/tier/wikis/artifact/tier_data.lua
@@ -1,0 +1,135 @@
+---
+-- @Liquipedia
+-- wiki=artifact
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until artifact switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/battlerite/tier_data.lua
+++ b/standard/tier/wikis/battlerite/tier_data.lua
@@ -1,0 +1,143 @@
+---
+-- @Liquipedia
+-- wiki=battlerite
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until battlerite switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/brawlhalla/tier_data.lua
+++ b/standard/tier/wikis/brawlhalla/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=brawlhalla
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/brawlstars/tier_data.lua
+++ b/standard/tier/wikis/brawlstars/tier_data.lua
@@ -1,0 +1,111 @@
+---
+-- @Liquipedia
+-- wiki=brawlstars
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until brawlstars switches to standardized tier/tiertype
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/callofduty/tier_data.lua
+++ b/standard/tier/wikis/callofduty/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/criticalops/tier_data.lua
+++ b/standard/tier/wikis/criticalops/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=criticalops
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/crossfire/tier_data.lua
+++ b/standard/tier/wikis/crossfire/tier_data.lua
@@ -1,0 +1,135 @@
+---
+-- @Liquipedia
+-- wiki=crossfire
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B3',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until crossfire switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/dota2/tier_data.lua
+++ b/standard/tier/wikis/dota2/tier_data.lua
@@ -1,0 +1,93 @@
+---
+-- @Liquipedia
+-- wiki=dota2
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Tier 1',
+			short = '1',
+			link = 'Tier 1 Tournaments',
+			category = 'Tier 1 Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Tier 2',
+			short = '2',
+			link = 'Tier 2 Tournaments',
+			category = 'Tier 2 Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Tier 3',
+			short = '3',
+			link = 'Tier 3 Tournaments',
+			category = 'Tier 3 Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'Tier 4',
+			short = '4',
+			link = 'Tier 4 Tournaments',
+			category = 'Tier 4 Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/fifa/tier_data.lua
+++ b/standard/tier/wikis/fifa/tier_data.lua
@@ -1,0 +1,127 @@
+---
+-- @Liquipedia
+-- wiki=fifa
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until fifa switches to standardized tier/tiertype
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/fighters/tier_data.lua
+++ b/standard/tier/wikis/fighters/tier_data.lua
@@ -1,0 +1,93 @@
+---
+-- @Liquipedia
+-- wiki=fighters
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Tier 1',
+			short = '1',
+			link = 'Tier 1 Tournaments',
+			category = 'Tier 1 Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Tier 2',
+			short = '2',
+			link = 'Tier 2 Tournaments',
+			category = 'Tier 2 Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Tier 3',
+			short = '3',
+			link = 'Tier 3 Tournaments',
+			category = 'Tier 3 Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'Tier 4',
+			short = '4',
+			link = 'Tier 4 Tournaments',
+			category = 'Tier 4 Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/freefire/tier_data.lua
+++ b/standard/tier/wikis/freefire/tier_data.lua
@@ -1,0 +1,119 @@
+---
+-- @Liquipedia
+-- wiki=freefire
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Tier 1',
+			short = '1',
+			link = 'Tier 1 Tournaments',
+			category = 'Tier 1 Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Tier 2',
+			short = '2',
+			link = 'Tier 2 Tournaments',
+			category = 'Tier 2 Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Tier 3',
+			short = '3',
+			link = 'Tier 3 Tournaments',
+			category = 'Tier 3 Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'Tier 4',
+			short = '4',
+			link = 'Tier 4 Tournaments',
+			category = 'Tier 4 Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until freefire switches to standardized tier/tiertype
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/halo/tier_data.lua
+++ b/standard/tier/wikis/halo/tier_data.lua
@@ -1,0 +1,101 @@
+---
+-- @Liquipedia
+-- wiki=halo
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+		ffa = {
+			value = 'FFA',
+			sort = 'B2',
+			name = 'FFA',
+			short = 'Showm.',
+			link = 'Free For All Tournaments',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/halo/tier_data.lua
+++ b/standard/tier/wikis/halo/tier_data.lua
@@ -95,7 +95,7 @@ return {
 			name = 'FFA',
 			short = 'Showm.',
 			link = 'Free For All Tournaments',
-			category = 'Showmatch Tournaments',
+			category = 'FFA Tournaments',
 		},
 	},
 }

--- a/standard/tier/wikis/hearthstone/tier_data.lua
+++ b/standard/tier/wikis/hearthstone/tier_data.lua
@@ -1,0 +1,143 @@
+---
+-- @Liquipedia
+-- wiki=hearthstone
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until hearthstone switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/heroes/tier_data.lua
+++ b/standard/tier/wikis/heroes/tier_data.lua
@@ -1,0 +1,135 @@
+---
+-- @Liquipedia
+-- wiki=heroes
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Tier 1',
+			short = '1',
+			link = 'Tier 1 Tournaments',
+			category = 'Tier 1 Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Tier 2',
+			short = '2',
+			link = 'Tier 2 Tournaments',
+			category = 'Tier 2 Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Tier 3',
+			short = '3',
+			link = 'Tier 3 Tournaments',
+			category = 'Tier 3 Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'Tier 4',
+			short = '4',
+			link = 'Tier 4 Tournaments',
+			category = 'Tier 4 Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until heroes switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/magic/tier_data.lua
+++ b/standard/tier/wikis/magic/tier_data.lua
@@ -1,0 +1,119 @@
+---
+-- @Liquipedia
+-- wiki=magic
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until magic switches to standardized tier/tiertype
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/mobilelegends/tier_data.lua
+++ b/standard/tier/wikis/mobilelegends/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=mobilelegends
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/overwatch/tier_data.lua
+++ b/standard/tier/wikis/overwatch/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=overwatch
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/pubg/tier_data.lua
+++ b/standard/tier/wikis/pubg/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=pubg
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/pubgmobile/tier_data.lua
+++ b/standard/tier/wikis/pubgmobile/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=pubgmobile
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatch Tournaments',
+			category = 'Showmatch Tournaments',
+		},
+		individual = {
+			value = 'Individual',
+			sort = 'B2',
+			name = 'Individual',
+			short = 'Indiv.',
+			link = 'Individual Tournaments',
+			category = 'Individual Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/rainbowsix/tier_data.lua
+++ b/standard/tier/wikis/rainbowsix/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=rainbowsix
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/rocketleague/tier_data.lua
+++ b/standard/tier/wikis/rocketleague/tier_data.lua
@@ -1,0 +1,117 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B3',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+		school = {
+			value = 'School',
+			sort = 'B2',
+			name = 'School',
+			short = 'School',
+			link = 'School Tournaments',
+			category = 'School Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/runeterra/tier_data.lua
+++ b/standard/tier/wikis/runeterra/tier_data.lua
@@ -1,0 +1,111 @@
+---
+-- @Liquipedia
+-- wiki=runeterra
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until runeterra switches to standardized tier/tiertype
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/sideswipe/tier_data.lua
+++ b/standard/tier/wikis/sideswipe/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=sideswipe
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/simracing/tier_data.lua
+++ b/standard/tier/wikis/simracing/tier_data.lua
@@ -1,0 +1,119 @@
+---
+-- @Liquipedia
+-- wiki=simracing
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until simracing switches to standardized tier/tiertype
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/splatoon/tier_data.lua
+++ b/standard/tier/wikis/splatoon/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=splatoon
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/splitgate/tier_data.lua
+++ b/standard/tier/wikis/splitgate/tier_data.lua
@@ -1,0 +1,101 @@
+---
+-- @Liquipedia
+-- wiki=splitgate
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B3',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/squadrons/tier_data.lua
+++ b/standard/tier/wikis/squadrons/tier_data.lua
@@ -1,0 +1,111 @@
+---
+-- @Liquipedia
+-- wiki=squadrons
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until squadrons switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/starcraft/tier_data.lua
+++ b/standard/tier/wikis/starcraft/tier_data.lua
@@ -1,0 +1,93 @@
+---
+-- @Liquipedia
+-- wiki=starcraft
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Premier',
+			short = 'Prem.',
+			link = 'Premier Tournaments',
+			category = 'Premier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Major',
+			short = 'Maj.',
+			link = 'Major Tournaments',
+			category = 'Major Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Minor',
+			short = 'Min.',
+			link = 'Minor Tournaments',
+			category = 'Minor Tournaments',
+		},
+		[-1] = {
+			value = '9',
+			sort = 'A5',
+			name = 'Misc',
+			short = 'Misc',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'B1',
+			name = 'Monthly',
+			short = 'Mon.',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'B2',
+			name = 'Weekly',
+			short = 'Week.',
+			category = 'Weekly Tournaments',
+		},
+		biweekly = {
+			value = 'Biweekly',
+			sort = 'B3',
+			name = 'Biweekly',
+			short = 'Biw.',
+			category = 'Biweekly Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B4',
+			name = 'Showmatch',
+			short = 'Showm.',
+			category = 'Showmatch Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'B5',
+			name = 'Qualifier',
+			short = 'Qual.',
+			category = 'Qualifier Tournaments',
+		},
+		charity = {
+			value = 'Charity',
+			sort = 'B6',
+			name = 'Charity',
+			short = 'Char.',
+			category = 'Charity Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/starcraft/tier_data.lua
+++ b/standard/tier/wikis/starcraft/tier_data.lua
@@ -52,6 +52,7 @@ return {
 			sort = 'B1',
 			name = 'Monthly',
 			short = 'Mon.',
+			link = 'Monthly Tournaments',
 			category = 'Monthly Tournaments',
 		},
 		weekly = {
@@ -59,6 +60,7 @@ return {
 			sort = 'B2',
 			name = 'Weekly',
 			short = 'Week.',
+			link = 'Weekly Tournaments',
 			category = 'Weekly Tournaments',
 		},
 		biweekly = {
@@ -66,6 +68,7 @@ return {
 			sort = 'B3',
 			name = 'Biweekly',
 			short = 'Biw.',
+			link = 'Biweekly Tournaments',
 			category = 'Biweekly Tournaments',
 		},
 		showmatch = {
@@ -73,6 +76,7 @@ return {
 			sort = 'B4',
 			name = 'Showmatch',
 			short = 'Showm.',
+			link = 'Showmatch Tournaments',
 			category = 'Showmatch Tournaments',
 		},
 		qualifier = {
@@ -80,6 +84,7 @@ return {
 			sort = 'B5',
 			name = 'Qualifier',
 			short = 'Qual.',
+			link = 'Qualifier Tournaments',
 			category = 'Qualifier Tournaments',
 		},
 		charity = {
@@ -87,6 +92,7 @@ return {
 			sort = 'B6',
 			name = 'Charity',
 			short = 'Char.',
+			link = 'Charity Tournaments',
 			category = 'Charity Tournaments',
 		},
 	},

--- a/standard/tier/wikis/teamfortress/tier_data.lua
+++ b/standard/tier/wikis/teamfortress/tier_data.lua
@@ -1,0 +1,119 @@
+---
+-- @Liquipedia
+-- wiki=teamfortress
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until teamfortress switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/tetris/tier_data.lua
+++ b/standard/tier/wikis/tetris/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=tetris
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/tft/tier_data.lua
+++ b/standard/tier/wikis/tft/tier_data.lua
@@ -39,7 +39,7 @@ return {
 			short = '?',
 		},
 
-		-- for legacy reasons until freefire switches to standardized tier/tiertype
+		-- for legacy reasons until tft switches to standardized tier/tiertype
 		weekly = {
 			value = 'Weekly',
 			sort = 'A7',

--- a/standard/tier/wikis/tft/tier_data.lua
+++ b/standard/tier/wikis/tft/tier_data.lua
@@ -1,0 +1,103 @@
+---
+-- @Liquipedia
+-- wiki=tft
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Tier 1',
+			short = '1',
+			link = 'Tier 1 Tournaments',
+			category = 'Tier 1 Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Tier 2',
+			short = '2',
+			link = 'Tier 2 Tournaments',
+			category = 'Tier 2 Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Tier 3',
+			short = '3',
+			link = 'Tier 3 Tournaments',
+			category = 'Tier 3 Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until freefire switches to standardized tier/tiertype
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/trackmania/tier_data.lua
+++ b/standard/tier/wikis/trackmania/tier_data.lua
@@ -1,0 +1,101 @@
+---
+-- @Liquipedia
+-- wiki=trackmania
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Tier 1',
+			short = '1',
+			link = 'Tier 1 Tournaments',
+			category = 'Tier 1 Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Tier 2',
+			short = '2',
+			link = 'Tier 2 Tournaments',
+			category = 'Tier 2 Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Tier 3',
+			short = '3',
+			link = 'Tier 3 Tournaments',
+			category = 'Tier 3 Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'Tier 4',
+			short = '4',
+			link = 'Tier 4 Tournaments',
+			category = 'Tier 4 Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+		campaign = {
+			value = 'Campaign',
+			sort = 'B2',
+			name = 'Campaign',
+			short = 'Camp.',
+			link = 'Campaigns',
+			category = 'Campaign Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/underlords/tier_data.lua
+++ b/standard/tier/wikis/underlords/tier_data.lua
@@ -1,0 +1,143 @@
+---
+-- @Liquipedia
+-- wiki=underlords
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until underlords switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/warcraft/tier_data.lua
+++ b/standard/tier/wikis/warcraft/tier_data.lua
@@ -1,0 +1,85 @@
+---
+-- @Liquipedia
+-- wiki=warcraft
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'Tier 1',
+			short = '1',
+			link = 'Tier 1 Tournaments',
+			category = 'Tier 1 Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'Tier 2',
+			short = '2',
+			link = 'Tier 2 Tournaments',
+			category = 'Tier 2 Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'Tier 3',
+			short = '3',
+			link = 'Tier 3 Tournaments',
+			category = 'Tier 3 Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'D1',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Show Matches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/warcraft/tier_data.lua
+++ b/standard/tier/wikis/warcraft/tier_data.lua
@@ -78,7 +78,7 @@ return {
 			sort = 'B1',
 			name = 'Showmatch',
 			short = 'Showm.',
-			link = 'Show Matches',
+			link = 'Showmatch Tournaments',
 			category = 'Showmatch Tournaments',
 		},
 	},

--- a/standard/tier/wikis/wildrift/tier_data.lua
+++ b/standard/tier/wikis/wildrift/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=wildrift
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/worldofwarcraft/tier_data.lua
+++ b/standard/tier/wikis/worldofwarcraft/tier_data.lua
@@ -1,0 +1,135 @@
+---
+-- @Liquipedia
+-- wiki=worldofwarcraft
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+
+		-- for legacy reasons until worldofwarcraft switches to standardized tier/tiertype
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/standard/tier/wikis/zula/tier_data.lua
+++ b/standard/tier/wikis/zula/tier_data.lua
@@ -1,0 +1,109 @@
+---
+-- @Liquipedia
+-- wiki=zula
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}


### PR DESCRIPTION
## Summary
Add tier data modules for wikis that do not need `Module:Tier/Custom` due to `.toIdentifier` overwrite

## How did you test this change?
N/A