### PR TITLE
Refactor infobox person base module

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -231,7 +231,7 @@ function Person:createInfobox()
 				statusToStore
 			)))
 
-	--move remove this after all customs have been cleaned up
+	--remove this after all customs have been cleaned up
 	--only here so we do not break role storage on 16 wikis ...
 	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
 

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -98,8 +98,8 @@ function Person:createInfobox()
 
 	-- check if non-representing is used and set an according value in self
 	-- so it can be accessed in the /Custom modules
-	args.country = Person:getStandardNationalityValue(args.country or args.nationality)
-	if args.country == Person:getStandardNationalityValue('non-representing') then
+	args.country = self:getStandardNationalityValue(args.country or args.nationality)
+	if args.country == self:getStandardNationalityValue('non-representing') then
 		self.nonRepresenting = true
 	end
 
@@ -273,8 +273,8 @@ function Person:_setLpdbData(args, links, status, personType)
 		romanizedname = args.romanized_name or args.name,
 		localizedname = String.isNotEmpty(args.romanized_name) and args.name or nil,
 		nationality = args.country, -- already standardized above
-		nationality2 = Person:getStandardNationalityValue(args.country2 or args.nationality2),
-		nationality3 = Person:getStandardNationalityValue(args.country3 or args.nationality3),
+		nationality2 = self:getStandardNationalityValue(args.country2 or args.nationality2),
+		nationality3 = self:getStandardNationalityValue(args.country3 or args.nationality3),
 		birthdate = self.age.birthDateIso,
 		deathdate = self.age.deathDateIso,
 		image = args.image,
@@ -442,12 +442,12 @@ function Person:_createLocations(args, personType)
 		return countryDisplayData
 	end
 
-	countryDisplayData[1] = Person:_createLocation(country, args.location, personType)
+	countryDisplayData[1] = self:_createLocation(country, args.location, personType)
 
 	local index = 2
 	country = args['country2'] or args['nationality2']
 	while(not String.isEmpty(country)) do
-		countryDisplayData[index] = Person:_createLocation(country, args['location' .. index], personType)
+		countryDisplayData[index] = self:_createLocation(country, args['location' .. index], personType)
 		index = index + 1
 		country = args['country' .. index] or args['nationality' .. index]
 	end

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -510,10 +510,10 @@ end
 function Person:getCategories(args, birthDisplay, personType, status)
 	if self:shouldStoreData(args) then
 		local team = args.teamlink or args.team
-		local categories = {
+		local categories = Array.append(self.age.categories,
 			personType .. 's',
-			status .. ' ' .. personType .. 's',
-		}
+			status .. ' ' .. personType .. 's'
+		)
 
 		if
 			not self.nonRepresenting and (args.country2 or args.nationality2)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -231,8 +231,6 @@ function Person:createInfobox()
 				statusToStore
 			)))
 
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if self:shouldStoreData(args) then
 		self:_definePageVariables(args)
 		self:_setLpdbData(
@@ -244,7 +242,7 @@ function Person:createInfobox()
 	end
 
 	return mw.html.create()
-		:node(builtInfobox)
+		:node(infobox:widgetInjector(self:createWidgetInjector()):build(widgets))
 		:node(WarningBox.displayAll(self.warnings))
 end
 

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -231,6 +231,10 @@ function Person:createInfobox()
 				statusToStore
 			)))
 
