### PR TITLE
Update LPL links to legacy domain

### DIFF
--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -73,7 +73,7 @@ return {
 	{
 		name = 'lpl',
 		icon = 'LPL Play icon.png',
-		prefixLink = 'https://letsplay.live/match/',
+		prefixLink = 'https://old.letsplay.live/match/',
 		label = 'Matchpage on LPL Play',
 	},
 	{

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -312,7 +312,7 @@ function matchFunctions.getVodStuff(match)
 		opl = match.opl and 'https://www.opleague.eu/match/' .. match.opl or nil,
 		esl = match.esl and 'https://play.eslgaming.com/match/' .. match.esl or nil,
 		faceit = match.faceit and 'https://www.faceit.com/en/rainbow_6/room/' .. match.faceit or nil,
-		lpl = match.lpl and 'https://letsplay.live/match/' .. match.lpl or nil,
+		lpl = match.lpl and 'https://old.letsplay.live/match/' .. match.lpl or nil,
 		r6esports = match.r6esports
 			and 'https://www.ubisoft.com/en-us/esports/rainbow-six/siege/match/' .. match.r6esports or nil,
 		challengermode = match.challengermode and 'https://www.challengermode.com/games/' .. match.challengermode or nil,

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -115,7 +115,11 @@ local PREFIXES = {
 	instagram = {'https://www.instagram.com/'},
 	kick = {'https://www.kick.com/'},
 	kuaishou = {'https://live.kuaishou.com/u/'},
-	letsplaylive = {'https://letsplay.live/profile/'},
+	letsplaylive = {
+		'https://old.letsplay.live/event/',
+		team = 'https://old.letsplay.live/team/',
+		player = 'https://old.letsplay.live/profile/',
+	},
 	loco = {'https://loco.gg/streamers/'},
 	lolchess = {'https://lolchess.gg/profile/'},
 	matcherino = {'https://matcherino.com/tournaments/'},


### PR DESCRIPTION
## Summary

They moved all the old stuff we have links for to `https://old.letsplay.live/`. So just moving that across. Also, added correct team and event link format.

## How did you test this change?

Just data :p