### PR TITLE
Add filter to remove cancelled/postponed tournaments

### DIFF
--- a/components/statistics/count.lua
+++ b/components/statistics/count.lua
@@ -231,7 +231,7 @@ function Count._baseConditions(args, isTournament)
 		endDateKey = 'enddate'
 		sortDateKey = 'sortdate'
 
-		if not Logic.readBool(args.includeAllStatus) then
+		if Logic.readBool(args.filterByStatus) then
 			conditions:add{ConditionNode(ColumnName('status'), Comparator.neq, 'cancelled')}
 			conditions:add{ConditionNode(ColumnName('status'), Comparator.neq, 'postponed')}
 		end

--- a/components/statistics/count.lua
+++ b/components/statistics/count.lua
@@ -230,6 +230,11 @@ function Count._baseConditions(args, isTournament)
 		startDateKey = 'startdate'
 		endDateKey = 'enddate'
 		sortDateKey = 'sortdate'
+
+		if not Logic.readBool(args.includeAllStatus) then
+			conditions:add{ConditionNode(ColumnName('status'), Comparator.neq, 'cancelled')}
+			conditions:add{ConditionNode(ColumnName('status'), Comparator.neq, 'postponed')}
+		end
 	else
 		startDateKey = 'date'
 		endDateKey = 'date'


### PR DESCRIPTION
Was doing some checks on the coverage table and there were cases where it was including cancelled tournaments that did not have proper date information.

Added a parameter to check select whether to filter them out or not
