### PR TITLE
Catch another edge case in warcraft match legacy wrapper

### DIFF
--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -13,6 +13,7 @@ local Table = require('Module:Table')
 
 local TBD = 'TBD'
 local NUMBER_OF_OPPONENTS = 2
+local MAX_NUMBER_OF_MAPS_IN_MULTI = 9
 
 local ConvertMapData = {}
 
@@ -89,84 +90,17 @@ function ConvertMapData.teamMulti(args)
 	end)
 
 	local opponentPlayers = {{}, {}}
+	local submatchIndex = 0
 	local mapIndex = 0
-	local submatchIndex = 1
-	local prefix = 'm' .. submatchIndex
 
-	while args[prefix .. 'p1'] or args[prefix .. 'p2'] or args[prefix .. 'map1'] do
-		--parse players
-		local mapPlayers = {{}, {}}
-		for opponentIndex = 1, NUMBER_OF_OPPONENTS do
-			local playerInputPrefix = prefix .. 'p' .. opponentIndex
-
-			local name = args[playerInputPrefix .. 'link'] or args[playerInputPrefix] or TBD
-			opponentPlayers[opponentIndex][name] = {
-				name = name,
-				displayname = args[playerInputPrefix] or name,
-				flag = args[playerInputPrefix .. 'flag'],
-				race = args[playerInputPrefix .. 'race'],
-			}
-			table.insert(mapPlayers[opponentIndex], Table.copy(opponentPlayers[opponentIndex][name] or {}))
-
-			--optional second player
-			local player2InputPrefix = prefix .. 'p' .. opponentIndex .. '-2'
-			local name2 = args[player2InputPrefix .. 'link'] or args[player2InputPrefix]
-			if name2 then
-				opponentPlayers[opponentIndex][name2] = {
-					name = name2,
-					displayname = args[player2InputPrefix] or name,
-					flag = args[player2InputPrefix .. 'flag'],
-					race = args[player2InputPrefix .. 'race'],
-				}
-			end
-			table.insert(mapPlayers[opponentIndex], Table.copy(opponentPlayers[opponentIndex][name2] or {}))
+	--the old template allowed missing submatches inbetween, hence need to loop like this
+	Array.forEach(Array.range(1, MAX_NUMBER_OF_MAPS_IN_MULTI), function(prefixIndex)
+		local prefix = 'm' .. prefixIndex
+		if args[prefix .. 'p1'] or args[prefix .. 'p2'] or args[prefix .. 'map1'] then
+			submatchIndex = submatchIndex + 1
+			mapIndex = ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, prefix, submatchIndex, mapIndex)
 		end
