### PR TITLE
Re-Add `Former Squad` header

### DIFF
--- a/components/squad/commons/squad.lua
+++ b/components/squad/commons/squad.lua
@@ -50,7 +50,9 @@ end
 
 function Squad:title()
 	local defaultTitle
-	if self.type == Squad.TYPE_INACTIVE then
+	if self.type == Squad.TYPE_FORMER then
+		defaultTitle = 'Former Squad'
+	elseif self.type == Squad.TYPE_INACTIVE then
 		defaultTitle = 'Inactive Players'
 	end
 


### PR DESCRIPTION
Adding back Former Squad as an auto generated title for the Squad table. Partial revert of #3349 
## Summary

Reverting some of the previous changes to allow for there to be discussion about the previous changes to figure out the best course forward. 

## How did you test this change?
dev on left, current on right
![Screenshot 2024-01-23 104102](https://github.com/Liquipedia/Lua-Modules/assets/75081997/72142220-1358-4fa9-860f-9be3899b4111)
