### PR TITLE
Fix: Mobile Legends match2 and hence adjust Infobox/Item

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
@@ -8,7 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Icon = require('Module:Icon')
+local MobileLegendIcon = require('Module:MobileLegendIcon')
 local ItemIcon = require('Module:ItemIcon')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
@@ -195,14 +195,14 @@ function CustomItem:_getCostDisplay()
 
 	local innerDiv = CustomItem._costInnerDiv(table.concat(costs, '&nbsp;/&nbsp;'))
 	local outerDiv = mw.html.create('div')
-		:wikitext(Icon.display({}, 'gold', '21') .. ' ' .. tostring(innerDiv))
+		:wikitext(MobileLegendIcon.display({}, 'gold', '21') .. ' ' .. tostring(innerDiv))
 	local display = tostring(outerDiv)
 
 	if String.isNotEmpty(self.args.recipecost) then
 		innerDiv = CustomItem._costInnerDiv('(' .. self.args.recipecost .. ')')
 		outerDiv = mw.html.create('div')
 			:css('padding-top', '3px')
-			:wikitext(Icon.display({}, 'recipe', '21') .. ' ' .. tostring(innerDiv))
+			:wikitext(MobileLegendIcon.display({}, 'recipe', '21') .. ' ' .. tostring(innerDiv))
 		display = display .. tostring(outerDiv)
 	end
 


### PR DESCRIPTION
## Summary
With #3856 an icon module was added to commons that gets called inside match2.
ML had a custom module in its place. Hence Match2 MatchSummary errored.
I moved the Module. Due to the old module being used in Infobox item we now have to adjust the import accordingly.

## How did you test this change?
Live