### PR TITLE
fix: BS infobox player role processing call

### DIFF
--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -175,7 +175,7 @@ end
 
 ---@param role string?
 ---@return {category: string, variable: string, isplayer: boolean?, personType: string}?
-function CustomPlayer:_getRoleData(role)
+function CustomPlayer._getRoleData(role)
 	return ROLES[(role or ''):lower()]
 end
 


### PR DESCRIPTION
## Summary
Function was defined as class function, but called without self.

## How did you test this change?
dev to live