### PR TITLE
Remove tier display from series infobox for smash

### DIFF
--- a/components/infobox/wikis/smash/infobox_series_custom.lua
+++ b/components/infobox/wikis/smash/infobox_series_custom.lua
@@ -26,6 +26,7 @@ function CustomSeries.run(frame)
 
 	_series.createWidgetInjector = CustomSeries.createWidgetInjector
 	_series.addToLpdb = CustomSeries.addToLpdb
+	_series.createLiquipediaTierDisplay = function() return nil end
 
 	return _series:createInfobox()
 end


### PR DESCRIPTION
## Summary

Tier display in series infobox is unwanted

## How did you test this change?

https://liquipedia.net/smash/index.php?title=Module%3AInfobox%2FSeries%2FCustom%2Fdev&type=revision&diff=423686&oldid=423661
