### PR TITLE
refactor(match2): extract common date logic

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -309,7 +309,7 @@ function MatchGroupInput.readDate(dateString, dateFallbacks)
 		}
 
 	elseif dateFallbacks then
-		local suggestedDate = Variables.varDefaultMulti(unpack(dateFallbacks))
+		local suggestedDate = Variables.varDefaultMulti(unpack(dateFallbacks), DateExt.defaultDate)
 		local missingDateCount = globalVars:get('num_missing_dates') or 0
 		globalVars:set('num_missing_dates', missingDateCount + 1)
 		local inexactDateString = (suggestedDate or '') .. ' + ' .. missingDateCount .. ' second'

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -79,7 +79,6 @@ function StarcraftMatchGroupInput._readDate(matchArgs)
 		'tournament_enddate',
 		DateExt.defaultDate
 	})
-	dateProps.dateexact = Logic.nilOr(Logic.readBoolOrNil(matchArgs.dateexact), dateProps.dateexact)
 	if dateProps.dateexact then
 		Variables.varDefine('matchDate', dateProps.date)
 	end

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -73,7 +73,6 @@ end
 function StarcraftMatchGroupInput._readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
 		'matchDate',
-		'Match_date',
 		'tournament_startdate',
 		'tournament_enddate',
 	})

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -72,24 +72,18 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 end
 
 function StarcraftMatchGroupInput._readDate(matchArgs)
-	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
-		dateProps.dateexact = Logic.nilOr(Logic.readBoolOrNil(matchArgs.dateexact), dateProps.dateexact)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
+		'matchDate',
+		'Match_date',
+		'tournament_startdate',
+		'tournament_enddate',
+		DateExt.defaultDate
+	})
+	dateProps.dateexact = Logic.nilOr(Logic.readBoolOrNil(matchArgs.dateexact), dateProps.dateexact)
+	if dateProps.dateexact then
 		Variables.varDefine('matchDate', dateProps.date)
-		return dateProps
-	else
-		local suggestedDate = Variables.varDefaultMulti(
-			'matchDate',
-			'Match_date',
-			'tournament_startdate',
-			'tournament_enddate',
-			DateExt.defaultDate
-		)
-		return {
-			date = MatchGroupInput.getInexactDate(suggestedDate),
-			dateexact = false,
-		}
 	end
+	return dateProps
 end
 
 function StarcraftMatchGroupInput._checkFinished(match)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -77,7 +77,6 @@ function StarcraftMatchGroupInput._readDate(matchArgs)
 		'Match_date',
 		'tournament_startdate',
 		'tournament_enddate',
-		DateExt.defaultDate
 	})
 	if dateProps.dateexact then
 		Variables.varDefine('matchDate', dateProps.date)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Faction = require('Module:Faction')
 local Flags = require('Module:Flags')
 local FnUtil = require('Module:FnUtil')

--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -235,15 +235,7 @@ end
 ---@param matchArgs table
 ---@return table
 function MatchFunctions.readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 ---@param match table

--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -60,7 +60,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match = MatchFunctions.getScoreFromMaps(match)
 
 	-- process match
-	Table.mergeInto(match, MatchFunctions.readDate(match))
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
 	match = MatchFunctions.getOpponents(match)
 	match = MatchFunctions.getTournamentVars(match)
 	match = MatchFunctions.getVodStuff(match)
@@ -230,12 +230,6 @@ function MatchFunctions.getScoreFromMaps(match)
 	end
 
 	return match
-end
-
----@param matchArgs table
----@return table
-function MatchFunctions.readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 ---@param match table

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -264,16 +264,11 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -294,7 +294,6 @@ function matchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
 		'tournament_enddate',
 		'tournament_startdate',
