### PR TITLE
Add support for an edge case in warcraft match2 submatches

### DIFF
--- a/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
+++ b/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
@@ -110,28 +110,29 @@ end
 
 ---@param args table
 function LegacyMatchMaps._readMaps(args)
+	local toNewKey = function(prefix, key)
+		local index, newKeyPrefix = string.match(key, '^' .. prefix .. 'p(%d)(%l+)$')
+		if index and newKeyPrefix then
+			return newKeyPrefix .. index
+		end
+		return string.gsub(key, '^' .. prefix, '')
+	end
+
 	for mapIndex = 1, MAX_NUM_MAPS do
 		local prefix = 'map' .. mapIndex
 		local map = Table.filterByKey(args, function(key) return String.startsWith(key, prefix) end)
 		map = Table.map(map, function(key, value)
 			args[key] = nil
+
 			if key == prefix then
 				return 'map', value
 			end
+
 			if key == prefix .. 'win' then
 				return 'winner', value
 			end
-			local heroesOpponentIndex = string.match(key, '^' .. prefix .. 'p(%d)heroes$')
-			if heroesOpponentIndex then
-				return 'heroes' .. heroesOpponentIndex, value
-			end
-			local raceOpponentIndex = string.match(key, '^' .. prefix .. 'p(%d)race$')
-			if raceOpponentIndex then
-				return 'race' .. raceOpponentIndex, value
-			end
 
-			local newKey = string.gsub(key, '^' .. prefix, '')
-			return newKey, value
+			return toNewKey(prefix, key), value
 		end)
 		map.vod = args['vodgame' .. mapIndex]
 		args['vodgame' .. mapIndex] = nil

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
@@ -37,6 +37,8 @@ function MatchGroupLegacyDefault.get(templateid, bracketType)
 		winner = 'map$1$win',
 		race1 = 'map$1$p1race',
 		race2 = 'map$1$p2race',
+		score1 = 'map$1$p1score',
+		score2 = 'map$1$p2score',
 		heroes1 = 'map$1$p1heroes',
 		heroes2 = 'map$1$p2heroes',
 		vod = 'vodgame$1$',

--- a/components/match2/wikis/warcraft/match_summary.lua
+++ b/components/match2/wikis/warcraft/match_summary.lua
@@ -345,7 +345,9 @@ function CustomMatchSummary.TeamSubmatch(submatch)
 
 	local details = SubmatchCollapsible()
 	for _, game in ipairs(submatch.games) do
-		details:game(CustomMatchSummary.Game(game, true))
+		if game.map ~= 'Submatch Score Fix' then
+			details:game(CustomMatchSummary.Game(game, true))
+		end
 	end
 
 	return submatchDisplay:addElement(details:create()):css('margin-bottom', '8px')


### PR DESCRIPTION
## Summary
Add support for an edge case in warcraft match2.
Sometimes they have map info and submatch total scores but not map winner/scores.
This adds the option to add a `|mapX={{Map|map=Submatch Score Fix|score1=2|score2=7}}` input to fix the submatch score (and match score).
This fix map is then not displayed.
This PR also adds support to legacy wrappers for this edge case.

if someone has a good and easy to implement idea to solve it better you are more than welcome ...

## How did you test this change?
dev