### PR TITLE
feat(infobox person): add death location support

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -137,8 +137,11 @@ function Person:createInfobox()
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Player') .. ' Information'},
-		Cell{name = 'Name', content = {args.name}},
-		Cell{name = 'Romanized Name', content = {args.romanized_name}},
+		Customizable{id = 'name', children = {
+				Cell{name = 'Name', content = {args.name}},
+				Cell{name = 'Romanized Name', content = {args.romanized_name}},
+			}
+		},
 		Customizable{id = 'nationality', children = {
 				Cell{name = 'Nationality', content = self:displayLocations()}
 			}

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -139,7 +139,6 @@ function Person:createInfobox()
 		Title{name = (args.informationType or 'Player') .. ' Information'},
 		Cell{name = 'Name', content = {args.name}},
 		Cell{name = 'Romanized Name', content = {args.romanized_name}},
-		Cell{name = 'Abbreviations', content = {args.abbreviations}},
 		Customizable{id = 'nationality', children = {
 				Cell{name = 'Nationality', content = self:displayLocations()}
 			}
@@ -272,7 +271,6 @@ function Person:_setLpdbData(args, links, status, personType)
 		name = args.romanized_name or args.name,
 		romanizedname = args.romanized_name or args.name,
 		localizedname = String.isNotEmpty(args.romanized_name) and args.name or nil,
-		abbreviations = args.abbreviations,
 		nationality = args.country, -- already standardized above
 		nationality2 = self:getStandardNationalityValue(args.country2 or args.nationality2),
 		nationality3 = self:getStandardNationalityValue(args.country3 or args.nationality3),

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -137,7 +137,7 @@ function Person:createInfobox()
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Player') .. ' Information'},
-		Customizable{id = 'name', children = {
+		Customizable{id = 'names', children = {
 				Cell{name = 'Name', content = {args.name}},
 				Cell{name = 'Romanized Name', content = {args.romanized_name}},
 			}

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -119,6 +119,7 @@ function Person:createInfobox()
 			birthdate = args.birth_date,
 			birthlocation = args.birth_location,
 			deathdate = args.death_date,
+			deathlocation = args.death_location,
 		})
 	if not ageCalculationSuccess then
 		age = self:_createAgeCalculationErrorMessage(age --[[@as string]])
@@ -138,6 +139,7 @@ function Person:createInfobox()
 		Title{name = (args.informationType or 'Player') .. ' Information'},
 		Cell{name = 'Name', content = {args.name}},
 		Cell{name = 'Romanized Name', content = {args.romanized_name}},
+		Cell{name = 'Abbreviations', content = {args.abbreviations}},
 		Customizable{id = 'nationality', children = {
 				Cell{name = 'Nationality', content = self:displayLocations()}
 			}
@@ -270,6 +272,7 @@ function Person:_setLpdbData(args, links, status, personType)
 		name = args.romanized_name or args.name,
 		romanizedname = args.romanized_name or args.name,
 		localizedname = String.isNotEmpty(args.romanized_name) and args.name or nil,
+		abbreviations = args.abbreviations,
 		nationality = args.country, -- already standardized above
 		nationality2 = self:getStandardNationalityValue(args.country2 or args.nationality2),
 		nationality3 = self:getStandardNationalityValue(args.country3 or args.nationality3),

--- a/components/infobox/extensions/commons/age_calculation.lua
+++ b/components/infobox/extensions/commons/age_calculation.lua
@@ -226,7 +226,8 @@ end
 function AgeCalculation.run(args)
 	local birthLocation = args.birthlocation
 	local birthDate = BirthDate(args.birthdate, birthLocation)
-	local deathDate = DeathDate(args.deathdate)
+	local deathLocation = args.deathlocation
+	local deathDate = DeathDate(args.deathdate, deathLocation)
 
 	AgeCalculation._assertValidDates(birthDate, deathDate)
 

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -102,7 +102,6 @@ end
 ---@param personType string
 ---@return table
 function CustomPlayer:adjustLPDB(lpdbData, args, personType)
-	lpdbData.extradata.abbreviations = args.abbreviations
 	lpdbData.extradata.role = Role.run{role = args.role, useDefault = true}.role
 	lpdbData.extradata.role2 = Role.run{role = args.role2}.role
 	return lpdbData

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -68,9 +68,8 @@ end
 function CustomPlayer:addCustomCells(widgets)
 	local args = self.args
 
-	table.insert(widgets, Cell{name = 'Abbreviations', content = {args.abbreviations}})
 	table.insert(widgets, Cell{name = 'Reported Salary', content = {args.salary}})
-	table.insert(widgets, Cell{name = 'Contract Length', content = {args.contract}})
+	table.insert(widgets, Cell{name = 'End of Contract', content = {args.contract}})
 	local statisticsCells = {
 		{key = 'races', name = 'Races'},
 		{key = 'wins', name = 'Wins'},

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -46,7 +46,6 @@ function CustomInjector:parse(id, widgets)
 
 	elseif id == 'name' then 
 		table.insert(widgets, Cell{name = 'Abbrevitions', content = {args.abbreviations}})
-		
 	elseif id == 'history' then
 		return {
 			Title{name = 'History'},

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -44,7 +44,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		self.caller:addCustomCells(widgets)
 
-	elseif id == 'name' then 
+	elseif id == 'name' then
 		table.insert(widgets, Cell{name = 'Abbrevitions', content = {args.abbreviations}})
 	elseif id == 'history' then
 		return {

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -43,6 +43,10 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		self.caller:addCustomCells(widgets)
+
+	elseif id == 'name' then 
+		table.insert(widgets, Cell{name = 'Abbrevitions', content = {args.abbreviations}})
+		
 	elseif id == 'history' then
 		return {
 			Title{name = 'History'},

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -44,7 +44,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		self.caller:addCustomCells(widgets)
 
-	elseif id == 'name' then
+	elseif id == 'names' then
 		table.insert(widgets, Cell{name = 'Abbrevitions', content = {args.abbreviations}})
 	elseif id == 'history' then
 		return {

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -99,6 +99,7 @@ end
 ---@param personType string
 ---@return table
 function CustomPlayer:adjustLPDB(lpdbData, args, personType)
+	lpdbData.extradata.abbreviations = args.abbreviations
 	lpdbData.extradata.role = Role.run{role = args.role, useDefault = true}.role
 	lpdbData.extradata.role2 = Role.run{role = args.role2}.role
 	return lpdbData


### PR DESCRIPTION
## Summary

Added death_location and abbreviations as params. Discussion regarding abbreviations [here](https://discord.com/channels/93055209017729024/1077895919200112722/1203059062216982550)

Also minor wording change for custom player infobox

## How did you test this change?

via dev for abbreviations parameter