-
-		local hasMissingWinner = false
-		local submatchScores = {0, 0}
-		for mapPrefix, map, submatchMapIndex in Table.iter.pairsByPrefix(args, prefix .. 'map') do
-			mapIndex = mapIndex + 1
-			local parsedPrefix = 'map' .. mapIndex
-			parsedArgs[parsedPrefix] = map
-			parsedArgs[parsedPrefix .. 'subgroup'] = submatchIndex
-
-			local winner = tonumber(args[prefix .. 'win' .. submatchMapIndex])
-			parsedArgs[parsedPrefix .. 'win'] = winner
-			if winner and submatchScores[winner] then
-				submatchScores[winner] = submatchScores[winner] + 1
-			elseif winner ~= 0 then
-				hasMissingWinner = true
-			end
-
-			Array.forEach(mapPlayers, function(players, opponentIndex)
-				Array.forEach(players, function(player, playerIndex)
-					parsedArgs[parsedPrefix .. 't' .. opponentIndex .. 'p' .. playerIndex] = player.name
-				end)
-				--only had race and heroes support for 1v1 submatches ...
-				local playerPrefix = parsedPrefix .. 't' .. opponentIndex .. 'p1'
-				parsedArgs[playerPrefix .. 'race'] = args[mapPrefix .. 'p' .. opponentIndex .. 'race'] or players[1].race
-				parsedArgs[playerPrefix .. 'heroes'] = args[mapPrefix .. 'p' .. opponentIndex .. 'heroes']
-			end)
-		end
-
-		if hasMissingWinner then
-			mapIndex = mapIndex + 1
-			local parsedPrefix = 'map' .. mapIndex
-			parsedArgs[parsedPrefix] = 'Submatch Score Fix'
-			parsedArgs[parsedPrefix .. 'subgroup'] = submatchIndex
-			parsedArgs[parsedPrefix .. 'p1score'] = (tonumber(args[prefix .. 'p1score']) or 0) - submatchScores[1]
-			parsedArgs[parsedPrefix .. 'p2score'] = (tonumber(args[prefix .. 'p2score']) or 0) - submatchScores[2]
-
-			Array.forEach(mapPlayers, function(players, opponentIndex)
-				Array.forEach(players, function(player, playerIndex)
-					parsedArgs[parsedPrefix .. 't' .. opponentIndex .. 'p' .. playerIndex] = player.name
-				end)
-			end)
-		end
-
-		submatchIndex = submatchIndex + 1
-		prefix = 'm' .. submatchIndex
-	end
+	end)
 
 	Array.forEach(opponentPlayers, function(players, opponentIndex)
 		Array.forEach(Array.extractValues(players), function(player, playerIndex)
@@ -175,6 +109,85 @@ function ConvertMapData.teamMulti(args)
 	end)
 
 	return Json.stringify(parsedArgs)
+end
+
+function ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, prefix, submatchIndex, mapIndex)
+	local players = {{}, {}}
+
+	Array.forEach(Array.range(1, NUMBER_OF_OPPONENTS), function(opponentIndex)
+		ConvertMapData._readSubmatchPlayers(args, players, opponentPlayers, prefix, opponentIndex)
+	end)
+
+	local hasMissingWinner = false
+	local submatchScores = {0, 0}
+	for mapPrefix, map, submatchMapIndex in Table.iter.pairsByPrefix(args, prefix .. 'map') do
+		mapIndex = mapIndex + 1
+		local parsedPrefix = 'map' .. mapIndex
+		parsedArgs[parsedPrefix] = map
+		parsedArgs[parsedPrefix .. 'subgroup'] = submatchIndex
+
+		local winner = tonumber(args[prefix .. 'win' .. submatchMapIndex])
+		parsedArgs[parsedPrefix .. 'win'] = winner
+		if winner and submatchScores[winner] then
+			submatchScores[winner] = submatchScores[winner] + 1
+		elseif winner ~= 0 then
+			hasMissingWinner = true
+		end
+
+		Array.forEach(players, function(players, opponentIndex)
+			Array.forEach(players, function(player, playerIndex)
+				parsedArgs[parsedPrefix .. 't' .. opponentIndex .. 'p' .. playerIndex] = player.name
+			end)
+			--only had race and heroes support for 1v1 submatches ...
+			local playerPrefix = parsedPrefix .. 't' .. opponentIndex .. 'p1'
+			parsedArgs[playerPrefix .. 'race'] = args[mapPrefix .. 'p' .. opponentIndex .. 'race'] or players[1].race
+			parsedArgs[playerPrefix .. 'heroes'] = args[mapPrefix .. 'p' .. opponentIndex .. 'heroes']
+		end)
+	end
+
+	if not hasMissingWinner then
+		return mapIndex
+	end
+
+	mapIndex = mapIndex + 1
+	local parsedPrefix = 'map' .. mapIndex
+	parsedArgs[parsedPrefix] = 'Submatch Score Fix'
+	parsedArgs[parsedPrefix .. 'subgroup'] = submatchIndex
+	parsedArgs[parsedPrefix .. 'p1score'] = (tonumber(args[prefix .. 'p1score']) or 0) - submatchScores[1]
+	parsedArgs[parsedPrefix .. 'p2score'] = (tonumber(args[prefix .. 'p2score']) or 0) - submatchScores[2]
+
+	Array.forEach(players, function(players, opponentIndex)
+		Array.forEach(players, function(player, playerIndex)
+			parsedArgs[parsedPrefix .. 't' .. opponentIndex .. 'p' .. playerIndex] = player.name
+		end)
+	end)
+
+	return mapIndex
+end
+
+function ConvertMapData._readSubmatchPlayers(args, players, opponentPlayers, prefix, opponentIndex)
+	local playerInputPrefix = prefix .. 'p' .. opponentIndex
+	local name = args[playerInputPrefix .. 'link'] or args[playerInputPrefix] or TBD
+	opponentPlayers[opponentIndex][name] = {
+		name = name,
+		displayname = args[playerInputPrefix] or name,
+		flag = args[playerInputPrefix .. 'flag'],
+		race = args[playerInputPrefix .. 'race'],
+	}
+	table.insert(players[opponentIndex], Table.copy(opponentPlayers[opponentIndex][name] or {}))
+
+	--optional second player
+	local player2InputPrefix = prefix .. 'p' .. opponentIndex .. '-2'
+	local name2 = args[player2InputPrefix .. 'link'] or args[player2InputPrefix]
+	if not name2 then return end
+
+	opponentPlayers[opponentIndex][name2] = {
+		name = name2,
+		displayname = args[player2InputPrefix] or name,
+		flag = args[player2InputPrefix .. 'flag'],
+		race = args[player2InputPrefix .. 'race'],
+	}
+	table.insert(players[opponentIndex], Table.copy(opponentPlayers[opponentIndex][name2] or {}))
 end
 
 return Class.export(ConvertMapData)

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -112,10 +112,10 @@ function ConvertMapData.teamMulti(args)
 end
 
 function ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, prefix, submatchIndex, mapIndex)
