### PR TITLE
Adjust Pokemon Match2 to take flags input automatically

### DIFF
--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -108,7 +108,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
-	Opponent.resolve(opponent, date)
+	Opponent.resolve(opponent, date, {syncPlayer=true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 


### PR DESCRIPTION
## Summary
**Make it so when inputting SoloOpponents in Match2 Bracket, you dont need to add flag all the time**
- If {{OpponentList}} is present above and with all flag inputs inside that, It takes from there
- If a player has page, It takes from their page right away
- When input flag on their first match, every subsequent match doesnt need to as flags being kept onto it

Generally made it easier for contributor, this was made possible after #3100 (since pre-3100 fix theres errorcodes)

## How did you test this change?
**/dev** on two live pages

**Mostly with player who has pages**
https://liquipedia.net/pokemon/index.php?title=Pokemon_Championships%2FInternational%2FNorth_America%2F2023%2FVGC&type=revision&diff=185663&oldid=185631

**All no-page players, utilizes the first match input then not input flag anymore after first round**
https://liquipedia.net/pokemon/index.php?title=Pokemon_Championships%2FNational%2FThailand%2F2023%2FVGC&type=revision&diff=185664&oldid=183533

_**Pokemon dont really used OpponentList unfortunately so I dont have live test cases for this but shouldnt be an issue**_

## Side Note
when I brought up this idea last week, hjp did mentioned me one thing 

> mind that fetching per opponent is not really a good idea since it means query calls per opponent
> using the var stuff via a participant table is heavily preferable imo

I did remove only **fetchPlayer=true** but idk if this warrants more edits to the code. So in this PR you will see only just syncPlayer being added

## Side Note 2
The other two 1v1 heavy match2 (Tetris and FIFA, which is still on PR but freezed due to SMW Prio) currently runs this same edit 
 since they needed as well. I PR the pokemon first because match2 already merged long ago
