### PR TITLE
data(match2): update cs2 platform links

### DIFF
--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -83,10 +83,17 @@ return {
 		label = 'Matchpage on epic.LAN',
 	},
 	{
-		name = 'pinger',
+		name = 'pinger-csgo',
 		icon = 'Pinger icon lightmode.png',
 		iconDark = 'Pinger icon darkmode.png',
 		prefixLink = 'https://pinger.kz/matches/csgo/',
+		label = 'Matchpage and Stats on Pinger',
+	},
+	{
+		name = 'pinger',
+		icon = 'Pinger icon lightmode.png',
+		iconDark = 'Pinger icon darkmode.png',
+		prefixLink = 'https://pinger.kz/tournaments/cs2/event/matches/',
 		label = 'Matchpage and Stats on Pinger',
 	},
 	{

--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -71,7 +71,7 @@ return {
 		label = 'Matchpage and Stats on SLTV',
 	},
 	{
-		name = 'lpl-legacy',
+		name = 'lpl-old',
 		icon = 'LPL Play icon.png',
 		prefixLink = 'https://old.letsplay.live/match/',
 		label = 'Matchpage on LPL Play',

--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -71,10 +71,17 @@ return {
 		label = 'Matchpage and Stats on SLTV',
 	},
 	{
-		name = 'lpl',
+		name = 'lpl-legacy',
 		icon = 'LPL Play icon.png',
 		prefixLink = 'https://old.letsplay.live/match/',
 		label = 'Matchpage on LPL Play',
+	},
+	{
+		name = 'lpl',
+		icon = 'letsplay.live 2024 icon lightmode.png',
+		iconDarl = 'letsplay.live 2024 icon darkmode.png',
+		prefixLink = 'https://gg.letsplay.live/report-score/',
+		label = 'Matchpage on letsplay.live',
 	},
 	{
 		name = 'epiclan',

--- a/components/match2/wikis/counterstrike/match_external_links.lua
+++ b/components/match2/wikis/counterstrike/match_external_links.lua
@@ -79,7 +79,7 @@ return {
 	{
 		name = 'lpl',
 		icon = 'letsplay.live 2024 icon lightmode.png',
-		iconDarl = 'letsplay.live 2024 icon darkmode.png',
+		iconDark = 'letsplay.live 2024 icon darkmode.png',
 		prefixLink = 'https://gg.letsplay.live/report-score/',
 		label = 'Matchpage on letsplay.live',
 	},


### PR DESCRIPTION
## Summary

Some platforms have updated their platforms with new slugs and/or migrated their old stuff to a legacy sub-domain. Will run bots after merge to update all the old links to their legacy variants.

## How did you test this change?

Just some data :p