### PR TITLE
Add option for map display names

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -114,7 +114,9 @@ unusual status.
 function DisplayHelper.MapAndStatus(game, config)
 	config = config or {}
 	local mapText
-	if game.map and not config.noLink then
+	if game.map and game.mapDisplayName then
+		mapText = '[[' .. game.map .. '|' .. game.mapDisplayName .. ']]'
+	elseif game.map and not config.noLink then
 		mapText = '[[' .. game.map .. ']]'
 	elseif game.map then
 		mapText = game.map

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -170,7 +170,8 @@ function StarcraftMatchGroupInput._getExtraData(match)
 				extradata,
 				match['veto' .. vetoIndex],
 				match['vetoplayer' .. vetoIndex] or match['vetoopponent' .. vetoIndex],
-				vetoIndex
+				vetoIndex,
+				match['veto' .. vetoIndex .. 'displayName']
 			)
 		end
 
@@ -185,9 +186,10 @@ function StarcraftMatchGroupInput._getExtraData(match)
 	return match
 end
 
-function StarcraftMatchGroupInput._getVeto(extradata, map, vetoBy, vetoIndex)
+function StarcraftMatchGroupInput._getVeto(extradata, map, vetoBy, vetoIndex, displayName)
 	extradata['veto' .. vetoIndex] = (map ~= nil) and mw.ext.TeamLiquidIntegration.resolve_redirect(map) or nil
 	extradata['veto' .. vetoIndex .. 'by'] = vetoBy
+	extradata['veto' .. vetoIndex .. 'displayname'] = displayName
 
 	return extradata
 end
