### PR TITLE
Restore bracketId

### DIFF
--- a/components/match2/commons/match_group_display_horizontallist.lua
+++ b/components/match2/commons/match_group_display_horizontallist.lua
@@ -70,6 +70,7 @@ function HorizontallistDisplay.BracketContainer(props)
 	DisplayUtil.assertPropTypes(props, HorizontallistDisplay.propTypes.BracketContainer)
 	return HorizontallistDisplay.Bracket({
 		bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId),
+		bracketId = props.bracketId,
 		config = props.config,
 	})
 end


### PR DESCRIPTION
## Summary

Restore bracketId to ensure a unique id on the wrapper
