### PR TITLE
fix(wc match2 copy paste): add missing `}}` for literal opponents map details

### DIFF
--- a/components/match2/wikis/warcraft/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/warcraft/get_match_group_copy_paste_wiki.lua
@@ -98,7 +98,7 @@ end
 ---@return string
 ---@diagnostic disable-next-line: inject-field
 function WikiCopyPaste._mapDetails(opponents, mode)
-	if mode[1] == Opponent.literal then return '' end
+	if mode[1] == Opponent.literal then return '}}' end
 	local lines = {''}
 
 	Array.forEach(Array.range(1, opponents), function(opponentIndex)


### PR DESCRIPTION
## Summary
fix(wc match2 copy paste): add missing `}}` for literal opponents map details

## How did you test this change?
live