### PR TITLE
Use commons default for participantsnumber on sc2

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -449,11 +449,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		or Logic.readBool(Variables.varDefault('tournament_finished')) and 'finished'
 	lpdbData.status = status
 	lpdbData.maps = Variables.varDefault('tournament_maps')
-	local participantsNumber = tonumber(Variables.varDefault('tournament_playerNumber')) or 0
-	if participantsNumber == 0 then
-		participantsNumber = args.team_number or 0
-	end
-	lpdbData.participantsnumber = participantsNumber
 	lpdbData.next = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_next))
 	lpdbData.previous = mw.ext.TeamLiquidIntegration.resolve_redirect(CustomLeague:_getPageNameFromChronology(_previous))
 


### PR DESCRIPTION
## Summary
Use commons default for participantsnumber on sc2.
Due to recent changes in the sc2 infobox league (namely adding and using racebreakdown extension) it now can use the commons part instead of having to overwrite it

## How did you test this change?
dev