### PR TITLE
Copy opponentplayers to players in fortnite ppt custom

### DIFF
--- a/components/prize_pool/wikis/fortnite/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/fortnite/prize_pool_custom.lua
@@ -39,6 +39,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		placement.placeStart
 	)
 
+	lpdbData.players = lpdbData.opponentplayers
+
 	local team = lpdbData.participant or ''
 	local lpdbPrefix = Variables.varDefault('lpdb_prefix') or ''
 


### PR DESCRIPTION
## Summary
Copy opponentplayers to players in fortnite ppt custom so that earnings functions in infobox player has the data available
(For non solo/team opponents commons sets empty table there)

## How did you test this change?
live, hot fix