### PR TITLE
Add support for series2 in TournamentsList

### DIFF
--- a/components/tournaments_listing/commons/tournaments_listing_conditions.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_conditions.lua
@@ -63,7 +63,10 @@ function TournamentsListingConditions.base(args)
 	end
 
 	if args.series then
-		conditions:add{ConditionNode(ColumnName('series'), Comparator.eq, args.series)}
+		conditions:add{ConditionTree(BooleanOperator.any):add{
+			ConditionNode(ColumnName('series'), Comparator.eq, args.series),
+			ConditionNode(ColumnName('extradata_series2'), Comparator.eq, args.series)
+		}}
 	end
 
 	if args.location then


### PR DESCRIPTION
## Summary
Multiple wikis store `series2` into extradata (in case a tournament is part of multiple series).
This allows the `series` condition to take that into account

## How did you test this change?
dev