### PR TITLE
fix(hdb): game was always default if no input

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -86,7 +86,12 @@ function HiddenDataBox.run(args)
 	HiddenDataBox.checkAndAssign('tournament_status', args.status, queryResult.status)
 	HiddenDataBox.checkAndAssign('tournament_mode', args.mode, queryResult.mode)
 
-	HiddenDataBox.checkAndAssign('tournament_game', Game.toIdentifier{game = args.game}, queryResult.game)
+	HiddenDataBox.checkAndAssign(
+		'tournament_game',
+		Game.toIdentifier{game = args.game, useDefault = false},
+		queryResult.game
+	)
+
 	HiddenDataBox.checkAndAssign('tournament_parent', parent)
 	HiddenDataBox.checkAndAssign('tournament_parentname', args.parentname, queryResult.name)
 


### PR DESCRIPTION
## Summary

Due to `Game.toIdentifier()` having `useDefault` fall back to true, it meant that if game wasn't supplied to HDB, it would always use the default game for that wiki and never the query result from the parent.

## How did you test this change?

tested on /dev.
