### PR TITLE
Fix walkover in Legacy Wrapper

### DIFF
--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -28,6 +28,7 @@ local DUMMY_MAP_NAME = 'default'
 local DEFAULT = 'default'
 local DEFAULT_WIN = 'W'
 local DEFAULT_LOSS = 'L'
+local FORFEIT = 'FF'
 local TBD = 'tbd'
 
 ---@param args table
@@ -66,7 +67,7 @@ function MatchMapsLegacy.convertOpponents(args)
 		local winner = tonumber(args.winner)
 		if args.walkover then
 			if tonumber(args.walkover) ~= 0 then
-				score = tonumber(args.walkover) == index and DEFAULT_WIN or DEFAULT_LOSS
+				score = tonumber(args.walkover) == index and DEFAULT_WIN or FORFEIT
 			end
 		elseif args['score' .. index] then
 			score = tonumber(args['score' .. index])
@@ -84,9 +85,9 @@ function MatchMapsLegacy.convertOpponents(args)
 		args['opponent' .. index .. 'literal'] = args['team' .. index .. 'league']
 
 		args['team' .. index] = nil
-		args.walkover = nil
 		args['score' .. index] = nil
 	end
+	args.walkover = nil
 	args.mapWinnersSet = nil
 
 	return args


### PR DESCRIPTION
## Summary

In a walkover the oposing opponent should have score set to 'FF' instead of 'L'. Also walkover was deleted after processing the first opponent.

## How did you test this change?

Live
