### PR TITLE
feat: add default LuaLS lua settings

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,12 @@
+{
+	"runtime.version": "Lua 5.1",
+	"runtime.plugin": "plugins/sumneko_plugin.lua",
+	"completion.autoRequire": false,
+	"diagnostics.severity": {
+		"trailing-space": "Error"
+	},
+	"diagnostics.neededFileStatus": {
+        "codestyle-check": "None",
+        "name-style-check": "None"
+    }
+}

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
 	"runtime.version": "Lua 5.1",
 	"runtime.plugin": "plugins/sumneko_plugin.lua",
 	"completion.autoRequire": false,


### PR DESCRIPTION
## Summary
Add default project settings for LuaLS (former sumneko-lua). 
These settings get higher prioty than manually set settings in VSCode when conflicting, but can still be overwritten by advance users with `--config-path`. 
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/5dbb1ddc-5bd5-4d14-94c9-5b18c067368b)

https://luals.github.io/wiki/configuration/#luarcjson-file

## How did you test this change?
VSCode