### PR TITLE
Use font icon for stormgate buildTime in CostDisplay

### DIFF
--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_cost_display.lua
@@ -8,6 +8,7 @@
 
 local Abbreviation = require('Module:Abbreviation')
 local Faction = require('Module:Faction')
+local Icon = require('Module:Icon')
 local Table = require('Module:Table')
 
 local CostDisplay = {}
@@ -22,8 +23,7 @@ local ICONS = {
 		default = Abbreviation.make('The', 'Therium'),
 	},
 	buildTime = {
-		--expect to get different ones per faction
-		default = '[[File:Buildtime_terran.gif|baseline|link=Game Speed]]',
+		default = Icon.makeIcon{iconName = 'time', size = '100%'},
 	},
 	supply = {
 		--expect to get different ones per faction

--- a/standard/icon_data.lua
+++ b/standard/icon_data.lua
@@ -69,4 +69,7 @@ return {
 	activeroster = 'fas fa-users',
 	history = 'fas fa-books',
 	media = 'fas fa-newspaper',
+
+	-- Usage: buildtime, duration, cooldown, ...
+	time = 'far fa-clock',
 }


### PR DESCRIPTION
## Summary
Use font icon for stormgate buildTime in CostDisplay
Looks way cleaner and we do not need to use the sc2 icon anymore

## How did you test this change?
N/A