### PR TITLE
Add missing games to WoT Info

### DIFF
--- a/standard/info/wikis/worldoftanks/info.lua
+++ b/standard/info/wikis/worldoftanks/info.lua
@@ -24,6 +24,45 @@ return {
 				lightMode = 'World of Tanks default lightmode.png',
 			},
 		},
+		['wot blitz'] = {
+			abbreviation = 'WoT Blitz',
+			name = 'World of Tanks Blitz',
+			link = 'World of Tanks Blitz',
+			logo = {
+				darkMode = 'World of Tanks Blitz default darkmode.png',
+				lightMode = 'World of Tanks Blitz default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'World of Tanks default darkmode.png',
+				lightMode = 'World of Tanks default lightmode.png',
+			},
+		},
+		['mir tankov'] = {
+			abbreviation = 'Tanki',
+			name = 'Mir Tankov',
+			link = 'Mir Tankov',
+			logo = {
+				darkMode = 'Mir Tankov default darkmode.png',
+				lightMode = 'Mir Tankov default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'World of Tanks default darkmode.png',
+				lightMode = 'World of Tanks default lightmode.png',
+			},
+		},
+		['tanks blitz'] = {
+			abbreviation = 'Tanks Blitz',
+			name = 'Tanks Blitz',
+			link = 'Tanks Blitz',
+			logo = {
+				darkMode = 'Tanks Blitz default darkmode.png',
+				lightMode = 'Tanks Blitz default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'World of Tanks default darkmode.png',
+				lightMode = 'World of Tanks default lightmode.png',
+			},
+		},
 	},
 	defaultGame = 'worldoftanks',
 	defaultRoundPrecision = 0,


### PR DESCRIPTION
## Summary
There were three missing games in this info modules
these related to the WoT Infobox changes which introduces |game= input as well

Currently Live