### PR TITLE
luacov should be read as a lua file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
 	"files.associations" : {
-		".busted": "lua"
+		".busted": "lua",
+		".luacov": "lua"
 	},
 	"css.validate": false,
 	"less.validate": false,


### PR DESCRIPTION
## Summary

.luacov should be read as a .lua not as a .json