### PR TITLE
Refactoring Valorant Team Infobox

### DIFF
--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -24,8 +24,6 @@ local CustomInjector = Class.new(Injector)
 function CustomTeam.run(frame)
 	local team = CustomTeam(frame)
 	team:setWidgetInjector(CustomInjector(team))
-	team.createBottomContent = CustomTeam.createBottomContent
-	team.addToLpdb = CustomTeam.addToLpdb
 	return team:createInfobox()
 end
 
@@ -42,13 +40,10 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Analysts', content = {args.analysts}}
 		)
 	end
-
 	return widgets
 end
 
 function CustomTeam:createBottomContent(args)
-	mw.logObeject("args "  .. args)
-	mw.logObeject("team "  .. team)
 	if not team.disbanded then
 		return Template.expandTemplate(
 			mw.getCurrentFrame(),

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -36,19 +36,21 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	if id == 'customcontent' then
-		return Array.append(widgets,
-			Cell{name = 'Analysts', content = {args.analysts}}
-		)
+		table.insert(widgets, Cell{
+				name = 'Analysts',
+				content = {args.analyst}
+		})
 	end
 	return widgets
 end
 
-function CustomTeam:createBottomContent(args)
+function CustomTeam:createBottomContent()
+	args = self.args
 	if not args.disbanded then
 		return Template.expandTemplate(
 			mw.getCurrentFrame(),
 			'Upcoming and ongoing tournaments of',
-			{team = args.name or self.pagename}
+			{team = self.name or self.pagename}
 		)
 	end
 end

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -44,7 +44,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomTeam:createBottomContent(args)
-	if not team.disbanded then
+	if not args.disbanded then
 		return Template.expandTemplate(
 			mw.getCurrentFrame(),
 			'Upcoming and ongoing tournaments of',

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -11,8 +11,8 @@ local Lua = require('Module:Lua')
 local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
-local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Team = Lua.import('Module:Infobox/Team')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -32,10 +32,6 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{name = 'In-Game Leader', content = {args.igl}}
 		}
-	end
-
-	if id == 'customcontent' then
-		return {Cell{name = 'Analysts', content = {args.analyst}}}
 	end
 	return widgets
 end

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Template = require('Module:Template')
@@ -36,17 +35,13 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	if id == 'customcontent' then
-		table.insert(widgets, Cell{
-				name = 'Analysts',
-				content = {args.analyst}
-		})
+		return {Cell{name = 'Analysts', content = {args.analyst}}}
 	end
 	return widgets
 end
 
 function CustomTeam:createBottomContent()
-	args = self.args
-	if not args.disbanded then
+	if not self.args.disbanded then
 		return Template.expandTemplate(
 			mw.getCurrentFrame(),
 			'Upcoming and ongoing tournaments of',


### PR DESCRIPTION
Prepares the Valorant Team Infobox for refactoring. This was done while adding analyst support to the infobox (trying to kill 2 birds with 1 stone).

## Summary
Refactor Valorant Infobox Team
- cleanup
- make use of #3669
- make use of #3663
- add annotations

## How did you test this change?
Tested via dev module