### PR TITLE
Moving hard coded stat row color to var

### DIFF
--- a/stylesheets/commons/Miscellaneous.css
+++ b/stylesheets/commons/Miscellaneous.css
@@ -2422,7 +2422,7 @@ Template(s): Match Page CSS
 Author(s): iMarbot
 *******************************************************************************/
 tr.stats-row:nth-child( 2n+1 ) {
-	background-color: #f5f5f5;
+	background-color: var( --clr-surface-2, #f5f5f5 );
 }
 
 @media ( max-width: 599px ) {


### PR DESCRIPTION
## Summary

To rollout Mobile Legends dark mode, we are fixing some spots where colors are still hardcoded. This solves the stream page as bellow:
![image](https://github.com/Liquipedia/Lua-Modules/assets/32543621/b790a171-01dc-455d-854c-d9354b1e03a6)