### PR TITLE
R6 Category adjustment

### DIFF
--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -164,7 +164,7 @@ function CustomLeague:getWikiCategories(args)
 	local platform = self:_platformLookup(args.platform)
 
 	return {
-		game and (game .. 'Competitions') or 'Tournaments without game version',
+		game and (game .. ' Competitions') or 'Tournaments without game version',
 		platform and (platform .. ' Tournaments') or nil,
 	}
 end


### PR DESCRIPTION
## Summary
Adds a space between the Game name and Competition in the Infobox League for Rainbow Six
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
