### PR TITLE
Add Match2 for World of Tanks

### DIFF
--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -27,7 +27,7 @@ local MAX_NUM_MAPS = 20
 local DEFAULT_BESTOF = 3
 
 local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
-local NOW = os.time(os.date('!*t') --[[@as osdate]])
+local NOW = os.time(os.date('!*t') --[[@as osdateparam]])
 
 -- containers for process helper functions
 local matchFunctions = {}
@@ -75,7 +75,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 
 	local teamTemplateDate = date ~= EPOCH_TIME_EXTENDED and date or DateExt.getContextualDateOrNow()
 
-	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer=true})
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer = true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -1,0 +1,454 @@
+---
+-- @Liquipedia
+-- wiki=worldoftanks
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+local Variables = require('Module:Variables')
+local DateExt = require('Module:Date/Ext')
+local Streams = require('Module:Links/Stream')
+
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
+
+local NP_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
+local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban', 'protect'}
+local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L', 'D' }
+local MAX_NUM_OPPONENTS = 2
+local MAX_NUM_MAPS = 20
+local DEFAULT_BESTOF = 3
+
+local EPOCH_TIME_EXTENDED = '1970-01-01T00:00:00+00:00'
+local NOW = os.time(os.date('!*t') --[[@as osdate]])
+
+-- containers for process helper functions
+local matchFunctions = {}
+local mapFunctions = {}
+local opponentFunctions = {}
+
+local CustomMatchGroupInput = {}
+
+-- called from Module:MatchGroup
+function CustomMatchGroupInput.processMatch(match)
+	-- Count number of maps, check for empty maps to remove, and automatically count score
+	match = matchFunctions.getBestOf(match)
+	match = matchFunctions.getScoreFromMapWinners(match)
+
+	-- process match
+	Table.mergeInto(
+		match,
+		matchFunctions.readDate(match)
+	)
+	match = matchFunctions.getOpponents(match)
+	match = matchFunctions.getTournamentVars(match)
+	matchFunctions.applyTournamentVarsToMaps(match)
+	match = matchFunctions.getVodStuff(match)
+	match = matchFunctions.getExtraData(match)
+
+	return match
+end
+
+-- called from Module:Match/Subobjects
+function CustomMatchGroupInput.processMap(map)
+	map = mapFunctions.getExtraData(map)
+	map = mapFunctions.getScoresAndWinner(map)
+
+	return map
+end
+
+function CustomMatchGroupInput.processOpponent(record, date)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	-- Convert byes to literals
+	if Opponent.isBye(opponent) then
+		opponent = {type = Opponent.literal, name = 'BYE'}
+	end
+
+	local teamTemplateDate = date ~= EPOCH_TIME_EXTENDED and date or DateExt.getContextualDateOrNow()
+
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer=true})
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+end
+
+-- called from Module:Match/Subobjects
+function CustomMatchGroupInput.processPlayer(player)
+	return player
+end
+
+--
+--
+-- function to check for draws
+function CustomMatchGroupInput.placementCheckDraw(table)
+	local last
+	for _, scoreInfo in pairs(table) do
+		if scoreInfo.status ~= 'S' and scoreInfo.status ~= 'D' then
+			return false
+		end
+		if last and last ~= scoreInfo.score then
+			return false
+		else
+			last = scoreInfo.score
+		end
+	end
+
+	return true
+end
+
+function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
+	-- Map or Match wasn't played, set not played
+	if
+		Table.includes(NP_STATUSES, data.finished) or
+		Table.includes(NP_STATUSES, data.winner)
+	then
+		data.resulttype = 'np'
+		data.finished = true
+	-- Map or Match is marked as finished.
+	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
+	elseif Logic.readBool(data.finished) then
+		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
+			data.winner = 0
+			data.resulttype = 'draw'
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
+		elseif CustomMatchGroupInput.placementCheckSpecialStatus(indexedScores) then
+			data.winner = CustomMatchGroupInput.getDefaultWinner(indexedScores)
+			data.resulttype = 'default'
+			if CustomMatchGroupInput.placementCheckFF(indexedScores) then
+				data.walkover = 'ff'
+			elseif CustomMatchGroupInput.placementCheckDQ(indexedScores) then
+				data.walkover = 'dq'
+			elseif CustomMatchGroupInput.placementCheckWL(indexedScores) then
+				data.walkover = 'l'
+			end
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'default')
+		else
+			local winner
+			indexedScores, winner = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, nil, data.finished)
+			data.winner = data.winner or winner
+		end
+	end
+
+	--set it as finished if we have a winner
+	if not String.isEmpty(data.winner) then
+		data.finished = true
+	end
+
+	return data, indexedScores
+end
+
+function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, finished)
+	if specialType == 'draw' then
+		for key, _ in pairs(opponents) do
+			opponents[key].placement = 1
+		end
+	elseif specialType == 'default' then
+		for key, _ in pairs(opponents) do
+			if key == winner then
+				opponents[key].placement = 1
+			else
+				opponents[key].placement = 2
+			end
+		end
+	else
+		local temporaryScore
+		local temporaryPlace = -99
+		local counter = 0
+		for scoreIndex, opp in Table.iter.spairs(opponents, CustomMatchGroupInput.placementSortFunction) do
+			local score = tonumber(opp.score) or ''
+			counter = counter + 1
+			if counter == 1 and Logic.isEmpty(winner) then
+				if finished then
+					winner = scoreIndex
+				end
+			end
+			if temporaryScore == score then
+				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or temporaryPlace
+			else
+				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or counter
+				temporaryPlace = counter
+				temporaryScore = score
+			end
+		end
+	end
+
+	return opponents, winner
+end
+
+function CustomMatchGroupInput.placementSortFunction(table, key1, key2)
+	local value1 = tonumber(table[key1].score) or -99
+	local value2 = tonumber(table[key2].score) or -99
+	return value1 > value2
+end
+
+-- Check if any team has a none-standard status
+function CustomMatchGroupInput.placementCheckSpecialStatus(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status ~= 'S' end)
+end
+
+-- function to check for forfeits
+function CustomMatchGroupInput.placementCheckFF(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'FF' end)
+end
+
+-- function to check for DQ's
+function CustomMatchGroupInput.placementCheckDQ(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'DQ' end)
+end
+
+-- function to check for W/L
+function CustomMatchGroupInput.placementCheckWL(table)
+	return Table.any(table, function (_, scoreinfo) return scoreinfo.status == 'L' end)
+end
+
+-- Get the winner when resulttype=default
+function CustomMatchGroupInput.getDefaultWinner(table)
+	for index, scoreInfo in pairs(table) do
+		if scoreInfo.status == 'W' then
+			return index
+		end
+	end
+	return -1
+end
+
+--
+-- match related functions
+--
+function matchFunctions.getBestOf(match)
+	match.bestof = Logic.emptyOr(match.bestof, Variables.varDefault('bestof', DEFAULT_BESTOF))
+	Variables.varDefine('bestof', match.bestof)
+	return match
+end
+
+-- Calculate the match scores based on the map results (counting map wins)
+-- Only update a teams result if it's
+-- 1) Not manually added
+-- 2) At least one map has a winner
+function matchFunctions.getScoreFromMapWinners(match)
+	local opponentNumber = 0
+	for index = 1, MAX_NUM_OPPONENTS do
+		if String.isEmpty(match['opponent' .. index]) then
+			break
+		end
+		opponentNumber = index
+	end
+	local newScores = {}
+	local foundScores = false
+
+	for i = 1, MAX_NUM_MAPS do
+		if match['map'..i] then
+			local winner = tonumber(match['map'..i].winner)
+			foundScores = true
+			if winner and winner > 0 and winner <= opponentNumber then
+				newScores[winner] = (newScores[winner] or 0) + 1
+			end
+		else
+			break
+		end
+	end
+
+	for index = 1, opponentNumber do
+		if not match['opponent' .. index].score and foundScores then
+			match['opponent' .. index].score = newScores[index] or 0
+		end
+	end
+
+	return match
+end
+
+function matchFunctions.readDate(matchArgs)
+	if matchArgs.date then
+		local dateProps = MatchGroupInput.readDate(matchArgs.date)
+		dateProps.hasDate = true
+		return dateProps
+	else
+		return {
+			date = EPOCH_TIME_EXTENDED,
+			dateexact = false,
+		}
+	end
+end
+
+function matchFunctions.getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
+	return MatchGroupInput.getCommonTournamentVars(match)
+end
+
+function matchFunctions.getVodStuff(match)
+	match.stream = Streams.processStreams(match)
+	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
+
+	match.links = {}
+	local links = match.links
+	if match.preview then links.preview = match.preview end
+
+	return match
+end
+
+function matchFunctions.getExtraData(match)
+	match.extradata = {
+		mvp = MatchGroupInput.readMvp(match),
+		mapveto = matchFunctions.getMapVeto(match),
+		casters = MatchGroupInput.readCasters(match),
+	}
+	return match
+end
+
+-- Parse the mapVeto input
+function matchFunctions.getMapVeto(match)
+	if not match.mapveto then return nil end
+
+	match.mapveto = Json.parseIfString(match.mapveto)
+
+	local vetoTypes = mw.text.split(match.mapveto.types or '', ',')
+	local deciders = mw.text.split(match.mapveto.decider or '', ',')
+	local vetoStart = match.mapveto.firstpick or ''
+	local deciderIndex = 1
+
+	local data = {}
+	for index, vetoType in ipairs(vetoTypes) do
+		vetoType = mw.text.trim(vetoType):lower()
+		if not Table.includes(ALLOWED_VETOES, vetoType) then
+			return nil -- Any invalid input will not store (ie hide) all vetoes.
+		end
+		if vetoType == 'decider' then
+			table.insert(data, {type = vetoType, decider = deciders[deciderIndex]})
+			deciderIndex = deciderIndex + 1
+		else
+			table.insert(data, {type = vetoType, team1 = match.mapveto['t1map'..index], team2 = match.mapveto['t2map'..index]})
+		end
+	end
+	if data[1] then
+		data[1].vetostart = vetoStart
+	end
+	return data
+end
+
+function matchFunctions.getOpponents(match)
+	-- read opponents and ignore empty ones
+	local opponents = {}
+	local isScoreSet = false
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		-- read opponent
+		local opponent = match['opponent' .. opponentIndex]
+		if not Logic.isEmpty(opponent) then
+			CustomMatchGroupInput.processOpponent(opponent, match.date)
+
+			-- Retrieve icon for team
+			if opponent.type == Opponent.team then
+				opponent.icon, opponent.icondark = opponentFunctions.getIcon(opponent.template)
+			end
+
+			-- apply status
+			if TypeUtil.isNumeric(opponent.score) then
+				opponent.status = 'S'
+				isScoreSet = true
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
+				opponent.status = opponent.score
+				opponent.score = -1
+			end
+			opponents[opponentIndex] = opponent
+		end
+	end
+
+	-- see if match should actually be finished if bestof limit was reached
+	if isScoreSet and not Logic.readBool(match.finished) then
+		local firstTo = math.ceil(match.bestof/2)
+		for _, item in pairs(opponents) do
+			if (tonumber(item.score) or 0) >= firstTo then
+				match.finished = true
+				break
+			end
+		end
+	end
+
+	-- see if match should actually be finished if score is set
+	if isScoreSet and not Logic.readBool(match.finished) and match.timestamp ~= DateExt.epochZero then
+		local threshold = match.dateexact and 30800 or 86400
+		if match.timestamp + threshold < NOW then
+			match.finished = true
+		end
+	end
+
+	-- apply placements and winner if finshed
+	if not String.isEmpty(match.winner) or Logic.readBool(match.finished) then
+		match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
+	end
+
+	-- Update all opponents with new values
+	for opponentIndex, opponent in pairs(opponents) do
+		match['opponent' .. opponentIndex] = opponent
+	end
+	return match
+end
+
+-- Apply Tournament Variables to map
+function matchFunctions.applyTournamentVarsToMaps(match)
+	for mapKey, map in Table.iter.pairsByPrefix(match, 'map') do
+		map.mode = Logic.emptyOr(map.mode, match.mode)
+		match[mapKey] = MatchGroupInput.getCommonTournamentVars(map, match)
+	end
+end
+
+--
+-- map related functions
+--
+
+-- Parse extradata information
+function mapFunctions.getExtraData(map)
+	map.extradata = {
+		comment = map.comment,
+		header = map.header,
+	}
+	return map
+end
+
+-- Calculate Score and Winner of the map
+function mapFunctions.getScoresAndWinner(map)
+	map.scores = {}
+	local indexedScores = {}
+	for scoreIndex = 1, MAX_NUM_OPPONENTS do
+		-- read scores
+		local score = map['score' .. scoreIndex] or map['t' .. scoreIndex .. 'score']
+		local obj = {}
+		if not Logic.isEmpty(score) then
+			if TypeUtil.isNumeric(score) then
+				obj.status = 'S'
+				obj.score = score
+			elseif Table.includes(ALLOWED_STATUSES, score) then
+				obj.status = score
+				obj.score = -1
+			end
+			table.insert(map.scores, score)
+			indexedScores[scoreIndex] = obj
+		else
+			break
+		end
+	end
+
+	map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
+
+	return map
+end
+
+--
+-- opponent related functions
+--
+function opponentFunctions.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	if raw then
+		local icon = Logic.emptyOr(raw.image, raw.legacyimage)
+		local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
+		return icon, iconDark
+	end
+end
+
+return CustomMatchGroupInput

