### PR TITLE
Add percentage support in prize pools

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement_base.lua
+++ b/components/prize_pool/commons/prize_pool_placement_base.lua
@@ -187,14 +187,14 @@ end
 
 function BasePlacement:_calculateFromPercentage(prizeTypes, hasLocalCurrency)
 	local baseMoney = tonumber(Variables.varDefault(hasLocalCurrency and
-			('tournament_prizepool' .. LOCAL_CURRENCY_VARIABLE_POST_FIX) or 
+			('tournament_prizepool' .. LOCAL_CURRENCY_VARIABLE_POST_FIX) or
 			('tournament_prizepool' .. BASE_CURRENCY:lower())
 		)) or 0
 
 	Array.forEach(self.opponents, function(opponent)
 		if opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] or self.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1]
 			or opponent.prizeRewards[PRIZE_TYPE_LOCAL_CURRENCY .. 1] or self.prizeRewards[PRIZE_TYPE_LOCAL_CURRENCY .. 1]
-			or (opponent.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1] or self.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1] or 0) == 0 
+			or (opponent.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1] or self.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1] or 0) == 0
 		then
 			return
 		end

--- a/components/prize_pool/commons/prize_pool_placement_base.lua
+++ b/components/prize_pool/commons/prize_pool_placement_base.lua
@@ -11,10 +11,15 @@ local Class = require('Module:Class')
 local Json = require('Module:Json')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+local Variables = require('Module:Variables')
 
 local Opponent = require('Module:OpponentLibraries').Opponent
 
+local BASE_CURRENCY = 'USD'
+local LOCAL_CURRENCY_VARIABLE_POST_FIX = 'local'
 local PRIZE_TYPE_BASE_CURRENCY = 'BASE_CURRENCY'
+local PRIZE_TYPE_LOCAL_CURRENCY = 'LOCAL_CURRENCY'
+local PRIZE_TYPE_PERCENTAGE = 'PERCENT'
 
 --- @class BasePlacement
 --- A BasePlacement is a set of opponents who all share the same final place/award in the tournament.
@@ -177,6 +182,26 @@ function BasePlacement:_setBaseFromRewards(prizesToUse, prizeTypes)
 		end)
 
 		opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] = baseReward
+	end)
+end
+
+function BasePlacement:_calculateFromPercentage(prizeTypes, hasLocalCurrency)
+	local baseMoney = tonumber(Variables.varDefault(hasLocalCurrency and
+			('tournament_prizepool' .. LOCAL_CURRENCY_VARIABLE_POST_FIX) or 
+			('tournament_prizepool' .. BASE_CURRENCY:lower())
+		)) or 0
+
+	Array.forEach(self.opponents, function(opponent)
+		if opponent.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1] or self.prizeRewards[PRIZE_TYPE_BASE_CURRENCY .. 1]
+			or opponent.prizeRewards[PRIZE_TYPE_LOCAL_CURRENCY .. 1] or self.prizeRewards[PRIZE_TYPE_LOCAL_CURRENCY .. 1]
+			or (opponent.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1] or self.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1] or 0) == 0 
+		then
+			return
+		end
+
+		local percentage = opponent.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1] or self.prizeRewards[PRIZE_TYPE_PERCENTAGE .. 1]
+		opponent.prizeRewards[(hasLocalCurrency and PRIZE_TYPE_LOCAL_CURRENCY or PRIZE_TYPE_BASE_CURRENCY) .. 1]
+			= baseMoney * percentage / 100
 	end)
 end
 


### PR DESCRIPTION
## Summary
Add percentage support in prize pools
## How did you test this change?
dev

![Screenshot 2023-09-30 133757](https://github.com/Liquipedia/Lua-Modules/assets/75081997/07f3b2b1-1d14-4ab0-b15a-110a22da8b1e)

to showcase that manual overwrite works (i.e. if usdprize or localprize are set manually it does not use % calculation):
![manual overwrites work too](https://github.com/Liquipedia/Lua-Modules/assets/75081997/aff47a16-1a76-413c-9c25-f28c09eaa2c5)
