### PR TITLE
feat(DateExt): Allow osdate/osdateparam as valid input in some functions

### DIFF
--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -38,8 +38,7 @@ DateExt.defaultYear = '0000'
 function DateExt.readTimestamp(dateString)
 	if type(dateString) == 'table' then
 		-- in this case we have osdate really being osdateparam
-		---@cast dateString osdateparam
-		return tonumber(os.time(dateString))
+		return tonumber(os.time(dateString --[[@as osdateparam]]))
 	end
 
 	if Logic.isEmpty(dateString) then

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -33,26 +33,26 @@ DateExt.defaultYear = '0000'
 --- The timezone offset is incorporated into the timestamp, and the timezone is discarded.
 --- If the timezone is not specified, then the date is assumed to be in UTC.
 --- Throws if the input string is non-empty and not a valid date.
----@param dateString string|number|osdate|osdateparam?
+---@param dateInput string|number|osdate|osdateparam?
 ---@return integer?
-function DateExt.readTimestamp(dateString)
-	if type(dateString) == 'table' then
+function DateExt.readTimestamp(dateInput)
+	if type(dateInput) == 'table' then
 		-- in this case we have osdate really being osdateparam
-		return tonumber(os.time(dateString --[[@as osdateparam]]))
+		return tonumber(os.time(dateInput --[[@as osdateparam]]))
 	end
 
-	if Logic.isEmpty(dateString) then
+	if Logic.isEmpty(dateInput) then
 		return nil
-	elseif type(dateString) == 'number' then
-		return dateString
+	elseif type(dateInput) == 'number' then
+		return dateInput
 	end
 
 	-- everything but strings was processed above
-	---@cast dateString string
+	---@cast dateInput string
 
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>
-	local tzTemplateOffset = dateString:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
-	local datePart = (mw.text.split(dateString, '<', true)[1]):gsub('-', '')
+	local tzTemplateOffset = dateInput:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
+	local datePart = (mw.text.split(dateInput, '<', true)[1]):gsub('-', '')
 	local timestampString = mw.getContentLanguage():formatDate('U', datePart .. (tzTemplateOffset or ''))
 	return tonumber(timestampString)
 end

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -33,17 +33,25 @@ DateExt.defaultYear = '0000'
 --- The timezone offset is incorporated into the timestamp, and the timezone is discarded.
 --- If the timezone is not specified, then the date is assumed to be in UTC.
 --- Throws if the input string is non-empty and not a valid date.
----@param dateString string|number|osdate
+---@param dateString string|number|osdate|osdateparam?
 ---@return integer?
 function DateExt.readTimestamp(dateString)
+	-- due to metatable stuff for osdate empty checks do not work properly on it
+	-- hence check if year, month and day are set instead
+	if type(dateString) == 'table' and dateString.year and dateString.month and dateString.day then
+		-- in this case we have osdate really being osdateparam
+		---@cast dateString osdateparam
+		return tonumber(os.time(dateString))
+	end
+
 	if Logic.isEmpty(dateString) then
 		return nil
 	elseif type(dateString) == 'number' then
 		return dateString
 	end
 
-	---since lua allows osdate to be treated as a string we cast it to be a string here
-	dateString = tostring(dateString)
+	-- everything but strings was processed above
+	---@cast dateString string
 
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>
 	local tzTemplateOffset = dateString:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -33,7 +33,7 @@ DateExt.defaultYear = '0000'
 --- The timezone offset is incorporated into the timestamp, and the timezone is discarded.
 --- If the timezone is not specified, then the date is assumed to be in UTC.
 --- Throws if the input string is non-empty and not a valid date.
----@param dateString string|number
+---@param dateString string|number|osdate
 ---@return integer?
 function DateExt.readTimestamp(dateString)
 	if Logic.isEmpty(dateString) then
@@ -41,6 +41,9 @@ function DateExt.readTimestamp(dateString)
 	elseif type(dateString) == 'number' then
 		return dateString
 	end
+
+	---since lua allows osdate to be treated as a string we cast it to be a string here
+	dateString = tostring(dateString)
 
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>
 	local tzTemplateOffset = dateString:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
@@ -50,7 +53,7 @@ function DateExt.readTimestamp(dateString)
 end
 
 --- Same as DateExt.readTimestamp, except that it returns nil upon failure.
----@param dateString string|number
+---@param dateString string|number|osdate
 ---@return integer?
 function DateExt.readTimestampOrNil(dateString)
 	local success, timestamp = pcall(DateExt.readTimestamp, dateString)
@@ -67,7 +70,7 @@ function DateExt.formatTimestamp(format, timestamp)
 end
 
 --- Converts a date string or timestamp into a format that can be used in the date param to Module:Countdown.
----@param dateOrTimestamp string|integer
+---@param dateOrTimestamp string|integer|osdate
 ---@return string
 function DateExt.toCountdownArg(dateOrTimestamp)
 	local timestamp = DateExt.readTimestamp(dateOrTimestamp)
@@ -76,20 +79,20 @@ end
 
 --- Truncates the time of day in a date string or timestamp, and returns the date formatted as yyyy-mm-dd.
 --- The time of day is truncated in the UTC timezone. The time of day and timezone are discarded.
----@param dateOrTimestamp string|integer
+---@param dateOrTimestamp string|integer|osdate
 ---@return string|number
 function DateExt.toYmdInUtc(dateOrTimestamp)
 	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp) or '')
 end
 
----@param dateString string|integer
+---@param dateString string|integer|osdate
 ---@return boolean
 function DateExt.isDefaultTimestamp(dateString)
 	return DateExt.readTimestamp(dateString) == DateExt.defaultTimestamp
 end
 
----@param dateString string|integer
----@return string|integer?
+---@param dateString string|integer|osdate
+---@return string|integer|osdate?
 function DateExt.nilIfDefaultTimestamp(dateString)
 	return not DateExt.isDefaultTimestamp(dateString) and dateString or nil
 end

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -36,9 +36,7 @@ DateExt.defaultYear = '0000'
 ---@param dateString string|number|osdate|osdateparam?
 ---@return integer?
 function DateExt.readTimestamp(dateString)
-	-- due to metatable stuff for osdate empty checks do not work properly on it
-	-- hence check if year, month and day are set instead
-	if type(dateString) == 'table' and dateString.year and dateString.month and dateString.day then
+	if type(dateString) == 'table' then
 		-- in this case we have osdate really being osdateparam
 		---@cast dateString osdateparam
 		return tonumber(os.time(dateString))


### PR DESCRIPTION
## Summary
Allow osdate/osdateparam as valid input in some dateExt functions

## How did you test this change?
dev