### PR TITLE
Omit enddate for 1-day tournaments

### DIFF
--- a/standard/tournaments_summary_table/commons/tournaments_summary_table.lua
+++ b/standard/tournaments_summary_table/commons/tournaments_summary_table.lua
@@ -229,12 +229,15 @@ function TournamentsSummaryTable.row(eventInformation, type)
 	local rowComponents = {
 		'\n** ' .. eventInformation.pagename,
 		displayName,
-		'startdate=' .. TournamentsSummaryTable._dateDisplay(eventInformation.startdate),
-		'enddate=' .. TournamentsSummaryTable._dateDisplay(eventInformation.enddate),
 		'icon=' .. icon,
 		'iconfile=' .. iconFile,
 		'icondarkfile=' .. (iconDarkFile or iconFile),
+		'startdate=' .. TournamentsSummaryTable._dateDisplay(eventInformation.startdate),
 	}
+	
+	if eventInformation.startdate ~= eventInformation.enddate then
+		table.insert(rowComponents, 'enddate=' .. TournamentsSummaryTable._dateDisplay(eventInformation.enddate))
+	end
 
 	return table.concat(rowComponents, ' | ')
 end

--- a/standard/tournaments_summary_table/commons/tournaments_summary_table.lua
+++ b/standard/tournaments_summary_table/commons/tournaments_summary_table.lua
@@ -234,7 +234,7 @@ function TournamentsSummaryTable.row(eventInformation, type)
 		'icondarkfile=' .. (iconDarkFile or iconFile),
 		'startdate=' .. TournamentsSummaryTable._dateDisplay(eventInformation.startdate),
 	}
-	
+
 	if eventInformation.startdate ~= eventInformation.enddate then
 		table.insert(rowComponents, 'enddate=' .. TournamentsSummaryTable._dateDisplay(eventInformation.enddate))
 	end


### PR DESCRIPTION
## Summary
Issue reported here: https://discord.com/channels/93055209017729024/268719633366777856/1096449675428646943
When using `Liquipedia:Tournaments` with `<tournaments />`, omitting the enddate for one-day tournaments will improve the display.

## How did you test this change?
via /dev on heroes

Now: 
![image](https://user-images.githubusercontent.com/16326643/232444128-072757c9-d685-4751-b4ec-dd966d0baf0e.png)
Before:
![image](https://user-images.githubusercontent.com/16326643/232444185-77d8e553-4751-487e-b221-8ff90a5d1450.png)
