### PR TITLE
Adding Breaking Point Icon and link to Call of Duty Match2

### DIFF
--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -283,6 +283,7 @@ function matchFunctions.getVodStuff(match)
 	local links = match.links
 	if match.reddit then links.reddit = 'https://redd.it/' .. match.reddit end
 	if match.cdl then links.cdl = 'https://callofdutyleague.com/en-us/match/' .. match.cdl end
+	if match.breakingpoint then links.breakingpoint = 'https://www.breakingpoint.gg/match/' .. match.breakingpoint end
 
 	return match
 end

--- a/components/match2/wikis/callofduty/match_summary.lua
+++ b/components/match2/wikis/callofduty/match_summary.lua
@@ -23,6 +23,11 @@ local NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 local LINK_DATA = {
 	cdl = {icon = 'File:Call of Duty League Logo Small.png', text = 'Call of Duty League matchpage'},
+	breakingpoint = {
+		icon = 'File:Breaking Point GG icon lightmode.png', 
+		iconDark = 'File:Breaking Point GG icon darkmode.png', 
+		text = 'Breaking Point matchpage'
+	},
 	reddit = {icon = 'File:Reddit-icon.png', text = 'Reddit stats'},
 }
 

--- a/components/match2/wikis/callofduty/match_summary.lua
+++ b/components/match2/wikis/callofduty/match_summary.lua
@@ -24,8 +24,8 @@ local NO_CHECK = '[[File:NoCheck.png|link=]]'
 local LINK_DATA = {
 	cdl = {icon = 'File:Call of Duty League Logo Small.png', text = 'Call of Duty League matchpage'},
 	breakingpoint = {
-		icon = 'File:Breaking Point GG icon lightmode.png', 
-		iconDark = 'File:Breaking Point GG icon darkmode.png', 
+		icon = 'File:Breaking Point GG icon lightmode.png',
+		iconDark = 'File:Breaking Point GG icon darkmode.png',
 		text = 'Breaking Point matchpage'
 	},
 	reddit = {icon = 'File:Reddit-icon.png', text = 'Reddit stats'},


### PR DESCRIPTION
## Summary
Adds the Breaking Point icon to the Call of Duty Match2. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested live here: [Userpage](https://liquipedia.net/callofduty/User:Fenrir.SPAZ/BPTestl)
LPDB Data:
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/0442dfaa-76d4-4ffc-a740-d59dc9c1ed84)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
