### PR TITLE
fix: print `erorStackTrace` as array in ErrorExt

### DIFF
--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -140,7 +140,7 @@ function ErrorExt.printErrorJson(error)
 	return Json.stringify({
 			errorShort = string.format('Lua error in %s:%s at line %s:%s.', unpack(mw.text.split(error.error, ':', true))),
 			stackTrace = stackTrace,
-		})
+		}, {asArray = true})
 end
 
 local Stash = {}


### PR DESCRIPTION
## Summary

Fix this broken due to the default to non-array json stringify.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/6e2773c2-1673-4a90-bc26-aa8b19389ed7)

## How did you test this change?

Live fixed.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/046b1081-e391-4850-bf64-350feb4bc4c6)

