### PR TITLE
Standardize mvp data

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -140,16 +140,14 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	local mvpInput = match.extradata.mvp
-	if mvpInput then
-		local mvpData = mw.text.split(mvpInput or '', ',')
-		if String.isNotEmpty(mvpData[1]) then
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData) do
-				if String.isNotEmpty(player) then
-					mvp:addPlayer(player)
-				end
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
 			end
+			mvp:setPoints(mvpData.points)
 
 			body:addRow(mvp)
 		end

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -146,7 +146,7 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		mvp = match.mvp,
+		mvp = MatchGroupInput.readMvp(match),
 	}
 	return match
 end

--- a/components/match2/wikis/brawlstars/match_legacy.lua
+++ b/components/match2/wikis/brawlstars/match_legacy.lua
@@ -142,9 +142,15 @@ function MatchLegacy._convertParameters(match2)
 
 	-- Handle extradata fields
 	local extradata = Json.parseIfString(match2.extradata)
-	match.extradata = {
-		mvp = extradata.mvp,
-	}
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
 
 	for index, map in pairs(match2.match2games or {}) do
 		match.extradata['vodgame' .. index] = map.vod

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -210,19 +210,18 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	local mvpInput = match.extradata.mvp
-	if mvpInput then
-		local mvpData = mw.text.split(mvpInput or '', ',')
-		if String.isNotEmpty(mvpData[1]) then
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData) do
-				if String.isNotEmpty(player) then
-					mvp:addPlayer(player)
-				end
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
 			end
+			mvp:setPoints(mvpData.points)
 
 			body:addRow(mvp)
 		end
+
 	end
 
 	-- Pre-Process Brawler picks

--- a/components/match2/wikis/callofduty/match_summary.lua
+++ b/components/match2/wikis/callofduty/match_summary.lua
@@ -105,7 +105,7 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	if (match.extradata or {}).mvp then
+	if match.extradata.mvp then
 		local mvpData = match.extradata.mvp
 		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -386,7 +386,7 @@ function matchFunctions.getExtraData(match)
 			match.featured,
 			matchFunctions.isFeatured(match)
 		),
-		mvp = match.mvp,
+		mvp = MatchGroupInput.readMvp(match),
 		headtohead = match.headtohead,
 	}
 	return match

--- a/components/match2/wikis/dota2/match_legacy.lua
+++ b/components/match2/wikis/dota2/match_legacy.lua
@@ -58,7 +58,15 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.gamecount = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.mvpteam = extradata.mvpteam
-	match.extradata.mvp = extradata.mvp
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
 	match.extradata.featured = tostring(extradata.featured)
 
 	local bracketData = Json.parseIfString(match2.match2bracketdata)

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -185,16 +185,14 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	local mvpInput = match.extradata.mvp
-	if mvpInput then
-		local mvpData = mw.text.split(mvpInput or '', ',')
-		if String.isNotEmpty(mvpData[1]) then
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData) do
-				if String.isNotEmpty(player) then
-					mvp:addPlayer(player)
-				end
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
 			end
+			mvp:setPoints(mvpData.points)
 
 			body:addRow(mvp)
 		end

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -317,7 +317,7 @@ function matchFunctions.getExtraData(match)
 	table.sort(casters, function(c1, c2) return c1.displayName:lower() < c2.displayName:lower() end)
 
 	match.extradata = {
-		mvp = matchFunctions.getMVP(match),
+		mvp = MatchGroupInput.readMvp(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil,
 	}
 	return match
@@ -360,22 +360,6 @@ function CustomMatchGroupInput._getCasterInformation(name, flag, displayName)
 		displayName = displayName,
 		flag = flag,
 	}
-end
-
--- Parse MVP input
-function matchFunctions.getMVP(match)
-	if not match.mvp then return {} end
-	local mvppoints = match.mvppoints or 1
-
-	-- Split the input
-	local players = mw.text.split(match.mvp, ',')
-
-	-- Trim the input
-	for index, player in pairs(players) do
-		players[index] = mw.text.trim(player)
-	end
-
-	return {players=players, points=mvppoints}
 end
 
 function matchFunctions.getOpponents(match)

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -187,7 +187,7 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	if (match.extradata or {}).mvp then
+	if match.extradata.mvp then
 		local mvpData = match.extradata.mvp
 		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()

