### PR TITLE
Adjust display in `formatMoney` for zero and non numeric values to dash

### DIFF
--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -22,6 +22,7 @@ local NON_BREAKING_SPACE = '&nbsp;'
 local USD = 'usd'
 local USD_TEMPLATE_ALIAS = '1'
 local DEFAULT_ROUND_PRECISION = 2
+local DASH = '-'
 
 function Currency.template(frame)
 	local args = Arguments.getArgs(frame)
@@ -105,17 +106,19 @@ function Currency.raw(currencyCode)
 	return CurrencyData[currencyCode:lower()]
 end
 
-function Currency.formatMoney(value, precision, forceRoundPrecision)
-	if not Logic.isNumeric(value) then
-		return 0
+function Currency.formatMoney(value, precision, forceRoundPrecision, displayZero)
+	if not Logic.isNumeric(value) or (value == 0 and not forceRoundPrecision) then
+		return displayZero and 0 or DASH
 	end
 	precision = tonumber(precision) or Info.defaultRoundPrecision or DEFAULT_ROUND_PRECISION
 
 	local roundedValue = Math.round{value, precision}
 	local integer, decimal = math.modf(roundedValue)
+
 	if precision <= 0 or decimal == 0 and not forceRoundPrecision then
 		return LANG:formatNum(integer)
 	end
+
 	return LANG:formatNum(integer) .. string.format('%.' .. precision .. 'f', decimal):sub(2)
 end
 

--- a/standard/test/currency_test.lua
+++ b/standard/test/currency_test.lua
@@ -14,6 +14,8 @@ local Variables = Lua.import('Module:Variables', {requireDevIfEnabled = true})
 
 local suite = ScribuntoUnit:new()
 
+local DASH = '-'
+
 function suite:testGetExchangeRate()
 	self:assertEquals(1.45, Currency.getExchangeRate{currency = 'EUR', currencyRate = '1.45', setVariables = true})
 	self:assertEquals(1.45, tonumber(Variables.varDefault('exchangerate_EUR')))
@@ -21,10 +23,13 @@ function suite:testGetExchangeRate()
 end
 
 function suite:testFormatMoney()
-	self:assertEquals(0, Currency.formatMoney('abc'))
-	self:assertEquals(0, Currency.formatMoney(nil))
+	self:assertEquals(DASH, Currency.formatMoney('abc'))
+	self:assertEquals(DASH, Currency.formatMoney(nil))
+	self:assertEquals(0, Currency.formatMoney('abc', nil, nil, true))
+	self:assertEquals(0, Currency.formatMoney(nil, nil, nil, true))
 	self:assertEquals('12', Currency.formatMoney(12))
 	self:assertEquals('1,200', Currency.formatMoney(1200))
+	self:assertEquals('1,200.00', Currency.formatMoney(1200, nil, true))
 	self:assertEquals('1,200.12', Currency.formatMoney(1200.12345))
 	self:assertEquals('1,200.1', Currency.formatMoney(1200.12345, 1))
 	self:assertEquals('1,200.1235', Currency.formatMoney(1200.12345, 4))


### PR DESCRIPTION
## Summary
Adjust display in `formatMoney` for zero and non numeric values to dash with the option to disable it

## How did you test this change?
dev + test suite