### PR TITLE
Allow teamStyle option for default MS headers

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -532,11 +532,10 @@ end
 
 ---Default header function
 ---@param match table
----@param options {noScore: boolean?}?
+---@param options {teamStyle: boolean?, width: string?, noScore:boolean?}?
 ---@return MatchSummaryHeader
 function MatchSummary.createDefaultHeader(match, options)
 	options = options or {}
-
 	local header = MatchSummary.Header()
 
 	if options.noScore then
@@ -578,8 +577,9 @@ end
 ---Default createMatch function for usage in Custom MatchSummary
 ---@param matchData table?
 ---@param CustomMatchSummary table
+---@param options {teamStyle: boolean?, width: string?, noScore: boolean?}?
 ---@return MatchSummaryMatch?
-function MatchSummary.createMatch(matchData, CustomMatchSummary)
+function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 	if not matchData then
 		return
 	end
@@ -587,7 +587,7 @@ function MatchSummary.createMatch(matchData, CustomMatchSummary)
 	local match = Match()
 
 	local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
-	match:header(createHeader(matchData))
+	match:header(createHeader(matchData, options))
 
 	match:body(CustomMatchSummary.createBody(matchData))
 
@@ -604,7 +604,7 @@ end
 ---Default getByMatchId function for usage in Custom MatchSummary
 ---@param CustomMatchSummary table
 ---@param args table
----@param options table?
+---@param options {teamStyle: boolean?, width: string?, noScore:boolean?}?
 ---@return Html
 function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 	assert(type(CustomMatchSummary.createBody) == 'function', 'Function "createBody" missing in "Module:MatchSummary"')
@@ -619,12 +619,12 @@ function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 	--additional header for when martin adds the the css and buttons for switching between match and reset match
 	--if bracketResetMatch then
 		--local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
-		--matchSummary:header(createHeader(match, {noScore = true}))
+		--matchSummary:header(createHeader(match, {noScore = true, teamStyle = options.teamStyle}))
 		--here martin can add the buttons for switching between match and reset match
 	--end
 
 	local createMatch = CustomMatchSummary.createMatch or function(matchData)
-		return MatchSummary.createMatch(matchData, CustomMatchSummary)
+		return MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 	end
 	matchSummary:addMatch(createMatch(match))
 	matchSummary:addMatch(createMatch(bracketResetMatch))

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -532,7 +532,7 @@ end
 
 ---Default header function
 ---@param match table
----@param options {teamStyle: boolean?, width: string?, noScore:boolean?}?
+---@param options {teamStyle: string?, width: string?, noScore:boolean?}?
 ---@return MatchSummaryHeader
 function MatchSummary.createDefaultHeader(match, options)
 	options = options or {}
@@ -577,7 +577,7 @@ end
 ---Default createMatch function for usage in Custom MatchSummary
 ---@param matchData table?
 ---@param CustomMatchSummary table
----@param options {teamStyle: boolean?, width: string?, noScore: boolean?}?
+---@param options {teamStyle: string?, width: string?, noScore: boolean?}?
 ---@return MatchSummaryMatch?
 function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 	if not matchData then
@@ -604,7 +604,7 @@ end
 ---Default getByMatchId function for usage in Custom MatchSummary
 ---@param CustomMatchSummary table
 ---@param args table
----@param options {teamStyle: boolean?, width: string?, noScore:boolean?}?
+---@param options {teamStyle: string?, width: string?, noScore:boolean?}?
 ---@return Html
 function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 	assert(type(CustomMatchSummary.createBody) == 'function', 'Function "createBody" missing in "Module:MatchSummary"')

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -532,23 +532,24 @@ end
 
 ---Default header function
 ---@param match table
----@param options {teamStyle: string?, width: string?, noScore:boolean?}?
+---@param options {teamStyle: teamStyle?, width: string?, noScore:boolean?}?
 ---@return MatchSummaryHeader
 function MatchSummary.createDefaultHeader(match, options)
 	options = options or {}
+	local teamStyle = options.teamStyle
 	local header = MatchSummary.Header()
 
 	if options.noScore then
 		return header
-			:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
-			:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+			:leftOpponent(header:createOpponent(match.opponents[1], 'left', teamStyle))
+			:rightOpponent(header:createOpponent(match.opponents[2], 'right', teamStyle))
 	end
 
 	return header
