### PR TITLE
Add Smashboards to links

### DIFF
--- a/components/infobox/commons/infobox_widget_links.lua
+++ b/components/infobox/commons/infobox_widget_links.lua
@@ -75,6 +75,7 @@ local _PRIORITY_GROUPS = {
 		'royaleapi',
 		'siege-gg',
 		'sk',
+		'smashboards',
 		'sostronk',
 		'start-gg',
 		'stratz',

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -139,6 +139,7 @@ local PREFIXES = {
 		player = 'https://siege.gg/players/',
 	},
 	sk = {'https://sk-gaming.com/member/'},
+	smashboards = {'https://smashboards.com/'},
 	snapchat = {'https://www.snapchat.com/add/'},
 	sostronk = {'https://www.sostronk.com/tournament/'},
 	['start-gg'] = {


### PR DESCRIPTION
## Summary

Add support for Smashboards links

Infobox icon already exists:
https://liquipedia.net/commons/Infobox_Icons#Smashboards

## How did you test this change?

Tested in dev