### PR TITLE
Implement circuit handling in Infobox League for Fighters

### DIFF
--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -316,7 +316,7 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 			output = output .. abbreviation
 		end
 	elseif String.isEmpty(abbreviation) then
-		output = output .. '[[' .. circuit .. '|' .. circuit .. ']]'
+		return output .. '[[' .. circuit .. ']]'
 	else
 		output = output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
 	end

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -299,7 +299,6 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 		date = Variables.varDefault('tournament_enddate'),
 		options = {noLink = not circuitPageExists}
 	}
-	
 	if output == LeagueIcon.display{} then
 		output = ''
 	else

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -12,11 +12,13 @@ local Currency = require('Module:Currency')
 local Game = require('Module:Game')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
+local LeagueIcon = Lua.import('Module:LeagueIcon', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -43,8 +45,9 @@ function CustomLeague.run(frame)
 
 	-- Auto Icon
 	local seriesIconLight, seriesIconDark = CustomLeague.getIconFromSeries(_args.series)
-	_args.icon = _args.icon or seriesIconLight
-	_args.icondark = _args.icondark or seriesIconDark
+	_args.circuitIconLight, _args.circuitIconDark = CustomLeague.getIconFromSeries(_args.circuit)
+	_args.icon = _args.icon or seriesIconLight or _args.circuitIconLight
+	_args.icondark = _args.icondark or seriesIconDark or _args.circuitIconDark
 
 	-- Normalize name
 	_args.game = Game.toIdentifier{game = _args.game}
@@ -88,10 +91,21 @@ function CustomInjector:parse(id, widgets)
 	if id == 'customcontent' then
 		if _args.circuit or _args.points or _args.circuit_next or _args.circuit_previous then
 			table.insert(widgets, Title{name = 'Circuit Information'})
-			table.insert(widgets, Cell{name = 'Circuit', content = {_args.circuit}})
-			table.insert(widgets, Cell{name = 'Circuit Tier', content = {
-				_args.circuittier and (_args.circuittier .. ' Tier') or nil}
-			})
+			table.insert(
+				widgets, 
+				Cell{
+						name = 'Circuit', 
+						content = {
+							CustomLeague:_createCircuit(
+								_args.circuit,
+								_args.circuitabbr,
+								_args.circuitIconLight,
+								_args.circuitIconLight or _args.circuitIconDark
+							)
+						}
+				}
+			)
+			table.insert(widgets, Cell{name = 'Circuit Tier', content = {_args.circuittier}})
 			table.insert(widgets, Cell{name = 'Tournament Region', content = {_args.region}})
 			table.insert(widgets, Cell{name = 'Points', content = {_args.points}})
 			table.insert(widgets, Chronology{content = {next = _args.circuit_next, previous = _args.circuit_previous}})
@@ -268,6 +282,46 @@ function CustomLeague:_cleanPrizeValue(value, currency)
 	value = string.gsub(value, '%$', '')
 
 	return value
+end
+
+function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
+	if String.isEmpty(circuit) then
+		return
+	end
+
+	local circuitPageExists = Page.exists(circuit)
+
+	local output = LeagueIcon.display{
+		icon = icon,
+		iconDark = iconDark,
+		series = circuit,
+		abbreviation = abbreviation,
+		date = Variables.varDefault('tournament_enddate'),
+		options = { noLink = not circuitPageExists }
+	}
+	
+	if output == LeagueIcon.display{} then
+		output = ''
+	else
+		output = output .. ' '
+		if not _args.icon then
+			League:_setIconVariable(output, icon, iconDark)
+		end
+	end
+
+	if not circuitPageExists then
+		if String.isEmpty(abbreviation) then
+			output = output .. circuit
+		else
+			output = output .. abbreviation
+		end
+	elseif String.isEmpty(abbreviation) then
+		output = output .. '[[' .. circuit .. '|' .. circuit .. ']]'
+	else
+		output = output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
+	end
+
+	return output
 end
 
 return CustomLeague

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -320,7 +320,6 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 	else
 	return output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
 	end
-
 end
 
 return CustomLeague

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -100,7 +100,7 @@ function CustomInjector:parse(id, widgets)
 								_args.circuit,
 								_args.circuitabbr,
 								_args.circuitIconLight,
-								_args.circuitIconLight or _args.circuitIconDark
+								_args.circuitIconDark or _args.circuitIconLight
 							)
 						}
 				}

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -321,7 +321,6 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 	return output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
 	end
 
