### PR TITLE
fix(matchticker): live matches missing opponent scores

### DIFF
--- a/components/match_ticker/commons/match_ticker_display_components.lua
+++ b/components/match_ticker/commons/match_ticker_display_components.lua
@@ -132,7 +132,7 @@ function Versus:scores()
 	end
 
 	Array.forEach(self.match.match2opponents, function(opponent, opponentIndex)
-		local score = opponent.status ~= SCORE_STATUS and opponent.status
+		local score = Logic.isNotEmpty(opponent.status) and opponent.status ~= SCORE_STATUS and opponent.status
 			or tonumber(opponent.score) or -1
 
 		table.insert(scores, setWinner(score ~= -1 and score or 0, opponentIndex))


### PR DESCRIPTION
## Summary

As discussed on discord for matches missing scores when first going live...

https://discord.com/channels/93055209017729024/874304000718172200/1186991934724648970

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/321ed301-592c-48c4-a082-2c8875e21625)


## How did you test this change?

tested on /dev

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/383532ad-341e-4d05-a6f4-b9d2c5d5ab23)

