### PR TITLE
ExternalMediaList: Use displayname for authors

### DIFF
--- a/components/external_media_links/external_media_list.lua
+++ b/components/external_media_links/external_media_list.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Flag = require('Module:Flags')
 local Logic = require('Module:Logic')
+local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
@@ -181,9 +182,15 @@ function MediaList._row(item, args)
 	end
 
 	local authors = {}
-	for _, author in Table.iter.pairsByPrefix(item.authors, 'author') do
+	for key, author in Table.iter.pairsByPrefix(item.authors, 'author') do
+		local displayname = item.authors[key .. 'dn']
 		if String.isNotEmpty(author) then
-			table.insert(authors, '[[' .. author .. ']]')
+			table.insert(authors,
+				Page.makeInternalLink({},
+					String.isNotEmpty(displayname) and displayname or author,
+					author
+				)
+			)
 		end
 	end
 	if Table.isNotEmpty(authors) then


### PR DESCRIPTION
## Summary
The new Module:ExternalMediaLink stores the displayname for authors, but it wasn't displayed when fetching them.

## How did you test this change?
via /dev:
![image](https://user-images.githubusercontent.com/16326643/233334897-8036de10-8cb2-44cc-a3db-e6f9590ba520.png)
Previously:
![image](https://user-images.githubusercontent.com/16326643/233335027-b63d135d-99cf-481d-a154-9d6efa8c4bd0.png)

