### PR TITLE
Added "specialRoles = true" for TeamHistoryAuto

### DIFF
--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -75,7 +75,7 @@ function CustomPlayer.run(frame)
 		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
 	end
 
-	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
+	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', specialRoles = 'true'}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent


### PR DESCRIPTION
## Summary

Adding specialRoles function to TeamHistoryAuto so it will show roles like "Retired" and "Banned" in th infobox of players.
A poll was held and people wanted to see this change

![image](https://github.com/Liquipedia/Lua-Modules/assets/36400524/b7263b82-a9ca-445e-9921-8831d83385ce)


## How did you test this change?

Dev module: https://liquipedia.net/rainbowsix/Module:Infobox/Person/Player/Custom/dev
Live page using |dev=1 (I will remove dev once merged): https://liquipedia.net/rainbowsix/AceeZ

Addtional test page: https://liquipedia.net/rainbowsix/User:Okidokie98/Test2

![image](https://github.com/Liquipedia/Lua-Modules/assets/36400524/a79fe971-c84f-4afd-8639-1ebeaf429081)
![image](https://github.com/Liquipedia/Lua-Modules/assets/36400524/a8747fe1-ca49-4dfe-b37a-cee9aa4062fa)


