### PR TITLE
Add `slotindex` as a lpdb_standingsentry field

### DIFF
--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -121,6 +121,7 @@ function StandingsStorage.entry(entry, standingsIndex)
 			buchholz = tonumber(entry.buchholz),
 		},
 		roundindex = roundIndex,
+		slotindex = slotIndex,
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, entry.extradata)),
 	}
 


### PR DESCRIPTION
## Summary
Add slotindex storage as it's own field. The field doesn't exist yet but is planned.

Once the field is created, consumers needs to be swapped over and then removed from extradata.
