### PR TITLE
AoE: Adjust storage of game data for players

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -358,7 +358,7 @@ function CustomPlayer._getGames()
 			if String.isEmpty(entry.game) then
 				return {}
 			end
-			return {name=entry.game, active = isActive(entry.game)}
+			return {name = entry.game, active = isActive(entry.game)}
 		end),
 		Table.isNotEmpty
 	)


### PR DESCRIPTION
## Summary
Previously, players with multiple games would have a comma-separated string of their games in extradata.
This adds additional keys`gameX` to extradata, which allows to query for specific games.
The old list is still available for consumer compatibility.
In addition, input of aoeXnet_id is stored in extradata to allow API consumers to match on them.

## How did you test this change?
via /dev
