### PR TITLE
fix(infobox): cs league breaks when no game input

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -31,7 +31,7 @@ local Title = Widgets.Title
 local Center = Widgets.Center
 
 ---@class CounterstrikeLeagueInfobox: InfoboxLeagueTemp
----@field gameData table?
+---@field gameData table
 ---@field valveTier {meta: string, name: string, link: string}?
 local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
@@ -189,10 +189,9 @@ end
 ---@param args table
 ---@return string[]
 function CustomLeague:getWikiCategories(args)
-	local gameData = self.gameData
+	local gameData = Table.isNotEmpty(self.gameData) and self.gameData
 	local categories = {
 		gameData and ((gameData.abbreviation or gameData.name) .. ' Tournaments') or 'Tournaments without game version',
-
 	}
 
 	if not Logic.readBool(args.cancelled) and

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -30,7 +30,7 @@ local Cell = Widgets.Cell
 local Title = Widgets.Title
 local Center = Widgets.Center
 
----@class CounterstrikeLeagueInfobox: InfoboxLeagueTemp
+---@class CounterstrikeLeagueInfobox: InfoboxLeague
 ---@field gameData table
 ---@field valveTier {meta: string, name: string, link: string}?
 local CustomLeague = Class.new(League)


### PR DESCRIPTION
## Summary

`Game.raw()` always returns empty table if it can't find the game. Annotation was wrong and so was code assumption following anno down the road.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/d286108d-0e6d-4924-bb09-e45d6ff08a85)

Instead, check if table is empty in this instance so that assumption is correct after.

## How did you test this change?

pushed live to fix broken pages.
