### PR TITLE
Updating deprecated unpack method

### DIFF
--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -97,7 +97,7 @@ function Building:createInfobox()
 	}
 
 	infobox:categories('Buildings')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:categories(table.unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_campaign_mission.lua
+++ b/components/infobox/commons/infobox_campaign_mission.lua
@@ -58,7 +58,7 @@ function Mission:createInfobox()
 
 	if Namespace.isMain() then
 		infobox:categories('Missions', 'Campaign')
-		infobox:categories(unpack(self:getWikiCategories(args)))
+		infobox:categories(table.unpack(self:getWikiCategories(args)))
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -94,7 +94,7 @@ function Character:createInfobox()
 
 	if Namespace.isMain() then
 		infobox:categories(args.informationType or 'Character')
-		infobox:categories(unpack(self:getWikiCategories(args)))
+		infobox:categories(table.unpack(self:getWikiCategories(args)))
 		self:setLpdbData(args)
 	end
 

--- a/components/infobox/commons/infobox_item.lua
+++ b/components/infobox/commons/infobox_item.lua
@@ -101,7 +101,7 @@ function Item:createInfobox()
 	}
 
 	infobox:categories('Items')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:categories(table.unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -257,7 +257,7 @@ function League:createInfobox()
 	local builtInfobox = self.infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 
 	if self:shouldStore(args) then
-		self.infobox:categories(unpack(self:_getCategories(args)))
+		self.infobox:categories(table.unpack(self:_getCategories(args)))
 		self:_setLpdbData(args, links)
 		self:_setSeoTags(args)
 	end

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -56,7 +56,7 @@ function Map:createInfobox()
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Maps', unpack(self:getWikiCategories(args)))
+		infobox:categories('Maps', table.unpack(self:getWikiCategories(args)))
 		self:_setLpdbData(args)
 	end
 

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -206,7 +206,7 @@ function Person:createInfobox()
 	infobox:bottom(self:createBottomContent())
 
 	local statusToStore = self:getStatusToStore(args)
-	infobox:categories(unpack(self:getCategories(
+	infobox:categories(table.unpack(self:getCategories(
 				args,
 				age.birth,
 				personType.category,

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -166,7 +166,7 @@ function Series:createInfobox()
 	}
 
 	if self:shouldStore(args) then
-		infobox:categories(unpack(self:_getCategories(args)))
+		infobox:categories(table.unpack(self:_getCategories(args)))
 	end
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_skill.lua
+++ b/components/infobox/commons/infobox_skill.lua
@@ -94,7 +94,7 @@ function Skill:createInfobox()
 
 	if Namespace.isMain() then
 		local categories = self:getCategories(args)
-		infobox:categories(unpack(categories))
+		infobox:categories(table.unpack(categories))
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -201,7 +201,7 @@ function Team:createInfobox()
 	-- Categories
 	if self:shouldStore(args) then
 		infobox:categories('Teams')
-		infobox:categories(unpack(self:getWikiCategories(args)))
+		infobox:categories(table.unpack(self:getWikiCategories(args)))
 	end
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_tool.lua
+++ b/components/infobox/commons/infobox_tool.lua
@@ -55,7 +55,7 @@ function Tool:createInfobox()
 	}
 
 	if Namespace.isMain() then
-		infobox:categories('Tools', unpack(self:getWikiCategories(args)))
+		infobox:categories('Tools', table.unpack(self:getWikiCategories(args)))
 	end
 
 	return infobox:widgetInjector(self:createWidgetInjector()):build(widgets)

--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -102,7 +102,7 @@ function Unit:createInfobox()
 	}
 
 	infobox:categories('Units')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:categories(table.unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -107,7 +107,7 @@ function Weapon:createInfobox()
 	}
 
 	infobox:categories('Weapons')
-	infobox:categories(unpack(self:getWikiCategories(args)))
+	infobox:categories(table.unpack(self:getWikiCategories(args)))
 
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_widget_cell.lua
+++ b/components/infobox/commons/infobox_widget_cell.lua
@@ -90,8 +90,8 @@ end
 ---@return {[1]: Html?}
 function Cell:make()
 	self:_new(self.name)
-	self:_class(unpack(self.classes or {}))
-	self:_content(unpack(self.content))
+	self:_class(table.unpack(self.classes or {}))
+	self:_content(table.unpack(self.content))
 
 	if self.contentDiv == nil then
 		return {}


### PR DESCRIPTION
## Summary
Updates the currently deprecated ``unpack`` method with ``table.unpack``. This doesnt change any major code elements but instead just updates the infoboxes to remove a deprecated line as tracked in #3431 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
This is currently untested, however ``table.unpack`` does the exact same thing (from what i can tell) as unpack did according to the [reference manual](https://www.lua.org/manual/5.4/manual.html#6.4.2:~:text=table.unpack%20(list%20%5B%2C%20i%20%5B%2C%20j%5D%5D)). 
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
