### PR TITLE
Fix double `trans_title` in ExternalMediaLink

### DIFF
--- a/components/external_media_links/external_media_link.lua
+++ b/components/external_media_links/external_media_link.lua
@@ -137,7 +137,7 @@ function ExternalMediaLink._display(args)
 	end
 
 	if args.trans_title then
-		display:wikitext(NON_BREAKING_SPACE .. Page.makeExternalLink(args.trans_title, args.trans_title))
+		display:wikitext(NON_BREAKING_SPACE .. '[' .. args.trans_title .. ']')
 	end
 
 	local authors = {}


### PR DESCRIPTION
## Summary

Currently some unexplained call is being made to `Module:Page` to make an external link of a text title (not even a link). So it causes it to double up like a `[https://google.com test link]` expected result.

![image](https://user-images.githubusercontent.com/5881994/227805717-7bc9da5e-1d56-407b-b908-bdccb35487ae.png)

## How did you test this change?

Tested with overwriting module on CS wiki. will delete when merged

![image](https://user-images.githubusercontent.com/5881994/227805759-3a21638d-e6d3-48f3-84ff-6b1b35080654.png)
