### PR TITLE
Create Rocket League map infobox

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_map_custom
+++ b/components/infobox/wikis/rocketleague/infobox_map_custom
@@ -1,0 +1,65 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague
+-- page=Module:Infobox/Map/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Map = Lua.import('Module:Infobox/Map')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+---@class RocketLeagueMapInfobox: MapInfobox
+local CustomMap = Class.new(Map)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomMap.run(frame)
+	local map = CustomMap(frame)
+	map:setWidgetInjector(CustomInjector(map))
+
+	return map:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		Array.appendWith(
+			widgets,
+			Cell{name = 'Layout', content = args.layout},
+			Cell{name = 'Versions', content = {args.versions}},
+			Cell{name = 'Playlists', content = args.playlists},
+			Cell{name = 'Gamemodes', content = {args.gamemodes}},
+		)
+	end
+	return widgets
+end
+
+---@param lpdbData table
+---@param args table
+---@return table
+function CustomMap:addToLpdb(lpdbData, args)
+	local resolveIfExists = function(value)
+		if not value then return end
+		return mw.ext.TeamLiquidIntegration.resolve_redirect(value)
+	end
+	lpdbData.extradata.creator = resolveIfExists(args.creator)
+	lpdbData.extradata.creator2 = resolveIfExists(args.creator2)
+
+	return lpdbData
+end
+
+return CustomMap

--- a/components/infobox/wikis/rocketleague/infobox_map_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_map_custom.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local Map = Lua.import('Module:Infobox/Map')

--- a/components/infobox/wikis/rocketleague/infobox_map_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_map_custom.lua
@@ -39,10 +39,10 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Layout', content = args.layout},
+			Cell{name = 'Layout', content = {args.layout}},
 			Cell{name = 'Versions', content = {args.versions}},
-			Cell{name = 'Playlists', content = args.playlists},
-			Cell{name = 'Gamemodes', content = {args.gamemodes}},
+			Cell{name = 'Playlists', content = {args.playlists}},
+			Cell{name = 'Gamemodes', content = {args.gamemodes}}
 		)
 	end
 	return widgets


### PR DESCRIPTION
## Summary
Creates a new Rocket League Infobox for Map pages 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
While some of these fields should (in theory) be broken down and dispalyed nicer, the wiki doesnt seem to care. So the format was copied exactly 
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/14a9452f-bde3-4041-8b3d-95ffefe70c26)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
