### PR TITLE
Hiding empty cells in WoT Infobox Map

### DIFF
--- a/components/infobox/wikis/worldoftanks/infobox_map_custom.lua
+++ b/components/infobox/wikis/worldoftanks/infobox_map_custom.lua
@@ -39,7 +39,7 @@ end
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
-	if id == 'location' then
+	if id == 'location' and not (String.isEmpty(args.location)) then
 		return {
 			Cell{
 				name = 'Location',
@@ -50,9 +50,15 @@ function CustomInjector:parse(id, widgets)
 		return Array.append(widgets,
 			Cell{name = 'Map Season', content = {args.season}},
 			Cell{name = 'Size', content = {(args.width or '') .. 'x' .. (args.height or '')}},
-			Cell{name = 'Battle Tier', content = {(args.btmin or '') .. '-' .. (args.btmax or '')}},
 			Cell{name = 'Game Modes', content = self.caller:_getGameMode(args)}
 		)
+	end
+	
+	if not (String.isEmpty(args.btmin) and String.isEmpty(args.btmax)) then
+		table.insert(widgets, Cell{
+			name = 'Battle Tier', 
+			content = {(args.btmin or '') .. '-' .. (args.btmax or '')}
+		})
 	end
 	return widgets
 end


### PR DESCRIPTION
## Summary
As reported in [discord](https://discord.com/channels/93055209017729024/1164213650291175444/1206616196254801981), not all Map pages on World of Tanks will have locations or Battle Tiers available. Therefore they should be hidden from view if empty.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Dev + [Live](https://liquipedia.net/worldoftanks/Arzagir_4.04)
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
