### PR TITLE
Fix brackets with more than 20 big-matches

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -334,7 +334,8 @@ namespace.
 ]]
 MatchGroupInput.fetchStandaloneMatchGroup = FnUtil.memoize(function(bracketId)
 	return mw.ext.LiquipediaDB.lpdb('match2', {
-		conditions = '[[namespace::130]] AND [[match2bracketid::'.. bracketId .. ']]'
+		conditions = '[[namespace::130]] AND [[match2bracketid::' .. bracketId .. ']]',
+		limit = 5000,
 	})
 end)
 


### PR DESCRIPTION
## Summary
Currently only 20 (LPDB default limit) big-matches will be pulled from LPDB for a bracket, as such gives unexpected results for brackets/matchlists with more than 20.

## How did you test this change?
Dev into live

