### PR TITLE
Catch empty string potentially causing some errors

### DIFF
--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -11,6 +11,7 @@ local DateExt = require('Module:Date/Ext')
 local Flags = require('Module:Flags')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
+local Logic = require('Module:Logic')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -226,7 +227,7 @@ PlayerExt.syncTeam. Enabled by default.
 ]]
 function PlayerExt.syncTeam(pageName, template, options)
 	options = options or {}
-	local date = DateExt.toYmdInUtc(options.date or DateExt.getContextualDateOrNow())
+	local date = DateExt.toYmdInUtc(Logic.emptyOr(options.date, DateExt.getContextualDateOrNow()))
 
 	local historyVar = playerVars:get(pageName .. '.teamHistory')
 	local history = historyVar and Json.parse(historyVar) or {}


### PR DESCRIPTION
## Summary
Catch empty string potentially causing some errors.
Currently if `options.date` is empty string `DateExt.toYmdInUtc` would error.
To circumvent this use `Logic.emptyOr` instead of plain `or`

## How did you test this change?
dev