### PR TITLE
Simplify `publishertier` definition in infoboxes (+ clean up)

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -81,6 +81,7 @@ function HiddenDataBox.run(args)
 
 	HiddenDataBox.checkAndAssign('tournament_liquipediatier', args.liquipediatier, queryResult.liquipediatier)
 	HiddenDataBox.checkAndAssign('tournament_liquipediatiertype', args.liquipediatiertype, queryResult.liquipediatiertype)
+	HiddenDataBox.checkAndAssign('tournament_publishertier', args.publishertier, queryResult.publishertier)
 
 	HiddenDataBox.checkAndAssign('tournament_type', args.type, queryResult.type)
 	HiddenDataBox.checkAndAssign('tournament_status', args.status, queryResult.status)

--- a/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/counterstrike/hidden_data_box_custom.lua
@@ -24,6 +24,7 @@ function CustomHiddenDataBox.run(args)
 	args.liquipediatier = Tier.toNumber(args.liquipediatier)
 
 	BasicHiddenDataBox.addCustomVariables = CustomHiddenDataBox.addCustomVariables
+
 	return BasicHiddenDataBox.run(args)
 end
 
@@ -44,7 +45,6 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_icon_darkmode', Variables.varDefault('tournament_icondark'))
 
 	Variables.varDefine('match_featured_override', args.featured)
-	Variables.varDefine('tournament_valve_major', args.valvemajor or (args.valvetier == 'Major' and 'true') or 'false')
 	BasicHiddenDataBox.checkAndAssign('tournament_valve_tier', args.valvetier, queryResult.publishertier)
 
 	Variables.varDefine('match_hidden', tostring(

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -446,6 +446,7 @@ function League:_setLpdbData(args, links)
 		prizepool = Variables.varDefault('tournament_prizepoolusd', 0),
 		liquipediatier = Variables.varDefault('tournament_liquipediatier'),
 		liquipediatiertype = Variables.varDefault('tournament_liquipediatiertype'),
+		publishertier = Variables.varDefault('tournament_publishertier'),
 		participantsnumber = tonumber(args.participants_number)
 			or tonumber(args.team_number)
 			or tonumber(args.player_number)

--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -90,12 +90,12 @@ function CustomInjector:parse(id, widgets)
 end
 
 
-function CustomLeague:liquipediaTierHighlighted()
-	return String.isNotEmpty(_args['ea-sponsored'])
+function CustomLeague:liquipediaTierHighlighted(args)
+	return String.isNotEmpty(args['ea-sponsored'])
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	return Logic.readBool(_args['ea-sponsored']) and _EA_ICON or ''
+function CustomLeague:appendLiquipediatierDisplay(args)
+	return Logic.readBool(args['ea-sponsored']) and _EA_ICON or ''
 end
 
 function CustomInjector:addCustomCells(widgets)
@@ -123,11 +123,11 @@ function CustomLeague:_makeBasedListFromArgs(base)
 	return foundArgs
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
-	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
-	Variables.varDefine('tournament_tiertype', _args.liquipediatiertype)
+	Variables.varDefine('tournament_ticker_name', args.tickername or '')
+	Variables.varDefine('tournament_tier', args.liquipediatier or '')
+	Variables.varDefine('tournament_tiertype', args.liquipediatiertype)
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')
@@ -140,24 +140,24 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('edate', edate)
 
 	--Apexs specific vars
-	Variables.varDefine('tournament_gamemode', string.lower(_args.mode or ''))
-	Variables.varDefine('tournament_series2', _args.series2 or '')
-	Variables.varDefine('tournament_publisher', _args['ea-sponsored'] or '')
-	Variables.varDefine('tournament_pro_circuit_tier', _args.pctier or '')
+	Variables.varDefine('tournament_gamemode', string.lower(args.mode or ''))
+	Variables.varDefine('tournament_series2', args.series2 or '')
+	Variables.varDefine('tournament_publisher', args['ea-sponsored'] or '')
+	Variables.varDefine('tournament_pro_circuit_tier', args.pctier or '')
 
 	local isIndividual = ''
-	if String.isNotEmpty(_args.player_number) then
+	if String.isNotEmpty(args.player_number) then
 		isIndividual = 'true'
 	end
 	Variables.varDefine('tournament_individual', isIndividual)
 
-	local eaMajor = _args.eamajor
+	local eaMajor = args.eamajor
 	if String.isEmpty(eaMajor) then
-		local eaTier = string.lower(_args.eatier or '')
+		local eaTier = string.lower(args.eatier or '')
 		if String.isNotEmpty(eaTier) and eaTier ~= 'online' then
 			eaMajor = eaTier
 		else
-			local algsTier = string.lower(_args.algstier or '')
+			local algsTier = string.lower(args.algstier or '')
 			if String.isNotEmpty(algsTier) and algsTier ~= 'online' then
 				eaMajor = algsTier
 			else
@@ -166,24 +166,23 @@ function CustomLeague:defineCustomPageVariables()
 		end
 	end
 	Variables.varDefine('tournament_publishertier', eaMajor)
-	local regionData = Locale.formatLocations(_args)
-	Variables.varDefine('tournament_location_region', regionData.region1 or _args.country)
+	local regionData = Locale.formatLocations(args)
+	Variables.varDefine('tournament_location_region', regionData.region1 or args.country)
 end
 
-function CustomLeague:addToLpdb(lpdbData)
-	lpdbData.publishertier = Variables.varDefault('tournament_publishertier', '')
+function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.individual = Variables.varDefault('tournament_individual', '')
-	lpdbData.extradata.platform = string.lower(_args.platform or 'pc')
+	lpdbData.extradata.platform = string.lower(args.platform or 'pc')
 
-	--retrieve sponsors from _args.sponsors if sponsorX, X=1,...,3, is empty
+	--retrieve sponsors from args.sponsors if sponsorX, X=1,...,3, is empty
 	if
-		String.isEmpty(_args.sponsor1) and
-		String.isEmpty(_args.sponsor2) and
-		String.isEmpty(_args.sponsor3) and
-		String.isNotEmpty(_args.sponsor)
+		String.isEmpty(args.sponsor1) and
+		String.isEmpty(args.sponsor2) and
+		String.isEmpty(args.sponsor3) and
+		String.isNotEmpty(args.sponsor)
 	then
 		lpdbData.sponsors = {}
-		local sponsors = mw.text.split(_args.sponsor, '<br>', true)
+		local sponsors = mw.text.split(args.sponsor, '<br>', true)
 		for key, item in pairs(sponsors) do
 			lpdbData.sponsors['sponsor' .. key] = item
 		end

--- a/components/infobox/wikis/arenafps/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenafps/infobox_league_custom.lua
@@ -113,12 +113,12 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or _args.name)
-	Variables.varDefine('tournament_tier', _args.liquipediatier)
-	Variables.varDefine('tournament_prizepool', _args.prizepoolusd)
-	Variables.varDefine('tournament_mode', _args.mode)
+	Variables.varDefine('tournament_ticker_name', args.tickername or args.name)
+	Variables.varDefine('tournament_tier', args.liquipediatier)
+	Variables.varDefine('tournament_prizepool', args.prizepoolusd)
+	Variables.varDefine('tournament_mode', args.mode)
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')
@@ -129,20 +129,20 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('date', edate)
 	Variables.varDefine('sdate', sdate)
 	Variables.varDefine('edate', edate)
-	Variables.varDefine('mode', _args.mode)
+	Variables.varDefine('mode', args.mode)
 end
 
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
 
-	if Game.name{game = _args.game} then
-		table.insert(categories, Game.name{game = _args.game} .. ' Competitions')
+	if Game.name{game = args.game} then
+		table.insert(categories, Game.name{game = args.game} .. ' Competitions')
 	else
 		table.insert(categories, 'Tournaments without game version')
 	end
 
-	if _args.mode then
-		table.insert(categories, _args.mode .. ' Tournaments')
+	if args.mode then
+		table.insert(categories, args.mode .. ' Tournaments')
 	else
 		table.insert(categories, 'Tournaments Missing Mode')
 	end

--- a/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_league_custom.lua
@@ -73,15 +73,14 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
-	lpdbData.publishertier = Logic.readBool(_args.publisherpremier) and 'true' or nil
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args.publisherpremier)
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_game', _game or args.game)
+	Variables.varDefine('tournament_publishertier', Logic.readBool(args.publisherpremier) and 'true' or nil)
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -90,11 +90,12 @@ function CustomLeague:appendLiquipediatierDisplay()
 end
 
 function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_publishertier', args['supercell-sponsored'])
