### PR TITLE
Fix: warcraft legacy match maps filterByKey condition

### DIFF
--- a/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
+++ b/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
@@ -15,7 +15,6 @@ local Logic = require('Module:Logic')
 local Match = require('Module:Match')
 local MatchGroup = require('Module:MatchGroup')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 

--- a/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
+++ b/components/match2/wikis/warcraft/legacy/legacy_match_maps.lua
@@ -121,7 +121,9 @@ function LegacyMatchMaps._readMaps(args)
 
 	for mapIndex = 1, MAX_NUM_MAPS do
 		local prefix = 'map' .. mapIndex
-		local map = Table.filterByKey(args, function(key) return String.startsWith(key, prefix) end)
+		local map = Table.filterByKey(args, function(key)
+			return key == prefix or string.find(key, '^' .. prefix .. '[^%d]')
+		end)
 		map = Table.map(map, function(key, value)
 			args[key] = nil
 


### PR DESCRIPTION
## Summary
`String.startsWith(key, prefix)` caught keys starting with `map10`, `map11`, ... in the `filterByKey` condition when only looking for `map1`.
This PR adjusts the condition to only filter for the wanted keys

## How did you test this change?
dev to live