### PR TITLE
Store big match links for matches with a big match

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -145,7 +145,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 		bracketData.qualifiedheader = args[matchKey .. 'qualifiedHeader']
 		bracketData.inheritedheader = MatchGroupInput._inheritedHeader(bracketData.header)
 
-		bracketData.matchPage = match.matchPage
+		bracketData.matchpage = match.matchPage
 
 		match.parent = context.tournamentParent
 		match.matchsection = context.matchSection

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -81,6 +81,8 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 			bracketData.sectionheader = context.sectionHeader
 			bracketData.dateheader = Logic.readBool(match.dateheader) or nil
 
+			bracketData.matchPage = match.matchPage
+
 			local nextMatchId = bracketId .. '_' .. MatchGroupInput._matchlistMatchIdFromIndex(matchIndex + 1)
 			bracketData.next = matchIndex ~= #matchKeys and nextMatchId or nil
 
@@ -142,6 +144,8 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 		bracketData.header = args[matchKey .. 'header'] or bracketData.header
 		bracketData.qualifiedheader = args[matchKey .. 'qualifiedHeader']
 		bracketData.inheritedheader = MatchGroupInput._inheritedHeader(bracketData.header)
+
+		bracketData.matchPage = match.matchPage
 
 		match.parent = context.tournamentParent
 		match.matchsection = context.matchSection

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -512,6 +512,8 @@ function matchFunctions.mergeWithStandalone(match)
 		return match
 	end
 
+	match.matchPage = 'Match:ID_' .. match.bracketid .. '_' .. match.matchid
+
 	-- Update Opponents from the Stanlone Match
 	match.opponent1 = standaloneMatch.match2opponents[1]
 	match.opponent2 = standaloneMatch.match2opponents[2]

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -57,6 +57,7 @@ function MatchLegacy._convertParameters(match2)
 	local extradata = Json.parseIfString(match2.extradata)
 	match.extradata.gamecount = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	match.extradata.matchsection = extradata.matchsection
+
 	local mvp = Json.parseIfString(extradata.mvp)
 	if mvp and mvp.players then
 		local players = {}
@@ -72,7 +73,9 @@ function MatchLegacy._convertParameters(match2)
 		if bracketData.inheritedheader then
 			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
+		match.extradata.matchpage = bracketData.matchpage
 	end
+
 
 	local opponents = match2.match2opponents or {}
 	match.extradata.team1icon = (opponents[1] or {}).icon

--- a/components/match2/wikis/leagueoflegends/match_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/match_legacy.lua
@@ -69,8 +69,8 @@ function MatchLegacy._convertParameters(match2)
 	end
 
 	local bracketData = Json.parseIfString(match2.match2bracketdata)
-	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
-		if bracketData.inheritedheader then
+	if type(bracketData) == 'table' then
+		if bracketData.type == 'bracket' and bracketData.inheritedheader then
 			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 		match.extradata.matchpage = bracketData.matchpage


### PR DESCRIPTION
## Summary
Store the link to the big match page for matches with a big match.

Also adds it to League of Legends match2 and match1.

## How did you test this change?
Tested with dev
lol m2 (bracketData):
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/2e33e509-efaa-45a4-b126-a8d90347ea2f)

lol m1 (extraData):
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/6d75748b-b9a0-4d88-8788-2627c50cb964)
