### PR TITLE
feat: Method to convert TZ offset to seconds

### DIFF
--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -119,4 +119,11 @@ function DateExt.parseIsoDate(str)
 	return {year = year, month = month, day = day}
 end
 
+--- Converts a timezone offset (e.g. `+2:00`) to a UTC offset in seconds.
+---@param offsetString string
+---@return integer?
+function DateExt.getOffsetSeconds(offsetString)
+	return tonumber(mw.getContentLanguage():formatDate('U', '1970-01-01T00:00:00' .. offsetString))
+end
+
 return DateExt

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -123,7 +123,7 @@ end
 ---@param offsetString string
 ---@return integer?
 function DateExt.getOffsetSeconds(offsetString)
-	return tonumber(mw.getContentLanguage():formatDate('U', '1970-01-01T00:00:00' .. offsetString))
+	return 0 - tonumber(mw.getContentLanguage():formatDate('U', '1970-01-01T00:00:00' .. offsetString))
 end
 
 return DateExt

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -120,10 +120,10 @@ function DateExt.parseIsoDate(str)
 end
 
 --- Converts a timezone offset (e.g. `+2:00`) to a UTC offset in seconds.
----@param offsetString string
----@return integer?
+---@param offsetString string?
+---@return integer # default `0`
 function DateExt.getOffsetSeconds(offsetString)
-	return 0 - tonumber(mw.getContentLanguage():formatDate('U', '1970-01-01T00:00:00' .. offsetString))
+	return 0 - tonumber(mw.getContentLanguage():formatDate('U', '1970-01-01T00:00:00' .. (offsetString or '')))
 end
 
 return DateExt


### PR DESCRIPTION
## Summary

Converts strings like `+2:00` into second values for offsetting unix timestamps.

Needed this functionality for a future PR and thought it's useful to have here rather than it being hidden inside the code of the upcoming PR there it's not really clear why or what it's doing.

## How did you test this change?

Debug console and `/dev` for future PR.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/d9e9e649-daba-4112-bed3-1cf833952674)
