### PR TITLE
fix(RL HDB): remove anno warning

### DIFF
--- a/components/hidden_data_box/wikis/rocketleague/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/rocketleague/hidden_data_box_custom.lua
@@ -11,7 +11,7 @@ local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
 local BasicHiddenDataBox = Lua.import('Module:HiddenDataBox')
-local CustomLeague = Lua.import('Module:Infobox/League/Custom')
+local CustomLeague = Lua.import('Module:Infobox/League/Custom') ---@type RocketleagueLeagueInfobox
 local CustomHiddenDataBox = {}
 
 ---@param args table


### PR DESCRIPTION
## Summary
Fix an annotation warning in rl hdb by telling it which custom infobox league it uses

## How did you test this change?
VSCode