### PR TITLE
Add lol wrapper for legacy match lists

### DIFF
--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -1,0 +1,247 @@
+---
+-- @Liquipedia
+-- wiki=leagueoflegends
+-- page=Module:MatchMaps/Legacy
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local MatchMapsLegacy = {}
+
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Json = require('Module:Json')
+local MatchGroup = require('Module:MatchGroup')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
+local Template = require('Module:Template')
+
+local MatchSubobjects = Lua.import('Module:Match/Subobjects', { requireDevIfEnabled = true })
+
+local globalVars = PageVariableNamespace()
+local matchlistVars = PageVariableNamespace('LegacyMatchlist')
+
+local MAX_NUMBER_OF_OPPONENTS = 2
+local MAX_NUMBER_OF_MAPS = 9
+local MAX_NUMBER_OF_MATCHES = 30
+local DUMMY_MAP_NAME = 'null'
+local DEFAULT = 'default'
+
+---@param args table
+---@return table
+function MatchMapsLegacy.copyDetailsToArgs(args, details)
+	for key, value in pairs(details) do
+		if Logic.isEmpty(args[key]) then
+			args[key] = value
+		end
+	end
+	args.details = nil
+	return args
+end
+
+---@param args table
+---@param details table
+---@return table
+function MatchMapsLegacy.setHeaderIfEmpty(args, details)
+	args.header = args.header or args.date
+	args.date = details.date or args.date
+	return args
+end
+
+---@param args table
+---@return table
+function MatchMapsLegacy.convertOpponents(args)
+	for index = 1, MAX_NUMBER_OF_OPPONENTS do
+		local template = args['team' .. index]
+		if (not template) or template == '&nbsp;' then
+			template = 'tbd'
+		else
+			template = string.lower(template)
+		end
+		local score
+		if args.walkover and tonumber(args.walkover) ~= 0 then
+			if tonumber(args.walkover) == index then
+				score = 'W'
+			else
+				score = 'L'
+			end
+		end
+
+		args['opponent' .. index] = {
+			score = score,
+			template = template,
+			type = 'team',
+		}
+
+		args['team' .. index] = nil
+		args.walkover = nil
+		args['score' .. index] = nil
+	end
+
+	return args
+end
+
+---@param args table
+---@param details table
+---@return table, table
+function MatchMapsLegacy.convertMaps(args, details)
+	for index = 1, MAX_NUMBER_OF_MAPS do
+		if details['match' .. index] then
+			-- match corresponds to MatchLua
+			match = Json.parseIfString(details['match' .. index] or '{}')
+			if Logic.isEmpty(match['win']) then
+				match['win'] = args['map' .. index .. 'win']
+			end
+			match['winner'] = match['win']
+			match['win'] = nil
+
+			if match['length'] and match['length']:lower() == DEFAULT then
+				match['walkover'] = match['winner']
+			end
+
+			match['map'] = DUMMY_MAP_NAME
+			local map = MatchSubobjects.luaGetMap(match)
+			map['map'] = nil
+			args['map' .. index] = map
+
+			args['map' .. index .. 'win'] = nil
+			details['match' .. index] = nil
+		else
+			break
+		end
+	end
+	return args, details
+end
+
+-- invoked by Template:MatchMapsLua
+---@param frame Frame
+---@return string
+function MatchMapsLegacy.convertMatch(frame)
+	local args = Arguments.getArgs(frame)
+	local details = Json.parseIfString(args.details or '{}')
+
+	args = MatchMapsLegacy.convertOpponents(args)
+	args, details = MatchMapsLegacy.convertMaps(args, details)
+
+	args = MatchMapsLegacy.setHeaderIfEmpty(args, details)
+	args = MatchMapsLegacy.copyDetailsToArgs(args, details)
+
+	if Logic.readBool(matchlistVars:get('isOldMatchList')) then
+		return Json.stringify(args)
+	else
+		Template.stashReturnValue(args, 'LegacyMatchlist')
+		return ''
+	end
+end
+
+-- invoked by Template:MatchList
+---@param frame Frame
+---@return string
+function MatchMapsLegacy.matchList(frame)
+	local args = Arguments.getArgs(frame)
+	assert(args.id, 'Missing id')
+
+	local store = Logic.nilOr(
+		Logic.readBoolOrNil(args.store),
+		not Logic.readBool(globalVars:get('disable_LPDB_storage'))
+	)
+	local hide = Logic.nilOr(Logic.readBoolOrNil(args.hide), true)
+	args.isLegacy = true
+	args.store = store
+	args.noDuplicateCheck = not store
+	args.collapsed = hide
+	args.attached = hide
+	args.title = Logic.nilOr(args.title, args[1])
+	args.width = args.width or '300px'
+
+	local matchsection = Logic.nilOr(args.lpdb_title, args.title)
+	if Logic.readBoolOrNil(matchsection) ~= false then
+		args.matchsection = matchsection
+	end
+
+	matchlistVars:set('isOldMatchList', 'true')
+	globalVars:set('islegacy', 'true')
+
+	for matchIndex = 1, MAX_NUMBER_OF_MATCHES do
+		if args['match' .. matchIndex] then
+			local match = Json.parse(args['match' .. matchIndex])
+			args['M' .. matchIndex .. 'header'] = match.header
+			match.header = nil
+			args['M' .. matchIndex] = Json.stringify(match)
+			args['match' .. matchIndex] = nil
+		else
+			break
+		end
+	end
+
+	matchlistVars:delete('isOldMatchList')
+	globalVars:delete('islegacy')
+
+	args[1] = nil
+	args.hide = nil
+	args.lpdb_title = nil
+
+	--pass the adjusted arguments to the MatchGroup
+	return MatchGroup.TemplateMatchlist(args)
+end
+
+-- invoked by Template:MatchListStart
+---@param frame Frame
+function MatchMapsLegacy.matchListStart(frame)
+	local args = Arguments.getArgs(frame)
+
+	local store = Logic.nilOr(
+		Logic.readBoolOrNil(args.store),
+		not Logic.readBool(globalVars:get('disable_LPDB_storage'))
+	)
+	local matchsection = Logic.nilOr(args.lpdb_title, args.title)
+	if Logic.readBoolOrNil(matchsection) ~= false then
+		matchlistVars:set('matchsection', matchsection)
+	end
+
+	matchlistVars:set('store', tostring(store))
+	matchlistVars:set('bracketid', args.id)
+	matchlistVars:set('matchListTitle', args.title or args[1] or 'Match List')
+	matchlistVars:set('width', args.width or '300px')
+	matchlistVars:set('hide', args.hide or 'true')
+	matchlistVars:set('patch', args.patch)
+	globalVars:set('islegacy', 'true')
+end
+
+-- invoked by MatchListEnd
+---@return string
+function MatchMapsLegacy.matchListEnd()
+	local bracketId = matchlistVars:get('bracketid')
+	assert(bracketId, 'Missing id')
+
+	local store = Logic.readBool(matchlistVars:get('store'))
+	local hide = Logic.readBool(matchlistVars:get('hide'))
+
+	local args = {
+		isLegacy = true,
+		id = bracketId,
+		store = store,
+		noDuplicateCheck = not store,
+		collapsed = hide,
+		attached = hide,
+		title = matchlistVars:get('matchListTitle'),
+		width = matchlistVars:get('width'),
+		matchsection = matchlistVars:get('matchsection'),
+		patch = matchlistVars:get('patch')
+	}
+
+	local matches = Template.retrieveReturnValues('LegacyMatchlist')
+
+	Array.forEach(matches, function(match, matchIndex)
+		args['M' .. matchIndex .. 'header'] = match.header
+		match.header = nil
+		args['M' .. matchIndex] = Json.stringify(match)
+	end)
+
+	globalVars:delete('islegacy')
+
+	return MatchGroup.MatchList(args)
+end
+
+return MatchMapsLegacy

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -62,12 +62,15 @@ function MatchMapsLegacy.convertOpponents(args)
 			template = string.lower(template)
 		end
 		local score
