### PR TITLE
Add Game version for TFT Infobox League

### DIFF
--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -110,11 +110,6 @@ function CustomLeague:_createPatchCell(args)
 	return content .. ' &ndash; [[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
 end
 
-function CustomLeague:addToLpdb(lpdbData, args)
-	lpdbData.game = Game.name{game = _args.game}
-	return lpdbData
-end
-
 function CustomLeague:getWikiCategories(args)
 	return {args.mode .. ' Mode Tournaments'}
 end

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 local Class = require('Module:Class')
+local Game = require('Module:Game')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -64,6 +65,10 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'gamesettings' then
 		table.insert(widgets, Cell{
+			name = 'Game Version',
+			content = {Game.name{game = _args.game}}
+		})
+		table.insert(widgets, Cell{
 			name = 'Patch',
 			content = {CustomLeague:_createPatchCell(_args)}
 		})
@@ -103,6 +108,11 @@ function CustomLeague:_createPatchCell(args)
 	end
 
 	return content .. ' &ndash; [[Patch ' .. args.epatch .. '|'.. args.epatch .. ']]'
+end
+
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.game = Game.name{game = _args.game}
+	return lpdbData
 end
 
 function CustomLeague:getWikiCategories(args)

--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -65,7 +65,7 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'gamesettings' then
 		table.insert(widgets, Cell{
-			name = 'Game Version',
+			name = 'Game',
 			content = {Game.name{game = _args.game}}
 		})
 		table.insert(widgets, Cell{


### PR DESCRIPTION
## Summary
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/3914b741-4e61-4455-886a-858b46990a27)
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/9419acf7-ffa2-476f-a89d-ffbe9f99f29f)

Editors want ability to show which game version (two that the wiki covers) is being played on that tournament

I decide to bring how Tetris implements with the Module:Game calls and an **addtolpdb** entry that relates to it

## How did you test this change?
|dev=1 on few pages

## (This is now resolved btw) **

Right now the **game** won't stored If theres no **|game=X** entry being input, I want to adjust in a way that if **|game=X** doesnt exist in the code input it always stores the default entry per Module:Info into **game**

Currently it does display already, but its not stored somehow

The differences 
|game=tft added https://liquipedia.net/tft/Special:LiquipediaDB/TFT_Vegas_Open
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/037fe2fc-0542-404a-a58a-0eced21a43ab)

|game=tft not added https://liquipedia.net/tft/Special:LiquipediaDB/Runeterra_Reforged/Championship
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/a46a9349-9851-432f-87a8-f0ddbc1c7775)

**both pages with |dev=1**