### PR TITLE
fix(m2, apex): also inherit header to m1 for matchlists

### DIFF
--- a/components/match2/wikis/apexlegends/match_legacy.lua
+++ b/components/match2/wikis/apexlegends/match_legacy.lua
@@ -33,7 +33,7 @@ function MatchLegacy._storeMatch1(match2)
 
 		-- Handle extradata fields
 		local bracketData = Json.parseIfString(match2.match2bracketdata)
-		if type(bracketData) == 'table' and bracketData.type == 'bracket' and bracketData.inheritedheader then
+		if type(bracketData) == 'table' and bracketData.inheritedheader then
 			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
 		end
 		local m1extradata = {}


### PR DESCRIPTION
## Summary
Set match1.header for matchlists also. It was meant to do it from the start, but forgot to fix the condition.

## How did you test this change?
Live