### PR TITLE
feat: add match2 status in info module

### DIFF
--- a/standard/info/commons/info.lua
+++ b/standard/info/commons/info.lua
@@ -28,4 +28,5 @@ return {
 
 	defaultTeamLogo = 'Liquipedia logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Liquipedia logo.png', ---@deprecated
+	match2 = 2,
 }

--- a/standard/info/wikis/ageofempires/info.lua
+++ b/standard/info/wikis/ageofempires/info.lua
@@ -95,4 +95,5 @@ return {
 
 	defaultTeamLogo = 'Age of Empires default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Age of Empires default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/apexlegends/info.lua
+++ b/standard/info/wikis/apexlegends/info.lua
@@ -29,4 +29,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Apex Legends default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Apex Legends default darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/arenafps/info.lua
+++ b/standard/info/wikis/arenafps/info.lua
@@ -405,4 +405,5 @@ return {
 	defaultGame = 'qc',
 	defaultTeamLogo = 'Quake logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Quake logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/arenaofvalor/info.lua
+++ b/standard/info/wikis/arenaofvalor/info.lua
@@ -75,4 +75,5 @@ return {
 		aov = 'Arena of ValorLogo.png', --Arena of Valor
 		hok = 'Honor of Kings 2018-12-24 Logo.png', --Honor of Kings
 	}, ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/artifact/info.lua
+++ b/standard/info/wikis/artifact/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'artifact',
 	defaultTeamLogo = 'Artifact allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Artifact allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/autochess/info.lua
+++ b/standard/info/wikis/autochess/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'autochess',
 	defaultTeamLogo = 'Auto Chess lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Auto Chess darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/battalion/info.lua
+++ b/standard/info/wikis/battalion/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'battalion',
 	defaultTeamLogo = 'Battalion generic logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Battalion generic logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/battlerite/info.lua
+++ b/standard/info/wikis/battlerite/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'battlerite',
 	defaultTeamLogo = 'Battlerite default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Battlerite default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/brawlhalla/info.lua
+++ b/standard/info/wikis/brawlhalla/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'brawl',
 	defaultTeamLogo = 'Brawlhalla Default logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Brawlhalla Default logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/brawlstars/info.lua
+++ b/standard/info/wikis/brawlstars/info.lua
@@ -29,4 +29,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Brawl Stars Default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Brawl Stars Default allmode.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/callofduty/info.lua
+++ b/standard/info/wikis/callofduty/info.lua
@@ -341,4 +341,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Call of Duty Default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Call of Duty Default darkmode.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/clashofclans/info.lua
+++ b/standard/info/wikis/clashofclans/info.lua
@@ -29,4 +29,5 @@ return {
 
 	defaultTeamLogo = 'Clash of Clans default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Clash of Clans default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/clashroyale/info.lua
+++ b/standard/info/wikis/clashroyale/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'cr',
 	defaultTeamLogo = 'Clash Royale.png', ---@deprecated
 	defaultTeamLogoDark = 'Clash Royale.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/counterstrike/info.lua
+++ b/standard/info/wikis/counterstrike/info.lua
@@ -129,6 +129,7 @@ local infoData = {
 		cscz = 'CS default darkmode.png',
 		cs2 = 'Counter-Strike 2 default lightmode.png',
 	}, ---@deprecated
+	match2 = 2,
 }
 
 infoData.games.cs16 = infoData.games.cs1

--- a/standard/info/wikis/criticalops/info.lua
+++ b/standard/info/wikis/criticalops/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'cops',
 	defaultTeamLogo = 'Critical Ops allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Critical Ops allmode.png', ---@deprecated
+	match2 = 2,
 }

--- a/standard/info/wikis/crossfire/info.lua
+++ b/standard/info/wikis/crossfire/info.lua
@@ -55,4 +55,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Crossfire default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Crossfire default darkmode.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/dota2/info.lua
+++ b/standard/info/wikis/dota2/info.lua
@@ -42,4 +42,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Dota2 logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Dota2 logo.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/fifa/info.lua
+++ b/standard/info/wikis/fifa/info.lua
@@ -419,4 +419,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'FIFA lightmode logo.png', ---@deprecated
 	defaultTeamLogoDark = 'FIFA darkmode logo.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -1640,4 +1640,5 @@ return {
 	defaultGame = 'fighters',
 	defaultTeamLogo = 'Fighters default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Fighters default darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/formula1/info.lua
+++ b/standard/info/wikis/formula1/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'formula1',
 	defaultTeamLogo = 'Sim Racing default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Sim Racing default darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/fortnite/info.lua
+++ b/standard/info/wikis/fortnite/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'fortnite',
 	defaultTeamLogo = 'Fortnite logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Fortnite logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/freefire/info.lua
+++ b/standard/info/wikis/freefire/info.lua
@@ -29,4 +29,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Freefire Default Logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Freefire Default Logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/halo/info.lua
+++ b/standard/info/wikis/halo/info.lua
@@ -106,4 +106,5 @@ return {
 	defaultGame = 'infinite',
 	defaultTeamLogo = 'Halo allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Halo allmode.png', ---@deprecated
+	match2 = 2,
 }

--- a/standard/info/wikis/hearthstone/info.lua
+++ b/standard/info/wikis/hearthstone/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'hs',
 	defaultTeamLogo = 'Hearthstone logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Hearthstone logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/heroes/info.lua
+++ b/standard/info/wikis/heroes/info.lua
@@ -29,4 +29,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Hots logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Hots logo.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/leagueoflegends/info.lua
+++ b/standard/info/wikis/leagueoflegends/info.lua
@@ -29,4 +29,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'League of Legends allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'League of Legends allmode.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/magic/info.lua
+++ b/standard/info/wikis/magic/info.lua
@@ -54,4 +54,5 @@ return {
 	defaultGame = 'tabletop',
 	defaultTeamLogo = 'Liquipedia logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Liquipedia logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/mobilelegends/info.lua
+++ b/standard/info/wikis/mobilelegends/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'mobilelegends',
 	defaultTeamLogo = 'Mobile Legends allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Mobile Legends allmode.png', ---@deprecated
+	match2 = 2,
 }

--- a/standard/info/wikis/naraka/info.lua
+++ b/standard/info/wikis/naraka/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'naraka',
 	defaultTeamLogo = 'NARAKA lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'NARAKA darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/omegastrikers/info.lua
+++ b/standard/info/wikis/omegastrikers/info.lua
@@ -29,4 +29,5 @@ return {
 
 	defaultTeamLogo = 'Omega Strikers default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Omega Strikers default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/osu/info.lua
+++ b/standard/info/wikis/osu/info.lua
@@ -42,5 +42,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'osu! default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'osu! default allmode.png', ---@deprecated
-	match2 = 0,
+	match2 = 2,
 }

--- a/standard/info/wikis/osu/info.lua
+++ b/standard/info/wikis/osu/info.lua
@@ -42,4 +42,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'osu! default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'osu! default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/overwatch/info.lua
+++ b/standard/info/wikis/overwatch/info.lua
@@ -41,4 +41,5 @@ return {
 	defaultGame = 'overwatch2',
 	defaultTeamLogo = 'Overwatch Logo lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Overwatch Logo darkmode.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/paladins/info.lua
+++ b/standard/info/wikis/paladins/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'paladins',
 	defaultTeamLogo = 'Paladins allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Paladins allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/pokemon/info.lua
+++ b/standard/info/wikis/pokemon/info.lua
@@ -223,4 +223,5 @@ return {
 	defaultGame = 'sv',
 	defaultTeamLogo = 'Pokemon logo std.png', ---@deprecated
 	defaultTeamLogoDark = 'Pokemon logo std.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/pubg/info.lua
+++ b/standard/info/wikis/pubg/info.lua
@@ -29,4 +29,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'PUBG Default logo.png', ---@deprecated
 	defaultTeamLogoDark = 'PUBG Default logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/pubgmobile/info.lua
+++ b/standard/info/wikis/pubgmobile/info.lua
@@ -68,4 +68,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'PUBG Mobile Default logo allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'PUBG Mobile Default logo allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -49,4 +49,5 @@ return {
 		siege = 'Rainbow Six Siege Logo darkmode.png',
 		vegas2 = 'Rainbow Six Vegas Logo darkmode.png',
 	}, ---@deprecated
+	match2 = 2,
 }

--- a/standard/info/wikis/rocketleague/info.lua
+++ b/standard/info/wikis/rocketleague/info.lua
@@ -42,4 +42,5 @@ return {
 	defaultTeamLogo = 'Rocket League.png', ---@deprecated
 	defaultTeamLogoDark = 'Rocket League.png', ---@deprecated
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
+	match2 = 2,
 }

--- a/standard/info/wikis/runeterra/info.lua
+++ b/standard/info/wikis/runeterra/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'runeterra',
 	defaultTeamLogo = 'Legends of Runeterra logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Legends of Runeterra logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/sideswipe/info.lua
+++ b/standard/info/wikis/sideswipe/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'sideswipe',
 	defaultTeamLogo = 'Sideswipe allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Sideswipe allmode.png', ---@deprecated
+	match2 = 2,
 }

--- a/standard/info/wikis/simracing/info.lua
+++ b/standard/info/wikis/simracing/info.lua
@@ -808,4 +808,5 @@ return {
 	defaultGame = 'sr',
 	defaultTeamLogo = 'Sim Racing default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Sim Racing default darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/smash/info.lua
+++ b/standard/info/wikis/smash/info.lua
@@ -93,4 +93,5 @@ return {
 	defaultGame = 'melee',
 	defaultTeamLogo = 'Smashlogo std.png', ---@deprecated
 	defaultTeamLogoDark = 'Smashlogo std.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/splatoon/info.lua
+++ b/standard/info/wikis/splatoon/info.lua
@@ -54,4 +54,5 @@ return {
 	defaultGame = '1',
 	defaultTeamLogo = 'Splatoon default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Splatoon default darkmode.png', ---@deprecated
+	match2 = 2,
 }

--- a/standard/info/wikis/splitgate/info.lua
+++ b/standard/info/wikis/splitgate/info.lua
@@ -31,4 +31,5 @@ return {
 		.. '(2021-06-01) Splitgate 2021 lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Splitgate allmode.png (2019) Change date '
 		.. '(2021-06-01) Splitgate 2021 darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/splitgate/info.lua
+++ b/standard/info/wikis/splitgate/info.lua
@@ -31,5 +31,5 @@ return {
 		.. '(2021-06-01) Splitgate 2021 lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Splitgate allmode.png (2019) Change date '
 		.. '(2021-06-01) Splitgate 2021 darkmode.png', ---@deprecated
-	match2 = 0,
+	match2 = 2,
 }

--- a/standard/info/wikis/squadrons/info.lua
+++ b/standard/info/wikis/squadrons/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'squadrons',
 	defaultTeamLogo = 'Star Wars Squadrons allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Star Wars Squadrons allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/starcraft/info.lua
+++ b/standard/info/wikis/starcraft/info.lua
@@ -32,4 +32,5 @@ return {
 
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
+	match2 = 1,
 }

--- a/standard/info/wikis/starcraft2/info.lua
+++ b/standard/info/wikis/starcraft2/info.lua
@@ -57,4 +57,5 @@ return {
 
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
+	match2 = 2,
 }

--- a/standard/info/wikis/stormgate/info.lua
+++ b/standard/info/wikis/stormgate/info.lua
@@ -31,4 +31,5 @@ return {
 	defaultTeamLogoDark = 'Stormgate default darkmode.png', ---@deprecated
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
+	match2 = 0,
 }

--- a/standard/info/wikis/stormgate/info.lua
+++ b/standard/info/wikis/stormgate/info.lua
@@ -31,5 +31,5 @@ return {
 	defaultTeamLogoDark = 'Stormgate default darkmode.png', ---@deprecated
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
-	match2 = 0,
+	match2 = 2,
 }

--- a/standard/info/wikis/teamfortress/info.lua
+++ b/standard/info/wikis/teamfortress/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'tf2',
 	defaultTeamLogo = 'Team Fortress logo.png', ---@deprecated
 	defaultTeamLogoDark = 'Team Fortress logo.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/tetris/info.lua
+++ b/standard/info/wikis/tetris/info.lua
@@ -445,5 +445,5 @@ return {
 
 	defaultTeamLogo = 'Tetris default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Tetris default allmode.png', ---@deprecated
-	match2 = 0,
+	match2 = 2,
 }

--- a/standard/info/wikis/tetris/info.lua
+++ b/standard/info/wikis/tetris/info.lua
@@ -445,4 +445,5 @@ return {
 
 	defaultTeamLogo = 'Tetris default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Tetris default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/tft/info.lua
+++ b/standard/info/wikis/tft/info.lua
@@ -42,4 +42,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Teamfight Tactics Double Up lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Teamfight Tactics Double Up darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/trackmania/info.lua
+++ b/standard/info/wikis/trackmania/info.lua
@@ -147,4 +147,5 @@ return {
 	defaultTeamLogoDark = 'Trackmania logo darkmode.png', ---@deprecated
 	opponentLibrary = 'Opponent',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
+	match2 = 1,
 }

--- a/standard/info/wikis/underlords/info.lua
+++ b/standard/info/wikis/underlords/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'underlords',
 	defaultTeamLogo = 'Dota Underlords lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Dota Underlords darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/valorant/info.lua
+++ b/standard/info/wikis/valorant/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'val',
 	defaultTeamLogo = 'VALORANT allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'VALORANT allmode.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/warcraft/info.lua
+++ b/standard/info/wikis/warcraft/info.lua
@@ -56,4 +56,5 @@ return {
 	defaultTeamLogoDark = 'Warcraft III logo.png', ---@deprecated
 	opponentLibrary = 'Opponent/Custom',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
+	match2 = 1,
 }

--- a/standard/info/wikis/warcraft/info.lua
+++ b/standard/info/wikis/warcraft/info.lua
@@ -56,5 +56,5 @@ return {
 	defaultTeamLogoDark = 'Warcraft III logo.png', ---@deprecated
 	opponentLibrary = 'Opponent/Custom',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
-	match2 = 1,
+	match2 = 2,
 }

--- a/standard/info/wikis/wildrift/info.lua
+++ b/standard/info/wikis/wildrift/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'wildrift',
 	defaultTeamLogo = 'Wild Rift Teamcard.png', ---@deprecated
 	defaultTeamLogoDark = 'Wild Rift Teamcard.png', ---@deprecated
+	match2 = 1,
 }

--- a/standard/info/wikis/worldoftanks/info.lua
+++ b/standard/info/wikis/worldoftanks/info.lua
@@ -68,4 +68,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'World of Tanks default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'World of Tanks default darkmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/worldoftanks/info.lua
+++ b/standard/info/wikis/worldoftanks/info.lua
@@ -68,5 +68,5 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'World of Tanks default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'World of Tanks default darkmode.png', ---@deprecated
-	match2 = 0,
+	match2 = 2,
 }

--- a/standard/info/wikis/worldofwarcraft/info.lua
+++ b/standard/info/wikis/worldofwarcraft/info.lua
@@ -28,4 +28,5 @@ return {
 	defaultGame = 'wow',
 	defaultTeamLogo = 'WoWlogo Default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'WoWlogo Default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/zula/info.lua
+++ b/standard/info/wikis/zula/info.lua
@@ -29,4 +29,5 @@ return {
 
 	defaultTeamLogo = 'Zula Global default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Zula Global default allmode.png', ---@deprecated
+	match2 = 0,
 }

--- a/standard/info/wikis/zula/info.lua
+++ b/standard/info/wikis/zula/info.lua
@@ -29,5 +29,5 @@ return {
 
 	defaultTeamLogo = 'Zula Global default allmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Zula Global default allmode.png', ---@deprecated
-	match2 = 0,
+	match2 = 2,
 }


### PR DESCRIPTION
## Summary
Add match2 status to Info Modules
Values are `2` (upcoming and historic uses match2), `1` (upcoming uses match2), `0` (upcoming does not use match2)
