### PR TITLE
Implement adding adjacent content to PPT table

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -482,33 +482,32 @@ function BasePrizePool:_shouldDisplayPrizeSummary()
 end
 
 function BasePrizePool:build(isAward)
-	local wrapper
-	if self.options.exchangeInfo or self.adjacentContent or self:_shouldDisplayPrizeSummary() then
-		wrapper = mw.html.create('div'):addClass('prizepool-section-wrapper')
-
-		if self:_shouldDisplayPrizeSummary() then
-			wrapper:tag('span'):wikitext(self:_getPrizeSummaryText())
-		end
-
-		local tablesWrapper = mw.html.create('div'):addClass('prizepool-section-tables')
-
-		tablesWrapper:node(self:_buildTable(isAward))
-
-		if self.adjacentContent then
-			tablesWrapper:wikitext(self.adjacentContent)
-		end
-
-		wrapper:node(tablesWrapper)
-
-		if self.options.exchangeInfo then
-			wrapper:wikitext(self:_currencyExchangeInfo())
-		end
-	else
-		wrapper = self:_buildTable(isAward)
-	end
+	local prizePoolTable = self:_buildTable(isAward)
 
 	if self.options.storeLpdb then
 		self:storeData()
+	end
+
+	if not (self.options.exchangeInfo or self.adjacentContent or self:_shouldDisplayPrizeSummary()) then
+		return prizePoolTable
+	end
+
+	local wrapper = mw.html.create('div'):addClass('prizepool-section-wrapper')
+
+	if self:_shouldDisplayPrizeSummary() then
+		wrapper:tag('span'):wikitext(self:_getPrizeSummaryText())
+	end
+
+	local tablesWrapper = mw.html.create('div'):addClass('prizepool-section-tables'):node(prizePoolTable)
+
+	if self.adjacentContent then
+		tablesWrapper:wikitext(self.adjacentContent)
+	end
+
+	wrapper:node(tablesWrapper)
+
+	if self.options.exchangeInfo then
+		wrapper:wikitext(self:_currencyExchangeInfo())
 	end
 
 	return wrapper


### PR DESCRIPTION
## Summary

With the new PPT tables, it was no longer possible to add adjacent content next to the PPT table but between the summary and conversion texts. This change allows for that to be possible using some CSS flexboxes.

| Choices Before | Now Possible |
|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/75bbf646-061c-443c-ba68-b0cd8c4f3a9c) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/35df1a34-d5c2-4555-91b0-ddc0114a449b) |
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/9effd99d-c4fb-4e6d-9b08-c64b228419cd) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/896ea65e-13e7-4a62-a87d-559c38af211b) | 

Nothing should be broken (afaik) from how it used to work before, although the basic layout even without adjacent content now uses flexbox - both for easier implementation and to fix annoying scrolling bug with old layout where text would also scroll:

https://github.com/Liquipedia/Lua-Modules/assets/5881994/0bb90d04-2de4-4be2-8baf-466139d1b836

https://github.com/Liquipedia/Lua-Modules/assets/5881994/2bd64955-5d81-49ac-944f-9d3ea41bf8ec

## CSS changes on commons

The following new css has been [added](https://liquipedia.net/commons/index.php?title=MediaWiki%3ACommon.css%2FPrizepooltable.css&type=revision&diff=523980&oldid=474922) (with `Resourceloaderarticles-cacheversion` also bumped):

```css
.prizepool-section-wrapper {
	display: flex;
	flex-direction: column;
	gap: 0.25em;
}

.prizepool-section-tables {
	display: flex;
	flex-wrap: wrap;
	flex-direction: row;
	gap: 1em;
}
```

## How did you test this change?

`/dev` on CS wiki. Not very extensive and I wasn't sure if this change would even be approved or if there's a better way to do it. Please let me know on that so I/we can make changes or I can text it further if it's fine as-is.
