### PR TITLE
Add pattern matching to `Table.includes`

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Logic = require('Module:Logic')
-
 local Table = {}
 
 ---@deprecated
@@ -32,12 +30,15 @@ end
 ---@param isPattern boolean?
 ---@return boolean
 function Table.includes(tbl, value, isPattern)
+	local Logic = require('Module:Logic')
+
 	for _, entry in pairs(tbl) do
 		if isPattern and Logic.isNumeric(string.find(entry, value))
 			or not isPattern and entry == value then
 				return true
 		end
 	end
+
 	return false
 end
 

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -6,6 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Logic = require('Module:Logic')
+
 local Table = {}
 
 ---@deprecated
@@ -27,11 +29,13 @@ end
 
 ---@param tbl table
 ---@param value any
+---@param isPattern boolean?
 ---@return boolean
-function Table.includes(tbl, value)
+function Table.includes(tbl, value, isPattern)
 	for _, entry in pairs(tbl) do
-		if entry == value then
-			return true
+		if isPattern and Logic.isNumeric(string.find(entry, value))
+			or not isPattern and entry == value then
+				return true
 		end
 	end
 	return false

--- a/standard/table.lua
+++ b/standard/table.lua
@@ -30,15 +30,12 @@ end
 ---@param isPattern boolean?
 ---@return boolean
 function Table.includes(tbl, value, isPattern)
-	local Logic = require('Module:Logic')
-
 	for _, entry in pairs(tbl) do
-		if isPattern and Logic.isNumeric(string.find(entry, value))
+		if isPattern and string.find(entry, value)
 			or not isPattern and entry == value then
 				return true
 		end
 	end
-
 	return false
 end
 

--- a/standard/test/table_test.lua
+++ b/standard/test/table_test.lua
@@ -135,6 +135,20 @@ function suite:testIncludes()
 	self:assertTrue(Table.includes(b, 'testValue3'))
 	self:assertFalse(Table.includes(a, 'testValue4'))
 	self:assertFalse(Table.includes(b, 'testValue4'))
+
+	self:assertTrue(Table.includes(a, 'testValue', false))
+	self:assertTrue(Table.includes(b, 'testValue', false))
+	self:assertTrue(Table.includes({'^estValue3$'}, '^estValue3$', false))
+	self:assertFalse(Table.includes(b, 'estValue', false))
+
+	self:assertTrue(Table.includes(a, 'testValue', true))
+	self:assertTrue(Table.includes(b, 'testValue', true))
+	self:assertTrue(Table.includes(b, 'testValue3', true))
+	self:assertTrue(Table.includes(b, 'estValue3', true))
+	self:assertTrue(Table.includes(b, 'testValue%d', true))
+	self:assertTrue(Table.includes(b, '^testValue%d$', true))
+	self:assertFalse(Table.includes(b, '^estValue3$', true))
+	self:assertFalse(Table.includes({'^estValue3$'}, '^estValue3$', true))
 end
 
 function suite:testFilterByKey()


### PR DESCRIPTION
## Summary

As an optional third param, `Table.includes` can now match for patterns in the table/array. If a user wants to match specifically full strings to pattern, they can use `^` and `$` in their pattern as they should be aware of pattern matching from `string.find()`.

## How did you test this change?

Tested using `/dev` and testcases.
