### PR TITLE
Add lighting variants to `overwatch` Infobox/Map

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_map_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_map_custom.lua
@@ -48,6 +48,10 @@ function CustomInjector:addCustomCells(widgets)
 		content = gameModes,
 	})
 	table.insert(widgets, Cell{
+		name = 'Times',
+		content = {_args.times}
+	})
+	table.insert(widgets, Cell{
 		name = 'Checkpoints',
 		content = {_args.checkpoints}
 	})

--- a/components/infobox/wikis/overwatch/infobox_map_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_map_custom.lua
@@ -48,8 +48,8 @@ function CustomInjector:addCustomCells(widgets)
 		content = gameModes,
 	})
 	table.insert(widgets, Cell{
-		name = 'Times',
-		content = {_args.times}
+		name = 'Lighting',
+		content = {_args.lighting}
 	})
 	table.insert(widgets, Cell{
 		name = 'Checkpoints',


### PR DESCRIPTION
## Summary

Overwatch maps now have different lighting options (dawn, morning, evening, night, overcast), this new parameter would allow a list of those.

## How did you test this change?

See [here](https://liquipedia.net/overwatch/User:Moonshot/sandbox).
