### PR TITLE
Add reworked MatchSummary as temp module

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -368,6 +368,12 @@ function MatchGroupUtil.fetchMatchForBracketDisplay(bracketId, matchId, options)
 		if bracketResetMatch then
 			return MatchGroupUtil.mergeBracketResetMatch(match, bracketResetMatch)
 		end
+	elseif options.returnBoth then
+		local bracketResetMatch = match
+			and match.bracketData.bracketResetMatchId
+			and bracket.matchesById[match.bracketData.bracketResetMatchId]
+
+		return match, bracketResetMatch
 	end
 
 	return match

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -250,11 +250,6 @@ function Footer:create()
 	return self.root
 end
 
----MatchSummary Casters Class
----@class MatchSummaryCasters
----@operator call: MatchSummaryCasters
----@field root Html
----@field casters string[]
 local Casters = Class.new(
 	function(self)
 		self.root = mw.html.create('div')
@@ -265,9 +260,6 @@ local Casters = Class.new(
 	end
 )
 
----adds a casters display to thge casters list
----@param caster {name: string, displayName: string, flag: string?}?
----@return MatchSummaryCasters
 function Casters:addCaster(caster)
 	if Logic.isNotEmpty(caster) then
 		---@cast caster -nil
@@ -282,8 +274,6 @@ function Casters:addCaster(caster)
 	return self
 end
 
----creates the casters display
----@return Html
 function Casters:create()
 	return self.root
 		:wikitext('Caster' .. (#self.casters > 1 and 's' or '') .. ': ')

--- a/components/match2/commons/match_summary_base_temp.lua
+++ b/components/match2/commons/match_summary_base_temp.lua
@@ -1,0 +1,637 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:MatchSummary/Base/temp
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Flags = require('Module:Flags')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local VodLink = require('Module:VodLink')
+
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
+---just a base class to avoid anno warnings
+---@class MatchSummaryRowInterface
+---@field create fun(self): Html
+
+---@class MatchSummaryBreak
+---@operator call: MatchSummaryBreak
+---@field root Html
+local Break = Class.new(
+	function(self)
+		self.root = mw.html.create('div'):addClass('brkts-popup-break')
+	end
+)
+
+---@return Html
+function Break:create()
+	return self.root
+end
+
+---@class MatchSummaryHeader
+---@operator call: MatchSummaryHeader
+---@field root Html
+---@field leftElement string|Html|number|nil
+---@field leftScoreElement Html?
+---@field rightElement string|Html|number|nil
+---@field rightScoreElement Html?
+local Header = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+			:addClass('brkts-popup-header-dev')
+			:css('justify-content', 'center')
+	end
+)
+
+---@param content string|Html|number|nil
+---@return MatchSummaryHeader
+function Header:leftOpponent(content)
+	self.leftElement = content
+	return self
+end
+
+---@param content Html
+---@return MatchSummaryHeader
+function Header:leftScore(content)
+	self.leftScoreElement = content:addClass('brkts-popup-header-opponent-score-left')
+	return self
+end
+
+---@param content Html
+---@return MatchSummaryHeader
+function Header:rightScore(content)
+	self.rightScoreElement = content:addClass('brkts-popup-header-opponent-score-right')
+	return self
+end
+
+---@param content string|Html|number|nil
+---@return MatchSummaryHeader
+function Header:rightOpponent(content)
+	self.rightElement = content
+	return self
+end
+
+---@param opponent standardOpponent
+---@param side 'left'|'right'
+---@param style teamStyle?
+---@return Html
+function Header:createOpponent(opponent, side, style)
+	local showLink = not Opponent.isTbd(opponent) and true or false
+	return OpponentDisplay.BlockOpponent{
+		flip = side == 'left',
+		opponent = opponent,
+		showLink = showLink,
+		overflow = 'ellipsis',
+		teamStyle = style or 'short',
+	}
+end
+
+---@param opponent standardOpponent
+---@return Html
+function Header:createScore(opponent)
+	local isWinner, scoreText
+	if opponent.placement2 then
+		-- Bracket Reset, show W/L
+		if opponent.placement2 == 1 then
+			isWinner = true
+			scoreText = 'W'
+		else
+			isWinner = false
+			scoreText = 'L'
+		end
+	else
+		isWinner = opponent.placement == 1 or opponent.advances
+		scoreText = OpponentDisplay.InlineScore(opponent)
+	end
+
+	return OpponentDisplay.BlockScore{
+		isWinner = isWinner,
+		scoreText = scoreText,
+	}
+end
+
+---@return Html
+function Header:create()
+	return self.root
+		:tag('div'):addClass('brkts-popup-header-opponent'):addClass('brkts-popup-header-opponent-left')
+			:node(self.leftElement)
+			:node(self.leftScoreElement or '')
+			:done()
+		:tag('div'):addClass('brkts-popup-header-opponent'):addClass('brkts-popup-header-opponent-right')
+			:node(self.rightScoreElement or '')
+			:node(self.rightElement)
+			:done()
+end
+
+---@class MatchSummaryRow: MatchSummaryRowInterface
+---@operator call: MatchSummaryRow
+---@field root Html
+---@field elements Html[]
+local Row = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+		self.root:addClass('brkts-popup-body-element')
+		self.elements = {}
+	end
+)
+
+---@param class string?
+---@return MatchSummaryRow
+function Row:addClass(class)
+	self.root:addClass(class)
+	return self
+end
+
+---@param name string
+---@param value string|number|nil
+---@return MatchSummaryRow
+function Row:css(name, value)
+	self.root:css(name, value)
+	return self
+end
+
+---@param element Html|string|nil
+---@return MatchSummaryRow
+function Row:addElement(element)
+	table.insert(self.elements, element)
+	return self
+end
+
+---@param elements (Html|string)[]
+---@return MatchSummaryRow
+function Row:addElements(elements)
+	for _, element in ipairs(elements) do
+		self:addElement(element)
+	end
+	return self
+end
+
+---@return Html
+function Row:create()
+	for _, element in pairs(self.elements) do
+		self.root:node(element)
+	end
+
+	return self.root
+end
+
+---@class MatchSummaryMvp: MatchSummaryRowInterface
+---@operator call: MatchSummaryMvp
+---@field root Html
+---@field players Html[]
+local Mvp = Class.new(
+	function(self)
+		self.root = mw.html.create('div'):addClass('brkts-popup-footer'):addClass('brkts-popup-mvp')
+		self.players = {}
+	end
+)
+
+---@param player table
+---@return MatchSummaryMvp
+function Mvp:addPlayer(player)
+	local playerDisplay
+	if Logic.isEmpty(player) then
+		return self
+	elseif type(player) == 'table' then
+		playerDisplay = '[[' .. player.name .. '|' .. player.displayname .. ']]'
+		if player.comment then
+			playerDisplay = playerDisplay .. ' (' .. player.comment .. ')'
+		end
+	else
+		playerDisplay = '[[' .. player .. ']]'
+	end
+
+	table.insert(self.players, playerDisplay)
+
+	return self
+end
+
+---@param points number
+---@return MatchSummaryMvp
+function Mvp:setPoints(points)
+	if Logic.isNumeric(points) then
+		self.points = points
+	end
+	return self
+end
+
+---@return Html
+function Mvp:create()
+	local span = mw.html.create('span')
+	span:wikitext(#self.players > 1 and 'MVPs: ' or 'MVP: ')
+		:wikitext(table.concat(self.players, ', '))
+	if self.points and self.points ~= 1 then
+		span:wikitext(' ('.. self.points ..'pts)')
+	end
+	self.root:node(span)
+	return self.root
+end
+
+---@class MatchSummaryBody
+---@operator call: MatchSummaryBody
+---@field root Html
+local Body = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+		self.root:addClass('brkts-popup-body')
+	end
+)
+
+---@param cssClass string?
+---@return MatchSummaryBody
+function Body:addClass(cssClass)
+	self.root:addClass(cssClass)
+	return self
+end
+
+---@param row MatchSummaryRowInterface
+---@return MatchSummaryBody
+function Body:addRow(row)
+	self.root:node(row:create())
+	return self
+end
+
+---@return Html
+function Body:create()
+	return self.root
+end
+
+---@class MatchSummaryComment
+---@operator call: MatchSummaryComment
+---@field root Html
+local Comment = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+			:addClass('brkts-popup-comment')
+			:css('white-space', 'normal')
+			:css('font-size', '85%')
+	end
+)
+
+---@param content Html|string|number
+---@return MatchSummaryComment
+function Comment:content(content)
+	self.root:node(content):node(Break():create())
+	return self
+end
+
+---@return Html
+function Comment:create()
+	return self.root
+end
+
+---@class MatchSummaryFooter
+---@operator call: MatchSummaryFooter
+---@field root Html
+---@field inner Html
+---@field elements (Html|string)[]
+local Footer = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+			:addClass('brkts-popup-footer')
+		self.inner = mw.html.create('div')
+			:addClass('brkts-popup-spaced vodlink')
+		self.elements = {}
+	end
+)
+
+---@param element Html
+---@return MatchSummaryFooter
+function Footer:addElement(element)
+	table.insert(self.elements, element)
+	return self
+end
+
+---@param link string
+---@param icon string
+---@param iconDark string?
+---@param text string
+---@return MatchSummaryFooter
+function Footer:addLink(link, icon, iconDark, text)
+	local content
+	if String.isEmpty(iconDark) then
+		content = '[[' .. icon .. '|link=' .. link .. '|32px|' .. text .. '|alt=' .. link .. ']]'
+	else
+		---@cast iconDark -nil
+		content = '[[' .. icon .. '|link=' .. link .. '|32px|' .. text .. '|alt=' .. link .. '|class=show-when-light-mode]]'
+			.. '[[' .. iconDark .. '|link=' .. link .. '|32px|' .. text .. '|alt=' .. link .. '|class=show-when-dark-mode]]'
+	end
+
+	table.insert(self.elements, content)
+	return self
+end
+
+---@param linkData table<string, {icon: string, text: string, iconDark: string?}>
+---@param links table<string, string>
+---@return MatchSummaryFooter
+function Footer:addLinks(linkData, links)
+	for linkType, link in pairs(links) do
+		local currentLinkData = linkData[linkType]
+		if not currentLinkData then
+			mw.log('Unknown link: ' .. linkType)
+		else
+			self:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text)
+		end
+	end
+
+	return self
+end
+
+---@return Html?
+function Footer:create()
+	if Table.isEmpty(self.elements) then
+		return
+	end
+	for _, element in ipairs(self.elements) do
+		self.inner:node(element)
+	end
+	self.root:node(self.inner)
+	return self.root
+end
+
+---MatchSummary Casters Class
+---@class MatchSummaryCasters: MatchSummaryRowInterface
+---@operator call: MatchSummaryCasters
+---@field casters string[]
+local Casters = Class.new(
+	function(self)
+		self.root = mw.html.create('div')
+			:addClass('brkts-popup-comment')
+			:css('white-space','normal')
+			:css('font-size','85%')
+		self.casters = {}
+	end
+)
+
+---adds a casters display to thge casters list
+---@param caster {name: string, displayName: string, flag: string?}?
+---@return MatchSummaryCasters
+function Casters:addCaster(caster)
+	if Logic.isNotEmpty(caster) then
+		---@cast caster -nil
+		local nameDisplay = '[[' .. caster.name .. '|' .. caster.displayName .. ']]'
+		if caster.flag then
+			table.insert(self.casters, Flags.Icon(caster.flag) .. '&nbsp;' .. nameDisplay)
+		else
+			table.insert(self.casters, nameDisplay)
+		end
+	end
+
+	return self
+end
+
+---creates the casters display
+---@return Html
+function Casters:create()
+	return self.root
+		:wikitext('Caster' .. (#self.casters > 1 and 's' or '') .. ': ')
+		:wikitext(mw.text.listToText(self.casters, ', ', ' & '))
+end
+
+---@class MatchSummaryMatch
+---@operator call: MatchSummaryMatch
+---@field root Html
+---@field headerElement Html?
+---@field bodyElement Html?
+---@field commentElement Html?
+---@field footerElement Html?
+local Match = Class.new(
+	function(self)
+		self.root = mw.html.create()
+	end
+)
+
+---@param header MatchSummaryHeader
+---@return MatchSummaryMatch
+function Match:header(header)
+	self.headerElement = header:create()
+	return self
+end
+
+---@param body MatchSummaryBody
+---@return MatchSummaryMatch
+function Match:body(body)
+	self.bodyElement = body:create()
+	return self
+end
+
+---@param comment MatchSummaryComment
+---@return MatchSummaryMatch
+function Match:comment(comment)
+	self.commentElement = comment:create()
+	return self
+end
+
+---@param footer MatchSummaryFooter
+---@return MatchSummaryMatch
+function Match:footer(footer)
+	self.footerElement = footer:create()
+	return self
+end
+
+---@return Html
+function Match:create()
+	self.root
+		:node(self.headerElement)
+		:node(Break():create())
+		:node(self.bodyElement)
+		:node(Break():create())
+
+	if self.commentElement ~= nil then
+		self.root
+			:node(self.commentElement)
+			:node(Break():create())
+	end
+
+	if self.footerElement ~= nil then
+		self.root:node(self.footerElement)
+	end
+
+	return self.root
+end
+
+---@class MatchSummary
+---@field Header MatchSummaryHeader
+---@field Body MatchSummaryBody
+---@field Comment MatchSummaryComment
+---@field Row MatchSummaryRow
+---@field Footer MatchSummaryFooter
+---@field Break MatchSummaryBreak
+---@field Mvp MatchSummaryMvp
+---@field Casters MatchSummaryCasters
+---@field Match MatchSummaryMatch
+---@field matches Html[]?
+---@field headerElement Html?
+---@field root Html?
+local MatchSummary = Class.new()
+MatchSummary.Header = Header
+MatchSummary.Body = Body
+MatchSummary.Comment = Comment
+MatchSummary.Row = Row
+MatchSummary.Footer = Footer
+MatchSummary.Break = Break
+MatchSummary.Mvp = Mvp
+MatchSummary.Casters = Casters
+MatchSummary.Match = Match
+
+---@param width string?
+---@return MatchSummary
+function MatchSummary:init(width)
+	self.matches = {}
+	self.root = mw.html.create('div')
+		:addClass('brkts-popup')
+		:css('width', width)
+	return self
+end
+
+---@param cssClass string?
+---@return MatchSummary
+function MatchSummary:addClass(cssClass)
+	self.root:addClass(cssClass)
+	return self
+end
+
+---@param header MatchSummaryHeader
+---@return MatchSummary
+function MatchSummary:header(header)
+	self.headerElement = header:create()
+	return self
+end
+
+---@param match MatchSummaryMatch
+---@return MatchSummary
+function MatchSummary:addMatch(match)
+	if not match then return self end
+
+	table.insert(self.matches, match:create())
+
+	return self
+end
+
+---@return Html
+function MatchSummary:create()
+	self.root:node(self.headerElement)
+
+	for _, match in ipairs(self.matches) do
+		self.root:node(match)
+	end
+
+	return self.root
+end
+
+---Default header function
+---@param match table
+---@param options {noScore: boolean?}?
+---@return MatchSummaryHeader
+function MatchSummary.createDefaultHeader(match, options)
+	options = options or {}
+
+	local header = MatchSummary.Header()
+
+	if options.noScore then
+		return header
+			:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+			:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+	end
+
+	return header
+		:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+		:leftScore(header:createScore(match.opponents[1]))
+		:rightScore(header:createScore(match.opponents[2]))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+end
+
+---Creates a match footer with vods if vods are set
+---@param match table
+---@param footer MatchSummaryFooter
+---@return MatchSummaryFooter
+function MatchSummary.addVodsToFooter(match, footer)
+	local vods = {}
+	for index, game in ipairs(match.games) do
+		if game.vod then
+			vods[index] = game.vod
+		end
+	end
+
+	if match.vod then
+		footer:addElement(VodLink.display{
+			vod = match.vod,
+		})
+	end
+	for index, vod in pairs(vods) do
+		footer:addElement(VodLink.display{
+			gamenum = index,
+			vod = vod,
+		})
+	end
+
+	return footer
+end
+
+---Default createMatch function for usage in Custom MatchSummary
+---@param matchData table
+---@param CustomMatchSummary table
+---@return MatchSummaryMatch?
+function MatchSummary.createMatch(matchData, CustomMatchSummary)
+	if not matchData then
+		return
+	end
+
+	local match = Match()
+
+	local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
+	match:header(createHeader(matchData))
+
+	match:body(CustomMatchSummary.createBody(matchData))
+
+	if matchData.comment then
+		local comment = MatchSummary.Comment():content(matchData.comment)
+		match:comment(comment)
+	end
+	local createFooter = CustomMatchSummary.addToFooter or MatchSummary.addVodsToFooter
+	match:footer(createFooter(matchData, MatchSummary.Footer()))
+
+	return match
+end
+
+---Default getByMatchId function for usage in Custom MatchSummary
+---@param CustomMatchSummary table
+---@param args table
+---@param options table?
+---@return Html
+function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
+	assert(type(CustomMatchSummary.createBody) == 'function', 'Function "createBody" missing in "Module:MatchSummary"')
+
+	options = options or {}
+
+	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+
+	local matchSummary = MatchSummary():init(options.width)
+
+	--additional header for when martin adds the the css and buttons for switching between match and reset match
+	--if bracketResetMatch then
+		--local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
+		--matchSummary:header(createHeader(match, {noScore = true}))
+		--here martin can add the buttons for switching between match and reset match
+	--end
+
+	local createMatch = CustomMatchSummary.createMatch or function(matchData)
+		return MatchSummary.createMatch(matchData, CustomMatchSummary)
+	end
+	matchSummary:addMatch(createMatch(match))
+	matchSummary:addMatch(createMatch(bracketResetMatch))
+
+	return matchSummary:create()
+end
+
+return MatchSummary

--- a/components/match2/commons/match_summary_base_temp.lua
+++ b/components/match2/commons/match_summary_base_temp.lua
@@ -615,7 +615,7 @@ function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 
 	options = options or {}
 
-	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId)
+	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, {returnBoth = true})
 
 	local matchSummary = MatchSummary():init(options.width)
 

