### PR TITLE
feat: use inheritedheader in match schedule

### DIFF
--- a/components/matches_schedule_display/commons/matches_schedule_display.lua
+++ b/components/matches_schedule_display/commons/matches_schedule_display.lua
@@ -218,7 +218,7 @@ end
 ---@return string
 function MatchesTable:determineMatchHeader(match)
 	local matchHeader = Logic.emptyOr(
-		match.match2bracketdata.header or match.extradata.matchsection,
+		match.match2bracketdata.inheritedheader or match.extradata.matchsection,
 		self.currentId == match.match2bracketid and self.currentMatchHeader or nil,
 		--if we do not have a matchHeader yet try:
 		-- 1) the title (in case it is a matchlist)


### PR DESCRIPTION
## Summary
Fixes cases for `|sdate` is in the middle of a round
Before
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/0045894c-f215-4a1e-8fb8-209cd0c7aa23)

After
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/dec98794-7558-422c-bc24-cadf35ce481f)


## How did you test this change?
dev
