### PR TITLE
fix: add missing `}}` in sg match copy paste

### DIFF
--- a/components/match2/wikis/stormgate/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/stormgate/get_match_group_copy_paste_wiki.lua
@@ -97,7 +97,7 @@ end
 ---@param hasHeroes boolean
 ---@return string
 function WikiCopyPaste._mapDetails(opponents, mode, hasHeroes)
-	if mode[1] == Opponent.literal or not hasHeroes then return '' end
+	if mode[1] == Opponent.literal or not hasHeroes then return '}}' end
 	local lines = {''}
 
 	Array.forEach(Array.range(1, opponents), function(opponentIndex)


### PR DESCRIPTION
## Summary
fix: add missing `}}` in sg match copy paste

## How did you test this change?
live as bug fix