### PR TITLE
fix(m2, apex): use correct number to apply bg from

### DIFF
--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -359,8 +359,8 @@ end
 ---@param statusSettings table
 ---@return table
 function MatchFunctions.setBgForOpponents(opponents, statusSettings)
-	Array.forEach(opponents, function(opponent, index)
-		opponent.extradata = {bg = statusSettings[index]}
+	Array.forEach(opponents, function(opponent)
+		opponent.extradata = {bg = statusSettings[opponent.placement]}
 	end)
 	return opponents
 end


### PR DESCRIPTION
## Summary
Don't use the index of the opponent, use their placement instead

## How did you test this change?
Live