### PR TITLE
Inherit tournament vars from parent matches to games

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -389,7 +389,11 @@ function MatchGroupInput.getCommonTournamentVars(obj, parent)
 	obj.game = Logic.emptyOr(obj.game, parent.game, Variables.varDefault('tournament_game'))
 	obj.icon = Logic.emptyOr(obj.icon, parent.icon, Variables.varDefault('tournament_icon'))
 	obj.icondark = Logic.emptyOr(obj.iconDark, parent.icondark, Variables.varDefault('tournament_icondark'))
-	obj.liquipediatier = Logic.emptyOr(obj.liquipediatier, parent.liquipediatier, Variables.varDefault('tournament_liquipediatier'))
+	obj.liquipediatier = Logic.emptyOr(
+		obj.liquipediatier,
+		parent.liquipediatier,
+		Variables.varDefault('tournament_liquipediatier')
+	)
 	obj.liquipediatiertype = Logic.emptyOr(
 		obj.liquipediatiertype,
 		parent.liquipediatiertype,

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -389,7 +389,7 @@ function MatchGroupInput.getCommonTournamentVars(obj, parent)
 	obj.game = Logic.emptyOr(obj.game, parent.game, Variables.varDefault('tournament_game'))
 	obj.icon = Logic.emptyOr(obj.icon, parent.icon, Variables.varDefault('tournament_icon'))
 	obj.icondark = Logic.emptyOr(obj.iconDark, parent.icondark, Variables.varDefault('tournament_icondark'))
-	obj.liquipediatier = Logic.emptyOr(obj.liquipediatier, parent.game, Variables.varDefault('tournament_liquipediatier'))
+	obj.liquipediatier = Logic.emptyOr(obj.liquipediatier, parent.liquipediatier, Variables.varDefault('tournament_liquipediatier'))
 	obj.liquipediatiertype = Logic.emptyOr(
 		obj.liquipediatiertype,
 		parent.liquipediatiertype,

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -384,20 +384,22 @@ function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
 -- Retrieves Common Tournament Variables used inside match2 and match2game
-function MatchGroupInput.getCommonTournamentVars(obj)
-	obj.game = Logic.emptyOr(obj.game, Variables.varDefault('tournament_game'))
-	obj.icon = Logic.emptyOr(obj.icon, Variables.varDefault('tournament_icon'))
-	obj.icondark = Logic.emptyOr(obj.iconDark, Variables.varDefault('tournament_icondark'))
-	obj.liquipediatier = Logic.emptyOr(obj.liquipediatier, Variables.varDefault('tournament_liquipediatier'))
+function MatchGroupInput.getCommonTournamentVars(obj, parent)
+	parent = parent or {}
+	obj.game = Logic.emptyOr(obj.game, parent.game, Variables.varDefault('tournament_game'))
+	obj.icon = Logic.emptyOr(obj.icon, parent.icon, Variables.varDefault('tournament_icon'))
+	obj.icondark = Logic.emptyOr(obj.iconDark, parent.icondark, Variables.varDefault('tournament_icondark'))
+	obj.liquipediatier = Logic.emptyOr(obj.liquipediatier, parent.game, Variables.varDefault('tournament_liquipediatier'))
 	obj.liquipediatiertype = Logic.emptyOr(
 		obj.liquipediatiertype,
+		parent.liquipediatiertype,
 		Variables.varDefault('tournament_liquipediatiertype')
 	)
-	obj.series = Logic.emptyOr(obj.series, Variables.varDefault('tournament_series'))
-	obj.shortname = Logic.emptyOr(obj.shortname, Variables.varDefault('tournament_shortname'))
-	obj.tickername = Logic.emptyOr(obj.tickername, Variables.varDefault('tournament_tickername'))
-	obj.tournament = Logic.emptyOr(obj.tournament, Variables.varDefault('tournament_name'))
-	obj.type = Logic.emptyOr(obj.type, Variables.varDefault('tournament_type'))
+	obj.series = Logic.emptyOr(obj.series, parent.series, Variables.varDefault('tournament_series'))
+	obj.shortname = Logic.emptyOr(obj.shortname, parent.shortname, Variables.varDefault('tournament_shortname'))
+	obj.tickername = Logic.emptyOr(obj.tickername, parent.tickername, Variables.varDefault('tournament_tickername'))
+	obj.tournament = Logic.emptyOr(obj.tournament, parent.tournament, Variables.varDefault('tournament_name'))
+	obj.type = Logic.emptyOr(obj.type, parent.type, Variables.varDefault('tournament_type'))
 
 	return obj
 end

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -61,7 +61,6 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processMap(map)
-	map = mapFunctions.getTournamentVars(map)
 	map = mapFunctions.getExtraData(map)
 	map = mapFunctions.getScoresAndWinner(map)
 
@@ -330,7 +329,14 @@ function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_valve_tier'))
 	match.status = Logic.emptyOr(match.status, Variables.varDefault('tournament_status'))
-	return MatchGroupInput.getCommonTournamentVars(match)
+	match = MatchGroupInput.getCommonTournamentVars(match)
+
+	--inherit from match to maps
+	for mapKey, map in Table.iter.pairsByPrefix(match, 'map') do
+		match[mapKey] = MatchGroupInput.getCommonTournamentVars(map, match)
+	end
+
+	return match
 end
 
 function matchFunctions.getLinks(match)
@@ -640,11 +646,6 @@ function mapFunctions.getScoresAndWinner(map)
 	end
 
 	return map
-end
-
-function mapFunctions.getTournamentVars(map)
-	map.mode = Logic.emptyOr(map.mode, Variables.varDefault('tournament_mode', 'team'))
-	return MatchGroupInput.getCommonTournamentVars(map)
 end
 
 --


### PR DESCRIPTION
## Summary

Fixes behaviour where games would not correctly inherit tournament vars from their match parent in cases where the parent had had them overwritten by manual input. Only changed on CS custom but can do to others if desired.

| Match | Game |
|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/9e249d29-1a30-466a-8f4c-8d0312c60de8) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/d52853d7-bef1-45a5-9776-02e27f7e9257) | 

Implementation by hjpa.

## How did you test this change?

Tested with `/dev` on the CS wiki by me.