### PR TITLE
Add other game versions to Zula

### DIFF
--- a/standard/info/wikis/zula/info.lua
+++ b/standard/info/wikis/zula/info.lua
@@ -24,6 +24,45 @@ return {
 				lightMode = 'Zula Global default allmode.png',
 			},
 		},
+		global = {
+			abbreviation = 'Global',
+			name = 'Zula Global',
+			link = 'Zula Global',
+			logo = {
+				darkMode = 'Zula Global default allmode.png',
+				lightMode = 'Zula Global default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Zula Global allmode.png',
+				lightMode = 'Zula Global allmode.png',
+			},
+		},
+		oyun = {
+			abbreviation = 'Oyun',
+			name = 'Zula Oyun',
+			link = 'Zula Oyun',
+			logo = {
+				darkMode = 'Zula Oyun allmode.png',
+				lightMode = 'Zula Oyun allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Zula Oyun allmode.png',
+				lightMode = 'Zula Oyun allmode.png',
+			},
+		},
+		europe = {
+			abbreviation = 'Europe',
+			name = 'Zula Europe',
+			link = 'Zula Europe',
+			logo = {
+				darkMode = 'Zula Oyun allmode.png',
+				lightMode = 'Zula Oyun allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Zula Oyun allmode.png',
+				lightMode = 'Zula Oyun allmode.png',
+			},
+		},
 	},
 	defaultGame = 'zula',
 


### PR DESCRIPTION
## Summary
This is part of #4026, Zula has 3 different game versions (in a CS-like manner)

## Note 
Is the line that says **match2 = 2** needs to be removed? I cant remember what it does now