### PR TITLE
Mitigate preservation of ghost broadcaster data

### DIFF
--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -124,8 +124,7 @@ end
 ---@return string
 function BroadcasterCard._display(broadcaster)
 	local displayName = broadcaster.displayName or broadcaster.name
-	displayName = (String.isEmpty(displayName) or displayName == broadcaster.id)
-		and '' or ('&nbsp;(' .. displayName ..')')
+	displayName = String.isEmpty(displayName) and '' or ('&nbsp;(' .. displayName ..')')
 
 	return '\n**' .. Flags.Icon{flag = broadcaster.flag, shouldLink = true}
 		.. '&nbsp;[[' .. broadcaster.page .. '|'.. broadcaster.id .. ']]'
@@ -147,6 +146,8 @@ end
 function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 	local resolvedCasterPage = mw.ext.TeamLiquidIntegration.resolve_redirect(casterPage):gsub(' ','_' )
 
+	local pageid = mw.title.getCurrentTitle().id
+
 	local function getPersonInfo()
 		local data = mw.ext.LiquipediaDB.lpdb('player', {
 			conditions = '[[pagename::' .. resolvedCasterPage .. ']]',
@@ -163,7 +164,7 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 		end
 
 		data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
-			conditions = '[[page::' .. resolvedCasterPage .. ']] AND [[name::!]] AND [[flag::!]]',
+			conditions = '[[page::' .. resolvedCasterPage .. ']] AND [[name::!]] AND [[flag::!]] AND [[pageid::!' .. pageid .. ']]',
 			query = 'name, flag, id',
 			order = 'date desc',
 			limit = 1

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -146,8 +146,6 @@ end
 function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 	local resolvedCasterPage = mw.ext.TeamLiquidIntegration.resolve_redirect(casterPage):gsub(' ','_' )
 
-	local pageid = mw.title.getCurrentTitle().id
-
 	local function getPersonInfo()
 		local data = mw.ext.LiquipediaDB.lpdb('player', {
 			conditions = '[[pagename::' .. resolvedCasterPage .. ']]',
@@ -164,7 +162,8 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 		end
 
 		data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
-			conditions = '[[page::' .. resolvedCasterPage .. ']] AND [[name::!]] AND [[flag::!]] AND [[pageid::!' .. pageid .. ']]',
+			conditions = '[[page::' .. resolvedCasterPage .. ']] AND [[name::!]] AND [[flag::!]]'
+				.. ' AND [[pagename::!' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
 			query = 'name, flag, id',
 			order = 'date desc',
 			limit = 1

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -124,7 +124,8 @@ end
 ---@return string
 function BroadcasterCard._display(broadcaster)
 	local displayName = broadcaster.displayName or broadcaster.name
-	displayName = String.isEmpty(displayName) and '' or ('&nbsp;(' .. displayName ..')')
+	displayName = (String.isEmpty(displayName) or displayName == broadcaster.id)
+		and '' or ('&nbsp;(' .. displayName ..')')
 
 	return '\n**' .. Flags.Icon{flag = broadcaster.flag, shouldLink = true}
 		.. '&nbsp;[[' .. broadcaster.page .. '|'.. broadcaster.id .. ']]'


### PR DESCRIPTION
## Summary

Avoid pulling ghost data by querying only on other pages.

Example:
| Before| After |
| --- | ----------- |
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/42142350/5ae51555-b2c0-42d7-a3aa-5f3df7336f32)| ![image](https://github.com/Liquipedia/Lua-Modules/assets/42142350/3b2198df-62ed-4584-a2de-f88420baf6c0) |

## How did you test this change?

/dev
