### PR TITLE
fix: remove region on infobox manufacturer

### DIFF
--- a/components/infobox/commons/infobox_manufacturer.lua
+++ b/components/infobox/commons/infobox_manufacturer.lua
@@ -105,7 +105,6 @@ function Manufacturer:setLpdbData(args)
 		image = args.image,
 		imagedark = args.imagedark,
 		extradata = {
-			region = args.region,
 			status = args.status,
 			locations = Locale.formatLocations(args),
 		}


### PR DESCRIPTION
## Summary

Forgot to remove the 'region' line which as unused + was suggested for removal previously

## How did you test this change?


