### PR TITLE
CoD Info Team: Make competesin always store

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_team_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_team_custom.lua
@@ -28,7 +28,7 @@ function CustomTeam:createBottomContent()
 end
 
 function CustomTeam:addToLpdb(lpdbData, args)
-	lpdbData.extradata.competesin = String.isNotEmpty(args.league) and args.league:upper() or nil
+	lpdbData.extradata.competesin = String.isNotEmpty(args.league) and args.league:upper() or ''
 
 	return lpdbData
 end

--- a/components/infobox/wikis/callofduty/infobox_team_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_team_custom.lua
@@ -28,7 +28,7 @@ function CustomTeam:createBottomContent()
 end
 
 function CustomTeam:addToLpdb(lpdbData, args)
-	lpdbData.extradata.competesin = String.isNotEmpty(args.league) and args.league:upper() or ''
+	lpdbData.extradata.competesin = (args.league or ''):upper()
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
This is one part I wasnt aware of back when adding this line at first, that is the Mobile and non-Mobile (that isnt CDL teams) clunked in same portal teams. My thought is to also use that **competesin** for Mobile teams to separate

The problem is, I can separate Mobile teams, but can't exclude them (see pics below)

Now I need the **competesin** to store empty or `''` as well for teams without that input 
(which is all teams except CDL and Mobile teams), Tested on |dev=1
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/dd638fb8-89c2-4746-8e10-9ae359e4ff03)

This would allow me to use `!MOBILE` to exclude through using **|condition=**

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/42d8673f-7ba5-423a-b6f0-cef52fbfacf4)

End goal of this PR is to do this:
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/37911e6d-109f-43ee-8916-692d667d08fe)
https://liquipedia.net/callofduty/Portal:Teams/Europe
