### PR TITLE
refactor(match2): clean up match copy pastes

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste.lua
+++ b/components/match2/commons/get_match_group_copy_paste.lua
@@ -14,7 +14,7 @@ bracket finder (and code generator) / matchlist code generator
 
 local Arguments = require('Module:Arguments')
 local BracketAlias = mw.loadData('Module:BracketAlias')
-local Class = mw.loadData('Module:Class')
+local Class = require('Module:Class')
 local Array = require('Module:Array')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/commons/get_match_group_copy_paste.lua
+++ b/components/match2/commons/get_match_group_copy_paste.lua
@@ -12,25 +12,26 @@ bracket finder (and code generator) / matchlist code generator
 
 ]]--
 
+local Arguments = require('Module:Arguments')
+local BracketAlias = mw.loadData('Module:BracketAlias')
+local Class = mw.loadData('Module:Class')
 local Array = require('Module:Array')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local WikiSpecific = Lua.import('Module:GetMatchGroupCopyPaste/wiki')
-local getArgs = require('Module:Arguments').getArgs
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
-local BracketAlias = Lua.requireIfExists('Module:BracketAlias', {loadData = true})
+local WikiSpecific = Lua.import('Module:GetMatchGroupCopyPaste/wiki')
 
 ---@class Match2CopyPaste
-local copyPaste = {}
+local CopyPaste = Class.new()
 
-function copyPaste.generateID()
+function CopyPaste.generateID()
 	--initiate the rnd generator
 	math.randomseed(os.time())
-	return copyPaste._generateID()
+	return CopyPaste._generateID()
 end
 
-function copyPaste._generateID()
+function CopyPaste._generateID()
 	local id = ''
 
 	for _ = 1, 10 do
@@ -45,13 +46,13 @@ function copyPaste._generateID()
 	end
 
 	if mw.ext.Brackets.checkBracketDuplicate(id) ~= 'ok' then
-		id = copyPaste._generateID()
+		id = CopyPaste._generateID()
 	end
 
 	return id
 end
 
-function copyPaste._getBracketData(templateid)
+function CopyPaste._getBracketData(templateid)
 	templateid = 'Bracket/' .. templateid
 	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateid)
 	assert(type(matches) == 'table')
@@ -88,7 +89,7 @@ function copyPaste._getBracketData(templateid)
 	return bracketDataList
 end
 
-function copyPaste._getHeader(headerCode, customHeader)
+function CopyPaste._getHeader(headerCode, customHeader)
 	local header = ''
 
 	if not headerCode then
@@ -109,9 +110,9 @@ function copyPaste._getHeader(headerCode, customHeader)
 	return header, customHeader
 end
 
-function copyPaste.bracket(frame, args)
+function CopyPaste.bracket(frame, args)
 	if not args then
-		args = getArgs(frame)
+		args = Arguments.getArgs(frame)
 	end
 	local out
 
@@ -119,7 +120,7 @@ function copyPaste.bracket(frame, args)
 	args.id = string.gsub(string.gsub(args.id, '^Bracket/', ''), '^bracket/', '')
 	local templateid = BracketAlias[string.lower(args.id)] or args.id
 
-	out, args = WikiSpecific.getStart(templateid, copyPaste.generateID(), 'bracket', args)
+	out, args = WikiSpecific.getStart(templateid, CopyPaste.generateID(), 'bracket', args)
 
 	local empty = Logic.readBool(args.empty)
 	local customHeader = Logic.readBool(args.customHeader)
@@ -128,7 +129,7 @@ function copyPaste.bracket(frame, args)
 	local mode = WikiSpecific.getMode(args.mode)
 	local headersUpTop = Logic.readBool(Logic.emptyOr(args.headersUpTop, true))
 
-	local bracketDataList = copyPaste._getBracketData(templateid)
+	local bracketDataList = CopyPaste._getBracketData(templateid)
 
 	local matchOut = ''
 	for index, bracketData in ipairs(bracketDataList) do
