### PR TITLE
Various fixes for League BM

### DIFF
--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -174,7 +174,10 @@ function BigMatch.run(frame)
 		end), ' ')
 	end
 	model.heroIcon = function(self)
-		local champion = type(self) == 'table' and self.champion or self
+		local champion = self
+		if type(self) == 'table' then
+			champion = self.champion
+		end
 		return HeroIcon._getImage{champion, date = model.date}
 	end
 

--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -246,6 +246,7 @@ function BigMatch._match2Director(args)
 			local team = map['team' .. teamIdx]
 
 			map['team' .. teamIdx .. 'side'] = team.color
+			team.players = team.players or {}
 
 			-- Sort players based on role
 			Array.sortInPlaceBy(team.players, function (player)

--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -185,7 +185,7 @@ function BigMatch.run(frame)
 end
 
 function BigMatch._sumItem(tbl, item)
-	return Array.reduce(Array.map(tbl, Operator.property(item)), Operator.add)
+	return Array.reduce(Array.map(tbl, Operator.property(item)), Operator.add, 0)
 end
 
 function BigMatch._abbreviateNumber(number)


### PR DESCRIPTION
## Summary
Fix three issues, 
* API returning bad player data 
* Init the reduce with `0` so that sum function will always return a number (previous would return nil if there were no player)
* If the champion property of a table was nil, then the table was picked as the string name of the champion.

## How did you test this change?
Live