### PR TITLE
feat: non-exact role names in role of

### DIFF
--- a/components/infobox/extensions/commons/role_of.lua
+++ b/components/infobox/extensions/commons/role_of.lua
@@ -28,7 +28,7 @@ function RoleOf.get(args)
 	local teamPage = mw.ext.TeamLiquidIntegration.resolve_redirect(team):gsub(' ', '_')
 	local staffData = mw.ext.LiquipediaDB.lpdb('squadplayer', {
 		conditions = '[[pagename::' .. teamPage .. ']] AND [[status::active]]',
-		query = 'id, link, nationality',
+		query = 'id, link, nationality, position, role',
 		limit = 100,
 	})
 
@@ -50,7 +50,7 @@ function RoleOf.get(args)
 			link = staff.link,
 			flag = staff.nationality,
 		}
-		table.insert(output, OpponentDisplay.InlineOpponent{opponent = opponent})
+		table.insert(output, tostring(OpponentDisplay.InlineOpponent{opponent = opponent}))
 	end)
 
 	return table.concat(output, ' ')


### PR DESCRIPTION
## Summary
The current role of has two issues. Firstly it requires a perfect match on the role, so a `Head Coach` would not be matched for role `Coach`. Secondly it will only display one arbitrary match, instead of all matches 

## How did you test this change?
Dev on dota2
