### PR TITLE
switch default date

### DIFF
--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -23,14 +23,11 @@ DateExt.minTimestamp = -62167219200
 DateExt.maxTimestamp = 253402300799
 
 -- default dateTime used in LPDB
-DateExt.defaultTimestamp = 0
-DateExt.defaultDateTime = '1970-01-01 00:00:00'
-DateExt.defaultDateTimeExtended = '1970-01-01T00:00:00+00:00'
-DateExt.defaultDate = '1970-01-01'
-DateExt.deaultYear = '1970'
-
----@deprecated just here until any usage (outside of git) has been resolved
-DateExt.epochZero = 0
+DateExt.defaultTimestamp = -62167219200
+DateExt.defaultDateTime = '0000-01-01 00:00:00'
+DateExt.defaultDateTimeExtended = '0000-01-01T00:00:00+00:00'
+DateExt.defaultDate = '0000-01-01'
+DateExt.deaultYear = '0000'
 
 --- Parses a date string into a timestamp, returning the number of seconds since UNIX epoch.
 --- The timezone offset is incorporated into the timestamp, and the timezone is discarded.


### PR DESCRIPTION
## Summary
Switch the default date from `1970-01-01` to `0000-01-01`

## Additional todo with merge:
- Adjust the templates:
  - https://liquipedia.net/commons/Template:DefaultYear
  - https://liquipedia.net/commons/Template:DefaultDate
  - https://liquipedia.net/commons/Template:DefaultDateTime
- change the default date in lpdb --> @FO-nTTaX / devs
- adjust the lpdb data (via sql access) --> @FO-nTTaX /devs

## How did you test this change?
N/A