### PR TITLE
Changing "North Macedonian" to "Macedonian"

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -838,7 +838,7 @@ local data = {
 	},
 	['northmacedonia'] = {
 		flag = 'File:mk_hd.png',
-		localised = 'North Macedonian',
+		localised = 'Macedonian',
 		name = 'North Macedonia',
 	},
 	['norway'] = {


### PR DESCRIPTION
## Summary

According to the [Prespa Agreement](https://en.wikipedia.org/wiki/Prespa_Agreement) the official demonym for North Macedonia is Macedonian, not North Macedonian.