### PR TITLE
PI: Calculate tense based on transferinfo

### DIFF
--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -546,7 +546,15 @@ function PlayerIntroduction:_teamDisplay(isDeceased)
 		return nil
 	end
 
-	local isCurrentTense = String.isNotEmpty(playerInfo.team) and not isDeceased
+	local isCurrentTense = not isDeceased
+		and (
+			String.isNotEmpty(playerInfo.team) or (
+				String.isNotEmpty(transferInfo.team) and (
+					transferInfo.type == TRANSFER_STATUS_CURRENT
+					or transferInfo.type == TRANSFER_STATUS_LOAN
+				)
+			)
+		)
 
 	local shouldDisplayTeam2 = isCurrentTense
 		and transferInfo.type == TRANSFER_STATUS_LOAN


### PR DESCRIPTION
## Summary
When the data on the player page isn't updated yet to save a team, but transfers are, team display in PI will use the wrong tense.
Was reported in https://discord.com/channels/93055209017729024/268719633366777856/1195408782931529789, will also adjust the Infobox to use TeamAuto by default. This still reduces the amount of purges required.

## How did you test this change?
via /dev
