### PR TITLE
Fix unit category in WC infobox unit

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_unit_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_unit_custom.lua
@@ -238,8 +238,8 @@ function CustomUnit.getUnitRaceType(args)--this gets more complex for units
 	if cleanedRace == Faction.toName('n') then
 		cleanedRace = 'Night Elf'
 	end
-	if (race == 'creeps' or race == 'demon') and (tonumber(args.passive) or 0) > 0 then
-		cleanedRace = 'Creep'
+	if (race == 'creeps' or race == 'demon') then
+		cleanedRace = (tonumber(args.passive) or 0) > 0 and 'Neutral' or 'Creep'
 	elseif race == 'other' or race == 'commoner' then
 		cleanedRace = 'Neutral'
 	end


### PR DESCRIPTION
## Summary
Old template code was `{{#ifexpr:{{{passive|0}}}>0|Neutral Special Units|Creep Special Units}}`, the module port inverted the logic and also dropped the `Special` inside Neutral Special Units.

## How did you test this change?
via /dev, then live
