### PR TITLE
feat(PlayerIntro): Add F1 custom

### DIFF
--- a/components/infobox/extensions/commons/player_introduction.lua
+++ b/components/infobox/extensions/commons/player_introduction.lua
@@ -402,11 +402,11 @@ function PlayerIntroduction:create()
 	local nationalityDisplay = self:_nationalityDisplay()
 	local gameDisplay = self:_gameDisplay()
 	local factionDisplay = self:_factionDisplay()
-	local typeDisplay = self:_typeDisplay()
+	local typeDisplay = self:typeDisplay()
 
 	return String.interpolate('${name}${born} ${tense} ${a}${status}${nationality}${game}'
 		.. '${faction}${type}${team}${subText}.${freeText}', {
-			name = self:_nameDisplay(),
+			name = self:nameDisplay(),
 			born = self:_bornDisplay(isDeceased),
 			tense = isDeceased and 'was' or 'is',
 			a = AnOrA._main{
@@ -427,7 +427,7 @@ end
 
 --- builds the name display
 ---@return string
-function PlayerIntroduction:_nameDisplay()
+function PlayerIntroduction:nameDisplay()
 	local nameQuotes = String.isNotEmpty(self.playerInfo.name) and '"' or ''
 
 	local nameDisplay = self._addConcatText(self.playerInfo.firstName, nil, true)
@@ -528,7 +528,7 @@ end
 
 --- builds the type display
 ---@return string?
-function PlayerIntroduction:_typeDisplay()
+function PlayerIntroduction:typeDisplay()
 	return self._addConcatText(self.playerInfo.type)
 		.. self._addConcatText(
 			self.playerInfo.type ~= TYPE_PLAYER and String.isNotEmpty(self.playerInfo.role2) and self.playerInfo.role2 or nil,
@@ -556,7 +556,7 @@ function PlayerIntroduction:_teamDisplay(isDeceased)
 
 	return String.interpolate(' ${tense} ${playedOrWorked} ${team}${team2}${roleDisplay}', {
 		tense = isCurrentTense and 'who is currently' or 'who last',
-		playedOrWorked = self:_playedOrWorked(isCurrentTense),
+		playedOrWorked = self:playedOrWorked(isCurrentTense),
 		team = PlayerIntroduction._displayTeam(isCurrentTense and playerInfo.team or transferInfo.team, transferInfo.date),
 		team2 = shouldDisplayTeam2
 			and (' on loan from' .. PlayerIntroduction._displayTeam(playerInfo.team2, transferInfo.date))
@@ -568,7 +568,7 @@ end
 
 ---@param isCurrentTense boolean
 ---@return string
-function PlayerIntroduction:_playedOrWorked(isCurrentTense)
+function PlayerIntroduction:playedOrWorked(isCurrentTense)
 	local playerInfo = self.playerInfo
 	local transferInfo = self.transferInfo
 	local role = self.transferInfo.standardizedRole

--- a/components/infobox/extensions/wikis/formula1/player_introduction_custom.lua
+++ b/components/infobox/extensions/wikis/formula1/player_introduction_custom.lua
@@ -1,0 +1,92 @@
+---
+-- @Liquipedia
+-- wiki=formula1
+-- page=Module:PlayerIntroduction/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local AnOrA = require('Module:A or an')
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local PlayerIntroduction = Lua.import('Module:PlayerIntroduction')
+
+local TRANSFER_STATUS_CURRENT = 'current'
+local TYPE_PLAYER = 'player'
+local INACTIVE_ROLE = 'inactive'
+
+---@class Formula1PlayerIntroduction: PlayerIntroduction
+local CustomPlayerIntroduction = Class.new(PlayerIntroduction)
+
+-- module entry point for PlayerIntroduction
+---@param args playerIntroArgsValues?
+---@return string
+function CustomPlayerIntroduction.run(args)
+	return CustomPlayerIntroduction(args):queryPlayerInfo():queryTransferData(true):adjustData():create()
+end
+
+-- template entry point for PlayerIntroduction
+---@param frame Frame
+---@return string
+function CustomPlayerIntroduction.templatePlayerIntroduction(frame)
+	return CustomPlayerIntroduction.run(Arguments.getArgs(frame))
+end
+
+---@param isCurrentTense boolean
+---@return string
+function CustomPlayerIntroduction:playedOrWorked(isCurrentTense)
+	local playerInfo = self.playerInfo
+	local transferInfo = self.transferInfo
+	local role = self.transferInfo.standardizedRole
+
+	if playerInfo.type ~= TYPE_PLAYER and isCurrentTense then
+		return 'working for'
+	elseif playerInfo.type ~= TYPE_PLAYER then
+		return 'worked for'
+	elseif not isCurrentTense then
+		return 'drove for'
+	elseif transferInfo.role == INACTIVE_ROLE and transferInfo.type == TRANSFER_STATUS_CURRENT then
+		return 'on the inactive roster of'
+	elseif self.options.showRole and role == 'streamer' or role == 'content creator' then
+		return AnOrA.main{role} .. ' for'
+	elseif self.options.showRole and String.isNotEmpty(role) then
+		return 'driving as ' .. AnOrA.main{role} .. ' for'
+	end
+
+	return ' driving for'
+end
+
+---@return string?
+function CustomPlayerIntroduction:typeDisplay()
+	local isNotOfTypePlayer = self.playerInfo.type ~= TYPE_PLAYER
+	local typeDisplay = isNotOfTypePlayer and self.playerInfo.type or 'driver'
+	return self._addConcatText(typeDisplay)
+		.. self._addConcatText(
+			isNotOfTypePlayer and String.isNotEmpty(self.playerInfo.role2) and self.playerInfo.role2 or nil,
+		' and ')
+end
+
+---@return string
+function CustomPlayerIntroduction:nameDisplay()
+	local nameDisplay = '<b>' .. self.playerInfo.id .. '</b>'
+
+	if Table.isNotEmpty(self.playerInfo.formerlyKnownAs) then
+		nameDisplay = nameDisplay .. self._addConcatText('(formerly known as ')
+			.. mw.text.listToText(self.playerInfo.formerlyKnownAs, ', ', ' and ')
+			.. ')'
+	end
+
+	if Table.isNotEmpty(self.playerInfo.alsoKnownAs) then
+		nameDisplay = nameDisplay .. self._addConcatText('(also known as ')
+			.. mw.text.listToText(self.playerInfo.alsoKnownAs, ', ', ' and ')
+			.. ')'
+	end
+
+	return nameDisplay
+end
+
+return CustomPlayerIntroduction


### PR DESCRIPTION
## Summary
Add F1 custom playerIntro.
Basically this switches several displays to use `driver`/`drove`/`drives`/... instead of `player`/`played`/`plays` and adjusts the name display.

## How did you test this change?
dev, under way