### PR TITLE
Convert `individualprizemoney` from string to number to avoid comparing string with number

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -433,6 +433,7 @@ function CustomPlayer._addPlacementToEarnings(earnings, earnings_total, data)
 		earnings[mode] = {}
 	end
 	local year = string.sub(data.date, 1, 4)
+	data.individualprizemoney = tonumber(data.individualprizemoney) or 0
 	earnings[mode][year] = (earnings[mode][year] or 0) + data.individualprizemoney
 	earnings['total'][year] = (earnings['total'][year] or 0) + data.individualprizemoney
 	earnings_total = (earnings_total or 0) + data.individualprizemoney


### PR DESCRIPTION
## Summary
Convert string to number and fallback to 0.
SC2 Infobox player broke on some pages due to indiv. prize money suddenly being a string instead of a number.
This PR catches those strings and converts them to numbers and falls back to 0 if the given value is not numeric.
Needed for summing up and fo comparing with another number.

## How did you test this change?
live, hotfix