### PR TITLE
Cleanup `Module:Infobox/Person`

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -522,7 +522,7 @@ function Person:getCategories(args, birthDisplay, personType, status)
 	end
 
 	Array.extendWith(categories, Array.map(self.locations, function(country)
-		return Flags.getLocalisation(country) .. personType .. 's'
+		return Flags.getLocalisation(country) .. ' ' .. personType .. 's'
 	end))
 
 	return self:getWikiCategories(categories)

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -231,10 +231,6 @@ function Person:createInfobox()
 				statusToStore
 			)))
 
-	--remove this after all customs have been cleaned up
-	--only here so we do not break role storage on 16 wikis ...
-	local builtInfobox = infobox:widgetInjector(self:createWidgetInjector()):build(widgets)
-
 	if self:shouldStoreData(args) then
 		self:_definePageVariables(args)
 		self:_setLpdbData(
@@ -246,9 +242,7 @@ function Person:createInfobox()
 	end
 
 	return mw.html.create()
-		:node(builtInfobox)
-		--kick above line and un-comment below line after customs have been cleaned up
-		--:node(infobox:build(widgets))
+		:node(infobox:build(widgets))
 		:node(WarningBox.displayAll(self.warnings))
 end
 

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -35,6 +35,7 @@ local Builder = Widgets.Builder
 local Customizable = Widgets.Customizable
 
 ---@class Person: BasicInfobox
+---@field locations string[]
 local Person = Class.new(BasicInfobox)
 
 Person.warnings = {}
@@ -80,6 +81,8 @@ end
 function Person:createInfobox()
 	local infobox = self.infobox
 	local args = self.args
+
+	self.locations = self:getLocations()
 
 	local lowerStatus = (args.status or ''):lower()
 	if lowerStatus == BANNED then
@@ -139,7 +142,7 @@ function Person:createInfobox()
 		Cell{name = 'Name', content = {args.name}},
 		Cell{name = 'Romanized Name', content = {args.romanized_name}},
 		Customizable{id = 'nationality', children = {
-				Cell{name = 'Nationality', content = self:_createLocations(args, personType.category)}
+				Cell{name = 'Nationality', content = self:displayLocations()}
 			}
 		},
 		Cell{name = 'Born', content = {age.birth}},
@@ -432,47 +435,26 @@ function Person:calculateEarnings(args)
 	}
 end
 
----@param args table
----@param personType string
 ---@return string[]
-function Person:_createLocations(args, personType)
-	local countryDisplayData = {}
-	local country = args.country or args.country1 or args.nationality or args.nationality1
-	if country == nil or country == '' then
-		return countryDisplayData
+function Person:getLocations()
+	local locations = {}
+	for _, country in Table.iter.pairsByPrefix(self.args, {'country', 'nationality'}, {requireIndex = false}) do
+		table.insert(locations, country)
 	end
 
-	countryDisplayData[1] = self:_createLocation(country, args.location, personType)
-
-	local index = 2
-	country = args['country2'] or args['nationality2']
-	while(not String.isEmpty(country)) do
-		countryDisplayData[index] = self:_createLocation(country, args['location' .. index], personType)
-		index = index + 1
-		country = args['country' .. index] or args['nationality' .. index]
-	end
-
-	return countryDisplayData
+	return Array.map(locations, function(country)
+		return Flags.CountryName(country)
+	end)
 end
 
----@param country string?
----@param location string?
----@param personType string
----@return string?
-function Person:_createLocation(country, location, personType)
-	if country == nil or country == '' then
-		return nil
-	end
-	local countryDisplay = Flags.CountryName(country)
-	local demonym = Flags.getLocalisation(countryDisplay) or ''
-
-	if Namespace.isMain() then
-		self.infobox:categories(demonym .. ' ' .. personType .. 's')
-	end
-
-	return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' ..
-		'[[:Category:' .. countryDisplay .. '|' .. countryDisplay .. ']]' ..
-		(location ~= nil and (',&nbsp;' .. location) or '')
+---@return string[]
+function Person:displayLocations()
+	return Array.map(self.locations, function(country, locationIndex)
+		local location = self.args['location' .. locationIndex]
+		return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' ..
+			Page.makeInternalLink(country, ':Category:' .. country) ..
+			(location and (',&nbsp;' .. location) or '')
+	end)
 end
 
 ---@param team string?