@@ -141,7 +142,7 @@ function copyPaste.bracket(frame, args)
 				header = '\n\n' .. '<!-- Third Place Match -->'
 			end
 		elseif matchKey ~= 'RxMTP' and matchKey ~= 'RxMBR' then
-			header, hasHeaderEntryParam = copyPaste._getHeader(bracketData.header, customHeader)
+			header, hasHeaderEntryParam = CopyPaste._getHeader(bracketData.header, customHeader)
 		end
 
 		if Logic.readBool(args.extra) or (matchKey ~= 'RxMTP' and matchKey ~= 'RxMBR') then
@@ -164,13 +165,13 @@ function copyPaste.bracket(frame, args)
 	return '<pre class="selectall" width=50%>' .. mw.text.nowiki(out) .. '</pre>'
 end
 
-function copyPaste.matchlist(frame, args)
+function CopyPaste.matchlist(frame, args)
 	if not args then
-		args = getArgs(frame)
+		args = Arguments.getArgs(frame)
 	end
 	local out
 
-	out, args = WikiSpecific.getStart(nil, copyPaste.generateID(), 'matchlist', args)
+	out, args = WikiSpecific.getStart(nil, CopyPaste.generateID(), 'matchlist', args)
 
 	local empty = Logic.readBool(args.empty)
 	local customHeader = Logic.readBool(args.customHeader)
@@ -197,13 +198,13 @@ function copyPaste.matchlist(frame, args)
 	return '<pre class="selectall" width=50%>' .. mw.text.nowiki(out) .. '</pre>'
 end
 
-function copyPaste.singleMatch(frame, args)
+function CopyPaste.singleMatch(frame, args)
 	if not args then
-		args = getArgs(frame)
+		args = Arguments.getArgs(frame)
 	end
 
 	local out
-	out, args = WikiSpecific.getStart(nil, copyPaste.generateID(), 'singlematch', args)
+	out, args = WikiSpecific.getStart(nil, CopyPaste.generateID(), 'singlematch', args)
 
 	local bestof = tonumber(args.bestof) or 3
 	local opponents = tonumber(args.opponents) or 2
@@ -215,4 +216,4 @@ function copyPaste.singleMatch(frame, args)
 	return '<pre class="selectall" width=50%>' .. mw.text.nowiki(out) .. '</pre>'
 end
 
-return copyPaste
+return CopyPaste

--- a/components/match2/commons/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/commons/get_match_group_copy_paste_wiki.lua
@@ -6,10 +6,5 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Table = require('Module:Table')
-
-local GetMatchGroupCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
-
---overwrite stuff you want to overwrite here^^
-
-return GetMatchGroupCopyPaste
+local Lua = require('Module:Lua')
+return Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')

--- a/components/match2/commons/starcraft_starcraft2/get_match_group_copy_paste_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/get_match_group_copy_paste_starcraft.lua
@@ -14,7 +14,7 @@ WikiSpecific Code for MatchList and Bracket Code Generators
 
 ]]--
 
-local wikiCopyPaste = {}
+local WikiCopyPaste = {}
 
 --allowed opponent types on the wiki (archon and 2v2 both are of type
 --"duo", but they need different code, hence them both being available here)
@@ -36,12 +36,12 @@ local MODES = {
 local DefaultMode = '1v1'
 
 --returns the cleaned opponent type
-function wikiCopyPaste.getMode(mode)
+function WikiCopyPaste.getMode(mode)
 	return MODES[string.lower(mode or '')] or DefaultMode
 end
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local indent = '    '
 
 	if bestof == 0 and args.score ~= 'false' then
@@ -57,7 +57,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	)
 
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, score or ''))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, score or ''))
 	end
 
 	if bestof ~= 0 then
@@ -88,7 +88,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, score)
+function WikiCopyPaste._getOpponent(mode, score)
 	local out
 
 	if mode == '1v1' then
