### PR TITLE
fix: Correct swapped cell names

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_character_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_character_custom.lua
@@ -99,9 +99,9 @@ function CustomInjector:parse(id, widgets)
 			Title{name = 'Level Changes'},
 			BreakDown{content = {'[[Experience|Level]]:', 1, 5, 10}, contentClasses = LEVEL_CHANGE_CLASSES},
 			BreakDown(CustomCharacter._toLevelChangesRow(
-				function(gainFactor) return self.caller:_calculateHitPoints(gainFactor) end, self.caller:_hitPointsRegenTitle())),
+				function(gainFactor) return self.caller:_calculateHitPoints(gainFactor) end, '[[Hit Points]]:')),
 			BreakDown(CustomCharacter._toLevelChangesRow(
-				function(gainFactor) return self.caller:_calculateHitPointsRegen(gainFactor) end, '[[Hit Points]]:')),
+				function(gainFactor) return self.caller:_calculateHitPointsRegen(gainFactor) end, self.caller:_hitPointsRegenTitle())),
 			BreakDown(CustomCharacter._toLevelChangesRow(
 				function(gainFactor) return self.caller:_calculateMana(gainFactor) end, '[[Mana]]:')),
 			BreakDown(CustomCharacter._toLevelChangesRow(

--- a/components/infobox/wikis/warcraft/infobox_character_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_character_custom.lua
@@ -100,8 +100,8 @@ function CustomInjector:parse(id, widgets)
 			BreakDown{content = {'[[Experience|Level]]:', 1, 5, 10}, contentClasses = LEVEL_CHANGE_CLASSES},
 			BreakDown(CustomCharacter._toLevelChangesRow(
 				function(gainFactor) return self.caller:_calculateHitPoints(gainFactor) end, '[[Hit Points]]:')),
-			BreakDown(CustomCharacter._toLevelChangesRow(
-				function(gainFactor) return self.caller:_calculateHitPointsRegen(gainFactor) end, self.caller:_hitPointsRegenTitle())),
+			BreakDown(CustomCharacter._toLevelChangesRow(function(gainFactor)
+				return self.caller:_calculateHitPointsRegen(gainFactor) end, self.caller:_hitPointsRegenTitle())),
 			BreakDown(CustomCharacter._toLevelChangesRow(
 				function(gainFactor) return self.caller:_calculateMana(gainFactor) end, '[[Mana]]:')),
 			BreakDown(CustomCharacter._toLevelChangesRow(


### PR DESCRIPTION
## Summary
Correct swapped cell names in warcraft `Module:Infobox/Character/Custom`

## How did you test this change?
live