### PR TITLE
Add medal stats modules

### DIFF
--- a/components/medal_stats/series_medal_stats.lua
+++ b/components/medal_stats/series_medal_stats.lua
@@ -1,0 +1,288 @@
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Medal = require('Module:Medal')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local Condition = require('Module:Condition')
+local ConditionTree = Condition.Tree
+local ConditionNode = Condition.Node
+local Comparator = Condition.Comparator
+local BooleanOperator = Condition.BooleanOperator
+local ColumnName = Condition.ColumnName
+
+local TODAY = os.date('%Y-%m-%d') --[[@as string]]
+
+---@class SeriesMedalStatsConfig
+---@field series string[]
+---@field tier string[]
+---@field tierType string[]
+---@field cutAfter number
+---@field startDate string?
+---@field endDate string?
+---@field placements string[]
+---@field external boolean
+---@field noNumber boolean
+---@field offset integer? only valid if not noNumber
+---@field limit integer? only valid if not noNumber
+---@field additionalConditions string
+---@field opponentTypes string[]
+
+---@class SeriesMedalStatsPlacementObject
+---@field opponentplayers table
+---@field placement string
+---@field date string
+---@field extradata table
+---@field opponentname string
+---@field opponenttype OpponentType
+---@field opponenttemplate string?
+
+---@class SeriesMedalStatsDataSet
+---@field identifier string
+---@field ['1'] number
+---@field ['2'] number
+---@field ['3'] number?
+---@field ['3-4'] number?
+---@field ['4'] number?
+---@field total number?
+
+---@class SeriesMedalStats
+---@operator call(table?): SeriesMedalStats
+---@field config SeriesMedalStatsConfig
+---@field rawData SeriesMedalStatsPlacementObject[]?
+---@field args table
+---@field data table?
+---@field dataAsArray SeriesMedalStatsDataSet[]?
+---@field display Html?
+local MedalStats = Class.new(function(self, args) self:init(args) end)
+
+
+---@param args table?
+---@return self
+function MedalStats:init(args)
+	self.args = args or {}
+	self.config = self:_getConfig()
+
+	return self
+end
+
+---@return SeriesMedalStatsConfig
+function MedalStats:_getConfig()
+	local args = self.args
+
+	local placements = {'1', '2'}
+	if Logic.readBool(args.bronze) then
+		table.insert(placements, '3')
+	end
+	if Logic.readBool(args.sf) then
+		table.insert(placements, '3-4')
+	end
+	if Logic.readBool(args.copper) then
+		table.insert(placements, '4')
+	end
+
+	---@param input string?
+	---@param sep string?
+	---@return string[]
+	local splitAndTrimIfExist = function(input, sep)
+		if String.isEmpty(input) then return {} end
+		---@cast input -nil
+		return Array.map(mw.text.split(input, sep or '||'), String.trim)
+	end
+
+	local series = splitAndTrimIfExist(args.series or mw.title.getCurrentTitle().prefixedText)
+
+	if not Logic.readBool(args.noredirect) then
+		series = Array.map(series, mw.ext.TeamLiquidIntegration.resolve_redirect)
+	end
+
+	series = Array.map(series, function(value) return (value:gsub('_', ' ')) end)
+
+	return {
+		series = series,
+		external = Logic.readBool(args.external),
+		tier = splitAndTrimIfExist(args.tier or args.liquipediatier),
+		tierType = splitAndTrimIfExist(args.tiertype or args.liquipediatiertype),
+		offset = tonumber(args.offset),
+		limit = tonumber(args.limit),
+		cutAfter = tonumber(args.cutafter) or 7,
+		noNumber = Logic.readBool(args.noNumber) or
+			(args.edate or args.sdate) and tonumber(args.offset) and tonumber(args.limit),
+		endDate = args.edate,
+		startDate = args.sdate,
+		placements = placements,
+		additionalConditions = args.additionalConditions or '',
+		opponentTypes = splitAndTrimIfExist(args.opponentType),
+	}
+end
+
+---@return self
+function MedalStats:query()
+	self.rawData = mw.ext.LiquipediaDB.lpdb('placement', {
+		conditions = self:_getConditions(),
+		query = 'opponentplayers, placement, extradata, date, opponentname, opponenttype, opponenttemplate',
+		sort = 'date desc',
+		limit = 5000,
+	})
+
+	return self
+end
+
+---@return string
+function MedalStats:_getConditions()
+	local config = self.config
+	local conditions = ConditionTree(BooleanOperator.all)
+
+	---@param field string
+	---@param arr string[]
+	local addOrCondition = function(field, arr)
+		if Table.isEmpty(arr) then return end
+		conditions:add(ConditionTree(BooleanOperator.any):add(Array.map(arr, function(value)
+			return ConditionNode(ColumnName(field), Comparator.eq, value)
+		end)))
+	end
+
+	addOrCondition('series', config.series)
+	addOrCondition('liquipediatier', config.tier)
+	addOrCondition('liquipediatiertype', config.tierType)
+	addOrCondition('placement', config.placements)
+	addOrCondition('opponenttype', config.opponentTypes)
+
+	local endDate = config.endDate or TODAY
+	addOrCondition('date', {endDate, '<' .. endDate})
+
+	if not config.external then
+		conditions:add{ConditionNode(ColumnName('prizepoolindex'), Comparator.eq, 1)}
+	end
+
+	if not config.noNumber then
+		conditions:add{ConditionNode(ColumnName('extradata_seriesnumber'), Comparator.eq, '!')}
+	end
+
+	if config.startDate then
+		addOrCondition('date', {config.startDate, '>' .. config.startDate})
+	end
+
+	return conditions:toString() .. config.additionalConditions
+end
+
+---@return Html?
+function MedalStats:create()
+	error('The `:create()` function has to be part of part of the specific module')
+end
+
+---@return table<string, integer>
+function MedalStats:setUpPlacementData()
+	return Table.merge(Table.map(self.config.placements, function(key, placement)
+		return placement, 0
+	end), {total = 0})
+end
+
+---@param getIdentifier fun(placement: SeriesMedalStatsPlacementObject): string?
+---@param placement SeriesMedalStatsPlacementObject
+function MedalStats:processByIdentifier(getIdentifier, placement)
+	local identifier = getIdentifier(placement)
+	if String.isEmpty(identifier) then return end
+	---@cast identifier -nil
+
+	local seriesNumber = tonumber((placement.extradata or {}).seriesnumber) or 0
+	local offset = self.config.offset
+	local limit = self.config.limit
+	if (offset and seriesNumber <= offset) or (limit and seriesNumber > limit) then
+		return
+	end
+
+	self.data[identifier] = self.data[identifier] or self:setUpPlacementData()
+	self.data[identifier][placement.placement] = self.data[identifier][placement.placement] + 1
+	self.data[identifier].total = self.data[identifier].total + 1
+end
+
+function MedalStats:sort()
+	self.data = Table.map(self.data, function(identifier, data)
+		data.identifier = identifier
+		return identifier, data
+	end)
+	self.dataAsArray = Array.extractValues(self.data)
+	self.data = nil
+	table.sort(self.dataAsArray, MedalStats.compare)
+end
+
+---@param row1 SeriesMedalStatsDataSet
+---@param row2 SeriesMedalStatsDataSet
+---@return boolean
+function MedalStats.compare(row1, row2)
+	local isNotEqual = function(key)
+		return (row1[key] or 0) ~= (row2[key] or 0)
+	end
+	local compare = function(key)
+		return (row1[key] or 0) > (row2[key] or 0)
+	end
+
+	if isNotEqual('1') then return compare('1') end
+	if isNotEqual('2') then return compare('2') end
+	if isNotEqual('3') then return compare('3') end
+	if isNotEqual('3-4') then return compare('3-4') end
+	if isNotEqual('4') then return compare('4') end
+
+	return row1.identifier:lower() < row2.identifier:lower()
+end
+
+---@param nameDisplay fun(identifier: string):string|Html
+---@param title string
+---@param cutAfterPartial string
+---@return Html?
+function MedalStats:defaultBuild(nameDisplay, title, cutAfterPartial)
+	if Table.isEmpty(self.dataAsArray) then
+		return
+	end
+	local display = mw.html.create('table')
+		:addClass('wikitable wikitable-striped wikitable-bordered prizepooltable collapsed')
+		:css('text-align', 'center')
+		:attr('data-cutafter', self.config.cutAfter)
+		:attr('data-opentext', 'Show remaining ' .. cutAfterPartial)
+		:attr('data-closetext', 'Hide remaining ' .. cutAfterPartial)
+		:node(self:header(title))
+
+	Array.forEach(self.dataAsArray, function(dataSet)
+		display:node(self:row(dataSet, nameDisplay))
+	end)
+
+	return display
+end
+
+---@param title string
+---@return Html
+function MedalStats:header(title)
+	local header = mw.html.create('tr')
+		:tag('th'):wikitext(title):done()
+
+	for _, place in ipairs(self.config.placements) do
+		header:tag('th'):wikitext(Medal[place])
+	end
+
+	header:tag('th'):css('text-weight', 'bold'):wikitext('Total')
+
+	return header
+end
+
+---@param dataSet SeriesMedalStatsDataSet
+---@param nameDisplay fun(identifier: string):string|Html
+---@return Html
+function MedalStats:row(dataSet, nameDisplay)
+	local row = mw.html.create('tr')
+		:tag('td')
+			:css('text-align', 'left')
+			:node(nameDisplay(dataSet.identifier))
+			:done()
+
+	for _, place in ipairs(self.config.placements) do
+		row:tag('td'):wikitext(dataSet[place])
+	end
+
+	row:tag('td'):css('font-weight', 'bold'):wikitext(dataSet.total)
+
+	return row
+end
+
+return MedalStats

