### PR TITLE
Make Brawl Stars stored publishertier in matches

### DIFF
--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -130,6 +130,7 @@ end
 
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 


### PR DESCRIPTION
## Summary
The line wasnt there
The wiki is also replacing its matchticker with the standard one on commons, but highlighted tiers was absent due to this line was missing

## How did you test this change?
|dev=1 and then LIVE