### PR TITLE
Pass through lpdb error messages

### DIFF
--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -55,9 +55,7 @@ function Lpdb.executeMassQuery(tableName, queryParameters, itemChecker, limit)
 		queryParameters.limit = math.min(queryParameters.limit, limit - queryParameters.offset)
 
 		local lpdbData = mw.ext.LiquipediaDB.lpdb(tableName, queryParameters)
-		if type(lpdbData) == 'string' then
-			error(lpdbData)
-		end
+		assert(type(lpdbData) == 'table', lpdbData)
 		for _, value in ipairs(lpdbData) do
 			if itemChecker(value) == false then
 				return

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -55,6 +55,9 @@ function Lpdb.executeMassQuery(tableName, queryParameters, itemChecker, limit)
 		queryParameters.limit = math.min(queryParameters.limit, limit - queryParameters.offset)
 
 		local lpdbData = mw.ext.LiquipediaDB.lpdb(tableName, queryParameters)
+		if type(lpdbData) == 'string' then
+			error(lpdbData)
+		end
 		for _, value in ipairs(lpdbData) do
 			if itemChecker(value) == false then
 				return


### PR DESCRIPTION
## Summary
In case parameters to LPDB are wrong (e.g. unknown column), the return type will be a string with a simple error message.
Since the call will fail anyway in the next line (ipairs on string), error earlier and display the message.

## How did you test this change?
via /dev

previously:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/badf4d2f-bd63-4d22-b2c4-2bb7bb1efcef)

with this change:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/e0d8f0ec-2ddd-4269-98fd-9704c3560700)
