### PR TITLE
Make USD prizepool rounding customizable

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -357,7 +357,8 @@ function League:_createPrizepool(args)
 		currency = args.localcurrency,
 		rate = args.currency_rate,
 		date = date or Variables.varDefault('tournament_enddate'),
-		displayRoundPrecision = args.displayRoundPrecision,
+		displayRoundPrecision = args.currencyDispPrecision,
+		varRoundPrecision = args.currencyVarPrecision
 	}
 end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -357,6 +357,7 @@ function League:_createPrizepool(args)
 		currency = args.localcurrency,
 		rate = args.currency_rate,
 		date = date or Variables.varDefault('tournament_enddate'),
+		displayRoundPrecision = args.displayRoundPrecision,
 	}
 end
 

--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -29,7 +29,7 @@ function PrizePoolCurrency.display(args)
 	local prizepoolUsd = PrizePoolCurrency._cleanValue(args.prizepoolusd)
 	local currencyRate = tonumber(args.rate)
 	local setVariables = Logic.emptyOr(args.setvariables, true)
-	local varRoundPrecision = tonumber(args.varRoundPrecision) or 'full'
+	local varRoundPrecision = tonumber(args.varRoundPrecision)
 	local displayRoundPrecision = tonumber(args.displayRoundPrecision) or 0
 
 	if not prizepool and not prizepoolUsd then
@@ -65,7 +65,7 @@ function PrizePoolCurrency.display(args)
 		end
 	end
 
-	if varRoundPrecision ~= 'full' then
+	if varRoundPrecision then
 		prizepoolUsd = Math.round{prizepoolUsd, varRoundPrecision}
 	end
 

--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -32,9 +32,9 @@ function PrizePoolCurrency.display(args)
 	local varRoundPrecision = tonumber(args.varRoundPrecision)
 	local displayRoundPrecision = tonumber(args.displayRoundPrecision) or 0
 
-if varRoundPrecision and varRoundPrecision < displayRoundPrecision then
+	if varRoundPrecision and varRoundPrecision < displayRoundPrecision then
 		return PrizePoolCurrency._errorMessage('Display precision cannot be higher than Variable precious')
-end
+	end
 
 	if not prizepool and not prizepoolUsd then
 		if Namespace.isMain() then

--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -77,7 +77,7 @@ function PrizePoolCurrency.display(args)
 		Variables.varDefine('tournament_currency_date', date)
 		Variables.varDefine('tournament_currency_text', text)
 		Variables.varDefine('tournament_prizepoollocal', prizepool or '')
-		Variables.varDefine('tournament_prizepoolusd', prizepoolUsd or '')
+		Variables.varDefine('tournament_prizepoolusd', prizepoolUsd)
 
 		-- legacy compatibility
 		Variables.varDefine('tournament_currency_rate', currencyRate or '')
@@ -88,7 +88,7 @@ function PrizePoolCurrency.display(args)
 		Variables.varDefine('currency rate', currencyRate)
 		Variables.varDefine('prizepool', prizepool or '')
 		Variables.varDefine('prizepool usd', prizepoolUsd or '')
