### PR TITLE
Store `publishertier` in match2 on VALORANT

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -316,6 +316,7 @@ end
 
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', DEFAULT_MODE))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 


### PR DESCRIPTION
## Summary

As title says; add code to store `publishertier` in match2 on VALORANT wiki.

## How did you test this change?

Tested on `/dev`.
