### PR TITLE
Fix "RandomEvent" stuff in sc2 participant table

### DIFF
--- a/components/participant_table/commons/participant_table_base.lua
+++ b/components/participant_table/commons/participant_table_base.lua
@@ -80,6 +80,7 @@ end
 ---@return ParticipantTableConfig
 function ParticipantTable.readConfig(args, parentConfig)
 	parentConfig = parentConfig or {}
+
 	local config = {
 		lpdbPrefix = args.lpdbPrefix or parentConfig.lpdbPrefix or Variables.varDefault('lpdbPrefix'),
 		noStorage = Logic.readBool(args.noStorage or parentConfig.noStorage or
@@ -171,6 +172,7 @@ function ParticipantTable:readSection(args)
 
 	section.entries = Array.map(Import.importFromMatchGroupSpec(config, entriesByName), function(entry)
 		entry.opponent = Opponent.resolve(entry.opponent, config.resolveDate, {syncPlayer = config.syncPlayers})
+		self:setCustomPageVariables(entry, config)
 		return entry
 	end)
 
@@ -179,6 +181,11 @@ function ParticipantTable:readSection(args)
 	end)
 
 	table.insert(self.sections, section)
+end
+
+---@param entry ParticipantTableEntry
+---@param config ParticipantTableConfig
+function ParticipantTable:setCustomPageVariables(entry, config)
 end
 
 ---@class ParticipantTableEntry
@@ -191,7 +198,7 @@ end
 ---@param sectionArgs table
 ---@param key string|number
 ---@param index number
----@param config any
+---@param config ParticipantTableConfig
 ---@return ParticipantTableEntry
 function ParticipantTable:readEntry(sectionArgs, key, index, config)
 	local prefix = 'p' .. index
@@ -263,7 +270,7 @@ function ParticipantTable:store()
 
 		lpdbData = Table.merge(lpdbTournamentData, lpdbData, {date = section.config.resolveDate, extradata = {}})
 
-		ParticipantTable:adjustLpdbData(lpdbData, entry, section.config)
+		self:adjustLpdbData(lpdbData, entry, section.config)
 
 		mw.ext.LiquipediaDB.lpdb_placement(self:objectName(lpdbData), Json.stringifySubTables(lpdbData))
 	end) end)

--- a/components/participant_table/commons/participant_table_base.lua
+++ b/components/participant_table/commons/participant_table_base.lua
@@ -31,6 +31,36 @@ local TournamentStructure = Lua.import('Module:TournamentStructure', {requireDev
 
 local pageVars = PageVariableNamespace('ParticipantTable')
 
+---@class ParticipantTableConfig
+---@field lpdbPrefix string?
+---@field noStorage boolean
+---@field matchGroupSpec table?
+---@field syncPlayers boolean
+---@field showCountBySection boolean
+---@field onlyNotable boolean
+---@field count number?
+---@field colSpan number
+---@field resolveDate string
+---@field sortPlayers boolean sort players within an opponent
+---@field sortOpponents boolean
+---@field showTeams boolean
+---@field title string?
+---@field importOnlyQualified boolean?
+---@field display boolean
+---@field width string
+---@field columnWidth string
+
+---@class ParticipantTableSection
+---@field config ParticipantTableConfig
+---@field entries ParticipantTableEntry
+
+---@class ParticipantTableEntry
+---@field opponent standardOpponent
+---@field name string
+---@field note string?
+---@field dq boolean
+---@field inputIndex integer?
+
 ---@class ParticipantTable
 ---@operator call(Frame): ParticipantTable
 ---@field args table
@@ -55,25 +85,6 @@ function ParticipantTable:read()
 
 	return self
 end
-
----@class ParticipantTableConfig
----@field lpdbPrefix string?
----@field noStorage boolean
----@field matchGroupSpec table?
----@field syncPlayers boolean
----@field showCountBySection boolean
----@field onlyNotable boolean
----@field count number?
----@field colSpan number
----@field resolveDate string
----@field sortPlayers boolean sort players within an opponent
----@field sortOpponents boolean
----@field showTeams boolean
----@field title string?
----@field importOnlyQualified boolean?
----@field display boolean
----@field width string
----@field columnWidth string
 
 ---@param args table
 ---@param parentConfig ParticipantTableConfig?
@@ -147,11 +158,6 @@ function ParticipantTable._stashArgs(potentialSection)
 	return potentialSection
 end
 
-
----@class ParticipantTableSection
----@field config ParticipantTableConfig
----@field entries ParticipantTableEntry
-
 ---@param args table
 function ParticipantTable:readSection(args)
 	local config = self.readConfig(args, self.config)
@@ -187,13 +193,6 @@ end
 ---@param config ParticipantTableConfig
 function ParticipantTable:setCustomPageVariables(entry, config)
 end
-
----@class ParticipantTableEntry
----@field opponent standardOpponent
----@field name string
----@field note string?
----@field dq boolean
----@field inputIndex integer?
 
 ---@param sectionArgs table
 ---@param key string|number

--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -60,6 +60,7 @@ function StarcraftParticipantTable.run(frame)
 	participantTable._displaySoloRaceTableSection = StarcraftParticipantTable._displaySoloRaceTableSection
 	participantTable._displayHeader = StarcraftParticipantTable._displayHeader
 	participantTable._getFactionNumbers = StarcraftParticipantTable._getFactionNumbers
+	participantTable.setCustomPageVariables = StarcraftParticipantTable.setCustomPageVariables
 
 	participantTable:read():store()
 
@@ -145,6 +146,10 @@ end
 ---@param entry StarcraftParticipantTableEntry
 ---@param config StarcraftParticipantTableConfig
 function StarcraftParticipantTable:adjustLpdbData(lpdbData, entry, config)
+	if config.isRandomEvent then
+		lpdbData.opponentplayers.p1faction = Faction.read('r')
+	end
+
 	local seriesNumber = tonumber(Variables.varDefault('tournament_series_number'))
 	local isQualified = entry.isQualified or config.isQualified
 
@@ -299,6 +304,14 @@ function StarcraftParticipantTable:_displaySoloRaceTableSection(section, faction
 		end)
 		self.display:node(sectionNode)
 	end)
+end
+
+---@param entry StarcraftParticipantTableEntry
+---@param config StarcraftParticipantTableConfig
+function StarcraftParticipantTable:setCustomPageVariables(entry, config)
+	if config.isRandomEvent then
+		Variables.varDefine(entry.opponent.players[1].displayName .. '_race', Faction.read('r'))
+	end
 end
 
 return StarcraftParticipantTable


### PR DESCRIPTION
## Summary
Fix "RandomEvent" stuff in sc2 participant table
- set race as random always in this case (both in lpdb data as well as wiki var)

Also:
- fix an anno (`any` --> `ParticipantTableConfig`)
- move class definition annos in base up
- fix a `ParticipantTable:` --> `self:` "typo"

## How did you test this change?
dev to live (since bug fix)