### PR TITLE
data(region): add missing china alias

### DIFF
--- a/standard/region/commons/region_data.lua
+++ b/standard/region/commons/region_data.lua
@@ -66,6 +66,7 @@ return {
 		['south korea'] = 'korea',
 
 		['in'] = 'india',
+		cn = 'china',
 		tr = 'turkey',
 		tw = 'taiwan',
 		jp = 'japan',


### PR DESCRIPTION
## Summary

Missed during initial PRs and is used on LoL wiki and probably other Riot wikis too.

## How did you test this change?

Just data but pushed live to fix pages and working fine.
