### PR TITLE
Add warcraft match1 to macth2 legacy wrapper for brackets

### DIFF
--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -36,7 +36,7 @@ function ConvertMapData.team(args)
 	args = args or {}
 
 	local parsedArgs = Table.filterByKey(args, function(key)
-		return string.match(key, 'map') == nil
+		return string.match(key, 'm%d') == nil
 	end)
 
 	local opponentPlayers = {{}, {}}
@@ -54,7 +54,7 @@ function ConvertMapData.team(args)
 			local name = args[playerInputPrefix .. 'link'] or args[playerInputPrefix] or TBD
 			local player = {
 				name = name,
-				displayname = args[playerInputPrefix] or TBD,
+				displayname = args[playerInputPrefix] or name,
 				flag = args[playerInputPrefix .. 'flag'],
 				race = args[playerInputPrefix .. 'race'],
 			}
@@ -64,6 +64,9 @@ function ConvertMapData.team(args)
 			parsedArgs[playerPrefix .. 'race'] = player.race
 			parsedArgs[playerPrefix .. 'heroes'] = args[playerInputPrefix .. 'heroes']
 		end
+
+		mapIndex = mapIndex + 1
+		prefix = 'm' .. mapIndex
 	end
 
 	Array.forEach(opponentPlayers, function(players, opponentIndex)
@@ -82,9 +85,55 @@ function ConvertMapData.teamMulti(args)
 	args = args or {}
 
 	local parsedArgs = Table.filterByKey(args, function(key)
-		return string.match(key, 'map') == nil
+		return string.match(key, 'm%d') == nil
 	end)
-mw.logObject(args)
+
+	local opponentPlayers = {{}, {}}
+	local mapIndex = 0
+	local submatchIndex = 1
+	local prefix = 'm' .. submatchIndex
+
+	while args[prefix .. 'p1'] or args[prefix .. 'p2'] or args[prefix .. 'map1'] do
+		--parse players
+		local mapPlayers = {{}, {}}
+		for opponentIndex = 1, NUMBER_OF_OPPONENTS do
+			local playerInputPrefix = prefix .. 'p' .. opponentIndex
+
+			local name = args[playerInputPrefix .. 'link'] or args[playerInputPrefix] or TBD
+			opponentPlayers[opponentIndex][name] = {
+				name = name,
+				displayname = args[playerInputPrefix] or name,
+				flag = args[playerInputPrefix .. 'flag'],
+				race = args[playerInputPrefix .. 'race'],
+			}
+			table.insert(mapPlayers, opponentPlayers[opponentIndex][name])
+
+			--optional second player
+			local player2InputPrefix = prefix .. 'p' .. opponentIndex .. '-2'
+			local name2 = args[player2InputPrefix .. 'link'] or args[player2InputPrefix]
+			if name2 then
+				opponentPlayers[opponentIndex][name2] = {
+					name = name2,
+					displayname = args[player2InputPrefix] or name,
+					flag = args[player2InputPrefix .. 'flag'],
+					race = args[player2InputPrefix .. 'race'],
+				}
+			end
+			table.insert(mapPlayers, opponentPlayers[opponentIndex][name2])
+		end
+
+
+
+
+
+
+
+
+		submatchIndex = submatchIndex + 1
+		prefix = 'm' .. submatchIndex
+	end
+
+
 
 	--[[
 	{{#if:{{{m1p1|}}}{{{m1p2|}}}{{{m1map1|}}}|{{BracketTeamMatchMulti/row

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -1,0 +1,107 @@
+---
+-- @Liquipedia
+-- wiki=warcraft
+-- page=Module:MatchGroup/Legacy/ConvertMapData
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Json = require('Module:Json')
+local Table = require('Module:Table')
+
+local TBD = 'TBD'
+local NUMBER_OF_OPPONENTS = 2
+
+local ConvertMapData = {}
+
+---@param args table?
+---@return string
+function ConvertMapData.solo(args)
+	args = args or {}
+	--sometimes win param is entered differently ...
+	for _, value, index in Table.iter.pairsByPrefix(args, 'win') do
+		args['map' .. index .. 'win'] = value
+		args['map' .. index] = args['map' .. index] or TBD
+	end
+
+	return Json.stringify(args)
+end
+
+--structure formerly used by `Template:BracketTeamMatch`
+---@param args table?
+---@return string
+function ConvertMapData.team(args)
+	args = args or {}
+
+	local parsedArgs = Table.filterByKey(args, function(key)
+		return string.match(key, 'map') == nil
+	end)
+
+	local opponentPlayers = {{}, {}}
+	local mapIndex = 1
+	local prefix = 'm' .. mapIndex
+	while args[prefix .. 'p1'] or args[prefix .. 'p2'] or args[prefix .. 'map'] do
+		local parsedPrefix = 'map' .. mapIndex
+		parsedArgs[parsedPrefix] = args[prefix .. 'map'] or TBD
+		parsedArgs[parsedPrefix .. 'win'] = args[prefix .. 'win']
+
+		for opponentIndex = 1, NUMBER_OF_OPPONENTS do
+			local playerInputPrefix = prefix .. 'p' .. opponentIndex
+			local playerPrefix = parsedPrefix .. 't' .. opponentIndex .. 'p1'
+
+			local name = args[playerInputPrefix .. 'link'] or args[playerInputPrefix] or TBD
+			local player = {
+				name = name,
+				displayname = args[playerInputPrefix] or TBD,
+				flag = args[playerInputPrefix .. 'flag'],
+				race = args[playerInputPrefix .. 'race'],
+			}
+			opponentPlayers[opponentIndex][name] = player
+
+			parsedArgs[playerPrefix] = name
+			parsedArgs[playerPrefix .. 'race'] = player.race
+			parsedArgs[playerPrefix .. 'heroes'] = args[playerInputPrefix .. 'heroes']
+		end
+	end
+
+	Array.forEach(opponentPlayers, function(players, opponentIndex)
+		Array.forEach(Array.extractValues(players), function(player, playerIndex)
+			parsedArgs['opponent' .. opponentIndex .. '_p' .. playerIndex] = Json.stringify(player)
+		end)
+	end)
+
+	return Json.stringify(parsedArgs)
+end
+
+--structure formerly used by `Template:BracketTeamMatchMulti`
+---@param args table?
+---@return string
+function ConvertMapData.teamMulti(args)
+	args = args or {}
+
+	local parsedArgs = Table.filterByKey(args, function(key)
+		return string.match(key, 'map') == nil
+	end)
+mw.logObject(args)
+
+	--[[
+	{{#if:{{{m1p1|}}}{{{m1p2|}}}{{{m1map1|}}}|{{BracketTeamMatchMulti/row
+|p1={{{m1p1|}}}|p1flag={{{m1p1flag|}}}|p1race={{{m1p1race|}}}|p1link={{{m1p1link|}}}
+|p1-2={{{m1p1-2|}}}|p1-2flag={{{m1p1-2flag|}}}|p1-2race={{{m1p1-2race|}}}|p1-2link={{{m1p1-2link|}}}
+|p2={{{m1p2|}}}|p2flag={{{m1p2flag|}}}|p2race={{{m1p2race|}}}|p2link={{{m1p2link|}}}
+|p2-2={{{m1p2-2|}}}|p2-2flag={{{m1p2-2flag|}}}|p2-2race={{{m1p2-2race|}}}|p2-2link={{{m1p2-2link|}}}
+|p1score={{{m1p1score|0}}}|p2score={{{m1p2score|0}}}|winner={{{m1win|}}}
+|map1={{{m1map1|}}}|map2={{{m1map2|}}}|map3={{{m1map3|}}}|map4={{{m1map4|}}}|map5={{{m1map5|}}}|map6={{{m1map6|}}}|map7={{{m1map7|}}}
+|win1={{{m1win1}}}|win2={{{m1win2}}}|win3={{{m1win3}}}|win4={{{m1win4}}}|win5={{{m1win5}}}|win6={{{m1win6}}}|win7={{{m1win7}}}
+|map1p1heroes={{{m1map1p1heroes|}}}|map2p1heroes={{{m1map2p1heroes|}}}|map3p1heroes={{{m1map3p1heroes|}}}|map4p1heroes={{{m1map4p1heroes|}}}|map5p1heroes={{{m1map5p1heroes|}}}|map6p1heroes={{{m1map6p1heroes|}}}|map7p1heroes={{{m1map7p1heroes|}}}
+|map1p2heroes={{{m1map1p2heroes|}}}|map2p2heroes={{{m1map2p2heroes|}}}|map3p2heroes={{{m1map3p2heroes|}}}|map4p2heroes={{{m1map4p2heroes|}}}|map5p2heroes={{{m1map5p2heroes|}}}|map6p2heroes={{{m1map6p2heroes|}}}|map7p2heroes={{{m1map7p2heroes|}}}
+|map1p1race={{{m1map1p1race|}}}|map2p1race={{{m1map2p1race|}}}|map3p1race={{{m1map3p1race|}}}|map4p1race={{{m1map4p1race|}}}|map5p1race={{{m1map5p1race|}}}|map6p1race={{{m1map6p1race|}}}|map7p1race={{{m1map7p1race|}}}
+|map1p2race={{{m1map1p2race|}}}|map2p2race={{{m1map2p2race|}}}|map3p2race={{{m1map3p2race|}}}|map4p2race={{{m1map4p2race|}}}|map5p2race={{{m1map5p2race|}}}|map6p2race={{{m1map6p2race|}}}|map7p2race={{{m1map7p2race|}}}
+|matchNo=1
+}}}}
+	]]
+end
+
+return Class.export(ConvertMapData)

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -126,6 +126,7 @@ function ConvertMapData.teamMulti(args)
 			mapIndex = mapIndex + 1
 			local parsedPrefix = 'map' .. mapIndex
 			parsedArgs[parsedPrefix] = map
+			parsedArgs[parsedPrefix .. 'subgroup'] = submatchIndex
 			parsedArgs[parsedPrefix .. 'win'] = args[prefix .. 'win' .. submatchMapIndex]
 
 			Array.forEach(mapPlayers, function(players, opponentIndex)

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -122,35 +122,35 @@ function ConvertMapData.teamMulti(args)
 			table.insert(mapPlayers, opponentPlayers[opponentIndex][name2])
 		end
 
+		for mapPrefix, map, submatchMapIndex in Table.iter.pairsByPrefix(args, prefix .. 'map') do
+			mapIndex = mapIndex + 1
+			local parsedPrefix = 'map' .. mapIndex
+			parsedArgs[parsedPrefix] = map
+			parsedArgs[parsedPrefix .. 'win'] = args[prefix .. 'win' .. submatchMapIndex]
 
-
-
-
-
-
+			Array.forEach(mapPlayers, function(players, opponentIndex)
+				Array.forEach(players, function(player, playerIndex)
+					local playerPrefix = parsedPrefix .. 't' .. opponentIndex .. 'p' .. playerIndex
+					parsedArgs[playerPrefix] = player.name
+				end)
+				--only had race and heroes support for 1v1 submatches ...
+				local playerPrefix = parsedPrefix .. 't' .. opponentIndex .. 'p1'
+				parsedArgs[playerPrefix .. 'race'] = args[mapPrefix .. 'p' .. opponentIndex .. 'race']
+				parsedArgs[playerPrefix .. 'heroes'] = args[mapPrefix .. 'p' .. opponentIndex .. 'heroes']
+			end)
+		end
 
 		submatchIndex = submatchIndex + 1
 		prefix = 'm' .. submatchIndex
 	end
 
+	Array.forEach(opponentPlayers, function(players, opponentIndex)
+		Array.forEach(Array.extractValues(players), function(player, playerIndex)
+			parsedArgs['opponent' .. opponentIndex .. '_p' .. playerIndex] = Json.stringify(player)
+		end)
+	end)
 
-
-	--[[
-	{{#if:{{{m1p1|}}}{{{m1p2|}}}{{{m1map1|}}}|{{BracketTeamMatchMulti/row
-|p1={{{m1p1|}}}|p1flag={{{m1p1flag|}}}|p1race={{{m1p1race|}}}|p1link={{{m1p1link|}}}
-|p1-2={{{m1p1-2|}}}|p1-2flag={{{m1p1-2flag|}}}|p1-2race={{{m1p1-2race|}}}|p1-2link={{{m1p1-2link|}}}
-|p2={{{m1p2|}}}|p2flag={{{m1p2flag|}}}|p2race={{{m1p2race|}}}|p2link={{{m1p2link|}}}
-|p2-2={{{m1p2-2|}}}|p2-2flag={{{m1p2-2flag|}}}|p2-2race={{{m1p2-2race|}}}|p2-2link={{{m1p2-2link|}}}
-|p1score={{{m1p1score|0}}}|p2score={{{m1p2score|0}}}|winner={{{m1win|}}}
-|map1={{{m1map1|}}}|map2={{{m1map2|}}}|map3={{{m1map3|}}}|map4={{{m1map4|}}}|map5={{{m1map5|}}}|map6={{{m1map6|}}}|map7={{{m1map7|}}}
-|win1={{{m1win1}}}|win2={{{m1win2}}}|win3={{{m1win3}}}|win4={{{m1win4}}}|win5={{{m1win5}}}|win6={{{m1win6}}}|win7={{{m1win7}}}
-|map1p1heroes={{{m1map1p1heroes|}}}|map2p1heroes={{{m1map2p1heroes|}}}|map3p1heroes={{{m1map3p1heroes|}}}|map4p1heroes={{{m1map4p1heroes|}}}|map5p1heroes={{{m1map5p1heroes|}}}|map6p1heroes={{{m1map6p1heroes|}}}|map7p1heroes={{{m1map7p1heroes|}}}
-|map1p2heroes={{{m1map1p2heroes|}}}|map2p2heroes={{{m1map2p2heroes|}}}|map3p2heroes={{{m1map3p2heroes|}}}|map4p2heroes={{{m1map4p2heroes|}}}|map5p2heroes={{{m1map5p2heroes|}}}|map6p2heroes={{{m1map6p2heroes|}}}|map7p2heroes={{{m1map7p2heroes|}}}
-|map1p1race={{{m1map1p1race|}}}|map2p1race={{{m1map2p1race|}}}|map3p1race={{{m1map3p1race|}}}|map4p1race={{{m1map4p1race|}}}|map5p1race={{{m1map5p1race|}}}|map6p1race={{{m1map6p1race|}}}|map7p1race={{{m1map7p1race|}}}
-|map1p2race={{{m1map1p2race|}}}|map2p2race={{{m1map2p2race|}}}|map3p2race={{{m1map3p2race|}}}|map4p2race={{{m1map4p2race|}}}|map5p2race={{{m1map5p2race|}}}|map6p2race={{{m1map6p2race|}}}|map7p2race={{{m1map7p2race|}}}
-|matchNo=1
-}}}}
-	]]
+	return Json.stringify(parsedArgs)
 end
 
 return Class.export(ConvertMapData)

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -106,7 +106,7 @@ function ConvertMapData.teamMulti(args)
 				flag = args[playerInputPrefix .. 'flag'],
 				race = args[playerInputPrefix .. 'race'],
 			}
-			table.insert(mapPlayers[opponentIndex], opponentPlayers[opponentIndex][name])
+			table.insert(mapPlayers[opponentIndex], Table.copy(opponentPlayers[opponentIndex][name] or {}))
 
 			--optional second player
 			local player2InputPrefix = prefix .. 'p' .. opponentIndex .. '-2'
@@ -119,7 +119,7 @@ function ConvertMapData.teamMulti(args)
 					race = args[player2InputPrefix .. 'race'],
 				}
 			end
