### PR TITLE
Update match summary to use CharacterIcon

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -27,6 +27,7 @@ local NUM_CHAMPIONS_PICK = 5
 
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 
 -- Champion Ban Class
 ---@class AovChampionBan: MatchSummaryRowInterface
@@ -270,7 +271,7 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
 		:node(CharacterIcon.Icon{
-			character = opponentChampionsData[index],
+			character = opponentChampionsData[index] or NO_CHARACTER,
 			class = 'brkts-champion-icon',
 			date = date,
 		})

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -9,11 +9,11 @@
 local CustomMatchSummary = {}
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local ExternalLinks = require('Module:ExternalLinks')
-local HeroIcon = require('Module:HeroIcon')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -269,8 +269,8 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		local champDisplay = mw.html.create('div')
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
-		:node(HeroIcon._getImage{
-			champ = opponentChampionsData[index],
+		:node(CharacterIcon.Icon{
+			character = opponentChampionsData[index],
 			class = 'brkts-champion-icon',
 			date = date,
 		})

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -30,6 +30,7 @@ local ICONS = {
 	check = GREEN_CHECK,
 }
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 local LINK_DATA = {}
 
 local CustomMatchSummary = {}
@@ -115,7 +116,7 @@ function Brawler:_opponentBrawlerDisplay(brawlerData, numberOfBrawlers, flip, da
 			:addClass('brkts-popup-side-color-' .. (flip and 'red' or 'blue'))
 			:css('float', flip and 'right' or 'left')
 			:node(CharacterIcon.Icon{
-				character = brawlerData[index],
+				character = brawlerData[index] or NO_CHARACTER,
 				class = 'brkts-champion-icon',
 				date = date,
 			})

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -6,18 +6,18 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
-local DisplayHelper = require('Module:MatchGroup/Display/Helper')
-local Logic = require('Module:Logic')
-local Lua = require('Module:Lua')
-local Table = require('Module:Table')
-local MapTypeIcon = require('Module:MapType')
-local String = require('Module:StringUtils')
-local Class = require('Module:Class')
-local BrawlerIcon = require('Module:BrawlerIcon')
 local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
+local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
+local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local MapTypeIcon = require('Module:MapType')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 
@@ -114,8 +114,8 @@ function Brawler:_opponentBrawlerDisplay(brawlerData, numberOfBrawlers, flip, da
 		local brawlerDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. (flip and 'red' or 'blue'))
 			:css('float', flip and 'right' or 'left')
-			:node(BrawlerIcon._getImage{
-				brawler = brawlerData[index],
+			:node(CharacterIcon.Icon{
+				character = brawlerData[index],
 				class = 'brkts-champion-icon',
 				date = date,
 			})

--- a/components/match2/wikis/clashroyale/match_summary.lua
+++ b/components/match2/wikis/clashroyale/match_summary.lua
@@ -8,7 +8,7 @@
 
 local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
-local CardIcon = require('Module:CardIcon')
+local CharacterIcon = require('Module:CharacterIcon')
 local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
@@ -26,6 +26,7 @@ local NUM_CARDS_PER_PLAYER = 8
 local CARD_COLOR_1 = 'blue'
 local CARD_COLOR_2 = 'red'
 local DEFAULT_CARD = 'transparent'
+local TRANSPARENT_CARD = '[[File:Transparent_icon.png|link=]]'
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 -- Normal links, from input/lpdb
@@ -383,7 +384,10 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 				:addClass('brkts-popup-side-color-' .. color)
 				:addClass('brkts-champion-icon')
 				:css('float', flip and 'right' or 'left')
-				:node(CardIcon._getImage{card, date = date})
+				:node(card == DEFAULT_CARD and TRANSPARENT_CARD or CharacterIcon.Icon{
+					character = card,
+					date = date
+				})
 			)
 		end
 

--- a/components/match2/wikis/clashroyale/match_summary.lua
+++ b/components/match2/wikis/clashroyale/match_summary.lua
@@ -25,10 +25,9 @@ local OpponentDisplay = OpponentLibraries.OpponentDisplay
 local NUM_CARDS_PER_PLAYER = 8
 local CARD_COLOR_1 = 'blue'
 local CARD_COLOR_2 = 'red'
-local DEFAULT_CARD = 'transparent'
-local TRANSPARENT_CARD = '[[File:Transparent_icon.png|link=]]'
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local DEFAULT_CARD = 'default'
 -- Normal links, from input/lpdb
 local LINK_DATA = {
 	preview = {icon = 'File:Preview Icon32.png', text = 'Preview'},
@@ -384,7 +383,7 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 				:addClass('brkts-popup-side-color-' .. color)
 				:addClass('brkts-champion-icon')
 				:css('float', flip and 'right' or 'left')
-				:node(card == DEFAULT_CARD and TRANSPARENT_CARD or CharacterIcon.Icon{
+				:node(CharacterIcon.Icon{
 					character = card,
 					date = date
 				})

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -8,12 +8,12 @@
 
 local CustomMatchSummary = {}
 
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local HeroIcon = require('Module:HeroIcon')
 local Table = require('Module:Table')
 local String = require('Module:StringUtils')
 local Array = require('Module:Array')
@@ -26,6 +26,7 @@ local MAX_NUM_BANS = 7
 local NUM_HEROES_PICK_TEAM = 5
 local NUM_HEROES_PICK_SOLO = 1
 local SIZE_HERO = '57x32px'
+local NO_HERO = '[[File:No Hero.png|link=|57x32px]]'
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 -- Normal links, from input/lpdb
@@ -299,12 +300,13 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	local color = opponentHeroesData.side or ''
 
 	for index = 1, numberOfHeroes do
+		local hero = opponentHeroesData[index]
 		local heroDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. color)
 			:addClass('brkts-popup-side-hero')
 			:addClass('brkts-popup-side-hero-hover')
-			:node(HeroIcon._getImage{
-				hero = opponentHeroesData[index],
+			:node(Logic.isEmpty(hero) and NO_HERO or CharacterIcon.Icon{
+				character = hero,
 				size = SIZE_HERO,
 			})
 		if numberOfHeroes == NUM_HEROES_PICK_SOLO then

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -26,9 +26,9 @@ local MAX_NUM_BANS = 7
 local NUM_HEROES_PICK_TEAM = 5
 local NUM_HEROES_PICK_SOLO = 1
 local SIZE_HERO = '57x32px'
-local NO_HERO = '[[File:No Hero.png|link=|57x32px]]'
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 -- Normal links, from input/lpdb
 local LINK_DATA = {
 	vod = {icon = 'File:VOD Icon.png', text = 'Watch VOD'},
@@ -300,13 +300,12 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	local color = opponentHeroesData.side or ''
 
 	for index = 1, numberOfHeroes do
-		local hero = opponentHeroesData[index]
 		local heroDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. color)
 			:addClass('brkts-popup-side-hero')
 			:addClass('brkts-popup-side-hero-hover')
-			:node(Logic.isEmpty(hero) and NO_HERO or CharacterIcon.Icon{
-				character = hero,
+			:node(CharacterIcon.Icon{
+				character = opponentHeroesData[index] or NO_CHARACTER,
 				size = SIZE_HERO,
 			})
 		if numberOfHeroes == NUM_HEROES_PICK_SOLO then

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -29,6 +29,7 @@ local NUM_CHAMPIONS_PICK = 5
 
 local GREEN_CHECK  = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 local MAP_VETO_START = '<b>Start Map Veto</b>'
 local ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]'
 local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
@@ -424,7 +425,7 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
 		:node(CharacterIcon.Icon{
-			character = opponentChampionsData[index],
+			character = opponentChampionsData[index] or NO_CHARACTER,
 			class = 'brkts-champion-icon',
 			date = date,
 		})

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -10,7 +10,7 @@ local CustomMatchSummary = {}
 
 local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
-local ChampionIcon = require('Module:HeroIcon')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
@@ -423,8 +423,8 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		local champDisplay = mw.html.create('div')
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
-		:node(ChampionIcon._getImage{
-			champ = opponentChampionsData[index],
+		:node(CharacterIcon.Icon{
+			character = opponentChampionsData[index],
 			class = 'brkts-champion-icon',
 			date = date,
 		})

--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -9,7 +9,7 @@
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
-local HeroIcon = require('Module:ChampionIcon')
+local CharacterIcon = require('Module:CharacterIcon')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -184,7 +184,10 @@ function BigMatch.run(frame)
 		if type(self) == 'table' then
 			champion = self.champion
 		end
-		return HeroIcon._getImage{champion, date = model.date}
+		return CharacterIcon.Icon{
+			character = champion --[[@as string]],
+			date = model.date
+		}
 	end
 
 	return BigMatch.render(model)

--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -29,6 +29,8 @@ local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
 local Template = Lua.import('Module:BigMatch/Template')
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 
+local NO_CHARACTER = 'default'
+
 local BigMatch = {}
 
 local KEYSTONES = Table.map({
@@ -183,9 +185,10 @@ function BigMatch.run(frame)
 		local champion = self
 		if type(self) == 'table' then
 			champion = self.champion
+			---@cast champion -table
 		end
 		return CharacterIcon.Icon{
-			character = champion --[[@as string]],
+			character = champion or NO_CHARACTER,
 			date = model.date
 		}
 	end

--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -8,8 +8,8 @@
 
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local CharacterIcon = require('Module:CharacterIcon')
+local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -9,9 +9,9 @@
 local CustomMatchSummary = {}
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
-local HeroIcon = require('Module:ChampionIcon')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -268,7 +268,10 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 	for index = 1, numberOfHeroes do
 		local heroDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. color)
-			:node(HeroIcon._getImage{opponentHeroesData[index], date = date})
+			:node(CharacterIcon.Icon{
+				character = opponentHeroesData[index],
+				date = date
+			})
 		if numberOfHeroes == NUM_HEROES_PICK_SOLO then
 			if flip then
 				heroDisplay:css('margin-right', '70px')

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -29,6 +29,7 @@ local NUM_HEROES_PICK_TEAM = 5
 local NUM_HEROES_PICK_SOLO = 1
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 
 -- Hero Ban Class
 ---@class LeagueoOfLegendsHeroBan: MatchSummaryRowInterface
@@ -269,7 +270,7 @@ function CustomMatchSummary._opponentHeroesDisplay(opponentHeroesData, numberOfH
 		local heroDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. color)
 			:node(CharacterIcon.Icon{
-				character = opponentHeroesData[index],
+				character = opponentHeroesData[index] or NO_CHARACTER,
 				date = date
 			})
 		if numberOfHeroes == NUM_HEROES_PICK_SOLO then

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -28,6 +28,7 @@ local NUM_CHAMPIONS_PICK = 5
 
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 
 -- Champion Ban Class
 ---@class MobileLegendsChampionBan: MatchSummaryRowInterface
@@ -282,7 +283,7 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
 		:node(CharacterIcon.Icon{
-			character = opponentChampionsData[index],
+			character = opponentChampionsData[index] or NO_CHARACTER,
 			class = 'brkts-champion-icon',
 			date = date
 		})

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -8,6 +8,7 @@
 
 local CustomMatchSummary = {}
 
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
@@ -15,7 +16,6 @@ local Icon = require('Module:Icon')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local ChampionIcon = require('Module:HeroIcon')
 local Table = require('Module:Table')
 local ExternalLinks = require('Module:ExternalLinks')
 local String = require('Module:StringUtils')
@@ -281,10 +281,10 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		local champDisplay = mw.html.create('div')
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
-		:node(ChampionIcon._getImage{
-			champ = opponentChampionsData[index],
+		:node(CharacterIcon.Icon{
+			character = opponentChampionsData[index],
 			class = 'brkts-champion-icon',
-			date = date,
+			date = date
 		})
 		if index == 1 then
 			champDisplay:css('padding-left', '2px')

--- a/components/match2/wikis/omegastrikers/match_summary.lua
+++ b/components/match2/wikis/omegastrikers/match_summary.lua
@@ -25,6 +25,7 @@ local ICONS = {
 	check = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'},
 	empty = '[[File:NoCheck.png|link=]]'
 }
+local NO_CHARACTER = 'default'
 
 local CustomMatchSummary = {}
 
@@ -76,7 +77,7 @@ function Striker:_opponentStrikerDisplay(strikerData, numberOfStrikers, flip, da
 			:addClass('brkts-popup-side-color-' .. (flip and 'red' or 'blue'))
 			:css('float', flip and 'right' or 'left')
 			:node(CharacterIcon.Icon{
-				character = strikerData[index],
+				character = strikerData[index] or NO_CHARACTER,
 				class = 'brkts-champion-icon',
 				date = date,
 			})

--- a/components/match2/wikis/omegastrikers/match_summary.lua
+++ b/components/match2/wikis/omegastrikers/match_summary.lua
@@ -8,6 +8,7 @@
 
 local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
@@ -16,7 +17,6 @@ local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
-local StrikerIcon = require('Module:StrikerIcon')
 local Table = require('Module:Table')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
@@ -75,8 +75,8 @@ function Striker:_opponentStrikerDisplay(strikerData, numberOfStrikers, flip, da
 		local strikerDisplay = mw.html.create('div')
 			:addClass('brkts-popup-side-color-' .. (flip and 'red' or 'blue'))
 			:css('float', flip and 'right' or 'left')
-			:node(StrikerIcon._getImage{
-				striker = strikerData[index],
+			:node(CharacterIcon.Icon{
+				character = strikerData[index],
 				class = 'brkts-champion-icon',
 				date = date,
 			})

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -28,6 +28,7 @@ local NUM_CHAMPIONS_PICK = 5
 
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 
 -- Champion Ban Class
 ---@class PokemonChampionBan: MatchSummaryRowInterface
@@ -260,7 +261,7 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
 		:node(CharacterIcon.Icon{
-			character = opponentChampionsData[index],
+			character = opponentChampionsData[index] or NO_CHARACTER,
 			class = 'brkts-champion-icon',
 			date = date,
 		})

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -8,13 +8,13 @@
 
 local CustomMatchSummary = {}
 
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local ChampionIcon = require('Module:HeroIcon')
 local Table = require('Module:Table')
 local ExternalLinks = require('Module:ExternalLinks')
 local String = require('Module:StringUtils')
@@ -259,8 +259,8 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		local champDisplay = mw.html.create('div')
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
-		:node(ChampionIcon._getImage{
-			champ = opponentChampionsData[index],
+		:node(CharacterIcon.Icon{
+			character = opponentChampionsData[index],
 			class = 'brkts-champion-icon',
 			date = date,
 		})

--- a/components/match2/wikis/valorant/big_match.lua
+++ b/components/match2/wikis/valorant/big_match.lua
@@ -6,8 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local AgentIcon = require('Module:AgentIcon')
 local Arguments = require('Module:Arguments')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
 local DivTable = require('Module:DivTable')
@@ -207,7 +207,10 @@ function BigMatch:stats(match, playerLookUp, opponents)
 						)
 						:cell(
 							mw.html.create('div')	:addClass('fb-match-page-valorant-stats-agent')
-													:wikitext(AgentIcon._getBracketIcon{player['agent']})
+													:wikitext(CharacterIcon.Icon{
+														character = player['agent'],
+														size = '20px'
+													})
 						)
 						:cell(mw.html.create('div'):wikitext(player['kills']))
 						:cell(mw.html.create('div'):wikitext(player['deaths']))

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local AgentIcon = require('Module:AgentIcon')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
@@ -62,7 +62,10 @@ function Agents:add(agent)
 		return self
 	end
 
-	self.text = self.text .. AgentIcon._getBracketIcon{agent}
+	self.text = self.text .. CharacterIcon.Icon{
+		character = agent,
+		size = '20px'
+	}
 	return self
 end
 

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -8,12 +8,12 @@
 
 local CustomMatchSummary = {}
 
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local ChampionIcon = require('Module:ChampionIcon')
 local Table = require('Module:Table')
 local ExternalLinks = require('Module:ExternalLinks')
 local String = require('Module:StringUtils')
@@ -266,8 +266,8 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		local champDisplay = mw.html.create('div')
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
-		:node(ChampionIcon._getImage{
-			champ = opponentChampionsData[index],
+		:node(CharacterIcon.Icon{
+			character = opponentChampionsData[index],
 			class = 'brkts-champion-icon',
 		})
 		if index == 1 then

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -27,6 +27,7 @@ local NUM_CHAMPIONS_PICK = 5
 
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHARACTER = 'default'
 
 -- Champion Ban Class
 ---@class WildriftChampionBan: MatchSummaryRowInterface
@@ -267,7 +268,7 @@ function CustomMatchSummary._opponentChampionsDisplay(opponentChampionsData, num
 		:addClass('brkts-popup-side-color-' .. color)
 		:css('float', flip and 'right' or 'left')
 		:node(CharacterIcon.Icon{
-			character = opponentChampionsData[index],
+			character = opponentChampionsData[index] or NO_CHARACTER,
 			class = 'brkts-champion-icon',
 		})
 		if index == 1 then


### PR DESCRIPTION
## Summary

Use CharacterIcon intead of AgentIcon/ ChampionIcon.

`Module:CharacterIcon/Data` was created for all the wikis listed bellow.

## How did you test this change?

All tested on /dev.

## Wikis

- [x] leagueoflegends *
- [x] wildrift *
- [x] valorant
- [x] dota2 
- [x] mobilelegends *
- [x] arenaofvalor *
- [x] heroes *
- [x] omegastrikers *
- [x] smite #3877
- [x] pokemon *
- [x] brawlstars
- [x] clashroyale?
*transparent?