### PR TITLE
Store mvp data on aov in a sane way

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -328,8 +328,7 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		mvp = match.mvp,
-		mvpteam = match.mvpteam or match.winner
+		mvp = MatchGroupInput.readMvp(match),
 	}
 	return match
 end

--- a/components/match2/wikis/arenaofvalor/match_legacy.lua
+++ b/components/match2/wikis/arenaofvalor/match_legacy.lua
@@ -56,8 +56,15 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata = {}
 	local extradata = Json.parseIfString(match2.extradata)
 	match.extradata.matchsection = extradata.matchsection
-	match.extradata.mvpteam = extradata.mvpteam
-	match.extradata.mvp = extradata.mvp
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
 	match.extradata.comment = extradata.comment
 
 	local opponents = match2.match2opponents or {}


### PR DESCRIPTION
## Summary
Store mvp data on aov in a sane way

## How did you test this change?
N/A, copied 1-1 from lol

## Remark
match1 storage (old stuff) adjusted and purge for those initiated
needs purge run for match2 matches after this pr is merged too
