### PR TITLE
Add excludeTiertype to conditions of `TournamentsListing`

### DIFF
--- a/components/tournaments_listing/commons/tournaments_listing_conditions.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_conditions.lua
@@ -129,7 +129,6 @@ function TournamentsListingConditions.base(args)
 		end
 		conditions:add{tierTypeConditions}
 	end
-	
 	args.excludeTiertype1 = args.excludeTiertype1 or args.excludeTiertype
 	if args.excludeTiertype1 then
 		local excludeTiertypeConditions = ConditionTree(BooleanOperator.all)

--- a/components/tournaments_listing/commons/tournaments_listing_conditions.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_conditions.lua
@@ -129,6 +129,17 @@ function TournamentsListingConditions.base(args)
 		end
 		conditions:add{tierTypeConditions}
 	end
+	
+	args.excludeTiertype1 = args.excludeTiertype1 or args.excludeTiertype
+	if args.excludeTiertype1 then
+		local excludeTiertypeConditions = ConditionTree(BooleanOperator.all)
+		for _, tier in Table.iter.pairsByPrefix(args, 'excludeTiertype') do
+			excludeTiertypeConditions:add{
+				ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, tier == NON_TIER_TYPE_INPUT and '' or tier)
+			}
+		end
+		conditions:add{excludeTiertypeConditions}
+	end
 
 	return conditions:toString()
 end


### PR DESCRIPTION
## Summary
Adds arguments  `exludeTiertypeX` to the conditions.
While in theory most usages can already be achieved with `tiertypeX=!tiertype`, this won't work to list only tournaments with a  set tiertype, unless you list all possible tiertypes.

## How did you test this change?
via /dev
