### PR TITLE
Create Team ELO Ratings

### DIFF
--- a/components/infobox/extensions/wikis/rocketleague/team_ranking.lua
+++ b/components/infobox/extensions/wikis/rocketleague/team_ranking.lua
@@ -16,8 +16,8 @@ local Class = require('Module:Class')
 
 --- Entry point
 -- returns a string representation which contains the current RLCS Points and rank of a team in terms of RLCS Points
--- @tparam table args
--- @treturn string|nil rankingString team's ranking string or nil if team has no points
+--- @param args table
+--- @return string|nil #rankingString team's ranking string or nil if team has no points
 function TeamRanking.run(args)
 	if not args['ranking'] then
 		error('Please provide a ranking name')

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local TeamRanking = require('Module:TeamRanking')

--- a/components/infobox/wikis/rocketleague/infobox_team_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_team_custom.lua
@@ -6,10 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local TeamRanking = require('Module:TeamRanking')
-local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
@@ -26,37 +26,29 @@ local _team
 function CustomTeam.run(frame)
 	local team = Team(frame)
 	_team = team
+	_team.args.rating, _team.args.ratingRank = CustomTeam.fetchRating(_team.pagename)
+
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.createWidgetInjector = CustomTeam.createWidgetInjector
 	return team:createInfobox()
 end
 
 function CustomInjector:addCustomCells(widgets)
-	Variables.varDefine('rating', _team.args.rating)
 	table.insert(widgets, Cell{
 		name = '[[Portal:Rating|LPRating]]',
-		content = {_team.args.rating or 'Not enough data'}
+		content = {
+			_team.args.rating and _team.args.ratingRank and
+				math.floor(_team.args.rating + 0.5) .. ' (Rank #'.. _team.args.ratingRank ..')'
+			or 'Not enough data'}
 	})
-	local rankingSuccess, rlcsRanking = pcall(TeamRanking.run, {
-		ranking = Variables.varDefault('ranking_name', ''),
-		team = _team.pagename
-	})
-	if not rankingSuccess then
-		rlcsRanking = CustomInjector:wrapErrorMessage(rlcsRanking)
-	end
 	table.insert(widgets, Cell{
 		name = '[[RankingTableRLCS|RLCS Points]]',
-		content = {rlcsRanking}
+		content = {TeamRanking.run{
+			ranking = _team.args.ranking_name,
+			team = _team.pagename
+		}}
 	})
 	return widgets
-end
-
-function CustomInjector:wrapErrorMessage(text)
-	local strongStart = '<strong class="error">Error: '
-	local strongEnd = '</strong>'
-	local errorText = text:gsub('Module:TeamRanking:%d+: ', '')
-	local outText = strongStart .. mw.text.nowiki(errorText) .. strongEnd
-	return outText
 end
 
 function CustomInjector:parse(_, widgets)
@@ -64,10 +56,35 @@ function CustomInjector:parse(_, widgets)
 end
 
 function CustomTeam:addToLpdb(lpdbData, args)
-	lpdbData.extradata.rating = Variables.varDefault('rating')
+	lpdbData.extradata.rating = _team.args.rating
 	lpdbData.extradata.tier = string.lower(args.tier or '')
 
 	return lpdbData
+end
+
+function CustomTeam.fetchRating(findTeam)
+	local latestSnap = mw.ext.LiquipediaDB.lpdb(
+		'datapoint',
+		{
+			query = 'extradata',
+			limit = 1,
+			order = 'date DESC',
+			conditions = '[[namespace::4]] AND [[type::LPR_SNAPSHOT]] AND [[name::rating]]'
+		}
+	)[1]
+	if not latestSnap then
+		return
+	end
+
+	if not latestSnap.extradata.table[findTeam] then
+		return
+	end
+
+	for rank, team in ipairs(latestSnap.extradata.ranks) do
+		if team == findTeam then
+			return latestSnap.extradata.table[findTeam].rating, rank
+		end
+	end
 end
 
 function CustomTeam:createWidgetInjector()