-			table.insert(mapPlayers[opponentIndex], opponentPlayers[opponentIndex][name2])
+			table.insert(mapPlayers[opponentIndex], Table.copy(opponentPlayers[opponentIndex][name2] or {}))
 		end
 
 		for mapPrefix, map, submatchMapIndex in Table.iter.pairsByPrefix(args, prefix .. 'map') do
@@ -136,7 +136,7 @@ function ConvertMapData.teamMulti(args)
 				end)
 				--only had race and heroes support for 1v1 submatches ...
 				local playerPrefix = parsedPrefix .. 't' .. opponentIndex .. 'p1'
-				parsedArgs[playerPrefix .. 'race'] = args[mapPrefix .. 'p' .. opponentIndex .. 'race']
+				parsedArgs[playerPrefix .. 'race'] = args[mapPrefix .. 'p' .. opponentIndex .. 'race'] or players[1].race
 				parsedArgs[playerPrefix .. 'heroes'] = args[mapPrefix .. 'p' .. opponentIndex .. 'heroes']
 			end)
 		end

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -106,7 +106,7 @@ function ConvertMapData.teamMulti(args)
 				flag = args[playerInputPrefix .. 'flag'],
 				race = args[playerInputPrefix .. 'race'],
 			}
-			table.insert(mapPlayers, opponentPlayers[opponentIndex][name])
+			table.insert(mapPlayers[opponentIndex], opponentPlayers[opponentIndex][name])
 
 			--optional second player
 			local player2InputPrefix = prefix .. 'p' .. opponentIndex .. '-2'
