### PR TITLE
Make faction module usable from invoke

### DIFF
--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local Class = require('Module:Class')
 local Data = mw.loadData('Module:Faction/Data')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -159,4 +160,4 @@ function Faction.bgClass(faction)
 	return factionProps and factionProps.bgClass or nil
 end
 
-return Faction
+return Class.export(Faction)


### PR DESCRIPTION
## Summary
Make faction module usable from invoke.
This is to fix some darkmode issues caused by using an outdated module in some pages. Switching over to new one is only possible if it can work properly from invoke

## How did you test this change?
dev

## Remark:
- After merge adjust Templates `p`, `t`, `z` both on bw and sc2