### PR TITLE
Add stormgate custom opponent modules

### DIFF
--- a/components/opponent/wikis/stormgate/opponent_custom.lua
+++ b/components/opponent/wikis/stormgate/opponent_custom.lua
@@ -1,0 +1,145 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Faction = require('Module:Faction')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local TeamTemplate = require('Module:TeamTemplate')
+local TypeUtil = require('Module:TypeUtil')
+
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local PlayerExt = Lua.import('Module:Player/Ext/Custom', {requireDevIfEnabled = true})
+
+local CustomOpponent = Table.deepCopy(Opponent)
+
+CustomOpponent.types.Player = TypeUtil.extendStruct(Opponent.types.Player, {
+	faction = 'string?',
+})
+
+CustomOpponent.types.PartyOpponent = TypeUtil.struct{
+	players = TypeUtil.array(CustomOpponent.types.Player),
+	type = TypeUtil.literalUnion(unpack(Opponent.partyTypes)),
+}
+
+CustomOpponent.types.Opponent = TypeUtil.union(
+	Opponent.types.TeamOpponent,
+	CustomOpponent.types.PartyOpponent,
+	Opponent.types.LiteralOpponent
+)
+
+---@class StormgateStandardPlayer:standardPlayer
+---@field faction string?
+
+---@class StormgateStandardOpponent:standardOpponent
+---@field players StormgateStandardPlayer[]
+---@field isArchon boolean
+---@field isSpecialArchon boolean?
+---@field extradata table
+
+---@param args table
+---@return StormgateStandardOpponent?
+function CustomOpponent.readOpponentArgs(args)
+	local opponent = Opponent.readOpponentArgs(args) --[[@as StormgateStandardOpponent?]]
+	local partySize = Opponent.partySize((opponent or {}).type)
+
+	if not opponent then
+		return nil
+	end
+
+	if partySize == 1 then
+		opponent.players[1].faction = Faction.read(args.faction)
+	elseif partySize then
+		for playerIx, player in ipairs(opponent.players) do
+			player.faction = Faction.read(args['p' .. playerIx .. 'faction'])
+		end
+	end
+
+	return opponent
+end
+
+---@param record table
+---@return StormgateStandardOpponent?
+function CustomOpponent.fromMatch2Record(record)
+	local opponent = Opponent.fromMatch2Record(record) --[[@as StormgateStandardOpponent?]]
+
+	if not opponent then
+		return nil
+	end
+
+	if Opponent.typeIsParty(opponent.type) then
+		for playerIx, player in ipairs(opponent.players) do
+			local playerRecord = record.match2players[playerIx]
+			player.faction = Faction.read(playerRecord.extradata.faction) or Faction.defaultFaction
+		end
+	end
+
+	return opponent
+end
+
+---@param opponent StormgateStandardOpponent
+---@return table?
+function CustomOpponent.toLpdbStruct(opponent)
+	local storageStruct = Opponent.toLpdbStruct(opponent)
+
+	if Opponent.typeIsParty(opponent.type) then
+		for playerIndex, player in pairs(opponent.players) do
+			storageStruct.opponentplayers['p' .. playerIndex .. 'faction'] = player.faction
+		end
+	end
+
+	return storageStruct
+end
+
+---@param storageStruct table
+---@return StormgateStandardOpponent?
+function CustomOpponent.fromLpdbStruct(storageStruct)
+	local opponent = Opponent.fromLpdbStruct(storageStruct) --[[@as StormgateStandardOpponent?]]
+
+	if not opponent then
+		return nil
+	end
+
+	if Opponent.partySize(storageStruct.opponenttype) then
+		for playerIndex, player in pairs(opponent.players) do
+			player.faction = storageStruct.opponentplayers['p' .. playerIndex .. 'faction']
+		end
+	end
+
+	return opponent
+end
+
+---@param opponent StormgateStandardOpponent
+---@param date string|number|nil
+---@param options {syncPlayer: boolean?}
+---@return StormgateStandardOpponent
+function CustomOpponent.resolve(opponent, date, options)
+	options = options or {}
+	if opponent.type == Opponent.team then
+		return Opponent.resolve(opponent --[[@as standardOpponent]], date, options) --[[@as StormgateStandardOpponent]]
+	elseif Opponent.typeIsParty(opponent.type) then
+		for _, player in ipairs(opponent.players) do
+			if options.syncPlayer then
+				local hasFaction = String.isNotEmpty(player.faction)
+				local savePageVar = not Opponent.playerIsTbd(player)
+				PlayerExt.syncPlayer(player, {savePageVar = savePageVar, date = date})
+				player.team =
+					PlayerExt.syncTeam(player.pageName:gsub(' ', '_'), player.team, {date = date, savePageVar = savePageVar})
+				player.faction = (hasFaction or player.faction ~= Faction.defaultFaction) and player.faction or nil
+			else
+				PlayerExt.populatePageName(player)
+			end
+			if player.team then
+				player.team = TeamTemplate.resolve(player.team, date)
+			end
+		end
+	end
+	return opponent
+end
+
+return CustomOpponent

