### PR TITLE
Make game schedule align better

### DIFF
--- a/components/match2/wikis/apexlegends/match_summary.lua
+++ b/components/match2/wikis/apexlegends/match_summary.lua
@@ -515,9 +515,10 @@ function CustomMatchSummary._createGameTab(game, idx)
 						:done()
 
 	if CustomMatchSummary._isLive(game) or CustomMatchSummary._isUpcoming(game) then
-		gameDetails:tag('div')
+		gameDetails:tag('li')
 				:tag('i')
 						:addClass('fas fa-clock')
+						:addClass('panel-content__game-schedule__icon')
 						:done()
 				:node(CustomMatchSummary._gameCountdown(game))
 	end

--- a/components/match2/wikis/apexlegends/match_summary.lua
+++ b/components/match2/wikis/apexlegends/match_summary.lua
@@ -751,7 +751,7 @@ function CustomMatchSummary._gameCountdown(game)
 		finished = CustomMatchSummary._isFinished(game) and 'true' or nil,
 	})
 
-	return mw.html.create('div'):addClass('panel-content__game-schedule__countdown'):addClass('match-countdown-block')
+	return mw.html.create('div'):addClass('match-countdown-block')
 			:node(require('Module:Countdown')._create(stream))
 			:node(game.vod and VodLink.display{vod = game.vod} or nil)
 end

--- a/stylesheets/commons/BattleRoyale/Panel.less
+++ b/stylesheets/commons/BattleRoyale/Panel.less
@@ -135,9 +135,23 @@ Author(s): Elysienna
 			padding: 0;
 			font-size: unset;
 			display: flex;
+			text-align: initial;
+
+			@media ( max-width: 767px ) {
+				flex-basis: 100%;
+				margin-bottom: 0.5rem;
+			}
 
 			.vodlink {
 				margin-left: 0.25rem;
+			}
+
+			.timer-object {
+				display: inline-flex;
+
+				@media ( max-width: 767px ) {
+					flex-wrap: wrap;
+				}
 			}
 		}
 	}

--- a/stylesheets/commons/BattleRoyale/Panel.less
+++ b/stylesheets/commons/BattleRoyale/Panel.less
@@ -110,6 +110,11 @@ Author(s): Elysienna
 			margin: 0;
 			display: flex;
 			align-items: center;
+
+			@media ( max-width: 767px ) {
+				flex-wrap: wrap;
+				margin-bottom: 0.5rem;
+			}
 		}
 
 		&__icon {
@@ -152,6 +157,10 @@ Author(s): Elysienna
 				@media ( max-width: 767px ) {
 					flex-wrap: wrap;
 				}
+			}
+
+			.timer-object-date {
+				margin-right: 1rem;
 			}
 		}
 	}

--- a/stylesheets/commons/BattleRoyale/Panel.less
+++ b/stylesheets/commons/BattleRoyale/Panel.less
@@ -136,7 +136,7 @@ Author(s): Elysienna
 			margin-right: 0.25rem;
 		}
 
-		div&__countdown {
+		.match-countdown-block {
 			padding: 0;
 			font-size: unset;
 			display: flex;

--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -350,7 +350,7 @@ Author(s): Elysienna
 	.match-countdown-block {
 		padding: 0;
 		font-size: unset;
-		font-weight: 400;
+		font-weight: normal;
 		font-style: italic;
 	}
 }

--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -346,4 +346,11 @@ Author(s): Elysienna
 			align-items: unset;
 		}
 	}
+
+	.match-countdown-block {
+		padding: 0;
+		font-size: unset;
+		font-weight: 400;
+		font-style: italic;
+	}
 }


### PR DESCRIPTION
## Summary

To better align the game schedule on overall standings.
Currently it looks like:
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/9ef44ee5-302e-49f9-91f7-c1be9e20e46e)
With the changes it looks like:
and on mobile:
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/639c56e6-dd31-4c04-ad32-b04073cf9e1d)

Also separated the match-countdown-block to have different styling in the panel schedule and panel table.
The table countdown now looks more according the design:
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/16a1007b-3060-408c-ae26-57ca27f93a2d)

## How did you test this change?

Tested the css on commons