-		DateExt.defaultDateTime
 	})
 	if matchArgs.date then
 		dateProps.hasDate = true

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -291,21 +291,16 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
+		'tournament_enddate',
+		'tournament_startdate',
+		DateExt.defaultDateTime
+	})
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		local suggestedDate = Variables.varDefaultMulti(
-			'tournament_enddate',
-			'tournament_startdate',
-			DateExt.defaultDateTime
-		)
-		return {
-			date = MatchGroupInput.getInexactDate(suggestedDate),
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -291,15 +291,7 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -51,10 +51,7 @@ local CustomMatchGroupInput = {}
 -- called from Module:MatchGroup
 function CustomMatchGroupInput.processMatch(match, options)
 	-- process match
-	Table.mergeInto(
-		match,
-		matchFunctions.readDate(match)
-	)
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
 	match = matchFunctions.getScoreFromMapWinners(match)
 	match = matchFunctions.getOpponents(match)
 	match = matchFunctions.getTournamentVars(match)
@@ -288,10 +285,6 @@ function matchFunctions.getScoreFromMapWinners(match)
 	end
 
 	return match
-end
-
-function matchFunctions.readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -121,9 +121,7 @@ end
 --
 
 function matchFunctions.readDate(matchArgs)
-	return matchArgs.date
-		and MatchGroupInput.readDate(matchArgs.date)
-		or {date = MatchGroupInput.getInexactDate(), dateexact = false}
+	return MatchGroupInput.readDate(matchArgs.date, {'tournament_enddate'})
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -254,16 +254,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = mw.getContentLanguage():formatDate('c', DateExt.defaultDateTime),
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Streams = require('Module:Links/Stream')

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -301,15 +301,7 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -42,10 +42,8 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match = matchFunctions.getScoreFromMapWinners(match)
 
 	-- process match
-	Table.mergeInto(
-		match,
-		matchFunctions.readDate(match)
-	)
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
+
 	match = matchFunctions.getOpponents(match)
 	match = matchFunctions.getTournamentVars(match)
 	match = matchFunctions.getVodStuff(match)
@@ -298,10 +296,6 @@ function matchFunctions.getScoreFromMapWinners(match)
 	end
 
 	return match
-end
-
-function matchFunctions.readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -312,16 +312,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -321,16 +321,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -264,16 +264,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -315,16 +315,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -41,20 +41,14 @@ local walkoverProcessing = CustomMatchGroupInput.walkoverProcessing
 
 -- called from Module:MatchGroup
 function CustomMatchGroupInput.processMatch(match)
-	Table.mergeInto(
-		match,
-		CustomMatchGroupInput._readDate(match)
-	)
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
+
 	CustomMatchGroupInput._getExtraData(match)
 	CustomMatchGroupInput._getTournamentVars(match)
 	CustomMatchGroupInput._adjustData(match)
 	CustomMatchGroupInput._getVodStuff(match)
 
 	return match
-end
-
-function CustomMatchGroupInput._readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function CustomMatchGroupInput._getTournamentVars(match)

--- a/components/match2/wikis/fifa/match_group_input_custom.lua
+++ b/components/match2/wikis/fifa/match_group_input_custom.lua
@@ -54,15 +54,7 @@ function CustomMatchGroupInput.processMatch(match)
 end
 
 function CustomMatchGroupInput._readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function CustomMatchGroupInput._getTournamentVars(match)

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -265,16 +265,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -294,7 +294,6 @@ function matchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
 		'tournament_enddate',
 		'tournament_startdate',
-		DateExt.defaultDateTime
 	})
 	if matchArgs.date then
 		dateProps.hasDate = true

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -291,21 +291,16 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
+		'tournament_enddate',
+		'tournament_startdate',
+		DateExt.defaultDateTime
+	})
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		local suggestedDate = Variables.varDefaultMulti(
-			'tournament_enddate',
-			'tournament_startdate',
-			DateExt.defaultDateTime
-		)
-		return {
-			date = MatchGroupInput.getInexactDate(suggestedDate),
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -58,10 +58,8 @@ local CustomMatchGroupInput = {}
 function CustomMatchGroupInput.processMatch(match, options)
 	options = options or {}
 	-- process match
-	Table.mergeInto(
-		match,
-		matchFunctions.readDate(match)
-	)
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
+
 	match = matchFunctions.getBestOf(match)
 	match = matchFunctions.getScoreFromMapWinners(match)
 	match = matchFunctions.getOpponents(match)
@@ -324,10 +322,6 @@ function matchFunctions.getScoreFromMapWinners(match)
 	end
 
 	return match
-end
-
-function matchFunctions.readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -327,15 +327,7 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/magic/match_group_input_custom.lua
+++ b/components/match2/wikis/magic/match_group_input_custom.lua
@@ -60,15 +60,7 @@ function CustomMatchGroupInput.processMatch(match)
 end
 
 function CustomMatchGroupInput._readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function CustomMatchGroupInput._getTournamentVars(match)

--- a/components/match2/wikis/magic/match_group_input_custom.lua
+++ b/components/match2/wikis/magic/match_group_input_custom.lua
@@ -47,20 +47,13 @@ function CustomMatchGroupInput.processMatch(match)
 		error('Unexpected number of opponents in a non-FFA match')
 	end
 
-	Table.mergeInto(
-		match,
-		CustomMatchGroupInput._readDate(match)
-	)
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
 	match = CustomMatchGroupInput._getExtraData(match)
 	match = CustomMatchGroupInput._getTournamentVars(match)
 	match = CustomMatchGroupInput._adjustData(match)
 	match = CustomMatchGroupInput._getVodStuff(match)
 
 	return match
-end
-
-function CustomMatchGroupInput._readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function CustomMatchGroupInput._getTournamentVars(match)

--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -294,7 +294,6 @@ function matchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
 		'tournament_enddate',
 		'tournament_startdate',
-		DateExt.defaultDateTime
 	})
 	if matchArgs.date then
 		dateProps.hasDate = true

