### PR TITLE
feat: remove lrthread

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -366,7 +366,6 @@ Match.matchFields = Table.map({
 	'links',
 	'liquipediatier',
 	'liquipediatiertype',
-	'lrthread',
 	'match2bracketdata',
 	'match2bracketid',
 	'match2id',

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -27,17 +27,12 @@ local LEFT_SIDE = 1
 local ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|First pick]]'
 local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|First pick]]'
 
-local htmlCreate = mw.html.create
-
 local GREEN_CHECK = '<i class="fa fa-check forest-green-text" style="width: 14px; text-align: center" ></i>'
 local ICONS = {
 	check = GREEN_CHECK,
 }
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
-local LINK_DATA = {
-	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
-}
+local LINK_DATA = {}
 
 local CustomMatchSummary = {}
 
@@ -273,7 +268,7 @@ end
 ---@return Html
 function CustomMatchSummary._gameScore(game, opponentIndex)
 	local score = game.scores[opponentIndex] or ''
-	return htmlCreate('div'):wikitext(score)
+	return mw.html.create('div'):wikitext(score)
 end
 
 ---@param game MatchGroupUtilGame
@@ -283,7 +278,7 @@ function CustomMatchSummary._createMapRow(game)
 
 	-- Add Header
 	if Logic.isNotEmpty(game.header) then
-		local mapHeader = htmlCreate('div')
+		local mapHeader = mw.html.create('div')
 			:wikitext(game.header)
 			:css('font-weight','bold')
 			:css('font-size','85%')
@@ -292,7 +287,7 @@ function CustomMatchSummary._createMapRow(game)
 		row:addElement(MatchSummary.Break():create())
 	end
 
-	local centerNode = htmlCreate('div')
+	local centerNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
 		:wikitext(CustomMatchSummary._getMapDisplay(game))
 		:css('text-align', 'center')
@@ -301,12 +296,12 @@ function CustomMatchSummary._createMapRow(game)
 		centerNode:addClass('brkts-popup-spaced-map-skip')
 	end
 
-	local leftNode = htmlCreate('div')
+	local leftNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
 		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 1, 'check'))
 		:node(CustomMatchSummary._gameScore(game, 1))
 
-	local rightNode = htmlCreate('div')
+	local rightNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
 		:node(CustomMatchSummary._gameScore(game, 2))
 		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 2, 'check'))
@@ -321,7 +316,7 @@ function CustomMatchSummary._createMapRow(game)
 	-- Add Comment
 	if Logic.isNotEmpty(game.comment) then
 		row:addElement(MatchSummary.Break():create())
-		local comment = htmlCreate('div')
+		local comment = mw.html.create('div')
 			:wikitext(game.comment)
 			:css('margin', 'auto')
 		row:addElement(comment)
@@ -344,7 +339,7 @@ end
 ---@param iconType string
 ---@return Html
 function CustomMatchSummary._createCheckMarkOrCross(showIcon, iconType)
-	local container = htmlCreate('div')
+	local container = mw.html.create('div')
 	container:addClass('brkts-popup-spaced'):css('line-height', '27px')
 
 	if showIcon then

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -342,7 +342,6 @@ end
 function matchFunctions.getLinks(match)
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
-	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))
 
 	match.links = {}
 

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -291,12 +291,8 @@ function matchFunctions.getVodStuff(match)
 
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
-	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))
-
 	match.links = {}
 	local links = match.links
-	if match.preview then links.preview = match.preview end
-	if match.esl then links.esl = 'https://play.eslgaming.com/match/' .. match.esl end
 	if match.faceit then links.faceit = 'https://www.faceit.com/en/halo_infinite/room/' .. match.faceit end
 	if match.halodatahive then links.halodatahive = 'https://halodatahive.com/Series/Summary/' .. match.halodatahive end
 	if match.stats then links.stats = match.stats end

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -26,13 +26,6 @@ local GREEN_CHECK = '<i class="fa fa-check forest-green-text" style="width: 14px
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 local LINK_DATA = {
-	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
-	esl = {
-		icon = 'File:ESL_2019_icon_lightmode.png',
-		iconDark = 'File:ESL_2019_icon_darkmode.png',
-		text = 'Match page on ESL'
-	},
 	faceit = {icon = 'File:FACEIT-icon.png', text = 'Match page on FACEIT'},
 	halodatahive = {icon = 'File:Halo Data Hive allmode.png',text = 'Match page on Halo Data Hive'},
 	headtohead = {

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -290,11 +290,8 @@ function matchFunctions.getVodStuff(match)
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
-	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))
-
 	match.links = {}
 	local links = match.links
