### PR TITLE
Fix game name in overwatch `info.lua`

### DIFF
--- a/standard/info/wikis/overwatch/info.lua
+++ b/standard/info/wikis/overwatch/info.lua
@@ -11,7 +11,7 @@ return {
 	wikiName = 'overwatch',
 	name = 'Overwatch',
 	games = {
-		ow = {
+		overwatch = {
 			abbreviation = 'OW',
 			name = 'Overwatch',
 			link = 'Overwatch',
@@ -24,7 +24,7 @@ return {
 				lightMode = 'Overwatch default lightmode.png',
 			},
 		},
-		ow2 = {
+		overwatch2 = {
 			abbreviation = 'OW2',
 			name = 'Overwatch 2',
 			link = 'Overwatch 2',
@@ -38,7 +38,7 @@ return {
 			},
 		},
 	},
-	defaultGame = 'ow2',
+	defaultGame = 'overwatch2',
 	defaultTeamLogo = 'Overwatch Logo lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Overwatch Logo darkmode.png', ---@deprecated
 }


### PR DESCRIPTION
## Summary

Incorrect game name is causing TeamCard errors like [these](https://liquipedia.net/overwatch/ZOTAC_Cup/2023/Asia/11#Top_16_Participants).

## How did you test this change?

Previously worked when I [changed it manually](https://liquipedia.net/overwatch/index.php?title=Module:Info&oldid=731961) (didn't realize it needed a PR)
