### PR TITLE
Adjust role data in tft infobox player

### DIFF
--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -29,7 +29,7 @@ local ROLES = {
 	talent = {category = 'Talents', value = 'Talent', type = 'talent'},
 	manager = {category = 'Managers', value = 'Manager', type = 'staff'},
 	producer = {category = 'Producers', value = 'Producer', type = 'talent'},
-	organizer = {category = 'Tournament Organizers', value = 'Organizer', type = 'staff'},
+	organizer = {category = 'Tournament Organizer', value = 'Organizer', type = 'staff'},
 	creator = {category = 'Content Creators', value = 'Content Creator', type = 'talent'},
 }
 ROLES['assistant coach'] = ROLES.coach

--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -29,8 +29,8 @@ local ROLES = {
 	talent = {category = 'Talents', value = 'Talent', type = 'talent'},
 	manager = {category = 'Managers', value = 'Manager', type = 'staff'},
 	producer = {category = 'Producers', value = 'Producer', type = 'talent'},
-	tournament organizer = {category = 'Tournament Organizers', value = 'Organizer', type = 'staff'},
-	content creator = {category = 'Content Creators', value = 'Content Creator', type = 'talent'},
+	organizer = {category = 'Tournament Organizers', value = 'Organizer', type = 'staff'},
+	creator = {category = 'Content Creators', value = 'Content Creator', type = 'talent'},
 }
 ROLES['assistant coach'] = ROLES.coach
 

--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -29,7 +29,7 @@ local ROLES = {
 	talent = {category = 'Talent', value = 'Talent', type = 'talent'},
 	manager = {category = 'Manager', value = 'Manager', type = 'staff'},
 	producer = {category = 'Producer', value = 'Producer', type = 'talent'},
-	organizer = {category = 'Tournament Organizer', value = 'Organizer', type = 'staff'},
+	organizer = {category = 'Tournament Organizer', value = 'Tournament Organizer', type = 'staff'},
 	creator = {category = 'Content Creator', value = 'Content Creator', type = 'talent'},
 }
 ROLES['assistant coach'] = ROLES.coach

--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -29,6 +29,8 @@ local ROLES = {
 	talent = {category = 'Talents', value = 'Talent', type = 'talent'},
 	manager = {category = 'Managers', value = 'Manager', type = 'staff'},
 	producer = {category = 'Producers', value = 'Producer', type = 'talent'},
+	tournament organizer = {category = 'Tournament Organizers', value = 'Organizer', type = 'staff'},
+	content creator = {category = 'Content Creators', value = 'Content Creator', type = 'talent'},
 }
 ROLES['assistant coach'] = ROLES.coach
 

--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -19,18 +19,18 @@ local Cell = Widgets.Cell
 
 local ROLES = {
 	-- Staff and Talents
-	analyst = {category = 'Analysts', value = 'Analyst', type = 'talent'},
-	observer = {category = 'Observers', value = 'Observer', type = 'talent'},
-	host = {category = 'Hosts', value = 'Host', type = 'talent'},
-	journalist = {category = 'Journalists', value = 'Journalist', type = 'talent'},
-	expert = {category = 'Experts', value = 'Expert', type = 'talent'},
-	coach = {category = 'Coaches', value = 'Coach', type = 'staff'},
-	caster = {category = 'Casters', value = 'Caster', type = 'talent'},
-	talent = {category = 'Talents', value = 'Talent', type = 'talent'},
-	manager = {category = 'Managers', value = 'Manager', type = 'staff'},
-	producer = {category = 'Producers', value = 'Producer', type = 'talent'},
+	analyst = {category = 'Analyst', value = 'Analyst', type = 'talent'},
+	observer = {category = 'Observer', value = 'Observer', type = 'talent'},
+	host = {category = 'Host', value = 'Host', type = 'talent'},
+	journalist = {category = 'Journalist', value = 'Journalist', type = 'talent'},
+	expert = {category = 'Expert', value = 'Expert', type = 'talent'},
+	coach = {category = 'Coach', value = 'Coach', type = 'staff'},
+	caster = {category = 'Caster', value = 'Caster', type = 'talent'},
+	talent = {category = 'Talent', value = 'Talent', type = 'talent'},
+	manager = {category = 'Manager', value = 'Manager', type = 'staff'},
+	producer = {category = 'Producer', value = 'Producer', type = 'talent'},
 	organizer = {category = 'Tournament Organizer', value = 'Organizer', type = 'staff'},
-	creator = {category = 'Content Creators', value = 'Content Creator', type = 'talent'},
+	creator = {category = 'Content Creator', value = 'Content Creator', type = 'talent'},
 }
 ROLES['assistant coach'] = ROLES.coach
 


### PR DESCRIPTION
## Summary
Added two roles to TFT infobox player:
1. Organizer: People who organize TFT Tournament
2. Content Creators: People who are important in TFT that make interview videos, tutorial videos and etc.

Additionally made category values singular to not have double `s` at the end when the category is set

## How did you test this change?
only data change