### PR TITLE
Use `prizemoney` in results tables as default

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -100,8 +100,9 @@ function ResultsTable:buildRow(placement)
 			:tag('td'):css('text-align', 'left'):cssText(groupAbbr and 'padding-left:14px' or nil):node(vsDisplay or groupAbbr)
 	end
 
+	local useIndivPrize = self.config.useIndivPrize and self.config.queryType ~= Opponent.team
 	row:tag('td'):wikitext(Currency.display('USD',
-			self.config.queryType ~= Opponent.team and placement.individualprizemoney or placement.prizemoney,
+			useIndivPrize and placement.individualprizemoney or placement.prizemoney,
 			{dashIfZero = true, abbreviation = false, formatValue = true}
 		))
 

--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -80,6 +80,7 @@ function BaseResultsTable:readConfig()
 		resultsSubPage = args.resultsSubPage or DEFAULT_RESULTS_SUB_PAGE,
 		displayDefaultLogoAsIs = Logic.readBool(args.displayDefaultLogoAsIs),
 		onlyHighlightOnValue = args.onlyHighlightOnValue,
+		useIndivPrize = Logic.readBool(args.useIndivPrize),
 		aliases = args.aliases and Array.map(mw.text.split(args.aliases, ','), String.trim) or {}
 	}
 

--- a/components/results_table/wikis/starcraft2/results_table_custom.lua
+++ b/components/results_table/wikis/starcraft2/results_table_custom.lua
@@ -35,6 +35,7 @@ local CustomResultsTable = {}
 function CustomResultsTable.results(frame)
 	local args = Arguments.getArgs(frame)
 	args.playerLimit = MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS
+	args.useIndivPrize = true
 
 	if Logic.readBool(args.awards) then
 		return CustomResultsTable.awards(args)
@@ -58,7 +59,7 @@ end
 
 function CustomResultsTable.awards(frame)
 	local args = Arguments.getArgs(frame)
-
+	args.useIndivPrize = true
 	args.data = Json.parseIfTable(Variables.varDefault('awardAchievements'))
 
 	if Logic.readBool(args.achievements) and Table.isEmpty(args.data) then


### PR DESCRIPTION
## Summary
List full prizemoney by default instead of individual prize money, with the option to use individual prize money.

## How did you test this change?
Dev

Before:
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/d2513ab3-d555-491e-81b1-3d4386aaff20)

After:
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/548bae8b-6cd9-4d56-a484-0b5df8addaae)
