### PR TITLE
ci(eslint): properly support ES2020

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,9 @@
 {
 	"extends": [
-		"wikimedia/client-es6",
-		"wikimedia/jquery",
-		"wikimedia/mediawiki"
+		"wikimedia/mediawiki",
+		"wikimedia/client/common",
+		"wikimedia/language/es2020",
+		"wikimedia/jquery"
 	],
 	"globals": {
 		"liquipedia": "readonly",
@@ -27,11 +28,8 @@
 		"es-x/no-property-shorthands": "off",
 		"max-len": ["warn", { "code": 120 }]
 	},
-	"parserOptions": {
-		"ecmaVersion": 2020
-	},
 	"env": {
-		"es6": true
+		"jquery": true
 	}
 }
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,4 +32,3 @@
 		"jquery": true
 	}
 }
-

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -21,4 +21,3 @@
 		"function-no-unknown": null
 	}
 }
-

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -330,7 +330,6 @@ liquipedia.battleRoyale = {
 	},
 
 	createBottomNav( instanceId, navigationTab, currentPanelIndex ) {
-		// eslint-disable-next-line es-x/no-object-values
 		const contentPanel = Object.values(
 			this.battleRoyaleMap[ instanceId ].navigationContentPanelTabContents[ navigationTab ]
 		)[ currentPanelIndex ];

--- a/javascript/commons/Bracket.js
+++ b/javascript/commons/Bracket.js
@@ -54,7 +54,7 @@ liquipedia.bracket = {
 			} );
 			document.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-team-middle, .bracket-team-inner, .bracket-player-top, .bracket-player-bottom, .bracket-player-middle, .bracket-player-inner, .matchlistslot, .matchslot, .grouptableslot' ).forEach( function( element ) {
 				element.addEventListener( 'mouseover', function() {
-					if ( liquipedia.bracket.highlighting.filteredSelectors.indexOf( element.dataset.highlightingkey ) === -1 ) {
+					if ( !liquipedia.bracket.highlighting.filteredSelectors.includes( element.dataset.highlightingkey ) ) {
 						liquipedia.bracket.highlighting.hoverCache[ element.dataset.highlightingkey ].forEach( function( node ) {
 							node.classList.add( 'bracket-hover' );
 							if ( typeof node.dataset.backgroundColorHover !== 'undefined' ) {
@@ -77,7 +77,7 @@ liquipedia.bracket = {
 			const urlparts = url.split( '/' );
 			let value = urlparts[ urlparts.length - 1 ];
 			value.replace( '-icon', '_std' );
-			if ( value.indexOf( '-' ) !== -1 ) {
+			if ( value.includes( '-' ) ) {
 				value = value.replace( '-logo', '' ).replace( '-std', '' );
 				value = value.split( '-' );
 				value = value[ value.length - 1 ];
@@ -110,7 +110,7 @@ liquipedia.bracket = {
 				} else {
 					// Team highlighting
 					fromselector = liquipedia.bracket.highlighting.getImageSelector( fromteamicon.src );
-					if ( liquipedia.bracket.highlighting.standardIcons.indexOf( fromselector ) !== -1 ) {
+					if ( liquipedia.bracket.highlighting.standardIcons.includes( fromselector ) ) {
 						fromselector = liquipedia.bracket.highlighting.getTextSelector( from );
 					}
 				}
@@ -122,7 +122,7 @@ liquipedia.bracket = {
 				} else {
 					// Team highlighting
 					toselector = liquipedia.bracket.highlighting.getImageSelector( toteamicon.src );
-					if ( liquipedia.bracket.highlighting.standardIcons.indexOf( toselector ) !== -1 ) {
+					if ( liquipedia.bracket.highlighting.standardIcons.includes( toselector ) ) {
 						toselector = liquipedia.bracket.highlighting.getTextSelector( to );
 					}
 				}
@@ -168,7 +168,7 @@ liquipedia.bracket = {
 				} else {
 					// Team highlighting
 					selector = liquipedia.bracket.highlighting.getImageSelector( teamicon.src );
-					if ( liquipedia.bracket.highlighting.standardIcons.indexOf( selector ) !== -1 ) {
+					if ( liquipedia.bracket.highlighting.standardIcons.includes( selector ) ) {
 						selector = liquipedia.bracket.highlighting.getTextSelector( element );
 					}
 				}


### PR DESCRIPTION
## Summary

Also, we've got a weird mix of ES6 and ES2020 settings in the ESLint config rn. The wikimedia extends are setting es-x rules to es6, parser is set to 2020, and then env is set to es6 again. It doesn't make much sense to me. I made a commit here to standardize it all to ES2020 and also added jquery to the env as it was missing.

## How did you test this change?

Tested in VS Code.