### PR TITLE
Use Dash instead of 'None' for empty broadcast partner list

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -30,6 +30,7 @@ local ColumnName = Condition.ColumnName
 local DEFAULT_LIMIT = 500
 local DEFAULT_ACHIEVEMENTS_LIMIT = 10
 local NONBREAKING_SPACE = '&nbsp;'
+local DASH = '&#8212;'
 local DEFAULT_TIERTYPE = 'General'
 local DEFAULT_ABOUT_LINK = 'Template:Weight/doc'
 local ACHIEVEMENTS_SORT_ORDER = 'weight desc, date desc'
@@ -312,7 +313,7 @@ function BroadcastTalentTable:_partnerList(tournament)
 	local partners = self:_getPartners(tournament)
 
 	if Table.isEmpty(partners) then
-		return 'None'
+		return DASH
 	end
 
 	local list = mw.html.create('ul')


### PR DESCRIPTION
## Summary
Use Dash instead of 'None' for empty broadcast partner list
as per discussion on discord

## How did you test this change?
dev
![Screenshot 2023-05-03 08 25 11](https://user-images.githubusercontent.com/75081997/235845107-0a448a4e-f0d2-485d-8d7e-d07b7c79d610.png)
