### PR TITLE
Fix warcraft team player input in match2

### DIFF
--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -348,7 +348,7 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 	local teamName = opponent.name
 	local playersData = Json.parseIfString(opponent.players) or {}
 
-	local inSertIntoPlayers = function(player)
+	local insertIntoPlayers = function(player)
 		if type(player) ~= 'table' or Logic.isEmpty(player) or Logic.isEmpty(player.name) then
 			return
 		end
@@ -364,11 +364,11 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 
 	for playerIndex = 1, MAX_NUM_PLAYERS do
 		--players from manual input as `opponnetX_pY`
-		inSertIntoPlayers(Json.parseIfString(Table.extract(match, 'opponent' .. opponentIndex .. '_p' .. playerIndex)))
+		insertIntoPlayers(Json.parseIfString(Table.extract(match, 'opponent' .. opponentIndex .. '_p' .. playerIndex)))
 
 		--players from wiki vars set by teamCard
 		local varPrefix = teamName .. '_p' .. playerIndex
-		inSertIntoPlayers({
+		insertIntoPlayers({
 			name = Variables.varDefault(varPrefix),
 			displayName = Variables.varDefault(varPrefix .. 'dn'),
 			race = Variables.varDefault(varPrefix .. 'race'),
@@ -377,7 +377,7 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 
 		--players from manual input in `opponent.players`
 		local playerPrefix
-		inSertIntoPlayers({
+		insertIntoPlayers({
 			name = playersData[playerPrefix],
 			displayName = playersData[playerPrefix .. 'dn'],
 			race = playersData[playerPrefix .. 'race'],

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -362,23 +362,30 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 		Table.deepMergeInto(players[player.name], player)
 	end
 
-	for playerIndex = 1, MAX_NUM_PLAYERS do
-		--players from manual input as `opponnetX_pY`
-		insertIntoPlayers(Json.parseIfString(Table.extract(match, 'opponent' .. opponentIndex .. '_p' .. playerIndex)))
-
-		--players from wiki vars set by teamCard
-		local varPrefix = teamName .. '_p' .. playerIndex
-		insertIntoPlayers({
-			name = Variables.varDefault(varPrefix),
+	local playerIndex = 1
+	local varPrefix = teamName .. '_p' .. playerIndex
+	local name = Variables.varDefault(varPrefix)
+	while name do
+		insertIntoPlayers{
+			name = name,
 			displayName = Variables.varDefault(varPrefix .. 'dn'),
 			race = Variables.varDefault(varPrefix .. 'race'),
 			flag = Variables.varDefault(varPrefix .. 'flag'),
-		})
+		}
+		playerIndex = playerIndex + 1
+		varPrefix = teamName .. '_p' .. playerIndex
+		name = Variables.varDefault(varPrefix)
+	end
 
-		--players from manual input in `opponent.players`
-		local playerPrefix = 'p' .. playerIndex
+	--players from manual input as `opponnetX_pY`
+	for _, player in Table.iter.pairsByPrefix(match, 'opponent' .. opponentIndex .. '_p') do
+		insertIntoPlayers(Json.parseIfString(player))
+	end
+
+	--players from manual input in `opponent.players`
+	for _, name, playerPrefix in Table.iter.pairsByPrefix(playersData, 'p') do
 		insertIntoPlayers({
-			name = playersData[playerPrefix],
+			name = name,
 			displayName = playersData[playerPrefix .. 'dn'],
 			race = playersData[playerPrefix .. 'race'],
 			flag = playersData[playerPrefix .. 'flag'],

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -376,7 +376,7 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 		})
 
 		--players from manual input in `opponent.players`
-		local playerPrefix
+		local playerPrefix = 'p' .. playerIndex
 		insertIntoPlayers({
 			name = playersData[playerPrefix],
 			displayName = playersData[playerPrefix .. 'dn'],

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -29,7 +29,6 @@ local ALLOWED_STATUSES = {'W', 'FF', 'DQ', 'L'}
 local CONVERT_STATUS_INPUT = {W = 'W', FF = 'FF', L = 'L', DQ = 'DQ', ['-'] = 'L'}
 local DEFAULT_LOSS_STATUSES = {'FF', 'L', 'DQ'}
 local MAX_NUM_OPPONENTS = 2
-local MAX_NUM_PLAYERS = 20
 local DEFAULT_BEST_OF = 99
 local LINKS_KEYS = {'preview', 'preview2', 'interview', 'interview2', 'review', 'recap', 'lrthread'}
 local MODE_MIXED = 'mixed'
@@ -383,9 +382,9 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 	end
 
 	--players from manual input in `opponent.players`
-	for _, name, playerPrefix in Table.iter.pairsByPrefix(playersData, 'p') do
+	for _, playerName, playerPrefix in Table.iter.pairsByPrefix(playersData, 'p') do
 		insertIntoPlayers({
-			name = name,
+			name = playerName,
 			displayName = playersData[playerPrefix .. 'dn'],
 			race = playersData[playerPrefix .. 'race'],
 			flag = playersData[playerPrefix .. 'flag'],


### PR DESCRIPTION
## Summary
Fix warcraft team player input in match2.
If reading player data from different sources (wiki var, manual input) it intermingles them in a way that can cause issues.
Namely it sometimes adds flags/displaynames/factions to the wrong players if several input methods are mixed.

## How did you test this change?
dev