+
 	--Legacy vars
 	Variables.varDefine('tournament_ticker_name', args.tickername or '')
 	Variables.varDefine('tournament_tier', args.liquipediatier or '')
 	Variables.varDefine('tournament_prizepool', args.prizepool or '')
-	Variables.varDefine('tournament_publishertier', args['supercell-sponsored'])
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')

--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -45,7 +45,6 @@ function CustomLeague.run(frame)
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
-	league.addToLpdb = CustomLeague.addToLpdb
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
 
@@ -90,17 +89,12 @@ function CustomLeague:appendLiquipediatierDisplay()
 	return Logic.readBool(_args['supercell-sponsored']) and ('&nbsp;' .. SUPERCELL_SPONSORED_ICON) or ''
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = args['supercell-sponsored']
-
-	return lpdbData
-end
-
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
-	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
-	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
+	Variables.varDefine('tournament_ticker_name', args.tickername or '')
+	Variables.varDefine('tournament_tier', args.liquipediatier or '')
+	Variables.varDefine('tournament_prizepool', args.prizepool or '')
+	Variables.varDefine('tournament_publishertier', args['supercell-sponsored'])
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')

--- a/components/infobox/wikis/callofduty/infobox_league_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_league_custom.lua
@@ -72,26 +72,25 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 
 	lpdbData.game = Game.name{game = args.game}
-	lpdbData.publishertier = args['atvi-sponsored']
 	lpdbData.extradata.individual = not String.isEmpty(args.player_number)
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	if _args.player_number then
 		Variables.varDefine('tournament_mode', 'solo')
 	end
-	Variables.varDefine('tournament_game', Game.name{game = _args.game})
-	Variables.varDefine('tournament_publishertier', _args['atvi-sponsored'])
+	Variables.varDefine('tournament_game', Game.name{game = args.game})
+	Variables.varDefine('tournament_publishertier', args['atvi-sponsored'])
 
 	--Legacy Vars:
-	Variables.varDefine('tournament_ticker_name', _args.tickername)
+	Variables.varDefine('tournament_ticker_name', args.tickername)
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end
 
 function CustomLeague:liquipediaTierHighlighted(args)
-	return Logic.readBool(_args['atvi-sponsored'])
+	return Logic.readBool(args['atvi-sponsored'])
 end
 
 function CustomLeague:_createNoWrappingSpan(content)

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
@@ -30,9 +31,9 @@ function CustomLeague.run(frame)
 	_args = league.args
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
-	league.addToLpdb = CustomLeague.addToLpdb
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.appendLiquipediatierDisplay = CustomLeague.appendLiquipediatierDisplay
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 
 	return league:createInfobox()
 end
@@ -54,14 +55,12 @@ function CustomLeague:liquipediaTierHighlighted(args)
 	return Logic.readBool(args['supercell-sponsored'])
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	return Logic.readBool(_args['supercell-sponsored']) and ('&nbsp;' .. SUPERCELL_SPONSORED_ICON) or ''
+function CustomLeague:appendLiquipediatierDisplay(args)
+	return Logic.readBool(args['supercell-sponsored']) and ('&nbsp;' .. SUPERCELL_SPONSORED_ICON) or ''
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = Logic.readBool(_args['supercell-sponsored']) and 'true' or nil
-
-	return lpdbData
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_publishertier', Logic.readBool(args['supercell-sponsored']) and 'true' or nil)
 end
 
 return CustomLeague

--- a/components/infobox/wikis/clashroyale/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashroyale/infobox_league_custom.lua
@@ -51,19 +51,18 @@ function CustomInjector:addCustomCells(widgets)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = args.publisherpremier
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
-	if _args.player_number then
+function CustomLeague:defineCustomPageVariables(args)
+	if args.player_number then
 		Variables.varDefine('tournament_mode', 'solo')
 	else
 		Variables.varDefine('tournament_mode', 'team')
 	end
-	Variables.varDefine('tournament_publishertier', _args['publisherpremier'])
+	Variables.varDefine('tournament_publishertier', args.publisherpremier)
 end
 
 return CustomLeague

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -194,8 +194,8 @@ end
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
 
-	if Table.isNotEmpty(_args.gameData) then
-		table.insert(categories, (_args.gameData.abbreviation or _args.gameData.name) .. ' Tournaments')
+	if Table.isNotEmpty(args.gameData) then
+		table.insert(categories, (args.gameData.abbreviation or args.gameData.name) .. ' Tournaments')
 	else
 		table.insert(categories, 'Tournaments without game version')
 	end
@@ -234,8 +234,8 @@ function CustomLeague:getWikiCategories(args)
 	return categories
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	if Logic.readBool(_args.cstrikemajor) then
+function CustomLeague:appendLiquipediatierDisplay(args)
+	if Logic.readBool(args.cstrikemajor) then
 		return ' [[File:cstrike-icon.png|x16px|link=Counter-Strike Majors|Counter-Strike Major]]'
 	end
 	return ''
@@ -268,7 +268,9 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_tier', tierName) -- Stores as X-tier, not the integer
 
 	-- Wiki specific vars
