### PR TITLE
fix: storage call in infobox manufacturer

### DIFF
--- a/components/infobox/commons/infobox_manufacturer.lua
+++ b/components/infobox/commons/infobox_manufacturer.lua
@@ -113,7 +113,7 @@ function Manufacturer:setLpdbData(args)
 	lpdbData = self:addToLpdb(lpdbData, args)
 
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
-	mw.ext.LiquipediaDB.lpdb_datapoint('manufacturer_' .. self.name, lpdbData.extradata)
+	mw.ext.LiquipediaDB.lpdb_datapoint('manufacturer_' .. self.name, lpdbData)
 end
 
 ---@param lpdbData table


### PR DESCRIPTION
## Summary

Removes the '.extradata' from the storage call.

## How did you test this change?

Live :/ (module page needs to be locked too)
