### PR TITLE
fix: Add matchsection to match1 extradata

### DIFF
--- a/components/match2/wikis/ageofempires/match_legacy.lua
+++ b/components/match2/wikis/ageofempires/match_legacy.lua
@@ -103,8 +103,11 @@ function MatchLegacy._convertParameters(match2)
 
 	match.staticid = match2.match2id
 
+	local extradata = Json.parseIfString(match2.extradata)
 	-- Handle extradata fields
-	match.extradata = {}
+	match.extradata = {
+		matchsection = extradata.matchsection or '',
+	}
 
 	match.extradata.bestof = match2.bestof ~= 0 and tostring(match2.bestof) or ''
 	local bracketData = Json.parseIfString(match2.match2bracketdata)


### PR DESCRIPTION
## Summary

Add matchsection to match1 extradata to make match2 compatible with `SwissTableLeagueTeam`.
[discord](https://discord.com/channels/93055209017729024/268719633366777856/1215956299791994932)

## How did you test this change?

live
