### PR TITLE
TFT: Add PlayerTeamAuto detection for player infobox

### DIFF
--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -13,6 +13,7 @@ local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -45,6 +46,13 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
+	if String.isEmpty(player.args.team) then
+		player.args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+
+	if String.isEmpty(player.args.team2) then
+		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
+	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
@@ -66,6 +74,9 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Role', content = {
 				CustomPlayer._getRoleData('role').value,
 				CustomPlayer._getRoleData('role2').value,
+				CustomPlayer._getRoleData('role3').value,
+				CustomPlayer._getRoleData('role4').value,
+				CustomPlayer._getRoleData('role5').value,
 			}},
 		}
 	elseif id == 'history' then
@@ -80,6 +91,9 @@ end
 function CustomPlayer:adjustLPDB(lpdbData)
 	lpdbData.extradata.role = Variables.varDefault('role')
 	lpdbData.extradata.role2 = Variables.varDefault('role2')
+	lpdbData.extradata.role3 = Variables.varDefault('role3')
+	lpdbData.extradata.role4 = Variables.varDefault('role4')
+	lpdbData.extradata.role5 = Variables.varDefault('role5')
 
 	return lpdbData
 end
@@ -96,6 +110,9 @@ end
 function CustomPlayer:defineCustomPageVariables(args)
 	Variables.varDefine('role', CustomPlayer._getRoleData('role').value)
 	Variables.varDefine('role2', CustomPlayer._getRoleData('role2').value)
+	Variables.varDefine('role3', CustomPlayer._getRoleData('role3').value)
+	Variables.varDefine('role4', CustomPlayer._getRoleData('role4').value)
+	Variables.varDefine('role5', CustomPlayer._getRoleData('role5').value)
 end
 
 function CustomPlayer:getPersonType(args)

--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -74,9 +74,6 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Role', content = {
 				CustomPlayer._getRoleData('role').value,
 				CustomPlayer._getRoleData('role2').value,
-				CustomPlayer._getRoleData('role3').value,
-				CustomPlayer._getRoleData('role4').value,
-				CustomPlayer._getRoleData('role5').value,
 			}},
 		}
 	elseif id == 'history' then
@@ -91,9 +88,6 @@ end
 function CustomPlayer:adjustLPDB(lpdbData)
 	lpdbData.extradata.role = Variables.varDefault('role')
 	lpdbData.extradata.role2 = Variables.varDefault('role2')
-	lpdbData.extradata.role3 = Variables.varDefault('role3')
-	lpdbData.extradata.role4 = Variables.varDefault('role4')
-	lpdbData.extradata.role5 = Variables.varDefault('role5')
 
 	return lpdbData
 end
@@ -110,9 +104,6 @@ end
 function CustomPlayer:defineCustomPageVariables(args)
 	Variables.varDefine('role', CustomPlayer._getRoleData('role').value)
 	Variables.varDefine('role2', CustomPlayer._getRoleData('role2').value)
-	Variables.varDefine('role3', CustomPlayer._getRoleData('role3').value)
-	Variables.varDefine('role4', CustomPlayer._getRoleData('role4').value)
-	Variables.varDefine('role5', CustomPlayer._getRoleData('role5').value)
 end
 
 function CustomPlayer:getPersonType(args)


### PR DESCRIPTION
## Summary

Requested by Taner (One of TFT's main contributors) to be added to player infoboxes.

## How did you test this change?

With /dev and preview loading player pages in mainspace. Also saved and checked Team is correctly stored in lpdb
