### PR TITLE
Adjust `Json.stringify`

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -243,32 +243,22 @@ function Match.copyRecords(matchRecord)
 	})
 end
 
----@param tbl string|table|nil
----@param options {isArray: boolean?}?
----@return string|nil
-local function stringifyIfTable(tbl, options)
-	if type(tbl) ~= 'table' then return end
-
-	options = options or {}
-	return options.isArray and mw.ext.LiquipediaDB.lpdb_create_array(tbl) or Json.stringify(tbl)
-end
-
 function Match.encodeJson(matchRecord)
-	matchRecord.match2bracketdata = stringifyIfTable(matchRecord.match2bracketdata)
-	matchRecord.stream = stringifyIfTable(matchRecord.stream)
-	matchRecord.links = stringifyIfTable(matchRecord.links)
-	matchRecord.extradata = stringifyIfTable(matchRecord.extradata)
+	matchRecord.match2bracketdata = Json.stringify(matchRecord.match2bracketdata)
+	matchRecord.stream = Json.stringify(matchRecord.stream)
+	matchRecord.links = Json.stringify(matchRecord.links)
+	matchRecord.extradata = Json.stringify(matchRecord.extradata)
 
 	for _, opponentRecord in ipairs(matchRecord.match2opponents) do
-		opponentRecord.extradata = stringifyIfTable(opponentRecord.extradata)
+		opponentRecord.extradata = Json.stringify(opponentRecord.extradata)
 		for _, playerRecord in ipairs(opponentRecord.match2players) do
-			playerRecord.extradata = stringifyIfTable(playerRecord.extradata)
+			playerRecord.extradata = Json.stringify(playerRecord.extradata)
 		end
 	end
 	for _, gameRecord in ipairs(matchRecord.match2games) do
-		gameRecord.extradata = stringifyIfTable(gameRecord.extradata)
-		gameRecord.participants = stringifyIfTable(gameRecord.participants)
-		gameRecord.scores = stringifyIfTable(gameRecord.scores, {isArray = true})
+		gameRecord.extradata = Json.stringify(gameRecord.extradata)
+		gameRecord.participants = Json.stringify(gameRecord.participants)
+		gameRecord.scores = Json.stringify(gameRecord.scores, {asArray = true})
 	end
 end
 

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -243,8 +243,14 @@ function Match.copyRecords(matchRecord)
 	})
 end
 
-local function stringifyIfTable(tbl)
-	return type(tbl) == 'table' and Json.stringify(tbl) or nil
+---@param tbl string|table|nil
+---@param options {isArray: boolean?}?
+---@return string|nil
+local function stringifyIfTable(tbl, options)
+	if type(tbl) ~= 'table' then return end
+
+	options = options or {}
+	return options.isArray and mw.ext.LiquipediaDB.lpdb_create_array(tbl) or Json.stringify(tbl)
 end
 
 function Match.encodeJson(matchRecord)
@@ -262,7 +268,7 @@ function Match.encodeJson(matchRecord)
 	for _, gameRecord in ipairs(matchRecord.match2games) do
 		gameRecord.extradata = stringifyIfTable(gameRecord.extradata)
 		gameRecord.participants = stringifyIfTable(gameRecord.participants)
-		gameRecord.scores = stringifyIfTable(gameRecord.scores)
+		gameRecord.scores = stringifyIfTable(gameRecord.scores, {isArray = true})
 	end
 end
 

--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -97,7 +97,7 @@ function Legacy.getTemplate(frame)
 
 	local mapping = Legacy._getMapping(templateid)
 
-	local out = json.stringify(mapping, true)
+	local out = json.stringify(mapping, {pretty = true})
 		:gsub('"([^\n:"]-)":', '%1 = ')
 		:gsub('type =', '["type"] =')
 		:gsub(' = %[(.-)%]', ' = { %1 }')

--- a/components/match2/wikis/starcraft/legacy/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft/legacy/match_group_legacy.lua
@@ -91,7 +91,7 @@ function Legacy.getTemplate(frame)
 
 	local mapping = Legacy._getMapping(templateid)
 
