### PR TITLE
feat: add match ticker and league information to CoD Team Infobox

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_team_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_team_custom.lua
@@ -14,7 +14,6 @@ local String = require('Module:StringUtils')
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 
 local CustomTeam = Class.new()
-local _doStore = true
 
 function CustomTeam.run(frame)
 	local team = Team(frame)
@@ -25,9 +24,7 @@ function CustomTeam.run(frame)
 end
 
 function CustomTeam:createBottomContent()
-	if _doStore then
-		return MatchTicker.participant{team = self.pagename}
-	end
+	return MatchTicker.participant{team = self.pagename}
 end
 
 function CustomTeam:addToLpdb(lpdbData, args)

--- a/components/infobox/wikis/callofduty/infobox_team_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_team_custom.lua
@@ -10,19 +10,14 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local MatchTicker = require('Module:MatchTicker/Custom')
 local String = require('Module:StringUtils')
-local Template = require('Module:Template')
-local Variables = require('Module:Variables')
 
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 
 local CustomTeam = Class.new()
-
-local _team
 local _doStore = true
 
 function CustomTeam.run(frame)
 	local team = Team(frame)
-	_team = team
 	team.createBottomContent = CustomTeam.createBottomContent
 	team.addToLpdb = CustomTeam.addToLpdb
 	team.getWikiCategories = CustomTeam.getWikiCategories

--- a/components/infobox/wikis/callofduty/infobox_team_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_team_custom.lua
@@ -1,0 +1,54 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local MatchTicker = require('Module:MatchTicker/Custom')
+local String = require('Module:StringUtils')
+local Template = require('Module:Template')
+local Variables = require('Module:Variables')
+
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local CustomTeam = Class.new()
+
+local _team
+local _doStore = true
+
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	_team = team
+	team.createBottomContent = CustomTeam.createBottomContent
+	team.addToLpdb = CustomTeam.addToLpdb
+	team.getWikiCategories = CustomTeam.getWikiCategories
+	return team:createInfobox()
+end
+
+function CustomTeam:createBottomContent()
+	if _doStore then
+		return MatchTicker.participant{team = self.pagename}
+	end
+end
+
+function CustomTeam:addToLpdb(lpdbData, args)
+	lpdbData.extradata.competesin = string.upper(args.league or '')
+
+	return lpdbData
+end
+
+function CustomTeam:getWikiCategories(args)
+	local categories = {}
+
+	if String.isNotEmpty(args.league) then
+		table.insert(categories, string.upper(args.league) .. ' Teams')
+	end
+
+	return categories
+end
+
+return CustomTeam

--- a/components/infobox/wikis/callofduty/infobox_team_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_team_custom.lua
@@ -28,7 +28,7 @@ function CustomTeam:createBottomContent()
 end
 
 function CustomTeam:addToLpdb(lpdbData, args)
-	lpdbData.extradata.competesin = string.upper(args.league or '')
+	lpdbData.extradata.competesin = String.isNotEmpty(args.league) and args.league:upper() or nil
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
The features I want are few things

- Embeds the Commons MatchTicker/custom into the Team Infobox
- Add extradata **competesin** which is the one uses for Overwatch, to define teams in the franchised league (OWL/CDL) this is to help with the Portal Teams able to show only CDL teams through an extradata condition call

## How did you test this change?
dev=1 on https://liquipedia.net/callofduty/Seattle_Surge
