### PR TITLE
AoE matchticker: disable infobox-wrapper

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -123,7 +123,11 @@ function CustomLeague:createBottomContent()
 	local yesterday = os.date('%Y-%m-%d', os.time() - SECONDS_PER_DAY)
 
 	if yesterday <= Variables.varDefault('tournament_enddate', '1970-01-01') then
-		return MatchTicker.get{args={parent = _league.pagename, limit = tonumber(_league.args.matchtickerlimit) or 7}}
+		return MatchTicker.get{args={
+			parent = _league.pagename,
+			limit = tonumber(_league.args.matchtickerlimit) or 7,
+			noInfoboxWrapper = true
+		}}
 	end
 end
 


### PR DESCRIPTION
## Summary
Since the matchticker is added to bottomContent, it already is in an infobox wrapper.
Disable the additional class when being called from the infobox to prevent an offset.

## How did you test this change?
/dev to live