### PR TITLE
Adjust prize pool testcases to #2717

### DIFF
--- a/components/prize_pool/test/prize_pool_test.lua
+++ b/components/prize_pool/test/prize_pool_test.lua
@@ -76,7 +76,7 @@ function suite:testHeaderInput()
 			showBaseCurrency = true,
 			storeLpdb = true,
 			storeSmw = true,
-			syncPlayers = false,
+			syncPlayers = true,
 		},
 		ppt.options
 	)


### PR DESCRIPTION
## Summary
Default value for `syncPlayers` was changed in #2717, but testcase wasn't adjusted

## How did you test this change?
via testcases/dev
