### PR TITLE
Fix role display in cs infobox player

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_person_player_custom.lua
@@ -210,7 +210,13 @@ function CustomPlayer._displayRole(roleData)
 		return Page.makeInternalLink(roleData['display' .. postFix], ':Category:' .. roleData['category' .. postFix])
 	end
 
-	return table.concat({toDisplay(), toDisplay(2)})
+	local role1Display = toDisplay()
+	local role2Display = toDisplay(2)
+	if role1Display and role2Display then
+		role2Display = '(' .. role2Display .. ')'
+	end
+
+	return table.concat({role1Display, role2Display}, ' ')
 end
 
 ---@param args table


### PR DESCRIPTION
## Summary
Fix role display in cs infobox player.
Reported by NiKoholic: https://discord.com/channels/93055209017729024/372075546231832576/1197732608482742432

## How did you test this change?
dev
![Screenshot 2024-01-19 091740](https://github.com/Liquipedia/Lua-Modules/assets/75081997/4edf3038-d437-4efa-abc7-74464fc9c6f3)