### PR TITLE
Adjust BroadcasterCard

### DIFF
--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -34,6 +34,7 @@ local BroadcasterCard = {}
 ---@field sort string|number
 ---@field date string
 ---@field flag string?
+---@field isManualInput boolean
 
 ---Template entry point
 ---@param frame Frame
@@ -100,6 +101,9 @@ function BroadcasterCard.create(frame)
 			date = date,
 			sort = tonumber(args[prefix .. 'sort'])
 		}
+		--if entered name and stored name as well as entered flag and stored flag match mark it as manual input
+		broadcaster.isManualInput = args[prefix .. 'name'] == name and args[prefix .. 'flag' ] == nationality
+
 		broadcaster.sort = BroadcasterCard.sortValue(broadcaster, args.sort, casterIndex)
 
 		BroadcasterCard.setLPDB(broadcaster, args.status)
@@ -206,7 +210,7 @@ end
 ---@param status string?
 function BroadcasterCard.setLPDB(caster, status)
 	local smName = Variables.varDefault('show_match_name') or ''
-	local extradata = {status = ''}
+	local extradata = {status = '', manualinput = tostring(caster.isManualInput)}
 	if Logic.readBool(Variables.varDefault('show_match')) then
 		extradata.showmatchname = smName
 		extradata.showmatch = 'true'

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -86,7 +86,7 @@ function BroadcasterCard.create(frame)
 	-- Add people
 	local casters = {}
 	for prefix, caster, casterIndex in Table.iter.pairsByPrefix(args, 'b') do
-		local link = args[prefix .. 'link'] or caster
+		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(args[prefix .. 'link'] or caster):gsub(' ','_')
 		local name, nationality = BroadcasterCard.getData(args, prefix, link, restrictedQuery)
 		local date = Variables.varDefault('tournament_enddate')
 
@@ -94,7 +94,7 @@ function BroadcasterCard.create(frame)
 			id = caster,
 			name = name or '',
 			displayName = args[prefix .. 'name_o'],
-			page = mw.ext.TeamLiquidIntegration.resolve_redirect(link):gsub(' ','_' ),
+			page = link,
 			language = language,
 			position = position,
 			weight = BroadcasterCard.getWeight(),
@@ -156,11 +156,9 @@ end
 ---@param restrictedQuery boolean
 ---@return string?, string?
 function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
-	local resolvedCasterPage = mw.ext.TeamLiquidIntegration.resolve_redirect(casterPage):gsub(' ','_' )
-
 	local function getPersonInfo()
 		local data = mw.ext.LiquipediaDB.lpdb('player', {
-			conditions = '[[pagename::' .. resolvedCasterPage .. ']]',
+			conditions = '[[pagename::' .. casterPage .. ']]',
 			query = 'romanizedname, name, pagename, nationality',
 			limit = 1,
 		})
@@ -176,7 +174,7 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 		end
 
 		data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
-			conditions = '[[extradata_manualinput::true]] AND [[page::' .. resolvedCasterPage .. ']]'
+			conditions = '[[extradata_manualinput::true]] AND [[page::' .. casterPage .. ']]'
 				.. ' AND ([[name::!]] OR [[flag::!]])'
 				.. ' AND [[pagename::!' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
 			query = 'name, flag',
@@ -188,8 +186,8 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 			return name, flag
 		end
 
-		return BroadcasterCard._findUnique(data, 'name', resolvedCasterPage) or name,
-			BroadcasterCard._findUnique(data, 'flag', resolvedCasterPage) or flag
+		return BroadcasterCard._findUnique(data, 'name', casterPage) or name,
+			BroadcasterCard._findUnique(data, 'flag', casterPage) or flag
 	end
 
 	return getPersonInfo()

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -172,7 +172,7 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 		end
 
 		data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
-			conditions = '[[page::' .. resolvedCasterPage .. ']] AND [[name::!]] AND [[flag::!]]'
+			conditions = '[[extradata_manualinput::true]] AND [[page::' .. resolvedCasterPage .. ']] AND [[name::!]] AND [[flag::!]]'
 				.. ' AND [[pagename::!' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
 			query = 'name, flag, id',
 			order = 'date desc',

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -156,41 +156,37 @@ end
 ---@param restrictedQuery boolean
 ---@return string?, string?
 function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
-	local function getPersonInfo()
-		local data = mw.ext.LiquipediaDB.lpdb('player', {
-			conditions = '[[pagename::' .. casterPage .. ']]',
-			query = 'romanizedname, name, pagename, nationality',
-			limit = 1,
-		})
+	local data = mw.ext.LiquipediaDB.lpdb('player', {
+		conditions = '[[pagename::' .. casterPage .. ']]',
+		query = 'romanizedname, name, pagename, nationality',
+		limit = 1,
+	})
 
-		if type(data) == 'table' and data[1] then
-			return String.nilIfEmpty(data[1].romanizedname) or data[1].name, data[1].nationality
-		end
-
-		local name, flag = args[prefix .. 'name'], args[prefix .. 'flag']
-
-		if String.isNotEmpty(name) and String.isNotEmpty(flag) or restrictedQuery then
-			return name, flag
-		end
-
-		data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
-			conditions = '[[extradata_manualinput::true]] AND [[page::' .. casterPage .. ']]'
-				.. ' AND ([[name::!]] OR [[flag::!]])'
-				.. ' AND [[pagename::!' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
-			query = 'name, flag',
-			groupby = 'flag asc, name asc',
-			limit = 5000,
-		})
-
-		if type(data) ~= 'table' or not data[1] then
-			return name, flag
-		end
-
-		return BroadcasterCard._findUnique(data, 'name', casterPage) or name,
-			BroadcasterCard._findUnique(data, 'flag', casterPage) or flag
+	if type(data) == 'table' and data[1] then
+		return String.nilIfEmpty(data[1].romanizedname) or data[1].name, data[1].nationality
 	end
 
