### PR TITLE
Uncouple matchlists from infobox classes by default

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -136,7 +136,7 @@ function MatchTicker:init(args)
 
 	local wrapperClasses = type(args.wrapperClasses) == 'table' and args.wrapperClasses
 		or args.wrapperClasses == NONE and {}
-		or {args.wrapperClasses or args.wrapperClass}
+		or {args.wrapperClasses}
 
 	if Logic.readBool(args.infoboxClass) or Logic.readBool(args.infoboxWrapperClass) then
 		table.insert(wrapperClasses, INFOBOX_DEFAULT_CLASS)

--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -46,7 +46,7 @@ local DEFAULT_QUERY_COLUMNS = {
 	'match2bracketdata',
 }
 local NONE = 'none'
-local WRAPPER_DEFAULT_CLASS = 'fo-nttax-infobox wiki-bordercolor-light'
+local INFOBOX_DEFAULT_CLASS = 'fo-nttax-infobox'
 local INFOBOX_WRAPPER_CLASS = 'fo-nttax-infobox-wrapper'
 local DEFAULT_LIMIT = 20
 local LIMIT_INCREASE = 20
@@ -136,15 +136,18 @@ function MatchTicker:init(args)
 
 	local wrapperClasses = type(args.wrapperClasses) == 'table' and args.wrapperClasses
 		or args.wrapperClasses == NONE and {}
-		or {args.wrapperClasses or WRAPPER_DEFAULT_CLASS}
+		or {args.wrapperClasses or args.wrapperClass}
 
-	local game = args.game and Game.abbreviation{game = args.game}:lower()
-
-	if Logic.readBool(args.infoboxWrapperClass) or game then
-		table.insert(wrapperClasses, INFOBOX_WRAPPER_CLASS)
+	if Logic.readBool(args.infoboxClass) then
+		table.insert(wrapperClasses, INFOBOX_DEFAULT_CLASS)
 	end
-	if game then
-		table.insert(wrapperClasses, 'infobox-' .. game)
+
+	if Logic.readBool(args.infoboxWrapperClass) then
+		table.insert(wrapperClasses, INFOBOX_WRAPPER_CLASS)
+		local game = args.game and Game.abbreviation{game = args.game}:lower()
+		if game then
+			table.insert(wrapperClasses, 'infobox-' .. game)
+		end
 	end
 	config.wrapperClasses = wrapperClasses
 

--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -138,7 +138,7 @@ function MatchTicker:init(args)
 		or args.wrapperClasses == NONE and {}
 		or {args.wrapperClasses or args.wrapperClass}
 
-	if Logic.readBool(args.infoboxClass) then
+	if Logic.readBool(args.infoboxClass) or Logic.readBool(args.infoboxWrapperClass) then
 		table.insert(wrapperClasses, INFOBOX_DEFAULT_CLASS)
 	end
 

--- a/components/match_ticker/commons/match_ticker_custom.lua
+++ b/components/match_ticker/commons/match_ticker_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Arguments = require('Module:Arguments')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
@@ -73,7 +74,7 @@ function CustomMatchTicker.participant(args, matches)
 	matches = matches or {}
 
 	--adjusting args
-	args.infoboxClass = true
+	args.infoboxClass = Logic.nilOr(Logic.readBoolOrNil(args.infoboxClass), true)
 
 	return mw.html.create()
 		:node(MatchTicker(Table.merge(args, {

--- a/components/match_ticker/commons/match_ticker_custom.lua
+++ b/components/match_ticker/commons/match_ticker_custom.lua
@@ -33,7 +33,7 @@ function CustomMatchTicker.tournament(frame)
 	args.infoboxWrapperClass = args.infoboxWrapperClass or true
 
 	return MatchTicker(args):query():create(
-		MatchTicker.DisplayComponents.Header('Upcoming matches')
+		MatchTicker.DisplayComponents.Header('Upcoming Matches')
 	)
 end
 

--- a/components/match_ticker/commons/match_ticker_custom.lua
+++ b/components/match_ticker/commons/match_ticker_custom.lua
@@ -30,6 +30,7 @@ function CustomMatchTicker.tournament(frame)
 	args.tournament = args.tournament or args.tournament1 or args[1] or CURRENT_PAGE
 	args.queryByParent = args.queryByParent or true
 	args.showAllTbdMatches = args.showAllTbdMatches or true
+	args.infoboxWrapperClass = args.infoboxWrapperClass or true
 
 	return MatchTicker(args):query():create(
 		MatchTicker.DisplayComponents.Header('Upcoming matches')

--- a/components/match_ticker/commons/match_ticker_custom.lua
+++ b/components/match_ticker/commons/match_ticker_custom.lua
@@ -35,7 +35,7 @@ function CustomMatchTicker.tournament(frame)
 	)
 end
 
----Entry point for display on main page
+---Entry point for display on the main page
 ---@param frame Frame
 ---@return Html|string
 function CustomMatchTicker.mainPage(frame)
@@ -43,7 +43,7 @@ function CustomMatchTicker.mainPage(frame)
 	return MatchTicker(args):query():create()
 end
 
----Entry point for display on main page
+---Entry point for display on player pages
 ---@param frame Frame
 ---@return Html
 function CustomMatchTicker.player(frame)
@@ -54,7 +54,7 @@ function CustomMatchTicker.player(frame)
 	return CustomMatchTicker.participant(args)
 end
 
----Entry point for display on main page
+---Entry point for display on team pages
 ---@param frame Frame
 ---@return Html
 function CustomMatchTicker.team(frame)
@@ -65,12 +65,15 @@ function CustomMatchTicker.team(frame)
 	return CustomMatchTicker.participant(args)
 end
 
----Entry point for display on main page
+---Entry point for display on any participant-type page
 ---@param args table
 ---@param matches {ongoing: table?, upcoming: table?, recent: table?}?
 ---@return Html
 function CustomMatchTicker.participant(args, matches)
 	matches = matches or {}
+
+	--adjusting args
+	args.infoboxClass = true
 
 	return mw.html.create()
 		:node(MatchTicker(Table.merge(args, {

--- a/components/match_ticker/commons/match_ticker_display_components.lua
+++ b/components/match_ticker/commons/match_ticker_display_components.lua
@@ -47,7 +47,7 @@ local NOW = os.date('%Y-%m-%d %H:%M', os.time(os.date('!*t') --[[@as osdateparam
 local Header = Class.new(
 	function(self, text)
 		self.root = mw.html.create('div')
-			:addClass('infobox-header wiki-backgroundcolor-light')
+			:addClass('infobox-header')
 			:wikitext(text)
 	end
 )


### PR DESCRIPTION
## Summary

Made some changes to matchticker to default to a standard component not embedded in an infobox, unless called via the participant entry point which is assumed to be inside an existing infobox wrapper (can be overwritten via `false`).

The `args.infoboxWrapperClass` is now used to create a standalone "infobox" which contains only a match ticker (header can be added too), and it forces on the inner infobox class too as it's needed.

The motivation for this change was initially because mainpage entry was adding the infobox class by default, but it also just made sense to me that the ticker shouldn't be tried to infobox classes by default anyway.

The dropped classes are unneeded (as far as I can see from testing) since their CSS is either overwritten by other CSS, ignored, or inherently added from newer skin CSS.

## How did you test this change?

`/dev` on CS and SC2.

Shouldn't need any changes to SC2 infobox modules, however, can drop the classes `none` from mainpage match lists now.