### PR TITLE
Add info text (summary) options for Infobox League

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -265,7 +265,7 @@ function League:createInfobox()
 	return mw.html.create()
 		:node(builtInfobox)
 		:node(WarningBox.displayAll(League.warnings))
-		:node(Logic.readBool(args.autointro) and self:seoText(args) or nil)
+		:node(Logic.readBool(args.autointro) and ('<br>' .. self:seoText(args)) or nil)
 end
 
 ---@param args table

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -52,7 +52,7 @@ function League.run(frame)
 	return league:createInfobox()
 end
 
----@return string
+---@return Html
 function League:createInfobox()
 	local args = self.args
 	args.abbreviation = self:_fetchAbbreviation()
@@ -262,7 +262,10 @@ function League:createInfobox()
 		self:_setSeoTags(args)
 	end
 
-	return tostring(builtInfobox) .. WarningBox.displayAll(League.warnings)
+	return mw.html.create()
+		:node(builtInfobox)
+		:node(WarningBox.displayAll(League.warnings))
+		:node(Logic.readBool(args.autointro) and self:seoText(args) or nil)
 end
 
 ---@param args table
@@ -433,6 +436,8 @@ function League:_definePageVariables(args)
 	-- if wikis want it unset they can unset it via the defineCustomPageVariables() call
 	Variables.varDefine('tournament_currency', args.localcurrency or '')
 
+	Variables.varDefine('tournament_summary', self:seoText(args))
+
 	self:defineCustomPageVariables(args)
 end
 
@@ -487,6 +492,7 @@ function League:_setLpdbData(args, links)
 		links = mw.ext.LiquipediaDB.lpdb_create_json(
 			Links.makeFullLinksForTableItems(links or {})
 		),
+		summary = self:seoText(args),
 		extradata = {
 			series2 = args.series2 and mw.ext.TeamLiquidIntegration.resolve_redirect(args.series2) or nil,
 		},


### PR DESCRIPTION
## Summary
Add info text options for Infobox League
- re-use the text we generate for seo
- store it in lpdb and wiki var
- add option to directly display it from the infobox via a switch param

## How did you test this change?
/dev