### PR TITLE
Apply date to `team` in SquadRow

### DIFF
--- a/components/squad/commons/squad_custom.lua
+++ b/components/squad/commons/squad_custom.lua
@@ -83,6 +83,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.role,
 		team = player.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	}
 	row:name{name = player.name}
 	row:role{role = player.role}

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -82,7 +82,8 @@ function SquadRow:id(args)
 
 	local teamNode = mw.html.create('td')
 	if args.team and mw.ext.TeamTemplate.teamexists(args.team) then
-		teamNode:wikitext(mw.ext.TeamTemplate.teamicon(args.team))
+		local date = String.nilIfEmpty(ReferenceCleaner.clean(args.date))
+		teamNode:wikitext(mw.ext.TeamTemplate.teamicon(args.team, date))
 		if args.teamrole then
 			teamNode:css('text-align', 'center')
 			teamNode:tag('div'):css('font-size', '85%'):tag('i'):wikitext(args.teamrole)

--- a/components/squad/wikis/apexlegends/squad_custom.lua
+++ b/components/squad/wikis/apexlegends/squad_custom.lua
@@ -82,6 +82,7 @@ function CustomSquad.run(frame)
 			role = player.role,
 			team = player.team,
 			teamrole = player.teamrole,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		}
 			:name{name = player.name}
 			:role({role = player.role})

--- a/components/squad/wikis/arenaofvalor/squad_custom.lua
+++ b/components/squad/wikis/arenaofvalor/squad_custom.lua
@@ -147,6 +147,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.role,
 		team = player.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	})
 	row:name{name = player.name}
 	row:position{role = player.role, position = player.position}

--- a/components/squad/wikis/counterstrike/squad_custom.lua
+++ b/components/squad/wikis/counterstrike/squad_custom.lua
@@ -82,6 +82,7 @@ function CustomSquad.run(frame)
 			role = player.role,
 			team = player.team,
 			teamrole = player.teamrole,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		}
 			:name{name = player.name}
 			:role{role = player.role}

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -118,6 +118,7 @@ function CustomSquad.run(frame)
 			role = player.role,
 			team = player.team,
 			teamrole = player.teamrole,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		}
 			:name{name = player.name}
 			:position{position = player.position, role = player.role and LANG:ucfirst(player.role) or nil}

--- a/components/squad/wikis/halo/squad_custom.lua
+++ b/components/squad/wikis/halo/squad_custom.lua
@@ -55,6 +55,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.thisTeam.role,
 		team = player.thisTeam.role == 'Loan' and player.oldTeam.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	})
 	row:name({name = player.name})
 	row:role({role = player.thisTeam.role})

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -116,6 +116,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.role,
 		team = player.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	})
 	row:name{name = player.name}
 	row:position{role = player.role, position = player.position}

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -147,6 +147,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.role,
 		team = player.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	})
 	row:name{name = player.name}
 	row:position{role = player.role, position = player.position}

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -182,6 +182,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.role,
 		team = player.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	})
 	if HAS_NUMBER then
 		row:number{number = player.number}

--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -55,6 +55,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.thisTeam.role,
 		team = player.thisTeam.role == 'Loan' and player.oldTeam.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	})
 	row:name({name = player.name})
 	row:role({role = player.thisTeam.role})

--- a/components/squad/wikis/rocketleague/squad_custom.lua
+++ b/components/squad/wikis/rocketleague/squad_custom.lua
@@ -33,6 +33,7 @@ function CustomSquad.run(frame)
 			captain = player.captain,
 			role = player.role,
 			team = player.team,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		})
 			:name({name = player.name})
 			:role({role = player.role})

--- a/components/squad/wikis/smash/squad_custom.lua
+++ b/components/squad/wikis/smash/squad_custom.lua
@@ -86,6 +86,7 @@ function CustomSquad.run(frame)
 			link = player.link,
 			team = player.activeteam,
 			name = Variables.varDefault('name') or player.name,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		}
 		row:mains{mains = mw.text.split(mains or '', ','), game = game}
 		row:date(player.joindate, 'Join Date:&nbsp;', 'joindate')

--- a/components/squad/wikis/starcraft/squad_custom.lua
+++ b/components/squad/wikis/starcraft/squad_custom.lua
@@ -85,6 +85,7 @@ function CustomSquad.run(frame)
 			flag = player.flag,
 			captain = player.captain,
 			role = player.role,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		}
 		row:name{name = name .. ' ' .. localizedName}
 

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -53,6 +53,7 @@ function CustomSquad.run(frame)
 			captain = player.captain,
 			role = player.role,
 			team = player.team,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		})
 			:name({name = player.name})
 			:role({role = player.role})

--- a/components/squad/wikis/valorant/squad_custom.lua
+++ b/components/squad/wikis/valorant/squad_custom.lua
@@ -131,6 +131,7 @@ function CustomSquad._playerRow(player, squadType)
 		role = player.role,
 		team = player.team,
 		teamrole = player.teamrole,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	}
 	row:name{name = player.name}
 	row:role{role = player.role}

--- a/components/squad/wikis/warcraft/squad_custom.lua
+++ b/components/squad/wikis/warcraft/squad_custom.lua
@@ -38,6 +38,7 @@ function CustomSquad.run(frame)
 			captain = player.captain,
 			role = player.role,
 			team = player.team,
+			date = player.leavedate or player.inactivedate or player.leavedate,
 		}
 		row:name{name = player.name}
 		row:role{role = player.role}

--- a/components/squad/wikis/wildrift/squad_custom.lua
+++ b/components/squad/wikis/wildrift/squad_custom.lua
@@ -147,6 +147,7 @@ function CustomSquad._playerRow(player, squadType)
 		captain = player.captain,
 		role = player.role,
 		team = player.team,
+		date = player.leavedate or player.inactivedate or player.leavedate,
 	})
 	row:name{name = player.name}
 	row:position{role = player.role, position = player.position}


### PR DESCRIPTION
## Summary

Presently, the teamicon is called without a date and can cause wrong historical data to be used. Added change to ensure that the latest date for that player is applied to that teamicon.

## How did you test this change?

Tested on `/dev`.
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/4b65fb5f-4786-4430-b3a3-f158a127f813)

