### PR TITLE
Save manually input player team to page var if `syncPlayer` is enabled

### DIFF
--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -304,10 +304,9 @@ function Opponent.resolve(opponent, date, options)
 	elseif Opponent.typeIsParty(opponent.type) then
 		for _, player in ipairs(opponent.players) do
 			if options.syncPlayer then
-				PlayerExt.syncPlayer(player, {savePageVar = not Opponent.playerIsTbd(player)})
-				if not player.team then
-					player.team = PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), nil, {date = date})
-				end
+				local savePageVar = not Opponent.playerIsTbd(player)
+				PlayerExt.syncPlayer(player, {savePageVar = savePageVar})
+				player.team = PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
 			else
 				PlayerExt.populatePageName(player)
 			end

--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -306,7 +306,8 @@ function Opponent.resolve(opponent, date, options)
 			if options.syncPlayer then
 				local savePageVar = not Opponent.playerIsTbd(player)
 				PlayerExt.syncPlayer(player, {savePageVar = savePageVar})
-				player.team = PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
+				player.team =
+					PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
 			else
 				PlayerExt.populatePageName(player)
 			end

--- a/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -160,10 +160,9 @@ function StarcraftOpponent.resolve(opponent, date, options)
 		for _, player in ipairs(opponent.players) do
 			if options.syncPlayer then
 				local hasRace = String.isNotEmpty(player.race)
-				StarcraftPlayerExt.syncPlayer(player, {savePageVar = not Opponent.playerIsTbd(player --[[@as standardPlayer]])})
-				if not player.team then
-					player.team = PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), nil, {date = date})
-				end
+				local savePageVar = not Opponent.playerIsTbd(player --[[@as standardPlayer]])
+				StarcraftPlayerExt.syncPlayer(player, {savePageVar = savePageVar})
+				player.team = PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
 				player.race = (hasRace or player.race ~= Faction.defaultFaction) and player.race or nil
 			else
 				PlayerExt.populatePageName(player)

--- a/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -162,7 +162,8 @@ function StarcraftOpponent.resolve(opponent, date, options)
 				local hasRace = String.isNotEmpty(player.race)
 				local savePageVar = not Opponent.playerIsTbd(player --[[@as standardPlayer]])
 				StarcraftPlayerExt.syncPlayer(player, {savePageVar = savePageVar})
-				player.team = PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
+				player.team =
+					PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
 				player.race = (hasRace or player.race ~= Faction.defaultFaction) and player.race or nil
 			else
 				PlayerExt.populatePageName(player)

--- a/components/opponent/wikis/warcraft/opponent_custom.lua
+++ b/components/opponent/wikis/warcraft/opponent_custom.lua
@@ -126,10 +126,10 @@ function CustomOpponent.resolve(opponent, date, options)
 		for _, player in ipairs(opponent.players) do
 			if options.syncPlayer then
 				local hasRace = String.isNotEmpty(player.race)
-				PlayerExt.syncPlayer(player, {savePageVar = not Opponent.playerIsTbd(player)})
-				if not player.team then
-					player.team = PlayerExt.syncTeam(player.pageName, nil, {date = date})
-				end
+				local savePageVar = not Opponent.playerIsTbd(player)
+				PlayerExt.syncPlayer(player, {savePageVar = savePageVar})
+				player.team =
+					PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
 				player.race = (hasRace or player.race ~= Faction.defaultFaction) and player.race or nil
 			else
 				PlayerExt.populatePageName(player)


### PR DESCRIPTION
not sure if it should be labeled as a bug or not
on one hand i think it was not intended to not set the wiki var but can not rule it out

## Summary
Save manually input player team to page var if `syncPlayer` is enabled
`PlayerExt.syncTeam` uses (and returns) the manual input if no team is specified manually.
So we do not need to do the `if not player.team then` check and can just pass the manual input along (instead of nil) instead.
This change results in the team data getting stored in page vars though.

## How did you test this change?
dev