### PR TITLE
Switch all `appendLiquipediatierDisplay` to object calls

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -344,7 +344,7 @@ function League:createLiquipediaTierDisplay(args)
 		return
 	end
 
-	return tierDisplay .. self.appendLiquipediatierDisplay(args)
+	return tierDisplay .. self:appendLiquipediatierDisplay(args)
 end
 
 function League:_createPrizepool(args)

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -234,7 +234,7 @@ end
 
 function Series:createLiquipediaTierDisplay(args)
 	return (Tier.display(args.liquipediatier, args.liquipediatiertype, {link = true}) or '')
-		.. self.appendLiquipediatierDisplay(args)
+		.. self:appendLiquipediatierDisplay(args)
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -369,7 +369,7 @@ function CustomLeague:createLiquipediaTierDisplay(args)
 		return
 	end
 
-	return tierDisplay .. self.appendLiquipediatierDisplay(args)
+	return tierDisplay .. self:appendLiquipediatierDisplay(args)
 end
 
 return CustomLeague

--- a/components/infobox/wikis/ageofempires/infobox_series_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_series_custom.lua
@@ -69,7 +69,7 @@ function CustomSeries:createLiquipediaTierDisplay(args)
 	return (Tier.display(
 		args.liquipediatier,
 		args.liquipediatiertype
-	) or '') .. self.appendLiquipediatierDisplay(args)
+	) or '') .. self:appendLiquipediatierDisplay(args)
 end
 
 return CustomSeries

--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -122,7 +122,7 @@ function CustomLeague:createLiquipediaTierDisplay(args)
 		return
 	end
 
-	return tierDisplay .. self.appendLiquipediatierDisplay(args)
+	return tierDisplay .. self:appendLiquipediatierDisplay(args)
 end
 
 function CustomLeague:liquipediaTierHighlighted()

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -481,7 +481,7 @@ function CustomLeague:createLiquipediaTierDisplay(args)
 		return
 	end
 
-	return tierDisplay .. self.appendLiquipediatierDisplay(args)
+	return tierDisplay .. self:appendLiquipediatierDisplay(args)
 end
 
 function CustomLeague:appendLiquipediatierDisplay(args)


### PR DESCRIPTION
## Summary

To fix issue of `self.appendLiquipediatierDisplay()` vs `self:appendLiquipediatierDisplay()`:

https://discord.com/channels/93055209017729024/372075546231832576/1139472665451696208

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/0d455c90-20a7-4ae9-8215-0eaa4f4e8988)


## How did you test this change?

Tested on `/dev` with LoL wiki.