-	return getPersonInfo()
+	local name, flag = args[prefix .. 'name'], args[prefix .. 'flag']
+
+	if String.isNotEmpty(name) and String.isNotEmpty(flag) or restrictedQuery then
+		return name, flag
+	end
+
+	data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
+		conditions = '[[extradata_manualinput::true]] AND [[page::' .. casterPage .. ']]'
+			.. ' AND ([[name::!]] OR [[flag::!]])'
+			.. ' AND [[pagename::!' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
+		query = 'name, flag',
+		groupby = 'flag asc, name asc',
+		limit = 5000,
+	})
+
+	if type(data) ~= 'table' or not data[1] then
+		return name, flag
+	end
+
+	return BroadcasterCard._findUnique(data, 'name', casterPage) or name,
+		BroadcasterCard._findUnique(data, 'flag', casterPage) or flag
 end
 
 ---@param data {name: string?, flag: string?}

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -188,8 +188,8 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 			return name, flag
 		end
 
-		return BroadcasterCard._findUnique(data, 'name') or name,
-			BroadcasterCard._findUnique(data, 'flag') or flag
+		return BroadcasterCard._findUnique(data, 'name', resolvedCasterPage) or name,
+			BroadcasterCard._findUnique(data, 'flag', resolvedCasterPage) or flag
 	end
 
 	return getPersonInfo()
@@ -197,8 +197,9 @@ end
 
 ---@param data {name: string?, flag: string?}
 ---@param property 'name'|'flag'
+---@param page string
 ---@return string?
-function BroadcasterCard._findUnique(data, property)
+function BroadcasterCard._findUnique(data, property, page)
 	--remove all empty values
 	local foundItems = Array.filter(data, function(item) return String.isNotEmpty(item[property]) end)
 	--extract the array of tables to an array of values want to look at
@@ -210,6 +211,8 @@ function BroadcasterCard._findUnique(data, property)
 	--if we only have 1 unique element then we have a definitive query, return the value
 	if #foundItems == 1 then
 		return foundItems[1]
+	elseif #foundItems > 1 then
+		mw.logObject(foundItems, property .. 's not unique for ' .. page)
 	end
 end
 

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -114,17 +114,23 @@ function BroadcasterCard.create(frame)
 	table.sort(casters, function(a, b) return a.sort < b.sort or (a.sort == b.sort and a.id:lower() < b.id:lower()) end)
 
 	for _, broadcaster in ipairs(casters) do
-		outputList = outputList .. BroadcasterCard._display(broadcaster)
+		outputList = outputList .. BroadcasterCard._display(broadcaster, {alwaysShowName = Logic.readBool(args.alwaysShowName)})
 	end
 
 	return outputList
 end
 
 ---@param broadcaster broadCasterData
+---@param options {alwaysShowName: boolean}
 ---@return string
-function BroadcasterCard._display(broadcaster)
+function BroadcasterCard._display(broadcaster, options)
 	local displayName = broadcaster.displayName or broadcaster.name
-	displayName = String.isEmpty(displayName) and '' or ('&nbsp;(' .. displayName ..')')
+
+	if String.isNotEmpty(displayName)  and (options.alwaysShowName or displayName ~= broadcaster.id) then
+		displayName = ('&nbsp;(' .. displayName ..')')
+	else
+		displayName = ''
+	end
 
 	return '\n**' .. Flags.Icon{flag = broadcaster.flag, shouldLink = true}
 		.. '&nbsp;[[' .. broadcaster.page .. '|'.. broadcaster.id .. ']]'

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -119,7 +119,8 @@ function BroadcasterCard.create(frame)
 	table.sort(casters, function(a, b) return a.sort < b.sort or (a.sort == b.sort and a.id:lower() < b.id:lower()) end)
 
 	for _, broadcaster in ipairs(casters) do
-		outputList = outputList .. BroadcasterCard._display(broadcaster, {alwaysShowName = Logic.readBool(args.alwaysShowName)})
+		local alwaysShowName = Logic.readBool(args.alwaysShowName)
+		outputList = outputList .. BroadcasterCard._display(broadcaster, {alwaysShowName = alwaysShowName})
 	end
 
 	return outputList

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -177,7 +177,8 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 
 		data = mw.ext.LiquipediaDB.lpdb('broadcasters', {
 			conditions = '[[extradata_manualinput::true]] AND [[page::' .. resolvedCasterPage .. ']]'
-				.. ' AND ([[name::!]] OR [[flag::!]])',
+				.. ' AND ([[name::!]] OR [[flag::!]])'
+				.. ' AND [[pagename::!' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
 			query = 'name, flag',
 			groupby = 'flag asc, name asc',
 			limit = 5000,

--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -180,7 +180,7 @@ function BroadcasterCard.getData(args, prefix, casterPage, restrictedQuery)
 				.. ' AND ([[name::!]] OR [[flag::!]])',
 			query = 'name, flag',
 			groupby = 'flag asc, name asc',
-			limit = 1
+			limit = 5000,
 		})
 
 		if type(data) ~= 'table' or not data[1] then


### PR DESCRIPTION
depends on #3202 and bot runs after it
might need resolving merge conflict after #3202

## Summary
Adjust BroadcasterCard as per our latest Modules sync discussion
- do not show name if name == id (with option switch to still show it)
- store indicator if it is manual input --> in #3202 
- restrict broadcasters query to only query from "manual input"
- query for names and flags "independently"
- make sure to only return values if there aren't different possible returns

## How did you test this change?
dev