### PR TITLE
Update MK1 icons for Fighters

### DIFF
--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -887,12 +887,12 @@ return {
 			name = 'Mortal Kombat 1',
 			link = 'Mortal Kombat 1',
 			logo = {
-				darkMode = 'Mortal Kombat 1 default darkmode.png',
-				lightMode = 'Mortal Kombat 1 default lightmode.png',
+				darkMode = 'Mortal Kombat 1 icon allmode.png',
+				lightMode = 'Mortal Kombat 1 icon allmode.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Mortal Kombat 1 default darkmode.png',
-				lightMode = 'Mortal Kombat 1 default lightmode.png',
+				darkMode = 'Mortal Kombat 1 allmode.png',
+				lightMode = 'Mortal Kombat 1 allmode.png',
 			},
 		},
 		mvc2 = {

--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -887,12 +887,12 @@ return {
 			name = 'Mortal Kombat 1',
 			link = 'Mortal Kombat 1',
 			logo = {
-				darkMode = 'Mortal Kombat 1 icon allmode.png',
-				lightMode = 'Mortal Kombat 1 icon allmode.png',
+				darkMode = 'Mortal Kombat 1 default allmode.png',
+				lightMode = 'Mortal Kombat 1 default allmode.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Mortal Kombat 1 allmode.png',
-				lightMode = 'Mortal Kombat 1 allmode.png',
+				darkMode = 'Mortal Kombat 1 default allmode.png',
+				lightMode = 'Mortal Kombat 1 default allmode.png',
 			},
 		},
 		mvc2 = {


### PR DESCRIPTION
## Summary

MK1 uses allmode icons, not lightmode/darkmode as currently specified.

## How did you test this change?

Applied by editor
https://liquipedia.net/fighters/index.php?title=Module%3AInfo&type=revision&diff=197383&oldid=189950