### PR TITLE
fix: CSS mistake in changes of #3688

### DIFF
--- a/stylesheets/commons/Teamcard.css
+++ b/stylesheets/commons/Teamcard.css
@@ -482,7 +482,7 @@ Author(s): iMarbot
 	z-index: 17;
 }
 
-.inotes-inner .dl {
+.inotes-inner dl {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary

`td` is an element not a class 🤦 

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/a182d3d3-aae4-42de-b8c3-5c61c3300f29)

## How did you test this change?

browser dev tools 200% this time 🫠
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/fe155aba-2da9-4f4f-b802-9ff22f5c4f6e)

Also pushed it live for now.