### PR TITLE
Add `populatePlayer` to stormgate `Module:Player/Ext/Custom`

### DIFF
--- a/components/opponent/wikis/stormgate/player_ext_custom.lua
+++ b/components/opponent/wikis/stormgate/player_ext_custom.lua
@@ -97,6 +97,11 @@ function CustomPlayerExt.syncPlayer(player, options)
 	return player
 end
 
+--Same as CustomPlayerExt.syncPlayer, except it does not save the player's flag to page variables.
+function CustomPlayerExt.populatePlayer(player, options)
+	return PlayerExt.syncPlayer(player, Table.merge(options, {savePageVar = false}))
+end
+
 function CustomPlayerExt.saveToPageVars(player)
 	if player.faction and player.faction ~= Faction.defaultFaction then
 		globalVars:set(player.displayName .. '_faction', player.faction)

--- a/components/opponent/wikis/stormgate/player_ext_custom.lua
+++ b/components/opponent/wikis/stormgate/player_ext_custom.lua
@@ -99,7 +99,7 @@ end
 
 --Same as CustomPlayerExt.syncPlayer, except it does not save the player's flag to page variables.
 function CustomPlayerExt.populatePlayer(player, options)
-	return PlayerExt.syncPlayer(player, Table.merge(options, {savePageVar = false}))
+	return CustomPlayerExt.syncPlayer(player, Table.merge(options, {savePageVar = false}))
 end
 
 function CustomPlayerExt.saveToPageVars(player)


### PR DESCRIPTION
## Summary
It is called from inside the match2 GTL.
Currently it gets copied from the commons base, but that only calls the commons `syncPlayer` function that does not sync faction.

## How did you test this change?
dev to live