### PR TITLE
Fix hotkey class for darkmode

### DIFF
--- a/stylesheets/commons/Miscellaneous.css
+++ b/stylesheets/commons/Miscellaneous.css
@@ -4458,7 +4458,7 @@ Template // Module: Key/Key2 // Hotkey
 Author(s): hjpalpha
 *******************************************************************************/
 .hotkey-key {
-	background-color: #f0f0f0;
+	background-color: var( --clr-moon-background-color, #f0f0f0 );
 	width: 32px;
 	font-size: 9pt;
 	border-style: outset;


### PR DESCRIPTION
## Summary
Fix the background color in hotkey class to be viable for darkmode

## How did you test this change?
browser inspect

before:
![Screenshot 2023-12-08 130213](https://github.com/Liquipedia/Lua-Modules/assets/75081997/073eea1d-f0f7-447d-b7f1-6a09e7a4e1d1)

after:
![Screenshot 2023-12-08 130232](https://github.com/Liquipedia/Lua-Modules/assets/75081997/ef57a0a6-5538-4b0b-8e46-76fa97c8a603)
