### PR TITLE
fix match2 bracket popups in safari on iOS17

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -318,7 +318,6 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 			:addClass('brkts-popup-side-color-' .. color)
 			:addClass('brkts-popup-side-hero')
 			:addClass('brkts-popup-side-hero-hover')
-			:css('float', flip and 'right' or 'left')
 			:node(HeroIcon._getImage{
 				hero = opponentHeroesData[index],
 				size = _SIZE_HERO,
@@ -339,6 +338,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 
 	local display = mw.html.create('div')
 		:addClass('brkts-popup-body-element-thumbs')
+		:addClass('brkts-popup-body-element-thumbs-' .. (flip and 'right' or 'left'))
 	for _, item in ipairs(opponentHeroesDisplay) do
 		display:node(item)
 	end

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -292,7 +292,6 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	for index = 1, numberOfHeroes do
 		local heroDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. color)
-			:css('float', flip and 'right' or 'left')
 			:node(HeroIcon._getImage{opponentHeroesData[index], date = date})
 		if numberOfHeroes == _NUM_HEROES_PICK_SOLO then
 			if flip then
@@ -310,6 +309,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 
 	local display = mw.html.create('div')
 		:addClass('brkts-popup-body-element-thumbs')
+		:addClass('brkts-popup-body-element-thumbs-' .. (flip and 'right' or 'left'))
 		:addClass('brkts-champion-icon')
 
 	for _, item in ipairs(opponentHeroesDisplay) do

--- a/components/match2/wikis/splatoon/match_summary.lua
+++ b/components/match2/wikis/splatoon/match_summary.lua
@@ -370,7 +370,6 @@ function CustomMatchSummary._opponentWeaponsDisplay(props)
 	local displayElements = Array.map(props.data, function(weapon)
 		return mw.html.create('div')
 			:addClass('brkts-champion-icon')
-			:css('float', flip and 'right' or 'left')
 			:node(WeaponIcon._getImage{
 				weapon = weapon,
 				game = props.game,
@@ -384,6 +383,7 @@ function CustomMatchSummary._opponentWeaponsDisplay(props)
 
 	local display = mw.html.create('div')
 		:addClass('brkts-popup-body-element-thumbs')
+		:addClass('brkts-popup-body-element-thumbs-' .. (flip and 'right' or 'left'))
 
 	for _, item in ipairs(displayElements) do
 		display:node(item)


### PR DESCRIPTION
## Summary
After the latest Safari update our match2 bracket popups have been semi-broken. This had first been reported via email and posted on our discord server here: https://discord.com/channels/93055209017729024/372075546231832576/1153996916808503360. I have reproduced the issue as shown in this screenshot:
![image](https://github.com/Liquipedia/Lua-Modules/assets/3266537/b0bc5790-5718-42a1-924e-34e67714668b)

The fix here is to avoid floats in flex items and instead add another inline-flex inside the area. I have already added classes that do this here: https://liquipedia.net/commons/index.php?title=MediaWiki%3ACommon.css%2FBrackets.css&type=revision&diff=524335&oldid=522838

Removing the floats is just cleanup since they don't do anything inside a flexbox container.

## How did you test this change?
I tested this by adding the relevant class via dev tools on all three relevant wikis.

Whilst I did not test this on an actual iPhone, I did test it on a desktop webkit and reproduced the bug there first, which makes me confident I have identified the actual bug. I also tested the new styles in both Firefox and Chrome to verify that they work there too.

The result looks like this on Dota2 which to me seems to be identical to the supposed look we previously had:
![image](https://github.com/Liquipedia/Lua-Modules/assets/3266537/9a13f220-c28c-449f-a51b-93a000ea15ab)

