### PR TITLE
Remove `returnEmptyIfNoResults` params in THA calls

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -46,7 +46,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
 		}

--- a/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
@@ -38,7 +38,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = mw.title.getCurrentTitle().prefixedText
 		}

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -51,7 +51,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
 		}

--- a/components/infobox/wikis/freefire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/freefire/infobox_person_player_custom.lua
@@ -67,7 +67,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
 		}

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -56,7 +56,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
 		}

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -79,7 +79,6 @@ function CustomPlayer.run(frame)
 
 	if String.isEmpty(player.args.history) then
 		player.args.history = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			hiderole = 'true',
 			iconModule = 'Module:PositionIcon/data',
 			addlpdbdata = 'true'

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -62,7 +62,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			iconModule = 'Module:PositionIcon/data',
 			player = _pagename

--- a/components/infobox/wikis/naraka/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_person_player_custom.lua
@@ -58,7 +58,7 @@ function CustomPlayer.run(frame)
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
 
-	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', returnEmptyIfNoResults = true}
+	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -46,7 +46,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
 		}

--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -72,7 +72,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
 		}

--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -75,7 +75,7 @@ function CustomPlayer.run(frame)
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
 
-	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', returnEmptyIfNoResults = true}
+	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent

--- a/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
@@ -35,7 +35,7 @@ local _player
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
-	player.args.history = TeamHistoryAuto._results{convertrole = 'true', returnEmptyIfNoResults = true}
+	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
 
 	_player = player
 	_args = player.args

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -60,7 +60,7 @@ function CustomPlayer.run(frame)
 	if String.isEmpty(player.args.team2) then
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
-	player.args.history = TeamHistoryAuto._results{convertrole = 'true', returnEmptyIfNoResults = true}
+	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -78,7 +78,7 @@ function CustomPlayer.run(frame)
 	end
 
 	if String.isEmpty(player.args.history) then
-		player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', returnEmptyIfNoResults = true}
+		player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
 	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB

--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -55,7 +55,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			returnEmptyIfNoResults = true,
 			convertrole = 'true',
 			player = _pagename
 		}


### PR DESCRIPTION
## Summary
Remove `returnEmptyIfNoResults` params in THA calls due to them now being redundant.
(Were only needed to move the stuff over to this functionality to not break existing usage.)

## How did you test this change?
dev on 3 wikis (representitive)