### PR TITLE
Add Infoboxes to osu

### DIFF
--- a/components/infobox/wikis/osu/infobox_league_custom.lua
+++ b/components/infobox/wikis/osu/infobox_league_custom.lua
@@ -40,7 +40,6 @@ local _MODES = {
 function CustomLeague.run(frame)
 	local league = League(frame)
 	_args = league.args
-	_league = league
 
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.createWidgetInjector = CustomLeague.createWidgetInjector

--- a/components/infobox/wikis/osu/infobox_league_custom.lua
+++ b/components/infobox/wikis/osu/infobox_league_custom.lua
@@ -24,15 +24,15 @@ local CustomInjector = Class.new(Injector)
 
 local _args
 
-local _MODES = {
-	standard = 'Standard[[Category:osu!standard Tournaments]]',
-	mania = 'Mania[[Category:osu!mania Tournaments]]',
-	['mania 4k'] = 'Mania (4 Keys)[[Category:osu!mania Tournaments]][[Category:osu!mania (4 Keys) Tournaments]]',
-	['mania 7k'] = 'Mania (7 Keys)[[Category:osu!mania Tournaments]][[Category:osu!mania (7 Keys) Tournaments]]',
-	taiko = 'Taiko[[Category:osu!taiko Tournaments]]',
-	catch = 'Catch[[Category:osu!catch Tournaments]]',
-	mixed  = 'Various Modes[[Category:Tournaments with Multiple game modes]]',
-	default = '[[Category:Unknown Mode Tournaments]]',
+local MODES = {
+	standard = {display = 'Standard', category = 'Osu!standard Tournaments'},
+	mania = {display = 'Mania', category = 'Osu!mania Tournaments'},
+	['mania 4k'] = {display = 'Mania (4 Keys)', category = 'Osu!mania (4 Keys) Tournaments'},
+	['mania 7k'] = {display = 'Mania (7 Keys)', category = 'Osu!mania (7 Keys) Tournaments'},
+	taiko = {display = 'Taiko', category = 'Osu!taiko Tournaments'},
+	catch = {display = 'Catch', category = 'Osu!catch Tournaments'},
+	mixed = {display = 'Various Modes', category = 'Tournaments with Multiple game modes'},
+	default = {display = 'Unknown', category = 'Unknown Mode Tournaments'},
 }
 
 ---@param frame Frame
@@ -45,6 +45,7 @@ function CustomLeague.run(frame)
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+	league.getWikiCategories = CustomLeague.getWikiCategories
 
 	return league:createInfobox()
 end
@@ -74,7 +75,7 @@ function CustomInjector:parse(id, widgets)
 				}
 			},
 			Cell{name = 'Game Mode', content = {
-					CustomLeague._getGameMode()
+					CustomLeague._getGameMode().display
 				}
 			},
 		}
@@ -97,7 +98,7 @@ function CustomLeague._getGameMode()
 		return nil
 	end
 
-	local mode = _MODES[string.lower(_args.mode or '')] or _MODES['default']
+	local mode = MODES[string.lower(_args.mode or '')] or MODES['default']
 	return mode
 end
 
@@ -119,6 +120,18 @@ function CustomLeague:_createNoWrappingSpan(content)
 	return mw.html.create('span')
 		:css('white-space', 'nowrap')
 		:node(content)
+end
+
+---@param args table
+---@return table
+function CustomLeague:getWikiCategories(args)
+	local categories = {}
+
+	if String.isNotEmpty(_args.mode) then
+		table.insert(categories, CustomLeague._getGameMode().category)
+	end
+
+	return categories
 end
 
 return CustomLeague

--- a/components/infobox/wikis/osu/infobox_league_custom.lua
+++ b/components/infobox/wikis/osu/infobox_league_custom.lua
@@ -95,11 +95,10 @@ end
 ---@return table
 function CustomLeague._getGameMode()
 	if String.isEmpty(_args.mode) then
-		return nil
+		return {}
 	end
 
-	local mode = MODES[string.lower(_args.mode or '')] or MODES['default']
-	return mode
+	return MODES[string.lower(_args.mode or '')] or MODES.default
 end
 
 ---@param args table
@@ -114,24 +113,10 @@ function CustomLeague:liquipediaTierHighlighted(args)
 	return Logic.readBool(args.publisherpremier)
 end
 
----@param content Html|string|number|nil
----@return Html
-function CustomLeague:_createNoWrappingSpan(content)
-	return mw.html.create('span')
-		:css('white-space', 'nowrap')
-		:node(content)
-end
-
 ---@param args table
 ---@return table
 function CustomLeague:getWikiCategories(args)