@@ -113,7 +113,7 @@ end
 --function that sets the text that starts the invoke of the MatchGroup Moduiles,
 --contains madatory stuff like bracketid, templateid and MatchGroup type (matchlist or bracket)
 --on sc2 also used to link to the documentation pages about the new bracket/match system
-function wikiCopyPaste.getStart(template, id, modus, args)
+function WikiCopyPaste.getStart(template, id, modus, args)
 	local tooltip = args.tooltip == 'true' and ('\n' .. mw.text.nowiki('<!--') ..
 		' For more information on Bracket parameters see Liquipedia:Brackets ' ..
 		mw.text.nowiki('-->') .. '\n' .. mw.text.nowiki('<!--') ..
@@ -129,4 +129,4 @@ function wikiCopyPaste.getStart(template, id, modus, args)
 	return out, args
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/apexlegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/apexlegends/get_match_group_copy_paste_wiki.lua
@@ -7,13 +7,14 @@
 --
 
 local Array = require('Module:Array')
-local Table = require('Module:Table')
-local BaseCopyPaste = require('Module:GetMatchGroupCopyPaste/wiki/Base')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
 -- WikiSpecific Code for MatchList and Bracket Code Generators
----@class ArenaFPSMatchCopyPaste: Match2CopyPasteBase
-local WikiCopyPaste = Table.copy(BaseCopyPaste)
+---@class ApexLegendsMatchCopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --allowed opponent types on the wiki
 local MODES = {

--- a/components/match2/wikis/arenafps/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/arenafps/get_match_group_copy_paste_wiki.lua
@@ -7,9 +7,11 @@
 --
 
 local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
-local Table = require('Module:Table')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[
 
 WikiSpecific Code for MatchList and Bracket Code Generators
@@ -17,7 +19,7 @@ WikiSpecific Code for MatchList and Bracket Code Generators
 ]]--
 
 ---@class ArenaFPSMatchCopyPaste: Match2CopyPasteBase
-local WikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --allowed opponent types on the wiki
 local MODES = {

--- a/components/match2/wikis/brawlstars/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/brawlstars/get_match_group_copy_paste_wiki.lua
@@ -6,9 +6,18 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Table = require('Module:Table')
 local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+--[[
+
+WikiSpecific Code for MatchList, Bracket and SingleMatch Code Generators
+
+]]--
 
 local _CONVERT_PICK_BAN_ENTRY = {
 	none = {},
@@ -31,18 +40,11 @@ local _LIMIT_OF_PARAM = {
 	player = 3,
 }
 
---[[
-
-WikiSpecific Code for MatchList, Bracket and SingleMatch Code Generators
-
-]]--
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 local indent = '    '
-
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
-
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		index == 1 and (indent .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
@@ -51,10 +53,10 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local score = args.score == 'true' and '|score=' or nil
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, score or ''))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, score or ''))
 	end
 
-	lines = wikiCopyPaste._getMaps(lines, bestof, args, index, opponents)
+	lines = WikiCopyPaste._getMaps(lines, bestof, args, index, opponents)
 
 	table.insert(lines, '}}')
 
@@ -62,7 +64,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, score)
+function WikiCopyPaste._getOpponent(mode, score)
 	local out
 
 	if mode == 'solo' then
@@ -78,14 +80,14 @@ end
 
 --subfunction used to generate the code for the Map template
 --sets up as many maps as specified via the bestoff param
-function wikiCopyPaste._getMaps(lines, bestof, args, matchIndex, numberOfOpponents)
+function WikiCopyPaste._getMaps(lines, bestof, args, matchIndex, numberOfOpponents)
 	if bestof > 0 then
 		local map = '{{Map'
 			.. '\n' .. indent .. indent .. '|map=|maptype=|firstpick='
 			.. '\n' .. indent .. indent .. '|score1=|score2='
 
 		for _, item in ipairs(_CONVERT_PICK_BAN_ENTRY[args.pickBan or ''] or {}) do
