### PR TITLE
fix: `Error/Ext` filtering and `mw.ext` errors

### DIFF
--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -110,8 +110,8 @@ function ErrorExt.printErrorJson(error)
 		local frameSplit = mw.text.split(frame, ':', true)
 		if (frameSplit[1] == '[C]' or frameSplit[1] == '(tail call)') then
 			stackEntry.prefix = frameSplit[1]
-			stackEntry.content = table.concat(frameSplit, ':', 2)
-		elseif frameSplit[1] == 'mw.lua' then
+			stackEntry.content = mw.text.trim(table.concat(frameSplit, ':', 2))
+		elseif frameSplit[1]:sub(1, 3) == 'mw.' then
 			stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
 			stackEntry.content =  table.concat(frameSplit, ':', 3)
 		elseif frameSplit[1] == 'Module' then
@@ -132,13 +132,15 @@ function ErrorExt.printErrorJson(error)
 				Array.sub(stackFrames, 2, #stackFrames),
 				function(frame) return String.trim(frame) end
 			),
-			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame, true) end
+			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame, false, true) end
 		)
 		Array.forEach(stackFrames, processStackFrame)
 	end)
 
+	local errorSplit = mw.text.split(error.error, ':', true)
 	return Json.stringify({
-			errorShort = string.format('Lua error in %s:%s at line %s:%s.', unpack(mw.text.split(error.error, ':', true))),
+			errorShort = (#errorSplit == 1) and string.format('Lua error: %s.', error.error)
+				or string.format('Lua error in %s:%s at line %s:%s.', unpack(errorSplit)),
 			stackTrace = stackTrace,
 		}, {asArray = true})
 end

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -132,7 +132,9 @@ function ErrorExt.printErrorJson(error)
 				Array.sub(stackFrames, 2, #stackFrames),
 				function(frame) return String.trim(frame) end
 			),
-			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame, false, true) end
+			function(frame) return not Table.any(FILTERED_STACK_ITEMS, function(_, filter)
+				return string.find(frame, filter) ~= nil
+			end) end
 		)
 		Array.forEach(stackFrames, processStackFrame)
 	end)

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -96,7 +96,7 @@ function ErrorExt.makeFullStackTrace(error)
 end
 
 ---Builds a JSON string for using with `liquipedia.customLuaErrors` JS module via error().
