### PR TITLE
AoE: Fix mismatch between id and pagename for PlayerIntroduction

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -118,7 +118,7 @@ function CustomPlayer.run(frame)
 		local _, roleType = CustomPlayer._getRoleType(_args.roleList)
 
 		autoPlayerIntro = PlayerIntroduction.run{
-			player = _args.id,
+			player = _player.pagename,
 			transferquery = 'datapoint',
 			defaultGame = 'Age of Empires II',
 			team = _args.team,


### PR DESCRIPTION
## Summary
PlayerIntroduction expects a pagename passed as player, which sometimes mismatches the ID (e.g. lowercase IDs)

## How did you test this change?
dev