### PR TITLE
Catch BYE matches as `resulttype = l` for match1

### DIFF
--- a/components/match2/wikis/counterstrike/match_legacy.lua
+++ b/components/match2/wikis/counterstrike/match_legacy.lua
@@ -126,6 +126,9 @@ function MatchLegacy.convertParameters(match2)
 				else
 					match[prefix] = opponent.name
 				end
+				if opponent.name == 'BYE' then
+					match.resulttype = 'l'
+				end
 			end
 			--When a match is overturned winner get score needed to win bestofx while loser gets score = 0
 			if isOverturned then


### PR DESCRIPTION
## Summary

When there is a literal opponent and they're a BYE, catch that and store the match as `resulttype` to be `l`. Needed for certain modules that depend on displaying results differently for non-standard results.

## How did you test this change?

Live on CS wiki.
