### PR TITLE
Add realname storage with `:id` in addition to `:name`

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -66,6 +66,7 @@ function SquadRow:id(args)
 
 	if String.isNotEmpty(args.name) then
 		cell:tag('br'):done():tag('i'):tag('small'):wikitext(args.name)
+		self.lpdbData.name = args.name
 	end
 
 	local teamNode = mw.html.create('td')


### PR DESCRIPTION
## Summary
Resolves #2854
If the real name is set through `:id` instead of `:name`, the LPDB data isn't being stored at the moment. 
This PR fixes this issue


## How did you test this change?

Dev module
![image](https://user-images.githubusercontent.com/3426850/231745545-cd1b84d6-a192-45c2-bf91-286e5e8b62c0.png)