@@ -723,8 +725,9 @@ function StarcraftMatchGroupInput._mapInput(match, mapIndex, subGroupIndex)
 
 	-- set initial extradata for maps
 	map.extradata = {
-		comment = map.comment or '',
-		header = map.header or '',
+		comment = map.comment,
+		displayname = map.mapDisplayName,
+		header = map.header,
 		noQuery = match.noQuery,
 		server = map.server,
 	}

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -31,7 +31,6 @@ local _CONVERT_STATUS_INPUT = {W = 'W', FF = 'FF', L = 'L', DQ = 'DQ', ['-'] = '
 local _DEFAULT_LOSS_STATUSES = {'FF', 'L', 'DQ'}
 local _MAX_NUM_OPPONENTS = 2
 local _MAX_NUM_PLAYERS = 30
-local _MAX_NUM_VETOS = 6
 local _MAX_NUM_VODGAMES = 9
 local _DEFAULT_BEST_OF = 99
 local _OPPONENT_MODE_TO_PARTIAL_MATCH_MODE = {
@@ -156,29 +155,24 @@ end
 function StarcraftMatchGroupInput._getExtraData(match)
 	local extradata
 	if Logic.readBool(match.ffa) then
-		extradata = getStarcraftFfaInputModule().getExtraData(match)
-	else
-		extradata = {
-			noQuery = match.noQuery,
-			casters = match.casters,
-			headtohead = match.headtohead,
-			ffa = 'false',
-		}
+		match.extradata = getStarcraftFfaInputModule().getExtraData(match)
+		return match
+	end
 
-		for vetoIndex = 1, _MAX_NUM_VETOS do
-			extradata = StarcraftMatchGroupInput._getVeto(
-				extradata,
-				match['veto' .. vetoIndex],
-				match['vetoplayer' .. vetoIndex] or match['vetoopponent' .. vetoIndex],
-				vetoIndex,
-				match['veto' .. vetoIndex .. 'displayName']
-			)
-		end
+	extradata = {
+		noQuery = match.noQuery,
+		casters = match.casters,
+		headtohead = match.headtohead,
+		ffa = 'false',
+	}
 
-		for subGroupIndex = 1, _MAX_NUM_MAPS do
-			extradata['subGroup' .. subGroupIndex .. 'header']
-				= StarcraftMatchGroupInput._getSubGroupHeader(subGroupIndex, match)
-		end
+	for prefix, vetoMap, vetoIndex in Table.iter.pairsByPrefix(match, 'veto') do
+		StarcraftMatchGroupInput._getVeto(extradata, vetoMap, match, prefix, vetoIndex)
+	end
+
+	for subGroupIndex = 1, _MAX_NUM_MAPS do
+		extradata['subGroup' .. subGroupIndex .. 'header']
+			= StarcraftMatchGroupInput._getSubGroupHeader(subGroupIndex, match)
 	end
 
 	match.extradata = extradata
@@ -186,12 +180,10 @@ function StarcraftMatchGroupInput._getExtraData(match)
 	return match
 end
 
-function StarcraftMatchGroupInput._getVeto(extradata, map, vetoBy, vetoIndex, displayName)
-	extradata['veto' .. vetoIndex] = (map ~= nil) and mw.ext.TeamLiquidIntegration.resolve_redirect(map) or nil
-	extradata['veto' .. vetoIndex .. 'by'] = vetoBy
-	extradata['veto' .. vetoIndex .. 'displayname'] = displayName
-
-	return extradata
+function StarcraftMatchGroupInput._getVeto(extradata, map, match, prefix, vetoIndex)
+	extradata[prefix] = map and mw.ext.TeamLiquidIntegration.resolve_redirect(map) or nil
+	extradata[prefix .. 'by'] = match['vetoplayer' .. vetoIndex] or match['vetoopponent' .. vetoIndex]
+	extradata[prefix .. 'displayname'] = match[prefix .. 'displayName']
 end
 
 function StarcraftMatchGroupInput._getSubGroupHeader(subGroupIndex, match)

--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -49,17 +49,21 @@ StarcraftMatchGroupUtil.types.GameOpponent = TypeUtil.struct({
 })
 
 ---@class StarcraftMatchGroupUtilGame: MatchGroupUtilGame
+---@field mapDisplayName string?
 ---@field opponents StarcraftMatchGroupUtilGameOpponent[]
 ---@field offraces table<integer, string[]>?
 StarcraftMatchGroupUtil.types.Game = TypeUtil.extendStruct(MatchGroupUtil.types.Game, {
 	opponents = TypeUtil.array(StarcraftMatchGroupUtil.types.Opponent),
+	mapDisplayName = 'string?',
 })
 ---@class StarcraftMatchGroupUtilVeto
 ---@field by number?
 ---@field map string
+---@field displayName string?
 StarcraftMatchGroupUtil.types.MatchVeto = TypeUtil.struct({
-	by = 'number',
+	by = 'number?',
 	map = 'string',
+	displayName = 'string?',
 })
 ---@class StarcraftMatchGroupUtilSubmatch
 ---@field games StarcraftMatchGroupUtilGame[]
@@ -112,6 +116,8 @@ function StarcraftMatchGroupUtil.matchFromRecord(record)
 	-- Compute game.opponents by looking up game.participants in match.opponents
 	for _, game in ipairs(match.games) do
 		game.opponents = StarcraftMatchGroupUtil.computeGameOpponents(game, match.opponents)
+		game.extradata = game.extradata or {}
+		game.mapDisplayName = game.extradata.displayname
 	end
 
 	-- Determine whether the match is a team match with different players each game
@@ -137,6 +143,8 @@ function StarcraftMatchGroupUtil.matchFromRecord(record)
 	for vetoIndex = 1, math.huge do
 		local map = Table.extract(extradata, 'veto' .. vetoIndex)
 		local by = tonumber(Table.extract(extradata, 'veto' .. vetoIndex .. 'by'))
+		local displayName = Table.extract(extradata, 'veto' .. vetoIndex .. 'displayname')
+
 		if not map then break end
 
 		table.insert(match.vetoes, {map = map, by = by})

--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -147,7 +147,7 @@ function StarcraftMatchGroupUtil.matchFromRecord(record)
 
 		if not map then break end
 
-		table.insert(match.vetoes, {map = map, by = by})
+		table.insert(match.vetoes, {map = map, by = by, displayName = displayName})
 	end
 
 	-- Misc

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -369,19 +369,24 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 	return StarcraftMatchSummarySubmatchRow():addElement(headerNode):addElement(bodyNode)
 end
 
----@param veto {map: string, by: number}
+---@param veto StarcraftMatchGroupUtilVeto
 ---@return MatchSummaryRow
 function StarcraftMatchSummary.Veto(veto)
 	local statusIcon = function(opponentIndex)
 		return StarcraftMatchSummary.toIcon(opponentIndex == veto.by and 'redCross')
 	end
 
-	veto.map = veto.map or TBD
+	local map = veto.map or TBD
+	if veto.displayName then
+		map = '[[' .. map .. '|' .. veto.displayName .. ']]'
+	elseif map:upper() ~= TBD then
+		map = '[[' .. map .. ']]'
+	end
 
 	return MatchSummary.Row():addClass('brkts-popup-sc-veto-body')
 		:addElement(statusIcon(1))
 		:addElement(mw.html.create('div'):addClass('brkts-popup-sc-veto-center')
-			:wikitext(veto.map:upper() == TBD and TBD or ('[[' .. veto.map .. ']]')))
+			:wikitext(map))
 		:addElement(statusIcon(2))
 end
 


### PR DESCRIPTION
## Summary
Add option for map display names in sc2/sc match2 as per request by a reviewer (that converted ~800 old match1 team stuff on sc2)
Also refactor veto input reading
- remove restriction to it only being 6 (sc2 now has a map pool of 9 instead of 7 and to be future proof leave it open end)
- cleaner code

## How did you test this change?
dev