### PR TITLE
Adjust AoE Tier link display in case of missing game

### DIFF
--- a/standard/tier/wikis/ageofempires/tier_custom.lua
+++ b/standard/tier/wikis/ageofempires/tier_custom.lua
@@ -64,7 +64,7 @@ function Tier.displaySingle(data, options)
 end
 
 function TierCustom.adjustLink(link, game)
-	return game .. '/' .. link
+	return String.isNotEmpty(game) and (game .. '/' .. link) or link
 end
 
 return TierCustom


### PR DESCRIPTION
## Summary
- fall back to normal tier link without game part
- avoids erroring in those cases and makes it usable in some edge cases (e.g. on portal statistics pages)

## How did you test this change?
/dev