### PR TITLE
Remove duplicate field in sc2 infobox building

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_building_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_building_custom.lua
@@ -58,7 +58,6 @@ function CustomInjector:addCustomCells(widgets)
 		widgets,
 		Cell{name = 'Size', content = {_args.size}},
 		Cell{name = 'Sight', content = {_args.sight}},
-		Cell{name = 'Sight', content = {_args.sight}},
 		Cell{name = 'Energy', content = {_args.energy}},
 		Cell{name = 'Detection/Attack Range', content = {_args.detection_range}}
 	)


### PR DESCRIPTION
## Summary
Remove duplicate field in sc2 infobox building
noticed by onYourOwn

## How did you test this change?
live by onYourOwn