### PR TITLE
Add defaultRoundPrecision data to info modules

### DIFF
--- a/standard/info/wikis/apexlegends/info.lua
+++ b/standard/info/wikis/apexlegends/info.lua
@@ -26,7 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'apexlegends',
-	defaultRoundPrecision = 2,
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Apex Legends default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Apex Legends default darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/apexlegends/info.lua
+++ b/standard/info/wikis/apexlegends/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'apexlegends',
+	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'Apex Legends default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Apex Legends default darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/brawlstars/info.lua
+++ b/standard/info/wikis/brawlstars/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'brawlstars',
+	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'Brawl Stars Default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Brawl Stars Default allmode.png', ---@deprecated
 }

--- a/standard/info/wikis/brawlstars/info.lua
+++ b/standard/info/wikis/brawlstars/info.lua
@@ -26,7 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'brawlstars',
-	defaultRoundPrecision = 2,
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Brawl Stars Default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Brawl Stars Default allmode.png', ---@deprecated
 }

--- a/standard/info/wikis/callofduty/info.lua
+++ b/standard/info/wikis/callofduty/info.lua
@@ -312,6 +312,7 @@ return {
 		},
 	},
 	defaultGame = 'cod',
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Call of Duty Default Lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Call of Duty Default Darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/crossfire/info.lua
+++ b/standard/info/wikis/crossfire/info.lua
@@ -52,6 +52,7 @@ return {
 		},
 	},
 	defaultGame = 'cf',
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Crossfire default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Crossfire default darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/dota2/info.lua
+++ b/standard/info/wikis/dota2/info.lua
@@ -39,6 +39,7 @@ return {
 		},
 	},
 	defaultGame = 'dota2',
+	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'Dota2 logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Dota2 logo.png', ---@deprecated
 }

--- a/standard/info/wikis/dota2/info.lua
+++ b/standard/info/wikis/dota2/info.lua
@@ -39,7 +39,7 @@ return {
 		},
 	},
 	defaultGame = 'dota2',
-	defaultRoundPrecision = 2,
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Dota2 logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Dota2 logo.png', ---@deprecated
 }

--- a/standard/info/wikis/fifa/info.lua
+++ b/standard/info/wikis/fifa/info.lua
@@ -390,6 +390,7 @@ return {
 		},
 	},
 	defaultGame = 'fifa',
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'FIFA lightmode logo.png', ---@deprecated
 	defaultTeamLogoDark = 'FIFA darkmode logo.png', ---@deprecated
 }

--- a/standard/info/wikis/freefire/info.lua
+++ b/standard/info/wikis/freefire/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'freefire',
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Freefire Default Logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Freefire Default Logo.png', ---@deprecated
 }

--- a/standard/info/wikis/heroes/info.lua
+++ b/standard/info/wikis/heroes/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'hots',
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Hots logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Hots logo.png', ---@deprecated
 }

--- a/standard/info/wikis/leagueoflegends/info.lua
+++ b/standard/info/wikis/leagueoflegends/info.lua
@@ -26,7 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'leagueoflegends',
-	defaultRoundPrecision = 2,
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'League of Legends allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'League of Legends allmode.png', ---@deprecated
 }

--- a/standard/info/wikis/leagueoflegends/info.lua
+++ b/standard/info/wikis/leagueoflegends/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'leagueoflegends',
+	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'League of Legends allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'League of Legends allmode.png', ---@deprecated
 }

--- a/standard/info/wikis/pubg/info.lua
+++ b/standard/info/wikis/pubg/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'pubg',
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'PUBG Default logo.png', ---@deprecated
 	defaultTeamLogoDark = 'PUBG Default logo.png', ---@deprecated
 }

--- a/standard/info/wikis/pubgmobile/info.lua
+++ b/standard/info/wikis/pubgmobile/info.lua
@@ -65,6 +65,7 @@ return {
 		},
 	},
 	defaultGame = 'pubgm',
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'PUBG Mobile Default logo allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'PUBG Mobile Default logo allmode.png', ---@deprecated
 }

--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -39,7 +39,7 @@ return {
 		},
 	},
 	defaultGame = 'siege',
-	defaultRoundPrecision = 2,
+	defaultRoundPrecision = 0,
 
 	defaultTeamLogo = {
 		siege = 'Rainbow Six Siege Logo lightmode.png',

--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -39,6 +39,7 @@ return {
 		},
 	},
 	defaultGame = 'siege',
+	defaultRoundPrecision = 2,
 
 	defaultTeamLogo = {
 		siege = 'Rainbow Six Siege Logo lightmode.png',

--- a/standard/info/wikis/rocketleague/info.lua
+++ b/standard/info/wikis/rocketleague/info.lua
@@ -39,7 +39,6 @@ return {
 		},
 	},
 	defaultGame = 'rl',
-	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'Rocket League.png', ---@deprecated
 	defaultTeamLogoDark = 'Rocket League.png', ---@deprecated
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',

--- a/standard/info/wikis/rocketleague/info.lua
+++ b/standard/info/wikis/rocketleague/info.lua
@@ -39,6 +39,7 @@ return {
 		},
 	},
 	defaultGame = 'rl',
+	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'Rocket League.png', ---@deprecated
 	defaultTeamLogoDark = 'Rocket League.png', ---@deprecated
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',

--- a/standard/info/wikis/splitgate/info.lua
+++ b/standard/info/wikis/splitgate/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'splitgate',
+	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'Splitgate allmode.png (2019) Change date '
 		.. '(2021-06-01) Splitgate 2021 lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Splitgate allmode.png (2019) Change date '

--- a/standard/info/wikis/splitgate/info.lua
+++ b/standard/info/wikis/splitgate/info.lua
@@ -26,7 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'splitgate',
-	defaultRoundPrecision = 2,
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Splitgate allmode.png (2019) Change date '
 		.. '(2021-06-01) Splitgate 2021 lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Splitgate allmode.png (2019) Change date '

--- a/standard/info/wikis/tft/info.lua
+++ b/standard/info/wikis/tft/info.lua
@@ -26,6 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'tft',
+	defaultRoundPrecision = 2,
 	defaultTeamLogo = 'Teamfight Tactics Double Up lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Teamfight Tactics Double Up darkmode.png', ---@deprecated
 }

--- a/standard/info/wikis/tft/info.lua
+++ b/standard/info/wikis/tft/info.lua
@@ -26,7 +26,7 @@ return {
 		},
 	},
 	defaultGame = 'tft',
-	defaultRoundPrecision = 2,
+	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Teamfight Tactics Double Up lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Teamfight Tactics Double Up darkmode.png', ---@deprecated
 }


### PR DESCRIPTION
## Summary
Add defaultRoundPrecision data to info modules for wikis that want to use `0` instead of the global default of `2`

## How did you test this change?
N/A, just data

spreadsheet: https://docs.google.com/spreadsheets/d/1jRN10vwuVo2S28o4YOls1U9CzWCd49QA09_GhmydZSc/edit#gid=0