### PR TITLE
Remove left margin of inotes dd elements after dd fix in skin

### DIFF
--- a/stylesheets/commons/Teamcard.css
+++ b/stylesheets/commons/Teamcard.css
@@ -486,6 +486,10 @@ Author(s): iMarbot
 	margin-bottom: 0;
 }
 
+.inotes-inner dd {
+	margin-left: 0;
+}
+
 .template-box .inotes-box {
 	background-color: var( --clr-background, #f8f9fa );
 	border-color: var( --table-border-color, #a2a9b1 );


### PR DESCRIPTION
## Summary

After we fixed the indendation of `<dd>` elements as intended by wikicode and MediaWiki core CSS there is now a left margin on inotes in team cards. This change removes that margin again specifically for this use case

## How did you test this change?

I tested this in the dev tools of my browser
