### PR TITLE
Extend, not overwrite extradata in CoD Infobox League

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_league_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_league_custom.lua
@@ -74,9 +74,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = Game.name{game = args.game}
 	lpdbData.publishertier = args['atvi-sponsored']
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.extradata = {
-		individual = not String.isEmpty(args.player_number),
-	}
+	lpdbData.extradata.individual = not String.isEmpty(args.player_number)
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
CoD Infobox league custom is overwriting the extradata instead of extending it, causing series2 to be lost.

## How did you test this change?
Live as series2 was needed now