### PR TITLE
Fix Esportal tournament links

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -202,6 +202,7 @@ PREFIXES = Table.merge(PREFIXES, CustomData.prefixes or {})
 
 local SUFFIXES = {
 	cntft = {'/1'},
+	esportal = {'/event/info'},
 	facebook = {
 		'',
 		stream = '/live',


### PR DESCRIPTION
## Summary

The site changed something and now it needs suffix to work 🫠

## How did you test this change?

I didn't but it's just adding a suffix, surely it's fine :D 