### PR TITLE
Adjust CrossFire Info year

### DIFF
--- a/standard/info/wikis/crossfire/info.lua
+++ b/standard/info/wikis/crossfire/info.lua
@@ -7,7 +7,7 @@
 --
 
 return {
-	startYear = 2016,
+	startYear = 2007,
 	wikiName = 'crossfire',
 	name = 'Crossfire',
 	games = {


### PR DESCRIPTION
The year 2016 causes transfer prior to 2016 to not show

2007 reflects the year the game launched.