### PR TITLE
feat: use `ResultOrError` in `DisplayUtil`

### DIFF
--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -110,8 +110,8 @@ function ErrorExt.printErrorJson(error)
 		local frameSplit = mw.text.split(frame, ':', true)
 		if (frameSplit[1] == '[C]' or frameSplit[1] == '(tail call)') then
 			stackEntry.prefix = frameSplit[1]
-			stackEntry.content = table.concat(frameSplit, ':', 2)
-		elseif frameSplit[1] == 'mw.lua' then
+			stackEntry.content = mw.text.trim(table.concat(frameSplit, ':', 2))
+		elseif frameSplit[1]:sub(1, 3) == 'mw.' then
 			stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
 			stackEntry.content =  table.concat(frameSplit, ':', 3)
 		elseif frameSplit[1] == 'Module' then
@@ -132,13 +132,15 @@ function ErrorExt.printErrorJson(error)
 				Array.sub(stackFrames, 2, #stackFrames),
 				function(frame) return String.trim(frame) end
 			),
-			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame, true) end
+			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame, false, true) end
 		)
 		Array.forEach(stackFrames, processStackFrame)
 	end)
 
+	local errorSplit = mw.text.split(error.error, ':', true)
 	return Json.stringify({
-			errorShort = string.format('Lua error in %s:%s at line %s:%s.', unpack(mw.text.split(error.error, ':', true))),
+			errorShort = (#errorSplit == 1) and string.format('Lua error: %s.', error.error)
+				or string.format('Lua error in %s:%s at line %s:%s.', unpack(errorSplit)),
 			stackTrace = stackTrace,
 		}, {asArray = true})
 end

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -132,7 +132,9 @@ function ErrorExt.printErrorJson(error)
 				Array.sub(stackFrames, 2, #stackFrames),
 				function(frame) return String.trim(frame) end
 			),
-			function(frame) return not Table.includes(FILTERED_STACK_ITEMS, frame, false, true) end
+			function(frame) return not Table.any(FILTERED_STACK_ITEMS, function(_, filter)
+				return string.find(frame, filter) ~= nil
+			end) end
 		)
 		Array.forEach(stackFrames, processStackFrame)
 	end)

--- a/standard/error_ext.lua
+++ b/standard/error_ext.lua
@@ -96,7 +96,7 @@ function ErrorExt.makeFullStackTrace(error)
 end
 
 ---Builds a JSON string for using with `liquipedia.customLuaErrors` JS module via error().
