### PR TITLE
Avoid indexing nil

### DIFF
--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -481,7 +481,7 @@ function BaseResultsTable.tournamentDisplayName(placement)
 end
 
 function BaseResultsTable:processVsData(placement)
-	local lastVs = placement.lastvsdata
+	local lastVs = placement.lastvsdata or {}
 
 	if String.isNotEmpty(lastVs.groupscore) then
 		return placement.groupscore, nil, Abbreviation.make('Grp S.', 'Group Stage')


### PR DESCRIPTION
## Summary
Avoid indexing nil in results table

## How did you test this change?
live, hotfix