### PR TITLE
Fix ppt color usage directly in td elements

### DIFF
--- a/stylesheets/commons/Prizepooltable.css
+++ b/stylesheets/commons/Prizepooltable.css
@@ -95,6 +95,12 @@ div.background-color-first-place {
 	background-color: var( --prize-pool-background-color, #ffe982 );
 }
 
+td.bg-first,
+td.bg-p1,
+td.background-color-first-place, {
+	background-color: var( --prize-pool-gold, #ffe982 );
+}
+
 body:not( .skin-bruinen ) tr.bg-first,
 body:not( .skin-bruinen ) div.bg-first,
 body:not( .skin-bruinen ) tr.bg-p1,
@@ -122,6 +128,12 @@ div.bg-p2,
 tr.background-color-second-place,
 div.background-color-second-place {
 	background-color: var( --prize-pool-background-color, #eeeeee );
+}
+
+td.bg-second,
+td.bg-p2,
+td.background-color-second-place, {
+	background-color: var( --prize-pool-silver, #eeeeee );
 }
 
 body:not( .skin-bruinen ) tr.bg-second,
@@ -153,6 +165,12 @@ div.background-color-third-place:not( :first-child ) {
 	background-color: var( --prize-pool-background-color, #f9e8c7 );
 }
 
+td.bg-third,
+td.bg-p3,
+td.background-color-third-place, {
+	background-color: var( --prize-pool-bronze, #f9e8c7 );
+}
+
 body:not( .skin-bruinen ) tr.bg-third,
 body:not( .skin-bruinen ) div.bg-third,
 body:not( .skin-bruinen ) tr.bg-p3,
@@ -180,6 +198,12 @@ div.bg-p4,
 tr.background-color-fourth-place,
 div.background-color-fourth-place {
 	background-color: var( --prize-pool-background-color, #f9dec7 );
+}
+
+td.bg-fourth,
+td.bg-p4,
+td.background-color-fourth-place, {
+	background-color: var( --prize-pool-copper, #f9dec7 );
 }
 
 body:not( .skin-bruinen ) tr.bg-fourth,

--- a/stylesheets/commons/Prizepooltable.css
+++ b/stylesheets/commons/Prizepooltable.css
@@ -97,7 +97,7 @@ div.background-color-first-place {
 
 td.bg-first,
 td.bg-p1,
-td.background-color-first-place, {
+td.background-color-first-place {
 	background-color: var( --prize-pool-gold, #ffe982 );
 }
 
@@ -132,7 +132,7 @@ div.background-color-second-place {
 
 td.bg-second,
 td.bg-p2,
-td.background-color-second-place, {
+td.background-color-second-place {
 	background-color: var( --prize-pool-silver, #eeeeee );
 }
 
@@ -167,7 +167,7 @@ div.background-color-third-place:not( :first-child ) {
 
 td.bg-third,
 td.bg-p3,
-td.background-color-third-place, {
+td.background-color-third-place {
 	background-color: var( --prize-pool-bronze, #f9e8c7 );
 }
 
@@ -202,7 +202,7 @@ div.background-color-fourth-place {
 
 td.bg-fourth,
 td.bg-p4,
-td.background-color-fourth-place, {
+td.background-color-fourth-place {
 	background-color: var( --prize-pool-copper, #f9dec7 );
 }
 


### PR DESCRIPTION
## Summary
There exists usage of the classes used in ppt directly in wikitables in the td elements.
Currently in this case it uses the `background-color: var( --clr-semantic-gold-80, #ffe982 );` definition from Colours.css.
This is not darkmode compliant.
This PR adjusts it for td elements so that if those classes are used directly in the td it shows the darkmode compliant color.

before:
![before](https://github.com/Liquipedia/Lua-Modules/assets/75081997/1d3812a7-18e4-4685-a0f7-e0a3f3d097b0)

after:
![after](https://github.com/Liquipedia/Lua-Modules/assets/75081997/d2001256-c65f-402b-832b-6fd1ab0d1268)

## How did you test this change?
inspect, see screenshots above