### PR TITLE
fix(FilterButtons) Correctly use values from localstorage

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -75,7 +75,7 @@ liquipedia.filterButtons = {
 					allButton = button;
 				} else {
 					buttons[ filterOn ] = button;
-					filterStates[ filterOn ] = filterStates[ filterOn ] || true;
+					filterStates[ filterOn ] = filterStates[ filterOn ] ?? true;
 				}
 				buttonElement.setAttribute( 'tabindex', '0' );
 			} );


### PR DESCRIPTION
## Summary
Do prevent always setting the filterstate to true on load, use nullish coalescing operator.
Similar assignments could also use this to express intentions, I can't test right now tho.

## How did you test this change?
