### PR TITLE
Fix import of DateExt in Ratings

### DIFF
--- a/components/ratings/ratings.lua
+++ b/components/ratings/ratings.lua
@@ -8,7 +8,7 @@
 
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
-local Date = require('Module:DateExt')
+local Date = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Lpdb = require('Module:Lpdb')

--- a/components/ratings/ratings_display.lua
+++ b/components/ratings/ratings_display.lua
@@ -8,7 +8,7 @@
 
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
-local Date = require('Module:DateExt')
+local Date = require('Module:Date/Ext')
 local Operator = require('Module:Operator')
 local Table = require('Module:Table')
 local Template = require('Module:Template')


### PR DESCRIPTION
## Summary
Add missing `/` in the module name for Date/Ext

## How did you test this change?
Live