### PR TITLE
Add new statistic Cell to Formula 1 Team Infobox

### DIFF
--- a/components/infobox/wikis/formula1/infobox_team_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_team_custom.lua
@@ -34,6 +34,7 @@ local STATISTICS = {
 	{key = 'points', name = 'Career Points'},
 	{key = 'firstentry', name = 'First entry'},
 	{key = 'firstwin', name = 'First win'},
+	{key = 'lastwin', name = 'Last win'},
 	{key = 'lastentry', name = 'Last entry'},
 }
 


### PR DESCRIPTION
Add cell to infobox_team_custom.lua

## Summary

added cell to display a team's last grand prix win on Formula 1

## How did you test this change?

Via dev
