### PR TITLE
Centre award in table

### DIFF
--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -77,7 +77,7 @@ function AwardsTable:buildRow(placement)
 			placement.pagename
 		))
 
-	row:tag('td'):css('text-align', 'center'):wikitext(placement.extradata.award)
+	row:tag('td'):wikitext(placement.extradata.award)
 
 	if self.config.playerResultsOfTeam or self.config.queryType ~= Opponent.team then
 		row:tag('td'):css('text-align', 'left'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(

--- a/components/results_table/commons/results_table_award.lua
+++ b/components/results_table/commons/results_table_award.lua
@@ -77,7 +77,7 @@ function AwardsTable:buildRow(placement)
 			placement.pagename
 		))
 
-	row:tag('td'):css('text-align', 'left'):wikitext(placement.extradata.award)
+	row:tag('td'):css('text-align', 'center'):wikitext(placement.extradata.award)
 
 	if self.config.playerResultsOfTeam or self.config.queryType ~= Opponent.team then
 		row:tag('td'):css('text-align', 'left'):attr('data-sort-value', placement.opponentname):node(self:opponentDisplay(


### PR DESCRIPTION
## Summary

Some award titles can be very short compared to others (and compared to the minimum column width), so I thought it looked a little better to centre them.

Before and after: 
![Comparison](https://github.com/Liquipedia/Lua-Modules/assets/42142350/4a2e5f92-0765-46e4-b8ba-a6e22ffe3f6a)

## How did you test this change?

/dev