### PR TITLE
Remove region from CS player infobox

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
@@ -107,9 +107,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = (role2 and 'Roles' or 'Role'), content = {role, role2}},
 		}
 	elseif id == 'region' then
-		return {
-			Cell{name = 'Region', content = {}},
-		}
+		return {}
 	end
 
 	return widgets

--- a/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
@@ -99,13 +99,16 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Years Active (Analyst)', content = {_args.years_active_analyst}},
 			Cell{name = 'Years Active (Talent)', content = {_args.years_active_talent}},
 		}
-
 	elseif id == 'role' then
 		local role = CustomPlayer._createRole('role', _args.role)
 		local role2 = CustomPlayer._createRole('role2', _args.role2)
 
 		return {
 			Cell{name = (role2 and 'Roles' or 'Role'), content = {role, role2}},
+		}
+	elseif id == 'region' then
+		return {
+			Cell{name = 'Region', content = {}},
 		}
 	end
 


### PR DESCRIPTION
## Summary

Creating region data module started adding regions to player infoboxes. This was unintended as we only wanted regions for tournament LPDB data (at least for now). Killed the region cell by overwriting it as blank as a quick fix.

If there is a better solution, please let me know or directly change it. Thanks.

## How did you test this change?

dev to live
