### PR TITLE
Fix participantTable excess row

### DIFF
--- a/components/participant_table/commons/participant_table_base.lua
+++ b/components/participant_table/commons/participant_table_base.lua
@@ -327,10 +327,10 @@ function ParticipantTable:displaySection(section)
 		sectionNode:node(self:displayEntry(entry):css('width', self.config.columnWidth .. 'px'))
 	end)
 
-	local nextColumn = (#entries % self.config.colSpan) + 1
-
-	Array.forEach(Array.range(nextColumn, self.config.colSpan),
-		function() sectionNode:node(self:empty()) end)
+	local currentColumn = (#entries) % self.config.colSpan
+	if currentColumn ~= 0 then
+		Array.forEach(Array.range(currentColumn + 1, self.config.colSpan), function() sectionNode:node(self:empty()) end)
+	end
 
 	self.display:node(sectionNode)
 end


### PR DESCRIPTION
## Summary
Fix participantTable excess row
Currently participant table displays an additional (unwanted) row if number of displayed entries is devisable by colSpan.
![Screenshot 2023-10-14 150548](https://github.com/Liquipedia/Lua-Modules/assets/75081997/8ca33d25-76c3-4e88-b216-fde907d7f119)
This PR fixes that
![Screenshot 2023-10-14 150601](https://github.com/Liquipedia/Lua-Modules/assets/75081997/f7b227e9-6903-4b46-a23f-c6fafc26ee1f)


## How did you test this change?
dev to live