### PR TITLE
Create Infobox Team for FIFA

### DIFF
--- a/components/infobox/wikis/fifa/infobox_team_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_team_custom.lua
@@ -1,0 +1,52 @@
+---
+-- @Liquipedia
+-- wiki=fifa
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local MatchTicker = require('Module:MatchTicker/Participant')
+local Template = require('Module:Template')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+local CustomTeam = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _team
+local _doStore = true
+
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	_team = team
+	team.createWidgetInjector = CustomTeam.createWidgetInjector
+	team.createBottomContent = CustomTeam.createBottomContent
+	team.addToLpdb = CustomTeam.addToLpdb
+	return team:createInfobox()
+end
+
+function CustomTeam:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomTeam:createBottomContent()
+	if _doStore then
+		return MatchTicker.run({team = _team.pagename})
+	end
+end
+
+function CustomTeam:addToLpdb(lpdbData, args)
+	lpdbData.region = Variables.varDefault('region', '')
+
+	return lpdbData
+end
+
+return CustomTeam


### PR DESCRIPTION
## Summary
The code base is VALORANT with IGL removed 

But the actual important part is I want Upcoming/Recent matches to be added, using the Match Ticker module that is ported from Starcraft2 
![image](https://user-images.githubusercontent.com/88981446/226682642-fb35bf08-0ed2-4029-abf0-fe7a0c8b2d82.png)

## How did you test this change?
/dev, but also LIVE 
https://liquipedia.net/fifa/AS_Monaco_Esports

