### PR TITLE
Add alt/caption text to Game icons

### DIFF
--- a/standard/game.lua
+++ b/standard/game.lua
@@ -20,7 +20,7 @@ local Info = Lua.import('Module:Info', {requireDevIfEnabled = true})
 
 local GamesData = Info.games
 
-local ICON_STRING = '[[File:${icon}|link=${link}|class=${class}|${size}]]'
+local ICON_STRING = '[[File:${icon}|${alt}|link=${link}|class=${class}|${size}]]'
 local DEFAULT_SIZE = '25x25px'
 local DEFAULT_SPAN_CLASS = 'icon-16px'
 local ICON_PLACEHOLDER = 'LeaguesPlaceholder.png'
@@ -148,10 +148,12 @@ function Game.icon(options)
 	if Table.isEmpty(gameData) then
 		gameIcons = Game._createIcon{icon = ICON_PLACEHOLDER, size = options.size}
 	elseif gameData.logo.lightMode == gameData.logo.darkMode then
-		gameIcons = Game._createIcon{icon = gameData.logo.lightMode, size = options.size, link = link}
+		gameIcons = Game._createIcon{icon = gameData.logo.lightMode, size = options.size, link = link, alt = gameData.name}
 	else
-		gameIcons = Game._createIcon{ icon = gameData.logo.lightMode, size = options.size, link = link, mode = 'light'} ..
-			Game._createIcon{icon = gameData.logo.darkMode, size = options.size, link = link, mode = 'dark'}
+		gameIcons = Game._createIcon{icon = gameData.logo.lightMode, size = options.size,
+				link = link, alt = gameData.name, mode = 'light'} ..
+			Game._createIcon{icon = gameData.logo.darkMode, size = options.size,
+				link = link, alt = gameData.name, mode = 'dark'}
 	end
 
 	if String.isNotEmpty(spanClass) then
@@ -161,7 +163,7 @@ function Game.icon(options)
 	end
 end
 
----@param options {mode: string?, icon: string?, size: string?, link: string?}
+---@param options {mode: string?, icon: string?, size: string?, link: string?, alt: string?}
 ---@return string
 function Game._createIcon(options)
 	return String.interpolate(
@@ -171,6 +173,7 @@ function Game._createIcon(options)
 			size = options.size or DEFAULT_SIZE,
 			class = options.mode and ('show-when-' .. options.mode .. '-mode') or '',
 			link = options.link or '',
+			alt = options.alt or options.link or '',
 		}
 	)
 end


### PR DESCRIPTION
## Summary

Currently if a link is omitted from a Game icon creation, then nothing is shown on hover. This is both bad for less knowledgeable users as well as users who rely on alt text for things like screen readers.

Added caption to the icon string and then create it from either game name or game link (as fallback). Mediawiki does the rest by setting it as hover text and alt text.

## How did you test this change?

Tested on `/dev`.