--- a/components/ratings/ratings.lua
+++ b/components/ratings/ratings.lua
@@ -1,0 +1,472 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Ratings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Ratings = {}
+
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local FnUtil = require('Module:FnUtil')
+local Json = require('Module:Json')
+local Lpdb = require('Module:Lpdb')
+local Table = require('Module:Table')
+local String = require('Module:StringUtils')
+
+-- Parameters related to LPDB
+local STATIC_CONDITIONS_MATCH = '[[mode::3v3]] AND [[finished::1]] AND [[liquipediatiertype::!School]]'
+local STATIC_CONDITIONS_LPR_TRANSFER = '[[namespace::4]] AND [[type::LPR_TRANSFER]]'
+local STATIC_CONDITIONS_LPR_RATING = '[[namespace::4]] AND [[type::LPR_SNAPSHOT]]'
+
+-- Parameters related to rating table
+local DAYS_IDLE_BEFORE_CLEANUP = 100
+local MATCHES_TO_KEEP_PER_TEAM = 5
+
+-- Parameters for the rating calculation
+local RATING_RANGE_FACTOR = 700.0
+local RATING_K = 15
+local RATING_INIT_VALUE = 1250
+
+---@param date osdate
+---@param customDays integer?
+---@return osdate
+local function stepDate(date, customDays)
+	local newDate = Table.copy(date)
+	newDate.day = newDate.day + (customDays or 1)
+	return newDate
+end
+
+---@param str string
+---@return osdate
+---@overload fun():nil
+local function parseDate(str)
+	if not str then
+		return
+	end
+	local y, m, d = str:match('^(%d%d%d%d)-?(%d?%d?)-?(%d?%d?)')
+	-- default to month and day = 1 if not set
+	if String.isEmpty(m) then
+		m = 1
+	end
+	if String.isEmpty(d) then
+		d = 1
+	end
+	-- create time
+	return {year = y, month = m, day = d}
+end
+
+local function getDateRangeConditions(dateStart, dateEnd)
+	dateEnd = dateEnd or dateStart
+	return '[[date::>' .. os.date('!%x', os.time(stepDate(dateStart, -1))) .. ' 23:59:59' .. ']]' ..
+		' AND [[date::<' .. os.date('!%x', os.time(stepDate(dateEnd))) .. ']]'
+end
+
+local function getAllTransfers()
+	local transfersAtDate = {}
+	Lpdb.executeMassQuery('datapoint', {
+		query = 'date, extradata',
+		order = 'date ASC',
+		conditions = STATIC_CONDITIONS_LPR_TRANSFER -- TODO: Date Range for memory performance
+	}, function (transfer)
+		local date = string.sub(transfer.date, 0, 10)
+		if not transfersAtDate[date] then
+			transfersAtDate[date] = {}
+		end
+		table.insert(transfersAtDate[date], transfer)
+	end)
+
+	return transfersAtDate
+end
+
+local function calcRating(rpSelf, rpOther, score1, score2, match)
+	local modExternalTable = {1, 1}
+	local tier = tonumber(match.liquipediatier)
+	local tierType = match.liquipediatiertype
+
+	local ratingSelf = rpSelf.rating
+	local ratingOther = rpOther.rating
+
+	-- some static parameters
+	local expectation = 1 / (1 + 10 ^ ((ratingOther - ratingSelf) / RATING_RANGE_FACTOR))
+
+	local max = math.max(score1, score2)
+	local win = (score1 > score2)
+
+	-- static tier modifier
+	local mod = 1
+	-- dynamic tier modifier
+	local mod2 = 1
+	-- low match count rating bonus per tier
+	local mod3 = 1
+	-- BestOf modifier
+	local modBO = 1
+	if max < 2 then
+		modBO = 0.6
+	elseif max > 3 then
+		modBO = 1.15
+	end
+	-- external modifier
+	local modExternal = modExternalTable[win and 1 or 2]
+
+	-- increase possible won points if number of matches is low
+	if win and rpSelf.matches < 30 then
+		modExternal = modExternal * 1.5
+	end
+
+	-- tierType
+	local modTierType = 1
+	if tierType == 'Qualifier' then
+		modTierType = 0.67
+	end
+
+	-- tier modification
+	local mWin = 600
+	local mLose = 600
+
+	local function calcMod2(base, multiplier)
+		return win and (0.5 / (1 + 10 ^ ((ratingSelf - base) / mWin))) + 1 or
+				((-1 / (1 + 10 ^ ((ratingSelf - base) / mLose))) + 1) * multiplier
+	end
+
+	if tier == 1 then
+		mod = 4.5
+		mod2 = calcMod2(2300, 1)
+	elseif tier == 2 then
+		mod = 3
+		mod2 = calcMod2(2100, 1.22)
+	elseif tier == 3 then
+		mod = 2
+		mod2 = calcMod2(2100, 1.1)
+	elseif tier == 4 then
+		mod = 0.75
+		mod2 = calcMod2(1800, 1)
+	else
+		mod = 0.2
+		mod2 = calcMod2(1800, 1)
+	end
+
+	local delta = RATING_K * ((win and 1 or 0) - expectation) * mod * mod2 * mod3 * modBO * modExternal * modTierType
+
+	-- set minimal gain/loss to +/- 1
+	if win and delta < 1 then
+		delta = 1
+	elseif not win and delta > -1 then
+		delta = -1
+	end
+
+	rpSelf.matches = rpSelf.matches + 1
+
+	-- set streak
+	if (rpSelf.streak > 0) then
+		rpSelf.streak = win and (rpSelf.streak + 1) or -1
+	elseif (rpSelf.streak < 0) then
+		rpSelf.streak = win and 1 or (rpSelf.streak - 1)
+	else
+		rpSelf.streak = win and 1 or -1
+	end
+
+	--set last matches
+	if Table.size(rpSelf.lastmatches) >= MATCHES_TO_KEEP_PER_TEAM then
+		table.remove(rpSelf.lastmatches, 1)
+	end
+	table.insert(rpSelf.lastmatches, {
+		id = match.match2id,
+		ratingChange = delta,
+		timestamp = os.time(parseDate(match.date)),
+	})
+
+	--[[
+	if roster ~= nil then
+		if roster.p1 ~= nil and roster.p1 ~= "" then
+			self.last_roster = roster
+		end
+	end
+	--]]
+
+	return ratingSelf + delta
+end
+
+local function storeRatingTable(ratingTable, date, name)
+	mw.log('stored ' .. date)
+	local placementsToStore = {}
+	local ratingTableToStore = {}
+	for team, data in Table.iter.spairs(ratingTable, function(tbl, a, b) return tbl[a].rating > tbl[b].rating end) do
+		if data.matches > 10 then
+			table.insert(placementsToStore, team)
+			ratingTableToStore[team] = data
+		end
+	end
+
+	mw.ext.LiquipediaDB.lpdb_datapoint(
+		'LPR_SNAPSHOT_' .. date .. '_' .. name,
+		{
+			date = date,
+			type = 'LPR_SNAPSHOT',
+			name = name,
+			extradata = Json.stringify({
+				ranks = placementsToStore,
+				table = ratingTableToStore
+			})
+		}
+	)
+end
+
+local function storeTransfer(from, to, date, mod)
+	date = os.date('!%x', date)
+	mw.ext.LiquipediaDB.lpdb_datapoint(
+		'LPR_TRANSFER_' .. date .. '_' .. from .. '_' .. to,
+		{
+			date = date,
+			type = 'LPR_TRANSFER',
+			extradata = Json.stringify({
+				from = from,
+				to = to,
+				mod = mod,
+			})
+		}
+	)
+end
+
+local function getLatestSnapshotDate(name)
+	local res = mw.ext.LiquipediaDB.lpdb(
+		'datapoint',
+		{
+			query = 'date',
+			limit = 1,
+			order = 'date DESC',
+			conditions = STATIC_CONDITIONS_LPR_RATING .. ' AND [[name::' .. name .. ']] AND [[pagename::!' .. mw.title.getCurrentTitle().text .. ']]'
+		}
+	)
+	return (res[1] or {}).date
+end
+
+local function getRatingTable(date, name)
+	local res = mw.ext.LiquipediaDB.lpdb(
+		'datapoint',
+		{
+			query = 'extradata',
+			limit = 1,
+			conditions = STATIC_CONDITIONS_LPR_RATING ..
+			' AND [[name::' .. name .. ']] AND [[date::' .. os.date('!%x', os.time(date)) .. ']]'
+		}
+	)
+	return Json.parseIfString(((res[1] or {}).extradata or {}).table) or {}
+end
+
+local processedMatches = 0
+local allMatches = 0
+local matchids = {}
+
+local function processMatch(ratingTable, match)
+	allMatches = allMatches + 1
+
+	if matchids[match.match2id] then
+		return
+	end
+	matchids[match.match2id] = true
+
+	-- get opponents
+	local op1 = (match.match2opponents or {})[1]
+	local op2 = (match.match2opponents or {})[2]
+	local extradata = match.extradata or {}
+
+	-- check match for validity
+	if not tonumber(match.liquipediatier) or not op1 or not op2 or op1.status ~= 'S' or op1.status ~= 'S' or
+			String.isEmpty(op1.name) or String.isEmpty(op2.name) or (op1.score == 0 and op2.score == 0)
+			or extradata.liquipediatiertype2 == 'School' then
+		return
+	end
+
+	-- get rating participants
+	local rp1 = ratingTable[op1.name] or {rating = RATING_INIT_VALUE, matches = 0, streak = 0, lastmatches = {}}
+	local rp2 = ratingTable[op2.name] or {rating = RATING_INIT_VALUE, matches = 0, streak = 0, lastmatches = {}}
+
+	-- calculate the new ratings
+	local newRating1 = calcRating(rp1, rp2, op1.score, op2.score, match)
+	local newRating2 = calcRating(rp2, rp1, op2.score, op1.score, match)
+
+	-- apply new ratings
+	rp1.rating = newRating1
+	rp2.rating = newRating2
+
+	-- update rating table
+	ratingTable[op1.name] = rp1
+	ratingTable[op2.name] = rp2
+
+	processedMatches = processedMatches + 1
+end
+
+local function processTransfer(ratingTable, transfer)
+	local data = (transfer.extradata or {})
+	local from = data.from
+	local to = data.to
+	local modifier = data.mod or 1
+
+	if String.isEmpty(from) then
+		-- New Team
+		mw.log('New', from, to)
+	elseif String.isEmpty(to) then
+		-- removal
+		ratingTable[from] = nil
+		mw.log('Del', from, to)
+	else
+		-- transfer
+		ratingTable[to], ratingTable[from] = ratingTable[from], nil
+		ratingTable[to] = ratingTable[to]
+		if ratingTable[to] then
+			ratingTable[to].rating = (ratingTable[to].rating - RATING_INIT_VALUE) * modifier + RATING_INIT_VALUE
+		end
+		mw.log('Move', from, to)
+	end
+end
+
+local function cleanRatingTable(ratingTable, today)
+	local cutOff = os.time(stepDate(today, -DAYS_IDLE_BEFORE_CLEANUP))
+	return Table.filterByKey(ratingTable, function(_, team)
+		return os.difftime(team.lastmatches[#team.lastmatches].timestamp, cutOff) >= 0
+	end)
+end
+
+local function newDay(ratingTable, transfersForDay)
+	if not transfersForDay then
+		return
+	end
+	local transferHandler = FnUtil.curry(processTransfer, ratingTable)
+	Array.forEach(transfersForDay, transferHandler)
+end
+
+local function newMonth(ratingTable, date, id, dateFormat)
+	ratingTable = cleanRatingTable(ratingTable, dateFormat)
+	storeRatingTable(ratingTable, date, id)
+end
+
+local function initStepDate(ratingTable, transfers, id)
+	local hasFirstMonth = false
+	---@param from osdate
+	---@param to osdate?
+	---@return osdate
+	return function(from, to)
+		if not to then
+			to = stepDate(from)
+		end
+		local current = from
+		local prev = stepDate(from, -1)
+		while os.time(current) < os.time(to) do
+			local date = os.date('!%F', os.time(current)) --[[@as osdate]]
+
+			if os.date('%m', os.time(prev)) ~= os.date('%m', os.time(current)) then
+				if hasFirstMonth then
+					newMonth(ratingTable, date, id, current)
+				else
+					hasFirstMonth = true
+				end
+			end
+
+			newDay(ratingTable, transfers[date])
+
+			prev = current
+			current = stepDate(current)
+		end
+		return to
+	end
+end
+
+--- calculates the rating and stores it to the LPDB
+function Ratings.calc(frame)
+	-- [[pagename::" .. mw.title.getCurrentTitle().text .. "]]"
+
+	local args = Arguments.getArgs(frame)
+	local id = args.id
+	if String.isEmpty(id) then
+		return '<code>id</code> is empty, needs to be set'
+	end
+
+	-- date params
+	local dateFrom = parseDate(args.dateFrom or getLatestSnapshotDate(id))
+	local dateTo = parseDate(args.dateTo or os.date('!%F')--[[@as string]])
+
+	-- Fetch data
+	local ratingTable = Table.map(getRatingTable(dateFrom, id), function(key, value)
+		-- Ensure key is string, can be lost in the parsing
+		return tostring(key), value
+	end)
+	local transfers = getAllTransfers()
+
+	-- perform calculation
+	local lastDate = stepDate(dateFrom, -1)
+
+	local newDateFunc = initStepDate(ratingTable, transfers, id)
+
+	Lpdb.executeMassQuery('match2', {
+		query = 'date,match2opponents,liquipediatier,liquipediatiertype,match2id,extradata',
+		order = 'date ASC',
+		limit = 500,
+		conditions = getDateRangeConditions(dateFrom, dateTo) .. ' AND ' .. STATIC_CONDITIONS_MATCH
+	}, function (match)
+		-- Check and handle new dates
+		lastDate = newDateFunc(lastDate, parseDate(match.date))
+
+		-- process match
+		processMatch(ratingTable, match)
+	end)
+
+	-- Tick through any remaining days
+	while os.time(lastDate) <= os.time(dateTo) do
+		lastDate = newDateFunc(lastDate)
+	end
+
+	if dateTo.day ~= 1 then
+		newMonth(ratingTable, os.date('!%F', os.time(dateTo)) --[[@as osdate]], id, dateTo)
+	end
+
+	-- text output
+	local out = ''
+	out = out .. 'All matches: ' .. allMatches .. '<br>'
+	out = out .. 'Valid matches: ' .. processedMatches .. '<br>'
+	--[[for team, data in Table.iter.spairs(ratingTable, function(tbl, a, b) return tbl[a].rating > tbl[b].rating end) do
+		out = out .. team .. " " .. Json.stringify(data) .. "<br>"
+	end ]]
+	--
+	return out
+end
+
+function Ratings.transfer(frame)
+	local args = Arguments.getArgs(frame)
+	local date = os.time(parseDate(args.date))
+	local from = mw.ext.TeamTemplate.teampage(args.from, args.date)
+	local to = String.isNotEmpty(args.to) and mw.ext.TeamTemplate.teampage(args.to, args.date) or ''
+	if String.startsWith(from, '<div class=') then
+		return from
+	elseif String.startsWith(to, '<div class=') then
+		return to
+	else
+		storeTransfer(from, to, date, tonumber(args.mod))
+	end
+	return '<code>' .. args.date .. ': ' .. from .. ' --> ' .. to .. '</code><br>'
+end
+
+function Ratings.store(frame)
+	local args = Arguments.getArgs(frame)
+	local date = os.time(parseDate(args.date))
+	local id = args.id
+	local rawTable = Json.parse(args.table)
+	local ratingTable = {}
+	for key, data in pairs(rawTable) do
+		local team = mw.ext.TeamTemplate.teampage(key, args.date)
+		if not String.startsWith(team, '<div class=') and tonumber(data.rating) then
+			ratingTable[team] = {
+				rating = tonumber(data.rating),
+				streak = tonumber(data.streak),
+				matches = tonumber(data.matches),
+				lastmatches = data.lastmatches
+			}
+		end
+	end
+	storeRatingTable(ratingTable, date, id)
+	return Json.stringify(rawTable)
+end
+
+return Ratings

--- a/components/ratings/ratings.lua
+++ b/components/ratings/ratings.lua
@@ -285,13 +285,10 @@ function Ratings._processTransfer(ratingTable, transfer)
 	local to = data.to
 	local modifier = tonumber(data.mod) or 1
 
-	if String.isEmpty(from) then
-		-- New
-		-- Nothing needed to be done
-	elseif String.isEmpty(to) then
+	if String.isEmpty(to) then
 		-- Removal
 		ratingTable[from] = nil
-	else
+	elseif String.isNotEmpty(from) then
 		-- Transfer
 		ratingTable[to], ratingTable[from] = ratingTable[from], nil
 		ratingTable[to] = ratingTable[to]

--- a/components/ratings/ratings.lua
+++ b/components/ratings/ratings.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Ratings = {}
-
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Date = require('Module:DateExt')
@@ -16,6 +14,9 @@ local Json = require('Module:Json')
 local Lpdb = require('Module:Lpdb')
 local Table = require('Module:Table')
 local String = require('Module:StringUtils')
+
+--- Liquipedia Ratings (LPR)
+local Ratings = {}
 
 -- Parameters related to LPDB
 local STATIC_CONDITIONS_MATCH = '[[mode::3v3]] AND [[finished::1]] AND [[liquipediatiertype::!School]]'

--- a/components/ratings/ratings_display.lua
+++ b/components/ratings/ratings_display.lua
@@ -6,14 +6,15 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local RatingsDisplay = {}
-
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Date = require('Module:DateExt')
 local Operator = require('Module:Operator')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
+
+--- Liquipedia Ratings (LPR) Display
+local RatingsDisplay = {}
 
 -- static conditions for LPDB
 local STATIC_CONDITIONS_LPR_SNAPSHOT = '[[namespace::4]] AND [[type::LPR_SNAPSHOT]]'
@@ -182,7 +183,7 @@ function RatingsDisplay.display(frame)
 	end)
 
 	local topTeams = Array.sub(teamRankings, 1, 10)
-	mw.logObject()
+
 	local topTeamChart = mw.ext.Charts.chart({
 		xAxis = {
 			type = 'category',

--- a/components/ratings/ratings_display.lua
+++ b/components/ratings/ratings_display.lua
@@ -1,0 +1,223 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Ratings/Display
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local RatingsDisplay = {}
+
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Operator = require('Module:Operator')
+local String = require('Module:StringUtils')
+local Template = require('Module:Template')
+
+-- static conditions for LPDB
+local STATIC_CONDITIONS_LPR_SNAPSHOT = '[[namespace::4]] AND [[type::LPR_SNAPSHOT]]'
+
+-- Settings
+local LIMIT_RANKS = 100
+local LIMIT_LPR_SNAPSHOT = 24
+
+local function getSnapshot(name, offset)
+	return mw.ext.LiquipediaDB.lpdb(
+		'datapoint',
+		{
+			query = 'extradata, date',
+			limit = 1,
+			offset = offset,
+			order = 'date DESC',
+			conditions = STATIC_CONDITIONS_LPR_SNAPSHOT .. ' AND [[name::' .. name .. ']]'
+		}
+	)[1]
+end
+
+---@param str string
+---@return osdate
+---@overload fun():nil
+local function parseDate(str)
+	if not str then
+		return
+	end
+	local y, m, d = str:match('^(%d%d%d%d)-?(%d?%d?)-?(%d?%d?)')
+	-- default to month and day = 1 if not set
+	if String.isEmpty(m) then
+		m = 1
+	end
+	if String.isEmpty(d) then
+		d = 1
+	end
+	-- create time
+	return {year = y, month = m, day = d}
+end
+
+local function getRegionOfTeam(name)
+	local res = mw.ext.LiquipediaDB.lpdb(
+		'team',
+		{
+			query = 'region',
+			limit = 1,
+			conditions = '[[pagename::' .. string.gsub(name, ' ', '_') .. ']]'
+		}
+	)
+	if not res[1] then
+		mw.log('Cannot find teampage for ' .. name)
+	end
+	return (res[1] or {}).region or '???'
+end
+
+local function createProgressionEntry(timestamp, rating)
+	return {
+		date = os.date('%Y-%m-%d', timestamp),
+		rating = math.floor(rating + 0.5),
+	}
+end
+
+function RatingsDisplay.display(frame)
+	local args = Arguments.getArgs(frame)
+
+	local latestSnapshot = getSnapshot(args.id)
+	if not latestSnapshot then
+		error('Could not find a Rating with this ID')
+	end
+	local latestSnapshotTime = os.time(parseDate(latestSnapshot.date))
+
+	-- apply limit to first rating table
+	local teamRanking = {}
+	for rank, teamName in ipairs(latestSnapshot.extradata.ranks) do
+		local team = latestSnapshot.extradata.table[teamName] or {}
+		team.name = teamName
+		table.insert(teamRanking, team)
+		if rank > LIMIT_RANKS then
+			break
+		end
+	end
+
+	latestSnapshot = nil
+
+	Array.forEach(teamRanking, function(team)
+		-- Future functionality: Latest Matches details per team
+		--[[
+		local match2ids = {}
+		local rcByMatch2id = {}
+		for _, item in ipairs(data.lastmatches) do
+			local match2id = item.id
+			table.insert(match2ids, match2id)
+			rcByMatch2id[match2id] = item.ratingChange
+		end
+		local lm = {}
+		for _, match in ipairs(getMatches(match2ids)) do
+			local ratingChange = rcByMatch2id[match.match2id]
+			local winner = tonumber(match.winner) or 1
+			local opponent = ratingChange and match.match2opponents[ratingChange > 0 and ((winner % 2) + 1) or winner] or {}
+			local historyMatch = {
+				id = match.match2id,
+				rc = ratingChange,
+				op = (opponent or {}).name or 'Error',
+				pn = match.pagename,
+				dt = match.date
+			}
+			table.insert(lm, historyMatch)
+		end
+		data.lastmatches = lm
+		--]]
+		team.progression = {
+			createProgressionEntry(latestSnapshotTime, team.rating)
+		}
+	end)
+
+	-- Build rating progression with older snapshots
+	for i = 1, LIMIT_LPR_SNAPSHOT do
+		local snapshot = getSnapshot(args.id, i)
+		if not snapshot then
+			break
+		end
+		local snapshotTime = os.time(parseDate(snapshot.date))
+
+		Array.forEach(teamRanking, function(team)
+			local rating = (snapshot.extradata.table[team.name] or {}).rating
+			if not rating then
+				return
+			end
+
+			table.insert(team.progression, createProgressionEntry(snapshotTime, rating))
+		end)
+	end
+
+	--- Update team information
+	Array.forEach(teamRanking, function(team)
+		--- Fetch the region
+		team.region = getRegionOfTeam(team.name)
+		--- Reverse the order of progression
+		team.progression = Array.reverse(team.progression)
+	end)
+
+	local htmlTable = mw.html.create('table'):addClass('wikitable'):css('text-align', 'center')
+		:tag('tr'):css('font-weight', 'bold')
+			:tag('td'):wikitext('#'):done()
+			:tag('td'):wikitext('Team'):done()
+			:tag('td'):wikitext('Rating'):done()
+			:tag('td'):wikitext('Region'):done()
+			:tag('td'):wikitext('Played'):done()
+			:tag('td'):wikitext('Streak'):done()
+			:tag('td'):wikitext('History'):done()
+		:allDone()
+
+	Array.forEach(teamRanking, function(team, rank)
+		local chart = mw.ext.Charts.chart({
+			xAxis = {
+				type = 'category',
+				data = Array.map(team.progression, Operator.property('date'))
+			},
+			yAxis = {
+				type = 'value',
+				min = 1250,
+				axisTick = {
+					interval = 50
+				}
+			},
+			tooltip = {
+				trigger = 'axis'
+			},
+			grid = {
+				show = true
+			},
+			size = {
+				height = 300,
+				width = 500
+			},
+			series = {
+				{
+					data = Array.map(team.progression, Operator.property('rating')),
+					type = 'line'
+				}
+			}
+		})
+
+		local popup = Template.expandTemplate(mw.getCurrentFrame(), 'Popup', {
+			label = 'Hist',
+			title = 'Details for ' .. mw.ext.TeamTemplate.team(team.name),
+			content = chart,
+		})
+
+		local streakText = team.streak > 1 and team.streak .. 'W' or (team.streak < -1 and (-team.streak) .. 'L') or '-'
+		local streakClass = (team.streak > 1 and 'group-table-rank-change-up')
+				or (team.streak < -1 and 'group-table-rank-change-down')
+				or nil
+
+		htmlTable:tag('tr')
+			:tag('td'):css('font-weight', 'bold'):wikitext(rank):done()
+			:tag('td'):css('text-align', 'left'):wikitext(mw.ext.TeamTemplate.team(team.name)):done()
+			:tag('td'):wikitext(math.floor(team.rating + 0.5)):done()
+			:tag('td'):wikitext(string.upper(team.region or '')):done()
+			:tag('td'):wikitext(team.matches):done()
+			:tag('td'):css('font-weight', 'bold'):addClass(streakClass):wikitext(streakText):done()
+			:tag('td'):wikitext(popup):done()
+	end)
+
+	return tostring(mw.html.create('div'):addClass('table-responsive'):node(htmlTable))
+end
+
+return RatingsDisplay

--- a/components/ratings/ratings_display.lua
+++ b/components/ratings/ratings_display.lua
@@ -81,7 +81,7 @@ local function getTeamRankings(id)
 		error('Could not find a Rating with this ID')
 	end
 	local teamRanking = {}
-	teamRanking.latestSnapshotTime = os.time(parseDate(snapshot.date))
+	teamRanking.date = os.time(parseDate(snapshot.date))
 
 	for rank, teamName in ipairs(snapshot.extradata.ranks) do
 		local team = snapshot.extradata.table[teamName] or {}
@@ -127,7 +127,7 @@ function RatingsDisplay.display(frame)
 		data.lastmatches = lm
 		--]]
 		team.progression = {
-			createProgressionEntry(teamRankings.latestSnapshotTime, team.rating)
+			createProgressionEntry(teamRankings.date, team.rating)
 		}
 	end)
 

--- a/components/ratings/ratings_display.lua
+++ b/components/ratings/ratings_display.lua
@@ -111,7 +111,8 @@ function RatingsDisplay.display(frame)
 		local teamInfo = RatingsDisplay._getTeamInfo(team.name)
 
 		team.region = teamInfo.region or '???'
-		team.shortName = mw.ext.TeamTemplate.teamexists(teamInfo.template or '') and mw.ext.TeamTemplate.raw(teamInfo.template).shortname or team.name
+		team.shortName = mw.ext.TeamTemplate.teamexists(teamInfo.template or '')
+				and mw.ext.TeamTemplate.raw(teamInfo.template).shortname or team.name
 		--- Reverse the order of progression
 		team.progression = Array.reverse(team.progression)
 	end)

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -102,7 +102,7 @@ function DateExt.parseIsoDate(str)
 	if not str then
 		return
 	end
