### PR TITLE
Update VALORANT highlighting conditions

### DIFF
--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -104,9 +104,9 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 
 	if Logic.readBool(args['riot-highlighted']) then
-		lpdbData.publishertier = 'Highlighted'
+		lpdbData.publishertier = 'highlighted'
 	elseif Logic.readBool(args['riot-sponsored']) then
-		lpdbData.publishertier = 'Sponsored'
+		lpdbData.publishertier = 'sponsored'
 	end
 
 	lpdbData.extradata.region = Template.safeExpand(mw.getCurrentFrame(), 'Template:Player region', {args.country})

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -103,8 +103,8 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 
-	if Logic.readBool(args.riotpremier) then
-		lpdbData.publishertier = 'major'
+	if Logic.readBool(args['riot-highlighted']) then
+		lpdbData.publishertier = 'Highlighted'
 	elseif Logic.readBool(args['riot-sponsored']) then
 		lpdbData.publishertier = 'Sponsored'
 	end
@@ -117,12 +117,12 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
-function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args['riot-sponsored'])
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args['riot-highlighted'])
 end
 
 function CustomLeague:appendLiquipediatierDisplay()
-	if Logic.readBool(_args['riot-sponsored']) then
+	if Logic.readBool(_args['riot-highlighted']) or Logic.readBool(_args['riot-sponsored']) then
 		return ' ' .. RIOT_ICON
 	end
 	return ''

--- a/components/tournaments_listing/commons/tournaments_listing_card_list.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_card_list.lua
@@ -12,7 +12,6 @@ local Class = require('Module:Class')
 local Currency = require('Module:Currency')
 local Flags = require('Module:Flags')
 local Game = require('Module:Game')
-local HighlightConditions = require('Module:HighlightConditions')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local LeagueIcon = require('Module:LeagueIcon')
@@ -27,6 +26,7 @@ local Opponent = OpponentLibraries.Opponent
 local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local Conditions = Lua.import('Module:TournamentsListing/Conditions', {requireDevIfEnabled = true})
+local HighlightConditions = Lua.import('Module:HighlightConditions', {requireDevIfEnabled = true})
 local Tier = Lua.import('Module:Tier/Custom', {requireDevIfEnabled = true})
 
 local LANG = mw.language.new('en')

--- a/standard/highlight_conditions/wikis/valorant/highlight_conditions.lua
+++ b/standard/highlight_conditions/wikis/valorant/highlight_conditions.lua
@@ -1,0 +1,18 @@
+---
+-- @Liquipedia
+-- wiki=valorant
+-- page=Module:HighlightConditions
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local HighlightConditions = {}
+
+--- Check arguments or queryData if the tournament should be highlighted
+---@param data table
+---@return boolean
+function HighlightConditions.tournament(data)
+	return (data.publishertier == 'Highlighted')
+end
+
+return HighlightConditions

--- a/standard/highlight_conditions/wikis/valorant/highlight_conditions.lua
+++ b/standard/highlight_conditions/wikis/valorant/highlight_conditions.lua
@@ -12,7 +12,7 @@ local HighlightConditions = {}
 ---@param data table
 ---@return boolean
 function HighlightConditions.tournament(data)
-	return (data.publishertier == 'Highlighted')
+	return (data.publishertier == 'highlighted')
 end
 
 return HighlightConditions


### PR DESCRIPTION
## Summary

At the request of the wiki editors, the following changes are being made: https://discord.com/channels/93055209017729024/684060921898860569/1133875400217464833

- `|riot-highlighted=true` will add both highlighting and riot icon.
- `|riot-sponsored=true` will add only riot icon.

For all tournament lists, broadcast lists, etc, they should be using the highlight conditions module, so that only `riot-highlighted` (`publishertier` being `highlighted`) triggers that.

(Also added dev support for highlighting conditions module in tournament list).

## How did you test this change?

Tested on `/dev`.
