### PR TITLE
Fallback `currentstatus` to `definitestatus` in standings storage

### DIFF
--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -124,6 +124,8 @@ function StandingsStorage.entry(entry, standingsIndex)
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, entry.extradata)),
 	}
 
+	lpdbEntry.currentstatus = lpdbEntry.currentstatus or lpdbEntry.definitestatus
+
 	mw.ext.LiquipediaDB.lpdb_standingsentry(
 		'standing_' .. standingsIndex .. '_' .. roundIndex .. '_' .. slotIndex,
 		Table.merge(lpdbEntry, Opponent.toLpdbStruct(entry.opponent))


### PR DESCRIPTION
## Summary
Fallback `currentstatus` to `definitestatus` in standings storage.

Some consumers need the `currentstatus` set to work properly (e.g. prizepool import).

Logically it also makes sense that if definite status is known and current status is unset to assume that current status = definite status.

## How did you test this change?
dev