### PR TITLE
feat(match2): sync party opponents' data for dota2

### DIFF
--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -123,7 +123,7 @@ function CustomMatchGroupInput.processOpponent(record, date)
 		)
 	end
 
-	Opponent.resolve(opponent, teamTemplateDate)
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer = true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 


### PR DESCRIPTION
## Summary

Apply `syncPlayer` for `Module:MatchGroup/Input/Custom` on Dota2 wiki so that party (solo) opponents can pull data from ParticipantsTable.

## How did you test this change?

Copied from CS wiki.