### PR TITLE
AoE: Automate team and history in Infobox player

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -16,9 +16,11 @@ local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')
 local Page = require('Module:Page')
 local PlayerIntroduction = require('Module:PlayerIntroduction')
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local Region = require('Module:Region')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -74,6 +76,23 @@ local INACTIVITY_THRESHOLD_BROADCAST = {month = 6}
 function CustomPlayer.run(frame)
 	_player = Player(frame)
 	_args = _player.args
+	
+	-- Automatic team, history
+	if String.isEmpty(_args.team) then
+		_args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+	automatedHistory = TeamHistoryAuto.results{player=_player.pagename, convertrole=true, addlpdbdata=true}
+	if String.isEmpty(_args.history) then
+		_args.history = automatedHistory
+	else
+		_args.history = tostring(mw.html.create('div')
+			:addClass("show-when-logged-in")
+			:addClass("navigation-not-searchable")
+			:tag('big'):wikitext("Automated History"):done()
+			:wikitext(automatedHistory)
+			:tag('big'):wikitext("Manual History"):done())
+			.. _args.history
+	end
 
 	-- Automatic achievements
 	_args.achievements = Achievements._player{player = _player.pagename}

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -76,12 +76,11 @@ local INACTIVITY_THRESHOLD_BROADCAST = {month = 6}
 function CustomPlayer.run(frame)
 	_player = Player(frame)
 	_args = _player.args
-	
 	-- Automatic team, history
 	if String.isEmpty(_args.team) then
 		_args.team = PlayerTeamAuto._main{team = 'team'}
 	end
-	automatedHistory = TeamHistoryAuto.results{player=_player.pagename, convertrole=true, addlpdbdata=true}
+	local automatedHistory = TeamHistoryAuto.results{player=_player.pagename, convertrole=true, addlpdbdata=true}
 	if String.isEmpty(_args.history) then
 		_args.history = automatedHistory
 	else


### PR DESCRIPTION
## Summary
With more and more transfer data actually being stored as transfers, this makes PlayerTeamAuto and TeamHistoryAuto the default if there is no manual override input.

For the history (inspired by SC2, where it was bot-added), there is a display of both for logged-in users to help migrating.
It might be advisable to restrict this even further, maybe editor+? I'm not aware of the appropriate class tho.

## How did you test this change?
via dev on various pages (even logged out)
