### PR TITLE
Do not flip opponent display for `hideResult == true`

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -87,7 +87,7 @@ function ResultsTable:buildRow(placement)
 		self.config.queryType ~= Opponent.team or
 		Table.isNotEmpty(self.config.aliases) then
 
-		row:tag('td'):css('text-align', 'left'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
+		row:tag('td'):css('text-align', self.config.hideResult and 'left' or 'right'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
 			placement,
 			{teamForSolo = not self.config.playerResultsOfTeam}
 		))

--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -87,7 +87,8 @@ function ResultsTable:buildRow(placement)
 		self.config.queryType ~= Opponent.team or
 		Table.isNotEmpty(self.config.aliases) then
 
-		row:tag('td'):css('text-align', self.config.hideResult and 'left' or 'right'):attr('data-sort-value', placement.opponentname)
+		row:tag('td'):css('text-align', self.config.hideResult and 'left' or 'right')
+			:attr('data-sort-value', placement.opponentname)
 			:node(self:opponentDisplay(placement,
 			{teamForSolo = not self.config.playerResultsOfTeam, flip = not self.config.hideResult}
 		))

--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -87,8 +87,8 @@ function ResultsTable:buildRow(placement)
 		self.config.queryType ~= Opponent.team or
 		Table.isNotEmpty(self.config.aliases) then
 
-		row:tag('td'):css('text-align', self.config.hideResult and 'left' or 'right'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
-			placement,
+		row:tag('td'):css('text-align', self.config.hideResult and 'left' or 'right'):attr('data-sort-value', placement.opponentname)
+			:node(self:opponentDisplay(placement,
 			{teamForSolo = not self.config.playerResultsOfTeam, flip = not self.config.hideResult}
 		))
 	end

--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -89,7 +89,7 @@ function ResultsTable:buildRow(placement)
 
 		row:tag('td'):css('text-align', self.config.hideResult and 'left' or 'right'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
 			placement,
-			{teamForSolo = not self.config.playerResultsOfTeam}
+			{teamForSolo = not self.config.playerResultsOfTeam, flip = not self.config.hideResult}
 		))
 	end
 

--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -87,9 +87,9 @@ function ResultsTable:buildRow(placement)
 		self.config.queryType ~= Opponent.team or
 		Table.isNotEmpty(self.config.aliases) then
 
-		row:tag('td'):css('text-align', 'right'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
+		row:tag('td'):css('text-align', 'left'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(
 			placement,
-			{flip = true, teamForSolo = not self.config.playerResultsOfTeam}
+			{teamForSolo = not self.config.playerResultsOfTeam}
 		))
 	end
 


### PR DESCRIPTION
## Summary

Similar to #2813 , the solo opponent display for results table has the name then flag layour the opponent, as intended when the lastOpponent is also displayed, - however for achievements tables with playerResultsOfTeam = true, this will undo the flip in that case and left align the name with flag first

## How did you test this change?

https://liquipedia.net/apexlegends/User:Dark_meluca/Test/ResultsTableNew/TeamAchievements

Was testing above with /dev, but another change to a dev module in the module sequence is currently causing what I think is an unrelated error,
Opening the pull request as a draft in the mean time, so as not to forget about it
