### PR TITLE
Allow reset match details in warcraft legacy bracket wrapper

### DIFF
--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_default.lua
@@ -138,7 +138,7 @@ function MatchGroupLegacyDefault.getMatchMapping(match, bracketData, bracketType
 		opponent2 = opponents[2],
 		finished = finished[1] .. '|' .. finished[2],
 		-- reference to variables that shall be flattened
-		['$flatten$'] = { 'R' .. round.R .. 'G' .. round.G .. 'details' }
+		['$flatten$'] = {reset and 'resetDetails' or ('R' .. round.R .. 'G' .. round.G .. 'details')}
 	}
 
 	bracketData[id] = MatchGroupLegacyDefault.addMaps(match)


### PR DESCRIPTION
## Summary
THis 1-line change allows reset match details in warcraft legacy bracket wrapper to work (after a bot run).

## How did you test this change?
dev (together with #3613 to be able to use dev)

## Additional information
This change doesn't work without an accompanied bot job that changes `"\}\}\s*\{\{[bB]racketMatchSummary"` to `"}}|resetDetails={{BracketMatchSummary"`.
The bot job can be run after or before merge (my bot is busy with other stuff today) though.
Currently Details for finals with rests are not shown at all due to the `{{BracketMatchSummary...}}{{BracketMatchSummary...}}` giving an invalid json.