### PR TITLE
Add 1 missing platform in FIFA Infobox League

### DIFF
--- a/components/infobox/wikis/fifa/infobox_league_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_league_custom.lua
@@ -25,6 +25,7 @@ local CustomInjector = Class.new(Injector)
 
 local PLATFORMS = {
 	pc = 'PC',
+	xbox = 'Xbox (2001)',
 	xbox360 = 'Xbox 360',
 	xboxone = 'Xbox One',
 	ps3 = 'PlayStation 3',


### PR DESCRIPTION
## Summary
Due to one of events that was missed out being covered on wiki https://liquipedia.net/fifa/FIFA_Interactive_World_Cup/2004 has a platform that isnt in the infobox right now. That being the original XBOX (2001)
