### PR TITLE
Minor rework of Currency display options

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -149,7 +149,7 @@ BasePrizePool.prizeTypes = {
 			if data > 0 then
 				return TableCell{content = {
 					Currency.display(BASE_CURRENCY, data,
-						{formatValue = true, formatPrecision = headerData.roundPrecision, abbreviation = false})
+						{formatValue = true, formatPrecision = headerData.roundPrecision, displayCurrencyCode = false})
 				}}
 			end
 		end,
@@ -188,7 +188,7 @@ BasePrizePool.prizeTypes = {
 			if data > 0 then
 				return TableCell{content = {
 					Currency.display(headerData.currency, data,
-					{formatValue = true, formatPrecision = headerData.roundPrecision, abbreviation = false})
+					{formatValue = true, formatPrecision = headerData.roundPrecision, displayCurrencyCode = false})
 				}}
 			end
 		end,

--- a/components/results_table/commons/results_table.lua
+++ b/components/results_table/commons/results_table.lua
@@ -117,7 +117,7 @@ function ResultsTable:buildRow(placement)
 	local useIndivPrize = self.config.useIndivPrize and self.config.queryType ~= Opponent.team
 	row:tag('td'):wikitext(Currency.display('USD',
 			useIndivPrize and placement.individualprizemoney or placement.prizemoney,
-			{dashIfZero = true, abbreviation = false, formatValue = true}
+			{dashIfZero = true, displayCurrencyCode = false, formatValue = true}
 		))
 
 	return row

--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -87,7 +87,7 @@ function AwardsTable:buildRow(placement)
 
 	row:tag('td'):wikitext(Currency.display('USD',
 			self.config.queryType ~= Opponent.team and placement.individualprizemoney or placement.prizemoney,
-			{dashIfZero = true, abbreviation = false, formatValue = true}
+			{dashIfZero = true, displayCurrencyCode = false, formatValue = true}
 		))
 
 	return row

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -36,7 +36,7 @@ local ColumnName = Condition.ColumnName
 
 local Count = Lua.import('Module:Count', {requireDevIfEnabled = true})
 
-local CURRENCY_FORMAT_OPTIONS = {dashIfZero = true, abbreviation = false, formatValue = true}
+local CURRENCY_FORMAT_OPTIONS = {dashIfZero = true, displayCurrencyCode = false, formatValue = true}
 local CURRENT_YEAR = tonumber(os.date('%Y')) --[[@as integer]]
 local DATE = os.date('%F') --[[@as string]]
 local EPOCH_DATE = '1970-01-01'

--- a/components/tournaments_listing/commons/tournaments_listing_card_list.lua
+++ b/components/tournaments_listing/commons/tournaments_listing_card_list.lua
@@ -274,7 +274,7 @@ function BaseTournamentsListing:_row(tournamentData)
 	if prizeValue > 0 then
 		priceCell
 			:wikitext(Currency.display('USD', prizeValue, {
-				dashIfZero = true, abbreviation = false, formatValue = true
+				dashIfZero = true, displayCurrencyCode = false, formatValue = true
 			}))
 	else
 		priceCell

--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -114,7 +114,8 @@ function Currency.display(currencyCode, prizeValue, options)
 		prizeDisplay = prizeDisplay .. currencySuffix
 	end
 	if options.displayCurrencyCode then
-		local currencyCodeDisplay = options.useHtmlStyling and Abbreviation.make(currencyData.code, currencyData.name) or currencyData.code
+		local currencyCodeDisplay = not options.useHtmlStyling and currencyData.code
+			or Abbreviation.make(currencyData.code, currencyData.name)
 		prizeDisplay = prizeDisplay .. (String.isNotEmpty(prizeDisplay) and spaceString or '') .. currencyCodeDisplay
 	end
 

--- a/standard/currency/currency.lua
+++ b/standard/currency/currency.lua
@@ -47,13 +47,14 @@ function Currency.template(frame)
 end
 
 ---@class currencyDisplayOptions
----@field abbreviation boolean?
 ---@field dashIfZero boolean?
+---@field displaySymbol boolean?
+---@field displayCurrencyCode boolean?
 ---@field forceRoundPrecision boolean?
 ---@field formatPrecision integer?
 ---@field formatValue boolean?
 ---@field setVariables boolean?
----@field symbol boolean?
+---@field useHtmlStyling boolean?
 
 ---@param currencyCode string?
 ---@param prizeValue string|number|nil
@@ -61,8 +62,9 @@ end
 ---@return string?
 function Currency.display(currencyCode, prizeValue, options)
 	options = options or {}
