### PR TITLE
Add status to Squad extradata for smash

### DIFF
--- a/components/squad/wikis/smash/squad_custom.lua
+++ b/components/squad/wikis/smash/squad_custom.lua
@@ -101,6 +101,8 @@ function CustomSquad.run(frame)
 			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 		end
 
+		row:setExtradata{status = squad.type}
+
 		squad:row(row:create(
 			mw.title.getCurrentTitle().prefixedText
 			.. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)


### PR DESCRIPTION
## Summary

Add status to extradata, similar to commons version

## How did you test this change?

Tested live, impacts lpdb only.