### PR TITLE
Remove Player Achivement Template on WoW

### DIFF
--- a/components/infobox/wikis/worldofwarcraft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/worldofwarcraft/infobox_person_player_custom.lua
@@ -8,7 +8,6 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/worldofwarcraft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/worldofwarcraft/infobox_person_player_custom.lua
@@ -38,8 +38,6 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_args = player.args
 
-	_args.achievements = Template.safeExpand(mw.getCurrentFrame(), 'Player achievements', {player.pagename})
-
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 	player.defineCustomPageVariables = CustomPlayer.defineCustomPageVariables
 	player.getWikiCategories = CustomPlayer.getWikiCategories


### PR DESCRIPTION

## Summary

Player Achivement Template on WoW doesn't work, and from what I can tell probably hasn't ever worked, so removing the call.


## How did you test this change?
Live