### PR TITLE
feat: add `substitutes` input for `TeamOpponenent` in match2

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -516,7 +516,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		soloOpponent = Opponent.resolve(soloOpponent, nil, {syncPlayer = true})
 		local soloPlayer = soloOpponent.players[1] or {}
 		return {
-			name = soloPlayer.pageName,
+			name = options.applyUnderScores and soloPlayer.pageName:gsub(' ', '_') or soloPlayer.pageName,
 			displayname = soloPlayer.displayName,
 			flag = soloPlayer.flag,
 		}

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -25,7 +25,7 @@ local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnable
 local OpponentLibraries = require('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
 
-local globalVars = PageVariableNamespace({cached = true})
+local globalVars = PageVariableNamespace{cached = true}
 
 local MatchGroupInput = {}
 

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -508,10 +508,11 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 	end
 
 	local oppoentToPlayerRecord = function(soloOpponentInput)
-		soloOpponent = Opponent.readOpponentArgs(Json.parseIfTable(soloOpponentInput) or {})
+		local soloOpponent = Opponent.readOpponentArgs(Json.parseIfTable(soloOpponentInput) or {})
 		if Opponent.isEmpty(soloOpponent) then
 			return
 		end
+		---@cast soloOpponent -nil
 		soloOpponent = Opponent.resolve(soloOpponent, nil, {syncPlayer = true})
 		local soloPlayer = soloOpponent.players[1] or {}
 		return {
@@ -534,6 +535,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		if player then
 			players[player.name] = subbedGames and players[player.name] or nil
 		end
+
 		opponent.extradata = Table.merge({substitutions = {}}, opponent.extradata or {})
 		table.insert(opponent.extradata.substitutions, {
 			substitute = MatchGroupUtil.playerFromRecord(substitute),
@@ -541,9 +543,9 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 			games = subbedGames and Array.map(mw.text.split(subbedGames, ';'), String.trim) or nil,
 			reason = substitutes['reason' .. index],
 		})
+
 		insertIntoPlayers(substitute)
 	end
-
 
 	--handle substitutes input for opponenets
 	for prefix, substituteOpponent in Table.iter.pairsByPrefix(substitutes, 'sub', {requireIndex = false}) do

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -517,7 +517,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		playerData = type(playerData) == 'string' and {playerData} or playerData
 		local player = {
 			displayName = Logic.emptyOr(playerData.displayName, playerData.displayname, playerData[1] or playerData.name),
-			pageName = Logic.emptyOr(playerData.pageName or playerData.pagename or playerData.link),
+			pageName = Logic.emptyOr(playerData.pageName, playerData.pagename, playerData.link),
 			flag = playerData.flag,
 		}
 		if Logic.isEmpty(player.displayName) then return end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -505,7 +505,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 	for _, playerName, playerPrefix in Table.iter.pairsByPrefix(playersData, 'p') do
 		insertIntoPlayers{
 			pageName = playerName,
-			displayname = playersData[playerPrefix .. 'dn'],
+			displayName = playersData[playerPrefix .. 'dn'],
 			flag = playersData[playerPrefix .. 'flag'],
 		}
 	end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -498,7 +498,6 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 	end
 
 	--players from manual input in `opponent.players`
-
 	local playersData = Json.parseIfString(opponent.players) or {}
 	for _, playerName, playerPrefix in Table.iter.pairsByPrefix(playersData, 'p') do
 		insertIntoPlayers({
@@ -518,6 +517,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		}
 	end
 
+	--handle substitutes input for opponenets
 	local substitutes = Json.parseIfTable(opponent.substitutes) or {}
 	for prefix, substituteOpponent in Table.iter.pairsByPrefix(substitutes, 'sub', {requireIndex = false}) do
 		local index = prefix:sub(4)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -510,12 +510,14 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		}
 	end
 
+	---@param playerData table|string|nil
 	---@return standardPlayer?
 	local getStandardPlayer = function(playerData)
 		if not playerData then return end
+		playerData = type(playerData) == 'string' and {playerData} or playerData
 		local player = {
-			displayName = Logic.emptyOr(playerData.displayName, playerData.displayName, playerData[1] or playerData.name),
-			pageName = Logic.emptyOr(playerData.pageName or playerData.pageName or playerData.link),
+			displayName = Logic.emptyOr(playerData.displayName, playerData.displayname, playerData[1] or playerData.name),
+			pageName = Logic.emptyOr(playerData.pageName or playerData.pagename or playerData.link),
 			flag = playerData.flag,
 		}
 		if Logic.isEmpty(player.displayName) then return end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -529,6 +529,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		substitutions = {}
 	end
 
+	--handle `substitutes` input for opponenets
 	Array.forEach(substitutions, function(substitution)
 		if type(substitution) ~= 'table' or not substitution['in'] then return end
 		local substitute = getStandardPlayer(substitution['in'])

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -529,7 +529,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		substitutions = {}
 	end
 
-	local handleSubstitution = function(substitution)
+	Array.forEach(substitutions, function(substitution)
 		if type(substitution) ~= 'table' or not substitution['in'] then return end
 		local substitute = getStandardPlayer(substitution['in'])
 
@@ -549,10 +549,7 @@ function MatchGroupInput.readPlayersOfTeam(match, opponentIndex, teamName, optio
 		})
 
 		insertIntoPlayers(substitute)
-	end
-
-	--handle `substitutes` input for opponenets
-	Array.forEach(substitutions, handleSubstitution)
+	end)
 
 	opponent.match2players = Array.extractValues(players)
 	Array.sortInPlaceBy(opponent.match2players, function (player)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -19,7 +19,7 @@ local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util', {requireDevIfEnabled = true})
-local PlayerExt = Lua.import('Module:Player/Ext', {requireDevIfEnabled = true})
+local PlayerExt = Lua.import('Module:Player/Ext/Custom', {requireDevIfEnabled = true})
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific', {requireDevIfEnabled = true})
 
 local OpponentLibraries = require('Module:OpponentLibraries')

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -6,10 +6,12 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Flags = require('Module:Flags')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Page = require('Module:Page')
 local PlayerDisplay = require('Module:Player/Display')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -10,6 +10,7 @@ local Class = require('Module:Class')
 local Flags = require('Module:Flags')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local PlayerDisplay = require('Module:Player/Display')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
@@ -281,6 +282,7 @@ local Comment = Class.new(
 ---@param content Html|string|number
 ---@return MatchSummaryComment
 function Comment:content(content)
+	if Logic.isEmpty(content) then return self end
 	self.root:node(content):node(Break():create())
 	return self
 end
@@ -575,6 +577,50 @@ function MatchSummary.addVodsToFooter(match, footer)
 	return footer
 end
 
+---Creates a match footer with vods if vods are set
+---@param match table
+---@return string
+function MatchSummary.createSubstitutesComment(match)
+	local comment = ''
+	mw.logObject(match)
+	for _, opponent in ipairs(match.opponents) do
+		local substitutions = (opponent.extradata or {}).substitutions
+		if Logic.isNotEmpty(substitutions) then
+			for _, substitution in ipairs(substitutions) do
+				local subString = ''
+				if Logic.isEmpty(substitution.player) and not Logic.isEmpty(substitution.substitute) then
+					subString = string.format('%s stands in',
+						tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute})
+					)
+				elseif not Logic.isEmpty(substitution.substitute) then
+					subString = string.format('%s stands in for %s',
+						tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute}),
+						tostring(PlayerDisplay.InlinePlayer{player = substitution.player})
+					)
+				end
+				if opponent.type == Opponent.team then
+					local team = require('Module:Team').queryRaw(opponent.template)
+					if team then
+						subString = string.format('%s on \'\'\'[[%s|%s]]\'\'\'', subString, team.page, team.shortname)
+					end
+				end
+				if Table.isNotEmpty(substitution.games) then
+					local gamesNoun = 'map' .. (#substitution.games > 1 and 's' or '')
+					subString = string.format('%s on %s %s', subString, gamesNoun, mw.text.listToText(substitution.games))
+				end
+				if String.isNotEmpty(substitution.reason) then
+					subString = string.format('%s due to %s.', subString, substitution.reason)
+				else
+					subString = subString .. '.'
+				end
+				comment = comment .. (Logic.isNotEmpty(comment) and tostring(Break():create()) or '') .. subString
+			end
+		end
+	end
+
+	return comment
+end
+
 ---Default createMatch function for usage in Custom MatchSummary
 ---@param matchData table?
 ---@param CustomMatchSummary table
@@ -592,8 +638,10 @@ function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 
 	match:body(CustomMatchSummary.createBody(matchData))
 
-	if matchData.comment then
-		local comment = MatchSummary.Comment():content(matchData.comment)
+	local substituteComment = MatchSummary.createSubstitutesComment(matchData)
+
+	if matchData.comment or substituteComment then
+		local comment = MatchSummary.Comment():content(matchData.comment):content(substituteComment)
 		match:comment(comment)
 	end
 	local createFooter = CustomMatchSummary.addToFooter or MatchSummary.addVodsToFooter

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -595,13 +595,13 @@ function MatchSummary.createSubstitutesComment(match)
 			if Logic.isEmpty(substitution.substitute) then
 				return
 			elseif Logic.isNotEmpty(substitution.player) then
-				table.insert(subString, string.format('%s stands in',
-					tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute})
-				))
-			else
 				table.insert(subString, string.format('%s stands in for %s',
 					tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute}),
 					tostring(PlayerDisplay.InlinePlayer{player = substitution.player})
