### PR TITLE
feat(participants): add CS custom for table

### DIFF
--- a/components/participant_table/wikis/counterstrike/participant_table_custom.lua
+++ b/components/participant_table/wikis/counterstrike/participant_table_custom.lua
@@ -1,0 +1,35 @@
+---
+-- @Liquipedia
+-- wiki=counterstrike
+-- page=Module:ParticipantTable/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local TextSanitizer = require('Module:TextSanitizer')
+local Variables = require('Module:Variables')
+
+local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
+
+local CustomParticipantTable = {}
+
+---@param frame Frame
+---@return Html?
+function CustomParticipantTable.run(frame)
+	local participantTable = ParticipantTable(frame)
+
+	participantTable.adjustLpdbData = CustomParticipantTable.adjustLpdbData
+
+	return participantTable:read():store():create()
+end
+
+---@param lpdbData table
+---@param entry ParticipantTableEntry
+---@param config ParticipantTableConfig
+function CustomParticipantTable:adjustLpdbData(lpdbData, entry, config)
+    lpdbData.qualifier = TextSanitizer.stripHTML(config.title)
+	lpdbData.extradata.status = Variables.varDefault('tournament_status', '')
+end
+
+return CustomParticipantTable


### PR DESCRIPTION
## Summary

Add CS wiki custom for ParticipantTable to adjust some LPDB data that's needed for some templates/modules that read placement LPDB data.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/92fb74b9-4860-4c54-af4e-001ef12e4203)

## How did you test this change?

Live as new module and we don't really use ParticipantTable anywhere already.
