### PR TITLE
Fix typo of filename in flag data

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1337,7 +1337,7 @@ local data = {
 		name = 'Africa',
 	},
 	['arabia'] = {
-		flag = 'File:ccc hd.png',
+		flag = 'File:gcc hd.png',
 		localised = 'Arabian',
 		name = 'Arabia',
 	},


### PR DESCRIPTION
## Summary

`ccc` -> `gcc`

## How did you test this change?

Live since broke wiki :(
