### PR TITLE
Add color inversion to vanguard icon

### DIFF
--- a/stylesheets/commons/Miscellaneous.css
+++ b/stylesheets/commons/Miscellaneous.css
@@ -4844,6 +4844,7 @@ Author(s): hjpalpha
 .theme--dark & {
 	img[ title="Human" ],
 	img[ title="Infernal" ],
+	img[ title="Vanguard" ],
 	img[ title="Orc" ],
 	img[ title="Undead" ],
 	img[ title="Night Elf" ],


### PR DESCRIPTION
## Summary
Was missed due to originally thinking the faction is called human

## How did you test this change?
N/A