### PR TITLE
Catch '0' (string) case for dash if zero in formatMoney

### DIFF
--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -107,7 +107,7 @@ function Currency.raw(currencyCode)
 end
 
 function Currency.formatMoney(value, precision, forceRoundPrecision, displayZero)
-	if not Logic.isNumeric(value) or (value == 0 and not forceRoundPrecision) then
+	if not Logic.isNumeric(value) or (tonimber(value) == 0 and not forceRoundPrecision) then
 		return displayZero and 0 or DASH
 	end
 	precision = tonumber(precision) or Info.defaultRoundPrecision or DEFAULT_ROUND_PRECISION

--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -107,7 +107,7 @@ function Currency.raw(currencyCode)
 end
 
 function Currency.formatMoney(value, precision, forceRoundPrecision, displayZero)
-	if not Logic.isNumeric(value) or (tonimber(value) == 0 and not forceRoundPrecision) then
+	if not Logic.isNumeric(value) or (tonumber(value) == 0 and not forceRoundPrecision) then
 		return displayZero and 0 or DASH
 	end
 	precision = tonumber(precision) or Info.defaultRoundPrecision or DEFAULT_ROUND_PRECISION

--- a/standard/test/currency_test.lua
+++ b/standard/test/currency_test.lua
@@ -25,6 +25,8 @@ end
 function suite:testFormatMoney()
 	self:assertEquals(DASH, Currency.formatMoney('abc'))
 	self:assertEquals(DASH, Currency.formatMoney(nil))
+	self:assertEquals(DASH, Currency.formatMoney('0'))
+	self:assertEquals(DASH, Currency.formatMoney(0))
 	self:assertEquals(0, Currency.formatMoney('abc', nil, nil, true))
 	self:assertEquals(0, Currency.formatMoney(nil, nil, nil, true))
 	self:assertEquals('12', Currency.formatMoney(12))


### PR DESCRIPTION
## Summary
Catch '0' (string) case for dash if zero in formatMoney.
And add testcase for it

## How did you test this change?
testsuite