### PR TITLE
Fix typo in defaultYear

### DIFF
--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -377,7 +377,7 @@ function matchFunctions.isFeatured(match)
 
 	local opponent1, opponent2 = match.opponent1, match.opponent2
 	local year, month = match.date:match('^(%d%d%d%d)-(%d%d)')
-	if year == DateExt.deaultYear then
+	if year == DateExt.defaultYear then
 		return false
 	end
 	if tonumber(month) < 3 then

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -775,7 +775,7 @@ function StatisticsPortal.playerAgeTable(args)
 	for _, player in ipairs(playerData) do
 		local birthdate = DateExt.readTimestamp(player.birthdate) --[[@as integer]]
 		local age = os.date('*t', os.difftime(TIMESTAMP, birthdate))
-		local yearAge = age.year - tonumber(DateExt.deaultYear)
+		local yearAge = age.year - tonumber(DateExt.defaultYear)
 		local dayAge = age.yday - 1
 
 		tbl:tag('tr')

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -27,7 +27,7 @@ DateExt.defaultTimestamp = -62167219200
 DateExt.defaultDateTime = '0000-01-01 00:00:00'
 DateExt.defaultDateTimeExtended = '0000-01-01T00:00:00+00:00'
 DateExt.defaultDate = '0000-01-01'
-DateExt.deaultYear = '0000'
+DateExt.defaultYear = '0000'
 
 --- Parses a date string into a timestamp, returning the number of seconds since UNIX epoch.
 --- The timezone offset is incorporated into the timestamp, and the timezone is discarded.

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -28,6 +28,7 @@ DateExt.defaultDateTime = '0000-01-01 00:00:00'
 DateExt.defaultDateTimeExtended = '0000-01-01T00:00:00+00:00'
 DateExt.defaultDate = '0000-01-01'
 DateExt.defaultYear = '0000'
+DateExt.deaultYear = '0000'
 
 --- Parses a date string into a timestamp, returning the number of seconds since UNIX epoch.
 --- The timezone offset is incorporated into the timestamp, and the timezone is discarded.


### PR DESCRIPTION
## Summary

Fix typo in defaultYear
Typo was found by spazer and reported [here](https://discord.com/channels/93055209017729024/372075546231832576/1207526671587082350)

This typo seems to be exclusive to defaultYear. I insource searched for the typo using deaultYear, Date, Month, Day. Most modules using the typos aren't on the git so I will open an issue to track them and subsequently change them following this pr.

https://github.com/Liquipedia/Lua-Modules/issues/3993

## How did you test this change?

N/A
