### PR TITLE
Adjust objectnames of match2 subobjects

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -273,14 +273,14 @@ function Match._storeMatch2InLpdb(unsplitMatchRecord)
 	local opponentIndexes = Array.map(records.opponentRecords, function(opponentRecord, opponentIndex)
 		local playerIndexes = Array.map(records.playerRecords[opponentIndex], function(player, playerIndex)
 			return mw.ext.LiquipediaDB.lpdb_match2player(
-				matchRecord.match2id .. '_m2o_' .. opponentIndex .. '_m2p_' .. string.format('%02d', playerIndex),
+				matchRecord.match2id .. '_m2o_' .. string.format('%02d', opponentIndex) .. '_m2p_' .. string.format('%02d', playerIndex),
 				player
 			)
 		end)
 
 		opponentRecord.match2players = table.concat(playerIndexes)
 		return mw.ext.LiquipediaDB.lpdb_match2opponent(
-			matchRecord.match2id .. '_m2o_' .. opponentIndex,
+			matchRecord.match2id .. '_m2o_' .. string.format('%02d', opponentIndex),
 			opponentRecord
 		)
 	end)

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -273,7 +273,8 @@ function Match._storeMatch2InLpdb(unsplitMatchRecord)
 	local opponentIndexes = Array.map(records.opponentRecords, function(opponentRecord, opponentIndex)
 		local playerIndexes = Array.map(records.playerRecords[opponentIndex], function(player, playerIndex)
 			return mw.ext.LiquipediaDB.lpdb_match2player(
-				matchRecord.match2id .. '_m2o_' .. string.format('%02d', opponentIndex) .. '_m2p_' .. string.format('%02d', playerIndex),
+				matchRecord.match2id .. '_m2o_' .. string.format('%02d', opponentIndex)
+						.. '_m2p_' .. string.format('%02d', playerIndex),
 				player
 			)
 		end)

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -287,7 +287,7 @@ function Match._storeMatch2InLpdb(unsplitMatchRecord)
 
 	local gameIndexes = Array.map(records.gameRecords, function(gameRecord, gameIndex)
 		return mw.ext.LiquipediaDB.lpdb_match2game(
-			matchRecord.match2id .. '_m2g_' .. gameIndex,
+			matchRecord.match2id .. '_m2g_' .. string.format('%03d', gameIndex),
 			gameRecord
 		)
 	end)


### PR DESCRIPTION
## Summary
Adjust objectnames of match2 subobjects so that when > 9 games/opponents are returned they are still in correct order

Currently matches shown via e.g. showBracket with >= 10 maps bug:
source:
![CA6C14BE-1B0F-4D0B-A4B4-FCAE7088D67D](https://github.com/Liquipedia/Lua-Modules/assets/75081997/e38fa054-a713-4186-b99a-df5c2420d915)
from query
![08BDA30B-BCEB-4D69-8EDF-A471DDD108E7](https://github.com/Liquipedia/Lua-Modules/assets/75081997/d6feeb3a-18dc-4199-902d-450461b8ac22)

presumably the same would happen with >9 opponents in a match (i.e. in BattleRoyale stuff)

it is the same fix we applied for match2players already

## How did you test this change?
dev