### PR TITLE
feat: save earnings by year in `earningsbyyear`

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -264,6 +264,7 @@ function Person:_setLpdbData(args, links, status, personType)
 		status = status,
 		type = personType,
 		earnings = self.totalEarnings,
+		earningsbyyear = {},
 		links = links,
 		extradata = {
 			firstname = args.givenname,

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -287,6 +287,7 @@ function Person:_setLpdbData(args, links, status, personType)
 
 	lpdbData = self:adjustLPDB(lpdbData, args, personType)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata)
+	lpdbData.earningsbyyear = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.earningsbyyear)
 	lpdbData.links = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.links)
 	local storageType = self:getStorageType(args, personType, status)
 

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -273,6 +273,7 @@ function Person:_setLpdbData(args, links, status, personType)
 
 	for year, earningsOfYear in pairs(self.earningsPerYear or {}) do
 		lpdbData.extradata['earningsin' .. year] = earningsOfYear
+		lpdbData.earningsbyyear[year] = earningsOfYear
 	end
 
 	-- Store additional team-templates in extradata

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -278,6 +278,7 @@ function Team:_setLpdbData(args, links)
 		textlesslogo = args.teamcardimage,
 		textlesslogodark = args.teamcardimagedark,
 		earnings = earnings,
+		earningsbyyear = {},
 		createdate = args.created,
 		disbanddate = ReferenceCleaner.clean(args.disbanded),
 		coach = args.coaches or args.coach,

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -292,6 +292,7 @@ function Team:_setLpdbData(args, links)
 
 	for year, earningsOfYear in pairs(self.earnings or {}) do
 		lpdbData.extradata['earningsin' .. year] = earningsOfYear
+		lpdbData.earningsbyyear[year] = earningsOfYear
 	end
 
 	lpdbData = self:addToLpdb(lpdbData, args)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -304,6 +304,7 @@ function Team:_setLpdbData(args, links)
 	end
 
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
+	lpdbData.earningsbyyear = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.earningsbyyear or {})
 	mw.ext.LiquipediaDB.lpdb_team('team_' .. self.name, lpdbData)
 end
 


### PR DESCRIPTION
## Summary
Save earnings by year into the new `earningsbyyear` field
## How did you test this change?
tested in dev