### PR TITLE
Adding new big portal style

### DIFF
--- a/stylesheets/commons/Mainpage.css
+++ b/stylesheets/commons/Mainpage.css
@@ -605,6 +605,24 @@ label[ for="tournaments-list-filter-ultimate" ]:before {
 	color: var( --wiki-color-medium );
 }
 
+/* Big Game Portal design */
+.big-portal {
+	padding: 1rem;
+}
+
+.big-portal .lp-col {
+	padding: 1rem;
+}
+
+.big-portal .portal-pills a {
+	padding: 5rem;
+	font-size: 1.25rem;
+}
+
+.big-portal .portal-pills .panel-icon {
+	font-size: 4rem;
+}
+
 /*******************************************************************************
 Template(s): Liquipedia:Special Events
 Author(s): Inflicted


### PR DESCRIPTION
## Summary

We are experimenting with a new portal style for the home page of an incoming new game. It's a very game focused page with bigger portal pills (thus the name big-portal)

Here is a screenshot of the final design:

![image](https://github.com/Liquipedia/Lua-Modules/assets/32543621/77ee115f-b514-462e-9dbb-035735fb8ec4)


## How did you test this change?

Implemented on my dev environment (the screenshot actually comes from it).

Regarding the implementation, as we are still testing, we would need to add the following lines in the Main Page:
```
<div class="big-portal">
<!-- Actual grid logic -->
</div>
```

If we want to make it more generic, we would update the `grid` module with variants. 