### PR TITLE
League BM: Tweak logic for popup and match showing

### DIFF
--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -73,6 +73,12 @@ local NOT_PLAYED = 'np'
 local DEFAULT_ITEM = 'EmptyIcon'
 local TEAMS = Array.range(1, 2)
 
+local BIG_MATCH_START_TIME = 1682892000 -- May 1st 2023 midnight
+
+function BigMatch.isEnabledFor(match)
+	return tonumber(match.liquipediatier) == 1 and (match.timestamp == 0 or match.timestamp > BIG_MATCH_START_TIME)
+end
+
 function BigMatch.run(frame)
 	local args = Arguments.getArgs(frame)
 

--- a/components/match2/wikis/leagueoflegends/brkts_wiki_specific.lua
+++ b/components/match2/wikis/leagueoflegends/brkts_wiki_specific.lua
@@ -1,0 +1,22 @@
+---
+-- @Liquipedia
+-- wiki=leagueoflegends
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true}))
+
+--
+-- Override functons
+--
+function WikiSpecific.matchHasDetails(match)
+	return Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true}).defaultMatchHasDetails or 
+		Lua.import('Module:BigMatch', {requireDevIfEnabled = true}).isEnabledFor(match)
+end
+
+return WikiSpecific

--- a/components/match2/wikis/leagueoflegends/brkts_wiki_specific.lua
+++ b/components/match2/wikis/leagueoflegends/brkts_wiki_specific.lua
@@ -15,7 +15,7 @@ local WikiSpecific = Table.copy(Lua.import('Module:Brkts/WikiSpecific/Base', {re
 -- Override functons
 --
 function WikiSpecific.matchHasDetails(match)
-	return Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true}).defaultMatchHasDetails or 
+	return Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true}).defaultMatchHasDetails or
 		Lua.import('Module:BigMatch', {requireDevIfEnabled = true}).isEnabledFor(match)
 end
 

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -19,6 +19,7 @@ local String = require('Module:StringUtils')
 local Array = require('Module:Array')
 local VodLink = require('Module:VodLink')
 
+local BigMatch = Lua.import('Module:BigMatch', {requireDevIfEnabled = true})
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
@@ -29,8 +30,6 @@ local _NUM_HEROES_PICK_TEAM = 5
 local _NUM_HEROES_PICK_SOLO = 1
 local _GREEN_CHECK = '[[File:GreenCheck.png|14x14px|link=]]'
 local _NO_CHECK = '[[File:NoCheck.png|link=]]'
-
-local BIG_MATCH_START_TIME = 1682892000 -- May 1st 2023 midnight
 
 -- Hero Ban Class
 local HeroBan = Class.new(
@@ -145,7 +144,7 @@ function CustomMatchSummary._createBody(match)
 		))
 	end
 
-	if tonumber(match.liquipediatier) == 1 and match.timestamp > BIG_MATCH_START_TIME then
+	if BigMatch.isEnabledFor(match) then
 		local matchPageElement = mw.html.create('center')
 		matchPageElement:wikitext('[[Match:ID_' .. match.matchId .. '|Match Page]]')
 						:css('display', 'block')


### PR DESCRIPTION
## Summary
Extract logic for Match Page link from MatchSummary to BigMatch.
All matches that should get a Match Page link will now also have the popup available.
Having a no-date will also count as after May 1st (still requires S-Tier).

## How did you test this change?
dev