### PR TITLE
Fixing Team Affiliate always throwing errors

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
@@ -54,7 +54,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return {
 			Cell{name = 'Abbreviation', content = {args.abbreviation}},
-			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {args.affiliate and Team.team(args.affiliate) or nil}}
+			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {args.affiliate and Team.team(nil, args.affiliate) or nil}}
 		}
 	end
 

--- a/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
@@ -10,6 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local RoleOf = require('Module:RoleOf')
 local String = require('Module:StringUtils')
+local TeamTemplate = require('Module:Team')
 local Template = require('Module:Template')
 local Variables = require('Module:Variables')
 
@@ -54,7 +55,8 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return {
 			Cell{name = 'Abbreviation', content = {args.abbreviation}},
-			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {args.affiliate and Team.team(nil, args.affiliate) or nil}}
+			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {
+				args.affiliate and TeamTemplate.team(nil, args.affiliate) or nil}}
 		}
 	end
 

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -41,7 +41,7 @@ function CustomInjector:parse(id, widgets)
 		})
 	elseif id == 'custom' then
 		return {
-			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {args.affiliate and Team.team(args.affiliate) or nil}}
+			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {args.affiliate and Team.team(nil, args.affiliate) or nil}}
 		}
 	end
 	return widgets

--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local TeamTemplate = require('Module:Team')
 local Template = require('Module:Template')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
@@ -41,7 +42,8 @@ function CustomInjector:parse(id, widgets)
 		})
 	elseif id == 'custom' then
 		return {
-			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {args.affiliate and Team.team(nil, args.affiliate) or nil}}
+			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {
+				args.affiliate and TeamTemplate.team(nil, args.affiliate) or nil}}
 		}
 	end
 	return widgets


### PR DESCRIPTION
## Summary
Corrects a bug from #3830 where when affiliate was set, it would throw an error "attempt to call field 'team' (a nil value)"
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
tested in dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
