### PR TITLE
Using the correct upcoming tournament template for Infobox player

### DIFF
--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -146,24 +146,23 @@ function CustomPlayer._createRole(key, role)
 end
 
 function CustomPlayer:createBottomContent(infobox)
-	if Player:shouldStoreData(_args) and String.isNotEmpty(_args.team) then
-		local teamPage = Team.page(mw.getCurrentFrame(),_args.team)
+	if Player:shouldStoreData(_args) then
 		return
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
+			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of player', {player = _pagename})
 	end
 end
 
 function CustomPlayer._isPlayerOrStaff()
-local roleData
-if String.isNotEmpty(_args.role) then
-	roleData = _ROLES[_args.role:lower()]
-end
--- If the role is missing, assume it is a player
-if roleData and roleData.isplayer == false then
-	return 'staff'
-else
-	return 'player'
-end
+	local roleData
+	if String.isNotEmpty(_args.role) then
+		roleData = _ROLES[_args.role:lower()]
+	end
+	-- If the role is missing, assume it is a player
+	if roleData and roleData.isplayer == false then
+		return 'staff'
+	else
+		return 'player'
+	end
 end
 
 return CustomPlayer


### PR DESCRIPTION
## Summary

PUBGM's infobox player has been using the team version of the upcoming tournament template, which causes some problems for tournaments where the players are not competing for their usual team, that's why it should be switched to use the player version instead.

## How did you test this change?

using dev module
