### PR TITLE
Use `Currency.formatMoney()` instead of formatnum

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -8,6 +8,7 @@
 
 local Abbreviation = require('Module:Abbreviation')
 local Class = require('Module:Class')
+local Currency = require('Module:Currency')
 local Game = require('Module:Game')
 local Info = require('Module:Info')
 local Json = require('Module:Json')
@@ -40,8 +41,6 @@ local Builder = Widgets.Builder
 local Team = Class.new(BasicInfobox)
 
 local LINK_VARIANT = 'team'
-
-local Language = mw.language.new('en')
 
 ---@enum statuses
 local Status = {
@@ -127,7 +126,7 @@ function Team:createInfobox()
 					'Approx. Total Winnings',
 					'Includes individual player earnings won&#10;while representing this team'
 				),
-				content = {self.totalEarnings > 0 and '$' .. Language:formatNum(self.totalEarnings) or nil}}
+				content = {self.totalEarnings > 0 and ('$' .. Currency.formatMoney(self.totalEarnings)) or nil}}
 			}
 		},
 		Customizable{id = 'custom', children = {}},

--- a/components/infobox/wikis/fortnite/infobox_team_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_team_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Currency = require('Module:Currency')
 local Lpdb = require('Module:Lpdb')
 local Lua = require('Module:Lua')
 local Math = require('Module:MathUtil')
@@ -54,7 +55,7 @@ function CustomInjector:parse(id, widgets)
 		local playerEarnings = self.caller.totalPlayerEarnings
 		table.insert(widgets, Cell{
 			name = PLAYER_EARNINGS_ABBREVIATION,
-			content = {playerEarnings ~= 0 and ('$' .. mw.language.new('en'):formatNum(Math.round(playerEarnings))) or nil}
+			content = {playerEarnings ~= 0 and ('$' .. Currency.formatMoney(playerEarnings)) or nil}
 		})
 	end
 

--- a/components/infobox/wikis/starcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_team_custom.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Currency = require('Module:Currency')
 local Info = require('Module:Info')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -72,7 +73,7 @@ function CustomInjector:parse(id, widgets)
 		table.insert(widgets, Cell{name = 'Gaming Director', content = {args['gaming director']}})
 	elseif id == 'earnings' then
 		local displayEarnings = function(value)
-			return value > 0 and '$' .. mw.language.new('en'):formatNum(value) or nil
+			return value > 0 and ('$' .. Currency.formatMoney(value)) or nil
 		end
 
 		return {

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Currency = require('Module:Currency')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lpdb = require('Module:Lpdb')
@@ -65,7 +66,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'earnings' then
 		local displayEarnings = function(value)
-			return value > 0 and '$' .. mw.language.new('en'):formatNum(value) or nil
+			return value > 0 and ('$' .. Currency.formatMoney(value)) or nil
 		end
 
 		return {


### PR DESCRIPTION
## Summary
As per martins comment in #3722 (after merge) use `Currency.formatMoney()` instead of formatnum

## How did you test this change?
not tested