### PR TITLE
Add achievements to player infoboxes + fix the issue on PlayerIntroduction

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -5,43 +5,89 @@
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
-
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local String = require('Module:StringUtils')
+local Team = require('Module:Team')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Variables = require('Module:Variables')
+local Template = require('Module:Template')
 local HeroIcon = require('Module:HeroIcon')
 local HeroNames = mw.loadData('Module:HeroNames')
-local Lua = require('Module:Lua')
-local Region = require('Module:Region')
-local Role = require('Module:Role')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local TeamHistoryAuto = require('Module:TeamHistoryAuto')
-
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Player = Lua.import('Module:Infobox/Person', {requireDevIfEnabled = true})
+local Achievements = Lua.import('Module:Infobox/Extension/Achievements', {requireDevIfEnabled = true})
 
+local ACHIEVEMENTS_BASE_CONDITIONS = {
+	'[[liquipediatiertype::!Showmatch]]',
+	'[[liquipediatiertype::!Qualifier]]',
+	'[[liquipediatiertype::!Charity]]',
+	'([[liquipediatier::1]] OR [[liquipediatier::2]])',
+	'[[placement::1]]',
+	'[[publishertier::true]]',
+}
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
-local Title = Widgets.Title
-local Center = Widgets.Center
-
-local _pagename = mw.title.getCurrentTitle().prefixedText
-local _role
-local _role2
+local Builder = Widgets.Builder
 local _SIZE_HERO = '25x25px'
+local _ROLES = {
+	-- Players
+	['exp'] = {category = 'EXP Laner', variable = 'EXP Laner', isplayer = true},
+	['roam'] = {category = 'Roamer', variable = 'Roamer', isplayer = true},
+	['jungle'] = {category = 'Jungler', variable = 'Jungler', isplayer = true},
+	['mid'] = {category = 'Mid Laner', variable = 'Mid Laner', isplayer = true},
+	['gold'] = {category = 'Gold Laner', variable = 'Gold Laner', isplayer = true},
+	-- Staff and Talents
+	['analyst'] = {category = 'Analysts', variable = 'Analyst', isplayer = false},
+	['observer'] = {category = 'Observers', variable = 'Observer', isplayer = false},
+	['host'] = {category = 'Hosts', variable = 'Host', isplayer = false},
+	['journalist'] = {category = 'Journalists', variable = 'Journalist', isplayer = false},
+	['expert'] = {category = 'Experts', variable = 'Expert', isplayer = false},
+	['coach'] = {category = 'Coaches', variable = 'Coach', isplayer = false},
+	['caster'] = {category = 'Casters', variable = 'Caster', isplayer = false},
+	['talent'] = {category = 'Talents', variable = 'Talent', isplayer = false},
+	['manager'] = {category = 'Managers', variable = 'Manager', isplayer = false},
+	['producer'] = {category = 'Producers', variable = 'Producer', isplayer = false},
+	['admin'] = {category = 'Admins', variable = 'Admin', isplayer = false},
+	['streamer'] = {category = 'Streamers', variable = 'Streamer', isplayer = false},
+}
+_ROLES['head coach'] = _ROLES.coach
+_ROLES['assistant coach'] = _ROLES.coach
+_ROLES['strategic coach'] = _ROLES.coach
+_ROLES['positional coach'] = _ROLES.coach
+_ROLES['jgl'] = _ROLES.jungle
+_ROLES['middle'] = _ROLES.mid
+_ROLES['carry'] = _ROLES.gold
+_ROLES['adc'] = _ROLES.gold
+_ROLES['bot'] = _ROLES.gold
+_ROLES['ad carry'] = _ROLES.gold
+_ROLES['sup'] = _ROLES.roam
 
 local CustomPlayer = Class.new()
 
 local CustomInjector = Class.new(Injector)
 
 local _args
-local _player
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
-	_player = player
 
+	if String.isEmpty(player.args.history) then
+		player.args.history = TeamHistoryAuto._results{
+			convertrole = 'true',
+			iconModule = 'Module:PositionIcon/data',
+			addlpdbdata = 'true'
+		}
+	end
+			-- Automatic achievements
+	player.args.achievements = Achievements.player{
+		baseConditions = ACHIEVEMENTS_BASE_CONDITIONS
+	}
 	player.adjustLPDB = CustomPlayer.adjustLPDB
+	player.createBottomContent = CustomPlayer.createBottomContent
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
 	_args = player.args
@@ -51,32 +97,34 @@ function CustomPlayer.run(frame)
 end
 
 function CustomInjector:parse(id, widgets)
-	if id == 'history' then
-		local manualHistory = _args.history
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
-			iconModule = 'Module:PositionIcon/data',
-			player = _pagename
-		}
-
-		if String.isNotEmpty(manualHistory) or automatedHistory then
-			return {
-				Title{name = 'History'},
-				Center{content = {manualHistory}},
-				Center{content = {automatedHistory}},
-			}
+	if id == 'status' then
+		local status = _args.status
+		if String.isNotEmpty(status) then
+			status = mw.getContentLanguage():ucfirst(status)
 		end