-	if match.preview then links.preview = match.preview end
 	if match.esl then links.esl = 'https://play.eslgaming.com/match/' .. match.esl end
 	if match.owl then links.owl = 'https://overwatchleague.com/en-us/match/' .. match.owl end
 	if match.owc then links.owc = 'https://www.overwatchcontenders.com/match/details/' .. match.owc end

--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -27,8 +27,6 @@ local ICONS = {
 }
 
 local LINK_DATA = {
-	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 	esl = {
 		icon = 'File:ESL_2019_icon_lightmode.png',
 		iconDark = 'File:ESL_2019_icon_darkmode.png',

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -306,7 +306,6 @@ function matchFunctions.getVodStuff(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
 	match.links = {
-		preview = match.preview,
 		stats = match.stats,
 		siegegg = match.siegegg and 'https://siege.gg/matches/' .. match.siegegg or nil,
 		opl = match.opl and 'https://www.opleague.eu/match/' .. match.opl or nil,

--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -32,8 +32,6 @@ local ROUND_ICONS = {
 local ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]'
 local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
 local LINK_DATA = {
-	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 	siegegg = {icon = 'File:SiegeGG icon.png', text = 'SiegeGG Match Page'},
 	opl = {icon = 'File:OPL Icon 2023 allmode.png', text = 'OPL Match Page'},
 	esl = {

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -305,11 +305,8 @@ function matchFunctions.getVodStuff(match)
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
-	match.lrthread = Logic.emptyOr(match.lrthread, Variables.varDefault('lrthread'))
-
 	match.links = {}
 	local links = match.links
-	if match.preview then links.preview = match.preview end
 	if match.esl then links.esl = 'https://play.eslgaming.com/match/' .. match.esl end
 	if match.stats then links.stats = match.stats end
 

--- a/components/match2/wikis/splitgate/match_summary.lua
+++ b/components/match2/wikis/splitgate/match_summary.lua
@@ -23,8 +23,6 @@ local ICONS = {
 }
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 local LINK_DATA = {
-	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
-	lrthread = {icon = 'File:LiveReport32.png', text = 'LiveReport.png'},
 }
 
 local CustomMatchSummary = {}

--- a/components/match2/wikis/starcraft/match_legacy.lua
+++ b/components/match2/wikis/starcraft/match_legacy.lua
@@ -105,7 +105,6 @@ function MatchLegacy._storeGames(match, match2, options)
 			submatch.date = game.date
 			submatch.dateexact = match2.dateexact or ''
 			submatch.stream = match2.stream
-			submatch.lrthread = match2.lrthread or ''
 			submatch.vod = game.vod
 			submatch.tournament = match2.tournament
 			submatch.tickername = match2.tickername

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -30,7 +30,7 @@ local CONVERT_STATUS_INPUT = {W = 'W', FF = 'FF', L = 'L', DQ = 'DQ', ['-'] = 'L
 local DEFAULT_LOSS_STATUSES = {'FF', 'L', 'DQ'}
 local MAX_NUM_OPPONENTS = 2
 local DEFAULT_BEST_OF = 99
-local LINKS_KEYS = {'preview', 'preview2', 'interview', 'interview2', 'review', 'recap', 'lrthread'}
+local LINKS_KEYS = {'preview', 'preview2', 'interview', 'interview2', 'review', 'recap'}
 local MODE_MIXED = 'mixed'
 local TBD = 'tbd'
 local NEUTRAL_HERO_FACTION = 'neutral'

--- a/components/match2/wikis/warcraft/match_summary.lua
+++ b/components/match2/wikis/warcraft/match_summary.lua
@@ -35,7 +35,6 @@ local LINKS_DATA = {
 	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
 	interview = {icon = 'File:Interview32.png', text = 'Interview'},
 	review = {icon = 'File:Reviews32.png', text = 'Review'},
-	lrthread = {icon = 'File:LiveReport32.png', text = 'Live Report Thread'},
 	h2h = {icon = 'File:Match Info Stats.png', text = 'Head-to-head statistics'},
 }
 LINKS_DATA.preview2 = LINKS_DATA.preview


### PR DESCRIPTION
## Summary

Remove LRThreads field storage. Removed it entirely on wikis that didn't have any usages of it. Took out a few cases of unused `preview` too while at it