+	--move remove this after all customs have been cleaned up
+	--only here so we do not break role storage on 16 wikis ...
+	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
+
 	if self:shouldStoreData(args) then
 		self:_definePageVariables(args)
 		self:_setLpdbData(
@@ -242,7 +246,9 @@ function Person:createInfobox()
 	end
 
 	return mw.html.create()
-		:node(infobox:widgetInjector(self:createWidgetInjector()):build(widgets))
+		:node(builtInfobox)
+		--kick above line and un-comment below line after customs have been cleaned up
+		--:node(infobox:build(widgets))
 		:node(WarningBox.displayAll(self.warnings))
 end
 

--- a/components/infobox/extensions/commons/age_calculation.lua
+++ b/components/infobox/extensions/commons/age_calculation.lua
@@ -221,7 +221,7 @@ function Age:_secondsToAge(seconds)
 end
 
 ---@param args table
----@return {birthDateIso: string?, deathDateIso: string?, categories: string[], birth: string?, death: string}
+---@return {birthDateIso: string?, deathDateIso: string?, categories: string[], birth: string?, death: string?}
 function AgeCalculation.run(args)
 	local birthLocation = args.birthlocation
 	local birthDate = BirthDate(args.birthdate, birthLocation)

--- a/components/infobox/extensions/commons/age_calculation.lua
+++ b/components/infobox/extensions/commons/age_calculation.lua
@@ -6,9 +6,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local String = require('Module:StringUtils')
-local Variables = require('Module:Variables')
 
 local AgeCalculation = {}
 
@@ -196,7 +196,6 @@ function Age:_secondsToAge(seconds)
 end
 
 function AgeCalculation.run(args)
-	local shouldStore = args.shouldstore
 	local birthLocation = args.birthlocation
 	local birthDate = BirthDate(args.birthdate, birthLocation)
 	local deathDate = DeathDate(args.deathdate)
@@ -205,25 +204,18 @@ function AgeCalculation.run(args)
 
 	local age = Age(birthDate, deathDate):makeDisplay()
 
-	if shouldStore then
-		if age.birth and not birthDate.isExact then
-			age.birth = age.birth .. '[[Category:Incomplete birth dates]]'
-		end
-
-		if birthDate.year then
-			age.birth = age.birth .. '[[Category:' .. birthDate.year .. ' births]]'
-		end
-
-		if age.death and not deathDate.isExact then
-			age.death = age.death .. '[[Category:Incomplete death dates]]'
-		end
-	end
+	local categories = Array.append({},
+		age.birth and not birthDate.isExact and 'Incomplete birth dates' or nil,
+		birthDate.year and (birthDate.year .. ' births') or nil,
+		age.death and not deathDate.isExact and 'Incomplete death dates' or nil
+	)
 
 	return {
 		birthDateIso = birthDate:makeIso(),
 		deathDateIso = deathDate:makeIso(),
 		birth = age.birth,
-		death = age.death
+		death = age.death,
+		categories = categories,
 	}
 end
 

--- a/components/infobox/extensions/commons/age_calculation.lua
+++ b/components/infobox/extensions/commons/age_calculation.lua
@@ -205,9 +205,6 @@ function AgeCalculation.run(args)
 
 	local age = Age(birthDate, deathDate):makeDisplay()
 
-	Variables.varDefine('player_birthdate', birthDate:makeIso())
-	Variables.varDefine('player_deathdate', deathDate:makeIso())
-
 	if shouldStore then
 		if age.birth and not birthDate.isExact then
 			age.birth = age.birth .. '[[Category:Incomplete birth dates]]'
@@ -223,6 +220,8 @@ function AgeCalculation.run(args)
 	end
 
 	return {
+		birthDateIso = birthDate:makeIso(),
+		deathDateIso = deathDate:makeIso(),
 		birth = age.birth,
 		death = age.death
 	}

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -21,7 +21,6 @@ local Region = require('Module:Region')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
-local Variables = require('Module:Variables')
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements', {requireDevIfEnabled = true})
 local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -134,8 +134,8 @@ function CustomPlayer.run(frame)
 			id = _args.id,
 			idIPA = _args.idIPA,
 			idAudio = _args.idAudio,
-			birthdate = Variables.varDefault('player_birthdate'),
-			deathdate = Variables.varDefault('player_deathdate'),
+			birthdate = _player.age.birthDateIso,
+			deathdate = _player.age.deathDateIso,
 			nationality = _args.country,
 			nationality2 = _args.country2,
 			nationality3 = _args.country3,
@@ -144,7 +144,9 @@ function CustomPlayer.run(frame)
 		}
 	end
 
-	return builtInfobox .. autoPlayerIntro
+	return mw.html.create()
+		:node(builtInfobox)
+		:node(autoPlayerIntro)
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -37,6 +37,8 @@ function CustomPlayer.run(frame)
 	_args = player.args
 	_args.autoTeam = true
 
+	_role = Role.run({role = _args.role})
+	_role2 = Role.run({role = _args.role2})
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
 
@@ -45,8 +47,6 @@ end
 
 function CustomInjector:parse(id, widgets)
 	if id == 'role' then