-	local categories = {}
-
-	if String.isNotEmpty(_args.mode) then
-		table.insert(categories, CustomLeague._getGameMode().category)
-	end
-
-	return categories
+	return {CustomLeague._getGameMode().category}
 end
 
 return CustomLeague

--- a/components/infobox/wikis/osu/infobox_league_custom.lua
+++ b/components/infobox/wikis/osu/infobox_league_custom.lua
@@ -1,0 +1,128 @@
+---
+-- @Liquipedia
+-- wiki=osu
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Game = require('Module:Game')
+local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+local Center = Widgets.Center
+
+local CustomLeague = Class.new()
+local CustomInjector = Class.new(Injector)
+
+local _args
+local _league
+
+local _MODES = {
+	standard = 'Standard[[Category:osu!standard Tournaments]]',
+	mania = 'Mania[[Category:osu!mania Tournaments]]',
+	['mania 4k'] = 'Mania (4 Keys)[[Category:osu!mania Tournaments]][[Category:osu!mania (4 Keys) Tournaments]]',
+	['mania 7k'] = 'Mania (7 Keys)[[Category:osu!mania Tournaments]][[Category:osu!mania (7 Keys) Tournaments]]',
+	taiko = 'Taiko[[Category:osu!taiko Tournaments]]',
+	catch = 'Catch[[Category:osu!catch Tournaments]]',
+	mixed  = 'Various Modes[[Category:Tournaments with Multiple game modes]]',
+	default = '[[Category:Unknown Mode Tournaments]]',
+}
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = League(frame)
+	_args = league.args
+	_league = league
+
+	league.addToLpdb = CustomLeague.addToLpdb
+	league.createWidgetInjector = CustomLeague.createWidgetInjector
+	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
+	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+
+	return league:createInfobox()
+end
+
+---@return WidgetInjector
+function CustomLeague:createWidgetInjector()
+	return CustomInjector()
+end
+
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:addCustomCells(widgets)
+	return {
+		Cell{name = 'Number of teams', content = {_args.team_number}},
+		Cell{name = 'Number of players', content = {_args.player_number}},
+	}
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	if id == 'gamesettings' then
+		return {
+			Cell{name = 'Game Version', content = {
+					Game.name{game = _args.game}
+				}
+			},
+			Cell{name = 'Game Mode', content = {
+					CustomLeague._getGameMode()
+				}
+			},
+		}
+	end
+	return widgets
+end
+
+---@param lpdbData table
+---@param args table
+---@return table
+function CustomLeague:addToLpdb(lpdbData, args)
+	lpdbData.game = Game.name{game = args.game}
+	return lpdbData
+end
+
+---@param args table
+---@return table
+function CustomLeague._getGameMode()
+	if String.isEmpty(_args.mode) then
+		return nil
+	end
+
+	local mode = _MODES[string.lower(_args.mode or '')] or _MODES['default']
+	return mode
+end
+
+---@param args table
+function CustomLeague:defineCustomPageVariables(args)
+	Variables.varDefine('tournament_publishertier', args.publisherpremier)
+	Variables.varDefine('tournament_game', Game.name{game = args.game})
+end
+
+---@param args table
+---@return boolean
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args.publisherpremier)
+end
+
+---@param content Html|string|number|nil
+---@return Html
+function CustomLeague:_createNoWrappingSpan(content)
+	return mw.html.create('span')
+		:css('white-space', 'nowrap')
+		:node(content)
+end
+
+return CustomLeague

--- a/components/infobox/wikis/osu/infobox_league_custom.lua
+++ b/components/infobox/wikis/osu/infobox_league_custom.lua
@@ -18,14 +18,11 @@ local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
-local Title = Widgets.Title
-local Center = Widgets.Center
 
 local CustomLeague = Class.new()
 local CustomInjector = Class.new(Injector)
 
 local _args
