### PR TITLE
Add "redirects" for `Player/Display/Custom`.

### DIFF
--- a/components/opponent/commons/player_display_custom.lua
+++ b/components/opponent/commons/player_display_custom.lua
@@ -1,0 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Player/Display/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+return Lua.import('Module:Player/Display')

--- a/components/opponent/wikis/starcraft/player_display_custom.lua
+++ b/components/opponent/wikis/starcraft/player_display_custom.lua
@@ -1,0 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=starcraft
+-- page=Module:Player/Display/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+return Lua.import('Module:Player/Display/Starcraft')

--- a/components/opponent/wikis/starcraft2/player_display_custom.lua
+++ b/components/opponent/wikis/starcraft2/player_display_custom.lua
@@ -1,0 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=starcraft2
+-- page=Module:Player/Display/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+return Lua.import('Module:Player/Display/Starcraft')


### PR DESCRIPTION
## Summary
Add "redirects" for `Player/Display/Custom` to `Player/Display` on commons.
Add "redirects" for `Player/Display/Custom` to `Player/Display/Starcraft` on sc2 and broodwar.

So i can call `Player/Display/Custom` in modules shared between sc(2) and other wikis.

## How did you test this change?
live