--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -337,7 +337,7 @@ function matchFunctions.getExtraData(match)
 		))
 	end
 	match.extradata = {
-		mvp = match.mvp,
+		mvp = MatchGroupInput.readMvp(match),
 		mvpteam = match.mvpteam or match.winner,
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil
 	}

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -58,7 +58,15 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.gamecount = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.mvpteam = extradata.mvpteam
-	match.extradata.mvp = extradata.mvp
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
 	match.extradata.comment = extradata.comment
 
 	local opponents = match2.match2opponents or {}

--- a/components/match2/wikis/mobilelegends/match_legacy.lua
+++ b/components/match2/wikis/mobilelegends/match_legacy.lua
@@ -58,15 +58,6 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.gamecount = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.mvpteam = extradata.mvpteam
-	local mvp = Json.parseIfString(extradata.mvp)
-	if mvp and mvp.players then
-		local players = {}
-		for _, player in ipairs(mvp.players) do
-			table.insert(players, player.name .. '|' .. player.displayname)
-		end
-		match.extradata.mvp = table.concat(players, ',')
-		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
-	end
 	match.extradata.comment = extradata.comment
 
 	local opponents = match2.match2opponents or {}

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -169,16 +169,14 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	local mvpInput = match.extradata.mvp
-	if mvpInput then
-		local mvpData = mw.text.split(mvpInput or '', ',')
-		if String.isNotEmpty(mvpData[1]) then
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData) do
-				if String.isNotEmpty(player) then
-					mvp:addPlayer(player)
-				end
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
 			end
+			mvp:setPoints(mvpData.points)
 
 			body:addRow(mvp)
 		end

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -313,25 +313,9 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		mvp = matchFunctions.getMVP(match),
+		mvp = MatchGroupInput.readMvp(match),
 	}
 	return match
-end
-
--- Parse MVP input
-function matchFunctions.getMVP(match)
-	if not match.mvp then return {} end
-	local mvppoints = match.mvppoints or 1
-
-	-- Split the input
-	local players = mw.text.split(match.mvp, ',')
-
-	-- Trim the input
-	for index, player in pairs(players) do
-		players[index] = mw.text.trim(player)
-	end
-
-	return {players=players, points=mvppoints}
 end
 
 function matchFunctions.getOpponents(match)

--- a/components/match2/wikis/overwatch/match_legacy.lua
+++ b/components/match2/wikis/overwatch/match_legacy.lua
@@ -8,7 +8,7 @@
 
 local MatchLegacy = {}
 
-local json = require('Module:Json')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -35,7 +35,7 @@ function MatchLegacy.storeMatch(match2, options)
 end
 
 function MatchLegacy.storeMatchSMW(match, match2)
-	local streams = json.parseIfString(match.stream or {})
+	local streams = Json.parseIfString(match.stream or {})
 	local icon = Variables.varDefault('tournament_icon')
 	mw.smw.subobject({
 		'legacymatch_' .. match2.match2id,
@@ -76,7 +76,7 @@ function MatchLegacy.storeGames(match, match2)
 		game.date = match.date
 		local scores = game2.scores or {}
 		if type(scores) == 'string' then
-			scores = json.parse(scores)
+			scores = Json.parse(scores)
 		end
 		game.opponent1score = scores[1] or 0
 		game.opponent2score = scores[2] or 0
@@ -107,7 +107,7 @@ function MatchLegacy._convertParameters(match2)
 
 	-- Handle extradata fields
 	match.extradata = {}
-	local extradata = json.parseIfString(match2.extradata)
+	local extradata = Json.parseIfString(match2.extradata)
 
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
@@ -121,7 +121,7 @@ function MatchLegacy._convertParameters(match2)
 
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.bestofx = match2.bestof ~= 0 and tostring(match2.bestof) or ''
-	local bracketData = json.parseIfString(match2.match2bracketdata)
+	local bracketData = Json.parseIfString(match2.match2bracketdata)
 	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
 		if bracketData.inheritedheader then
 			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]

--- a/components/match2/wikis/overwatch/match_legacy.lua
+++ b/components/match2/wikis/overwatch/match_legacy.lua
@@ -109,9 +109,13 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata = {}
 	local extradata = json.parseIfString(match2.extradata)
 
-	local mvp = json.parseIfString(extradata.mvp)
+	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
-		match.extradata.mvp = table.concat(mvp.players, ',')
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
 		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
 	end
 

--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -123,7 +123,7 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	if (match.extradata or {}).mvp then
+	if match.extradata.mvp then
 		local mvpData = match.extradata.mvp
 		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -328,7 +328,7 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		mvp = match.mvp,
+		mvp = MatchGroupInput.readMvp(match),
 		mvpteam = match.mvpteam or match.winner
 	}
 	return match

