### PR TITLE
ci: upgrade checkout action to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup lua
         uses: leafo/gh-actions-lua@v9
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup lua
         uses: leafo/gh-actions-lua@v9

--- a/.github/workflows/resources.yml
+++ b/.github/workflows/resources.yml
@@ -7,7 +7,7 @@ jobs:
   test-resources:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install modules
         run: npm install
       - name: Run test

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 


### PR DESCRIPTION
## Summary

[Github is retiring Node16 in a couple of months](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and actions/checkout@v3 is using node16. Upgrading to v4 which is using node20.