### PR TITLE
Fix display issue of bestof in TM matchsummary

### DIFF
--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -83,7 +83,7 @@ end
 ---@return Html
 function Header:createScoreBoard(score, bestof, isNotFinished)
 	local scoreBoardNode = mw.html.create('div')
-		:addClass('brkts-popup-spaced')
+		:addClass('brkts-popup-score')
 
 	if bestof > 0 and isNotFinished then
 		return scoreBoardNode
@@ -93,7 +93,6 @@ function Header:createScoreBoard(score, bestof, isNotFinished)
 				:css('text-align', 'center')
 				:node(score)
 			)
-			:node('<br>')
 			:node(mw.html.create('span')
 				:wikitext('(')
 				:node(Abbreviation.make(


### PR DESCRIPTION
## Summary
Reported on discord https://discord.com/channels/93055209017729024/372075546231832576/1163510231410679978

## How did you test this change?
inspector->live
