### PR TITLE
ResultsTable: Do not wrap game icons in span

### DIFF
--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -77,7 +77,7 @@ function ResultsTable:buildRow(placement)
 	end
 
 	if self.config.displayGameIcons then
-		row:tag('td'):node(Game.icon{game = placement.game})
+		row:tag('td'):node(Game.icon{game = placement.game, noSpan = true})
 	end
 
 	local tournamentDisplayName = BaseResultsTable.tournamentDisplayName(placement)


### PR DESCRIPTION
## Summary
#2807 introduced a span with default class `icon-16px` for usages of `Game.icon`.
This leads to weird display in case of the results table, where game icons are in a separate column.

## How did you test this change?
via /dev on the wikis using this feature.
No dev:
![Screenshot from 2023-07-25 16-37-34](https://github.com/Liquipedia/Lua-Modules/assets/16326643/7797aebb-0f8e-4030-93e0-4b54d6704625)
![Screenshot from 2023-07-25 16-38-40](https://github.com/Liquipedia/Lua-Modules/assets/16326643/782a2ebd-3fe7-4400-9a04-16427a40e071)


Dev:
![Screenshot from 2023-07-25 16-37-53](https://github.com/Liquipedia/Lua-Modules/assets/16326643/55d6d470-236c-467c-b657-9eb1e1b4bc02)
![Screenshot from 2023-07-25 16-38-55](https://github.com/Liquipedia/Lua-Modules/assets/16326643/2c2f5239-7013-453c-b56d-303522999070)