### PR TITLE
fix(match2): timestamp default `0` missed in #3897

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -509,7 +510,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		parent = record.parent,
 		resultType = nilIfEmpty(record.resulttype),
 		stream = Json.parseIfString(record.stream) or {},
-		timestamp = tonumber(Table.extract(extradata, 'timestamp')) or 0,
+		timestamp = DateExt.readTimestamp(record.date),
 		tournament = record.tournament,
 		type = nilIfEmpty(record.type) or 'literal',
 		vod = nilIfEmpty(record.vod),

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -510,7 +509,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		parent = record.parent,
 		resultType = nilIfEmpty(record.resulttype),
 		stream = Json.parseIfString(record.stream) or {},
-		timestamp = DateExt.readTimestamp(record.date),
+		timestamp = tonumber(Table.extract(extradata, 'timestamp')),
 		tournament = record.tournament,
 		type = nilIfEmpty(record.type) or 'literal',
 		vod = nilIfEmpty(record.vod),


### PR DESCRIPTION
## Summary

As found on discord: 
https://discord.com/channels/93055209017729024/874304000718172200/1204127039293100033

This was still defaulting to `0` timestamp instead of `-62167219200`, causing issues in some display stuff.

Reading match records was still relying on `timestamp` entry in extradata that isn't set in a lot of wiki customs when the date is empty. Instead, just convert from date to timestamp on the fly like this to make sure it doesn't happen again. No need for default fallback either.

Maybe there is a performance impact from this though, so can also do it like this if we still want to rely on timestamp in extradata:
https://liquipedia.net/commons/index.php?title=Module:MatchGroup/Util/dev&diff=549569&oldid=549574
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/402589e0-2f2b-4f7a-b2eb-e4b10a3c9652)


## How did you test this change?

`/dev`.