### PR TITLE
Refactor Patch Infoboxes

### DIFF
--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -90,21 +90,32 @@ function Patch:createInfobox()
 end
 
 --- Allows for overriding this functionality
+---Adjust Lpdb data
+---@param lpdbData table
+---@param args table
+---@return table
+function Patch:addToLpdb(lpdbData, args)
+	return lpdbData
+end
+
+--- Allows for overriding this functionality
 ---@param args table
 function Patch:setLpdbData(args)
-	local date = args.release
-	local monthAndDay = mw.getContentLanguage():formatDate('m-d', date)
-	local informationType = self:getInformationType(args):lower()
-	mw.ext.LiquipediaDB.lpdb_datapoint(informationType .. '_' .. self.name, {
-		name = args.name,
-		type = informationType,
-		information = monthAndDay,
+	local lpdbData = {
+		name = self.name,
+		type = self:getInformationType(args):lower(),
 		image = args.image,
-		date = date,
-		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
-			highlights = self:getAllArgsForBase(args, 'highlight')
+		imagedark = args.imagedark,
+		date = args.release,
+		information = mw.getContentLanguage():formatDate('m-d', date),
+		extradata = { 
+			highlights = self:getAllArgsForBase(args, 'highlight') 
 		},
-	})
+	}
+
+	lpdbData = self:addToLpdb(lpdbData, args)
+	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
+	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, lpdbData)
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -116,7 +116,6 @@ function Patch:setLpdbData(args)
 	}
 
 	lpdbData = self:addToLpdb(lpdbData, args)
-	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
 	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, Json.stringifySubTables(lpdbData))
 end
 

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -107,12 +107,12 @@ function Patch:setLpdbData(args)
 		image = args.image,
 		imagedark = args.imagedark,
 		date = args.release,
-		information = mw.getContentLanguage():formatDate('m-d', date),
-		extradata = { 
-			highlights = self:getAllArgsForBase(args, 'highlight') 
+		information = mw.getContentLanguage():formatDate('m-d', args.release),
+		extradata = {
+			highlights = self:getAllArgsForBase(args, 'highlight')
 		},
 	}
-
+	
 	lpdbData = self:addToLpdb(lpdbData, args)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
 	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, lpdbData)

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -7,9 +7,11 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')
 local Table = require('Module:Table')
+local Variables = require('Module:Variables')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic', {requireDevIfEnabled = true})
 
@@ -81,7 +83,7 @@ function Patch:createInfobox()
 		Center{content = {args.footnotes}},
 	}
 
-	if Namespace.isMain() then
+	if Namespace.isMain() and not Logic.readBool(Variables.varDefault('disable_LPDB_storage')) then
 		infobox:categories(self:getInformationType(args))
 		self:setLpdbData(args)
 	end

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -117,7 +117,7 @@ function Patch:setLpdbData(args)
 
 	lpdbData = self:addToLpdb(lpdbData, args)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
-	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, lpdbData)
+	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, Json.stringifySubTables(lpdbData))
 end
 
 --- Allows for overriding this functionality

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -112,7 +112,7 @@ function Patch:setLpdbData(args)
 			highlights = self:getAllArgsForBase(args, 'highlight')
 		},
 	}
-	
+
 	lpdbData = self:addToLpdb(lpdbData, args)
 	lpdbData.extradata = mw.ext.LiquipediaDB.lpdb_create_json(lpdbData.extradata or {})
 	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, lpdbData)

--- a/components/infobox/wikis/dota2/infobox_patch_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_patch_custom.lua
@@ -11,13 +11,12 @@ local Lua = require('Module:Lua')
 
 local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 
-local CustomPatch = Class.new()
+local CustomPatch = Class.new(Patch)
 
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
-	local patch = Patch(frame)
-
+	local patch = CustomPatch(frame)
 	patch.getChronologyData = CustomPatch.getChronologyData
 
 	return patch:createInfobox()

--- a/components/infobox/wikis/dota2/infobox_patch_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_patch_custom.lua
@@ -11,13 +11,13 @@ local Lua = require('Module:Lua')
 
 local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 
+---@class Dota2PatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
 
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
-	patch.getChronologyData = CustomPatch.getChronologyData
 
 	return patch:createInfobox()
 end

