### PR TITLE
Create Infobox League for Clash of Clans

### DIFF
--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -60,7 +60,6 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.publishertier = Logic.readBool(_args['supercell-sponsored']) and 'true' or nil
-	lpdbData.participantsnumber = args.team_number
 
 	return lpdbData
 end

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -32,7 +32,6 @@ function CustomLeague.run(frame)
 	_args = _league.args
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
-	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
@@ -62,7 +61,7 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = Logic.readBool(_args['supercell-sponsored'])
+	lpdbData.publishertier = Logic.readBool(_args['supercell-sponsored']) and 'true' or nil
 	lpdbData.participantsnumber = args.team_number
 
 	return lpdbData

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -1,0 +1,149 @@
+---
+-- @Liquipedia
+-- wiki=clashofclans
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+local SUPERCELL_SPONSORED_ICON = '[[File:Supercell lightmode.png|x18px|link=Supercell'
+	.. '|Tournament sponsored by Supercell.|class=show-when-light-mode]][[File:Supercell darkmode.png'
+	.. '|x18px|link=Supercell|Tournament sponsored by Supercell.|class=show-when-dark-mode]]'
+
+local ORGANIZER_ICONS = {
+	supercell = '[[File:Supercell lightmode.png|x18px|link=Supercell|Supercell|class=show-when-light-mode]]'
+		.. '[[File:Supercell darkmode.png|x18px|link=Supercell|Supercell|class=show-when-dark-mode]] ',
+	['esports engine'] = '[[File:Esports Engine icon allmode.png|x18px|link=Esports Engine|Esports Engine]] ',
+	['esl'] = '[[File:ESL 2019 icon lightmode.png|x18px|link=ESL|ESL|class=show-when-light-mode]]'
+		.. '[[File:ESL 2019 icon darkmode.png|x18px|link=ESL|ESL|class=show-when-dark-mode]] ',
+	['faceit'] = '[[File:FACEIT icon allmode.png|x18px|link=Esports Engine|Esports Engine]] ',
+}
+
+local _args
+local _league
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_league = league
+	_args = _league.args
+
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
+
+	return league:createInfobox()
+end
+
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'organizers' then
+		local organizers = CustomLeague._createOrganizers()
+		local title = Table.size(organizers) == 1 and 'Organizer' or 'Organizers'
+
+		return {
+			Cell{
+				name = title,
+				content = organizers
+			}
+		}
+	end
+
+	return widgets
+end
+
+function CustomInjector:addCustomCells(widgets)
+	local args = _args
+	table.insert(widgets, Cell{
+		name = 'Teams',
+		content = {args.team_number}
+	})
+
+	return widgets
+end
+
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args['supercell-sponsored'])
+end
+
+function CustomLeague:appendLiquipediatierDisplay()
+	return Logic.readBool(_args['supercell-sponsored']) and ('&nbsp;' .. SUPERCELL_SPONSORED_ICON) or ''
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.publishertier = args['supercell-sponsored']
+	lpdbData.participantsnumber = args.team_number
+
+	return lpdbData
+end
+
+function CustomLeague:defineCustomPageVariables()
+	--Legacy vars
+	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
+	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
+	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
+
+	--Legacy date vars
+	local sdate = Variables.varDefault('tournament_startdate', '')
+	local edate = Variables.varDefault('tournament_enddate', '')
+	Variables.varDefine('tournament_sdate', sdate)
+	Variables.varDefine('tournament_edate', edate)
+	Variables.varDefine('tournament_date', edate)
+	Variables.varDefine('date', edate)
+	Variables.varDefine('sdate', sdate)
+	Variables.varDefine('edate', edate)
+end
+
+function CustomLeague._organizerIcon(organizer)
+	if not organizer then return '' end
+
+	return ORGANIZER_ICONS[organizer:lower()] or ''
+end
+
+function CustomLeague._createOrganizers()
+	if not _args.organizer then
+		return {}
+	end
+
+	local organizers = {
+		CustomLeague._organizerIcon(_args.organizer) .. _league:createLink(
+			_args.organizer, _args['organizer-name'], _args['organizer-link'], _args.organizerref),
+	}
+
+	local index = 2
+	while not String.isEmpty(_args['organizer' .. index]) do
+		table.insert(
+			organizers,
+			CustomLeague._organizerIcon(_args['organizer' .. index]) .. _league:createLink(
+				_args['organizer' .. index],
+				_args['organizer' .. index .. '-name'],
+				_args['organizer' .. index .. '-link'],
+				_args['organizerref' .. index])
+		)
+		index = index + 1
+	end
+
+	return organizers
+end
+
+return CustomLeague

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -9,9 +9,6 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
-local Table = require('Module:Table')
-local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -62,7 +62,7 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = _args['supercell-sponsored'] == 'true' and 'true' or nil
+	lpdbData.publishertier = Logic.readBool(_args['supercell-sponsored'])
 	lpdbData.participantsnumber = args.team_number
 
 	return lpdbData

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -21,15 +21,13 @@ local SUPERCELL_SPONSORED_ICON = '[[File:Supercell lightmode.png|x18px|link=Supe
 	.. '|x18px|link=Supercell|Tournament sponsored by Supercell.|class=show-when-dark-mode]]'
 
 local _args
