### PR TITLE
Use `Module:Iterator` instead of `Module:IteratorUtil`

### DIFF
--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -7,7 +7,7 @@
 --
 
 local Array = require('Module:Array')
-local IteratorUtil = require('Module:IteratorUtil')
+local IteratorUtil = require('Module:Iterator')
 local MathUtil = require('Module:MathUtil')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')

--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -7,7 +7,7 @@
 --
 
 local Array = require('Module:Array')
-local IteratorUtil = require('Module:Iterator')
+local Iterator = require('Module:Iterator')
 local MathUtil = require('Module:MathUtil')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -25,7 +25,7 @@ function MatchGroupCoordinates.dfsFrom(bracketDatasById, start)
 end
 
 function MatchGroupCoordinates.dfs(bracket)
-	return IteratorUtil.flatMap(function(_, rootMatchId)
+	return Iterator.flatMap(function(_, rootMatchId)
 		return MatchGroupCoordinates.dfsFrom(bracket.bracketDatasById, rootMatchId)
 	end, ipairs(bracket.rootMatchIds))
 end


### PR DESCRIPTION
## Summary
`Module:Iterator` is on the git and identical to `Module:IteratorUtil`

Note: This is the last consumer of the duplicate module so we can kill https://liquipedia.net/commons/Module:IteratorUtil after merge

## How did you test this change?
N/A