### PR TITLE
Add `Retired` display in heroes infobox person

### DIFF
--- a/components/infobox/wikis/heroes/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/heroes/infobox_person_player_custom.lua
@@ -43,6 +43,13 @@ function CustomInjector:addCustomCells(widgets)
 	return widgets
 end
 
+function CustomInjector:parse(id, widgets)
+	if id == 'history' and string.match(_args.retired or '', '%d%d%d%d') then
+		table.insert(widgets, Cell{name = 'Retired', content = {_args.retired}})
+	end
+	return widgets
+end
+
 function CustomPlayer:createWidgetInjector()
 	return CustomInjector()
 end


### PR DESCRIPTION
## Summary
Add `Retired` display in heroes infobox person as [per request by the wikis contributors](https://discord.com/channels/93055209017729024/268719633366777856/1153644417673072733)

## How did you test this change?
dev