-		Variables.varDefine('tournament_prizepool', prizepoolUsd or '')
+		Variables.varDefine('tournament_prizepool', prizepoolUsd)
 	end
 
 	local display = Currency.display(USD, prizepoolUsd, {

--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -18,7 +18,6 @@ local PrizePoolCurrency = {}
 
 local NOW = os.date('!%F')
 local USD = 'USD'
-local LANG = mw.language.new('en')
 local CATEGRORY = '[[Category:Tournaments with invalid prize pool]]'
 
 function PrizePoolCurrency.display(args)
@@ -92,10 +91,17 @@ function PrizePoolCurrency.display(args)
 		Variables.varDefine('tournament_prizepool', prizepoolUsd or '')
 	end
 
-	local display = Currency.display(USD, prizepoolUsd, {setVariables = false, formatValue = true, formatPrecision = displayRoundPrecision})
+	local display = Currency.display(USD, prizepoolUsd, {
+			setVariables = false,
+			formatValue = true,
+			formatPrecision = displayRoundPrecision
+		})
 	if String.isNotEmpty(prizepool) then
-		display = Currency.display(currency, prizepool, {setVariables = true, formatValue = true, formatPrecision = displayRoundPrecision})
-			.. '<br>(≃ ' .. display .. ')'
+		display = Currency.display(currency, prizepool, {
+				setVariables = true,
+				formatValue = true,
+				formatPrecision = displayRoundPrecision
+			}) .. '<br>(≃ ' .. display .. ')'
 	end
 
 	return display

--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -41,7 +41,7 @@ function PrizePoolCurrency.display(args)
 			return (args.prizepool or args.prizepoolUsd or '')
 				.. '[[Category:Tournaments with invalid prize pool]]'
 		else
-			return (args.prizepool or args.prizepoolUsd or '')
+			return args.prizepool or args.prizepoolUsd or ''
 		end
 	end
 
@@ -80,18 +80,18 @@ function PrizePoolCurrency.display(args)
 
 		Variables.varDefine('tournament_currency_date', date)
 		Variables.varDefine('tournament_currency_text', text)
-		Variables.varDefine('tournament_prizepoollocal', prizepool or '')
+		Variables.varDefine('tournament_prizepoollocal', prizepool)
 		Variables.varDefine('tournament_prizepoolusd', prizepoolUsd)
 
 		-- legacy compatibility
-		Variables.varDefine('tournament_currency_rate', currencyRate or '')
-		Variables.varDefine('tournament_prizepool_local', prizepool or '')
-		Variables.varDefine('tournament_prizepool_usd', prizepoolUsd or '')
-		Variables.varDefine('currency', args.currency and currency or '')
+		Variables.varDefine('tournament_currency_rate', currencyRate)
+		Variables.varDefine('tournament_prizepool_local', prizepool)
+		Variables.varDefine('tournament_prizepool_usd', prizepoolUsd)
+		Variables.varDefine('currency', args.currency and currency)
 		Variables.varDefine('currency date', date)
 		Variables.varDefine('currency rate', currencyRate)
-		Variables.varDefine('prizepool', prizepool or '')
-		Variables.varDefine('prizepool usd', prizepoolUsd or '')
+		Variables.varDefine('prizepool', prizepool)
+		Variables.varDefine('prizepool usd', prizepoolUsd)
 		Variables.varDefine('tournament_prizepool', prizepoolUsd)
 	end
 

--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -32,6 +32,10 @@ function PrizePoolCurrency.display(args)
 	local varRoundPrecision = tonumber(args.varRoundPrecision)
 	local displayRoundPrecision = tonumber(args.displayRoundPrecision) or 0
 
+if varRoundPrecision and varRoundPrecision < displayRoundPrecision then
+		return PrizePoolCurrency._errorMessage('Display precision cannot be higher than Variable precious')
+end
+
 	if not prizepool and not prizepoolUsd then
 		if Namespace.isMain() then
 			return (args.prizepool or args.prizepoolUsd or '')


### PR DESCRIPTION
## Summary

Want to enable automatic USD conversion for CS wiki, however, also don't like the current 0 precision rounding that's baked in. This allows for that to be modified by args input and by wiki customs. Will follow up with a CS PR to change it there. Also, probably can use this as a cleaner solution for #2699.

## How did you test this change?

`/dev` on commons and CS. 

Not enabled: 
![image](https://user-images.githubusercontent.com/5881994/226274820-68c1332b-5ba4-4f39-a450-e6c35e5b695a.png)

Enabled and set to 2:
![image](https://user-images.githubusercontent.com/5881994/226274872-cba023b8-181a-44c5-88e2-215293f2c13b.png)

Also tested on R6 (works fine) and Fighters (no effect due to custom overrides).