+				))
+			else
+				table.insert(subString, string.format('%s stands in',
+					tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute})
 				))
 			end
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -608,7 +608,7 @@ function MatchSummary.createSubstitutesComment(match)
 			if opponent.type == Opponent.team then
 				local team = require('Module:Team').queryRaw(opponent.template)
 				if team then
-					table.insert(subString, string.format('on \'\'\'%s\'\'\'', Page.makeInternalLink(team.shortname, team.page)))
+					table.insert(subString, string.format('on <b>%s</b>', Page.makeInternalLink(team.shortname, team.page)))
 				end
 			end
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -590,13 +590,15 @@ function MatchSummary.createSubstitutesComment(match)
 			return
 		end
 
-		for _, substitution in ipairs(substitutions) do
+		Array.forEach(substitutions, function(substitution)
 			local subString = {}
-			if Logic.isEmpty(substitution.player) and not Logic.isEmpty(substitution.substitute) then
+			if Logic.isEmpty(substitution.substitute) then
+				return
+			elseif Logic.isNotEmpty(substitution.player) then
 				table.insert(subString, string.format('%s stands in',
 					tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute})
 				))
-			elseif not Logic.isEmpty(substitution.substitute) then
+			else
 				table.insert(subString, string.format('%s stands in for %s',
 					tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute}),
 					tostring(PlayerDisplay.InlinePlayer{player = substitution.player})
