### PR TITLE
Fix sc/sc2 ppt var passalong

### DIFF
--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
@@ -79,7 +79,7 @@ function CustomPrizePool.run(frame)
 	-- set an additional wiki-var for legacy reasons so that combination with award prize pools still work
 	Variables.varDefine('prize pool table id', prizePoolIndex)
 
-	if Logic.readBool(args.storelpdb) then
+	if prizePool.options.storeLpdb then
 		-- stash the lpdb_placement data so teamCards can use them
 		pageVars:set('placementRecords.' .. prizePoolIndex, Json.stringify(_lpdb_stash))
 	end


### PR DESCRIPTION
## Summary
Fix sc/sc2 ppt var passalong
introduced with #3459
`args.storelpdb` is now nil usually, hence use the (imo better) `prizePool.options.storeLpdb`


## How did you test this change?
dev to live as bug fix