--- a/components/infobox/wikis/fortnite/infobox_patch_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_patch_custom.lua
@@ -11,15 +11,13 @@ local Lua = require('Module:Lua')
 
 local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 
-local CustomPatch = Class.new()
+--@Class HaloPatchInfobox: PatchInfobox
+local CustomPatch = Class.new(Patch)
 
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
-	local patch = Patch(frame)
-	patch.args.informationType = 'Version'
-
-	patch.getChronologyData = CustomPatch.getChronologyData
+	local patch = CustomPatch(frame)
 
 	return patch:createInfobox()
 end

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -33,9 +33,8 @@ end
 ---@param id String
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
 	if id == 'custom' then
-		return{ 
+		return{
 			Cell{name = 'Game Version', content = {CustomPatch._getGameVersion(self.caller.args)}, options = {makeLink = true}},
 		}
 	end
@@ -57,7 +56,7 @@ end
 
 ---@return string?
 function CustomPatch._getGameVersion()
-	local game = string.lower(args.game or '')
+	local game = string.lower(self.caller.args.game or '')
 	return GAME[game]
 end
 

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -15,8 +15,9 @@ local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
-local _GAME = mw.loadData('Module:GameVersion')
+local GAME = mw.loadData('Module:GameVersion')
 
+--@Class HaloPatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
 local CustomInjector = Class.new(Injector)
 
@@ -29,28 +30,16 @@ function CustomPatch.run(frame)
 	return patch:createInfobox()
 end
 
----@param widgets Widget[]
+---@param id String
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	if id == 'customcontent' then
-		return{
-			Cell{name = 'Game Version', content = {CustomPatch._getGameVersion()}, options = {makeLink = true}},
+	local args = self.caller.args
+	if id == 'custom' then
+		return{ 
+			Cell{name = 'Game Version', content = {CustomPatch._getGameVersion(self.caller.args)}, options = {makeLink = true}},
 		}
 	end
 	return widgets
-end
-
----@param args table
-function CustomPatch:setLpdbData(args)
-	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, {
-		name = self.name,
-		type = 'patch',
-		information = CustomPatch:_getGameVersion(),
-		date = args.release,
-		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
-			version = args.version,
-		}
-	})
 end
 
 ---@param args table
@@ -67,9 +56,9 @@ function CustomPatch:getChronologyData(args)
 end
 
 ---@return string?
-function CustomPatch._getGameVersion(args)
+function CustomPatch._getGameVersion()
 	local game = string.lower(args.game or '')
-	return _GAME[game]
+	return GAME[game]
 end
 
 return CustomPatch

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -31,6 +31,7 @@ function CustomPatch.run(frame)
 end
 
 ---@param id String
+---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
@@ -54,9 +55,10 @@ function CustomPatch:getChronologyData(args)
 	return data
 end
 
+---@param args table
 ---@return string?
-function CustomPatch._getGameVersion()
-	local game = string.lower(self.caller.args.game or '')
+function CustomPatch._getGameVersion(args)
+	local game = string.lower(args.game or '')
 	return GAME[game]
 end
 

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -9,13 +9,12 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
+local Game = Lua.import('Module:Game', {requireDevIfEnabled = true})
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
 local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
-
-local GAME = mw.loadData('Module:GameVersion')
 
 --@Class HaloPatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
@@ -27,7 +26,7 @@ function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
 	patch:setWidgetInjector(CustomInjector(patch))
 
-	patch.args.game = Game.toIdentifie{game = patch.args.game}
+	patch.args.game = Game.toIdentifier{game = patch.args.game}
 
 	return patch:createInfobox()
 end
@@ -64,13 +63,6 @@ function CustomPatch:getChronologyData(args)
 		data.next = args.next .. ' Patch|' .. args.next_link
 	end
 	return data
-end
-
----@param args table
----@return string?
-function CustomPatch._getGameVersion(args)
-	local game = string.lower(args.game or '')
-	return GAME[game]
 end
 
 return CustomPatch

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -27,6 +27,8 @@ function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
 	patch:setWidgetInjector(CustomInjector(patch))
 
