### PR TITLE
PPT: Set empty tables for lpdb json fields

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -814,6 +814,10 @@ function BasePrizePool:storeData()
 		icondark = Variables.varDefault('tournament_icondark'),
 		game = Variables.varDefault('tournament_game'),
 		prizepoolindex = prizePoolIndex,
+		lastvsdata = {},
+		opponentplayers = {},
+		players = {},
+		extradata = {},
 	}
 
 	local lpdbData = {}


### PR DESCRIPTION
## Summary
As discussed in discord:
The change to `Json.stringifySubTables` introduced in #3497 changed the values of `nil` fields when stored in LPDB.
This sets json fields to empty tables by default, so they are of type table when being read from LPDB again.
In TeamCard/Storage this is similar, but at least players/opponentplayers are already set as empty table there.

## How did you test this change?
via /dev (see [here](https://liquipedia.net/commons/Special:LiquipediaDB/MainspaceTest#placement) - these testcases don't entirely prove how the issue is fixed, but they show it does not break anything)