### PR TITLE
Add arab speaking language flag data

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1472,6 +1472,11 @@ local data = {
 		localised = '',
 		name = 'Russian Speaking',
 	},
+	['arabicspeaking'] = {
+		flag = 'File:Arab league hd.png',
+		localised = '',
+		name = 'Arabic Speaking',
+	},
 	['non-representing'] = {
 		flag = 'File:non hd.png',
 		localised = 'non-country representing',
@@ -2120,10 +2125,12 @@ local aliases = {
 	['esmx'] = 'spanishspeaking',
 	['ptbr'] = 'portuguesespeaking',
 	['ruby'] = 'russianspeaking',
+	['arab'] = 'arabicspeaking',
 
 	--language flag aliases
 	['engspeaking'] = 'englishspeaking',
 	['gerspeaking'] = 'germanspeaking',
+	['arabstates'] = 'arabicspeaking',
 
 	['ff'] = 'filler',
 	['fillerflag'] = 'filler',

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -2130,7 +2130,7 @@ local aliases = {
 	--language flag aliases
 	['engspeaking'] = 'englishspeaking',
 	['gerspeaking'] = 'germanspeaking',
-	['arabstates'] = 'arabicspeaking',
+	['araspeaking'] = 'arabicspeaking',
 
 	['ff'] = 'filler',
 	['fillerflag'] = 'filler',
@@ -2163,6 +2163,7 @@ local languageThreeLetter = {
 	['spa'] = 'spanishspeaking',
 	['por'] = 'portuguesespeaking',
 	['rus'] = 'russianspeaking',
+	['ara'] = 'arabicspeaking',
 }
 
 -- This table includes


### PR DESCRIPTION

## Summary

Noticed a few wikis uses "arab states" as a language entry when recording different language streams:

https://liquipedia.net/commons/Special:GlobalWhatLinksHere?wpPageTitle=Template%3AFlagNoLink%2Farab_states&wpNamespace=-1337420&wpFormIdentifier=gwlh-form

No data in the MasterData module throws an "Unknown Flag" error, so have added the data structure.

## How did you test this change?

Using a local version of Flags/MasterData
https://liquipedia.net/apexlegends/User:Dark_meluca/Test/FlagUnknown
