### PR TITLE
Removing toccolours hardcoded colors

### DIFF
--- a/stylesheets/commons/Colours.css
+++ b/stylesheets/commons/Colours.css
@@ -689,6 +689,11 @@ ul.nav-tabs li.game-wiiu,
 	border-color: var( --clr-cinnabar-80, #ee6767 );
 }
 
+/* MEDIAWIKI OVERRIDE */
+.toccolours {
+	background-color: var( --clr-surface-1, #f8f9fa );
+}
+
 /* ICON IN VISITED LINK COLOR FIX */
 .brkts-popup-body-element a:visited {
 	& .fad,


### PR DESCRIPTION
## Summary

This is a hard fix for the _toccolours_ Mediawiki class that uses hard colors (which clashes with dark mode). Example here:
https://liquipedia.net/mobilelegends/M5_World_Championship
![image](https://github.com/Liquipedia/Lua-Modules/assets/32543621/0cc93543-47e0-446e-a6f9-a86e45be8ee0)

Note: Not sure if this is the correct place for the fix

## How did you test this change?

In my test environment: http://killian.wiki.tldev.eu/rocketleague/Test_Background
