### PR TITLE
AoE: Add matchticker to infobox league

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -33,6 +33,8 @@ local Center = Widgets.Center
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
+local SECONDS_PER_DAY = 86400
+
 local _league
 local categories = {}
 
@@ -118,12 +120,10 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomLeague:createBottomContent()
-	if os.date("%Y-%m-%d") <= Variables.varDefault('tournament_enddate', '1970-01-01') then
-		return MatchTicker.get{args={
-			tournament = _league.pagename,
-			limit = tonumber(_league.args.matchtickerlimit) or 7,
-			queryByParent = true
-		}}
+	local yesterday = os.date('%Y-%m-%d', os.time() - SECONDS_PER_DAY)
+
+	if yesterday <= Variables.varDefault('tournament_enddate', '1970-01-01') then
+		return MatchTicker.get{args={parent = _league.pagename, limit = tonumber(_league.args.matchtickerlimit) or 7}}
 	end
 end
 

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -14,6 +14,7 @@ local GameModeLookup = require('Module:GameModeLookup')
 local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local MapMode = require('Module:MapMode')
+local MatchTicker = require('Module:Matches Tournament')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -46,6 +47,7 @@ function CustomLeague.run(frame)
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createLiquipediaTierDisplay = CustomLeague.createLiquipediaTierDisplay
 	league.getWikiCategories = CustomLeague.getWikiCategories
+	league.createBottomContent = CustomLeague.createBottomContent
 
 	return league:createInfobox()
 end
@@ -115,6 +117,11 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+function CustomLeague:createBottomContent()
+	if os.date("%Y-%m-%d") <= Variables.varDefault('tournament_enddate', '1970-01-01') then
+		return MatchTicker.get{args={[1] = _league.pagename, limit = tonumber(_league.args.matchtickerlimit) or 7}}
+	end
+end
 
 function CustomLeague:getWikiCategories(args)
 	if String.isEmpty(args.game) then

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -119,7 +119,11 @@ end
 
 function CustomLeague:createBottomContent()
 	if os.date("%Y-%m-%d") <= Variables.varDefault('tournament_enddate', '1970-01-01') then
-		return MatchTicker.get{args={[1] = _league.pagename, limit = tonumber(_league.args.matchtickerlimit) or 7}}
+		return MatchTicker.get{args={
+			tournament = _league.pagename,
+			limit = tonumber(_league.args.matchtickerlimit) or 7,
+			queryByParent = true
+		}}
 	end
 end
 


### PR DESCRIPTION
## Summary
Adds a (match1) MatchTicker to infobox league if the tournament is upcoming or ongoing.

Since matchtickers are currently added manually using [a template](https://liquipedia.net/ageofempires/Template:Upcoming_matches_tournament), please either blank this template temporarily when merging or ping me so i can remove then duplicated usages.

## How did you test this change?
via /dev
