### PR TITLE
Catch nil in `BroadcastTalentTable`

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -87,7 +87,7 @@ function BroadcastTalentTable:_readArgs(args)
 	}
 
 	local broadcaster = String.isNotEmpty(args.broadcaster) and args.broadcaster or self:_getBroadcaster()
-	self.broadcaster = mw.ext.TeamLiquidIntegration.resolve_redirect(broadcaster):gsub(' ', '_')
+	self.broadcaster = broadcaster and mw.ext.TeamLiquidIntegration.resolve_redirect(broadcaster):gsub(' ', '_') or nil
 
 	self.aliases = args.aliases and Array.map(mw.text.split(args.aliases:gsub(' ', '_'), ','), String.trim) or {}
 	table.insert(self.aliases, self.broadcaster)


### PR DESCRIPTION
## Summary
Catch nil in `BroadcastTalentTable`.

In non main space `BroadcastTalentTable` errors if no broadcaster is specified. This change catches the nil that is causing an error in `mw.ext.TeamLiquidIntegration.resolve_redirect`

## How did you test this change?
live since easy bug fix