### PR TITLE
Adjust parsing of team players in matches on some wikis

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -410,7 +410,7 @@ function MatchGroupInput.readMvp(match)
 	local parsedPlayers = Array.map(players, function(player, playerIndex)
 		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(mw.text.split(player, '|')[1]):gsub(' ', '_')
 		for _, opponent in Table.iter.pairsByPrefix(match, 'opponent') do
-			for _, lookUpPlayer in pairs(opponent.match2players) do
+			for _, lookUpPlayer in pairs(opponent.match2players or {}) do
 				if link == lookUpPlayer.name then
 					return Table.merge(lookUpPlayer,
 						{team = opponent.name, template = opponent.template, comment = match['mvp' .. playerIndex .. 'comment']})

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -263,13 +263,14 @@ function matchFunctions.getOpponents(args)
 end
 
 function matchFunctions.getPlayers(match, opponentIndex, teamName)
+	match['opponent' .. opponentIndex].match2players = {}
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
 		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		if not Table.isEmpty(player) then
-			match['opponent' .. opponentIndex .. '_p' .. playerIndex] = player
+			table.insert(match['opponent' .. opponentIndex].match2players, player)
 		end
 	end
 	return match

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -440,8 +440,7 @@ end
 
 -- Get Playerdata from Vars (get's set in TeamCards) for team opponents
 function matchFunctions.getTeamPlayers(match, opponentIndex, teamName)
-	-- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
-	local count = 1
+	match['opponent' .. opponentIndex].match2players = {}
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
@@ -449,8 +448,7 @@ function matchFunctions.getTeamPlayers(match, opponentIndex, teamName)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
-			match['opponent' .. opponentIndex .. '_p' .. count] = player
-			count = count + 1
+			table.insert(match['opponent' .. opponentIndex].match2players, player)
 		end
 	end
 	return match

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -396,8 +396,7 @@ end
 
 -- Get Playerdata from Vars (get's set in TeamCards) for team opponents
 function matchFunctions.getTeamPlayers(match, opponentIndex, teamName)
-	-- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
-	local count = 1
+	match['opponent' .. opponentIndex].match2players = {}
 	for playerIndex = 1, _MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
@@ -405,8 +404,7 @@ function matchFunctions.getTeamPlayers(match, opponentIndex, teamName)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
-			match['opponent' .. opponentIndex .. '_p' .. count] = player
-			count = count + 1
+			table.insert(match['opponent' .. opponentIndex].match2players, player)
 		end
 	end
 	return match

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -463,8 +463,7 @@ end
 
 -- Get Playerdata from Vars (get's set in TeamCards)
 function matchFunctions.getPlayers(match, opponentIndex, teamName)
-	-- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
-	local count = 1
+	match['opponent' .. opponentIndex].match2players = {}
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
@@ -472,8 +471,7 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
-			match['opponent' .. opponentIndex .. '_p' .. count] = player
-			count = count + 1
+			table.insert(match['opponent' .. opponentIndex].match2players, player)
 		end
 	end
 	return match

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -436,8 +436,7 @@ end
 
 -- Get Playerdata from Vars (get's set in TeamCards)
 function matchFunctions.getPlayers(match, opponentIndex, teamName)
-	-- match._storePlayers will break after the first empty player. let's make sure we don't leave any gaps.
-	local count = 1
+	match['opponent' .. opponentIndex].match2players = {}
 	for playerIndex = 1, _MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
@@ -445,8 +444,7 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
-			match['opponent' .. opponentIndex .. '_p' .. count] = player
-			count = count + 1
+			table.insert(match['opponent' .. opponentIndex].match2players, player)
 		end
 	end
 	return match

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -423,6 +423,7 @@ function matchFunctions.getOpponents(match)
 end
 
 function matchFunctions.getPlayers(match, opponentIndex, teamName)
+	match['opponent' .. opponentIndex].match2players = {}
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		-- parse player
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
@@ -430,9 +431,10 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
 		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
-			match['opponent' .. opponentIndex .. '_p' .. playerIndex] = player
+			table.insert(match['opponent' .. opponentIndex].match2players, player)
 		end
 	end
+
 	return match
 end
 


### PR DESCRIPTION
## Summary
- Avoid nil
- Adjust player of team input processing. Directly set players into `opponent.match2players` instead of pushing them into `match['opponent' .. opponentIndex .. '_p' .. playerIndex]` which then later on gets made into what we now directly achieve.

This solves a bug with mvp stuff, where it expects the player info being inside `match2players` already for processing mvp input.

## How did you test this change?
/dev