### PR TITLE
Add CSV input to vod2 for links for 3+ vod parts

### DIFF
--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -6,9 +6,11 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 
@@ -225,7 +227,7 @@ function CustomMatchSummary.getByMatchId(args)
 	if Logic.isNotEmpty(match.links.vod2) then
 		for _, vod2 in ipairs(match.links.vod2) do
 			local link, gameIndex = unpack(vod2)
-			secondVods[gameIndex] = link
+			secondVods[gameIndex] = Array.map(mw.text.split(link, ','), String.trim)
 		end
 		match.links.vod2 = nil
 	end
@@ -348,18 +350,22 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 	end
 
 	-- Match vod
-	if secondVods[0] then
+	if Table.isNotEmpty(secondVods[0]) then
 		addVodLink(nil, match.vod, 1)
-		addVodLink(nil, secondVods[0], 2)
+		Array.forEach(secondVods[0], function(vodlink, vodindex)
+				addVodLink(nil, vodlink, vodindex + 1)
+			end)
 	else
 		addVodLink(nil, match.vod, nil)
 	end
 
 	-- Game Vods
 	for index, vod in pairs(vods) do
-		if secondVods[index] then
+		if Table.isNotEmpty(secondVods[index]) then
 			addVodLink(index, vod, 1)
-			addVodLink(index, secondVods[index], 2)
+			Array.forEach(secondVods[index], function(vodlink, vodindex)
+				addVodLink(index, vodlink, vodindex + 1)
+			end)
 		else
 			addVodLink(index, vod, nil)
 		end


### PR DESCRIPTION
## Summary

Currently can only add part 1 and part 2 links of a vod for a match or a game. This is aimed at adding support for unlimited number of extra parts (for example, 4 parts).

![image](https://user-images.githubusercontent.com/5881994/229607826-9cfda5a4-f86c-43dd-b3a7-4be81f6d4968.png)
![image](https://user-images.githubusercontent.com/5881994/229607898-1946de20-27e9-41d8-b3e0-71b68aebb9bf.png)


## How did you test this change?

`/dev` on CS wiki. Still works with just 2 parts and no commas too.
![image](https://user-images.githubusercontent.com/5881994/229607997-a122e62d-b513-4fda-83cd-13a751887734.png)
![image](https://user-images.githubusercontent.com/5881994/229608038-3c8ed562-a354-4e1d-a28a-e82f9b11bb1e.png)


## Better solution

A better solution would to be support multiple VoDs per game2 and match2 in LPDB and commons match modules. But that's out of my scope right now for this "quick" fix. If someone has a good way of doing it, please feel free to suggest or open an issue about it.
