### PR TITLE
PPT: Fill placement.players from opponentplayers

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -267,6 +267,7 @@ function Placement:_getLpdbData(...)
 		}
 
 		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(opponent.opponentData))
+		lpdbData.players = lpdbData.players or lpdbData.opponentplayers
 
 		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
 		if Opponent.isTbd(opponent.opponentData) then


### PR DESCRIPTION
## Summary
Some modules (e.g. NotabilityChecker) still use the `players` field, which wasn't saved for e.g. DuoOpponents.


## How did you test this change?
via dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
