### PR TITLE
Squad: Add roster-coach class for all roles containing coach

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -132,14 +132,8 @@ function SquadRow:role(args)
 
 	if role == 'sub' then
 		self.content:addClass('sub')
-	elseif role == 'coach' then
-		self.content:addClass('coach')
-		self.content:addClass('roster-coach')
-	elseif role == 'coach/manager' then
-		self.content:addClass('coach/manager')
-		self.content:addClass('roster-coach')
-	elseif role == 'coach/substitute' then
-		self.content:addClass('coach/substitute')
+	elseif role:find('coach', 1, true) then
+		self.content:addClass(role)
 		self.content:addClass('roster-coach')
 	end
 


### PR DESCRIPTION
## Summary
Instead of listing various roles that contain coach, string match the word `coach` to determine whether a person is a coach.
As far as i can tell the class with plain role names aren't used anywhere, so they could be removed as well.

## How did you test this change?
via /dev
new:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/7310e90b-2951-43b7-80f1-a6cd7c6a93af)
old:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/81336216-3883-457c-967a-72c74ff06a11)
