### PR TITLE
Account for sc2 special case in BroadCasterTealentTable

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -341,6 +341,14 @@ end
 ---@return string
 function BroadcastTalentTable:_tierDisplay(tournament)
 	local tier, tierType, options = Tier.parseFromQueryData(tournament)
+	if not tier then
+		--on sc2 sometimes there are broadcaster cards on series pages
+		--for those the additional tournament data is stored in extradata
+		--including tier and tier type
+		tier, tierType, options = Tier.parseFromQueryData(tournament.extradata)
+	end
+
+	assert(tier, 'Broadcaster event with unset or invalid liquipedia tier: ' .. tournament.pagename)
 
 	options.link = true
 	options.shortIfBoth = true


### PR DESCRIPTION
## Summary
On sc2 sometimes there are broadcaster cards on series pages for those the additional tournament data is stored in extradata including tier and tier type

Before #3009 this resultet in no tier shown.
After #3009 it now throws errors due to the tier.sort function expecting a valid tier.

This PR adjusts the tier parsing in the BroadCasterTealentTable so that as a fallback it looks into extradata to parse the tier.
It also improves the error message in case of invalid/unset tiers.

## How did you test this change?
dev