### PR TITLE
Fix `Module:Infobox/Extension/Achievements`

### DIFF
--- a/components/infobox/extensions/commons/infobox_extension_achievements.lua
+++ b/components/infobox/extensions/commons/infobox_extension_achievements.lua
@@ -15,7 +15,7 @@ local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
 local Team = require('Module:Team')
 
-local CustomDefaultOptions = Lua.loadDataIfExists('Module:Infobox/Extension/Achievements/Custom') or {}
+local CustomDefaultOptions = Lua.requireIfExists('Module:Infobox/Extension/Achievements/Custom') or {}
 
 local Opponent = require('Module:OpponentLibraries').Opponent
 

--- a/components/infobox/extensions/commons/infobox_extension_achievements.lua
+++ b/components/infobox/extensions/commons/infobox_extension_achievements.lua
@@ -98,7 +98,7 @@ function Achievements.teamSolo(args)
 	local options = Achievements._readOptions(args)
 
 	return Achievements.display(Achievements._fetchDataForTeam(
-		Achievements._getTeamNames(), Opponent.team, options), options)
+		Achievements._getTeamNames(), Opponent.solo, options), options)
 end
 
 ---Entry point for infobox team to fetch team achievements as icon strings
@@ -108,7 +108,7 @@ function Achievements.team(args)
 	local options = Achievements._readOptions(args)
 
 	return Achievements.display(Achievements._fetchDataForTeam(
-		Achievements._getTeamNames(), Opponent.solo, options), options)
+		Achievements._getTeamNames(), Opponent.team, options), options)
 end
 
 ---Fetches (historical) teamNames (both with underscore and without) of a given team


### PR DESCRIPTION
## Summary
use `requireIfExists` over `loadDataIfExists` since one of the options allowed to pass along is a function

## How did you test this change?
live, broke sc2