### PR TITLE
Add PlayerTeamAuto

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -69,7 +69,7 @@ function Person:createInfobox()
 	end
 
 	if Logic.readBool(args.autoTeam) then
-		local team, team2 = PlayerIntroduction.playerTeamAuto()
+		local team, team2 = PlayerIntroduction.playerTeamAuto{player=self.pagename}
 		args.team = Logic.emptyOr(args.team, team)
 		args.team2 = Logic.emptyOr(args.team2, team2)
 	end

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -69,7 +69,7 @@ function Person:createInfobox()
 	end
 
 	if Logic.readBool(args.autoTeam) then
-		local team, team2 = PlayerIntroduction.playerTeamAuto{}
+		local team, team2 = PlayerIntroduction.playerTeamAuto()
 		args.team = Logic.emptyOr(args.team, team)
 		args.team2 = Logic.emptyOr(args.team2, team2)
 	end

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')
@@ -20,8 +21,9 @@ local WarningBox = require('Module:WarningBox')
 local AgeCalculation = Lua.import('Module:AgeCalculation', {requireDevIfEnabled = true})
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
 local Earnings = Lua.import('Module:Earnings', {requireDevIfEnabled = true})
-local Links = Lua.import('Module:Links', {requireDevIfEnabled = true})
 local Flags = Lua.import('Module:Flags', {requireDevIfEnabled = true})
+local Links = Lua.import('Module:Links', {requireDevIfEnabled = true})
+local PlayerIntroduction = Lua.import('Module:PlayerIntroduction', {requireDevIfEnabled = true})
 local Region = Lua.import('Module:Region', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -64,6 +66,12 @@ function Person:createInfobox()
 
 	if String.isEmpty(args.id) then
 		error('You need to specify an "id"')
+	end
+
+	if Logic.readBool(args.autoTeam) then
+		local team, team2 = PlayerIntroduction.playerTeamAuto{}
+		args.team = Logic.emptyOr(args.team, team)
+		args.team2 = Logic.emptyOr(args.team2, team2)
 	end
 
 	-- check if non-representing is used and set an according value in self
@@ -284,8 +292,7 @@ function Person:_setLpdbData(args, links, status, personType)
 	end
 
 	lpdbData = self:adjustLPDB(lpdbData, args, personType)
-	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata)
-	lpdbData.links = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.links)
+	lpdbData = Json.stringifySubTables(lpdbData)
 	local storageType = self:getStorageType(args, personType, status)
 
 	mw.ext.LiquipediaDB.lpdb_player(storageType .. '_' .. (args.id or self.name), lpdbData)

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -78,7 +78,7 @@ function PlayerIntroduction.templatePlayerIntroduction(frame)
 end
 
 -- module entry point for PlayerIntroduction
----@param args playerIntroArgsValues
+---@param args playerIntroArgsValues?
 ---@return string
 function PlayerIntroduction.run(args)
 	return PlayerIntroduction(args):queryPlayerInfo():queryTransferData(true):adjustData():create()
@@ -95,7 +95,7 @@ function PlayerIntroduction.templatePlayerTeamAuto(frame)
 end
 
 -- module entry point for PlayerTeamAuto
----@param args playerIntroArgsValues
+---@param args playerIntroArgsValues?
 ---@return string?
 ---@return string?
 function PlayerIntroduction.playerTeamAuto(args)
@@ -112,7 +112,7 @@ end
 ---@param args playerIntroArgsValues
 ---@return self
 function PlayerIntroduction:init(args)
