### PR TITLE
Update Overwatch League/Contenders icons

### DIFF
--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -37,8 +37,8 @@ local _LINK_DATA = {
 		iconDark = 'File:ESL_2019_icon_darkmode.png',
 		text = 'Match page on ESL'
 	},
-	owl = {icon = 'File:Overwatch League allmode.png', text = 'Overwatch League matchpage'},
-	owc = {icon = 'File:OWC-BMS icon.png', text = 'OW Contenders matchpage'},
+	owl = {icon = 'File:Overwatch League 2023 allmode.png', text = 'Overwatch League matchpage'},
+	owc = {icon = 'File:Overwatch Contenders logo.png', text = 'Overwatch Contenders matchpage'},
 	jcg = {icon = 'File:JCG-BMS icon.png', text = 'JCG matchpage'},
 	oceow = {icon = 'File:OCEOW-BMS icon.png', text = 'OCEOverwatch matchpage'},
 	tespa = {icon = 'File:Tespa icon.png', text = 'Tespa matchpage'},


### PR DESCRIPTION
## Summary

Updating to 2023 OWL logo and better Contenders icon

## How did you test this change?

[first match here](https://liquipedia.net/overwatch/User:Moonshot/sandbox2#Results)
