### PR TITLE
fix: add missing `_` in function names

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_map_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_map_custom.lua
@@ -126,9 +126,9 @@ function CustomInjector:parse(id, widgets)
 				Cell{name = 'Rush distance', content = {args.rushDistance and (args.rushDistance .. ' seconds') or nil}},
 				Cell{name = 'Available Resources', content = {self.caller:_resourcesDisplay(args)}},
 			},
-			self.caller:addCellsFromDataTable(args, LADDER_HISTORY),
+			self.caller:_addCellsFromDataTable(args, LADDER_HISTORY),
 			{hasCampData and Title{name = 'Camp Information'} or nil},
-			self.caller:addCellsFromDataTable(args, CAMPS)
+			self.caller:_addCellsFromDataTable(args, CAMPS)
 		)
 	end
 


### PR DESCRIPTION
## Summary
Fix function calls (missing `_`).
introduced with #3728

## How did you test this change?
live as bug fix