### PR TITLE
Add localid to Player extradata in smash

### DIFF
--- a/components/infobox/wikis/smash/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/smash/infobox_person_player_custom.lua
@@ -116,6 +116,7 @@ function CustomPlayer:createWidgetInjector()
 end
 
 function CustomPlayer:adjustLPDB(lpdbData)
+	lpdbData.extradata.localid = _args.localid
 	lpdbData.extradata.maingame = _args.game or Info.defaultGame
 	for game in pairs(Info.games) do
 		lpdbData.extradata['main' .. game] = _args['main-' .. game]


### PR DESCRIPTION
## Summary

Add localid to extradata to aid querying of players with foreign tags

## How did you test this change?

Tested in dev
