### PR TITLE
Awards Table: Undo Flip for non team opponents

### DIFF
--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -65,7 +65,7 @@ function AwardsTable:buildRow(placement)
 	if self.config.playerResultsOfTeam or self.config.opponentType ~= Opponent.team then
 		row:tag('td'):css('text-align', 'left'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
 			placement,
-			{flip = false, teamForSolo = not self.config.playerResultsOfTeam}
+			{teamForSolo = not self.config.playerResultsOfTeam}
 		))
 	end
 

--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -63,9 +63,9 @@ function AwardsTable:buildRow(placement)
 	row:tag('td'):css('text-align', 'left'):wikitext(placement.extradata.award)
 
 	if self.config.playerResultsOfTeam or self.config.opponentType ~= Opponent.team then
-		row:tag('td'):css('text-align', 'right'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
+		row:tag('td'):css('text-align', 'left'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
 			placement,
-			{flip = true, teamForSolo = not self.config.playerResultsOfTeam}
+			{flip = false, teamForSolo = not self.config.playerResultsOfTeam}
 		))
 	end
 


### PR DESCRIPTION


## Summary

Currently the awards table flips the order of flag and player name and right aligns them, which is done when displaying last result in the results table. However its not needed in the awards table, so have reverted to standard display.

## How did you test this change?

Tested alongside #2812 using /dev