+		local winner = tonumber(args.winner)
 		if args.walkover then
 			if tonumber(args.walkover) ~= 0 then
 				score = tonumber(args.walkover) == index and DEFAULT_WIN or DEFAULT_LOSS
 			end
-		else
+		elseif args['score' .. index] then
 			score = tonumber(args['score' .. index])
+		elseif not args.mapWinnersSet and winner then
+			score = winner == index and DEFAULT_WIN or DEFAULT_LOSS
 		end
 
 		if template ~= TBD then
@@ -83,6 +86,7 @@ function MatchMapsLegacy.convertOpponents(args)
 		args.walkover = nil
 		args['score' .. index] = nil
 	end
+	args.mapWinnersSet = nil
 
 	return args
 end
@@ -135,6 +139,9 @@ function MatchMapsLegacy.convertMaps(args, details)
 
 	Array.mapIndexes(function (index)
 		local map = getMapFromDetails(index) or getMapOnlyWithWinner(index)
+		if map and map.winner then
+			args.mapWinnersSet = true
+		end
 		args['map' .. index] = map
 		args['map' .. index .. 'win'] = nil
 		details['match' .. index] = nil
@@ -162,9 +169,9 @@ function MatchMapsLegacy.convertMatch(frame)
 	local args = Arguments.getArgs(frame)
 	local details = Json.parseIfString(args.details or '{}')
 
+	args, details = MatchMapsLegacy.convertMaps(args, details)
 	args = MatchMapsLegacy.convertOpponents(args)
 	args = MatchMapsLegacy.handleLiteralsForOpponents(args)
-	args, details = MatchMapsLegacy.convertMaps(args, details)
 	args = MatchMapsLegacy.setHeaderIfEmpty(args, details)
 	args = MatchMapsLegacy.copyDetailsToArgs(args, details)
 	args = MatchMapsLegacy.handleLocation(args)

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -27,6 +27,8 @@ local MAX_NUMBER_OF_MAPS = 9
 local MAX_NUMBER_OF_MATCHES = 30
 local DUMMY_MAP_NAME = 'null'
 local DEFAULT = 'default'
+local DEFAULT_WIN = 'W'
+local DEFAULT_LOSS = 'L'
 
 ---@param args table
 ---@return table
@@ -60,12 +62,12 @@ function MatchMapsLegacy.convertOpponents(args)
 			template = string.lower(template)
 		end
 		local score
-		if args.walkover and tonumber(args.walkover) ~= 0 then
-			if tonumber(args.walkover) == index then
-				score = 'W'
-			else
-				score = 'L'
+		if args.walkover then
+			if tonumber(args.walkover) ~= 0 then
+				score = tonumber(args.walkover) == index and DEFAULT_WIN or DEFAULT_LOSS
 			end
+		else
+			score = tonumber(args['score' .. index])
 		end
 
 		args['opponent' .. index] = {
@@ -107,6 +109,15 @@ function MatchMapsLegacy.convertMaps(args, details)
 
 			args['map' .. index .. 'win'] = nil
 			details['match' .. index] = nil
+		elseif args['map' .. index .. 'win'] then
+			local map = MatchSubobjects.luaGetMap{
+				winner = args['map' .. index .. 'win'],
+				map = DUMMY_MAP_NAME
+			}
+			map['map'] = nil
+			args['map' .. index] = map
+
+			args['map' .. index .. 'win'] = nil
 		else
 			break
 		end

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -149,7 +149,8 @@ end
 ---@return table
 function MatchMapsLegacy.handleLocation(args)
 	if args.location then
-		local locationComment = 'Match ' .. (Logic.readBool(args.finished) and 'was' or 'being') .. ' played in ' .. args.location
+		local matchStatus = Logic.readBool(args.finished) and 'was' or 'being'
+		local locationComment = 'Match ' .. matchStatus .. ' played in ' .. args.location
 		args.comment = args.comment and (args.comment .. '<br>' .. locationComment) or locationComment
 		args.location = nil
 	end

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -127,7 +127,7 @@ end
 
 -- invoked by Template:MatchMapsLua
 ---@param frame Frame
----@return string
+---@return string?
 function MatchMapsLegacy.convertMatch(frame)
 	local args = Arguments.getArgs(frame)
 	local details = Json.parseIfString(args.details or '{}')
@@ -142,7 +142,6 @@ function MatchMapsLegacy.convertMatch(frame)
 		return Json.stringify(args)
 	else
 		Template.stashReturnValue(args, 'LegacyMatchlist')
-		return ''
 	end
 end
 

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -145,6 +145,17 @@ function MatchMapsLegacy.convertMaps(args, details)
 	return args, details
 end
 
+---@param args table
+---@return table
+function MatchMapsLegacy.handleLocation(args)
+	if args.location then
+		local locationComment = 'Match ' .. (Logic.readBool(args.finished) and 'was' or 'being') .. ' played in ' .. args.location
+		args.comment = args.comment and (args.comment .. '<br>' .. locationComment) or locationComment
+		args.location = nil
+	end
+	return args
+end
+
 -- invoked by Template:MatchMapsLua
 ---@param frame Frame
 ---@return string?
@@ -155,9 +166,9 @@ function MatchMapsLegacy.convertMatch(frame)
 	args = MatchMapsLegacy.convertOpponents(args)
 	args = MatchMapsLegacy.handleLiteralsForOpponents(args)
 	args, details = MatchMapsLegacy.convertMaps(args, details)
-
 	args = MatchMapsLegacy.setHeaderIfEmpty(args, details)
 	args = MatchMapsLegacy.copyDetailsToArgs(args, details)
+	args = MatchMapsLegacy.handleLocation(args)
 
 	if Logic.readBool(matchlistVars:get('isOldMatchList')) then
 		return Json.stringify(args)

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -92,19 +92,19 @@ function MatchMapsLegacy.convertMaps(args, details)
 		if details['match' .. index] then
 			-- match corresponds to MatchLua
 			local match = Json.parseIfString(details['match' .. index] or '{}')
-			if Logic.isEmpty(match['win']) then
-				match['win'] = args['map' .. index .. 'win']
+			if Logic.isEmpty(match.win) then
+				match.win = args['map' .. index .. 'win']
 			end
-			match['winner'] = match['win']
-			match['win'] = nil
+			match.winner = match.win
+			match.win = nil
 
-			if match['length'] and match['length']:lower() == DEFAULT then
-				match['walkover'] = match['winner']
+			if match.length and match.length:lower() == DEFAULT then
+				match.walkover = match.winner
 			end
 
-			match['map'] = DUMMY_MAP_NAME
+			match.map = DUMMY_MAP_NAME
 			local map = MatchSubobjects.luaGetMap(match)
-			map['map'] = nil
+			map.map = nil
 			args['map' .. index] = map
 
 			args['map' .. index .. 'win'] = nil
@@ -114,7 +114,7 @@ function MatchMapsLegacy.convertMaps(args, details)
 				winner = args['map' .. index .. 'win'],
 				map = DUMMY_MAP_NAME
 			}
-			map['map'] = nil
+			map.map = nil
 			args['map' .. index] = map
 
 			args['map' .. index .. 'win'] = nil

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -25,7 +25,7 @@ local matchlistVars = PageVariableNamespace('LegacyMatchlist')
 local MAX_NUMBER_OF_OPPONENTS = 2
 local MAX_NUMBER_OF_MAPS = 9
 local MAX_NUMBER_OF_MATCHES = 30
-local DUMMY_MAP_NAME = 'null'
+local DUMMY_MAP_NAME = 'default'
 local DEFAULT = 'default'
 local DEFAULT_WIN = 'W'
 local DEFAULT_LOSS = 'L'
@@ -122,7 +122,6 @@ function MatchMapsLegacy.convertMaps(args, details)
 
 			match.map = DUMMY_MAP_NAME
 			local map = MatchSubobjects.luaGetMap(match)
-			map.map = nil
 			args['map' .. index] = map
 
 			args['map' .. index .. 'win'] = nil
@@ -132,7 +131,6 @@ function MatchMapsLegacy.convertMaps(args, details)
 				winner = args['map' .. index .. 'win'],
 				map = DUMMY_MAP_NAME
 			}
