### PR TITLE
feat: create automated team gallery

### DIFF
--- a/standard/gallery.lua
+++ b/standard/gallery.lua
@@ -28,7 +28,7 @@ function Gallery.run(args)
 	local height = tonumber((string.gsub(args.height or '', 'px$', ''))) or DEFAULT_HEIGHT
 
 	---@param index integer
-	---@return {imageLightMode: string, imageDarkMode: string?, caption: string?, link: string?}?
+	---@return {imageLightMode: string, imageDarkMode: string?, caption: string, below: string|Html?, link: string?}?
 	local processImageInput = function(index)
 		local rawInput = args[index]
 		local input = type(rawInput) == 'table' and rawInput or Json.parseIfTable(args[index])
@@ -43,6 +43,7 @@ function Gallery.run(args)
 			imageDarkMode = input.darkmode,
 			caption = input.caption,
 			link = input.link,
+			below = input.below,
 		}
 	end
 
@@ -60,7 +61,7 @@ function Gallery.run(args)
 	return gallery
 end
 
----@param input {imageLightMode: string, imageDarkMode: string?, caption: string?, link: string?}
+---@param input {imageLightMode: string, imageDarkMode: string?, caption: string, below: string|Html?, link: string?}
 ---@param height number
 ---@return Html
 function Gallery._makeImage(input, height)
@@ -84,14 +85,16 @@ function Gallery._makeImage(input, height)
 			:node(image)
 			:done()
 
-	local text = input.caption and
-		mw.html.create('div'):addClass('gallerytext'):wikitext(input.caption)
+	local text = (input.below or input.caption) and
+		mw.html.create('div'):addClass('gallerytext'):node(input.below or input.caption)
 		or nil
 
 	local extendedWidth = width + 4
 
 	return mw.html.create('li')
 		:addClass('gallerybox')
+		:css('vertical-align', 'top')
+		:css('display', 'inline-block')
 		:css('width', extendedWidth .. 'px')
 		:tag('div')
 			:css('width', extendedWidth .. 'px')

--- a/standard/gallery.lua
+++ b/standard/gallery.lua
@@ -30,7 +30,8 @@ function Gallery.run(args)
 	---@param index integer
 	---@return {imageLightMode: string, imageDarkMode: string?, caption: string?, link: string?}?
 	local processImageInput = function(index)
-		local input = Json.parseIfTable(args[index])
+		local rawInput = args[index]
+		local input = type(rawInput) == 'table' and rawInput or Json.parseIfTable(args[index])
 		if Logic.isEmpty(input) then return end
 		---@cast input -nil
 

