### PR TITLE
Add temporary highlighting to matchpage link

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -149,7 +149,7 @@ function CustomMatchSummary._createBody(match)
 		matchPageElement:wikitext('[[Match:ID_' .. match.matchId .. '|Match Page]]')
 						:css('display', 'block')
 						:css('margin', 'auto')
-		body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(matchPageElement))
+		body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(matchPageElement):addClass('brkts-popup-mvp'))
 	end
 
 	-- Iterate each map


### PR DESCRIPTION
## Summary
Add a temporary highlight to the match page link
![image](https://user-images.githubusercontent.com/3426850/236148043-9d4b3024-ed2d-4b3a-99a2-3e34c6e66b7e.png)


## How did you test this change?
Live