-		_role = Role.run({role = _args.role})
-		_role2 = Role.run({role = _args.role2})
 		return {
 			Cell{name = _role2.display and 'Roles' or 'Role', content = {_role.display, _role2.display}}
 		}

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -46,6 +46,9 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
+	player.roleData = CustomPlayer._getRole(player.args.role)
+	player.roleData2 = CustomPlayer._getRole(player.args.role2)
+
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
@@ -63,9 +66,9 @@ function CustomPlayer.run(frame)
 			name = Logic.emptyOr(_args.romanized_name, _args.name),
 			romanizedname = _args.romanized_name,
 			status = _args.status,
-			type = Variables.varDefault('type'),
-			role = Variables.varDefault('role'),
-			role2 = Variables.varDefault('role2'),
+			type = player.roleData.personType,
+			role = player.roleData.variable,
+			role2 = player.roleData2.variable,
 			id = _args.id,
 			idIPA = _args.idIPA,
 			idAudio = _args.idAudio,
@@ -128,10 +131,10 @@ function CustomPlayer:createWidgetInjector()
 end
 
 function CustomPlayer:adjustLPDB(lpdbData)
-	lpdbData.extradata.role = Variables.varDefault('role')
-	lpdbData.extradata.role2 = Variables.varDefault('role2')
+	lpdbData.extradata.role = self.roleData.variable
+	lpdbData.extradata.role2 = self.roleData2.variable
 
-	lpdbData.type = Variables.varDefault('type', 'player')
+	lpdbData.type = Logic.emptyOr(self.roleData.variable, 'player')
 
 	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {_args.country})
 
@@ -174,24 +177,21 @@ function CustomPlayer._createRole(role)
 end
 
 function CustomPlayer:defineCustomPageVariables(args)
-	local roleData = CustomPlayer._getRole(args.role)
-
-	if roleData then
-		Variables.varDefine('role', roleData.variable)
-		Variables.varDefine('type', roleData.personType)
+	if self.roleData then
+		Variables.varDefine('role', self.roleData.variable)
+		Variables.varDefine('type', self.roleData.personType)
 	end
 
 	-- If the role is missing, assume it is a player
-	if roleData and roleData.isplayer == false then
+	if self.roleData and self.roleData.isplayer == false then
 		Variables.varDefine('isplayer', 'false')
 	else
 		Variables.varDefine('isplayer', 'true')
 	end
 
-	local role2Data = CustomPlayer._getRole(args.role2)
-	if role2Data then
-		Variables.varDefine('role2', role2Data.variable)
-		Variables.varDefine('type2', role2Data.personType)
+	if self.roleData2 then
+		Variables.varDefine('role2', self.roleData2.variable)
+		Variables.varDefine('type2', self.roleData2.personType)
 	end
 end
 

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -46,8 +46,8 @@ local _args
 function CustomPlayer.run(frame)
 	local player = Player(frame)
 
-	player.roleData = CustomPlayer._getRole(player.args.role)
-	player.roleData2 = CustomPlayer._getRole(player.args.role2)
+	player.roleData = CustomPlayer._getRole(player.args.role) or {}
+	player.roleData2 = CustomPlayer._getRole(player.args.role2) or {}
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createBottomContent = CustomPlayer.createBottomContent

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -69,8 +69,8 @@ function CustomPlayer.run(frame)
 			id = _args.id,
 			idIPA = _args.idIPA,
 			idAudio = _args.idAudio,
-			birthdate = Variables.varDefault('player_birthdate'),
-			deathdate = Variables.varDefault('player_deathdate'),
+			birthdate = player.age.birthDateIso,
+			deathdate = player.age.deathDateIso,
 			nationality = _args.country,
 			nationality2 = _args.country2,
 			nationality3 = _args.country3,
@@ -81,7 +81,9 @@ function CustomPlayer.run(frame)
 		autoPlayerIntro = _args.freetext
 	end
 
-	return builtInfobox .. autoPlayerIntro
+	return mw.html.create()
+		:node(builtInfobox)
+		:node(autoPlayerIntro)
 end
 
 function CustomInjector:parse(id, widgets)

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -41,6 +41,8 @@ function CustomPlayer.run(frame)
 	_args = player.args
 	_player = player
 	_args.autoTeam = true
+	_role = Role.run({role = _args.role})
+	_role2 = Role.run({role = _args.role2})
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
@@ -66,8 +68,6 @@ function CustomInjector:parse(id, widgets)
 		end
 	elseif id == 'region' then return {}
 	elseif id == 'role' then
