### PR TITLE
Store team status in LPDB

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -40,6 +40,12 @@ local _LINK_VARIANT = 'team'
 local Language = mw.language.new('en')
 local _defaultEarningsFunctionUsed = false
 
+---@enum statuses
+local Status = {
+	ACTIVE = 'active',
+	DISBANDED = 'disbanded',
+}
+
 local _warnings = {}
 
 function Team.run(frame)
@@ -277,6 +283,7 @@ function Team:_setLpdbData(args, links)
 		coach = args.coaches or args.coach,
 		manager = args.manager,
 		template = self.teamTemplate.historicaltemplate or self.teamTemplate.templatename,
+		status = args.disbanded and Status.DISBANDED or Status.ACTIVE,
 		links = mw.ext.LiquipediaDB.lpdb_create_json(
 			Links.makeFullLinksForTableItems(links or {}, 'team')
 		),


### PR DESCRIPTION
## Summary
Store `active` and `disbanded` status in the new LPDB `status` field for teams. This allows Portal:Team and similar to actually function properly.

## How did you test this change?
dev