@@ -538,6 +520,10 @@ function Person:getCategories(args, birthDisplay, personType, status)
 	if String.isNotEmpty(team) and not mw.ext.TeamTemplate.teamexists(team) then
 		table.insert(categories, 'Players with invalid team')
 	end
+
+	Array.extendWith(categories, Array.map(self.locations, function(country)
+		return Flags.getLocalisation(country) .. personType .. 's'
+	end))
 
 	return self:getWikiCategories(categories)
 end

--- a/components/infobox/wikis/dota2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_player_custom.lua
@@ -62,7 +62,6 @@ local CONVERSION_PLAYER_ID_TO_STEAM = 61197960265728
 ---@field role {category: string, variable: string, isplayer: boolean?}?
 ---@field role2 {category: string, variable: string, isplayer: boolean?}?
 ---@field basePageName string
----@field locations string[]
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 
@@ -87,7 +86,6 @@ function CustomPlayer.run(frame)
 	player.role = player:_getRoleData(player.args.role)
 	player.role2 = player:_getRoleData(player.args.role2)
 	player.basePageName = mw.title.getCurrentTitle().baseText
-	player.locations = player:_getLocations()
 
 	return player:createInfobox()
 end
@@ -148,10 +146,6 @@ function CustomInjector:parse(id, widgets)
 				caller:_displayRole(caller.role),
 				caller:_displayRole(caller.role2),
 			}},
-		}
-	elseif id == 'nationality' then
-		return {
-			Cell{name = 'Nationality', content = caller:_createLocations()}
 		}
 	end
 	return widgets
@@ -233,14 +227,6 @@ function CustomPlayer:_getStatusContents()
 	return statusContents
 end
 
----@return table
-function CustomPlayer:_createLocations()
-	return Array.map(self.locations, function(country)
-		return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' ..
-			Page.makeInternalLink(country, ':Category:' .. country)
-	end)
-end
-
 ---@param categories string[]
 ---@return string[]
 function CustomPlayer:getWikiCategories(categories)
@@ -262,7 +248,7 @@ function CustomPlayer:getWikiCategories(categories)
 end
 
 ---@return string[]
-function CustomPlayer:_getLocations()
+function CustomPlayer:getLocations()
 	return Array.map(self:getAllArgsForBase(self.args, 'country'), function(country)
 		return Flags.CountryName(country)
 	end)

--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -32,7 +32,6 @@ local BANNED = mw.loadData('Module:Banned')
 local NOT_APPLICABLE = 'N/A'
 
 ---@class RocketleagueInfoboxPlayer: Person
----@field locations string[]
 ---@field basePageName string
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
@@ -48,7 +47,6 @@ function CustomPlayer.run(frame)
 	player.args.banned = tostring(player.args.banned or '')
 
 	player.basePageName = mw.title.getCurrentTitle().baseText
-	player.locations = player:_getLocations()
 
 	return player:createInfobox()
 end
@@ -138,7 +136,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'nationality' then
 		return {
 			Cell{name = 'Location', content = {args.location}},
-			Cell{name = 'Nationality', content = caller:_createLocations()}
+			Cell{name = 'Nationality', content = caller:displayLocations()}
 		}
 	end
 	return widgets
@@ -287,8 +285,8 @@ function CustomPlayer._getStatusContents(args)
 	return statusContents
 end
 
----@return table
-function CustomPlayer:_createLocations()
+---@return string[]
+function CustomPlayer:displayLocations()
 	return Array.map(self.locations, function(country)
 		return Flags.Icon({flag = country, shouldLink = true}) .. '&nbsp;' ..
 			Page.makeInternalLink(country, ':Category:' .. country)
@@ -296,7 +294,7 @@ function CustomPlayer:_createLocations()
 end
 
 ---@return string[]
-function CustomPlayer:_getLocations()
+function CustomPlayer:getLocations()
 	return Array.map(self:getAllArgsForBase(self.args, 'country'), function(country)
 		return Flags.CountryName(country)
 	end)


### PR DESCRIPTION
## Summary
After all the customs are now adjusted we can do a cleanup of the commons base.
- move build to after storage
- refactor locations stuff
  - move category setting from inside display to categories function
  - use `Table.iter.parisByPrefix`

## How did you test this change?
previews with dev on sc2 (using commons), dota2 and rl (both having custom location stuff)