### PR TITLE
Add informationType overwrite option for infobox map

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -68,11 +68,11 @@ end
 
 --- Returns completed infobox
 ---@param widgets Widget[]
----@return Html?
+---@return Html
 function Infobox:build(widgets)
 	for _, widget in ipairs(widgets) do
 		if widget == nil or widget['is_a'] == nil then
-			return error('Infobox:build can only accept Widgets')
+			error('Infobox:build can only accept Widgets')
 		end
 		widget:setContext({injector = self.injector})
 

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -51,7 +51,7 @@ function Infobox:categories(...)
 end
 
 ---Sets the widgetInjector
----@param injector any
+---@param injector WidgetInjector?
 ---@return self
 function Infobox:widgetInjector(injector)
 	self.injector = injector

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -14,11 +14,11 @@ local Variables = require('Module:Variables')
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory', {requireDevIfEnabled = true})
 
 ---@class Infobox
----@field frame Frame
----@field root Html
----@field adbox Html
----@field content Html
----@field injector WidgetInjector
+---@field frame Frame?
+---@field root Html?
+---@field adbox Html?
+---@field content Html?
+---@field injector WidgetInjector?
 local Infobox = Class.new()
 
 --- Inits the Infobox instance

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -13,9 +13,19 @@ local Variables = require('Module:Variables')
 
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory', {requireDevIfEnabled = true})
 
+---@class Infobox
+---@field frame Frame
+---@field root Html
+---@field adbox Html
+---@field content Html
+---@field injector WidgetInjector
 local Infobox = Class.new()
 
 --- Inits the Infobox instance
+---@param frame Frame
+---@param gameName string
+---@param forceDarkMode boolean?
+---@return Infobox
 function Infobox:create(frame, gameName, forceDarkMode)
 	self.frame = frame
 	self.root = mw.html.create('div')
@@ -32,22 +42,33 @@ function Infobox:create(frame, gameName, forceDarkMode)
 	return self
 end
 
+---Adds categories
+---@param ... string?
+---@return Infobox
 function Infobox:categories(...)
 	Array.forEach({...}, function(cat) return mw.ext.TeamLiquidIntegration.add_category(cat) end)
 	return self
 end
 
+---Sets the widgetInjector
+---@param injector any
+---@return Infobox
 function Infobox:widgetInjector(injector)
 	self.injector = injector
 	return self
 end
 
+---Adds a custom widgets to the bottom of the infobox
+---@param wikitext string|number|Html|nil
+---@return Infobox
 function Infobox:bottom(wikitext)
 	self.bottomContent = wikitext
 	return self
 end
 
 --- Returns completed infobox
+---@param widgets Widget[]
+---@return Html?
 function Infobox:build(widgets)
 	for _, widget in ipairs(widgets) do
 		if widget == nil or widget['is_a'] == nil then

--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -25,7 +25,7 @@ local Infobox = Class.new()
 ---@param frame Frame
 ---@param gameName string
 ---@param forceDarkMode boolean?
----@return Infobox
+---@return self
 function Infobox:create(frame, gameName, forceDarkMode)
 	self.frame = frame
 	self.root = mw.html.create('div')
@@ -44,7 +44,7 @@ end
 
 ---Adds categories
 ---@param ... string?
----@return Infobox
+---@return self
 function Infobox:categories(...)
 	Array.forEach({...}, function(cat) return mw.ext.TeamLiquidIntegration.add_category(cat) end)
 	return self
@@ -52,7 +52,7 @@ end
 
 ---Sets the widgetInjector
 ---@param injector any
----@return Infobox
+---@return self
 function Infobox:widgetInjector(injector)
 	self.injector = injector
 	return self
@@ -60,7 +60,7 @@ end
 
 ---Adds a custom widgets to the bottom of the infobox
 ---@param wikitext string|number|Html|nil
----@return Infobox
+---@return self
 function Infobox:bottom(wikitext)
 	self.bottomContent = wikitext
 	return self

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -15,6 +15,13 @@ local Table = require('Module:Table')
 local Info = Lua.import('Module:Info', {requireDevIfEnabled = true})
 local Infobox = Lua.import('Module:Infobox', {requireDevIfEnabled = true})
 
