### PR TITLE
Parameter update for `|score1=|score2=`

### DIFF
--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -53,7 +53,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	end
 	for i = 1, bestof do
 		out = out .. '\n\t|map' .. i .. '={{Map|map='
-		if not mapDetails then
+		if showScore then
 			out = out .. '|score1=|score2='
 		end
 		out = out .. '|finished='


### PR DESCRIPTION
## Summary

Change parameter to showScore for each map once enabled instead of only when mapDetails are turned off

When the parameter "showScore" has been set to true in the BracketGen then it will show "|score1= |score2=" in the map section every time, instead of only showing that part when mapDetails has been turned off. 

(Saves me to do a few find+replace moves for tournaments where only mapScores are known)

## How did you test this change?

Did a live update on the module and tested it with any bracket (bracketID: 2 for example) and it shows the wanted result.

Module: https://liquipedia.net/rainbowsix/Module:GetMatchGroupCopyPaste/wiki
Bracket Gen: [Example Bracket](https://liquipedia.net/rainbowsix/Special:RunQuery/BracketCopyPaste?title=Special%3ARunQuery%2FBracketCopyPaste&pfRunQueryFormName=BracketCopyPaste&GetBracketCopyPaste=id%3D2%26empty%3Dfalse%26mode%3DTeam%26bestof%3D2%26mapPool%3D9%26streams%3Dfalse%26score%3Dtrue%26mapVeto%3Dfalse%26detailedMap%3Dtrue%26detailedMapOT%3Dfalse%26customHeader%3Dfalse%26extra%3Dfalse%26tooltip%3Dfalse&wpRunQuery=&pf_free_text=&GetBracketCopyPaste%5Bid%5D=2&GetBracketCopyPaste%5Bempty%5D=false&GetBracketCopyPaste%5Bmode%5D=Team&GetBracketCopyPaste%5Bbestof%5D=2&GetBracketCopyPaste%5BmapPool%5D=9&GetBracketCopyPaste%5Bstreams%5D=false&GetBracketCopyPaste%5Bscore%5D=true&GetBracketCopyPaste%5BmapVeto%5D=false&GetBracketCopyPaste%5BdetailedMap%5D=true&GetBracketCopyPaste%5BdetailedMapOT%5D=false&GetBracketCopyPaste%5BcustomHeader%5D=false&GetBracketCopyPaste%5Bextra%5D=false&GetBracketCopyPaste%5Btooltip%5D=false&wpRunQuery=&pf_free_text=)

![image](https://github.com/Liquipedia/Lua-Modules/assets/36400524/6797f3ee-79e3-4829-95fe-229b0d67422d)

