### PR TITLE
Update `strikr` link

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -172,7 +172,7 @@ local PREFIXES = {
 	},
 	steam = {'https://steamcommunity.com/id/'},
 	steamtv = {'https://steam.tv/'},
-	strikr = {'https://strikr.gg/pilot/'},
+	strikr = {'https://strikr.pro/'},
 	privsteam = {'https://steamcommunity.com/groups/'},
 	pubsteam = {'https://steamcommunity.com/groups/'},
 	spotify = {'https://open.spotify.com/'},

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -172,7 +172,7 @@ local PREFIXES = {
 	},
 	steam = {'https://steamcommunity.com/id/'},
 	steamtv = {'https://steam.tv/'},
-	strikr = {'https://strikr.pro/'},
+	strikr = {'https://strikr.pro/pilot'},
 	privsteam = {'https://steamcommunity.com/groups/'},
 	pubsteam = {'https://steamcommunity.com/groups/'},
 	spotify = {'https://open.spotify.com/'},

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -172,7 +172,7 @@ local PREFIXES = {
 	},
 	steam = {'https://steamcommunity.com/id/'},
 	steamtv = {'https://steam.tv/'},
-	strikr = {'https://strikr.pro/pilot'},
+	strikr = {'https://strikr.pro/pilot/'},
 	privsteam = {'https://steamcommunity.com/groups/'},
 	pubsteam = {'https://steamcommunity.com/groups/'},
 	spotify = {'https://open.spotify.com/'},


### PR DESCRIPTION
## Summary
Update `strikr` link as per mention on discord by benjastrike
https://discord.com/channels/93055209017729024/268719633366777856/1212824886796488745
> Hi, there is a |strikr= website for playersinfobox, but the domain of the page change to https://strikr.pro/, how can i change that?

## How did you test this change?
N/A