--- a/components/match2/commons/match_summary_base_temp.lua
+++ b/components/match2/commons/match_summary_base_temp.lua
@@ -557,23 +557,19 @@ end
 ---@param footer MatchSummaryFooter
 ---@return MatchSummaryFooter
 function MatchSummary.addVodsToFooter(match, footer)
-	local vods = {}
-	for index, game in ipairs(match.games) do
-		if game.vod then
-			vods[index] = game.vod
-		end
-	end
-
 	if match.vod then
 		footer:addElement(VodLink.display{
 			vod = match.vod,
 		})
 	end
-	for index, vod in pairs(vods) do
-		footer:addElement(VodLink.display{
-			gamenum = index,
-			vod = vod,
-		})
+
+	for gameIndex, game in ipairs(match.games) do
+		if game.vod then
+			footer:addElement(VodLink.display{
+				gamenum = gameIndex,
+				vod = game.vod,
+			})
+		end
 	end
 
 	return footer

--- a/components/match2/commons/match_summary_base_temp.lua
+++ b/components/match2/commons/match_summary_base_temp.lua
@@ -362,6 +362,7 @@ end
 ---MatchSummary Casters Class
 ---@class MatchSummaryCasters: MatchSummaryRowInterface
 ---@operator call: MatchSummaryCasters
