### PR TITLE
fix: typo in wild rift m2 causes error

### DIFF
--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -7,7 +7,7 @@
 --
 
 local ChampionNames = mw.loadData('Module:ChampionNames')
-local DateExt = require('Module:DateExt')
+local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')


### PR DESCRIPTION
## Summary
Introduced in #3942

## How did you test this change?
Live by Martin