-	Variables.varDefine('tournament_valve_tier', mw.getContentLanguage():ucfirst((args.valvetier or ''):lower()))
+	local valveTier = mw.getContentLanguage():ucfirst((args.valvetier or ''):lower())
+	Variables.varDefine('tournament_valve_tier', valveTier)
+	Variables.varDefine('tournament_publishertier', valveTier)
 	Variables.varDefine('tournament_cstrike_major', args.cstrikemajor)
 
 	Variables.varDefine('tournament_mode',
@@ -297,7 +299,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		lpdbData.prizepool = 0
 	end
 
-	lpdbData.publishertier = args.valvetier
 	lpdbData.maps = table.concat(League:getAllArgsForBase(args, 'map'), ';')
 	lpdbData.sortdate = args.sort_date or lpdbData.enddate
 
@@ -306,7 +307,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.enddate_raw = args.edate or args.date
 	lpdbData.extradata.shortname2 = args.shortname2
 
-	Array.forEach(CustomLeague.getRestrictions(_args.restrictions),
+	Array.forEach(CustomLeague.getRestrictions(args.restrictions),
 		function(res) lpdbData.extradata['restriction_' .. res.data] = 1 end)
 
 	-- Extradata variable
@@ -316,14 +317,14 @@ function CustomLeague:addToLpdb(lpdbData, args)
 end
 
 function CustomLeague:_createGameCell(args)
-	if Table.isEmpty(_args.gameData) and String.isEmpty(args.patch) then
+	if Table.isEmpty(args.gameData) and String.isEmpty(args.patch) then
 		return nil
 	end
 
 	local content = ''
 
-	if Table.isNotEmpty(_args.gameData) then
-		content = content .. Page.makeInternalLink({}, _args.gameData.name, _args.gameData.link)
+	if Table.isNotEmpty(args.gameData) then
+		content = content .. Page.makeInternalLink({}, args.gameData.name, args.gameData.link)
 	end
 
 	if String.isEmpty(args.epatch) and String.isNotEmpty(args.patch) then

--- a/components/infobox/wikis/criticalops/infobox_league_custom.lua
+++ b/components/infobox/wikis/criticalops/infobox_league_custom.lua
@@ -79,10 +79,10 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	-- Wiki Custom
-	Variables.varDefine('tournament_mode', (_args.individual or _args. player_number) and '1v1' or 'team')
-	Variables.varDefine('patch', _args.patch or '')
+	Variables.varDefine('tournament_mode', (args.individual or args. player_number) and '1v1' or 'team')
+	Variables.varDefine('patch', args.patch or '')
 end
 
 function CustomLeague:_createNoWrappingSpan(content)

--- a/components/infobox/wikis/crossfire/infobox_league_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_league_custom.lua
@@ -72,15 +72,14 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = CustomLeague._getGameVersion() or args.game
-	lpdbData.publishertier = args.cfpremier
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_game', CustomLeague._getGameVersion() or _args.game)
-	Variables.varDefine('tournament_publishertier', _args.cfpremier)
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_game', CustomLeague._getGameVersion() or args.game)
+	Variables.varDefine('tournament_publishertier', args.cfpremier)
 	--Legacy Vars:
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))

--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -105,20 +105,19 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	if String.isEmpty(_args.pctier) and Logic.readBool(_args.valvepremier) then
+function CustomLeague:appendLiquipediatierDisplay(args)
+	if String.isEmpty(args.pctier) and Logic.readBool(args.valvepremier) then
 		return ' ' .. Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox')
 	end
 	return ''
 end
 
-function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args.valvepremier)
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args.valvepremier)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = string.lower(args.game or 'dota2')
-	lpdbData.publishertier = args.pctier
 
 	lpdbData.extradata.valvepremier = String.isNotEmpty(args.valvepremier) and '1' or '0'
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
@@ -127,23 +126,23 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	-- Custom Vars
-	Variables.varDefine('tournament_pro_circuit_points', _args.points or '')
-	local isIndividual = String.isNotEmpty(_args.individual) or String.isNotEmpty(_args.player_number)
+	Variables.varDefine('tournament_pro_circuit_points', args.points or '')
+	local isIndividual = String.isNotEmpty(args.individual) or String.isNotEmpty(args.player_number)
 	Variables.varDefine('tournament_individual', isIndividual and 'true' or '')
-	Variables.varDefine('tournament_valve_premier', _args.valvepremier)
-	Variables.varDefine('tournament_publisher_major', _args.valvepremier)
-	Variables.varDefine('tournament_pro_circuit_tier', _args.pctier)
-	Variables.varDefine('tournament_publishertier', _args.pctier)
-	Variables.varDefine('tournament_game', string.lower(_args.game or 'dota2'))
+	Variables.varDefine('tournament_valve_premier', args.valvepremier)
+	Variables.varDefine('tournament_publisher_major', args.valvepremier)
+	Variables.varDefine('tournament_pro_circuit_tier', args.pctier)
+	Variables.varDefine('tournament_publishertier', args.pctier)
+	Variables.varDefine('tournament_game', string.lower(args.game or 'dota2'))
 
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
-	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
-	Variables.varDefine('tournament_tier_type', _args.liquipediatiertype)
-	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
-	Variables.varDefine('tournament_mode', _args.mode or '')
+	Variables.varDefine('tournament_ticker_name', args.tickername or '')
+	Variables.varDefine('tournament_tier', args.liquipediatier or '')
+	Variables.varDefine('tournament_tier_type', args.liquipediatiertype)
+	Variables.varDefine('tournament_prizepool', args.prizepool or '')
+	Variables.varDefine('tournament_mode', args.mode or '')
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')

--- a/components/infobox/wikis/fifa/infobox_league_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_league_custom.lua
@@ -51,7 +51,6 @@ function CustomLeague.run(frame)
 
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
-	league.addToLpdb = CustomLeague.addToLpdb
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
 	league.getWikiCategories = CustomLeague.getWikiCategories
 
@@ -91,17 +90,12 @@ function CustomLeague:liquipediaTierHighlighted(args)
 	return Logic.readBool(args.publisherpremier)
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = Logic.readBool(args.publisherpremier) and 'true' or nil
-
-	return lpdbData
-end
-
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or _args.name)
-	Variables.varDefine('tournament_tier', _args.liquipediatier)
-	Variables.varDefine('tournament_mode', _args.mode)
+	Variables.varDefine('tournament_ticker_name', args.tickername or args.name)
+	Variables.varDefine('tournament_tier', args.liquipediatier)
+	Variables.varDefine('tournament_mode', args.mode)
+	Variables.varDefine('tournament_publishertier', Logic.readBool(args.publisherpremier) and 'true' or nil)
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')
@@ -112,20 +106,20 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('date', edate)
 	Variables.varDefine('sdate', sdate)
 	Variables.varDefine('edate', edate)
-	Variables.varDefine('mode', _args.mode)
+	Variables.varDefine('mode', args.mode)
 end
 
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
 
-	if _args.game then
-		table.insert(categories, _args.game .. ' Competitions')
+	if args.game then
+		table.insert(categories, args.game .. ' Competitions')
 	else
 		table.insert(categories, 'Tournaments without game version')
 	end
 
-	if _args.platform then
-		table.insert(categories, _args.platform .. ' Tournaments')
+	if args.platform then
+		table.insert(categories, args.platform .. ' Tournaments')
 	else
 		table.insert(categories, 'Tournaments without platform')
 	end

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -116,37 +116,37 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.participantsnumber = string.gsub(_args.player_number or '', ',', '')
+	lpdbData.participantsnumber = string.gsub(args.player_number or '', ',', '')
 
-	if Logic.readBool(_args.overview) then
+	if Logic.readBool(args.overview) then
 		lpdbData.game = 'none'
 	end
 
