### PR TITLE
fix(filterbuttons): keep compatibility with existing classes

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -201,6 +201,7 @@ liquipedia.filterButtons = {
 
 			filterGroup.filterableItems.forEach( ( filterableItem ) => {
 				if ( filterableItem.hidden ) {
+					filterableItem.element.classList.remove( filterGroup.effectClass );
 					filterableItem.element.classList.add( this.hiddenCategoryClass );
 				} else {
 					filterableItem.element.classList.replace( this.hiddenCategoryClass, filterGroup.effectClass );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -48,7 +48,7 @@ liquipedia.filterButtons = {
 		this.localStorageKey = this.buildLocalStorageKey();
 		this.generateFilterGroups( filterButtonGroups );
 		this.generateFilterableItems();
-		this.initalizeButtons();
+		this.initializeButtons();
 		this.performUpdate();
 	},
 
@@ -109,7 +109,7 @@ liquipedia.filterButtons = {
 		} );
 	},
 
-	initalizeButtons: function() {
+	initializeButtons: function() {
 		const handleClick = function( button, filterGroup, event ) {
 			if ( ( event.type === 'click' ) || ( event.type === 'keypress' && event.key === 'Enter' ) ) {
 				liquipedia.tracker.track( 'Filter button clicked: ' + button.element.textContent, true );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -201,9 +201,9 @@ liquipedia.filterButtons = {
 
 			filterGroup.filterableItems.forEach( ( filterableItem ) => {
 				if ( filterableItem.hidden ) {
-					filterableItem.element.className = this.hiddenCategoryClass;
-				} else if ( filterableItem.element.classList.contains( this.hiddenCategoryClass ) ) {
-					filterableItem.element.className = filterGroup.effectClass;
+					filterableItem.element.classList.add( this.hiddenCategoryClass );
+				} else {
+					filterableItem.element.classList.replace( this.hiddenCategoryClass, filterGroup.effectClass );
 				}
 			} );
 		} );


### PR DESCRIPTION
## Summary

In order to maintain compatibility with filters applied directly onto elements with other classes, re-worked how the filter classes are applied to not delete existing classes. Not really a bug as it didn't break anything existing, but want to be able to use them like this for an upcoming project.

## How did you test this change?

Tested on the dev wiki as before.
