### PR TITLE
Create `upperCaseFirst` in StringUtils

### DIFF
--- a/standard/string_utils.lua
+++ b/standard/string_utils.lua
@@ -126,7 +126,7 @@ function String.interpolate(s, tbl)
 	)
 end
 
----Upercases the first char of a string
+---Uppercase the first letter of a string
 ---@param str string
 ---@return string
 function String.upperCaseFirst(str)

--- a/standard/string_utils.lua
+++ b/standard/string_utils.lua
@@ -126,4 +126,11 @@ function String.interpolate(s, tbl)
 	)
 end
 
+---Upercases the first char of a string
+---@param str string
+---@return string
+function String.upperCaseFirst(str)
+	return mw.getContentLanguage():ucfirst(str)
+end
+
 return String

--- a/standard/test/string_utils_test.lua
+++ b/standard/test/string_utils_test.lua
@@ -72,7 +72,7 @@ end
 
 function suite:testUpperCaseFirst()
 	self:assertEquals('Top', String.upperCaseFirst('top'))
-	-- test with special char `ü` (string.upper could not catch it)
+	-- test with non-ascii character (string.upper only works on ascii characters)
 	self:assertEquals('Übung', String.upperCaseFirst('übung'))
 end
 

--- a/standard/test/string_utils_test.lua
+++ b/standard/test/string_utils_test.lua
@@ -70,4 +70,10 @@ function suite:testInterpolate()
 	self:assertEquals('I\'m 40 years old', String.interpolate('I\'m ${age} years old', {age = 40}))
 end
 
+function suite:testUpperCaseFirst()
+	self:assertEquals('Top', String.upperCaseFirst('top'))
+	-- test with special char `ü` (string.upper could not catch it)
+	self:assertEquals('Übung', String.upperCaseFirst('übung'))
+end
+
 return suite


### PR DESCRIPTION
## Summary
Add `upperCaseFirst` function to StringUtils.
Uses `mw.getContentLanguage():ucfirst`, but unlike that one this function can be used directly in `Array.map` etc.

## How did you test this change?
dev + testcases