### PR TITLE
Adjust group abbr display

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -94,10 +94,10 @@ function ResultsTable:buildRow(placement)
 	end
 
 	if not self.config.hideResult then
-		local score, vsDisplay = self:processVsData(placement)
+		local score, vsDisplay, groupAbbr = self:processVsData(placement)
 		row
 			:tag('td'):wikitext(score):done()
-			:tag('td'):css('text-align', 'left'):node(vsDisplay)
+			:tag('td'):css('text-align', 'left'):cssText(groupAbbr and 'padding-left:14px' or nil):node(vsDisplay or groupAbbr)
 	end
 
 	row:tag('td'):wikitext('$' .. Currency.formatMoney(

--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -134,8 +134,6 @@ function BaseResultsTable:create()
 		return self
 	end
 
-	Array.forEach(data, function(placement) self:processLegacyVsData(placement) end)
-
 	table.sort(data, function(placement1, placement2) return placement1.date > placement2.date end)
 
 	if self.config.onlyAchievements then
@@ -486,7 +484,7 @@ function BaseResultsTable:processVsData(placement)
 	local lastVs = placement.lastvsdata
 
 	if String.isNotEmpty(lastVs.groupscore) then
-		return placement.groupscore, Abbreviation.make('Grp S.', 'Group Stage')
+		return placement.groupscore, nil, Abbreviation.make('Grp S.', 'Group Stage')
 	end
 
 	local score = ''
@@ -497,25 +495,6 @@ function BaseResultsTable:processVsData(placement)
 	local vsDisplay = self:opponentDisplay(lastVs, {isLastVs = true})
 
 	return score, vsDisplay
-end
-
--- overwritable
-function BaseResultsTable:processLegacyVsData(placement)
-	if Table.isNotEmpty(placement.lastvsdata) then
-		return placement
-	end
-
-	local lastVs = {score = placement.lastvsscore, groupscore = placement.groupscore}
-	-- lets assume opponentType of the vs opponent is the same as of the opponent
-	lastVs.opponenttype = placement.opponenttype
-	-- assume lastvs is team template for teams and pagename & displayname for players
-	-- if wikis store them in extradata they can overwrite this function until lastvsdata field is filled
-	lastVs.opponentplayers = {p1 = placement.lastvs, p1dn = placement.lastvs}
-	lastVs.opponenttemplate = placement.lastvs
-
-	placement.lastvsdata = lastVs
-
-	return placement
 end
 
 function BaseResultsTable:buildHeader()


### PR DESCRIPTION
## Summary
- by now all wikis should use the new ppts and got purged, so the lastvsdata field should be filled (except for smash-like wikis which do not use this anyways), hence kick `processLegacyVsData`
- adjust group abbr display, add left padding to align it with team icons as per martins suggestion

## How did you test this change?
dev