### PR TITLE
Add F1-related placement

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -52,15 +52,6 @@ Placement.specialStatuses = {
 		end,
 		lpdb = 'DQ',
 	},
-	DNS = {
-		active = function (args)
-			return Logic.readBool(args.dns)
-		end,
-		display = function ()
-			return Abbreviation.make('DNS', 'Did not start')
-		end,
-		lpdb = 'DNS',
-	},
 	DNF = {
 		active = function (args)
 			return Logic.readBool(args.dnf)
@@ -78,33 +69,6 @@ Placement.specialStatuses = {
 			return Abbreviation.make('DNP', 'Did not participate')
 		end,
 		lpdb = 'DNP',
-	},
-	DNPQ = {
-		active = function (args)
-			return Logic.readBool(args.dnpq)
-		end,
-		display = function ()
-			return Abbreviation.make('DNPQ', 'Did not pre-qualify')
-		end,
-		lpdb = 'DNPQ',
-	},
-	DNQ = {
-		active = function (args)
-			return Logic.readBool(args.dnq)
-		end,
-		display = function ()
-			return Abbreviation.make('DNQ', 'Did not qualify')
-		end,
-		lpdb = 'DNQ',
-	},
-	NC = {
-		active = function (args)
-			return Logic.readBool(args.nc)
-		end,
-		display = function ()
-			return Abbreviation.make('NC', 'Not classified')
-		end,
-		lpdb = 'NC',
 	},
 	W = {
 		active = function (args)

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -52,6 +52,15 @@ Placement.specialStatuses = {
 		end,
 		lpdb = 'DQ',
 	},
+	DNS = {
+		active = function (args)
+			return Logic.readBool(args.dns)
+		end,
+		display = function ()
+			return Abbreviation.make('DNS', 'Did not start')
+		end,
+		lpdb = 'DNS',
+	},
 	DNF = {
 		active = function (args)
 			return Logic.readBool(args.dnf)
@@ -69,6 +78,33 @@ Placement.specialStatuses = {
 			return Abbreviation.make('DNP', 'Did not participate')
 		end,
 		lpdb = 'DNP',
+	},
+	DNPQ = {
+		active = function (args)
+			return Logic.readBool(args.dnpq)
+		end,
+		display = function ()
+			return Abbreviation.make('DNPQ', 'Did not pre-qualify')
+		end,
+		lpdb = 'DNPQ',
+	},
+	DNQ = {
+		active = function (args)
+			return Logic.readBool(args.dnq)
+		end,
+		display = function ()
+			return Abbreviation.make('DNQ', 'Did not qualify')
+		end,
+		lpdb = 'DNQ',
+	},
+	NC = {
+		active = function (args)
+			return Logic.readBool(args.nc)
+		end,
+		display = function ()
+			return Abbreviation.make('NC', 'Not classified')
+		end,
+		lpdb = 'NC',
 	},
 	W = {
 		active = function (args)

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -39,7 +39,12 @@ local PLACEMENT_CLASSES = {
 	['w'] = 'placement-win',
 	['l'] = 'placement-lose',
 	['dq'] = 'placement-lose',
+	['dnf'] = 'placement-dnp',
+	['dns'] = 'placement-dnp',
+	['dnpq'] = 'placement-dnp',
 	['dnp'] = 'placement-dnp',
+	['dnq'] = 'placement-dnp',
+	['nc'] = 'placement-dnp',
 	['proceeded'] = 'placement-up',
 	['stay'] = 'placement-stay',
 	['relegated'] = 'placement-down',
@@ -55,9 +60,14 @@ local CUSTOM_SORTS = {
 	['l'] = '1030',
 	['relegated'] = '1031',
 	['dnp'] = '1032',
-	['dq'] = '1033',
-	['div'] = '1034',
-	[''] = '1035',
+	['dnpq'] = '1033',
+	['dnf'] = '1034',
+	['dns'] = '1035',
+	['dnq'] = '1036',
+	['nc'] = '1037',
+	['dq'] = '1038',
+	['div'] = '1039',
+	[''] = '1040',
 }
 
 local prizepoolClasses = {
@@ -69,6 +79,12 @@ local prizepoolClasses = {
 	q = 'bg-win',
 	l = 'bg-lose',
 	dq = 'bg-dq',
+	dnq = 'bg-dq',
+	dns = 'bg-dq',
+	dnf = 'bg-dq',
+	dnp = 'bg-dq',
+	dnpq = 'bg-dq',
+	nc = 'bg-dq',
 }
 
 ---Processes a placement text input into raw data.

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -87,12 +87,13 @@ local prizepoolClasses = {
 	nc = 'bg-dq',
 }
 
-local useBlackTextFor = {
+local USE_BLACK_TEXT = {
 	'dnf',
 	'dns',
 	'dnpq',
 	'dnp',
 	'dnq',
+	'dq',
 	'nc',
 }
 
@@ -135,7 +136,7 @@ function Placement.raw(placement)
 	end
 
 	-- Determine any black text placements
-	raw.blackText = Table.includes(useBlackTextFor, raw.placement[1])
+	raw.blackText = Table.includes(USE_BLACK_TEXT, raw.placement[1])
 
 	return raw
 end

--- a/standard/placement.lua
+++ b/standard/placement.lua
@@ -87,6 +87,15 @@ local prizepoolClasses = {
 	nc = 'bg-dq',
 }
 
+local useBlackTextFor = {
+	'dnf',
+	'dns',
+	'dnpq',
+	'dnp',
+	'dnq',
+	'nc',
+}
+
 ---Processes a placement text input into raw data.
 ---Returned table will not always contain every key.
 ---@param placement string?
@@ -126,7 +135,7 @@ function Placement.raw(placement)
 	end
 
 	-- Determine any black text placements
-	raw.blackText = (raw.placement[1] == 'dnp')
+	raw.blackText = Table.includes(useBlackTextFor, raw.placement[1])
 
 	return raw
 end


### PR DESCRIPTION
## Summary
F1 needs an array of additional placement, since the added ones cannot be substituted by the existing one we have (which also exists in F1 in a different context, would result in we putting the wrong classification if we had to sub in/out)

These included
**DNQ** (Participated, but failed to Qualify for the main race)
**DNPQ** (Participated, but failed to Pre-Qualify into the Main Qualify)
**DNS** (Participated, Does qualified, but failed to Start the main race)
**NC** (Ended a season with no points, in the past instead of providing a numbered placement, the official result will determine this as **Not Classified** but does complete every event, which is a different context of DQ)

Additionally DNF and DNP already existed so those are usable

## How did you test this change?
/dev

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/83928dfb-3757-4dee-8d0d-bd3a7f7a5f2c)