### PR TITLE
Do not import QualLose when winners are not imported

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -326,10 +326,11 @@ function Import._computeBracketPlacementGroups(bracket, options)
 			end
 
 			-- Opponents knocked out from sole section (se) or lower bracket (de)
-			if coordinates.sectionIndex == #bracket.sections
+			if (not bracket.bracketDatasById[matchId].qualLose or options.importWinners) and (
+				coordinates.sectionIndex == #bracket.sections
 
 				-- Include opponents directly knocked out from the upper bracket
-				or firstDeRoundIndex and coordinates.roundIndex < firstDeRoundIndex then
+				or firstDeRoundIndex and coordinates.roundIndex < firstDeRoundIndex) then
 
 				table.insert(groupKeys, {2, coordinates.depth, 2})
 			end


### PR DESCRIPTION
## Summary
Currently PPT imports `qualLose` even when winner import is disabled for the stage.
This PR changes it so that if winner import is disabled for a stage `qualLose` in that stage will not be imported.
`qualLose` indicates a Loser of a match still advancing to the next stage, so from a logical point of view it makes sense to only import them if winner import is enabled

## How did you test this change?
/dev