### PR TITLE
Remove bottom margin from final infobox match

### DIFF
--- a/stylesheets/commons/Mainpage.css
+++ b/stylesheets/commons/Mainpage.css
@@ -374,7 +374,7 @@ table.infobox_matches_content {
 }
 
 .infobox_matches_content:last-child {
-	margin-bottom: 0;
+	margin-bottom: 0 !important;
 }
 
 .infobox_matches_content .table {


### PR DESCRIPTION
## Summary

Add `!important` to `.infobox_matches_content:last-child`'s `margin-bottom` so that it overrides `table.infobox_matches_content`'s `margin-bottom`

## How did you test this change?

Inspect element

| Before:                                                                                                          | After:                                                                                                          |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![Before](https://github.com/Liquipedia/Lua-Modules/assets/42142350/304e58e4-e605-4b6b-b423-7f8098588d4a) | ![After](https://github.com/Liquipedia/Lua-Modules/assets/42142350/b1915a75-cd75-4fb1-b18b-a38de8fcc38d) |