### PR TITLE
Catch an edge case in finished query in sc2 infobox league

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -124,8 +124,8 @@ function CustomLeague:_isFinished(args)
 	end
 
 	return mw.ext.LiquipediaDB.lpdb('placement', {
-		conditions = '[[pagename::' .. string.gsub(mw.title.getCurrentTitle().text, ' ', '_') .. ']] '
-			.. 'AND [[opponentname::!TBD]] AND [[placement::1]]',
+		conditions = '[[pagename::' .. string.gsub(self.pagename, ' ', '_') .. ']] '
+			.. 'AND [[opponentname::!TBD]] AND [[opponentname::!]] AND [[placement::1]]',
 		query = 'date',
 		order = 'date asc',
 		limit = 1


### PR DESCRIPTION
## Summary
Manually input Solo Opponents in prizepool with empty input set an empty opponentname in lpdb, hence the query to check if the event is finished does fail due to that.
This PR catches that edge case and also makes use of `self.pagename` over `mw.title.getCurrentTitle().text` in the line above that.

## How did you test this change?
dev