### PR TITLE
fix(infobox team): created sometimes not working as intended

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -343,7 +343,7 @@ function Team:_setLpdbData(args, links)
 		textlesslogodark = args.teamcardimagedark,
 		earnings = self.totalEarnings,
 		earningsbyyear = self.yearlyEarnings or {},
-		createdate = ReferenceCleaner.clean(args.created),
+		createdate = args.created,
 		disbanddate = ReferenceCleaner.clean(args.disbanded),
 		coach = args.coaches or args.coach,
 		manager = args.manager,

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -206,7 +206,7 @@ end
 ---@return string|number|nil # storage date
 ---@return string[] # display elements
 function Team:processCreateDates()
-	local earliestGameTimestamp = Team._parseDate(self.args.created) or Date.maxTimestamp
+	local earliestGameTimestamp = Team._parseDate(ReferenceCleaner.clean(self.args.created)) or Date.maxTimestamp
 
 	local created = Array.map(self:getAllArgsForBase(self.args, 'created'), function (creation)
 		local splitInput = Array.map(mw.text.split(creation, ':'), String.trim)
@@ -221,7 +221,7 @@ function Team:processCreateDates()
 
 		if game:lower() == 'org' then
 			icon = self:_getTeamIcon(cleanDate)
-			icon = icon and '[[File:' .. icon .. ']]' or nil
+			icon = String.isNotEmpty(icon) and '[[File:' .. icon .. ']]' or nil
 		else
 			local timestamp = Team._parseDate(cleanDate)
 			if timestamp and timestamp < earliestGameTimestamp then
@@ -263,7 +263,7 @@ function Team._parseDate(date)
 		return
 	end
 
-	return Date.readTimestamp(date)
+	return Date.readTimestampOrNil(date)
 end
 
 ---@param region string?


### PR DESCRIPTION
## Summary

Fixes 3 related issues:
1) Unexpected input errors 
  - Caused by not having ReferenceCleaner.clean in the inital parse date
  - Added start and end of the regex to check for valid string as additional security
2) Basic input with just date not storing into LPDB
  - Caused by the same as above
3) Team having STD images not showing `[[File:]]`
  - Fixed with the String.isNotEmpty() check

The two first were caused during a refactor to clean up the code before release, and that case wasn't retested.
## How did you test this change?
Live