### PR TITLE
Fix bug for ML matches with even Bestof

### DIFF
--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -439,15 +440,11 @@ function matchFunctions.getOpponents(match)
 	end
 
 	-- see if match should actually be finished if bestof limit was reached
-	if isScoreSet and not Logic.readBool(match.finished) then
-		local firstTo = math.ceil(match.bestof/2)
-		for _, item in pairs(opponents) do
-			if tonumber(item.score or 0) >= firstTo then
-				match.finished = true
-				break
-			end
-		end
-	end
+	match.finished = Logic.readBool(match.finished)
+		or isScoreSet and (
+			Array.any(opponents, function(opponent) return tonumber(opponent.score or 0) > match.bestof/2 end)
+			or Array.all(opponents, function(opponent) return tonumber(opponent.score or 0) == match.bestof/2 end)
+		)
 
 	-- see if match should actually be finished if score is set
 	if isScoreSet and not Logic.readBool(match.finished) and match.hasDate then


### PR DESCRIPTION
## Summary
> Bo2 have a bug when the 1st game result inputted the system acknowledge that the Match is done.
i suspect that because the system use formula of n/2 where n is Bo(n). this will make the match end when the first game result inputed.

https://discord.com/channels/93055209017729024/1084072695253176330/1084072695253176330

## How did you test this change?
dev