### PR TITLE
fix(infobox person): anno warning

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -464,6 +464,7 @@ function Person:_createTeam(team, link)
 	if String.isEmpty(link) then
 		return nil
 	end
+	---@cast link -nil
 
 	if mw.ext.TeamTemplate.teamexists(link) then
 		local data = mw.ext.TeamTemplate.raw(link)


### PR DESCRIPTION
## Summary
Fix an annotation warning in infobox person by casting `nil` away after an `isEmpty` check.

## How did you test this change?
VSCode