### PR TITLE
ci: upgrade `action-junit-report` to `v4`

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -28,7 +28,7 @@ jobs:
           luacheck ./ --formatter=JUnit > report.xml
 
       - name: Report lint
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v4
         if: always()
         with:
           report_paths: 'report.xml'
@@ -58,7 +58,7 @@ jobs:
           busted -v --run=ci --output=junit > busted.xml
 
       - name: Report test
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v4
         if: always()
         with:
           report_paths: 'busted.xml'


### PR DESCRIPTION
## Summary
[Github is retiring Node16 in a couple of months](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and action-junit-report@v3 is using node16. Upgrading to v4 which is using node20.
