### PR TITLE
Fix maximum value comparison

### DIFF
--- a/components/external_media_links/external_media_link.lua
+++ b/components/external_media_links/external_media_link.lua
@@ -71,7 +71,7 @@ function ExternalMediaLink._store(args)
 		authors['author' .. authorIndex .. 'dn'] = author
 	end
 	-- set a maximum for authors due to the same being used in queries
-	assert(Table.size(authors) <= MAXIMUM_VALUES.authors,
+	assert(Table.size(authors) <= 2*MAXIMUM_VALUES.authors,
 		'Maximum Value of authors (' .. MAXIMUM_VALUES.authors .. ') exceeded')
 	lpdbData.authors = mw.ext.LiquipediaDB.lpdb_create_json(authors)
 


### PR DESCRIPTION
## Summary
The table contains 2 entries per author, so `MAX_VALUES.authors` should be doubled.

## How did you test this change?
/dev
