### PR TITLE
Fix match2 for afps

### DIFF
--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -49,7 +49,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match = matchFunctions.getOpponents(match)
 	match = matchFunctions.getTournamentVars(match)
 	match = matchFunctions.getVodStuff(match)
-	match = matchFunctions.getExtraData(match)
 
 	return match
 end


### PR DESCRIPTION
## Summary

https://liquipedia.net/arenafps/Quake_World_Championship/2023#Group_Stage

Trying to call a function that doesn't exist

## How did you test this change?
Live