### PR TITLE
Add Omega Strikers player and league infobox

### DIFF
--- a/components/infobox/wikis/omegastrikers/infobox_league_custom.lua
+++ b/components/infobox/wikis/omegastrikers/infobox_league_custom.lua
@@ -16,7 +16,7 @@ local League = Lua.import('Module:Infobox/League')
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
----@class SmiteLeagueInfobox: InfoboxLeague
+---@class OmegaStrikersLeagueInfobox: InfoboxLeague
 local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
 

--- a/components/infobox/wikis/omegastrikers/infobox_league_custom.lua
+++ b/components/infobox/wikis/omegastrikers/infobox_league_custom.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- wiki=omegastrikers
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+---@class SmiteLeagueInfobox: InfoboxLeague
+local CustomLeague = Class.new(League)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		return {
+			Cell{name = 'Number of teams', content = {args.team_number}},
+			Cell{name = 'Number of players', content = {args.player_number}},
+		}
+	end
+	return widgets
+end
+
+---@param args table
+---@return boolean
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args.publisherpremier)
+end
+
+---@param args table
+function CustomLeague:customParseArguments(args)
+	self.data.publishertier = tostring(Logic.readBool(args.publisherpremier))
+end
+
+return CustomLeague

--- a/components/infobox/wikis/omegastrikers/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/omegastrikers/infobox_person_player_custom.lua
@@ -20,22 +20,22 @@ local Cell = Widgets.Cell
 
 local ROLES = {
 	-- Players
-	['forward'] = {category = 'Forwards', display = 'Forward'},
-	['goalie'] = {category = 'Goalies', display = 'Goalie'},
-	['goalkeeper'] = {category = 'Goalkeepers', display = 'Goalkeeper'},
-	['flex'] = {category = 'Flex', display = 'Flex'},
+	forward = {category = 'Forwards', display = 'Forward'},
+	goalie = {category = 'Goalies', display = 'Goalie'},
+	goalkeeper = {category = 'Goalkeepers', display = 'Goalkeeper'},
+	flex = {category = 'Flex', display = 'Flex'},
 
 	-- Staff and Talents
-	['analyst'] = {category = 'Analysts', display = 'Analyst'},
-	['observer'] = {category = 'Observers', display = 'Observer'},
-	['host'] = {category = 'Hosts', display = 'Host'},
-	['coach'] = {category = 'Coaches', display = 'Coach'},
-	['caster'] = {category = 'Casters', display = 'Caster'},
+	analyst = {category = 'Analysts', display = 'Analyst'},
+	observer = {category = 'Observers', display = 'Observer'},
+	host = {category = 'Hosts', display = 'Host'},
+	coach = {category = 'Coaches', display = 'Coach'},
+	caster = {category = 'Casters', display = 'Caster'},
 }
 
 ---@class OmegaStrikersInfoboxPlayer: Person
----@field role table
----@field role2 table
+---@field role {category: string, display: string}?
+---@field role2 {category: string, display: string}?
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/components/infobox/wikis/omegastrikers/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/omegastrikers/infobox_person_player_custom.lua
@@ -1,0 +1,95 @@
+---
+-- @Liquipedia
+-- wiki=omegastrikers
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Player = Lua.import('Module:Infobox/Person')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+local ROLES = {
+	-- Players
+	['forward'] = {category = 'Forwards', display = 'Forward'},
+	['goalie'] = {category = 'Goalies', display = 'Goalie'},
+	['goalkeeper'] = {category = 'Goalkeepers', display = 'Goalkeeper'},
+	['flex'] = {category = 'Flex', display = 'Flex'},
+
+	-- Staff and Talents
+	['analyst'] = {category = 'Analysts', display = 'Analyst'},
+	['observer'] = {category = 'Observers', display = 'Observer'},
+	['host'] = {category = 'Hosts', display = 'Host'},
+	['coach'] = {category = 'Coaches', display = 'Coach'},
+	['caster'] = {category = 'Casters', display = 'Caster'},
+}
+
+---@class OmegaStrikersInfoboxPlayer: Person
+---@field role table
+---@field role2 table
+local CustomPlayer = Class.new(Player)
+local CustomInjector = Class.new(Injector)
+
+function CustomPlayer.run(frame)
+	local player = CustomPlayer(frame)
+
+	player:setWidgetInjector(CustomInjector(player))
+
+	player.args.autoTeam = true
+	player.args.history = TeamHistoryAuto._results{
+		convertrole = true,
+		player = player.pagename
+	}
+	player.role = player:_getRoleData(player.args.role)
+	player.role2 = player:_getRoleData(player.args.role2)
+
+	return player:createInfobox()
+end
+
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+
+	if id == 'role' then
+		return {
+			Cell{name = 'Role', content = {
+				caller:_displayRole(caller.role),
+				caller:_displayRole(caller.role2),
+			}},
+		}
+	end
+	return widgets
+end
+
+---@param role string?
+---@return {category: string, display: string, isplayer: boolean?}?
+function CustomPlayer:_getRoleData(role)
+	return ROLES[(role or ''):lower()]
+end
+
+---@param roleData {category: string, display: string, isplayer: boolean?}?
+---@return string?
+function CustomPlayer:_displayRole(roleData)
+	if not roleData then return end
+
+	return Page.makeInternalLink(roleData.display, ':Category:' .. roleData.category)
+end
+
+---@param categories string[]
+---@return string[]
+function CustomPlayer:getWikiCategories(categories)
+	return Array.append(categories,
+		(self.role or {}).category,
+		(self.role2 or {}).category
+	)
+end
+
+return CustomPlayer


### PR DESCRIPTION
I've come to realize these two were lost in the radar and was never added to GitHub, so I did. Player and League Infobox for Omega Strikers 

This include a refactoring of these module to be based on the recently merged SMITE ones 

- League Infobox have the Game function removed (OS dont need one here)
- The old Player Infobox had similar Role/Data situation like SMITE, so we're porting that one here with the fixes. The old one also have signature characters but also similar to SMITE it is better to move away from it

## Note
The infoboxes are Live since the wiki is up last year, the new version in this PR are just being tested both dev=1 and live just today

Has both infobox in this module