+---@field root Html
 ---@field casters string[]
 local Casters = Class.new(
 	function(self)

--- a/components/match2/commons/match_summary_base_temp.lua
+++ b/components/match2/commons/match_summary_base_temp.lua
@@ -615,7 +615,8 @@ function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 
 	options = options or {}
 
-	local match, bracketResetMatch = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, {returnBoth = true})
+	local match, bracketResetMatch =
+		MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, {returnBoth = true})
 
 	local matchSummary = MatchSummary():init(options.width)
 

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -168,7 +168,6 @@ end
 function CustomMatchSummary.addToFooter(match, footer)
 	footer = MatchSummary.addVodsToFooter(match, footer)
 
-	match.links.lrthread = match.links.lrthread or match.lrthread
 
 	return footer:addLinks(LINK_DATA, match.links)
 end

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -10,7 +10,6 @@ local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
-local VodLink = require('Module:VodLink')
 local MapTypeIcon = require('Module:MapType')
 local String = require('Module:StringUtils')
 local Class = require('Module:Class')
@@ -19,8 +18,7 @@ local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
 local Json = require('Module:Json')
 
-local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
+local MatchSummary = Lua.import('Module:MatchSummary/Base/temp', {requireDevIfEnabled = true})
 
 local _EPOCH_TIME = '1970-01-01 00:00:00'
 local _EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
