### PR TITLE
refactor: drop usage of legacy `smw_prefix`

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -116,7 +116,7 @@ BasePrizePool.config = {
 	lpdbPrefix = {
 		default = '',
 		read = function(args)
-			return args.lpdb_prefix or Variables.varDefault('lpdb_prefix') or Variables.varDefault('smw_prefix')
+			return args.lpdb_prefix or Variables.varDefault('lpdb_prefix')
 		end
 	},
 	abbreviateTbd = {

--- a/components/prize_pool/commons/prize_pool_legacy.lua
+++ b/components/prize_pool/commons/prize_pool_legacy.lua
@@ -55,7 +55,7 @@ function LegacyPrizePool.run(dependency)
 
 	newArgs.prizesummary = (header.prizeinfo and not header.noprize) and true or false
 	newArgs.cutafter = header.cutafter
-	newArgs.lpdb_prefix = header.lpdb_prefix or header.smw_prefix
+	newArgs.lpdb_prefix = header.lpdb_prefix
 	newArgs.fillPlaceRange = Logic.readBool(header.fillPlaceRange) or false
 
 	if Currency.raw(header.localcurrency) then

--- a/components/prize_pool/wikis/dota2/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/dota2/prize_pool_custom.lua
@@ -44,11 +44,11 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.extradata.series2 = Variables.varDefault('tournament_series2', '')
 
 	local redirectedTeam = mw.ext.TeamLiquidIntegration.resolve_redirect(lpdbData.participant)
-	local smwPrefix = Variables.varDefault('smw_prefix')
-	smwPrefix = smwPrefix and (smwPrefix .. '_') or ''
+	local lpdbPrefix = Variables.varDefault('lpdb_prefix')
+	lpdbPrefix = lpdbPrefix and (lpdbPrefix .. '_') or ''
 
-	Variables.varDefine(redirectedTeam .. '_' .. smwPrefix .. 'date', lpdbData.date)
-	Variables.varDefine(smwPrefix .. (redirectedTeam:lower()) .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(redirectedTeam .. '_' .. lpdbPrefix .. 'date', lpdbData.date)
+	Variables.varDefine(lpdbPrefix .. (redirectedTeam:lower()) .. '_prizepoints', lpdbData.extradata.prizepoints)
 
 
 	return lpdbData

--- a/components/prize_pool/wikis/halo/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/halo/prize_pool_custom.lua
@@ -42,7 +42,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.publishertier = Variables.varDefault('tournament_hcs_premier', '')
 
 	local team = lpdbData.participant or ''
-	local lpdbPrefix = Variables.varDefault('lpdb_prefix') or Variables.varDefault('smw_prefix') or ''
+	local lpdbPrefix = Variables.varDefault('lpdb_prefix') or ''
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)

--- a/components/prize_pool/wikis/leagueoflegends/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/leagueoflegends/prize_pool_custom.lua
@@ -43,10 +43,10 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.extradata.publisherpremier = Variables.varDefault('tournament_publisher_major') and 'true' or ''
 
 	local team = lpdbData.participant or ''
-	local smwPrefix = Variables.varDefault('smw_prefix', '')
+	local lpdbPrefix = Variables.varDefault('lpdb_prefix', '')
 
-	Variables.varDefine('enddate_' .. smwPrefix .. team, lpdbData.date)
-	Variables.varDefine('ranking' .. smwPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
 
 
 	return lpdbData

--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -37,8 +37,7 @@ function TeamCardStorage.saveToLpdb(args, teamObject, players, playerPrize)
 		end
 	end
 
-	local lpdbPrefix = args.lpdb_prefix or args.smw_prefix
-		or Variables.varDefault('lpdb_prefix') or Variables.varDefault('smw_prefix') or ''
+	local lpdbPrefix = args.lpdb_prefix or Variables.varDefault('lpdb_prefix') or ''
 
 	-- Setup LPDB Data
 	local lpdbData = {}


### PR DESCRIPTION
## Summary
Will need bot run when going live to replace `smw_prefix` with `lpdb_prefix`

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
