### PR TITLE
fix(region): don't remap latam to south america

### DIFF
--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -14,11 +14,9 @@ return {
 		['north america'] = 'na',
 		['northern america'] = 'na',
 
-		la = 'sa',
 		sam = 'sa',
 		['south america'] = 'sa',
 		['southern america'] = 'sa',
-		['latin america'] = 'sa',
 
 		['middle america'] = 'central america',
 
@@ -44,6 +42,7 @@ return {
 
 		['latin america north'] = 'latam north',
 		['latin america south'] = 'latam south',
+		la = 'latin america',
 
 		['apacn'] = 'apac north',
 		['asia pacific north'] = 'apac north',


### PR DESCRIPTION
## Summary

There already exists a latam region in the data, so we shouldn't remap it to south america.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/7d3c1d7c-8338-4b23-9ea9-b2904b2b36bb)

https://discord.com/channels/93055209017729024/268719633366777856/1201624845784453280

Due to wiki custom remapping SA to LATAM, and then region module remapping it back, it ended up in a endless loop fighting over itself until it overflows the stack.

## How did you test this change?

live to fix broken pages.
