### PR TITLE
Sync players during opponent resolve in tetris match input processing

### DIFF
--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -287,7 +287,7 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 		)
 	end
 
-	Opponent.resolve(opponent, teamTemplateDate)
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer = true})
 
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 


### PR DESCRIPTION
## Summary
Sync players during opponent resolve in tetris match input processing.
Apparently it was set in the version used but never added to the PR ...
Hence the merge of the PR broke flag inheritance functionality.
This PR adds it back.

## How did you test this change?
live