### PR TITLE
Saving release date into the date field

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -193,6 +193,7 @@ function CustomHero:setLpdbData(args)
 		type = 'hero',
 		name = args.heroname or _pagename,
 		image = args.image,
+		date = _args.releasedate,
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
 			releasedate = args.releasedate,
 		})

--- a/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_hero_custom.lua
@@ -193,7 +193,7 @@ function CustomHero:setLpdbData(args)
 		type = 'hero',
 		name = args.heroname or _pagename,
 		image = args.image,
-		date = _args.releasedate,
+		date = args.releasedate,
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
 			releasedate = args.releasedate,
 		})


### PR DESCRIPTION
## Summary
The Mobile Legends Hero Infobox currently has a ``releasedate`` parameter that is saved into extra data. This changes this from being saved in extradata to being saved into the ``Date`` field in LPDB. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested with Dev module on a live page.
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
