### PR TITLE
Add Custom Earnings for World of Tanks

### DIFF
--- a/components/earnings/wikis/worldoftanks/earnings.lua
+++ b/components/earnings/wikis/worldoftanks/earnings.lua
@@ -1,0 +1,16 @@
+---
+-- @Liquipedia
+-- wiki=worldoftanks
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+CustomEarnings.defaultNumberOfStoredPlayersPerMatch = 21
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
## Summary
Unlike other wikis, World of Tanks has a significant coverage of **15vs15** which includes a **18-21 player teamcards** on the wiki. This Custom Earnings is to set the upper limit to **21** the most number seen in a teamcard from what I told

Previously without these the earnings just stops after 10th player

## How did you test this change?
LIVE