### PR TITLE
Replace nil return with empty table return

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -403,7 +403,7 @@ end
 function CustomLeague.createRestrictionsCell(restrictions)
 	local restrictionData = CustomLeague.getRestrictions(restrictions)
 	if #restrictionData == 0 then
-		return
+		return {}
 	end
 
 	return Array.map(restrictionData, function(res) return League:createLink(res.link, res.name) end)


### PR DESCRIPTION
## Summary
Replace nil return with empty table return to not error on unpack in widget
intorduced via #2731

## How did you test this change?
live