--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -291,21 +291,16 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
+		'tournament_enddate',
+		'tournament_startdate',
+		DateExt.defaultDateTime
+	})
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		local suggestedDate = Variables.varDefaultMulti(
-			'tournament_enddate',
-			'tournament_startdate',
-			DateExt.defaultDateTime
-		)
-		return {
-			date = MatchGroupInput.getInexactDate(suggestedDate),
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/omegastrikers/match_group_input_custom.lua
+++ b/components/match2/wikis/omegastrikers/match_group_input_custom.lua
@@ -116,9 +116,7 @@ end
 --
 
 function matchFunctions.readDate(matchArgs)
-	return matchArgs.date
-		and MatchGroupInput.readDate(matchArgs.date)
-		or {date = MatchGroupInput.getInexactDate(), dateexact = false}
+	return MatchGroupInput.readDate(matchArgs.date, {'tournament_enddate'})
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -261,16 +261,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -266,16 +266,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -290,21 +290,16 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
+		'tournament_enddate',
+		'tournament_startdate',
+		DateExt.defaultDateTime
+	})
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		local suggestedDate = Variables.varDefaultMulti(
-			'tournament_enddate',
-			'tournament_startdate',
-			DateExt.defaultDateTime
-		)
-		return {
-			date = MatchGroupInput.getInexactDate(suggestedDate),
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -293,7 +293,6 @@ function matchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
 		'tournament_enddate',
 		'tournament_startdate',
-		DateExt.defaultDateTime
 	})
 	if matchArgs.date then
 		dateProps.hasDate = true

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -287,15 +287,7 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getVodStuff(match)

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -41,7 +41,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match = matchFunctions.getScoreFromMapWinners(match)
 
 	-- process match
-	Table.mergeInto(match, matchFunctions.readDate(match))
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
 	match = matchFunctions.getOpponents(match)
 	match = CustomMatchGroupInput.getTournamentVars(match)
 	match = matchFunctions.getVodStuff(match)
@@ -284,10 +284,6 @@ function matchFunctions.getScoreFromMapWinners(match)
 	match.opponent1 = opponent1
 	match.opponent2 = opponent2
 	return match
-end
-
-function matchFunctions.readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function matchFunctions.getVodStuff(match)

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -12,7 +12,6 @@ local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Array = require('Module:Array')
 local Lua = require('Module:Lua')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
@@ -33,8 +32,6 @@ local MAX_NUM_VODGAMES = 20
 local _RESULT_TYPE_DRAW = 'draw'
 local _EARNINGS_LIMIT_FOR_FEATURED = 10000
 local _CURRENT_YEAR = os.date('%Y')
-
-local globalVars = PageVariableNamespace()
 
 -- containers for process helper functions
 local matchFunctions = {}

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -137,12 +137,7 @@ end
 -- match related functions
 --
 function matchFunctions.readDate(matchArgs)
-	return matchArgs.date
-		and MatchGroupInput.readDate(matchArgs.date)
-		or {
-			date = MatchGroupInput.getInexactDate(globalVars:get('tournament_enddate')),
-			dateexact = false,
-		}
+	return MatchGroupInput.readDate(matchArgs.date, {'tournament_enddate'})
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -10,7 +10,6 @@ local CustomMatchGroupInput = {}
 
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
@@ -29,8 +28,6 @@ local _MAX_NUM_PLAYERS = 10
 local _RESULT_TYPE_DRAW = 'draw'
 local _EARNINGS_LIMIT_FOR_FEATURED = 10000
 local _CURRENT_YEAR = os.date('%Y')
