### PR TITLE
Store LPDB data for player's history on CoD

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -48,6 +48,7 @@ function CustomInjector:parse(id, widgets)
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
 			convertrole = 'true',
+			addlpdbdata = 'true',
 			player = _pagename
 		}
 

--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -47,8 +47,8 @@ function CustomInjector:parse(id, widgets)
 	if id == 'history' then
 		local manualHistory = _args.history
 		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
-			addlpdbdata = 'true',
+			convertrole = true,
+			addlpdbdata = true,
 			player = _pagename
 		}
 


### PR DESCRIPTION
## Summary
Store LPDB data for Players' Team History on CoD. This is so automatically retrieval of player's team can be enabled on other pages via Opponent.sync()

## How did you test this change?
dev=1 https://liquipedia.net/callofduty/Special:LiquipediaDB/Drazah