--- a/components/match2/wikis/worldoftanks/match_summary.lua
+++ b/components/match2/wikis/worldoftanks/match_summary.lua
@@ -277,7 +277,7 @@ function CustomMatchSummary._createMapRow(game)
 
 	local centerNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
-		:wikitext(CustomMatchSummary._getMapDisplay(game))
+		:wikitext(Page.makeInternalLink(game.map))
 		:css('text-align', 'center')
 
 	if game.resultType == 'np' then
@@ -317,10 +317,6 @@ end
 
 ---@param game MatchGroupUtilGame
 ---@return string
-function CustomMatchSummary._getMapDisplay(game)
-	return Page.makeInternalLink(game.map)
-end
-
 ---@param showIcon boolean?
 ---@param iconType string?
 ---@return Html

--- a/components/match2/wikis/worldoftanks/match_summary.lua
+++ b/components/match2/wikis/worldoftanks/match_summary.lua
@@ -315,8 +315,6 @@ function CustomMatchSummary._createMapRow(game)
 	return row
 end
 
----@param game MatchGroupUtilGame
----@return string
 ---@param showIcon boolean?
 ---@param iconType string?
 ---@return Html

--- a/components/match2/wikis/worldoftanks/match_summary.lua
+++ b/components/match2/wikis/worldoftanks/match_summary.lua
@@ -1,0 +1,336 @@
+---
+-- @Liquipedia
+-- wiki=worldoftanks
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Abbreviation = require('Module:Abbreviation')
+local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local Table = require('Module:Table')
+local String = require('Module:StringUtils')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
+local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
+
+local MAP_VETO_START = '<b>Start Map Veto</b>'
+local ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]'
+local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
+local NONE = '-'
+local TBD = Abbreviation.make('TBD', 'To Be Determined') --[[@as string]]
+
+---@enum icons
+local Icon = {
+	CHECK = '<i class="fa fa-check forest-green-text" style="width: 14px; text-align: center" ></i>',
+	EMPTY = '[[File:NoCheck.png|link=]]',
+}
+
+local LINK_DATA = {
+	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
+}
+
+local VETO_TYPE_TO_TEXT = {
+	ban = 'BAN',
+	pick = 'PICK',
+	decider = 'DECIDER',
+	defaultban = 'DEFAULT BAN',
+
+}
+local CustomMatchSummary = {}
+
+-- Map Veto Class
+---@class self: MatchSummaryRowInterface
+---@operator call: self
+---@field root Html
+---@field table Html
+local MapVeto = Class.new(
+	function(self)
+		self.root = mw.html.create('div'):addClass('brkts-popup-mapveto')
+		self.table = self.root:tag('table')
+			:addClass('wikitable-striped'):addClass('collapsible'):addClass('collapsed')
+		self:createHeader()
+	end
+)
+
+---@return self
+function MapVeto:createHeader()
+	self.table:tag('tr')
+		:tag('th'):css('width','33%'):done()
+		:tag('th'):css('width','34%'):wikitext('Map Veto'):done()
+		:tag('th'):css('width','33%'):done()
+	return self
+end
+
+---@param firstVeto number?
+---@param format string?
+---@return self
+function MapVeto:vetoStart(firstVeto, format)
+	format = format and ('Veto format: ' .. format) or nil
+	local textLeft
+	local textCenter
+	local textRight
+	if firstVeto == 1 then
+		textLeft = MAP_VETO_START
+		textCenter = ARROW_LEFT
+		textRight = format
+	elseif firstVeto == 2 then
+		textLeft = format
+		textCenter = ARROW_RIGHT
+		textRight = MAP_VETO_START
+	else return self end
+
+	self.table:tag('tr'):addClass('brkts-popup-mapveto-vetostart')
+		:tag('th'):wikitext(textLeft):done()
+		:tag('th'):wikitext(textCenter):done()
+		:tag('th'):wikitext(textRight):done()
+
+	return self
+end
+
+---@param map1 string?
+---@param map2 string?
+---@return string, string
+function MapVeto._displayMaps(map1, map2)
+	if Logic.isEmpty(map1) and Logic.isEmpty(map2) then
+		return TBD, TBD
+	end
+
+	return Page.makeInternalLink(map1) or NONE,
+		Page.makeInternalLink(map2) or NONE
+end
+
+---@param map string?
+---@return self
+function MapVeto:addDecider(map)
+	map = Page.makeInternalLink(map) or TBD
+	local row = mw.html.create('tr'):addClass('brkts-popup-mapveto-vetoround')
+
+	self:addColumnVetoType(row, 'brkts-popup-mapveto-decider', 'DECIDER')
+	self:addColumnVetoMap(row, map)
+	self:addColumnVetoType(row, 'brkts-popup-mapveto-decider', 'DECIDER')
+
+	self.table:node(row)
+	return self
+end
+
+---@param vetoType string?
+---@param map1 string?
+---@param map2 string?
+---@return self
+function MapVeto:addRound(vetoType, map1, map2)
+	map1, map2 = MapVeto._displayMaps(map1, map2)
+
+	local vetoText = VETO_TYPE_TO_TEXT[vetoType]
+
+	if not vetoText then return self end
+
+	local class = 'brkts-popup-mapveto-' .. vetoType
+
+	local row = mw.html.create('tr'):addClass('brkts-popup-mapveto-vetoround')
+
+	self:addColumnVetoMap(row, map1)
+	self:addColumnVetoType(row, class, vetoText)
+	self:addColumnVetoMap(row, map2)
+
+	self.table:node(row)
+	return self
+end
+
+---@param row Html
+---@param styleClass string
+---@param vetoText string
+---@return self
+function MapVeto:addColumnVetoType(row, styleClass, vetoText)
+	row:tag('td')
+		:tag('span')
+			:addClass(styleClass)
+			:addClass('brkts-popup-mapveto-vetotype')
+			:wikitext(vetoText)
+	return self
+end
+
+---@param row Html
+---@param map string
+---@return self
+function MapVeto:addColumnVetoMap(row, map)
+	row:tag('td'):wikitext(map):done()
+	return self
+end
+
+---@return Html
+function MapVeto:create()
+	return self.root
+end
+
+---@param args table
+---@return Html
+function CustomMatchSummary.getByMatchId(args)
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
+end
+
+---@param match MatchGroupUtilMatch
+---@param footer MatchSummaryFooter
+---@return MatchSummaryFooter
+function CustomMatchSummary.addToFooter(match, footer)
+	footer = MatchSummary.addVodsToFooter(match, footer)
+
+	return footer:addLinks(LINK_DATA, match.links)
+end
+
+---@param match MatchGroupUtilMatch
+---@return MatchSummaryBody
+function CustomMatchSummary.createBody(match)
+	local body = MatchSummary.Body()
+
+	if match.dateIsExact or match.timestamp ~= DateExt.epochZero then
+		-- dateIsExact means we have both date and time. Show countdown
+		-- if match is not epoch=0, we have a date, so display the date
+		body:addRow(MatchSummary.Row():addElement(
+			DisplayHelper.MatchCountdownBlock(match)
+		))
+	end
+
+	-- Iterate each map
+	for _, game in ipairs(match.games) do
+		if game.map then
+			body:addRow(CustomMatchSummary._createMapRow(game))
+		end
+	end
+
+	-- Add Match MVP(s)
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
+			local mvp = MatchSummary.Mvp()
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
+			end
+			mvp:setPoints(mvpData.points)
+
+			body:addRow(mvp)
+		end
+
+	end
+
+	-- Add casters
+	if String.isNotEmpty(match.extradata.casters) then
+		local casters = Json.parseIfString(match.extradata.casters)
+		local casterRow = MatchSummary.Casters()
+		for _, caster in pairs(casters) do
+			casterRow:addCaster(caster)
+		end
+
+		body:addRow(casterRow)
+	end
+
+	-- Add the Map Vetoes
+	if match.extradata.mapveto then
+		local vetoData = match.extradata.mapveto
+		if vetoData then
+			local mapVeto = MapVeto()
+
+			for _,vetoRound in ipairs(vetoData) do
+				if vetoRound.vetostart then
+					mapVeto:vetoStart(tonumber(vetoRound.vetostart))
+				end
+				if vetoRound.type == 'decider' then
+					mapVeto:addDecider(vetoRound.decider)
+				else
+					mapVeto:addRound(vetoRound.type, vetoRound.team1, vetoRound.team2)
+				end
+			end
+
+			body:addRow(mapVeto)
+		end
+	end
+
+	return body
+end
+---@param game MatchGroupUtilGame
+---@param opponentIndex integer
+---@return Html
+function CustomMatchSummary._gameScore(game, opponentIndex)
+	return mw.html.create('div'):wikitext(game.scores[opponentIndex])
+end
+
+---@param game MatchGroupUtilGame
+---@return MatchSummaryRow
+function CustomMatchSummary._createMapRow(game)
+	local row = MatchSummary.Row()
+
+	-- Add Header
+	if Logic.isNotEmpty(game.header) then
+		local mapHeader = mw.html.create('div')
+			:wikitext(game.header)
+			:css('font-weight','bold')
+			:css('font-size','85%')
+			:css('margin','auto')
+		row:addElement(mapHeader)
+		row:addElement(MatchSummary.Break():create())
+	end
+
+	local centerNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:wikitext(CustomMatchSummary._getMapDisplay(game))
+		:css('text-align', 'center')
+
+	if game.resultType == 'np' then
+		centerNode:addClass('brkts-popup-spaced-map-skip')
+	end
+
+	local leftNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 1, Icon.CHECK))
+		:node(CustomMatchSummary._gameScore(game, 1))
+		:css('width', '20%')
+
+	local rightNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(CustomMatchSummary._gameScore(game, 2))
+		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 2, Icon.CHECK))
+		:css('width', '20%')
+
+	row:addElement(leftNode)
+		:addElement(centerNode)
+		:addElement(rightNode)
+
+	row:addClass('brkts-popup-body-game')
+		:css('overflow', 'hidden')
+
+	-- Add Comment
+	if Logic.isNotEmpty(game.comment) then
+		row:addElement(MatchSummary.Break():create())
+		local comment = mw.html.create('div')
+			:wikitext(game.comment)
+			:css('margin', 'auto')
+		row:addElement(comment)
+	end
+
+	return row
+end
+
+---@param game MatchGroupUtilGame
+---@return string
+function CustomMatchSummary._getMapDisplay(game)
+	return Page.makeInternalLink(game.map)
+end
+
+---@param showIcon boolean?
+---@param iconType string?
+---@return Html
+function CustomMatchSummary._createCheckMarkOrCross(showIcon, iconType)
+	local container = mw.html.create('div'):addClass('brkts-popup-spaced'):css('line-height', '27px')
+
+	if showIcon then
+		return container:node(iconType)
+	end
+	return container:node(Icon.EMPTY)
+end
+
+return CustomMatchSummary


### PR DESCRIPTION
## Summary
New Wiki - 2 teams controlling Tanks trying to win the game.

**The match2 is basically carbon copy (1:1) to osu! match2** because both were developed stuff together. Only osu specific stuff like protects in bans and mplink are not carried over the rest is exactly the same with nothing changed. 

Tanks and osu actually very identical in the way match works 
(has map names, has scores, has vetoes, only that Tanks is more on Teams and less on Solos)


