### PR TITLE
Add tracking category for locationless tournaments on CS

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -220,6 +220,10 @@ function CustomLeague:getWikiCategories(args)
 		table.insert(categories, 'Infobox league lacking localcurrency')
 	end
 
+	if String.isEmpty(args.country) then
+		table.insert(categories, 'Tournaments without location')
+	end
+
 	if String.isNotEmpty(args.sort_date) then
 		table.insert(categories, 'Tournaments with custom sort date')
 	end


### PR DESCRIPTION
## Summary

We have a decent number of tournaments without a country or location, adding this tracking category to find and eliminate them.


## How did you test this change?

Tested on `/dev`.
