### PR TITLE
Create Operator standard lib

### DIFF
--- a/standard/operator.lua
+++ b/standard/operator.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Table = require('Module:Table')
-
 local Operator = {}
 
 function Operator.add(a, b)
@@ -40,9 +38,9 @@ function Operator.item(item)
 end
 
 function Operator.method(funcName, ...)
-	local args = Table.pack(...)
+	local args = {...}
 	return function(tbl)
-		return tbl[funcName](args)
+		return tbl[funcName](unpack(args))
 	end
 end
 

--- a/standard/operator.lua
+++ b/standard/operator.lua
@@ -1,0 +1,49 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Operator
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Table = require('Module:Table')
+
+local Operator = {}
+
+function Operator.add(a, b)
+	return a + b
+end
+
+function Operator.sub(a, b)
+	return a - b
+end
+
+function Operator.mul(a, b)
+	return a * b
+end
+
+function Operator.div(a, b)
+	return a / b
+end
+
+function Operator.pow(a, b)
+	return math.pow(a, b)
+end
+
+function Operator.item(item)
+	if string.find(item, '%.') then
+		error('Pathing not yet supported in itemGetter')
+	end
+	return function(tbl)
+		return tbl[item]
+	end
+end
+
+function Operator.method(funcName, ...)
+	local args = Table.pack(...)
+	return function(tbl)
+		return tbl[funcName](args)
+	end
+end
+
+return Operator

--- a/standard/operator.lua
+++ b/standard/operator.lua
@@ -28,9 +28,9 @@ function Operator.pow(a, b)
 	return math.pow(a, b)
 end
 
-function Operator.item(item)
+function Operator.property(item)
 	if string.find(item, '%.') then
-		error('Pathing not yet supported in itemGetter')
+		error('Pathing not yet supported in property')
 	end
 	return function(tbl)
 		return tbl[item]

--- a/standard/operator.lua
+++ b/standard/operator.lua
@@ -39,8 +39,8 @@ end
 
 function Operator.method(funcName, ...)
 	local args = {...}
-	return function(tbl)
-		return tbl[funcName](unpack(args))
+	return function(obj)
+		return obj[funcName](obj, unpack(args))
 	end
 end
 

--- a/standard/test/operator_test.lua
+++ b/standard/test/operator_test.lua
@@ -1,0 +1,50 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Operator/testcases
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local ScribuntoUnit = require('Module:ScribuntoUnit')
+
+local Array = Lua.import('Module:Array', {requireDevIfEnabled = true})
+local Operator = Lua.import('Module:Operator', {requireDevIfEnabled = true})
+
+local suite = ScribuntoUnit:new()
+
+function suite:testMath()
+	local foo = {5, 3, 2, 1}
+	self:assertEquals(11, Array.reduce(foo, Operator.add), 'Add')
+	self:assertEquals(-1, Array.reduce(foo, Operator.sub), 'Sub')
+	self:assertEquals(30, Array.reduce(foo, Operator.mul), 'Mul')
+	self:assertEquals(5/3/2, Array.reduce(foo, Operator.div), 'Div')
+	self:assertEquals(15625, Array.reduce(foo, Operator.pow), 'Pow')
+end
+
+function suite:testItem()
+	local foo = {
+		{a = 3, b = 'abc'},
+		{a = 5, b = 'cedf'},
+		{a = 4, b = 'sfd'},
+	}
+	self:assertDeepEquals({3, 5, 4}, Array.map(foo, Operator.item('a')))
+end
+
+function suite:testMethod()
+	local foo = {
+		{a = 3, b = 'abc', f = function(s, a)
+			return s.a + a
+		end},
+		{a = 5, b = 'cedf', f = function(s)
+			return s.a + 5
+		end},
+		{a = 4, b = 'sfd', f = function(s)
+			return s.a + 3
+		end},
+	}
+	self:assertDeepEquals({4, 10, 7}, Array.map(foo, Operator.method('f', 1)))
+end
+
+return suite

--- a/standard/test/operator_test.lua
+++ b/standard/test/operator_test.lua
@@ -23,13 +23,13 @@ function suite:testMath()
 	self:assertEquals(15625, Array.reduce(foo, Operator.pow), 'Pow')
 end
 
-function suite:testItem()
+function suite:testProperty()
 	local foo = {
 		{a = 3, b = 'abc'},
 		{a = 5, b = 'cedf'},
 		{a = 4, b = 'sfd'},
 	}
-	self:assertDeepEquals({3, 5, 4}, Array.map(foo, Operator.item('a')))
+	self:assertDeepEquals({3, 5, 4}, Array.map(foo, Operator.property('a')))
 end
 
 function suite:testMethod()


### PR DESCRIPTION
## Summary
Allows for code simplifications (less boilerplate) when it comes to functional style functions such as `map` and `reduce`.

Given the following table
```lua
local foo = {
  { a = 3, b = 'abc'},
  { a = 5, b = 'cedf'},
  { a = 4, b = 'sfd'},
}
```
To sort it (in place) by `a`
```lua
-- Current
Array.sortInPlaceBy(foo, function(struct) return struct.a end)
-- With this PR
Array.sortInPlaceBy(foo, Operator.property('a'))
```

To fetch items
```lua
-- Current
Array.map(foo, function(struct) return struct.b end)
-- With this PR
Array.map(foo, Operator.property('b'))
```

To sum all elements in an array
```lua
-- Current
Array.reduce(arr, function(a, b) return a + b end)
-- With this PR
Array.reduce(arr, Operator.add)
```


## How did you test this change?
[Tests](https://liquipedia.net/commons/Module_talk:Operator/testcases)