-	self.args = args
+	self.args = args or {}
 
 	self.player = mw.ext.TeamLiquidIntegration.resolve_redirect(
 		args.player or args[1] or mw.title.getCurrentTitle().text

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -130,8 +130,8 @@ end
 
 ---@param queryOnlyIfPlayerInfoIsFound boolean
 ---@return self
-function PlayerIntroduction:queryTransferData(queryOnlyIfPlayerInfoIsFound)
-	if queryOnlyIfPlayerInfoIsFound and Table.isEmpty(self.playerInfo) then
+function PlayerIntroduction:queryTransferData(queryOnlyIfPlayerInfoIsPresent)
+	if queryOnlyIfPlayerInfoIsPresent and Table.isEmpty(self.playerInfo) then
 		return self
 	end
 

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -102,17 +102,12 @@ function PlayerIntroduction.playerTeamAuto(args)
 	return PlayerIntroduction(args):queryTransferData(false):returnTeams()
 end
 
---legacy, temp needed to switch the template:PlayerTeamAuto after merge
----@deprecated
-function PlayerIntroduction.main(frame)
-	return PlayerIntroduction.templatePlayerTeamAuto(frame)
-end
-
 --- Init function for PlayerIntroduction
----@param args playerIntroArgsValues
+---@param args playerIntroArgsValues?
 ---@return self
 function PlayerIntroduction:init(args)
-	self.args = args or {}
+	args = args or {}
+	self.args = args
 
 	self.player = mw.ext.TeamLiquidIntegration.resolve_redirect(
 		args.player or args[1] or mw.title.getCurrentTitle().text

--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -25,120 +25,153 @@ local SKIP_ROLE = 'skip'
 local INACTIVE_ROLE = 'inactive'
 local DEFAULT_DATE = '1970-01-01'
 
+---@class playerIntroArgsValues
+---@field [1] string?
+---@field player string?
+---@field playerInfo string?
+---@field birthdate string?
+---@field deathdate string?
+---@field defaultGame string?
+---@field faction string?
+---@field faction2 string?
+---@field faction3 string?
+---@field firstname string?
+---@field lastname string?
+---@field freetext string?
+---@field game string?
+---@field id string?
+---@field name string?
+---@field nationality string?
+---@field nationality2 string?
+---@field nationality3 string?
+---@field role string?
+---@field role2 string?
+---@field status string?
+---@field subtext string?
+---@field team string?
+---@field team2 string?
+---@field type string?
+---@field transferquery string?
+---@field convert_role boolean?
+---@field show_role boolean?
+---@field show_faction boolean?
+---@field formername1 string?
+---@field formername2 string?
+---@field formername3 string?
+---@field aka1 string?
+---@field aka2 string?
+---@field aka3 string?
+
 ---@class PlayerIntroduction
 ---@operator call(playerIntroArgsValues): PlayerIntroduction
+---@field player string
+---@field args playerIntroArgsValues
+---@field playerInfo table
+---@field transferInfo table
 local PlayerIntroduction = Class.new(function(self, ...) self:init(...) end)
 
----@deprecated
---- only for legacy support
----@param args table
----@return string
-function PlayerIntroduction._main(args)
-	return PlayerIntroduction.run(args)
-end
-
----@deprecated
---- only for legacy support
----@param frame Frame
----@return string
-function PlayerIntroduction.main(frame)
-	return PlayerIntroduction.run(Arguments.getArgs(frame))
-end
-
----@deprecated
---- only legacy support for `Module:PlayerTeamAuto`
----@param player string
----@param queryType string?
----@return table
-function PlayerIntroduction._get_lpdbtransfer(player, queryType)
-	return PlayerIntroduction._readTransferData(player, queryType == 'datapoint')
-end
-
--- template entry point
+-- template entry point for PlayerIntroduction
 ---@param frame Frame
 ---@return string
 function PlayerIntroduction.templatePlayerIntroduction(frame)
 	return PlayerIntroduction.run(Arguments.getArgs(frame))
 end
 
--- module entry point
----@param args table
+-- module entry point for PlayerIntroduction
+---@param args playerIntroArgsValues
 ---@return string
 function PlayerIntroduction.run(args)
-	return PlayerIntroduction(args):create()
+	return PlayerIntroduction(args):queryPlayerInfo():queryTransferData(true):adjustData():create()
 end
 
----@class playerIntroArgsValues
----@field [1] string?,
----@field player string?,
----@field playerInfo string?,
----@field birthdate string?,
----@field deathdate string?,
----@field defaultGame string?,
----@field faction string?,
----@field faction2 string?,
----@field faction3 string?,
----@field firstname string?,
----@field lastname string?,
----@field freetext string?,
----@field game string?,
----@field id string?,
----@field name string?,
----@field nationality string?,
----@field nationality2 string?,
----@field nationality3 string?,
----@field role string?,
----@field role2 string?,
----@field status string?,
----@field subtext string?,
----@field team string?,
----@field team2 string?,
----@field type string?,
----@field transferquery string?,
----@field convert_role boolean?,
----@field show_role boolean?,
----@field show_faction boolean?
----@field formername1 string?,
----@field formername2 string?,
----@field formername3 string?,
----@field aka1 string?,
----@field aka2 string?,
----@field aka3 string?,
+-- template entry point for PlayerTeamAuto
+---@param frame Frame
+---@return string
+function PlayerIntroduction.templatePlayerTeamAuto(frame)
+	local args = Arguments.getArgs(frame)
+	local team, team2 = PlayerIntroduction.playerTeamAuto(args)
+
+	return args.team == 'team2' and (team2 or '') or team or ''
+end
+
+-- module entry point for PlayerTeamAuto
+---@param args playerIntroArgsValues
+---@return string?
+---@return string?
+function PlayerIntroduction.playerTeamAuto(args)
+	return PlayerIntroduction(args):queryTransferData(false):returnTeams()
+end
+
+--legacy, temp needed to switch the template:PlayerTeamAuto after merge
+---@deprecated
+function PlayerIntroduction.main(frame)
+	return PlayerIntroduction.templatePlayerTeamAuto(frame)
+end
 
 --- Init function for PlayerIntroduction
 ---@param args playerIntroArgsValues
 ---@return self
 function PlayerIntroduction:init(args)
+	self.args = args
+
 	self.player = mw.ext.TeamLiquidIntegration.resolve_redirect(
 		args.player or args[1] or mw.title.getCurrentTitle().text
 	):gsub(' ', '_')
 
+	return self
+end
+
+---@return self
+function PlayerIntroduction:queryPlayerInfo()
 	local playerInfo = {}
-	if Logic.emptyOr(args.playerInfo, SHOULD_QUERY_KEYWORD) == SHOULD_QUERY_KEYWORD then
+	if Logic.emptyOr(self.args.playerInfo, SHOULD_QUERY_KEYWORD) == SHOULD_QUERY_KEYWORD then
 		playerInfo = self:_playerQuery()
 	end
 
-	self:_parsePlayerInfo(args, playerInfo)
+	self:_parsePlayerInfo(self.args, playerInfo)
 
-	if Table.isEmpty(self.playerInfo) then
+	return self
+end
+
+---@param queryOnlyIfPlayerInfoIsFound boolean
+---@return self
+function PlayerIntroduction:queryTransferData(queryOnlyIfPlayerInfoIsFound)
+	if queryOnlyIfPlayerInfoIsFound and Table.isEmpty(self.playerInfo) then
 		return self
 	end
 
 	-- can not use `:` here due to `Module:PlayerTeamAuto`
-	self.transferInfo = PlayerIntroduction._readTransferData(self.player, args.transferquery == 'datapoint')
+	self.transferInfo = PlayerIntroduction._readTransferData(self.player, self.args.transferquery == 'datapoint')
 
+	return self
+end
+
+---@return string?
+---@return string?
+function PlayerIntroduction:returnTeams()
+	local transfer = self.transferInfo
+	if not transfer or (transfer.type ~= 'current' and transfer.type ~= 'loan') then
+		return
+	end
+
+	return transfer.team, transfer.team2
+end
+
+---@return self
+function PlayerIntroduction:adjustData()
 	self:_adjustTransferData()
 
-	self:_roleAdjusts(args)
+	self:_roleAdjusts(self.args)
 
 	self.options = {
-		showRole = Logic.readBool(args.show_role),
-		showFaction = Logic.readBool(args.show_faction),
+		showRole = Logic.readBool(self.args.show_role),
+		showFaction = Logic.readBool(self.args.show_faction),
 	}
 
 	return self
 end
 
+---@return table
 function PlayerIntroduction:_playerQuery()
 	local queryData = mw.ext.LiquipediaDB.lpdb('player', {
 		conditions = '[[pagename::' .. self.player .. ']]',

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -17,7 +17,6 @@ local Namespace = require('Module:Namespace')
 local Operator = require('Module:Operator')
 local Page = require('Module:Page')
 local PlayerIntroduction = require('Module:PlayerIntroduction')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local Region = require('Module:Region')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -78,10 +77,7 @@ local INACTIVITY_THRESHOLD_BROADCAST = {month = 6}
 function CustomPlayer.run(frame)
 	_player = Player(frame)
 	_args = _player.args
-	-- Automatic team, history
-	if String.isEmpty(_args.team) then
-		_args.team = PlayerTeamAuto._main{team = 'team'}
-	end
+	_args.autoTeam = true
 	local automatedHistory = TeamHistoryAuto.results{player=_player.pagename, convertrole=true, addlpdbdata=true}
 	if String.isEmpty(_args.history) then
 		_args.history = automatedHistory

--- a/components/infobox/wikis/apexlegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_person_player_custom.lua
@@ -11,7 +11,6 @@ local Class = require('Module:Class')
 local LegendIcon = require('Module:LegendIcon')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local UpcomingMatches = require('Module:Matches Player')
@@ -56,19 +55,12 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -12,7 +12,6 @@ local HeroIcon = require('Module:HeroIcon')
 local HeroNames = mw.loadData('Module:HeroNames')
 local Lua = require('Module:Lua')
 local Role = require('Module:Role')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -14,7 +14,6 @@ local Lua = require('Module:Lua')
 local Role = require('Module:Role')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
@@ -37,14 +36,7 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_player = player
 	_args = player.args
-
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
+	_args.autoTeam = true
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector

--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -11,7 +11,6 @@ local GameAppearances = require('Module:GetGameAppearances')
 local Lua = require('Module:Lua')
 local Role = require('Module:Role')
 local String = require('Module:StringUtils')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -34,16 +33,9 @@ local _role2
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_args = player.args
+	_args.autoTeam = true
 	_role = Role.run({role = _args.role})
 	_role2 = Role.run({role = _args.role2})
-
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -14,7 +14,6 @@ local Role = require('Module:Role')
 local Region = require('Module:Region')
 local Math = require('Module:MathUtil')
 local String = require('Module:StringUtils')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
@@ -41,14 +40,7 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_args = player.args
 	_player = player
-
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
+	_args.autoTeam = true
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -11,7 +11,6 @@ local GameAppearances = require('Module:GetGameAppearances')
 local Lua = require('Module:Lua')
 local Region = require('Module:Region')
 local Role = require('Module:Role')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
@@ -36,18 +35,11 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local Team = require('Module:Team')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
@@ -65,14 +64,6 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	if String.isEmpty(player.args.history) then
 		player.args.history = TeamHistoryAuto._results{
 			hiderole = 'true',
@@ -86,6 +77,7 @@ function CustomPlayer.run(frame)
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -13,7 +13,6 @@ local HeroNames = mw.loadData('Module:HeroNames')
 local Lua = require('Module:Lua')
 local Region = require('Module:Region')
 local Role = require('Module:Role')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
@@ -42,18 +41,11 @@ function CustomPlayer.run(frame)
 	local player = Player(frame)
 	_player = player
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/naraka/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_person_player_custom.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local HeroIcon = require('Module:HeroIcon')
 local Lua = require('Module:Lua')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Team = require('Module:Team')
@@ -50,14 +49,6 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
@@ -65,6 +56,7 @@ function CustomPlayer.run(frame)
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Template = require('Module:Template')
@@ -49,19 +48,12 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 	player.createBottomContent = CustomPlayer.createBottomContent
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -11,7 +11,6 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local OperatorIcon = require('Module:OperatorIcon')
 local Page = require('Module:Page')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Team = require('Module:Team')
@@ -67,14 +66,6 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', specialRoles = 'true'}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
@@ -82,6 +73,7 @@ function CustomPlayer.run(frame)
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/tft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/tft/infobox_person_player_custom.lua
@@ -13,7 +13,6 @@ local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -46,20 +45,13 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 	player.defineCustomPageVariables = CustomPlayer.defineCustomPageVariables
 	player.getPersonType = CustomPlayer.getPersonType
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -10,7 +10,6 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local PlayersSignatureAgents = require('Module:PlayersSignatureAgents')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local Region = require('Module:Region')
 local String = require('Module:StringUtils')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
@@ -53,13 +52,6 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
 	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
@@ -67,6 +59,7 @@ function CustomPlayer.run(frame)
 	player.getPersonType = CustomPlayer.getPersonType
 
 	_args = player.args
+	_args.autoTeam = true
 	_player = player
 
 	return player:createInfobox()

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -11,7 +11,6 @@ local Class = require('Module:Class')
 local ChampionIcon = require('Module:ChampionIcon')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 local String = require('Module:StringUtils')
 local Team = require('Module:Team')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
@@ -69,14 +68,6 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	if String.isEmpty(player.args.history) then
 		player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
 	end
@@ -86,6 +77,7 @@ function CustomPlayer.run(frame)
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 
 	return player:createInfobox()
 end

--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -11,7 +11,6 @@ local Lua = require('Module:Lua')
 local Role = require('Module:Role')
 local String = require('Module:StringUtils')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
-local PlayerTeamAuto = require('Module:PlayerTeamAuto')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
@@ -33,18 +32,11 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	if String.isEmpty(player.args.team) then
-		player.args.team = PlayerTeamAuto._main{team = 'team'}
-	end
-
-	if String.isEmpty(player.args.team2) then
-		player.args.team2 = PlayerTeamAuto._main{team = 'team2'}
-	end
-
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
+	_args.autoTeam = true
 	_role = Role.run({role = _args.role})
 	_role2 = Role.run({role = _args.role2})
 


### PR DESCRIPTION
note: merge should happen coordinated so that https://liquipedia.net/commons/Template:PlayerTeamAuto can be adjusted right after the merge

## Summary
- Merge PlayerTeamAuto module (non git) into `Module:PlayerIntroduction` (git)
- Add PlayerTeamAuto (locked behind option param) to Infobox/Person commons base

## How did you test this change?
dev