### PR TITLE
Add `streamer` as role to Overwatch Infobox player

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -42,6 +42,7 @@ local ROLES = {
 	['talent'] = {category = 'Talents', variable = 'Talent', isplayer = false},
 	['manager'] = {category = 'Managers', variable = 'Manager', isplayer = false},
 	['producer'] = {category = 'Producers', variable = 'Producer', isplayer = false},
+	['streamer'] = {category = 'Streamers', variable = 'Streamer', isplayer = false},
 }
 ROLES['assistant coach'] = ROLES.coach
 


### PR DESCRIPTION
## Summary

Adding Streamer as a supported role

## How did you test this change?

[Tested here.](https://liquipedia.net/overwatch/User:Moonshot/sandbox4) via /dev