+---@class BasicInfobox
+---@operator call(Frame): BasicInfobox
+---@field args table
+---@field pagename string
+---@field name string
+---@field wiki string
+---@field infobox Infobox
 local BasicInfobox = Class.new(
 	function(self, frame)
 		self.args = Arguments.getArgs(frame)
@@ -26,26 +33,43 @@ local BasicInfobox = Class.new(
 	end
 )
 
+---Creates an empty WidgetInjector
+---@return nil
 function BasicInfobox:createWidgetInjector()
 	return nil
 end
 
 --- Allows for overriding this functionality
+---Adds custom cells to an infobox
+---@param infobox Infobox
+---@param args table
+---@return Infobox
 function BasicInfobox:addCustomCells(infobox, args)
 	return infobox
 end
 
 --- Allows for overriding this functionality
+---Add bottom content below the infobox, e.g. matchtickers
+---@return nil
 function BasicInfobox:createBottomContent()
 	return nil
 end
 
 --- Allows for overriding this functionality
+---Set wikispecific categories
+---@param args table
+---@return table
 function BasicInfobox:getWikiCategories(args)
 	return {}
 end
 
 --- Allows for using this for customCells
+---Fetches all arguments from the args table for a given base
+---@generic K, V
+---@param args {[K]: V}
+---@param base string
+---@param options {makeLink: boolean?}
+---@return V[]
 function BasicInfobox:getAllArgsForBase(args, base, options)
 	options = options or {}
 

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -41,7 +41,7 @@ end
 
 --- Allows for overriding this functionality
 ---Add bottom content below the infobox, e.g. matchtickers
----@return nil
+---@return string?
 function BasicInfobox:createBottomContent()
 	return nil
 end
@@ -59,7 +59,7 @@ end
 ---@generic K, V
 ---@param args {[K]: V}
 ---@param base string
----@param options {makeLink: boolean?}
+---@param options {makeLink: boolean?}?
 ---@return V[]
 function BasicInfobox:getAllArgsForBase(args, base, options)
 	options = options or {}

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -34,7 +34,7 @@ local BasicInfobox = Class.new(
 )
 
 ---Creates an empty WidgetInjector
----@return nil
+---@return WidgetInjector?
 function BasicInfobox:createWidgetInjector()
 	return nil
 end

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -40,15 +40,6 @@ function BasicInfobox:createWidgetInjector()
 end
 
 --- Allows for overriding this functionality
----Adds custom cells to an infobox
----@param infobox Infobox
----@param args table
----@return Infobox
-function BasicInfobox:addCustomCells(infobox, args)
-	return infobox
-end
-
---- Allows for overriding this functionality
 ---Add bottom content below the infobox, e.g. matchtickers
 ---@return nil
 function BasicInfobox:createBottomContent()

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -22,7 +22,7 @@ local Customizable = Widgets.Customizable
 ---@class MapInfobox:BasicInfobox
 local Map = Class.new(BasicInfobox)
 
----comment
+---Entry point of map infobox
 ---@param frame Frame
 ---@return Html
 function Map.run(frame)
@@ -30,7 +30,7 @@ function Map.run(frame)
 	return map:createInfobox()
 end
 
----@return Html?
+---@return Html
 function Map:createInfobox()
 	local infobox = self.infobox
 	local args = self.args

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -19,13 +19,18 @@ local Title = Widgets.Title
 local Center = Widgets.Center
 local Customizable = Widgets.Customizable
 
+---@class MapInfobox:BasicInfobox
 local Map = Class.new(BasicInfobox)
 
+---comment
+---@param frame Frame
+---@return Html
 function Map.run(frame)
 	local map = Map(frame)
 	return map:createInfobox()
 end
 
+---@return Html?
 function Map:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
@@ -38,7 +43,7 @@ function Map:createInfobox()
 			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
-		Title{name = 'Map Information'},
+		Title{name = (args.informationType or 'Map') .. ' Information'},
 		Cell{name = 'Creator', content = {
 				args.creator or args['created-by'], args.creator2 or args['created-by2']}, options = { makeLink = true }
 		},
@@ -59,20 +64,32 @@ function Map:createInfobox()
 end
 
 --- Allows for overriding this functionality
+---Builds the display Name for the header
+---@param args table
+---@return string
 function Map:getNameDisplay(args)
 	return args.name
 end
 
 --- Allows for overriding this functionality
+---Add wikispecific categories
+---@param args table
+---@return table
 function Map:getWikiCategories(args)
 	return {}
 end
 
 --- Allows for overriding this functionality
+---Adjust Lpdb data
+---@param lpdbData table
+---@param args table
+---@return table
 function Map:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
+---Stores the lpdb data
+---@param args table
 function Map:_setLpdbData(args)
 	local lpdbData = {
 		name = self.name,

--- a/components/infobox/commons/infobox_widget.lua
+++ b/components/infobox/commons/infobox_widget.lua
@@ -13,7 +13,7 @@ local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabl
 
 ---@class Widget
 ---@operator call(): Widget
----@field public injector function?
+---@field public injector WidgetInjector?
 local Widget = Class.new()
 
 local _ERROR_TEXT = '<span style="color:#ff0000;font-weight:bold" class="show-when-logged-in">' ..

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -14,14 +14,14 @@ local Injector = Class.new()
 ---Parses the widgets
 ---@param id string
 ---@param widgets Widget[]
----@return Widget[]
+---@return Widget[]?
 function Injector:parse(id, widgets)
 	return widgets
 end
 
 ---Adds custom cells
 ---@param widgets Widget[]
----@return Widget[]
+---@return Widget[]?
 function Injector:addCustomCells(widgets)
 	return {}
 end

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -8,12 +8,20 @@
 
 local Class = require('Module:Class')
 
+---@class WidgetInjector
 local Injector = Class.new()
 
+---Parses the widgets
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
 function Injector:parse(id, widgets)
 	return widgets
 end
 
+---Adds custom cells
+---@param widgets Widget[]
+---@return Widget[]
 function Injector:addCustomCells(widgets)
 	return {}
 end


### PR DESCRIPTION
stacked on #2990 because i fucked up and am lazy

## Summary
- Add informationType overwrite option for infobox map
- Add annotations in files so the warnings shut up in `infobox_map.lua`

## How did you test this change?
/dev for kicking the redundant function --> preview tests on several pages on several wikis for team, league and player infoboxes
rest N/A