### PR TITLE
Add MatchTicker to FIFA Team Infobox

### DIFF
--- a/components/infobox/wikis/fifa/infobox_team_custom.lua
+++ b/components/infobox/wikis/fifa/infobox_team_custom.lua
@@ -8,23 +8,20 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local MatchTicker = require('Module:MatchTicker/Participant')
+local MatchTicker = require('Module:MatchTicker/Custom')
 
 local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
 
 local CustomTeam = Class.new()
 
-local _team
-
 function CustomTeam.run(frame)
 	local team = Team(frame)
-	_team = team
 	team.createBottomContent = CustomTeam.createBottomContent
 	return team:createInfobox()
 end
 
 function CustomTeam:createBottomContent()
-	return MatchTicker.run{team = _team.pagename}
+	return MatchTicker.participant{team = self.pagename}
 end
 
 return CustomTeam


### PR DESCRIPTION
## Summary
Add MatchTicker to FIFA Team Infobox, this is like the #3407 pull request 

Tested with Dev=1 on some pages