### PR TITLE
Catch non strings for string match

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -215,7 +215,7 @@ function League:createInfobox()
 								Title{name = 'Chronology'},
 								Chronology{
 									content = Table.filterByKey(args, function(key)
-										return key:match('^previous%d?$') ~= nil or key:match('^next%d?$') ~= nil
+										return type(key) == 'string' and (key:match('^previous%d?$') ~= nil or key:match('^next%d?$') ~= nil)
 									end)
 								}
 							}


### PR DESCRIPTION
## Summary
Catch non strings for string match checks in infobox league

reason is to avoid errors like on:
https://liquipedia.net/valorant/DreamHack_Community_Clash/Season_1.5/Qualifier_1
![IMG_4876](https://github.com/Liquipedia/Lua-Modules/assets/75081997/517d5d8b-ed0e-4a28-8058-0f0d5c5e5805)


## How did you test this change?
dev