### PR TITLE
Make {{Solo/DuoOpponent}} worked on AoV match2

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -108,7 +108,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
-	Opponent.resolve(opponent, date)
+	Opponent.resolve(opponent, date, {syncPlayer=true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
@@ -368,7 +368,7 @@ function matchFunctions.getOpponents(match)
 						maxNumPlayers = _MAX_NUM_PLAYERS,
 					})
 				end
-			elseif Opponent.typeIsParty(opponent) then
+			elseif Opponent.typeIsParty(opponent.type) then
 				opponent.match2players = Json.parseIfString(opponent.match2players) or {}
 				opponent.match2players[1].name = opponent.name
 			elseif opponent.type ~= Opponent.literal then


### PR DESCRIPTION
## Summary

We had around half dozen ish of Solo events and exactly 1 2V2 tournaments  for AOV wiki
originally the **(opponent)** within typeIsParty were written in a way its unable to make {{Solo or 2v2Opponent}} worked.
 
Display needs no change

## How did you test this change?
https://liquipedia.net/arenaofvalor/User:Hesketh2/indiv 
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/2894822f-2ee6-4d6b-be7a-4f96ac10dc6f)


## Side Note
Additionally I added the **syncPlayers** as well for Auto Flags.
