### PR TITLE
Adjust `Array.extractValues` and `Array.extractKeys` to allow sorting via provided iterators

### DIFF
--- a/standard/array.lua
+++ b/standard/array.lua
@@ -357,11 +357,11 @@ end
 ---@return {[I]: V}
 
 function Array.extractValuesInOrder(tbl, order)
-    local array = {}
-    for _, item in Table.iter.spairs(tbl, order) do
-        table.insert(array, item)
-    end
-    return array
+	local array = {}
+	for _, item in Table.iter.spairs(tbl, order) do
+		table.insert(array, item)
+	end
+	return array
 end
 
 --[[

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -354,7 +354,7 @@ end
 ---@generic K, V
 ---@param tbl {[K]: V}
 ---@param order? fun(tbl: {[K]: V}, key1: K, key2: K): boolean
----@return {[I]: V}
+---@return V[]
 
 function Array.extractValuesInOrder(tbl, order)
 	local array = {}

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -351,7 +351,7 @@ function Array.extractValues(tbl)
 end
 
 ---@comment Extracts values from a given table into an array in a sorted way
----@generic K, V, I
+---@generic K, V
 ---@param tbl {[K]: V}
 ---@param order? fun(tbl: {[K]: V}, key1: K, key2: K): boolean
 ---@return {[I]: V}

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -334,34 +334,35 @@ function Array.range(from, to)
 	return elements
 end
 
-function Array.extractKeys(tbl)
-	local keys = {}
-	for key, _ in pairs(tbl) do
-		table.insert(keys, key)
-	end
-	return keys
-end
 
-function Array.extractValues(tbl)
-	local values = {}
-	for _, value in pairs(tbl) do
-		table.insert(values, value)
-	end
-	return values
-end
-
----@comment Extracts values from a given table into an array in a sorted way
+---@comment Extracts keys from a given table into an array. An order can be supplied via an iterator.
 ---@generic K, V
 ---@param tbl {[K]: V}
----@param order? fun(tbl: {[K]: V}, key1: K, key2: K): boolean
----@return V[]
-
-function Array.extractValuesInOrder(tbl, order)
+---@param iterator function?
+---@param ... any
+---@return K[]
+function Array.extractKeys(tbl, iterator, ...)
+	iterator = iterator or pairs
 	local array = {}
-	for _, item in Table.iter.spairs(tbl, order) do
-		table.insert(array, item)
-	end
-	return array
+	for key, _ in iterator(tbl, ...) do
+        table.insert(array, key)
+    end
+    return array
+end
+
+---@comment Extracts values from a given table into an array. An order can be supplied via an iterator.
+---@generic K, V
+---@param tbl {[K]: V}
+---@param iterator function?
+---@param ... any
+---@return V[]
+function Array.extractValues(tbl, iterator, ...)
+	iterator = iterator or pairs
+	local array = {}
+	for _, item in iterator(tbl, ...) do
+        table.insert(array, item)
+    end
+    return array
 end
 
 --[[

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -350,6 +350,20 @@ function Array.extractValues(tbl)
 	return values
 end
 
+---@comment Extracts values from a given table into an array in a sorted way
+---@generic K, V, I
+---@param tbl {[K]: V}
+---@param order? fun(tbl: {[K]: V}, key1: K, key2: K): boolean
+---@return {[I]: V}
+
+function Array.extractValuesInOrder(tbl, order)
+    local array = {}
+    for _, item in Table.iter.spairs(tbl, order) do
+        table.insert(array, item)
+    end
+    return array
+end
+
 --[[
 Applies a function to each element in an array.
 

--- a/standard/test/array_test.lua
+++ b/standard/test/array_test.lua
@@ -141,4 +141,15 @@ function suite:testReduce()
 	self:assertDeepEquals(1, Array.reduce({2, 3, 5}, pow, 1))
 end
 
+function suite:testExtractValuesInOrder()
+	local a = {i = 1, j = 2, k = 3, z = 0}
+
+	local customOrder1 = function(_, key1, key2) return key1 > key2 end
+	local customOrder2 = function(tbl, key1, key2) return tbl[key1] < tbl[key2] end
+
+	self:assertDeepEquals({1, 2, 3, 0}, Array.extractValuesInOrder(a))
+	self:assertDeepEquals({0, 3, 2, 1}, Array.extractValuesInOrder(a, customOrder1))
+	self:assertDeepEquals({0, 1, 2, 3}, Array.extractValuesInOrder(a, customOrder2))
+end
+
 return suite

--- a/standard/test/array_test.lua
+++ b/standard/test/array_test.lua
@@ -151,6 +151,10 @@ function suite:testExtractValues()
 	self:assertDeepEquals({1, 2, 3, 0}, Array.extractValues(a, Table.iter.spairs))
 	self:assertDeepEquals({0, 3, 2, 1}, Array.extractValues(a, Table.iter.spairs, customOrder1))
 	self:assertDeepEquals({0, 1, 2, 3}, Array.extractValues(a, Table.iter.spairs, customOrder2))
+
+	local extractedArray = Array.extractValues(a)
+	table.sort(extractedArray)
+	self:assertDeepEquals({0, 1, 2, 3}, extractedArray)
 end
 
 function suite:testExtractKeys()
@@ -162,6 +166,10 @@ function suite:testExtractKeys()
 	self:assertDeepEquals({'i', 'j', 'k', 'z'}, Array.extractKeys(a, Table.iter.spairs))
 	self:assertDeepEquals({'z', 'k', 'j', 'i'}, Array.extractKeys(a, Table.iter.spairs, customOrder1))
 	self:assertDeepEquals({'z', 'i', 'j', 'k'}, Array.extractKeys(a, Table.iter.spairs, customOrder2))
+
+	local extractedKeys = Array.extractKeys(a)
+	table.sort(extractedKeys)
+	self:assertDeepEquals({'i', 'j', 'k', 'z'}, extractedKeys)
 end
 
 return suite

--- a/standard/test/array_test.lua
+++ b/standard/test/array_test.lua
@@ -7,6 +7,7 @@
 --
 
 local Lua = require('Module:Lua')
+local Table = require('Module:Table')
 local ScribuntoUnit = require('Module:ScribuntoUnit')
 
 local Array = Lua.import('Module:Array', {requireDevIfEnabled = true})
@@ -141,15 +142,26 @@ function suite:testReduce()
 	self:assertDeepEquals(1, Array.reduce({2, 3, 5}, pow, 1))
 end
 
-function suite:testExtractValuesInOrder()
+function suite:testExtractValues()
 	local a = {i = 1, j = 2, k = 3, z = 0}
 
 	local customOrder1 = function(_, key1, key2) return key1 > key2 end
 	local customOrder2 = function(tbl, key1, key2) return tbl[key1] < tbl[key2] end
 
-	self:assertDeepEquals({1, 2, 3, 0}, Array.extractValuesInOrder(a))
-	self:assertDeepEquals({0, 3, 2, 1}, Array.extractValuesInOrder(a, customOrder1))
-	self:assertDeepEquals({0, 1, 2, 3}, Array.extractValuesInOrder(a, customOrder2))
+	self:assertDeepEquals({1, 2, 3, 0}, Array.extractValues(a, Table.iter.spairs))
+	self:assertDeepEquals({0, 3, 2, 1}, Array.extractValues(a, Table.iter.spairs, customOrder1))
+	self:assertDeepEquals({0, 1, 2, 3}, Array.extractValues(a, Table.iter.spairs, customOrder2))
+end
+
+function suite:testExtractKeys()
+	local a = {k = 3, i = 1, z = 0, j = 2}
+
+	local customOrder1 = function(_, key1, key2) return key1 > key2 end
+	local customOrder2 = function(tbl, key1, key2) return tbl[key1] < tbl[key2] end
+
+	self:assertDeepEquals({'i', 'j', 'k', 'z'}, Array.extractKeys(a, Table.iter.spairs))
+	self:assertDeepEquals({'z', 'k', 'j', 'i'}, Array.extractKeys(a, Table.iter.spairs, customOrder1))
+	self:assertDeepEquals({'z', 'i', 'j', 'k'}, Array.extractKeys(a, Table.iter.spairs, customOrder2))
 end
 
 return suite


### PR DESCRIPTION
## Summary
Adjust `Array.extractValues` and `Array.extractKeys` to allow sorting via provided iterators

## How did you test this change?
with /dev, using Array/testcases
