### PR TITLE
AoE: Fix wrong game info in HDB

### DIFF
--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -43,6 +43,8 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('edate', Variables.varDefault('tournament_enddate', ''))
 	Variables.varDefine('sdate', Variables.varDefault('tournament_startdate', ''))
 
+	Variables.varDefine('tournament_game', args.game or queryResult.game)
+
 	--headtohead option
 	Variables.varDefine('tournament_headtohead', args.headtohead)
 	Variables.varDefine('headtohead', args.headtohead)


### PR DESCRIPTION
## Summary
AoE match expects names, not identifiers.
Issue introduced with #3655 

## How did you test this change?
live