@@ -31,22 +29,25 @@ local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|First pick]]'
 
 local htmlCreate = mw.html.create
 
-local _GREEN_CHECK = '<i class="fa fa-check forest-green-text" style="width: 14px; text-align: center" ></i>'
-local _ICONS = {
-	check = _GREEN_CHECK,
+local GREEN_CHECK = '<i class="fa fa-check forest-green-text" style="width: 14px; text-align: center" ></i>'
+local ICONS = {
+	check = GREEN_CHECK,
 }
-local _NO_CHECK = '[[File:NoCheck.png|link=]]'
-local _LINK_DATA = {
-	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
+local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local LINK_DATA = {
 	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
 	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 }
-
 
 local CustomMatchSummary = {}
 
 
 -- Brawler Pick/Ban Class
+---@class BrawlstarsMatchSummaryBrawler: MatchSummaryRowInterface
+---@operator call: BrawlstarsMatchSummaryBrawler
+---@field root Html
+---@field table Html
+---@field isBan boolean?
 local Brawler = Class.new(
 	function(self, options)
 		options = options or {}
@@ -58,6 +59,7 @@ local Brawler = Class.new(
 	end
 )
 
+---@return BrawlstarsMatchSummaryBrawler
 function Brawler:createHeader()
 	self.table:tag('tr')
 		:tag('th'):css('width','35%'):wikitext(''):done()
@@ -68,6 +70,12 @@ function Brawler:createHeader()
 	return self
 end
 
+---@param brawlerData {[1]: table<integer, string>, [2]: table<integer, string>, numberOfPicks: integer}
+---@param gameNumber integer
+---@param numberBrawlers integer
+---@param date string
+---@param firstPick integer?
+---@return BrawlstarsMatchSummaryBrawler
 function Brawler:row(brawlerData, gameNumber, numberBrawlers, date, firstPick)
 	if numberBrawlers > 0 then
 		self.table:tag('tr')
@@ -90,6 +98,9 @@ function Brawler:row(brawlerData, gameNumber, numberBrawlers, date, firstPick)
 	return self
 end
 
+---@param firstPick integer?
+---@param side integer
+---@return string?
 function Brawler._firstPick(firstPick, side)
 	if firstPick ~= side then
 		return nil
@@ -98,6 +109,11 @@ function Brawler._firstPick(firstPick, side)
 	return side == LEFT_SIDE and ARROW_LEFT or ARROW_RIGHT
 end
 
+---@param brawlerData table<integer, string>
+---@param numberOfBrawlers integer
+---@param flip boolean
+---@param date string
+---@return Html
 function Brawler:_opponentBrawlerDisplay(brawlerData, numberOfBrawlers, flip, date)
 	local opponentBrawlerDisplay = {}
 
@@ -135,87 +151,31 @@ function Brawler:_opponentBrawlerDisplay(brawlerData, numberOfBrawlers, flip, da
 	return display
 end
 
+---@return Html
 function Brawler:create()
 	return self.root
 end
 
+---@param args table
+---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	local options = {mergeBracketResetMatch = false}
-	local match = MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, args.matchId, options)
-	local bracketResetMatch = match and match.bracketData and match.bracketData.bracketResetMatchId
-		and MatchGroupUtil.fetchMatchForBracketDisplay(args.bracketId, match.bracketData.bracketResetMatchId, options)
-
-	local matchSummary = MatchSummary():init()
-
-	matchSummary:header(CustomMatchSummary._createHeader(match))
-		:body(CustomMatchSummary._createBody(match))
-
-	if bracketResetMatch then
-		matchSummary:resetHeader(CustomMatchSummary._createHeader(bracketResetMatch))
-			:resetBody(CustomMatchSummary._createBody(bracketResetMatch))
-	end
-
-	-- comment
-	if match.comment then
-		local comment = MatchSummary.Comment():content(match.comment)
-		matchSummary:comment(comment)
-	end
-
-	-- footer
-	local vods = {}
-	for index, game in ipairs(match.games) do
-		if game.vod then
-			vods[index] = game.vod
-		end
-	end
-
-	match.links.lrthread = match.lrthread
-	match.links.vod = match.vod
-	if not Table.isEmpty(vods) or not Table.isEmpty(match.links) then
-		local footer = MatchSummary.Footer()
-
-		-- Game Vods
-		for index, vod in pairs(vods) do
-			footer:addElement(VodLink.display{
-				gamenum = index,
-				vod = vod,
-				source = vod.url
-			})
-		end
-
-		-- Match Vod + other links
-		local buildLink = function (linkType, link)
-			local linkData = _LINK_DATA[linkType]
-			if not linkData then
-				mw.log('linkType "' .. linkType .. '" is not supported by Module:MatchSummary')
-			else
-				return '[[' .. linkData.icon .. '|link=' .. link .. '|15px|' .. linkData.text .. ']]'
-			end
-		end
-
-		for linkType, link in pairs(match.links) do
-			footer:addElement(buildLink(linkType,link))
-		end
-
-		matchSummary:footer(footer)
-	end
-
-	return matchSummary:create()
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
+---@param match table
+---@param footer MatchSummaryFooter
+---@return MatchSummaryFooter
+function CustomMatchSummary.addToFooter(match, footer)
+	footer = MatchSummary.addVodsToFooter(match, footer)
 
-function CustomMatchSummary._createHeader(match)
-	local header = MatchSummary.Header()
+	match.links.lrthread = match.links.lrthread or match.lrthread
 
-	header:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
-		:leftScore(header:createScore(match.opponents[1]))
-		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
-
-	return header
+	return footer:addLinks(LINK_DATA, match.links)
 end
 
-function CustomMatchSummary._createBody(match)
+---@param match table
+---@return MatchSummaryBody
+function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
 	if match.dateIsExact or (match.date ~= _EPOCH_TIME_EXTENDED and match.date ~= _EPOCH_TIME) then
@@ -309,11 +269,16 @@ function CustomMatchSummary._createBody(match)
 	return body
 end
 
+---@param game table
+---@param opponentIndex integer
+---@return Html
 function CustomMatchSummary._gameScore(game, opponentIndex)
 	local score = game.scores[opponentIndex] or ''
 	return htmlCreate('div'):wikitext(score)
 end
 
+---@param game table
+---@return MatchSummaryRow
 function CustomMatchSummary._createMapRow(game)
 	local row = MatchSummary.Row()
 
@@ -366,22 +331,27 @@ function CustomMatchSummary._createMapRow(game)
 	return row
 end
 
+---@param game table
+---@return string
 function CustomMatchSummary._getMapDisplay(game)
 	local mapDisplay = '[[' .. game.map .. ']]'
 	if String.isNotEmpty(game.extradata.maptype) then
-		mapDisplay = MapTypeIcon.display(game.extradata.maptype) .. mapDisplay
+		return MapTypeIcon.display(game.extradata.maptype) .. mapDisplay
 	end
 	return mapDisplay
 end
 
+---@param showIcon boolean
+---@param iconType string
+---@return Html
 function CustomMatchSummary._createCheckMarkOrCross(showIcon, iconType)
 	local container = htmlCreate('div')
 	container:addClass('brkts-popup-spaced'):css('line-height', '27px')
 
 	if showIcon then
-		container:node(_ICONS[iconType])
+		container:node(ICONS[iconType])
 	else
-		container:node(_NO_CHECK)
+		container:node(NO_CHECK)
 	end
 
 	return container


### PR DESCRIPTION
## Summary
Add reworked MatchSummary as temp module
Also Adjust MatchGroup/Util accordingly.

The temp module is done so we can switch wiki after wiki over instead of having to do all at the same time.
After all wikis are switched over we can kick the old one and move the temp one in its place (together with adjusting all customs to then again point towards the notmal base)
Also can simplify the fetchMatchForBracketDisplay function in MatchGroupUtil after all wikis have been switched

## How did you test this change?
as dev of the normal one, see #3295