### PR TITLE
Add Match2 for osu!

### DIFF
--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -1,0 +1,459 @@
+---
+-- @Liquipedia
+-- wiki=osu
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+local Variables = require('Module:Variables')
+local DateExt = require('Module:Date/Ext')
+local Streams = require('Module:Links/Stream')
+local Match = require('Module:Match')
+
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
+
+local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban', 'protect'}
+local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L', 'D' }
+local MAX_NUM_OPPONENTS = 8
+local MAX_NUM_MAPS = 20
+local DEFAULT_BESTOF = 3
+
+local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+
+local NOW = os.time(os.date('!*t'))
+local LANG = mw.getContentLanguage()
+local MATCHTIME = tonumber(LANG:formatDate('U', Match.date))
+local THRESHOLD = Match.dateexact and 30800 or 86400
+
+-- containers for process helper functions
+local matchFunctions = {}
+local mapFunctions = {}
+local opponentFunctions = {}
+
+local CustomMatchGroupInput = {}
+
+-- called from Module:MatchGroup
+function CustomMatchGroupInput.processMatch(match)
+	-- Count number of maps, check for empty maps to remove, and automatically count score
+	match = matchFunctions.getBestOf(match)
+	match = matchFunctions.getScoreFromMapWinners(match)
+
+	-- process match
+	Table.mergeInto(
+		match,
+		matchFunctions.readDate(match)
+	)
+	match = matchFunctions.getOpponents(match)
+	match = matchFunctions.getTournamentVars(match)
+	match = matchFunctions.getVodStuff(match)
+	match = matchFunctions.getExtraData(match)
+
+	return match
+end
+
+-- called from Module:Match/Subobjects
+function CustomMatchGroupInput.processMap(map)
+	map = mapFunctions.getExtraData(map)
+	map = mapFunctions.getScoresAndWinner(map)
+	map = mapFunctions.getTournamentVars(map)
+
+	return map
+end
+
+function CustomMatchGroupInput.processOpponent(record, date)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	-- Convert byes to literals
+	if Opponent.isBye(opponent) then
+		opponent = {type = Opponent.literal, name = 'BYE'}
+	end
+
+	local teamTemplateDate = date ~= EPOCH_TIME_EXTENDED and date or DateExt.getContextualDateOrNow()
+
+	Opponent.resolve(opponent, teamTemplateDate)
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+end
+
+-- called from Module:Match/Subobjects
+function CustomMatchGroupInput.processPlayer(player)
+	return player
+end
+
+--
+--
+-- function to check for draws
+function CustomMatchGroupInput.placementCheckDraw(table)
+	local last
+	for _, scoreInfo in pairs(table) do
+		if scoreInfo.status ~= 'S' and scoreInfo.status ~= 'D' then
+			return false
+		end
+		if last and last ~= scoreInfo.score then
+			return false
+		else
+			last = scoreInfo.score
+		end
+	end
+
+	return true
+end
+
+function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
+	-- Map or Match wasn't played, set not played
+	if
+		data.finished == 'skip' or
+		data.finished == 'np' or
+		data.finished == 'cancelled' or
+		data.finished == 'canceled' or
+		data.winner == 'skip' or
+		data.winner == 'np' or
+		data.winner == 'cancelled' or
+		data.winner == 'canceled'
+	then
+		data.resulttype = 'np'
+		data.finished = true
+	-- Map or Match is marked as finished.
+	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
+	elseif Logic.readBool(data.finished) then
+		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
+			data.winner = 0
+			data.resulttype = 'draw'
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
+		elseif CustomMatchGroupInput.placementCheckSpecialStatus(indexedScores) then
+			data.winner = CustomMatchGroupInput.getDefaultWinner(indexedScores)
+			data.resulttype = 'default'
+			if CustomMatchGroupInput.placementCheckFF(indexedScores) then
+				data.walkover = 'ff'
+			elseif CustomMatchGroupInput.placementCheckDQ(indexedScores) then
+				data.walkover = 'dq'
+			elseif CustomMatchGroupInput.placementCheckWL(indexedScores) then
+				data.walkover = 'l'
+			end
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'default')
+		else
+			local winner
+			indexedScores, winner = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, nil, data.finished)
+			data.winner = data.winner or winner
+		end
+	end
+
+	--set it as finished if we have a winner
+	if not String.isEmpty(data.winner) then
+		data.finished = true
+	end
+
+	return data, indexedScores
+end
+
+function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, finished)
+	if specialType == 'draw' then
+		for key, _ in pairs(opponents) do
+			opponents[key].placement = 1
+		end
+	elseif specialType == 'default' then
+		for key, _ in pairs(opponents) do
+			if key == winner then
+				opponents[key].placement = 1
+			else
+				opponents[key].placement = 2
+			end
+		end
+	else
+		local temporaryScore = -99
+		local temporaryPlace = -99
+		local counter = 0
+		for scoreIndex, opp in Table.iter.spairs(opponents, CustomMatchGroupInput.placementSortFunction) do
+			local score = tonumber(opp.score) or ''
+			counter = counter + 1
+			if counter == 1 and (winner or '') == '' then
+				if finished then
+					winner = scoreIndex
+				end
+			end
+			if temporaryScore == score then
+				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or temporaryPlace
+			else
+				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or counter
+				temporaryPlace = counter
+				temporaryScore = score
+			end
+		end
+	end
+
+	return opponents, winner
+end
+
+function CustomMatchGroupInput.placementSortFunction(table, key1, key2)
+	local value1 = tonumber(table[key1].score) or -99
+	local value2 = tonumber(table[key2].score) or -99
+	return value1 > value2
+end
+
+-- Check if any team has a none-standard status
+function CustomMatchGroupInput.placementCheckSpecialStatus(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ~= 'S' end)
+end
+
+-- function to check for forfeits
+function CustomMatchGroupInput.placementCheckFF(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'FF' end)
+end
+
+-- function to check for DQ's
+function CustomMatchGroupInput.placementCheckDQ(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'DQ' end)
+end
+
+-- function to check for W/L
+function CustomMatchGroupInput.placementCheckWL(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'L' end)
+end
+
+-- Get the winner when resulttype=default
+function CustomMatchGroupInput.getDefaultWinner(table)
+	for index, scoreInfo in pairs(table) do
+		if scoreInfo.status == 'W' then
+			return index
+		end
+	end
+	return -1
+end
+
+--
+-- match related functions
+--
+function matchFunctions.getBestOf(match)
+	match.bestof = Logic.emptyOr(match.bestof, Variables.varDefault('bestof', DEFAULT_BESTOF))
+	Variables.varDefine('bestof', match.bestof)
+	return match
+end
+
+-- Calculate the match scores based on the map results (counting map wins)
+-- Only update a teams result if it's
+-- 1) Not manually added
+-- 2) At least one map has a winner
+function matchFunctions.getScoreFromMapWinners(match)
+	local opponentNumber = 0
+	for index = 1, MAX_NUM_OPPONENTS do
+		if String.isEmpty(match['opponent' .. index]) then
+			break
+		end
+		opponentNumber = index
+	end
+	local newScores = {}
+	local foundScores = false
+
+	for i = 1, MAX_NUM_MAPS do
+		if match['map'..i] then
+			local winner = tonumber(match['map'..i].winner)
+			foundScores = true
+			if winner and winner > 0 and winner <= opponentNumber then
+				newScores[winner] = (newScores[winner] or 0) + 1
+			end
+		else
+			break
+		end
+	end
+
+	for index = 1, opponentNumber do
+		if not match['opponent' .. index].score and foundScores then
+			match['opponent' .. index].score = newScores[index] or 0
+		end
+	end
+
+	return match
+end
+
+function matchFunctions.readDate(matchArgs)
+	if matchArgs.date then
+		local dateProps = MatchGroupInput.readDate(matchArgs.date)
+		dateProps.hasDate = true
+		return dateProps
+	else
+		return {
+			date = EPOCH_TIME_EXTENDED,
+			dateexact = false,
+		}
+	end
+end
+
+function matchFunctions.getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
+
+	match = MatchGroupInput.getCommonTournamentVars(match)
+
+	return match
+end
+
+function matchFunctions.getVodStuff(match)
+	match.stream = Streams.processStreams(match)
+	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
+
+	match.links = {}
+	local links = match.links
+	if match.preview then links.preview = match.preview end
+	if match.mplink then links.mplink = 'https://osu.ppy.sh/community/matches/' .. match.mplink end
+	if match.mplink2 then links.mplink2 = 'https://osu.ppy.sh/community/matches/' .. match.mplink2 end
+	if match.mplink3 then links.mplink3 = 'https://osu.ppy.sh/community/matches/' .. match.mplink3 end
+
+	return match
+end
+
+function matchFunctions.getExtraData(match)
+	match.extradata = {
+		mvp = MatchGroupInput.readMvp(match),
+		mapveto = matchFunctions.getMapVeto(match),
+	}
+	return match
+end
+
+-- Parse the mapVeto input
+function matchFunctions.getMapVeto(match)
+	if not match.mapveto then return nil end
+
+	local mapVeto = Json.parseIfString(match.mapveto)
+
+	local data = {
+		vetostart = mapVeto.vetostart,
+		format = mapVeto.format,
+	}
+	for index, vetoType in ipairs(mw.text.split(mapVeto.types or '', ',')) do
+		vetoType = mw.text.trim(vetoType):lower()
+		if not Table.includes(ALLOWED_VETOES, vetoType) then
+			return nil -- Any invalid input will not store (ie hide) all vetoes.
+		end
+		table.insert(data, {type = vetoType, team1 = mapVeto['t1map'..index], team2 = mapVeto['t2map'..index]})
+	end
+
+	return data
+end
+
+function matchFunctions.getOpponents(match)
+	-- read opponents and ignore empty ones
+	local opponents = {}
+	local isScoreSet = false
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		-- read opponent
+		local opponent = match['opponent' .. opponentIndex]
+		if not Logic.isEmpty(opponent) then
+			CustomMatchGroupInput.processOpponent(opponent, match.date)
+
+			-- Retrieve icon for team
+			if opponent.type == Opponent.team then
+				opponent.icon, opponent.icondark = opponentFunctions.getIcon(opponent.template)
+			end
+
+			-- apply status
+			if TypeUtil.isNumeric(opponent.score) then
+				opponent.status = 'S'
+				isScoreSet = true
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
+				opponent.status = opponent.score
+				opponent.score = -1
+			end
+			opponents[opponentIndex] = opponent
+		end
+	end
+
+	-- see if match should actually be finished if bestof limit was reached
+	if isScoreSet and not Logic.readBool(match.finished) then
+		local firstTo = math.ceil(match.bestof/2)
+		for _, item in pairs(opponents) do
+			if (tonumber(item.score) or 0) >= firstTo then
+				match.finished = true
+				break
+			end
+		end
+	end
+
+	-- see if match should actually be finished if score is set
+	if isScoreSet and not Logic.readBool(match.finished) and match.hasDate then
+		if MATCHTIME + THRESHOLD < NOW then
+			match.finished = true
+		end
+	end
+
+	-- apply placements and winner if finshed
+	if not String.isEmpty(match.winner) or Logic.readBool(match.finished) then
+		match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
+	end
+
+	-- Update all opponents with new values
+	for opponentIndex, opponent in pairs(opponents) do
+		match['opponent' .. opponentIndex] = opponent
+	end
+	return match
+end
+
+--
+-- map related functions
+--
+
+-- Parse extradata information
+function mapFunctions.getExtraData(map)
+	map.extradata = {
+		comment = map.comment,
+		header = map.header,
+	}
+	return map
+end
+
+-- Calculate Score and Winner of the map
+function mapFunctions.getScoresAndWinner(map)
+	map.scores = {}
+	local indexedScores = {}
+	for scoreIndex = 1, MAX_NUM_OPPONENTS do
+		-- read scores
+		local score = map['score' .. scoreIndex] or map['t' .. scoreIndex .. 'score']
+		local obj = {}
+		if not Logic.isEmpty(score) then
+			if TypeUtil.isNumeric(score) then
+				obj.status = 'S'
+				obj.score = score
+			elseif Table.includes(ALLOWED_STATUSES, score) then
+				obj.status = score
+				obj.score = -1
+			end
+			table.insert(map.scores, score)
+			indexedScores[scoreIndex] = obj
+		else
+			break
+		end
+	end
+
+	map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
+
+	return map
+end
+
+function mapFunctions.getTournamentVars(map)
+	map.mode = Logic.emptyOr(map.mode, Variables.varDefault('tournament_mode', 'team'))
+
+	map = MatchGroupInput.getCommonTournamentVars(map)
+
+	return map
+end
+
+--
+-- opponent related functions
+--
+function opponentFunctions.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	if raw then
+		local icon = Logic.emptyOr(raw.image, raw.legacyimage)
+		local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
+		return icon, iconDark
+	end
+end
+
+return CustomMatchGroupInput


### PR DESCRIPTION
## Summary
New Wiki - Rhythm Game. 

**The basis is changing on the fly, as its based on the newest revision of #3392 (CrossFire match2)** 
(The reason to not use CoD instead is because it would run into same changes needed on 3392)

Some Changes were made
- Few extra links were added **(mplinks,mplinks2 & 3)**
- Added Map Veto, this is ported from Heroes  that's already merged

Some parts still need help on CSS classes
- Outside of **Decider, Ban, Pick** there is now another Veto type **Protect** which right now doesnt had any color background wrapped around it, I need it to have one. In this case Protect would get any sort of blue so applying the **seedup** (blue) color could do
- 
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/d7a0bdf8-9368-4d5c-9715-6822834566d1)

Processing and Summary will be in here, I may likely kicked Legacy later since I wanted to use the Next/Downstream GTL for the wiki (due to 1v1 & Teams are seen equally like FIFA)

## How did you test this change?
LIVE as it is newly installed wiki