### PR TITLE
Redirect player ext custom

### DIFF
--- a/components/opponent/commons/player_ext_custom.lua
+++ b/components/opponent/commons/player_ext_custom.lua
@@ -1,0 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Player/Ext/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+return Lua.import('Module:Player/Ext', {requireDevIfEnabled = true})

--- a/components/opponent/wikis/starcraft/player_ext_custom.lua
+++ b/components/opponent/wikis/starcraft/player_ext_custom.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=commons
+-- wiki=starcraft
 -- page=Module:Player/Ext/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/components/opponent/wikis/starcraft/player_ext_custom.lua
+++ b/components/opponent/wikis/starcraft/player_ext_custom.lua
@@ -1,0 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Player/Ext/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+return Lua.import('Module:Player/Ext/Starcraft', {requireDevIfEnabled = true})

--- a/components/opponent/wikis/starcraft2/player_ext_custom.lua
+++ b/components/opponent/wikis/starcraft2/player_ext_custom.lua
@@ -1,0 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Player/Ext/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+return Lua.import('Module:Player/Ext/Starcraft', {requireDevIfEnabled = true})

--- a/components/opponent/wikis/starcraft2/player_ext_custom.lua
+++ b/components/opponent/wikis/starcraft2/player_ext_custom.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=commons
+-- wiki=starcraft2
 -- page=Module:Player/Ext/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute


### PR DESCRIPTION
## Summary
Redirect player ext custom on commons and sc2/sc

Reason: need it to be directly callable instead of having to check which one to use in e.g. GTL (match2 version) so i can bring it up to be usable for stormgate

## How did you test this change?
N/A
