### PR TITLE
Create `eq` and `neq` operator functions

### DIFF
--- a/standard/operator.lua
+++ b/standard/operator.lua
@@ -8,6 +8,7 @@
 
 local Operator = {}
 
+---Uses the __add metamethod (a + b)
 ---@param a number
 ---@param b number
 ---@return number
@@ -15,6 +16,7 @@ function Operator.add(a, b)
 	return a + b
 end
 
+---Uses the __sub metamethod (a - b)
 ---@param a number
 ---@param b number
 ---@return number
@@ -22,6 +24,7 @@ function Operator.sub(a, b)
 	return a - b
 end
 
+---Uses the __mul metamethod (a * b)
 ---@param a number
 ---@param b number
 ---@return number
@@ -29,6 +32,7 @@ function Operator.mul(a, b)
 	return a * b
 end
 
+---Uses the __div metamethod (a / b)
 ---@param a number
 ---@param b number
 ---@return number
@@ -36,11 +40,28 @@ function Operator.div(a, b)
 	return a / b
 end
 
+---Uses the __pow metamethod (a ^ b)
 ---@param a number
 ---@param b number
 ---@return number
 function Operator.pow(a, b)
-	return math.pow(a, b)
+	return a ^ b
+end
+
+---Uses the __eq metamethod (a == b)
+---@param a any
+---@param b any
+---@return any
+function Operator.eq(a, b)
+	return a == b
+end
+
+--- Uses the __eq metamethod and with negatated results (a ~= b)
+---@param a any
+---@param b any
+---@return any
+function Operator.neq(a, b)
+	return a ~= b
 end
 
 ---@param item string|number

--- a/standard/operator.lua
+++ b/standard/operator.lua
@@ -56,7 +56,7 @@ function Operator.eq(a, b)
 	return a == b
 end
 
---- Uses the __eq metamethod and with negatated results (a ~= b)
+--- Uses the __eq metamethod with negated result (a ~= b)
 ---@param a any
 ---@param b any
 ---@return any

--- a/standard/test/operator_test.lua
+++ b/standard/test/operator_test.lua
@@ -23,6 +23,17 @@ function suite:testMath()
 	self:assertEquals(15625, Array.reduce(foo, Operator.pow), 'Pow')
 end
 
+function suite:testEquality()
+	local curry = function(f, x)
+		return function(y)
+			return f(x, y)
+		end
+	end
+	local foo = {5, 3, 2, 1}
+	self:assertDeepEquals({2}, Array.filter(foo, curry(Operator.eq, 2)), 'eq')
+	self:assertDeepEquals({5, 3, 1}, Array.filter(foo, curry(Operator.neq, 2)), 'neq')
+end
+
 function suite:testProperty()
 	local foo = {
 		{a = 3, b = 'abc'},


### PR DESCRIPTION
## Summary
Create `Operator.eq` and `Operator.neq`. 

Some boy scouting with changing `math.pow(a, b)` to `a ^ b` to make it be usable on anything with the correct metamethod implemented.

## How did you test this change?
https://liquipedia.net/commons/Module_talk:Operator/testcases