### PR TITLE
Add warcraft infobox patch

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_patch_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_patch_custom.lua
@@ -114,17 +114,17 @@ function CustomPatch._automaticChronologyData(args)
 		return
 	end
 
-	local baseConditions = '[[type:patch]] AND [[extradata_balanceupdates::true]] AND [[date::<'
+	local baseConditions = '[[type:patch]] AND [[extradata_balanceupdates::true]] AND '
 
 	local previousBalanceUpdate = mw.ext.LiquipediaDB.lpdb('datapoint', {
-		conditions = baseConditions .. '<' .. args.release .. ']]',
+		conditions = baseConditions .. '[[date::<' .. args.release .. ']]',
 		order = 'date desc',
 		query = 'name',
 		limit = 1,
 	})[1] or {}
 
 	local nextBalanceUpdate = mw.ext.LiquipediaDB.lpdb('datapoint', {
-		conditions = baseConditions .. '>' .. args.release .. ']]',
+		conditions = baseConditions .. '[[date::>' .. args.release .. ']]',
 		order = 'date desc',
 		query = 'name',
 		limit = 1,

--- a/components/infobox/wikis/warcraft/infobox_patch_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_patch_custom.lua
@@ -1,0 +1,143 @@
+---
+-- @Liquipedia
+-- wiki=warcraft
+-- page=Module:Infobox/Patch/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+local CustomPatch = Class.new()
+
+local BALANCE_UPDATE = 'Balance Update'
+local IGNORE_NET_EASE_RELEASE_BEFORE = DateExt.readTimestamp('2011-03-23')
+local SKIP = 'skip'
+local SKIPPED = 'skipped'
+
+local _args
+
+local CustomInjector = Class.new(Injector)
+
+function CustomPatch.run(frame)
+	local customPatch = Patch(frame)
+	_args = customPatch.args
+
+	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
+	customPatch.getChronologyData = CustomPatch.getChronologyData
+	customPatch.addToLpdb = CustomPatch.addToLpdb
+
+	return customPatch:createInfobox()
+end
+
+function CustomPatch:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:parse(id, widgets)
+	if id == 'release' then
+		return {
+			Cell{name = '[[Public Test Realm|PTR]] Release Date', content = {_args.release_ptr}},
+			Cell{name = 'Release Date', content = {_args.release}},
+			Cell{name = '[[NetEase]] Release Date', content = {CustomPatch._netEaseRelease(_args)}},
+		}
+	end
+
+	return widgets
+end
+
+function CustomPatch._netEaseRelease(args)
+	if not args.release or DateExt.readTimestamp(args.release) <= IGNORE_NET_EASE_RELEASE_BEFORE then
+		return
+	end
+
+	return args.release_netease == SKIP and SKIPPED or args.release_netease
+end
+
+function CustomPatch:addToLpdb(args)
+	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.pagename, {
+		name = self.name,
+		type = 'patch',
+		information = monthAndDay,
+		date = args.release,
+		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
+			beta = tostring(Logic.readBool(args.beta)),
+			version = self.name,
+			release = args.release,
+			neteaserelease = args.release_netease ~= SKIP and args.release_netease or nil,
+			ptrdate = args.release_ptr,
+			balanceupdates = tostring(CustomPatch._hasBalanceUpdate(args)),
+			previous = args.previous and ('Patch args.previous') or nil,
+			next = args.next and ('Patch args.previous') or nil,
+		})
+	})
+end
+
+function CustomPatch:getChronologyData(args)
+	local previousBalanceUpdate, nextBalanceUpdate = CustomPatch._automaticChronologyData(args)
+
+	local toBalanceUpdateLink = function(input)
+		return input and (input .. '#Balance_Updates|' .. input) or nil
+	end
+
+	local toPatch = function(input)
+		return input and ('Patch ' .. input .. '|' .. input) or nil
+	end
+
+	if not args.previous and not args.next then
+		return {
+			previous = toBalanceUpdateLink(previousBalanceUpdate),
+			next = toBalanceUpdateLink(nextBalanceUpdate),
+		}
+	end
+
+	return {
+		previous = toPatch(args.previous),
+		next = toPatch(args.next),
+		previous2 = toBalanceUpdateLink(previousBalanceUpdate),
+		next2 = toBalanceUpdateLink(nextBalanceUpdate),
+	}
+end
+
+function CustomPatch._automaticChronologyData(args)
+	if not args.release or not CustomPatch._hasBalanceUpdate(args) then
+		return
+	end
+
+	local baseConditions = '[[type:patch]] AND [[extradata_balanceupdates::true]] AND [[date::<'
+
+	local previousBalanceUpdate = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = baseConditions .. '<' .. args.release .. ']]',
+		order = 'date desc',
+		query = 'name',
+		limit = 1,
+	})[1] or {}
+
+	local nextBalanceUpdate = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = baseConditions .. '>' .. args.release .. ']]',
+		order = 'date desc',
+		query = 'name',
+		limit = 1,
+	})[1] or {}
+
+	return previousBalanceUpdate.name, nextBalanceUpdate.name
+end
+
+function CustomPatch._hasBalanceUpdate(args)
+	return Array.any(Array.mapIndexes(function(index) return args['highlight' .. index] end), function(highlight)
+		return String.contains(highlight, BALANCE_UPDATE)
+	end)
+end
+
+return CustomPatch

