### PR TITLE
Add a nil check in notability checker

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -184,6 +184,10 @@ function NotabilityChecker._calculateWeightForTournament(tier, tierType, placeme
 		Config.weights, function(tierWeights) return tierWeights['tier'] == tier end
 		)
 
+	if not weightForTier then
+		return 0
+	end
+
 	local tierPoints = Array.find(
 		weightForTier['tiertype'],
 		function(pointsForType)

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -188,12 +188,12 @@ function NotabilityChecker._calculateWeightForTournament(tier, tierType, placeme
 		return 0
 	end
 
-	local tierPoints = Array.find(
+	local tierPoints = (Array.find(
 		weightForTier['tiertype'],
 		function(pointsForType)
 			return pointsForType['name'] == (tierType or Config.TIER_TYPE_GENERAL)
 		end
-	)['points']
+	) or {}).points
 
 	if not tierPoints then
 		return 0

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -194,6 +194,11 @@ function NotabilityChecker._calculateWeightForTournament(tier, tierType, placeme
 			return pointsForType['name'] == (tierType or Config.TIER_TYPE_GENERAL)
 		end
 	)['points']
+
+	if not tierPoints then
+		return 0
+	end
+
 	local placementDropOffFunction = Config.placementDropOffFunction(tier, tierType)
 
 	local placementValue = NotabilityChecker._preparePlacement(placement)


### PR DESCRIPTION
## Summary
Add a nil check in notability checker
needed due to misc now being -1 across the board and some wikis not wanting misc/-1 to count
the nil check takes place after the array.find and hence if a wiki has data set for -1 it will still work there while it catches the case where a wiki has not set config weight data for -1
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live, bug fix, only nil check
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
