### PR TITLE
feat(pstats): use m2 info instead of args

### DIFF
--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -251,7 +251,7 @@ function StatisticsPortal._coverageMatchTableRow(args, parameters)
 	local matchCountValue
 	local gameCountValue
 
-	if Logic.readBool(args.queryMatch2) then
+	if Info.match2 == 2 then
 		matchCountValue = Count.match2gamesData(parameters)
 		gameCountValue = Count.match2(parameters)
 	else


### PR DESCRIPTION
## Summary
Use the match2 flag in Module:Info, from #3643 to determine when to use Match2 querying, instead of an args parameter.

## How did you test this change?