-		_role = Role.run({role = _args.role})
-		_role2 = Role.run({role = _args.role2})
 		return {
 			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
 		}

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -40,6 +40,8 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 	_args.autoTeam = true
+	_role = Role.run({role = _args.role})
+	_role2 = Role.run({role = _args.role2})
 
 	return player:createInfobox()
 end
@@ -61,8 +63,6 @@ function CustomInjector:parse(id, widgets)
 		end
 	elseif id == 'region' then return {}
 	elseif id == 'role' then
-		_role = Role.run({role = _args.role})
-		_role2 = Role.run({role = _args.role2})
 		return {
 			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
 		}

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -46,6 +46,8 @@ function CustomPlayer.run(frame)
 
 	_args = player.args
 	_args.autoTeam = true
+	_role = Role.run({role = _args.role})
+	_role2 = Role.run({role = _args.role2})
 
 	return player:createInfobox()
 end
@@ -68,8 +70,6 @@ function CustomInjector:parse(id, widgets)
 		end
 	elseif id == 'region' then return {}
 	elseif id == 'role' then
-		_role = Role.run({role = _args.role})
-		_role2 = Role.run({role = _args.role2})
 		return {
 			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
 		}

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -23,8 +23,6 @@ local Title = Widgets.Title
 local Center = Widgets.Center
 
 local _pagename = mw.title.getCurrentTitle().prefixedText
-local _role
-local _role2
 
 local CustomPlayer = Class.new()
 
@@ -34,7 +32,11 @@ local _args
 
 function CustomPlayer.run(frame)
 	local player = Player(frame)
+	player:setWidgetInjector(CustomInjector(player))
 	_args = player.args
+
+	player.roleData = Role.run({role = _args.role})
+	player.roleData2 = Role.run({role = _args.role2})
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
@@ -59,10 +61,8 @@ function CustomInjector:parse(id, widgets)
 		end
 	elseif id == 'region' then return {}
 	elseif id == 'role' then
-		_role = Role.run({role = _args.role})
-		_role2 = Role.run({role = _args.role2})
 		return {
-			Cell{name = 'Role(s)', content = {_role.display, _role2.display}}
+			Cell{name = 'Role(s)', content = {self.caller.roleData.display, self.caller.roleData2.display}}
 		}
 	end
 	return widgets
@@ -77,14 +77,10 @@ function CustomInjector:addCustomCells(widgets)
 	}
 end
 
-function CustomPlayer:createWidgetInjector()
-	return CustomInjector()
-end
-
 function CustomPlayer:adjustLPDB(lpdbData)
-	lpdbData.extradata.isplayer = _role.isPlayer or 'true'
-	lpdbData.extradata.role = _role.role
-	lpdbData.extradata.role2 = _role2.role
+	lpdbData.extradata.isplayer = self.roleData.isPlayer or 'true'
+	lpdbData.extradata.role = self.roleData.role
+	lpdbData.extradata.role2 = self.roleData2.role
 
 	lpdbData.region = String.nilIfEmpty(Region.name({region = _args.region, country = _args.country}))
 

--- a/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
@@ -40,6 +40,8 @@ function CustomPlayer.run(frame)
 
 	_player = player
 	_args = player.args
+	_role = Role.run({role = _args.role})
+	_role2 = Role.run({role = _args.role2})
 
 	player.adjustLPDB = CustomPlayer.adjustLPDB
 	player.createWidgetInjector = CustomPlayer.createWidgetInjector
@@ -51,8 +53,6 @@ function CustomInjector:parse(id, widgets)
 	if id == 'region' then return {}
 
 	elseif id == 'role' then
-		_role = Role.run({role = _args.role})
-		_role2 = Role.run({role = _args.role2})
 		return {
 			Cell{name = _role2.display and 'Roles' or 'Role', content = {_role.display, _role2.display}}
 		}


### PR DESCRIPTION
## Summary
Refactor infobox person base module
- refactor agecalculation to not have to rely on wiki variables and be able to handle categories better
- return html instead of string
- kick "global" vars
- codestyle cleanups
- ...

## Note
The changes to the customs are only so that we do not break them.
The customs will get refactored in other PRs later on

## How did you test this change?
- [x] preview tests on 5 wikis
- [x] lpdb data test on sc2
- [x] letting editors test on their own wikis (for 3.5 days) https://discord.com/channels/93055209017729024/878766918880874536/1192775362875248680