### PR TITLE
Add `Tier.toIdentifier` overwrite for smash

### DIFF
--- a/standard/tier/wikis/smash/tier_custom.lua
+++ b/standard/tier/wikis/smash/tier_custom.lua
@@ -13,6 +13,15 @@ local Tier = Lua.import('Module:Tier/Utils', {requireDevIfEnabled = true})
 
 local TierCustom = Table.copy(Tier)
 
+--- Converts input to standardized identifier format
+---@param input string|integer|nil
+---@return string|integer
+function Tier.toIdentifier(input)
+	-- for smash `''` is a valid tier ...
+	return tonumber(input)
+		or string.lower(input or ''):gsub(' ', '')
+end
+
 --- Builds the display for a given (tier, tierType) tuple
 --- smash want to have tier displayed without tiertype
 --- tiertype gets only stored and used for queries


### PR DESCRIPTION
## Summary
Add `Tier.toIdentifier` overwrite for smash.
Due to their non standard setup we need to allow empty string as valid identifier.

## How did you test this change?
live as hot fix since broadcast talent table was broken on smash on some pages