### PR TITLE
fix: use prefix instead of hardcoded `'map'`

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -158,7 +158,7 @@ end
 ---@param args table
 ---@return {link: string, displayname: string}[]
 function CustomLeague:_getMaps(prefix, args)
-	local maps = Table.map(self:getAllArgsForBase(args, 'map'), function(mapIndex, map)
+	local maps = Table.map(self:getAllArgsForBase(args, prefix), function(mapIndex, map)
 		local mapArray = mw.text.split(map, '|')
 
 		mapArray[1] = (MapsData[mapArray[1]:lower()] or {}).name or mapArray[1]


### PR DESCRIPTION
## Summary
Use prefixvar that gets passed to function instead of hardcoded `'map'` so we actually get different maps for the different map lists

## How did you test this change?
live as bug fix