-			map.map = nil
 			args['map' .. index] = map
 
 			args['map' .. index .. 'win'] = nil

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -276,6 +276,13 @@ function MatchMapsLegacy.matchListEnd()
 		args['M' .. matchIndex] = Json.stringify(match)
 	end)
 
+	matchlistVars:delete('store')
+	matchlistVars:delete('bracketid')
+	matchlistVars:delete('matchListTitle')
+	matchlistVars:delete('width')
+	matchlistVars:delete('hide')
+	matchlistVars:delete('patch')
+	matchlistVars:delete('matchsection')
 	globalVars:delete('islegacy')
 
 	return MatchGroup.MatchList(args)

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -127,11 +127,10 @@ function MatchMapsLegacy.convertMaps(args, details)
 		if not args['map' .. index .. 'win'] then
 			return nil
 		end
-		local map = MatchSubobjects.luaGetMap{
+		return MatchSubobjects.luaGetMap{
 			winner = args['map' .. index .. 'win'],
 			map = DUMMY_MAP_NAME
 		}
-		return map
 	end
 
 	Array.mapIndexes(function (index)

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -89,7 +89,7 @@ function MatchMapsLegacy.convertMaps(args, details)
 	for index = 1, MAX_NUMBER_OF_MAPS do
 		if details['match' .. index] then
 			-- match corresponds to MatchLua
-			match = Json.parseIfString(details['match' .. index] or '{}')
+			local match = Json.parseIfString(details['match' .. index] or '{}')
 			if Logic.isEmpty(match['win']) then
 				match['win'] = args['map' .. index .. 'win']
 			end

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -192,8 +192,7 @@ function MatchMapsLegacy.matchList(frame)
 	args.hide = nil
 	args.lpdb_title = nil
 
-	--pass the adjusted arguments to the MatchGroup
-	return MatchGroup.TemplateMatchlist(args)
+	return MatchGroup.MatchList(args)
 end
 
 -- invoked by Template:MatchListStart

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -91,8 +91,7 @@ end
 ---@return table
 function MatchMapsLegacy.handleLiteralsForOpponents(args)
 	for index = 1, MAX_NUMBER_OF_OPPONENTS do
-		local opponent = args['opponent' .. index]
-		if Logic.isEmpty(opponent) then
+		if Logic.isEmpty(args['opponent' .. index]) then
 			args['opponent' .. index] = {
 				['type'] = 'literal', template = 'tbd', name = args['opponent' .. index .. 'literal']
 			}

--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -31,6 +31,7 @@ local DEFAULT_LOSS = 'L'
 local TBD = 'tbd'
 
 ---@param args table
+---@param details table
 ---@return table
 function MatchMapsLegacy.copyDetailsToArgs(args, details)
 	for key, value in pairs(details) do


### PR DESCRIPTION
## Summary

Add wrapper for league of legends match lists.

## How did you test this change?

[Sandbox](https://liquipedia.net/leagueoflegends/User:LuckeLucky/sandbox)

## Next step:
Create 2 new templates: One to replace [Template:MatchList](https://liquipedia.net/leagueoflegends/Template:MatchList) and another one to replace [Template:MatchListStart](https://liquipedia.net/leagueoflegends/Template:MatchListStart).Also need to add a condition to [BracketMatchSummary](https://liquipedia.net/leagueoflegends/Template:BracketMatchSummary) and [MatchLua](https://liquipedia.net/leagueoflegends/Template:Match/old) to create a Json if they are wrapped by a LegacyMatchList.