### PR TITLE
fix(results-tbl): Newly historical TTs break player team querying

### DIFF
--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -336,11 +336,8 @@ function BaseResultsTable._getOpponentTemplates(opponent)
 	end
 
 	local opponentTeamTemplates = Team.queryHistorical(opponentTemplate)
-	if opponentTeamTemplates then
-		return Array.append(Array.extractValues(opponentTeamTemplates), opponentTemplate)
-	end
 
-	return {opponentTemplate}
+	return Array.append(Array.extractValues(opponentTeamTemplates or {}), opponentTemplate)
 end
 
 ---Builds Lpdb conditions for players on a given team

--- a/components/results_table/commons/results_table_base.lua
+++ b/components/results_table/commons/results_table_base.lua
@@ -336,8 +336,11 @@ function BaseResultsTable._getOpponentTemplates(opponent)
 	end
 
 	local opponentTeamTemplates = Team.queryHistorical(opponentTemplate)
+	if opponentTeamTemplates then
+		return Array.append(Array.extractValues(opponentTeamTemplates), opponentTemplate)
+	end
 
-	return opponentTeamTemplates and Array.extractValues(opponentTeamTemplates) or {opponentTemplate}
+	return {opponentTemplate}
 end
 
 ---Builds Lpdb conditions for players on a given team


### PR DESCRIPTION
## Summary

Bug reported on discord: https://discord.com/channels/93055209017729024/268719633366777856/1188884214775545866

When a  historical team template is first created over the top of an existing non-historical, it breaks the query logic of the results table as it instantly expects all results to now be using a sub-template team template, but that takes time to actually spread across all the pages' data.

The query before is like this:

```
([[opponentplayers_p1template::anonymo esports 2021]] OR [[opponentplayers_p2template::anonymo esports 2021]] OR [[opponentplayers_p3template::anonymo esports 2021]] OR [[opponentplayers_p4template::anonymo esports 2021]] OR [[opponentplayers_p5template::anonymo esports 2021]] OR [[opponentplayers_p1template::anonymo esports orig]] OR [[opponentplayers_p2template::anonymo esports orig]] OR [[opponentplayers_p3template::anonymo esports orig]] OR [[opponentplayers_p4template::anonymo esports orig]] OR [[opponentplayers_p5template::anonymo esports orig]]) AND [[opponenttype::!team]]
```

(notice only `anonymo esports 2021` and `anonymo esports orig` are searched for, but not `anonymo esports` which is still left on tons of pages before they get purged or something.)

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/14f79d99-b7ff-4cce-866f-4f8ff8ba6fac)

## How did you test this change?

`/dev` using TFT wiki.

New query now also has `anonymo esports`.
```
([[opponentplayers_p1template::anonymo esports 2021]] OR [[opponentplayers_p2template::anonymo esports 2021]] OR [[opponentplayers_p3template::anonymo esports 2021]] OR [[opponentplayers_p4template::anonymo esports 2021]] OR [[opponentplayers_p5template::anonymo esports 2021]] OR [[opponentplayers_p1template::anonymo esports orig]] OR [[opponentplayers_p2template::anonymo esports orig]] OR [[opponentplayers_p3template::anonymo esports orig]] OR [[opponentplayers_p4template::anonymo esports orig]] OR [[opponentplayers_p5template::anonymo esports orig]] OR [[opponentplayers_p1template::anonymo esports]] OR [[opponentplayers_p2template::anonymo esports]] OR [[opponentplayers_p3template::anonymo esports]] OR [[opponentplayers_p4template::anonymo esports]] OR [[opponentplayers_p5template::anonymo esports]]) AND [[opponenttype::!team]]
```

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/c307c40e-efa9-4c93-8345-b78b8bd9c52f)
