### PR TITLE
fix: bash typo

### DIFF
--- a/scripts/deploy_res.sh
+++ b/scripts/deploy_res.sh
@@ -51,7 +51,7 @@ for file in $files; do
   fileContents=$(cat "$file")
   fileName=$(basename "$file")
 
-  if [[ $file == *.js ]]
+  if [[ $file == *.js ]]; then
     page="MediaWiki:Common.js/${fileName}"
   else
     page="MediaWiki:Common.css/${fileName}"


### PR DESCRIPTION
## Summary
Fix a typo in the deploy script. 

Tested locally that it doesn't error.