--- a/standard/gallery.lua
+++ b/standard/gallery.lua
@@ -1,0 +1,114 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Gallery
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Image = require('Module:Image')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+
+local DEFAULT_HEIGHT = 200
+
+local Gallery = {}
+
+function Gallery.template(frame)
+	return Gallery.run(Arguments.getArgs(frame))
+end
+
+---@param args table?
+---@return Html?
+function Gallery.run(args)
+	args = args or {}
+
+	local height = tonumber((string.gsub(args.height or '', 'px$', ''))) or DEFAULT_HEIGHT
+
+	---@param index integer
+	---@return {imageLightMode: string, imageDarkMode: string?, caption: string?, link: string?}?
+	local processImageInput = function(index)
+		local input = Json.parseIfTable(args[index])
+		if Logic.isEmpty(input) then return end
+		---@cast input -nil
+
+		local imageLightMode = input.lightmode or input[1]
+		if Logic.isEmpty(imageLightMode) then return end
+
+		return {
+			imageLightMode = imageLightMode,
+			imageDarkMode = input.darkmode,
+			caption = input.caption,
+			link = input.link,
+		}
+	end
+
+	local images = Array.mapIndexes(processImageInput)
+
+	if Logic.isEmpty(images) then return end
+
+	local gallery = mw.html.create('ul')
+		:addClass('gallery mw-gallery-packed')
+
+	Array.forEach(images, function(imageData)
+		gallery:node(Gallery._makeImage(imageData, height))
+	end)
+
+	return gallery
+end
+
+---@param input {imageLightMode: string, imageDarkMode: string?, caption: string?, link: string?}
+---@param height number
+---@return Html
+function Gallery._makeImage(input, height)
+	local imageLightMode = input.imageLightMode
+	local imageDarkMode = input.imageDarkMode
+
+	local width = Gallery._calculateWidth(imageLightMode, height)
+
+	local image = Image.display(imageLightMode, imageDarkMode, {
+		link = input.link,
+		alt = input.caption,
+		caption = input.caption,
+		size = width,
+	})
+
+	local thumb = mw.html.create('div')
+		:addClass('thumb')
+		:css('width', width .. 'px')
+		:tag('div')
+			:css('margin', '0px auto')
+			:node(image)
+			:done()
+
+	local text = input.caption and
+		mw.html.create('div'):addClass('gallerytext'):wikitext(input.caption)
+		or nil
+
+	local extendedWidth = width + 4
+
+	return mw.html.create('li')
+		:addClass('gallerybox')
+		:css('width', extendedWidth .. 'px')
+		:tag('div')
+			:css('width', extendedWidth .. 'px')
+			:node(thumb)
+			:node(text)
+		:done()
+end
+
+---@param imageLightMode string
+---@param height number
+---@return number
+function Gallery._calculateWidth(imageLightMode, height)
+	local title = mw.title.new('File:' .. imageLightMode)
+	assert(title, '"File:' .. imageLightMode .. '" does not exist')
+	local fileInfo = title.file
+	local fileWidth = tonumber(fileInfo.width)
+	local fileHeight = tonumber(fileInfo.height)
+	return math.ceil(height * fileWidth / fileHeight)
+end
+
+return Gallery

