### PR TITLE
feat(infobox team): support darkmode in created field for team logo

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -254,7 +254,6 @@ function Team:_getTeamIcon(date)
 	local iconDark = self.teamTemplate.historicaltemplate
 		and mw.ext.TeamTemplate.raw(self.teamTemplate.historicaltemplate, date).imagedark
 		or self.teamTemplate.imagedark
-		or icon
 
 	return icon, iconDark
 end

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -221,7 +221,6 @@ function Team:processCreateDates()
 		local cleanDate = ReferenceCleaner.clean(date)
 
 		if game:lower() == 'org' then
-			local teamIcon, teamIconDark = self:_getTeamIcon(cleanDate)
 			icon = Image.display(self:_getTeamIcon(cleanDate))
 		else
 			local timestamp = Team._parseDate(cleanDate)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -224,7 +224,7 @@ function Team:processCreateDates()
 			local toIcon = function(iconFile, mode)
 				if String.isEmpty(iconFile) then return '' end
 				return '[[File:' .. iconFile .. '|class=show-when-' .. mode .. '-mode]]'
-			end				
+			end
 			icon = toIcon(teamIcon, 'light') .. toIcon(teamIconDark, 'dark')
 		else
 			local timestamp = Team._parseDate(cleanDate)

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -220,8 +220,12 @@ function Team:processCreateDates()
 		local cleanDate = ReferenceCleaner.clean(date)
 
 		if game:lower() == 'org' then
-			icon = self:_getTeamIcon(cleanDate)
-			icon = String.isNotEmpty(icon) and '[[File:' .. icon .. ']]' or nil
+			local teamIcon, teamIconDark = self:_getTeamIcon(cleanDate)
+			local toIcon = function(iconFile, mode)
+				if String.isEmpty(iconFile) then return '' end
+				return '[[File:' .. iconFile .. '|class=show-when-' .. mode .. '-mode]]'
+			end				
+			icon = toIcon(teamIcon, 'light') .. toIcon(teamIconDark, 'dark')
 		else
 			local timestamp = Team._parseDate(cleanDate)
 			if timestamp and timestamp < earliestGameTimestamp then
@@ -240,20 +244,28 @@ end
 
 ---@param date? string
 ---@return string?
+---@return string?
 function Team:_getTeamIcon(date)
 	if not self.teamTemplate then
 		return
 	end
 
-	return self.teamTemplate.historicaltemplate
+	local icon = self.teamTemplate.historicaltemplate
 		and mw.ext.TeamTemplate.raw(self.teamTemplate.historicaltemplate, date).image
 		or self.teamTemplate.image
+
+	local iconDark = self.teamTemplate.historicaltemplate
+		and mw.ext.TeamTemplate.raw(self.teamTemplate.historicaltemplate, date).imagedark
+		or self.teamTemplate.imagedark
+		or icon
+
+	return icon, iconDark
 end
 
 ---@param date? string
 ---@return boolean
 function Team._isValidDate(date)
-	return date and date:match('%d%d%d%d-[%d%?]?[%d%?]?-[%d%?]?[%d%?]?')
+	return date and date:match('%d%d%d%d%-?[%d%?]?[%d%?]?%-?[%d%?]?[%d%?]?')
 end
 
 ---@param date string

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -260,7 +260,7 @@ end
 ---@param date? string
 ---@return boolean
 function Team._isValidDate(date)
-	return date and date:match('%d%d%d%d%-?[%d%?]?[%d%?]?%-?[%d%?]?[%d%?]?')
+	return date and date:match('%d%d%d%d-[%d%?]?[%d%?]?-[%d%?]?[%d%?]?')
 end
 
 ---@param date string

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -11,6 +11,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Date = require('Module:Date/Ext')
 local Game = require('Module:Game')
+local Image = require('Module:Image')
 local Info = require('Module:Info')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -221,11 +222,7 @@ function Team:processCreateDates()
 
 		if game:lower() == 'org' then
 			local teamIcon, teamIconDark = self:_getTeamIcon(cleanDate)
-			local toIcon = function(iconFile, mode)
-				if String.isEmpty(iconFile) then return '' end
-				return '[[File:' .. iconFile .. '|class=show-when-' .. mode .. '-mode]]'
-			end
-			icon = toIcon(teamIcon, 'light') .. toIcon(teamIconDark, 'dark')
+			icon = Image.display(self:_getTeamIcon(cleanDate))
 		else
 			local timestamp = Team._parseDate(cleanDate)
 			if timestamp and timestamp < earliestGameTimestamp then


### PR DESCRIPTION
depends on #3996

## Summary
Make org icon in infobox teams created darkmode compatible

## How did you test this change?
dev