--- a/components/medal_stats/series_medal_stats_faction.lua
+++ b/components/medal_stats/series_medal_stats_faction.lua
@@ -1,0 +1,56 @@
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Faction = require('Module:Faction')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+
+local MedalStatsBase = Lua.import('Module:SeriesMedalStats', {requireDevIfEnabled = true})
+
+---@class SeriesMedalStatsFaction: SeriesMedalStats
+local MedalStats = Class.new(MedalStatsBase)
+
+function MedalStats.run(frame)
+	local args = Arguments.getArgs(frame)
+
+	--only query for solo opponents (only for them faction stats make sense)
+	args.opponentTypes = Opponent.solo
+
+	return MedalStats(args):query():create()
+end
+
+---@return Html?
+function MedalStats:create()
+	if Table.isEmpty(self.rawData) then return end
+
+	self:_processData()
+
+	local nameDisplay = function(identifier)
+		return Faction.Icon{faction = identifier, showLink = false} .. ' ' .. Faction.toName(identifier)
+	end
+
+	return self:defaultBuild(nameDisplay, self.args.title or 'Race', self.args.cutAfterPartial or 'Races')
+end
+
+function MedalStats:_processData()
+	---@param placement SeriesMedalStatsPlacementObject
+	---@return string?
+	local getIdentifier = function(placement)
+		return (placement.opponentplayers or {}).p1faction
+	end
+
+	self.data = {}
+
+	Array.forEach(self.rawData, function(placement)
+		return self:processByIdentifier(getIdentifier, placement)
+	end)
+
+	self.rawData = nil
+
+	self:sort()
+end
+
+return MedalStats

