### PR TITLE
Add vars to DateExt for date switch

### DIFF
--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -22,7 +22,14 @@ DateExt.minTimestamp = -62167219200
 -- 9999-12-31 23:59:59
 DateExt.maxTimestamp = 253402300799
 
--- 1970-01-01 00:00:00
+-- default dateTime used in LPDB
+DateExt.defaultTimestamp = 0
+DateExt.defaultDateTime = '1970-01-01 00:00:00'
+DateExt.defaultDateTimeExtended = '1970-01-01T00:00:00+00:00'
+DateExt.defaultDate = '1970-01-01'
+DateExt.deaultYear = '1970'
+
+---@deprecated just here until any usage (outside of git) has been resolved
 DateExt.epochZero = 0
 
 --- Parses a date string into a timestamp, returning the number of seconds since UNIX epoch.


### PR DESCRIPTION
## Summary
Prep date switch by adding additional consts to `Module:Date/Ext` and using them in git modules.
We can also adjust other modules on commons (and on the wikis) to use them instead of hardcoded 1970 dates.
A swift merge would allow me to adjust non git modules (~400) in the next days for the default date switch.

## How did you test this change?
N/A