### PR TITLE
fix: escape division signs

### DIFF
--- a/stylesheets/commons/GroupTableLeague.css
+++ b/stylesheets/commons/GroupTableLeague.css
@@ -82,7 +82,7 @@ Author: warnull
 	.group-table-header-row,
 	.group-table-result-row {
 		display: grid;
-		grid-column: 1 / -1;
+		grid-column: ~"1 / -1";
 		grid-template-columns: 36px 1fr repeat( 8, auto );
 	}
 }
@@ -211,7 +211,7 @@ Author: warnull
 	.swiss-table-header-row,
 	.swiss-table-body-row {
 		display: grid;
-		grid-column: 1 / -1;
+		grid-column: ~"1 / -1";
 		grid-template-columns: 50% 50%;
 	}
 

--- a/stylesheets/commons/OpponentList.css
+++ b/stylesheets/commons/OpponentList.css
@@ -42,7 +42,7 @@ Author: warnull
 .opponent-list-section-title {
 	background-color: var( --table-header-variant-background-color, #eaecf0 );
 	font-weight: bold;
-	grid-column: 1 / -1;
+	grid-column: ~"1 / -1";
 	text-align: center;
 }
 
@@ -53,7 +53,7 @@ Author: warnull
 @supports not (display: contents) {
 	.opponent-list-section {
 		display: block;
-		grid-column: 1 / -1;
+		grid-column: ~"1 / -1";
 	}
 
 	.opponent-list-party {
@@ -68,7 +68,7 @@ Author: warnull
 
 .opponent-list-tbd {
 	font-style: italic;
-	grid-column: 1 / -1;
+	grid-column: ~"1 / -1";
 	text-align: center;
 }
 
@@ -121,7 +121,7 @@ Author: warnull
 }
 
 .opponent-list-team {
-	grid-column: 1 / -1;
+	grid-column: ~"1 / -1";
 	min-width: 120px;
 }
 
@@ -136,7 +136,7 @@ Author: warnull
 
 .opponent-list-literal {
 	font-style: italic;
-	grid-column: 1 / -1;
+	grid-column: ~"1 / -1";
 	min-width: 120px;
 }
 
@@ -189,7 +189,7 @@ Author: warnull
 	.participant-table-header,
 	.participant-table-section {
 		display: grid;
-		grid-column: 1 / -1;
+		grid-column: ~"1 / -1";
 		grid-template-columns: repeat( 3, 1fr );
 	}
 }
@@ -365,7 +365,7 @@ Author: hjpalpha
 
 .participantTable-faction > .participantTable-row > .participantTable-tbd,
 .participantTable-faction > .participantTable-row > .participantTable-title {
-	grid-column: 1 / -1;
+	grid-column: ~"1 / -1";
 }
 
 .participantTable-faction > .participantTable-row {

--- a/stylesheets/commons/Prizepooltable.css
+++ b/stylesheets/commons/Prizepooltable.css
@@ -279,7 +279,7 @@ Author: warnull
 
 .prize-pool-toggle-expand.prize-pool-toggle-expand.prize-pool-toggle-expand.prize-pool-toggle-expand > * {
 	color: unset;
-	grid-column: 1 / -1;
+	grid-column: ~"1 / -1";
 	text-decoration: none;
 }
 
@@ -366,13 +366,13 @@ Author: warnull
 }
 
 .prize-pool-team {
-	grid-column: prime / -1;
+	grid-column: ~"prime / -1";
 	text-align: left;
 }
 
 .prize-pool-literal {
 	font-style: italic;
-	grid-column: prime / -1;
+	grid-column: ~"prime / -1";
 }
 
 .prize-pool-entry.brkts-opponent-hover::after {
@@ -423,7 +423,7 @@ Author: warnull
 	.prize-pool-header,
 	.prize-pool-slot-area,
 	.prize-pool-toggle-expand {
-		grid-column: 1 / -1;
+		grid-column: ~"1 / -1";
 	}
 
 	.prize-pool-header {
@@ -453,7 +453,7 @@ Author: warnull
  */
 
 .starcraft-prize-pool-special-prize {
-	grid-column: prime / usd-prize;
+	grid-column: ~"prime / usd-prize";
 }
 
 .starcraft-prize-pool-archon-race {
@@ -526,7 +526,7 @@ Author: Rathoz
 }
 
 .ppt-toggle-expand {
-	grid-column: 1 / -1;
+	grid-column: ~"1 / -1";
 }
 
 /*******************************************************************************

--- a/stylesheets/commons/Teamcard.css
+++ b/stylesheets/commons/Teamcard.css
@@ -439,7 +439,7 @@ Author: warnull
 }
 
 .rts-team-table-header-row-players {
-	grid-column: entry 1 / -1;
+	grid-column: ~"entry 1 / -1";
 	min-width: 100px;
 }
 
@@ -460,7 +460,7 @@ Author: warnull
 
 .rts-team-table-tbd-entry {
 	font-style: italic;
-	grid-column: entry 1 / -1;
+	grid-column: ~"entry 1 / -1";
 	min-width: 100px;
 	text-align: center;
 }


### PR DESCRIPTION
## Summary
`less` complies `grid-column: 5 / -1` into `grid-column: -5` by default (it does math). This has been fixed in [newer versions of less](https://lesscss.org/usage/#less-options-math), but we're still running [2.X](https://github.com/less/less.js/issues/1880).

For now apply the escaping work around, where `~""` will be treated as pure-css by the less complier and not ass less