### PR TITLE
fix(matchticker): Unexpected behaviour when TT doesn't exist

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -120,7 +120,8 @@ function MatchTicker:init(args)
 		not (config.upcoming or config.ongoing)),
 		'Invalid recent, upcoming, ongoing combination')
 
-	local teamPages = args.team and Team.queryHistoricalNames(args.team) or nil
+	local teamPages = args.team and Team.queryHistoricalNames(args.team)
+		or args.team and {args.team} or nil
 	if teamPages then
 		Array.extendWith(teamPages,
 		Array.map(teamPages, function(team) return (team:gsub(' ', '_')) end),


### PR DESCRIPTION
## Summary

If a team argument is passed by the team doesn't have a team template, the behaviour switches to being a ticker for all teams and isn't filtered anymore. This isn't really intended behaviour imo.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/9297d814-73ff-446d-a7e4-43765c91b663)

## How did you test this change?

`/dev`

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/c742b9ec-014c-407a-a529-02b1082633c2)

and still works fine on teams with TTs:

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/b8f36968-3a4e-4843-b5e0-1532d2466642)
