### PR TITLE
feat: Add `arePatterns` to `Table.includes()`

### DIFF
--- a/standard/table.lua
+++ b/standard/table.lua
@@ -27,12 +27,15 @@ end
 
 ---@param tbl table
 ---@param value any
----@param isPattern boolean?
+---@param isPattern boolean? If `value` is a Lua pattern **(mutex: `arePatterns`)**
+---@param arePatterns boolean? If `tbl` contains Lua patterns **(mutex: `isPattern`)**
 ---@return boolean
-function Table.includes(tbl, value, isPattern)
+function Table.includes(tbl, value, isPattern, arePatterns)
+	assert(not (isPattern and arePatterns), "isPattern and arePatterns are mutually exclusive!")
 	for _, entry in pairs(tbl) do
 		if isPattern and string.find(entry, value)
-			or not isPattern and entry == value then
+			or arePatterns and string.find(value, entry)
+			or not (isPattern or arePatterns) and entry == value then
 				return true
 		end
 	end

--- a/standard/test/table_test.lua
+++ b/standard/test/table_test.lua
@@ -130,6 +130,7 @@ end
 function suite:testIncludes()
 	local a = {'testValue', 'testValue2', 'testValue3'}
 	local b = {key1 = 'testValue', key2 = 'testValue2', 'testValue3'}
+	local c = {key1 = '^testValue%d$', '^testValue$', 'rest'}
 	self:assertTrue(Table.includes(a, 'testValue'))
 	self:assertTrue(Table.includes(b, 'testValue'))
 	self:assertTrue(Table.includes(b, 'testValue3'))
@@ -149,6 +150,15 @@ function suite:testIncludes()
 	self:assertTrue(Table.includes(b, '^testValue%d$', true))
 	self:assertFalse(Table.includes(b, '^estValue3$', true))
 	self:assertFalse(Table.includes({'^estValue3$'}, '^estValue3$', true))
+
+	self:assertTrue(Table.includes(c, 'testValue', false, true))
+	self:assertTrue(Table.includes(c, 'testValue2', false, true))
+	self:assertTrue(Table.includes(c, 'rest', false, true))
+	self:assertTrue(Table.includes(c, 'rested', false, true))
+	self:assertFalse(Table.includes(c, 'estValue', false, true))
+	self:assertFalse(Table.includes(c, 'testValue ', false, true))
+	self:assertFalse(Table.includes(c, 'testValueddd', false, true))
+	self:assertFalse(Table.includes(c, 'badValue', false, true))
 end
 
 function suite:testFilterByKey()


### PR DESCRIPTION
## Summary

Previously I added `isPattern` to `Table.includes()` in #3448, however, I actually wanted the opposite functionality and accidentally superimposing two of the inputs at one point meant the PR actually added something different than what I needed.

Adding `arePatterns` to mean that the table itself is a list of patterns to compare to a given string. Mutually exclusive with `isPattern` as patterns compared to pattern seemed silly/wrong.

## Optional changes

Here are some thing that I am open to changing if people think it would be better:

- [ ] Swapping both of the pattern parameters to an `options` table. (afaik no one has used `isPattern` anywhere yet except me)?
- [ ] Allow both of the options to be true, but then just compare them as normal strings? (as that's kinda what you're asking for by making both true)
- [ ] Renaming the options/params to some other names if these are disliked?

## How did you test this change?

`/dev` testcases and in an upcoming PR.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/df481be6-b980-4723-b778-820e58682d9f)

