### PR TITLE
Stats: Make minimum earnings configurable

### DIFF
--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -56,6 +56,7 @@ local GAMES = Array.map(Array.extractValues(Info.games, Table.iter.spairs), func
 	return value.name
 end)
 local DEFAULT_TIERTYPES = {'', 'Weekly', 'Monthly'}
+local MINIMUM_EARNINGS = 1000
 
 
 local StatisticsPortal = {}
@@ -689,7 +690,7 @@ function StatisticsPortal.earningsTable(args)
 		args.allowedPlacements,
 		DEFAULT_ALLOWED_PLACES
 	)
-	args.minimumEarnings = tonumber(args.minimumEarnings) or 1000
+	args.minimumEarnings = tonumber(args.minimumEarnings) or MINIMUM_EARNINGS
 
 	local earningsFunction = function (a)
 		if String.isNotEmpty(args.year) and a.extradata then

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -689,6 +689,7 @@ function StatisticsPortal.earningsTable(args)
 		args.allowedPlacements,
 		DEFAULT_ALLOWED_PLACES
 	)
+	args.minimumEarnings = tonumber(args.minimumEarnings) or 1000
 
 	local earningsFunction = function (a)
 		if String.isNotEmpty(args.year) and a.extradata then
@@ -722,7 +723,7 @@ function StatisticsPortal.earningsTable(args)
 		local opponentDisplay
 		local earnings = earningsFunction(opponent)
 
-		if opponentIndex > args.limit or earnings < 1000 then break end
+		if opponentIndex > args.limit or earnings < args.minimumEarnings then break end
 
 		if args.opponentType == Opponent.team then
 			opponentDisplay = OpponentDisplay.BlockOpponent{


### PR DESCRIPTION
## Summary
On some wikis (for specific years) there aren't many players with more than 1k earnings, so the table was missing many.
Make the value configurable but default to 1000.

## How did you test this change?
via /dev
