### PR TITLE
Fetch more tournaments by default; sc2 can use callByYear

### DIFF
--- a/components/tournaments_listing/commons/tournaments_listing_card_list.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_card_list.lua
@@ -35,6 +35,7 @@ local POSTPONED = 'postponed'
 local DELAYED = 'delayed'
 local CANCELLED = 'cancelled'
 local DEFAULT_ALLOWED_PLACES = '1,2,1-2,2-3,W,L'
+local DEFAULT_LIMIT= 5000
 
 --- @class BaseTournamentsListing
 local BaseTournamentsListing = Class.new(function(self, ...) self:init(...) end)
@@ -92,7 +93,7 @@ function BaseTournamentsListing:_query()
 		query = 'pagename, name, icon, icondark, organizers, startdate, enddate, status, locations, series, '
 			.. 'prizepool, participantsnumber, game, liquipediatier, liquipediatiertype, extradata, publishertier, type',
 		order = self.args.order,
-		limit = self.args.limit,
+		limit = self.args.limit or DEFAULT_LIMIT,
 		offset = self.config.offset,
 	})
 end

--- a/components/tournaments_listing/commons/tournaments_listing_card_list.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_card_list.lua
@@ -35,7 +35,7 @@ local POSTPONED = 'postponed'
 local DELAYED = 'delayed'
 local CANCELLED = 'cancelled'
 local DEFAULT_ALLOWED_PLACES = '1,2,1-2,2-3,W,L'
-local DEFAULT_LIMIT= 5000
+local DEFAULT_LIMIT = 5000
 
 --- @class BaseTournamentsListing
 local BaseTournamentsListing = Class.new(function(self, ...) self:init(...) end)

--- a/components/tournaments_listing/wikis/starcraft2/tournaments_listing_card_list_custom.lua
+++ b/components/tournaments_listing/wikis/starcraft2/tournaments_listing_card_list_custom.lua
@@ -23,7 +23,7 @@ local NON_QUALIFIER = '!Qualifier'
 
 function CustomTournamentsListing.run(args)
 	args = args or {}
-	
+
 	if Logic.readBool(args.byYear) then
 		args.byYear = nil
 		return CustomTournamentsListing.byYear(args)

--- a/components/tournaments_listing/wikis/starcraft2/tournaments_listing_card_list_custom.lua
+++ b/components/tournaments_listing/wikis/starcraft2/tournaments_listing_card_list_custom.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local Game = require('Module:Game')
 local Info = require('Module:Info')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local TournamentsListing = Lua.import('Module:TournamentsListing/CardList', {requireDevIfEnabled = true})
@@ -22,6 +23,11 @@ local NON_QUALIFIER = '!Qualifier'
 
 function CustomTournamentsListing.run(args)
 	args = args or {}
+	
+	if Logic.readBool(args.byYear) then
+		args.byYear = nil
+		return CustomTournamentsListing.byYear(args)
+	end
 
 	args.game = args.game
 		and Game.name{game = args.game, useDefault = false}


### PR DESCRIPTION
## Summary
- Adjust sc2 custom to be able to call by year from template
- adjust default limit for query from 20 to 5000

## How did you test this change?
live