### PR TITLE
Remove force rounding in results and awards tables

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -102,7 +102,7 @@ function ResultsTable:buildRow(placement)
 
 	row:tag('td'):wikitext('$' .. Currency.formatMoney(
 			self.config.queryType ~= Opponent.team and placement.individualprizemoney
-			or placement.prizemoney, nil, true
+			or placement.prizemoney
 		))
 
 	return row

--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -72,7 +72,7 @@ function AwardsTable:buildRow(placement)
 
 	row:tag('td'):wikitext('$' .. Currency.formatMoney(
 			self.config.opponentType ~= Opponent.team and placement.individualprizemoney
-			or placement.prizemoney, nil, true
+			or placement.prizemoney
 		))
 
 	return row


### PR DESCRIPTION
## Summary
since we centered the prize display (as per vote on discord) this makes way less sense since it doesn't fix the right align anymore

## How did you test this change?
dev