### PR TITLE
feat: Space icons in Infobox Achievements

### DIFF
--- a/components/infobox/extensions/commons/infobox_extension_achievements.lua
+++ b/components/infobox/extensions/commons/infobox_extension_achievements.lua
@@ -133,7 +133,6 @@ end
 
 ---@class AchievementIconsOptions
 ---@field noTemplate boolean
----@field spacedIcons boolean
 ---@field onlyForFirstPrizePoolOfPage boolean
 ---@field adjustItem fun(item:table):table
 ---@field baseConditions string[]
@@ -146,7 +145,6 @@ function Achievements._readOptions(args)
 
 	return {
 		noTemplate = Logic.readBool(Logic.nilOr(args.noTemplate, CustomDefaultOptions.noTemplate)),
-		spacedIcons = Logic.readBool(args.spacedIcons),
 		onlyForFirstPrizePoolOfPage = Logic.readBool(Logic.nilOr(
 			args.onlyForFirstPrizePoolOfPage,
 			CustomDefaultOptions.onlyForFirstPrizePoolOfPage

--- a/components/infobox/extensions/commons/infobox_extension_achievements.lua
+++ b/components/infobox/extensions/commons/infobox_extension_achievements.lua
@@ -21,6 +21,7 @@ local CustomDefaultOptions = Lua.requireIfExists('Module:Infobox/Extension/Achie
 local OpponentLibrary = require('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
 
+local NON_BREAKING_SPACE = '&nbsp;'
 local DEFAULT_PLAYER_LIMIT = 10
 local DEFAULT_BASE_CONDITIONS = {
 	'[[liquipediatiertype::!Qualifier]]',
@@ -132,6 +133,7 @@ end
 
 ---@class AchievementIconsOptions
 ---@field noTemplate boolean
+---@field spacedIcons boolean
 ---@field onlyForFirstPrizePoolOfPage boolean
 ---@field adjustItem fun(item:table):table
 ---@field baseConditions string[]
@@ -144,6 +146,7 @@ function Achievements._readOptions(args)
 
 	return {
 		noTemplate = Logic.readBool(Logic.nilOr(args.noTemplate, CustomDefaultOptions.noTemplate)),
+		spacedIcons = Logic.readBool(args.spacedIcons),
 		onlyForFirstPrizePoolOfPage = Logic.readBool(Logic.nilOr(
 			args.onlyForFirstPrizePoolOfPage,
 			CustomDefaultOptions.onlyForFirstPrizePoolOfPage
@@ -204,8 +207,11 @@ function Achievements.display(data, options)
 
 	Array.sortInPlaceBy(data, Operator.property('date'))
 
-	return String.nilIfEmpty(table.concat(Array.map(data, function(item)
-		return Achievements._displayIcon(item, options)
+	return String.nilIfEmpty(table.concat(Array.flatMap(data, function(item, index)
+		return {
+			Achievements._displayIcon(item, options),
+			options.spacedIcons and (index ~= #data) and NON_BREAKING_SPACE or nil,
+		}
 	end)))
 end
 

--- a/components/infobox/extensions/commons/infobox_extension_achievements.lua
+++ b/components/infobox/extensions/commons/infobox_extension_achievements.lua
@@ -207,12 +207,9 @@ function Achievements.display(data, options)
 
 	Array.sortInPlaceBy(data, Operator.property('date'))
 
-	return String.nilIfEmpty(table.concat(Array.flatMap(data, function(item, index)
-		return {
-			Achievements._displayIcon(item, options),
-			options.spacedIcons and (index ~= #data) and NON_BREAKING_SPACE or nil,
-		}
-	end)))
+	return String.nilIfEmpty(table.concat(Array.map(data, function(item)
+		return Achievements._displayIcon(item, options)
+	end), NON_BREAKING_SPACE))
 end
 
 ---Build the icon for a single entry


### PR DESCRIPTION
## Summary

For use in #3632 since dota2 has their icons spaced out.

| default | spaced |
|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/693471fd-e4fa-4f98-a05e-9f66e0291666) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/fcaaac93-5336-47d1-8638-6fcd05a91b49) | 

## How did you test this change?

Tested on `/dev`
