### PR TITLE
Fix RL solo opponent parsing in legacy brackets

### DIFF
--- a/components/match2/wikis/rocketleague/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/rocketleague/legacy/match_group_legacy_default.lua
@@ -103,7 +103,8 @@ function MatchGroupLegacyDefault._getMatchMapping(match, bracketData, bracketTyp
 				score = 'R' .. round.R .. 'D' .. round.D .. 'score',
 				['$notEmpty$'] = 'R' .. round.R .. 'D' .. round.D,
 				name = 'R' .. round.R .. 'D' .. round.D,
-				displayname = 'R' .. round.R .. 'D' .. round.D .. 'display',
+				link = 'R' .. round.R .. 'D' .. round.D,
+				p1 = 'R' .. round.R .. 'D' .. round.D .. 'display',
 				flag = 'R' .. round.R .. 'D' .. round.D .. 'flag'
 			}
 		end
@@ -125,7 +126,8 @@ function MatchGroupLegacyDefault._getMatchMapping(match, bracketData, bracketTyp
 				score = 'R' .. round.R .. 'W' .. round.W .. 'score' .. (reset and '2' or ''),
 				['$notEmpty$'] = 'R' .. round.R .. 'W' .. round.W,
 				name = 'R' .. round.R .. 'W' .. round.W,
-				displayname = 'R' .. round.R .. 'W' .. round.W .. 'display',
+				link = 'R' .. round.R .. 'W' .. round.W,
+				p1 = 'R' .. round.R .. 'W' .. round.W .. 'display',
 				flag = 'R' .. round.R .. 'W' .. round.W .. 'flag'
 			}
 		end
@@ -150,7 +152,8 @@ function MatchGroupLegacyDefault._getMatchMapping(match, bracketData, bracketTyp
 				score = 'R' .. round.R .. 'D' .. round.D .. 'score',
 				['$notEmpty$'] = 'R' .. round.R .. 'D' .. round.D,
 				name = 'R' .. round.R .. 'D' .. round.D,
-				displayname = 'R' .. round.R .. 'D' .. round.D .. 'display',
+				link = 'R' .. round.R .. 'D' .. round.D,
+				p1 = 'R' .. round.R .. 'D' .. round.D .. 'display',
 				flag = 'R' .. round.R .. 'D' .. round.D .. 'flag'
 			}
 		end
@@ -172,7 +175,8 @@ function MatchGroupLegacyDefault._getMatchMapping(match, bracketData, bracketTyp
 				score = 'R' .. round.R .. 'W' .. round.W .. 'score' .. (reset and '2' or ''),
 				['$notEmpty$'] = 'R' .. round.R .. 'W' .. round.W,
 				name = 'R' .. round.R .. 'W' .. round.W,
-				displayname = 'R' .. round.R .. 'W' .. round.W .. 'display',
+				link = 'R' .. round.R .. 'W' .. round.W,
+				p1 = 'R' .. round.R .. 'W' .. round.W .. 'display',
 				flag = 'R' .. round.R .. 'W' .. round.W .. 'flag'
 			}
 		end


### PR DESCRIPTION
## Summary
RL had RxDydisplay input to specify a custom displayname.
The currently used legacy conversion doesn't work, this PR fixes that.
Note: link being a duplicate of name and p1 being the (optional) displayname makes sense due to:
In opponent module reading opp args for solo opponents gets the link from the link value while the display name is determined via `args[1] or args.p1 or args.name`, so
- if p1 (optional display input) is set it is used as displayName
- if p1 is not set it falls back to name, the page name

## How did you test this change?
dev