--- a/components/medal_stats/series_medal_stats_flag.lua
+++ b/components/medal_stats/series_medal_stats_flag.lua
@@ -1,0 +1,56 @@
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Flags = require('Module:Flags')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+
+local MedalStatsBase = Lua.import('Module:SeriesMedalStats', {requireDevIfEnabled = true})
+
+---@class SeriesMedalStatsFlag: SeriesMedalStats
+local MedalStats = Class.new(MedalStatsBase)
+
+function MedalStats.run(frame)
+	local args = Arguments.getArgs(frame)
+
+	--only query for solo opponents (only for them flag stats make sense)
+	args.opponentTypes = Opponent.solo
+
+	return MedalStats(args):query():create()
+end
+
+---@return Html?
+function MedalStats:create()
+	if Table.isEmpty(self.rawData) then return end
+
+	self:_processData()
+
+	local nameDisplay = function(identifier)
+		return Flags.Icon{flag = identifier, shouldLink = false} .. ' ' .. Flags.CountryName(identifier)
+	end
+
+	return self:defaultBuild(nameDisplay, 'Country', 'Countries')
+end
+
+function MedalStats:_processData()
+	---@param placement SeriesMedalStatsPlacementObject
+	---@return string?
+	local getIdentifier = function(placement)
+		return (placement.opponentplayers or {}).p1flag
+	end
+
+	self.data = {}
+
+	Array.forEach(self.rawData, function(placement)
+		return self:processByIdentifier(getIdentifier, placement)
+	end)
+
+	self.rawData = nil
+
+	self:sort()
+end
+
+return MedalStats

