### PR TITLE
Add functionality to match2 to skip X rounds in display

### DIFF
--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -18,18 +18,15 @@ local MatchGroupBase = Lua.import('Module:MatchGroup/Base', {requireDevIfEnabled
 local MatchGroupConfig = Lua.loadDataIfExists('Module:MatchGroup/Config')
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+local ShortenBracket = Lua.import('Module:MatchGroup/ShortenBracket', {requireDevIfEnabled = true})
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
---[[
-	The core module behind every type of MatchGroup. A MatchGroup is a collection of matches, such as a bracket or
-	a matchlist.
-]]
+-- The core module behind every type of MatchGroup. A MatchGroup is a collection of matches, such as a bracket or
+-- a matchlist.
 local MatchGroup = {}
 
---[[
-	Sets up a MatchList, a list of matches displayed vertically. The matches
-	are saved to LPDB.
-]]
+-- Sets up a MatchList, a list of matches displayed vertically. The matches
+-- are saved to LPDB.
 function MatchGroup.MatchList(args)
 	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'matchlist')
 	local matches = MatchGroupInput.readMatchlist(options.bracketId, args)
@@ -52,9 +49,7 @@ function MatchGroup.MatchList(args)
 	return table.concat(Array.map(parts, tostring))
 end
 
---[[
-	Sets up a Bracket, a tree structure of matches. The matches are saved to LPDB.
-]]
+-- Sets up a Bracket, a tree structure of matches. The matches are saved to LPDB.
 function MatchGroup.Bracket(args)
 	local options, optionsWarnings = MatchGroupBase.readOptions(args, 'bracket')
 	local matches, bracketWarnings = MatchGroupInput.readBracket(options.bracketId, args, options)
@@ -78,17 +73,27 @@ function MatchGroup.Bracket(args)
 	return table.concat(Array.map(parts, tostring))
 end
 
---[[
-Displays a matchlist or bracket specified by ID.
-]]
+-- Displays a matchlist or bracket specified by ID.
 function MatchGroup.MatchGroupById(args)
 	local bracketId = args.id or args[1]
 	args.id = bracketId
 	args[1] = bracketId
 	assert(bracketId, 'Missing bracket ID')
 
-	local matches = MatchGroupUtil.fetchMatches(bracketId)
+	local matches
+
+	if args.shortTemplate then
+		matches = ShortenBracket.fetchAndAdjustMatches{
+			bracketId = bracketId,
+			shortTemplate = args.shortTemplate,
+			args = args,
+		}
+	else
+		matches = MatchGroupUtil.fetchMatches(bracketId)
+	end
+
 	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
+
 	local matchGroupType = matches[1].bracketData.type
 
 	local config
@@ -109,9 +114,7 @@ function MatchGroup.MatchGroupById(args)
 	})
 end
 
---[[
-Displays a singleMatch specified by a bracket ID and matchID.
-]]
+-- Displays a singleMatch specified by a bracket ID and matchID.
 function MatchGroup.MatchByMatchId(args)
 	local bracketId = args.id
 	local matchId = args.matchid
@@ -167,7 +170,6 @@ if FeatureFlag.get('perf') then
 end
 
 Lua.autoInvokeEntryPoints(MatchGroup, 'Module:MatchGroup')
-
 
 MatchGroup.deprecatedCategory = '[[Category:Pages using deprecated Match Group functions]]'
 

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -83,16 +83,15 @@ function MatchGroup.MatchGroupById(args)
 	local matches
 
 	if args.shortTemplate then
