### PR TITLE
Add sync player to CoD Match2 Processing

### DIFF
--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -71,7 +71,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		opponent = {type = Opponent.literal, name = 'BYE'}
 	end
 
-	Opponent.resolve(opponent, date)
+	Opponent.resolve(opponent, date, {syncPlayer=true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 


### PR DESCRIPTION
## Summary
Auto flag retrieval on Brackets when {{Solo}} or {{DuoOpponents}} used
(Which turns out, quite a good amount over in Call of Duty)

## How did you test this change?
|dev=1 at (flags now all retrieved from the first appearance and no need to add flag onward for later matches)

https://liquipedia.net/callofduty/WorldGaming/Canadian_Championship/2016#Results