### PR TITLE
TemplateEngine: Improve non-happy path

### DIFF
--- a/standard/template_engine.lua
+++ b/standard/template_engine.lua
@@ -121,7 +121,8 @@ function TemplateEngine:_variable(template, context)
 		if type(value) == 'function' then
 			value = value(context.model)
 		end
-		value = value or variable -- Doesn't follow mustache standard, should be `or ''` to follow.
+		value = value or ''
+		value = tostring(value) -- Call the __tostring meta-method on any structures.
 		return escape and mw.text.nowiki(value) or value
 	end))
 end
@@ -144,8 +145,8 @@ function Context:find(variableName)
 	while context do
 		local path = Table.mapValues(mw.text.split(variableName, TABLE_SPLIT_CHAR, true), toNumberIfNumeric)
 		local key = Table.extract(path, #path)
-		local tbl =  Table.getByPath(context.model, path)
-		if tbl[key] then
+		local tbl =  Table.getByPathOrNil(context.model, path)
+		if tbl and tbl[key] then
 			return tbl[key]
 		end
 		context = context.parent


### PR DESCRIPTION
## Summary
Solves 3 issues:
* Follow standard when variable is missing (empty string instead of variable name)
* If a table on the way doesn't exist (eg `{{foo.bar.lorum}}` and `bar` doesn't exist in `foo`, then it currently gives an exception, now it will just empty string it as intended)
* If the value is a stringable object that's not a string (yet), eg a `mw.html` object, currently it will throw an exception, now it will tostring the obj first (and work). 

## How did you test this change?
Testcases