### PR TITLE
Fix non args case in sc/bw infobox costdisplay extension

### DIFF
--- a/components/infobox/extensions/wikis/starcraft/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/starcraft/infobox_extension_cost_display.lua
@@ -55,9 +55,10 @@ local CONCAT_VALUE = '&nbsp;'
 ---@field supplyTotal string|number?
 
 ---@param args scCostDisplayArgsValues
+---@return string?
 function CostDisplay.run(args)
 	if not args then
-		return {}
+		return nil
 	end
 
 	local faction = Faction.read(args.faction)

--- a/components/infobox/extensions/wikis/starcraft2/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/starcraft2/infobox_extension_cost_display.lua
@@ -58,9 +58,10 @@ local CONCAT_VALUE = '&nbsp;'
 ---@field supplyTotal string|number?
 
 ---@param args sc2CostDisplayArgsValues
+---@return string?
 function CostDisplay.run(args)
 	if not args then
-		return {}
+		return nil
 	end
 
 	local faction = Faction.read(args.faction)


### PR DESCRIPTION
## Summary
- Add return annotation
- fix return to be `string?` instead of `string|table|nil`

## How did you test this change?
N/A