### PR TITLE
Avoid showing zero-dollar prize in results and awards

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -100,10 +100,12 @@ function ResultsTable:buildRow(placement)
 			:tag('td'):css('text-align', 'left'):node(vsDisplay)
 	end
 
-	row:tag('td'):wikitext('$' .. Currency.formatMoney(
-			self.config.queryType ~= Opponent.team and placement.individualprizemoney
-			or placement.prizemoney, nil, true
-		))
+	local money = self.config.queryType ~= Opponent.team and placement.individualprizemoney or placement.prizemoney
+	row:tag('td'):wikitext(
+		(tonumber(money) or 0) > 0
+		and ('$' .. Currency.formatMoney(money, nil, true))
+		or '<b>-</b>'
+	)
 
 	return row
 end

--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -70,10 +70,12 @@ function AwardsTable:buildRow(placement)
 		))
 	end
 
-	row:tag('td'):wikitext('$' .. Currency.formatMoney(
-			self.config.opponentType ~= Opponent.team and placement.individualprizemoney
-			or placement.prizemoney, nil, true
-		))
+	local money = self.config.queryType ~= Opponent.team and placement.individualprizemoney or placement.prizemoney
+	row:tag('td'):wikitext(
+		(tonumber(money) or 0) > 0
+		and ('$' .. Currency.formatMoney(money, nil, true))
+		or '<b>-</b>'
+	)
 
 	return row
 end


### PR DESCRIPTION
## Summary

Avoid showing zero dollars as a prize in results and awards, I believe a lack of a prize is a better representation

## How did you test this change?

/dev module

![Example](https://user-images.githubusercontent.com/42142350/231826428-333f6f28-b1be-4d4c-9325-808596314a17.png)
