### PR TITLE
Fix demonym for Oceania

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1443,7 +1443,7 @@ local data = {
 	},
 	['oceania'] = {
 		flag = 'File:anz hd.png',
-		localised = 'Oceanic',
+		localised = 'Oceanian',
 		name = 'Oceania',
 	},
 	['southamerica'] = {


### PR DESCRIPTION
## Summary
Reported on discord, `Oceanian` is the correct demonym

## How did you test this change?
N/A
