### PR TITLE
Fix Wiki Categories

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_league_custom.lua
@@ -217,7 +217,7 @@ function CustomLeague._getPlatform()
 	end
 end
 
-function CustomLeague.getWikiCategories(args)
+function CustomLeague:getWikiCategories(args)
 	local categories = {}
 	if String.isNotEmpty(args.algstier) then
 		table.insert(categories, 'Apex Legends Global Series Tournaments')

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -158,7 +158,7 @@ function CustomHero:createWidgetInjector()
 	return CustomInjector()
 end
 
-function CustomHero.getWikiCategories()
+function CustomHero:getWikiCategories()
 	local categories = {}
 	if Namespace.isMain() then
 		categories = {'Heroes'}

--- a/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
@@ -161,7 +161,7 @@ function CustomItem:createWidgetInjector()
 	return CustomInjector()
 end
 
-function CustomItem.getWikiCategories()
+function CustomItem:getWikiCategories()
 	if Namespace.isMain() then
 		if
 			String.isNotEmpty(_args.str) or

--- a/components/infobox/wikis/starcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_team_custom.lua
@@ -122,7 +122,7 @@ function CustomTeam:addToLpdb(lpdbData)
 	return lpdbData
 end
 
-function CustomTeam.getWikiCategories()
+function CustomTeam:getWikiCategories()
 	local categories = {}
 	if String.isNotEmpty(_args.disbanded) then
 		table.insert(categories, 'Disbanded Teams')

--- a/components/infobox/wikis/starcraft2/infobox_campaign_mission_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_campaign_mission_custom.lua
@@ -79,7 +79,7 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
-function CustomMission.getWikiCategories()
+function CustomMission:getWikiCategories()
 	_fullGameName = _GAME_SWITCH[_args.game] or 'Wings of Liberty'
 	return {
 		_fullGameName .. ' Missions',

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -145,7 +145,7 @@ function CustomTeam:addToLpdb(lpdbData)
 	return lpdbData
 end
 
-function CustomTeam.getWikiCategories()
+function CustomTeam:getWikiCategories()
 	local categories = {}
 	if String.isNotEmpty(_args.disbanded) then
 		table.insert(categories, 'Disbanded Teams')

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -105,7 +105,7 @@ function CustomLeague:_createPatchCell(args)
 	return content .. ' &ndash; [[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
 end
 
-function CustomLeague.getWikiCategories(args)
+function CustomLeague:getWikiCategories(args)
 	return {args.mode .. ' Mode Tournaments'}
 end
 return CustomLeague

--- a/components/infobox/wikis/wildrift/infobox_item_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_item_custom.lua
@@ -258,7 +258,7 @@ function CustomItem:createWidgetInjector()
 	return CustomInjector()
 end
 
-function CustomItem.getWikiCategories()
+function CustomItem:getWikiCategories()
 	if Namespace.isMain() then
 		if not String.isEmpty(_args.str) then
 			table.insert(_categories, 'Strength Items')

--- a/components/infobox/wikis/wildrift/infobox_unit_champion.lua
+++ b/components/infobox/wikis/wildrift/infobox_unit_champion.lua
@@ -157,7 +157,7 @@ function CustomChampion:createWidgetInjector()
 	return CustomInjector()
 end
 
-function CustomChampion.getWikiCategories()
+function CustomChampion:getWikiCategories()
 	local categories = {}
 	if Namespace.isMain() then
 		categories = {'Champions'}


### PR DESCRIPTION
## Summary
Fix incorrect function headers (`.` vs `:`) on a few wiki customs. 

Only TFT and Apex with a real effect (as they use the param)

## How did you test this change?
Live on FTF