### PR TITLE
fix: error when attribute content is empty on MLBB infobox item

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
@@ -266,7 +266,7 @@ function CustomItem:_getAttributeCells(attributeCells)
 	return Array.map(attributeCells, function(attribute)
 		local funct = attribute.funct or DEFAULT_ATTRIBUTE_DISPLAY_FUNCTION
 		local content = CustomItem[funct](self, attribute.parameter)
-		if String.isEmpty(content) then return end
+		if String.isEmpty(content) then return nil end
 		return Cell{name = attribute.name, content = {content}}
 	end)
 end


### PR DESCRIPTION
## Summary
pass back `nil` instead of nothing so the `table.insert` in `Array.map` doesn't throw

## How did you test this change?
live as bug fix