### PR TITLE
Add `passed away` as special team in squads

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -39,6 +39,7 @@ local SquadRow = Class.new(
 SquadRow.specialTeamsTemplateMapping = {
 	retired = 'Team/retired',
 	inactive = 'Team/inactive',
+	['passed away'] = 'Team/passed away',
 }
 
 


### PR DESCRIPTION
## Summary
Add `passed away` as special team in squads

Note the according template exists on commons (with overwrite for a link on cs)

## How did you test this change?
N/A, only adding a special team exception 