-	lpdbData.extradata.assumedprizepool = tostring(_args.prizepoolassumed)
-	lpdbData.extradata.circuit = _args.circuit
-	lpdbData.extradata.circuittier = _args.circuittier
-	lpdbData.extradata.circuit2 = _args.circuit2
-	lpdbData.extradata.circuit2tier = _args.circuit2tier
+	lpdbData.extradata.assumedprizepool = tostring(args.prizepoolassumed)
+	lpdbData.extradata.circuit = args.circuit
+	lpdbData.extradata.circuittier = args.circuittier
+	lpdbData.extradata.circuit2 = args.circuit2
+	lpdbData.extradata.circuit2tier = args.circuit2tier
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	-- Custom vars
-	Variables.varDefine('assumedpayout', tostring(_args.prizepoolassumed))
-	Variables.varDefine('circuit', _args.circuit)
-	Variables.varDefine('circuittier', _args.circuittier)
-	Variables.varDefine('circuitabbr', _args.circuitabbr)
-	Variables.varDefine('circuit2', _args.circuit2)
-	Variables.varDefine('circuit2tier', _args.circuit2tier)
-	Variables.varDefine('circuit2abbr', _args.circuit2abbr)
-	Variables.varDefine('seriesabbr', _args.abbreviation)
+	Variables.varDefine('assumedpayout', tostring(args.prizepoolassumed))
+	Variables.varDefine('circuit', args.circuit)
+	Variables.varDefine('circuittier', args.circuittier)
+	Variables.varDefine('circuitabbr', args.circuitabbr)
+	Variables.varDefine('circuit2', args.circuit2)
+	Variables.varDefine('circuit2tier', args.circuit2tier)
+	Variables.varDefine('circuit2abbr', args.circuit2abbr)
+	Variables.varDefine('seriesabbr', args.abbreviation)
 	Variables.varDefine('tournament_link', self.pagename)
 
 	-- Legacy vars
-	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
+	Variables.varDefine('tournament_tier', args.liquipediatier or '')
 	Variables.varDefine('prizepoolusd', Variables.varDefault('tournament_prizepoolusd'))
-	Variables.varDefine('tournament_entrants', string.gsub(_args.player_number or '', ',', ''))
+	Variables.varDefine('tournament_entrants', string.gsub(args.player_number or '', ',', ''))
 	Variables.varDefine('localcurrency', Variables.varDefault('tournament_currency', ''):upper())
 
 	-- Legacy date vars
@@ -164,8 +164,8 @@ end
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
 
-	if _args.game then
-		table.insert(categories, Game.name{game = _args.game} .. ' Competitions')
+	if args.game then
+		table.insert(categories, Game.name{game = args.game} .. ' Competitions')
 	end
 
 	return categories

--- a/components/infobox/wikis/fortnite/infobox_league_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_league_custom.lua
@@ -26,7 +26,6 @@ function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
 
-	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
@@ -51,20 +50,14 @@ function CustomInjector:addCustomCells(widgets)
 	return widgets
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = args.epicpremier
-
-	return lpdbData
-end
-
-function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_publishertier', _args.epicpremier)
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_publishertier', args.epicpremier)
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end
 
-function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args.epicpremier)
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args.epicpremier)
 end
 
 return CustomLeague

--- a/components/infobox/wikis/halo/infobox_league_custom.lua
+++ b/components/infobox/wikis/halo/infobox_league_custom.lua
@@ -98,7 +98,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = CustomLeague:_concatArgs('map')
 
 	lpdbData.game = _game or args.game
-	lpdbData.publishertier = args['hcs-sponsored']
 
 	lpdbData.extradata.maps = Json.stringify(maps)
 	lpdbData.extradata.individual = not String.isEmpty(args.player_number)

--- a/components/infobox/wikis/hearthstone/infobox_league_custom.lua
+++ b/components/infobox/wikis/hearthstone/infobox_league_custom.lua
@@ -90,12 +90,12 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or _args.name)
-	Variables.varDefine('tournament_tier', _args.liquipediatier)
-	Variables.varDefine('tournament_prizepool', _args.prizepoolusd)
-	Variables.varDefine('tournament_mode', _args.mode)
+	Variables.varDefine('tournament_ticker_name', args.tickername or args.name)
+	Variables.varDefine('tournament_tier', args.liquipediatier)
+	Variables.varDefine('tournament_prizepool', args.prizepoolusd)
+	Variables.varDefine('tournament_mode', args.mode)
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')
@@ -106,21 +106,21 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('date', edate)
 	Variables.varDefine('sdate', sdate)
 	Variables.varDefine('edate', edate)
-	Variables.varDefine('mode', _args.mode)
+	Variables.varDefine('mode', args.mode)
 end
 
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
 
-	if _args.mode then
-		table.insert(categories, _args.mode .. ' Tournaments')
+	if args.mode then
+		table.insert(categories, args.mode .. ' Tournaments')
 	end
 
 	return categories
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	if Logic.readBool(_args.blizzardpremier) then
+function CustomLeague:appendLiquipediatierDisplay(args)
+	if Logic.readBool(args.blizzardpremier) then
 		return '[[File:Blizzard_logo.png|x12px|link=Blizzard Entertainment|Premier Tournament held by Blizzard]]'
 	end
 

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -62,20 +62,18 @@ function CustomInjector:addCustomCells(widgets)
 	return widgets
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	if Logic.readBool(_args.riotpremier) then
+function CustomLeague:appendLiquipediatierDisplay(args)
+	if Logic.readBool(args.riotpremier) then
 		return ' ' .. RIOT_ICON
 	end
 	return ''
 end
 
-function CustomLeague:liquipediaTierHighlighted()
-	return Logic.readBool(_args.riotpremier)
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args.riotpremier)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = Logic.readBool(args.riotpremier) and '1' or ''
-
 	lpdbData.extradata.individual = String.isNotEmpty(args.participants_number) or
 			String.isNotEmpty(args.individual) and 'true' or ''
 
@@ -84,17 +82,17 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	-- Custom Vars
-	Variables.varDefine('tournament_riot_premier', _args.riotpremier)
-	Variables.varDefine('tournament_publisher_major', _args.riotpremier)
-	Variables.varDefine('tournament_publishertier', Logic.readBool(_args.riotpremier) and '1' or nil)
+	Variables.varDefine('tournament_riot_premier', args.riotpremier)
+	Variables.varDefine('tournament_publisher_major', args.riotpremier)
+	Variables.varDefine('tournament_publishertier', Logic.readBool(args.riotpremier) and '1' or nil)
 
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
-	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
+	Variables.varDefine('tournament_ticker_name', args.tickername or '')
+	Variables.varDefine('tournament_tier', args.liquipediatier or '')
 	Variables.varDefine('tournament_tier_type', Variables.varDefault('tournament_liquipediatiertype'))
-	Variables.varDefine('tournament_mode', _args.mode or '')
+	Variables.varDefine('tournament_mode', args.mode or '')
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')

--- a/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
@@ -29,7 +29,6 @@ function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
 
-	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
@@ -62,17 +61,11 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function League:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = _args['moonton-sponsored'] == 'true' and 'true' or nil
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_patch', args.patch)
+	Variables.varDefine('tournament_endpatch', args.epatch)
 
-	return lpdbData
-end
-
-function League:defineCustomPageVariables()
-	Variables.varDefine('tournament_patch', _args.patch)
-	Variables.varDefine('tournament_endpatch', _args.epatch)
-
-	Variables.varDefine('tournament_publishertier', _args['moonton-sponsored'])
+	Variables.varDefine('tournament_publishertier', Logic.readBool(args['moonton-sponsored']) and 'true' or nil)
 		--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
