### PR TITLE
Silence some annoying annotatrion warnings about missing annos

### DIFF
--- a/standard/links_stream.lua
+++ b/standard/links_stream.lua
@@ -122,10 +122,11 @@ StreamLinks.StreamKey = Class.new(
 )
 local StreamKey = StreamLinks.StreamKey
 
----@param tbl StreamKey
----@overload fun(tbl: string, languageCode: string, index: integer): StreamKey
----@overload fun(tbl: string): StreamKey
----@diagnostic disable-next-line: incomplete-signature-doc
+---@param tbl string
+---@param languageCode string
+---@param index integer
+---@overload fun(self, tbl: StreamKey): StreamKey
+---@overload fun(self, tbl: string): StreamKey
 function StreamKey:new(tbl, languageCode, index)
 	local platform
 	-- Input is another StreamKey - Make a copy

--- a/standard/links_stream.lua
+++ b/standard/links_stream.lua
@@ -125,6 +125,7 @@ local StreamKey = StreamLinks.StreamKey
 ---@param tbl StreamKey
 ---@overload fun(tbl: string, languageCode: string, index: integer): StreamKey
 ---@overload fun(tbl: string): StreamKey
+---@diagnostic disable-next-line: incomplete-signature-doc
 function StreamKey:new(tbl, languageCode, index)
 	local platform
 	-- Input is another StreamKey - Make a copy

--- a/standard/ordinal/ordinal.lua
+++ b/standard/ordinal/ordinal.lua
@@ -186,6 +186,7 @@ end
 
 ---@deprecated
 ---@param value string|number|nil
+---@param _ nil
 ---@param superScript boolean?
 ---@return string?
 function Ordinal._ordinal(value, _, superScript)


### PR DESCRIPTION
## Summary
Silence some annoying annotatrion warnings about missing annos
- add `---@param _ nil`
- `---@diagnostic disable-next-line: incomplete-signature-doc` for a case where the other params are caught by overload

## How did you test this change?
N/A