### PR TITLE
Add option to force non raceTable display

### DIFF
--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -23,6 +23,7 @@ local Variables = require('Module:Variables')
 ---@field isQualified boolean?
 ---@field manualFactionCounts table<string, number?>
 ---@field soloColumnWidth number
+---@field soloAsRaceTable boolean
 
 ---@class StarcraftParticipantTableEntry: ParticipantTableEntry
 ---@field isQualified boolean?
@@ -60,7 +61,7 @@ function StarcraftParticipantTable.run(frame)
 
 	participantTable:read():store()
 
-	if StarcraftParticipantTable.isPureSolo(participantTable.sections) then
+	if StarcraftParticipantTable.isPureSolo(participantTable.sections) and participantTable.config.soloAsRaceTable then
 		participantTable.create = StarcraftParticipantTable.createSoloRaceTable
 	end
 
@@ -87,6 +88,8 @@ function StarcraftParticipantTable.readConfig(args, parentConfig)
 	Array.forEach(Faction.knownFactions, function(faction)
 		config.manualFactionCounts[faction] = tonumber(args[Faction.toName(faction):lower()])
 	end)
+
+	config.soloAsRaceTable = not Logic.readBool(args.soloNotAsRaceTable)
 
 	return config
 end


### PR DESCRIPTION
## Summary
Add option to force non raceTable display.
Needed for some events where custom invented races are used.

## How did you test this change?
dev