### PR TITLE
Fix: lowercase key where it is expected to be lowercase

### DIFF
--- a/components/infobox/wikis/worldofwarcraft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/worldofwarcraft/infobox_person_player_custom.lua
@@ -17,13 +17,13 @@ local Cell = Widgets.Cell
 
 local ROLES = {
 	-- Playes
-	['healer'] = {category = 'Healers', variable = 'Healer'},
-	['DPS'] = {category = 'DPS players', variable = 'DPS'},
+	healer = {category = 'Healers', variable = 'Healer'},
+	dps = {category = 'DPS players', variable = 'DPS'},
 
 	-- Staff and Talents
-	['analyst'] = {category = 'Analysts', variable = 'Analyst'},
-	['host'] = {category = 'Hosts', variable = 'Host'},
-	['caster'] = {category = 'Casters', variable = 'Caster'},
+	analyst = {category = 'Analysts', variable = 'Analyst'},
+	host = {category = 'Hosts', variable = 'Host'},
+	caster = {category = 'Casters', variable = 'Caster'},
 }
 
 ---@class WorldofwarcraftInfoboxPlayer: Person


### PR DESCRIPTION
## Summary
Currently if dps is entered as a role on wow wiki it (and subsequent roles) are not shown.
This is caused due to the key in the roles table not being lowercased.
This PR fixes that and also removes the `['...']` around the keys in that table.

## How did you test this change?
dev