### PR TITLE
Add Spotify and Apple Podcasts links & icons

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -23,6 +23,7 @@ local PREFIXES = {
 	},
 	abiosgaming = {'https://abiosgaming.com/tournaments/'},
 	apexlegendsstatus = {'https://apexlegendsstatus.com/profile/uid/PC/'},
+	['apple-podcasts'] = {'https://podcasts.apple.com/'},
 	afreeca = {
 		'http://afreecatv.com/',
 		stream = 'https://play.afreecatv.com/',
@@ -152,6 +153,7 @@ local PREFIXES = {
 	strikr = {'https://strikr.gg/pilot/'},
 	privsteam = {'https://steamcommunity.com/groups/'},
 	pubsteam = {'https://steamcommunity.com/groups/'},
+	spotify = {'https://open.spotify.com/'},
 	steamalternative = {'https://steamcommunity.com/profiles/'},
 	stratz = {
 		'https://stratz.com/leagues/',


### PR DESCRIPTION
## Summary
Files : 
https://liquipedia.net/commons/File:InfoboxIcon_Apple_Podcasts.png
https://liquipedia.net/commons/File:InfoboxIcon_Spotify.png 

This is mainly for the F1 wiki as there's a portal to cover podcasts, however we're missing icons for Spotify and Apple Podcasts.

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/5d21ab21-a98d-463e-8924-b6a2cf2db06f)

