### PR TITLE
feat: Make parent Class available in WidgetInjector if passed along

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -54,7 +54,7 @@ end
 ---@param injector WidgetInjector?
 ---@return self
 function Infobox:widgetInjector(injector)
-	self.injector = injector
+	self.injector = injector or self.injector
 	return self
 end
 

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -33,10 +33,10 @@ local BasicInfobox = Class.new(
 	end
 )
 
----@param Injector WidgetInjector?
+---@param injector WidgetInjector?
 ---@return self
-function BasicInfobox:setWidgetInjector(Injector)
-	self.infobox:widgetInjector(Injector)
+function BasicInfobox:setWidgetInjector(injector)
+	self.infobox:widgetInjector(injector)
 	return self
 end
 

--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -33,6 +33,13 @@ local BasicInfobox = Class.new(
 	end
 )
 
+---@param Injector WidgetInjector?
+---@return self
+function BasicInfobox:setWidgetInjector(Injector)
+	self.infobox:widgetInjector(Injector)
+	return self
+end
+
 ---Creates an empty WidgetInjector
 ---@return WidgetInjector?
 function BasicInfobox:createWidgetInjector()

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -34,4 +34,3 @@ function Injector:addCustomCells(widgets)
 end
 
 return Injector
-

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -10,12 +10,12 @@ local Class = require('Module:Class')
 
 ---@class WidgetInjector
 ---@operator call(table?): WidgetInjector
----@field parent table?
+---@field caller table?
 local Injector = Class.new(
 	---@param self self
-	---@param parent table?
-	function(self, parent)
-		self.parent = parent
+	---@param caller table?
+	function(self, caller)
+		self.caller = caller
 end)
 
 ---Parses the widgets

--- a/components/infobox/commons/infobox_widget_injector.lua
+++ b/components/infobox/commons/infobox_widget_injector.lua
@@ -9,7 +9,14 @@
 local Class = require('Module:Class')
 
 ---@class WidgetInjector
-local Injector = Class.new()
+---@operator call(table?): WidgetInjector
+---@field parent table?
+local Injector = Class.new(
+	---@param self self
+	---@param parent table?
+	function(self, parent)
+		self.parent = parent
+end)
 
 ---Parses the widgets
 ---@param id string

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -53,12 +53,12 @@ local CICON = '[[File:CIcon.png|text-bottom|Challenger League]]'
 
 function CustomLeague.run(frame)
 	local league = League(frame)
+	league:setWidgetInjector(CustomInjector(league))
 	_league = league
 
 	league.args.game = league.args.game == GAME_MOD and GAME_MOD or Game.name{game = league.args.game}
 	league.args.liquipediatiertype = league.args.liquipediatiertype or league.args.tiertype
 
-	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.addToLpdb = CustomLeague.addToLpdb
 	league.shouldStore = CustomLeague.shouldStore
@@ -66,10 +66,6 @@ function CustomLeague.run(frame)
 	league.getWikiCategories = CustomLeague.getWikiCategories
 
 	return league:createInfobox()
-end
-
-function CustomLeague:createWidgetInjector()
-	return CustomInjector(self)
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -64,7 +64,7 @@ function CustomLeague:createWidgetInjector()
 end
 
 function CustomInjector:parse(id, widgets)
-	local args = self.parent.args
+	local args = self.caller.args
 	if id == 'gamesettings' then
 		return {
 			Cell{name = 'Game version', content = {
@@ -116,17 +116,17 @@ function CustomInjector:parse(id, widgets)
 		--maps
 		if String.isNotEmpty(args.map1) then
 			table.insert(widgets, Title{name = args['maptitle'] or 'Maps'})
-			table.insert(widgets, Center{content = self.parent:_mapsDisplay('map')})
+			table.insert(widgets, Center{content = self.caller:_mapsDisplay('map')})
 		end
 
 		if String.isNotEmpty(args['2map1']) then
 			table.insert(widgets, Title{name = args['2maptitle'] or '2v2 Maps'})
-			table.insert(widgets, Center{content = self.parent:_mapsDisplay('2map')})
+			table.insert(widgets, Center{content = self.caller:_mapsDisplay('2map')})
 		end
 
 		if String.isNotEmpty(args['3map1']) then
 			table.insert(widgets, Title{name = args['3maptitle'] or '3v3 Maps'})
-			table.insert(widgets, Center{content = self.parent:_mapsDisplay('3map')})
+			table.insert(widgets, Center{content = self.caller:_mapsDisplay('3map')})
 		end
 	end
 	return widgets


### PR DESCRIPTION
is thiss generally a good idea?

## Summary
- Make parent Class available in WidgetInjector if passed along
  - with that we also have access to args etc.
- as an example usage updates sc2 infobox league accordingly
  - this infobox still needs a proper cleanup afterwards (incl. adding annos), it is just here as poc

## How did you test this change?
dev
tested without the updates to the /Custom also and it doesn't break anything there too

## Todo after the PR (sep. PRs, probably mostly wiki by wiki):
- clean up all infoboxes to get rid of `_args` and `_league` (and similar)
  - might clean up the infoboxes a bit here and there while doing that (and also add remaining annos)