### PR TITLE
fix(teamcard): inconsistent inotes height

### DIFF
--- a/stylesheets/commons/Teamcard.css
+++ b/stylesheets/commons/Teamcard.css
@@ -482,8 +482,8 @@ Author(s): iMarbot
 	z-index: 17;
 }
 
-.inotes-inner {
-	margin-bottom: -10pt;
+.inotes-inner .dl {
+	margin-bottom: 0;
 }
 
 .template-box .inotes-box {


### PR DESCRIPTION
## Summary

Something weird going on with teamcards that causes sometimes `<dl>` to be present or not. If anyone can work out why, please go ahead.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/2481b02f-eafd-4e89-928d-98ceda15a97f)

See discord for more details: https://discord.com/channels/93055209017729024/268719633366777856/1187077920318042134

Anyway, this changes the CSS styling to avoid this issue. It's cleaner this way too, no margin created, instead of creating one and then negating it later on in a parent div.

## How did you test this change?

Browser dev tools.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/15c2cdd8-bdd0-4f99-8d8a-87053f88037c)
