### PR TITLE
Add Infobox Building for Clash of Clans

### DIFF
--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -60,8 +60,8 @@ function CustomInjector:addCustomCells(widgets)
 
 	if Table.any(_args, function(key) return MODE_AVAILABILITY[key] end) then
 		table.insert(widgets, Title{name = 'Mode Availability'})
-		local MODE_AVAILABILITYOrder = function(tbl, a, b) return tbl[a].order < tbl[b].order end
-		for key, item in Table.iter.spairs(MODE_AVAILABILITY, MODE_AVAILABILITYOrder) do
+		local modeAvailabilityOrder = function(tbl, a, b) return tbl[a].order < tbl[b].order end
+		for key, item in Table.iter.spairs(MODE_AVAILABILITY, modeAvailabilityOrder) do
 			table.insert(widgets, Cell{name = item.name, content = {_args[key]}})
 		end
 	end

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+local Namespace = require('Module:Namespace')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Building = Lua.import('Module:Infobox/Building', {requireDevIfEnabled = true})
@@ -18,6 +19,12 @@ local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 
+local modeAvailability = {
+	home 	= {order = 1, name = 'Home Village'},
+	builder = {order = 2, name = 'Builder Base'},
+	clan 	= {order = 3, name = 'Clan Capital'},
+	}
+
 ---@class CustomBuildingInfobox: BuildingInfobox
 local CustomBuilding = Class.new()
 
@@ -25,7 +32,7 @@ local CustomBuilding = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
-local _pagename = mw.title.getCurrentTitle().text
+local PAGENAME = mw.title.getCurrentTitle().text
 
 ---@param frame Frame
 ---@return Html
@@ -53,11 +60,6 @@ function CustomInjector:addCustomCells(widgets)
 		Cell{name = 'Release Date', content = {_args.releasedate}}
 	)
 
-local modeAvailability = {
-		home = {order = 1, name = 'Home Village'},
-		builder = {order = 2, name = 'Builder Base'},
-		clan = {order = 3, name = 'Clan Capital'},
-	}
 	if Table.any(_args, function(key) return modeAvailability[key] end) then
 		table.insert(widgets, Title{name = 'Mode Availability'})
 		local modeAvailabilityOrder = function(tbl, a, b) return tbl[a].order < tbl[b].order end
@@ -72,6 +74,16 @@ end
 ---@return WidgetInjector
 function CustomBuilding:createWidgetInjector()
 	return CustomInjector()
+end
+
+---@param args table
+---@return string[]
+function CustomBuilding:getWikiCategories(args)
+	local categories = {}
+	if Namespace.isMain() then
+		categories = {'Buildings'}
+	end
+	return categories
 end
 
 ---@param args table

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -31,7 +31,6 @@ local CustomBuilding = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
-local PAGENAME = mw.title.getCurrentTitle().text
 
 ---@param frame Frame
 ---@return Html

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -90,10 +90,10 @@ end
 function CustomBuilding:setLpdbData(args)
 	local lpdbData = {
 		type = 'building',
-		name = args.name or _pagename,
+		name = args.name or PAGENAME,
 		image = args.image
 	}
