### PR TITLE
feat(participants): Allow teams in participants table

### DIFF
--- a/components/participant_table/commons/participant_table_base.lua
+++ b/components/participant_table/commons/participant_table_base.lua
@@ -164,7 +164,7 @@ function ParticipantTable:readSection(args)
 	local section = {config = config}
 
 	local entriesByName = {}
-	Table.mapArgumentsByPrefix(args, {'p', 'player', 'team'}, function(key, index)
+	Table.mapArgumentsByPrefix(args, {'p', 'player'}, function(key, index)
 		local entry = self:readEntry(args, key, index, config)
 		if entriesByName[entry.name] then
 			error('Duplicate Input "|' .. key .. '=' .. args[key] .. '"')

--- a/components/participant_table/commons/participant_table_base.lua
+++ b/components/participant_table/commons/participant_table_base.lua
@@ -164,7 +164,7 @@ function ParticipantTable:readSection(args)
 	local section = {config = config}
 
 	local entriesByName = {}
-	Table.mapArgumentsByPrefix(args, {'p', 'player'}, function(key, index)
+	Table.mapArgumentsByPrefix(args, {'p', 'player', 'team'}, function(key, index)
 		local entry = self:readEntry(args, key, index, config)
 		if entriesByName[entry.name] then
 			error('Duplicate Input "|' .. key .. '=' .. args[key] .. '"')
@@ -216,8 +216,7 @@ function ParticipantTable:readEntry(sectionArgs, key, index, config)
 		note = valueFromArgs('note'),
 	}
 
-	assert(Opponent.isType(opponentArgs.type) and opponentArgs.type ~= Opponent.team,
-		'Missing or unsupported opponent type for "' .. sectionArgs[key] .. '"')
+	assert(Opponent.isType(opponentArgs.type), 'Invalid opponent type for "' .. sectionArgs[key] .. '"')
 
 	local opponent = Opponent.readOpponentArgs(opponentArgs) or {}
 


### PR DESCRIPTION
## Summary

Want to be able to use this table for teams too as it's compact and handy for displaying lists of teams that are participating (sometimes grouped) without needing to fill out team cards that have specific seeding assigned to them.

hjpa suggested disable storage for teams, but actually it would be useful to have it working for there too for the reason I mentioned above. Can still manually disable it if not used strictly for creating LPDB placements.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/2aef9798-e5e7-49dc-bdc8-8f7fe865beec)

(sorry for awful screenshot, W11 HDR 👍 )

## How did you test this change?

`/dev` on https://liquipedia.net/counterstrike/Test