### PR TITLE
Add awards as a tier type for Formula1

### DIFF
--- a/standard/tier/wikis/formula1/tier_data.lua
+++ b/standard/tier/wikis/formula1/tier_data.lua
@@ -104,7 +104,7 @@ return {
 			short = 'Showm.',
 			link = 'Showmatches',
 			category = 'Showmatch Tournaments',
-		},	
+		},
 		award = {
 			value = 'Awards',
 			sort = 'B3',

--- a/standard/tier/wikis/formula1/tier_data.lua
+++ b/standard/tier/wikis/formula1/tier_data.lua
@@ -104,6 +104,14 @@ return {
 			short = 'Showm.',
 			link = 'Showmatches',
 			category = 'Showmatch Tournaments',
+		},	
+		misc = {
+			value = 'Awards',
+			sort = 'B3',
+			name = 'Awards',
+			short = 'Awards',
+			link = 'Awards Shows',
+			category = 'Awards Shows',
 		},
 	}
 }

--- a/standard/tier/wikis/formula1/tier_data.lua
+++ b/standard/tier/wikis/formula1/tier_data.lua
@@ -105,7 +105,7 @@ return {
 			link = 'Showmatches',
 			category = 'Showmatch Tournaments',
 		},	
-		misc = {
+		award = {
 			value = 'Awards',
 			sort = 'B3',
 			name = 'Awards',


### PR DESCRIPTION
## Summary

Add awards tier type to Tier_data for use on awards pages


## How did you test this change?

Tested a while back using the main module 
