### PR TITLE
Remove duplicate Partners

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -15,6 +15,7 @@ local HighlightConditions = require('Module:HighlightConditions')
 local LeagueIcon = require('Module:LeagueIcon')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')
+local Operator = require('Module:Operator')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -315,6 +316,9 @@ function BroadcastTalentTable:_partnerList(tournament)
 		return 'None'
 	end
 
+	partners = BroadcastTalentTable._removeDuplicatePartners(partners)
+	Array.sortInPlaceBy(partners, Operator.property('page'))
+
 	local list = mw.html.create('ul')
 	for _, partner in ipairs(partners) do
 		list:tag('li'):wikitext(Flags.Icon{flag = partner.flag} .. NONBREAKING_SPACE
@@ -358,8 +362,17 @@ function BroadcastTalentTable:_getPartners(tournament)
 	return mw.ext.LiquipediaDB.lpdb('broadcasters', {
 		query = 'id, page, flag',
 		conditions = conditions:toString(),
-		groupBy = 'page asc',
 	})
+end
+
+function BroadcastTalentTable._removeDuplicatePartners(partners)
+	local uniquePartners = {}
+
+	for _, partner in ipairs(partners) do
+		uniquePartners[partner.page] = partner
+	end
+
+	return Array.extractValues(uniquePartners)
 end
 
 function BroadcastTalentTable:_footer()


### PR DESCRIPTION
## Summary
Remove duplicate Partners in BroadcastTalentTable when merging partners of >= 2 roles.

## How did you test this change?
/dev