### PR TITLE
Adding Game Categories to WoT Infobox League

### DIFF
--- a/components/infobox/wikis/worldoftanks/infobox_league_custom.lua
+++ b/components/infobox/wikis/worldoftanks/infobox_league_custom.lua
@@ -102,7 +102,7 @@ function CustomLeague:getWikiCategories(args)
 	if not Game.name{game = args.game} then
 		return {'Tournaments without game version'}
 	end
-	return {Game.name{game = args.game} .. ' Competitions')}
+	return {Game.name{game = args.game} .. ' Competitions'}
 end
 
 ---@param content Html|string|number|nil

--- a/components/infobox/wikis/worldoftanks/infobox_league_custom.lua
+++ b/components/infobox/wikis/worldoftanks/infobox_league_custom.lua
@@ -99,15 +99,10 @@ end
 ---@param args table
 ---@return table
 function CustomLeague:getWikiCategories(args)
-	local categories = {}
-
-	if not Game.name{game = _args.game} then
-		table.insert(categories, 'Tournaments without game version')
-	else
-		table.insert(categories, Game.name{game = _args.game} .. ' Competitions')
+	if not Game.name{game = args.game} then
+		return {'Tournaments without game version'}
 	end
-
-	return categories
+	return {Game.name{game = args.game} .. ' Competitions')}
 end
 
 ---@param content Html|string|number|nil

--- a/components/infobox/wikis/worldoftanks/infobox_league_custom.lua
+++ b/components/infobox/wikis/worldoftanks/infobox_league_custom.lua
@@ -40,6 +40,7 @@ function CustomLeague.run(frame)
 	league.createWidgetInjector = CustomLeague.createWidgetInjector
 	league.defineCustomPageVariables = CustomLeague.defineCustomPageVariables
 	league.liquipediaTierHighlighted = CustomLeague.liquipediaTierHighlighted
+	league.getWikiCategories = CustomLeague.getWikiCategories
 
 	return league:createInfobox()
 end
@@ -93,6 +94,20 @@ end
 ---@return boolean
 function CustomLeague:liquipediaTierHighlighted(args)
 	return Logic.readBool(args.publisherpremier)
+end
+
+---@param args table
+---@return table
+function CustomLeague:getWikiCategories(args)
+	local categories = {}
+
+	if not Game.name{game = _args.game} then
+		table.insert(categories, 'Tournaments without game version')
+	else
+		table.insert(categories, Game.name{game = _args.game} .. ' Competitions')
+	end
+
+	return categories
 end
 
 ---@param content Html|string|number|nil


### PR DESCRIPTION
## Summary
Since World of Tanks wiki has 4 games (or 4 possible games) it covers on the wiki, this adds a category for events played on each of these games. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
This is just Category tracking and no LPDB changes or saving.
This is currently being tested live via dev here: [Test page](https://liquipedia.net/worldoftanks/Legendary_Seven_Autumn/2023/Offline)
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/588ba879-d024-4805-af70-667ebe2bde97)
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/06f0c3a1-450a-4b78-9c0e-9e4215e2c94c)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