-		matches = ShortenBracket.fetchAndAdjustMatches{
+		matches, args, bracketId = ShortenBracket.fetchAndAdjustMatches{
 			bracketId = bracketId,
 			shortTemplate = args.shortTemplate,
 			args = args,
 		}
 	else
 		matches = MatchGroupUtil.fetchMatches(bracketId)
+		assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
 	end
-
-	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
 
 	local matchGroupType = matches[1].bracketData.type
 

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -78,8 +78,6 @@ function MatchGroup.MatchGroupById(args)
 	local bracketId = args.id or args[1]
 	assert(bracketId, 'Missing bracket ID')
 
-	local matches
-
 	if args.shortTemplate then
 		bracketId = ShortenBracket.adjustMatchesAndBracketId{
 			bracketId = bracketId,
@@ -90,7 +88,7 @@ function MatchGroup.MatchGroupById(args)
 	args.id = bracketId
 	args[1] = bracketId
 
-	matches = MatchGroupUtil.fetchMatches(bracketId)
+	local matches = MatchGroupUtil.fetchMatches(bracketId)
 	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
 
 	local matchGroupType = matches[1].bracketData.type

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -76,22 +76,22 @@ end
 -- Displays a matchlist or bracket specified by ID.
 function MatchGroup.MatchGroupById(args)
 	local bracketId = args.id or args[1]
-	args.id = bracketId
-	args[1] = bracketId
 	assert(bracketId, 'Missing bracket ID')
 
 	local matches
 
 	if args.shortTemplate then
-		matches, args, bracketId = ShortenBracket.fetchAndAdjustMatches{
+		bracketId = ShortenBracket.adjustMatchesAndBracketId{
 			bracketId = bracketId,
 			shortTemplate = args.shortTemplate,
-			args = args,
 		}
-	else
-		matches = MatchGroupUtil.fetchMatches(bracketId)
-		assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
 	end
+
+	args.id = bracketId
+	args[1] = bracketId
+
+	matches = MatchGroupUtil.fetchMatches(bracketId)
+	assert(#matches ~= 0, 'No data found for bracketId=' .. bracketId)
 
 	local matchGroupType = matches[1].bracketData.type
 

--- a/components/match2/commons/match_group_shorten_bracket.lua
+++ b/components/match2/commons/match_group_shorten_bracket.lua
@@ -67,7 +67,6 @@ function ShortenBracket._processMatches(matches, idLength, skipRounds, newBracke
 		local matchId = string.sub(match.match2id, idLength + 2)
 		local round = tonumber(string.sub(matchId, 2, 3))
 
-
 		-- keep reset/3rd place match, i.e. last round
 		if not round then
 			table.insert(newMatches, match)
@@ -76,7 +75,8 @@ function ShortenBracket._processMatches(matches, idLength, skipRounds, newBracke
 		elseif round > skipRounds then
 			local newMatchId = 'R' .. string.format('%02d', round - skipRounds) .. '-M' .. string.sub(matchId, -3)
 
-			assert(_bracket_datas_by_id[newMatchId], 'bracket <--> short bracket missmatch: ' .. newMatchId)
+			assert(_bracket_datas_by_id[newMatchId], 'bracket <--> short bracket missmatch: No bracket data found for '
+				.. newMatchId .. ' (calculated from ' .. matchId .. ')')
 
 			match.match2id = newBracketId .. '_' .. newMatchId
 

--- a/components/match2/commons/match_group_shorten_bracket.lua
+++ b/components/match2/commons/match_group_shorten_bracket.lua
@@ -68,6 +68,7 @@ function ShortenBracket._processMatches(matches, idLength, skipRounds, newBracke
 
 		-- keep reset/3rd place match, i.e. last round
 		if not round then
+			match.match2id = newBracketId .. '_' .. matchId
 			table.insert(newMatches, match)
 
 		-- valid match we want to keep

--- a/components/match2/commons/match_group_shorten_bracket.lua
+++ b/components/match2/commons/match_group_shorten_bracket.lua
@@ -1,0 +1,99 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchGroup/ShortenBracket
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Json = require('Module:Json')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+
+local ShortenBracket = {}
+
+local FIRST_MATCH_KEY = 'R01-M001'
+
+local _bracket_datas_by_id
+
+--- Fetches and adjusts matches so they can be displayed in the shortened format
+---@param props {bracketId: string, shortTemplate: string, args: table}
+---@return table
+function ShortenBracket.fetchAndAdjustMatches(props)
+	local shortTemplate = 'Bracket/' .. string.gsub(props.shortTemplate, '^[bB]racket/', '')
+	local matches = MatchGroupUtil.fetchMatchRecords(props.bracketId)
+	_bracket_datas_by_id = MatchGroupInput._fetchBracketDatas(shortTemplate, props.bracketId)
+
+	assert(matches[1].match2bracketdata.type == 'bracket',
+		'The data found for id "' .. props.bracketId .. '" is not a bracket')
+
+	return ShortenBracket._processMatches(
+		matches,
+		string.len(props.bracketId),
+		ShortenBracket._getSkipRoundValue(shortTemplate, props.bracketId, matches[1]),
+		props.bracketId
+	)
+end
+
+function ShortenBracket._getSkipRoundValue(shortTemplate, bracketId, firstMatch)
+	local newRoundCount = _bracket_datas_by_id[FIRST_MATCH_KEY].coordinates.roundCount
+	local oldRoundCount = firstMatch.match2bracketdata.coordinates.roundCount
+
+	return oldRoundCount - newRoundCount
+end
+
+function ShortenBracket._processMatches(matches, idLength, skipRounds, bracketId)
+	local newMatches = {}
+
+	for _, match in ipairs(matches) do
+		local matchId = string.sub(match.match2id, idLength + 2)
+		local round = tonumber(string.sub(matchId, 2, 3))
+
+
+		-- keep reset/3rd place match, i.e. last round
+		if not round then
+			table.insert(newMatches, match)
+
+		-- valid match we want to keep
+		elseif round > skipRounds then
+			local newMatchId = 'R' .. string.format('%02d', round - skipRounds) .. '-M' .. string.sub(matchId, -3)
+
+			assert(_bracket_datas_by_id[newMatchId], 'bracket <--> short bracket missmatch: ' .. newMatchId)
+
+			match.match2id = string.sub(match.match2id, 1, idLength + 1) .. newMatchId
+
+			-- nil some stuff before merge
+			match.match2bracketdata.loweredges = nil
+
+			match.match2bracketdata = Table.merge(match.match2bracketdata, _bracket_datas_by_id[newMatchId], {
+				header = match.match2bracketdata.header
+			})
+
+			-- have to do this after the merge so that correct `match.match2bracketdata.lowerMatchIds` is available
+			match.match2bracketdata.loweredges = ShortenBracket._calculateLowerEdges(match)
+
+			table.insert(newMatches, match)
+		end
+	end
+
+	assert(newMatches[1], 'The provided id and shortTemplate values leave an empty bracket')
+
+	Variables.varDefine('match2bracket_' .. bracketId, Json.stringify(newMatches))
+
+	return MatchGroupUtil.fetchMatchGroup(bracketId).matches
+end
+
+function ShortenBracket._calculateLowerEdges(match)
+	return Array.map(
+		MatchGroupUtil.autoAssignLowerEdges(#match.match2bracketdata.lowerMatchIds, #match.match2opponents),
+		MatchGroupUtil.indexTableToRecord
+	)
+end
+
+return ShortenBracket

--- a/components/match2/commons/match_group_shorten_bracket.lua
+++ b/components/match2/commons/match_group_shorten_bracket.lua
@@ -27,10 +27,12 @@ local _bracket_datas_by_id
 function ShortenBracket.fetchAndAdjustMatches(props)
 	local shortTemplate = 'Bracket/' .. string.gsub(props.shortTemplate, '^[bB]racket/', '')
 	local matches = MatchGroupUtil.fetchMatchRecords(props.bracketId)
-	_bracket_datas_by_id = MatchGroupInput._fetchBracketDatas(shortTemplate, props.bracketId)
+	assert(#matches ~= 0, 'No data found for bracketId=' .. props.bracketId)
 
 	assert(matches[1].match2bracketdata.type == 'bracket',
 		'The data found for id "' .. props.bracketId .. '" is not a bracket')
+
+	_bracket_datas_by_id = MatchGroupInput._fetchBracketDatas(shortTemplate, props.bracketId)
 
 	return ShortenBracket._processMatches(
 		matches,
@@ -69,6 +71,7 @@ function ShortenBracket._processMatches(matches, idLength, skipRounds, bracketId
 
 			-- nil some stuff before merge
 			match.match2bracketdata.loweredges = nil
+			match.match2bracketdata.skipround = nil
 
 			match.match2bracketdata = Table.merge(match.match2bracketdata, _bracket_datas_by_id[newMatchId], {
 				header = match.match2bracketdata.header
@@ -83,6 +86,7 @@ function ShortenBracket._processMatches(matches, idLength, skipRounds, bracketId
 
 	assert(newMatches[1], 'The provided id and shortTemplate values leave an empty bracket')
 
+	-- store as wiki var so it can be retrieved by the display function
 	Variables.varDefine('match2bracket_' .. bracketId, Json.stringify(newMatches))
 
 	return MatchGroupUtil.fetchMatchGroup(bracketId).matches

--- a/components/match2/commons/match_group_shorten_bracket.lua
+++ b/components/match2/commons/match_group_shorten_bracket.lua
@@ -12,7 +12,6 @@ local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
-local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates', {requireDevIfEnabled = true})
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
 


### PR DESCRIPTION
Alternative solution to #2780

## Summary
Add functionality to `ShowBracket` to skip X rounds in display
- query the match data for a given matchGroup id
- assert it is a valid id and the retrieved data is a bracket
- remove the first X rounds and adjust the remaining matches so they can be used for showBracket display

requested by @DMeluca on discord
main goal is to have the option to have an overview page that has reduced include size

## How did you test this change?
live for new module + dev versions of the modules that get adjusted
example page: https://liquipedia.net/starcraft2/Liquipedia:BracketUpdate/Test

![Screenshot 2023-03-23 15 31 14](https://user-images.githubusercontent.com/75081997/227236065-be1aff13-f52c-4f8e-a34a-25870037f22c.png)
![Screenshot 2023-03-23 15 31 17](https://user-images.githubusercontent.com/75081997/227236073-5cad7b80-bed2-4831-bc95-0829f7937333.png)

