### PR TITLE
feat(faction) Icon: default link to name if no pageName is set

### DIFF
--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -207,7 +207,7 @@ function Faction.Icon(props)
 
 	return '[['
 		.. iconName
-		.. '|link=' .. (props.showLink and factionProps.pageName or factionProps.name or '')
+		.. '|link=' .. (props.showLink and (factionProps.pageName or factionProps.name) or '')
 		.. '|' .. size
 		.. (props.showTitle ~= false and '|' .. (props.title or factionProps.name) or '')
 		.. ']]'

--- a/components/faction/commons/faction.lua
+++ b/components/faction/commons/faction.lua
@@ -207,7 +207,7 @@ function Faction.Icon(props)
 
 	return '[['
 		.. iconName
-		.. '|link=' .. (props.showLink and factionProps.pageName or '')
+		.. '|link=' .. (props.showLink and factionProps.pageName or factionProps.name or '')
 		.. '|' .. size
 		.. (props.showTitle ~= false and '|' .. (props.title or factionProps.name) or '')
 		.. ']]'


### PR DESCRIPTION
## Summary
As most factions don't have a pagename that differs from name, default to that for links unless pageName exists
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
via /dev