--- a/components/match2/wikis/pokemon/match_legacy.lua
+++ b/components/match2/wikis/pokemon/match_legacy.lua
@@ -58,7 +58,15 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata.gamecount = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.mvpteam = extradata.mvpteam
-	match.extradata.mvp = extradata.mvp
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
 	match.extradata.comment = extradata.comment
 
 	local opponents = match2.match2opponents or {}

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -141,16 +141,14 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	local mvpInput = match.extradata.mvp
-	if mvpInput then
-		local mvpData = mw.text.split(mvpInput or '', ',')
-		if String.isNotEmpty(mvpData[1]) then
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
 			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData) do
-				if String.isNotEmpty(player) then
-					mvp:addPlayer(player)
-				end
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
 			end
+			mvp:setPoints(mvpData.points)
 
 			body:addRow(mvp)
 		end

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -336,7 +336,7 @@ function matchFunctions.getExtraData(match)
 
 	match.extradata = {
 		mapveto = matchFunctions.getMapVeto(match),
-		mvp = matchFunctions.getMVP(match),
+		mvp = MatchGroupInput.readMvp(match),
 		casters = Table.isNotEmpty(casters) and Json.stringify(casters) or nil
 	}
 	return match
@@ -409,16 +409,6 @@ function matchFunctions.getMapVeto(match)
 		data[1].vetostart = vetoStart
 	end
 	return data
-end
-
--- Parse MVP input
-function matchFunctions.getMVP(match)
-	if not match.mvp then return nil end
-
-	-- Split & trim the input
-	local players = Array.map(mw.text.split(match.mvp, ','), String.trim)
-
-	return {players = players, points = match.mvppoints or 1}
 end
 
 function matchFunctions.getOpponents(match)

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -148,10 +148,14 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata = {}
 	local extradata = json.parseIfString(match2.extradata)
 
-	local mvp = json.parseIfString(extradata.mvp)
+	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
-		mvp.players = Table.mapValues(mvp.players, mw.ext.TeamLiquidIntegration.resolve_redirect)
-		match.extradata.mvp = table.concat(mvp.players, ',') .. ';' .. mvp.points
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
 	end
 
 	match.extradata.matchsection = extradata.matchsection

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -8,7 +8,7 @@
 
 local MatchLegacy = {}
 
-local json = require('Module:Json')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -35,8 +35,8 @@ function MatchLegacy.storeMatch(match2, options)
 end
 
 function MatchLegacy.storeMatchSMW(match, match2)
