### PR TITLE
Add `years_active_talent` param to Valorant infoboxes

### DIFF
--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -79,6 +79,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Years Active (Player)', content = {_args.years_active}},
 			Cell{name = 'Years Active (Org)', content = {_args.years_active_manage}},
 			Cell{name = 'Years Active (Coach)', content = {_args.years_active_coach}},
+			Cell{name = 'Years Active (Talent)', content = {_args.years_active_talent}},
 		}
 	elseif id == 'role' then
 		return {


### PR DESCRIPTION
## Summary
Add `years_active_talent` param to Valorant infoboxes, it already exists in the [documentation of the template](https://liquipedia.net/valorant/Template:Infobox_player), it's just not added to the module.

## How did you test this change?
