### PR TITLE
Add elite series and italian rocket championship history fields in infobox player

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -90,7 +90,7 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Center{content = {_args.history_odl}})
 		end
 		if not String.isEmpty(_args.history_irc) then
-			table.insert(widgets, Title{name = '[[Italian Rocket Championship|Italian Rocket Championship]] History'})
+			table.insert(widgets, Title{name = '[[Italian Rocket Championship]] History'})
 			table.insert(widgets, Center{content = {_args.history_irc}})
 		end
 		if not String.isEmpty(_args.history_elite_series) then

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -94,7 +94,7 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Center{content = {_args.history_irc}})
 		end
 		if not String.isEmpty(_args.history_elite_series) then
-			table.insert(widgets, Title{name = '[[Elite Series|Elite Series]] History'})
+			table.insert(widgets, Title{name = '[[Elite Series]] History'})
 			table.insert(widgets, Center{content = {_args.history_elite_series}})
 		end
 	elseif id == 'role' then

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -89,7 +89,7 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Title{name = '[[Oceania Draft League|Oceania Draft League]] History'})
 			table.insert(widgets, Center{content = {_args.history_odl}})
 		end
-		if not String.isEmpty(_args.history_irc) then
+		if String.isNotEmpty(_args.history_irc) then
 			table.insert(widgets, Title{name = '[[Italian Rocket Championship]] History'})
 			table.insert(widgets, Center{content = {_args.history_irc}})
 		end

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -93,7 +93,7 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Title{name = '[[Italian Rocket Championship]] History'})
 			table.insert(widgets, Center{content = {_args.history_irc}})
 		end
-		if not String.isEmpty(_args.history_elite_series) then
+		if String.isNotEmpty(_args.history_elite_series) then
 			table.insert(widgets, Title{name = '[[Elite Series]] History'})
 			table.insert(widgets, Center{content = {_args.history_elite_series}})
 		end

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -89,6 +89,14 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Title{name = '[[Oceania Draft League|Oceania Draft League]] History'})
 			table.insert(widgets, Center{content = {_args.history_odl}})
 		end
+		if not String.isEmpty(_args.history_irc) then
+			table.insert(widgets, Title{name = '[[Italian Rocket Championship|Italian Rocket Championship]] History'})
+			table.insert(widgets, Center{content = {_args.history_irc}})
+		end
+		if not String.isEmpty(_args.history_elite_series) then
+			table.insert(widgets, Title{name = '[[Elite Series|Elite Series]] History'})
+			table.insert(widgets, Center{content = {_args.history_elite_series}})
+		end
 	elseif id == 'role' then
 		return {
 			Cell{name = 'Current Role', content = {_args.role}},


### PR DESCRIPTION
## Summary

Change to create two new history in the player section corresponding to nationals league (Italian Rocket Championship and Elite Series). Since they are yearly leagues, it makes more sense to create a different team history showcasing the teams the player played under in this particular league.



<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?



 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

https://liquipedia.net/rocketleague/User:Dark_meluca/infoboxTest
https://liquipedia.net/rocketleague/Module:Infobox/Person/Player/Custom/dev

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
