### PR TITLE
Enhance sc2 costdisplay in infobox unit and building

### DIFF
--- a/components/infobox/extensions/wikis/starcraft2/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/starcraft2/infobox_extension_cost_display.lua
@@ -52,6 +52,10 @@ local CONCAT_VALUE = '&nbsp;'
 ---@field gasForced boolean?
 ---@field buildTimeForced boolean?
 ---@field supplyForced boolean?
+---@field mineralsTotal string|number?
+---@field gasTotal string|number?
+---@field buildTimeTotal string|number?
+---@field supplyTotal string|number?
 
 ---@param args sc2CostDisplayArgsValues
 function CostDisplay.run(args)
@@ -67,7 +71,8 @@ function CostDisplay.run(args)
 		local icon = iconData[faction] or iconData.default
 		local value = tonumber(args[key]) or 0
 		if value ~= 0 or args[key .. 'Forced'] then
-			local display = icon .. CONCAT_VALUE .. value
+			local display = icon .. CONCAT_VALUE .. value ..
+				(args[key .. 'Total'] and (CONCAT_VALUE .. '(' .. args[key .. 'Total'] .. ')') or '')
 			table.insert(displays, display)
 		end
 	end

--- a/components/infobox/wikis/starcraft2/infobox_building_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_building_custom.lua
@@ -69,10 +69,13 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Cost', content = {CostDisplay.run{
 				faction = _race,
 				minerals = _args.min,
+				mineralsTotal = _args.totalmin,
 				mineralsForced = true,
 				gas = _args.gas,
+				gasTotal = _args.totalgas,
 				gasForced = true,
 				buildTime = _args.buildtime,
+				buildTimeTotal = _args.totalbuildtime,
 			}}},
 		}
 	elseif id == 'requirements' then
@@ -181,8 +184,11 @@ function CustomBuilding:setLpdbData(args)
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
 			builtby = args.builtby,
 			minerals = args.min,
+			mineralstotal = args.totalmin,
 			gas = args.gas,
+			gastotal = args.totalgas,
 			buildtime = args.buildtime,
+			buildtimetotal = args.totalbuildtime,
 			hp = args.hp,
 			shield = args.shield,
 			armor = args.armor or 1,

--- a/components/infobox/wikis/starcraft2/infobox_unit_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_unit_custom.lua
@@ -82,11 +82,15 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Cost', content = {CostDisplay.run{
 				faction = _args.race,
 				minerals = _args.min,
+				mineralsTotal = _args.totalmin,
 				mineralsForced = true,
 				gas = _args.gas,
+				gasTotal = _args.totalgas,
 				gasForced = true,
 				buildTime = _args.buildtime,
+				buildTimeTotal = _args.totalbuildtime,
 				supply = _args.supply or _args.control or _args.psy,
+				supplyTotal = _args.totalsupply or _args.totalcontrol or _args.totalpsy,
 			}}},
 		}
 	elseif id == 'requirements' then
@@ -183,8 +187,11 @@ function CustomUnit:setLpdbData(args)
 			builtfrom = args.builtfrom,
 			requires = args.requires,
 			minerals = args.min,
+			mineralstotal = args.totalmin,
 			gas = args.gas,
+			gastotal = args.totalgas,
 			buildtime = args.buildtime,
+			buildtimetotal = args.totalbuildtime,
 			attributes = args.attributes,
 			hp = args.hp,
 			shield = args.shield,
@@ -201,6 +208,8 @@ function CustomUnit:setLpdbData(args)
 			morphs = args.morphs,
 			strong_against = args.strong,
 			weak_against = args.weak,
+			supply = args.supply or args.control or args.psy,
+			supplytotal = args.totalsupply or args.totalcontrol or args.totalpsy,
 		}),
 	}
 	mw.ext.LiquipediaDB.lpdb_datapoint(args.name or '', lpdbData)


### PR DESCRIPTION
## Summary
Some units/buildings in sc2 have total costs (e.g. `Lurker` which is morphed from `Hydralisk`, so the total cost of a Lurker is the costs of the Hydralisk + the costs for the morph)
This PR adds the option for total cost input (incl. display and storage). It also adds storage for supply in infobox unit so that the LPDB data is better.^^

## How did you test this change?
dev into live (very low risk, could already let the one that requested it update the pages)