### PR TITLE
Parse unix timestamp to ISO for comparison

### DIFF
--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -226,7 +226,7 @@ PlayerExt.syncTeam. Enabled by default.
 ]]
 function PlayerExt.syncTeam(pageName, template, options)
 	options = options or {}
-	local date = options.date or DateExt.getContextualDateOrNow()
+	local date = DateExt.toYmdInUtc(options.date or DateExt.getContextualDateOrNow())
 
 	local historyVar = playerVars:get(pageName .. '.teamHistory')
 	local history = historyVar and Json.parse(historyVar) or {}


### PR DESCRIPTION
## Summary
date was used for comparison with leavedate (iso string) from player history

## How did you test this change?
via /dev by hjp