### PR TITLE
COD: Add Custom Opponent Display

### DIFF
--- a/components/opponent/wikis/callofduty/opponent_display_custom.lua
+++ b/components/opponent/wikis/callofduty/opponent_display_custom.lua
@@ -1,0 +1,54 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:OpponentDisplay/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
+
+---Display components for opponents used by the COD wiki
+---@class CallOfDutyOpponentDisplay: OpponentDisplay
+local CustomOpponentDisplay = Table.copy(OpponentDisplay)
+
+---Displays an opponent as an inline element. Useful for describing opponents in prose.
+---@param props InlineOpponentProps
+---@return Html|string|nil
+function CustomOpponentDisplay.InlineOpponent(props)
+	local opponent = props.opponent
+
+	if Opponent.typeIsParty(opponent.type) then
+		return OpponentDisplay.InlinePlayers(props)(props)
+	end
+
+	 return OpponentDisplay.InlineOpponent(props)
+end
+
+--[[
+Displays an opponent as a block element. The width of the component is
+determined by its layout context, and not of the opponent.
+]]
+---@param props BlockOpponentProps
+---@return Html
+function CustomOpponentDisplay.BlockOpponent(props)
+	local opponent = props.opponent
+	-- Default TBDs to not show links
+	local showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
+
+	if Opponent.typeIsParty(opponent.type) then
+		return OpponentDisplay.BlockPlayers(Table.merge(props, {showLink = showLink}))
+	end
+
+	return OpponentDisplay.BlockOpponent(props)
+end
+
+return CustomOpponentDisplay

--- a/components/opponent/wikis/callofduty/opponent_display_custom.lua
+++ b/components/opponent/wikis/callofduty/opponent_display_custom.lua
@@ -6,15 +6,12 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DisplayUtil = require('Module:DisplayUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
 local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
-local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
 
 ---Display components for opponents used by the COD wiki
 ---@class CallOfDutyOpponentDisplay: OpponentDisplay
@@ -27,7 +24,7 @@ function CustomOpponentDisplay.InlineOpponent(props)
 	local opponent = props.opponent
 
 	if Opponent.typeIsParty(opponent.type) then
-		return OpponentDisplay.InlinePlayers(props)(props)
+		return OpponentDisplay.InlinePlayers(props)
 	end
 
 	 return OpponentDisplay.InlineOpponent(props)

--- a/standard/info/wikis/callofduty/info.lua
+++ b/standard/info/wikis/callofduty/info.lua
@@ -341,4 +341,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Call of Duty Default Lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Call of Duty Default Darkmode.png', ---@deprecated
+	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }

--- a/standard/info/wikis/callofduty/info.lua
+++ b/standard/info/wikis/callofduty/info.lua
@@ -21,7 +21,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		bo = {
@@ -34,7 +34,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		bo2 = {
@@ -47,7 +47,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		bo3 = {
@@ -60,7 +60,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		bo4 = {
@@ -73,7 +73,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		bocw = {
@@ -86,7 +86,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		cod = {
@@ -99,7 +99,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		cod2 = {
@@ -112,7 +112,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		cod3 = {
@@ -125,7 +125,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		cod4 = {
@@ -138,7 +138,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		codm = {
@@ -151,7 +151,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		ghosts = {
@@ -164,7 +164,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		iw = {
@@ -177,7 +177,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		mw2 = {
@@ -190,7 +190,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		mw2019 = {
@@ -203,7 +203,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		mw3 = {
@@ -216,7 +216,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		mwii = {
@@ -229,7 +229,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		mwiii = {
@@ -242,7 +242,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		vg = {
@@ -255,7 +255,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		waw = {
@@ -268,7 +268,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		wwii = {
@@ -281,7 +281,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		wz = {
@@ -294,7 +294,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		wz2 = {
@@ -307,7 +307,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		wzm = {
@@ -320,7 +320,7 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 		online = {
@@ -333,13 +333,13 @@ return {
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default Lightmode.png',
+				lightMode = 'Call of Duty Default lightmode.png',
 			},
 		},
 	},
 	defaultGame = 'cod',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Call of Duty Default Lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Call of Duty Default Darkmode.png', ---@deprecated
+	defaultTeamLogo = 'Call of Duty Default lightmode.png', ---@deprecated
+	defaultTeamLogoDark = 'Call of Duty Default darkmode.png', ---@deprecated
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }


### PR DESCRIPTION
## <s>NEED FIX BEFORE PROCEED</s>
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/731d9192-aa34-49a0-a0ab-a6b99d57d8ff)
I removed (props)(props) to just (props) this seems to fix it


## Summary
**Includes Module:Info in this PR as well**

Its sole purpose is so that Prize Pool with Trio Opponent works.
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/c86ad84b-a7cc-487d-952a-e08819c43b52)

Very likely COD will run into covering Battle Royale events that prized in this manner in future

Few changes were made to ensure Solo/Duo/Team Prizepool are unaffected as well as matchlist/bracket not breaking 

## How did you test this change?
https://liquipedia.net/callofduty/User:Hesketh2/Test