### PR TITLE
HotFix Broadcaster talent table: escape nil

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -157,6 +157,7 @@ function BroadcastTalentTable:_fetchTournaments()
 	local tournaments = {}
 	local pageNames = {}
 	for _, tournament in pairs(queryData) do
+		tournament.extradata = tournament.extradata or {}
 		if not pageNames[tournament.pagename] or Logic.readBool(tournament.extradata.showmatch) then
 			tournament.positions = {tournament.position}
 			table.insert(tournaments, tournament)


### PR DESCRIPTION
## Summary
HotFix Broadcaster talent table: escape nil
Introduced via #3014

Fixes the most common error caused by recent changes
the tier sort also breaks some pages on sc2 but not as many

## How did you test this change?
live