### PR TITLE
Fix Bug for AoV Matches with even Bestof

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -394,15 +395,11 @@ function matchFunctions.getOpponents(match)
 	end
 
 	-- see if match should actually be finished if bestof limit was reached
-	if isScoreSet and not Logic.readBool(match.finished) then
-		local firstTo = math.ceil(match.bestof/2)
-		for _, item in pairs(opponents) do
-			if tonumber(item.score or 0) >= firstTo then
-				match.finished = true
-				break
-			end
-		end
-	end
+        match.finished = Logic.readBool(match.finished)
+		or isScoreSet and (
+			Array.any(opponents, function(opponent) return tonumber(opponent.score or 0) > match.bestof/2 end)
+			or Array.all(opponents, function(opponent) return tonumber(opponent.score or 0) == match.bestof/2 end)
+		)
 
 	-- see if match should actually be finished if score is set
 	if isScoreSet and not Logic.readBool(match.finished) and match.hasDate then


### PR DESCRIPTION
## Summary
Problem with Bo2 matches automatically marking a match is done when the 1st game in the match is completed. This is caused by the code calculating that one side having ceil(n/2) where n is the Bo(n) is the number of matches required for one side to win the series; but does not take into account ties that exists for even best ofs

## How did you test this change?
Dev
[Code originally used to fix similar in ML wiki](https://github.com/Liquipedia/Lua-Modules/pull/2711)