-	elseif id == 'region' then return {}
-	elseif id == 'role' then
-		_role = Role.run({role = _args.role})
-		_role2 = Role.run({role = _args.role2})
+
 		return {
-			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
+			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true},
+						status) or status}},
 		}
+	elseif id == 'role' then
+		return {
+			Cell{name = 'Role', content = {
+				CustomPlayer._createRole('role', _args.role),
+				CustomPlayer._createRole('role2', _args.role2),
+				CustomPlayer._createRole('role3', _args.role3)
+			}},
+		}
+	elseif id == 'history' then
+		table.insert(widgets, Cell{
+			name = 'Retired',
+			content = {_args.retired}
+		})
+	elseif id == 'region' then
+		return {}
 	end
 	return widgets
 end
-
 
 function CustomInjector:addCustomCells(widgets)
 	-- Signature Heroes
@@ -115,18 +163,65 @@ function CustomPlayer:createWidgetInjector()
 end
 
 function CustomPlayer:adjustLPDB(lpdbData)
-	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
-	lpdbData.extradata.role = _role.role
-	lpdbData.extradata.role2 = _role2.role
+	lpdbData.extradata.role = Variables.varDefault('role')
+	lpdbData.extradata.role2 = Variables.varDefault('role2')
+	lpdbData.extradata.role3 = Variables.varDefault('role3')
 
-	-- store signature heroes with standardized name
-	for heroIndex, hero in ipairs(Player:getAllArgsForBase(_args, 'hero')) do
-		lpdbData.extradata['signatureHero' .. heroIndex] = HeroNames[hero:lower()]
+	lpdbData.extradata.hero1 = _args.hero1 or _args.hero
+	lpdbData.extradata.hero2 = _args.hero2
+	lpdbData.extradata.hero3 = _args.hero3
+	lpdbData.extradata.hero4 = _args.hero4
+	lpdbData.extradata.hero5 = _args.hero5
+	lpdbData.type = CustomPlayer._isPlayerOrStaff()
+
+	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {_args.country})
+
+	if String.isNotEmpty(_args.team2) then
+		lpdbData.extradata.team2 = mw.ext.TeamTemplate.raw(_args.team2).page
 	end
 
-	lpdbData.region = String.nilIfEmpty(Region.name({region = _args.region, country = _args.country}))
-
 	return lpdbData
+end
+
+function CustomPlayer:createBottomContent(infobox)
+	if Player:shouldStoreData(_args) and String.isNotEmpty(_args.team) then
+		local teamPage = Team.page(mw.getCurrentFrame(),_args.team)
+		return
+			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing matches of', {team = teamPage}) ..
+			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
+	end
+end
+
+function CustomPlayer._createRole(key, role)
+	if String.isEmpty(role) then
+		return nil
+	end
+
+	local roleData = _ROLES[role:lower()]
+	if not roleData then
+		return nil
+	end
+	if Player:shouldStoreData(_args) then
+		local categoryCoreText = 'Category:' .. roleData.category
+
+		return '[[' .. categoryCoreText .. ']]' .. '[[:' .. categoryCoreText .. '|' ..
+			Variables.varDefineEcho(key or 'role', roleData.variable) .. ']]'
+	else
+		return Variables.varDefineEcho(key or 'role', roleData.variable)
+	end
+end
+
+function CustomPlayer._isPlayerOrStaff()
+	local roleData
+	if String.isNotEmpty(_args.role) then
+		roleData = _ROLES[_args.role:lower()]
+	end
+	-- If the role is missing, assume it is a player
+	if roleData and roleData.isplayer == false then
+		return 'staff'
+	else
+		return 'player'
+	end
 end
 
 return CustomPlayer


### PR DESCRIPTION
## Summary
1.Main reason is to keep the wiki consistent across all player pages and to have less manual maintance.
Only retrieves S-Tier, A-Tier tournaments and publishertier=true currently into the "Achivements" widget
2.PlayerIntroduction text for staff is consider staff as player, Staff should be text as working
E.g : https://liquipedia.net/mobilelegends/Ducky
no dev:
![ScreenShot Tool -20231226152458](https://github.com/Liquipedia/Lua-Modules/assets/94455582/dc317058-86f7-4253-b593-93cc4387da25)
dev:
![ScreenShot Tool -20231226152346](https://github.com/Liquipedia/Lua-Modules/assets/94455582/bba81408-1b3d-4da8-95bd-bc717ae5aacf)

## How did you test this change?
/dev  module: https://liquipedia.net/mobilelegends/Module:Infobox/Person/Player/Custom/dev
Using |dev=1 : 
https://liquipedia.net/mobilelegends/Ducky
https://liquipedia.net/mobilelegends/FlapTzy
