### PR TITLE
fix: minor typo in fifa match2

### DIFF
--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -92,7 +92,7 @@ function CustomMatchGroupInput._adjustData(match)
 	end
 
 	local scores = Array.map(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
-		local score = CustomMatchGroupInput._computeOpponentMatchScore(match, opponentIndex, true)
+		local score = CustomMatchGroupInput._computeOpponentMatchScore(match, opponentIndex)
 		match['opponent' .. opponentIndex].score = score
 		if Logic.isNumeric(score) then
 			match['opponent' .. opponentIndex].status = SCORE_STATUS


### PR DESCRIPTION
## Summary
The called function only has two parameters, while caller supplier three. Remove the 3rd, redundant, one.

## How did you test this change?
Not at all