### PR TITLE
Add `Json.stringifySubTables`

### DIFF
--- a/standard/json.lua
+++ b/standard/json.lua
@@ -26,6 +26,22 @@ function Json.stringify(obj, pretty)
 	return mw.text.jsonEncode(obj, pretty == true and mw.text.JSON_PRETTY or nil)
 end
 
+---Json-stringifies a given table.
+---@param obj table
+---@param pretty boolean?
+---@return table
+function Json.stringifySubTables(obj, pretty)
+	local objectWithStringifiedSubtables = {}
+	for key, item in pairs(obj) do
+		if type(item) == 'table' then
+			objectWithStringifiedSubtables[key] = Json.stringify(item, pretty)
+		else
+			objectWithStringifiedSubtables[key] = item
+		end
+	end
+
+	return objectWithStringifiedSubtables
+end
 
 ---Parses a given JSON encoded table to its table representation.
 ---If the parse fails it returns an empty table.

--- a/standard/json.lua
+++ b/standard/json.lua
@@ -26,7 +26,7 @@ function Json.stringify(obj, pretty)
 	return mw.text.jsonEncode(obj, pretty == true and mw.text.JSON_PRETTY or nil)
 end
 
----Json-stringifies a given table.
+---Json-stringifies subtables of a given table.
 ---@param obj table
 ---@param pretty boolean?
 ---@return table

--- a/standard/test/json_test.lua
+++ b/standard/test/json_test.lua
@@ -44,4 +44,11 @@ function suite:testParseIfTable()
 	self:assertDeepEquals(nil, (Json.parseIfTable('banana')))
 end
 
+function suite:testStringifySubTables()
+	self:assertDeepEquals({}, Json.stringifySubTables{})
+	self:assertDeepEquals({abc = 'def'}, Json.stringifySubTables{abc = 'def'})
+	self:assertDeepEquals({abc = '["b","c"]'}, Json.stringifySubTables{abc = {'b', 'c'}})
+	self:assertDeepEquals({a = '{"d":1,"b":"c"}', e = 'f'}, Json.stringifySubTables{a = {b = 'c', d = 1}, e = 'f'})
+end
+
 return suite


### PR DESCRIPTION
## Summary
Add `Json.stringifySubTables`, a function that stringifies all subtables of a given table.
Useful for e.g. a table with subtables to be stored into lpdb

## How did you test this change?
test cases