### PR TITLE
Fix some issues in `PlayerIntroduction`

### DIFF
--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -553,7 +553,7 @@ function PlayerIntroduction:_playedOrWorked(isCurrentTense)
 		return 'on the inactive roster of'
 	elseif self.options.showRole and role == 'streamer' or role == 'content creator' then
 		return AnOrA.main{role} .. ' for'
-	elseif self.options.showRole and role then
+	elseif self.options.showRole and String.isNotEmpty(role) then
 		return 'playing as ' .. AnOrA.main{role} .. ' for'
 	end
 

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -285,7 +285,9 @@ function PlayerIntroduction._readTransferFromTransfers(player)
 		query = 'fromteam, toteam, role2, date, extradata'
 	})
 
-	assert(type(queryData[1]) == 'table', queryData)
+	if type(queryData[1]) ~= 'table' then
+		return {}
+	end
 
 	queryData = queryData[1]
 	local extradata = queryData.extradata
@@ -386,7 +388,7 @@ function PlayerIntroduction:create()
 			game = gameDisplay or '',
 			faction = factionDisplay or '',
 			type = typeDisplay or '',
-			team = self:_teamDisplay(isDeceased),
+			team = self:_teamDisplay(isDeceased) or '',
 			subText = self.playerInfo.subText or '',
 			freeText = self.playerInfo.freeText or '',
 		}

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -413,7 +413,7 @@ function PlayerIntroduction:_nameDisplay()
 	end
 
 	if Table.isNotEmpty(self.playerInfo.alsoKnownAs) then
-		nameDisplay = nameDisplay .. self._addConcatText('(also known as')
+		nameDisplay = nameDisplay .. self._addConcatText('(also known as ')
 			.. mw.text.listToText(self.playerInfo.alsoKnownAs, ', ', ' and ')
 			.. ')'
 	end
@@ -451,7 +451,7 @@ end
 ---@return string?
 function PlayerIntroduction:_statusDisplay(isDeceased)
 	if self.playerInfo.status ~= 'active' and not isDeceased then
-		return self.playerInfo.status
+		return self._addConcatText(self.playerInfo.status)
 	end
 
 	return nil
@@ -470,7 +470,7 @@ function PlayerIntroduction:_nationalityDisplay()
 		return nil
 	end
 
-	return table.concat(nationalities, '/')
+	return self._addConcatText(table.concat(nationalities, '/'))
 end
 
 --- builds the game display

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -529,7 +529,7 @@ function PlayerIntroduction:_teamDisplay(isDeceased)
 	return String.interpolate(' ${tense} ${playedOrWorked} ${team}${team2}${roleDisplay}', {
 		tense = isCurrentTense and 'who is currently' or 'who last',
 		playedOrWorked = self:_playedOrWorked(isCurrentTense),
-		team = PlayerIntroduction._displayTeam(transferInfo.team, transferInfo.date),
+		team = PlayerIntroduction._displayTeam(transferInfo.team or playerInfo.team, transferInfo.date),
 		team2 = shouldDisplayTeam2
 			and (' on loan from' .. PlayerIntroduction._displayTeam(playerInfo.team2, transferInfo.date))
 			or '',

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -391,8 +391,8 @@ function PlayerIntroduction:create()
 			faction = factionDisplay or '',
 			type = typeDisplay or '',
 			team = self:_teamDisplay(isDeceased) or '',
-			subText = self.playerInfo.subText or '',
-			freeText = self.playerInfo.freeText or '',
+			subText = self._addConcatText(self.playerInfo.subText),
+			freeText = self._addConcatText(self.playerInfo.freeText),
 		}
 	)
 end

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -236,7 +236,9 @@ function PlayerIntroduction._readTransferFromDataPoints(player)
 		query = 'information, extradata',
 	})
 
-	assert(type(queryData[1]) == 'table', queryData)
+	if type(queryData[1]) ~= 'table' then
+		return {}
+	end
 
 	table.sort(queryData, function (dataPoint1, dataPoint2)
 		local extradata1 = dataPoint1.extradata


### PR DESCRIPTION
## Summary
Fixes:
- catch players without transfer history in 
reported by Omarion: https://discord.com/channels/93055209017729024/372075546231832576/1116762129089970276
- catch players with team in infobox but no transfer history
reported by @DMeluca https://discord.com/channels/93055209017729024/372075546231832576/1117521149794992169 ff
- missing spaces in some cases
reported by Gravy: https://discord.com/channels/93055209017729024/268719633366777856/1117428095285219378

## How did you test this change?
dev to live since bug