+	patch.args.game = Game.toIdentifie{game = patch.args.game}
+
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Class = require('Module:Class')
-local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 
 local Game = Lua.import('Module:Game', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -16,7 +16,7 @@ local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
---@Class HaloPatchInfobox: PatchInfobox
+---@Class HaloPatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
 local CustomInjector = Class.new(Injector)
 

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -42,6 +42,15 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+---@param lpdbData table
+---@param args table
+---@return table
+function CustomPatch:addToLpdb(lpdbData, args)
+	lpdbData.extradata.game = args.game
+
+	return lpdbData
+end
+
 ---@param args table
 ---@return {previous: string?, next: string?}
 function CustomPatch:getChronologyData(args)

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 
 local Game = Lua.import('Module:Game', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -36,7 +36,7 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return{
-			Cell{name = 'Game Version', content = {CustomPatch._getGameVersion(self.caller.args)}, options = {makeLink = true}},
+			Cell{name = 'Game Version', content = {Game.name{game = self.caller.args}}, options = {makeLink = true}},
 		}
 	end
 	return widgets

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -25,7 +25,7 @@ local CustomInjector = Class.new(Injector)
 ---@return Html
 function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
-	patch.setWidgetInjector(CustomInjector(patch))
+	patch:setWidgetInjector(CustomInjector(patch))
 
 	return patch:createInfobox()
 end

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -15,37 +15,28 @@ local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
-local _args
-
 local _GAME = mw.loadData('Module:GameVersion')
 
-local CustomPatch = Class.new()
+local CustomPatch = Class.new(Patch)
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
-	local customPatch = Patch(frame)
-	_args = customPatch.args
-	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
-	customPatch.getChronologyData = CustomPatch.getChronologyData
-	customPatch.setLpdbData = CustomPatch.setLpdbData
-	return customPatch:createInfobox()
-end
+	local patch = CustomPatch(frame)
+	patch.setWidgetInjector(CustomInjector(patch))
 
----@return WidgetInjector
-function CustomPatch:createWidgetInjector()
-	return CustomInjector()
+	return patch:createInfobox()
 end
 
 ---@param widgets Widget[]
 ---@return Widget[]
-function CustomInjector:addCustomCells(widgets)
-	table.insert(widgets, Cell{
-		name = 'Game Version',
-		content = {CustomPatch._getGameVersion()},
-		options = {makeLink = true}
-	})
+function CustomInjector:parse(id, widgets)
+	if id == 'customcontent' then
+		return{
+			Cell{name = 'Game Version', content = {CustomPatch._getGameVersion()}, options = {makeLink = true}},
+		}
+	end
 	return widgets
 end
 
@@ -76,8 +67,9 @@ function CustomPatch:getChronologyData(args)
 end
 
 ---@return string?
-function CustomPatch._getGameVersion()
-	local game = string.lower(_args.game or '')
+function CustomPatch._getGameVersion(args)
+	local game = string.lower(args.game or '')
 	return _GAME[game]
 end
+
 return CustomPatch

--- a/components/infobox/wikis/halo/infobox_patch_custom.lua
+++ b/components/infobox/wikis/halo/infobox_patch_custom.lua
@@ -37,7 +37,7 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return{
-			Cell{name = 'Game Version', content = {Game.name{game = self.caller.args}}, options = {makeLink = true}},
+			Cell{name = 'Game Version', content = {Game.name{game = self.caller.args.game}}, options = {makeLink = true}},
 		}
 	end
 	return widgets

--- a/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
@@ -23,7 +23,7 @@ local CustomInjector = Class.new(Injector)
 function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
 	patch:setWidgetInjector(CustomInjector(patch))
-	
+
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
@@ -15,6 +15,7 @@ local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
+---@class R6PatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
 local CustomInjector = Class.new(Injector)
 
@@ -23,7 +24,7 @@ local CustomInjector = Class.new(Injector)
 function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
 	patch:setWidgetInjector(CustomInjector(patch))
-
+	
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
@@ -24,7 +24,7 @@ local CustomInjector = Class.new(Injector)
 function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
 	patch:setWidgetInjector(CustomInjector(patch))
-
+	
 	return patch:createInfobox()
 end
 
@@ -43,18 +43,14 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+---@param lpdbData table
 ---@param args table
-function CustomPatch:setLpdbData(args)
-	local date = args.release or args.pcrelease or args.consolerelease
-	mw.ext.LiquipediaDB.lpdb_datapoint('patch_' .. self.name, {
-		name = args.name,
-		type = 'patch',
-		information = args.game,
-		date = date,
-		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
-			version = args.version,
-		}
-	})
+---@return table
+function CustomPatch:addToLpdb(lpdbData, args)
+	lpdbData.extradata.version = args.version
+	lpdbData.extradata.game = args.game
+
+	return lpdbData
 end
 
 ---@param args table

--- a/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
@@ -24,7 +24,7 @@ local CustomInjector = Class.new(Injector)
 function CustomPatch.run(frame)
 	local patch = CustomPatch(frame)
 	patch:setWidgetInjector(CustomInjector(patch))
-	
+
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
@@ -15,45 +15,28 @@ local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
-local _args
-
-local CustomPatch = Class.new()
+local CustomPatch = Class.new(Patch)
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
-	local customPatch = Patch(frame)
-	_args = customPatch.args
-	customPatch.createWidgetInjector = CustomPatch.createWidgetInjector
-	customPatch.getChronologyData = CustomPatch.getChronologyData
-	customPatch.setLpdbData = CustomPatch.setLpdbData
-	return customPatch:createInfobox()
-end
-
----@return WidgetInjector
-function CustomPatch:createWidgetInjector()
-	return CustomInjector()
+	local patch = CustomPatch(frame)
+	patch:setWidgetInjector(CustomInjector(patch))
+	
+	return patch:createInfobox()
 end
 
 ---@param id string
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
 	if id == 'release' then
 		return {
-			Cell{
-				name = 'Release Date',
-				content = {_args.release}
-			},
-			Cell{
-				name = 'PC Release Date',
-				content = {_args.pcrelease}
-			},
-			Cell{
-				name = 'Console Release Date',
-				content = {_args.consolerelease}
-			},
+			Cell{name = 'Release Date', content = {args.release}},
+			Cell{name = 'PC Release Date', content = {args.pcrelease}},
+			Cell{name = 'Console Release Date', content = {args.consolerelease}},
 		}
 	end
 	return widgets

--- a/components/infobox/wikis/valorant/infobox_patch_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_patch_custom.lua
@@ -18,7 +18,7 @@ local CustomPatch = Class.new(Patch)
 function CustomPatch.run(frame)
 	local patch = Patch(frame)
 	patch.getChronologyData = CustomPatch.getChronologyData
-	
+
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/valorant/infobox_patch_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_patch_custom.lua
@@ -18,7 +18,7 @@ local CustomPatch = Class.new(Patch)
 ---@return Html
 function CustomPatch.run(frame)
 	local patch = Patch(frame)
-	
+
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/valorant/infobox_patch_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_patch_custom.lua
@@ -11,14 +11,14 @@ local Lua = require('Module:Lua')
 
 local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 
+---@class ValorantPatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
 
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
 	local patch = Patch(frame)
-	patch.getChronologyData = CustomPatch.getChronologyData
-
+	
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/valorant/infobox_patch_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_patch_custom.lua
@@ -11,15 +11,14 @@ local Lua = require('Module:Lua')
 
 local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
 
-local CustomPatch = Class.new()
+local CustomPatch = Class.new(Patch)
 
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
 	local patch = Patch(frame)
-
 	patch.getChronologyData = CustomPatch.getChronologyData
-
+	
 	return patch:createInfobox()
 end
 

--- a/components/infobox/wikis/valorant/infobox_patch_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_patch_custom.lua
@@ -17,7 +17,7 @@ local CustomPatch = Class.new(Patch)
 ---@param frame Frame
 ---@return Html
 function CustomPatch.run(frame)
-	local patch = Patch(frame)
+	local patch = CustomPatch(frame)
 
 	return patch:createInfobox()
 end


### PR DESCRIPTION
## Summary
Rewrites the Infobox Patch modules for wikis not being handled by hjp

- [x] Valorant 
- [x] Rainbow Six
- [x] Dota 2
- [x] Halo
- [x] Fortnite

This PR also requires a refactor to the Base Infobox/Patch in order to correct the custom versions of LPDB saving (they were previously overriding the LPDB). 

- [x] Base 

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev with patch pages using ``|dev=1`` to confirm LPDB data saving and display
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
