### PR TITLE
Add Serbia and Montenegro flag data

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -2150,6 +2150,7 @@ local aliases = {
 	['ukni'] = 'northernireland',
 
 	--language flag abbreviations
+	['usgb'] = 'englishspeaking',
 	['usuk'] = 'englishspeaking',
 	['deat'] = 'germanspeaking',
 	['esmx'] = 'spanishspeaking',

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1302,15 +1302,15 @@ local data = {
 	},
 
 	-- ISO 3166-1 alpha-2 Traditional Reservations
+	['serbiaandmontenegro'] = {
+		flag = 'File:cs_hd.png',
+		localised = 'Serbian and Montenegrin',
+		name = 'Serbia and Montenegro',
+	},
 	['yugoslavia'] = {
 		flag = 'File:yu_hd.png',
 		localised = 'Yugoslavian',
 		name = 'Yugoslavia',
-	},
-	['serbiaandmontenegro'] = {
-		flag = 'File:yu_hd.png',
-		localised = 'Serbian and Montenegrin',
-		name = 'Serbia and Montenegro',
 	},
 
 	-- ISO 3166-2:GB

--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1307,6 +1307,11 @@ local data = {
 		localised = 'Yugoslavian',
 		name = 'Yugoslavia',
 	},
+	['serbiaandmontenegro'] = {
+		flag = 'File:yu_hd.png',
+		localised = 'Serbian and Montenegrin',
+		name = 'Serbia and Montenegro',
+	},
 
 	-- ISO 3166-2:GB
 	['england'] = {
@@ -1782,6 +1787,7 @@ local twoLetter = {
 
 	--   ISO 3166-1 alpha-2 Traditional Reservations
 	['yu'] = 'yugoslavia',
+	['cs'] = 'serbiaandmontenegro',
 }
 
 -- This table includes:


### PR DESCRIPTION
## Summary

Yugoslavia renamed to Serbia and Montenegro in 2003 and received a new ISO code (from `yu` to `cs)`. Adding the new country name and codes.

Also added a `usgb` alias for English speaking since its `us` and `gb` flag combined rather than `uk` flag.

## How did you test this change?

Just some flag data :D