### PR TITLE
Fix conditions for opponent display for Team Awards

### DIFF
--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -62,7 +62,7 @@ function AwardsTable:buildRow(placement)
 
 	row:tag('td'):css('text-align', 'left'):wikitext(placement.extradata.award)
 
-	if self.config.playerResultsOfTeam or self.config.opponentType ~= Opponent.team then
+	if self.config.playerResultsOfTeam or self.config.queryType ~= Opponent.team then
 		row:tag('td'):css('text-align', 'right'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
 			placement,
 			{flip = true, teamForSolo = not self.config.playerResultsOfTeam}


### PR DESCRIPTION
## Summary

Team Logo would still show in Team Awards Table, resulting in missing column

![image](https://user-images.githubusercontent.com/97838082/228891726-82896e6a-71fe-4d3e-8bfc-059193d2e0c7.png)


## How did you test this change?

https://liquipedia.net/apexlegends/User:Dark_meluca/Test/ResultsTableNew/TeamAchievements 

with dev

