### PR TITLE
Add Patch support for PUBG (PC)

### DIFF
--- a/components/infobox/wikis/pubg/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_league_custom.lua
@@ -9,6 +9,7 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local PageLink = require('Module:Page')
 local String = require('Module:StringUtils')
 local Template = require('Module:Template')
 local Table = require('Module:Table')
@@ -91,6 +92,10 @@ function CustomInjector:parse(id, widgets)
 					CustomLeague:_getGameMode()
 				}
 			},
+			Cell{name = 'Patch', content = {
+					CustomLeague._getPatchVersion()
+				}
+			},
 			Cell{name = 'Platform', content = {
 					CustomLeague:_getPlatform()
 				}
@@ -165,6 +170,17 @@ function CustomLeague:_getPlatform()
 	local platform = string.lower(_args.platform or '')
 
 	return _PLATFORMS[platform] or _PLATFORMS['default']
+end
+
+function CustomLeague._getPatchVersion()
+	if String.isEmpty(_args.patch) then return nil end
+	local content = PageLink.makeInternalLink(_args.patch, 'Patch ' .. _args.patch)
+	if not String.isEmpty(_args.epatch) then
+		content = content .. '&nbsp;&ndash;&nbsp;'
+		content = content .. PageLink.makeInternalLink(_args.epatch, 'Patch ' .. _args.epatch)
+	end
+
+	return content
 end
 
 return CustomLeague

--- a/components/infobox/wikis/pubg/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_league_custom.lua
@@ -28,6 +28,8 @@ local CustomInjector = Class.new(Injector)
 local _args
 local _game
 
+local NONE_BREAKING_SPACE = '&nbsp;'
+local DASH = '&ndash;'
 local _GAME = mw.loadData('Module:GameVersion')
 
 local _MODES = {
@@ -84,22 +86,10 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'gamesettings' then
 		return {
-			Cell{name = 'Game version', content = {
-					CustomLeague._getGameVersion()
-				}
-			},
-			Cell{name = 'Game mode', content = {
-					CustomLeague:_getGameMode()
-				}
-			},
-			Cell{name = 'Patch', content = {
-					CustomLeague._getPatchVersion()
-				}
-			},
-			Cell{name = 'Platform', content = {
-					CustomLeague:_getPlatform()
-				}
-			},
+			Cell{name = 'Game version', content = {CustomLeague._getGameVersion()}},
+			Cell{name = 'Game mode', content = {CustomLeague:_getGameMode()}},
+			Cell{name = 'Patch', content = {CustomLeague._getPatchVersion()}},
+			Cell{name = 'Platform', content = {CustomLeague:_getPlatform()}},
 		}
 	elseif id == 'customcontent' then
 		if _args.player_number then
@@ -175,9 +165,9 @@ end
 function CustomLeague._getPatchVersion()
 	if String.isEmpty(_args.patch) then return nil end
 	local content = PageLink.makeInternalLink(_args.patch, 'Patch ' .. _args.patch)
-	if not String.isEmpty(_args.epatch) then
-		content = content .. '&nbsp;&ndash;&nbsp;'
-		content = content .. PageLink.makeInternalLink(_args.epatch, 'Patch ' .. _args.epatch)
+	if String.isNotEmpty(_args.epatch) then
+		return content .. NONE_BREAKING_SPACE .. DASH .. NONE_BREAKING_SPACE
+			.. PageLink.makeInternalLink(_args.epatch, 'Patch ' .. _args.epatch)
 	end
 
 	return content


### PR DESCRIPTION
## Summary
Ability to display patch numbers for PUBG (PC), was something that editors actually covered in the form of Text under format for a while. 

The code were brought from how Mobile Legends implement the Patch on infobox module

## How did you test this change?
|dev=1
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/307be4cd-7841-4a47-b509-b4cb21a292f7)
https://liquipedia.net/pubg/PUBG_Nations_Cup/2023

## Side Note 
only these two lines that I didnt copy over, is it needed? (since the value is already stored under LPDB data for both patch and epatch fields already)

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/b3f546cd-0f14-4fdb-88e4-7d94a0418091)

