### PR TITLE
Enable ppt import on warcraft starting 2023-10-16

### DIFF
--- a/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
@@ -8,6 +8,7 @@
 
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')
@@ -24,6 +25,7 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 local CustomPrizePool = {}
 
 local PRIZE_TYPE_POINTS = 'POINTS'
+local AUTOMATION_START_DATE = '2023-10-16'
 
 -- Template entry point
 function CustomPrizePool.run(frame)
@@ -32,8 +34,8 @@ function CustomPrizePool.run(frame)
 	-- adjust import settings params
 	args.allGroupsUseWdl = Logic.emptyOr(args.allGroupsUseWdl, true)
 	args.groupScoreDelimiter = '-'
-	-- currently no match2 implemented; enable once it is with the date it goes live as switch date
-	args.import = Logic.emptyOr(args.import, false)
+	-- match2 implemented as of 2023-10-15
+	args.import = Logic.nilOr(args.import, DateExt.getContextualDateOrNow() >= AUTOMATION_START_DATE)
 
 	local prizePool = PrizePool(args)
 


### PR DESCRIPTION
## Summary
Default enable ppt import on warcraft starting 2023-10-16, since match2 has been rolled out on warcraft wiki.

## How did you test this change?
dev