### PR TITLE
Apex: Update publishertier storage in prizepool

### DIFF
--- a/components/prize_pool/wikis/apexlegends/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/apexlegends/prize_pool_custom.lua
@@ -44,7 +44,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
 	lpdbData.extradata.location = Variables.varDefault('tournament_location_region', '')
-	lpdbData.extradata['is ea major'] = Variables.varDefault('tournament_ea_major', '')
+	lpdbData.publishertier = Variables.varDefault('tournament_publishertier', '')
 	return lpdbData
 end
 


### PR DESCRIPTION
## Summary
To be pushed after #2841 to standardise storage into prizepools

## How did you test this change?
Also tested with /dev
https://liquipedia.net/apexlegends/Dark_meluca/Test/InfoboxLeague

