### PR TITLE
HOTFIX: Fix header in apex match legacy

### DIFF
--- a/components/match2/wikis/apexlegends/match_legacy.lua
+++ b/components/match2/wikis/apexlegends/match_legacy.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=rainbowsix
+-- wiki=apexlegends
 -- page=Module:Match/Legacy
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute


### PR DESCRIPTION
## Summary
HOTFIX: Fix header in apex match legacy, it shredded R6 legacy storage

## How did you test this change?
N/A, reverted the bot deployed stuff on r6 manually, but this needs to be merged before next sync else legacy storage on R6 breaks again