### PR TITLE
Add PlayerTeamAuto to AOV Infobox player

### DIFF
--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -37,7 +37,7 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_player = player
 	_args = player.args
-	
+
 	if String.isEmpty(player.args.team) then
 		player.args.team = PlayerTeamAuto._main{team = 'team'}
 	end

--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -12,7 +12,9 @@ local HeroIcon = require('Module:HeroIcon')
 local HeroNames = mw.loadData('Module:HeroNames')
 local Lua = require('Module:Lua')
 local Role = require('Module:Role')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
@@ -35,6 +37,14 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_player = player
 	_args = player.args
+	
+	if String.isEmpty(player.args.team) then
+		player.args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+
+	if String.isEmpty(player.args.team2) then
+		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
+	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector


### PR DESCRIPTION
## Summary
Add the PlayerTeamAuto feature to Arena of Valor wiki, which apparently were left unadded compared to other games in the similar branches 

Tested on https://liquipedia.net/arenaofvalor/FirstOne with |dev=1 

## Side Note 
dont mind the first revision name, I thought of putting both on same PR but I had issues with the PUBG one so this is for just AoV 