### PR TITLE
Setup Infobox League for Zula

### DIFF
--- a/components/infobox/wikis/zula/infobox_league_custom.lua
+++ b/components/infobox/wikis/zula/infobox_league_custom.lua
@@ -1,0 +1,63 @@
+---
+-- @Liquipedia
+-- wiki=zula
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Game = require('Module:Game')
+local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+---@class SmiteLeagueInfobox: InfoboxLeague
+local CustomLeague = Class.new(League)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		return {
+			Cell{name = 'Number of teams', content = {args.team_number}},
+			Cell{name = 'Number of players', content = {args.player_number}},
+		}
+	elseif id == 'gamesettings' then
+		return {
+			Cell{name = 'Game', content = {Game.name{game = args.game}}},
+		}
+	end
+	return widgets
+end
+
+---@param args table
+---@return boolean
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args.publisherpremier)
+end
+
+---@param args table
+function CustomLeague:customParseArguments(args)
+	self.data.publishertier = tostring(Logic.readBool(args.publisherpremier))
+end
+
+return CustomLeague

--- a/components/infobox/wikis/zula/infobox_league_custom.lua
+++ b/components/infobox/wikis/zula/infobox_league_custom.lua
@@ -17,7 +17,7 @@ local League = Lua.import('Module:Infobox/League')
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 
----@class SmiteLeagueInfobox: InfoboxLeague
+---@class ZulaLeagueInfobox: InfoboxLeague
 local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
 


### PR DESCRIPTION
## Summary
Apparently this was also a lost module that left unadded, this is based on SMITE's recently merged Infobox league.
As ZULA specificly wants just the highlights and the ability to show the different game versions

I would originally ported cod but realize there might be some significant changes needed due to COD is merged for a long time

**On LIVE**