-	local year, month, day = str:match('^(%d%d%d%d)-?(%d?%d?)-?(%d?%d?)')
+	local year, month, day = str:match('^(%d%d%d%d)%-?(%d?%d?)%-?(%d?%d?)')
 	-- Default month and day to 1 if not set
 	if String.isEmpty(month) then
 		month = 1
@@ -110,7 +110,7 @@ function DateExt.parseIsoDate(str)
 	if String.isEmpty(day) then
 		day = 1
 	end
-	-- create time
+	-- create simplified osdate
 	return {year = year, month = month, day = day}
 end
 

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -92,4 +92,26 @@ function DateExt.getContextualDateOrNow()
 		or os.date('%F') --[[@as string]]
 end
 
+--- Parses a YYYY-MM-DD string into a simplified osdate class
+--- String must start with the YYYY. Text is allowed after after the DD.
+--- YYYY is required, MM and DD are optional. They are assumed to be 1 if not supplied.
+---@param str string
+---@return osdate
+---@overload fun():nil
+function DateExt.parseIsoDate(str)
+	if not str then
+		return
+	end
+	local year, month, day = str:match('^(%d%d%d%d)-?(%d?%d?)-?(%d?%d?)')
+	-- Default month and day to 1 if not set
+	if String.isEmpty(month) then
+		month = 1
+	end
+	if String.isEmpty(day) then
+		day = 1
+	end
+	-- create time
+	return {year = year, month = month, day = day}
+end
+
 return DateExt

