### PR TITLE
fix: ResultOrError `errorShort` formatting with extra colons

### DIFF
--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -155,7 +155,7 @@ function Error:getErrorJson()
 	end)
 
 	local errorSplit = mw.text.split(self.error, ':', true)
-	local errorText = ''
+	local errorText
 	if #errorSplit == 4 then
 		errorText = string.format('Lua error in %s:%s at line %s:%s.', unpack(errorSplit))
 	elseif #errorSplit > 4 then

--- a/standard/result_or_error.lua
+++ b/standard/result_or_error.lua
@@ -155,9 +155,17 @@ function Error:getErrorJson()
 	end)
 
 	local errorSplit = mw.text.split(self.error, ':', true)
+	local errorText = ''
+	if #errorSplit == 4 then
+		errorText = string.format('Lua error in %s:%s at line %s:%s.', unpack(errorSplit))
+	elseif #errorSplit > 4 then
+		errorText = string.format('Lua error in %s:%s at line %s:%s', unpack(Array.sub(errorSplit, 1, 4)))
+		errorText = errorText .. ':' .. table.concat(Array.sub(errorSplit, 5), ':') .. '.'
+	else
+		errorText = string.format('Lua error: %s.', self.error)
+	end
 	return Json.stringify({
-			errorShort = (#errorSplit == 1) and string.format('Lua error: %s.', self.error)
-				or string.format('Lua error in %s:%s at line %s:%s.', unpack(errorSplit)),
+			errorShort = errorText,
 			stackTrace = stackTrace,
 		}, {asArray = true})
 end


### PR DESCRIPTION
## Summary

When reading and error message, if the error text or assertion error text contains `:`, then whatever follows get eaten by the text splitting and then not printed out by the string formatting since it doesn't expect it.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/1b079675-35f0-4f2d-9825-9c88bd619428)


Added some code to handle splits that are larger than the expected four.

## How did you test this change?

`/dev`

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/18ab2ba7-54e0-402f-8c99-840e5a279353)

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/2e7421c4-ca2a-4c84-82ea-0d11859e0ea9)

