### PR TITLE
feat: add `placementsExtendImportLimit` toggle to PPT import

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -64,7 +64,7 @@ function Import._getConfig(args, placements)
 
 	return {
 		ignoreNonScoreEliminations = Logic.readBool(args.ignoreNonScoreEliminations),
-		importLimit = Import._importLimit(args.importLimit, placements),
+		importLimit = Import._importLimit(args.importLimit, placements, args.placementsExtendImportLimit),
 		matchGroupsSpec = TournamentStructure.readMatchGroupsSpec(args)
 			or TournamentStructure.currentPageSpec(),
 		groupElimStatuses = Array.map(
@@ -105,10 +105,15 @@ function Import._enableImport(importInput)
 	)
 end
 
-function Import._importLimit(importLimitInput, placements)
+function Import._importLimit(importLimitInput, placements, placementsExtendImportLimit)
 	local importLimit = tonumber(importLimitInput)
+
 	if not importLimit then
 		return
+	end
+
+	if not Logic.readBool(placementsExtendImportLimit) then
+		return importLimit
 	end
 
 	-- if the number of entered entries is higher use that instead

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
@@ -48,6 +48,7 @@ function CustomPrizePool.run(frame)
 	args.prizesummary = Logic.emptyOr(args.prizesummary, false)
 	args.exchangeinfo = Logic.emptyOr(args.exchangeinfo, false)
 	args.syncPlayers = Logic.emptyOr(args.syncPlayers, true)
+	args.placementsExtendImportLimit = Logic.emptyOr(args.placementsExtendImportLimit, true)
 
 	-- overwrite some wiki vars for this PrizePool call
 	_tournament_name = args['tournament name']


### PR DESCRIPTION
## Summary

Makes `importLimit` a hard limit on importing, rather than allow overriding by adding extra placements. Disabled on BW & SC2 due to them using opposite functionality.

## How did you test this change?

Tested on `/dev` and new functionality works correct.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/189964dd-1df5-45fc-82cc-4674f82b2ac4)


@hjpalpha could you test SC2 or BW dev please on a page that uses the old functionality?
