### PR TITLE
feat(filterButtons): Exclude disabling some filters with "All" button

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -70,11 +70,12 @@ liquipedia.filterButtons = {
 			this.buttonFilterAll[ filterGroup ] = this.buttonContainerElements[ filterGroup ].querySelector( '[data-filter-on=all]' );
 			// Get always active filters
 			this.activeAlwaysFilters[ filterGroup ] = [];
-			var activeAlwaysFilters = this.buttonContainerElements[ filterGroup ].getAttribute( 'data-filter-always-active' )
-			if ( typeof activeAlwaysFilters === 'string' )
-				activeAlwaysFilters.split( ',' ).forEach( function(alwaysActiveFilter) {
+			var activeAlwaysFilters = this.buttonContainerElements[ filterGroup ].getAttribute( 'data-filter-always-active' );
+			if ( typeof activeAlwaysFilters === 'string' ) {
+				activeAlwaysFilters.split( ',' ).forEach( function( alwaysActiveFilter ) {
 					this.activeAlwaysFilters[ filterGroup ].push( alwaysActiveFilter );
-				}, this )
+				}, this );
+			}
 
 			var itemQS = '[data-filter-group=' + filterGroup + '][data-filter-category]';
 			if ( filterGroup === this.bcFilterGroup ) {
@@ -95,8 +96,8 @@ liquipedia.filterButtons = {
 	 * If button contains activeClass from start, toggle items.
 	 * When a button is clicked for the first time it will be added to the local storage to remember selection.
 	 *
-	 * @param button
-	 * @param filterGroup
+	 * @param {HTMLSpanElement} button
+	 * @param {string} filterGroup
 	 */
 	filterButtonAllInit: function( button, filterGroup ) {
 		if ( button ) {
@@ -124,8 +125,8 @@ liquipedia.filterButtons = {
 	 * Handles buttons except for the 'all' button.
 	 * Filter items on click and Enter key and write to localStorage.
 	 *
-	 * @param buttons
-	 * @param filterGroup
+	 * @param {HTMLSpanElement[]} buttons
+	 * @param {string} filterGroup
 	 */
 	filterButtonsInit: function( buttons, filterGroup ) {
 		buttons.forEach( function( button ) {
@@ -151,8 +152,8 @@ liquipedia.filterButtons = {
 	/**
 	 * Initial check if button states need to be changed
 	 *
-	 * @param filterGroup
-	 * @param button
+	 * @param {string} filterGroup
+	 * @param {HTMLSpanElement} button
 	 */
 	initButtonState: function( filterGroup, button ) {
 		// Check for data in local storage
@@ -212,12 +213,13 @@ liquipedia.filterButtons = {
 		this.activeFilters[ filterGroup ] = this.activeAlwaysFilters[ filterGroup ].slice( 0 );
 
 		this.buttons[ filterGroup ].forEach( function( button ) {
-			if ( ! this.activeAlwaysFilters[ filterGroup ].includes( button.getAttribute( 'data-filter-on' ) ) )
+			if ( !this.activeAlwaysFilters[ filterGroup ].includes( button.getAttribute( 'data-filter-on' ) ) ) {
 				button.classList.remove( this.activeButtonClass );
+			}
 		}.bind( this ) );
 
 		this.items[ filterGroup ].forEach( function( item ) {
-			if ( ! this.activeAlwaysFilters[ filterGroup ].includes( item.getAttribute( 'data-filter-category' ) ) ) {
+			if ( !this.activeAlwaysFilters[ filterGroup ].includes( item.getAttribute( 'data-filter-category' ) ) ) {
 				item.classList.remove( 'filter-effect-' + this.filterEffect[ filterGroup ] );
 				item.classList.add( this.hiddenCategoryClass );
 			}
@@ -277,7 +279,7 @@ liquipedia.filterButtons = {
 	/**
 	 * Add tabindex attribute to element
 	 *
-	 * @param element
+	 * @param {HTMLElement} element
 	 */
 	setTabIndex: function( element ) {
 		element.setAttribute( 'tabindex', '0' );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -74,7 +74,7 @@ liquipedia.filterButtons = {
 			if ( typeof activeAlwaysFilters === 'string' )
 				activeAlwaysFilters.split( ',' ).forEach( function(alwaysActiveFilter) {
 					this.activeAlwaysFilters[ filterGroup ].push( alwaysActiveFilter );
-				} )
+				}, this )
 
 			var itemQS = '[data-filter-group=' + filterGroup + '][data-filter-category]';
 			if ( filterGroup === this.bcFilterGroup ) {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -209,7 +209,7 @@ liquipedia.filterButtons = {
 	},
 
 	hideAllItems: function( filterGroup ) {
-		this.activeFilters[ filterGroup ] = this.activeAlwaysFilters[ filterGroup ];
+		this.activeFilters[ filterGroup ] = this.activeAlwaysFilters[ filterGroup ].slice( 0 );
 
 		this.buttons[ filterGroup ].forEach( function( button ) {
 			if ( ! this.activeAlwaysFilters[ filterGroup ].includes( button.getAttribute( 'data-filter-on' ) ) )

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -42,6 +42,7 @@ liquipedia.filterButtons = {
 	buttons: {},
 	items: {},
 	activeFilters: {},
+	activeAlwaysFilters: {},
 	localStorageKey: null,
 	localStorageValue: {},
 
@@ -67,6 +68,13 @@ liquipedia.filterButtons = {
 			this.buttons[ filterGroup ] = this.buttonContainerElements[ filterGroup ].querySelectorAll( ':scope > [data-filter-on]:not([data-filter-on=all])' );
 			// Get only 'all' button
 			this.buttonFilterAll[ filterGroup ] = this.buttonContainerElements[ filterGroup ].querySelector( '[data-filter-on=all]' );
+			// Get always active filters
+			this.activeAlwaysFilters[ filterGroup ] = [];
+			var activeAlwaysFilters = this.buttonContainerElements[ filterGroup ].getAttribute( 'data-filter-always-active' )
+			if ( typeof activeAlwaysFilters === 'string' )
+				activeAlwaysFilters.split( ',' ).forEach( function(alwaysActiveFilter) {
+					this.activeAlwaysFilters[ filterGroup ].push( alwaysActiveFilter );
+				} )
 
 			var itemQS = '[data-filter-group=' + filterGroup + '][data-filter-category]';
 			if ( filterGroup === this.bcFilterGroup ) {
@@ -201,15 +209,18 @@ liquipedia.filterButtons = {
 	},
 
 	hideAllItems: function( filterGroup ) {
-		this.activeFilters[ filterGroup ] = [];
+		this.activeFilters[ filterGroup ] = this.activeAlwaysFilters[ filterGroup ];
 
 		this.buttons[ filterGroup ].forEach( function( button ) {
-			button.classList.remove( this.activeButtonClass );
+			if ( ! this.activeAlwaysFilters[ filterGroup ].includes( button.getAttribute( 'data-filter-on' ) ) )
+				button.classList.remove( this.activeButtonClass );
 		}.bind( this ) );
 
 		this.items[ filterGroup ].forEach( function( item ) {
-			item.classList.remove( 'filter-effect-' + this.filterEffect[ filterGroup ] );
-			item.classList.add( this.hiddenCategoryClass );
+			if ( ! this.activeAlwaysFilters[ filterGroup ].includes( item.getAttribute( 'data-filter-category' ) ) ) {
+				item.classList.remove( 'filter-effect-' + this.filterEffect[ filterGroup ] );
+				item.classList.add( this.hiddenCategoryClass );
+			}
 		}.bind( this ) );
 
 		this.buttonFilterAll[ filterGroup ].classList.remove( this.activeButtonClass );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -202,8 +202,10 @@ liquipedia.filterButtons = {
 		}.bind( this ) );
 
 		this.items[ filterGroup ].forEach( function( item ) {
-			item.classList.add( 'filter-effect-' + this.filterEffect[ filterGroup ] );
-			item.classList.remove( this.hiddenCategoryClass );
+			if ( this.activeFilters[ filterGroup ].includes( item.getAttribute( 'data-filter-category' ) ) ) {
+				item.classList.add( 'filter-effect-' + this.filterEffect[ filterGroup ] );
+				item.classList.remove( this.hiddenCategoryClass );
+			}
 		}.bind( this ) );
 
 		this.buttonFilterAll[ filterGroup ].classList.add( this.activeButtonClass );


### PR DESCRIPTION
## Summary

Added functionality to javascript of filter buttons to have certain filters that are not disabled by the "All" toggle. This is useful for tiertypes because of the default "empty" tiertype. If used for something that isn't the empty tier type and a button is still rendered, then you can still toggle it manually.

https://liquipedia.net/commons/index.php?title=Module%3ATournamentsList%2Fdev&type=revision&diff=542325&oldid=542323

https://github.com/Liquipedia/Lua-Modules/assets/5881994/667e3b4b-551d-4893-a5dd-3852bd533cdb

(Monthly is also set as always active for demo purposes only)

## How did you test this change?

Tested on dev wiki.

http://darkrai.wiki.tldev.eu/rocketleague/Main_Page
