### PR TITLE
Add LPDB data for importing from legacy group slots

### DIFF
--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -20,6 +20,7 @@ local Opponent = require('Module:OpponentLibraries').Opponent
 local StandingsStorage = {}
 local ALLOWED_SCORE_BOARD_KEYS = {'w', 'd', 'l'}
 local SCOREBOARD_FALLBACK = {w = 0, d = 0, l = 0}
+local DISQUALIFIED = 'dq'
 
 ---@param data table
 function StandingsStorage.run(data)
@@ -167,6 +168,9 @@ function StandingsStorage.fromTemplateHeader(frame)
 		return
 	end
 
+	data.roundcount = tonumber(data.roundcount) or 1
+	data.finished = Logic.nilOr(Logic.readBoolOrNil(data.finished), true)
+
 	StandingsStorage.table(data)
 end
 
@@ -240,8 +244,14 @@ function StandingsStorage.fromTemplateEntry(frame)
 
 	data.opponent = Opponent.resolve(Opponent.readOpponentArgs(opponentArgs) or Opponent.tbd(), date)
 
-	-- Template don't have SlotIndex, use placement as workaround
-	data.slotindex = data.placement
+	if (data.placement or ''):lower() == DISQUALIFIED then
+		data.definitestatus = DISQUALIFIED
+		data.currentstatus = DISQUALIFIED
+	end
+
+	-- If template doesn't have SlotIndex, use placement as workaround
+	data.slotindex = tonumber(data.slotindex) or tonumber(data.placement)
+	data.placement = tonumber(data.placement) or data.slotindex
 
 	data.match = {w = data.win_m, d = data.tie_m, l = data.lose_m}
 	data.game = {w = data.win_g, d = data.tie_g, l = data.lose_g}

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -169,7 +169,7 @@ function StandingsStorage.fromTemplateHeader(frame)
 	end
 
 	data.roundcount = tonumber(data.roundcount) or 1
-	data.finished = Logic.nilOr(Logic.readBoolOrNil(data.finished), true)
+	data.finished = Logic.readBool(data.finished)
 
 	StandingsStorage.table(data)
 end

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -249,9 +249,9 @@ function StandingsStorage.fromTemplateEntry(frame)
 		data.currentstatus = DISQUALIFIED
 	end
 
-	-- If template doesn't have SlotIndex, use placement as workaround
-	data.slotindex = tonumber(data.slotindex) or tonumber(data.placement)
-	data.placement = tonumber(data.placement) or data.slotindex
+ 	data.placement = tonumber(data.placement)
+ 	-- If template doesn't have slotIndex, use placement as workaround
+ 	data.slotindex = tonumber(data.slotindex) or data.placement
 
 	data.match = {w = data.win_m, d = data.tie_m, l = data.lose_m}
 	data.game = {w = data.win_g, d = data.tie_g, l = data.lose_g}

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -249,9 +249,9 @@ function StandingsStorage.fromTemplateEntry(frame)
 		data.currentstatus = DISQUALIFIED
 	end
 
- 	data.placement = tonumber(data.placement)
- 	-- If template doesn't have slotIndex, use placement as workaround
- 	data.slotindex = tonumber(data.slotindex) or data.placement
+	data.placement = tonumber(data.placement)
+	-- If template doesn't have slotIndex, use placement as workaround
+	data.slotindex = tonumber(data.slotindex) or data.placement
 
 	data.match = {w = data.win_m, d = data.tie_m, l = data.lose_m}
 	data.game = {w = data.win_g, d = data.tie_g, l = data.lose_g}


### PR DESCRIPTION
## Summary

Add missing data that is needed for importing into prize pools from legacy group table slots. Along with these wikicode edits:

https://liquipedia.net/commons/index.php?title=Template:StandingsData&diff=508174&oldid=484011
https://liquipedia.net/counterstrike/index.php?title=Template:GroupTableSlot&diff=2549876&oldid=2338665

## How did you test this change?

`/dev` on CS wiki on https://liquipedia.net/counterstrike/ESL/Pro_League/Season_6/North_America

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/e046fd37-0c2f-44d1-affc-d561f7b1ec28)

