### PR TITLE
Add `Idol Showdown` to the Fighters

### DIFF
--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -1610,6 +1610,19 @@ return {
 				lightMode = 'League of Legends allmode.png',
 			},
 		},
+		['idol showdown'] = {
+			abbreviation = 'Idol Showdown',
+			name = 'Idol Showdown',
+			link = 'Idol Showdown',
+			logo = {
+				darkMode = 'Idol Showdown allmode.png',
+				lightMode = 'Idol Showdown allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Idol Showdown allmode.png',
+				lightMode = 'Idol Showdown allmode.png',
+			},
+		},
 	},
 	defaultGame = 'fighters',
 	defaultTeamLogo = 'Fighters default lightmode.png', ---@deprecated


### PR DESCRIPTION
## Summary
Add [Idol Showdown](https://twitter.com/IdolShowdown)
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/95c809d8-2f1c-4600-aefa-c39f7cbf0596)

## How did you test this change?
Tested on User Page
