### PR TITLE
Don't fail deploys catastrophically

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -119,6 +119,7 @@ for luaFile in $luaFiles; do
     if [[ "${result}" == "Success" ]]; then
       echo "...${result}"
     else
+      echo "...failed to deploy"
       allModulesDeployed=false
     fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -127,7 +127,8 @@ for luaFile in $luaFiles; do
     sleep 4
   fi
 
-  if [[ ! $allModulesDeployed ]]; then
+  if [ "$allModulesDeployed" != true ]; then
+    echo "DEBUG: Some modules were not deployed!"
     exit 1
   fi
 done

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -118,12 +118,12 @@ for luaFile in $luaFiles; do
     echo "DEBUG: ...${rawResult}"
     if [[ "${result}" == "Success" ]]; then
       echo "...${result}"
+      echo '...done'
     else
       echo "...failed to deploy"
       allModulesDeployed=false
     fi
 
-    echo '...done'
     # Don't get rate limited
     sleep 4
   fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,8 +20,8 @@ else
   gitDeployReason='Automated Weekly Re-Sync'
 fi
 
-for luaFile in $luaFiles
-do
+allModulesDeployed=true
+for luaFile in $luaFiles; do
   if [[ -n "$1" ]]; then
     luaFile="./$luaFile"
   fi
@@ -30,8 +30,7 @@ do
 
   [[ $fileContents =~ $pat ]]
 
-  if [[ "${BASH_REMATCH[1]}" == "" ]]
-  then
+  if [[ "${BASH_REMATCH[1]}" == "" ]]; then
     echo '...skipping - no magic comment found'
   else
     wiki="${BASH_REMATCH[1]}"
@@ -49,8 +48,7 @@ do
     wikiApiUrl="${WIKI_BASE_URL}/${wiki}/api.php"
     ckf="cookie_${wiki}.ck"
 
-    if [[ ${loggedin[${wiki}]} != 1 ]]
-    then
+    if [[ ${loggedin[${wiki}]} != 1 ]]; then
       # Login
       echo "...logging in on \"${wiki}\""
       loginToken=$(
@@ -121,12 +119,16 @@ do
     if [[ "${result}" == "Success" ]]; then
       echo "...${result}"
     else
-      exit 1
+      allModulesDeployed=false
     fi
 
     echo '...done'
     # Don't get rate limited
     sleep 4
+  fi
+
+  if [[ ! $allModulesDeployed ]]; then
+    exit 1
   fi
 done
 


### PR DESCRIPTION
## Summary

Currently if a deploy fails due to some error (protected page or whatever else), it will halt there and not continue with any other modules. This change logs that something failed but lets the deployment attempt to continue. At the end, if something failed, it will then error the script, rather than mid-way through.

Also cleaned up the if/for code styling.

## How did you test this change?

Tested on my fork of the repo using dev wiki.
