### PR TITLE
EMList: Resolve redirect for author before querying

### DIFF
--- a/components/external_media_links/external_media_list.lua
+++ b/components/external_media_links/external_media_list.lua
@@ -62,7 +62,7 @@ function MediaList._parseArgs(args)
 
 	return {
 		types = args.type and Array.map(Array.map(mw.text.split(args.type, ','), String.trim), string.lower) or nil,
-		author = args.author,
+		author = args.author and mw.ext.TeamLiquidIntegration.resolve_redirect(args.author) or nil,
 		subjects = Array.mapIndexes(function(subjectIndex)
 			return args['subject' .. subjectIndex] or args['player' .. subjectIndex]
 		end),


### PR DESCRIPTION
## Summary
ExternalMediaLinks store authors with resolved redirects, which also replaces underscores with whitespace and capitalizes the first character.
This change applies the same processing before querying to allow the same input to work.

## How did you test this change?
via /dev
