### PR TITLE
Fix BroadcastTalentTable achievements sorting

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -157,7 +157,7 @@ function BroadcastTalentTable:_fetchTournaments()
 
 	if args.isAchievementsTable then
 		table.sort(tournaments, function(item1, item2)
-			return item1.date == item2.date and item1.pagename < item2.pagename or item1.date < item2.date
+			return item1.date == item2.date and item1.pagename < item2.pagename or item1.date > item2.date
 		end)
 		return {[''] = tournaments}
 	end


### PR DESCRIPTION
## Summary

Sorting on table was inverted.

![image](https://user-images.githubusercontent.com/5881994/235475935-54c3df36-dc31-43a0-8719-4daf23da129a.png)


## How did you test this change?

Tested on `/dev`.

![image](https://user-images.githubusercontent.com/5881994/235475948-a7a4ab7e-ebf3-4c99-800e-42c3f7d8be7a.png)
