### PR TITLE
fix: do not use `stylelint-less` v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"grunt-stylelint": "*",
 		"postcss-less": "*",
 		"stylelint-config-wikimedia": "*",
-		"stylelint-less": "*"
+		"stylelint-less": "2.x.x"
 	},
 	"scripts": {
 		"test": "grunt main",


### PR DESCRIPTION
## Summary
`stylelint-less` just released v3, which uses `stylelint` v16. 
`grunt-stylelint` does however not yet support `stylelint` v16, causing a conflict, and breaking our pipeline atm.

Force `stylelint-less` back to v2.