### PR TITLE
Add missing `player.displayname` reading for brawlstars

### DIFF
--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -269,6 +269,7 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
 		player.name = player.name or Variables.varDefault(teamName .. '_p' .. playerIndex)
 		player.flag = player.flag or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'flag')
+		player.displayname = player.displayname or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 		if not Table.isEmpty(player) then
 			table.insert(match['opponent' .. opponentIndex].match2players, player)
 		end


### PR DESCRIPTION
## Summary
Add missing displayname reading for brawlstars

## How did you test this change?
live, hotfix