### PR TITLE
Fix WC legacy duo prize pool lastVsData for first slot

### DIFF
--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -99,8 +99,8 @@ function LegacyPrizePool.run(dependency)
 		end
 	end
 
-	if CUSTOM_HANDLER.adjustBeforeRun then
-		newArgs = CUSTOM_HANDLER.adjustBeforeRun(newArgs)
+	if CUSTOM_HANDLER.afterSlots then
+		newArgs = CUSTOM_HANDLER.afterSlots(newArgs)
 	end
 
 	-- iterate over slots and merge opponents into the slots directly

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -99,6 +99,10 @@ function LegacyPrizePool.run(dependency)
 		end
 	end
 
+	if CUSTOM_HANDLER.adjustBeforeRun then
+		newArgs = CUSTOM_HANDLER.adjustBeforeRun(newArgs)
+	end
+
 	-- iterate over slots and merge opponents into the slots directly
 	local numberOfSlots = newSlotIndex
 	for slotIndex = 1, numberOfSlots do

--- a/components/prize_pool/wikis/warcraft/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/warcraft/prize_pool_legacy_custom.lua
@@ -172,7 +172,7 @@ function CustomLegacyPrizePool._readOpponentArgs(props)
 	return opponentData
 end
 
-function CustomLegacyPrizePool.adjustBeforeRun(newArgs)
+function CustomLegacyPrizePool.afterSlots(newArgs)
 	if _cache.opponentType == Opponent.duo then
 		for _, slot in ipairs(newArgs) do
 			slot.opponents = Array.map(slot.opponents, CustomLegacyPrizePool._addDuoLastVs)

--- a/components/prize_pool/wikis/warcraft/prize_pool_legacy_custom.lua
+++ b/components/prize_pool/wikis/warcraft/prize_pool_legacy_custom.lua
@@ -114,10 +114,6 @@ function CustomLegacyPrizePool.overwriteMapOpponents(slot, newData, mergeSlots)
 	local opponents = Array.map(Array.range(1, slot.opponentsInSlot), function(opponentIndex)
 		return mapOpponent(opponentIndex) or {} end)
 
-	if _cache.opponentType == Opponent.duo then
-		opponents = Array.map(opponents, CustomLegacyPrizePool._addDuoLastVs)
-	end
-
 	return opponents
 end
 
@@ -174,6 +170,16 @@ function CustomLegacyPrizePool._readOpponentArgs(props)
 	opponentData.vs = slot['lastvs' .. opponentIndex] -- this is just a ref to a different opponent
 
 	return opponentData
+end
+
+function CustomLegacyPrizePool.adjustBeforeRun(newArgs)
+	if _cache.opponentType == Opponent.duo then
+		for _, slot in ipairs(newArgs) do
+			slot.opponents = Array.map(slot.opponents, CustomLegacyPrizePool._addDuoLastVs)
+		end
+	end
+
+	return newArgs
 end
 
 function CustomLegacyPrizePool._addDuoLastVs(opponent)


### PR DESCRIPTION
## Summary
Currently for the first slot no last vs data is set in Warcrafts legacy duo prize pools.
That is due to the fact that at the point the first slot is processed the second slot isn't present yet.
Warcraft used a (pretty stupid) reference system. So to be able to add the lastVsData to the first slot the Array map for adding the last vs data has to be moved after all slots have been processed.
This PR does that.

## How did you test this change?
dev