### PR TITLE
Fix nil index on unprocessable filenames

### DIFF
--- a/components/tournaments_summary_table/commons/tournaments_summary_table.lua
+++ b/components/tournaments_summary_table/commons/tournaments_summary_table.lua
@@ -283,7 +283,7 @@ function TournamentsSummaryTable.row(eventInformation, type)
 	local iconFile = ''
 	if String.isNotEmpty(eventInformation.icon) then
 		local iconInput = string.gsub(eventInformation.icon, 'File:', '')
-		if mw.title.new('Media:' .. iconInput).exists then
+		if (mw.title.new('Media:' .. iconInput) or {}).exists then
 			iconFile = 'File:' .. iconInput
 		end
 	end
@@ -291,7 +291,7 @@ function TournamentsSummaryTable.row(eventInformation, type)
 	local iconDarkFile
 	if String.isNotEmpty(eventInformation.icondark) then
 		local iconInput = string.gsub(eventInformation.icondark, 'File:', '')
-		if mw.title.new('Media:' .. iconInput).exists then
+		if (mw.title.new('Media:' .. iconInput) or {}).exists then
 			iconDarkFile = 'File:' .. iconInput
 		end
 	end


### PR DESCRIPTION
## Summary
In case of unprocessable filenames ([example](https://liquipedia.net/ageofempires/index.php?title=Energy%27s_Slapfest/1&diff=360864&oldid=360860)), mw.title.new returns `nil` causing a nil indexing error.

## How did you test this change?
live
