### PR TITLE
Add PlayerTeamAuto to COD InfoPlayer

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -11,6 +11,7 @@ local GameAppearances = require('Module:GetGameAppearances')
 local Lua = require('Module:Lua')
 local Role = require('Module:Role')
 local String = require('Module:StringUtils')
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -35,6 +36,14 @@ function CustomPlayer.run(frame)
 	_args = player.args
 	_role = Role.run({role = _args.role})
 	_role2 = Role.run({role = _args.role2})
+
+	if String.isEmpty(player.args.team) then
+		player.args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+
+	if String.isEmpty(player.args.team2) then
+		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
+	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector


### PR DESCRIPTION
## Summary
add PlayerTeamAuto to call of duty player infobox so that **|team=** input is Automated 

Tested with dev=1