### PR TITLE
fix: change single-quotes to double-quotes to fix

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,8 @@
 {
 	"extends": "stylelint-config-wikimedia",
 	"plugins": [
-		"stylelint-less"
+		"stylelint-less",
+		"stylelint-stylistic"
 	],
 	"customSyntax": "postcss-less",
 	"rules": {
@@ -15,13 +16,9 @@
 		"selector-pseudo-element-colon-notation": null,
 		"no-duplicate-selectors": null,
 		"function-url-no-scheme-relative": null,
-		"declaration-no-important": null
-	},
-	"overrides": [ {
-		"files": ["*.css", "**/*.css"],
-		"rules": {
-			"function-no-unknown": null
-		}
-	} ]
+		"declaration-no-important": null,
+		"stylistic/string-quotes": "double",
+		"function-no-unknown": null
+	}
 }
 

--- a/stylesheets/commons/Bracket.css
+++ b/stylesheets/commons/Bracket.css
@@ -282,13 +282,13 @@ td.bracket-game .icon {
 }
 
 .table-battleroyale-results-round .icon {
-	right: calc( ~'50% - 5px' );
+	right: calc( ~"50% - 5px" );
 }
 
 .table-battleroyale-results-round .bracket-popup-wrapper {
 	position: absolute;
 	top: 5px;
-	left: calc( ~'50% - 165px' );
+	left: calc( ~"50% - 165px" );
 }
 
 /* Archon mode brackets */
@@ -481,7 +481,7 @@ Author(s): FO-nTTaX, salle
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-header .bracket-popup-header-left,
 .bracket-popup-wrapper .bracket-popup .bracket-popup-header .bracket-popup-header-right {
-	width: calc( ~'50% - 2px' );
+	width: calc( ~"50% - 2px" );
 	padding: 5px;
 	display: inline-block;
 	white-space: nowrap;
@@ -547,7 +547,7 @@ Author(s): FO-nTTaX, salle
 .bracket-popup-wrapper .bracket-popup .bracket-popup-header-vs:after,
 .bracket-popup-wrapper .bracket-popup .bracket-popup-header:after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	width: 100%;
 	display: block;
 }
@@ -601,7 +601,7 @@ Author(s): FO-nTTaX, salle
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-body .bracket-popup-body-match:after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	width: 100%;
 	display: block;
 }
@@ -621,7 +621,7 @@ Author(s): FO-nTTaX, salle
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-body .bracket-popup-body-time:after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	width: 100%;
 	display: block;
 }
@@ -633,7 +633,7 @@ Author(s): FO-nTTaX, salle
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-body .bracket-popup-body-bans:after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	width: 100%;
 	display: block;
 }
@@ -648,14 +648,14 @@ Author(s): FO-nTTaX, salle
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-body .bracket-popup-body-comment:after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	width: 100%;
 	display: block;
 }
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-body:after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	width: 100%;
 	display: block;
 }
@@ -669,7 +669,7 @@ Author(s): FO-nTTaX, salle
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-footer:after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	width: 100%;
 	display: block;
 }
@@ -682,7 +682,7 @@ Author(s): FO-nTTaX, salle
 }
 
 .bracket-popup-wrapper .bracket-popup .bracket-popup-header .bracket-popup-header-center {
-	width: calc( ~'100% - 2px' );
+	width: calc( ~"100% - 2px" );
 	padding: 2.5px;
 	display: inline-block;
 	white-space: nowrap;
@@ -1565,7 +1565,7 @@ Author(s): FO-nTTaX
 		width: calc( 11 * 68px + 10 * 10px + 22px + 10px ) !important;
 	}
 
-	.bracket-doubles .bracket-column-matches-s2 .bracket-score[ style*='right' ][ style*='39px' ] {
+	.bracket-doubles .bracket-column-matches-s2 .bracket-score[ style*="right" ][ style*="39px" ] {
 		right: 22px !important;
 	}
 }

