### PR TITLE
Add brawlstars infobox map

### DIFF
--- a/components/infobox/wikis/brawlstars/infobox_map_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_map_custom.lua
@@ -1,0 +1,92 @@
+---
+-- @Liquipedia
+-- wiki=starcraft
+-- page=Module:Infobox/Map/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local ModeIcon = require('Module:ModeIcon')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Map = Lua.import('Module:Infobox/Map', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Center = Widgets.Center
+local Title = Widgets.Title
+
+local CustomMap = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _map
+
+function CustomMap.run(frame)
+	local customMap = Map(frame)
+	_map = customMap
+	_args = customMap.args
+
+	customMap.createWidgetInjector = CustomMap.createWidgetInjector
+
+	return mw.html.create()
+		:node(customMap:createInfobox())
+		:node(CustomMap._intro(_args))
+end
+
+function CustomMap._intro(args)
+	local modes = CustomMap._getModes(args)
+
+	local alsoKnownAs = ''
+
+	local intro = mw.html.create()
+		:tag('b'):wikitext(_map.name):done()
+		:wikitext(' is a map')
+		:wikitext(modes and (' for ' .. mw.text.listToText(modes, ', ', ' and ')) or '')
+		:wikitext(' in '):done()
+		:tag('i'):wikitext('Brawl Stars'):done()
+		:wikitext('.')
+
+	local alsoKnownAs = _map:getAllArgsForBase(args, 'aka')
+
+	if Table.isEmpty(alsoKnownAs) then
+		return intro
+	end
+
+	alsoKnownAs = Array.map(alsoKnownAs, function(aka) return '<b>' .. aka .. '</b>' end)
+
+	return intro:wikitext(' The map was formerly known as ')
+		:wikitext(mw.text.listToText(alsoKnownAs, ', ', ' and ') .. '.')
+end
+
+function CustomMap:createWidgetInjector()
+	return CustomInjector()
+end
+
+function CustomInjector:addCustomCells(widgets)
+	local modes = CustomMap._getModes(_args)
+
+	Array.appendWith(widgets,
+		Cell{name = 'Environment', content = {_args.environment}},
+		Title{name = modes and 'Mode' or nil},
+		Center{content = modes and {table.concat(modes, '<br>')} or nil}
+	)
+
+	return widgets
+end
+
+function CustomMap._getModes(args)
+	local modes = _map:getAllArgsForBase(args, 'mode')
+
+	if Table.isEmpty(modes) then return end
+
+	return Array.map(modes, ModeIcon.run)
+end
+
+return CustomMap

--- a/components/infobox/wikis/brawlstars/infobox_map_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_map_custom.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=starcraft
+-- wiki=brawlstars
 -- page=Module:Infobox/Map/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -27,6 +27,8 @@ local CustomInjector = Class.new(Injector)
 local _args
 local _map
 
+---@param frame Frame
+---@return Html
 function CustomMap.run(frame)
 	local customMap = Map(frame)
 	_map = customMap
@@ -39,6 +41,8 @@ function CustomMap.run(frame)
 		:node(CustomMap._intro(_args))
 end
 
+---@param args table
+---@return Html
 function CustomMap._intro(args)
 	local modes = CustomMap._getModes(args)
 
@@ -62,10 +66,13 @@ function CustomMap._intro(args)
 		:wikitext(mw.text.listToText(alsoKnownAs, ', ', ' and ') .. '.')
 end
 
+---@return WidgetInjector
 function CustomMap:createWidgetInjector()
 	return CustomInjector()
 end
 
+---@param widgets Widget[]
+---@return Widget[]
 function CustomInjector:addCustomCells(widgets)
 	local modes = CustomMap._getModes(_args)
 
@@ -78,6 +85,8 @@ function CustomInjector:addCustomCells(widgets)
 	return widgets
 end
 
+---@param args table
+---@return string[]?
 function CustomMap._getModes(args)
 	local modes = _map:getAllArgsForBase(args, 'mode')
 

--- a/components/infobox/wikis/brawlstars/infobox_map_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_map_custom.lua
@@ -49,7 +49,7 @@ function CustomMap._intro(args)
 	local intro = mw.html.create()
 		:tag('b'):wikitext(_map.name):done()
 		:wikitext(' is a map')
-		:wikitext(modes and (' for ' .. mw.text.listToText(modes, ', ', ' and ')) or '')
+		:wikitext(modes and (' for ' .. mw.text.listToText(modes, ', ', ', and ')) or '')
 		:wikitext(' in '):done()
 		:tag('i'):wikitext('Brawl Stars'):done()
 		:wikitext('.')
@@ -63,7 +63,7 @@ function CustomMap._intro(args)
 	alsoKnownAs = Array.map(alsoKnownAs, function(aka) return '<b>' .. aka .. '</b>' end)
 
 	return intro:wikitext(' The map was formerly known as ')
-		:wikitext(mw.text.listToText(alsoKnownAs, ', ', ' and ') .. '.')
+		:wikitext(mw.text.listToText(alsoKnownAs, ', ', ', and ') .. '.')
 end
 
 ---@return WidgetInjector

--- a/components/infobox/wikis/brawlstars/infobox_map_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_map_custom.lua
@@ -49,7 +49,7 @@ function CustomMap._intro(args)
 	local intro = mw.html.create()
 		:tag('b'):wikitext(_map.name):done()
 		:wikitext(' is a map')
-		:wikitext(modes and (' for ' .. mw.text.listToText(modes, ', ', ', and ')) or '')
+		:wikitext(modes and (' for ' .. mw.text.listToText(modes)) or '')
 		:wikitext(' in '):done()
 		:tag('i'):wikitext('Brawl Stars'):done()
 		:wikitext('.')
@@ -63,7 +63,7 @@ function CustomMap._intro(args)
 	alsoKnownAs = Array.map(alsoKnownAs, function(aka) return '<b>' .. aka .. '</b>' end)
 
 	return intro:wikitext(' The map was formerly known as ')
-		:wikitext(mw.text.listToText(alsoKnownAs, ', ', ', and ') .. '.')
+		:wikitext(mw.text.listToText(alsoKnownAs) .. '.')
 end
 
 ---@return WidgetInjector

--- a/components/infobox/wikis/brawlstars/infobox_map_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_map_custom.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local ModeIcon = require('Module:ModeIcon')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -42,8 +41,6 @@ end
 
 function CustomMap._intro(args)
 	local modes = CustomMap._getModes(args)
-
-	local alsoKnownAs = ''
 
 	local intro = mw.html.create()
 		:tag('b'):wikitext(_map.name):done()


### PR DESCRIPTION
## Summary
Add brawlstars infobox map

## How did you test this change?
"live" since new module

## Remark
When comparingh to the template version you will notice that this module has several fields less. That is due to those not being used at all. (Added tracking categories and touched the 60 pages the infobox is used on.)

## Reminder for myself
Need to do a bot run with rolling it out (adjusting the template to call the module) to adjust the mode input since that get (imo) imporved.
Additionally clean up aka stuff to be now part of infobox.