### PR TITLE
Add `wrapTryOrLog` and `tryOrElseLog` to `Module:Logic`

### DIFF
--- a/standard/logic.lua
+++ b/standard/logic.lua
@@ -155,6 +155,7 @@ end
 ---@return function
 function Logic.wrapTryOrLog(f, makeError)
 	return function(...)
+		--need to pack and unpack so we can pass `...` along, using it directly results in the module not being savable
 		local args = require('Module:Table').pack(...)
 		return Logic.tryOrElseLog(function() return f(unpack(args)) end, nil, makeError)
 	end

--- a/standard/logic.lua
+++ b/standard/logic.lua
@@ -139,7 +139,7 @@ function Logic.tryOrElseLog(f, other, makeError)
 				error = makeError(error)
 			end
 
-			require('Module:Error/Ext/downstream').logAndStash(error)
+			require('Module:Error/Ext').logAndStash(error)
 
 			if other then
 				return other(error)

--- a/standard/logic.lua
+++ b/standard/logic.lua
@@ -6,6 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Error = require('Module:Error')
+
 local Logic = {}
 
 ---Returns `val1` if it isn't empty else returns `val2` if that isn't empty, else returns default
@@ -128,6 +130,10 @@ end
 function Logic.tryOrElseLog(f, other, makeError)
 	return Logic.try(f)
 		:catch(function(error)
+			if type(error) == 'string' then
+				error = Error(error)
+			end
+
 			error.header = 'Error occured while calling a function: (caught by Logic.tryOrElseLog)'
 			if makeError then
 				error = makeError(error)

--- a/standard/logic.lua
+++ b/standard/logic.lua
@@ -124,8 +124,8 @@ end
 ---Returns the result of a function if successful. Otherwise it returns the result of the second function.
 ---If the first function fails, its error is logged to the console and stashed away for display.
 ---@param f fun(): any
----@param other? fun(error: Error): any
----@param makeError? fun(error: Error): Error function that allows customizing Error instance being logged and stashed.
+---@param other? fun(error: error): any
+---@param makeError? fun(error: error): error function that allows customizing Error instance being logged and stashed.
 ---@return any?
 function Logic.tryOrElseLog(f, other, makeError)
 	return Logic.try(f)
@@ -151,7 +151,7 @@ end
 ---Returns the result of a function if successful. Otherwise it returns nil.
 ---If the first function fails, its error is logged to the console and stashed away for display.
 ---@param f fun(): any
----@param makeError? fun(error: Error): Error function that allows customizing Error instance being logged and stashed.
+---@param makeError? fun(error: error): error function that allows customizing Error instance being logged and stashed.
 ---@return function
 function Logic.wrapTryOrLog(f, makeError)
 	return function(...)

--- a/standard/logic.lua
+++ b/standard/logic.lua
@@ -155,7 +155,7 @@ end
 ---@return function
 function Logic.wrapTryOrLog(f, makeError)
 	return function(...)
-		--need to pack and unpack so we can pass `...` along, using it directly results in the module not being savable
+		--Need to pack the vararg, so it can be passed to the inner function
 		local args = require('Module:Table').pack(...)
 		return Logic.tryOrElseLog(function() return f(unpack(args)) end, nil, makeError)
 	end


### PR DESCRIPTION
depends on #3063 

## Summary
Add `wrapTryOrLog` and `tryOrElseLog` to `Module:Logic`

With this we can kill `Module:Logic/downstream` and i think those 2 functions are a nice and useful addition.
(All other usages of `Module:Logic/downstream` have been eliminated in non dev/archived modules.)

## How did you test this change?
Factually already in use in several non git modules via downstream
