### PR TITLE
Add dark theme usage tracking

### DIFF
--- a/javascript/commons/Miscellaneous.js
+++ b/javascript/commons/Miscellaneous.js
@@ -717,6 +717,13 @@ liquipedia.tracker = {
 				} );
 			} );
 		}
+		if ( mw.config.get( 'skin' ) === 'lakesideview' ) {
+			if ( window.localStorage.getItem( 'LiquipediaDarkMode' ) === 'true' ) {
+				liquipedia.tracker.track( 'Page view with dark theme enabled' );
+			} else {
+				liquipedia.tracker.track( 'Page view with dark theme disabled' );
+			}
+		}
 	}
 };
 liquipedia.core.modules.push( 'tracker' );


### PR DESCRIPTION
## Summary

We want to understand what percentage of page views use the dark theme if available.

## How did you test this change?

I did not test this

## Related internal ticket
* https://gitlab.com/teamliquid-dev/liquipedia/web/extensions/teamliquidintegration/-/issues/27
