### PR TITLE
Fix CS PPT legacy tournament name

### DIFF
--- a/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_custom.lua
@@ -47,8 +47,8 @@ function CustomPrizePool.run(frame)
 		prizePool:setConfig('storeLpdb', false)
 	end
 
-	HEADER_DATA.tournamentName = args['tournament name']
-	HEADER_DATA.resultName = args['custom-name']
+	HEADER_DATA.tournamentName = args['tournamentName']
+	HEADER_DATA.resultName = args['resultName']
 
 	Variables.varDefine('prizepool_resultName', HEADER_DATA.resultName)
 

--- a/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/counterstrike/prize_pool_legacy_custom.lua
@@ -20,8 +20,9 @@ end
 
 function CustomLegacyPrizePool.customHeader(newArgs, CACHED_DATA, header)
 	newArgs.qualifier = header.qualifier
-	newArgs['custom-name'] = header['custom-name']
-	newArgs.points1link = header['points-link']
+	newArgs['tournamentName'] = header['tournament name']
+	newArgs['points1link'] = header['points-link']
+	newArgs['resultName'] = header['custom-name']
 
 	return newArgs
 end


### PR DESCRIPTION
## Summary

The `tournament name` field was not being mapped to a header argument in legacy. Added that and also renamed some of the others to have less better names in the non-legacy module.

## How did you test this change?

Tested `/dev`.