### PR TITLE
Parse json strings in `Match._moveRecordsFromMatchToList`

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -202,7 +202,7 @@ end
 function Match._moveRecordsFromMatchToList(match, list, typePrefix)
 	for key, item in Table.iter.pairsByPrefix(match, typePrefix) do
 		match[key] = nil
-		table.insert(list, item)
+		table.insert(list, Json.parseIfTable(item) or item)
 	end
 
 	return list


### PR DESCRIPTION
## Summary
Parse json strings in `Match._moveRecordsFromMatchToList`.
This PR fixes Valorant bigMatch

## How did you test this change?
dev