-	local out = json.stringify(mapping, true)
+	local out = json.stringify(mapping, {pretty = true})
 		:gsub('"([^\n:"]-)":', '%1 = ')
 		:gsub('type =', '["type"] =')
 		:gsub(' = %[(.-)%]', ' = { %1 }')

--- a/components/match2/wikis/starcraft2/legacy/match_group_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_group_legacy.lua
@@ -93,7 +93,7 @@ function Legacy.getTemplate(frame)
 
 	local mapping = Legacy._getMapping(templateid)
 
-	local out = json.stringify(mapping, true)
+	local out = json.stringify(mapping, {pretty = true})
 		:gsub('"([^\n:"]-)":', '%1 = ')
 		:gsub('type =', '["type"] =')
 		:gsub(' = %[(.-)%]', ' = { %1 }')

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -77,7 +77,7 @@ function StandingsStorage.table(data)
 			title = mw.text.trim(cleanedTitle),
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),
 			type = data.type,
-			matches = mw.ext.LiquipediaDB.lpdb_create_array(data.matches or {}),
+			matches = Json.stringify(data.matches or {}, {asArray = true}),
 			config = mw.ext.LiquipediaDB.lpdb_create_json(config),
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, data.extradata)),
 		}

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -77,7 +77,7 @@ function StandingsStorage.table(data)
 			title = mw.text.trim(cleanedTitle),
 			section = Variables.varDefault('last_heading', ''):gsub('<.->', ''),
 			type = data.type,
-			matches = Json.stringify(data.matches or {}),
+			matches = mw.ext.LiquipediaDB.lpdb_create_array(data.matches or {}),
 			config = mw.ext.LiquipediaDB.lpdb_create_json(config),
 			extradata = mw.ext.LiquipediaDB.lpdb_create_json(Table.merge(extradata, data.extradata)),
 		}

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -662,7 +662,7 @@ function mw.ext.LiquipediaDB.lpdb_create_json(obj) end
 
 ---@param obj any[]
 ---@return string
----Encode an Array to a JSON string. Errors are raised if the passed value cannot be encoded in JSON.
+---Encode an Array to a JSON array. Errors are raised if the passed value cannot be encoded in JSON.
 function mw.ext.LiquipediaDB.lpdb_create_array(obj) end
 
 return mw

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -657,7 +657,7 @@ mw.ext.LiquipediaDB = {}
 
 ---@param obj table
 ---@return string
----Encode a table to a JSON string. Errors are raised if the passed value cannot be encoded in JSON.
+---Encode a table to a JSON object. Errors are raised if the passed value cannot be encoded in JSON.
 function mw.ext.LiquipediaDB.lpdb_create_json(obj) end
 
 ---@param obj any[]

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -652,4 +652,17 @@ function mw.title:canonicalUrl(query) end
 ---@return string?
 function mw.title:getContent() end
 
+mw.ext = {}
+mw.ext.LiquipediaDB = {}
+
+---@param obj table
+---@return string
+---Encode a table to a JSON string. Errors are raised if the passed value cannot be encoded in JSON.
+function mw.ext.LiquipediaDB.lpdb_create_json(obj) end
+
+---@param obj any[]
+---@return string
+---Encode an Array to a JSON string. Errors are raised if the passed value cannot be encoded in JSON.
+function mw.ext.LiquipediaDB.lpdb_create_array(obj) end
+
 return mw

--- a/standard/json.lua
+++ b/standard/json.lua
@@ -34,11 +34,10 @@ function Json.stringify(obj, options)
 	end
 	options = options or {}
 
-	if options.pretty == true then
-		return mw.text.jsonEncode(obj, mw.text.JSON_PRETTY)
-	elseif options.asArray then
-		return mw.ext.LiquipediaDB.lpdb_create_array(obj)
+	if options.pretty or options.asArray then
+		return mw.text.jsonEncode(obj, options.pretty and mw.text.JSON_PRETTY or nil)
 	end