-			map = map .. wikiCopyPaste._pickBanParams(item, numberOfOpponents)
+			map = map .. WikiCopyPaste._pickBanParams(item, numberOfOpponents)
 		end
 
 		for mapIndex = 1, bestof do
@@ -102,7 +104,7 @@ function wikiCopyPaste._getMaps(lines, bestof, args, matchIndex, numberOfOpponen
 	return lines
 end
 
-function wikiCopyPaste._pickBanParams(key, numberOfOpponents)
+function WikiCopyPaste._pickBanParams(key, numberOfOpponents)
 	local shortKey = _PARAM_TO_SHORT[key]
 	local limit = _LIMIT_OF_PARAM[key]
 	local display = ''
@@ -117,4 +119,4 @@ function wikiCopyPaste._pickBanParams(key, numberOfOpponents)
 	return display
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/counterstrike/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/counterstrike/get_match_group_copy_paste_wiki.lua
@@ -7,27 +7,29 @@
 --
 
 local Logic = require('Module:Logic')
+local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
-local Table = require('Module:Table')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 local Opponent = Lua.import('Module:Opponent')
-local wikiCopyPaste = Table.copy(Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base'))
+
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 local GSL_STYLE_WITH_EXTRA_MATCH_INDICATOR = 'gf'
 local GSL_WINNERS = 'winners'
 local GSL_LOSERS = 'losers'
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local streams = Logic.readBool(args.streams)
 	local showScore = Logic.readBool(args.score)
 	local mapDetails = Logic.readBool(args.detailedMap)
 	local mapDetailsOT = Logic.readBool(args.detailedMapOT)
 	local hltv = Logic.readBool(args.hltv)
-	local mapStats = args.mapStats and wikiCopyPaste._ipairsSet(mw.text.split(args.mapStats, ', ')) or {}
+	local mapStats = args.mapStats and WikiCopyPaste._ipairsSet(mw.text.split(args.mapStats, ', ')) or {}
 	local matchMatchpages = args.matchMatchpages and
-								wikiCopyPaste._ipairsSet(mw.text.split(args.matchMatchpages, ', ')) or {}
+								WikiCopyPaste._ipairsSet(mw.text.split(args.matchMatchpages, ', ')) or {}
 	local out = '{{Match'
 
 	if hltv then
@@ -37,7 +39,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	out = out .. '\n\t'
 	for i = 1, opponents do
-		out = out .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, showScore)
+		out = out .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, showScore)
 	end
 
 	out = out .. '\n\t|date= |finished='
@@ -79,7 +81,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, showScore)
+function WikiCopyPaste._getOpponent(mode, showScore)
 	local score = showScore and '|score=' or ''
 
 	if mode == Opponent.solo then
@@ -91,7 +93,7 @@ function wikiCopyPaste._getOpponent(mode, showScore)
 	end
 end
 
-function wikiCopyPaste._ipairsSet(tbl)
+function WikiCopyPaste._ipairsSet(tbl)
 	local valuesSet = {}
 	local array = {}
 
@@ -105,7 +107,7 @@ function wikiCopyPaste._ipairsSet(tbl)
 	return array
 end
 
-function wikiCopyPaste.getStart(template, id, modus, args)
+function WikiCopyPaste.getStart(template, id, modus, args)
 	args.namedMatchParams = false
 	args.headersUpTop = Logic.readBool(Logic.emptyOr(args.headersUpTop, true))
 	local out = '{{' .. (
@@ -135,4 +137,4 @@ function wikiCopyPaste.getStart(template, id, modus, args)
 	return out, args
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/dota2/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/dota2/get_match_group_copy_paste_wiki.lua
@@ -7,18 +7,21 @@
 --
 
 local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[
 
 WikiSpecific Code for MatchList and Bracket Code Generators
 
 ]]--
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local indent = ''
 
 	if bestof == 0 and args.score ~= 'false' then
