### PR TITLE
feat(filterbuttons): implement optional curated button

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -167,10 +167,10 @@ liquipedia.filterButtons = {
 				}
 			} );
 
+			filterGroup.allButton.active = allState;
 			if ( filterGroup.curatedButton ) {
 				filterGroup.curatedButton.active = filterGroup.curated;
 			}
-			filterGroup.allButton.active = allState;
 
 			filterGroup.filterableItems.forEach( ( filterableItem ) => {
 				if ( filterGroup.curated ) {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -78,14 +78,17 @@ liquipedia.filterButtons = {
 						filter: filterOn,
 						active: true
 					};
-					if ( filterOn === 'all' || filterOn === 'curated' ) {
-						if ( filterOn === 'curated' ) {
+					switch ( filterOn ) {
+						case 'curated':
 							button.curatedGroups = buttonElement.dataset.curatedGroups?.split( ',' ) ?? [];
-						}
-						filterGroupEntry[ filterOn + 'Button' ] = button;
-					} else {
-						filterGroupEntry.buttons[ filterOn ] = button;
-						filterGroupEntry.filterStates[ filterOn ] = filterGroupEntry.filterStates[ filterOn ] ?? true;
+							// fallthrough intended
+						case 'all':
+							filterGroupEntry[ filterOn + 'Button' ] = button;
+							break;
+						default:
+							filterGroupEntry.buttons[ filterOn ] = button;
+							filterGroupEntry.filterStates[ filterOn ] =
+								filterGroupEntry.filterStates[ filterOn ] ?? true;
 					}
 					buttonElement.setAttribute( 'tabindex', '0' );
 				}

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -66,6 +66,7 @@ liquipedia.filterButtons = {
 				alwaysActive: buttonsDiv.dataset.filterAlwaysActive?.split( ',' ) ?? [],
 				effectClass: 'filter-effect-' + ( buttonsDiv.dataset.filterEffect ?? this.fallbackFilterEffect ),
 				filterStates: localStorage[ filterGroup ]?.filterStates ?? {},
+				curated: localStorage[ filterGroup ]?.curated ?? false,
 				filterableItems: []
 			};
 
@@ -78,6 +79,9 @@ liquipedia.filterButtons = {
 						active: true
 					};
 					if ( filterOn === 'all' || filterOn === 'curated' ) {
+						if ( filterOn === 'curated' ) {
+							button.curatedGroups = buttonElement.dataset.curatedGroups?.split( ',' ) ?? [];
+						}
 						filterGroupEntry[ filterOn + 'Button' ] = button;
 					} else {
 						filterGroupEntry.buttons[ filterOn ] = button;
@@ -97,6 +101,7 @@ liquipedia.filterButtons = {
 			filterGroup.filterableItems.push( {
 				element: filterableItem,
 				value: filterableItem.dataset.filterCategory,
+				curated: filterableItem.dataset.curated !== undefined,
 				hidden: false
 			} );
 		} );
@@ -106,30 +111,38 @@ liquipedia.filterButtons = {
 		const handleClick = function( button, filterGroup, event ) {
 			if ( ( event.type === 'click' ) || ( event.type === 'keypress' && event.key === 'Enter' ) ) {
 				liquipedia.tracker.track( 'Filter button clicked: ' + button.element.textContent, true );
-				if ( button.filter === 'all' ) {
-					Object.entries( filterGroup.filterStates ).forEach( ( [ filterState ] ) => {
-						if ( !filterGroup.alwaysActive.includes( filterState ) ) {
-							filterGroup.filterStates[ filterState ] = !button.active;
-						}
-					} );
-				} else {
-					filterGroup.filterStates[ button.filter ] = !button.active;
+				switch ( button.filter ) {
+					case 'all':
+						Object.entries( filterGroup.filterStates ).forEach( ( [ filterState ] ) => {
+							if ( !filterGroup.alwaysActive.includes( filterState ) ) {
+								filterGroup.filterStates[ filterState ] = !button.active;
+							}
+						} );
+						break;
+					case 'curated':
+						button.curatedGroups?.forEach( ( curatableFilterGroup ) => {
+							this.filterGroups[ curatableFilterGroup ].curated = !button.active;
+						} );
+						break;
+					default:
+						filterGroup.filterStates[ button.filter ] = !button.active;
 				}
 				this.performUpdate();
 			}
 		};
 
 		Object.values( this.filterGroups ).forEach( ( filterGroup ) => {
+			const buttons = Object.values( filterGroup.buttons );
+			buttons.push( filterGroup.allButton );
+			if ( filterGroup.curatedButton ) {
+				buttons.push( filterGroup.curatedButton );
+			}
 
-			Object.values( filterGroup.buttons ).forEach( ( button ) => {
+			buttons.forEach( ( button ) => {
 				const buttonEventHandler = handleClick.bind( this, button, filterGroup );
 				button.element.addEventListener( 'click', buttonEventHandler );
 				button.element.addEventListener( 'keypress', buttonEventHandler );
 			} );
-
-			const allEventHandler = handleClick.bind( this, filterGroup.allButton, filterGroup );
-			filterGroup.allButton.element.addEventListener( 'click', allEventHandler );
-			filterGroup.allButton.element.addEventListener( 'keypress', allEventHandler );
 
 		} );
 	},
@@ -142,17 +155,29 @@ liquipedia.filterButtons = {
 
 	updateFromFilterStates: function() {
 		Object.values( this.filterGroups ).forEach( ( filterGroup ) => {
-
 			let allState = true;
+
 			Object.values( filterGroup.buttons ).forEach( ( button ) => {
-				button.active = filterGroup.filterStates[ button.filter ];
-				allState = allState && button.active;
+				if ( filterGroup.curated ) {
+					button.active = false;
+					allState = false;
+				} else {
+					button.active = filterGroup.filterStates[ button.filter ];
+					allState = allState && button.active;
+				}
 			} );
 
+			if ( filterGroup.curatedButton ) {
+				filterGroup.curatedButton.active = filterGroup.curated;
+			}
 			filterGroup.allButton.active = allState;
 
 			filterGroup.filterableItems.forEach( ( filterableItem ) => {
-				filterableItem.hidden = !filterGroup.filterStates[ filterableItem.value ];
+				if ( filterGroup.curated ) {
+					filterableItem.hidden = !filterableItem.curated;
+				} else {
+					filterableItem.hidden = !filterGroup.filterStates[ filterableItem.value ];
+				}
 			} );
 
 		} );
@@ -162,6 +187,9 @@ liquipedia.filterButtons = {
 		Object.values( this.filterGroups ).forEach( ( filterGroup ) => {
 			const buttons = Object.values( filterGroup.buttons );
 			buttons.push( filterGroup.allButton );
+			if ( filterGroup.curatedButton ) {
+				buttons.push( filterGroup.curatedButton );
+			}
 
 			buttons.forEach( ( button ) => {
 				if ( button.active ) {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -226,7 +226,7 @@ liquipedia.filterButtons = {
 	setLocalStorage: function() {
 		const filterGroups = {};
 		Object.values( this.filterGroups ).forEach( ( filterGroup ) => {
-			filterGroups[ filterGroup.name ] = { filterStates: filterGroup.filterStates };
+			filterGroups[ filterGroup.name ] = { filterStates: filterGroup.filterStates, curated: filterGroup.curated };
 		} );
 		window.localStorage.setItem( this.localStorageKey, JSON.stringify( filterGroups ) );
 	}

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -120,12 +120,14 @@ liquipedia.filterButtons = {
 								filterGroup.filterStates[ filterState ] = !button.active;
 							}
 						} );
+						filterGroup.curated = false;
 						break;
 					case 'curated':
 						filterGroup.curated = !button.active;
 						break;
 					default:
 						filterGroup.filterStates[ button.filter ] = !button.active;
+						filterGroup.curated = false;
 				}
 				this.performUpdate();
 			}

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -66,7 +66,7 @@ liquipedia.filterButtons = {
 				alwaysActive: buttonsDiv.dataset.filterAlwaysActive?.split( ',' ) ?? [],
 				effectClass: 'filter-effect-' + ( buttonsDiv.dataset.filterEffect ?? this.fallbackFilterEffect ),
 				filterStates: localStorage[ filterGroup ]?.filterStates ?? {},
-				curated: localStorage[ filterGroup ]?.curated ?? false,
+				curated: localStorage[ filterGroup ]?.curated ?? buttonsDiv.dataset.filterDefaultCurated === 'true',
 				filterableItems: []
 			};
 

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -80,8 +80,6 @@ liquipedia.filterButtons = {
 					};
 					switch ( filterOn ) {
 						case 'curated':
-							button.curatedGroups = buttonElement.dataset.curatedGroups?.split( ',' ) ?? [];
-							// fallthrough intended
 						case 'all':
 							filterGroupEntry[ filterOn + 'Button' ] = button;
 							break;
@@ -124,9 +122,7 @@ liquipedia.filterButtons = {
 						} );
 						break;
 					case 'curated':
-						button.curatedGroups?.forEach( ( curatableFilterGroup ) => {
-							this.filterGroups[ curatableFilterGroup ].curated = !button.active;
-						} );
+						filterGroup.curated = !button.active;
 						break;
 					default:
 						filterGroup.filterStates[ button.filter ] = !button.active;

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -68,6 +68,7 @@ liquipedia.filterButtons = {
 				filterStates: localStorage[ filterGroup ]?.filterStates ?? {},
 				filterableItems: []
 			};
+
 			buttonsDiv.querySelectorAll( ':scope > .filter-button' ).forEach(
 				( /** @type HTMLElement */ buttonElement ) => {
 					const filterOn = buttonElement.dataset.filterOn ?? '';
@@ -76,8 +77,8 @@ liquipedia.filterButtons = {
 						filter: filterOn,
 						active: true
 					};
-					if ( filterOn === 'all' ) {
-						filterGroupEntry.allButton = button;
+					if ( filterOn === 'all' || filterOn === 'curated' ) {
+						filterGroupEntry[ filterOn + 'Button' ] = button;
 					} else {
 						filterGroupEntry.buttons[ filterOn ] = button;
 						filterGroupEntry.filterStates[ filterOn ] = filterGroupEntry.filterStates[ filterOn ] ?? true;

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -88,7 +88,8 @@ liquipedia.filterButtons = {
 						default:
 							filterGroupEntry.buttons[ filterOn ] = button;
 							filterGroupEntry.filterStates[ filterOn ] =
-								filterGroupEntry.filterStates[ filterOn ] ?? true;
+								filterGroupEntry.filterStates[ filterOn ] ??
+									!( buttonElement.dataset.filterDefault === 'false' );
 					}
 					buttonElement.setAttribute( 'tabindex', '0' );
 				}

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -68,21 +68,23 @@ liquipedia.filterButtons = {
 				filterStates: localStorage[ filterGroup ]?.filterStates ?? {},
 				filterableItems: []
 			};
-			buttonsDiv.querySelectorAll( ':scope > .filter-button' ).forEach( ( /** @type HTMLElement */ buttonElement ) => {
-				const filterOn = buttonElement.dataset.filterOn ?? '';
-				const button = {
-					element: buttonElement,
-					filter: filterOn,
-					active: true
-				};
-				if ( filterOn === 'all' ) {
-					filterGroupEntry.allButton = button;
-				} else {
-					filterGroupEntry.buttons[ filterOn ] = button;
-					filterGroupEntry.filterStates[ filterOn ] = filterGroupEntry.filterStates[ filterOn ] ?? true;
+			buttonsDiv.querySelectorAll( ':scope > .filter-button' ).forEach(
+				( /** @type HTMLElement */ buttonElement ) => {
+					const filterOn = buttonElement.dataset.filterOn ?? '';
+					const button = {
+						element: buttonElement,
+						filter: filterOn,
+						active: true
+					};
+					if ( filterOn === 'all' ) {
+						filterGroupEntry.allButton = button;
+					} else {
+						filterGroupEntry.buttons[ filterOn ] = button;
+						filterGroupEntry.filterStates[ filterOn ] = filterGroupEntry.filterStates[ filterOn ] ?? true;
+					}
+					buttonElement.setAttribute( 'tabindex', '0' );
 				}
-				buttonElement.setAttribute( 'tabindex', '0' );
-			} );
+			);
 
 			this.filterGroups[ filterGroup ] = filterGroupEntry;
 		} );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -143,7 +143,6 @@ liquipedia.filterButtons = {
 				button.element.addEventListener( 'click', buttonEventHandler );
 				button.element.addEventListener( 'keypress', buttonEventHandler );
 			} );
-
 		} );
 	},
 
@@ -179,7 +178,6 @@ liquipedia.filterButtons = {
 					filterableItem.hidden = !filterGroup.filterStates[ filterableItem.value ];
 				}
 			} );
-
 		} );
 	},
 
@@ -206,7 +204,6 @@ liquipedia.filterButtons = {
 					filterableItem.element.className = filterGroup.effectClass;
 				}
 			} );
-
 		} );
 	},
 

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -161,14 +161,10 @@ liquipedia.filterButtons = {
 
 	updateDOM: function() {
 		Object.values( this.filterGroups ).forEach( ( filterGroup ) => {
+			const buttons = Object.values( filterGroup.buttons );
+			buttons.push( filterGroup.allButton );
 
-			if ( filterGroup.allButton.active ) {
-				filterGroup.allButton.element.classList.add( this.activeButtonClass );
-			} else {
-				filterGroup.allButton.element.classList.remove( this.activeButtonClass );
-			}
-
-			Object.values( filterGroup.buttons ).forEach( ( button ) => {
+			buttons.forEach( ( button ) => {
 				if ( button.active ) {
 					button.element.classList.add( this.activeButtonClass );
 				} else {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -60,10 +60,14 @@ liquipedia.filterButtons = {
 
 		filterButtonGroups.forEach( ( buttonsDiv ) => {
 			const filterGroup = buttonsDiv.dataset.filterGroup ?? this.fallbackFilterGroup;
-			const filterStates = localStorage[ filterGroup ]?.filterStates ?? {};
-			const alwaysActiveFilters = buttonsDiv.dataset.filterAlwaysActive;
-			const buttons = [];
-			let allButton;
+			const filterGroupEntry = {
+				name: filterGroup,
+				buttons: [],
+				alwaysActive: buttonsDiv.dataset.filterAlwaysActive?.split( ',' ) ?? [],
+				effectClass: 'filter-effect-' + ( buttonsDiv.dataset.filterEffect ?? this.fallbackFilterEffect ),
+				filterStates: localStorage[ filterGroup ]?.filterStates ?? {},
+				filterableItems: []
+			};
 			buttonsDiv.querySelectorAll( ':scope > .filter-button' ).forEach( ( /** @type HTMLElement */ buttonElement ) => {
 				const filterOn = buttonElement.dataset.filterOn ?? '';
 				const button = {
@@ -72,23 +76,15 @@ liquipedia.filterButtons = {
 					active: true
 				};
 				if ( filterOn === 'all' ) {
-					allButton = button;
+					filterGroupEntry.allButton = button;
 				} else {
-					buttons[ filterOn ] = button;
-					filterStates[ filterOn ] = filterStates[ filterOn ] ?? true;
+					filterGroupEntry.buttons[ filterOn ] = button;
+					filterGroupEntry.filterStates[ filterOn ] = filterGroupEntry.filterStates[ filterOn ] ?? true;
 				}
 				buttonElement.setAttribute( 'tabindex', '0' );
 			} );
 
-			this.filterGroups[ filterGroup ] = {
-				name: filterGroup,
-				buttons: buttons,
-				allButton: allButton,
-				alwaysActive: ( typeof alwaysActiveFilters === 'string' ) ? alwaysActiveFilters.split( ',' ) : [],
-				effectClass: 'filter-effect-' + ( buttonsDiv.dataset.filterEffect ?? this.fallbackFilterEffect ),
-				filterStates: filterStates,
-				filterableItems: []
-			};
+			this.filterGroups[ filterGroup ] = filterGroupEntry;
 		} );
 	},
 


### PR DESCRIPTION
## Summary

Adding the functionality to use a new optional "curated" button to instantly swap to a list of tournaments defined by the wiki editors.

* Clicking the button at any point will automatically disable all other filters for that filter group and apply a pre-defined curated list of tournaments. Other filter groups will still apply, so you can further filter the list as you wish.
* Clicking the all button when curated is active will just do the normal all-button functionality.
* Clicking another button when curated is active will enable that button and restore all other buttons to their state before curated was activated.
* All states are remembered even on page reload.

Also re-added missing default filters functionality that I unintentionally overwrote in the previous PR due to it not being applied by a data field but rather the presence/lack of the button `hidden` class.

https://github.com/Liquipedia/Lua-Modules/assets/5881994/0d530f0e-60cc-4ec5-8924-fc4451eb8e76

Lua module changes to go along with this (disabled by default, ofc): https://liquipedia.net/commons/index.php?title=Module%3ATournamentsList%2Fdev&type=revision&diff=554263&oldid=554267

## How did you test this change?

Tested as a user-script and on Darkrai's dev wiki. Tested both with and without curated enabled and seems to function correctly.