### PR TITLE
Add alias support for `Table.iter.pairsByPrefix`

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -546,14 +546,27 @@ will print out `p1 p2 p3`
 ---@param prefix string
 ---@param options? {requireIndex: boolean}
 ---@return function
-function Table.iter.pairsByPrefix(tbl, prefix, options)
+function Table.iter.pairsByPrefix(tbl, prefixes, options)
 	options = options or {}
+
+	if type(prefixes) == 'string' then
+		prefixes = {prefixes}
+	end
+
+	local getByPrefixes = function(index)
+		for _, prefix in ipairs(prefixes) do
+			local key = prefix .. index
+			if tbl[key] then
+				return key, tbl[key]
+			end
+		end
+	end
+
 	local i = 1
 	return function()
-		local key = prefix .. i
-		local value = tbl[key]
+		local key, value = getByPrefixes(i)
 		if options.requireIndex == false and i == 1 and not value then
-			key, value = prefix, tbl[prefix]
+			key, value = getByPrefixes('')
 		end
 		i = i + 1
 		if value then

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -543,7 +543,7 @@ end
 will print out `p1 p2 p3`
 ]]
 ---@param tbl table
----@param prefix string
+---@param prefix string|string[]
 ---@param options? {requireIndex: boolean}
 ---@return function
 function Table.iter.pairsByPrefix(tbl, prefixes, options)

--- a/standard/test/table_test.lua
+++ b/standard/test/table_test.lua
@@ -156,6 +156,8 @@ function suite:testPairsByPrefix()
 	local args = {
 		p = 'a',
 		plink = 'b',
+		f1 = 'a2',
+		f1link = 'b2',
 		p2 = 'c',
 		p2link = 'd',
 		p3 = 'e',
@@ -179,6 +181,19 @@ function suite:testPairsByPrefix()
 		self:assertTrue(args[prefix .. 'link'])
 	end
 	self:assertEquals(0, cnt)
+
+	cnt = 0
+	for prefix in Table.iter.pairsByPrefix(args, {'p', 'f'}) do
+		cnt = cnt + 1
+		self:assertTrue(args[prefix])
+		self:assertTrue(args[prefix .. 'link'])
+		if cnt == 1 then
+			self:assertEquals('f1', prefix)
+		else
+			self:assertEquals('p' .. cnt, prefix)
+		end
+	end
+	self:assertEquals(3, cnt)
 
 	args.p1, args.p1link = args.p, args.plink
 	args.p, args.plink = nil, nil


### PR DESCRIPTION
## Summary
Add alias support for `Table.iter.pairsByPrefix`

## How did you test this change?
dev + testcase