### PR TITLE
Remove misc as tiertype for RL

### DIFF
--- a/standard/tier/wikis/rocketleague/tier_data.lua
+++ b/standard/tier/wikis/rocketleague/tier_data.lua
@@ -89,14 +89,6 @@ return {
 			link = 'Qualifier Tournaments',
 			category = 'Qualifier Tournaments',
 		},
-		misc = {
-			value = 'Misc',
-			sort = 'A9',
-			name = 'Misc',
-			short = 'Misc',
-			link = 'Miscellaneous Tournaments',
-			category = 'Miscellaneous Tournaments',
-		},
 		showmatch = {
 			value = 'Showmatch',
 			sort = 'B1',


### PR DESCRIPTION
## Summary
Remove misc as tiertype for RL
forgot to remove it when i set up the data module

## How did you test this change?
N/A