### PR TITLE
Switch from tickername to name in Broadcasts Table by default

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -48,6 +48,7 @@ local BroadcastTalentTable = Class.new(function(self, ...) self:init(...) end)
 ---		edate: string?,
 ---		achievements: string|boolean|nil,
 ---		displayGameIcon: string|boolean|nil,
+---		useTickerNames: string|boolean|nil,
 ---		limit: string|number|nil,
 ---		aboutAchievementsLink: string|boolean|nil,
 ---		onlyHighlightOnValue: string?,
@@ -76,6 +77,7 @@ function BroadcastTalentTable:_readArgs(args)
 		aboutAchievementsLink = args.aboutAchievementsLink or DEFAULT_ABOUT_LINK,
 		showTierType = Logic.nilOr(Logic.readBoolOrNil(args.showtiertype), true),
 		displayGameIcon = Logic.readBool(args.displayGameIcon),
+		useTickerNames = Logic.readBool(args.useTickerNames),
 		isAchievementsTable = isAchievementsTable,
 		year = tonumber(args.year),
 		startDate = args.sdate,
@@ -248,7 +250,7 @@ function BroadcastTalentTable:_row(tournament)
 			name = tournament.name,
 		}):done()
 		:tag('td'):css('text-align', 'left'):wikitext(Page.makeInternalLink({},
-			BroadcastTalentTable._tournamentDisplayName(tournament),
+			self:_tournamentDisplayName(tournament),
 			tournament.pagename
 		)):done()
 		:tag('td'):wikitext(table.concat(tournament.positions, '<br>')):done()
@@ -276,14 +278,15 @@ function BroadcastTalentTable._fetchTournamentData(tournament)
 	return Table.merge(queryData[1], tournament)
 end
 
-function BroadcastTalentTable._tournamentDisplayName(tournament)
+function BroadcastTalentTable:_tournamentDisplayName(tournament)
 	-- this is not the extradata of the tournament but of the broadcaster (they got merged together)
 	local extradata = tournament.extradata or {}
 	if Logic.readBool(extradata.showmatch) and String.isNotEmpty(extradata.showmatchname) then
 		return extradata.showmatchname
 	end
 
-	local displayName = String.isNotEmpty(tournament.tickername) and tournament.tickername
+	local displayName = String.isNotEmpty(tournament.tickername)
+			and self.args.useTickerNames and tournament.tickername
 		or String.isNotEmpty(tournament.name) and tournament.name
 		or tournament.parent:gsub('_', ' ')
 


### PR DESCRIPTION
## Summary

Old commons module previously used full name by default. Restores that while allowing wikis to override to still use tickername if they wish (e.g., SC2).

![image](https://user-images.githubusercontent.com/5881994/236082777-b3cbc750-356d-4c5e-acac-e058a6db3e59.png)


## How did you test this change?

`/dev`

![image](https://user-images.githubusercontent.com/5881994/236082795-0cdb953f-7d24-4015-8d73-2d331442b38b.png)

## Should this be the default?

If there is a desire for tickername to remain default by more than just SC2, then maybe we can change it. Feel free to comment your opinions.