### PR TITLE
feat: Add `Json.parseStringified()` for parsing escaped JSON strings

### DIFF
--- a/standard/json.lua
+++ b/standard/json.lua
@@ -9,6 +9,7 @@
 local Json = {}
 
 local Arguments = require('Module:Arguments')
+local Table = require('Module:Table')
 
 ---Json-stringifies all arguments from a supplied frame.
 ---@param frame Frame
@@ -103,6 +104,20 @@ function Json.parseIfTable(any)
 		end
 	end
 	return nil
+end
+
+---Parses a given JSON input from a template call to `Json.stringify()`.
+---If the parse fails it returns the original input.
+---Second return value boolean indicates a failed parse.
+---@param obj string
+---@return table, boolean
+---@overload fun(obj: any): any, boolean
+function Json.parseStringified(str)
+	local tbl = Json.parseIfTable(str)
+	if not tbl then
+		return str, true
+	end
+	return Table.mapValues(tbl, Json.parseStringified), false
 end
 
 return Json

--- a/standard/test/json_test.lua
+++ b/standard/test/json_test.lua
@@ -61,4 +61,21 @@ function suite:testStringifySubTables()
 	self:assertDeepEquals({a = '{"d":1,"b":"c"}', e = 'f'}, Json.stringifySubTables{a = {b = 'c', d = 1}, e = 'f'})
 end
 
+function suite:testParseStringified()
+	self:assertDeepEquals({}, (Json.parseStringified(Json.stringify{})))
+	self:assertDeepEquals({abc = 'def'}, (Json.parseStringified(Json.stringify{abc = 'def'})))
+	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parseStringified(Json.stringify{abc = {'b', 'c'}})))
+	self:assertDeepEquals(mw.loadData('Module:Flags/MasterData'), (Json.parseStringified(Json.stringify(mw.loadData('Module:Flags/MasterData')))))
+	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified(Json.stringify({1, 2, 3}, {asArray = true}))))
+	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified(Json.stringify{1, 2, 3})))
+
+	self:assertDeepEquals({}, (Json.parseStringified('[]')))
+	self:assertDeepEquals(nil, (Json.parseStringified()))
+	self:assertDeepEquals('string', (Json.parseStringified('string')))
+	self:assertDeepEquals({abc = 'def'}, (Json.parseStringified('{"abc":"def"}')))
+	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parseStringified('{"abc":{"1":"b","2":"c"}}')))
+	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified('[1,2,3]')))
+	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified('{"1":1,"2":2,"3":3}')))
+end
+
 return suite

--- a/standard/test/json_test.lua
+++ b/standard/test/json_test.lua
@@ -69,6 +69,9 @@ function suite:testParseStringified()
 	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified(Json.stringify({1, 2, 3}, {asArray = true}))))
 	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified(Json.stringify{1, 2, 3})))
 
+	self:assertDeepEquals({abc = {'b', 'c'}, b = {'a', 'c'}}, (Json.parseStringified(Json.stringify{abc = {'b', 'c'}, b = Json.stringify{'a', 'c'}})))
+	self:assertDeepEquals({abc = {'b', 'c'}, b = {'a', 'c'}}, (Json.parseStringified('{"b":"{\\"1\\":\\"a\\",\\"2\\":\\"c\\"}","abc":{"1":"b","2":"c"}}')))
+
 	self:assertDeepEquals({}, (Json.parseStringified('[]')))
 	self:assertDeepEquals(nil, (Json.parseStringified()))
 	self:assertDeepEquals('string', (Json.parseStringified('string')))

--- a/standard/test/json_test.lua
+++ b/standard/test/json_test.lua
@@ -65,12 +65,21 @@ function suite:testParseStringified()
 	self:assertDeepEquals({}, (Json.parseStringified(Json.stringify{})))
 	self:assertDeepEquals({abc = 'def'}, (Json.parseStringified(Json.stringify{abc = 'def'})))
 	self:assertDeepEquals({abc = {'b', 'c'}}, (Json.parseStringified(Json.stringify{abc = {'b', 'c'}})))
-	self:assertDeepEquals(mw.loadData('Module:Flags/MasterData'), (Json.parseStringified(Json.stringify(mw.loadData('Module:Flags/MasterData')))))
+	self:assertDeepEquals(
+		mw.loadData('Module:Flags/MasterData'),
+		(Json.parseStringified(Json.stringify(mw.loadData('Module:Flags/MasterData'))))
+	)
 	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified(Json.stringify({1, 2, 3}, {asArray = true}))))
 	self:assertDeepEquals({1, 2, 3}, (Json.parseStringified(Json.stringify{1, 2, 3})))
 
-	self:assertDeepEquals({abc = {'b', 'c'}, b = {'a', 'c'}}, (Json.parseStringified(Json.stringify{abc = {'b', 'c'}, b = Json.stringify{'a', 'c'}})))
-	self:assertDeepEquals({abc = {'b', 'c'}, b = {'a', 'c'}}, (Json.parseStringified('{"b":"{\\"1\\":\\"a\\",\\"2\\":\\"c\\"}","abc":{"1":"b","2":"c"}}')))
+	self:assertDeepEquals(
+		{abc = {'b', 'c'}, b = {'a', 'c'}},
+		(Json.parseStringified(Json.stringify{abc = {'b', 'c'}, b = Json.stringify{'a', 'c'}}))
+	)
+	self:assertDeepEquals(
+		{abc = {'b', 'c'}, b = {'a', 'c'}},
+		(Json.parseStringified('{"b":"{\\"1\\":\\"a\\",\\"2\\":\\"c\\"}","abc":{"1":"b","2":"c"}}'))
+	)
 
 	self:assertDeepEquals({}, (Json.parseStringified('[]')))
 	self:assertDeepEquals(nil, (Json.parseStringified()))


### PR DESCRIPTION
## Summary

As part of #3524, allow a single method to parse a whole nested sequence of `{{Json}}` template calls. Also works without any nested escaped JSONs.

## How did you test this change?

`/dev` and testcases.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/851ef51b-6083-43fd-b1b8-271d48c9f3f2)