@@ -119,7 +119,7 @@ function ConvertMapData.teamMulti(args)
 					race = args[player2InputPrefix .. 'race'],
 				}
 			end
-			table.insert(mapPlayers, opponentPlayers[opponentIndex][name2])
+			table.insert(mapPlayers[opponentIndex], opponentPlayers[opponentIndex][name2])
 		end
 
 		for mapPrefix, map, submatchMapIndex in Table.iter.pairsByPrefix(args, prefix .. 'map') do

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
@@ -1,0 +1,207 @@
+---
+-- @Liquipedia
+-- wiki=warcraft
+-- page=Module:MatchGroup/Legacy/Default
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local MatchGroupLegacyDefault = {}
+
+local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+
+local MAX_NUM_MAPS = 20
+local MAX_NUM_PLAYERS_IN_TEAM_SUBMATCH = 4 --at least for old matches
+local MAX_NUM_OPPONENTS = 2
+
+local _roundData
+
+function MatchGroupLegacyDefault.get(templateid, bracketType)
+	local LowerHeader = {}
+	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateid)
+
+	assert(type(matches) == 'table')
+	local bracketData = {}
+	_roundData = _roundData or {}
+	local lastround = 0
+	for _, match in ipairs(matches) do
+		bracketData, lastround, LowerHeader =
+			MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+	end
+
+	-- add reference for map mappings
+	bracketData['$$map'] = {
+		['$notEmpty$'] = 'map$1$',
+		map = 'map$1$',
+		winner = 'map$1$win',
+		race1 = 'map$1$p1race',
+		race2 = 'map$1$p2race',
+		heroes1 = 'map$1$p1heroes',
+		heroes2 = 'map$1$p2heroes',
+		vod = 'vodgame$1$',
+		subgroup = 'map$1$subgroup',
+	}
+
+	if bracketType == 'team' then
+		for playerIndex = 1, MAX_NUM_PLAYERS_IN_TEAM_SUBMATCH do
+			--names
+			bracketData['$$map']['t1p' .. playerIndex] = 'map$1$t1p' .. playerIndex
+			bracketData['$$map']['t2p' .. playerIndex] = 'map$1$t2p' .. playerIndex
+			--races
+			bracketData['$$map']['t1p' .. playerIndex .. 'race'] = 'map$1$t1p' .. playerIndex .. 'race'
+			bracketData['$$map']['t2p' .. playerIndex .. 'race'] = 'map$1$t2p' .. playerIndex .. 'race'
+			--heroes
+			bracketData['$$map']['t1p' .. playerIndex .. 'heroes'] = 'map$1$t1p' .. playerIndex .. 'heroes'
+			bracketData['$$map']['t2p' .. playerIndex .. 'heroes'] = 'map$1$t2p' .. playerIndex .. 'heroes'
+		end
+	end
+
+	for n=1,lastround do
+		bracketData['R' .. n .. 'M1header'] = 'R' .. n
+		if LowerHeader[n] then
+			bracketData['R' .. n .. 'M' .. LowerHeader[n] .. 'header'] = 'L' .. n
+		end
+	end
+
+	return bracketData
+end
+
+local lastRound
+function MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType, LowerHeader)
+	local id = String.split(match.match2id, '_')[2] or match.match2id
+	id = id:gsub('0*([1-9])', '%1'):gsub('%-', '')
+	local bd = match.match2bracketdata
+
+	local roundNum
+	local round
+	local reset = false
+	if id == 'RxMTP' then
+		round = lastRound
+	elseif id == 'RxMBR' then
+		round = lastRound
+		round.G = round.G - 2
+		round.W = round.W - 2
+		round.D = round.D - 2
+		reset = true
+	else
+		roundNum = id:match('R%d*'):gsub('R', '')
+		roundNum = tonumber(roundNum)
+		round = _roundData[roundNum] or { R = roundNum, G = 0, D = 1, W = 1 }
+	end
+	round.G = round.G + 1
+
+	if string.match(bd.header or '', '^!l') then
+		LowerHeader[roundNum or ''] = round.G
+	end
+
+	local readOpponent = function(prefix)
+		return {
+			['type'] = 'type',
+			prefix,
+			template = prefix .. 'team',
+			p1flag = prefix .. 'flag',
+			p1race = prefix .. 'race',
+			p1link = prefix .. 'link',
+			score = prefix .. 'score',
+			win = prefix .. 'win',
+			['$notEmpty$'] = bracketType == 'team' and (prefix .. 'team') or prefix,
+		}
+	end
+
+	local opponents = {}
+	local finished = {}
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		local prefix
+		if not reset and
+			(Logic.isEmpty(bd.toupper) and opponentIndex == 1 or
+			Logic.isEmpty(bd.tolower) and opponentIndex == 2) then
+
+			prefix = 'R' .. round.R .. 'D' .. round.D
+			round.D = round.D + 1
+		else
+			prefix = 'R' .. round.R .. 'W' .. round.W
+			round.D = round.D + 1
+		end
+
+		opponents[opponentIndex] = readOpponent(prefix)
+		finished[opponentIndex] = prefix .. 'win'
+	end
+
+	match = {
+		opponent1 = opponents[1],
+		opponent2 = opponents[2],
+		finished = finished[1] .. '|' .. finished[2],
+		-- reference to variables that shall be flattened
+		['$flatten$'] = { 'R' .. round.R .. 'G' .. round.G .. 'details' }
+	}
+
+	bracketData[id] = MatchGroupLegacyDefault.addMaps(match)
+	lastRound = round
+	_roundData[round.R] = round
+
+	return bracketData, round.R, LowerHeader
+end
+
+--[[
+custom mappings are used to overwrite the default mappings
+in the cases where the default mappings do not fit the
+parameter format of the old bracket
+]]--
+
+--this can be used for custom mappings too
+function MatchGroupLegacyDefault.addMaps(match)
+	for mapIndex = 1, MAX_NUM_MAPS do
+		match['map' .. mapIndex] = {
+			['$ref$'] = 'map',
+			['$1$'] = mapIndex
+		}
+	end
+	return match
+end
+
+--this is for custom mappings
+---@param data {opp1: string, opp2: string, details: string}
+---@param bracketType string
+---@return table
+function MatchGroupLegacyDefault.matchMappingFromCustom(data, bracketType)
+	--data has the form {opp1, opp2, details}
+
+	local readOpponent = function(prefix)
+		return {
+			['type'] = 'type',
+			['$notEmpty$'] = bracketType == 'team' and (prefix .. 'team') or prefix,
+			prefix,
+			template = prefix .. 'team',
+			p1flag = prefix .. 'flag',
+			p1race = prefix .. 'race',
+			p1link = prefix .. 'link',
+			score = prefix .. 'score',
+			win = prefix .. 'win',
+		}
+	end
+
+	local mapping = {
+		['$flatten$'] = {data.details .. 'details'},
+		['finished'] = data.opp1 .. 'win|' .. data.opp2 .. 'win',
+		opponent1 = readOpponent(data.opp1),
+		opponent2 = readOpponent(data.opp2),
+	}
+	mapping = MatchGroupLegacyDefault.addMaps(mapping)
+
+	return mapping
+end
+
+--this is for custom mappings for Reset finals matches
+--it switches score2 into the place of score
+--and sets flatten to nil
+function MatchGroupLegacyDefault.matchResetMappingFromCustom(mapping)
+	local mappingReset = mw.clone(mapping)
+	mappingReset.opponent1.score = mapping.opponent1.score .. '2'
+	mappingReset.opponent2.score = mapping.opponent2.score .. '2'
+	mappingReset['$flatten$'] = nil
+	return mappingReset
+end
+
+return MatchGroupLegacyDefault

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
@@ -8,7 +8,6 @@
 
 local MatchGroupLegacyDefault = {}
 
