### PR TITLE
Add warcraft `Infobox/Extension/CostDisplay`

### DIFF
--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
@@ -15,7 +15,7 @@ local ICONS = {
 	lumber = '[[File:Lumber WC3 Icon.gif|15}px|link=Lumber]]',
 	buildTime = '[[File:Cooldown Clock.png|15px]]',
 	food = '[[File:Food WC3 Icon.gif|15px|link=Food]]',
-} 
+}
 local ORDER = {
 	'gold',
 	'lumber',

--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
@@ -39,6 +39,7 @@ local CONCAT_VALUE = '&nbsp;'
 ---@field foodTotal string|number?
 
 ---@param args scCostDisplayArgsValues
+---@return string[]
 function CostDisplay.run(args)
 	if not args then
 		return {}

--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
@@ -47,7 +47,7 @@ function CostDisplay.run(args)
 	local displays = {}
 	for _, key in pairs(ORDER) do
 		local value = tonumber(args[key]) or 0
-		if value ~= 0 or args[key .. 'Forced'] then
+		if value ~= 0 or args[key .. 'Forced'] or args[key .. 'Total'] then
 			local display = ICONS[key] .. CONCAT_VALUE .. value ..
 				(args[key .. 'Total'] and (CONCAT_VALUE .. '(' .. args[key .. 'Total'] .. ')') or '')
 			table.insert(displays, display)

--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
@@ -39,10 +39,10 @@ local CONCAT_VALUE = '&nbsp;'
 ---@field foodTotal string|number?
 
 ---@param args scCostDisplayArgsValues
----@return string[]?
+---@return string?
 function CostDisplay.run(args)
 	if not args then
-		return {}
+		return nil
 	end
 
 	local displays = {}

--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
@@ -39,7 +39,7 @@ local CONCAT_VALUE = '&nbsp;'
 ---@field foodTotal string|number?
 
 ---@param args scCostDisplayArgsValues
----@return string[]
+---@return string[]?
 function CostDisplay.run(args)
 	if not args then
 		return {}

--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
@@ -1,0 +1,64 @@
+---
+-- @Liquipedia
+-- wiki=starcraft
+-- page=Module:Infobox/Extension/CostDisplay
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Table = require('Module:Table')
+
+local CostDisplay = {}
+
+local ICONS = {
+	gold = '[[File:Gold WC3 Icon.gif|15px|link=Gold]]',
+	lumber = '[[File:Lumber WC3 Icon.gif|15}px|link=Lumber]]',
+	buildTime = '[[File:Cooldown Clock.png|15px]]',
+	food = '[[File:Food WC3 Icon.gif|15px|link=Food]]',
+} 
+local ORDER = {
+	'gold',
+	'lumber',
+	'buildTime',
+	'food',
+}
+local CONCAT_VALUE = '&nbsp;'
+
+---@class wcCostDisplayArgsValues
+---@field gold string?
+---@field lumber string|number?
+---@field buildTime string|number?
+---@field food string|number?
+---@field goldForced boolean?
+---@field lumberForced boolean?
+---@field buildTimeForced boolean?
+---@field foodForced boolean?
+---@field goldTotal string|number?
+---@field lumberTotal string|number?
+---@field buildTimeTotal string|number?
+---@field foodTotal string|number?
+
+---@param args scCostDisplayArgsValues
+function CostDisplay.run(args)
+	if not args then
+		return {}
+	end
+
+	local displays = {}
+	for _, key in pairs(ORDER) do
+		local value = tonumber(args[key]) or 0
+		if value ~= 0 or args[key .. 'Forced'] then
+			local display = ICONS[key] .. CONCAT_VALUE .. value ..
+				(args[key .. 'Total'] and (CONCAT_VALUE .. '(' .. args[key .. 'Total'] .. ')') or '')
+			table.insert(displays, display)
+		end
+	end
+
+	if Table.isEmpty(displays) then
+		return nil
+	end
+
+	return table.concat(displays, CONCAT_VALUE)
+end
+
+return CostDisplay

--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_cost_display.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=starcraft
+-- wiki=warcraft
 -- page=Module:Infobox/Extension/CostDisplay
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute


### PR DESCRIPTION
## Summary
Add warcraft `Infobox/Extension/CostDisplay`
Differs from sc/sc2 since icons are not faction dependent and icon data is different

## How did you test this change?
as part of some infoboxes currently being build