### PR TITLE
Fix wrapper valorant

### DIFF
--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -198,7 +198,7 @@ function MatchMapsLegacy._handleOpponents(args)
 				score = args['score' .. index]
 			end
 		elseif args['score' .. index] then
-			score = tonumber(args['score' .. index])
+			score = args['score' .. index]
 		elseif not args.mapWinnersSet and winner then
 			score = winner == index and DEFAULT_WIN or DEFAULT_LOSS
 		end

--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -47,8 +47,6 @@ function MatchMapsLegacy._handlePlayersStats(prefix, args)
 		local teamKey = prefix .. 't' .. opponentIndex
 		Array.forEach(Array.range(1, MAX_NUMBER_OF_PLAYERS), function(playerIndex)
 			local player = args[teamKey .. 'p' .. playerIndex]
-			if Logic.isEmpty(player) then return end
-
 			local kda = Table.extract(args, teamKey .. 'kda' .. playerIndex) or ''
 			local kills, deaths, assists = kda:match("(%d+)%/(%d+)%/(%d+)")
 

--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -193,8 +193,11 @@ function MatchMapsLegacy._handleOpponents(args)
 		local score
 		local winner = tonumber(args.winner)
 		if args.walkover then
-			if tonumber(args.walkover) ~= 0 then
-				score = tonumber(args.walkover) == index and DEFAULT_WIN or FORFEIT
+			local walkover = tonumber(args.walkover)
+			if walkover and walkover ~= 0 then
+				score = walkover == index and DEFAULT_WIN or FORFEIT
+			else
+				score = args['score' .. index]
 			end
 		elseif args['score' .. index] then
 			score = tonumber(args['score' .. index])


### PR DESCRIPTION
## Summary

`walkover` is sometimes set as `true` on MatchMaps.
Sometimes, only the agent is input, so we should not stop parsing if player is empty.

## How did you test this change?

Live.
