### PR TITLE
Move date functions from TournamentUtil to DateExt

### DIFF
--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -53,7 +53,8 @@ function DateExt.readTimestampOrNil(dateString)
 	return success and timestamp or nil
 end
 
---- Formats a timestamp according to the specified format. The format string is the same used by mw.language.formatDate and {{#time}}.
+--- Formats a timestamp according to the specified format.
+--- The format string is the same used by mw.language.formatDate and {{#time}}.
 ---@param format string
 ---@param timestamp string|integer
 ---@return string
@@ -89,7 +90,7 @@ end
 --- Fetches contextualDate on a tournament page with fallback to now.
 ---@return string
 function DateExt.getContextualDateOrNow()
-	return TournamentUtil.getContextualDate()
+	return DateExt.getContextualDate()
 		or os.date('%F')
 end
 

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -104,4 +104,18 @@ function DateExt.toYmdInUtc(dateOrTimestamp)
 	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp))
 end
 
+--- Fetches contextualDate on a tournament page.
+---@return string
+function DateExt.getContextualDate()
+	return globalVars:get('tournament_enddate')
+		or globalVars:get('tournament_startdate')
+end
+
+--- Fetches contextualDate on a tournament page with fallback to now.
+---@return string
+function DateExt.getContextualDateOrNow()
+	return TournamentUtil.getContextualDate()
+		or os.date('%F')
+end
+
 return DateExt

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -7,6 +7,7 @@
 --
 
 local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
 
 --[[
 Functions for working with dates strings and timestamps.
@@ -81,8 +82,8 @@ end
 --- Fetches contextualDate on a tournament page.
 ---@return string
 function DateExt.getContextualDate()
-	return globalVars:get('tournament_enddate')
-		or globalVars:get('tournament_startdate')
+	return Variables.varDefault('tournament_enddate')
+		or Variables.varDefault('tournament_startdate')
 end
 
 --- Fetches contextualDate on a tournament page with fallback to now.

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -24,22 +24,12 @@ DateExt.maxTimestamp = 253402300799
 -- 1970-01-01 00:00:00
 DateExt.epochZero = 0
 
---[[
-Parses a date string into a timestamp, returning the number of seconds since
-UNIX epoch. The timezone offset is incorporated into the timestamp, and the
-timezone is discarded. If the timezone is not specified, then the date is
-assumed to be in UTC.
-
-Throws if the input string is non-empty and not a valid date.
-
-Example:
-
-DateExt.readTimestamp('2021-10-17 17:40 <abbr data-tz="-4:00">EDT</abbr>')
--- Returns 1634506800
-
-DateExt.readTimestamp('2021-10-17 21:40')
--- Returns 1634506800
-]]
+--- Parses a date string into a timestamp, returning the number of seconds since UNIX epoch.
+--- The timezone offset is incorporated into the timestamp, and the timezone is discarded.
+--- If the timezone is not specified, then the date is assumed to be in UTC.
+--- Throws if the input string is non-empty and not a valid date.
+---@param dateString string
+---@return integer=
 function DateExt.readTimestamp(dateString)
 	if String.isEmpty(dateString) then
 		return nil
@@ -54,52 +44,36 @@ function DateExt.readTimestamp(dateString)
 	return tonumber(timestampString)
 end
 
---[[
-Same as DateExt.readTimestamp, except that it returns nil upon failure.
-]]
+--- Same as DateExt.readTimestamp, except that it returns nil upon failure.
+---@param dateString string
+---@return integer?
 function DateExt.readTimestampOrNil(dateString)
 	local success, timestamp = pcall(DateExt.readTimestamp, dateString)
 	return success and timestamp or nil
 end
 
---[[
-Formats a timestamp according to the specified format. The format string is the
-same used by mw.language.formatDate and {{#time}}.
-
-Example:
-DateExt.formatTimestamp('c', 1634506800)
--- Returns 2021-10-17T21:40:00+00:00
-
-Date format reference:
-https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions#.23time
-https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.language:formatDate
-]]
+--- Formats a timestamp according to the specified format. The format string is the same used by mw.language.formatDate and {{#time}}.
+---@param format string
+---@param timestamp string|integer
+---@return string
 function DateExt.formatTimestamp(format, timestamp)
 	return mw.getContentLanguage():formatDate(format, '@' .. timestamp)
 end
 
---[[
-Converts a date string or timestamp into a format that can be used in the date
-param to Module:Countdown.
-]]
+--- Converts a date string or timestamp into a format that can be used in the date param to Module:Countdown.
+---@param format string
+---@param dateOrTimestamp string|integer
+---@return string
 function DateExt.toCountdownArg(dateOrTimestamp)
 	local timestamp = DateExt.readTimestamp(dateOrTimestamp)
 	return DateExt.formatTimestamp('F j, Y - H:i', timestamp) .. ' <abbr data-tz="+0:00"></abbr>'
 end
 
---[[
-Truncates the time of day in a date string or timestamp, and returns the date
-formatted as yyyy-mm-dd. The time of day is truncated in the UTC timezone. The
-time of day and timezone are discarded.
-
-Examples:
-DateExt.toYmdInUtc('November 08, 2021 - 13:00 <abbr data-tz="+2:00">CET</abbr>')
--- Returns 2021-11-08
-
-DateExt.toYmdInUtc('2021-11-08 17:00 <abbr data-tz="-8:00">PST</abbr>')
--- Returns 2021-11-09
-
-]]
+--- Truncates the time of day in a date string or timestamp, and returns the date formatted as yyyy-mm-dd.
+--- The time of day is truncated in the UTC timezone. The time of day and timezone are discarded.
+---@param format string
+---@param dateOrTimestamp string|integer
+---@return string
 function DateExt.toYmdInUtc(dateOrTimestamp)
 	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp))
 end

--- a/standard/test/date_ext_test.lua
+++ b/standard/test/date_ext_test.lua
@@ -8,6 +8,7 @@
 
 local Lua = require('Module:Lua')
 local ScribuntoUnit = require('Module:ScribuntoUnit')
+local Variables = require('Module:Variables')
 
 local DateExt = Lua.import('Module:Date/Ext', {requireDevIfEnabled = true})
 
@@ -25,6 +26,19 @@ end
 function suite:testToYmdInUtc()
 	self:assertEquals('2021-11-08', DateExt.toYmdInUtc('November 08, 2021 - 13:00 <abbr data-tz="+2:00">CET</abbr>'))
 	self:assertEquals('2021-11-09', DateExt.toYmdInUtc('2021-11-08 17:00 <abbr data-tz="-8:00">PST</abbr>'))
+end
+
+function suite:testGetContextualDateOrNow()
+	self:assertEquals(os.date('%F'), DateExt.getContextualDateOrNow())
+	self:assertEquals(nil, DateExt.getContextualDate())
+
+	Variables.varDefine('tournament_startdate', '2021-12-24')
+	self:assertEquals('2021-12-24', DateExt.getContextualDateOrNow())
+	self:assertEquals('2021-12-24', DateExt.getContextualDate())
+
+	Variables.varDefine('tournament_enddate', '2021-12-28')
+	self:assertEquals('2021-12-28', DateExt.getContextualDateOrNow())
+	self:assertEquals('2021-12-28', DateExt.getContextualDate())
 end
 
 return suite


### PR DESCRIPTION
## Summary
- move date functions from TournamentUtil to DateExt
- convert comments to annotations

## How did you test this change?
dev

## non git modules needing adjusting after this is merged
- [ ] https://liquipedia.net/commons/index.php?title=Module:TeamList/Rts&action=submit
- [ ] https://liquipedia.net/commons/index.php?title=Module:Player/Ext/downstream&action=submit
- [ ] https://liquipedia.net/commons/index.php?title=Module:OpponentList&action=submit
- [ ] https://liquipedia.net/commons/index.php?title=Module:Player/Ext/Starcraft/downstream&action=submit
- [ ] https://liquipedia.net/commons/index.php?title=Module:DistTable/Starcraft&action=submit
- [ ] https://liquipedia.net/commons/index.php?title=Module:OpponentList/Starcraft&action=submit
- [ ] https://liquipedia.net/commons/index.php?title=Module:GroupTableLeague/next/downstream&action=submit
- [ ] https://liquipedia.net/commons/index.php?title=Module:GroupTableLeague/next/downstreamHalo&action=submit