### PR TITLE
Switch CS infobox league to store extradata in single var

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Json = require('Module:Json')
 local Namespace = require('Module:Namespace')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
@@ -284,8 +285,6 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_tier', tierName) -- Stores as X-tier, not the integer
 
 	-- Wiki specific vars
-	Variables.varDefine('raw_sdate', args.sdate or args.date)
-	Variables.varDefine('raw_edate', args.edate or args.date)
 	Variables.varDefine('tournament_valve_major',
 		(args.valvetier or ''):lower() == _TIER_VALVE_MAJOR and 'true' or args.valvemajor)
 	Variables.varDefine('tournament_valve_tier',
@@ -323,13 +322,16 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.team_number or args.player_number
 	lpdbData.sortdate = args.sort_date or lpdbData.enddate
 
-	lpdbData.extradata.prizepoollocal = Variables.varDefault('prizepoollocal', '')
-	lpdbData.extradata.startdate_raw = Variables.varDefault('raw_sdate', '')
-	lpdbData.extradata.enddate_raw = Variables.varDefault('raw_edate', '')
+	lpdbData.extradata.prizepoollocal = Variables.varDefault('prizepoollocal')
+	lpdbData.extradata.startdate_raw = args.sdate or args.date
+	lpdbData.extradata.enddate_raw = args.edate or args.date
 	lpdbData.extradata.shortname2 = args.shortname2
 
 	Array.forEach(CustomLeague.getRestrictions(_args.restrictions),
 		function(res) lpdbData.extradata['restriction_' .. res.data] = 1 end)
+
+	-- Extradata variable
+	Variables.varDefine('tournament_extradata', Json.stringify(lpdbData.extradata))
 
 	return lpdbData
 end

--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -54,7 +54,7 @@ function CustomPrizePool.run(frame)
 
 	if Logic.readBool(args.qualifier) then
 		local extradata = Json.parseIfTable(Variables.varDefault('tournament_extradata')) or {}
-		extradata.qualifier = '1', -- This is the new field, rest are just what Infobox League sets
+		extradata.qualifier = '1' -- This is the new field, rest are just what Infobox League sets
 		mw.ext.LiquipediaDB.lpdb_tournament('tournament_'.. Variables.varDefault('tournament_name', ''), {
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json(extradata)
 		})

--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -10,6 +10,7 @@ local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Json = require('Module:Json')
 local Namespace = require('Module:Namespace')
 local Variables = require('Module:Variables')
 
@@ -52,13 +53,10 @@ function CustomPrizePool.run(frame)
 	Variables.varDefine('prizepool_resultName', HEADER_DATA.resultName)
 
 	if Logic.readBool(args.qualifier) then
+		local extradata = Json.parseIfString(Variables.varDefault('tournament_extradata'))
+		extradata.qualifier = '1', -- This is the new field, rest are just what Infobox League sets
 		mw.ext.LiquipediaDB.lpdb_tournament('tournament_'.. Variables.varDefault('tournament_name', ''), {
-			extradata = mw.ext.LiquipediaDB.lpdb_create_json{
-				prizepoollocal = Variables.varDefault('prizepoollocal', ''),
-				startdate_raw = Variables.varDefault('raw_sdate', ''),
-				enddate_raw = Variables.varDefault('raw_edate', ''),
-				qualifier = '1', -- This is the new field, rest are just what Infobox League sets
-			}
+			extradata = mw.ext.LiquipediaDB.lpdb_create_json(extradata)
 		})
 	end
 

--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -53,7 +53,7 @@ function CustomPrizePool.run(frame)
 	Variables.varDefine('prizepool_resultName', HEADER_DATA.resultName)
 
 	if Logic.readBool(args.qualifier) then
-		local extradata = Json.parseIfString(Variables.varDefault('tournament_extradata'))
+		local extradata = Json.parseIfTable(Variables.varDefault('tournament_extradata')) or {}
 		extradata.qualifier = '1', -- This is the new field, rest are just what Infobox League sets
 		mw.ext.LiquipediaDB.lpdb_tournament('tournament_'.. Variables.varDefault('tournament_name', ''), {
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json(extradata)


### PR DESCRIPTION
## Summary

Allow prize pool to not need to be updated every time something in infobox changes.

## How did you test this change?

Tested on `/dev` on cs wiki.
