### PR TITLE
Fix team player input handling

### DIFF
--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -346,6 +346,8 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 	local teamName = opponent.name
 	local playersData = Json.parseIfString(opponent.players) or {}
 
+	local playerNames = {}
+
 	local players = {}
 
 	for playerIndex = 1, MAX_NUM_PLAYERS do
@@ -365,7 +367,8 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 		player.displayname = player.displayname or playersData['p' .. playerIndex .. 'dn']
 			or Variables.varDefault(teamName .. '_p' .. playerIndex .. 'dn')
 
-		if Table.isNotEmpty(player) or faction then
+		if (Table.isNotEmpty(player) or faction) and not playerNames[player.name] then
+			playerNames[player.name] = true
 			player.extradata = {faction = faction or Faction.defaultFaction}
 			table.insert(players, player)
 		end


### PR DESCRIPTION
## Summary
Fix warcraft match2 team player input handling. Namely suppress duplicate entries from manual + wiki var inheritance

## How did you test this change?
dev