-local _league
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 function CustomLeague.run(frame)
 	local league = League(frame)
-	_league = league
-	_args = _league.args
+	_args = league.args
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.addToLpdb = CustomLeague.addToLpdb

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -23,15 +23,6 @@ local SUPERCELL_SPONSORED_ICON = '[[File:Supercell lightmode.png|x18px|link=Supe
 	.. '|Tournament sponsored by Supercell.|class=show-when-light-mode]][[File:Supercell darkmode.png'
 	.. '|x18px|link=Supercell|Tournament sponsored by Supercell.|class=show-when-dark-mode]]'
 
-local ORGANIZER_ICONS = {
-	supercell = '[[File:Supercell lightmode.png|x18px|link=Supercell|Supercell|class=show-when-light-mode]]'
-		.. '[[File:Supercell darkmode.png|x18px|link=Supercell|Supercell|class=show-when-dark-mode]] ',
-	['esports engine'] = '[[File:Esports Engine icon allmode.png|x18px|link=Esports Engine|Esports Engine]] ',
-	['esl'] = '[[File:ESL 2019 icon lightmode.png|x18px|link=ESL|ESL|class=show-when-light-mode]]'
-		.. '[[File:ESL 2019 icon darkmode.png|x18px|link=ESL|ESL|class=show-when-dark-mode]] ',
-	['faceit'] = '[[File:FACEIT icon allmode.png|x18px|link=Esports Engine|Esports Engine]] ',
-}
-
 local _args
 local _league
 
@@ -56,27 +47,10 @@ function CustomLeague:createWidgetInjector()
 	return CustomInjector()
 end
 
-function CustomInjector:parse(id, widgets)
-	if id == 'organizers' then
-		local organizers = CustomLeague._createOrganizers()
-		local title = Table.size(organizers) == 1 and 'Organizer' or 'Organizers'
-
-		return {
-			Cell{
-				name = title,
-				content = organizers
-			}
-		}
-	end
-
-	return widgets
-end
-
 function CustomInjector:addCustomCells(widgets)
-	local args = _args
 	table.insert(widgets, Cell{
 		name = 'Teams',
-		content = {args.team_number}
+		content = {_args.team_number}
 	})
 
 	return widgets
@@ -91,59 +65,10 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = args['supercell-sponsored']
+	lpdbData.publishertier = _args['supercell-sponsored'] == 'true' and 'true' or nil
 	lpdbData.participantsnumber = args.team_number
 
 	return lpdbData
-end
-
-function CustomLeague:defineCustomPageVariables()
-	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
-	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
-	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
-
-	--Legacy date vars
-	local sdate = Variables.varDefault('tournament_startdate', '')
-	local edate = Variables.varDefault('tournament_enddate', '')
-	Variables.varDefine('tournament_sdate', sdate)
-	Variables.varDefine('tournament_edate', edate)
-	Variables.varDefine('tournament_date', edate)
-	Variables.varDefine('date', edate)
-	Variables.varDefine('sdate', sdate)
-	Variables.varDefine('edate', edate)
-end
-
-function CustomLeague._organizerIcon(organizer)
-	if not organizer then return '' end
-
-	return ORGANIZER_ICONS[organizer:lower()] or ''
-end
-
-function CustomLeague._createOrganizers()
-	if not _args.organizer then
-		return {}
-	end
-
-	local organizers = {
-		CustomLeague._organizerIcon(_args.organizer) .. _league:createLink(
-			_args.organizer, _args['organizer-name'], _args['organizer-link'], _args.organizerref),
-	}
-
-	local index = 2
-	while not String.isEmpty(_args['organizer' .. index]) do
-		table.insert(
-			organizers,
-			CustomLeague._organizerIcon(_args['organizer' .. index]) .. _league:createLink(
-				_args['organizer' .. index],
-				_args['organizer' .. index .. '-name'],
-				_args['organizer' .. index .. '-link'],
-				_args['organizerref' .. index])
-		)
-		index = index + 1
-	end
-
-	return organizers
 end
 
 return CustomLeague


### PR DESCRIPTION
## Summary
Infobox league for New Wiki CoC 
**Clean Port of Brawl Stars** 

Stuff that mentions **Supercell** would need to be stay as they are from same publisher, but please check two side notes

## How did you test this change?
LIVE - https://liquipedia.net/clashofclans/Clash_of_Clans_World_Championship/2021

## Side Note
1. Since Brawl InfoLeague is existed for quite a while already (as early as last year) , Do I need to removed this section if it shouldnt be there for a Pre Alpha? 
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/62226655-6015-4967-9037-871ffd527583)

2. Should I need to revise the parameter name **supercellpremier** for the highlighted tier to be **publisherpremier** parameter instead?
