### PR TITLE
Store `liquipediatiertype2` on RL Match2 extradata

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -198,6 +198,7 @@ function matchFunctions.getExtraData(match)
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 		hasopponent1 = Logic.isNotEmpty(opponent1.name) and opponent1.type ~= Opponent.literal,
 		hasopponent2 = Logic.isNotEmpty(opponent2.name) and opponent2.type ~= Opponent.literal,
+		liquipediatiertype2 = Variables.varDefault('tournament_tiertype2'),
 	}
 	return match
 end


### PR DESCRIPTION
## Summary
As title says, needed for rating to properly filter tiertypes from valid matches.

## How did you test this change?
Tested with /dev