### PR TITLE
Adding LAN and LAS as Latin America Region aliases

### DIFF
--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -44,6 +44,8 @@ return {
 
 		['latin america north'] = 'latam north',
 		['latin america south'] = 'latam south',
+		lan = ['latam north'],
+		las = ['latam south'],
 
 		['apacn'] = 'apac north',
 		['asia pacific north'] = 'apac north',

--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -44,8 +44,8 @@ return {
 
 		['latin america north'] = 'latam north',
 		['latin america south'] = 'latam south',
-		lan = ['latam north'],
-		las = ['latam south'],
+		lan = 'latam north',
+		las = 'latam south',
 
 		['apacn'] = 'apac north',
 		['asia pacific north'] = 'apac north',

--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -43,7 +43,7 @@ return {
 		['latin america north'] = 'latam north',
 		['latin america south'] = 'latam south',
 
-    lan = 'latam north',
+		lan = 'latam north',
 		las = 'latam south',
 
 		['apacn'] = 'apac north',

--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -42,7 +42,7 @@ return {
 
 		['latin america north'] = 'latam north',
 		['latin america south'] = 'latam south',
-
+		la = 'latin america',
 		lan = 'latam north',
 		las = 'latam south',
 


### PR DESCRIPTION
## Summary
Adds LAN (LATAM North) and LAS (LATAM South) as aliases for Latin America.
Neither of these are currently used by ISO Alpha-3 (see below)
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/bb6d1620-cb39-4e02-a2dc-b178357e6513)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
