### PR TITLE
fix(ppt test): Add a date to arguments

### DIFF
--- a/spec/prize_pool_spec.lua
+++ b/spec/prize_pool_spec.lua
@@ -33,7 +33,7 @@ describe('prize pool', function()
 		qualifies1name = 'A Display',
 		freetext = 'A title',
 		import = false,
-		[1] = {localprize = '1,000', [1] = {'Rathoz', flag='se'}},
+		[1] = {localprize = '1,000', [1] = {'Rathoz', flag='se', date='2024-02-09'}},
 	}
 
 	it('parameters are correctly parsed', function()


### PR DESCRIPTION
## Summary
The ppt arguments didn't have a date set and defaulted to the day of execution.

## How did you test this change?
CI
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
