### PR TITLE
Tetris: Add ability to display map game scores in MatchSummary

### DIFF
--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -56,6 +56,14 @@ function CustomMatchSummary.createBody(match)
 end
 
 ---@param game MatchGroupUtilGame
+---@param opponentIndex integer
+---@return Html
+function CustomMatchSummary._gameScore(game, opponentIndex)
+	local score = game.scores[opponentIndex] or ''
+	return mw.html.create('div'):wikitext(score)
+end
+
+---@param game MatchGroupUtilGame
 ---@return MatchSummaryRow
 function CustomMatchSummary._createGame(game)
 	local row = MatchSummary.Row()
@@ -64,12 +72,24 @@ function CustomMatchSummary._createGame(game)
 		:css('font-size', '84%')
 		:css('padding', '4px')
 		:css('min-height', '32px')
-	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))
-	row:addElement(mw.html.create('div')
+
+	local leftNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+	    :node(CustomMatchSummary._createCheckMark(game.winner == 1))
+		:node(CustomMatchSummary._gameScore(game, 1))
+
+	local centerNode = mw.html.create('div')
 		:addClass('brkts-popup-body-element-vertical-centered')
 		:wikitext(game.map)
-	)
-	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 2))
+
+	local rightNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(CustomMatchSummary._gameScore(game, 2))
+		:node(CustomMatchSummary._createCheckMark(game.winner == 2))
+
+	row:addElement(leftNode)
+		:addElement(centerNode)
+		:addElement(rightNode)
 
 	-- Add Comment
 	if not Logic.isEmpty(game.comment) then

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -59,8 +59,7 @@ end
 ---@param opponentIndex integer
 ---@return Html
 function CustomMatchSummary._gameScore(game, opponentIndex)
-	local score = game.scores[opponentIndex] or ''
-	return mw.html.create('div'):wikitext(score)
+	return mw.html.create('div'):wikitext(game.scores[opponentIndex])
 end
 
 ---@param game MatchGroupUtilGame


### PR DESCRIPTION
## Summary
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

We want to record the [TWC final bracket](https://worlds.tetr.io/brackets/#ZX), where matches are bo3 sets, ft11 rounds. We were thinking of using Map to represent these sets, but the default Map display doesn't include the game scores of each round:

Example:
![image](https://github.com/Liquipedia/Lua-Modules/assets/5766317/0517a590-0034-4983-952f-d576c2b4fff1)

So, tried copying some ideas over from https://liquipedia.net/callofduty/Module:MatchSummary, which is pretty similar to what we want.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->

Sample bracket

https://liquipedia.net/tetris/Module:MatchSummary/dev

https://liquipedia.net/tetris/index.php?title=User:Mitsu_at/Sandbox&oldid=15229

![image](https://github.com/Liquipedia/Lua-Modules/assets/5766317/026f7bba-dd99-485f-996f-20a90ed1ca29)