--- a/components/opponent/wikis/stormgate/opponent_display_custom.lua
+++ b/components/opponent/wikis/stormgate/opponent_display_custom.lua
@@ -1,0 +1,160 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:OpponentDisplay/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DisplayUtil = require('Module:DisplayUtil')
+local Faction = require('Module:Faction')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+
+local Opponent = Lua.import('Module:Opponent/Custom', {requireDevIfEnabled = true})
+local OpponentDisplay = Lua.import('Module:OpponentDisplay', {requireDevIfEnabled = true})
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom', {requireDevIfEnabled = true})
+local PlayerDisplay = Lua.import('Module:Player/Display/Custom', {requireDevIfEnabled = true})
+
+local CustomOpponentDisplay = Table.merge(OpponentDisplay, {propTypes = {}, types={}})
+
+CustomOpponentDisplay.propTypes.InlineOpponent = TypeUtil.extendStruct(OpponentDisplay.propTypes.InlineOpponent, {
+	opponent = MatchGroupUtil.types.GameOpponent,
+	showFaction = 'boolean?',
+})
+
+---Display component for an opponent entry appearing in a bracket match.
+---@class StormgateBracketOpponentEntry
+---@operator call(...): StormgateBracketOpponentEntry
+---@field content Html
+---@field root Html
+CustomOpponentDisplay.BracketOpponentEntry = Class.new(
+	---@param self self
+	---@param opponent StormgateStandardOpponent
+	---@param options {forceShortName: boolean}
+	function(self, opponent, options)
+		local showFactionBackground = opponent.type == Opponent.solo or opponent.extradata.hasFactionOrFlag
+
+		self.content = mw.html.create('div'):addClass('brkts-opponent-entry-left')
+			:addClass(showFactionBackground and Faction.bgClass(opponent.players[1].faction) or nil)
+
+		if opponent.type == Opponent.team then
+			self.content:node(OpponentDisplay.BlockTeamContainer({
+				showLink = false,
+				style = 'hybrid',
+				team = opponent.team,
+				template = opponent.template,
+			}))
+		else
+			self.content:node(CustomOpponentDisplay.BlockOpponent({
+				opponent = opponent,
+				overflow = 'ellipsis',
+				playerClass = 'starcraft-bracket-block-player',
+				showLink = false,
+			}))
+		end
+
+		self.root = mw.html.create('div'):addClass('brkts-opponent-entry')
+			:node(self.content)
+	end
+)
+
+CustomOpponentDisplay.BracketOpponentEntry.addScores = OpponentDisplay.BracketOpponentEntry.addScores
+
+---@class StormgateInlineOpponentProps: InlineOpponentProps
+---@field opponent StormgateStandardOpponent
+---@field showFaction boolean?
+
+---@param props StormgateInlineOpponentProps
+---@return Html|string|nil
+function CustomOpponentDisplay.InlineOpponent(props)
+	DisplayUtil.assertPropTypes(props, CustomOpponentDisplay.propTypes.InlineOpponent)
+	local opponent = props.opponent
+
+	if Opponent.typeIsParty((opponent or {}).type) then
+		return CustomOpponentDisplay.InlinePlayers(props)
+	end
+
+	return OpponentDisplay.InlineOpponent(props)
+end
+
+CustomOpponentDisplay.propTypes.BlockOpponent = TypeUtil.extendStruct(OpponentDisplay.propTypes.BlockOpponent, {
+	opponent = MatchGroupUtil.types.GameOpponent,
+	showFaction = 'boolean?',
+	playerClass = 'string?',
+})
+
+---@class StormgateBlockOpponentProps: BlockOpponentProps
+---@field opponent StormgateStandardOpponent
+---@field showFaction boolean?
+
+---@param props StormgateBlockOpponentProps
+---@return Html
+function CustomOpponentDisplay.BlockOpponent(props)
+	DisplayUtil.assertPropTypes(props, CustomOpponentDisplay.propTypes.BlockOpponent)
+	local opponent = props.opponent
+
+	opponent.extradata = opponent.extradata or {}
+	-- Default TBDs to not show links
+	local showLink = Logic.nilOr(props.showLink, not Opponent.isTbd(opponent))
+
+	if opponent.type == Opponent.literal and opponent.extradata.hasFactionOrFlag then
+		return CustomOpponentDisplay.BlockPlayers(Table.merge(props, {showLink = showLink}))
+	elseif Opponent.typeIsParty((opponent or {}).type) then
+		return CustomOpponentDisplay.BlockPlayers(Table.merge(props, {showLink = showLink}))
+	end
+
+	return OpponentDisplay.BlockOpponent(props)
+end
+
+---@param props StormgateInlineOpponentProps
+---@return Html
+function CustomOpponentDisplay.InlinePlayers(props)
+	local showFaction = props.showFaction ~= false
+	local opponent = props.opponent
+
+	local playerTexts = Array.map(opponent.players, function(player)
+		return tostring(PlayerDisplay.InlinePlayer(Table.merge(props, {player = player, showFaction = showFaction})))
+	end)
+
+	if props.flip then
+		playerTexts = Array.reverse(playerTexts)
+	end
+
+	return mw.html.create('span')
+		:node(table.concat(playerTexts, ' / '))
+end
+
+---@param props StormgateBlockOpponentProps
+---@return Html
+function CustomOpponentDisplay.BlockPlayers(props)
+	local opponent = props.opponent
+	local showFaction = props.showFaction ~= false
+
+	--only apply note to first player, hence extract it here
+	local note = Table.extract(props, 'note')
+
+	local playerNodes = Array.map(opponent.players, function(player, playerIndex)
+		return PlayerDisplay.BlockPlayer(Table.merge(props, {
+			team = player.team,
+			player = player,
+			showFaction = showFaction,
+			note = playerIndex == 1 and note or nil,
+		})):addClass(props.playerClass)
+	end)
+
+	local playersNode = mw.html.create('div')
+		:addClass(props.showPlayerTeam and 'player-has-team' or nil)
+
+	for _, playerNode in ipairs(playerNodes) do
+		playersNode:node(playerNode)
+	end
+
+	return playersNode
+end
+
+return CustomOpponentDisplay

