### PR TITLE
Add attack infobox extension for stormgate

### DIFF
--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
@@ -1,0 +1,97 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Infobox/Extension/Attack
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Table = require('Module:Table')
+local String = require('Module:StringUtils')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+
+local Attack = {}
+
+---@class StormgateAttackData
+---@field name string
+---@field targets string[]?
+---@field damage number?
+---@field damagePercentage string
+---@field effect string
+---@field speed number?
+---@field dps number?
+---@field bonus string
+---@field bonusDamage number?
+---@field bonusDps number?
+---@field range number?
+
+---@param args table?
+---@param attackIndex integer
+---@param faction string
+---@return Widget[]?
+function Attack.run(args, attackIndex, faction)
+	if Table.isEmpty(args) then return end
+	---@cast args -nil
+	assert(args.name, 'Please specify a name for attack ' .. attackIndex)
+	assert(faction, 'Faction needs to be specified')
+
+	local data = Attack._parse(args)
+
+	Attack._store(data, args, faction, attackIndex)
+
+	return {
+		Title{name = 'Attack' .. attackIndex .. ': ' .. args.name},
+		Cell{name = 'Target', content = data.targets},
+		Cell{name = 'Damage', content = {data.damagePercentage and (data.damagePercentage .. '%') or data.damage}},
+		Cell{name = 'Effect', content = {data.effect}},
+		Cell{name = 'Attack Speed', content = {data.speed}},
+		Cell{name = 'DPS', content = {data.dps}},
+		Cell{name = 'Bonus vs', content = {data.bonus}},
+		Cell{name = 'Bonus Damage', content = {data.bonusDamage}},
+		Cell{name = 'Bonus DPS', content = {data.bonusDps}},
+		Cell{name = 'Range', content = {data.range}},
+	}
+end
+
+---@param args table
+---@return StormgateAttackData
+function Attack._parse(args)
+	return {
+		targets = Array.map(args.target and mw.text.split(args.target or '', ','), function(target)
+			return mw.getContentLanguage():ucfirst(String.trim(target):lower())
+		end),
+		damage = tonumber(args.damage),
+		damagePercentage = tonumber(args.damage_percentage),
+		effect = args.effect,
+		speed = tonumber(args.speed),
+		dps = tonumber(args.dps),
+		bonus = args.bonus,
+		bonusDamage = tonumber(args.bonus_damage),
+		bonusDps = tonumber(args.bonus_dps),
+		range = tonumber(args.range),
+	}
+end
+
+---@param data StormgateAttackData
+---@param args table
+---@param faction string
+---@param attackIndex integer
+function Attack._store(data, args, faction, attackIndex)
+	local objectName = 'attack_' .. attackIndex .. args.name
+	local extradata = Table.map(data, function (key, value) return key:lower(), value end)
+
+	mw.ext.LiquipediaDB.lpdb_datapoint(objectName, {
+		name = args.name,
+		type = 'attack',
+		information = faction,
+		image = args.image,
+		imagedark = args.imagedark,
+		extradata = mw.ext.LiquipediaDB.lpdb_create_json(extradata),
+	})
+end
+
+return Attack

--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
@@ -7,8 +7,9 @@
 --
 
 local Array = require('Module:Array')
-local Table = require('Module:Table')
+local Json = require('Module:Json')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
@@ -29,13 +30,13 @@ local Attack = {}
 ---@field bonusDps number?
 ---@field range number?
 
----@param args table?
+---@param argsJson string
 ---@param attackIndex integer
 ---@param faction string
 ---@return Widget[]?
-function Attack.run(args, attackIndex, faction)
-	if Table.isEmpty(args) then return end
-	---@cast args -nil
+function Attack.run(argsJson, attackIndex, faction)
+	local args = Json.parseIfTable(argsJson)
+	if not args then return end
 	assert(args.name, 'Please specify a name for attack ' .. attackIndex)
 	assert(faction, 'Faction needs to be specified')
 


### PR DESCRIPTION
## Summary
Add attack infobox extension for stormgate.
It will be used in infoboxes unit/building/hero (to be created later this week).
It stores the attack data so we can retrieve it for automated overview pages.

intended usage in the infoboxes:
```lua
for _, attackArgs, attackIndex in Table.iter.pairsByPrefix(args, 'attack') do
	Array.extendWith(widgets, Attack.run(attackArgs, attackIndex, self.faction)
end
```

## How did you test this change?
N/A (consumers do not exist yet)