### PR TITLE
Add bo3.gg links to CS match summary

### DIFF
--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -230,6 +230,22 @@ return {
 	},
 	{},
 	{
+		name = 'bo3gg',
+		icon = 'bo3.gg icon allmode.png',
+		prefixLink = 'https://bo3.gg/matches/',
+		label = 'bo3.gg Matchpage',
+		max = 2,
+		stats = {'bo3ggstats'}
+	},
+	{
+		name = 'bo3ggstats',
+		icon = 'stats',
+		prefixLink = 'https://bo3.gg/matches/',
+		label = 'Stats on bo3.gg',
+		isMapStats = true
+	},
+	{},
+	{
 		name = 'cstats',
 		icon = 'stats',
 		prefixLink = '',

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -345,6 +345,7 @@ function matchFunctions.getLinks(match)
 
 	local platforms = mw.loadData('Module:MatchExternalLinks')
 	table.insert(platforms, {name = 'vod2', isMapStats = true})
+	local matchPlatforms = {}
 
 	for _, platform in ipairs(platforms) do
 		-- Stat external links inserted in {{Map}}
@@ -356,15 +357,19 @@ function matchFunctions.getLinks(match)
 
 			if match[name] then
 				table.insert(platformLinks, {prefixLink .. match[name] .. suffixLink, 0})
+				matchPlatforms[name] = match[name]
 				match[name] = nil
 			end
 
 			if platform.isMapStats then
 				for i = 1, match.bestof do
 					local map = match['map' .. i]
-					if map and map[platform.name] then
-						table.insert(platformLinks, {prefixLink .. match['map' .. i][name] .. suffixLink, i})
-						match['map' .. i][platform.name] = nil
+					if map and map[name] then
+						table.insert(platformLinks, {prefixLink .. map[name] .. suffixLink, i})
+						match['map' .. i][name] = nil
+					elseif map and (name == 'bo3ggstats') and matchPlatforms['bo3gg'] and Logic.readBool(map.finished) then
+						local mapName = map.map:lower():gsub('dust ii', 'dust2')
+						table.insert(platformLinks, {prefixLink .. matchPlatforms['bo3gg'] .. '/' .. mapName .. suffixLink, i})
 					end
 				end
 			else


### PR DESCRIPTION
## Summary

Add `bo3.gg` links similar to HLTV for match summary links on CS wiki. Also added code to generate stats links automatically for the site using map names on finished maps.

A bit of code clean-up too (using existing local scope vars instead of calling from higher scope vars).

## How did you test this change?

Tested on `/dev` using CS wiki.
