### PR TITLE
Update KGS symbol to use HTML underline

### DIFF
--- a/standard/currency/currency_data.lua
+++ b/standard/currency/currency_data.lua
@@ -382,7 +382,7 @@ return {
 		symbol = {
 			hasSpace = true,
 			isAfter = true,
-			text = 'С̲',
+			text = '<u>С</u>',
 		},
 	},
 	khr = {


### PR DESCRIPTION
## Summary

Just looks silly to use the current rendering. Better to be like on 1st place row. Can move to unicode `⃀` when it is finally added to most OS default fonts.

![image](https://user-images.githubusercontent.com/5881994/225650018-85072c46-9448-4945-82aa-7359d74bc4c8.png)

## How did you test this change?

Seems to work fine on dev module.
![image](https://user-images.githubusercontent.com/5881994/225650740-4f651ae9-ba5c-4fc4-85cc-9f961ca47153.png)
