### PR TITLE
PPT: Fallback to link

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -238,7 +238,7 @@ BasePrizePool.prizeTypes = {
 				title = context[prefix .. 'name'] or Logic.emptyOr(
 					tournamentData.tickername,
 					tournamentData.name,
-					tournamentData.pagename:gsub('_', ' '):gsub('/', ' ')
+					(tournamentData.pagename or link):gsub('_', ' '):gsub('/', ' ')
 				),
 				icon = tournamentData.icon or context[prefix .. 'icon'],
 				iconDark = tournamentData.icondark or context[prefix .. 'icondark']


### PR DESCRIPTION
## Summary
In case a qualified-to page did not exist, there is no pagename and therefore the gsub errored.
Example: https://liquipedia.net/ageofempires/Civilization_War/1/Qualifier

## How did you test this change?
via /dev to live