-	mw.ext.LiquipediaDB.lpdb_datapoint('building' .. (args.name or _pagename), lpdbData)
+	mw.ext.LiquipediaDB.lpdb_datapoint('building' .. (args.name or PAGENAME), lpdbData)
 end
 
 return CustomBuilding

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -1,0 +1,92 @@
+---
+-- @Liquipedia
+-- wiki=clashofclans
+-- page=Module:Infobox/Building/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Math = require('Module:Math')
+local Namespace = require('Module:Namespace')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Building = Lua.import('Module:Infobox/Building', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+local Breakdown = Widgets.Breakdown
+
+---@class CustomBuildingInfobox: BuildingInfobox
+local CustomBuilding = Class.new()
+
+---@class CustomWidgetInjector: WidgetInjector
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _pagename = mw.title.getCurrentTitle().text
+local NON_BREAKING_SPACE = '&nbsp;'
+
+---@param frame Frame
+---@return Html
+function CustomBuilding.run(frame)
+	local building = Building(frame)
+	_args = building.args
+	_args.informationType = 'Building'
+
+	building.getWikiCategories = CustomBuilding.getWikiCategories
+	building.setLpdbData = CustomBuilding.setLpdbData
+	building.createWidgetInjector = CustomBuilding.createWidgetInjector
+
+	return building:createInfobox()
+end
+
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:addCustomCells(widgets)
+	Array.appendWith(
+		widgets,
+		Cell{name = 'Range', content = {_args.range}},
+		Cell{name = 'Damage Type', content = {_args.damage}},
+		Cell{name = 'Target', content = {_args.target}},
+		Cell{name = 'Favorite Target', content = {_args.favtarget}},
+		Cell{name = 'Release Date', content = {_args.releasedate}}
+	)
+
+local modeAvailability = {
+		home = {order = 1, name = 'Home Village'},
+		builder = {order = 2, name = 'Builder Base'},
+		clan = {order = 3, name = 'Clan Capital'},
+	}
+	if Table.any(_args, function(key) return modeAvailability[key] end) then
+		table.insert(widgets, Title{name = 'Mode Availability'})
+		local modeAvailabilityOrder = function(tbl, a, b) return tbl[a].order < tbl[b].order end
+		for key, item in Table.iter.spairs(modeAvailability, modeAvailabilityOrder) do
+			table.insert(widgets, Cell{name = item.name, content = {_args[key]}})
+		end
+	end
+
+	return widgets
+end
+
+---@return WidgetInjector
+function CustomBuilding:createWidgetInjector()
+	return CustomInjector()
+end
+
+---@param args table
+function CustomBuilding:setLpdbData(args)
+	local lpdbData = {
+		type = 'building',
+		name = args.name or _pagename,
+		image = args.image
+	}
+	mw.ext.LiquipediaDB.lpdb_datapoint('building' .. (args.name or _pagename), lpdbData)
+end
+
+return CustomBuilding

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -19,7 +19,7 @@ local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 
-local modeAvailability = {
+local MODE_AVAILABILITY = {
 	home 	= {order = 1, name = 'Home Village'},
 	builder = {order = 2, name = 'Builder Base'},
 	clan 	= {order = 3, name = 'Clan Capital'},
@@ -41,7 +41,6 @@ function CustomBuilding.run(frame)
 	_args = building.args
 	_args.informationType = 'Building'
 
-	building.getWikiCategories = CustomBuilding.getWikiCategories
 	building.setLpdbData = CustomBuilding.setLpdbData
 	building.createWidgetInjector = CustomBuilding.createWidgetInjector
 
@@ -60,10 +59,10 @@ function CustomInjector:addCustomCells(widgets)
 		Cell{name = 'Release Date', content = {_args.releasedate}}
 	)
 
-	if Table.any(_args, function(key) return modeAvailability[key] end) then
+	if Table.any(_args, function(key) return MODE_AVAILABILITY[key] end) then
 		table.insert(widgets, Title{name = 'Mode Availability'})
-		local modeAvailabilityOrder = function(tbl, a, b) return tbl[a].order < tbl[b].order end
-		for key, item in Table.iter.spairs(modeAvailability, modeAvailabilityOrder) do
+		local MODE_AVAILABILITYOrder = function(tbl, a, b) return tbl[a].order < tbl[b].order end
+		for key, item in Table.iter.spairs(MODE_AVAILABILITY, MODE_AVAILABILITYOrder) do
 			table.insert(widgets, Cell{name = item.name, content = {_args[key]}})
 		end
 	end
@@ -74,16 +73,6 @@ end
 ---@return WidgetInjector
 function CustomBuilding:createWidgetInjector()
 	return CustomInjector()
-end
-
----@param args table
----@return string[]
-function CustomBuilding:getWikiCategories(args)
-	local categories = {}
-	if Namespace.isMain() then
-		categories = {'Buildings'}
-	end
-	return categories
 end
 
 ---@param args table

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -47,7 +47,7 @@ function CustomInjector:addCustomCells(widgets)
 	Array.appendWith(
 		widgets,
 		Cell{name = 'Range', content = {_args.range}},
-		Cell{name = 'Damage Type', content = {_args.damagetypo}},
+		Cell{name = 'Damage Type', content = {_args.damagetype}},
 		Cell{name = 'Target', content = {_args.target}},
 		Cell{name = 'Favorite Target', content = {_args.favtarget}},
 		Cell{name = 'Release Date', content = {_args.releasedate}}

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -38,7 +38,6 @@ local PAGENAME = mw.title.getCurrentTitle().text
 function CustomBuilding.run(frame)
 	local building = Building(frame)
 	_args = building.args
-	_args.informationType = 'Building'
 
 	building.setLpdbData = CustomBuilding.setLpdbData
 	building.createWidgetInjector = CustomBuilding.createWidgetInjector
@@ -76,12 +75,13 @@ end
 
 ---@param args table
 function CustomBuilding:setLpdbData(args)
+	local name = args.name or mw.title.getCurrentTitle().text
 	local lpdbData = {
 		type = 'building',
-		name = args.name or PAGENAME,
+		name = name,
 		image = args.image
 	}
-	mw.ext.LiquipediaDB.lpdb_datapoint('building' .. (args.name or PAGENAME), lpdbData)
+	mw.ext.LiquipediaDB.lpdb_datapoint('building' .. name, lpdbData)
 end
 
 return CustomBuilding

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -22,7 +22,7 @@ local MODE_AVAILABILITY = {
 	home 	= {order = 1, name = 'Home Village'},
 	builder = {order = 2, name = 'Builder Base'},
 	clan 	= {order = 3, name = 'Clan Capital'},
-	}
+}
 
 ---@class CustomBuildingInfobox: BuildingInfobox
 local CustomBuilding = Class.new()

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -9,9 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local Math = require('Module:Math')
-local Namespace = require('Module:Namespace')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -20,7 +17,6 @@ local Building = Lua.import('Module:Infobox/Building', {requireDevIfEnabled = tr
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
-local Breakdown = Widgets.Breakdown
 
 ---@class CustomBuildingInfobox: BuildingInfobox
 local CustomBuilding = Class.new()
@@ -30,7 +26,6 @@ local CustomInjector = Class.new(Injector)
 
 local _args
 local _pagename = mw.title.getCurrentTitle().text
-local NON_BREAKING_SPACE = '&nbsp;'
 
 ---@param frame Frame
 ---@return Html

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
-local Namespace = require('Module:Namespace')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Building = Lua.import('Module:Infobox/Building', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/clashofclans/infobox_building_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_building_custom.lua
@@ -47,7 +47,7 @@ function CustomInjector:addCustomCells(widgets)
 	Array.appendWith(
 		widgets,
 		Cell{name = 'Range', content = {_args.range}},
-		Cell{name = 'Damage Type', content = {_args.damage}},
+		Cell{name = 'Damage Type', content = {_args.damagetypo}},
 		Cell{name = 'Target', content = {_args.target}},
 		Cell{name = 'Favorite Target', content = {_args.favtarget}},
 		Cell{name = 'Release Date', content = {_args.releasedate}}


### PR DESCRIPTION
## Summary
Clash of Clans is Base-Building game, editors want to make a page covering the available Buildings in the game

I had no experience tackle Module:Infobox/Building before, so I decide to start it from Module:Infobox/Unit/Hero (from Mobile Legends, since I had familiarity with it) then change calls from anything **Hero** to use **Building** instead (as well as calling Infobox/Building instead of Unit), hence the code will look a bit weird

## How did you test this change?
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/12d910a2-5c5c-4320-9ff8-61ce654ea802)

https://liquipedia.net/clashofclans/User:Hesketh2/Cannon
