### PR TITLE
Disable dashIfZero in calling `.formatMoney` from `.display`

### DIFF
--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -88,7 +88,7 @@ function Currency.display(currencyCode, prizeValue, options)
 	end
 	if prizeValue then
 		if Logic.isNumeric(prizeValue) and options.formatValue then
-			prizeValue = Currency.formatMoney(prizeValue, options.formatPrecision, options.forceRoundPrecision)
+			prizeValue = Currency.formatMoney(prizeValue, options.formatPrecision, options.forceRoundPrecision, false)
 		end
 		prizeDisplay = prizeDisplay .. prizeValue
 	end


### PR DESCRIPTION
## Summary
Disable dashIfZero in calling `.formatMoney` from `.display`

Reasoning:
dashIfZero is already evalutated at lines 52-54, so in line 91 it needs to be disabled to not get wrong dashes instead of zeros

## How did you test this change?
dev