### PR TITLE
Adjust Start Year in Simracing Info

### DIFF
--- a/standard/info/wikis/simracing/info.lua
+++ b/standard/info/wikis/simracing/info.lua
@@ -7,7 +7,7 @@
 --
 
 return {
-	startYear = 2019,
+	startYear = 1998,
 	wikiName = 'simracing',
 	name = 'Sim Racing',
 	games = {

--- a/standard/info/wikis/simracing/info.lua
+++ b/standard/info/wikis/simracing/info.lua
@@ -7,7 +7,7 @@
 --
 
 return {
-	startYear = 1998,
+	startYear = 2000,
 	wikiName = 'simracing',
 	name = 'Sim Racing',
 	games = {


### PR DESCRIPTION
## Summary
- Start Year being 2019 cause transfers before that to not worked until sdate is set in TimelineSquadAuto
- 2019 doesnt feel fitting anyway, since most of games in the list came out before so I've switched the startdate to 1998 which is few years before the oldest game in the list (GP3 - 2000)