### PR TITLE
Change `varRoundPrecision` default to 2

### DIFF
--- a/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
+++ b/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua
@@ -29,10 +29,10 @@ function PrizePoolCurrency.display(args)
 	local prizepoolUsd = PrizePoolCurrency._cleanValue(args.prizepoolusd)
 	local currencyRate = tonumber(args.rate)
 	local setVariables = Logic.emptyOr(args.setvariables, true)
-	local varRoundPrecision = tonumber(args.varRoundPrecision)
+	local varRoundPrecision = tonumber(args.varRoundPrecision) or (args.varRoundPrecision == 'full' and 'full') or 2
 	local displayRoundPrecision = tonumber(args.displayRoundPrecision) or 0
 
-	if varRoundPrecision and varRoundPrecision < displayRoundPrecision then
+	if Logic.isNumeric(varRoundPrecision) and varRoundPrecision < displayRoundPrecision then
 		return PrizePoolCurrency._errorMessage('Display precision cannot be higher than Variable precious')
 	end
 
@@ -69,7 +69,7 @@ function PrizePoolCurrency.display(args)
 		end
 	end
 
-	if varRoundPrecision then
+	if Logic.isNumeric(varRoundPrecision) then
 		prizepoolUsd = Math.round{prizepoolUsd, varRoundPrecision}
 	end
 


### PR DESCRIPTION
## Summary

I realize it should actually have been 2 instead of full since we store that in LPDB directly. Causing issues:
![image](https://user-images.githubusercontent.com/5881994/226464875-c18e6147-3740-4719-9280-4f9ebebb93ea.png)

## How did you test this change?

`/dev`.

before change: 
![image](https://user-images.githubusercontent.com/5881994/226464939-35fea068-8577-4ee6-a011-5004bcf936cf.png)

with change:
![image](https://user-images.githubusercontent.com/5881994/226464965-1fd0d35d-551f-4b93-a195-1cf5f2924dda.png)

with change + `full`:
![image](https://user-images.githubusercontent.com/5881994/226464998-d02864e6-3c33-4baa-b01d-a209ffa0d0a1.png)