-	local players = {{}, {}}
+	local playersArrays = {{}, {}}
 
 	Array.forEach(Array.range(1, NUMBER_OF_OPPONENTS), function(opponentIndex)
-		ConvertMapData._readSubmatchPlayers(args, players, opponentPlayers, prefix, opponentIndex)
+		ConvertMapData._readSubmatchPlayers(args, playersArrays, opponentPlayers, prefix, opponentIndex)
 	end)
 
 	local hasMissingWinner = false
@@ -134,7 +134,7 @@ function ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, pref
 			hasMissingWinner = true
 		end
 
-		Array.forEach(players, function(players, opponentIndex)
+		Array.forEach(playersArrays, function(players, opponentIndex)
 			Array.forEach(players, function(player, playerIndex)
 				parsedArgs[parsedPrefix .. 't' .. opponentIndex .. 'p' .. playerIndex] = player.name
 			end)
@@ -156,7 +156,7 @@ function ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, pref
 	parsedArgs[parsedPrefix .. 'p1score'] = (tonumber(args[prefix .. 'p1score']) or 0) - submatchScores[1]
 	parsedArgs[parsedPrefix .. 'p2score'] = (tonumber(args[prefix .. 'p2score']) or 0) - submatchScores[2]
 
-	Array.forEach(players, function(players, opponentIndex)
+	Array.forEach(playersArrays, function(players, opponentIndex)
 		Array.forEach(players, function(player, playerIndex)
 			parsedArgs[parsedPrefix .. 't' .. opponentIndex .. 'p' .. playerIndex] = player.name
 		end)


### PR DESCRIPTION
## Summary
In the old `BracketTeamMatchMulti` they allowed missing maps, but only had max maps 1-9.
This PR adjusts the code so it can allows missing maps accordingly.
After this is merged all old team matches can be wrapper converted on warcraft, only leaving <250 pages with 2v2 stuff still to be converted (2v2 stuff never stored into match1 at all anyways).

## How did you test this change?
dev