+
 	return mw.ext.LiquipediaDB.lpdb_create_json(obj)
 end
 

--- a/standard/json.lua
+++ b/standard/json.lua
@@ -23,7 +23,8 @@ end
 ---@param pretty boolean?
 ---@return string
 function Json.stringify(obj, pretty)
-	return mw.text.jsonEncode(obj, pretty == true and mw.text.JSON_PRETTY or nil)
+	return pretty == true and mw.text.jsonEncode(obj, mw.text.JSON_PRETTY) or
+		mw.ext.LiquipediaDB.lpdb_create_json(obj)
 end
 
 ---Json-stringifies subtables of a given table.

--- a/standard/json.lua
+++ b/standard/json.lua
@@ -28,10 +28,6 @@ function Json.stringify(obj, options)
 		return obj
 	end
 
-	--temp workaround until adjusted in 2 non git modules:
-	if type(options) == 'boolean' then
-		options = {pertty = options}
-	end
 	options = options or {}
 
 	if options.pretty or options.asArray then

--- a/standard/json.lua
+++ b/standard/json.lua
@@ -28,6 +28,10 @@ function Json.stringify(obj, options)
 		return obj
 	end
 
+	--temp workaround until adjusted in 2 non git modules:
+	if type(options) == 'boolean' then
+		options = {pertty = options}
+	end
 	options = options or {}
 
 	if options.pretty == true then

--- a/standard/json.lua
+++ b/standard/json.lua
@@ -19,12 +19,23 @@ function Json.fromArgs(frame)
 end
 
 ---Json-stringifies a given table.
----@param obj table
----@param pretty boolean?
----@return string
-function Json.stringify(obj, pretty)
-	return pretty == true and mw.text.jsonEncode(obj, mw.text.JSON_PRETTY) or
-		mw.ext.LiquipediaDB.lpdb_create_json(obj)
+---@param obj table|string
+---@param options {pretty: boolean?, asArray: boolean?}
+---@return string?
+---@overload fun(any: any): any
+function Json.stringify(obj, options)
+	if type(obj) ~= 'table' then
+		return obj
+	end
+
+	options = options or {}
+
+	if options.pretty == true then
+		return mw.text.jsonEncode(obj, mw.text.JSON_PRETTY)
+	elseif options.asArray then
+		return mw.ext.LiquipediaDB.lpdb_create_array(obj)
+	end
+	return mw.ext.LiquipediaDB.lpdb_create_json(obj)
 end
 
 ---Json-stringifies subtables of a given table.
@@ -35,7 +46,7 @@ function Json.stringifySubTables(obj, pretty)
 	local objectWithStringifiedSubtables = {}
 	for key, item in pairs(obj) do
 		if type(item) == 'table' then
-			objectWithStringifiedSubtables[key] = Json.stringify(item, pretty)
+			objectWithStringifiedSubtables[key] = Json.stringify(item, {pretty = pretty})
 		else
 			objectWithStringifiedSubtables[key] = item
 		end

--- a/standard/test/json_test.lua
+++ b/standard/test/json_test.lua
@@ -16,30 +16,36 @@ local suite = ScribuntoUnit:new()
 function suite:testStringify()
 	self:assertEquals('[]', Json.stringify{})
 	self:assertEquals('{"abc":"def"}', Json.stringify{abc = 'def'})
-	self:assertEquals('{"abc":["b","c"]}', Json.stringify{abc = {'b', 'c'}})
+	self:assertEquals('{"abc":{"1":"b","2":"c"}}', Json.stringify{abc = {'b', 'c'}})
 	self:assertTrue(string.len(Json.stringify(mw.loadData('Module:Flags/MasterData'))) > 3)
 end
 
 function suite:testParse()
 	self:assertDeepEquals({}, (Json.parse('[]')))
+	self:assertDeepEquals({}, (Json.parse('{}')))
 	self:assertDeepEquals({abc = 'def'}, (Json.parse('{"abc":"def"}')))
 	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parse('{"abc":["b","c"]}')))
