### PR TITLE
Add option for ppt import to ignore opponents that have `opponnet.status ~= 'S'`

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -62,6 +62,7 @@ function Import._getConfig(args, placements)
 	end
 
 	return {
+		ignoreNonScoreEliminations = Logic.readBool(args.ignoreNonScoreEliminations),
 		importLimit = Import._importLimit(args.importLimit, placements),
 		matchGroupsSpec = TournamentStructure.readMatchGroupsSpec(args)
 			or TournamentStructure.currentPageSpec(),
@@ -254,7 +255,7 @@ function Import._computeBracketPlacementEntries(matchRecords, options)
 				entry.opponent
 				and entry.opponent.type == Opponent.literal
 				and Opponent.toName(entry.opponent):lower() == BYE_OPPONENT_NAME
-			)
+			) and (not Import.config.ignoreNonScoreEliminations or entry.opponent.status == SCORE_STATUS)
 		end)
 	end
 


### PR DESCRIPTION
resolves #3183

## Summary
Add option for ppt import to ignore opponents that have `opponnet.status ~= 'S'`

## How did you test this change?
dev
![Screenshot 2023-08-11 12 42 47](https://github.com/Liquipedia/Lua-Modules/assets/75081997/bf013f88-7bef-41d7-80ab-9f6276dc28f2)