--- a/components/infobox/wikis/warcraft/infobox_patch_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_patch_custom.lua
@@ -30,6 +30,8 @@ local _args
 
 local CustomInjector = Class.new(Injector)
 
+---@param frame Frame
+---@return Html
 function CustomPatch.run(frame)
 	local customPatch = Patch(frame)
 	_args = customPatch.args
@@ -41,10 +43,14 @@ function CustomPatch.run(frame)
 	return customPatch:createInfobox()
 end
 
+---@return WidgetInjector
 function CustomPatch:createWidgetInjector()
 	return CustomInjector()
 end
 
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
 function CustomInjector:parse(id, widgets)
 	if id == 'release' then
 		return {
@@ -57,6 +63,8 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+---@param args table
+---@return string?
 function CustomPatch._netEaseRelease(args)
 	if not args.release or DateExt.readTimestamp(args.release) <= IGNORE_NET_EASE_RELEASE_BEFORE then
 		return
@@ -65,7 +73,8 @@ function CustomPatch._netEaseRelease(args)
 	return args.release_netease == SKIP and SKIPPED or args.release_netease
 end
 
-function CustomPatch:addToLpdb(args)
+---@param args table
+function CustomPatch:setLpdbData(args)
 	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.pagename, {
 		name = self.name,
 		type = 'patch',
@@ -83,6 +92,8 @@ function CustomPatch:addToLpdb(args)
 	})
 end
 
+---@param args table
+---@return {previous: string?, next: string?, previous2: string?, next2: string?}
 function CustomPatch:getChronologyData(args)
 	local previousBalanceUpdate, nextBalanceUpdate = CustomPatch._automaticChronologyData(args)
 
@@ -109,6 +120,9 @@ function CustomPatch:getChronologyData(args)
 	}
 end
 
+---@param args table
+---@return string?
+---@return string?
 function CustomPatch._automaticChronologyData(args)
 	if not args.release or not CustomPatch._hasBalanceUpdate(args) then
 		return
@@ -133,6 +147,8 @@ function CustomPatch._automaticChronologyData(args)
 	return previousBalanceUpdate.name, nextBalanceUpdate.name
 end
 
+---@param args table
+---@return boolean
 function CustomPatch._hasBalanceUpdate(args)
 	return Array.any(Array.mapIndexes(function(index) return args['highlight' .. index] end), function(highlight)
 		return String.contains(highlight, BALANCE_UPDATE)

--- a/components/infobox/wikis/warcraft/infobox_patch_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_patch_custom.lua
@@ -69,7 +69,6 @@ function CustomPatch:addToLpdb(args)
 	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.pagename, {
 		name = self.name,
 		type = 'patch',
-		information = monthAndDay,
 		date = args.release,
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
 			beta = tostring(Logic.readBool(args.beta)),


### PR DESCRIPTION
depends on #3238 

## Summary
Add warcraft infobox patch

## How did you test this change?
dev into live
`Module:Infobox/Patch/Custom` was used for a function used by the old template version which is now integrated into the new module
to not break shit due to merge i pushed the module over after testing and adjusted the template accordingly