### PR TITLE
Add B Tier to BigMatch and change startdate to 2021 May

### DIFF
--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -74,9 +74,9 @@ end)
 local NOT_PLAYED = 'np'
 local DEFAULT_ITEM = 'EmptyIcon'
 local TEAMS = Array.range(1, 2)
-local AVAILABLE_FOR_TIERS = {1, 2}
+local AVAILABLE_FOR_TIERS = {1, 2, 3}
 
-local BIG_MATCH_START_TIME = 1680566400 -- April 4th 2023 midnight
+local BIG_MATCH_START_TIME = 1619827201 -- May 1st 2021 midnight
 
 function BigMatch.isEnabledFor(match)
 	return Table.includes(AVAILABLE_FOR_TIERS, tonumber(match.liquipediatier))


### PR DESCRIPTION
Updated the availability for BigMatch to extend to B tiered tournaments, as well as from 1st of May, 2021 onwards.

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
