### PR TITLE
Remove redundant `requireDevIfEnabled` from aoe git modules

### DIFF
--- a/components/earnings/wikis/ageofempires/earnings.lua
+++ b/components/earnings/wikis/ageofempires/earnings.lua
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+local CustomEarnings = Lua.import('Module:Earnings/Base')
 
 CustomEarnings.defaultNumberOfStoredPlayersPerMatch = 15
 

--- a/components/faction/wikis/ageofempires/faction_data.lua
+++ b/components/faction/wikis/ageofempires/faction_data.lua
@@ -11,268 +11,268 @@ local Array = require('Module:Array')
 local AOE2_SUFFIX = '/Age of Empires II'
 
 local factionPropsAoE2 = {
-    armenians = {
-        index = 1,
-        name = 'Armenians',
-        faction = 'armenians',
-    },
-    aztecs = {
-        index = 2,
-        name = 'Aztecs',
-        pageName = 'Aztecs' .. AOE2_SUFFIX,
-        faction = 'aztecs',
-    },
-    berbers = {
-        index = 3,
-        name = 'Berbers',
-        faction = 'berbers',
-    },
-    bengalis = {
-        index = 4,
-        name = 'Bengalis',
-        faction = 'bengalis',
-    },
-    bohemians = {
-        index = 4,
-        name = 'Bohemians',
-        faction = 'bohemians',
-    },
-    britons = {
-        index = 5,
-        name = 'Britons',
-        faction = 'britons',
-    },
-    bulgarians = {
-        index = 6,
-        name = 'Bulgarians',
-        faction = 'bulgarians',
-    },
-    burgundians = {
-        index = 7,
-        name = 'Burgundians',
-        faction = 'burgundians',
-    },
-    burmese = {
-        index = 8,
-        name = 'Burmese',
-        faction = 'burmese',
-    },
-    byzantines = {
-        index = 9,
-        name = 'Byzantines',
-        faction = 'byzantines',
-    },
-    celts = {
-        index = 10,
-        name = 'Celts',
-        pageName = 'Celts' .. AOE2_SUFFIX,
-        faction = 'celts',
-    },
-    chinese = {
-        index = 11,
-        name = 'Chinese',
-        pageName = 'Chinese' .. AOE2_SUFFIX,
-        faction = 'chinese',
-    },
-    cumans = {
-        index = 12,
-        name = 'Cumans',
-        faction = 'cumans',
-    },
-    dravidians = {
-        index = 13,
-        name = 'Dravidians',
-        faction = 'dravidians',
-    },
-    ethiopians = {
-        index = 14,
-        name = 'Ethiopians',
-        faction = 'ethiopians',
-    },
-    franks = {
-        index = 15,
-        name = 'Franks',
-        faction = 'franks',
-    },
-    georgians = {
-        index = 16,
-        name = 'Georgians',
-        faction = 'georgians',
-    },
-    goths = {
-        index = 17,
-        name = 'Goths',
-        faction = 'goths',
-    },
-    gurjaras = {
-        index = 18,
-        name = 'Gurjaras',
-        faction = 'gurjaras',
-    },
-    hindustanis = {
-        index = 19,
-        name = 'Hindustanis',
-        faction = 'hindustanis',
-    },
-    huns = {
-        index = 20,
-        name = 'Huns',
-        faction = 'huns',
-    },
-    incas = {
-        index = 21,
-        name = 'Incas',
-        pageName = 'Incas' .. AOE2_SUFFIX,
-        faction = 'incas',
-    },
-    indians = {
-        index = 22,
-        name = 'Indians',
-        pageName = 'Indians' .. AOE2_SUFFIX .. '/The_Forgotten',
-        faction = 'indians',
-    },
-    italians = {
-        index = 23,
-        name = 'Italians',
-        faction = 'italians',
-    },
-    japanese = {
-        index = 24,
-        name = 'Japanese',
-        pageName = 'Japanese' .. AOE2_SUFFIX,
-        faction = 'japanese',
-    },
-    khmer = {
-        index = 25,
-        name = 'Khmer',
-        faction = 'khmer',
-    },
-    koreans = {
-        index = 26,
-        name = 'Koreans',
-        faction = 'koreans',
-    },
-    lithuanians = {
-        index = 27,
-        name = 'Lithuanians',
-        faction = 'lithuanians',
-    },
-    magyars = {
-        index = 28,
-        name = 'Magyars',
-        faction = 'magyars',
-    },
-    malay = {
-        index = 29,
-        name = 'Malay',
-        faction = 'malay',
-    },
-    malians = {
-        index = 30,
-        name = 'Malians',
-        pageName = 'Malians' .. AOE2_SUFFIX,
-        faction = 'malians',
-    },
-    mayans = {
-        index = 31,
-        name = 'Mayans',
-        faction = 'mayans',
-    },
-    mongols = {
-        index = 32,
-        name = 'Mongols',
-        pageName = 'Mongols' .. AOE2_SUFFIX,
-        faction = 'mongols',
-    },
-    persians = {
-        index = 33,
-        name = 'Persians',
-        pageName = 'Persians' .. AOE2_SUFFIX,
-        faction = 'persians',
-    },
-    poles = {
-        index = 34,
-        name = 'Poles',
-        faction = 'poles',
-    },
-    portuguese = {
-        index = 35,
-        name = 'Portuguese',
-        pageName = 'Portuguese' .. AOE2_SUFFIX,
-        faction = 'portuguese',
-    },
-    romans = {
-        index = 36,
-        name = 'Romans',
-        pageName = 'Romans' .. AOE2_SUFFIX,
-        faction = 'romans',
-    },
-    saracens = {
-        index = 37,
-        name = 'Saracens',
-        faction = 'saracens',
-    },
-    sicilians = {
-        index = 38,
-        name = 'Sicilians',
-        faction = 'sicilians',
-    },
-    slavs = {
-        index = 39,
-        name = 'Slavs',
-        faction = 'slavs',
-    },
-    spanish = {
-        index = 40,
-        name = 'Spanish',
-        pageName = 'Spanish' .. AOE2_SUFFIX,
-        faction = 'spanish',
-    },
-    tatars = {
-        index = 41,
-        name = 'Tatars',
-        faction = 'tatars',
-    },
-    teutons = {
-        index = 42,
-        name = 'Teutons',
-        faction = 'teutons',
-    },
-    turks = {
-        index = 43,
-        name = 'Turks',
-        faction = 'turks',
-    },
-    vietnamese = {
-        index = 44,
-        name = 'Vietnamese',
-        faction = 'vietnamese',
-    },
-    vikings = {
-        index = 45,
-        name = 'Vikings',
-        pageName = 'Vikings' .. AOE2_SUFFIX,
-        faction = 'vikings',
-    },
+	armenians = {
+		index = 1,
+		name = 'Armenians',
+		faction = 'armenians',
+	},
+	aztecs = {
+		index = 2,
+		name = 'Aztecs',
+		pageName = 'Aztecs' .. AOE2_SUFFIX,
+		faction = 'aztecs',
+	},
+	berbers = {
+		index = 3,
+		name = 'Berbers',
+		faction = 'berbers',
+	},
+	bengalis = {
+		index = 4,
+		name = 'Bengalis',
+		faction = 'bengalis',
+	},
+	bohemians = {
+		index = 4,
+		name = 'Bohemians',
+		faction = 'bohemians',
+	},
+	britons = {
+		index = 5,
+		name = 'Britons',
+		faction = 'britons',
+	},
+	bulgarians = {
+		index = 6,
+		name = 'Bulgarians',
+		faction = 'bulgarians',
+	},
+	burgundians = {
+		index = 7,
+		name = 'Burgundians',
+		faction = 'burgundians',
+	},
+	burmese = {
+		index = 8,
+		name = 'Burmese',
+		faction = 'burmese',
+	},
+	byzantines = {
+		index = 9,
+		name = 'Byzantines',
+		faction = 'byzantines',
+	},
+	celts = {
+		index = 10,
+		name = 'Celts',
+		pageName = 'Celts' .. AOE2_SUFFIX,
+		faction = 'celts',
+	},
+	chinese = {
+		index = 11,
+		name = 'Chinese',
+		pageName = 'Chinese' .. AOE2_SUFFIX,
+		faction = 'chinese',
+	},
+	cumans = {
+		index = 12,
+		name = 'Cumans',
+		faction = 'cumans',
+	},
+	dravidians = {
+		index = 13,
+		name = 'Dravidians',
+		faction = 'dravidians',
+	},
+	ethiopians = {
+		index = 14,
+		name = 'Ethiopians',
+		faction = 'ethiopians',
+	},
+	franks = {
+		index = 15,
+		name = 'Franks',
+		faction = 'franks',
+	},
+	georgians = {
+		index = 16,
+		name = 'Georgians',
+		faction = 'georgians',
+	},
+	goths = {
+		index = 17,
+		name = 'Goths',
+		faction = 'goths',
+	},
+	gurjaras = {
+		index = 18,
+		name = 'Gurjaras',
+		faction = 'gurjaras',
+	},
+	hindustanis = {
+		index = 19,
+		name = 'Hindustanis',
+		faction = 'hindustanis',
+	},
+	huns = {
+		index = 20,
+		name = 'Huns',
+		faction = 'huns',
+	},
+	incas = {
+		index = 21,
+		name = 'Incas',
+		pageName = 'Incas' .. AOE2_SUFFIX,
+		faction = 'incas',
+	},
+	indians = {
+		index = 22,
+		name = 'Indians',
+		pageName = 'Indians' .. AOE2_SUFFIX .. '/The_Forgotten',
+		faction = 'indians',
+	},
+	italians = {
+		index = 23,
+		name = 'Italians',
+		faction = 'italians',
+	},
+	japanese = {
+		index = 24,
+		name = 'Japanese',
+		pageName = 'Japanese' .. AOE2_SUFFIX,
+		faction = 'japanese',
+	},
+	khmer = {
+		index = 25,
+		name = 'Khmer',
+		faction = 'khmer',
+	},
+	koreans = {
+		index = 26,
+		name = 'Koreans',
+		faction = 'koreans',
+	},
+	lithuanians = {
+		index = 27,
+		name = 'Lithuanians',
+		faction = 'lithuanians',
+	},
+	magyars = {
+		index = 28,
+		name = 'Magyars',
+		faction = 'magyars',
+	},
+	malay = {
+		index = 29,
+		name = 'Malay',
+		faction = 'malay',
+	},
+	malians = {
+		index = 30,
+		name = 'Malians',
+		pageName = 'Malians' .. AOE2_SUFFIX,
+		faction = 'malians',
+	},
+	mayans = {
+		index = 31,
+		name = 'Mayans',
+		faction = 'mayans',
+	},
+	mongols = {
+		index = 32,
+		name = 'Mongols',
+		pageName = 'Mongols' .. AOE2_SUFFIX,
+		faction = 'mongols',
+	},
+	persians = {
+		index = 33,
+		name = 'Persians',
+		pageName = 'Persians' .. AOE2_SUFFIX,
+		faction = 'persians',
+	},
+	poles = {
+		index = 34,
+		name = 'Poles',
+		faction = 'poles',
+	},
+	portuguese = {
+		index = 35,
+		name = 'Portuguese',
+		pageName = 'Portuguese' .. AOE2_SUFFIX,
+		faction = 'portuguese',
+	},
+	romans = {
+		index = 36,
+		name = 'Romans',
+		pageName = 'Romans' .. AOE2_SUFFIX,
+		faction = 'romans',
+	},
+	saracens = {
+		index = 37,
+		name = 'Saracens',
+		faction = 'saracens',
+	},
+	sicilians = {
+		index = 38,
+		name = 'Sicilians',
+		faction = 'sicilians',
+	},
+	slavs = {
+		index = 39,
+		name = 'Slavs',
+		faction = 'slavs',
+	},
+	spanish = {
+		index = 40,
+		name = 'Spanish',
+		pageName = 'Spanish' .. AOE2_SUFFIX,
+		faction = 'spanish',
+	},
+	tatars = {
+		index = 41,
+		name = 'Tatars',
+		faction = 'tatars',
+	},
+	teutons = {
+		index = 42,
+		name = 'Teutons',
+		faction = 'teutons',
+	},
+	turks = {
+		index = 43,
+		name = 'Turks',
+		faction = 'turks',
+	},
+	vietnamese = {
+		index = 44,
+		name = 'Vietnamese',
+		faction = 'vietnamese',
+	},
+	vikings = {
+		index = 45,
+		name = 'Vikings',
+		pageName = 'Vikings' .. AOE2_SUFFIX,
+		faction = 'vikings',
+	},
 
-    unknown = {
-        index = 46,
-        name = 'Unknown',
-        faction = 'unknown',
-    },
+	unknown = {
+		index = 46,
+		name = 'Unknown',
+		faction = 'unknown',
+	},
 }
 
 return {
-    factionProps = {
-        aoe2 = factionPropsAoE2,
-    },
-    defaultFaction = 'unknown',
-    factions = {
-        aoe2 = Array.extractKeys(factionPropsAoE2)
-    },
-    aliases = {
-        aoe2 = {
+	factionProps = {
+		aoe2 = factionPropsAoE2,
+	},
+	defaultFaction = 'unknown',
+	factions = {
+		aoe2 = Array.extractKeys(factionPropsAoE2)
+	},
+	aliases = {
+		aoe2 = {
 
-        },
-    },
+		},
+	},
 }

