### PR TITLE
Inherit starttime from infobox to first match

### DIFF
--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -62,16 +62,21 @@ end
 ---@param matchArgs table
 ---@return table
 function CustomMatchGroupInput._readDate(matchArgs)
-	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
-		dateProps.dateexact = Logic.nilOr(Logic.readBoolOrNil(matchArgs.dateexact), dateProps.dateexact)
+	local suggestedDate = Variables.varDefault('matchDate') or Variables.varDefault('Match_date')
+
+	local tournamentStartTime = Variables.varDefault('tournament_starttimeraw')
+
+	if matchArgs.date or (not suggestedDate and tournamentStartTime) then
+		local dateProps = MatchGroupInput.readDate(matchArgs.date or tournamentStartTime)
+		dateProps.dateexact = Logic.nilOr(
+			Logic.readBoolOrNil(matchArgs.dateexact),
+			matchArgs.date and dateProps.dateexact or false
+		)
 		Variables.varDefine('matchDate', dateProps.date)
 		return dateProps
 	end
 
-	local suggestedDate = Variables.varDefaultMulti(
-		'matchDate',
-		'Match_date',
+	suggestedDate = suggestedDate or Variables.varDefaultMulti(
 		'tournament_startdate',
 		'tournament_enddate',
 		'1970-01-01'


### PR DESCRIPTION
## Summary
Warcraft sets starttime of the event in infobox (if known). Inherit that to the first match.

## How did you test this change?
dev