### PR TITLE
Update Strikr link: new domain

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -172,7 +172,7 @@ local PREFIXES = {
 	},
 	steam = {'https://steamcommunity.com/id/'},
 	steamtv = {'https://steam.tv/'},
-	strikr = {'https://strikr.gg/pilot/'},
+	strikr = {'https://strikr.pro/pilot/'},
 	privsteam = {'https://steamcommunity.com/groups/'},
 	pubsteam = {'https://steamcommunity.com/groups/'},
 	spotify = {'https://open.spotify.com/'},


### PR DESCRIPTION
## Summary

https://strikr.gg is no longer up. An approved clone of it has recently been created over at https://strikr.pro, hosted by lukimana and receiving on-going development by me.

## How did you test this change?

Since strikr.pro is a fork, the `strikr.pro/pilot/` route works like `strikr.gg/pilot/` route used to.