### PR TITLE
refactor: use timestamps conditions in match summary

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -101,7 +101,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/brawlstars/match_summary.lua
+++ b/components/match2/wikis/brawlstars/match_summary.lua
@@ -170,7 +170,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/callofduty/match_summary.lua
+++ b/components/match2/wikis/callofduty/match_summary.lua
@@ -51,7 +51,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/clashofclans/match_summary.lua
+++ b/components/match2/wikis/clashofclans/match_summary.lua
@@ -60,9 +60,9 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= Date.defaultDateTimeExtended and match.date ~= Date.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= Date.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
-		-- if match is not epoch=0, we have a date, so display the date
+		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(
 			DisplayHelper.MatchCountdownBlock(match)
 		))

--- a/components/match2/wikis/counterstrike/match_summary.lua
+++ b/components/match2/wikis/counterstrike/match_summary.lua
@@ -287,12 +287,12 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		if Logic.isNotEmpty(match.extradata.status) then
 			match.stream = {rawdatetime = true}
 		end
 		-- dateIsExact means we have both date and time. Show countdown
-		-- if match is not epoch=0, we have a date, so display the date
+		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(
 			DisplayHelper.MatchCountdownBlock(match)
 		))

--- a/components/match2/wikis/criticalops/match_summary.lua
+++ b/components/match2/wikis/criticalops/match_summary.lua
@@ -258,7 +258,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		if Logic.isNotEmpty(match.extradata.status) then
 			match.stream = {rawdatetime = true}
 		end

--- a/components/match2/wikis/crossfire/match_summary.lua
+++ b/components/match2/wikis/crossfire/match_summary.lua
@@ -49,7 +49,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not epoch=0, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -143,9 +143,9 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
-		-- if match is not epoch=0, we have a date, so display the date
+		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(
 			DisplayHelper.MatchCountdownBlock(match)
 		))

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -82,9 +82,9 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
-		-- if match is not epoch=0, we have a date, so display the date
+		-- if match is not default time, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(
 			DisplayHelper.MatchCountdownBlock(match)
 		))

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -229,7 +229,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -102,7 +102,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/omegastrikers/match_summary.lua
+++ b/components/match2/wikis/omegastrikers/match_summary.lua
@@ -125,7 +125,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -63,7 +63,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -102,7 +102,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/splitgate/match_summary.lua
+++ b/components/match2/wikis/splitgate/match_summary.lua
@@ -43,7 +43,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -296,7 +296,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -100,7 +100,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default date, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/zula/match_summary.lua
+++ b/components/match2/wikis/zula/match_summary.lua
@@ -258,7 +258,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or (match.date ~= DateExt.defaultDateTimeExtended and match.date ~= DateExt.defaultDateTime) then
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
 		if Logic.isNotEmpty(match.extradata.status) then
 			match.stream = {rawdatetime = true}
 		end


### PR DESCRIPTION
## Summary
Since #3921 good timestamps are always available. Use those instead of the double string check.
Final part of #1889 cleanup

## How did you test this change?
Changes to what other wikis already use