### PR TITLE
fix: incorrect match2bracketdata json serialization

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -244,7 +244,7 @@ function Match.copyRecords(matchRecord)
 end
 
 function Match.encodeJson(matchRecord)
-	matchRecord.match2bracketdata = Json.stringify(matchRecord.match2bracketdata)
+	matchRecord.match2bracketdata = Json.stringify(matchRecord.match2bracketdata, {asArray = true})
 	matchRecord.stream = Json.stringify(matchRecord.stream)
 	matchRecord.links = Json.stringify(matchRecord.links)
 	matchRecord.extradata = Json.stringify(matchRecord.extradata)


### PR DESCRIPTION
## Summary
`lowerEdges` & `lowerMatchIds` of `match2bracketdata` should be arrays, not objects. Use the old mixed serialization instead of the object forced one, for this key.

## How did you test this change?
Tested with dev