### PR TITLE
Fix LoL match icons missing `File:`

### DIFF
--- a/components/match2/wikis/leagueoflegends/big_match_template.lua
+++ b/components/match2/wikis/leagueoflegends/big_match_template.lua
@@ -33,7 +33,7 @@ return {
 				{{#vods}}
 					<div class="match-bm-lol-match-additional-list">{{#icons}}{{&.}}{{/icons}}</div>
 				{{/vods}}
-				<div class="match-bm-lol-match-additional-list">{{#links}}[[File:{{icon}}|link={{link}}|15px|{{text}}]]{{/links}}</div>
+				<div class="match-bm-lol-match-additional-list">{{#links}}[[{{icon}}|link={{link}}|15px|{{text}}]]{{/links}}</div>
 				{{#patch}}
 					<div class="match-bm-lol-match-additional-list">[[Patch {{patch}}]]</div>
 				{{/patch}}

--- a/components/match2/wikis/leagueoflegends/match_links.lua
+++ b/components/match2/wikis/leagueoflegends/match_links.lua
@@ -7,7 +7,16 @@
 --
 
 return {
-	reddit = {icon = 'File:Reddit-icon.png', text = 'Reddit Thread'},
-	gol = {icon = 'File:Gol.gg allmode.png', text = 'GolGG Match Report'},
-	factor = {icon = 'File:Factor.gg lightmode.png', iconDark = 'File:Factor.gg darkmode.png', text = 'FactorGG Match Report'},
+	reddit = {
+		icon = 'File:Reddit-icon.png',
+		text = 'Reddit Thread',
+	},
+	gol = {
+		icon = 'File:Gol.gg allmode.png',
+		text = 'GolGG Match Report',
+	},
+	factor = {icon = 'File:Factor.gg lightmode.png',
+		iconDark = 'File:Factor.gg darkmode.png',
+		text = 'FactorGG Match Report',
+	},
 }

--- a/components/match2/wikis/leagueoflegends/match_links.lua
+++ b/components/match2/wikis/leagueoflegends/match_links.lua
@@ -15,7 +15,8 @@ return {
 		icon = 'File:Gol.gg allmode.png',
 		text = 'GolGG Match Report',
 	},
-	factor = {icon = 'File:Factor.gg lightmode.png',
+	factor = {
+		icon = 'File:Factor.gg lightmode.png',
 		iconDark = 'File:Factor.gg darkmode.png',
 		text = 'FactorGG Match Report',
 	},

--- a/components/match2/wikis/leagueoflegends/match_links.lua
+++ b/components/match2/wikis/leagueoflegends/match_links.lua
@@ -7,8 +7,7 @@
 --
 
 return {
-	vod = {icon = 'VOD Icon.png', text = 'Watch VOD'},
-	reddit = {icon = 'Reddit-icon.png', text = 'Reddit Thread'},
-	gol = {icon = 'Gol.gg_allmode.png', text = 'GolGG Match Report'},
-	factor = {icon = 'Factor.gg lightmode.png', iconDark = 'Factor.gg darkmode.png', text = 'FactorGG Match Report'},
+	reddit = {icon = 'File:Reddit-icon.png', text = 'Reddit Thread'},
+	gol = {icon = 'File:Gol.gg allmode.png', text = 'GolGG Match Report'},
+	factor = {icon = 'File:Factor.gg lightmode.png', iconDark = 'File:Factor.gg darkmode.png', text = 'FactorGG Match Report'},
 }


### PR DESCRIPTION
## Summary

From #3334, I think file names started requiring `File:` but that was missing here and caused issues:
https://discord.com/channels/93055209017729024/276340346831765504/1159157532674248867

(Also vod icon not needed anymore)

## How did you test this change?

Straight to live fix.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/5392951d-fb4b-4122-b0ad-5d85d33f2de3)
