### PR TITLE
Fix CS PPT `resultName` not being stored

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -50,6 +50,8 @@ function CustomPrizePool.run(frame)
 	HEADER_DATA.tournamentName = args['tournament name']
 	HEADER_DATA.resultName = args['custom-name']
 
+	Variables.varDefine('prizepool_resultName', HEADER_DATA.resultName)
+
 	if Logic.readBool(args.qualifier) then
 		mw.ext.LiquipediaDB.lpdb_tournament('tournament_'.. Variables.varDefault('tournament_name', ''), {
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json{

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -20,6 +20,7 @@ end
 
 function CustomLegacyPrizePool.customHeader(newArgs, CACHED_DATA, header)
 	newArgs.qualifier = header.qualifier
+	newArgs['custom-name'] = header['custom-name']
 	newArgs.points1link = header['points-link']
 
 	return newArgs


### PR DESCRIPTION
## Summary

Custom group score result names were being lost due to removal of var `custom result name` definition when moved to github version of PPT.

![image](https://user-images.githubusercontent.com/5881994/227802136-79232472-6993-482d-9f40-b0e9c3b17f48.png)

## How did you test this change?

`/dev` on CS wiki.

![image](https://user-images.githubusercontent.com/5881994/227802112-826c3094-dd5e-4ea0-a7b3-32577cd761ea.png)

https://liquipedia.net/counterstrike/index.php?title=Module:TeamCard/Custom&diff=2493866&oldid=2320290

## Future plans?

Ideally maybe we can move this to `lastvsdata` instead like `lastvsdata.groupscorename` for example? So, that way it won't need to be re-defined in TeamCard extradata. Just an idea.