+	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parse('{"abc":{"1":"b","2":"c"}}')))
 	self:assertDeepEquals({}, (Json.parse{a = 1}))
 	self:assertDeepEquals({}, (Json.parse('banana')))
 end
 
 function suite:testParseIfString()
 	self:assertDeepEquals({}, (Json.parseIfString('[]')))
+	self:assertDeepEquals({}, (Json.parseIfString('{}')))
 	self:assertDeepEquals({abc = 'def'}, (Json.parseIfString('{"abc":"def"}')))
 	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parseIfString('{"abc":["b","c"]}')))
+	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parseIfString('{"abc":{"1":"b","2":"c"}}')))
 	self:assertDeepEquals({a = 1}, (Json.parseIfString{a = 1}))
 	self:assertDeepEquals({}, (Json.parseIfString('banana')))
 end
 
 function suite:testParseIfTable()
 	self:assertDeepEquals({}, (Json.parseIfTable('[]')))
+	self:assertDeepEquals({}, (Json.parseIfTable('{}')))
 	self:assertDeepEquals({abc = 'def'}, (Json.parseIfTable('{"abc":"def"}')))
 	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parseIfTable('{"abc":["b","c"]}')))
+	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parseIfTable('{"abc":{"1":"b","2":"c"}}')))
 	self:assertDeepEquals(nil, (Json.parseIfTable{a = 1}))
 	self:assertDeepEquals(nil, (Json.parseIfTable('banana')))
 end
@@ -47,7 +53,7 @@ end
 function suite:testStringifySubTables()
 	self:assertDeepEquals({}, Json.stringifySubTables{})
 	self:assertDeepEquals({abc = 'def'}, Json.stringifySubTables{abc = 'def'})
-	self:assertDeepEquals({abc = '["b","c"]'}, Json.stringifySubTables{abc = {'b', 'c'}})
+	self:assertDeepEquals({abc = '{"1":"b","2":"c"}'}, Json.stringifySubTables{abc = {'b', 'c'}})
 	self:assertDeepEquals({a = '{"d":1,"b":"c"}', e = 'f'}, Json.stringifySubTables{a = {b = 'c', d = 1}, e = 'f'})
 end
 

--- a/standard/test/json_test.lua
+++ b/standard/test/json_test.lua
@@ -18,6 +18,8 @@ function suite:testStringify()
 	self:assertEquals('{"abc":"def"}', Json.stringify{abc = 'def'})
 	self:assertEquals('{"abc":{"1":"b","2":"c"}}', Json.stringify{abc = {'b', 'c'}})
 	self:assertTrue(string.len(Json.stringify(mw.loadData('Module:Flags/MasterData'))) > 3)
+	self:assertEquals(nil, Json.stringify())
+	self:assertEquals('string', Json.stringify('string'))
 end
 
 function suite:testParse()

--- a/standard/test/json_test.lua
+++ b/standard/test/json_test.lua
@@ -20,6 +20,8 @@ function suite:testStringify()
 	self:assertTrue(string.len(Json.stringify(mw.loadData('Module:Flags/MasterData'))) > 3)
 	self:assertEquals(nil, Json.stringify())
 	self:assertEquals('string', Json.stringify('string'))
+	self:assertEquals('[1,2,3]', Json.stringify({1, 2, 3}, {asArray = true}))
+	self:assertEquals('{"1":1,"2":2,"3":3}', Json.stringify{1, 2, 3})
 end
 
 function suite:testParse()


### PR DESCRIPTION
## Summary
Adjust `Json.stringify` to use `mw.ext.LiquipediaDB.lpdb_create_json` over `mw.text.jsonEncode` for performance reasons.
- adjust testcases
- use options table over simple `pretty` boolean var
- add option to still encade as array (if it is an array)
- adjust `match2game.score` to use `mw.ext.LiquipediaDB.lpdb_create_array` to keep lpdb data as is
- adjust `standingstable.macthes` to use `mw.ext.LiquipediaDB.lpdb_create_array` to keep lpdb data as is
- adjust git consumers that use pretty

## How did you test this change?
dev & testcases & storage tests on sc2
