### PR TITLE
Sync party opponents' data in CS match2

### DIFF
--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -88,7 +88,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		)
 	end
 
-	Opponent.resolve(opponent, teamTemplateDate)
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer = true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 


### PR DESCRIPTION
## Summary

Apply `syncPlayer` for `Module:MatchGroup/Input/Custom` on CS wiki so that party (solo) opponents can pull data from ParticipantsTable.

## How did you test this change?

`/dev`.
