### PR TITLE
Remove legacy wiki variables

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -741,7 +741,7 @@ end
 
 --- Returns the default date based on wiki-variables set in the Infobox League
 function BasePrizePool._getTournamentDate()
-	return Variables.varDefaultMulti('tournament_enddate', 'tournament_edate', 'edate', TODAY)
+	return Variables.varDefault('tournament_enddate', TODAY)
 end
 
 function BasePrizePool:storeData()
@@ -753,7 +753,7 @@ function BasePrizePool:storeData()
 		parent = Variables.varDefault('tournament_parent'),
 		series = Variables.varDefault('tournament_series'),
 		shortname = Variables.varDefault('tournament_tickername'),
-		startdate = Variables.varDefaultMulti('tournament_startdate', 'tournament_sdate', 'sdate', ''),
+		startdate = Variables.varDefault('tournament_startdate'),
 		mode = Variables.varDefault('tournament_mode'),
 		type = Variables.varDefault('tournament_type'),
 		liquipediatier = Variables.varDefault('tournament_liquipediatier'),

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -65,8 +65,8 @@ function TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, lpdbPrefix
 	local title = mw.title.getCurrentTitle().text
 	local tournamentName = Variables.varDefault('tournament name pp') or Variables.varDefault('tournament_name')
 	local date = Variables.varDefault('tournament_date')
-	local startDate = Variables.varDefault('tournament_startdate', Variables.varDefault('tournament_sdate', date))
-	local endDate = Variables.varDefault('tournament_enddate', Variables.varDefault('tournament_edate', date))
+	local startDate = Variables.varDefault('tournament_startdate', date)
+	local endDate = Variables.varDefault('tournament_enddate', date)
 
 	lpdbData.participant = team
 	lpdbData.tournament = tournamentName or title


### PR DESCRIPTION
## Summary
Remove usage of legacy wiki variables, now that all(*) wikis have stanardized league infobox
\* not smash

## How did you test this change?
Tested with dev