### PR TITLE
TournamentsListing: fix inverted logic causing mobile display issues

### DIFF
--- a/components/tournaments_listing/commons/tournaments_listing_card_list.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_card_list.lua
@@ -279,7 +279,7 @@ function BaseTournamentsListing:_row(tournamentData)
 	else
 		priceCell
 			:wikitext(NONBREAKING_SPACE)
-			:addClass(participantNumber == -1 and 'Blank' or nil)
+			:addClass('Blank')
 	end
 
 	row:tag('div')

--- a/components/tournaments_listing/commons/tournaments_listing_card_list.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_card_list.lua
@@ -293,7 +293,7 @@ function BaseTournamentsListing:_row(tournamentData)
 	else
 		participantsNumberCell
 			:wikitext('-')
-			:addClass(prizeValue > 0 and 'Blank' or nil)
+			:addClass(not config.showTier and prizeValue == 0 and 'Blank' or nil)
 	end
 
 	if status == CANCELLED then


### PR DESCRIPTION
## Summary

This logic was wrong on the CS module that pre-dates this one and is possibly where this has been "copied" from. Anyway, this fixes the following display issue when both prize pool and participants number are missing:

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/14f6150b-6f29-4738-ba95-fd70f6c22db4)

## How did you test this change?

Tested on `/dev` and then also pushed live.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/9eb10df9-10c5-47f3-9026-9b04324783ce)

Also ensured it still works properly when tiers are shown:

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/078e2a93-0ba9-46f7-8b1f-73299846d89f)
