### PR TITLE
Store GameGroups Extradata for Tetris

### DIFF
--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -70,6 +70,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = args.player_number or args.team_number
 	lpdbData.publishertier = args.publisherpremier
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
+	lpdbData.extradata.gamegroup = (Game.raw{game = args.game, useDefault = false} or {}).gameGroup
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
Requested by the community, as Tetris has a very large number of games covered on the wiki and the contributor wants ability to separate games by group (Including Others, Modern, Classic ,TGM). Since each of the four are very distinct in each other

Similar to how smash did, but since Tetris Groups is consisting of multiple games. The idea is to stored a new extradata called **gamegroup** to help identify which games goes to which group.

Key part that this get used is

- Tournaments List on the Portal:Tournaments, to be able to show only tournaments for each group separately as this were what being requested by (using **AND [[game::X]]** in  additionalConditions is unfeasible were talking 20+ instead of 5) 

gamegroup stores as extradata in Info League, then we identify groups for each game through **Module:info**

## How did you test this change?
/dev and a brief LIVE test
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/ff39984b-0f4a-48db-bbc7-d5c9c5900caa)

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/ab968b46-f3f2-450f-9fbe-027d11c9bc9a)


## Side Note
has two files 