### PR TITLE
Fix condition in Notability Checker

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -109,7 +109,7 @@ function NotabilityChecker._calculatePersonNotability(person)
 	-- Add conditions.
 	-- We check for names with spaces, then names with underscores.
 	local conditions = {}
-	for _, name in pairs({person, person:gsub(' ', '_')}) do
+	for _, name in pairs({person, (person:gsub(' ', '_'))}) do
 		table.insert(conditions, '[[participant::' .. name .. ']]')
 		for i = 1, Config.MAX_NUMBER_OF_PARTICIPANTS do
 			table.insert(conditions, '[[players_p' .. tostring(i) .. '::' .. name .. ']]')


### PR DESCRIPTION
## Summary
Gsub returns two values, the substituted string, and number of occurances. 
In a `{}`, it will insert both values into the table.

This caused an extra unintended loop to be executed. In certain scenarios, this could attribute placements to where it shouldn't been. (Eg. on Rocket League, a player name with 2 spaces would match against the participant `2` who had a 5th place in a C-Tier tournament, awarding them an extra 35 points.

## How did you test this change?
Live