### PR TITLE
Add Tonamel to links

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -78,6 +78,7 @@ local _PRIORITY_GROUPS = {
 		'sostronk',
 		'start-gg',
 		'stratz',
+		'tonamel',
 		'toornament',
 		'trackmania-io',
 		'vlr',

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -176,6 +176,7 @@ local PREFIXES = {
 	},
 	tlprofile = {'https://tl.net/forum/profile.php?user='},
 	tlstream = {'https://tl.net/video/streams/'},
+	tonamel = {'https://tonamel.com/competition/'},
 	toornament = {'https://www.toornament.com/tournaments/'},
 	['trackmania-io'] = {
 		'https://trackmania.io/#/competitions/comp/',


### PR DESCRIPTION
## Summary

Add support for Tonamel links

Infobox icon already exists:
https://liquipedia.net/commons/Infobox_Icons#Tonamel

## How did you test this change?

Tested in dev