### PR TITLE
AoE: Check whether mappages are linked correctly

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -321,12 +321,28 @@ function CustomLeague:_getMaps()
 			display = nil
 		end
 
+		CustomLeague:_checkMapInformation(display or link, link, Variables.varDefault('tournament_game'))
+
 		table.insert(maps, {link = link, name = display, mode = mode, image = args[prefix .. 'image']})
 	end
 
 	_league.maps = maps
 
 	return maps
+end
+
+function CustomLeague:_checkMapInformation(name, link, game)
+	local data = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = '[[type::map]] AND [[pagename::' .. link:gsub(' ', '_') .. ']]',
+		query = 'name, extradata'
+	})
+	if #data and Table.isNotEmpty(data[1]) then
+		local extradata = data[1].extradata or {}
+		if extradata.game ~= game then
+			mw.logObject('Map ' .. name .. ' is linking to ' .. link .. ', an ' .. extradata.game .. ' page.')
+			table.insert(categories, 'Tournaments linking to maps for a different game')
+		end
+	end
 end
 
 function CustomLeague:_displayMaps(maps)

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -336,7 +336,7 @@ function CustomLeague:_checkMapInformation(name, link, game)
 		conditions = '[[type::map]] AND [[pagename::' .. link:gsub(' ', '_') .. ']]',
 		query = 'name, extradata'
 	})
-	if #data and Table.isNotEmpty(data[1]) then
+	if Table.isNotEmpty(data[1]) then
 		local extradata = data[1].extradata or {}
 		if extradata.game ~= game then
 			mw.logObject('Map ' .. name .. ' is linking to ' .. link .. ', an ' .. extradata.game .. ' page.')


### PR DESCRIPTION
## Summary
Since some mapnames are present in multiple games and there is no standard suffix currently, it can happen that maps entered on a tournament page link to the wrong page.
This introduces a small check for map data from a page, and adds a tracking category if a mismatch between games is detected.

## How did you test this change?
via /dev
