### PR TITLE
VAL Infobox Map - Adding null check to location

### DIFF
--- a/components/infobox/wikis/valorant/infobox_map_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_map_custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local Map = Lua.import('Module:Infobox/Map')
@@ -36,7 +37,7 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
-	if id == 'location' then
+	if id == 'location' and String.isNotEmpty(args.location) then
 		return {
 			Cell{
 				name = 'Location',


### PR DESCRIPTION
## Summary
Adds a null check to the Location of the Valorant Infobox. Since not all maps in the game have valid locations with flags, this is required to keep both the auto flags being added, and not throwing errors when no location is added. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
