### PR TITLE
feat(games): Don't return fake games from `Game.listGames()`

### DIFF
--- a/standard/game.lua
+++ b/standard/game.lua
@@ -92,6 +92,10 @@ function Game.listGames(options)
 		return Array.sortBy(gamesList, getGameOrder)
 	end
 
+	Array.filter(gamesList, function(game)
+		return not game.fake
+	end)
+
 	return gamesList
 end
 

--- a/standard/game.lua
+++ b/standard/game.lua
@@ -93,7 +93,7 @@ function Game.listGames(options)
 	end
 
 	Array.filter(gamesList, function(game)
-		return not game.fake
+		return not game.unlisted
 	end)
 
 	return gamesList

--- a/standard/info/wikis/counterstrike/info.lua
+++ b/standard/info/wikis/counterstrike/info.lua
@@ -83,6 +83,7 @@ local infoData = {
 		},
 		csgocs2 = {
 			order = 6,
+			fake = true,
 			abbreviation = 'CS:GO/CS2',
 			name = 'CS:GO / CS2',
 			link = 'Counter-Strike 2',

--- a/standard/info/wikis/counterstrike/info.lua
+++ b/standard/info/wikis/counterstrike/info.lua
@@ -83,7 +83,7 @@ local infoData = {
 		},
 		csgocs2 = {
 			order = 6,
-			fake = true,
+			unlisted = true,
 			abbreviation = 'CS:GO/CS2',
 			name = 'CS:GO / CS2',
 			link = 'Counter-Strike 2',


### PR DESCRIPTION
## Summary

Due to there being fake CS2/CS:GO game on the cs wiki, it gets returned by this function but it really shouldn't. Add a param to demote fake games and then use it as a filter.

## How did you test this change?

Untested yet. Will test a bit later, but it should work. Feel free to give feedback on the name `fake`.