### PR TITLE
Fix showmatches in `BroadcastTalentTable`

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -296,7 +296,21 @@ function BroadcastTalentTable._fetchTournamentData(tournament)
 
 	queryData[1].tournamentExtradata = queryData[1].extradata
 
-	return Table.merge(queryData[1], tournament)
+	local tournamentData = Table.merge(queryData[1], tournament)
+
+	local extradata = tournamentData.extradata or {}
+	if Logic.readBool(extradata.showmatch) then
+		if String.isNotEmpty(extradata.liquipediatier) then
+			tournamentData.liquipediatier = extradata.liquipediatier
+		end
+		if String.isNotEmpty(extradata.liquipediatiertype) then
+			tournamentData.liquipediatiertype = extradata.liquipediatiertype
+		else
+			tournamentData.liquipediatiertype = 'Showmatch'
+		end
+	end
+
+	return tournamentData
 end
 
 ---@param tournament table
@@ -323,20 +337,8 @@ end
 ---@param tournament table
 ---@return string
 function BroadcastTalentTable:_tierDisplay(tournament)
-	-- this is not the extradata of the tournament but of the broadcaster (they got merged together)
-	local extradata = tournament.extradata or {}
-	if Logic.readBool(extradata.showmatch) then
-		if String.isNotEmpty(extradata.liquipediatier) then
-			tournament.liquipediatier = extradata.liquipediatier
-		end
-		if String.isNotEmpty(extradata.liquipediatiertype) then
-			tournament.liquipediatiertype = extradata.liquipediatiertype
-		else
-			tournament.liquipediatiertype = 'Showmatch'
-		end
-	end
-
 	local tier, tierType, options = Tier.parseFromQueryData(tournament)
+
 	options.link = true
 	options.shortIfBoth = true
 	options.onlyTierTypeIfBoth = self.args.showTierType and tournament.liquipediatiertype ~= DEFAULT_TIERTYPE


### PR DESCRIPTION
## Summary

Broadcast talent for on-page showmatches like these (https://liquipedia.net/counterstrike/BLAST/Major/2023/Paris#Showmatch) have been broken since the start it seems? They just get doubled up in terms of the same role:

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/933c4452-1de1-4bf5-b782-f2d774d35c02)

Just adding some change to not do the role-merging stuff on showmatches isn't enough either since the display doesn't match the rest of the tiers.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/7a624c20-eb9a-4f18-9e1b-423a31e1e1f6)

Switched to using tier and tiertype from broadcaster extradata and falling back to `Showmatch` tiertype if nothing is set in that regard.

(Will update the fix to sorting in #3009 after this is merged since it's easier that way)

## How did you test this change?

`/dev` on cs and rl wikis.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/5fad5cec-1044-4b6f-a31a-46714e22ceff)

