### PR TITLE
Add missing deploy header

### DIFF
--- a/standard/links/commons/links_priority_groups.lua
+++ b/standard/links/commons/links_priority_groups.lua
@@ -1,3 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Links/PriorityGroups
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 return {
 	core = {
 		'home',


### PR DESCRIPTION
## Summary
Module:Links/PriorityGroups was apparently maintained via git, but had no deploy header to wasn't pushed live automatically.

## How did you test this change?
N/A