### PR TITLE
Changing OW handling of leagues on team pages

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_team_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_team_custom.lua
@@ -42,9 +42,7 @@ end
 function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.region = Variables.varDefault('region', '')
 
-	if String.isNotEmpty(args.league) then
-		lpdbData.extradata.competesin = string.upper(args.league)
-	end
+	lpdbData.extradata.competesin = String.isNotEmpty(args.league) and string.upper(args.league) or nil
 
 	return lpdbData
 end
@@ -53,8 +51,7 @@ function CustomTeam:getWikiCategories(args)
 	local categories = {}
 
 	if String.isNotEmpty(args.league) then
-		local division = string.upper(args.league)
-		table.insert(categories, division .. ' Teams')
+		table.insert(categories, string.upper(args.league) .. ' Teams')
 	end
 
 	return categories

--- a/components/infobox/wikis/overwatch/infobox_team_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_team_custom.lua
@@ -42,9 +42,9 @@ end
 function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.region = Variables.varDefault('region', '')
 
-	lpdbData.extradata = {
-		owl = String.isNotEmpty(args.owl),
-	}
+	if String.isNotEmpty(args.league) then
+		lpdbData.extradata.competesin = string.upper(args.league)
+	end
 
 	return lpdbData
 end
@@ -52,8 +52,9 @@ end
 function CustomTeam:getWikiCategories(args)
 	local categories = {}
 
-	if String.isNotEmpty(args.owl) then
-		table.insert(categories, 'Overwatch League Teams')
+	if String.isNotEmpty(args.league) then
+		local division = string.upper(args.league)
+		table.insert(categories, division .. ' Teams')
 	end
 
 	return categories

--- a/components/infobox/wikis/overwatch/infobox_team_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_team_custom.lua
@@ -42,7 +42,7 @@ end
 function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.region = Variables.varDefault('region', '')
 
-	lpdbData.extradata.competesin = String.isNotEmpty(args.league) and string.upper(args.league) or nil
+	lpdbData.extradata.competesin = string.upper(args.league or '')
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
Changes the handling of which leagues team compete in to fall more in line with League of Legends. 
Currently OWL teams have a parameter called ``|owl=franchise name`` that is saved as a boolean in LPDB. Instead, this is changing that parameter to ``|league=league name`` and allowing that to be saved in LPDB as ``competes_in``
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev module tested live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