-local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -672,9 +672,7 @@ function CustomMatchGroupInput._processTeamPlayerMapData(players, map, opponentI
 	local playerData = {}
 
 	local numberOfPlayers = 0
---mw.logObject(map, 'map')
 	for prefix, playerInput, playerIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
---mw.logObject(playerInput, prefix)
 		numberOfPlayers = numberOfPlayers + 1
 		if playerInput:lower() == TBD then
 			amountOfTbds = amountOfTbds + 1

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -343,7 +343,7 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 	local players = {}
 
 	for playerIndex = 1, MAX_NUM_PLAYERS do
-		local player = Json.parseIfString(match['opponent' .. opponentIndex .. '_p' .. playerIndex]) or {}
+		local player = Json.parseIfString(Table.extract(match, 'opponent' .. opponentIndex .. '_p' .. playerIndex)) or {}
 
 		player.name = Logic.emptyOr(player.name, playersData['p' .. playerIndex],
 			Variables.varDefault(teamName .. '_p' .. playerIndex))
@@ -672,7 +672,9 @@ function CustomMatchGroupInput._processTeamPlayerMapData(players, map, opponentI
 	local playerData = {}
 
 	local numberOfPlayers = 0
+--mw.logObject(map, 'map')
 	for prefix, playerInput, playerIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'p') do
+--mw.logObject(playerInput, prefix)
 		numberOfPlayers = numberOfPlayers + 1
 		if playerInput:lower() == TBD then
 			amountOfTbds = amountOfTbds + 1


### PR DESCRIPTION
## Summary
Add warcraft match1 to macth2 legacy wrapper for brackets.
Due to warcraft having several different MatchSummary templates with different input structure for map data also need something to catch that.
As of now does NOT support 2v2 legacy matches.

## How did you test this change?
new modules "live", the `Module:MatchGroup/Input/Custom` via dev
https://liquipedia.net/warcraft/User:Hjpalpha/Legacy