### PR TITLE
Use `returnEmptyIfNoResults` param in THA where applicable

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -55,7 +55,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'role' then

--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -25,7 +25,6 @@ local CustomPlayer = Class.new()
 
 local CustomInjector = Class.new(Injector)
 
-local EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 local _args
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
@@ -46,20 +45,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
-		})
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if String.isNotEmpty(manualHistory) or String.isNotEmpty(automatedHistory) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'role' then

--- a/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
@@ -47,7 +47,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
@@ -22,7 +22,6 @@ local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
 local CustomPlayer = Class.new()
 local CustomInjector = Class.new(Injector)
 
-local EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 local _args
 
 function CustomPlayer.run(frame)
@@ -38,20 +37,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = mw.title.getCurrentTitle().prefixedText
-		})
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -27,7 +27,6 @@ local Center = Widgets.Center
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
 local _role2
-local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 local _CURRENT_YEAR = tonumber(os.date('%Y'))
 
 local CustomPlayer = Class.new()
@@ -51,20 +50,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
-		}) or ''
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == _EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if String.isNotEmpty(manualHistory) or String.isNotEmpty(automatedHistory) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -60,7 +60,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/freefire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/freefire/infobox_person_player_custom.lua
@@ -22,8 +22,6 @@ local Cell = Widgets.Cell
 local Title = Widgets.Title
 local Center = Widgets.Center
 
-local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
-
 local _ROLES = {
 	-- Players
 	support = {category = 'Support players', variable = 'Support', isplayer = true},
@@ -68,20 +66,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
-		}) or ''
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == _EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if String.isNotEmpty(manualHistory) or String.isNotEmpty(automatedHistory) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'role' then

--- a/components/infobox/wikis/freefire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/freefire/infobox_person_player_custom.lua
@@ -76,7 +76,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'role' then

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -65,7 +65,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -26,7 +26,6 @@ local Center = Widgets.Center
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
 local _role2
-local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 
 local CustomPlayer = Class.new()
 
@@ -56,20 +55,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
-		}) or ''
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == _EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -78,11 +78,12 @@ function CustomPlayer.run(frame)
 	end
 
 	if String.isEmpty(player.args.history) then
-		player.args.history = tostring(TeamHistoryAuto._results{
+		player.args.history = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			hiderole = 'true',
 			iconModule = 'Module:PositionIcon/data',
 			addlpdbdata = 'true'
-		})
+		}
 	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -81,7 +81,7 @@ function CustomPlayer.run(frame)
 		player.args.history = tostring(TeamHistoryAuto._results{
 			hiderole = 'true',
 			iconModule = 'Module:PositionIcon/data',
-			addlpdbdata='true'
+			addlpdbdata = 'true'
 		})
 	end
 

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -72,7 +72,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -29,7 +29,6 @@ local Center = Widgets.Center
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
 local _role2
-local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 local _SIZE_HERO = '25x25px'
 
 local CustomPlayer = Class.new()
@@ -62,21 +61,18 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			iconModule = 'Module:PositionIcon/data',
 			player = _pagename
-		}) or ''
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == _EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/naraka/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_person_player_custom.lua
@@ -58,7 +58,7 @@ function CustomPlayer.run(frame)
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
 
-	player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata='true'})
+	player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata = 'true'})
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent

--- a/components/infobox/wikis/naraka/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_person_player_custom.lua
@@ -58,7 +58,7 @@ function CustomPlayer.run(frame)
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
 
-	player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata = 'true'})
+	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', returnEmptyIfNoResults = true}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -25,7 +25,6 @@ local Center = Widgets.Center
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
 local _role2
-local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 
 local CustomPlayer = Class.new()
 
@@ -46,20 +45,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
-		}) or ''
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == _EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if String.isNotEmpty(manualHistory) or String.isNotEmpty(automatedHistory) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -55,7 +55,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'region' then return {}

--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -25,7 +25,6 @@ local Title = Widgets.Title
 local Center = Widgets.Center
 
 local _pagename = mw.title.getCurrentTitle().prefixedText
-local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 
 local _ROLES = {
 	-- Staff and Talents
@@ -72,20 +71,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
-		}) or ''
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == _EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 		end
 	elseif id == 'status' then

--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -81,7 +81,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 		end
 	elseif id == 'status' then

--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -75,7 +75,7 @@ function CustomPlayer.run(frame)
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
 
-	player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata = 'true'})
+	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', returnEmptyIfNoResults = true}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent

--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -75,7 +75,7 @@ function CustomPlayer.run(frame)
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
 
-	player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata='true'})
+	player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata = 'true'})
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent

--- a/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
@@ -35,7 +35,7 @@ local _player
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
-	player.args.history = tostring(TeamHistoryAuto._results{convertrole = 'true'})
+	player.args.history = TeamHistoryAuto._results{convertrole = 'true', returnEmptyIfNoResults = true}
 
 	_player = player
 	_args = player.args

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -60,7 +60,7 @@ function CustomPlayer.run(frame)
 	if String.isEmpty(player.args.team2) then
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
-	player.args.history = tostring(TeamHistoryAuto._results{convertrole = 'true'})
+	player.args.history = TeamHistoryAuto._results{convertrole = 'true', returnEmptyIfNoResults = true}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -78,7 +78,7 @@ function CustomPlayer.run(frame)
 	end
 
 	if String.isEmpty(player.args.history) then
-		player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata = 'true'})
+		player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', returnEmptyIfNoResults = true}
 	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -78,7 +78,7 @@ function CustomPlayer.run(frame)
 	end
 
 	if String.isEmpty(player.args.history) then
-		player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata='true'})
+		player.args.history = tostring(TeamHistoryAuto._results{addlpdbdata = 'true'})
 	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB

--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -64,7 +64,7 @@ function CustomInjector:parse(id, widgets)
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
+				Center{content = {automatedHistory}},
 			}
 			end
 		end

--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -23,7 +23,6 @@ local Center = Widgets.Center
 local _pagename = mw.title.getCurrentTitle().prefixedText
 local _role
 local _role2
-local _EMPTY_AUTO_HISTORY = '<table style="width:100%;text-align:left"></table>'
 
 local CustomPlayer = Class.new()
 
@@ -55,20 +54,17 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results({
+		local automatedHistory = TeamHistoryAuto._results{
+			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
-		})
-		automatedHistory = tostring(automatedHistory)
-		if automatedHistory == _EMPTY_AUTO_HISTORY then
-			automatedHistory = nil
-		end
+		}
 
-		if not (String.isEmpty(manualHistory) and String.isEmpty(automatedHistory)) then
+		if String.isNotEmpty(manualHistory) or automatedHistory then
 			return {
 				Title{name = 'History'},
 				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
+				Center{content = {automatedHistory and tostring(automatedHistory) or nil}},
 			}
 			end
 		end


### PR DESCRIPTION
## Summary
Use `returnEmptyIfNoResults` param in THA where applicable.
With that simplify the usage.
After this PR is merged THA can be adjusted to use this param by default and after that can open another PR to kick the param everywhere again but leave the simplifications in play.

## How did you test this change?
- case1: wikis calling THA inside the module and checking against empty ones and merging them with the manual ones
  - /dev on cod wiki + preview tests on several player pages, some which have THA results and some which do not.
- case2: wikis calling THA inside the module inside the history args
  - /dev on R6 wiki + preview tests on several player pages, some which have THA results and some which do not.
    - note that here we have a tiny (imo desireable) change: if an empty THA is returned now the history section vanishes as before it would have displayed an empty one