### PR TITLE
Fixing style bracket designer buttons

### DIFF
--- a/stylesheets/commons/Brackets.css
+++ b/stylesheets/commons/Brackets.css
@@ -1304,6 +1304,8 @@ div.brkts-opponent-hover-active::after {
 	text-align: center;
 	width: 22px;
 	margin: 1px;
+	border-radius: 0;
+	min-height: 0;
 }
 
 .brkts-designer-gallery-grid {


### PR DESCRIPTION
## Summary

The bracket designer buttons design is broken on dark mode and the new skin (see picture below). This is due to the `button` CSS rules adding a radius and minimum height. I fixed it by putting the default value to 0.

![image](https://github.com/Liquipedia/Lua-Modules/assets/32543621/f6765f66-b992-459e-9ea3-1944e7b528f8)

## How did you test this change?

Tested on my dev environment [here](http://killian.wiki.tldev.eu/rocketleague/Special:BracketDesigner)

## Note

[Gitlab ticket](https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/issues/51)
