### PR TITLE
League BM: Fix issues around Empty Opponents

### DIFF
--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -90,9 +90,13 @@ function BigMatch.run(frame)
 
 	-- Add more opponent data field
 	Array.forEach(model.opponents, function (opponent, index)
+		opponent.opponentIndex = index
+
+		if not opponent.template or not mw.ext.TeamTemplate.teamexists(opponent.template) then
+			return
+		end
 		local teamTemplate = mw.ext.TeamTemplate.raw(opponent.template)
 
-		opponent.opponentIndex = index
 		opponent.iconDisplay = mw.ext.TeamTemplate.teamicon(opponent.template)
 		opponent.shortname = teamTemplate.shortname
 		opponent.page = teamTemplate.page

--- a/components/match2/wikis/leagueoflegends/big_match_template.lua
+++ b/components/match2/wikis/leagueoflegends/big_match_template.lua
@@ -12,7 +12,7 @@ return {
 		[=[
 			<div class="match-bm-lol-match-header">
 				<div class="match-bm-lol-match-header-overview">
-					<div class="match-bm-lol-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-lol-match-header-team-long">[[{{page}}|{{name}}]]</div><div class="match-bm-lol-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div>{{generateSeriesDots}}</div>{{/opponents.1}}</div>
+					<div class="match-bm-lol-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-lol-match-header-team-long">{{#page}}[[{{page}}|{{name}}]]{{/page}}</div><div class="match-bm-lol-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div>{{generateSeriesDots}}</div>{{/opponents.1}}</div>
 					<div class="match-bm-lol-match-header-result">{{#isBestOfOne}}{{#games.1.apiInfo}}{{team1.scoreDisplay}}&ndash;{{team2.scoreDisplay}}{{/games.1.apiInfo}}{{/isBestOfOne}}{{^isBestOfOne}}{{opponents.1.score}}&ndash;{{opponents.2.score}}{{/isBestOfOne}}</div>
 					<div class="match-bm-lol-match-header-team">{{#opponents.2}}{{&iconDisplay}}<div class="match-bm-lol-match-header-team-long">[[{{page}}|{{name}}]]</div><div class="match-bm-lol-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div>{{generateSeriesDots}}</div>{{/opponents.2}}</div>
 				</div>


### PR DESCRIPTION
## Summary
Fix two issues with big match:
* Empty opponent would cause errors due to incorrect team template
* In-optimal display for Empty Opponents

## How did you test this change?
Dev