### PR TITLE
Fix links in infobox series

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -348,10 +348,9 @@ end
 ---@param variant string?
 ---@return {[string]: string}
 function Links.makeFullLinksForTableItems(links, variant)
-	for key, item in pairs(links) do
-		links[key] = Links.makeFullLink(Links.removeAppendedNumber(key), item, variant)
-	end
-	return links
+	return Table.map(links, function(key, item)
+		return key, Links.makeFullLink(Links.removeAppendedNumber(key), item, variant)
+	end)
 end
 
 --remove appended number


### PR DESCRIPTION
## Summary
Fix links in infobox series

![Screenshot 2024-01-03 12 34 16](https://github.com/Liquipedia/Lua-Modules/assets/75081997/92b56c52-c731-4cf8-8d80-97d4873e7912)

Due to changing the order in processing the `Links.makeFullLinksForTableItems` now happens before the display and hence changes the links table.
To avoid that make `Links.makeFullLinksForTableItems` not mutate anymore

## How did you test this change?
dev

