### PR TITLE
feat(stormgate infobox league): automate patches

### DIFF
--- a/components/infobox/extensions/commons/infobox_extension_patch_auto.lua
+++ b/components/infobox/extensions/commons/infobox_extension_patch_auto.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=stormgate
+-- wiki=commons
 -- page=Module:Infobox/Extension/PatchAuto
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_patch_auto.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_patch_auto.lua
@@ -1,0 +1,92 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Infobox/Extension/PatchAuto
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local String = require('Module:StringUtils')
+
+local TODAY = os.date('!%Y-%m-%d', os.time())
+
+local PatchAuto = {}
+
+---@param data table
+---@param args table
+---@return table
+function PatchAuto.run(data, args)
+	local patch = PatchAuto._fetchPatchData(data.patch, args.patch_display)
+	local endPatch = PatchAuto._fetchPatchData(data.endPatch, args.epatch_display)
+	if patch and endPatch or not data.startDate then
+		return PatchAuto._toData(data, patch or {}, endPatch or {})
+	end
+
+	local endDate = data.endDate or TODAY
+	local patches = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = '[[type::patch]] OR ([[date::<' .. endDate .. ']] OR [[date::' .. endDate .. ']])',
+		query = 'name, pagename, date',
+		limit = 5000,
+		order = 'date desc',
+	})
+	patch = patch or PatchAuto._getPatch(patches, data.startDate)
+	endPatch = endPatch or PatchAuto._getPatch(patches, endDate)
+
+	return PatchAuto._toData(data, patch or {}, endPatch or {})
+end
+
+---@param patch string?
+---@param patchDisplay string?
+---@return {link: string?, display: string?}?
+function PatchAuto._fetchPatchData(patch, patchDisplay)
+	if not patch then
+		return
+	elseif patchDisplay then
+		patch = patch:gsub(' ', '_')
+		return {link = patch, display = patchDisplay}
+	end
+
+	patch = patch:gsub(' ', '_')
+
+	local patchData = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = '[[type::patch]] AND [[pagename::' .. patch .. ']]',
+		query = 'name',
+		limit = 1
+	})[1]
+
+	assert(patchData, '"' .. patch .. '" is not a valid patch')
+
+	patchDisplay = String.nilIfEmpty(patchData.name) or patch:gsub('_', ' ')
+	return {link = patch, display = patchDisplay}
+end
+
+---@param patches {pagename: string, name: string?, date: string}[]
+---@param date any
+---@return table
+function PatchAuto._getPatch(patches, date)
+	for _, patch in ipairs(patches) do
+		if patch.date <= date then
+			return {link = patch.pagename, display = patch.name}
+		end
+	end
+
+	return {}
+end
+
+---@param data table
+---@param patch {link: string?, display: string?}
+---@param endPatch {link: string?, display: string?}
+---@return table
+function PatchAuto._toData(data, patch, endPatch)
+	data.patch = patch.link
+	data.endPatch = endPatch.link or data.patch
+	data.patchDisplay = patch.display
+	-- only set endPatch display if not equal to patch display
+	if patch.display ~= endPatch.display then
+		data.endPatchDisplay = endPatch.display
+	end
+
+	return data
+end
+
+return PatchAuto

--- a/components/infobox/wikis/stormgate/infobox_league_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_league_custom.lua
@@ -18,6 +18,7 @@ local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
+local PatchAuto = Lua.import('Module:Infobox/Extension/PatchAuto')
 local RaceBreakdown = Lua.import('Module:Infobox/Extension/RaceBreakdown')
 
 local Widgets = require('Module:Infobox/Widget/All')
@@ -49,6 +50,7 @@ function CustomLeague:customParseArguments(args)
 	args.maps = self:_getMaps(args)
 	self.data.status = self:_getStatus(args)
 	self.data.publishertier = tostring(Logic.readBool(args.publishertier))
+	self.data = PatchAuto.run(self.data, args)
 end
 
 ---@param args table
@@ -99,7 +101,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'gamesettings' then
-		table.insert(widgets, Cell{name = 'Game Version', content = {CustomLeague._getGameVersion(args)}})
+		table.insert(widgets, Cell{name = 'Game Version', content = {self.caller:_getGameVersion()}})
 	elseif id == 'customcontent' then
 		if args.player_number and args.player_number > 0 then
 			Array.appendWith(widgets,
@@ -142,12 +144,11 @@ function CustomLeague:_mapsDisplay(maps)
 	)
 end
 
----@param args table
 ---@return string?
-function CustomLeague._getGameVersion(args)
+function CustomLeague:_getGameVersion()
 	return table.concat({
-		Page.makeInternalLink(args.patch),
-		Page.makeInternalLink(args.epatch ~= args.patch and args.patch and args.epatch or nil)
+		Page.makeInternalLink({}, self.data.patchDisplay, self.data.patch),
+		Page.makeInternalLink({}, self.data.endPatchDisplay, self.data.endPatch)
 	}, ' &ndash; ')
 end
 


### PR DESCRIPTION
## Summary
Automate patches in infobox league on stormgate.
- if no patch is entered retrive the correct patch (based on dates)
- if patch is entered but patch display is not retrieve the patch name for diplay

## How did you test this change?
extension "live" as new and not in use, infobox league via dev