@@ -620,7 +622,7 @@ function MatchSummary.createSubstitutesComment(match)
 			end
 
 			table.insert(comment, table.concat(subString, ' ') .. '.')
-		end
+		end)
 	end)
 
 	return table.concat(comment, tostring(Break():create()))

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -626,6 +626,8 @@ function MatchSummary.createSubstitutesComment(match)
 		end)
 	end)
 
+	if Logic.isEmpty(comment) then return end
+
 	return table.concat(comment, tostring(Break():create()))
 end
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -591,17 +591,18 @@ function MatchSummary.createSubstitutesComment(match)
 		end
 
 		Array.forEach(substitutions, function(substitution)
-			local subString = {}
 			if Logic.isEmpty(substitution.substitute) then
 				return
-			elseif Logic.isNotEmpty(substitution.player) then
-				table.insert(subString, string.format('%s stands in for %s',
-					tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute}),
+			end
+
+			local subString = {}
+			table.insert(subString, string.format('%s stands in',
+				tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute})
+			))
+
+			if Logic.isNotEmpty(substitution.player) then
+				table.insert(subString, string.format('for %s',
 					tostring(PlayerDisplay.InlinePlayer{player = substitution.player})
-				))
-			else
-				table.insert(subString, string.format('%s stands in',
-					tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute})
 				))
 			end
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -582,7 +582,6 @@ end
 ---@return string
 function MatchSummary.createSubstitutesComment(match)
 	local comment = ''
-	mw.logObject(match)
 	for _, opponent in ipairs(match.opponents) do
 		local substitutions = (opponent.extradata or {}).substitutions
 		if Logic.isNotEmpty(substitutions) then

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -505,7 +505,9 @@ function matchFunctions.getOpponents(match)
 
 			-- get players from vars for teams
 			if opponent.type == Opponent.team and not Logic.isEmpty(opponent.name) then
-				match = MatchGroupInput.readPlayersOfTeam(match, opponentIndex, opponent.name)
+				match = MatchGroupInput.readPlayersOfTeam(match, opponentIndex, opponent.name, {
+					maxNumPlayers = 5, resolveRedirect = true, applyUnderScores = true
+				})
 			end
 		end
 	end

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -257,31 +257,6 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----CreateMatch cs specific overwrite due to altered styles for match comment
----@param matchData table?
----@return MatchSummaryMatch?
-function CustomMatchSummary.createMatch(matchData)
-	if not matchData then
-		return
-	end
-
-	local match = MatchSummary.Match()
-
-	match
-		:header(MatchSummary.createDefaultHeader(matchData))
-		:body(CustomMatchSummary.createBody(matchData))
-
-	if matchData.comment then
-		local comment = MatchSummary.Comment():content(matchData.comment)
-		comment.root:css('display', 'block'):css('text-align', 'center')
-		match:comment(comment)
-	end
-
-	match:footer(CustomMatchSummary.addToFooter(matchData, MatchSummary.Footer()))
-
-	return match
-end
-
 ---@param match MatchGroupUtilMatch
 ---@param footer MatchSummaryFooter
 ---@return MatchSummaryFooter


### PR DESCRIPTION
## Summary

Adding the functionality of replacing players within a team opponent for a specific match2 match. Often teams have a sub for a single match and that player doesn't get a record anywhere (in data) that they played, except maybe a manual comment on the match.

Now, the with the following input, players can be replaced in-data for specific matches, and an automatic comment will be added to the match.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/cefe088f-7982-44e0-acf3-9d6a7e9f1b55)

A player can either replace another player entirely in a match, or for a specific game only. If they replace them entirely, then the subbed-out player will be removed from the player list, otherwise they will still remain and the sub will be added as an extra player. Players can also stand-in for no-one if a team only had four players at the time but the game needs five, or whatever.

The substitutes input processing is only for teams currently, so this will only work for teams. However, the display component should work (haven't tested as it can't currently happen) for non-team (a.k.a. party) opponents too.

(also made some small CS changes too just to utilize this new functionality correctly.)

## How did you test this change?

`/dev` on the CS wiki.

https://liquipedia.net/counterstrike/User:IMarbot/SubsTest

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/b8ee399e-388b-4baf-88a0-4698f1c62d84)
