### PR TITLE
AoE: Use unresolved map name in case of redirects

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -163,8 +163,6 @@ function CustomLeague:defineCustomPageVariables(args)
 	)
 	Variables.varDefine('tournament_headtohead', args.headtohead)
 
-	-- Legacy tier vars
-
 	-- Legacy notability vars
 	Variables.varDefine('tournament_notability_mod', args.notabilitymod or 1)
 
@@ -317,9 +315,12 @@ function CustomLeague:_getMaps()
 			display = mapInput[1]
 		else
 			link = mapInput[1]
-			display = mapInput[2]
+			display = mapInput[2] or mapInput[1]
 		end
 		link = mw.ext.TeamLiquidIntegration.resolve_redirect(link)
+		if link == display then
+			display = nil
+		end
 
 		table.insert(maps, {link = link, name = display, mode = mode, image = args[prefix .. 'image']})
 	end


### PR DESCRIPTION
## Summary
When a map name is a redirect, the expected display is the unresolved name. Therefore, the display name needs to be set, but can be dropped to reduce JSON length if resolved and unresolved name match.

## How did you test this change?
via dev
