### PR TITLE
Fix CS Info Module

### DIFF
--- a/standard/info/wikis/counterstrike/info.lua
+++ b/standard/info/wikis/counterstrike/info.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local infoData = {
+return {
 	startYear = 2000,
 	wikiName = 'counterstrike',
 	name = 'Counter-Strike',
@@ -93,7 +93,3 @@ local infoData = {
 		cscz = 'CS default darkmode.png',
 	}, ---@deprecated
 }
-
-infoData.games.cs16 = infoData.games.cs
-
-return infoData


### PR DESCRIPTION
## Summary
Adjust cs module:Info to have the same formatting as all other wikis (remove the wrong alias that nil-ed one of the wanted values)

## How did you test this change?
live