### PR TITLE
ci: add support for `.less` files in sync for resources

### DIFF
--- a/scripts/deploy_res.sh
+++ b/scripts/deploy_res.sh
@@ -8,7 +8,7 @@ if [[ -n "$1" ]]; then
   files=$1
   gitDeployReason="\"$(git log -1 --pretty='%h %s')\""
 else
-  files=$(find stylesheets javascript -type f -name '*.css' -o -name '*.js')
+  files=$(find stylesheets javascript -type f -name '*.less' -o -name '*.css' -o -name '*.js')
   gitDeployReason='Automated Weekly Re-Sync'
 fi
 


### PR DESCRIPTION
## Summary
After #3851 the weekly syncing for resources should deploy `.less` files in addition to `.css` and `.js`.

## Test
`find stylesheets javascript -type f -name '*.less' -o -name '*.css' -o -name '*.js'`
```
stylesheets/commons/Achievement.less
stylesheets/commons/Ambox.less
stylesheets/commons/AutomaticPointsTable.less
stylesheets/commons/Bracket.less
stylesheets/commons/Brackets.less
stylesheets/commons/Colours.less
stylesheets/commons/Columns.less
stylesheets/commons/Crosstable.less
stylesheets/commons/DivTable.less
stylesheets/commons/FilterButtons.less
stylesheets/commons/Grid.less
stylesheets/commons/GroupTableLeague.less
stylesheets/commons/Icons.less
stylesheets/commons/Infobox.less
stylesheets/commons/Mainpage.less
stylesheets/commons/Matchseries.less
stylesheets/commons/Miscellaneous.less
stylesheets/commons/Navbox.less
stylesheets/commons/NavFrame.less
stylesheets/commons/OpponentList.less
stylesheets/commons/Panels.less
stylesheets/commons/Prizepooltable.less
stylesheets/commons/Quote.less
stylesheets/commons/Selectall.less
stylesheets/commons/Statisticstable.less
stylesheets/commons/Swisstable.less
stylesheets/commons/Tables.less
stylesheets/commons/Tabs.less
stylesheets/commons/Teamcard.less
stylesheets/commons/TeamTemplates.less
stylesheets/commons/Techtree.less
javascript/commons/Bracket.js
javascript/commons/Collapse.js
javascript/commons/Commons_mainpage.js
javascript/commons/Commons_tools.js
javascript/commons/CopyToClipboard.js
javascript/commons/Countdown.js
javascript/commons/Crosstable.js
javascript/commons/FilterButtons.js
javascript/commons/Liquipedia_links.js
javascript/commons/Mainpage.js
javascript/commons/Miscellaneous.js
javascript/commons/Prizepooltable.js
javascript/commons/Selectall.js
javascript/commons/SiteNotice.js
javascript/commons/Tabs.js
```