### PR TITLE
BR - Change padding for placements and kills

### DIFF
--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -189,7 +189,7 @@ Author(s): Elysienna
 				display: flex;
 				justify-content: center;
 				align-items: center;
-				padding: 0.75rem 0;
+				padding: 0.5rem 0;
 				background-color: #fafafa;
 			}
 
@@ -198,7 +198,7 @@ Author(s): Elysienna
 				display: flex;
 				justify-content: center;
 				align-items: center;
-				padding: 0.75rem 0;
+				padding: 0.5rem 0;
 
 				.panel-table__row:not( .row--header ) & {
 					background-color: #ffffff;


### PR DESCRIPTION
## Summary

As requested, the padding in the BR tables for placements and kills is reduced to 0.5rem.

## How did you test this change?

Chrome dev tools
