### PR TITLE
Alternative to #3736 make all faction data game specific

### DIFF
--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -56,7 +56,7 @@ local byLowerName = Table.map(byName, transformWrapper(function(name, faction) r
 ---@param game string?
 ---@return boolean
 function Faction.isValid(faction, game)
-	return String.isNotEmpty(game) and (Data.factionProps[game] or {})[faction] ~= nil
+	return game and (Data.factionProps[game] or {})[faction] ~= nil
 		or Data.factionProps[faction] ~= nil
 end
 
@@ -65,7 +65,7 @@ end
 ---@param game string?
 ---@return table?
 function Faction.getProps(faction, game)
-	return String.isNotEmpty(game) and (Data.factionProps[game] or {})[faction]
+	return game and (Data.factionProps[game] or {})[faction]
 		or Data.factionProps[faction]
 end
 
@@ -84,11 +84,13 @@ function Faction.read(faction, options)
 
 	faction = faction:lower()
 	return Faction.isValid(faction, options.game) and faction
-		or (String.isNotEmpty(options.game) and (byLowerName[options.game] or {})[faction] or byLowerName[faction])
+		or (options.game and (byLowerName[options.game] or {})[faction] or byLowerName[faction])
 		or (
 			options.alias ~= false
-			and (String.isNotEmpty(options.game) and (Faction.aliases[options.game] or {})[faction]
-			or Faction.aliases[faction])
+			and (
+				options.game and (Faction.aliases[options.game] or {})[faction]
+				or Faction.aliases[faction]
+			)
 		) or nil
 end
 
@@ -168,8 +170,7 @@ function Faction.Icon(props)
 		size = size .. 'px'
 	end
 
-	local iconData = String.isNotEmpty(props.game)
-		and (IconData.byFaction[props.game] or {})[faction]
+	local iconData = props.game and (IconData.byFaction[props.game] or {})[faction]
 		or IconData.byFaction[faction]
 		or {}
 	local iconName = iconData.icon

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -56,7 +56,7 @@ local byLowerName = Table.map(byName, transformWrapper(function(name, faction) r
 ---@param game string?
 ---@return boolean
 function Faction.isValid(faction, game)
-	return String.isNotEmpty(game) and Data.factionProps[game] ~= nil and Data.factionProps[game][faction] ~= nil
+	return String.isNotEmpty(game) and (Data.factionProps[game] or {})[faction] ~= nil
 		or Data.factionProps[faction] ~= nil
 end
 
@@ -65,7 +65,7 @@ end
 ---@param game string?
 ---@return table?
 function Faction.getProps(faction, game)
-	return String.isNotEmpty(game) and Data.factionProps[game][faction]
+	return String.isNotEmpty(game) and (Data.factionProps[game] or {})[faction]
 		or Data.factionProps[faction]
 end
 
@@ -84,9 +84,12 @@ function Faction.read(faction, options)
 
 	faction = faction:lower()
 	return Faction.isValid(faction, options.game) and faction
-		or (String.isNotEmpty(options.game) and byLowerName[options.game][faction] or byLowerName[faction])
-		or (options.alias ~= false and (String.isNotEmpty(options.game) and Faction.aliases[options.game][faction] or Faction.aliases[faction]))
-		or nil
+		or (String.isNotEmpty(options.game) and (byLowerName[options.game] or {})[faction] or byLowerName[faction])
+		or (
+			options.alias ~= false
+			and (String.isNotEmpty(options.game) and (Faction.aliases[options.game] or {})[faction]
+			or Faction.aliases[faction])
+		) or nil
 end
 
 --- Parses multiple factions from input.
@@ -157,7 +160,10 @@ function Faction.Icon(props)
 		size = size .. 'px'
 	end
 
-	local iconData = String.isNotEmpty(props.game) and IconData.byFaction[props.game][faction] or IconData.byFaction[faction] or {}
+	local iconData = String.isNotEmpty(props.game)
+		and (IconData.byFaction[props.game] or {})[faction]
+		or IconData.byFaction[faction]
+		or {}
 	local iconName = iconData.icon
 	if not iconName then return end
 

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -130,12 +130,20 @@ function Faction.toName(faction, game)
 	return factionProps and factionProps.name or nil
 end
 
+---@class FactionIconProps
+---@field faction string
+---@field showLink boolean?
+---@field showTitle boolean?
+---@field size string|number|nil
+---@field title string?
+---@field game string?
 Faction.propTypes.Icon = TypeUtil.struct{
 	faction = 'string',
 	showLink = 'boolean?',
 	showTitle = 'boolean?',
 	size = TypeUtil.union('string', 'number', 'nil'),
 	title = 'string?',
+	game = 'string?',
 }
 
 local namedSizes = {
@@ -146,7 +154,7 @@ local namedSizes = {
 }
 
 --- Returns the icon of an entered faction identifier
----@param props {faction: string?, game: string?, size: string|number|nil, showLink: boolean?, showTitle: boolean?, title: string?}
+---@param props FactionIconProps
 ---@return string?
 function Faction.Icon(props)
 	local faction = Faction.read(props.faction, {game=props.game})

--- a/components/faction/wikis/ageofempires/faction_data.lua
+++ b/components/faction/wikis/ageofempires/faction_data.lua
@@ -8,12 +8,7 @@
 
 local Array = require('Module:Array')
 
-local AOE1_SUFFIX = '/Age of Empires I'
 local AOE2_SUFFIX = '/Age of Empires II'
-local AOE3_SUFFIX = '/Age of Empires III'
-local AOE4_SUFFIX = '/Age of Empires IV'
-local AOM_SUFFIX = '/Age of Mythology'
-local AOEO_SUFFIX = '/Age of Empires Online'
 
 local factionPropsAoE2 = {
     armenians = {

--- a/components/faction/wikis/ageofempires/faction_data.lua
+++ b/components/faction/wikis/ageofempires/faction_data.lua
@@ -1,0 +1,284 @@
+---
+-- @Liquipedia
+-- wiki=ageofempires
+-- page=Module:Faction/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+
+local AOE1_SUFFIX = '/Age of Empires I'
+local AOE2_SUFFIX = '/Age of Empires II'
+local AOE3_SUFFIX = '/Age of Empires III'
+local AOE4_SUFFIX = '/Age of Empires IV'
+local AOM_SUFFIX = '/Age of Mythology'
+local AOEO_SUFFIX = '/Age of Empires Online'
+
+local factionPropsAoE2 = {
+    armenians = {
+        index = 1,
+        name = 'Armenians',
+        faction = 'armenians',
+    },
+    aztecs = {
+        index = 2,
+        name = 'Aztecs',
+        pageName = 'Aztecs' .. AOE2_SUFFIX,
+        faction = 'aztecs',
+    },
+    berbers = {
+        index = 3,
+        name = 'Berbers',
+        faction = 'berbers',
+    },
+    bengalis = {
+        index = 4,
+        name = 'Bengalis',
+        faction = 'bengalis',
+    },
+    bohemians = {
+        index = 4,
+        name = 'Bohemians',
+        faction = 'bohemians',
+    },
+    britons = {
+        index = 5,
+        name = 'Britons',
+        faction = 'britons',
+    },
+    bulgarians = {
+        index = 6,
+        name = 'Bulgarians',
+        faction = 'bulgarians',
+    },
+    burgundians = {
+        index = 7,
+        name = 'Burgundians',
+        faction = 'burgundians',
+    },
+    burmese = {
+        index = 8,
+        name = 'Burmese',
+        faction = 'burmese',
+    },
+    byzantines = {
+        index = 9,
+        name = 'Byzantines',
+        faction = 'byzantines',
+    },
+    celts = {
+        index = 10,
+        name = 'Celts',
+        pageName = 'Celts' .. AOE2_SUFFIX,
+        faction = 'celts',
+    },
+    chinese = {
+        index = 11,
+        name = 'Chinese',
+        pageName = 'Chinese' .. AOE2_SUFFIX,
+        faction = 'chinese',
+    },
+    cumans = {
+        index = 12,
+        name = 'Cumans',
+        faction = 'cumans',
+    },
+    dravidians = {
+        index = 13,
+        name = 'Dravidians',
+        faction = 'dravidians',
+    },
+    ethiopians = {
+        index = 14,
+        name = 'Ethiopians',
+        faction = 'ethiopians',
+    },
+    franks = {
+        index = 15,
+        name = 'Franks',
+        faction = 'franks',
+    },
+    georgians = {
+        index = 16,
+        name = 'Georgians',
+        faction = 'georgians',
+    },
+    goths = {
+        index = 17,
+        name = 'Goths',
+        faction = 'goths',
+    },
+    gurjaras = {
+        index = 18,
+        name = 'Gurjaras',
+        faction = 'gurjaras',
+    },
+    hindustanis = {
+        index = 19,
+        name = 'Hindustanis',
+        faction = 'hindustanis',
+    },
+    huns = {
+        index = 20,
+        name = 'Huns',
+        faction = 'huns',
+    },
+    incas = {
+        index = 21,
+        name = 'Incas',
+        pageName = 'Incas' .. AOE2_SUFFIX,
+        faction = 'incas',
+    },
+    indians = {
+        index = 22,
+        name = 'Indians',
+        pageName = 'Indians' .. AOE2_SUFFIX .. '/The_Forgotten',
+        faction = 'indians',
+    },
+    italians = {
+        index = 23,
+        name = 'Italians',
+        faction = 'italians',
+    },
+    japanese = {
+        index = 24,
+        name = 'Japanese',
+        pageName = 'Japanese' .. AOE2_SUFFIX,
+        faction = 'japanese',
+    },
+    khmer = {
+        index = 25,
+        name = 'Khmer',
+        faction = 'khmer',
+    },
+    koreans = {
+        index = 26,
+        name = 'Koreans',
+        faction = 'koreans',
+    },
+    lithuanians = {
+        index = 27,
+        name = 'Lithuanians',
+        faction = 'lithuanians',
+    },
+    magyars = {
+        index = 28,
+        name = 'Magyars',
+        faction = 'magyars',
+    },
+    malay = {
+        index = 29,
+        name = 'Malay',
+        faction = 'malay',
+    },
+    malians = {
+        index = 30,
+        name = 'Malians',
+        pageName = 'Malians' .. AOE2_SUFFIX,
+        faction = 'malians',
+    },
+    mayans = {
+        index = 31,
+        name = 'Mayans',
+        faction = 'mayans',
+    },
+    mongols = {
+        index = 32,
+        name = 'Mongols',
+        pageName = 'Mongols' .. AOE2_SUFFIX,
+        faction = 'mongols',
+    },
+    persians = {
+        index = 33,
+        name = 'Persians',
+        pageName = 'Persians' .. AOE2_SUFFIX,
+        faction = 'persians',
+    },
+    poles = {
+        index = 34,
+        name = 'Poles',
+        faction = 'poles',
+    },
+    portuguese = {
+        index = 35,
+        name = 'Portuguese',
+        pageName = 'Portuguese' .. AOE2_SUFFIX,
+        faction = 'portuguese',
+    },
+    romans = {
+        index = 36,
+        name = 'Romans',
+        pageName = 'Romans' .. AOE2_SUFFIX,
+        faction = 'romans',
+    },
+    saracens = {
+        index = 37,
+        name = 'Saracens',
+        faction = 'saracens',
+    },
+    sicilians = {
+        index = 38,
+        name = 'Sicilians',
+        faction = 'sicilians',
+    },
+    slavs = {
+        index = 39,
+        name = 'Slavs',
+        faction = 'slavs',
+    },
+    spanish = {
+        index = 40,
+        name = 'Spanish',
+        pageName = 'Spanish' .. AOE2_SUFFIX,
+        faction = 'spanish',
+    },
+    tatars = {
+        index = 41,
+        name = 'Tatars',
+        faction = 'tatars',
+    },
+    teutons = {
+        index = 42,
+        name = 'Teutons',
+        faction = 'teutons',
+    },
+    turks = {
+        index = 43,
+        name = 'Turks',
+        faction = 'turks',
+    },
+    vietnamese = {
+        index = 44,
+        name = 'Vietnamese',
+        faction = 'vietnamese',
+    },
+    vikings = {
+        index = 45,
+        name = 'Vikings',
+        pageName = 'Vikings' .. AOE2_SUFFIX,
+        faction = 'vikings',
+    },
+
+    unknown = {
+        index = 46,
+        name = 'Unknown',
+        faction = 'unknown',
+    },
+}
+
+return {
+    byGame = true,
+    factionProps = {
+        aoe2 = factionPropsAoE2,
+    },
+    defaultFaction = 'unknown',
+    factions = {
+        aoe2 = Array.extractKeys(factionPropsAoE2)
+    },
+    aliases = {
+        aoe2 = {
+
+        },
+    },
+}

--- a/components/faction/wikis/ageofempires/faction_icon_data.lua
+++ b/components/faction/wikis/ageofempires/faction_icon_data.lua
@@ -1,0 +1,160 @@
+---
+-- @Liquipedia
+-- wiki=ageofempires
+-- page=Module:Faction/IconData
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local byFactionAoe2 = {
+	armenians = {
+		icon = 'File:Armenians AoE2 icon.png'
+	},
+    aztecs = {
+		icon = 'File:Aztecs AoE2 icon.png'
+	},
+    berbers = {
+		icon = 'File:Berbers AoE2 icon.png'
+	},
+    bengalis = {
+		icon = 'File:Bengalis AoE2 icon.png'
+	},
+    bohemians = {
+		icon = 'File:Bohemians AoE2 icon.png'
+	},
+    britons = {
+		icon = 'File:Britons AoE2 icon.png'
+	},
+    bulgarians = {
+		icon = 'File:Bulgarians AoE2 icon.png'
+	},
+    burgundians = {
+		icon = 'File:Burgundians AoE2 icon.png'
+	},
+    burmese = {
+		icon = 'File:Burmese AoE2 icon.png'
+	},
+    byzantines = {
+		icon = 'File:Byzantines AoE2 icon.png'
+	},
+    celts = {
+		icon = 'File:Celts AoE2 icon.png'
+	},
+    chinese = {
+		icon = 'File:Chinese AoE2 icon.png'
+	},
+    cumans = {
+		icon = 'File:Cumans AoE2 icon.png'
+	},
+    dravidians = {
+		icon = 'File:Dravidians AoE2 icon.png'
+	},
+    ethiopians = {
+		icon = 'File:Ethiopians AoE2 icon.png'
+	},
+    franks = {
+		icon = 'File:Franks AoE2 icon.png'
+	},
+    georgians = {
+		icon = 'File:Georgians AoE2 icon.png'
+	},
+    goths = {
+		icon = 'File:Goths AoE2 icon.png'
+	},
+    gurjaras = {
+		icon = 'File:Gurjaras AoE2 icon.png'
+	},
+    hindustanis = {
+		icon = 'File:Hindustanis AoE2 icon.png'
+	},
+    huns = {
+		icon = 'File:Huns AoE2 icon.png'
+	},
+    incas = {
+		icon = 'File:Incas AoE2 icon.png'
+	},
+    indians = {
+		icon = 'File:Indians AoE2 icon.png'
+	},
+    italians = {
+		icon = 'File:Italians AoE2 icon.png'
+	},
+    japanese = {
+		icon = 'File:Japanese AoE2 icon.png'
+	},
+    khmer = {
+		icon = 'File:Khmer AoE2 icon.png'
+	},
+    koreans = {
+		icon = 'File:Koreans AoE2 icon.png'
+	},
+    lithuanians = {
+		icon = 'File:Lithuanians AoE2 icon.png'
+	},
+    magyars = {
+		icon = 'File:Magyars AoE2 icon.png'
+	},
+    malay = {
+		icon = 'File:Malay AoE2 icon.png'
+	},
+    malians = {
+		icon = 'File:Malians AoE2 icon.png'
+	},
+    mayans = {
+		icon = 'File:Mayans AoE2 icon.png'
+	},
+    mongols = {
+		icon = 'File:Mongols AoE2 icon.png'
+	},
+    persians = {
+		icon = 'File:Persians AoE2 icon.png'
+	},
+    poles = {
+		icon = 'File:Poles AoE2 icon.png'
+	},
+    portuguese = {
+		icon = 'File:Portuguese AoE2 icon.png'
+	},
+    romans = {
+		icon = 'File:Romans AoE2 icon.png'
+	},
+    saracens = {
+		icon = 'File:Saracens AoE2 icon.png'
+	},
+    sicilians = {
+		icon = 'File:Sicilians AoE2 icon.png'
+	},
+    slavs = {
+		icon = 'File:Slavs AoE2 icon.png'
+	},
+    spanish = {
+		icon = 'File:Spanish AoE2 icon.png'
+	},
+    tatars = {
+		icon = 'File:Tatars AoE2 icon.png'
+	},
+    teutons = {
+		icon = 'File:Teutons AoE2 icon.png'
+	},
+    turks = {
+		icon = 'File:Turks AoE2 icon.png'
+	},
+    vietnamese = {
+		icon = 'File:Vietnamese AoE2 icon.png'
+	},
+    vikings = {
+		icon = 'File:Vikings AoE2 icon.png'
+	},
+
+    unknown = {
+		icon = 'File:Char head filler.png'
+	},
+}
+
+
+return {
+	byGame = true,
+	byFaction = {
+		aoe2 = byFactionAoe2,
+	},
+}

--- a/components/faction/wikis/stormgate/faction_data.lua
+++ b/components/faction/wikis/stormgate/faction_data.lua
@@ -6,6 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Info = require('Module:Info')
+
 local factionProps = {
 	v = {
 		bgClass = 'stormgate-vanguard',
@@ -36,13 +38,24 @@ local factionProps = {
 }
 
 return {
-	factionProps = factionProps,
-	defaultFaction = 'u',
-	factions = {'v', 'i', 'r', 'u'},
-	knownFactions = {'v', 'i', 'r'},
-	coreFactions = {'v', 'i'},
-	aliases = {
-		human = 'v',
-		host = 'i',
+	defaultGame = Info.defaultGame,
+	factionProps = {
+		[Info.defaultGame] = factionProps,
 	},
+	defaultFaction = 'u',
+	factions = {
+		[Info.defaultGame] = {'v', 'i', 'r', 'u'},
+	},
+	knownFactions = {
+		[Info.defaultGame] = {'v', 'i', 'r'},
+	},
+	coreFactions = {
+		[Info.defaultGame] = {'v', 'i'},
+	},
+	aliases = {
+		[Info.defaultGame] = {
+			human = 'v',
+			host = 'i',
+		},
+	}
 }


### PR DESCRIPTION
## Summary
As per title, alternative to #3736 that will create the same (exported) Faction structure on all wikis, with factions per game.
Requires modification of all other faction data to be game-specific, example of stormgate is given.

In addition and more severe, requires adjusting every module that uses one of the exported tables like `coreFactions`, `knownFactions` etc.
 
## How did you test this change?
TBD
