### PR TITLE
Justifying panels for big portal

### DIFF
--- a/stylesheets/commons/Mainpage.css
+++ b/stylesheets/commons/Mainpage.css
@@ -610,6 +610,10 @@ label[ for="tournaments-list-filter-ultimate" ]:before {
 	padding: 1rem;
 }
 
+.big-portal .lp-row {
+	justify-content: center;
+}
+
 .big-portal .lp-col {
 	padding: 1rem;
 }


### PR DESCRIPTION
## Summary

We are experimenting with a new portal style for the home page of an incoming new game. It's a very game-focused page with bigger portal pills (thus the name big-portal).

It was also asked to justify the content to the center, which is what this PR is doing.

## How did you test this change?

I have implemented and tested it in my dev environment.