### PR TITLE
Add niconico to Links

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -118,6 +118,7 @@ local _PRIORITY_GROUPS = {
 		'kuaishou',
 		'kick',
 		'cc',
+		'niconico',
 		'nimotv',
 		'openrec',
 		'steamtv',

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -119,6 +119,7 @@ local PREFIXES = {
 	matcherino = {'https://matcherino.com/tournaments/'},
 	matcherinolink = {'https://matcherino.com/t/'},
 	mildom = {'https://www.mildom.com/'},
+	niconico = {'https://www.nicovideo.jp/'},
 	nimotv = {'https://www.nimo.tv/'},
 	['nwc3l'] = {
 		'',


### PR DESCRIPTION
## Summary

Add support for niconico in infobox links

Infobox icon already exists:
https://liquipedia.net/commons/Infobox_Icons#Niconico

## How did you test this change?

dev