### PR TITLE
refactor: default `requireDevIfEnabled` to true in Lua.import

### DIFF
--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -65,7 +65,7 @@ end
 function Lua.import(name, options)
 	options = options or {}
 	local importFunction = options.loadData and mw.loadData or require
-	if options.requireDevIfEnabled == false then
+	if options.requireDevIfEnabled ~= false then
 		if StringUtils.endsWith(name, '/dev') then
 			error('Lua.import: Module name should not end in \'/dev\'')
 		end

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -56,16 +56,16 @@ function Lua.loadDataIfExists(name)
 end
 
 ---Imports a module by its name.
----
----Allows requireDevIfEnabled option (requires the development version of a module if it
----exists and the dev feature flag is enabled. Otherwise requires the non-development module).
+---By default it will include the /dev module if in dev mode activated. This can be turned off by setting
+--- the requireDevIfEnabled option to false.
+--- Optionally mw.loaddata can be used instead of require by passing the loadData option.
 ---@param name string
 ---@param options {requireDevIfEnabled: boolean?, loadData: boolean?}?
 ---@return unknown
 function Lua.import(name, options)
 	options = options or {}
 	local importFunction = options.loadData and mw.loadData or require
-	if options.requireDevIfEnabled then
+	if options.requireDevIfEnabled == false then
 		if StringUtils.endsWith(name, '/dev') then
 			error('Lua.import: Module name should not end in \'/dev\'')
 		end


### PR DESCRIPTION
## Summary

Every single occurance of Lua.import (that I could find) has `requireDevIfEnabled=true`. Since this is clearly the default way of using Lua.import, we can skip some verbosity by skipping this flag.

## Test
Setup a simple test module to ensure correct dev and non-dev are imported