### PR TITLE
Add Manual points table

### DIFF
--- a/components/manual_points_table/commons/manual_points_table.lua
+++ b/components/manual_points_table/commons/manual_points_table.lua
@@ -54,19 +54,19 @@ local ManualPointsTable = Class.new(
 ---@param args table
 ---@return Html
 function ManualPointsTable:_makeSubHeader(args)
-	local row = mw.html.create('tr')
+	local subHeader = mw.html.create('tr')
 		:tag('th'):wikitext('#'):done()
 		:tag('th'):wikitext(self.isSolo and 'Player' or 'Team'):done()
 
 	if self.isSolo and self.showPlayerTeam then
-		row:tag('th'):wikitext('Team')
+		subHeader:tag('th'):wikitext('Team')
 	end
 
 	Array.mapIndexes(function(index)
 		local event = args['event' .. index]
 		local eventLink = args['event' .. index .. 'link']
 		if String.isNotEmpty(event) then
-			row:tag('th')
+			subHeader:tag('th')
 				:css('min-width:80px')
 				:wikitext(String.isNotEmpty(eventLink) and '[['.. eventLink .. '|' .. event .. ']]' or event)
 		end
@@ -74,11 +74,11 @@ function ManualPointsTable:_makeSubHeader(args)
 		return event
 	end)
 
-	row:tag('th')
+	subHeader:tag('th')
 		:css('min-width:80px')
 		:wikitext('Points')
 
-	return row
+	return subHeader
 end
 
 ---@param slot table
@@ -86,52 +86,52 @@ end
 ---@param suffix string
 ---@return Html
 function ManualPointsTable:_makePointsCell(slot, points, suffix)
-	local td = mw.html.create('td')
+	local pointsCell = mw.html.create('td')
 		:addClass(Logic.readBool(slot['gold' .. suffix]) and 'gold-text-alt' or nil)
 		:addClass(Logic.readBool(slot['active' .. suffix]) and 'bg-active' or nil)
 		:css('font-weight', Logic.readBool(slot['gold' .. suffix]) and 'bold' or nil)
 
 	if Table.includes(POINTS_TYPES, points:lower()) then
-		td:wikitext(POINTS_ACTIONS[points:lower()](slot['link' .. suffix] and slot['link' .. suffix] or ''))
+		pointsCell:wikitext(POINTS_ACTIONS[points:lower()](slot['link' .. suffix] and slot['link' .. suffix] or ''))
 	else
-		td:wikitext(suffix == TOTAL and '\'\'\'' .. points .. '\'\'\'' or points)
+		pointsCell:wikitext(suffix == TOTAL and '\'\'\'' .. points .. '\'\'\'' or points)
 	end
 
-	return td
+	return pointsCell
 end
 
 ---@param slot table
-function ManualPointsTable:_makeParticipantSlot(slot)
-	local td = mw.html.create('td')
+function ManualPointsTable:_makeParticipantCell(slot)
+	local participantCell = mw.html.create('td')
 		:css('text-align', 'left')
 
 	if self.isSolo then
-		td:node(PlayerDisplay.InlinePlayer{player = {
+		participantCell:node(PlayerDisplay.InlinePlayer{player = {
 			displayName = slot[1],
 			pageName = slot[1],
 			flag = slot.flag,
 			showLink = true
 		}})
 	else
-		td:node(OpponentDisplay.InlineOpponent{opponent = {
+		participantCell:node(OpponentDisplay.InlineOpponent{opponent = {
 			type = Opponent.team,
 			template = slot[1]
 		}})
 	end
 
-	return td
+	return participantCell
 end
 
 ---@param slot table
 ---@return Html
-function ManualPointsTable:_makeSlot(slot)
+function ManualPointsTable:_makeSlotRow(slot)
 	local slotRow = mw.html.create('tr')
 		:addClass(slot.bg and 'bg-' .. slot.bg or nil)
 		:tag('td')
 			:addClass(slot.pbg and 'bg-' .. slot.pbg or nil)
 			:wikitext(slot.place and '\'\'\'' .. slot.place .. '\'\'\'' or '')
 			:done()
-		:node(self:_makeParticipantSlot(slot))
+		:node(self:_makeParticipantCell(slot))
 			:done()
 
 	if self.isSolo and self.showPlayerTeam then
@@ -187,7 +187,7 @@ function ManualPointsTable.run()
 	wrapper:node(manualPointsTable:_makeSubHeader(header))
 
 	Array.forEach(slots, function (slot)
-		wrapper:node(manualPointsTable:_makeSlot(slot))
+		wrapper:node(manualPointsTable:_makeSlotRow(slot))
 	end)
 
 	return mw.html.create('div')

--- a/components/manual_points_table/commons/manual_points_table.lua
+++ b/components/manual_points_table/commons/manual_points_table.lua
@@ -14,11 +14,8 @@ local Logic = require('Module:Logic')
 local PlayerDisplay = require('Module:Player/Display')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local OpponentLibraries = require('Module:OpponentLibraries')
+local Team = require('Module:Team')
 local Template = require('Module:Template')
-
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local NONBREAKING_SPACE = '&nbsp;'
 local TOTAL = 'total'
@@ -119,10 +116,7 @@ function ManualPointsTable:_makeParticipantCell(slot)
 		if String.isNotEmpty(slot.flag) then
 			teamOpponentText = teamOpponentText .. Flags.Icon{flag = slot.flag} .. NONBREAKING_SPACE
 		end
-		teamOpponentText = teamOpponentText .. tostring(OpponentDisplay.InlineOpponent{opponent = {
-			type = Opponent.team,
-			template = slot[1]
-		}})
+		teamOpponentText = teamOpponentText .. tostring(Team.team(nil, slot[1]) or '')
 		participantCell:wikitext(teamOpponentText)
 	end
 
@@ -144,10 +138,7 @@ function ManualPointsTable:_makeSlotRow(slot)
 	if self.isSolo and self.showPlayerTeam then
 		if String.isNotEmpty(slot.team) then
 			slotRow:tag('td')
-				:node(OpponentDisplay.InlineOpponent{opponent = {
-					type = Opponent.team,
-					template = slot.team,
-				}, teamStyle = 'short'})
+				:node(Team.icon(nil, slot.team) or nil)
 		else
 			slotRow:tag('td'):wikitext('')
 		end

--- a/components/manual_points_table/commons/manual_points_table.lua
+++ b/components/manual_points_table/commons/manual_points_table.lua
@@ -74,8 +74,8 @@ function ManualPointsTable._makePointsCell(slot, points, suffix)
 		:addClass(Logic.readBool(slot['active' .. suffix]) and 'bg-active' or '')
 		:css('font-weight', Logic.readBool(slot['gold' .. suffix]) and 'bold' or nil)
 
-	if Table.includes(POINTS_TYPES, points) then
-		td:wikitext(POINTS_ACTIONS[points](slot['link' .. suffix] and slot['link' .. suffix] or ''))
+	if Table.includes(POINTS_TYPES, points:lower()) then
+		td:wikitext(POINTS_ACTIONS[points:lower()](slot['link' .. suffix] and slot['link' .. suffix] or ''))
 	else
 		td:wikitext(suffix == TOTAL and '\'\'\'' .. points .. '\'\'\'' or points)
 	end

--- a/components/manual_points_table/commons/manual_points_table.lua
+++ b/components/manual_points_table/commons/manual_points_table.lua
@@ -9,6 +9,7 @@
 local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Flags = require('Module:Flags')
 local Logic = require('Module:Logic')
 local PlayerDisplay = require('Module:Player/Display')
 local String = require('Module:StringUtils')
@@ -19,6 +20,7 @@ local Template = require('Module:Template')
 local Opponent = OpponentLibraries.Opponent
 local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
+local NONBREAKING_SPACE = '&nbsp;'
 local TOTAL = 'total'
 local QUALIFIED = 'q'
 local DID_NOT_QUALIFY = 'dnq'
@@ -113,10 +115,15 @@ function ManualPointsTable:_makeParticipantCell(slot)
 			showLink = true
 		}})
 	else
-		participantCell:node(OpponentDisplay.InlineOpponent{opponent = {
+		local teamOpponentText = ''
+		if String.isNotEmpty(slot.flag) then
+			teamOpponentText = teamOpponentText .. Flags.Icon{flag = slot.flag} .. NONBREAKING_SPACE
+		end
+		teamOpponentText = teamOpponentText .. tostring(OpponentDisplay.InlineOpponent{opponent = {
 			type = Opponent.team,
 			template = slot[1]
 		}})
+		participantCell:wikitext(teamOpponentText)
 	end
 
 	return participantCell
@@ -170,7 +177,7 @@ function ManualPointsTable.run()
 	local slots = Array.sub(args, 2)
 
 	manualPointsTable.isSolo = Logic.readBool(header.isSolo)
-	manualPointsTable.showPlayerTeam = Logic.readBool(header.showPlayerTeam)
+	manualPointsTable.showPlayerTeam = Logic.readBool(header.teams)
 
 	local wrapper = mw.html.create('table')
 		:addClass('table table-bordered wikitable prizepooltable collapsed')
@@ -180,7 +187,7 @@ function ManualPointsTable.run()
 
 	if String.isNotEmpty(header.title) then
 		wrapper:tag('tr'):tag('th')
-			:css('colspan', 100)
+			:attr('colspan', 100)
 			:wikitext(header.title)
 	end
 

--- a/components/manual_points_table/commons/manual_points_table.lua
+++ b/components/manual_points_table/commons/manual_points_table.lua
@@ -1,0 +1,144 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:ManualPointsTable
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Abbreviation = require('Module:Abbreviation')
+local Array = require('Module:Array')
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local Team = require('Module:Team')
+local Template = require('Module:Template')
+
+local TOTAL = 'total'
+local QUALIFIED = 'q'
+local DID_NOT_QUALIFY = 'dnq'
+local DISBANDED = 'disbanded'
+local POINTS_TYPES = {
+	QUALIFIED,
+	DID_NOT_QUALIFY,
+	DISBANDED
+}
+
+local POINTS_ACTIONS = {
+	[QUALIFIED] = function (link)
+		return '[[File:GreenCheck.png|Qualified|link=' .. link .. ']]'
+	end,
+	[DID_NOT_QUALIFY] = function ()
+		return Abbreviation.make('DNQ', 'Did not qualify')
+	end,
+	[DISBANDED] = function ()
+		return '[[File:RedCross.png|Disbanded or ineligible]]'
+	end
+}
+
+local ManualPointsTable = {}
+
+---@param args table
+---@return Html
+function ManualPointsTable._makeSubHeader(args)
+	local row = mw.html.create('tr')
+		:tag('th'):wikitext('#'):done()
+		:tag('th'):wikitext('Team'):done()
+
+	Array.mapIndexes(function(index)
+		local event = args['event' .. index]
+		local eventLink = args['event' .. index .. 'link']
+		if String.isNotEmpty(event) then
+			row:tag('th')
+				:css('min-width:80px')
+				:wikitext(String.isNotEmpty(eventLink) and '[['.. eventLink .. '|' .. event .. ']]' or event)
+		end
+
+		return event
+	end)
+
+	row:tag('th')
+		:css('min-width:80px')
+		:wikitext('Points')
+
+	return row
+end
+
+---@param slot table
+---@param points string
+---@param suffix string
+---@return Html
+function ManualPointsTable._makePointsCell(slot, points, suffix)
+	local td = mw.html.create('td')
+		:addClass(Logic.readBool(slot['gold' .. suffix]) and 'gold-text-alt' or '')
+		:addClass(Logic.readBool(slot['active' .. suffix]) and 'bg-active' or '')
+		:css('font-weight', Logic.readBool(slot['gold' .. suffix]) and 'bold' or nil)
+
+	if Table.includes(POINTS_TYPES, points) then
+		td:wikitext(POINTS_ACTIONS[points](slot['link' .. suffix] and slot['link' .. suffix] or ''))
+	else
+		td:wikitext(suffix == TOTAL and '\'\'\'' .. points .. '\'\'\'' or points)
+	end
+
+	return td
+end
+
+---@param slot table
+function ManualPointsTable._makeSlot(slot)
+	local row = mw.html.create('tr')
+		:addClass(slot.bg and 'bg-' .. slot.bg or '')
+		:tag('td')
+			:addClass(slot.pbg and 'bg-' .. slot.pbg or '')
+			:wikitext(slot.place and '\'\'\'' .. slot.place .. '\'\'\'' or '')
+			:done()
+		:tag('td')
+			:css('text-align', 'left')
+			:wikitext(slot[1] and Team.team(nil, slot[1]) or '')
+			:done()
+
+	for _, points, pointsIndex in Table.iter.pairsByPrefix(slot, 'points') do
+		row:node(
+			ManualPointsTable._makePointsCell(slot, points, pointsIndex)
+		)
+	end
+
+	if String.isNotEmpty(slot.total) then
+		row:node(
+			ManualPointsTable._makePointsCell(slot, slot.total, TOTAL)
+		)
+	end
+
+	return row
+end
+
+-- invoked by Template:Points end
+---@return Html
+function ManualPointsTable.run()
+	local args = Template.retrieveReturnValues('ManualPointsTable')
+	local header =  Array.sub(args, 1, 1)[1]
+	local slots = Array.sub(args, 2)
+
+	local wrapper = mw.html.create('table')
+		:addClass('table table-bordered wikitable prizepooltable collapsed')
+		:css('text-align', 'center')
+		:css('margin-top', header.margin or 0)
+		:attr('data-cutafter', header.cutafter or 100)
+
+	if String.isNotEmpty(header.title) then
+		wrapper:tag('tr'):tag('th')
+			:css('colspan', 100)
+			:wikitext(header.title)
+	end
+
+	wrapper:node(ManualPointsTable._makeSubHeader(header))
+
+	Array.forEach(slots, function (slot)
+		wrapper:node(ManualPointsTable._makeSlot(slot))
+	end)
+
+	return mw.html.create('div')
+		:addClass('table-responsive')
+		:node(wrapper)
+end
+
+return ManualPointsTable

--- a/components/manual_points_table/commons/manual_points_table.lua
+++ b/components/manual_points_table/commons/manual_points_table.lua
@@ -104,6 +104,9 @@ function ManualPointsTable:_makeParticipantCell(slot)
 	local participantCell = mw.html.create('td')
 		:css('text-align', 'left')
 
+	if String.isEmpty(slot[1]) then
+		return participantCell:wikitext(Abbreviation.make('TBD', 'To Be Determined'))
+	end
 	if self.isSolo then
 		participantCell:node(PlayerDisplay.InlinePlayer{player = {
 			displayName = slot[1],

--- a/components/manual_points_table/commons/manual_points_table.lua
+++ b/components/manual_points_table/commons/manual_points_table.lua
@@ -108,9 +108,16 @@ function ManualPointsTable:_makeParticipantCell(slot)
 		return participantCell:wikitext(Abbreviation.make('TBD', 'To Be Determined'))
 	end
 	if self.isSolo then
+		local name = slot[1]
+		local link = slot[1]
+		if String.contains(name, '|') then
+			local splitName = mw.text.split(name, '|')
+			link = splitName[1]
+			name = splitName[2]
+		end
 		participantCell:node(PlayerDisplay.InlinePlayer{player = {
-			displayName = slot[1],
-			pageName = slot[1],
+			displayName = name,
+			pageName = link,
 			flag = slot.flag,
 			showLink = true
 		}})

--- a/stylesheets/commons/Colours.css
+++ b/stylesheets/commons/Colours.css
@@ -566,6 +566,10 @@ ul.nav-tabs li.game-64,
 	color: var( --clr-semantic-gold-40, #ffdd3c );
 }
 
+.gold-text-alt {
+	color: #ffaa00;
+}
+
 .gold-bg {
 	background-color: var( --clr-semantic-gold-90, #fff6c9 );
 }
@@ -674,6 +678,12 @@ ul.nav-tabs li.game-wiiu,
 
 .transparent-bg-striped {
 	background: repeating-linear-gradient( 135deg, transparent, transparent 4px, rgba( 0, 0, 0, 0.5 ) 4px, rgba( 0, 0, 0, 0.5 ) 8px );
+}
+
+.bg-active {
+	background: #009E60;
+	font-weight: bold;
+	color: white;
 }
 
 /* BORDER COLOURS */

--- a/stylesheets/commons/Colours.css
+++ b/stylesheets/commons/Colours.css
@@ -681,9 +681,9 @@ ul.nav-tabs li.game-wiiu,
 }
 
 .bg-active {
-	background: #009E60;
+	background: #009e60;
 	font-weight: bold;
-	color: white;
+	color: #ffffff;
 }
 
 /* BORDER COLOURS */


### PR DESCRIPTION
## Summary

Use a commons version for the following templates:

- [Template:Points start](https://liquipedia.net/commons/Template:Points_start)
- [Template:Points start indiv](https://liquipedia.net/commons/Template:Points_start_indiv)
- [Template:Points slot](https://liquipedia.net/commons/Template:Points_slot)
- [Template:Points slot indiv](https://liquipedia.net/commons/Template:Points_slot_indiv)
- [Template:Points end](https://liquipedia.net/commons/Template:Points_end)

## How did you test this change?

[userpage](https://liquipedia.net/commons/User:LuckeLucky)

### Usages of the default template:
[LEC Championship Points 2023](https://liquipedia.net/leagueoflegends/LEC/2023/Championship_Points)
[World Cyber Games 2023 Open Leaderboard](https://liquipedia.net/clashroyale/World_Cyber_Games/2023/Open_Leaderboard)
