### PR TITLE
Add pseudo game "CS:GO/CS2" to cs wiki

### DIFF
--- a/standard/info/wikis/counterstrike/info.lua
+++ b/standard/info/wikis/counterstrike/info.lua
@@ -73,16 +73,30 @@ local infoData = {
 			name = 'Global Offensive',
 			link = 'Counter-Strike: Global Offensive',
 			logo = {
-				darkMode = 'csgo icon.png',
-				lightMode = 'csgo icon.png',
+				darkMode = 'CSGO gameicon allmode.png',
+				lightMode = 'CSGO gameicon allmode.png',
 			},
 			defaultTeamLogo = {
 				darkMode = 'CSGO default darkmode.png',
 				lightMode = 'CSGO default lightmode.png',
 			},
 		},
-		cs2 = {
+		csgocs2 = {
 			order = 6,
+			abbreviation = 'CS:GO/CS2',
+			name = 'CS:GO / CS2',
+			link = 'Counter-Strike 2',
+			logo = {
+				darkMode = 'CSGO-CS2 gameicon allmode.png',
+				lightMode = 'CSGO-CS2 gameicon allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Counter-Strike 2 default darkmode.png',
+				lightMode = 'Counter-Strike 2 default lightmode.png',
+			},
+		},
+		cs2 = {
+			order = 7,
 			abbreviation = 'CS2',
 			name = 'Counter-Strike 2',
 			link = 'Counter-Strike 2',


### PR DESCRIPTION
## Summary

Because ESL decided to move already ongoing tournaments from CS:GO to CS2 (😠), we now have to deal with this. I thought about adding multiple game support to the infobox but that would require changing the base infobox too and not just CS custom. Also, what would we even do for the `tournament_game` var?? Would have to have like a switch date or something and maybe multiple vars, and then have to add display support for that in other modules too... so yeah, nope.

Instead just making this not really real game for the purpose. Then will override game per-match or using vardefine somewhere on the pages.

## How did you test this change?

/dev and then pushed to live also as needed ASAP.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/ec51d29d-d153-4358-b4c1-bbb4e383959c)

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/734b2e63-1947-4a85-8571-b18127d1ab68)
