### PR TITLE
Add Hidden Data Box Custom - Apex

### DIFF
--- a/components/hidden_data_box/wikis/apexlegends/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/apexlegends/hidden_data_box_custom.lua
@@ -1,0 +1,40 @@
+---
+-- @Liquipedia
+-- wiki=apexlegends
+-- page=Module:HiddenDataBox/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Variables = require('Module:Variables')
+
+local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox', {requireDevIfEnabled = true})
+local CustomHiddenDataBox = {}
+
+function CustomHiddenDataBox.run(args)
+	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+	return BasicHiddenDataBox.run(args)
+end
+
+function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	queryResult.extradata = queryResult.extradata or {}
+
+	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('date', Variables.varDefault('tournament_enddate'))
+	Variables.varDefine('sdate', Variables.varDefault('tournament_startdate'))
+	Variables.varDefine('edate', Variables.varDefault('tournament_enddate'))
+
+	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier'))
+	Variables.varDefine('tournament_tier_type', Variables.varDefault('tournament_liquipediatiertype'))
+	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
+	Variables.varDefine('tournament_icon_dark', Variables.varDefault('tournament_icondark'))
+	Variables.varDefine('tournament_parent_page', Variables.varDefault('tournament_parent'))
+
+	Variables.varDefine('tournament_mode', Variables.varDefault('tournament_mode', 'team'))
+end
+
+return Class.export(CustomHiddenDataBox)


### PR DESCRIPTION
## Summary

The current Template version needed updated anyway, so the standardised one has been set up with the match1 legacy variables.

## How did you test this change?

dev

![image](https://user-images.githubusercontent.com/97838082/228866140-0480feca-fa00-49e4-8c8e-42eda01ddc9e.png)

The image shows a comparison of the test page with the original mainspace page. Match data is the same, but with the addition of mode saved with a default value for 'team'