+local Variables = require('Moduke:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
@@ -35,6 +36,8 @@ function CustomLeague.run(frame)
 	_args = league.args
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+
 	return league:createInfobox()
 end
 
@@ -62,9 +65,12 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_publishertier', args.narakapremier)
+end
+
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = args.platform
-	lpdbData.publishertier = args.narakapremier
 
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number)
 

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -103,10 +103,6 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 
-	if CustomLeague:_validPublisherTier(args.blizzardtier) then
-		lpdbData.publishertier = args.blizzardtier:lower()
-	end
-
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
@@ -116,7 +112,7 @@ function CustomLeague:_validPublisherTier(publishertier)
 	return String.isNotEmpty(publishertier) and _BLIZZARD_TIERS[publishertier:lower()]
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
 	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
 	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
@@ -128,7 +124,10 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tournament_edate', edate)
 	Variables.varDefine('tournament_date', edate)
 
-	Variables.varDefine('tournament_blizzard_premier', _args.publishertier or '')
+	if CustomLeague:_validPublisherTier(args.blizzardtier) then
+		Variables.varDefine('tournament_blizzard_premier', args.blizzardtier:lower())
+	end
+
 end
 
 function CustomLeague:getWikiCategories(args)

--- a/components/infobox/wikis/pokemon/infobox_league_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_league_custom.lua
@@ -71,16 +71,15 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = CustomLeague._getGameVersion()
-	lpdbData.publishertier = args.pokemonpremier
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 	lpdbData.mode = CustomLeague:_getGameMode()
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_game', CustomLeague._getGameVersion())
-	Variables.varDefine('tournament_publishertier', _args['pokemonpremier'])
+	Variables.varDefine('tournament_publishertier', args.pokemonpremier)
 	Variables.varDefine('tournament_mode', CustomLeague:_getGameMode())
 
 	--Legacy Vars:

--- a/components/infobox/wikis/pubg/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_league_custom.lua
@@ -113,15 +113,14 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = _game or args.game
-	lpdbData.publishertier = args.pubgpremier
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args['pubgpremier'])
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_game', _game or args.game)
+	Variables.varDefine('tournament_publishertier', args.pubgpremier)
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
@@ -111,15 +111,14 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = args.platform
-	lpdbData.publishertier = args.pubgpremier
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_game', _game or _args.game)
-	Variables.varDefine('tournament_publishertier', _args['pubgpremier'])
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_game', _game or args.game)
+	Variables.varDefine('tournament_publishertier', args.pubgpremier)
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
 end

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -125,10 +125,6 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 
-	if CustomLeague:_validPublisherTier(args.ubisofttier) then
-		lpdbData.publishertier = args.ubisofttier:lower()
-	end
-
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 	lpdbData.extradata.startdatetext = CustomLeague:_standardiseRawDate(args.sdate or args.date)
 	lpdbData.extradata.enddatetext = CustomLeague:_standardiseRawDate(args.edate or args.date)
@@ -154,17 +150,21 @@ function CustomLeague:_standardiseRawDate(dateString)
 	return dateString
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	-- Variables with different handling compared to commons
 	Variables.varDefine('tournament_liquipediatiertype',
 		Variables.varDefault('tournament_liquipediatiertype', DEFAULT_TIERTYPE))
 
+	if CustomLeague:_validPublisherTier(args.ubisofttier) then
+		Variables.varDefault('tournament_publishertier', args.ubisofttier:lower())
+	end
+
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or '')
-	Variables.varDefine('tournament_tier', _args.liquipediatier or '')
+	Variables.varDefine('tournament_ticker_name', args.tickername or '')
+	Variables.varDefine('tournament_tier', args.liquipediatier or '')
 	Variables.varDefine('tournament_tier_type', Variables.varDefault('tournament_liquipediatiertype'))
-	Variables.varDefine('tournament_prizepool', _args.prizepool or '')
-	Variables.varDefine('tournament_mode', _args.mode or '')
+	Variables.varDefine('tournament_prizepool', args.prizepool or '')
+	Variables.varDefine('tournament_mode', args.mode or '')
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -156,7 +156,7 @@ function CustomLeague:defineCustomPageVariables(args)
 		Variables.varDefault('tournament_liquipediatiertype', DEFAULT_TIERTYPE))
 
 	if CustomLeague:_validPublisherTier(args.ubisofttier) then
-		Variables.varDefault('tournament_publishertier', args.ubisofttier:lower())
+		Variables.varDefine('tournament_publishertier', args.ubisofttier:lower())
 	end
 
 	--Legacy vars

--- a/components/infobox/wikis/simracing/infobox_league_custom.lua
+++ b/components/infobox/wikis/simracing/infobox_league_custom.lua
@@ -71,11 +71,11 @@ function CustomInjector:addCustomCells(widgets)
 	return widgets
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or _args.name)
-	Variables.varDefine('tournament_tier', _args.liquipediatier)
-	Variables.varDefine('tournament_mode', _args.mode)
+	Variables.varDefine('tournament_ticker_name', args.tickername or args.name)
+	Variables.varDefine('tournament_tier', args.liquipediatier)
+	Variables.varDefine('tournament_mode', args.mode)
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')
@@ -86,14 +86,14 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('date', edate)
 	Variables.varDefine('sdate', sdate)
 	Variables.varDefine('edate', edate)
-	Variables.varDefine('mode', _args.mode)
+	Variables.varDefine('mode', args.mode)
 end
 
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
 
-	if _args.game then
-		table.insert(categories, _args.game .. ' Competitions')
+	if args.game then
+		table.insert(categories, args.game .. ' Competitions')
 	else
 		table.insert(categories, 'Tournaments without game version')
 	end
@@ -107,11 +107,11 @@ function CustomLeague:liquipediaTierHighlighted(args)
 	end)
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
+function CustomLeague:appendLiquipediatierDisplay(args)
 	local content = ''
 
 	for param, icon in pairs(SPECIAL_SPONSORS) do
-		if _args[param..'-sponsored'] then
+		if args[param..'-sponsored'] then
 			content = content .. icon
 		end
 	end

--- a/components/infobox/wikis/splatoon/infobox_league_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_league_custom.lua
@@ -69,15 +69,14 @@ end
 
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.game = CustomLeague._getGameVersion()
-	lpdbData.publishertier = Logic.readBool(_args.publisherpremier) or nil
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 
 	return lpdbData
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('tournament_game', CustomLeague._getGameVersion())
-	Variables.varDefine('tournament_publishertier', _args.publisherpremier)
+	Variables.varDefine('tournament_publishertier', Logic.readBool(args.publisherpremier) and 'true' or nil)
 end
 
 function CustomLeague._getGameVersion()

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -228,11 +228,11 @@ function CustomLeague:_makeBasedListFromArgs(prefix)
 	return {table.concat(foundArgs, '&nbsp;• ')}
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
 	local name = self.name
-	Variables.varDefine('tournament_ticker_name', _args.tickername or name)
-	Variables.varDefine('tournament_abbreviation', _args.abbreviation or '')
+	Variables.varDefine('tournament_ticker_name', args.tickername or name)
+	Variables.varDefine('tournament_abbreviation', args.abbreviation or '')
 	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier', ''))
 
 	--Legacy date vars
