### PR TITLE
BrawlStars: Store minimum secured points in var

### DIFF
--- a/components/prize_pool/wikis/brawlstars/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/brawlstars/prize_pool_custom.lua
@@ -69,6 +69,10 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		series = Variables.varDefault('tournament_series'),
 	})
 
+	if Opponent.isTbd(opponent.opponentData) then
+		Variables.varDefine('minimum_secured', lpdbData.extradata.prizepoints)
+	end
+
 	return lpdbData
 end
 


### PR DESCRIPTION
## Summary
Brawlstars uses the AutoPointsTable from RL, so match the setting of the minimum secured points to the one from RL.

## How did you test this change?
via /dev
