### PR TITLE
Add option to show `type` in Resultstables

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -29,6 +29,10 @@ function ResultsTable:buildHeader()
 		:tag('th'):css('min-width', '80px'):wikitext('Place'):done()
 		:tag('th'):css('min-width', '75px'):wikitext('Tier'):done()
 
+	if self.config.showType then
+		header:tag('th'):css('min-width', '50px'):wikitext('Type')
+	end
+
 	if self.config.displayGameIcons then
 		header:tag('th'):node(Abbreviation.make('G.', 'Game'))
 	end
@@ -62,6 +66,10 @@ function ResultsTable:buildRow(placement)
 	local tierDisplay, tierSortValue = self:tierDisplay(placement)
 
 	row:tag('td'):attr('data-sort-value', tierSortValue):wikitext(tierDisplay)
+
+	if self.config.showType then
+		row:tag('td'):wikitext(placement.type)
+	end
 
 	if self.config.displayGameIcons then
 		row:tag('td'):node(Game.icon{game = placement.game})

--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -22,8 +22,14 @@ function AwardsTable:buildHeader()
 	local header = mw.html.create('tr')
 		:tag('th'):css('width', '100px'):wikitext('Date'):done()
 		:tag('th'):css('min-width', '75px'):wikitext('Tier'):done()
+
+	if self.config.showType then
+		header:tag('th'):css('min-width', '50px'):wikitext('Type')
+	end
+
+	header
 		:tag('th'):css('width', '275px'):attr('colspan', 2):wikitext('Tournament'):done()
-		:tag('th'):css('min-width', '225px'):wikitext('Award'):done()
+		:tag('th'):css('min-width', '225px'):wikitext('Award')
 
 	if self.config.queryType ~= Opponent.team then
 		header:tag('th'):css('min-width', '70px'):wikitext('Team')
@@ -44,6 +50,10 @@ function AwardsTable:buildRow(placement)
 	local tierDisplay, tierSortValue = self:tierDisplay(placement)
 
 	row:tag('td'):attr('data-sort-value', tierSortValue):wikitext(tierDisplay)
+
+	if self.config.showType then
+		row:tag('td'):wikitext(placement.type)
+	end
 
 	local tournamentDisplayName = BaseResultsTable.tournamentDisplayName(placement)
 

--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -69,6 +69,7 @@ function BaseResultsTable:readConfig()
 	local args = self.args
 
 	local config = {
+		showType = Logic.readBool(args.showType),
 		order = args.order or DEFAULT_VALUES.order,
 		hideResult = Logic.readBool(args.hideresult),
 		resolveOpponent = Logic.readBool(args.resolve or DEFAULT_VALUES.resolveOpponent),

--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -411,12 +411,16 @@ function BaseResultsTable:opponentDisplay(data, options)
 			opponent = Opponent.tbd(),
 			flip = options.flip,
 		}
-	elseif self.config.displayDefaultLogoAsIs or
-		data.opponenttype ~= Opponent.team and (data.opponenttype ~= Opponent.solo or not options.teamForSolo) then
-
+	elseif data.opponenttype ~= Opponent.team and (data.opponenttype ~= Opponent.solo or not options.teamForSolo) then
 		return OpponentDisplay.BlockOpponent{
 			opponent = Opponent.fromLpdbStruct(data),
 			flip = options.flip,
+		}
+	elseif self.config.displayDefaultLogoAsIs then
+		return OpponentDisplay.BlockOpponent{
+			opponent = Opponent.fromLpdbStruct(data),
+			flip = options.flip,
+			teamStyle = 'icon',
 		}
 	end
 


### PR DESCRIPTION
## Summary
- Add option to show `type` in Resultstables
- Fix team display in `displayDefaultLogoAsIs` case

## How did you test this change?
dev + preview

![Screenshot 2023-05-29 15 13 55](https://github.com/Liquipedia/Lua-Modules/assets/75081997/8ea0f738-936b-4641-8cf8-8d2d55d9a513)