### PR TITLE
Add styles for `sfrac` template

### DIFF
--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -5215,6 +5215,38 @@ Author(s): Scribunto developer(s)
 }
 
 /*******************************************************************************
+Author(s): Hjpalpha, based on a template copied from Wikipedia
+Template: Sfrac
+*******************************************************************************/
+.sfrac {
+	display: inline-block;
+	font-size: 85%;
+	text-align: center;
+}
+
+.sfrac .numerator{
+	display: block;
+	line-height: 1em;
+	margin: 0 0.1em;
+}
+
+.sfrac .denominator{
+	display: block;
+	line-height: 1em;
+	margin: 0 0.1em;
+	border-top: 1px solid;
+}
+
+.sfrac .frac{
+	position: absolute;
+	left: -10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}
+
+/*******************************************************************************
 Hexagon portraits
 Use case: Hexagon shaped portraits originally created for /heroes/Portal:Heroes
 Author(s): PhiLtheFisH, FO-nTTaX, salle

--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -5224,20 +5224,20 @@ Template: Sfrac
 	text-align: center;
 }
 
-.sfrac .numerator{
+.sfrac .numerator {
 	display: block;
 	line-height: 1em;
 	margin: 0 0.1em;
 }
 
-.sfrac .denominator{
+.sfrac .denominator {
 	display: block;
 	line-height: 1em;
 	margin: 0 0.1em;
 	border-top: 1px solid;
 }
 
-.sfrac .frac{
+.sfrac .frac {
 	position: absolute;
 	left: -10000px;
 	top: auto;


### PR DESCRIPTION
## Summary
Add styles for `sfrac` template so we can get rid of the hardcoded color (border top/bottom).

## How did you test this change?
secret commons