### PR TITLE
Import brackets with multiple elimination levels into prize pools

### DIFF
--- a/components/match2/commons/match_group_coordinates.lua
+++ b/components/match2/commons/match_group_coordinates.lua
@@ -319,11 +319,6 @@ opponents leave the tournament directly from the upper bracket.
 The third place match is not counted.
 ]]
 function MatchGroupCoordinates.computeRawCounts(bracket)
-	if #bracket.sections > 2 then
-		-- Triple elimination brackets are not supported
-		return {}
-	end
-
 	local reverseRounds = Array.reverse(bracket.rounds)
 
 	local countsBySection = Array.map(Array.range(1, #bracket.sections), function(sectionIx) return 0 end)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -379,28 +379,20 @@ function Import._getPreTiebreakMatchIds(bracket)
 	return sfMatchIds
 end
 
--- Finds the first round in where upper bracket opponents drop to the lower
--- bracket. Returns nil if it cannot be determined unambiguously, or if the
--- bracket is not double elimination.
+-- Gets the first round of each level (section) of a bracket where losers drop to the level below.
+-- Returns empty array if the bracket is single elimination. If no losers drop to a lower level, then
+-- the array will contain `-1` for that level.
 ---@return number[]
 function Import._findBracketFirstDropdownRounds(bracket)
-	local firstDropdownRoundPerSection = {}
 	if #bracket.sections == 1 then
-		return firstDropdownRoundPerSection
+		return {}
 	end
 	local countsByRound = MatchGroupCoordinates.computeRawCounts(bracket)
-	for sectionIndex = 2, #bracket.sections do
-		for roundIndex = 1, #bracket.rounds do
-			local lbCount = countsByRound[roundIndex][sectionIndex]
-			if lbCount == 0 then
-				firstDropdownRoundPerSection[sectionIndex - 1] = roundIndex
-				break
-			else
-				firstDropdownRoundPerSection[sectionIndex - 1] = -1
-			end
-		end
-	end
-	return firstDropdownRoundPerSection
+	return Array.map(Array.range(2, #bracket.sections), function(sectionIndex)
+		return Array.find(Array.range(1, #bracket.rounds), function(roundIndex)
+			return countsByRound[roundIndex][sectionIndex] == 0
+		end) or -1
+	end)
 end
 
 function Import._mergePlacements(lpdbEntries, placements)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -315,25 +315,32 @@ function Import._computeBracketPlacementGroups(bracket, options)
 			return {}
 
 		else
-			local groupKeys = {}
+			local function shouldImportKnockedOutOpponents()
+				if not (not bracket.bracketDatasById[matchId].qualLose or options.importWinners) then
+					return false
+				elseif coordinates.sectionIndex == #bracket.sections then
+					-- Always include lowest bracket section 
+					return true
+				elseif firstDropdownRoundIndexes[coordinates.sectionIndex] == -1 then
+					-- No dropdown opponents for this level
+					return false
+				elseif coordinates.roundIndex < firstDropdownRoundIndexes[coordinates.sectionIndex] then
+					-- Also include opponents directly knocked out from an upper bracket
+					return true
+				end
+				return false
+			end
 
-			-- Winners of root matches
+			local groupKeys = {}
 			if coordinates.depth == 0 and options.importWinners then
+				-- Winners of root matches
 				table.insert(groupKeys, {0, coordinates.sectionIndex, 1})
 				-- in case of qualLose also Loser of root match if not lower bracket (lower bracket gets handled below)
 				if bracket.bracketDatasById[matchId].qualLose and coordinates.sectionIndex ~= #bracket.sections then
 					table.insert(groupKeys, {0, coordinates.sectionIndex, 2})
 				end
-			end
-
-			-- Opponents knocked out from sole section (se) or lower bracket (de)
-			if (not bracket.bracketDatasById[matchId].qualLose or options.importWinners) and (
-				-- Include lowest bracket section always
-				coordinates.sectionIndex == #bracket.sections
-
-				-- Include opponents directly knocked out from an upper bracket
-				or firstDropdownRoundIndexes[coordinates.sectionIndex] and firstDropdownRoundIndexes[coordinates.sectionIndex] ~= -1 and coordinates.roundIndex < firstDropdownRoundIndexes[coordinates.sectionIndex]) then
-
+			elseif shouldImportKnockedOutOpponents() then
+				-- Opponents knocked out from sole section (se) or lower sections (de/te/etc.)
 				table.insert(groupKeys, {2, coordinates.depth, 2})
 			end
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -319,7 +319,7 @@ function Import._computeBracketPlacementGroups(bracket, options)
 				if not (not bracket.bracketDatasById[matchId].qualLose or options.importWinners) then
 					return false
 				elseif coordinates.sectionIndex == #bracket.sections then
-					-- Always include lowest bracket section 
+					-- Always include lowest bracket section
 					return true
 				elseif firstDropdownRoundIndexes[coordinates.sectionIndex] == -1 then
 					-- No dropdown opponents for this level

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -332,7 +332,7 @@ function Import._computeBracketPlacementGroups(bracket, options)
 				coordinates.sectionIndex == #bracket.sections
 
 				-- Include opponents directly knocked out from an upper bracket
-				or firstDropdownRoundIndexes[coordinates.sectionIndex] and coordinates.roundIndex < firstDropdownRoundIndexes[coordinates.sectionIndex]) then
+				or firstDropdownRoundIndexes[coordinates.sectionIndex] and firstDropdownRoundIndexes[coordinates.sectionIndex] ~= -1 and coordinates.roundIndex < firstDropdownRoundIndexes[coordinates.sectionIndex]) then
 
 				table.insert(groupKeys, {2, coordinates.depth, 2})
 			end
@@ -384,7 +384,7 @@ end
 -- bracket is not double elimination.
 ---@return number[]
 function Import._findBracketFirstDropdownRounds(bracket)
-	local firstDropdownRoundPerSection = {-1}
+	local firstDropdownRoundPerSection = {}
 	if #bracket.sections == 1 then
 		return firstDropdownRoundPerSection
 	end
@@ -394,7 +394,8 @@ function Import._findBracketFirstDropdownRounds(bracket)
 			local lbCount = countsByRound[roundIndex][sectionIndex]
 			if lbCount == 0 then
 				firstDropdownRoundPerSection[sectionIndex - 1] = roundIndex
-			elseif lbCount > 0 then
+				break
+			else
 				firstDropdownRoundPerSection[sectionIndex - 1] = -1
 			end
 		end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -339,7 +339,8 @@ function Import._computeBracketPlacementGroups(bracket, options)
 				if bracket.bracketDatasById[matchId].qualLose and coordinates.sectionIndex ~= #bracket.sections then
 					table.insert(groupKeys, {0, coordinates.sectionIndex, 2})
 				end
-			elseif shouldImportKnockedOutOpponents() then
+			end
+			if shouldImportKnockedOutOpponents() then
 				-- Opponents knocked out from sole section (se) or lower sections (de/te/etc.)
 				table.insert(groupKeys, {2, coordinates.depth, 2})
 			end


### PR DESCRIPTION
## Summary

Previously only double-elim (and single, ofc) brackets were supported for importing into prize pools. Adding functionality to support any number of elimination level brackets.

## How did you test this change?

Lightly tested on CS wiki with `/dev` on SE, DE, and TE brackets.

Example of the fix working: https://liquipedia.net/counterstrike/index.php?title=ESL/Challenger_League/Season_44/North_America/Relegation&diff=2579820&oldid=2540158