### PR TITLE
Force TBD maps in matches to not link

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -232,6 +232,8 @@ end
 ---@param options {noLink: boolean}?
 ---@return (Html|string)[]
 function StarcraftMatchSummary.Game(game, options)
+	options = options or {}
+	options.noLink = options.noLink or (game.map or ''):upper() == TBD
 	local getWinnerIcon = function(opponentIndex)
 		return StarcraftMatchSummary.toIcon(game.resultType == 'draw' and 'yellowLine'
 			or game.winner == opponentIndex and 'greenCheck')


### PR DESCRIPTION
## Summary
This little 1 line change forces `TBD` maps in starcraft/starcraft2/stormgate matches to not link the TBD.

## How did you test this change?
dev
![Screenshot 2023-12-20 123033](https://github.com/Liquipedia/Lua-Modules/assets/75081997/c4ec9c71-2484-4391-88f5-e5b7f2014256)
![Screenshot 2023-12-20 123055](https://github.com/Liquipedia/Lua-Modules/assets/75081997/ce4f1f67-e981-4b0c-a172-0deddedf451c)