-		:leftOpponent(header:createOpponent(match.opponents[1], 'left'))
+		:leftOpponent(header:createOpponent(match.opponents[1], 'left', teamStyle))
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
-		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
+		:rightOpponent(header:createOpponent(match.opponents[2], 'right', teamStyle))
 end
 
 ---Creates a match footer with vods if vods are set
@@ -577,7 +578,7 @@ end
 ---Default createMatch function for usage in Custom MatchSummary
 ---@param matchData table?
 ---@param CustomMatchSummary table
----@param options {teamStyle: string?, width: string?, noScore: boolean?}?
+---@param options {teamStyle: teamStyle?, width: string?, noScore: boolean?}?
 ---@return MatchSummaryMatch?
 function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 	if not matchData then
@@ -604,7 +605,7 @@ end
 ---Default getByMatchId function for usage in Custom MatchSummary
 ---@param CustomMatchSummary table
 ---@param args table
----@param options {teamStyle: string?, width: string?, noScore:boolean?}?
+---@param options {teamStyle: teamStyle?, width: string?, noScore:boolean?}?
 ---@return Html
 function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 	assert(type(CustomMatchSummary.createBody) == 'function', 'Function "createBody" missing in "Module:MatchSummary"')

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -92,7 +92,7 @@ function StarcraftMatchSummary.MatchSummaryContainer(args)
 	--additional header for when martin adds the the css and buttons for switching between match and reset match
 	--if bracketResetMatch then
 		--local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
-		--matchSummary:header(createHeader(match, {noScore = true}))
+		--matchSummary:header(createHeader(match, {noScore = true, teamStyle = options.teamStyle}))
 		--here martin can add the buttons for switching between match and reset match
 	--end
 

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -81,7 +81,7 @@ end
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -103,7 +103,7 @@ end
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -81,7 +81,7 @@ end
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -82,7 +82,7 @@ end
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -82,7 +82,7 @@ end
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -178,8 +178,9 @@ function CustomMatchSummary.getByMatchId(args)
 end
 
 ---@param match MatchGroupUtilMatch
+---@param options {teamStyle: boolean?, width: string?}?
 ---@return RocketleagueMatchSummaryHeader
-function CustomMatchSummary.createHeader(match)
+function CustomMatchSummary.createHeader(match, options)
 	local header = Header()
 
 	return header

--- a/components/match2/wikis/sideswipe/match_summary.lua
+++ b/components/match2/wikis/sideswipe/match_summary.lua
@@ -146,8 +146,9 @@ function CustomMatchSummary.getByMatchId(args)
 end
 
 ---@param match MatchGroupUtilMatch
+---@param options {teamStyle: boolean?, width: string?}?
 ---@return SideswipeMatchSummaryHeader
-function CustomMatchSummary.createHeader(match)
+function CustomMatchSummary.createHeader(match, options)
 	local header = Header()
 
 	return header

--- a/components/match2/wikis/splatoon/match_summary.lua
+++ b/components/match2/wikis/splatoon/match_summary.lua
@@ -165,7 +165,7 @@ end
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '490px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '490px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -127,8 +127,9 @@ function CustomMatchSummary.getByMatchId(args)
 end
 
 ---@param match MatchGroupUtilMatch
+---@param options {teamStyle: boolean?, width: string?}?
 ---@return TrackmaniaMatchSummaryHeader
-function CustomMatchSummary.createHeader(match)
+function CustomMatchSummary.createHeader(match, options)
 	local header = Header()
 
 	return header

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -290,7 +290,7 @@ local CustomMatchSummary = {}
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '480px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '480px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/warcraft/match_summary.lua
+++ b/components/match2/wikis/warcraft/match_summary.lua
@@ -95,7 +95,7 @@ function CustomMatchSummary.getByMatchId(args)
 	--additional header for when martin adds the the css and buttons for switching between match and reset match
 	--if bracketResetMatch then
 		--local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
-		--matchSummary:header(createHeader(match, {noScore = true}))
+		--matchSummary:header(createHeader(match, {noScore = true, teamStyle = options.teamStyle}))
 		--here martin can add the buttons for switching between match and reset match
 	--end
 


### PR DESCRIPTION
## Summary
Allow teamStyle option for default MS headers
- also adjust wikis according to what they used before the MS rework.

## How did you test this change?
dev