### PR TITLE
Update `Resourceloaderarticles-cacheversion` on resource deploy

### DIFF
--- a/scripts/deploy_res.sh
+++ b/scripts/deploy_res.sh
@@ -105,6 +105,26 @@ done
 if [ "$allDeployed" != true ]; then
   echo "DEBUG: Some files were not deployed!"
   exit 1
+else
+  cacheResult=$(
+    curl \
+      -s \
+      -b "$ckf" \
+      -c "$ckf" \
+      --data-urlencode "messagename=Resourceloaderarticles-cacheversion" \
+      --data-urlencode "value=$(git log -1 --pretty='%h')" \
+      -H "User-Agent: ${userAgent}" \
+      -H 'Accept-Encoding: gzip' \
+      -X POST "${wikiApiUrl}?format=json&action=updatelpmwmessageapi" \
+      | gunzip \
+      | jq ".updatelpmwmessageapi.message" -r
+  )
+  if [[ "${cacheResult}" == "Successfully changed the message value" ]]; then
+  	echo "Resource cache version updated succesfully!"
+  else
+    echo "DEBUG: Resource cache version unable to be updated!"
+    exit 1
+  fi
 fi
 
 rm -f cookie_*


### PR DESCRIPTION
## Summary

With Liquipedia/LiquipediaMediaWikiMessages#4 being merged, we can now automatically update the resource loader cache version on new resource merges.

## How did you test this change?

I tested the general bash and its syntax, however, I did not test the actual curl request itself.