@@ -247,16 +247,16 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('lpdbtime', mw.getContentLanguage():formatDate('U', endDate))
 
 	--SC specific vars
-	Variables.varDefine('tournament_mode', _args.mode or '1v1')
-	Variables.varDefine('headtohead', _args.headtohead or 'true')
+	Variables.varDefine('tournament_mode', args.mode or '1v1')
+	Variables.varDefine('headtohead', args.headtohead or 'true')
 	--series number
-	local seriesNumber = _args.number or ''
+	local seriesNumber = args.number or ''
 	if String.isNotEmpty(seriesNumber) then
 		seriesNumber = string.format('%05i', seriesNumber)
 	end
 	Variables.varDefine('tournament_series_number', seriesNumber)
 	--check if tournament is finished
-	local finished = Logic.readBool(_args.finished)
+	local finished = Logic.readBool(args.finished)
 	local queryDate = Variables.varDefault('tournament_enddate', '2999-99-99')
 	if not finished and os.date('%Y-%m-%d') >= queryDate then
 		local data = mw.ext.LiquipediaDB.lpdb('placement', {
@@ -275,27 +275,27 @@ function CustomLeague:defineCustomPageVariables()
 	-- do not resolve redirect on the series input
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them
-	Variables.varDefine('tournament_series', _args.series)
+	Variables.varDefine('tournament_series', args.series)
 end
 
-function CustomLeague:addToLpdb(lpdbData)
+function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.tickername = lpdbData.tickername or lpdbData.name
 	lpdbData.patch = Variables.varDefault('patch', '')
 	lpdbData.endpatch = Variables.varDefault('epatch', '')
-	local status = _args.status
+	local status = args.status
 		or Logic.readBool(Variables.varDefault('cancelled tournament')) and 'cancelled'
 		or Logic.readBool(Variables.varDefault('tournament_finished')) and 'finished'
 	lpdbData.status = status
 	lpdbData.maps = CustomLeague:_concatArgs('map')
-	lpdbData.participantsnumber = Variables.varDefault('tournament_playerNumber', _args.team_number or 0)
+	lpdbData.participantsnumber = Variables.varDefault('tournament_playerNumber', args.team_number or 0)
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
 	-- do not resolve redirect on the series input
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them
-	lpdbData.series = _args.series
+	lpdbData.series = args.series
 
-	lpdbData.extradata.female = Logic.readBool(_args.female) or nil
+	lpdbData.extradata.female = Logic.readBool(args.female) or nil
 
 	return lpdbData
 end

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -417,27 +417,27 @@ function CustomLeague:_makeBasedListFromArgs(prefix)
 	return {table.concat(foundArgs, '&nbsp;• ')}
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--override var to standardize its entries
-	Variables.varDefine('tournament_game', _args.game)
+	Variables.varDefine('tournament_game', args.game)
 
 	--patch data
 	CustomLeague._setPatchData()
-	Variables.varDefine('patch', _args.patch)
-	Variables.varDefine('epatch', _args.epatch)
+	Variables.varDefine('patch', args.patch)
+	Variables.varDefine('epatch', args.epatch)
 
 	--SC2 specific vars
-	Variables.varDefine('tournament_mode', _args.mode or '1v1')
-	Variables.varDefine('headtohead', _args.headtohead or 'true')
-	Variables.varDefine('tournament_publishertier', tostring(Logic.readBool(_args.featured)))
+	Variables.varDefine('tournament_mode', args.mode or '1v1')
+	Variables.varDefine('headtohead', args.headtohead or 'true')
+	Variables.varDefine('tournament_publishertier', tostring(Logic.readBool(args.featured)))
 	--series number
-	local seriesNumber = _args.number
+	local seriesNumber = args.number
 	if Logic.isNumeric(seriesNumber) then
 		seriesNumber = string.format('%05i', seriesNumber)
 		Variables.varDefine('tournament_series_number', seriesNumber)
 	end
 	--check if tournament is finished
-	local finished = Logic.readBool(_args.finished)
+	local finished = Logic.readBool(args.finished)
 	local queryDate = Variables.varDefault('tournament_enddate', '2999-99-99')
 	if not finished and os.date('%Y-%m-%d') >= queryDate then
 		local data = mw.ext.LiquipediaDB.lpdb('placement', {
@@ -473,24 +473,23 @@ function CustomLeague._getMaps(prefix)
 	end)
 end
 
-function CustomLeague:addToLpdb(lpdbData)
+function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.tickername = lpdbData.tickername or lpdbData.name
-	lpdbData.game = _args.game
+	lpdbData.game = args.game
 	lpdbData.patch = Variables.varDefault('patch', '')
 	lpdbData.endpatch = Variables.varDefaultMulti('epatch', 'patch', '')
-	local status = _args.status
+	local status = args.status
 		or Logic.readBool(Variables.varDefault('cancelled tournament')) and 'cancelled'
 		or Logic.readBool(Variables.varDefault('tournament_finished')) and 'finished'
 	lpdbData.status = status
 	lpdbData.maps = Variables.varDefault('tournament_maps')
 	local participantsNumber = tonumber(Variables.varDefault('tournament_playerNumber')) or 0
 	if participantsNumber == 0 then
-		participantsNumber = _args.team_number or 0
+		participantsNumber = args.team_number or 0
 	end
 	lpdbData.participantsnumber = participantsNumber
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
-	lpdbData.publishertier = Variables.varDefault('tournament_publishertier')
 
 	lpdbData.extradata.seriesnumber = Variables.varDefault('tournament_series_number')
 
@@ -517,7 +516,7 @@ function CustomLeague:getWikiCategories(args)
 		return {}
 	end
 
-	local betaPrefix = String.isNotEmpty(_args.beta) and 'Beta ' or ''
+	local betaPrefix = String.isNotEmpty(args.beta) and 'Beta ' or ''
 	local gameAbbr = Game.abbreviation{game = args.game}
 	return {betaPrefix .. gameAbbr .. ' Competitions'}
 end

--- a/components/infobox/wikis/teamfortress/infobox_league_custom.lua
+++ b/components/infobox/wikis/teamfortress/infobox_league_custom.lua
@@ -78,11 +78,11 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
-	Variables.varDefine('tournament_ticker_name', _args.tickername or _args.name)
-	Variables.varDefine('tournament_tier', _args.liquipediatier)
-	Variables.varDefine('tournament_prizepool', _args.prizepoolusd)
+	Variables.varDefine('tournament_ticker_name', args.tickername or args.name)
+	Variables.varDefine('tournament_tier', args.liquipediatier)
+	Variables.varDefine('tournament_prizepool', args.prizepoolusd)
 
 	--Legacy date vars
 	local sdate = Variables.varDefault('tournament_startdate', '')
@@ -98,8 +98,8 @@ end
 function CustomLeague:getWikiCategories(args)
 	local categories = {}
 
-	if _args.mode then
-		table.insert(categories, _args.mode .. ' Tournaments')
+	if args.mode then
+		table.insert(categories, args.mode .. ' Tournaments')
 	end
 
 	return categories

--- a/components/infobox/wikis/tetris/infobox_league_custom.lua
+++ b/components/infobox/wikis/tetris/infobox_league_custom.lua
@@ -78,8 +78,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.game = Game.name{game = _args.game}
-	lpdbData.publishertier = args.publisherpremier
+	lpdbData.game = Game.name{game = args.game}
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 	lpdbData.extradata.gamegroup = CustomLeague._determineGameGroup(lpdbData.game)
 
@@ -94,13 +93,13 @@ function CustomLeague._determineGameGroup(game)
 	end
 end
 
-function League:defineCustomPageVariables()
-	if _args.team_number then
+function CustomLeague:defineCustomPageVariables(args)
+	if args.team_number then
 		Variables.varDefine('tournament_mode', 'team')
 	else
 		Variables.varDefine('tournament_mode', 'individual')
 	end
-	Variables.varDefine('tournament_publishertier', _args.publisherpremier)
+	Variables.varDefine('tournament_publishertier', args.publisherpremier)
 end
 
 function CustomLeague:liquipediaTierHighlighted(args)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -80,15 +80,15 @@ function CustomLeague:liquipediaTierHighlighted(args)
 	return Logic.readBool(args['riot-sponsored'])
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	if Logic.readBool(_args['riot-sponsored']) then
+function CustomLeague:appendLiquipediatierDisplay(args)
+	if Logic.readBool(args['riot-sponsored']) then
 		return ' ' .. RIOT_ICON
 	end
 	return ''
 end
 
-function CustomLeague:defineCustomPageVariables()
-	Variables.varDefine('tournament_mode', string.lower(_args.mode or ''))
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_mode', string.lower(args.mode or ''))
 end
 
 function CustomLeague:_createPatchCell(args)
@@ -106,6 +106,6 @@ function CustomLeague:_createPatchCell(args)
 end
 
 function CustomLeague.getWikiCategories(args)
-	return {_args.mode .. ' Mode Tournaments'}
+	return {args.mode .. ' Mode Tournaments'}
 end
 return CustomLeague

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -103,12 +103,6 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(_league:getAllArgsForBase(args, 'map'), ';')
 
-	if Logic.readBool(args['riot-highlighted']) then
-		lpdbData.publishertier = 'highlighted'
-	elseif Logic.readBool(args['riot-sponsored']) then
-		lpdbData.publishertier = 'sponsored'
-	end
-
 	lpdbData.extradata.region = Template.safeExpand(mw.getCurrentFrame(), 'Template:Player region', {args.country})
 	lpdbData.extradata.startdate_raw = args.sdate or args.date
 	lpdbData.extradata.enddate_raw = args.edate or args.date
@@ -144,12 +138,19 @@ function CustomLeague:_createPatchCell(args)
 	return content
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	-- Wiki Custom
-	Variables.varDefine('female', _args.female or 'false')
-	Variables.varDefine('tournament_riot_premier', _args.riotpremier and 'true' or '')
-	Variables.varDefine('tournament_mode', (_args.individual or _args. player_number) and '1v1' or 'team')
-	Variables.varDefine('patch', _args.patch or '')
+	Variables.varDefine('female', args.female or 'false')
+	Variables.varDefine('tournament_riot_premier', args.riotpremier and 'true' or '')
+	Variables.varDefine('tournament_mode', (args.individual or args.player_number) and '1v1' or 'team')
+	Variables.varDefine('patch', args.patch or '')
+
+	-- Publishertier vars
+	if Logic.readBool(args['riot-highlighted']) then
+		Variables.varDefine('tournament_publishertier', 'highlighted')
+	elseif Logic.readBool(args['riot-sponsored']) then
+		Variables.varDefine('tournament_publishertier', 'sponsored')
+	end
 
 	--Legacy vars
 	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername', ''))

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -360,7 +360,9 @@ function CustomLeague:defineCustomPageVariables(args)
 	end
 
 	--publisher tier
-	Variables.varDefine('tournament_publishertier', ESL_TIERS[(args.eslprotier or ''):lower()] and args.eslprotier:lower() or nil)
+	Variables.varDefine('tournament_publishertier',
+		ESL_TIERS[(args.eslprotier or ''):lower()] and args.eslprotier:lower() or nil
+	)
 
 	CustomLeague._getGameVersion()
 end

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -295,13 +295,13 @@ function CustomLeague._playerRaceBreakDown()
 	return playerBreakDown or {}
 end
 
-function CustomLeague:defineCustomPageVariables()
+function CustomLeague:defineCustomPageVariables(args)
 	--Legacy vars
 	local name = self.name
-	Variables.varDefine('tournament_ticker_name', _args.tickername or name)
+	Variables.varDefine('tournament_ticker_name', args.tickername or name)
 	Variables.varDefine('tournament_tier', Variables.varDefault('tournament_liquipediatier', ''))
 	Variables.varDefine('tournament_icon_filename', Variables.varDefault('tournament_icon'))
-	Variables.varDefine('tournament_icon_name', (_args.abbreviation or ''):lower())
+	Variables.varDefine('tournament_icon_name', (args.abbreviation or ''):lower())
 
 	Variables.varDefine('usd prize', Variables.varDefault('tournament_prizepoolusd'))
 	Variables.varDefine('localcurrency', Variables.varDefault('tournament_currency'))
@@ -312,17 +312,17 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('tempdate', Variables.varDefault('tournament_enddate'))
 
 	-- Warcraft specific stuff
-	Variables.varDefine('environment', (_args.type or ''):lower() == OFFLINE and OFFLINE or ONLINE)
+	Variables.varDefine('environment', (args.type or ''):lower() == OFFLINE and OFFLINE or ONLINE)
 
-	if _args.starttime then
-		Variables.varDefine('tournament_starttimeraw', Variables.varDefault('tournament_startdate', '') .. _args.starttime)
+	if args.starttime then
+		Variables.varDefine('tournament_starttimeraw', Variables.varDefault('tournament_startdate', '') .. args.starttime)
 
 		local startTime = Variables.varDefault('tournament_startdate', '') .. ' '
-			.. _args.starttime:gsub('<.*', '')
+			.. args.starttime:gsub('<.*', '')
 
 		Variables.varDefine('tournament_starttime', startTime)
 		Variables.varDefine('start_time', startTime)
-		local timeZone = _args.starttime:match('data%-tz="(.-)"')
+		local timeZone = args.starttime:match('data%-tz="(.-)"')
 		if timeZone then
 			Variables.varDefine('tournament_timezone', timeZone)
 		end
@@ -331,10 +331,10 @@ function CustomLeague:defineCustomPageVariables()
 	Variables.varDefine('firstmatch', CustomLeague._getFirstMatchTime())
 
 	--override var to standardize its entries
-	Variables.varDefine('tournament_game', GAMES[_args.game])
+	Variables.varDefine('tournament_game', GAMES[args.game])
 
 	--check if tournament is finished
-	local finished = Logic.readBoolOrNil(_args.finished)
+	local finished = Logic.readBoolOrNil(args.finished)
 	local queryDate = Variables.varDefault('tournament_enddate', '2999-99-99')
 	if finished == nil and os.date('%Y-%m-%d') >= queryDate then
 		local data = mw.ext.LiquipediaDB.lpdb('placement', {
@@ -354,7 +354,7 @@ function CustomLeague:defineCustomPageVariables()
 	local maps = CustomLeague._getMaps('map')
 	Variables.varDefine('tournament_maps', maps and Json.stringify(maps) or '')
 
-	local seriesNumber = _args.number
+	local seriesNumber = args.number
 	if Logic.isNumeric(seriesNumber) then
 		Variables.varDefine('tournament_series_number', seriesNumber)
 	end
@@ -390,25 +390,25 @@ function CustomLeague._getMaps(prefix)
 	end)
 end
 
-function CustomLeague:addToLpdb(lpdbData)
+function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.tickername = lpdbData.tickername or lpdbData.name
-	lpdbData.game = GAMES[_args.game]
+	lpdbData.game = GAMES[args.game]
 	lpdbData.patch = Variables.varDefault('tournament_patch')
 	lpdbData.endpatch = Variables.varDefault('tournament_endpatch', Variables.varDefault('tournament_patch'))
-	local status = _args.status
+	local status = args.status
 		or Logic.readBool(Variables.varDefault('cancelled tournament')) and 'cancelled'
 		or Logic.readBool(Variables.varDefault('tournament_finished')) and 'finished'
 	lpdbData.status = status
 	lpdbData.maps = Variables.varDefault('tournament_maps')
-	local participantsNumber = tonumber(_args.team_number) or 0
+	local participantsNumber = tonumber(args.team_number) or 0
 	if participantsNumber == 0 then
-		participantsNumber = tonumber(_args.player_number) or 0
+		participantsNumber = tonumber(args.player_number) or 0
 	end
 	lpdbData.participantsnumber = participantsNumber
 	lpdbData.sortdate = Variables.varDefault('tournament_starttime')
 		and (Variables.varDefault('tournament_starttime') .. (Variables.varDefault('tournament_timezone') or ''))
 		or Variables.varDefault('firstmatch', Variables.varDefault('tournament_startdate'))
-	lpdbData.publishertier = ESL_TIERS[(_args.eslprotier or ''):lower()] and _args.eslprotier:lower() or nil
+	lpdbData.publishertier = ESL_TIERS[(args.eslprotier or ''):lower()] and args.eslprotier:lower() or nil
 	lpdbData.mode = CustomLeague._getMode()
 	lpdbData.extradata.seriesnumber = Variables.varDefault('tournament_series_number')
 
@@ -437,7 +437,7 @@ function CustomLeague._determineGame()
 end
 
 function CustomLeague:addParticipantTypeCategory(args)
-	return {(MODES[_args.mode] or MODES.default).category .. ' Tournaments'}
+	return {(MODES[args.mode] or MODES.default).category .. ' Tournaments'}
 end
 
 function CustomLeague:getWikiCategories(args)
@@ -480,8 +480,8 @@ function CustomLeague:createLiquipediaTierDisplay(args)
 	return tierDisplay .. self.appendLiquipediatierDisplay(args)
 end
 
-function CustomLeague:appendLiquipediatierDisplay()
-	local modeDisplay = (MODES[_args.mode] or {}).tier
+function CustomLeague:appendLiquipediatierDisplay(args)
+	local modeDisplay = (MODES[args.mode] or {}).tier
 	if not modeDisplay then
 		return ''
 	end

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -359,6 +359,9 @@ function CustomLeague:defineCustomPageVariables(args)
 		Variables.varDefine('tournament_series_number', seriesNumber)
 	end
 
+	--publisher tier
+	Variables.varDefine('tournament_publishertier', ESL_TIERS[(args.eslprotier or ''):lower()] and args.eslprotier:lower() or nil)
+
 	CustomLeague._getGameVersion()
 end
 
@@ -408,7 +411,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.sortdate = Variables.varDefault('tournament_starttime')
 		and (Variables.varDefault('tournament_starttime') .. (Variables.varDefault('tournament_timezone') or ''))
 		or Variables.varDefault('firstmatch', Variables.varDefault('tournament_startdate'))
-	lpdbData.publishertier = ESL_TIERS[(args.eslprotier or ''):lower()] and args.eslprotier:lower() or nil
 	lpdbData.mode = CustomLeague._getMode()
 	lpdbData.extradata.seriesnumber = Variables.varDefault('tournament_series_number')
 

--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -29,7 +29,6 @@ function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
 
-	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
@@ -62,21 +61,15 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function League:addToLpdb(lpdbData, args)
-	lpdbData.publishertier = Logic.readBool(args.riotpremier) and 'true' or nil
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_patch', args.patch)
+	Variables.varDefine('tournament_endpatch', args.epatch)
 
-	return lpdbData
-end
-
-function League:defineCustomPageVariables()
-	Variables.varDefine('tournament_patch', _args.patch)
-	Variables.varDefine('tournament_endpatch', _args.epatch)
-
-	Variables.varDefine('tournament_publishertier', _args['riotpremier'])
+	Variables.varDefine('tournament_publishertier', Logic.readBool(args.riotpremier) and 'true' or nil)
 
 	--Legacy Vars:
 	Variables.varDefine('tournament_edate', Variables.varDefault('tournament_enddate'))
-	Variables.varDefine('tournament_riot_premier', _args['riotpremier'])
+	Variables.varDefine('tournament_riot_premier', args.riotpremier)
 end
 
 function CustomLeague:liquipediaTierHighlighted(args)


### PR DESCRIPTION
## Summary

Switching custom infoboxes from messy `publishertier` definition code to simplified version where they just set the variable `tournament_publishertier` and then that's used by commons module to set into LPDB. This allows other components on the tournament pages such as teamcards and prize pools to have access to the variable correctly for LPDB storage.

Also added default setting of the variable from LPDB in HiddenDataBox if it's set in the parent tournament data.

(Also changed a bunch of `_args` to `args` where possible as clean up).

## How did you test this change?

Tested on `/dev` on cs, dota2, r6, and sc2 wikis.

Still present in tournament table:
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/1d49a8ad-9fb4-4368-83c6-c5a55b1bfb9d)

But also now present in placement table too (and all others that check the var):
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/719813ee-2c35-48ff-9bb5-d4fca4e30238)

Before it was not present in placements and others:
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/e3ac764e-419a-4c0f-8be2-7cd0c15f9e41)

## The more noteworthy changes

- https://github.com/Liquipedia/Lua-Modules/pull/3179/files#diff-f7ad8158442fc0d80e26cf2e63d90f742eada1adaac893a894614b53de043613

- https://github.com/Liquipedia/Lua-Modules/pull/3179/files#diff-de69c0472f61fe1cb2022f99553eb516b2d71fb019244565b4fdcb45cbe2fba8

- https://github.com/Liquipedia/Lua-Modules/pull/3179/files#diff-2facd293c163b25e6702d939c09402b8edcb37eebbad3245ddbf13bd10a7e308

- https://github.com/Liquipedia/Lua-Modules/pull/3179/files#diff-ec644538100cc18c2b50a0714471b93ab205d3b7a8a1e0329832c222aefe2bf3

- https://github.com/Liquipedia/Lua-Modules/pull/3179/files#diff-a79d9d5d3264d52a24591ca9f50dadd8c006ebc860b34fe3b7a000e3e08bcdc6

- All the other changes are just derivatives of these ones, if it makes reviewing any easier.