### PR TITLE
feat(MatchSummary): Add RIB link support

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -349,6 +349,7 @@ function matchFunctions.getVodStuff(match)
 
 	match.links = {}
 	if match.vlr then match.links.vlr = 'https://vlr.gg/' .. match.vlr end
+	if match.rib then match.links.rib = 'https://rib.gg/series/' .. match.rib end
 
 	return match
 end

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -25,7 +25,7 @@ local NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 local LINK_DATA = {
 	vlr = {icon = 'File:VLR icon.png', text = 'Matchpage and Stats on VLR'},
-	rib = {icon = 'File:RIB icon.png', text = 'Matchpage and Stats on RIB'},
+	rib = {icon = 'File:RIB icon lightmode.png', text = 'Matchpage and Stats on RIB'},
 }
 
 ---@class ValorantAgents

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -25,6 +25,7 @@ local NO_CHECK = '[[File:NoCheck.png|link=]]'
 
 local LINK_DATA = {
 	vlr = {icon = 'File:VLR icon.png', text = 'Matchpage and Stats on VLR'},
+	rib = {icon = 'File:RIB icon.png', text = 'Matchpage and Stats on RIB'},
 }
 
 ---@class ValorantAgents


### PR DESCRIPTION
## Summary

We have VLR on matchpages, and now RIB is becoming more popular as well and thought it would be nice to have their match pages as a link as well. I do contribute on RIB as well, not sure if that counts as a conflict of interest either.

## How did you test this change?

Needs further testing, not sure how to properly test on live so some help would be appreciated, tried to use dev modules
