### PR TITLE
chore(vscode): codestyle check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -149,4 +149,4 @@ ignore_space_after_colon = false
 
 remove_call_expression_list_finish_comma = false
 # keep / always / same_line / replace_with_newline / never
-end_statement_with_semicolon = keep
+end_statement_with_semicolon = same_line

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,152 @@
+[*.lua]
+# [basic]
+
+# optional space/tab
+indent_style = tab
+# if indent_style is space, this is valid
+indent_size = 4
+# if indent_style is tab, this is valid
+tab_width = 4
+# none/single/double
+quote_style = single
+
+continuation_indent = 8
+
+# this mean utf8 length , if this is 'unset' then the line width is no longer checked
+# this option decides when to chopdown the code
+max_line_length = 120
+
+# optional crlf/lf/cr/auto, if it is 'auto', in windows it is crlf other platforms are lf
+# in neovim the value 'auto' is not a valid option, please use 'unset' 
+end_of_line = auto
+
+#  none/ comma / semicolon / only_kv_colon
+table_separator_style = none
+
+#optional keep/never/always/smart
+trailing_table_separator = keep
+
+# keep/remove/remove_table_only/remove_string_only
+call_arg_parentheses = keep
+
+detect_end_of_line = false
+
+# this will check text end with new line
+insert_final_newline = true
+
+# [space]
+space_around_table_field_list = false
+
+space_before_attribute = false
+
+space_before_function_open_parenthesis = false
+
+space_before_function_call_open_parenthesis = false
+
+space_before_closure_open_parenthesis = false
+
+# optional always/only_string/only_table/none
+# or true/false
+space_before_function_call_single_arg = only_string
+
+space_before_open_square_bracket = false
+
+space_inside_function_call_parentheses = false
+
+space_inside_function_param_list_parentheses = false
+
+space_inside_square_brackets = false
+
+# like t[#t+1] = 1
+space_around_table_append_operator = true
+
+ignore_spaces_inside_function_call = false
+
+space_before_inline_comment = 1
+
+# [operator space]
+space_around_math_operator = true
+
+space_after_comma = true
+
+space_after_comma_in_for_statement = true
+
+# true/false or none/always/no_space_asym
+space_around_concat_operator = true
+
+space_around_logical_operator = true
+
+# true/false or none/always/no_space_asym
+space_around_assign_operator = true
+
+# [align]
+
+align_call_args = false
+
+align_function_params = false
+
+align_continuous_assign_statement = false
+
+align_continuous_rect_table_field = false
+
+align_continuous_line_space = 2
+
+align_if_branch = false
+
+# option none / always / contain_curly/
+align_array_table = none
+
+align_continuous_similar_call_args = false
+
+align_continuous_inline_comment = false
+# option none / always / only_call_stmt
+align_chain_expr = none
+
+# [indent]
+
+never_indent_before_if_condition = false
+
+never_indent_comment_on_if_branch = false
+
+keep_indents_on_empty_lines = false
+# [line space]
+
+# The following configuration supports four expressions
+# keep  
+# fixed(n)   
+# min(n)
+# max(n)
+# for eg. min(2)
+
+line_space_after_if_statement = keep
+
+line_space_after_do_statement = keep
+
+line_space_after_while_statement = keep
+
+line_space_after_repeat_statement = keep
+
+line_space_after_for_statement = keep
+
+line_space_after_local_or_assign_statement = keep
+
+line_space_after_function_statement = fixed(2)
+
+line_space_after_expression_statement = keep
+
+line_space_after_comment = keep
+
+line_space_around_block = fixed(1)
+# [line break]
+break_all_list_when_line_exceed = false
+
+auto_collapse_lines = false
+
+break_before_braces = false
+
+# [preference]
+ignore_space_after_colon = false
+
+remove_call_expression_list_finish_comma = false
+# keep / always / same_line / replace_with_newline / never
+end_statement_with_semicolon = keep

--- a/.luarc.json
+++ b/.luarc.json
@@ -4,10 +4,11 @@
 	"runtime.plugin": "plugins/sumneko_plugin.lua",
 	"completion.autoRequire": false,
 	"diagnostics.severity": {
-		"trailing-space": "Error"
+		"trailing-space": "Error",
+		"codestyle-check": "Information"
 	},
 	"diagnostics.neededFileStatus": {
-        "codestyle-check": "None",
+        "codestyle-check": "Opened",
         "name-style-check": "None"
     }
 }


### PR DESCRIPTION
## Summary
Activate code style checking directly in VSCode. Currently setting default warning level to `information` as there's a ton of them.

Style can be formatted by `alt + shift + f` by default, for current document. Or by right clicking and selecting `format document`.

Biggest difference towards what we use a lot of is the setting of `continuation_indent = 8`. This will be double indent for wrapped/continuous line.
That would change 

```lua
    if a or b or c and thisIsLongLineNeedWrap
        and d and e then

        return true
```
into
```lua
    if a or b or c and thisIsLongLineNeedWrap
            and d and e then

        return true
```

There are some minor issues, specifically `:tag()` chaining, as it doesn't understand that it should be another level deeper with it. We'll look into it have to solve it.