-	local streams = json.parseIfString(match.stream or {})
-	local links = json.parseIfString(match.links or {})
+	local streams = Json.parseIfString(match.stream or {})
+	local links = Json.parseIfString(match.links or {})
 	local icon = Variables.varDefault('tournament_icon')
 	mw.smw.subobject({
 		'legacymatch_' .. match2.match2id,
@@ -68,17 +68,17 @@ function MatchLegacy.storeGames(match, match2)
 	for gameIndex, game2 in ipairs(match2.match2games or {}) do
 		local game = Table.deepCopy(game2)
 		-- Extradata
-		local extradata = json.parseIfString(game2.extradata)
+		local extradata = Json.parseIfString(game2.extradata)
 		game.extradata = {}
 		game.extradata.gamenumber = gameIndex
 		if extradata.t1bans and extradata.t2bans then
-			game.extradata.opponent1bans = table.concat(json.parseIfString(extradata.t1bans), ', ')
-			game.extradata.opponent2bans = table.concat(json.parseIfString(extradata.t2bans), ', ')
+			game.extradata.opponent1bans = table.concat(Json.parseIfString(extradata.t1bans), ', ')
+			game.extradata.opponent2bans = table.concat(Json.parseIfString(extradata.t2bans), ', ')
 		end
 		if extradata.t1firstside and extradata.t1halfs and extradata.t2halfs then
-			extradata.t1firstside = json.parseIfString(extradata.t1firstside)
-			extradata.t1halfs = json.parseIfString(extradata.t1halfs)
-			extradata.t2halfs = json.parseIfString(extradata.t2halfs)
+			extradata.t1firstside = Json.parseIfString(extradata.t1firstside)
+			extradata.t1halfs = Json.parseIfString(extradata.t1halfs)
+			extradata.t2halfs = Json.parseIfString(extradata.t2halfs)
 			local team1 = {}
 			local team2 = {}
 			if extradata.t1firstside.rt == 'atk' then
@@ -115,7 +115,7 @@ function MatchLegacy.storeGames(match, match2)
 		game.date = match.date
 		local scores = game2.scores or {}
 		if type(scores) == 'string' then
-			scores = json.parse(scores)
+			scores = Json.parse(scores)
 		end
 		game.opponent1score = scores[1] or 0
 		game.opponent2score = scores[2] or 0
@@ -146,7 +146,7 @@ function MatchLegacy._convertParameters(match2)
 
 	-- Handle extradata fields
 	match.extradata = {}
-	local extradata = json.parseIfString(match2.extradata)
+	local extradata = Json.parseIfString(match2.extradata)
 
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
@@ -160,14 +160,14 @@ function MatchLegacy._convertParameters(match2)
 
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.bestofx = match2.bestof ~= 0 and tostring(match2.bestof) or ''
-	local bracketData = json.parseIfString(match2.match2bracketdata)
+	local bracketData = Json.parseIfString(match2.match2bracketdata)
 	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
 		if bracketData.inheritedheader then
 			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 	end
 
-	local veto = json.parseIfString(extradata.mapveto)
+	local veto = Json.parseIfString(extradata.mapveto)
 	if veto then
 		for k, round in ipairs(veto) do
 			if k == 1 then

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -148,16 +148,6 @@ function MatchLegacy._convertParameters(match2)
 	match.extradata = {}
 	local extradata = Json.parseIfString(match2.extradata)
 
-	local mvp = Json.parseIfString(extradata.mvp)
-	if mvp and mvp.players then
-		local players = {}
-		for _, player in ipairs(mvp.players) do
-			table.insert(players, player.name .. '|' .. player.displayname)
-		end
-		match.extradata.mvp = table.concat(players, ',')
-		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
-	end
-
 	match.extradata.matchsection = extradata.matchsection
 	match.extradata.bestofx = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	local bracketData = Json.parseIfString(match2.match2bracketdata)

--- a/components/match2/wikis/splatoon/match_legacy.lua
+++ b/components/match2/wikis/splatoon/match_legacy.lua
@@ -77,15 +77,6 @@ function MatchLegacy._convertParameters(match2)
 
 	-- Handle extradata fields
 	local extradata = Json.parseIfString(match2.extradata)
-	local mvp = Json.parseIfString(extradata.mvp)
-	if mvp and mvp.players then
-		local players = {}
-		for _, player in ipairs(mvp.players) do
-			table.insert(players, player.name .. '|' .. player.displayname)
-		end
-		match.extradata.mvp = table.concat(players, ',')
-		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
-	end
 
 	for index, map in pairs(match2.match2games or {}) do
 		match.extradata['vodgame' .. index] = map.vod

--- a/components/match2/wikis/splatoon/match_legacy.lua
+++ b/components/match2/wikis/splatoon/match_legacy.lua
@@ -77,9 +77,15 @@ function MatchLegacy._convertParameters(match2)
 
 	-- Handle extradata fields
 	local extradata = Json.parseIfString(match2.extradata)
-	match.extradata = {
-		mvp = extradata.mvp,
-	}
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
 
 	for index, map in pairs(match2.match2games or {}) do
 		match.extradata['vodgame' .. index] = map.vod

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -330,7 +330,7 @@ end
 function matchFunctions.getExtraData(match)
 	match.extradata = {
 		mapveto = matchFunctions.getMapVeto(match),
-		mvp = matchFunctions.getMVP(match),
+		mvp = MatchGroupInput.readMvp(match),
 		isconverted = 0
 	}
 	return match
@@ -356,22 +356,6 @@ function matchFunctions.getMapVeto(match)
 	end
 
 	return vetoData
-end
-
--- Parse MVP input
-function matchFunctions.getMVP(match)
-	if not match.mvp then return {} end
-	local mvppoints = match.mvppoints or 1
-
-	-- Split the input
-	local players = mw.text.split(match.mvp, ',')
-
-	-- Trim the input
-	for index,player in pairs(players) do
-		players[index] = mw.text.trim(player)
-	end
-
-	return {players=players, points=mvppoints}
 end
 
 function matchFunctions.getOpponents(match)

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -332,28 +332,9 @@ end
 function matchFunctions.getExtraData(match)
 	match.extradata = {
 		mapveto = matchFunctions.getMapVeto(match),
-		mvp = matchFunctions.getMVP(match),
+		mvp = MatchGroupInput.readMvp(match),
 	}
 	return match
-end
-
--- Parse MVP input
-function matchFunctions.getMVP(match)
-	if String.isEmpty(match.mvp) then
-		return nil
-	end
-
-	local mvpPoints = tonumber(match.mvppoints) or 1
-
-	-- Split the input
-	local players = mw.text.split(match.mvp, ',')
-
-	-- Trim the input
-	for index,player in pairs(players) do
-		players[index] = mw.text.trim(player)
-	end
-
-	return {players = players, points = mvpPoints}
 end
 
 -- Parse the mapVeto input

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -140,14 +140,18 @@ function CustomMatchSummary._createBody(match)
 	end
 
 	-- Add Match MVP(s)
-	local mvpData = match.extradata.mvp
-	if mvpData and mvpData.players and mvpData.players[1] then
-		local mvp = MatchSummary.Mvp()
-		for _, player in ipairs(mvpData.players) do
-			mvp:addPlayer(player)
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
+			local mvp = MatchSummary.Mvp()
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
+			end
+			mvp:setPoints(mvpData.points)
+
+			body:addRow(mvp)
 		end
 
-		body:addRow(mvp)
 	end
 
 	-- Pre-Process Champion Ban Data

--- a/components/mvp_table/commons/mvp_table.lua
+++ b/components/mvp_table/commons/mvp_table.lua
@@ -28,7 +28,7 @@ local MvpTable = {}
 ---Fetches mvpData for a given set of matchGroupIds or tournaments.
 ---Displays the fetched data as a table.
 ---@param args table
----@return Html|string
+---@return Html|string|nil
 function MvpTable.run(args)
 	args = args or {}
 	args = MvpTable._parseArgs(args)
@@ -117,7 +117,6 @@ function MvpTable._parseArgs(args)
 end
 
 ---@param args mvpTableParsedArgs
----@param conditions string
 ---@return string
 function MvpTable._buildConditions(args)
 	local matchGroupIDConditions


### PR DESCRIPTION
## Summary
Standardize mvp data
- use via commons provided function to read/parse mvp input
- adjust matchSummary and Legacy storage accordingly
- fix some anno warning in mvp table

With the commons mvpTable now supporting both the new format as well as match1 legacy data we can easily adjust all wikis on match2 that have mvp data to store it in the same format

## How did you test this change?
hard copy from lol