----@param error error
+---@param error Error
 ---@return string?
 function ErrorExt.printErrorJson(error)
 	local stackTrace = {}

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -8,6 +8,16 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Json = require('Module:Json')
+local Page = require('Module:Page')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local FILTERED_ERROR_STACK_ITEMS = {
+	'^Module:ResultOrError:%d+: in function <Module:ResultOrError:%d+>$',
+	'^%[C%]: in function \'xpcall\'$',
+	'^Module:ResultOrError:%d+: in function \'try\'$',
+}
 
 --[[
 A structurally typed, immutable class that represents either a result or an
@@ -102,8 +112,56 @@ function Error:map(_, onError)
 		or ResultOrError.Result()
 end
 
+---Errors with a JSON string for use by `liquipedia.customLuaErrors` JS module.
 function Error:get()
-	error(require('Module:Error/Ext').printErrorJson(self), 0)
+	local stackTrace = {}
+
+	local processStackFrame = function(frame, frameIndex)
+		if frameIndex == 1 and frame == '[C]: ?' then
+			return
+		end
+
+		local stackEntry = {content = frame}
+		local frameSplit = mw.text.split(frame, ':', true)
+		if (frameSplit[1] == '[C]' or frameSplit[1] == '(tail call)') then
+			stackEntry.prefix = frameSplit[1]
+			stackEntry.content = mw.text.trim(table.concat(frameSplit, ':', 2))
+		elseif frameSplit[1]:sub(1, 3) == 'mw.' then
+			stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
+			stackEntry.content =  table.concat(frameSplit, ':', 3)
+		elseif frameSplit[1] == 'Module' then
+			local wiki = not Page.exists(table.concat(frameSplit, ':', 1, 2)) and 'commons'
+				or mw.text.split(mw.title.getCurrentTitle():canonicalUrl(), '/', true)[4] or 'commons'
+			stackEntry.link = {wiki = wiki, title = table.concat(frameSplit, ':', 1, 2), ln = frameSplit[3]}
+			stackEntry.prefix = table.concat(frameSplit, ':', 1, 3)
+			stackEntry.content = table.concat(frameSplit, ':', 4)
+		end
+
+		table.insert(stackTrace, stackEntry)
+	end
+
+	Array.forEach(self.stacks, function(stack)
+		local stackFrames = mw.text.split(stack, '\n')
+		stackFrames = Array.filter(
+			Array.map(
+				Array.sub(stackFrames, 2, #stackFrames),
+				function(frame) return String.trim(frame) end
+			),
+			function(frame) return not Table.any(FILTERED_ERROR_STACK_ITEMS, function(_, filter)
+				return string.find(frame, filter) ~= nil
+			end) end
+		)
+		Array.forEach(stackFrames, processStackFrame)
+	end)
+
+	local errorSplit = mw.text.split(self.error, ':', true)
+	local errorJson = Json.stringify({
+			errorShort = (#errorSplit == 1) and string.format('Lua error: %s.', self.error)
+				or string.format('Lua error in %s:%s at line %s:%s.', unpack(errorSplit)),
+			stackTrace = stackTrace,
+		}, {asArray = true})
+
+	error(errorJson, 0)
 end
 
 --[[

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -14,7 +14,7 @@ A structurally typed, immutable class that represents either a result or an
 error. Used for representing the outcome of a function that can throw.
 
 Usage:
-
+```
 local socketOrError = ResultOrError.try(function()
 	return socketlib.open()
 end)
@@ -27,7 +27,10 @@ local parsedText = socketOrError
 		socketOrError:map(function(socket) socket:close() end)
 	end)
 	:get()
+```
 ]]
+---@class ResultOrError
+---@field is_a? function
 local ResultOrError = Class.new(function(self)
 	-- ResultOrError is an abstract class. Don't call this constructor directly.
 	--error('Cannot construct abstract class')
@@ -60,6 +63,8 @@ end
 --[[
 Result case
 ]]
+---@class Result
+---@field result any
 local Result = Class.new(ResultOrError, function(self, result)
 	self.result = result
 end)
@@ -83,6 +88,9 @@ continuation of the stack trace of the error that was handled (and so on).
 This allows error handlers to rethrow the original error without losing the
 stack trace, and is needed to implement :finally().
 ]]
+---@class Error
+---@field error string?
+---@field stacks string[]?
 local Error = Class.new(ResultOrError, function(self, error, stacks)
 	self.error = error
 	self.stacks = stacks

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -39,8 +39,7 @@ local parsedText = socketOrError
 	:get()
 ```
 ]]
----@class ResultOrError
----@field is_a? function
+---@class ResultOrError: BaseClass
 local ResultOrError = Class.new(function(self)
 	-- ResultOrError is an abstract class. Don't call this constructor directly.
 	--error('Cannot construct abstract class')
@@ -180,7 +179,7 @@ automatically include both stack traces.
 ]]
 ---@param f function
 ---@param lowerStacks table?
----@return ResultOrError
+---@return Result|Error
 function ResultOrError.try(f, lowerStacks)
 	local resultOrError
 	xpcall(
@@ -206,12 +205,16 @@ array of results. Otherwise returns a ResultOrError of the first error. Note
 that this function swaps the types: it converts an array of ResultOrErrors of
 values into a ResultOrError of an array of values.
 ]]
+---@param resultOrErrors ResultOrError[]
+---@return Result|Error
 function ResultOrError.all(resultOrErrors)
 	local results = {}
 	for _, resultOrError in ipairs(resultOrErrors) do
 		if resultOrError:isResult() then
+			---@cast resultOrError Result
 			table.insert(results, resultOrError.result)
 		else
+			---@cast resultOrError Error
 			return resultOrError
 		end
 	end
@@ -223,12 +226,16 @@ If any input ResultOrErrors is a result, then returns the first such
 ResultOrError. Otherwise, all input ResultOrErrors are errors, and this
 aggregates them together and returns a ResultOrError of the aggregate error.
 ]]
+---@param resultOrErrors ResultOrError[]
+---@return Result|Error
 function ResultOrError.any(resultOrErrors)
 	local errors = {}
 	for _, resultOrError in ipairs(resultOrErrors) do
 		if resultOrError:isResult() then
+			---@cast resultOrError Result
 			return resultOrError
 		else
+			---@cast resultOrError Error
 			table.insert(errors, resultOrError.error)
 		end
 	end


### PR DESCRIPTION
## Summary

Instead of printing out a hard-to-read stack trace, use the new result or error printing functionality here too.

## How did you test this change?

Tested on `/dev`.
