### PR TITLE
Catch nil in broodwar infobox map

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_map_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_map_custom.lua
@@ -75,7 +75,7 @@ end
 function CustomMap:addToLpdb(lpdbData, args)
 	lpdbData.name = CustomMap:getNameDisplay(args)
 	lpdbData.extradata = {
-		creator = mw.ext.TeamLiquidIntegration.resolve_redirect(args.creator),
+		creator = args.creator and mw.ext.TeamLiquidIntegration.resolve_redirect(args.creator) or nil,
 		spawns = args.players,
 		height = args.height,
 		width = args.width,


### PR DESCRIPTION
## Summary
Catch nil in broodwar infobox map

## How did you test this change?
live as bug fix