### PR TITLE
Fix gradient display below infoboxes

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -47,7 +47,7 @@ local DEFAULT_QUERY_COLUMNS = {
 	'match2bracketdata',
 }
 local NONE = 'none'
-local INFOBOX_DEFAULT_CLASS = 'fo-nttax-infobox'
+local INFOBOX_DEFAULT_CLASS = 'fo-nttax-infobox panel'
 local INFOBOX_WRAPPER_CLASS = 'fo-nttax-infobox-wrapper'
 local DEFAULT_LIMIT = 20
 local LIMIT_INCREASE = 20


### PR DESCRIPTION
## Summary
Fix gradient display of matchtickers below infoboxes.
With #3758 we fixed the gradient showing badly on ios devices.
But that also made it so that below infoboxes the gtradient wouldn't show up at all.
This PR adds an additional `panel` class so that the gradients show there again.
(Note prior to #3758 the gradient was also displayed badly below infoboxes on ios.)

## How did you test this change?
dev