### PR TITLE
Set page category when requiring dev modules

### DIFF
--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -70,7 +70,11 @@ function Lua.import(name, options)
 		end
 
 		local devName = name .. '/dev'
-		if require('Module:FeatureFlag').get('dev') and Lua.moduleExists(devName) then
+		local devEnabled = require('Module:FeatureFlag').get('dev')
+		if devEnabled and require('Module:Namespace').isMain() then
+			mw.ext.TeamLiquidIntegration.add_category('Pages using dev modules')
+		end
+		if devEnabled and Lua.moduleExists(devName) then
 			return require(devName)
 		else
 			return require(name)


### PR DESCRIPTION
## Summary

Sets `Pages using dev modules` category on any pages using (or trying to use) dev modules via Lua invoke or Lua import. Seems to be something we want as seen on discord (https://discord.com/channels/93055209017729024/874304000718172200/1157311906042875984), so added it with help of hjpa. Only applies to namespaces that are considered "main" by the namespace module.

## How did you test this change?

Tested on `/dev` module using temporary Lua/dev invoke template in userspace and mainspace.
