### PR TITLE
chore: test coverage for local running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 node_modules
 package-lock.json
+luacov.report.out
+luacov.stats.out

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,8 @@
+return {
+	configfile = '.luacov',
+	includeuntestedfiles = {'standard'},
+	include = {'standard/*'},
+	exclude = {'wikis/*'},
+	runreport = false, -- Don't work properly for some reason, have to do a manual `luacov` call afterwards
+	deletestats = true,
+}


### PR DESCRIPTION
## Summary
Setup getting test coverage stats locally

How to run locally (assuming both `busted` and `luacov` are install)
`busted -c && luacov`

## How did you test this change?

```
==============================================================================
Summary
==============================================================================

File                                                                            Hits Missed Coverage
----------------------------------------------------------------------------------------------------
standard/abbreviation.lua                                                       8    0      100.00%
standard/array.lua                                                              123  70     63.73%
standard/class.lua                                                              54   19     73.97%
standard/condition.lua                                                          60   1      98.36%
standard/currency.lua                                                           77   20     79.38%
standard/currency_data.lua                                                      875  0      100.00%
standard/date_ext.lua                                                           38   8      82.61%
standard/error.lua                                                              0    20     0.00%
standard/error_display.lua                                                      0    52     0.00%
standard/error_ext.lua                                                          0    60     0.00%
standard/feature_flag.lua                                                       22   18     55.00%
standard/flags.lua                                                              82   30     73.21%
standard/flags_master_data.lua                                                  2119 0      100.00%
standard/fn_util.lua                                                            23   1      95.83%
standard/format_table.lua                                                       40   3      93.02%
standard/game.lua                                                               104  8      92.86%
standard/hidden_sort.lua                                                        0    7      0.00%
standard/highlight_conditions/commons/highlight_conditions.lua                  0    13     0.00%
standard/hotkey.lua                                                             0    13     0.00%
standard/info/commons/info.lua                                                  23   0      100.00%
standard/iterator.lua                                                           5    18     21.74%
standard/json.lua                                                               11   36     23.40%
standard/league_icon.lua                                                        0    150    0.00%
standard/links/commons/links.lua                                                0    88     0.00%
standard/links/commons/links_priority_groups.lua                                0    5      0.00%
standard/links_stream.lua                                                       0    80     0.00%
standard/locale.lua                                                             48   0      100.00%
standard/logic.lua                                                              59   18     76.62%
standard/lpdb.lua                                                               87   13     87.00%
standard/lpdb/lpdb_injector.lua                                                 0    5      0.00%
standard/lua.lua                                                                27   50     35.06%
standard/math_util.lua                                                          24   0      100.00%
standard/mock/mock_lpdb.lua                                                     0    88     0.00%
standard/namespace.lua                                                          0    19     0.00%
standard/operator.lua                                                           22   1      95.65%
standard/ordinal.lua                                                            81   16     83.51%
standard/ordinal_data.lua                                                       107  0      100.00%
standard/page.lua                                                               24   0      100.00%
standard/page_variable_namespace.lua                                            34   9      79.07%
standard/placement.lua                                                          112  16     87.50%
standard/reference_cleaner.lua                                                  11   8      57.89%
standard/region/commons/region.lua                                              43   2      95.56%
standard/region/commons/region_data.lua                                         152  0      100.00%
standard/region/extensions/ept.lua                                              0    17     0.00%
standard/region/extensions/ept_data.lua                                         0    5      0.00%
standard/result_or_error.lua                                                    30   76     28.30%
standard/smw_injector.lua                                                       0    5      0.00%
standard/string_utils.lua                                                       34   12     73.91%
standard/table.lua                                                              163  41     79.90%
standard/template.lua                                                           10   24     29.41%
standard/template_engine.lua                                                    73   1      98.65%
standard/test/json_test.lua                                                     0    65     0.00%
standard/test/lua_test.lua                                                      0    27     0.00%
standard/test/namespace_test.lua                                                0    35     0.00%
standard/test/template_test.lua                                                 0    32     0.00%
standard/text_sanitizer.lua                                                     14   1      93.33%
standard/tier/commons/tier_custom.lua                                           0    2      0.00%
standard/tier/commons/tier_data.lua                                             86   0      100.00%
standard/tier/commons/tier_utils.lua                                            70   12     85.37%
standard/timezone.lua                                                           35   0      100.00%
standard/timezone_data.lua                                                      304  0      100.00%
standard/tournament_structure.lua                                               0    164    0.00%
standard/tournaments_summary_table/commons/tournaments_summary_table.lua        0    182    0.00%
standard/tournaments_summary_table/commons/tournaments_summary_table_custom.lua 0    2      0.00%
standard/tree_util.lua                                                          3    8      27.27%
standard/type_util.lua                                                          35   121    22.44%
standard/variables.lua                                                          17   0      100.00%
standard/vod_link.lua                                                           0    28     0.00%
standard/warning_box.lua                                                        0    16     0.00%
----------------------------------------------------------------------------------------------------
Total                                                                           5369 1841   74.47%
```