### PR TITLE
fix(lakeside): CS wiki teamcard toggle buttons

### DIFF
--- a/stylesheets/commons/Teamcard.less
+++ b/stylesheets/commons/Teamcard.less
@@ -169,6 +169,8 @@ Author(s): ???
 	margin-left: 25px;
 	transform: rotate( 90deg );
 	transform-origin: top left;
+	border-radius: unset !important;
+	min-height: unset !important;
 }
 
 .wiki-apexlegends .teamcard-former-toggle-button button {


### PR DESCRIPTION
## Summary

With lakeside view skin, button css styling is being applied to buttons that shouldn't have it due to specific application.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/22332031-8f15-435f-830a-c7415c483108)

## How did you test this change?

Browser dev tools

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/530265c9-c984-43d2-9f86-83f8e4b58df1)

----

cc @liquidely can we please add `justify-content: center;` to `.main-content-column button` in the skin so that the buttons' text is also centered correctly?

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/c20f3bed-c1c7-45a1-a513-2311278f0e5b)

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/786e76ac-8611-4411-939d-ceae34ef0553)