-
-local globalVars = PageVariableNamespace()
 
 -- containers for process helper functions
 local matchFunctions = {}

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -104,12 +104,7 @@ end
 -- match related functions
 --
 function matchFunctions.readDate(matchArgs)
-	return matchArgs.date
-		and MatchGroupInput.readDate(matchArgs.date)
-		or {
-			date = MatchGroupInput.getInexactDate(globalVars:get('tournament_enddate')),
-			dateexact = false,
-		}
+	return MatchGroupInput.readDate(matchArgs.date, {'tournament_enddate'})
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -321,7 +321,9 @@ end
 
 function matchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date)
-	dateProps.hasDate = true
+	if dateProps.dateexact then
+		dateProps.hasDate = true
+	end
 	return dateProps
 end
 

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -321,7 +321,7 @@ end
 
 function matchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date)
-	if dateProps.dateexact then
+	if dateProps.date then
 		dateProps.hasDate = true
 	end
 	return dateProps

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -320,17 +320,9 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
-	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
-		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
+	dateProps.hasDate = true
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -273,16 +273,12 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/stormgate/match_group_input_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_input_custom.lua
@@ -75,16 +75,12 @@ function CustomMatchGroupInput._readDate(matchArgs)
 		return dateProps
 	end
 
-	suggestedDate = suggestedDate or Variables.varDefaultMulti(
+	return MatchGroupInput.readDate(nil, {
+		'matchDate',
 		'tournament_startdate',
 		'tournament_enddate',
 		DateExt.defaultDate
-	)
-
-	return {
-		date = MatchGroupInput.getInexactDate(suggestedDate),
-		dateexact = false,
-	}
+	})
 end
 
 ---@param match table

--- a/components/match2/wikis/stormgate/match_group_input_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Faction = require('Module:Faction')
 local Flags = require('Module:Flags')
 local HeroData = mw.loadData('Module:HeroData')

--- a/components/match2/wikis/stormgate/match_group_input_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_input_custom.lua
@@ -61,26 +61,17 @@ end
 ---@param matchArgs table
 ---@return table
 function CustomMatchGroupInput._readDate(matchArgs)
-	local suggestedDate = Variables.varDefault('matchDate')
-
-	local tournamentStartTime = Variables.varDefault('tournament_starttimeraw')
-
-	if matchArgs.date or (not suggestedDate and tournamentStartTime) then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date or tournamentStartTime)
-		dateProps.dateexact = Logic.nilOr(
-			Logic.readBoolOrNil(matchArgs.dateexact),
-			matchArgs.date and dateProps.dateexact or false
-		)
-		Variables.varDefine('matchDate', dateProps.date)
-		return dateProps
-	end
-
-	return MatchGroupInput.readDate(nil, {
+	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
 		'matchDate',
 		'tournament_startdate',
-		'tournament_enddate',
-		DateExt.defaultDate
+		'tournament_enddate'
 	})
+
+	if dateProps.dateexact then
+		Variables.varDefine('matchDate', dateProps.date)
+	end
+
+	return dateProps
 end
 
 ---@param match table

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -60,15 +60,7 @@ function CustomMatchGroupInput.processMatch(match)
 end
 
 function CustomMatchGroupInput._readDate(matchArgs)
-	if matchArgs.date then
-		return MatchGroupInput.readDate(matchArgs.date)
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-			timestamp = DateExt.defaultTimestamp,
-		}
-	end
+	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function CustomMatchGroupInput._getTournamentVars(match)

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -47,20 +47,13 @@ function CustomMatchGroupInput.processMatch(match)
 		error('Unexpected number of opponents in a non-FFA match')
 	end
 
-	Table.mergeInto(
-		match,
-		CustomMatchGroupInput._readDate(match)
-	)
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
 	match = CustomMatchGroupInput._getExtraData(match)
 	match = CustomMatchGroupInput._getTournamentVars(match)
 	match = CustomMatchGroupInput._adjustData(match)
 	match = CustomMatchGroupInput._getVodStuff(match)
 
 	return match
-end
-
-function CustomMatchGroupInput._readDate(matchArgs)
-	return MatchGroupInput.readDate(matchArgs.date)
 end
 
 function CustomMatchGroupInput._getTournamentVars(match)

--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -128,12 +128,7 @@ end
 -- match related functions
 --
 function matchFunctions.readDate(matchArgs)
