### PR TITLE
fix: typo in annotation class

### DIFF
--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -916,7 +916,7 @@ mw.ext = {}
 mw.ext.LiquipediaDB = require('definitions.liquipedia_db')
 
 mw.ext.VariablesLua = {}
----@alias wikiVaribleKey string|number
+---@alias wikiVariableKey string|number
 ---@alias wikiVariableValue string|number|nil
 
 ---Fake storage for enviroment simulation
@@ -924,7 +924,7 @@ mw.ext.VariablesLua = {}
 mw.ext.VariablesLua.variablesStorage = {}
 
 ---Stores a wiki-variable and returns the empty string
----@param name wikiVaribleKey
+---@param name wikiVariableKey
 ---@param value wikiVariableValue
 ---@return string #always an empty string
 function mw.ext.VariablesLua.vardefine(name, value)
@@ -933,7 +933,7 @@ function mw.ext.VariablesLua.vardefine(name, value)
 end
 
 ---Stores a wiki-variable and returns the stored value
----@param name wikiVaribleKey Key of the wiki-variable
+---@param name wikiVariableKey Key of the wiki-variable
 ---@param value wikiVariableValue Value of the wiki-variable
 ---@return string
 function mw.ext.VariablesLua.vardefineecho(name, value)
@@ -942,14 +942,14 @@ function mw.ext.VariablesLua.vardefineecho(name, value)
 end
 
 ---Gets the stored value of a wiki-variable
----@param name wikiVaribleKey Key of the wiki-variable
+---@param name wikiVariableKey Key of the wiki-variable
 ---@return string
 function mw.ext.VariablesLua.var(name)
 	return mw.ext.VariablesLua.variablesStorage[name] and tostring(mw.ext.VariablesLua.variablesStorage[name]) or ''
 end
 
 ---Checks if a wiki-variable is stored
----@param name wikiVaribleKey Key of the wiki-variable
+---@param name wikiVariableKey Key of the wiki-variable
 ---@return boolean
 function mw.ext.VariablesLua.varexist(name)
 	return mw.ext.VariablesLua.variablesStorage[name] ~= nil

--- a/standard/page_variable_namespace.lua
+++ b/standard/page_variable_namespace.lua
@@ -16,19 +16,19 @@ local Namespace = Class.new(function(self, prefix)
 	self.prefix = prefix
 end)
 
----@param key wikiVaribleKey
+---@param key wikiVariableKey
 ---@return string?
 function Namespace:get(key)
 	return StringUtils.nilIfEmpty(mw.ext.VariablesLua.var(self.prefix .. key))
 end
 
----@param key wikiVaribleKey
+---@param key wikiVariableKey
 ---@param value wikiVariableValue
 function Namespace:set(key, value)
 	mw.ext.VariablesLua.vardefine(self.prefix .. key, Logic.emptyOr(value))
 end
 
----@param key wikiVaribleKey
+---@param key wikiVariableKey
 function Namespace:delete(key)
 	self:set(key, nil)
 end

--- a/standard/variables.lua
+++ b/standard/variables.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local Variables = {}
 
 ---Stores a wiki-variable and returns the empty string
----@param name wikiVaribleKey Key of the wiki-variable
+---@param name wikiVariableKey Key of the wiki-variable
 ---@param value wikiVariableValue Value of the wiki-variable
 ---@return string #always the empty string
 function Variables.varDefine(name, value)
@@ -19,7 +19,7 @@ function Variables.varDefine(name, value)
 end
 
 ---Stores a wiki-variable and returns the stored value
----@param name wikiVaribleKey Key of the wiki-variable
+---@param name wikiVariableKey Key of the wiki-variable
 ---@param value wikiVariableValue Value of the wiki-variable
 ---@return string
 function Variables.varDefineEcho(name, value)
@@ -28,17 +28,17 @@ end
 
 ---Gets the stored value of a wiki-variable
 ---@generic T
----@param name wikiVaribleKey Key of the wiki-variable
+---@param name wikiVariableKey Key of the wiki-variable
 ---@param default T fallback value if wiki-variable is not defined
 ---@return string|T
----@overload fun(name: wikiVaribleKey):string?
+---@overload fun(name: wikiVariableKey):string?
 function Variables.varDefault(name, default)
 	local val = mw.ext.VariablesLua.var(name)
 	return (val ~= '' and val ~= nil) and val or default
 end
 
 ---
----@param ... wikiVaribleKey wiki-variable keys
+---@param ... wikiVariableKey wiki-variable keys
 ---@return string
 function Variables.varDefaultMulti(...)
 	--pack varargs
@@ -55,7 +55,7 @@ function Variables.varDefaultMulti(...)
 	return varargs[varargs.n]
 end
 
----@param name wikiVaribleKey Key of the wiki-variable
+---@param name wikiVariableKey Key of the wiki-variable
 ---@return boolean
 function Variables.varExists(name)
 	return Variables.varDefault(name) ~= nil


### PR DESCRIPTION
## Summary
`wikiVaribleKey` --> `wikiVariableKey`

## How did you test this change?
N/A