--- a/components/faction/wikis/ageofempires/faction_icon_data.lua
+++ b/components/faction/wikis/ageofempires/faction_icon_data.lua
@@ -10,143 +10,143 @@ local byFactionAoe2 = {
 	armenians = {
 		icon = 'File:Armenians AoE2 icon.png'
 	},
-    aztecs = {
+	aztecs = {
 		icon = 'File:Aztecs AoE2 icon.png'
 	},
-    berbers = {
+	berbers = {
 		icon = 'File:Berbers AoE2 icon.png'
 	},
-    bengalis = {
+	bengalis = {
 		icon = 'File:Bengalis AoE2 icon.png'
 	},
-    bohemians = {
+	bohemians = {
 		icon = 'File:Bohemians AoE2 icon.png'
 	},
-    britons = {
+	britons = {
 		icon = 'File:Britons AoE2 icon.png'
 	},
-    bulgarians = {
+	bulgarians = {
 		icon = 'File:Bulgarians AoE2 icon.png'
 	},
-    burgundians = {
+	burgundians = {
 		icon = 'File:Burgundians AoE2 icon.png'
 	},
-    burmese = {
+	burmese = {
 		icon = 'File:Burmese AoE2 icon.png'
 	},
-    byzantines = {
+	byzantines = {
 		icon = 'File:Byzantines AoE2 icon.png'
 	},
-    celts = {
+	celts = {
 		icon = 'File:Celts AoE2 icon.png'
 	},
-    chinese = {
+	chinese = {
 		icon = 'File:Chinese AoE2 icon.png'
 	},
-    cumans = {
+	cumans = {
 		icon = 'File:Cumans AoE2 icon.png'
 	},
-    dravidians = {
+	dravidians = {
 		icon = 'File:Dravidians AoE2 icon.png'
 	},
-    ethiopians = {
+	ethiopians = {
 		icon = 'File:Ethiopians AoE2 icon.png'
 	},
-    franks = {
+	franks = {
 		icon = 'File:Franks AoE2 icon.png'
 	},
-    georgians = {
+	georgians = {
 		icon = 'File:Georgians AoE2 icon.png'
 	},
-    goths = {
+	goths = {
 		icon = 'File:Goths AoE2 icon.png'
 	},
-    gurjaras = {
+	gurjaras = {
 		icon = 'File:Gurjaras AoE2 icon.png'
 	},
-    hindustanis = {
+	hindustanis = {
 		icon = 'File:Hindustanis AoE2 icon.png'
 	},
-    huns = {
+	huns = {
 		icon = 'File:Huns AoE2 icon.png'
 	},
-    incas = {
+	incas = {
 		icon = 'File:Incas AoE2 icon.png'
 	},
-    indians = {
+	indians = {
 		icon = 'File:Indians AoE2 icon.png'
 	},
-    italians = {
+	italians = {
 		icon = 'File:Italians AoE2 icon.png'
 	},
-    japanese = {
+	japanese = {
 		icon = 'File:Japanese AoE2 icon.png'
 	},
-    khmer = {
+	khmer = {
 		icon = 'File:Khmer AoE2 icon.png'
 	},
-    koreans = {
+	koreans = {
 		icon = 'File:Koreans AoE2 icon.png'
 	},
-    lithuanians = {
+	lithuanians = {
 		icon = 'File:Lithuanians AoE2 icon.png'
 	},
-    magyars = {
+	magyars = {
 		icon = 'File:Magyars AoE2 icon.png'
 	},
-    malay = {
+	malay = {
 		icon = 'File:Malay AoE2 icon.png'
 	},
-    malians = {
+	malians = {
 		icon = 'File:Malians AoE2 icon.png'
 	},
-    mayans = {
+	mayans = {
 		icon = 'File:Mayans AoE2 icon.png'
 	},
-    mongols = {
+	mongols = {
 		icon = 'File:Mongols AoE2 icon.png'
 	},
-    persians = {
+	persians = {
 		icon = 'File:Persians AoE2 icon.png'
 	},
-    poles = {
+	poles = {
 		icon = 'File:Poles AoE2 icon.png'
 	},
-    portuguese = {
+	portuguese = {
 		icon = 'File:Portuguese AoE2 icon.png'
 	},
-    romans = {
+	romans = {
 		icon = 'File:Romans AoE2 icon.png'
 	},
-    saracens = {
+	saracens = {
 		icon = 'File:Saracens AoE2 icon.png'
 	},
-    sicilians = {
+	sicilians = {
 		icon = 'File:Sicilians AoE2 icon.png'
 	},
-    slavs = {
+	slavs = {
 		icon = 'File:Slavs AoE2 icon.png'
 	},
-    spanish = {
+	spanish = {
 		icon = 'File:Spanish AoE2 icon.png'
 	},
-    tatars = {
+	tatars = {
 		icon = 'File:Tatars AoE2 icon.png'
 	},
-    teutons = {
+	teutons = {
 		icon = 'File:Teutons AoE2 icon.png'
 	},
-    turks = {
+	turks = {
 		icon = 'File:Turks AoE2 icon.png'
 	},
-    vietnamese = {
+	vietnamese = {
 		icon = 'File:Vietnamese AoE2 icon.png'
 	},
-    vikings = {
+	vikings = {
 		icon = 'File:Vikings AoE2 icon.png'
 	},
 
-    unknown = {
+	unknown = {
 		icon = 'File:Char head filler.png'
 	},
 }

--- a/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/ageofempires/hidden_data_box_custom.lua
@@ -11,7 +11,7 @@ local Lua = require('Module:Lua')
 local Tier = require('Module:Tier/Custom')
 local Variables = require('Module:Variables')
 
-local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox', {requireDevIfEnabled = true})
+local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox')
 
 local CustomHiddenDataBox = {}
 

--- a/components/infobox/wikis/ageofempires/infobox_league_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_league_custom.lua
@@ -22,9 +22,9 @@ local Table = require('Module:Table')
 local Tier = require('Module:Tier/Custom')
 local Variables = require('Module:Variables')
 
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
-local League = Lua.import('Module:Infobox/League', {requireDevIfEnabled = true})
-local ReferenceCleaner = Lua.import('Module:ReferenceCleaner', {requireDevIfEnabled = true})
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+local ReferenceCleaner = Lua.import('Module:ReferenceCleaner')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/infobox/wikis/ageofempires/infobox_map_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_map_custom.lua
@@ -13,8 +13,8 @@ local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
-local Map = Lua.import('Module:Infobox/Map', {requireDevIfEnabled = true})
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Map = Lua.import('Module:Infobox/Map')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/infobox/wikis/ageofempires/infobox_series_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_series_custom.lua
@@ -10,7 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Tier = require('Module:Tier/Custom')
 
-local Series = Lua.import('Module:Infobox/Series', {requireDevIfEnabled = true})
+local Series = Lua.import('Module:Infobox/Series')
 
 ---@class AoeSeriesInfobox: SeriesInfobox
 local CustomSeries = Class.new(Series)

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -14,9 +14,9 @@ local OpponentLibrary = require('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
 local TeamTemplates = require('Module:Team')
 
-local Achievements = Lua.import('Module:Infobox/Extension/Achievements', {requireDevIfEnabled = true})
-local Injector = Lua.import('Module:Infobox/Widget/Injector', {requireDevIfEnabled = true})
-local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Team = Lua.import('Module:Infobox/Team')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell

--- a/components/prize_pool/wikis/ageofempires/prize_pool_award_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_award_custom.lua
@@ -11,8 +11,8 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
-local AwardPrizePool = Lua.import('Module:PrizePool/Award', {requireDevIfEnabled = true})
-local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local AwardPrizePool = Lua.import('Module:PrizePool/Award')
+local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 
 local CustomLpdbInjector = Class.new(LpdbInjector)
 

--- a/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
@@ -17,9 +17,9 @@ local Variables = require('Module:Variables')
 local OpponentLibrary = require('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
 
-local PrizePool = Lua.import('Module:PrizePool', {requireDevIfEnabled = true})
+local PrizePool = Lua.import('Module:PrizePool')
 
-local LpdbInjector = Lua.import('Module:Lpdb/Injector', {requireDevIfEnabled = true})
+local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 local CustomLpdbInjector = Class.new(LpdbInjector)
 
 local CustomPrizePool = {}

--- a/standard/tier/wikis/ageofempires/tier_custom.lua
+++ b/standard/tier/wikis/ageofempires/tier_custom.lua
@@ -12,7 +12,7 @@ local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local Tier = Lua.import('Module:Tier/Utils', {requireDevIfEnabled = true})
+local Tier = Lua.import('Module:Tier/Utils')
 
 local NON_BREAKING_SPACE = '&nbsp;'
 


### PR DESCRIPTION
## Summary
Remove redundant `requireDevIfEnabled` from aoe git modules
Also fix some indents in faction data modules

## How did you test this change?
N/A