### PR TITLE
Add highlights for FIFA League Infobox

### DIFF
--- a/components/infobox/wikis/fifa/infobox_league_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_league_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Game = require('Module:Game')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
@@ -51,6 +52,7 @@ function CustomLeague.run(frame)
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.getWikiCategories = CustomLeague.getWikiCategories
 
 	return league:createInfobox()
@@ -85,8 +87,13 @@ function CustomInjector:addCustomCells(widgets)
 	return widgets
 end
 
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(_args.publisherpremier)
+end
+
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
+	lpdbData.publishertier = _args['publisherpremier'] == 'true' and 'true' or nil
 
 	return lpdbData
 end

--- a/components/infobox/wikis/fifa/infobox_league_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_league_custom.lua
@@ -88,12 +88,12 @@ function CustomInjector:addCustomCells(widgets)
 end
 
 function CustomLeague:liquipediaTierHighlighted(args)
-	return Logic.readBool(_args.publisherpremier)
+	return Logic.readBool(args.publisherpremier)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.publishertier = _args['publisherpremier'] == 'true' and 'true' or nil
+	lpdbData.publishertier = Logic.readBool(args['publisherpremier']) and 'true' or nil
 
 	return lpdbData
 end

--- a/components/infobox/wikis/fifa/infobox_league_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_league_custom.lua
@@ -93,7 +93,7 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
-	lpdbData.publishertier = Logic.readBool(args['publisherpremier']) and 'true' or nil
+	lpdbData.publishertier = Logic.readBool(args.publisherpremier) and 'true' or nil
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
Targeting this on {{TournamentsList}} portal
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/1296c465-7f98-4e73-bd53-75ab87aa41e5)

## How did you test this change?
Briefly edited into LIVE infobox, no side errors 
