### PR TITLE
Add stormgate CostDisplay infobox extension

### DIFF
--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_cost_display.lua
@@ -1,0 +1,91 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Infobox/Extension/CostDisplay
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Abbreviation = require('Module:Abbreviation')
+local Faction = require('Module:Faction')
+local Table = require('Module:Table')
+
+local CostDisplay = {}
+
+--currently the ingame icons are still temporary
+--use placeholders until ingame icons are final and we get them
+local ICONS = {
+	luminite = {
+		default = Abbreviation.make('Lum', 'Luminite'),
+	},
+	therium = {
+		default = Abbreviation.make('The', 'Therium'),
+	},
+	buildTime = {
+		--expect to get different ones per faction
+		default = '[[File:Buildtime_terran.gif|baseline|link=Game Speed]]',
+	},
+	supply = {
+		--expect to get different ones per faction
+		default = '[[File:Supply-terran.gif|baseline|link=Supply]]',
+	},
+	animus = {
+		default = Abbreviation.make('Ani', 'Animus'),
+	},
+}
+local ORDER = {
+	'luminite',
+	'therium',
+	'buildTime',
+	'supply',
+	'animus',
+}
+local CONCAT_VALUE = '&nbsp;'
+
+---@class StormgateCostDisplayArgsValues
+---@field faction string?
+---@field luminite string|number?
+---@field therium string|number?
+---@field buildTime string|number?
+---@field supply string|number?
+---@field animus string|number?
+---@field luminiteForced boolean?
+---@field theriumForced boolean?
+---@field buildTimeForced boolean?
+---@field supplyForced boolean?
+---@field animusForced boolean?
+---@field luminiteTotal string|number?
+---@field theriumTotal string|number?
+---@field buildTimeTotal string|number?
+---@field supplyTotal string|number?
+---@field animusTotal string|number?
+
+---@param args StormgateCostDisplayArgsValues
+---@return string?
+function CostDisplay.run(args)
+	if not args then
+		return nil
+	end
+
+	local faction = Faction.read(args.faction)
+
+	local displays = {}
+	for _, key in pairs(ORDER) do
+		local iconData = ICONS[key]
+		local icon = iconData[faction] or iconData.default
+		local value = tonumber(args[key]) or 0
+		if value ~= 0 or args[key .. 'Forced'] or args[key .. 'Total'] then
+			local display = icon .. CONCAT_VALUE .. value ..
+				(args[key .. 'Total'] and (CONCAT_VALUE .. '(' .. args[key .. 'Total'] .. ')') or '')
+			table.insert(displays, display)
+		end
+	end
+
+	if Table.isEmpty(displays) then
+		return nil
+	end
+
+	return table.concat(displays, CONCAT_VALUE)
+end
+
+return CostDisplay


### PR DESCRIPTION
## Summary
Add stormgate CostDisplay infobox extension.
It will be used in infoboxes unit/building/hero (probably will create them later this week) and probably some other non git cases too.
It follows closely the sc2 version but with different keys.
Since the game is still in beta we do not have proper icons as of now, hence for now using place holders instead.

## How did you test this change?
N/A