### PR TITLE
Adjust stormgate unit and building infoboxes

### DIFF
--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Json = require('Module:Json')
+local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
@@ -22,7 +23,7 @@ local Attack = {}
 ---@field targets string[]?
 ---@field damage number?
 ---@field damagePercentage string
----@field effect string
+---@field effect string[]
 ---@field speed number?
 ---@field dps number?
 ---@field bonus string
@@ -48,7 +49,7 @@ function Attack.run(argsJson, attackIndex, faction)
 		Title{name = 'Attack' .. attackIndex .. ': ' .. args.name},
 		Cell{name = 'Target', content = data.targets},
 		Cell{name = 'Damage', content = {data.damagePercentage and (data.damagePercentage .. '%') or data.damage}},
-		Cell{name = 'Effect', content = {data.effect}},
+		Cell{name = 'Effect', content = Array.map(data.effect, function(effect) return Page.makeInternalLink(effect) end)},
 		Cell{name = 'Attack Speed', content = {data.speed}},
 		Cell{name = 'DPS', content = {data.dps}},
 		Cell{name = 'Bonus vs', content = {data.bonus}},
@@ -67,7 +68,7 @@ function Attack._parse(args)
 		end),
 		damage = tonumber(args.damage),
 		damagePercentage = tonumber(args.damage_percentage),
-		effect = args.effect,
+		effect = Attack._readCommaSeparatedList(args.effect),
 		speed = tonumber(args.speed),
 		dps = tonumber(args.dps),
 		bonus = args.bonus,
@@ -75,6 +76,15 @@ function Attack._parse(args)
 		bonusDps = tonumber(args.bonus_dps),
 		range = tonumber(args.range),
 	}
+end
+
+---@param inputString string?
+---@param makeLink boolean?
+---@return string[]
+function Attack._readCommaSeparatedList(inputString, makeLink)
+	if String.isEmpty(inputString) then return {} end
+	---@cast inputString -nil
+	return Array.map(mw.text.split(inputString, ','), String.trim)
 end
 
 ---@param data StormgateAttackData

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -59,6 +59,10 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Sight', content = {args.sight}},
 			Cell{name = 'Energy', content = {caller:_energyDisplay()}}
 		)
+		-- moved to the bottom due to having headers that would look ugly if in place where attack is set in commons
+		for _, attackArgs, attackIndex in Table.iter.pairsByPrefix(args, 'attack') do
+			Array.extendWith(widgets, Attack.run(attackArgs, attackIndex, caller.faction))
+		end
 	elseif id == 'cost' then
 		return {
 			Cell{name = 'Cost', content = {CostDisplay.run{
@@ -100,10 +104,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Health', content = {args.health and (ICON_HP .. ' ' .. args.health) or nil}},
 			Cell{name = 'Armor', content = caller:_getArmorDisplay()},
 		}
-	elseif id == 'attack' then
-		for _, attackArgs, attackIndex in Table.iter.pairsByPrefix(args, 'attack') do
-			Array.extendWith(widgets, Attack.run(attackArgs, attackIndex, caller.faction))
-		end
+	elseif id == 'attack' then return {}
 	end
 	return widgets
 end

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -96,7 +96,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'unlocks' then
 		return {
 			Cell{name = 'Unlocks', content = caller:_readCommaSeparatedList(args.unlocks, true)},
-			Cell{name = 'Passive', content = caller:_readCommaSeparatedList(args.passive)},
+			Cell{name = 'Passive', content = caller:_readCommaSeparatedList(args.passive, true)},
 			Cell{name = 'Supply Gained', content = caller:_readCommaSeparatedList(args.supply)},
 		}
 	elseif id == 'defense' then

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -59,7 +59,7 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'builtfrom' then
 		return {
-			Cell{name = 'Built From', content = {Page.makeInternalLink(args.built, args.built_link)}},
+			Cell{name = 'Built From', content = caller:_readCommaSeparatedList(args.built, true)},
 		}
 	elseif id == 'requirements' then
 		return {
@@ -180,7 +180,7 @@ function CustomUnit:setLpdbData(args)
 		imagedark = args.imagedark,
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
 			type = self:_readCommaSeparatedList(args.type),
-			builtfrom = args.built_link or args.built,
+			builtfrom = self:_readCommaSeparatedList(args.built),
 			techrequirement = self:_readCommaSeparatedList(args.tech_requirement),
 			buildingrequirement = self:_readCommaSeparatedList(args.building_requirement),
 			luminite = tonumber(args.luminite),
@@ -224,7 +224,7 @@ function CustomUnit:getWikiCategories(args)
 	end
 
 	return Array.append(categories,
-		faction .. unitType
+		faction .. ' ' .. unitType
 	)
 end
 

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -82,7 +82,7 @@ function CustomInjector:parse(id, widgets)
 				animus = args.animus,
 				animusTotal = args.totalanimus,
 			}}},
-			Cell{name = 'Build Time', content = {args.build_time and (args.build_time .. 's') or nil}},
+			Cell{name = 'Build Time', content = {args.buildtime and (args.buildtime .. 's') or nil}},
 			Cell{name = 'Recharge Time', content = {args.charge_time and (args.charge_time .. 's') or nil}},
 		}
 	elseif id == 'hotkey' then
@@ -90,22 +90,23 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Hotkeys', content = {CustomUnit._hotkeys(args.hotkey, args.hotkey2)}},
 			Cell{name = 'Macrokeys', content = {CustomUnit._hotkeys(args.macro_key, args.macro_key2)}},
 		}
-	elseif id == 'attack' then
-		for _, attackArgs, attackIndex in Table.iter.pairsByPrefix(args, 'attack') do
-			Array.extendWith(widgets, Attack.run(attackArgs, attackIndex, caller.faction))
-		end
+	elseif id == 'attack' then return {}
 	elseif id == 'defense' then
 		return {
 			Cell{name = 'Health', content = {caller:_getHealthDisplay()}},
 			Cell{name = 'Armor', content = caller:_getArmorDisplay()},
 		}
 	elseif id == 'custom' then
-		return {
+		Array.appendWith(widgets,
 			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
 			Cell{name = 'Sight', content = {args.sight}},
 			Cell{name = 'Speed', content = {args.speed}},
-			Cell{name = 'Passive', content = caller:_readCommaSeparatedList(args.passive, true)},
-		}
+			Cell{name = 'Passive', content = caller:_readCommaSeparatedList(args.passive, true)}
+		)
+		-- moved to the bottom due to having headers that would look ugly if in place where attack is set in commons
+		for _, attackArgs, attackIndex in Table.iter.pairsByPrefix(args, 'attack') do
+			Array.extendWith(widgets, Attack.run(attackArgs, attackIndex, caller.faction))
+		end
 	end
 
 	return widgets
@@ -190,7 +191,7 @@ function CustomUnit:setLpdbData(args)
 			totalsupply = tonumber(args.totalsupply),
 			animus = tonumber(args.animus),
 			totalanimus = tonumber(args.totalanimus),
-			buildtime = tonumber(args.build_time),
+			buildtime = tonumber(args.buildtime),
 			rechargetime = tonumber(args.charge_time),
 			sight = tonumber(args.sight),
 			speed = tonumber(args.speed),


### PR DESCRIPTION
## Summary
At request by contributors:
- unify buildtime key between the infoboxes
- Move Attack display to bottom of the infoboxes so it looks better (due to the attacks having headers)
- change effect in attacks to csv and linking display
- make passive link in buildings
- make built comma sep list in infobox unit
- add a missing space in unit categories

## How did you test this change?
live since not yet really in use