### PR TITLE
Add some escapes in tier library

### DIFF
--- a/standard/tier/commons/tier_utils.lua
+++ b/standard/tier/commons/tier_utils.lua
@@ -165,7 +165,7 @@ function Tier.displaySingle(data, options)
 
 	if Logic.readBool(options.link) and data.link then
 		return Page.makeInternalLink({}, display, data.link)
-	elseif String.isNotEmpty(options.link) then
+	elseif Logic.readBoolOrNil(options.link) == nil and String.isNotEmpty(options.link) then
 		return Page.makeInternalLink({}, display, options.link)
 	end
 

--- a/standard/tier/commons/tier_utils.lua
+++ b/standard/tier/commons/tier_utils.lua
@@ -17,6 +17,7 @@ local Table = require('Module:Table')
 local TierData = mw.loadData('Module:Tier/Data')
 
 local NON_BREAKING_SPACE = '&nbsp;'
+local DEFAULT_TIER_TYPE = 'General'
 
 local Tier = {}
 
@@ -112,7 +113,10 @@ end
 ---@param queryData table
 ---@return string?, string?, table
 function Tier.parseFromQueryData(queryData)
-	return queryData.liquipediatier, queryData.liquipediatiertype, {}
+	local tierType = queryData.liquipediatiertype
+	tierType = tierType ~= DEFAULT_TIER_TYPE and tierType or nil
+
+	return queryData.liquipediatier, tierType, {}
 end
 
 --- Builds the display for a given (tier, tierType) tuple

--- a/standard/tier/wikis/starcraft2/tier_custom.lua
+++ b/standard/tier/wikis/starcraft2/tier_custom.lua
@@ -55,7 +55,7 @@ function TierCustom.display(tier, tierType, options)
 
 	if Logic.readBool(link) and tierData.link then
 		return Page.makeInternalLink({}, display, tierData.link)
-	elseif String.isNotEmpty(link) then
+	elseif Logic.readBoolOrNil(options.link) == nil and String.isNotEmpty(link) then
 		return Page.makeInternalLink({}, display, link)
 	end
 

--- a/standard/tier/wikis/starcraft2/tier_custom.lua
+++ b/standard/tier/wikis/starcraft2/tier_custom.lua
@@ -55,7 +55,7 @@ function TierCustom.display(tier, tierType, options)
 
 	if Logic.readBool(link) and tierData.link then
 		return Page.makeInternalLink({}, display, tierData.link)
-	elseif Logic.readBoolOrNil(options.link) == nil and String.isNotEmpty(link) then
+	elseif Logic.readBoolOrNil(link) == nil and String.isNotEmpty(link) then
 		return Page.makeInternalLink({}, display, link)
 	end
 

--- a/standard/tier/wikis/warcraft/tier_custom.lua
+++ b/standard/tier/wikis/warcraft/tier_custom.lua
@@ -61,7 +61,7 @@ function Tier.displaySingle(data, options)
 
 	if Logic.readBool(options.link) and data.link then
 		return Page.makeInternalLink({}, display, TierCustom.adjustLink(data.link, options.mode))
-	elseif String.isNotEmpty(options.link) then
+	elseif Logic.readBoolOrNil(options.link) == nil and String.isNotEmpty(options.link) then
 		return Page.makeInternalLink({}, display, options.link)
 	end
 


### PR DESCRIPTION
## Summary
- escape `false` in tier library in link option parsing
- escape default tierType when parsing from query

## How did you test this change?
dev