### PR TITLE
LOL Big Match: Sort picks based on role

### DIFF
--- a/components/match2/wikis/leagueoflegends/big_match_template.lua
+++ b/components/match2/wikis/leagueoflegends/big_match_template.lua
@@ -57,14 +57,14 @@ return {
 				<div class="match-bm-lol-game-veto-overview">
 					<div class="match-bm-lol-game-veto-overview-team"><div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
 						<div class="match-bm-lol-game-veto-overview-team-veto">
-							<ul class="match-bm-lol-game-veto-overview-pick" aria-labelledby="picks">{{#apiInfo.t1.pick}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}<div class="match-bm-lol-game-veto-pick-bar-{{apiInfo.team1side}}"></div></li>{{/apiInfo.t1.pick}}</ul>
-							<ul class="match-bm-lol-game-veto-overview-ban" aria-labelledby="bans">{{#apiInfo.t1.ban}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}</li>{{/apiInfo.t1.ban}}</ul>
+							<ul class="match-bm-lol-game-veto-overview-pick" aria-labelledby="picks">{{#apiInfo.team1.pick}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}<div class="match-bm-lol-game-veto-pick-bar-{{apiInfo.team1side}}"></div></li>{{/apiInfo.team1.pick}}</ul>
+							<ul class="match-bm-lol-game-veto-overview-ban" aria-labelledby="bans">{{#apiInfo.team1.ban}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}</li>{{/apiInfo.team1.ban}}</ul>
 						</div>
 					</div>
 					<div class="match-bm-lol-game-veto-overview-team"><div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
 						<div class="match-bm-lol-game-veto-overview-team-veto">
-							<ul class="match-bm-lol-game-veto-overview-pick" aria-labelledby="picks">{{#apiInfo.t2.pick}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}<div class="match-bm-lol-game-veto-pick-bar-{{apiInfo.team2side}}"></div></li>{{/apiInfo.t2.pick}}</ul>
-							<ul class="match-bm-lol-game-veto-overview-ban" aria-labelledby="bans">{{#apiInfo.t2.ban}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}</li>{{/apiInfo.t2.ban}}</ul>
+							<ul class="match-bm-lol-game-veto-overview-pick" aria-labelledby="picks">{{#apiInfo.team2.pick}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}<div class="match-bm-lol-game-veto-pick-bar-{{apiInfo.team2side}}"></div></li>{{/apiInfo.team2.pick}}</ul>
+							<ul class="match-bm-lol-game-veto-overview-ban" aria-labelledby="bans">{{#apiInfo.team2.ban}}<li class="match-bm-lol-game-veto-overview-item">{{&heroIcon}}</li>{{/apiInfo.team2.ban}}</ul>
 						</div>
 					</div>
 				</div>

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -578,24 +578,25 @@ function mapFunctions.getParticipants(map, opponents)
 	local participants = {}
 	local heroData = {}
 	for opponentIndex = 1, _MAX_NUM_OPPONENTS do
-		local team = 't' .. opponentIndex
+		local teamShort = 't' .. opponentIndex
+		local team = 'team' .. opponentIndex
 		if not map[team] then
 			local picks, bans = {}, {}
 			for playerIndex = 1, _MAX_NUM_PLAYERS do
-				table.insert(picks, map[team .. 'c' .. playerIndex])
+				table.insert(picks, map[teamShort .. 'c' .. playerIndex])
 			end
 
-			for _, ban in Table.iter.pairsByPrefix(map, team .. 'b') do
+			for _, ban in Table.iter.pairsByPrefix(map, teamShort .. 'b') do
 				table.insert(bans, ban)
 			end
-			map['t' .. opponentIndex] = {pick = picks, ban = bans}
+			map[team] = {pick = picks, ban = bans}
 		end
 
 		Array.forEach(map[team].pick, function (hero, idx)
-			heroData['team' .. opponentIndex .. 'champion' .. idx] = HeroNames[hero and hero:lower()]
+			heroData[team .. 'champion' .. idx] = HeroNames[hero and hero:lower()]
 		end)
 		Array.forEach(map[team].ban, function (hero, idx)
-			heroData['team' .. opponentIndex .. 'ban' .. idx] = HeroNames[hero and hero:lower()]
+			heroData[team .. 'ban' .. idx] = HeroNames[hero and hero:lower()]
 		end)
 	end
 


### PR DESCRIPTION
## Summary
Requirement that picks should be sorted on Role. This forces the picks to be gathered from player section isntead of vetos.

Also clean up the code.

## How did you test this change?
Dev module in preview