-local _league
 
 local _MODES = {
 	standard = 'Standard[[Category:osu!standard Tournaments]]',

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -1,0 +1,138 @@
+---
+-- @Liquipedia
+-- wiki=osu
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local String = require('Module:StringUtils')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
+local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+local ROLES = {
+	-- Players
+	['igl'] = {category = 'In-game leaders', variable = 'In-game leader', isplayer = true},
+
+	-- Staff and Talents
+	['analyst'] = {category = 'Analysts', variable = 'Analyst', staff = true},
+	['broadcast analyst'] = {category = 'Broadcast Analysts', variable = 'Broadcast Analyst', talent = true},
+	['observer'] = {category = 'Observers', variable = 'Observer', talent = true},
+	['host'] = {category = 'Host', variable = 'Host', talent = true},
+	['coach'] = {category = 'Coaches', variable = 'Coach', staff = true},
+	['caster'] = {category = 'Casters', variable = 'Caster', talent = true},
+	['manager'] = {category = 'Managers', variable = 'Manager', staff = true},
+	['referee'] = {category = 'Referees', variable = 'Referee', staff = true},
+	['mapper'] = {category = 'Mappers', variable = 'Mapper', staff = true},
+	['streamer'] = {category = 'Streamers', variable = 'Streamer', talent = true},
+}
+
+local CustomPlayer = Class.new()
+
+local CustomInjector = Class.new(Injector)
+
+local _args
+
+---@param frame Frame
+---@return Html
+function CustomPlayer.run(frame)
+	local player = Player(frame)
+
+	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
+	player.createWidgetInjector = CustomPlayer.createWidgetInjector
+	player.getPersonType = CustomPlayer.getPersonType
+
+	_args = player.args
+
+	return player:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	if id == 'status' then
+		return {
+			Cell{name = 'Status', content = CustomPlayer._getStatusContents()},
+			Cell{name = 'Years Active', content = {_args.years_active}},
+		}
+	elseif id == 'role' then
+		return {
+			Cell{name = 'Role', content = {
+				CustomPlayer._createRole('role', _args.role),
+				CustomPlayer._createRole('role2', _args.role2)
+			}},
+		}
+	elseif id == 'history' then
+		table.insert(widgets, Cell{
+			name = 'Retired',
+			content = {_args.retired}
+		})
+	end
+	return widgets
+end
+
+---@return WidgetInjector
+function CustomPlayer:createWidgetInjector()
+	return CustomInjector()
+end
+
+---@return string[]
+function CustomPlayer._getStatusContents()
+	return {Page.makeInternalLink({onlyIfExists = true}, _args.status) or _args.status}
+end
+
+---@param key string
+---@param role string?
+---@return string?
+function CustomPlayer._createRole(key, role)
+	if String.isEmpty(role) then
+		return nil
+	end
+	---@cast role -nil
+
+	local roleData = ROLES[role:lower()]
+	if not roleData then
+		return nil
+	end
+	if Player:shouldStoreData(_args) then
+		local categoryCoreText = 'Category:' .. roleData.category
+
+		return '[[' .. categoryCoreText .. ']]' .. '[[:' .. categoryCoreText .. '|' ..
+			Variables.varDefineEcho(key or 'role', roleData.variable) .. ']]'
+	else
+		return Variables.varDefineEcho(key or 'role', roleData.variable)
+	end
+end
+
+---@param role string?
+---@return boolean
+function CustomPlayer._isNotPlayer(role)
+	local roleData = ROLES[(role or ''):lower()]
+	return roleData and (roleData.talent or roleData.staff)
+end
+
+---@param args table
+---@return {store: string, category: string}
+function CustomPlayer:getPersonType(args)
+	local roleData = ROLES[(args.role or ''):lower()]
+	if roleData then
+		if roleData.staff then
+			return {store = 'staff', category = 'Staff'}
+		elseif roleData.talent then
+			return {store = 'talent', category = 'Talent'}
+		end
+	end
+	return {store = 'player', category = 'Player'}
+end
+
+return CustomPlayer

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -114,13 +114,6 @@ function CustomPlayer._createRole(key, role)
 	end
 end
 
----@param role string?
----@return boolean
-function CustomPlayer._isNotPlayer(role)
-	local roleData = ROLES[(role or ''):lower()]
-	return roleData and (roleData.talent or roleData.staff)
-end
-
 ---@param args table
 ---@return {store: string, category: string}
 function CustomPlayer:getPersonType(args)

--- a/components/infobox/wikis/osu/infobox_team_custom.lua
+++ b/components/infobox/wikis/osu/infobox_team_custom.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- wiki=osu
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local MatchTicker = require('Module:MatchTicker/Custom')
+
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local CustomTeam = Class.new()
+
+---@param frame Frame
+---@return Html
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	team.createBottomContent = CustomTeam.createBottomContent
+	return team:createInfobox()
+end
+
+---@return Html
+function CustomTeam:createBottomContent()
+	return MatchTicker.participant{team = self.pagename}
+end
+
+return CustomTeam


### PR DESCRIPTION
## Side Note
Has all three in this PR
Based on the merged one for World of Tanks

## Summary 
This includes three Infoboxes
- **Team** (no changes from Tanks)
- **Player** (same as Tanks, only few role changes)
- **League** (removed Maps and add Game Modes param instead)
 
Currently on LIVE 
