### PR TITLE
Fix: Cast string to number

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -433,7 +433,7 @@ end
 function CustomPlayer:_isAwardAchievemnet(placement, tier)
 	return String.isNotEmpty((placement.extradata or {}).award) and (
 		tier == 1 or
-		tier == 2 and placement.individualprizemoney > 50
+		tier == 2 and (tonumber(placement.individualprizemoney) or 0) > 50
 	)
 end
 


### PR DESCRIPTION
## Summary
In SC2 infobox person player custom we compare `placement.individualprizemoney` to 50.
To avoid an error cast `placement.individualprizemoney` to be numeric (with 0 as fallback).

## How did you test this change?
live as bug fix