### PR TITLE
Statistics: Add option to abbreviate game in piechart

### DIFF
--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -11,6 +11,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Currency = require('Module:Currency')
 local DateExt = require('Module:Date/Ext')
+local Game = require('Module:Game')
 local Info = require('Module:Info')
 local LeagueIcon = require('Module:LeagueIcon')
 local Lpdb = require('Module:Lpdb')
@@ -928,6 +929,13 @@ function StatisticsPortal._getPieChartData(args, groupBy, defaultValue, groupVal
 	local chartData = Array.map(Array.extractValues(groupValues), function(value)
 		return prizes[value:lower()]
 	end)
+	
+	if groupBy == 'game' and Logic.readBool(args.abbreviateGame) then
+		chartData = Array.map(chartData, function(entry)
+			entry.name = Game.abbreviation{game=entry.name}
+			return entry
+		end)
+	end
 
 	return StatisticsPortal._drawPieChart(args, chartData)
 end


### PR DESCRIPTION
## Summary
Adds an option to abbreviate game names in pie charts.
Game names are often quite long, which leads to weird wrapping of the numeric values they precede.
Increasing the width of the chart helps, but shortening the game names provides additional space.
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/58d22a3e-135f-4d20-9df2-61697881d34d)


## How did you test this change?
via /dev:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/fd44edfb-b47e-4b4c-89ad-e3be9a446054)