-	return output
 end
 
 return CustomLeague

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -318,7 +318,7 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 	elseif String.isEmpty(abbreviation) then
 		return output .. '[[' .. circuit .. ']]'
 	else
-		output = output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
+	return output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
 	end
 
 	return output

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -92,7 +92,7 @@ function CustomInjector:parse(id, widgets)
 		if _args.circuit or _args.points or _args.circuit_next or _args.circuit_previous then
 			table.insert(widgets, Title{name = 'Circuit Information'})
 			table.insert(
-				widgets, 
+				widgets,
 				Cell{
 					name = 'Circuit', 
 					content = {

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -94,15 +94,15 @@ function CustomInjector:parse(id, widgets)
 			table.insert(
 				widgets, 
 				Cell{
-						name = 'Circuit', 
-						content = {
-							CustomLeague:_createCircuit(
-								_args.circuit,
-								_args.circuitabbr,
-								_args.circuitIconLight,
-								_args.circuitIconDark or _args.circuitIconLight
-							)
-						}
+					name = 'Circuit', 
+					content = {
+						CustomLeague:_createCircuit(
+							_args.circuit,
+							_args.circuitabbr,
+							_args.circuitIconLight,
+							_args.circuitIconDark or _args.circuitIconLight
+						)
+					}
 				}
 			)
 			table.insert(widgets, Cell{name = 'Circuit Tier', content = {_args.circuittier}})
@@ -317,6 +317,7 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 		end
 	elseif String.isEmpty(abbreviation) then
 		return output .. '[[' .. circuit .. ']]'
+	end
 	return output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
 end
 

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -297,7 +297,7 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 		series = circuit,
 		abbreviation = abbreviation,
 		date = Variables.varDefault('tournament_enddate'),
-		options = { noLink = not circuitPageExists }
+		options = {noLink = not circuitPageExists}
 	}
 	
 	if output == LeagueIcon.display{} then

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -311,7 +311,7 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 
 	if not circuitPageExists then
 		if String.isEmpty(abbreviation) then
-			output = output .. circuit
+			return output .. circuit
 		else
 			output = output .. abbreviation
 		end

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -317,7 +317,6 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 		end
 	elseif String.isEmpty(abbreviation) then
 		return output .. '[[' .. circuit .. ']]'
-	else
 	return output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
 	end
 end

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -94,7 +94,7 @@ function CustomInjector:parse(id, widgets)
 			table.insert(
 				widgets,
 				Cell{
-					name = 'Circuit', 
+					name = 'Circuit',
 					content = {
 						CustomLeague:_createCircuit(
 							_args.circuit,

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -318,7 +318,6 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 	elseif String.isEmpty(abbreviation) then
 		return output .. '[[' .. circuit .. ']]'
 	return output .. '[[' .. circuit .. '|' .. abbreviation .. ']]'
-	end
 end
 
 return CustomLeague

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -313,7 +313,7 @@ function CustomLeague:_createCircuit(circuit, abbreviation, icon, iconDark)
 		if String.isEmpty(abbreviation) then
 			return output .. circuit
 		else
-			output = output .. abbreviation
+			return output .. abbreviation
 		end
 	elseif String.isEmpty(abbreviation) then
 		return output .. '[[' .. circuit .. ']]'


### PR DESCRIPTION
## Summary

Parse circuit input to resolve link, abbreviation, and icon from the circuit page.
If no series icon exists, save circuit icon in lpdb
Remove "Tier" suffix from circuit tier

## How did you test this change?

Tested in dev on https://liquipedia.net/fighters/Canada_Cup/2019/SFV