### PR TITLE
Add stash/retrieve options to `Module:Error/Display` and `Module:Error/Ext`

### DIFF
--- a/standard/error_display.lua
+++ b/standard/error_display.lua
@@ -6,10 +6,44 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
 local ErrorExt = require('Module:Error/Ext')
 local TypeUtil = require('Module:TypeUtil')
 
 local ErrorDisplay = {types = {}, propTypes = {}}
+
+---@param props {limit: integer?, errors: error[]}
+---@return Html
+function ErrorDisplay.ErrorList(props)
+	local defaultLimit = 5
+	local limit = props.limit or defaultLimit
+
+	local boxesNode = mw.html.create('span'):addClass('stashed-errors')
+	for index, error in ipairs(props.errors) do
+		boxesNode:node(ErrorDisplay.ErrorBox(error))
+
+		if index == limit and limit < #props.errors then
+			local overflowNode = ErrorDisplay.Box{
+				text = (#props.errors - limit) .. ' additional errors not shown',
+			}
+			boxesNode:node(overflowNode)
+			return boxesNode
+		end
+	end
+
+	return boxesNode
+end
+
+---Entry point of Template:StashedErrors
+---@param frame Frame
+---@return Html
+function ErrorDisplay.TemplateStashedErrors(frame)
+	local args = Arguments.getArgs(frame)
+	return ErrorDisplay.ErrorList{
+		errors = ErrorExt.Stash.retrieve(),
+		limit = tonumber(args.limit),
+	}
+end
 
 -- Error instance
 ErrorDisplay.types.Error = TypeUtil.struct{
@@ -49,10 +83,10 @@ end
 ---@param error error
 ---@return Html
 function ErrorDisplay.ErrorBox(error)
-	return ErrorDisplay.Box({
+	return ErrorDisplay.Box{
 		hasDetails = error.stacks ~= nil,
 		text = tostring(error),
-	})
+	}
 end
 
 ---Shows the message and stack trace of a lua error. Suitable for use in a popup.

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -7,9 +7,22 @@
 --
 
 local Array = require('Module:Array')
+local Error = require('Module:Error')
+local Json = require('Module:Json')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 
+local pageVars = PageVariableNamespace('ErrorStash')
+
+local _local_errors = {}
+
 local ErrorExt = {}
+
+---@param error error
+function ErrorExt.logAndStash(error)
+	ErrorExt.Stash.add(error)
+	ErrorExt.log(error)
+end
 
 ---@param error error
 function ErrorExt.log(error)
@@ -72,6 +85,40 @@ function ErrorExt.makeFullStackTrace(error)
 		end))
 	)
 	return table.concat(parts, '\n')
+end
+
+local Stash = {}
+ErrorExt.Stash = Stash
+
+---Adds an Error instance to the local store.
+---@param error error
+---@param storeAsPageVar boolean
+function Stash.add(error, storeAsPageVar)
+	if storeAsPageVar then
+		local count = tonumber(pageVars:get('count')) or 0
+		pageVars:set('count', count + 1)
+		pageVars:set(count + 1, Json.stringify{error})
+	else
+		table.insert(_local_errors, error)
+	end
+end
+
+---Returns all errors (locally and from page variables), and clears the store.
+---@return error[]
+function Stash.retrieve()
+	local errors = {}
+
+	local count = tonumber(pageVars:get('count')) or 0
+	pageVars:delete('count')
+	for i = 1, count do
+		Array.extendWith(errors, Array.map(Json.parse(pageVars:get(i)), Error))
+		pageVars:delete(i)
+	end
+
+	Array.extendWith(errors, _local_errors)
+	_local_errors = {}
+
+	return errors
 end
 
 return ErrorExt


### PR DESCRIPTION
## Summary
Add stash/retrieve options to `Module:Error/Display` and `Module:Error/Ext`

With this change we can dissolve seversal /downstream (and a few non git) modules.

## How did you test this change?
via /downstream