--- a/components/opponent/wikis/stormgate/player_display_custom.lua
+++ b/components/opponent/wikis/stormgate/player_display_custom.lua
@@ -1,0 +1,155 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Player/Display/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Abbreviation = require('Module:Abbreviation')
+local DisplayUtil = require('Module:DisplayUtil')
+local Faction = require('Module:Faction')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local TypeUtil = require('Module:TypeUtil')
+
+local CustomMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom', {requireDevIfEnabled = true})
+local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local PlayerDisplay = Lua.import('Module:Player/Display', {requireDevIfEnabled = true})
+local PlayerExt = Lua.import('Module:Player/Ext/Custom', {requireDevIfEnabled = true})
+
+local TBD_ABBREVIATION = Abbreviation.make('TBD', 'To be determined (or to be decided)')
+local ZERO_WIDTH_SPACE = '&#8203;'
+
+local CustomPlayerDisplay = {propTypes = {}}
+
+CustomPlayerDisplay.propTypes.BlockPlayer = {
+	dq = 'boolean?',
+	flip = 'boolean?',
+	overflow = TypeUtil.optional(DisplayUtil.types.OverflowModes),
+	player = CustomMatchGroupUtil.types.Player,
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showPlayerTeam = 'boolean?',
+	showFaction = 'boolean?',
+	abbreviateTbd = 'boolean?',
+	note = 'string?',
+}
+
+function CustomPlayerDisplay.BlockPlayer(props)
+	DisplayUtil.assertPropTypes(props, CustomPlayerDisplay.propTypes.BlockPlayer)
+	local player = props.player
+
+	local nameNode = mw.html.create(props.dq and 's' or 'span')
+		:wikitext(
+			props.abbreviateTbd and Opponent.playerIsTbd(player) and TBD_ABBREVIATION
+			or props.showLink ~= false and player.pageName
+			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
+			or Logic.emptyOr(player.displayName, ZERO_WIDTH_SPACE)
+		)
+	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
+
+	if props.note then
+		nameNode = mw.html.create('span'):addClass('name')
+			:node(nameNode)
+			:tag('sup'):addClass('note'):wikitext(props.note):done()
+	else
+		nameNode:addClass('name')
+	end
+
+	local flagNode
+	if props.showFlag ~= false and player.flag then
+		flagNode = PlayerDisplay.Flag(player.flag)
+	end
+
+	local factionNode
+	if props.showFaction ~= false and player.faction ~= Faction.defaultFaction then
+		factionNode = mw.html.create('span'):addClass('race')
+			:wikitext(CustomPlayerDisplay.Faction(player.faction))
+	end
+
+	local teamNode
+	if props.showPlayerTeam and player.team and player.team:lower() ~= 'tbd' then
+		teamNode = mw.html.create('span')
+			:wikitext('&nbsp;')
+			:node(mw.ext.TeamTemplate.teampart(player.team))
+	end
+
+	return mw.html.create('div'):addClass('block-player starcraft-block-player')
+		:addClass(props.flip and 'flipped' or nil)
+		:addClass(props.showPlayerTeam and 'has-team' or nil)
+		:node(flagNode)
+		:node(factionNode)
+		:node(nameNode)
+		:node(teamNode)
+end
+
+CustomPlayerDisplay.propTypes.InlinePlayerContainer = {
+	date = 'string?',
+	dq = 'boolean?',
+	flip = 'boolean?',
+	player = 'table',
+	savePageVar = 'boolean?',
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showFaction = 'boolean?',
+}
+
+function CustomPlayerDisplay.InlinePlayerContainer(props)
+	DisplayUtil.assertPropTypes(props, CustomPlayerDisplay.propTypes.InlinePlayerContainer)
+	PlayerExt.syncPlayer(props.player, {
+		date = props.date,
+		savePageVar = props.savePageVar,
+	})
+
+	return CustomPlayerDisplay.InlinePlayer(props)
+end
+
+CustomPlayerDisplay.propTypes.InlinePlayer = {
+	dq = 'boolean?',
+	flip = 'boolean?',
+	player = CustomMatchGroupUtil.types.Player,
+	showFlag = 'boolean?',
+	showLink = 'boolean?',
+	showFaction = 'boolean?',
+}
+function CustomPlayerDisplay.InlinePlayer(props)
+	DisplayUtil.assertPropTypes(props, CustomPlayerDisplay.propTypes.InlinePlayer)
+	local player = props.player
+
+	local flag = props.showFlag ~= false and player.flag
+		and PlayerDisplay.Flag(player.flag)
+		or nil
+
+	local faction = props.showFaction ~= false and player.faction ~= Faction.defaultFaction
+		and CustomPlayerDisplay.Faction(player.faction)
+		or nil
+
+	local nameAndLink = props.showLink ~= false and player.pageName
+		and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
+		or player.displayName
+	if props.dq then
+		nameAndLink = '<s>' .. nameAndLink .. '</s>'
+	end
+
+	local text
+	if props.flip then
+		text = nameAndLink
+			.. (faction and '&nbsp;' .. faction or '')
+			.. (flag and '&nbsp;' .. flag or '')
+	else
+		text = (flag and flag .. '&nbsp;' or '')
+			.. (faction and faction .. '&nbsp;' or '')
+			.. nameAndLink
+	end
+
+	return mw.html.create('span'):addClass('starcraft-inline-player')
+		:addClass(props.flip and 'flipped' or nil)
+		:wikitext(text)
+end
+
+function CustomPlayerDisplay.Faction(faction)
+	return Faction.Icon{size = 'small', showLink = false, showTitle = false, faction = faction}
+end
+
+return CustomPlayerDisplay

