### PR TITLE
Catch matches with literal opponents in sc2 vs stats on player pages

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -330,19 +330,19 @@ function CustomPlayer._addScoresToVS(vs, opponents, player, playerWithoutUndersc
 	local plOpp = opponents[plIndex]
 	local vsOpp = opponents[vsIndex]
 
-	local prace = Faction.read(plOpp.match2players[1].extradata.faction)
-	prace = prace and prace ~= Faction.defaultFaction and prace or 'r'
-	local orace = Faction.read(vsOpp.match2players[1].extradata.faction) or 'r'
-	orace = orace and orace ~= Faction.defaultFaction and orace or 'r'
+	local pRace = Faction.read(plOpp.match2players[1].extradata.faction)
+	pRace = pRace and pRace ~= Faction.defaultFaction and pRace or 'r'
+	local oRace = Faction.read(vsOpp.match2players[1].extradata.faction) or 'r'
+	oRace = oRace and oRace ~= Faction.defaultFaction and oRace or 'r'
 
-	vs[prace][orace].win = vs[prace][orace].win + (tonumber(plOpp.score or 0) or 0)
-	vs[prace][orace].loss = vs[prace][orace].loss + (tonumber(vsOpp.score or 0) or 0)
+	vs[pRace][oRace].win = vs[pRace][oRace].win + (tonumber(plOpp.score or 0) or 0)
+	vs[pRace][oRace].loss = vs[pRace][oRace].loss + (tonumber(vsOpp.score or 0) or 0)
 
-	vs['total'][orace].win = vs['total'][orace].win + (tonumber(plOpp.score or 0) or 0)
-	vs['total'][orace].loss = vs['total'][orace].loss + (tonumber(vsOpp.score or 0) or 0)
+	vs['total'][oRace].win = vs['total'][oRace].win + (tonumber(plOpp.score or 0) or 0)
+	vs['total'][oRace].loss = vs['total'][oRace].loss + (tonumber(vsOpp.score or 0) or 0)
 
-	vs[prace]['total'].win = vs[prace]['total'].win + (tonumber(plOpp.score or 0) or 0)
-	vs[prace]['total'].loss = vs[prace]['total'].loss + (tonumber(vsOpp.score or 0) or 0)
+	vs[pRace]['total'].win = vs[pRace]['total'].win + (tonumber(plOpp.score or 0) or 0)
+	vs[pRace]['total'].loss = vs[pRace]['total'].loss + (tonumber(vsOpp.score or 0) or 0)
 
 	vs['total']['total'].win = vs['total']['total'].win + (tonumber(plOpp.score or 0) or 0)
 	vs['total']['total'].loss = vs['total']['total'].loss + (tonumber(vsOpp.score or 0) or 0)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -314,8 +314,7 @@ end
 
 function CustomPlayer._addScoresToVS(vs, opponents, player, playerWithoutUnderscore)
 	--catch matches vs empty opponents and literals
-	if not opponents[1] or not opponents[2] or
-		opponents[1].type == Opponent.literal or opponents[2].type == Opponent.literal then
+	if #opponents ~= 2 or Array.any(opponents, function(opponent) return opponent.type == Opponent.literal end) then
 
 		return vs
 	end

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -314,7 +314,9 @@ end
 
 function CustomPlayer._addScoresToVS(vs, opponents, player, playerWithoutUnderscore)
 	--catch matches vs empty opponents and literals
-	if not opponents[1] or not opponents[2] or opponents[1].type == Opponent.literal or opponents[2].type == Opponent.literal then
+	if not opponents[1] or not opponents[2] or
+		opponents[1].type == Opponent.literal or opponents[2].type == Opponent.literal then
+
 		return vs
 	end
 

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -313,34 +313,37 @@ function CustomPlayer._setVarsForVS(table)
 end
 
 function CustomPlayer._addScoresToVS(vs, opponents, player, playerWithoutUnderscore)
+	--catch matches vs empty opponents and literals
+	if not opponents[1] or not opponents[2] or opponents[1].type == Opponent.literal or opponents[2].type == Opponent.literal then
+		return vs
+	end
+
 	local plIndex = 1
 	local vsIndex = 2
-	--catch matches vs empty opponents
-	if opponents[1] and opponents[2] then
-		if opponents[2].name == player or opponents[2].name == playerWithoutUnderscore then
-			plIndex = 2
-			vsIndex = 1
-		end
-		local plOpp = opponents[plIndex]
-		local vsOpp = opponents[vsIndex]
 
-		local prace = Faction.read(plOpp.match2players[1].extradata.faction)
-		prace = prace and prace ~= Faction.defaultFaction and prace or 'r'
-		local orace = Faction.read(vsOpp.match2players[1].extradata.faction) or 'r'
-		orace = orace and orace ~= Faction.defaultFaction and orace or 'r'
-
-		vs[prace][orace].win = vs[prace][orace].win + (tonumber(plOpp.score or 0) or 0)
-		vs[prace][orace].loss = vs[prace][orace].loss + (tonumber(vsOpp.score or 0) or 0)
-
-		vs['total'][orace].win = vs['total'][orace].win + (tonumber(plOpp.score or 0) or 0)
-		vs['total'][orace].loss = vs['total'][orace].loss + (tonumber(vsOpp.score or 0) or 0)
-
-		vs[prace]['total'].win = vs[prace]['total'].win + (tonumber(plOpp.score or 0) or 0)
-		vs[prace]['total'].loss = vs[prace]['total'].loss + (tonumber(vsOpp.score or 0) or 0)
-
-		vs['total']['total'].win = vs['total']['total'].win + (tonumber(plOpp.score or 0) or 0)
-		vs['total']['total'].loss = vs['total']['total'].loss + (tonumber(vsOpp.score or 0) or 0)
+	if opponents[2].name == player or opponents[2].name == playerWithoutUnderscore then
+		plIndex = 2
+		vsIndex = 1
 	end
+	local plOpp = opponents[plIndex]
+	local vsOpp = opponents[vsIndex]
+
+	local prace = Faction.read(plOpp.match2players[1].extradata.faction)
+	prace = prace and prace ~= Faction.defaultFaction and prace or 'r'
+	local orace = Faction.read(vsOpp.match2players[1].extradata.faction) or 'r'
+	orace = orace and orace ~= Faction.defaultFaction and orace or 'r'
+
+	vs[prace][orace].win = vs[prace][orace].win + (tonumber(plOpp.score or 0) or 0)
+	vs[prace][orace].loss = vs[prace][orace].loss + (tonumber(vsOpp.score or 0) or 0)
+
+	vs['total'][orace].win = vs['total'][orace].win + (tonumber(plOpp.score or 0) or 0)
+	vs['total'][orace].loss = vs['total'][orace].loss + (tonumber(vsOpp.score or 0) or 0)
+
+	vs[prace]['total'].win = vs[prace]['total'].win + (tonumber(plOpp.score or 0) or 0)
+	vs[prace]['total'].loss = vs[prace]['total'].loss + (tonumber(vsOpp.score or 0) or 0)
+
+	vs['total']['total'].win = vs['total']['total'].win + (tonumber(plOpp.score or 0) or 0)
+	vs['total']['total'].loss = vs['total']['total'].loss + (tonumber(vsOpp.score or 0) or 0)
 
 	return vs
 end


### PR DESCRIPTION
## Summary
- Catch matches with literal opponents in sc2 vs stats on player pages
- use early return instead of having almost the entire function in one if

## How did you test this change?
dev to live since it was causing an error on 1 page