### PR TITLE
Add SquadType to SquadPlayer ObjectNames

### DIFF
--- a/components/squad/wikis/apexlegends/squad_custom.lua
+++ b/components/squad/wikis/apexlegends/squad_custom.lua
@@ -106,6 +106,7 @@ function CustomSquad.run(frame)
 				'_' .. player.id .. '_' ..
 				ReferenceCleaner.clean(player.joindate)
 				.. (player.role and '_' .. player.role or '')
+				.. '_' .. squad.type
 		))
 
 		index = index + 1

--- a/components/squad/wikis/arenaofvalor/squad_custom.lua
+++ b/components/squad/wikis/arenaofvalor/squad_custom.lua
@@ -166,6 +166,7 @@ function CustomSquad._playerRow(player, squadType)
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')
+		.. '_' .. squadType
 	)
 end
 

--- a/components/squad/wikis/counterstrike/squad_custom.lua
+++ b/components/squad/wikis/counterstrike/squad_custom.lua
@@ -106,6 +106,7 @@ function CustomSquad.run(frame)
 			'_' .. player.id .. '_' ..
 			ReferenceCleaner.clean(player.joindate) ..
 			(player.role and '_' .. player.role or '')
+			.. '_' .. squad.type
 		))
 
 		index = index + 1

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -145,6 +145,7 @@ function CustomSquad.run(frame)
 			.. '_' .. link .. '_'
 			.. ReferenceCleaner.clean(player.joindate)
 			.. (player.role and '_' .. player.role or '')
+			.. '_' .. squad.type
 		))
 
 		index = index + 1

--- a/components/squad/wikis/halo/squad_custom.lua
+++ b/components/squad/wikis/halo/squad_custom.lua
@@ -71,7 +71,8 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. player.joindate)
+	local pageName = mw.title.getCurrentTitle().prefixedText
+	return row:create(pageName .. '_' .. player.id .. '_' .. player.joindate .. '_' .. squadType)
 end
 
 return CustomSquad

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -137,6 +137,7 @@ function CustomSquad._playerRow(player, squadType)
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')
+		.. '_' .. squad.type
 	)
 end
 

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -137,7 +137,7 @@ function CustomSquad._playerRow(player, squadType)
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')
-		.. '_' .. squad.type
+		.. '_' .. squadType
 	)
 end
 

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -166,6 +166,7 @@ function CustomSquad._playerRow(player, squadType)
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')
+		.. '_' .. squadType
 	)
 end
 

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -204,6 +204,7 @@ function CustomSquad._playerRow(player, squadType)
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')
+		.. '_' .. squadType
 	)
 end
 

--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -74,6 +74,7 @@ function CustomSquad._playerRow(player, squadType)
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_'
 		.. player.joindate .. (player.role and '_' .. player.role or '')
+		.. '_' .. squadType
 	)
 end
 

--- a/components/squad/wikis/rocketleague/squad_custom.lua
+++ b/components/squad/wikis/rocketleague/squad_custom.lua
@@ -55,6 +55,7 @@ function CustomSquad.run(frame)
 			Variables.varDefault('squad_name',
 			mw.title.getCurrentTitle().prefixedText) .. '_' .. link .. '_' .. ReferenceCleaner.clean(player.joindate)
 			.. (player.role and '_' .. player.role or '')
+			.. '_' .. squad.type
 		))
 
 		index = index + 1

--- a/components/squad/wikis/smash/squad_custom.lua
+++ b/components/squad/wikis/smash/squad_custom.lua
@@ -107,6 +107,7 @@ function CustomSquad.run(frame)
 			mw.title.getCurrentTitle().prefixedText
 			.. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 			.. (player.role and '_' .. player.role or '')
+			.. '_' .. squad.type
 		))
 
 		Variables.varDefine('nationality', '')

--- a/components/squad/wikis/starcraft/squad_custom.lua
+++ b/components/squad/wikis/starcraft/squad_custom.lua
@@ -110,6 +110,7 @@ function CustomSquad.run(frame)
 			mw.title.getCurrentTitle().prefixedText
 			.. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 			.. (player.role and '_' .. player.role or '')
+			.. '_' .. squad.type
 		))
 	end)
 

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -91,6 +91,7 @@ function CustomSquad.run(frame)
 		squad:row(row:create(
 			squadName .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 			.. (player.role and '_' .. player.role or '')
+			.. '_' .. squad.type
 		))
 
 		index = index + 1

--- a/components/squad/wikis/valorant/squad_custom.lua
+++ b/components/squad/wikis/valorant/squad_custom.lua
@@ -158,6 +158,7 @@ function CustomSquad._playerRow(player, squadType)
 		.. '_' .. player.id .. '_'
 		.. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')
+		.. '_' .. squadType
 	)
 end
 

--- a/components/squad/wikis/warcraft/squad_custom.lua
+++ b/components/squad/wikis/warcraft/squad_custom.lua
@@ -58,6 +58,7 @@ function CustomSquad.run(frame)
 			mw.title.getCurrentTitle().prefixedText
 			.. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 			.. (player.role and '_' .. player.role or '')
+			.. '_' .. squad.type
 		))
 	end)
 

--- a/components/squad/wikis/wildrift/squad_custom.lua
+++ b/components/squad/wikis/wildrift/squad_custom.lua
@@ -166,6 +166,7 @@ function CustomSquad._playerRow(player, squadType)
 	return row:create(
 		mw.title.getCurrentTitle().prefixedText .. '_' .. player.id .. '_' .. ReferenceCleaner.clean(player.joindate)
 		.. (player.role and '_' .. player.role or '')
+		.. '_' .. squadType
 	)
 end
 


### PR DESCRIPTION
## Summary
Add SquadType as part of the Objectname, to ensure entries of different types are not merged.

## How did you test this change?
Dev on Rocket League