----@param error error
+---@param error Error
 ---@return string?
 function ErrorExt.printErrorJson(error)
 	local stackTrace = {}

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -39,8 +39,7 @@ local parsedText = socketOrError
 	:get()
 ```
 ]]
----@class ResultOrError
----@field is_a? function
+---@class ResultOrError: BaseClass
 local ResultOrError = Class.new(function(self)
 	-- ResultOrError is an abstract class. Don't call this constructor directly.
 	--error('Cannot construct abstract class')
@@ -73,7 +72,7 @@ end
 --[[
 Result case
 ]]
----@class Result
+---@class Result: ResultOrError
 ---@field result any
 local Result = Class.new(ResultOrError, function(self, result)
 	self.result = result
@@ -98,7 +97,7 @@ continuation of the stack trace of the error that was handled (and so on).
 This allows error handlers to rethrow the original error without losing the
 stack trace, and is needed to implement :finally().
 ]]
----@class Error
+---@class Error: ResultOrError
 ---@field error string?
 ---@field stacks string[]?
 local Error = Class.new(ResultOrError, function(self, error, stacks)

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -8,6 +8,16 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Json = require('Module:Json')
+local Page = require('Module:Page')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local FILTERED_ERROR_STACK_ITEMS = {
+	'^Module:ResultOrError:%d+: in function <Module:ResultOrError:%d+>$',
+	'^%[C%]: in function \'xpcall\'$',
+	'^Module:ResultOrError:%d+: in function \'try\'$',
+}
 
 --[[
 A structurally typed, immutable class that represents either a result or an
@@ -102,8 +112,56 @@ function Error:map(_, onError)
 		or ResultOrError.Result()
 end
 
+---Errors with a JSON string for use by `liquipedia.customLuaErrors` JS module.
 function Error:get()
-	error(require('Module:Error/Ext').printErrorJson(self), 0)
+	local stackTrace = {}
+
+	local processStackFrame = function(frame, frameIndex)
+		if frameIndex == 1 and frame == '[C]: ?' then
+			return
+		end
+
+		local stackEntry = {content = frame}
+		local frameSplit = mw.text.split(frame, ':', true)
+		if (frameSplit[1] == '[C]' or frameSplit[1] == '(tail call)') then
+			stackEntry.prefix = frameSplit[1]
+			stackEntry.content = mw.text.trim(table.concat(frameSplit, ':', 2))
+		elseif frameSplit[1]:sub(1, 3) == 'mw.' then
+			stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
+			stackEntry.content =  table.concat(frameSplit, ':', 3)
+		elseif frameSplit[1] == 'Module' then
+			local wiki = not Page.exists(table.concat(frameSplit, ':', 1, 2)) and 'commons'
+				or mw.text.split(mw.title.getCurrentTitle():canonicalUrl(), '/', true)[4] or 'commons'
+			stackEntry.link = {wiki = wiki, title = table.concat(frameSplit, ':', 1, 2), ln = frameSplit[3]}
+			stackEntry.prefix = table.concat(frameSplit, ':', 1, 3)
+			stackEntry.content = table.concat(frameSplit, ':', 4)
+		end
+
+		table.insert(stackTrace, stackEntry)
+	end
+
+	Array.forEach(self.stacks, function(stack)
+		local stackFrames = mw.text.split(stack, '\n')
+		stackFrames = Array.filter(
+			Array.map(
+				Array.sub(stackFrames, 2, #stackFrames),
+				function(frame) return String.trim(frame) end
+			),
+			function(frame) return not Table.any(FILTERED_ERROR_STACK_ITEMS, function(_, filter)
+				return string.find(frame, filter) ~= nil
+			end) end
+		)
+		Array.forEach(stackFrames, processStackFrame)
+	end)
+
+	local errorSplit = mw.text.split(self.error, ':', true)
+	local errorJson = Json.stringify({
+			errorShort = (#errorSplit == 1) and string.format('Lua error: %s.', self.error)
+				or string.format('Lua error in %s:%s at line %s:%s.', unpack(errorSplit)),
+			stackTrace = stackTrace,
+		}, {asArray = true})
+
+	error(errorJson, 0)
 end
 
 --[[

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -14,7 +14,7 @@ A structurally typed, immutable class that represents either a result or an
 error. Used for representing the outcome of a function that can throw.
 
 Usage:
-
+```
 local socketOrError = ResultOrError.try(function()
 	return socketlib.open()
 end)
@@ -27,7 +27,10 @@ local parsedText = socketOrError
 		socketOrError:map(function(socket) socket:close() end)
 	end)
 	:get()
+```
 ]]
+---@class ResultOrError
+---@field is_a? function
 local ResultOrError = Class.new(function(self)
 	-- ResultOrError is an abstract class. Don't call this constructor directly.
 	--error('Cannot construct abstract class')
@@ -60,6 +63,8 @@ end
 --[[
 Result case
 ]]
+---@class Result
+---@field result any
 local Result = Class.new(ResultOrError, function(self, result)
 	self.result = result
 end)
@@ -83,6 +88,9 @@ continuation of the stack trace of the error that was handled (and so on).
 This allows error handlers to rethrow the original error without losing the
 stack trace, and is needed to implement :finally().
 ]]
+---@class Error
+---@field error string?
+---@field stacks string[]?
 local Error = Class.new(ResultOrError, function(self, error, stacks)
 	self.error = error
 	self.stacks = stacks


### PR DESCRIPTION
## Summary

Four (one minor) fixes in this PR:

- `error.error` sometimes didn't match the expected pattern of `string.format`, so it was causing errors.
- `mw.ext...` stack lines wouldn't be processed correctly.
- filtering of unneeded error lines wasn't working.
- sometimes certain lines needed whitespace trimming (minor).

Also, moved from `Module:Error/Ext` to `Module:ResultOrError` as this is working on class `Error` which is sub-class of `ResultOrError` and not the class `error` or `Error` from `Module:Error`.

## How did you test this change?

`/dev`.

| Borked | Fixed |
|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/ab287a3b-2e2d-4030-8b81-50d8584f9ae5) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/553c4aad-a953-47e2-ad1e-5e38bfbbf8ed) |