@@ -34,7 +37,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	)
 
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, displayScore))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, displayScore))
 	end
 
 	if args.hasDate == 'true' then
@@ -89,7 +92,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, displayScore)
+function WikiCopyPaste._getOpponent(mode, displayScore)
 	local scoreText = displayScore and '|score=' or ''
 
 	if mode == 'solo' then
@@ -101,4 +104,4 @@ function wikiCopyPaste._getOpponent(mode, displayScore)
 	end
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/dota2/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/dota2/get_match_group_copy_paste_wiki.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[

--- a/components/match2/wikis/halo/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/halo/get_match_group_copy_paste_wiki.lua
@@ -7,15 +7,17 @@
 --
 
 local Array = require('Module:Array')
-local Table = require('Module:Table')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[
 
 WikiSpecific Code for MatchList and Bracket Code Generators
 
 ]]--
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --allowed opponent types on the wiki
 local MODES = {
@@ -27,12 +29,12 @@ local MODES = {
 local DefaultMode = 'team'
 
 --returns the cleaned opponent type
-function wikiCopyPaste.getMode(mode)
+function WikiCopyPaste.getMode(mode)
 	return MODES[string.lower(mode or '')] or DefaultMode
 end
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local indent = '    '
 
 	if bestof == 0 and args.score ~= 'false' then
@@ -48,7 +50,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	)
 
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, score))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, score))
 	end
 
 	if bestof ~= 0 then
@@ -66,7 +68,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, score)
+function WikiCopyPaste._getOpponent(mode, score)
 	local out
 
 	if mode == 'solo' then
@@ -80,4 +82,4 @@ function wikiCopyPaste._getOpponent(mode, score)
 	return out
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[

--- a/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
@@ -7,18 +7,21 @@
 --
 
 local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[
 
 WikiSpecific Code for MatchList and Bracket Code Generators
 
 ]]--
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local indent = '  '
 
 	if bestof == 0 and args.score ~= 'false' then
@@ -33,7 +36,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	)
 
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, displayScore))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, displayScore))
 	end
 
 	if args.hasDate == 'true' then
@@ -85,7 +88,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, displayScore)
+function WikiCopyPaste._getOpponent(mode, displayScore)
 	local scoreText = displayScore and '|score=' or ''
 
 	if mode == 'solo' then
@@ -97,4 +100,4 @@ function wikiCopyPaste._getOpponent(mode, displayScore)
 	end
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -6,9 +6,11 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Table = require('Module:Table')
+local Lua = require('Module:Lua')
+local Class = require('Module:Class')
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 local VETOES = {
 	[0] = '',
@@ -24,7 +26,7 @@ local VETOES = {
 }
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = args.score == 'true'
 	local mapDetails = args.detailedMap == 'true'
 	local mapDetailsOT = args.detailedMapOT == 'true'
@@ -37,7 +39,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	end
 
 	for i = 1, opponents do
-		out = out .. '\n\t|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, showScore)
+		out = out .. '\n\t|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, showScore)
 	end
 
 	if mapVeto and VETOES[bestof] then
@@ -81,7 +83,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, showScore)
+function WikiCopyPaste._getOpponent(mode, showScore)
 	local score = showScore and '|score=' or ''
 
 	if mode == 'solo' then
@@ -93,4 +95,4 @@ function wikiCopyPaste._getOpponent(mode, showScore)
 	end
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/rocketleague/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rocketleague/get_match_group_copy_paste_wiki.lua
@@ -7,10 +7,12 @@
 --
 
 local Array = require('Module:Array')
+local Class = require('Module:Class')
 local FnUtil = require('Module:FnUtil')
-local Table = require('Module:Table')
+local Lua = require('Module:Lua')
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --allowed opponent types on the wiki
 local MODES = { ['solo'] = 'solo', ['team'] = 'team' }
