### PR TITLE
Fix: Move `not ` to correct line

### DIFF
--- a/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
+++ b/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
@@ -50,8 +50,8 @@ function LegacyMatchMaps.solo(frame)
 		width = args.width,
 		collapsed = Logic.nilOr(Logic.readBoolOrNil(args.hide), true),
 		attached = Logic.nilOr(Logic.readBoolOrNil(args.hide), true),
-		store = not store,
-		noDuplicateCheck = store,
+		store = store,
+		noDuplicateCheck = not store,
 	}
 
 	for _, matchInput, matchIndex in Table.iter.pairsByPrefix(args, 'match') do


### PR DESCRIPTION
## Summary
Fix: Move `not ` to correct line in warcraft LegacyMatchMaps

## How did you test this change?
live bug fix