### PR TITLE
Set flag px size and handle missing flags better

### DIFF
--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -160,7 +160,10 @@ function Flags.CountryName(flagName)
 		return MasterData.data[flagKey].name
 	else
 		mw.log('Unknown flag: ', flagName)
-		return mw.text.trim(mw.text.split(Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. flagName), '|', true)[2] or '')
+		return mw.text.trim(mw.text.split(mw.text.split(
+					Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. flagName),
+					'Category:', true)[2] or '',
+						"[%]%|]", false)[1])
 	end
 end
 

--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -57,12 +57,12 @@ function Flags.Icon(args, flagName)
 		end
 	elseif shouldLink then
 		mw.log('Unknown flag: ', flagName)
-		return Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. mw.ustring.lower(flagName)) ..
-				'[[Category:Pages with unknown flags]]'
+		mw.ext.TeamLiquidIntegration.add_category('Pages with unknown flags')
+		return Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. mw.ustring.lower(flagName))
 	else
 		mw.log('Unknown flag: ', flagName)
-		return Template.safeExpand(mw.getCurrentFrame(), 'FlagNoLink/' .. mw.ustring.lower(flagName)) ..
-				'[[Category:Pages with unknown flags]]'
+		mw.ext.TeamLiquidIntegration.add_category('Pages with unknown flags')
+		return Template.safeExpand(mw.getCurrentFrame(), 'FlagNoLink/' .. mw.ustring.lower(flagName))
 	end
 end
 
@@ -160,6 +160,7 @@ function Flags.CountryName(flagName)
 		return MasterData.data[flagKey].name
 	else
 		mw.log('Unknown flag: ', flagName)
+		mw.ext.TeamLiquidIntegration.add_category('Pages with unknown flags')
 		return mw.text.trim(mw.text.split(mw.text.split(
 					Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. flagName),
 					'Category:', true)[2] or '',

--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -51,9 +51,9 @@ function Flags.Icon(args, flagName)
 				link = 'Category:' .. flagData.name
 			end
 			return '<span class="flag">[[' .. flagData.flag ..
-				'|' .. flagData.name .. '|link=' .. link .. ']]</span>'
+				'|36x24px|' .. flagData.name .. '|link=' .. link .. ']]</span>'
 		else
-			return '<span class="flag">[[' .. flagData.flag .. '|link=]]</span>'
+			return '<span class="flag">[[' .. flagData.flag .. '|36x24px|link=]]</span>'
 		end
 	elseif shouldLink then
 		mw.log('Unknown flag: ', flagName)


### PR DESCRIPTION
## Summary

Uploaded higher resolution flags to commons (for mobile devices, etc.) similar to #3114. So need this to enforce the actual flag files served to users as with the other PR's icons.

Also amended code which parses expanded wikicode of `{{Flag}}` templates to split on Category which is a better alternative and less prone to breakage as seen earlier in discord:

https://discord.com/channels/93055209017729024/372075546231832576/1139971859350294659

Also added tracking category using lua and changed other outputs to use lua too rather than wikicode category setting.

## How did you test this change?

Tested on `/dev`. Also now live as hotfix to break because of changes to `{{Flag}}` templates' code. Category stuff isn't live, however, is tested.
