### PR TITLE
fix: match ticket bug introduced with #3448

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -292,7 +292,7 @@ function MatchTicker:adjustMatch(match)
 	local opponentNames = Array.append({self.config.player}, self.config.teamPages)
 	if
 		--check for the name value
-		Table.includes(opponentNames, match.match2opponents[2].name:gsub(' ', '_'))
+		Table.includes(opponentNames, (match.match2opponents[2].name:gsub(' ', '_')))
 		--check inside match2players too for the player value
 		or self.config.player and Table.any(match.match2opponents[2].match2players, function(_, playerData)
 			return (playerData.name or ''):gsub(' ', '_') == self.config.player end)


### PR DESCRIPTION
## Summary
Table.includes now support an addition parameter, and with string.gsub returning two, that value is always truthy, and as such would activate pattern mode.

## How did you test this change?
Live