### PR TITLE
Default prize to whole-number

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -102,7 +102,7 @@ function ResultsTable:buildRow(placement)
 
 	row:tag('td'):css('text-align', 'right'):wikitext('$' .. Currency.formatMoney(
 			self.config.queryType ~= Opponent.team and placement.individualprizemoney
-			or placement.prizemoney
+			or placement.prizemoney, 0
 		))
 
 	return row


### PR DESCRIPTION
## Summary

Default prize to whole-number
Most prizes on Rocket League are not divisible by the number of players (typically 3), resulting in decimalised prizes, player earnings rounds by default but not the results table

## How did you test this change?

On module