@@ -20,13 +22,13 @@ local indent = '    '
 local DefaultMode = 'team'
 
 --returns the cleaned opponent type
-function wikiCopyPaste.getMode(mode)
+function WikiCopyPaste.getMode(mode)
 	return MODES[string.lower(mode or '')] or DefaultMode
 end
 
 --subfunction used to generate the code for the Map template
 --sets up as many maps as specified via the bestoff param
-wikiCopyPaste._getMaps = FnUtil.memoize(function(bestof)
+WikiCopyPaste._getMaps = FnUtil.memoize(function(bestof)
 	local map = table.concat({
 		'{{Map',
 		indent .. indent .. '|map=',
@@ -51,12 +53,12 @@ end)
 
 --returns the Code for a Match, depending on the input
 --for more customization please change stuff here^^
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local out = tostring(mw.message.new('BracketConfigMatchTemplate'))
 	if out == '⧼BracketConfigMatchTemplate⧽' then
 		local opponentLines = {}
 		for i = 1, opponents do
-			table.insert(opponentLines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode))
+			table.insert(opponentLines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode))
 		end
 
 		local lines = Array.extend({
@@ -72,15 +74,15 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		out = out:gsub('<nowiki>', '')
 		out = out:gsub('</nowiki>', '')
 		for i = 1, opponents do
-			out = out:gsub('[ \t]*|opponent' .. i .. '=' , indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode))
+			out = out:gsub('[ \t]*|opponent' .. i .. '=' , indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode))
 		end
 
 		out = out:gsub('[ \t]*|map1=.*\n' , '<<maps>>')
 			:gsub('[ \t]*|map%d+=.*\n' , '')
-			:gsub('<<maps>>' , wikiCopyPaste._getMaps(bestof))
+			:gsub('<<maps>>' , WikiCopyPaste._getMaps(bestof))
 
 		return out .. '\n'
 	end
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/splitgate/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/splitgate/get_match_group_copy_paste_wiki.lua
@@ -7,18 +7,20 @@
 --
 
 local Array = require('Module:Array')
-local Table = require('Module:Table')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[
 
 WikiSpecific Code for MatchList, Bracket, and SingleMatch Code Generators
 
 ]]--
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local indent = '    '
 
 	if bestof == 0 and args.score ~= 'false' then
@@ -34,7 +36,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	)
 
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, score))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, score))
 	end
 
 	if bestof ~= 0 then
@@ -54,7 +56,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, score)
+function WikiCopyPaste._getOpponent(mode, score)
 	local out
 
 	if mode == 'solo' then
@@ -68,4 +70,4 @@ function wikiCopyPaste._getOpponent(mode, score)
 	return out
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/starcraft/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/starcraft/get_match_group_copy_paste_wiki.lua
@@ -6,4 +6,5 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-return require('Module:GetMatchGroupCopyPaste/Starcraft')
+local Lua = require('Module:Lua')
+return Lua.import('Module:GetMatchGroupCopyPaste/Starcraft')

--- a/components/match2/wikis/starcraft2/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/starcraft2/get_match_group_copy_paste_wiki.lua
@@ -6,4 +6,5 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-return require('Module:GetMatchGroupCopyPaste/Starcraft')
+local Lua = require('Module:Lua')
+return Lua.import('Module:GetMatchGroupCopyPaste/Starcraft')

--- a/components/match2/wikis/stormgate/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/stormgate/get_match_group_copy_paste_wiki.lua
@@ -7,13 +7,12 @@
 --
 
 local Array = require('Module:Array')
