### PR TITLE
Add `Flags.isValidFlagInput` function

### DIFF
--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -244,4 +244,8 @@ function Flags._convertToLangKey(langName)
 		or langName
 end
 
+function Flags.isValidFlagInput(flagInput)
+	return String.isNotEmpty(Flags._convertToKey(flagInput))
+end
+
 return Class.export(Flags)

--- a/standard/test/flags_test.lua
+++ b/standard/test/flags_test.lua
@@ -72,4 +72,10 @@ function suite:testCountryCode()
 	self:assertEquals(nlOutput, Flags.CountryCode('holland'))
 end
 
+function suite:testIsValidFlagInput()
+	self:assertEquals(true, Flags.isValidFlagInput('de'))
+	self:assertEquals(true, Flags.isValidFlagInput('germany'))
+	self:assertEquals(false, Flags.isValidFlagInput('aaaaaaa'))
+end
+
 return suite


### PR DESCRIPTION
## Summary
Add `Flags.isValidFlagInput` function and according testcases.
Intended usage is in some sc2 modules where we would like to filter provided args keys for valid flags.
`local someVar = Table.filterByKey(args, Flags.isValidFlagInput)`

## How did you test this change?
dev