--- a/standard/team_logo_gallery.lua
+++ b/standard/team_logo_gallery.lua
@@ -83,7 +83,8 @@ function TeamLogoGallery._makeCaptionAndBelow(imageData, endDate, index, finalNa
 		return caption, caption
 	end
 
-	local number = index == 1 and 'Original' or Ordinal.written(index)
+	local number = index == 1 and 'Original' or
+		mw.getContentLanguage():ucfirst(Ordinal.written(index) --[[@as string]])
 
 	local caption = number .. ' logo'
 	local below = mw.html.create('p')
@@ -102,7 +103,7 @@ function TeamLogoGallery._makeCaptionAndBelow(imageData, endDate, index, finalNa
 	local month = DateExt.formatTimestamp('F', DateExt.readTimestamp(endDate)--[[@as integer]])
 	local dateArray = mw.text.split(endDate, '-', true)
 	local year = dateArray[1]
-	local day = dateArray[3]
+	local day = tonumber(dateArray[3])
 	local daySuffix = Ordinal.suffix(day)
 
 	caption = caption .. ' (prior to ' .. month .. ' ' .. day .. daySuffix .. ', ' .. year .. ')'
@@ -112,7 +113,7 @@ function TeamLogoGallery._makeCaptionAndBelow(imageData, endDate, index, finalNa
 		:tag('small')
 			:wikitext('(prior to ' .. month .. '&nbsp;' .. day)
 			:tag('sup'):wikitext(daySuffix):done()
-			:wikitext(',&nbsp;' .. year)
+			:wikitext(',&nbsp;' .. year .. ')')
 
 	return caption, below
 end

--- a/standard/team_logo_gallery.lua
+++ b/standard/team_logo_gallery.lua
@@ -1,0 +1,120 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:TeamLogoGallery
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
+local Gallery = require('Module:Gallery')
+local Game = require('Module:Game')
+local Logic = require('Module:Logic')
+local Ordinal = require('Module:Ordinal')
+local Table = require('Module:Table')
+local Team = require('Module:Team')
+
+local TeamLogoGallery = {}
+
+---@param args table?
+---@return Html?
+function TeamLogoGallery.run(args)
+	args = args or {}
+	local name = (args.name or mw.title.getCurrentTitle().prefixedText):gsub('_', ' '):lower()
+
+	assert(mw.ext.TeamTemplate.teamexists(name), 'Missing team template "' .. name .. '"')
+
+	local imageData = TeamLogoGallery._getImageData(name)
+
+	return Gallery.run(imageData)
+end
+
+---@param name string
+---@return {imageLightMode: string, imageDarkMode: string?, caption: string}[]
+function TeamLogoGallery._getImageData(name)
+	local historicalTeamTemplates = Logic.emptyOr(Team.queryHistorical(name)) or {[DateExt.defaultDate] = name}
+
+	local imageDatas = {}
+	for startDate, teamTemplate in Table.iter.spairs(historicalTeamTemplates) do
+		table.insert(imageDatas, {
+			startDate = startDate,
+			raw = mw.ext.TeamTemplate.raw(teamTemplate)
+		})
+	end
+
+	local finalName = imageDatas[#imageDatas].raw.name
+
+	return Array.map(imageDatas, function(imageData, index)
+		local image = Logic.emptyOr(imageData.raw.image, imageData.raw.legacyimage)
+		if not image or Game.isDefaultTeamLogo{logo = image} then
+			return nil
+		end
+
+		local previous = imageDatas[index - 1] or {raw = {}}
+		local previousImage = Logic.emptyOr(previous.raw.image, previous.raw.legacyimage)
+		if previousImage == image then
+			return nil
+		end
+
+		local nextStartDate = (imageDatas[index + 1] or {}).startDate
+
+		local caption, below = TeamLogoGallery._makeCaptionAndBelow(imageData, nextStartDate, index, finalName)
+
+		return {
+			lightmode = image,
+			darkmode = Logic.emptyOr(imageData.raw.imagedark, imageData.raw.legacyimagedark),
+			caption = caption,
+			below = below,
+		}
+	end)
+end
+
+---@param imageData {startDate: string, raw: table}
+---@param endDate string?
+---@param index integer
+---@param finalName string
+---@return string
+---@return Html|string
+function TeamLogoGallery._makeCaptionAndBelow(imageData, endDate, index, finalName)
+	if not endDate then
+		local caption = 'Current logo'
+		return caption, caption
+	end
+
+	local number = index == 1 and 'Original' or Ordinal.written(index)
+
+	local caption = number .. ' logo'
+	local below = mw.html.create('p')
+		:wikitext(caption)
+
+	local teamName = imageData.raw.name
+	if teamName ~= finalName then
+		caption = caption .. ', as ' .. teamName
+		below:wikitext(', as '):tag('b'):wikitext(teamName)
+	end
+
+	if not endDate then
+		return caption, below
+	end
+
+	local month = DateExt.formatTimestamp('F', DateExt.readTimestamp(endDate)--[[@as integer]])
+	local dateArray = mw.text.split(endDate, '-', true)
+	local year = dateArray[1]
+	local day = dateArray[3]
+	local daySuffix = Ordinal.suffix(day)
+
+	caption = caption .. ' (prior to ' .. month .. ' ' .. day .. daySuffix .. ', ' .. year .. ')'
+
+	below
+		:tag('br', {selfClosing = true}):done()
+		:tag('small')
+			:wikitext('(prior to ' .. month .. '&nbsp;' .. day)
+			:tag('sup'):wikitext(daySuffix):done()
+			:wikitext(',&nbsp;' .. year)
+
+	return caption, below
+end
+
+return Class.export(TeamLogoGallery)


### PR DESCRIPTION
## Summary
- `Module:Gallery` builds a gallery display without using the extension.
- `Module:TeamLogoGallery` builds a gallery of the teams team logos
  - uses (historical) team templates and `Module:Gallery`

## How did you test this change?
"live" as new modules