### PR TITLE
Produce clean ResultOrError errors by default

### DIFF
--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -15,10 +15,9 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local FILTERED_STACK_ITEMS = {
-	'Module:ResultOrError:124: in function <Module:ResultOrError:123>',
-	'Module:ResultOrError:115: in function <Module:ResultOrError:114>',
-	'[C]: in function \'xpcall\'',
-	'Module:ResultOrError:113: in function \'try\'',
+	'^Module:ResultOrError:%d+: in function <Module:ResultOrError:%d+>$',
+	'^%[C%]: in function \'xpcall\'$',
+	'^Module:ResultOrError:%d+: in function \'try\'$',
 }
 
 local pageVars = PageVariableNamespace('ErrorStash')
@@ -133,7 +132,7 @@ function ErrorExt.printErrorJson(error)
 				Array.sub(stackFrames, 2, #stackFrames),
 				function(frame) return String.trim(frame) end
 			),
-			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame) end
+			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame, true) end
 		)
 		Array.forEach(stackFrames, processStackFrame)
 	end)

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -87,6 +87,48 @@ function ErrorExt.makeFullStackTrace(error)
 	return table.concat(parts, '\n')
 end
 
+---Builds a JSON string for using with `liquipedia.customLuaErrors` JS module via error().
+---@param error error
+---@return string
+function ErrorExt.printErrorJson(error)
+	local stackTrace = {}
+	for _, stack in ipairs(error.stacks) do
+		local stackFrames = mw.text.split(stack, '\n')
+		stackFrames = Array.filter(
+			Array.map(
+				Array.sub(stackFrames, 2, #stackFrames),
+				function(frame) return String.trim(frame) end
+			),
+			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame) end
+		)
+		for index, frame in ipairs(stackFrames) do
+			if not (index == 1 and frame == '[C]: ?') then
+				local stackEntry = {content = frame}
+				local frameSplit = mw.text.split(frame, ':', true)
+				if (frameSplit[1] == '[C]' or frameSplit[1] == '(tail call)') then
+					stackEntry.prefix = frameSplit[1]
+					stackEntry.content = table.concat(frameSplit, ':', 2)
+				elseif frameSplit[1] == 'mw.lua' then
+					stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
+					stackEntry.content =  table.concat(frameSplit, ':', 3)
+				elseif frameSplit[1] == 'Module' then
+					local wiki = not Page.exists(table.concat(frameSplit, ':', 1, 2)) and 'commons'
+						or mw.text.split(mw.title.getCurrentTitle():canonicalUrl(), '/', true)[4] or 'commons'
+					stackEntry.link = {wiki = wiki, title = table.concat(frameSplit, ':', 1, 2), ln = frameSplit[3]}
+					stackEntry.prefix = table.concat(frameSplit, ':', 1, 3)
+					stackEntry.content = table.concat(frameSplit, ':', 4)
+				end
+				table.insert(stackTrace, stackEntry)
+			end
+		end
+	end
+
+	return Json.stringify({
+			errorShort = string.format('Lua error in %s:%s at line %s:%s.', unpack(mw.text.split(error.error, ':', true)))
+			, stackTrace = stackTrace,
+		})
+end
+
 local Stash = {}
 ErrorExt.Stash = Stash
 

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -98,10 +98,35 @@ end
 
 ---Builds a JSON string for using with `liquipedia.customLuaErrors` JS module via error().
 ---@param error error
----@return string
+---@return string?
 function ErrorExt.printErrorJson(error)
 	local stackTrace = {}
-	for _, stack in ipairs(error.stacks) do
+
+	local processStackFrame = function(frame, frameIndex)
+		if frameIndex == 1 and frame == '[C]: ?' then
+			return
+		end
+
+		local stackEntry = {content = frame}
+		local frameSplit = mw.text.split(frame, ':', true)
+		if (frameSplit[1] == '[C]' or frameSplit[1] == '(tail call)') then
+			stackEntry.prefix = frameSplit[1]
+			stackEntry.content = table.concat(frameSplit, ':', 2)
+		elseif frameSplit[1] == 'mw.lua' then
+			stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
+			stackEntry.content =  table.concat(frameSplit, ':', 3)
+		elseif frameSplit[1] == 'Module' then
+			local wiki = not Page.exists(table.concat(frameSplit, ':', 1, 2)) and 'commons'
+				or mw.text.split(mw.title.getCurrentTitle():canonicalUrl(), '/', true)[4] or 'commons'
+			stackEntry.link = {wiki = wiki, title = table.concat(frameSplit, ':', 1, 2), ln = frameSplit[3]}
+			stackEntry.prefix = table.concat(frameSplit, ':', 1, 3)
+			stackEntry.content = table.concat(frameSplit, ':', 4)
+		end
+
+		table.insert(stackTrace, stackEntry)
+	end
+
+	Array.forEach(error.stacks, function(stack)
 		local stackFrames = mw.text.split(stack, '\n')
 		stackFrames = Array.filter(
 			Array.map(
@@ -110,31 +135,12 @@ function ErrorExt.printErrorJson(error)
 			),
 			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame) end
 		)
