### PR TITLE
BR - Team name overflow in table

### DIFF
--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -296,6 +296,7 @@ Author(s): Elysienna
 		&--team {
 			flex-basis: 15rem;
 			flex-grow: 0;
+			overflow: hidden;
 		}
 
 		&--total-points {


### PR DESCRIPTION
## Summary

Sometimes the team name is longer than the reserved cell space in the table, which causes the cell to expand. I talked with Jasper how to solve this and we decided to add an overflow to the cell and to encourage using shorter bracket display names. 

## How did you test this change?

I tested the css in the browser console.
