### PR TITLE
Count qualifier earnings in sc2 team infoboxes

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -249,7 +249,6 @@ function CustomTeam.getEarningsAndMedalsData(team)
 	local conditions = ConditionTree(BooleanOperator.all):add{
 		ConditionNode(ColumnName('date'), Comparator.neq, '1970-01-01 00:00:00'),
 		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Charity'),
-		ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Qualifier'),
 		ConditionTree(BooleanOperator.any):add{
 			ConditionNode(ColumnName('prizemoney'), Comparator.gt, '0'),
 			ConditionTree(BooleanOperator.all):add{


### PR DESCRIPTION
## Summary
Count qualifier earnings in sc2 team infoboxes
- Kick the no qualifier condition (they are already excluded for the medals stuff etc.)

## How did you test this change?
dev