### PR TITLE
Changed "Six Major" to "Major" in Ubisoft Tiers

### DIFF
--- a/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_league_custom.lua
@@ -45,7 +45,7 @@ local UBISOFT_TIERS = {
 	pl = 'Pro League',
 	cl = 'Challenger League',
 	national = 'National',
-	major = 'Six Major',
+	major = 'Major',
 	minor = 'Minor',
 }
 


### PR DESCRIPTION
Only a visual text change so it will link to the correct page .../Major instead of .../Six Major

## Summary

Changing the name in Ubisoft-tier for the Major events to represent the correct format and to link to the correct page.
Going from Six Major (Only under ESL this name was used) to just "Major" since BLAST has taken over the production.

## How did you test this change?

Dev module, the result can be seen on the picture: 
![image](https://github.com/Liquipedia/Lua-Modules/assets/36400524/aaaaa54b-9282-4495-82f8-6d877560a5f8)

Before image: 
![image](https://github.com/Liquipedia/Lua-Modules/assets/36400524/b84632dc-6b02-44a2-92ef-40131aaeaec5)
