### PR TITLE
Illuvial portal headers

### DIFF
--- a/stylesheets/commons/Miscellaneous.css
+++ b/stylesheets/commons/Miscellaneous.css
@@ -5482,3 +5482,11 @@ Author(s): PhiLtheFisH, FO-nTTaX, salle
 	background-color: #cccccc;
 	transition: 0.5s;
 }
+
+.wiki-illuvium .hexagon-affinity-header {
+	text-align: left;
+}
+
+.wiki-illuvium .hexagon-class-header {
+	text-align: right;
+}


### PR DESCRIPTION
Adding CSS for new headers in the Illuvials portal in the Illuvium wiki

## Summary

Added two <h4> tags to Portal:Illuvials in the Illuvium wiki and I'm adding these classes to make them alligned with the icons that exist there already.

## How did you test this change?

Tested directly in the wiki by changing the CSS file on Commons.