### PR TITLE
Fix gradient issue on ios for matchtickers

### DIFF
--- a/components/match_ticker/commons/match_ticker_display_components.lua
+++ b/components/match_ticker/commons/match_ticker_display_components.lua
@@ -169,7 +169,6 @@ function ScoreBoard:create()
 	local winner = tonumber(match.winner)
 
 	return self.root
-		:addClass(WINNER_TO_BG_CLASS[winner])
 		:node(self:opponent(match.match2opponents[1], winner == 1, true):addClass('team-left'))
 		:node(self:versus())
 		:node(self:opponent(match.match2opponents[2], winner == 2):addClass('team-right'))
@@ -346,7 +345,9 @@ function Match:create()
 	if isBrMatch then
 		matchDisplay:node(self:brMatchRow())
 	else
-		matchDisplay:node(self:standardMatchRow())
+		matchDisplay
+			:addClass(WINNER_TO_BG_CLASS[tonumber(self.match.winner)])
+			:node(self:standardMatchRow())
 	end
 
 	matchDisplay:node(self:detailsRow(isBrMatch))


### PR DESCRIPTION
## Summary
Fix gradient issue on ios for matchtickers by moving the gradient class from the row to the table element.
The 2nd row has a set BG via css and hence the gradient gets ignored there anyways.

## How did you test this change?
dev + dev page: https://liquipedia.net/starcraft2/Liquipedia:Upcoming_and_ongoing_matches_on_mainpage/dev
viewed on iPhone, samsung galaxy 22 enterprise (android; chrome), desktop (both on chrome, firefox)