### PR TITLE
Add `args.reformed` to team history

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -173,11 +173,12 @@ function Team:createInfobox()
 			children = {
 				Builder{
 					builder = function()
-						if args.created or args.disbanded then
+						if args.created or args.disbanded or args.reformed then
 							return {
 								Title{name = 'History'},
 								Cell{name = 'Created', content = {args.created}},
-								Cell{name = 'Disbanded', content = {args.disbanded}}
+								Cell{name = 'Disbanded', content = {args.disbanded}},
+								Cell{name = 'Reformed', content = {args.reformed}},
 							}
 						end
 					end


### PR DESCRIPTION
## Summary
As a replacement for the `historyX` parameter previously used on heroes: https://discord.com/channels/93055209017729024/268719633366777856/1153644417673072733

Discussion: Should the date be stored in LPDB? If so, new field or extradata?

## How did you test this change?
TBD
