### PR TITLE
Fix Battlerite `Module:Info` structure

### DIFF
--- a/standard/info/wikis/battlerite/info.lua
+++ b/standard/info/wikis/battlerite/info.lua
@@ -11,10 +11,10 @@ return {
 	wikiName = 'battlerite',
 	name = 'Battlerite',
 	games = {
-		abbreviation = 'Battlerite',
-		name = 'Battlerite',
-		link = 'Battlerite',
 		battlerite = {
+			abbreviation = 'Battlerite',
+			name = 'Battlerite',
+			link = 'Battlerite',
 			logo = {
 				darkMode = 'Logo filler event.png',
 				lightMode = 'Logo filler event.png',
@@ -26,6 +26,6 @@ return {
 		},
 	},
 	defaultGame = 'battlerite',
-	defaultTeamLogo = 'Battlerite logo.png', ---@deprecated
-	defaultTeamLogoDark = 'Battlerite logo.png', ---@deprecated
+	defaultTeamLogo = 'Battlerite default allmode.png', ---@deprecated
+	defaultTeamLogoDark = 'Battlerite default allmode.png', ---@deprecated
 }

--- a/standard/info/wikis/battlerite/info.lua
+++ b/standard/info/wikis/battlerite/info.lua
@@ -20,8 +20,8 @@ return {
 				lightMode = 'Logo filler event.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Battlerite logo.png',
-				lightMode = 'Battlerite logo.png',
+				darkMode = 'Battlerite default allmode.png',
+				lightMode = 'Battlerite default allmode.png',
 			},
 		},
 	},


### PR DESCRIPTION
I have moved the original file to a new name and uploaded a allmode version for it, now some tables started to break so this change should fix those issues. (even the file redirect broke it, my bad...)

[Example of broken page right now, it breaks once I had updated the team template from the "old" legacy filename to the "new" one https://liquipedia.net/battlerite/Averse ]

Old link: https://liquipedia.net/commons/File:Battlerite_logo.png?redirect=no
New link: https://liquipedia.net/commons/File:Battlerite_default_allmode.png
