### PR TITLE
Use td instead of th for game icons

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -64,7 +64,7 @@ function ResultsTable:buildRow(placement)
 	row:tag('td'):attr('data-sort-value', tierSortValue):wikitext(tierDisplay)
 
 	if self.config.displayGameIcons then
-		row:tag('th'):node(Game.icon{game = placement.game})
+		row:tag('td'):node(Game.icon{game = placement.game})
 	end
 
 	local tournamentDisplayName = BaseResultsTable.tournamentDisplayName(placement)


### PR DESCRIPTION
## Summary
Game icons were put into a `<th>` resulting in weird styles and bugged header.

## How did you test this change?
/dev