### PR TITLE
Fix attach order bug for players in lpdb match2

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -274,7 +274,7 @@ function Match._storeMatch2InLpdb(unsplitMatchRecord)
 	local opponentIndexes = Array.map(records.opponentRecords, function(opponentRecord, opponentIndex)
 		local playerIndexes = Array.map(records.playerRecords[opponentIndex], function(player, playerIndex)
 			return mw.ext.LiquipediaDB.lpdb_match2player(
-				matchRecord.match2id .. '_m2o_' .. opponentIndex .. '_m2p_' .. playerIndex,
+				matchRecord.match2id .. '_m2o_' .. opponentIndex .. '_m2p_' .. string.format('%02d', playerIndex),
 				player
 			)
 		end)


### PR DESCRIPTION
Resolves #2882

## Summary
Adjust objectname in `lpdb_match2player` to fix a bug where the players are attached in wrong order if 10+ players in an opponent.

While attaching it seems to sort by objectname, hence adjusting the objectname to be sortable correctly seems to fix the lpdb bug.

## How did you test this change?
dev