### PR TITLE
Results table format money adjust

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -102,7 +102,7 @@ function ResultsTable:buildRow(placement)
 
 	row:tag('td'):css('text-align', 'right'):wikitext('$' .. Currency.formatMoney(
 			self.config.queryType ~= Opponent.team and placement.individualprizemoney
-			or placement.prizemoney
+			or placement.prizemoney, nil, true
 		))
 
 	return row

--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -71,7 +71,7 @@ function AwardsTable:buildRow(placement)
 
 	row:tag('td'):css('text-align', 'right'):wikitext('$' .. Currency.formatMoney(
 			self.config.opponentType ~= Opponent.team and placement.individualprizemoney
-			or placement.prizemoney
+			or placement.prizemoney, nil, true
 		))
 
 	return row


### PR DESCRIPTION
depends on #2800

## Summary
Adjust prize money display in results and awards tables to use forced round precision

## How did you test this change?
dev