### PR TITLE
Fix typos in warcraft `MatchGroup/Legacy/Default`

### DIFF
--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
@@ -121,7 +121,7 @@ function MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType
 			round.D = round.D + 1
 		else
 			prefix = 'R' .. round.R .. 'W' .. round.W
-			round.D = round.D + 1
+			round.W = round.W + 1
 		end
 
 		opponents[opponentIndex] = readOpponent(prefix)

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
@@ -103,7 +103,7 @@ function MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType
 			p1flag = prefix .. 'flag',
 			p1race = prefix .. 'race',
 			p1link = prefix .. 'link',
-			score = prefix .. 'score',
+			score = prefix .. 'score' .. (reset and '2' or ''),
 			win = prefix .. 'win',
 			['$notEmpty$'] = bracketType == 'team' and (prefix .. 'team') or prefix,
 		}


### PR DESCRIPTION
## Summary
Fix typos in warcraft `MatchGroup/Legacy/Default`

## How did you test this change?
live (not in use yet except on test page)