### PR TITLE
feat(prizepool): add skipping placements from start when importing

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -130,7 +130,6 @@ end
 -- fills in placements and opponents using data fetched from LPDB
 function Import._importPlacements(inputPlacements)
 	local stages = TournamentStructure.fetchStages(Import.config.matchGroupsSpec)
-	local startingPlacement = 1 + (Import.config.placementsToSkip or 0)
 
 	local placementEntries = Array.flatten(Array.map(Array.reverse(stages), function(stage, reverseStageIndex)
 				local stageIndex = #stages + 1 - reverseStageIndex
@@ -144,6 +143,8 @@ function Import._importPlacements(inputPlacements)
 					})
 			end))
 
+	placementEntries = Array.sub(placementEntries, 1 + (Import.config.placementsToSkip or 0))
+
 	-- Apply importLimit if set
 	if Import.config.importLimit then
 		-- array of partial sums of the number of entries until a given placement/slot
@@ -151,10 +152,8 @@ function Import._importPlacements(inputPlacements)
 		-- slotIndex of the slot until which we want to import based on importLimit
 		local slotIndex = Array.indexOf(importedEntriesSums, function(sum) return Import.config.importLimit <= sum end)
 		if slotIndex ~= 0 then
-			placementEntries = Array.sub(placementEntries, startingPlacement, slotIndex - 1)
+			placementEntries = Array.sub(placementEntries, 1, slotIndex - 1)
 		end
-	else
-		placementEntries = Array.sub(placementEntries, startingPlacement)
 	end
 
 	return Import._mergePlacements(placementEntries, inputPlacements)

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -169,14 +169,18 @@ function Import._computeStagePlacementEntries(stage, options)
 	end)
 
 	local startingPlacement = 1 + (options.placementsToSkip or 0)
+	local endingPlacement = options.importLimit
+	if options.importLimit > 0 and startingPlacement > 1 then
+		endingPlacement = options.importLimit + options.placementsToSkip
+	end
 
 	local maxPlacementCount = Array.max(Array.map(
 			groupPlacementEntries,
 			function(placementEntries) return #placementEntries end
 		)) or 0
 
-	maxPlacementCount = options.importLimit > 0
-		and math.min(maxPlacementCount, options.importLimit)
+	maxPlacementCount = endingPlacement > 0
+		and math.min(maxPlacementCount, endingPlacement)
 		or maxPlacementCount
 
 	return Array.map(Array.range(startingPlacement, maxPlacementCount), function(placementIndex)


### PR DESCRIPTION
## Summary

Essentially adding functionality like importLimit but in the reverse direction when importing a stage in PPT. Could do this before in a different way for group stages using elim colors, but doesn't work for brackets obv.

Example here where need to import first bottom two teams from each group, then the play-in bracket, and then finally winners of the groups from the first part.

https://liquipedia.net/counterstrike/BLAST/Premier/2024/Spring/Groups

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/7b42fb40-7c2e-463b-81da-798ba111d498)

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/b803f64a-d8e8-429a-999c-5d8015fb9b6b)

## How did you test this change?

`/dev` running live on that example page.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/466d153f-f6f1-4261-9129-a7300ab7a9d0)

