### PR TITLE
Fix double span in darkmode game icons

### DIFF
--- a/standard/game.lua
+++ b/standard/game.lua
@@ -147,20 +147,26 @@ function Game.icon(options)
 		(String.isNotEmpty(options.spanClass) and options.spanClass) or
 			DEFAULT_SPAN_CLASS
 
+	local gameIcons
+
 	if gameData.logo.lightMode == gameData.logo.darkMode then
-		return Game._createIcon{icon = gameData.logo.lightMode, size = options.size, link = link, spanClass = spanClass}
+		gameIcons = Game._createIcon{icon = gameData.logo.lightMode, size = options.size, link = link, spanClass = spanClass}
+	else
+		gameIcons = Game._createIcon{size = options.size, link = link, mode = 'light', icon = gameData.logo.lightMode} ..
+			Game._createIcon{size = options.size, link = link, mode = 'dark', icon = gameData.logo.darkMode}
 	end
 
-	return Game._createIcon{size = options.size, link = link, mode = 'light',
-		icon = gameData.logo.lightMode, spanClass = spanClass}
-	.. Game._createIcon{size = options.size, link = link, mode = 'dark',
-		icon = gameData.logo.darkMode, spanClass = spanClass}
+	if String.isNotEmpty(spanClass) then
+		return tostring(mw.html.create('span'):addClass(spanClass):node(gameIcons))
+	else
+		return gameIcons
+	end
 end
 
----@param options {mode: string?, icon: string?, size: string?, link: string?, spanClass: string?}
+---@param options {mode: string?, icon: string?, size: string?, link: string?}
 ---@return string
 function Game._createIcon(options)
-	local iconString = String.interpolate(
+	return String.interpolate(
 		ICON_STRING,
 		{
 			icon = options.icon,
@@ -169,11 +175,6 @@ function Game._createIcon(options)
 			link = options.link or '',
 		}
 	)
-	if String.isNotEmpty(options.spanClass) then
-		return tostring(mw.html.create('span'):addClass(options.spanClass):node(iconString))
-	else
-		return iconString
-	end
 end
 
 ---Fetches a text display for a given game


### PR DESCRIPTION
## Summary

Due to an oversight in design (by me), game icons with darkmode versions cause two spans to appear, but since the hiding is done via class on the image rather than span, it leaves a span there and shifts the icons over.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/231d3a26-d5d7-4666-bab0-440445550e4e)

This PR makes it so it's just one span with multiple images inside which fixes the issues.

## How did you test this change?

Tested on `/dev`.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/96e6b9c9-761e-4889-9e3c-d94eadf48961)

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/0d7de629-71ee-40fa-b648-872b0b86bb05)