-	return matchArgs.date
-		and MatchGroupInput.readDate(matchArgs.date)
-		or {
-			date = MatchGroupInput.getInexactDate(Variables.varDefault('tournament_enddate')),
-			dateexact = false,
-		}
+	return MatchGroupInput.readDate(matchArgs.date, {'tournament_enddate'})
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -338,16 +338,12 @@ end
 ---@param matchArgs table
 ---@return table
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+
+	return dateProps
 end
 
 ---@param match table

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -81,7 +81,6 @@ function CustomMatchGroupInput._readDate(matchArgs)
 		'matchDate',
 		'tournament_startdate',
 		'tournament_enddate',
-		DateExt.defaultDate
 	})
 end
 

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Faction = require('Module:Faction')
 local Flags = require('Module:Flags')
 local HeroData = mw.loadData('Module:HeroData')

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -77,16 +77,13 @@ function CustomMatchGroupInput._readDate(matchArgs)
 		return dateProps
 	end
 
-	suggestedDate = suggestedDate or Variables.varDefaultMulti(
+	return MatchGroupInput.readDate(nil, {
+		'matchDate',
+		'Match_date',
 		'tournament_startdate',
 		'tournament_enddate',
 		DateExt.defaultDate
-	)
-
-	return {
-		date = MatchGroupInput.getInexactDate(suggestedDate),
-		dateexact = false,
-	}
+	})
 end
 
 ---@param match table

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -63,7 +63,7 @@ end
 ---@param matchArgs table
 ---@return table
 function CustomMatchGroupInput._readDate(matchArgs)
-	local suggestedDate = Variables.varDefault('matchDate') or Variables.varDefault('Match_date')
+	local suggestedDate = Variables.varDefault('matchDate')
 
 	local tournamentStartTime = Variables.varDefault('tournament_starttimeraw')
 
@@ -79,7 +79,6 @@ function CustomMatchGroupInput._readDate(matchArgs)
 
 	return MatchGroupInput.readDate(nil, {
 		'matchDate',
-		'Match_date',
 		'tournament_startdate',
 		'tournament_enddate',
 		DateExt.defaultDate

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -290,21 +290,15 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
+		'tournament_enddate',
+		'tournament_startdate',
+		DateExt.defaultDateTime
+	})
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		local suggestedDate = Variables.varDefaultMulti(
-			'tournament_enddate',
-			'tournament_startdate',
-			DateExt.defaultDateTime
-		)
-		return {
-			date = MatchGroupInput.getInexactDate(suggestedDate),
-			dateexact = false,
-		}
 	end
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -293,7 +293,6 @@ function matchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInput.readDate(matchArgs.date, {
 		'tournament_enddate',
 		'tournament_startdate',
-		DateExt.defaultDateTime
 	})
 	if matchArgs.date then
 		dateProps.hasDate = true

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local ChampionNames = mw.loadData('Module:ChampionNames')
-local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -261,16 +261,11 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/zula/match_group_input_custom.lua
+++ b/components/match2/wikis/zula/match_group_input_custom.lua
@@ -313,16 +313,11 @@ function matchFunctions.getScoreFromMapWinners(match)
 end
 
 function matchFunctions.readDate(matchArgs)
+	local dateProps = MatchGroupInput.readDate(matchArgs.date)
 	if matchArgs.date then
-		local dateProps = MatchGroupInput.readDate(matchArgs.date)
 		dateProps.hasDate = true
-		return dateProps
-	else
-		return {
-			date = DateExt.defaultDateTimeExtended,
-			dateexact = false,
-		}
 	end
+	return dateProps
 end
 
 function matchFunctions.getTournamentVars(match)

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -53,7 +53,7 @@ function DateExt.readTimestamp(dateString)
 end
 
 --- Same as DateExt.readTimestamp, except that it returns nil upon failure.
----@param dateString string
+---@param dateString string|number
 ---@return integer?
 function DateExt.readTimestampOrNil(dateString)
 	local success, timestamp = pcall(DateExt.readTimestamp, dateString)


### PR DESCRIPTION
## Summary
Extract most of the date handling logic to commons. This is the first step in solving #1889, where the timestamp will always be available on all wikis. Then a follow up step to change usages to timestamp instead of time comparisons. 

## How did you test this change?
Tested the 4 different cases
* Has proper date
* Has no date, but can (and is allowed to) fetch from vars
* Has no date, and allowed to fetch from vars, but nothing in there
* Has no date and is not allowed to fetch from vars