--- a/standard/test/date_ext_test.lua
+++ b/standard/test/date_ext_test.lua
@@ -39,6 +39,19 @@ function suite:testGetContextualDateOrNow()
 	Variables.varDefine('tournament_enddate', '2021-12-28')
 	self:assertEquals('2021-12-28', DateExt.getContextualDateOrNow())
 	self:assertEquals('2021-12-28', DateExt.getContextualDate())
+
+	Variables.varDefine('tournament_startdate')
+	Variables.varDefine('tournament_enddate')
+end
+
+function suite:parseIsoDate()
+	self:assertDeepEquals({year = 2023, month = 7, day = 24}, DateExt.parseIsoDate('2023-07-24'))
+	self:assertDeepEquals({year = 2023, month = 7, day = 24}, DateExt.parseIsoDate('2023-07-24asdkosdkmoasjoikmakmslkm'))
+	self:assertDeepEquals({year = 2023, month = 7, day = 1}, DateExt.parseIsoDate('2023-07'))
+	self:assertDeepEquals({year = 2023, month = 7, day = 1}, DateExt.parseIsoDate('2023-07sdfsdfdfs'))
+	self:assertDeepEquals({year = 2023, month = 1, day = 1}, DateExt.parseIsoDate('2023'))
+	self:assertDeepEquals({year = 2023, month = 1, day = 1}, DateExt.parseIsoDate('202334rdfg'))
+	self:assertEquals(nil, DateExt.parseIsoDate())
 end
 
 return suite


### PR DESCRIPTION
## Summary
Create Team ELO Rating component.

Currently hardcoded settings, only works on Rocket League (which is the only thing that in scope for now)

## How did you test this change?
Semi-live 
https://liquipedia.net/rocketleague/Liquipedia:RatingV2

Infobox
with /dev