--- a/components/opponent/wikis/stormgate/player_ext_custom.lua
+++ b/components/opponent/wikis/stormgate/player_ext_custom.lua
@@ -1,0 +1,108 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Player/Ext/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
+local Flags = require('Module:Flags')
+local Faction = require('Module:Faction')
+local FnUtil = require('Module:FnUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local PlayerExt = Lua.import('Module:Player/Ext', {requireDevIfEnabled = true})
+
+local CustomPlayerExt = Table.deepCopy(PlayerExt)
+
+local globalVars = PlayerExt.globalVars
+
+CustomPlayerExt.fetchPlayer = FnUtil.memoize(function(resolvedPageName)
+	local rows = mw.ext.LiquipediaDB.lpdb('player', {
+		conditions = '[[pagename::' .. resolvedPageName:gsub(' ', '_') .. ']]',
+		query = 'nationality, extradata',
+	})
+
+	local record = rows[1]
+	if record then
+		local factionHistory = Logic.readBool(record.extradata.factionhistorical)
+			and CustomPlayerExt.fetchFactionHistory(resolvedPageName)
+			or nil
+
+		return {
+			flag = String.nilIfEmpty(Flags.CountryName(record.nationality)),
+			faction = Faction.read(record.extradata.faction),
+			factionHistory = factionHistory,
+		}
+	end
+end)
+
+function CustomPlayerExt.fetchPlayerFaction(resolvedPageName, date)
+	local lpdbPlayer = CustomPlayerExt.fetchPlayer(resolvedPageName)
+	if lpdbPlayer and lpdbPlayer.factionHistory then
+		date = date or DateExt.getContextualDateOrNow()
+		local entry = Array.find(lpdbPlayer.factionHistory, function(entry) return date <= entry.endDate end)
+		return entry and Faction.read(entry.faction)
+	else
+		return lpdbPlayer and lpdbPlayer.faction
+	end
+end
+
+function CustomPlayerExt.fetchPlayerFlag(resolvedPageName)
+	local lpdbPlayer = CustomPlayerExt.fetchPlayer(resolvedPageName)
+	return lpdbPlayer and String.nilIfEmpty(Flags.CountryName(lpdbPlayer.flag))
+end
+
+function CustomPlayerExt.fetchFactionHistory(resolvedPageName)
+	local conditions = {
+		'[[type::playerfaction]]',
+		'[[pagename::' .. resolvedPageName:gsub(' ', '_') .. ']]',
+	}
+	local rows = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = table.concat(conditions, ' and '),
+		query = 'information, extradata',
+	})
+
+	local factionHistory = Array.map(rows, function(row)
+		return {
+			endDate = row.extradata.enddate,
+			faction = Faction.read(row.information),
+			startDate = row.extradata.startdate,
+		}
+	end)
+	Array.sortInPlaceBy(factionHistory, function(entry) return entry.startDate end)
+	return factionHistory
+end
+
+
+function CustomPlayerExt.syncPlayer(player, options)
+	options = options or {}
+
+	player = PlayerExt.syncPlayer(player, options)
+
+	player.faction = player.faction
+		or globalVars:get(player.displayName .. '_faction')
+		or options.fetchPlayer ~= false and CustomPlayerExt.fetchPlayerFaction(player.pageName, options.date)
+		or Faction.defaultFaction
+
+	if options.savePageVar ~= false then
+		CustomPlayerExt.saveToPageVars(player)
+	end
+
+	return player
+end
+
+function CustomPlayerExt.saveToPageVars(player)
+	if player.faction and player.faction ~= Faction.defaultFaction then
+		globalVars:set(player.displayName .. '_faction', player.faction)
+	end
+
+	PlayerExt.saveToPageVars(player)
+end
+
+return CustomPlayerExt

--- a/standard/info/wikis/stormgate/info.lua
+++ b/standard/info/wikis/stormgate/info.lua
@@ -29,7 +29,7 @@ return {
 	defaultRoundPrecision = 0,
 	defaultTeamLogo = 'Stormgate default lightmode.png', ---@deprecated
 	defaultTeamLogoDark = 'Stormgate default darkmode.png', ---@deprecated
-	opponentLibrary = 'Opponent/Starcraft',
-	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
+	opponentLibrary = 'Opponent/Custom',
+	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 	match2 = 2,
 }


### PR DESCRIPTION
## Summary
Add stormgate custom opponent modules instead of using sc2 versions via commons.
The base for these modules is a copy from the same modules on warcraft and renaming race to faction everywhere.

## How did you test this change?
to be done (together with other PRs)
