### PR TITLE
Fix Role issue for Tetris

### DIFF
--- a/components/infobox/wikis/tetris/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_person_player_custom.lua
@@ -54,12 +54,12 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomPlayer:adjustLPDB(lpdbData)
-	
+
 	local isplayer = 'true'
 	if CustomPlayer._isNotPlayer() then
 		isplayer = 'false'
 	end
-	
+
 	lpdbData.extradata.isplayer = isplayer
 	lpdbData.extradata.role = _role.variable
 	lpdbData.extradata.role2 = _role2.variable

--- a/components/infobox/wikis/tetris/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_person_player_custom.lua
@@ -72,10 +72,6 @@ function CustomPlayer._createRole(key, role)
 	end
 end
 
-function CustomPlayer._isNotPlayer()
-	return _role and (_role.staff or _role.talent)
-end
-
 function CustomPlayer:getPersonType(args)
 	local roleData = _role
 	if roleData then

--- a/components/infobox/wikis/tetris/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_person_player_custom.lua
@@ -55,12 +55,6 @@ end
 
 function CustomPlayer:adjustLPDB(lpdbData)
 
-	local isplayer = 'true'
-	if CustomPlayer._isNotPlayer() then
-		isplayer = 'false'
-	end
-
-	lpdbData.extradata.isplayer = isplayer
 	lpdbData.extradata.role = _role.variable
 	lpdbData.extradata.role2 = _role2.variable
 	return lpdbData

--- a/components/infobox/wikis/tetris/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_person_player_custom.lua
@@ -13,14 +13,16 @@ local Role = require('Module:Role')
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
 
-local _role
-local _role2
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
 
 local CustomPlayer = Class.new()
 
 local CustomInjector = Class.new(Injector)
 
 local _args
+local _role
+local _role2
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
@@ -30,6 +32,7 @@ function CustomPlayer.run(frame)
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+	player.getPersonType = CustomPlayer.getPersonType
 
 	return player:createInfobox(frame)
 end
@@ -38,10 +41,57 @@ function CustomPlayer:createWidgetInjector()
 	return CustomInjector()
 end
 
+function CustomInjector:parse(id, widgets)
+	if id == 'role' then
+		return {
+			Cell{name = 'Role', content = {
+				CustomPlayer._createRole('role', _role),
+				CustomPlayer._createRole('role2', _role2)
+			}},
+		}
+	end
+	return widgets
+end
+
 function CustomPlayer:adjustLPDB(lpdbData)
-	lpdbData.extradata.role = _role.role
-	lpdbData.extradata.role2 = _role2.role
+	
+	local isplayer = 'true'
+	if CustomPlayer._isNotPlayer() then
+		isplayer = 'false'
+	end
+	
+	lpdbData.extradata.isplayer = isplayer
+	lpdbData.extradata.role = _role.variable
+	lpdbData.extradata.role2 = _role2.variable
 	return lpdbData
+end
+
+function CustomPlayer._createRole(key, role)
+	local roleData = role
+	if not roleData then
+		return nil
+	end
+	if Player:shouldStoreData(_args) then
+		return roleData.category
+	else
+		return roleData.variable
+	end
+end
+
+function CustomPlayer._isNotPlayer()
+	return _role and (_role.staff or _role.talent)
+end
+
+function CustomPlayer:getPersonType(args)
+	local roleData = _role
+	if roleData then
+		if roleData.staff then
+			return {store = 'Staff', category = 'Staff'}
+		elseif roleData.talent then
+			return {store = 'Talent', category = 'Talent'}
+		end
+	end
+	return {store = 'Player', category = 'Player'}
 end
 
 return CustomPlayer


### PR DESCRIPTION
## Summary
3 Main issue happens with Tetris Player Infobox

- In the Portal Players module, every player gets counted under Staff & Talent accidentally
- Role inside the infobox, even if matched Module:Role/Data it did not get linkede (but was made to be linked to a category from the data module)
- |role2= while being stored, never gets to displayed
- make isPlayer stored and properly

## How did you test this change?
/Dev - https://liquipedia.net/tetris/Marq_Maier (isPlayer true and has category as player because no role is added in the page, intended) & https://liquipedia.net/tetris/Marq_Maier (Roles being blue-linked, isPlayer counted as False as intended)