-		for index, frame in ipairs(stackFrames) do
-			if not (index == 1 and frame == '[C]: ?') then
-				local stackEntry = {content = frame}
-				local frameSplit = mw.text.split(frame, ':', true)
-				if (frameSplit[1] == '[C]' or frameSplit[1] == '(tail call)') then
-					stackEntry.prefix = frameSplit[1]
-					stackEntry.content = table.concat(frameSplit, ':', 2)
-				elseif frameSplit[1] == 'mw.lua' then
-					stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
-					stackEntry.content =  table.concat(frameSplit, ':', 3)
-				elseif frameSplit[1] == 'Module' then
-					local wiki = not Page.exists(table.concat(frameSplit, ':', 1, 2)) and 'commons'
-						or mw.text.split(mw.title.getCurrentTitle():canonicalUrl(), '/', true)[4] or 'commons'
-					stackEntry.link = {wiki = wiki, title = table.concat(frameSplit, ':', 1, 2), ln = frameSplit[3]}
-					stackEntry.prefix = table.concat(frameSplit, ':', 1, 3)
-					stackEntry.content = table.concat(frameSplit, ':', 4)
-				end
-				table.insert(stackTrace, stackEntry)
-			end
-		end
-	end
+		Array.forEach(stackFrames, processStackFrame)
+	end)
 
 	return Json.stringify({
-			errorShort = string.format('Lua error in %s:%s at line %s:%s.', unpack(mw.text.split(error.error, ':', true)))
-			, stackTrace = stackTrace,
+			errorShort = string.format('Lua error in %s:%s at line %s:%s.', unpack(mw.text.split(error.error, ':', true))),
+			stackTrace = stackTrace,
 		})
 end
 

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -9,8 +9,17 @@
 local Array = require('Module:Array')
 local Error = require('Module:Error')
 local Json = require('Module:Json')
+local Page = require('Module:Page')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+
+local FILTERED_STACK_ITEMS = {
+	'Module:ResultOrError:124: in function <Module:ResultOrError:123>',
+	'Module:ResultOrError:115: in function <Module:ResultOrError:114>',
+	'[C]: in function \'xpcall\'',
+	'Module:ResultOrError:113: in function \'try\'',
+}
 
 local pageVars = PageVariableNamespace('ErrorStash')
 

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -95,7 +95,7 @@ function Error:map(_, onError)
 end
 
 function Error:get()
-	error(table.concat(Array.extend(self.error, self.stacks), '\n'))
+	error(require('Module:ErrorExt').printErrorJson(self), 0)
 end
 
 --[[


### PR DESCRIPTION
## Summary

Previously, `Module:ResultOrError` would just throw a list of stack traces whenever it errors and it was just a nightmare to read. Now, using some client javascript, these errors will be parsed into identical errors as from default Scribunto. Since this has to go through the `error()` call (unless each module using `ResultOrError` wants to catch the errors themselves), it had to be done this way.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/99e2b3ee-dc91-4b40-8d94-960a12691fd0)

## JS module required to this to work:

Otherwise it'll just look like this:
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/90141e51-632c-4376-9bb3-c08e5ef246b8)

```js
liquipedia.customLuaErrors = {
	init: function() {
		var $dialog = $('<div>').dialog({
			title: mw.msg('scribunto-parser-dialog-title'),
			autoOpen: false
		});
		$('.scribunto-error').each(function() {
			try {
				var parsedError = JSON.parse(this.innerHTML.toString().slice(11, -1));
				var $backtraceList = $('<ol>', {class: 'scribunto-trace'});
				parsedError.stackTrace.forEach(function(stackItem) {
					var $backtraceItem = $('<li>');
					var $prefix = $('<b>');
					var prefixText = $('<div>').html(stackItem.prefix).text();
					if (stackItem.link instanceof Object) {
						$('<a>', {
							text: prefixText,
							href: '/' + stackItem.link.wiki + '/' + stackItem.link.title + '#mw-ce-l' + stackItem.link.ln,
							target: '_blank'
						}).appendTo($prefix);
					} else {
						$prefix.text(prefixText);
					}
					$backtraceItem.append($prefix);
					$backtraceItem.append(document.createTextNode(': ' + $('<div>').html(stackItem.content).text()));
					$backtraceItem.appendTo($backtraceList);
				});
				var $errorDiv = $('<div>').append(
					$('<p>', {text: parsedError.errorShort})
				).append(
					$('<p>', {text: 'Backtrace:'})
				).append(
					$backtraceList
				);
				var $newError = $('<span>', {text: parsedError.errorShort, class: 'scribunto-error'});
				$(this).replaceWith($newError);
				$newError.on('click', function(e) {
					$dialog.dialog('close').html($errorDiv).dialog('option', 'position', [e.clientX + 5, e.clientY + 5]).dialog('open');
				});
			} catch (ignored) {}
		});
	}
};
liquipedia.core.modules.push('customLuaErrors');
```

## How did you test this change?

`/dev` and running JS module as a userscript.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/3aa1b633-c899-46a4-a3c2-5913fafb3d71)

## Merge prerequisites

* [x] I have asked Alex to have a look at the JS code for any issues.
* [x] When approved, add to commons either as a new JS resource or part of the existing misc one.