### PR TITLE
Add Link to Game cell if there's an existing page

### DIFF
--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -118,7 +118,11 @@ function CustomInjector:parse(id, widgets)
 
 	elseif id == 'gamesettings' then
 		return {
-			Cell{name = 'Game', content = {Game.name{game = _args.game}}},
+			Cell{name = 'Game', content = {Page.makeInternalLink(
+				{onlyIfExists = true},
+				Game.name{game = _args.game},
+				Game.link{game = _args.game}
+			) or Game.name{game = _args.game}}},
 			Cell{name = 'Version', content = {_args.version}},
 		}
 	end


### PR DESCRIPTION
Links are retrieved via Module:Game/Module:Info(link)

## Summary

Suggested change to connect existing Game title pages better into the wiki infrastructure by linking them via Infobox league.

## How did you test this change?

Test via local dev module. Tested for cases: page exists; page doesn't exist; no game input; nonsense game input.
