### PR TITLE
Use 32px icons for match links and vods

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -221,10 +221,10 @@ end
 function Footer:addLink(link, icon, iconDark, text)
 	local content
 	if String.isEmpty(iconDark) then
-		content = '[['..icon..'|link='..link..'|15px|'..text..'|alt=' .. link .. ']]'
+		content = '[['..icon..'|link='..link..'|32px|'..text..'|alt=' .. link .. ']]'
 	else
-		content = '[['..icon..'|link='..link..'|15px|'..text..'|alt=' .. link .. '|class=show-when-light-mode]]'
-			.. '[['..iconDark..'|link='..link..'|15px|'..text..'|alt=' .. link .. '|class=show-when-dark-mode]]'
+		content = '[['..icon..'|link='..link..'|32px|'..text..'|alt=' .. link .. '|class=show-when-light-mode]]'
+			.. '[['..iconDark..'|link='..link..'|32px|'..text..'|alt=' .. link .. '|class=show-when-dark-mode]]'
 	end
 
 	self.inner:wikitext(content)

--- a/standard/vod_link.lua
+++ b/standard/vod_link.lua
@@ -18,9 +18,9 @@ function VodLink.display(args)
 
 	if Logic.readBool(args.novod) then
 		return mw.html.create('span')
-			:addClass('plainlinks')
+			:addClass('plainlinks vodlink')
 			:attr('title', 'Help Liquipedia find this VOD')
-			:wikitext('[[File:NoVod.png|link=]]')
+			:wikitext('[[File:NoVod.png|32px|link=]]')
 	end
 
 	local title
@@ -48,7 +48,7 @@ function VodLink.display(args)
 	return mw.html.create('span')
 		:addClass('plainlinks vodlink')
 		:attr('title', title)
-		:wikitext('[[File:' .. fileName .. '|link=' .. link .. ']]')
+		:wikitext('[[File:' .. fileName .. '|32px|link=' .. link .. ']]')
 end
 
 return Class.export(VodLink, {frameOnly = true})


### PR DESCRIPTION
## Summary

Should be 16px not 15px, and also that part is done via CSS class `vodlinks` (so we can 32px instead for higher PPI devices).

Blurry before change:
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/824a0247-9586-41ae-832d-e7a6a835c717)


## How did you test this change?

Tested with dev. CSS class has existed for ages already so won't need any delay to being pushed.

After change not blurry:
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/543db911-4c4c-4198-be34-a4fedcb5fdfa)

