### PR TITLE
Set notabilitymod for qualified placements

### DIFF
--- a/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
@@ -25,6 +25,7 @@ local CustomPrizePool = {}
 
 local PRIZE_TYPE_QUALIFIES = 'QUALIFIES'
 local PRIZE_TYPE_POINTS = 'POINTS'
+local QUALIFIER = 'Qualifier'
 local TIER_VALUE = {10, 6, 4, 2}
 
 -- Template entry point
@@ -75,8 +76,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end
 
 	lpdbData.qualified = Array.any(Array.filter(placement.parent.prizes, prizeIsQualifier), opponentHasPrize) and 1 or 0
-	if lpdbData.qualified == 1 then
-		-- Avoid duplicate score of qualified persons (qualifier+main event)
+	if lpdbData.liquipediatiertype == QUALIFIER and lpdbData.qualified == 1 then
 		lpdbData.extradata.notabilitymod = '0'
 	end
 

--- a/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
@@ -75,6 +75,10 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end
 
 	lpdbData.qualified = Array.any(Array.filter(placement.parent.prizes, prizeIsQualifier), opponentHasPrize) and 1 or 0
+	if lpdbData.qualified == 1 then
+		-- Avoid duplicate score of qualified persons (qualifier+main event)
+		lpdbData.extradata.notabilitymod = '0'
+	end
 
 	-- Variable to communicate with TeamCards
 	Variables.varDefine('enddate_' .. lpdbData.participant, lpdbData.date)

--- a/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
@@ -76,7 +76,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end
 
 	lpdbData.qualified = Array.any(Array.filter(placement.parent.prizes, prizeIsQualifier), opponentHasPrize) and 1 or 0
-	if lpdbData.liquipediatiertype == QUALIFIER and lpdbData.qualified == 1 then
+	if Variables.varDefault('tournament_liquipediatiertype') == QUALIFIER and lpdbData.qualified == 1 then
 		lpdbData.extradata.notabilitymod = '0'
 	end
 


### PR DESCRIPTION
## Summary
Sets the notabilitymod to 0 to not have qualified opponents get inflated score in notabilitychecker (as in, score from qualifier and main event).
It would be an alternative to adjust the extra dropoff function to have drops for first placement as well.

## How did you test this change?
via /dev