-	options.symbol = Logic.emptyOr(options.symbol, true)
-	options.abbreviation = Logic.emptyOr(options.abbreviation, true)
+	options.displaySymbol = Logic.emptyOr(options.displaySymbol, true)
+	options.displayCurrencyCode = Logic.emptyOr(options.displayCurrencyCode, true)
+	options.useHtmlStyling = Logic.emptyOr(options.useHtmlStyling, true)
 
 	if options.dashIfZero and tonumber(prizeValue) == 0 then
 		return DASH
@@ -77,15 +79,16 @@ function Currency.display(currencyCode, prizeValue, options)
 		return nil
 	end
 
+	local spaceString = options.useHtmlStyling and NON_BREAKING_SPACE or ' '
+
 	local currencyPrefix = ''
 	if currencyData.symbol.text and not currencyData.symbol.isAfter then
-		currencyPrefix = currencyData.symbol.text .. (currencyData.symbol.hasSpace and NON_BREAKING_SPACE or '')
+		currencyPrefix = currencyData.symbol.text .. (currencyData.symbol.hasSpace and spaceString or '')
 	end
 	local currencySuffix = ''
 	if currencyData.symbol.text and currencyData.symbol.isAfter then
-		currencySuffix = (currencyData.symbol.hasSpace and NON_BREAKING_SPACE or '') .. currencyData.symbol.text
+		currencySuffix = (currencyData.symbol.hasSpace and spaceString or '') .. currencyData.symbol.text
 	end
-	local currencyAbbreviation = Abbreviation.make(currencyData.code, currencyData.name)
 
 	if options.setVariables then
 		Variables.varDefine('localcurrencycode', currencyData.code or '')
@@ -93,12 +96,12 @@ function Currency.display(currencyCode, prizeValue, options)
 		Variables.varDefine('localcurrencysymbolafter', currencySuffix)
 	end
 
-	if options.abbreviation and currencyData.symbol.text == currencyData.code then
-		options.symbol = false
+	if options.displayCurrencyCode and currencyData.symbol.text == currencyData.code then
+		options.displaySymbol = false
 	end
 
 	local prizeDisplay = ''
-	if options.symbol then
+	if options.displaySymbol then
 		prizeDisplay = prizeDisplay .. currencyPrefix
 	end
 	if prizeValue then
@@ -107,11 +110,12 @@ function Currency.display(currencyCode, prizeValue, options)
 		end
 		prizeDisplay = prizeDisplay .. prizeValue
 	end
-	if options.symbol then
+	if options.displaySymbol then
 		prizeDisplay = prizeDisplay .. currencySuffix
 	end
-	if options.abbreviation then
-		prizeDisplay = prizeDisplay .. (prizeDisplay ~= '' and NON_BREAKING_SPACE or '') .. currencyAbbreviation
+	if options.displayCurrencyCode then
+		local currencyCodeDisplay = options.useHtmlStyling and Abbreviation.make(currencyData.code, currencyData.name) or currencyData.code
+		prizeDisplay = prizeDisplay .. (String.isNotEmpty(prizeDisplay) and spaceString or '') .. currencyCodeDisplay
 	end
 
 	return prizeDisplay

--- a/standard/test/currency_test.lua
+++ b/standard/test/currency_test.lua
@@ -63,6 +63,7 @@ function suite:testDisplay()
 	self:assertEquals('€1,200&nbsp;<abbr title="Euro">EUR</abbr>', Currency.display('EUR', 1200, {formatValue = true}))
 	self:assertEquals('€1200&nbsp;<abbr title="Euro">EUR</abbr>', Currency.display('EUR', 1200))
 	self:assertEquals('€&nbsp;<abbr title="Euro">EUR</abbr>', Currency.display('EUR'))
+	self:assertEquals('€ EUR', Currency.display('EUR', nil, {useHtmlStyling = false}))
 end
 
 return suite


### PR DESCRIPTION
## Summary

As part of wanting to fix an issue with `Module:MetadataGenerator`, I needed some more configurability of the display from this module. I changed the name of two existing options to be a bit better (imo) and added a new option too.

- `symbol` -> `displaySymbol` (functionality 1:1)
- `abbreviation` -> `displayCurrencyCode` (functionality 1:1 if not changing `useHtmlStyling`)
- `useHtmlStyling` is new and stops `&nbsp;` and `<abbr>` from being used.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/0c3c8f78-a0b5-4881-9919-8bd98e13c5d9)

## How did you test this change?

`/dev` ofc :D 

## After merge checklist

The following non-git modules have been pre-prepared for the merge to not break them. Just need to remove `abbreviation` after that.

- [ ] https://liquipedia.net/clashofclans/index.php?title=Module:QuickviewPage&diff=6548&oldid=5650
- [ ] https://liquipedia.net/dota2/index.php?title=Module:StatisticsPortal/DPC&diff=1455065&oldid=1443588