### PR TITLE
Append award name to team award object names too

### DIFF
--- a/components/prize_pool/commons/prize_pool_award.lua
+++ b/components/prize_pool/commons/prize_pool_award.lua
@@ -90,12 +90,13 @@ function AwardPrizePool:_lpdbObjectName(lpdbEntry, prizePoolIndex, lpdbPrefix)
 	if String.isNotEmpty(lpdbPrefix) then
 		objectName = objectName .. '_' .. lpdbPrefix
 	end
+
+	-- Append the award name in case there is a participant who gets several awards
+	objectName = objectName .. '_' .. lpdbEntry.extradata.award
+
 	if lpdbEntry.opponenttype == Opponent.team then
 		return objectName .. '_' .. mw.ustring.lower(lpdbEntry.participant)
 	end
-
-	-- Append the award name in case there is a player who gets several awards
-	objectName = objectName .. '_' .. lpdbEntry.extradata.award
 
 	-- for non team opponents the pagename can be case sensitive
 	-- so objectname needs to be case sensitive to avoid edge cases


### PR DESCRIPTION
## Summary
Append award name to team award object names too

requested by Okidokie98
https://discord.com/channels/93055209017729024/268719633366777856/1087878626856402995

## How did you test this change?
dev