### PR TITLE
Add stormgate match support via using sc/sc2 via commons

### DIFF
--- a/components/match2/wikis/stormgate/brkts_wiki_specific.lua
+++ b/components/match2/wikis/stormgate/brkts_wiki_specific.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local FnUtil = require('Module:FnUtil')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local BaseWikiSpecific = Lua.import('Module:Brkts/WikiSpecific/Base', {requireDevIfEnabled = true})
+
+---@class StormgateBrktsWikiSpecific: BrktsWikiSpecific
+local WikiSpecific = Table.copy(BaseWikiSpecific)
+
+WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
+	local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
+	return StarcraftMatchGroupUtil.matchFromRecord
+end)
+
+WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
+	local InputModule = Lua.import('Module:MatchGroup/Input/Starcraft', {requireDevIfEnabled = true})
+	return InputModule.processMatch
+end)
+
+function WikiSpecific.getMatchGroupContainer(matchGroupType)
+	if matchGroupType == 'matchlist' then
+		local MatchList = Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true})
+		return MatchList.MatchlistContainer
+	end
+
+	local Bracket = Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true})
+	return Bracket.BracketContainer
+end
+
+function WikiSpecific.getMatchContainer(displayMode)
+	if displayMode == 'singleMatch' then
+		-- Single match, displayed flat on a page (no popup)
+		local SingleMatch = Lua.import(
+			'Module:MatchGroup/Display/SingleMatch/Starcraft',
+			{requireDevIfEnabled = true}
+		)
+		return SingleMatch.SingleMatchContainer
+	end
+end
+
+WikiSpecific.matchHasDetails = FnUtil.lazilyDefineFunction(function()
+	local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft', {requireDevIfEnabled = true})
+	return StarcraftMatchGroupUtil.matchHasDetails
+end)
+
+-- useless functions that should be present for some default checks
+-- would get called from Module:Match/Subobjects if we wouldn't circumvent that module completly
+WikiSpecific.processMap = FnUtil.identity
+
+return WikiSpecific

--- a/components/match2/wikis/stormgate/brkts_wiki_specific.lua
+++ b/components/match2/wikis/stormgate/brkts_wiki_specific.lua
@@ -25,16 +25,30 @@ WikiSpecific.processMatch = FnUtil.lazilyDefineFunction(function()
 	return InputModule.processMatch
 end)
 
+---@param matchGroupType string
+---@return function
 function WikiSpecific.getMatchGroupContainer(matchGroupType)
 	if matchGroupType == 'matchlist' then
-		local MatchList = Lua.import('Module:MatchGroup/Display/Matchlist/Starcraft', {requireDevIfEnabled = true})
-		return MatchList.MatchlistContainer
+		local MatchList = Lua.import('Module:MatchGroup/Display/Matchlist', {requireDevIfEnabled = true})
+		return WikiSpecific.adjustMatchGroupContainerConfig(MatchList.MatchlistContainer)
 	end
 
-	local Bracket = Lua.import('Module:MatchGroup/Display/Bracket/Starcraft', {requireDevIfEnabled = true})
-	return Bracket.BracketContainer
+	local Bracket = Lua.import('Module:MatchGroup/Display/Bracket', {requireDevIfEnabled = true})
+	return WikiSpecific.adjustMatchGroupContainerConfig(Bracket.BracketContainer)
 end
 
+---@param displayContainer function
+---@return function
+function WikiSpecific.adjustMatchGroupContainerConfig(displayContainer)
+	local StarcraftMatchSummary = Lua.import('Module:MatchSummary/Starcraft', {requireDevIfEnabled = true})
+	return function(props, matches)
+		local config = Table.merge(props.config, {MatchSummaryContainer = StarcraftMatchSummary.MatchSummaryContainer})
+		return displayContainer(Table.merge(props, {config = config}), matches)
+	end
+end
+
+---@param displayMode string
+---@return function?
 function WikiSpecific.getMatchContainer(displayMode)
 	if displayMode == 'singleMatch' then
 		-- Single match, displayed flat on a page (no popup)

--- a/components/match2/wikis/stormgate/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/stormgate/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,9 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return require('Module:GetMatchGroupCopyPaste/Starcraft')


### PR DESCRIPTION
depends on #3624

## Summary
Add stormgate match support via using sc/sc2 via commons
As per our current (not official) information there is no hero stuff in stormgate 1v1 esports, hence can just use sc/sc2 match system for now, which mostly is located on commons anyways

## How did you test this change?
N/A, copy from sc/sc2

## info
using sc(2) match2 for now due to not having the time to get a match2 setup for stormgate
we will have to give it its own match2 setup when 3v3 with heroes is added to the game.
Then we will also rename race params to faction params to fit the naming used by the game devs better.