### PR TITLE
Refine sort order

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -544,7 +544,7 @@ function Import._groupLastVsAdditionalData(lpdbEntry)
 
 	local matchData = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = '[[opponent::' .. opponentName .. ']] AND (' .. table.concat(matchConditions, ' OR ') .. ')',
-		order = 'date desc',
+		order = 'date desc, match2id desc',
 		query = 'date, match2opponents, winner',
 		limit = 1
 	})


### PR DESCRIPTION
## Summary
Refine sort order in the lastVs retrieval for group stages in PPT Import.

Currently it only checks by date but if match data sets (for whatever reason) the same date for matches this could cause the wrong match being used.
This PR refines the sort order so that the likelihood of the wrong match getting chosen gets reduced.

## How did you test this change?
dev