### PR TITLE
Prepare for killing `addCustomCells`

### DIFF
--- a/components/infobox/commons/infobox_widget_customizable.lua
+++ b/components/infobox/commons/infobox_widget_customizable.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Infobox/Widget', {requireDevIfEnabled = true})
@@ -29,7 +30,9 @@ function Customizable:make()
 		return self.children
 	end
 	if self.id == 'custom' then
-		return self.context.injector:addCustomCells(self.children)
+		local widgets = Logic.emptyOr(self.context.injector:addCustomCells(self.children), self.children, {})
+		---@cast widgets -nil
+		self.children = widgets
 	end
 	return self.context.injector:parse(self.id, self.children)
 end


### PR DESCRIPTION
## Summary
Prepare for killing `addCustomCells` and moving it into parse.
These changes technically allow for `addCustomCells` usage while also having `custom` in `:parse`.
The intention is to be able to progress away from `:addCustomCells` entirely and move them all into `:parse`.
AFTER all customs have been adjusted we can remove the entire if

## How did you test this change?
/dev, together with #3663