--- a/stylesheets/commons/Brackets.css
+++ b/stylesheets/commons/Brackets.css
@@ -64,7 +64,7 @@
 	border-radius: 2px;
 	border: 1px solid var( --brackets-header-border-color, #aaaaaa );
 	color: var( --clr-on-background );
-	margin-left: calc( ~'var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--skip-round)' );
+	margin-left: calc( ~"var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--skip-round)" );
 	overflow: hidden;
 	padding: 4px;
 	text-align: center;
@@ -75,7 +75,7 @@
 
 .brkts-header:first-child,
 .brkts-round-center:first-child {
-	margin-left: calc( ~'(var(--match-width) + var(--round-horizontal-margin)) * var(--skip-round)' );
+	margin-left: calc( ~"(var(--match-width) + var(--round-horizontal-margin)) * var(--skip-round)" );
 }
 
 .brkts-third-place-header {
@@ -83,7 +83,7 @@
 }
 
 .brkts-qualified-header {
-	margin-left: calc( ~'var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--qual-skip)' );
+	margin-left: calc( ~"var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--qual-skip)" );
 }
 
 .brkts-header-option {
@@ -104,7 +104,7 @@
 .brkts-round-lower-connectors {
 	align-self: stretch;
 	position: relative;
-	width: calc( ~'var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--skip-round)' );
+	width: calc( ~"var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--skip-round)" );
 }
 
 .brkts-line {
@@ -130,18 +130,18 @@
 }
 
 .brkts-br-wrapper.brkts-br-wrapper {
-	width: calc( ~'var(--match-width) + var(--score-width)' );
+	width: calc( ~"var(--match-width) + var(--score-width)" );
 }
 
 .brkts-bracket .brkts-match-info-icon {
-	left: calc( ~'var(--match-width) - var(--score-width) - 8px' );
+	left: calc( ~"var(--match-width) - var(--score-width) - 8px" );
 	position: absolute;
 }
 
 .brkts-round-qual-connectors {
 	align-self: stretch;
 	position: relative;
-	width: calc( ~'var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--qual-skip)' );
+	width: calc( ~"var(--round-horizontal-margin) + (var(--match-width) + var(--round-horizontal-margin)) * var(--qual-skip)" );
 }
 
 .brkts-round-qual {
@@ -297,7 +297,7 @@
 	border: 1px solid var( --table-border-color, #bbbbbb );
 	display: grid;
 	font-size: 13px;
-	grid-template-columns: ~'[opponent] 4fr [score] minmax(30px, 1fr) [icon] 0px [score] minmax(30px, 1fr) [opponent] 4fr';
+	grid-template-columns: ~"[opponent] 4fr [score] minmax(30px, 1fr) [icon] 0px [score] minmax(30px, 1fr) [opponent] 4fr";
 	line-height: 1.48;
 }
 
@@ -359,7 +359,7 @@
 	.brkts-matchlist-match {
 		display: grid;
 		grid-column: span 5;
-		grid-template-columns: ~'[opponent] 4fr [score] minmax(30px, 1fr) [icon] 0px [score] minmax(30px, 1fr) [opponent] 4fr';
+		grid-template-columns: ~"[opponent] 4fr [score] minmax(30px, 1fr) [icon] 0px [score] minmax(30px, 1fr) [opponent] 4fr";
 	}
 }
 
@@ -752,7 +752,7 @@
 	border: 0;
 	border-radius: 0;
 	letter-spacing: 0.1em;
-	font-family: 'Source Code Pro', monospace;
+	font-family: "Source Code Pro", monospace;
 }
 
 .brkts-popup-mapveto .brkts-popup-mapveto-pick {
@@ -1211,7 +1211,7 @@ div.brkts-opponent-hover {
 }
 
 div.brkts-opponent-hover::after {
-	content: '';
+	content: "";
 	height: 100%;
 	left: 0;
 	pointer-events: none;
@@ -1660,7 +1660,7 @@ div.brkts-opponent-hover-active::after {
 
 .brkts-opponent-entry .team-template-image-icon,
 .brkts-opponent-entry .team-template-image-legacy {
-	height: calc( ~'var(--opponent-height, 22px) - 4px' );
+	height: calc( ~"var(--opponent-height, 22px) - 4px" );
 	width: var( --brkts-team-icon-width, 44px );
 	justify-content: center;
 	display: inline-flex;

--- a/stylesheets/commons/Crosstable.css
+++ b/stylesheets/commons/Crosstable.css
@@ -8,8 +8,8 @@ Author(s): FO-nTTaX
 @crosstable-green: var( --table-green-background-color, #ddf4dd );
 @crosstable-red: var( --table-red-background-color, #fbdfdf );
 
-.crosstable[ class*='row-' ] td,
-.crosstable[ class*='col-' ] td {
+.crosstable[ class*="row-" ] td,
+.crosstable[ class*="col-" ] td {
 	opacity: 0.5;
 	-moz-box-shadow: inset 0 0 10px -7px rgba( 0, 0, 0, 1 ), inset 0 0 10px -7px rgba( 0, 0, 0, 1 );
 	-webkit-box-shadow: inset 0 0 10px -7px rgba( 0, 0, 0, 1 ), inset 0 0 10px -7px rgba( 0, 0, 0, 1 );

--- a/stylesheets/commons/DivTable.css
+++ b/stylesheets/commons/DivTable.css
@@ -282,7 +282,7 @@ Author(s): iMarbot
 		justify-content: center;
 
 		&::before {
-			content: '#';
+			content: "#";
 		}
 	}
 

--- a/stylesheets/commons/Grid.css
+++ b/stylesheets/commons/Grid.css
@@ -203,7 +203,7 @@ License: MIT
 }
 
 .lp-no-gutters > .lp-col,
-.lp-no-gutters > [ class*='lp-col-' ] {
+.lp-no-gutters > [ class*="lp-col-" ] {
 	padding-right: 0;
 	padding-left: 0;
 }

--- a/stylesheets/commons/Icons.css
+++ b/stylesheets/commons/Icons.css
@@ -17,7 +17,7 @@ Note: When adding a new icon, please add to
 
 	.darkmode &,
 	.theme--dark &,
-	[ data-darkreader-scheme='dark' ] & {
+	[ data-darkreader-scheme="dark" ] & {
 		background-position: -32px -32px;
 	}
 	// Sizes
@@ -35,147 +35,147 @@ Note: When adding a new icon, please add to
 
 		.darkmode &,
 		.theme--dark &,
-		[ data-darkreader-scheme='dark' ] & {
+		[ data-darkreader-scheme="dark" ] & {
 			background-position: -32px 0;
 		}
 	}
 	// Images
-	.icon-make-image( 5ewin, '//liquipedia.net/commons/images/c/cf/InfoboxIcon_5Ewin.png' );
-	.icon-make-image( abios, '//liquipedia.net/commons/images/2/21/InfoboxIcon_Abios.png' );
-	.icon-make-image( afreeca, '//liquipedia.net/commons/images/7/7c/InfoboxIcon_Afreeca.png' );
-	.icon-make-image( afreecatv, '//liquipedia.net/commons/images/7/7c/InfoboxIcon_Afreeca.png' );
-	.icon-make-image( aligulac, '//liquipedia.net/commons/images/7/74/InfoboxIcon_Aligulac.png' );
-	.icon-make-image( aoezone, '//liquipedia.net/commons/images/e/ea/InfoboxIcon_AoEZone.png' );
-	.icon-make-image( apexlegendsstatus, '//liquipedia.net/commons/images/e/e7/InfoboxIcon_ApexLegendsStatus.png' );
-	.icon-make-image( apple-podcasts, '//liquipedia.net/commons/images/0/06/InfoboxIcon_Apple_Podcasts.png' );
-	.icon-make-image( ask-fm, '//liquipedia.net/commons/images/b/b8/InfoboxIcon_AskFM.png' );
-	.icon-make-image( azubu, '//liquipedia.net/commons/images/6/62/InfoboxIcon_Azubu.png' );
-	.icon-make-image( b5csgo, '//liquipedia.net/commons/images/5/52/InfoboxIcon_B5csgo.png' );
-	.icon-make-image( battlefy, '//liquipedia.net/commons/images/9/96/InfoboxIcon_BATTLEFY.png' );
-	.icon-make-image( best-gg, '//liquipedia.net/commons/images/0/01/InfoboxIcon_BESTGG.png' );
-	.icon-make-image( bilibili, '//liquipedia.net/commons/images/5/50/InfoboxIcon_bilibili.png' );
-	.icon-make-image( binary-beast, '//liquipedia.net/commons/images/a/af/InfoboxIcon_BinaryBeast.png' );
-	.icon-make-image( booyah, '//liquipedia.net/commons/images/b/bb/InfoboxIcon_BOOYAH.png' );
-	.icon-make-image( bracket, '//liquipedia.net/commons/images/d/d5/InfoboxIcon_Bracket.png' );
-	.icon-make-image( cafe-daum, '//liquipedia.net/commons/images/c/c9/InfoboxIcon_Daum.png' );
-	.icon-make-image( caffeine, '//liquipedia.net/commons/images/4/4b/InfoboxIcon_Caffeine.png' );
-	.icon-make-image( cc, '//liquipedia.net/commons/images/4/46/InfoboxIcon_cc.png' );
-	.icon-make-image( challengermode, '//liquipedia.net/commons/images/1/19/InfoboxIcon_Challengermode.png' );
-	.icon-make-image( challonge, '//liquipedia.net/commons/images/c/cd/InfoboxIcon_Challonge.png' );
-	.icon-make-image( cntft, '//liquipedia.net/commons/images/e/ea/InfoboxIcon_CNTFT.png' );
-	.icon-make-image( corestrike, '//liquipedia.net/commons/images/a/aa/InfoboxIcon_CoreStrike.png' );
-	.icon-make-image( cybergamer, '//liquipedia.net/commons/images/4/4e/InfoboxIcon_CyberGamer.png' );
-	.icon-make-image( dailymotion, '//liquipedia.net/commons/images/0/07/InfoboxIcon_Dailymotion.png' );
-	.icon-make-image( datdota, '//liquipedia.net/commons/images/2/24/InfoboxIcon_Datdota.png' );
-	.icon-make-image( discord, '//liquipedia.net/commons/images/c/c6/InfoboxIcon_Discord.png' );
-	.icon-make-image( dlive, '//liquipedia.net/commons/images/4/43/InfoboxIcon_DLive.png' );
-	.icon-make-image( dotabuff, '//liquipedia.net/commons/images/9/90/InfoboxIcon_Dotabuff.png' );
-	.icon-make-image( douyu, '//liquipedia.net/commons/images/b/bc/InfoboxIcon_DouyuTV.png' );
-	.icon-make-image( douyutv, '//liquipedia.net/commons/images/b/bc/InfoboxIcon_DouyuTV.png' );
-	.icon-make-image( douyin, '//liquipedia.net/commons/images/4/47/InfoboxIcon_TikTok.png' ); // Intended to be TikTok
-	.icon-make-image( email, '//liquipedia.net/commons/images/2/2f/InfoboxIcon_Email.png' );
-	.icon-make-image( escharts, '//liquipedia.net/commons/images/9/99/InfoboxIcon_EsportsCharts.png' );
-	.icon-make-image( esea, '//liquipedia.net/commons/images/9/99/InfoboxIcon_ESEA.png' );
-	.icon-make-image( esea-league, '//liquipedia.net/commons/images/8/8e/InfoboxIcon_ESEA_League.png' );
-	.icon-make-image( esl, '//liquipedia.net/commons/images/4/44/InfoboxIcon_ESL.png' );
-	.icon-make-image( esportal, '//liquipedia.net/commons/images/c/c2/InfoboxIcon_Esportal.png' );
-	.icon-make-image( etf2l, '//liquipedia.net/commons/images/6/61/InfoboxIcon_ETF2L.png' );
-	.icon-make-image( facebook, '//liquipedia.net/commons/images/1/1e/InfoboxIcon_Facebook.png' );
-	.icon-make-image( facebook-gaming, '//liquipedia.net/commons/images/8/8d/InfoboxIcon_Facebook_Gaming.png' );
-	.icon-make-image( faceit, '//liquipedia.net/commons/images/e/e6/InfoboxIcon_FACEIT.png' );
-	.icon-make-image( factor, '//liquipedia.net/commons/images/1/15/InfoboxIcon_Factor.png' );
-	.icon-make-image( fanclub, '//liquipedia.net/commons/images/f/fe/InfoboxIcon_TLFanPage.png' );
-	.icon-make-image( flickr, '//liquipedia.net/commons/images/d/d2/InfoboxIcon_Flickr.png' );
-	.icon-make-image( gamersclub, '//liquipedia.net/commons/images/a/a5/InfoboxIcon_Gamers_Club.png' );
-	.icon-make-image( garena, '//liquipedia.net/commons/images/6/6b/InfoboxIcon_Garena.png' );
-	.icon-make-image( github, '//liquipedia.net/commons/images/f/fc/InfoboxIcon_GitHub.png' );
-	.icon-make-image( google-plus, '//liquipedia.net/commons/images/4/40/InfoboxIcon_Google%2B.png' );
-	.icon-make-image( gosugamers, '//liquipedia.net/commons/images/f/f0/InfoboxIcon_GosuGamers.png' );
-	.icon-make-image( halodatahive, '//liquipedia.net/commons/images/e/e9/InfoboxIcon_HaloDataHive.png' );
-	.icon-make-image( haojiao, '//liquipedia.net/commons/images/6/68/InfoboxIcon_Haojiao.png' );
-	.icon-make-image( hitbox, '//liquipedia.net/commons/images/b/b6/InfoboxIcon_HitboxTV.png' );
-	.icon-make-image( home, '//liquipedia.net/commons/images/2/2f/InfoboxIcon_Website.png' );
-	.icon-make-image( huomao, '//liquipedia.net/commons/images/4/46/InfoboxIcon_HuomaoTV.png' );
-	.icon-make-image( huomaotv, '//liquipedia.net/commons/images/4/46/InfoboxIcon_HuomaoTV.png' );
-	.icon-make-image( huya, '//liquipedia.net/commons/images/0/05/InfoboxIcon_HuyaTV.png' );
-	.icon-make-image( huyatv, '//liquipedia.net/commons/images/0/05/InfoboxIcon_HuyaTV.png' );
-	.icon-make-image( iccup, '//liquipedia.net/commons/images/2/2c/InfoboxIcon_ICCUP.png' );
-	.icon-make-image( instagram, '//liquipedia.net/commons/images/7/7d/InfoboxIcon_Instagram.png' );
-	.icon-make-image( king-kong, '//liquipedia.net/commons/images/4/43/InfoboxIcon_King_Kong.png' );
-	.icon-make-image( kick, '//liquipedia.net/commons/images/5/57/InfoboxIcon_Kick.png' );
-	.icon-make-image( kuaishou, '//liquipedia.net/commons/images/f/f9/InfoboxIcon_Kuaishou.png' );
-	.icon-make-image( letsplaylive, '//liquipedia.net/commons/images/2/2c/InfoboxIcon_LetsPlay.Live.png' );
-	.icon-make-image( linkedin, '//liquipedia.net/commons/images/9/97/InfoboxIcon_LinkedIn.png' );
-	.icon-make-image( liquipedia, '//liquipedia.net/commons/images/d/de/InfoboxIcon_Liquipedia.png' );
-	.icon-make-image( loco, '//liquipedia.net/commons/images/0/06/InfoboxIcon_Loco.png' );
-	.icon-make-image( lolchess, '//liquipedia.net/commons/images/0/0f/InfoboxIcon_LoLCHESS.png' );
-	.icon-make-image( masteroverwatch, '//liquipedia.net/commons/images/6/60/InfoboxIcon_MasterOverwatch.png' );
-	.icon-make-image( matcherino, '//liquipedia.net/commons/images/8/8c/InfoboxIcon_Matcherino.png' );
-	.icon-make-image( mildom, '//liquipedia.net/commons/images/8/81/InfoboxIcon_Mildom.png' );
-	.icon-make-image( mixer, '//liquipedia.net/commons/images/8/85/InfoboxIcon_Mixer.png' );
-	.icon-make-image( music, '//liquipedia.net/commons/images/3/37/InfoboxIcon_Music.png' );
-	.icon-make-image( niconico, '//liquipedia.net/commons/images/b/bf/InfoboxIcon_Niconico.png' );
-	.icon-make-image( nimotv, '//liquipedia.net/commons/images/f/f7/InfoboxIcon_NimoTV.png' );
-	.icon-make-image( nwc3l, '//liquipedia.net/commons/images/1/1c/InfoboxIcon_NWC3L.png' );
-	.icon-make-image( octane, '//liquipedia.net/commons/images/d/da/InfoboxIcon_Octane.png' );
-	.icon-make-image( openrec, '//liquipedia.net/commons/images/9/98/InfoboxIcon_OPENREC.png' );
-	.icon-make-image( opgg, '//liquipedia.net/commons/images/b/b6/InfoboxIcon_OPGG.png' );
-	.icon-make-image( osu, '//liquipedia.net/commons/images/e/e2/InfoboxIcon_osu.png' );
-	.icon-make-image( pandatv, '//liquipedia.net/commons/images/d/d3/InfoboxIcon_PandaTV.png' );
-	.icon-make-image( patreon, '//liquipedia.net/commons/images/b/b1/InfoboxIcon_Patreon.png' );
-	.icon-make-image( play2live, '//liquipedia.net/commons/images/a/a0/InfoboxIcon_Play2Live.png' );
-	.icon-make-image( reddit, '//liquipedia.net/commons/images/5/59/InfoboxIcon_Reddit.png' );
-	.icon-make-image( replay, '//liquipedia.net/commons/images/5/52/InfoboxIcon_Replay.png' );
-	.icon-make-image( rgl, '//liquipedia.net/commons/images/9/91/InfoboxIcon_RGL.png' );
-	.icon-make-image( royaleapi, '//liquipedia.net/commons/images/7/74/InfoboxIcon_RoyaleAPI.png' );
-	.icon-make-image( rules, '//liquipedia.net/commons/images/d/d0/InfoboxIcon_Rules.png' );
-	.icon-make-image( shift, '//liquipedia.net/commons/images/6/61/InfoboxIcon_Shift.png' );
-	.icon-make-image( siegegg, '//liquipedia.net/commons/images/e/e2/InfoboxIcon_SiegeGG.png' );
-	.icon-make-image( skgaming, '//liquipedia.net/commons/images/0/01/InfoboxIcon_SK.png' );
-	.icon-make-image( skype, '//liquipedia.net/commons/images/2/29/InfoboxIcon_Skype.png' );
-	.icon-make-image( smashboards, '//liquipedia.net/commons/images/a/aa/InfoboxIcon_SmashBoards.png' );
-	.icon-make-image( smashcast, '//liquipedia.net/commons/images/d/db/InfoboxIcon_Smashcast.png' );
-	.icon-make-image( smash-gg, '//liquipedia.net/commons/images/3/3c/InfoboxIcon_SmashGG.png' );
-	.icon-make-image( start-gg, '//liquipedia.net/commons/images/9/9d/InfoboxIcon_StartGG.png' );
-	.icon-make-image( snapchat, '//liquipedia.net/commons/images/f/fc/InfoboxIcon_Snapchat.png' );
-	.icon-make-image( sostronk, '//liquipedia.net/commons/images/4/4e/InfoboxIcon_SoStronk.png' );
-	.icon-make-image( spotify, '//liquipedia.net/commons/images/1/14/InfoboxIcon_Spotify.png' );
-	.icon-make-image( steam, '//liquipedia.net/commons/images/d/d0/InfoboxIcon_Steam.png' );
-	.icon-make-image( stratz, '//liquipedia.net/commons/images/3/3e/InfoboxIcon_Stratz.png' );
-	.icon-make-image( stream, '//liquipedia.net/commons/images/c/c2/InfoboxIcon_Stream.png' );
-	.icon-make-image( strikr, '//liquipedia.net/commons/images/0/06/InfoboxIcon_Strikr.png' );
-	.icon-make-image( telegram, '//liquipedia.net/commons/images/e/e7/InfoboxIcon_Telegram.png' );
-	.icon-make-image( tencent, '//liquipedia.net/commons/images/4/42/InfoboxIcon_Tencent.png' );
-	.icon-make-image( tencent-games, '//liquipedia.net/commons/images/b/b5/InfoboxIcon_Tencent_Games.png' );
-	.icon-make-image( tftv, '//liquipedia.net/commons/images/2/2b/InfoboxIcon_tftv.png' );
-	.icon-make-image( threads, '//liquipedia.net/commons/images/0/0d/InfoboxIcon_Threads.png' );
-	.icon-make-image( tiktok, '//liquipedia.net/commons/images/4/47/InfoboxIcon_TikTok.png' );
-	.icon-make-image( tlpd, '//liquipedia.net/commons/images/0/07/InfoboxIcon_TLPDInt.png' );
-	.icon-make-image( tlpd-hots, '//liquipedia.net/commons/images/e/e3/InfoboxIcon_TLPDHoTS.png' );
-	.icon-make-image( tlpd-wol, '//liquipedia.net/commons/images/0/07/InfoboxIcon_TLPDInt.png' );
-	.icon-make-image( tlpd-wol-korea, '//liquipedia.net/commons/images/7/78/InfoboxIcon_TLPDKor.png' );
-	.icon-make-image( tlpd-sospa, '//liquipedia.net/commons/images/9/9d/InfoboxIcon_TLPDSonic.png' );
-	.icon-make-image( tlprofile, '//liquipedia.net/commons/images/f/f3/InfoboxIcon_TLProfile.png' );
-	.icon-make-image( tlstream, '//liquipedia.net/commons/images/b/b3/InfoboxIcon_TLStream.png' );
-	.icon-make-image( tonamel, '//liquipedia.net/commons/images/e/e1/InfoboxIcon_Tonamel.png' );
-	.icon-make-image( toornament, '//liquipedia.net/commons/images/c/cb/InfoboxIcon_Toornament.png' );
-	.icon-make-image( tournament, '//liquipedia.net/commons/images/a/a8/InfoboxIcon_Trophy.png' );
-	.icon-make-image( trackmania-io, '//liquipedia.net/commons/images/3/31/InfoboxIcon_TrackmaniaIO.png' );
-	.icon-make-image( trovo, '//liquipedia.net/commons/images/0/02/InfoboxIcon_Trovo.png' );
-	.icon-make-image( twitch, '//liquipedia.net/commons/images/6/61/InfoboxIcon_Twitch.png' );
-	.icon-make-image( twitch2, '//liquipedia.net/commons/images/6/61/InfoboxIcon_Twitch.png' );
-	.icon-make-image( twitter, '//liquipedia.net/commons/images/1/19/InfoboxIcon_Twitter.png' );
-	.icon-make-image( vidio, '//liquipedia.net/commons/images/6/62/InfoboxIcon_Vidio.png' );
-	.icon-make-image( vod, '//liquipedia.net/commons/images/5/56/InfoboxIcon_Vod.png' );
-	.icon-make-image( vk, '//liquipedia.net/commons/images/d/d7/InfoboxIcon_VK.png' );
-	.icon-make-image( vkontakte, '//liquipedia.net/commons/images/d/d7/InfoboxIcon_VK.png' );
-	.icon-make-image( vlr, '//liquipedia.net/commons/images/f/f7/InfoboxIcon_VLR.png' );
-	.icon-make-image( weibo, '//liquipedia.net/commons/images/9/92/InfoboxIcon_Weibo.png' );
-	.icon-make-image( yandexefir, '//liquipedia.net/commons/images/6/6c/InfoboxIcon_Yandex_Efir.png' );
-	.icon-make-image( youku, '//liquipedia.net/commons/images/8/8e/InfoboxIcon_Youku.png' );
-	.icon-make-image( youtube, '//liquipedia.net/commons/images/6/6c/InfoboxIcon_YouTube.png' );
-	.icon-make-image( zhangyutv, '//liquipedia.net/commons/images/c/cf/InfoboxIcon_ZhangyuTV.png' );
-	.icon-make-image( zhanqitv, '//liquipedia.net/commons/images/b/b0/InfoboxIcon_ZhanqiTV.png' );
+	.icon-make-image( 5ewin, "//liquipedia.net/commons/images/c/cf/InfoboxIcon_5Ewin.png" );
+	.icon-make-image( abios, "//liquipedia.net/commons/images/2/21/InfoboxIcon_Abios.png" );
+	.icon-make-image( afreeca, "//liquipedia.net/commons/images/7/7c/InfoboxIcon_Afreeca.png" );
+	.icon-make-image( afreecatv, "//liquipedia.net/commons/images/7/7c/InfoboxIcon_Afreeca.png" );
+	.icon-make-image( aligulac, "//liquipedia.net/commons/images/7/74/InfoboxIcon_Aligulac.png" );
+	.icon-make-image( aoezone, "//liquipedia.net/commons/images/e/ea/InfoboxIcon_AoEZone.png" );
+	.icon-make-image( apexlegendsstatus, "//liquipedia.net/commons/images/e/e7/InfoboxIcon_ApexLegendsStatus.png" );
+	.icon-make-image( apple-podcasts, "//liquipedia.net/commons/images/0/06/InfoboxIcon_Apple_Podcasts.png" );
+	.icon-make-image( ask-fm, "//liquipedia.net/commons/images/b/b8/InfoboxIcon_AskFM.png" );
+	.icon-make-image( azubu, "//liquipedia.net/commons/images/6/62/InfoboxIcon_Azubu.png" );
+	.icon-make-image( b5csgo, "//liquipedia.net/commons/images/5/52/InfoboxIcon_B5csgo.png" );
+	.icon-make-image( battlefy, "//liquipedia.net/commons/images/9/96/InfoboxIcon_BATTLEFY.png" );
+	.icon-make-image( best-gg, "//liquipedia.net/commons/images/0/01/InfoboxIcon_BESTGG.png" );
+	.icon-make-image( bilibili, "//liquipedia.net/commons/images/5/50/InfoboxIcon_bilibili.png" );
+	.icon-make-image( binary-beast, "//liquipedia.net/commons/images/a/af/InfoboxIcon_BinaryBeast.png" );
+	.icon-make-image( booyah, "//liquipedia.net/commons/images/b/bb/InfoboxIcon_BOOYAH.png" );
+	.icon-make-image( bracket, "//liquipedia.net/commons/images/d/d5/InfoboxIcon_Bracket.png" );
+	.icon-make-image( cafe-daum, "//liquipedia.net/commons/images/c/c9/InfoboxIcon_Daum.png" );
+	.icon-make-image( caffeine, "//liquipedia.net/commons/images/4/4b/InfoboxIcon_Caffeine.png" );
+	.icon-make-image( cc, "//liquipedia.net/commons/images/4/46/InfoboxIcon_cc.png" );
+	.icon-make-image( challengermode, "//liquipedia.net/commons/images/1/19/InfoboxIcon_Challengermode.png" );
+	.icon-make-image( challonge, "//liquipedia.net/commons/images/c/cd/InfoboxIcon_Challonge.png" );
+	.icon-make-image( cntft, "//liquipedia.net/commons/images/e/ea/InfoboxIcon_CNTFT.png" );
+	.icon-make-image( corestrike, "//liquipedia.net/commons/images/a/aa/InfoboxIcon_CoreStrike.png" );
+	.icon-make-image( cybergamer, "//liquipedia.net/commons/images/4/4e/InfoboxIcon_CyberGamer.png" );
+	.icon-make-image( dailymotion, "//liquipedia.net/commons/images/0/07/InfoboxIcon_Dailymotion.png" );
+	.icon-make-image( datdota, "//liquipedia.net/commons/images/2/24/InfoboxIcon_Datdota.png" );
+	.icon-make-image( discord, "//liquipedia.net/commons/images/c/c6/InfoboxIcon_Discord.png" );
+	.icon-make-image( dlive, "//liquipedia.net/commons/images/4/43/InfoboxIcon_DLive.png" );
+	.icon-make-image( dotabuff, "//liquipedia.net/commons/images/9/90/InfoboxIcon_Dotabuff.png" );
+	.icon-make-image( douyu, "//liquipedia.net/commons/images/b/bc/InfoboxIcon_DouyuTV.png" );
+	.icon-make-image( douyutv, "//liquipedia.net/commons/images/b/bc/InfoboxIcon_DouyuTV.png" );
+	.icon-make-image( douyin, "//liquipedia.net/commons/images/4/47/InfoboxIcon_TikTok.png" ); // Intended to be TikTok
+	.icon-make-image( email, "//liquipedia.net/commons/images/2/2f/InfoboxIcon_Email.png" );
+	.icon-make-image( escharts, "//liquipedia.net/commons/images/9/99/InfoboxIcon_EsportsCharts.png" );
+	.icon-make-image( esea, "//liquipedia.net/commons/images/9/99/InfoboxIcon_ESEA.png" );
+	.icon-make-image( esea-league, "//liquipedia.net/commons/images/8/8e/InfoboxIcon_ESEA_League.png" );
+	.icon-make-image( esl, "//liquipedia.net/commons/images/4/44/InfoboxIcon_ESL.png" );
+	.icon-make-image( esportal, "//liquipedia.net/commons/images/c/c2/InfoboxIcon_Esportal.png" );
+	.icon-make-image( etf2l, "//liquipedia.net/commons/images/6/61/InfoboxIcon_ETF2L.png" );
+	.icon-make-image( facebook, "//liquipedia.net/commons/images/1/1e/InfoboxIcon_Facebook.png" );
+	.icon-make-image( facebook-gaming, "//liquipedia.net/commons/images/8/8d/InfoboxIcon_Facebook_Gaming.png" );
+	.icon-make-image( faceit, "//liquipedia.net/commons/images/e/e6/InfoboxIcon_FACEIT.png" );
+	.icon-make-image( factor, "//liquipedia.net/commons/images/1/15/InfoboxIcon_Factor.png" );
+	.icon-make-image( fanclub, "//liquipedia.net/commons/images/f/fe/InfoboxIcon_TLFanPage.png" );
+	.icon-make-image( flickr, "//liquipedia.net/commons/images/d/d2/InfoboxIcon_Flickr.png" );
+	.icon-make-image( gamersclub, "//liquipedia.net/commons/images/a/a5/InfoboxIcon_Gamers_Club.png" );
+	.icon-make-image( garena, "//liquipedia.net/commons/images/6/6b/InfoboxIcon_Garena.png" );
+	.icon-make-image( github, "//liquipedia.net/commons/images/f/fc/InfoboxIcon_GitHub.png" );
+	.icon-make-image( google-plus, "//liquipedia.net/commons/images/4/40/InfoboxIcon_Google%2B.png" );
+	.icon-make-image( gosugamers, "//liquipedia.net/commons/images/f/f0/InfoboxIcon_GosuGamers.png" );
+	.icon-make-image( halodatahive, "//liquipedia.net/commons/images/e/e9/InfoboxIcon_HaloDataHive.png" );
+	.icon-make-image( haojiao, "//liquipedia.net/commons/images/6/68/InfoboxIcon_Haojiao.png" );
+	.icon-make-image( hitbox, "//liquipedia.net/commons/images/b/b6/InfoboxIcon_HitboxTV.png" );
+	.icon-make-image( home, "//liquipedia.net/commons/images/2/2f/InfoboxIcon_Website.png" );
+	.icon-make-image( huomao, "//liquipedia.net/commons/images/4/46/InfoboxIcon_HuomaoTV.png" );
+	.icon-make-image( huomaotv, "//liquipedia.net/commons/images/4/46/InfoboxIcon_HuomaoTV.png" );
+	.icon-make-image( huya, "//liquipedia.net/commons/images/0/05/InfoboxIcon_HuyaTV.png" );
+	.icon-make-image( huyatv, "//liquipedia.net/commons/images/0/05/InfoboxIcon_HuyaTV.png" );
+	.icon-make-image( iccup, "//liquipedia.net/commons/images/2/2c/InfoboxIcon_ICCUP.png" );
+	.icon-make-image( instagram, "//liquipedia.net/commons/images/7/7d/InfoboxIcon_Instagram.png" );
+	.icon-make-image( king-kong, "//liquipedia.net/commons/images/4/43/InfoboxIcon_King_Kong.png" );
+	.icon-make-image( kick, "//liquipedia.net/commons/images/5/57/InfoboxIcon_Kick.png" );
+	.icon-make-image( kuaishou, "//liquipedia.net/commons/images/f/f9/InfoboxIcon_Kuaishou.png" );
+	.icon-make-image( letsplaylive, "//liquipedia.net/commons/images/2/2c/InfoboxIcon_LetsPlay.Live.png" );
+	.icon-make-image( linkedin, "//liquipedia.net/commons/images/9/97/InfoboxIcon_LinkedIn.png" );
+	.icon-make-image( liquipedia, "//liquipedia.net/commons/images/d/de/InfoboxIcon_Liquipedia.png" );
+	.icon-make-image( loco, "//liquipedia.net/commons/images/0/06/InfoboxIcon_Loco.png" );
+	.icon-make-image( lolchess, "//liquipedia.net/commons/images/0/0f/InfoboxIcon_LoLCHESS.png" );
+	.icon-make-image( masteroverwatch, "//liquipedia.net/commons/images/6/60/InfoboxIcon_MasterOverwatch.png" );
+	.icon-make-image( matcherino, "//liquipedia.net/commons/images/8/8c/InfoboxIcon_Matcherino.png" );
+	.icon-make-image( mildom, "//liquipedia.net/commons/images/8/81/InfoboxIcon_Mildom.png" );
+	.icon-make-image( mixer, "//liquipedia.net/commons/images/8/85/InfoboxIcon_Mixer.png" );
+	.icon-make-image( music, "//liquipedia.net/commons/images/3/37/InfoboxIcon_Music.png" );
+	.icon-make-image( niconico, "//liquipedia.net/commons/images/b/bf/InfoboxIcon_Niconico.png" );
+	.icon-make-image( nimotv, "//liquipedia.net/commons/images/f/f7/InfoboxIcon_NimoTV.png" );
+	.icon-make-image( nwc3l, "//liquipedia.net/commons/images/1/1c/InfoboxIcon_NWC3L.png" );
+	.icon-make-image( octane, "//liquipedia.net/commons/images/d/da/InfoboxIcon_Octane.png" );
+	.icon-make-image( openrec, "//liquipedia.net/commons/images/9/98/InfoboxIcon_OPENREC.png" );
+	.icon-make-image( opgg, "//liquipedia.net/commons/images/b/b6/InfoboxIcon_OPGG.png" );
+	.icon-make-image( osu, "//liquipedia.net/commons/images/e/e2/InfoboxIcon_osu.png" );
+	.icon-make-image( pandatv, "//liquipedia.net/commons/images/d/d3/InfoboxIcon_PandaTV.png" );
+	.icon-make-image( patreon, "//liquipedia.net/commons/images/b/b1/InfoboxIcon_Patreon.png" );
+	.icon-make-image( play2live, "//liquipedia.net/commons/images/a/a0/InfoboxIcon_Play2Live.png" );
+	.icon-make-image( reddit, "//liquipedia.net/commons/images/5/59/InfoboxIcon_Reddit.png" );
+	.icon-make-image( replay, "//liquipedia.net/commons/images/5/52/InfoboxIcon_Replay.png" );
+	.icon-make-image( rgl, "//liquipedia.net/commons/images/9/91/InfoboxIcon_RGL.png" );
+	.icon-make-image( royaleapi, "//liquipedia.net/commons/images/7/74/InfoboxIcon_RoyaleAPI.png" );
+	.icon-make-image( rules, "//liquipedia.net/commons/images/d/d0/InfoboxIcon_Rules.png" );
+	.icon-make-image( shift, "//liquipedia.net/commons/images/6/61/InfoboxIcon_Shift.png" );
+	.icon-make-image( siegegg, "//liquipedia.net/commons/images/e/e2/InfoboxIcon_SiegeGG.png" );
+	.icon-make-image( skgaming, "//liquipedia.net/commons/images/0/01/InfoboxIcon_SK.png" );
+	.icon-make-image( skype, "//liquipedia.net/commons/images/2/29/InfoboxIcon_Skype.png" );
+	.icon-make-image( smashboards, "//liquipedia.net/commons/images/a/aa/InfoboxIcon_SmashBoards.png" );
+	.icon-make-image( smashcast, "//liquipedia.net/commons/images/d/db/InfoboxIcon_Smashcast.png" );
+	.icon-make-image( smash-gg, "//liquipedia.net/commons/images/3/3c/InfoboxIcon_SmashGG.png" );
+	.icon-make-image( start-gg, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_StartGG.png" );
+	.icon-make-image( snapchat, "//liquipedia.net/commons/images/f/fc/InfoboxIcon_Snapchat.png" );
+	.icon-make-image( sostronk, "//liquipedia.net/commons/images/4/4e/InfoboxIcon_SoStronk.png" );
+	.icon-make-image( spotify, "//liquipedia.net/commons/images/1/14/InfoboxIcon_Spotify.png" );
+	.icon-make-image( steam, "//liquipedia.net/commons/images/d/d0/InfoboxIcon_Steam.png" );
+	.icon-make-image( stratz, "//liquipedia.net/commons/images/3/3e/InfoboxIcon_Stratz.png" );
+	.icon-make-image( stream, "//liquipedia.net/commons/images/c/c2/InfoboxIcon_Stream.png" );
+	.icon-make-image( strikr, "//liquipedia.net/commons/images/0/06/InfoboxIcon_Strikr.png" );
+	.icon-make-image( telegram, "//liquipedia.net/commons/images/e/e7/InfoboxIcon_Telegram.png" );
+	.icon-make-image( tencent, "//liquipedia.net/commons/images/4/42/InfoboxIcon_Tencent.png" );
+	.icon-make-image( tencent-games, "//liquipedia.net/commons/images/b/b5/InfoboxIcon_Tencent_Games.png" );
+	.icon-make-image( tftv, "//liquipedia.net/commons/images/2/2b/InfoboxIcon_tftv.png" );
+	.icon-make-image( threads, "//liquipedia.net/commons/images/0/0d/InfoboxIcon_Threads.png" );
+	.icon-make-image( tiktok, "//liquipedia.net/commons/images/4/47/InfoboxIcon_TikTok.png" );
+	.icon-make-image( tlpd, "//liquipedia.net/commons/images/0/07/InfoboxIcon_TLPDInt.png" );
+	.icon-make-image( tlpd-hots, "//liquipedia.net/commons/images/e/e3/InfoboxIcon_TLPDHoTS.png" );
+	.icon-make-image( tlpd-wol, "//liquipedia.net/commons/images/0/07/InfoboxIcon_TLPDInt.png" );
+	.icon-make-image( tlpd-wol-korea, "//liquipedia.net/commons/images/7/78/InfoboxIcon_TLPDKor.png" );
+	.icon-make-image( tlpd-sospa, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_TLPDSonic.png" );
+	.icon-make-image( tlprofile, "//liquipedia.net/commons/images/f/f3/InfoboxIcon_TLProfile.png" );
+	.icon-make-image( tlstream, "//liquipedia.net/commons/images/b/b3/InfoboxIcon_TLStream.png" );
+	.icon-make-image( tonamel, "//liquipedia.net/commons/images/e/e1/InfoboxIcon_Tonamel.png" );
+	.icon-make-image( toornament, "//liquipedia.net/commons/images/c/cb/InfoboxIcon_Toornament.png" );
+	.icon-make-image( tournament, "//liquipedia.net/commons/images/a/a8/InfoboxIcon_Trophy.png" );
+	.icon-make-image( trackmania-io, "//liquipedia.net/commons/images/3/31/InfoboxIcon_TrackmaniaIO.png" );
+	.icon-make-image( trovo, "//liquipedia.net/commons/images/0/02/InfoboxIcon_Trovo.png" );
+	.icon-make-image( twitch, "//liquipedia.net/commons/images/6/61/InfoboxIcon_Twitch.png" );
+	.icon-make-image( twitch2, "//liquipedia.net/commons/images/6/61/InfoboxIcon_Twitch.png" );
+	.icon-make-image( twitter, "//liquipedia.net/commons/images/1/19/InfoboxIcon_Twitter.png" );
+	.icon-make-image( vidio, "//liquipedia.net/commons/images/6/62/InfoboxIcon_Vidio.png" );
+	.icon-make-image( vod, "//liquipedia.net/commons/images/5/56/InfoboxIcon_Vod.png" );
+	.icon-make-image( vk, "//liquipedia.net/commons/images/d/d7/InfoboxIcon_VK.png" );
+	.icon-make-image( vkontakte, "//liquipedia.net/commons/images/d/d7/InfoboxIcon_VK.png" );
+	.icon-make-image( vlr, "//liquipedia.net/commons/images/f/f7/InfoboxIcon_VLR.png" );
+	.icon-make-image( weibo, "//liquipedia.net/commons/images/9/92/InfoboxIcon_Weibo.png" );
+	.icon-make-image( yandexefir, "//liquipedia.net/commons/images/6/6c/InfoboxIcon_Yandex_Efir.png" );
+	.icon-make-image( youku, "//liquipedia.net/commons/images/8/8e/InfoboxIcon_Youku.png" );
+	.icon-make-image( youtube, "//liquipedia.net/commons/images/6/6c/InfoboxIcon_YouTube.png" );
+	.icon-make-image( zhangyutv, "//liquipedia.net/commons/images/c/cf/InfoboxIcon_ZhangyuTV.png" );
+	.icon-make-image( zhanqitv, "//liquipedia.net/commons/images/b/b0/InfoboxIcon_ZhanqiTV.png" );
 }
 
 .icon-make-size( @size ) {
@@ -190,7 +190,7 @@ Note: When adding a new icon, please add to
 
 		.darkmode &,
 		.theme--dark &,
-		[ data-darkreader-scheme='dark' ] & {
+		[ data-darkreader-scheme="dark" ] & {
 			background-position: -@size1x -@size1x;
 		}
 
@@ -199,7 +199,7 @@ Note: When adding a new icon, please add to
 
 			.darkmode &,
 			.theme--dark &,
-			[ data-darkreader-scheme='dark' ] & {
+			[ data-darkreader-scheme="dark" ] & {
 				background-position: -@size1x 0;
 			}
 		}

--- a/stylesheets/commons/Infobox.css
+++ b/stylesheets/commons/Infobox.css
@@ -392,26 +392,26 @@ Author(s): iMarbot
 *******************************************************************************/
 .infobox-image {
 	& img {
-		&[ src*='allmode' ],
-		&[ src*='darkmode' ],
-		&[ src*='lightmode' ] {
+		&[ src*="allmode" ],
+		&[ src*="darkmode" ],
+		&[ src*="lightmode" ] {
 			max-height: 500px;
 			max-width: 100%;
 			width: auto !important;
 			height: auto !important;
 
-			&:not( [ src*='padded' ] ) {
+			&:not( [ src*="padded" ] ) {
 				padding: 15px;
 			}
 		}
 	}
 
 	&.darkmode {
-		html:not( [ data-darkreader-scheme='dark' ] ):not( .theme--dark ) .fo-nttax-infobox-wrapper:not( .infobox-darkmodeforced ) & {
+		html:not( [ data-darkreader-scheme="dark" ] ):not( .theme--dark ) .fo-nttax-infobox-wrapper:not( .infobox-darkmodeforced ) & {
 			display: none;
 		}
 
-		html:not( [ data-darkreader-scheme='dark' ] ):not( .theme--dark ) .infobox-darkmodeforced & {
+		html:not( [ data-darkreader-scheme="dark" ] ):not( .theme--dark ) .infobox-darkmodeforced & {
 			background: #1e2021;
 		}
 
@@ -419,18 +419,18 @@ Author(s): iMarbot
 			background-position: center;
 			background-size: cover;
 
-			&[ src*='ESL_Pro_League' ] {
+			&[ src*="ESL_Pro_League" ] {
 				background-image: url( //liquipedia.net/commons/images/6/6d/ESL_Pro_League_2019_background.png );
 			}
 
-			&[ src*='ESL_Challenger_League' ] {
+			&[ src*="ESL_Challenger_League" ] {
 				background-image: url( //liquipedia.net/commons/images/4/4e/ESL_Challenger_League_background.jpg );
 			}
 		}
 	}
 
 	&.lightmode {
-		html[ data-darkreader-scheme='dark' ] &,
+		html[ data-darkreader-scheme="dark" ] &,
 		html.theme--dark &,
 		.infobox-darkmodeforced & {
 			display: none;
@@ -442,13 +442,13 @@ Author(s): iMarbot
 Template(s): Player photos (cutout shots) styling
 Author(s): iMarbot
 *******************************************************************************/
-.infobox-image img[ src*='playerphoto' ] {
+.infobox-image img[ src*="playerphoto" ] {
 	max-height: 500px;
 	max-width: 100%;
 	width: auto !important;
 	height: auto !important;
 
-	&:not( [ src*='padded' ] ) {
+	&:not( [ src*="padded" ] ) {
 		padding: 15px 15px 0;
 	}
 }

--- a/stylesheets/commons/Mainpage.css
+++ b/stylesheets/commons/Mainpage.css
@@ -35,7 +35,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 	padding: 0 5px;
 }
 
-#mw-content-text .row > [ class*='col-' ] {
+#mw-content-text .row > [ class*="col-" ] {
 	padding-left: 5px;
 	padding-right: 5px;
 }
@@ -72,7 +72,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	width: calc( ~'100% - 120px' );
+	width: calc( ~"100% - 120px" );
 	display: inline-block;
 	margin-bottom: -5px;
 	padding-left: 35px;
@@ -237,7 +237,7 @@ body.page-Main_Page .mainpage-transfer .divRow:nth-of-type( n + 17 ) {
 	.mainpage-transfer > div > div.Name {
 		display: inline-block;
 		float: none;
-		width: calc( ~'100% - 125px' ) !important;
+		width: calc( ~"100% - 125px" ) !important;
 		text-align: left;
 		border: 0 !important;
 	}
@@ -275,7 +275,7 @@ body.page-Main_Page .mainpage-transfer .divRow:nth-of-type( n + 17 ) {
 	background-color: var( --matches-transfer-green-background-color, rgba( 0, 255, 0, 0.065 ) ) !important;
 }
 
-[ data-darkreader-scheme='dark' ] .mainpage-transfer .mainpage-transfer-to-team,
+[ data-darkreader-scheme="dark" ] .mainpage-transfer .mainpage-transfer-to-team,
 .theme--dark .mainpage-transfer .mainpage-transfer-to-team {
 	background-color: var( --matches-transfer-green-background-color, rgba( 0, 172, 0, 0.133 ) ) !important;
 }
@@ -284,7 +284,7 @@ body.page-Main_Page .mainpage-transfer .divRow:nth-of-type( n + 17 ) {
 	background-color: var( --matches-transfer-red-background-color, rgba( 153, 0, 34, 0.065 ) ) !important;
 }
 
-[ data-darkreader-scheme='dark' ] .mainpage-transfer .mainpage-transfer-from-team,
+[ data-darkreader-scheme="dark" ] .mainpage-transfer .mainpage-transfer-from-team,
 .theme--dark .mainpage-transfer .mainpage-transfer-from-team {
 	background-color: var( --matches-transfer-red-background-color, rgba( 223, 0, 0, 0.125 ) ) !important;
 }
@@ -457,49 +457,49 @@ body.page-Main_Page .rankingtable tr:nth-of-type( n + 7 ) {
 	display: none;
 }
 
-label[ for^='tournaments-list-filter-' ] {
+label[ for^="tournaments-list-filter-" ] {
 	cursor: pointer;
 	vertical-align: middle;
-	width: calc( ~'100% / 4' );
+	width: calc( ~"100% / 4" );
 	text-align: center;
 	padding: 10px 0;
 	margin: 0;
 }
 
-label[ for^='tournaments-list-filter-' ]:before {
+label[ for^="tournaments-list-filter-" ]:before {
 	padding: 5px;
 }
 
-label[ for='tournaments-list-filter-64' ] {
+label[ for="tournaments-list-filter-64" ] {
 	background-color: #d5e5b6;
 }
 
-label[ for='tournaments-list-filter-64' ]:before {
-	content: '64';
+label[ for="tournaments-list-filter-64" ]:before {
+	content: "64";
 }
 
-label[ for='tournaments-list-filter-melee' ] {
+label[ for="tournaments-list-filter-melee" ] {
 	background-color: #b6e5c6;
 }
 
-label[ for='tournaments-list-filter-melee' ]:before {
-	content: 'Melee';
+label[ for="tournaments-list-filter-melee" ]:before {
+	content: "Melee";
 }
 
-label[ for='tournaments-list-filter-pm' ] {
+label[ for="tournaments-list-filter-pm" ] {
 	background-color: #c6b6e5;
 }
 
-label[ for='tournaments-list-filter-pm' ]:before {
-	content: 'Project M';
+label[ for="tournaments-list-filter-pm" ]:before {
+	content: "Project M";
 }
 
-label[ for='tournaments-list-filter-ultimate' ] {
+label[ for="tournaments-list-filter-ultimate" ] {
 	background-color: #e5b6d5;
 }
 
-label[ for='tournaments-list-filter-ultimate' ]:before {
-	content: 'Ultimate';
+label[ for="tournaments-list-filter-ultimate" ]:before {
+	content: "Ultimate";
 }
 
 .tournaments-list .filter-64,
@@ -507,10 +507,10 @@ label[ for='tournaments-list-filter-ultimate' ]:before {
 .tournaments-list .filter-pm,
 .tournaments-list .filter-ultimate,
 .tournaments-list .filter-none,
-#tournaments-list-filter-64:not( :checked ) ~ label[ for='tournaments-list-filter-64' ],
-#tournaments-list-filter-melee:not( :checked ) ~ label[ for='tournaments-list-filter-melee' ],
-#tournaments-list-filter-pm:not( :checked ) ~ label[ for='tournaments-list-filter-pm' ],
-#tournaments-list-filter-ultimate:not( :checked ) ~ label[ for='tournaments-list-filter-ultimate' ] {
+#tournaments-list-filter-64:not( :checked ) ~ label[ for="tournaments-list-filter-64" ],
+#tournaments-list-filter-melee:not( :checked ) ~ label[ for="tournaments-list-filter-melee" ],
+#tournaments-list-filter-pm:not( :checked ) ~ label[ for="tournaments-list-filter-pm" ],
+#tournaments-list-filter-ultimate:not( :checked ) ~ label[ for="tournaments-list-filter-ultimate" ] {
 	opacity: 0.5;
 	transition: 0.5s;
 }
@@ -524,22 +524,22 @@ label[ for='tournaments-list-filter-ultimate' ]:before {
 #tournaments-list-filter-melee:checked ~ .tournaments-list .filter-melee,
 #tournaments-list-filter-pm:checked ~ .tournaments-list .filter-pm,
 #tournaments-list-filter-ultimate:checked ~ .tournaments-list .filter-ultimate,
-#tournaments-list-filter-64:not( :checked ) ~ #tournaments-list-filter-melee:not( :checked ) ~ #tournaments-list-filter-pm:not( :checked ) ~ #tournaments-list-filter-ultimate:not( :checked ) ~ label[ for^='tournaments-list-filter-' ],
-#tournaments-list-filter-64:checked ~ label[ for='tournaments-list-filter-64' ],
-#tournaments-list-filter-melee:checked ~ label[ for='tournaments-list-filter-melee' ],
-#tournaments-list-filter-pm:checked ~ label[ for='tournaments-list-filter-pm' ],
-#tournaments-list-filter-ultimate:checked ~ label[ for='tournaments-list-filter-ultimate' ] {
+#tournaments-list-filter-64:not( :checked ) ~ #tournaments-list-filter-melee:not( :checked ) ~ #tournaments-list-filter-pm:not( :checked ) ~ #tournaments-list-filter-ultimate:not( :checked ) ~ label[ for^="tournaments-list-filter-" ],
+#tournaments-list-filter-64:checked ~ label[ for="tournaments-list-filter-64" ],
+#tournaments-list-filter-melee:checked ~ label[ for="tournaments-list-filter-melee" ],
+#tournaments-list-filter-pm:checked ~ label[ for="tournaments-list-filter-pm" ],
+#tournaments-list-filter-ultimate:checked ~ label[ for="tournaments-list-filter-ultimate" ] {
 	opacity: 1;
 	transition: 0.5s;
 }
 
 /* icon list */
 .mainpage-icons-10 img {
-	width: calc( ~'10% - 3.45px' );
+	width: calc( ~"10% - 3.45px" );
 }
 
 .mainpage-icons-14 img {
-	width: calc( ~'7.1% - 3.45px' );
+	width: calc( ~"7.1% - 3.45px" );
 }
 
 .mainpage-icons-10 img,
@@ -560,17 +560,17 @@ label[ for='tournaments-list-filter-ultimate' ]:before {
 	}
 
 	.mainpage-icons-10 img {
-		width: calc( ~'20% - 3.45px' );
+		width: calc( ~"20% - 3.45px" );
 	}
 
 	.mainpage-icons-14 img {
-		width: calc( ~'14.2% - 3.45px' );
+		width: calc( ~"14.2% - 3.45px" );
 	}
 }
 
 @media ( max-width: 380px ) {
 	.mainpage-icons-14 img {
-		width: calc( ~'20% - 3.45px' );
+		width: calc( ~"20% - 3.45px" );
 	}
 }
 
@@ -667,11 +667,11 @@ Author(s): iMarbot
 Template(s): Commons latest uploads
 Author(s): FO-nTTaX
 *******************************************************************************/
-#latest-uploads img[ src*='darkmode' ] {
+#latest-uploads img[ src*="darkmode" ] {
 	background-color: #272727;
 	padding: 5px;
 }
 
-#images-taken-on-this-day img[ src*='darkmode' ] {
+#images-taken-on-this-day img[ src*="darkmode" ] {
 	background-color: #272727;
 }

--- a/stylesheets/commons/Miscellaneous.css
+++ b/stylesheets/commons/Miscellaneous.css
@@ -204,7 +204,7 @@ Author(s): FO-nTTaX, Elysienna
 	color: #676767;
 	border-radius: 0.25rem;
 	font-size: 0.75rem;
-	font-family: 'Open Sans', sans-serif;
+	font-family: "Open Sans", sans-serif;
 	font-weight: bold;
 	padding: 0.125rem 0.25rem;
 	top: 0.0625rem;
@@ -227,7 +227,7 @@ Author(s): FO-nTTaX, Elysienna
 }
 
 .liquipedia-links-badge--tooltip:before {
-	content: '';
+	content: "";
 	position: absolute;
 	top: 0.25rem;
 	left: -0.3125rem;
@@ -279,7 +279,7 @@ Template(s): TeamHistory
 Author(s): FO-nTTaX
 *******************************************************************************/
 .th-mono {
-	font-family: 'Droid Sans Mono', monospace;
+	font-family: "Droid Sans Mono", monospace;
 	letter-spacing: -1.4px;
 }
 
@@ -296,8 +296,8 @@ Author(s): FO-nTTaX
 	margin: 0;
 }
 
-#sidebar-toc .row > [ class*='col-' ],
-#scroll-wrapper-toc .row > [ class*='col-' ] {
+#sidebar-toc .row > [ class*="col-" ],
+#scroll-wrapper-toc .row > [ class*="col-" ] {
 	padding-left: 5px;
 	padding-right: 5px;
 }
@@ -320,7 +320,7 @@ Author(s): FO-nTTaX
 
 .participants-table-buttons::after {
 	clear: both;
-	content: ' ';
+	content: " ";
 	display: block;
 }
 
@@ -446,7 +446,7 @@ span.icon-small.darkmode {
 	display: none;
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	span.league-icon-small-image.lightmode,
 	span.icon-small.lightmode {
@@ -511,7 +511,7 @@ Author(s): FO-nTTaX
 }
 
 .timeline-row > div:nth-of-type( 2 ) {
-	width: calc( ~'100% - 150px' );
+	width: calc( ~"100% - 150px" );
 }
 
 .timeline-period {
@@ -689,7 +689,7 @@ Author(s): FO-nTTaX, Rapture
 
 .spellcard-description {
 	display: inline-block;
-	width: calc( ~'100% - 124px' );
+	width: calc( ~"100% - 124px" );
 	border-width: 1px 0;
 	border-style: solid;
 	padding: 5px 0;
@@ -1197,7 +1197,7 @@ Author(s): spazer
 	border-style: solid;
 	padding-left: 2px;
 	margin: 5px 0 0 5px;
-	width: calc( ~'100% - 10px' );
+	width: calc( ~"100% - 10px" );
 	text-align: center;
 }
 
@@ -1257,14 +1257,14 @@ span.vodlink.darkmode {
 	display: none;
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	span.vodlink.lightmode {
 		display: none;
 	}
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	span.vodlink.darkmode {
 		display: inline-block;
@@ -1275,14 +1275,14 @@ span.vodlink.darkmode {
 	display: none;
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.vodlink span.lightmode {
 		display: none;
 	}
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.vodlink span.darkmode {
 		display: inline;
@@ -1353,7 +1353,7 @@ Author(s): QuadratClown
 .rl-responsive-table {
 	border-collapse: collapse;
 	margin: 0;
-	width: calc( ~'100% - 347px' );
+	width: calc( ~"100% - 347px" );
 	table-layout: fixed;
 }
 
@@ -1466,7 +1466,7 @@ Author(s): QuadratClown
 .rl-responsive-table-sortable {
 	border-collapse: collapse;
 	margin: 0;
-	width: calc( ~'100% - 347px' );
+	width: calc( ~"100% - 347px" );
 	table-layout: fixed;
 }
 
@@ -1642,7 +1642,7 @@ Author(s): Rapture
 	background-color: var( --table-header-background-color, var( --clr-surface-4, #f5f5f5 ) );
 }
 
-.roster-card > tbody > tr > th.large-only[ colspan='1' ] {
+.roster-card > tbody > tr > th.large-only[ colspan="1" ] {
 	display: none;
 }
 
@@ -1707,11 +1707,11 @@ Author(s): Rapture
 		border: 1px solid var( --table-border-color, var( --clr-border, #bbbbbb ) );
 	}
 
-	.roster-card > tbody > tr > th.large-only[ colspan='10' ] {
+	.roster-card > tbody > tr > th.large-only[ colspan="10" ] {
 		display: none;
 	}
 
-	.roster-card > tbody > tr > th.large-only[ colspan='1' ] {
+	.roster-card > tbody > tr > th.large-only[ colspan="1" ] {
 		display: table-cell;
 	}
 
@@ -1819,7 +1819,7 @@ Author(s): Rapture
 	padding: 5px;
 }
 
-.stand-in-card > tbody > tr > th.large-only[ colspan='1' ] {
+.stand-in-card > tbody > tr > th.large-only[ colspan="1" ] {
 	display: none;
 }
 
@@ -1849,11 +1849,11 @@ Author(s): Rapture
 		border: 1px solid var( --clr-border, #bbbbbb );
 	}
 
-	.stand-in-card > tbody > tr > th.large-only[ colspan='10' ] {
+	.stand-in-card > tbody > tr > th.large-only[ colspan="10" ] {
 		display: none;
 	}
 
-	.stand-in-card > tbody > tr > th.large-only[ colspan='1' ] {
+	.stand-in-card > tbody > tr > th.large-only[ colspan="1" ] {
 		display: table-cell;
 	}
 
@@ -2041,7 +2041,7 @@ Author(s): iMarbot
 *******************************************************************************/
 @media ( min-width: 650px ) {
 	.roster-notes-squash div {
-		max-width: calc( ~'100% - 350px' );
+		max-width: calc( ~"100% - 350px" );
 	}
 }
 
@@ -2120,10 +2120,10 @@ img.player-role-icon {
 	image-rendering: -webkit-optimize-contrast;
 }
 
-.player-role-icon img[ title='Captain' ],
-.player-role-icon img[ title='In-Game Leader' ],
-img.player-role-icon[ alt='Captain' ],
-img.player-role-icon[ alt='In-Game Leader' ] {
+.player-role-icon img[ title="Captain" ],
+.player-role-icon img[ title="In-Game Leader" ],
+img.player-role-icon[ alt="Captain" ],
+img.player-role-icon[ alt="In-Game Leader" ] {
 	height: 13px;
 	width: 18px;
 	vertical-align: baseline;
@@ -2150,7 +2150,7 @@ kbd {
 	padding: 1px 2px;
 	border-radius: 3px;
 	font-weight: 500;
-	font-family: 'Open Sans', sans-serif;
+	font-family: "Open Sans", sans-serif;
 }
 
 /*******************************************************************************
@@ -2831,7 +2831,7 @@ Author(s): Rapture
 	padding: 0 !important;
 }
 
-#main-content-column .form-field-tokens input[ type='search' ] {
+#main-content-column .form-field-tokens input[ type="search" ] {
 	height: auto;
 	padding: 0;
 	margin: 3px 0 0 5px;
@@ -2878,7 +2878,7 @@ Author(s): iMarbot
 	display: none;
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.icon-16px.lightmode {
 		display: none;
@@ -3216,7 +3216,7 @@ div.battleground-banner {
 	padding-left: 26px;
 	line-height: 104px;
 	color: #f8f8f9 !important;
-	font-family: 'Exo', 'Trebuchet MS', 'Helvetica', sans-serif;
+	font-family: "Exo", "Trebuchet MS", "Helvetica", sans-serif;
 	font-size: 390%;
 	font-weight: 600;
 	text-shadow: 0 0 25px #3622f2;
@@ -3230,7 +3230,7 @@ div.battleground-banner {
 	padding-left: 26px;
 	line-height: 104px;
 	color: #f8f8f9 !important;
-	font-family: 'Exo', 'Trebuchet MS', 'Helvetica', sans-serif;
+	font-family: "Exo", "Trebuchet MS", "Helvetica", sans-serif;
 	font-size: 390%;
 	font-weight: 600;
 	text-shadow: 0 0 25px #b12a2a;
@@ -3349,8 +3349,8 @@ Author(s): salle
 }
 
 .team-portal-list .tp-rank-card .tp-photo {
-	height: calc( ~'19vw / 4 * 3 - 5px' );
-	width: calc( ~'19vw - 5px' );
+	height: calc( ~"19vw / 4 * 3 - 5px" );
+	width: calc( ~"19vw - 5px" );
 	text-align: center;
 	overflow: hidden;
 }
@@ -4400,18 +4400,18 @@ ul.match-bm-lol-game-veto-overview-pick {
 Template(s): Darkmode images on file pages
 Author(s): FO-nTTaX, iMarbot
 *******************************************************************************/
-html:not( [ data-darkreader-scheme='dark' ] ):not( .theme--dark ) & {
-	#file img[ src*='darkmode' ]:not( :hover ),
-	.searchResultImage img[ src*='darkmode' ],
-	.gallerybox img[ src*='darkmode' ] {
+html:not( [ data-darkreader-scheme="dark" ] ):not( .theme--dark ) & {
+	#file img[ src*="darkmode" ]:not( :hover ),
+	.searchResultImage img[ src*="darkmode" ],
+	.gallerybox img[ src*="darkmode" ] {
 		background-color: #272727;
 	}
 }
 
-#file img[ src*='lightmode' ]:not( :hover ),
-.searchResultImage img[ src*='lightmode' ],
-.gallerybox img[ src*='lightmode' ] {
-	[ data-darkreader-scheme='dark' ] & {
+#file img[ src*="lightmode" ]:not( :hover ),
+.searchResultImage img[ src*="lightmode" ],
+.gallerybox img[ src*="lightmode" ] {
+	[ data-darkreader-scheme="dark" ] & {
 		background-color: #808080;
 	}
 
@@ -4420,8 +4420,8 @@ html:not( [ data-darkreader-scheme='dark' ] ):not( .theme--dark ) & {
 	}
 }
 
-.filehistory a img[ src*='darkmode' ],
-#file img[ src*='darkmode' ]:hover {
+.filehistory a img[ src*="darkmode" ],
+#file img[ src*="darkmode" ]:hover {
 	background: url( data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAAAAAA6mKC9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAHElEQVQY02MUZoAADijNxIAG6CPAArP/x8C6AwCutQE9GsmfRAAAAABJRU5ErkJggg== ) repeat;
 }
 
@@ -4498,12 +4498,12 @@ Author(s): hjpalpha
 *******************************************************************************/
 
 .show-when-dark-mode,
-[ data-darkreader-scheme='dark' ] .show-when-light-mode,
+[ data-darkreader-scheme="dark" ] .show-when-light-mode,
 .theme--dark .show-when-light-mode {
 	display: none !important;
 }
 
-[ data-darkreader-scheme='dark' ] .show-when-dark-mode,
+[ data-darkreader-scheme="dark" ] .show-when-dark-mode,
 .theme--dark .show-when-dark-mode {
 	display: unset !important;
 }
@@ -4530,7 +4530,7 @@ Author(s): hjpalpha
 Template: Matchpage Lightmode/Darkmode class
 Author(s): iMarbot
 *******************************************************************************/
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.matchpage span.banner.lightmode,
 	.matchpage div.logo.lightmode {
@@ -4543,7 +4543,7 @@ Author(s): iMarbot
 	display: none;
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.matchpage span.banner.darkmode,
 	.matchpage div.logo.darkmode {
@@ -4555,39 +4555,39 @@ Author(s): iMarbot
 Template: Darkmode 32px icons
 Author(s): iMarbot
 *******************************************************************************/
-[ data-darkreader-scheme='dark' ],
+[ data-darkreader-scheme="dark" ],
 .theme--dark {
 	& .vodlink img,
 	.group-table-header-right img {
-		&[ src*='VOD_Icon' ],
-		&[ src*='Match_Info_Stats' ],
-		&[ src*='/Trial.png' ],
-		&[ src*='/Substitution.png' ],
-		&[ src*='Reviews32' ],
-		&[ src*='Preview_Icon32' ],
-		&[ src*='LiveReport32' ],
-		&[ src*='Interview32' ],
-		&[ src*='Highlights_Icon32' ],
-		&[ src*='Captain_Icon' ],
-		&[ src*='Recap_Icon' ] {
+		&[ src*="VOD_Icon" ],
+		&[ src*="Match_Info_Stats" ],
+		&[ src*="/Trial.png" ],
+		&[ src*="/Substitution.png" ],
+		&[ src*="Reviews32" ],
+		&[ src*="Preview_Icon32" ],
+		&[ src*="LiveReport32" ],
+		&[ src*="Interview32" ],
+		&[ src*="Highlights_Icon32" ],
+		&[ src*="Captain_Icon" ],
+		&[ src*="Recap_Icon" ] {
 			filter: invert( 1 );
 		}
 	}
 
 	& img.player-role-icon,
 	.rts-team-list-icon-tag img {
-		&[ src*='/Trial.png' ],
-		&[ src*='/Substitution.png' ],
-		&[ src*='Captain_Icon' ] {
+		&[ src*="/Trial.png" ],
+		&[ src*="/Substitution.png" ],
+		&[ src*="Captain_Icon" ] {
 			filter: invert( 1 );
 		}
 	}
 }
 
 .theme--dark img.player-role-icon {
-	&[ src*='/Trial.png' ],
-	&[ src*='/Substitution.png' ],
-	&[ src*='Captain_Icon' ] {
+	&[ src*="/Trial.png" ],
+	&[ src*="/Substitution.png" ],
+	&[ src*="Captain_Icon" ] {
 		filter: invert( 1 );
 	}
 }
@@ -4887,10 +4887,10 @@ Author(s): hjpalpha
 .theme--dark .participant-table-race-header.Protoss .opponent-list-cell-content img,
 .theme--dark .participant-table-race-header.Zerg .opponent-list-cell-content img,
 .theme--dark .participant-table-race-header.Terran .opponent-list-cell-content img,
-.theme--dark img[ title='Protoss' ],
-.theme--dark img[ title='Zerg' ],
-.theme--dark img[ title='Terran' ],
-.theme--dark img[ title='Random' ] {
+.theme--dark img[ title="Protoss" ],
+.theme--dark img[ title="Zerg" ],
+.theme--dark img[ title="Terran" ],
+.theme--dark img[ title="Random" ] {
 	filter: grayscale( 100% ) brightness( 40 );
 }
 
@@ -5136,7 +5136,7 @@ Author(s): salle
 }
 
 .tyre-graph-bar {
-	width: calc( ~'100% - 80px' );
+	width: calc( ~"100% - 80px" );
 	border-left: 1px solid var( --clr-secondary-39, #646464 );
 	height: 12px;
 	display: inline-flex;

--- a/stylesheets/commons/Navbox.css
+++ b/stylesheets/commons/Navbox.css
@@ -13,7 +13,7 @@ ul.hlist,
 }
 
 .hlist li:after {
-	content: ' · ';
+	content: " · ";
 	font-weight: bold;
 	margin: 0 0.25em 0 0.3em;
 }

--- a/stylesheets/commons/OpponentList.css
+++ b/stylesheets/commons/OpponentList.css
@@ -88,7 +88,7 @@ Author: warnull
 
 .brkts-opponent-hover > .opponent-list-cell::after {
 	clip-path: inset( -5px 0 -5px -1px );
-	content: '';
+	content: "";
 	height: 100%;
 	left: 0;
 	pointer-events: none;
@@ -330,7 +330,7 @@ Author: hjpalpha
 
 .brkts-opponent-hover > .participantTable-entry::after {
 	clip-path: inset( -4px 0 -4px -1px );
-	content: '';
+	content: "";
 	height: 100%;
 	left: 0;
 	pointer-events: none;

--- a/stylesheets/commons/Prizepooltable.css
+++ b/stylesheets/commons/Prizepooltable.css
@@ -31,39 +31,39 @@ table.prizepooltable.collapsed .prizepooltablehide {
 	}
 }
 
-html.client-js .prizepooltable.collapsed[ data-cutafter='0' ] tr:nth-child( n+3 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='1' ] tr:nth-child( n+4 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='2' ] tr:nth-child( n+5 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='3' ] tr:nth-child( n+6 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='4' ] tr:nth-child( n+7 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='5' ] tr:nth-child( n+8 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='6' ] tr:nth-child( n+9 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='7' ] tr:nth-child( n+10 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='8' ] tr:nth-child( n+11 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='9' ] tr:nth-child( n+12 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='10' ] tr:nth-child( n+13 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='11' ] tr:nth-child( n+14 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='12' ] tr:nth-child( n+15 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='13' ] tr:nth-child( n+16 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='14' ] tr:nth-child( n+17 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='15' ] tr:nth-child( n+18 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='16' ] tr:nth-child( n+19 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='17' ] tr:nth-child( n+20 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='18' ] tr:nth-child( n+21 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='19' ] tr:nth-child( n+22 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='20' ] tr:nth-child( n+23 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='21' ] tr:nth-child( n+24 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='22' ] tr:nth-child( n+25 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='23' ] tr:nth-child( n+26 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='24' ] tr:nth-child( n+27 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='25' ] tr:nth-child( n+28 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='26' ] tr:nth-child( n+29 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='27' ] tr:nth-child( n+30 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='28' ] tr:nth-child( n+31 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='29' ] tr:nth-child( n+32 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='30' ] tr:nth-child( n+33 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='31' ] tr:nth-child( n+34 ),
-html.client-js .prizepooltable.collapsed[ data-cutafter='32' ] tr:nth-child( n+35 ) {
+html.client-js .prizepooltable.collapsed[ data-cutafter="0" ] tr:nth-child( n+3 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="1" ] tr:nth-child( n+4 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="2" ] tr:nth-child( n+5 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="3" ] tr:nth-child( n+6 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="4" ] tr:nth-child( n+7 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="5" ] tr:nth-child( n+8 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="6" ] tr:nth-child( n+9 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="7" ] tr:nth-child( n+10 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="8" ] tr:nth-child( n+11 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="9" ] tr:nth-child( n+12 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="10" ] tr:nth-child( n+13 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="11" ] tr:nth-child( n+14 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="12" ] tr:nth-child( n+15 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="13" ] tr:nth-child( n+16 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="14" ] tr:nth-child( n+17 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="15" ] tr:nth-child( n+18 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="16" ] tr:nth-child( n+19 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="17" ] tr:nth-child( n+20 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="18" ] tr:nth-child( n+21 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="19" ] tr:nth-child( n+22 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="20" ] tr:nth-child( n+23 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="21" ] tr:nth-child( n+24 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="22" ] tr:nth-child( n+25 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="23" ] tr:nth-child( n+26 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="24" ] tr:nth-child( n+27 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="25" ] tr:nth-child( n+28 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="26" ] tr:nth-child( n+29 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="27" ] tr:nth-child( n+30 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="28" ] tr:nth-child( n+31 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="29" ] tr:nth-child( n+32 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="30" ] tr:nth-child( n+33 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="31" ] tr:nth-child( n+34 ),
+html.client-js .prizepooltable.collapsed[ data-cutafter="32" ] tr:nth-child( n+35 ) {
 	display: none;
 }
 
@@ -360,8 +360,8 @@ Author: warnull
 	text-align: left;
 }
 
-.prize-pool-entry > .prize-pool-player:not( [ data-player-index='1' ] ),
-.prize-pool-entry > .prize-pool-player-team:not( [ data-player-index='1' ] ) {
+.prize-pool-entry > .prize-pool-player:not( [ data-player-index="1" ] ),
+.prize-pool-entry > .prize-pool-player-team:not( [ data-player-index="1" ] ) {
 	border-top: 0;
 }
 
@@ -391,7 +391,7 @@ Author: warnull
 
 .brkts-opponent-hover > .prize-pool-cell::after {
 	clip-path: inset( -5px 0 -5px -1px );
-	content: '';
+	content: "";
 	height: 100%;
 	left: 0;
 	pointer-events: none;
@@ -444,7 +444,7 @@ Author: warnull
 	.prize-pool-entry {
 		display: grid;
 		grid-column-start: 2;
-		grid-template-columns: ~'[prime] 1fr [player-team] 1fr';
+		grid-template-columns: ~"[prime] 1fr [player-team] 1fr";
 	}
 }
 

--- a/stylesheets/commons/Statisticstable.css
+++ b/stylesheets/commons/Statisticstable.css
@@ -29,7 +29,7 @@ tr.dota-stat-row > td {
 
 .dota-stat-popup {
 	border: 1px solid #a9a9a9;
-	width: calc( ~'100% - 5px' );
+	width: calc( ~"100% - 5px" );
 	min-width: 1150px;
 	background: var( --clr-background, #f8f9fa );
 	position: absolute;

--- a/stylesheets/commons/TeamTemplates.css
+++ b/stylesheets/commons/TeamTemplates.css
@@ -82,7 +82,7 @@ span.team-template-team-bracket {
 .team-template-team-bracket .team-template-image-legacy {
 	vertical-align: 0;
 	height: var( --team-template-bracket-height, 21px );
-	width: calc( ~'var(--team-template-bracket-height, 21px) * 2.4' );
+	width: calc( ~"var(--team-template-bracket-height, 21px) * 2.4" );
 }
 
 .team-template-team-bracket .team-template-image-icon img {
@@ -127,7 +127,7 @@ Author(s): iMarbot, Darkrai
 	display: none;
 }
 
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.team-template-image-icon.lightmode,
 	.team-template-image-icon.team-template-lightmode,

--- a/stylesheets/commons/Teamcard.css
+++ b/stylesheets/commons/Teamcard.css
@@ -97,7 +97,7 @@ Author(s): ???
 		width: 100%;
 	}
 
-	.teamcard:not( .teamcard-nomobile ) table.logo img:not( [ src$='.svg' ] ) {
+	.teamcard:not( .teamcard-nomobile ) table.logo img:not( [ src$=".svg" ] ) {
 		width: auto;
 		height: auto;
 		max-width: 90%;
@@ -148,7 +148,7 @@ Author(s): ???
 }
 
 .teamcard-toggle-button::after {
-	content: ' ';
+	content: " ";
 	display: block;
 	clear: left;
 }
@@ -280,7 +280,7 @@ Author(s): iMarbot
 Template(s): TeamCard Dark Reader support
 Author(s): iMarbot
 *******************************************************************************/
-[ data-darkreader-scheme='dark' ] &,
+[ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.teamcard span.logo-lightmode {
 		display: none !important;

--- a/stylesheets/commons/Techtree.css
+++ b/stylesheets/commons/Techtree.css
@@ -23,7 +23,7 @@ Author(s): FO-nTTaX, based on http://thecodeplayer.com/walkthrough/css3-family-t
 
 .techtree li::before,
 .techtree li::after {
-	content: '';
+	content: "";
 	position: absolute;
 	top: 0;
 	right: 50%;
@@ -62,7 +62,7 @@ Author(s): FO-nTTaX, based on http://thecodeplayer.com/walkthrough/css3-family-t
 }
 
 .techtree ul ul::before {
-	content: '';
+	content: "";
 	position: absolute;
 	top: 0;
 	left: 50%;


### PR DESCRIPTION
## Summary

Change the quote-style to `double` instead of default `single`. This is because single quotes ends up being problematic when there's a combination of `var` and `calc` together (such as here https://github.com/Liquipedia/Lua-Modules/pull/3551/files#diff-2fad38bd1d381f4a4e899cceb22da429ce989db910ffad93c03c27632d2b1ec1R78), breaking the parsing all together