### PR TITLE
Remove redundant `requireDevIfEnabled` from r6 git modules

### DIFF
--- a/components/hidden_data_box/wikis/rainbowsix/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/rainbowsix/hidden_data_box_custom.lua
@@ -10,7 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
-local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox', {requireDevIfEnabled = true})
+local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox')
 local CustomHiddenDataBox = {}
 
 ---@param args table

--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -14,8 +14,8 @@ local PageLink = require('Module:Page')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
 
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
-local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_patch_custom.lua
@@ -9,8 +9,8 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
-local Patch = Lua.import('Module:Infobox/Patch', {requireDevIfEnabled = true})
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Patch = Lua.import('Module:Infobox/Patch')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/infobox/wikis/rainbowsix/infobox_team_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_team_custom.lua
@@ -10,8 +10,8 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
-local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
-local Achievements = Lua.import('Module:Infobox/Extension/Achievements', {requireDevIfEnabled = true})
+local Team = Lua.import('Module:Infobox/Team')
+local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 
 local ACHIEVEMENTS_BASE_CONDITIONS = {
 	'[[liquipediatiertype::!Showmatch]]',

--- a/components/infobox/wikis/rainbowsix/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_weapon_custom.lua
@@ -13,8 +13,8 @@ local Lua = require('Module:Lua')
 local OperatorIcon = require('Module:OperatorIcon')
 local Table = require('Module:Table')
 
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
-local Weapon = Lua.import('Module:Infobox/Weapon', {requireDevIfEnabled = true})
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Weapon = Lua.import('Module:Infobox/Weapon')
 
 ---@class RainbowsixWeaponInfobox: WeaponInfobox
 local CustomWeapon = Class.new(Weapon)

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -16,8 +16,8 @@ local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
 
-local MatchGroupInput = Lua.import('Module:MatchGroup/Input', {requireDevIfEnabled = true})
-local Opponent = Lua.import('Module:Opponent', {requireDevIfEnabled = true})
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
+local Opponent = Lua.import('Module:Opponent')
 
 local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L', 'D' }
 local ALLOWED_VETOES = { 'decider', 'pick', 'ban', 'defaultban' }

--- a/components/match2/wikis/rainbowsix/match_legacy.lua
+++ b/components/match2/wikis/rainbowsix/match_legacy.lua
@@ -13,7 +13,7 @@ local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy._convertParameters(match2)

--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -15,8 +15,8 @@ local OperatorIcon = require('Module:OperatorIcon')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper', {requireDevIfEnabled = true})
-local MatchSummary = Lua.import('Module:MatchSummary/Base', {requireDevIfEnabled = true})
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
 
 local POSITION_LEFT = 1
 local POSITION_RIGHT = 2

--- a/components/prize_pool/wikis/rainbowsix/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/rainbowsix/prize_pool_custom.lua
@@ -13,9 +13,9 @@ local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Variables = require('Module:Variables')
 
-local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+local PrizePool = Lua.import('Module:PrizePool')
 
-local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 local CustomLpdbInjector = Class.new(LpdbInjector)
 
 local CustomPrizePool = {}

--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -9,9 +9,9 @@
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local Squad = Lua.import('Module:Squad', {requireDevIfEnabled = true})
-local SquadRow = Lua.import('Module:Squad/Row', {requireDevIfEnabled = true})
-local SquadAutoRefs = Lua.import('Module:SquadAuto/References', {requireDevIfEnabled = true})
+local Squad = Lua.import('Module:Squad')
+local SquadRow = Lua.import('Module:Squad/Row')
+local SquadAutoRefs = Lua.import('Module:SquadAuto/References')
 
 local CustomSquad = {}
 


### PR DESCRIPTION
## Summary
Remove redundant `requireDevIfEnabled` from r6 git modules

## How did you test this change?
N/A