### PR TITLE
Fix: Use correct class in bw infobox unit

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_unit_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_unit_custom.lua
@@ -34,7 +34,7 @@ local UNKNOWN_RACE = 'u'
 ---@param frame Frame
 ---@return Html
 function CustomUnit.run(frame)
-	local unit = Unit(frame)
+	local unit = CustomUnit(frame)
 	unit:setWidgetInjector(CustomInjector(unit))
 
 	return unit:createInfobox()


### PR DESCRIPTION
## Summary
Use correct class in bw infobox unit so that infobox unit doesn't error and displays correctly again on broodwar.
Bug introduced with #3798

## How did you test this change?
live as bug fix