### PR TITLE
EML: Fill event-link from resolved event

### DIFF
--- a/components/external_media_links/external_media_link.lua
+++ b/components/external_media_links/external_media_link.lua
@@ -88,9 +88,7 @@ function ExternalMediaLink._store(args)
 		translator = args.translator,
 		event = args.event,
 		event_link = mw.ext.TeamLiquidIntegration.resolve_redirect(
-			String.isNotEmpty(args['event-link']) and args['event-link']
-			or String.isNotEmpty(args.event) and args.event
-			or ''
+			Logic.emptyOr(args['event-link'], args.event, '')
 		),
 		subject_organization = args.subject_organization1, --legacy
 	}

--- a/components/external_media_links/external_media_link.lua
+++ b/components/external_media_links/external_media_link.lua
@@ -87,7 +87,11 @@ function ExternalMediaLink._store(args)
 		translation = args.translation,
 		translator = args.translator,
 		event = args.event,
-		event_link = args['event-link'],
+		event_link = mw.ext.TeamLiquidIntegration.resolve_redirect(
+			String.isNotEmpty(args['event-link']) and args['event-link']
+			or String.isNotEmpty(args.event) and args.event
+			or ''
+		),
 		subject_organization = args.subject_organization1, --legacy
 	}
 
@@ -245,7 +249,7 @@ function ExternalMediaLink.wrapper(args)
 		type = args.type and args.type:lower() or nil,
 		of = args.of,
 		event = args.event,
-		['event-link'] = args['event-link'] and mw.ext.TeamLiquidIntegration.resolve_redirect(args['event-link']) or nil,
+		['event-link'] = args['event-link'],
 		language = args.language,
 		translation = args.translation,
 		translator = args.translator,


### PR DESCRIPTION
## Summary
Previously, `extradata_event_link` would only be stored when specifically entered but not when only event was entered.
This leads to EMLs not being displayed when querying for an event, since conditioning would only be on link, not on event:
https://github.com/Liquipedia/Lua-Modules/blob/main/components/external_media_links/external_media_list.lua#L118

This will always store said extradata point, either with the specific link input, or with the event, or with an empty string (previously, the field was nil)

I guess eventually we'd want to `gsub(' ', '_')` there as well, but that would require a change in the query part as well

## How did you test this change?
via /dev