### PR TITLE
Remove CoD wiki from dev deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 userAgent="GitHub Autodeploy Bot/1.1.0 (${WIKI_UA_EMAIL})"
-devWikis=('callofduty' 'rocketleague' 'commons')
+devWikis=('rocketleague' 'commons')
 pat='\-\-\-\
 \-\- @Liquipedia\
 \-\- wiki=([^


### PR DESCRIPTION
## Summary
The CoD dev wiki is currently unmaintained and doesn't work

## How did you test this change?