+local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
-local CopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
-
-local OpponentLibrary = require('Module:OpponentLibraries')
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+local OpponentLibrary = Lua.import('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
 
 local INDENT = '\t'
@@ -31,7 +30,7 @@ local MODE_CONVERSION = {
 MODE_CONVERSION.default = MODE_CONVERSION['1v1']
 
 ---@class StormgateMatch2CopyPaste:Match2CopyPasteBase
-local WikiCopyPaste = Table.copy(CopyPaste)
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 ---Returns the cleaned opponent type
 ---@param mode string

--- a/components/match2/wikis/valorant/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/valorant/get_match_group_copy_paste_wiki.lua
@@ -6,9 +6,11 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Table = require('Module:Table')
+local Lua = require('Module:Lua')
+local Class = require('Module:Class')
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 local VETOES = {
 	[0] = '',
@@ -22,7 +24,7 @@ local VETOES = {
 }
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local indent = '  '
 	local showScore = args.score == 'true'
 	local mapDetails = args.detailedMap == 'true'
@@ -38,7 +40,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	end
 
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, showScore))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, showScore))
 	end
 
 	if mapVeto and VETOES[bestof] then
@@ -77,7 +79,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, showScore)
+function WikiCopyPaste._getOpponent(mode, showScore)
 	local score = showScore and '|score=' or ''
 
 	if mode == 'team' then
@@ -87,4 +89,4 @@ function wikiCopyPaste._getOpponent(mode, showScore)
 	end
 end
 
-return wikiCopyPaste
+return WikiCopyPaste

--- a/components/match2/wikis/warcraft/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/warcraft/get_match_group_copy_paste_wiki.lua
@@ -7,13 +7,12 @@
 --
 
 local Array = require('Module:Array')
+local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
-local CopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
-
-local OpponentLibrary = require('Module:OpponentLibraries')
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+local OpponentLibrary = Lua.import('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
 
 local INDENT = '\t'
@@ -30,7 +29,7 @@ local MODE_CONVERSION = {
 }
 MODE_CONVERSION.default = MODE_CONVERSION['1v1']
 
-local WikiCopyPaste = Table.copy(CopyPaste)
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 ---Returns the cleaned opponent type
 ---@param mode string

--- a/components/match2/wikis/wildrift/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/wildrift/get_match_group_copy_paste_wiki.lua
@@ -7,15 +7,17 @@
 --
 
 local Array = require('Module:Array')
-local Table = require('Module:Table')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
 
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 --[[
 
 WikiSpecific Code for MatchList and Bracket Code Generators
 
 ]]--
 
-local wikiCopyPaste = Table.copy(require('Module:GetMatchGroupCopyPaste/wiki/Base'))
+local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 --allowed opponent types on the wiki
 local MODES = {
@@ -28,12 +30,12 @@ local MODES = {
 local DefaultMode = 'team'
 
 --returns the cleaned opponent type
-function wikiCopyPaste.getMode(mode)
+function WikiCopyPaste.getMode(mode)
 	return MODES[string.lower(mode or '')] or DefaultMode
 end
 
 --returns the Code for a Match, depending on the input
-function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local indent = '    '
 
 	if bestof == 0 and args.score ~= 'false' then
@@ -51,7 +53,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	)
 
 	for i = 1, opponents do
-		table.insert(lines, indent .. '|opponent' .. i .. '=' .. wikiCopyPaste._getOpponent(mode, score))
+		table.insert(lines, indent .. '|opponent' .. i .. '=' .. WikiCopyPaste._getOpponent(mode, score))
 	end
 
 	if bestof ~= 0 then
@@ -89,7 +91,7 @@ function wikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 --subfunction used to generate the code for the Opponent template, depending on the type of opponent
-function wikiCopyPaste._getOpponent(mode, score)
+function WikiCopyPaste._getOpponent(mode, score)
 	local out
 
 	if mode == 'solo' then
@@ -103,4 +105,4 @@ function wikiCopyPaste._getOpponent(mode, score)
 	return out
 end
 
-return wikiCopyPaste
+return WikiCopyPaste


### PR DESCRIPTION
## Summary
Clean up the Copy Pastas a bit, fixes annotations warnings etc 
No functional changes

## How did you test this change?

Tested commons + r6