### PR TITLE
CS HDB: Move logic from Template to Module

### DIFF
--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -7,7 +7,10 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local HiddenMatches = mw.loadData('Module:HiddenMatchDetermination')
+local Table = require('Module:Table')
 local Tier = require('Module:Tier/Custom')
 local Variables = require('Module:Variables')
 
@@ -23,6 +26,7 @@ function CustomHiddenDataBox.run(args)
 end
 
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
+	local hiddenMatches = false
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate'))
@@ -39,6 +43,13 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('match_featured_override', args.featured)
 	Variables.varDefine('tournament_valve_major', args.valvemajor or (args.valvetier == 'Major' and 'true') or 'false')
 	BasicHiddenDataBox.checkAndAssign('tournament_valve_tier', args.valvetier, queryResult.publishertier)
+
+	if Logic.readBool(args.hidden) or Table.includes(HiddenMatches, Variables.varDefault('tournament_name')) then
+		hiddenMatches = true
+	end
+
+	Variables.varDefine('tournament_subpage', 'true')
+	Variables.varDefine('match_hidden', tostring(hiddenMatches))
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -26,7 +26,6 @@ function CustomHiddenDataBox.run(args)
 end
 
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
-	local hiddenMatches = false
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 	Variables.varDefine('tournament_date', Variables.varDefault('tournament_enddate'))
@@ -44,12 +43,13 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_valve_major', args.valvemajor or (args.valvetier == 'Major' and 'true') or 'false')
 	BasicHiddenDataBox.checkAndAssign('tournament_valve_tier', args.valvetier, queryResult.publishertier)
 
+	local hiddenMatches = false
 	if Logic.readBool(args.hidden) or Table.includes(HiddenMatches, Variables.varDefault('tournament_name')) then
 		hiddenMatches = true
 	end
+	Variables.varDefine('match_hidden', tostring(hiddenMatches))
 
 	Variables.varDefine('tournament_subpage', 'true')
-	Variables.varDefine('match_hidden', tostring(hiddenMatches))
 end
 
 return Class.export(CustomHiddenDataBox)

--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -43,11 +43,10 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_valve_major', args.valvemajor or (args.valvetier == 'Major' and 'true') or 'false')
 	BasicHiddenDataBox.checkAndAssign('tournament_valve_tier', args.valvetier, queryResult.publishertier)
 
-	local hiddenMatches = false
-	if Logic.readBool(args.hidden) or Table.includes(HiddenMatches, Variables.varDefault('tournament_name')) then
-		hiddenMatches = true
-	end
-	Variables.varDefine('match_hidden', tostring(hiddenMatches))
+	Variables.varDefine('match_hidden', tostring(
+		Logic.readBool(args.hidden)
+		or Table.includes(HiddenMatches, Variables.varDefault('tournament_name'))
+	))
 
 	Variables.varDefine('tournament_subpage', 'true')
 end


### PR DESCRIPTION
## Summary
Moved wikicode logic from the Template into the Module for Counterstrike's HDB.
https://liquipedia.net/counterstrike/index.php?title=Template:HiddenDataBox&action=edit

## How did you test this change?
Tested with dev module