### PR TITLE
fix: results table using wrong TT after creating historical

### DIFF
--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -479,13 +479,13 @@ function BaseResultsTable:opponentDisplay(data, options)
 		return
 	end
 
+	local rawTeamTemplate = Team.queryRaw(teamTemplate, data.date) or {}
+
 	local teamDisplay = OpponentDisplay.BlockOpponent{
-		opponent = {template = teamTemplate, type = Opponent.team},
+		opponent = {template = rawTeamTemplate.templatename, type = Opponent.team},
 		flip = options.flip,
 		teamStyle = 'icon',
 	}
-
-	local rawTeamTemplate = Team.queryRaw(teamTemplate)
 
 	if self:shouldDisplayAdditionalText(rawTeamTemplate, not options.isLastVs) then
 		return BaseResultsTable.teamIconDisplayWithText(teamDisplay, rawTeamTemplate, options.flip)


### PR DESCRIPTION
## Summary

Due to team templates being stored in LPDB for opponents, when creating a historical template, the tournament pages need to all be purged to store the correct sub-template then. This causes issues on results table where the team template data is assumed to be accurate when it might not be.

See: https://discord.com/channels/93055209017729024/372075546231832576/1180160034236289145

Fixed by parsing the team template with result date before passing off to opponent display to ensure that if the parent historical team template is still in LPDB data of opponent, then we still display the correct sub-template on results.

## How did you test this change?

`/dev`