### PR TITLE
fix: make featured queryable in dota2 match2

### DIFF
--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -382,10 +382,11 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		featured = Logic.emptyOr(
+		featured = tostring(Logic.emptyOr(
 			match.featured,
-			matchFunctions.isFeatured(match)
-		),
+			matchFunctions.isFeatured(match),
+			''
+		)),
 		mvp = MatchGroupInput.readMvp(match),
 		headtohead = match.headtohead,
 	}


### PR DESCRIPTION
## Summary
Store the featured as a string in the extradata. So that it can be filtered on in the an LPDB query.

## How did you test this change?

Live