### PR TITLE
Add support for CoreStrike link

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -52,6 +52,7 @@ local PREFIXES = {
 		player = 'https://challonge.com/users/',
 	},
 	cntft = {'https://lol.qq.com/tft/#/masterDetail/'},
+	corestrike = {'https://corestrike.gg/lookup/'},
 	datdota = {
 		'https://www.datdota.com/leagues/',
 		player = 'https://www.datdota.com/players/',


### PR DESCRIPTION
Adding support for CoreStrike links (Omega Strikers Stats site)


Example URL: https://corestrike.gg/lookup/PuffyFPS

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
  - Does this break SMW on any of the wikis?
-->
