### PR TITLE
Disable region cell on VAL, AoE player infobox

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -163,6 +163,8 @@ function CustomInjector:parse(id, widgets)
 				end)
 			}
 		}
+	elseif id == 'region' then
+		return {}
 	end
 	return widgets
 end

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -14,7 +14,6 @@ local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local Region = require('Module:Region')
 local String = require('Module:StringUtils')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
-local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -10,8 +10,9 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local PlayersSignatureAgents = require('Module:PlayersSignatureAgents')
-local String = require('Module:StringUtils')
 local PlayerTeamAuto = require('Module:PlayerTeamAuto')
+local Region = require('Module:Region')
+local String = require('Module:StringUtils')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Template = require('Module:Template')
 local Variables = require('Module:Variables')
@@ -93,6 +94,8 @@ function CustomInjector:parse(id, widgets)
 			name = 'Retired',
 			content = {_args.retired}
 		})
+	elseif id == 'region' then
+		return {}
 	end
 	return widgets
 end
@@ -123,7 +126,7 @@ function CustomPlayer:adjustLPDB(lpdbData)
 	lpdbData.extradata.agent2 = Variables.varDefault('agent2')
 	lpdbData.extradata.agent3 = Variables.varDefault('agent3')
 
-	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {_args.country})
+	lpdbData.region = Region.name({region = _args.region, country = _args.country})
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary

Similarly to CS, val and aoe wikis want to use `Module:Region/CountryData` without it adding region to player pages automatically. Disable that like on CS. Also switch from template expansion for data definition of region to using region module (val only).

## How did you test this change?

tested on dev module.

## Merge pre-requisites

- [x] Move https://liquipedia.net/valorant/Module:Region/CountryData/dev to non-dev.