### PR TITLE
css: Make matchticker versus score more compact

### DIFF
--- a/stylesheets/commons/Mainpage.css
+++ b/stylesheets/commons/Mainpage.css
@@ -332,7 +332,7 @@ table.infobox_matches_content {
 .infobox_matches_content .versus {
 	width: 4%;
 	text-align: center;
-	vertical-align: baseline;
+	padding: 0 5px;
 }
 
 .infobox_matches_content .versus-lower {

--- a/stylesheets/commons/Mainpage.css
+++ b/stylesheets/commons/Mainpage.css
@@ -332,7 +332,7 @@ table.infobox_matches_content {
 .infobox_matches_content .versus {
 	width: 4%;
 	text-align: center;
-	padding: 0 5px;
+	padding: 2px 5px;
 }
 
 .infobox_matches_content .versus-lower {


### PR DESCRIPTION
## Summary

The new match ticker takes up more vertical space than the old one. A small css change to make it like the old one and vertically center the score/versus text.

| Old Ticker | New Ticker | Compact Ticker |
|--------|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/6404107d-5a0a-4454-a80f-c65693b1200e) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/c7d38c4e-2d3b-4bbd-8a2b-78990b5eaa90) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/3e5d3704-a2c6-406d-89df-9e7adc69be2d) | 

## How did you test this change?

Using browser dev tools.
