### PR TITLE
Use mw.ustring.lower over string.lower

### DIFF
--- a/components/prize_pool/wikis/brawlstars/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/brawlstars/prize_pool_custom.lua
@@ -58,7 +58,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, 'QUALIFIES1') and 1 or 0
 
-	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints', lpdbData.extradata.prizepoints)
 
 	if not Opponent.isTbd(opponent.opponentData) then
 		Variables.varDefine('qualified_' .. lpdbData.opponentname, lpdbData.qualified)


### PR DESCRIPTION
## Summary
Since the commons TeamCard/Custom uses mw.ustring already, variable names didn't match in case of captial unicode letters.

## How did you test this change?
dev to live