--- a/components/medal_stats/series_medal_stats_participant.lua
+++ b/components/medal_stats/series_medal_stats_participant.lua
@@ -1,0 +1,99 @@
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
+local MedalStatsBase = Lua.import('Module:SeriesMedalStats', {requireDevIfEnabled = true})
+
+---@class SeriesMedalStatsParticipant: SeriesMedalStats
+---@field teams table<string, string>
+local MedalStats = Class.new(MedalStatsBase)
+
+function MedalStats.run(frame)
+	local args = Arguments.getArgs(frame)
+
+	--only query for solo opponents (only for them participantTeam stats make sense)
+	args.opponentTypes = Opponent.solo
+
+	return MedalStats(args):query():create()
+end
+
+---@return Html?
+function MedalStats:create()
+	if Table.isEmpty(self.rawData) then return end
+
+	self:_processData()
+
+	local nameDisplay = function(identifier)
+		return OpponentDisplay.BlockOpponent{opponent = self.opponents[identifier]}
+	end
+
+	return self:defaultBuild(nameDisplay, 'Participant', 'Participants')
+end
+
+function MedalStats:_processData()
+	self.teams = {}
+	self.opponents = {}
+
+	---@param teamTemplate string
+	---@return string?
+	local resolveTeamToIdentifier = function(teamTemplate)
+		local rawData = mw.ext.TeamTemplate.raw(teamTemplate)
+
+		if not rawData or not rawData.page then return end
+
+		local identifier = mw.ext.TeamLiquidIntegration.resolve_redirect(rawData.page):lower()
+
+		self.teams[teamTemplate] = identifier
+
+		return identifier
+	end
+
+	---@param placement SeriesMedalStatsPlacementObject
+	---@return string?
+	local getIdentifier = function(placement)
+		if placement.opponenttype == Opponent.literal or not placement.opponentname then return end
+
+		if placement.opponenttype ~= Opponent.team then
+			local identifier = placement.opponentname
+			self.opponents[identifier] = Opponent.fromLpdbStruct(placement)
+
+			if Opponent.isTbd(self.opponents[identifier]) then return end
+
+			return identifier
+		end
+
+		local teamTemplate = placement.opponentname
+		if String.isEmpty(teamTemplate) then
+			return
+		end
+		---@cast teamTemplate -nil
+
+		teamTemplate = teamTemplate:lower():gsub('_', ' ')
+
+		local identifier = self.teams[teamTemplate] or resolveTeamToIdentifier(teamTemplate)
+		self.opponents[identifier] = Opponent.fromLpdbStruct(placement)
+
+		if Opponent.isTbd(self.opponents[identifier]) then return end
+
+		return identifier
+	end
+
+	self.data = {}
+
+	Array.forEach(self.rawData, function(placement)
+		return self:processByIdentifier(getIdentifier, placement)
+	end)
+
+	self.rawData = nil
+
+	self:sort()
+end
+
+return MedalStats

--- a/components/medal_stats/series_medal_stats_participantTeam.lua
+++ b/components/medal_stats/series_medal_stats_participantTeam.lua
@@ -1,0 +1,92 @@
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+
+local MedalStatsBase = Lua.import('Module:SeriesMedalStats', {requireDevIfEnabled = true})
+
+---@class SeriesMedalStatsParticipantTeam: SeriesMedalStats
+---@field teams table<string, string>
+local MedalStats = Class.new(MedalStatsBase)
+
+function MedalStats.run(frame)
+	local args = Arguments.getArgs(frame)
+
+	--only query for solo opponents (only for them participantTeam stats make sense)
+	args.opponentTypes = Opponent.solo
+
+	--reduce due to having text above
+	args.cutafter = tonumber(args.cutafter) or 5
+
+	return MedalStats(args):query():create()
+end
+
+---@return Html?
+function MedalStats:create()
+	if Table.isEmpty(self.rawData) then return end
+
+	self:_processData()
+
+	local nameDisplay = function(identifier)
+		return mw.ext.TeamTemplate.team(identifier)
+	end
+
+	local display = self:defaultBuild(nameDisplay, 'Team', 'Teams')
+	if not display then return end
+
+	return mw.html.create()
+		:tag('b'):wikitext('Note'):done()
+		:wikitext(': Medals won per Team shows the team that a player was<br>on when the medal was won, ')
+		:tag('b'):wikitext('not'):done()
+		:wikitext(' their current team.')
+		:node(display)
+end
+
+function MedalStats:_processData()
+	self.teams = {}
+
+	---@param teamTemplate string
+	---@return string?
+	local resolveTeamToIdentifier = function(teamTemplate)
+		local rawData = mw.ext.TeamTemplate.raw(teamTemplate)
+
+		if not rawData or not rawData.page then return end
+
+		local identifier = mw.ext.TeamLiquidIntegration.resolve_redirect(rawData.page):lower()
+
+		self.teams[teamTemplate] = identifier
+
+		return identifier
+	end
+
+	---@param placement SeriesMedalStatsPlacementObject
+	---@return string?
+	local getIdentifier = function(placement)
+		local teamTemplate = (placement.opponentplayers or {}).p1team
+		if String.isEmpty(teamTemplate) then
+			return
+		end
+		---@cast teamTemplate -nil
+
+		teamTemplate = teamTemplate:lower():gsub('_', ' ')
+
+		return self.teams[teamTemplate] or resolveTeamToIdentifier(teamTemplate)
+	end
+
+	self.data = {}
+
+	Array.forEach(self.rawData, function(placement)
+		return self:processByIdentifier(getIdentifier, placement)
+	end)
+
+	self.rawData = nil
+
+	self:sort()
+end
+
+return MedalStats


### PR DESCRIPTION
## Summary
Add medal stats modules. Those are cleanly rewritten modules originating from sc2.
The faction version will probably be only usable on SC/SC2/WC/Stormgat.
The ParticipantTeam and Flag ones should be usable on all 1v1 bases series and the Participant one should be usable for all series pages on all wikis that have standardized prize pool data.

## How did you test this change?
"live" (new modules replacing the old shitty ones)