### PR TITLE
fix(m2, apex): broken completed icon

### DIFF
--- a/components/match2/wikis/apexlegends/match_summary.lua
+++ b/components/match2/wikis/apexlegends/match_summary.lua
@@ -26,7 +26,7 @@ local OpponentDisplay = OpponentLibraries.OpponentDisplay
 local NOW = os.time(os.date('!*t') --[[@as osdateparam]])
 
 local MATCH_STATUS_TO_ICON = {
-	finished = Icon.makeIcon{iconName = 'winner', color = 'icon--green', size = '110%'},
+	finished = 'fas fa-check icon--green',
 	live = 'fas fa-circle icon--red',
 	upcoming = 'fas fa-clock',
 }

--- a/components/match2/wikis/apexlegends/match_summary.lua
+++ b/components/match2/wikis/apexlegends/match_summary.lua
@@ -11,7 +11,6 @@ local CustomMatchSummary = {}
 local Array = require('Module:Array')
 local Date = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
-local Icon = require('Module:Icon')
 local Lua = require('Module:Lua')
 local Ordinal = require('Module:Ordinal')
 local Page = require('Module:Page')


### PR DESCRIPTION
## Summary
Fix unintended changes to Apex's match summary in #3856 icon that broke the completed icon

## How did you test this change?
Live