### PR TITLE
Fortnite Player: Add PlayerTeamAuto and lpdbdata for History

### DIFF
--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -14,6 +14,7 @@ local Role = require('Module:Role')
 local Region = require('Module:Region')
 local Math = require('Module:Math')
 local String = require('Module:StringUtils')
+local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -41,6 +42,14 @@ function CustomPlayer.run(frame)
 	_args = player.args
 	_player = player
 
+	if String.isEmpty(player.args.team) then
+		player.args.team = PlayerTeamAuto._main{team = 'team'}
+	end
+
+	if String.isEmpty(player.args.team2) then
+		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
+	end
+
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
@@ -51,6 +60,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
+			addlpdbdata = 'true',
 			convertrole = 'true',
 			player = _pagename
 		}

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -60,8 +60,8 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			addlpdbdata = 'true',
-			convertrole = 'true',
+			addlpdbdata = true,
+			convertrole = true,
 			player = _pagename
 		}
 


### PR DESCRIPTION
## Summary
- PlayerTeamAuto is self explanatory (starting to few like if this would be a good commons feature in the future)
- 
- the **addlpdbdata** is to do few things
1. make the Auto History in the module able to stored datapoints of transfers
2. to allow both {{OpponentList}} and Prize Pool to be able to retrieve player's team icon automatically that depends on stored transfer and the dates stored in that tournament page, which is a huge efficiency increase for wikis like Fortnite

## How did you test this change?
https://liquipedia.net/fortnite/User:Hesketh2 (Opponent List)
https://liquipedia.net/fortnite/Bugha (Player Infobox dev=1)