### PR TITLE
Statistics: Adjust coverageTournamentTable

### DIFF
--- a/components/statistics/count.lua
+++ b/components/statistics/count.lua
@@ -121,19 +121,24 @@ end
 ---@return table
 function Count.tournamentsByTier(args)
 	args = args or {}
-	
+
 	local lpdbConditions = Count._baseConditions(args, true)
-	
+
 	local data = mw.ext.LiquipediaDB.lpdb('tournament', {
 		conditions = lpdbConditions:toString(),
 		query = 'liquipediatier, liquipediatiertype, count::objectname',
 		groupby = 'liquipediatier asc, liquipediatiertype asc'
 	})
-	
+
 	return Table.mapValues(
 		Table.groupBy(data, function(_, tbl) return Table.extract(tbl, 'liquipediatier') end),
 		function(tierTable)
-			return Table.map(tierTable, function(_, typeTable) return typeTable['liquipediatiertype'], typeTable['count_objectname'] end)
+			return Table.map(
+				tierTable,
+				function(_, typeTable)
+					return typeTable['liquipediatiertype'], typeTable['count_objectname']
+				end
+			)
 		end
 	)
 end

--- a/components/statistics/count.lua
+++ b/components/statistics/count.lua
@@ -116,6 +116,27 @@ function Count.tournaments(args)
 	return Count._query('tournament', lpdbConditions)
 end
 
+---Counts the number of tournaments played on a wiki per tier/tiertype
+---@param args table?
+---@return table
+function Count.tournamentsByTier(args)
+	args = args or {}
+	
+	local lpdbConditions = Count._baseConditions(args, true)
+	
+	local data = mw.ext.LiquipediaDB.lpdb('tournament', {
+		conditions = lpdbConditions:toString(),
+		query = 'liquipediatier, liquipediatiertype, count::objectname',
+		groupby = 'liquipediatier asc, liquipediatiertype asc'
+	})
+	
+	return Table.mapValues(
+		Table.groupBy(data, function(_, tbl) return Table.extract(tbl, 'liquipediatier') end),
+		function(tierTable)
+			return Table.map(tierTable, function(_, typeTable) return typeTable['liquipediatiertype'], typeTable['count_objectname'] end)
+		end
+	)
+end
 
 ---Counts the number of placements for a specified opponent on a wiki
 ---@param args table?

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -372,7 +372,7 @@ function StatisticsPortal._coverageTournamentTableRow(args, parameters)
 			end
 		end
 	end
-	
+
 	if String.isNotEmpty(args.showOther) then
 		local countOther = Array.reduce(
 			Array.flatten(Array.map(Array.extractValues(countData),

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -344,7 +344,7 @@ function StatisticsPortal._coverageTournamentTableRow(args, parameters)
 				return value == rowIndex
 			end) then
 				local tierData = countData[rowValue.value] or {}
-				local tournamentCount = tonumber(Table.extract(tierData, "")) or 0
+				local tournamentCount = tonumber(Table.extract(tierData, '')) or 0
 				runningTally = runningTally + tournamentCount
 				resultsRow:tag(tagType)
 					:wikitext(LANG:formatNum(tournamentCount))
@@ -359,8 +359,8 @@ function StatisticsPortal._coverageTournamentTableRow(args, parameters)
 			if tierTypeData then
 				local count = Array.reduce(
 					Array.map(Array.extractValues(countData),
-						function(el, index)
-							return Table.extract(el, tierTypeValue) or 0
+						function(typeCounts, index)
+							return Table.extract(typeCounts, tierTypeValue) or 0
 						end
 					),
 					Operator.add, 0

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -376,8 +376,8 @@ function StatisticsPortal._coverageTournamentTableRow(args, parameters)
 	if String.isNotEmpty(args.showOther) then
 		local countOther = Array.reduce(
 			Array.flatten(Array.map(Array.extractValues(countData),
-				function(el, index)
-					return Table.isNotEmpty(el) and Array.extractValues(el) or 0
+				function(typeCounts, index)
+					return Table.isNotEmpty(typeCounts) and Array.extractValues(typeCounts) or 0
 				end
 			)), Operator.add, 0)
 		runningTally = runningTally + countOther

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -352,7 +352,7 @@ function StatisticsPortal._coverageTournamentTableRow(args, parameters)
 			end
 		end
 	end
-	
+
 	if String.isNotEmpty(args.showTierTypes) then
 		for _, tierTypeValue in pairs(mw.text.split(args.showTierTypes, ',', true)) do
 			local _, tierTypeData = Tier.raw(nil, tierTypeValue)
@@ -376,7 +376,7 @@ function StatisticsPortal._coverageTournamentTableRow(args, parameters)
 	if String.isNotEmpty(args.showOther) then
 		local countOther = Array.reduce(
 			Array.flatten(Array.map(Array.extractValues(countData),
-				function(el, index) 
+				function(el, index)
 					return Table.isNotEmpty(el) and Array.extractValues(el) or 0
 				end
 			)), Operator.add, 0)
@@ -385,7 +385,6 @@ function StatisticsPortal._coverageTournamentTableRow(args, parameters)
 			:wikitext(LANG:formatNum(countOther))
 			:css('text-align', 'right')
 	end
-	
 
 	resultsRow:tag(tagType)
 		:wikitext(LANG:formatNum(runningTally))


### PR DESCRIPTION
## Summary
Fixes #3162 
The old version would result in tournaments counted multiple times into the total when displaying tiertypes in the table as well as miss tournaments.

Things to discuss:
- [x] Should there be an option to include specific tiertypes into the tier counts? (e.g. Weeklies into their Tier etc.)
- [x] The Count module currently uses sortdate when querying for a year. This differs from the TournamentsListing, which is using enddate: https://github.com/Liquipedia/Lua-Modules/blob/fb09dfee0a243152385e47dcdc8dee63a3a9b521/components/tournaments_listing/commons/tournaments_listing_conditions.lua#L33
- [x] What to include under "other" (this PR will include any tournament that is not included in other columns)

## How did you test this change?
via /dev on https://liquipedia.net/ageofempires/User:Dark_meluca/PortalStatisticsTest/CoverageTest/2019

