### PR TITLE
fix: Use hero name alias in arenaofvalor

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -53,6 +53,9 @@ local mapFunctions = {}
 local CustomMatchGroupInput = {}
 
 -- called from Module:MatchGroup
+---@param match table
+---@param options table?
+---@return table
 function CustomMatchGroupInput.processMatch(match, options)
 	-- Count number of maps, check for empty maps to remove, and automatically count score
 	match = matchFunctions.getBestOf(match)
@@ -74,6 +77,8 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
+---@param match table
+---@return table
 function matchFunctions.adjustMapData(match)
 	local opponents = {}
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
@@ -89,6 +94,8 @@ function matchFunctions.adjustMapData(match)
 end
 
 -- called from Module:Match/Subobjects
+---@param map table
+---@return table
 function CustomMatchGroupInput.processMap(map)
 	if map.map == DUMMY_MAP then
 		map.map = nil
@@ -98,6 +105,8 @@ function CustomMatchGroupInput.processMap(map)
 	return map
 end
 
+---@param record table
+---@param timestamp number
 function CustomMatchGroupInput.processOpponent(record, timestamp)
 	local opponent = Opponent.readOpponentArgs(record)
 		or Opponent.blank()
@@ -121,6 +130,8 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 end
 
 -- called from Module:Match/Subobjects
+---@param player table
+---@return table
 function CustomMatchGroupInput.processPlayer(player)
 	return player
 end
@@ -128,6 +139,8 @@ end
 --
 --
 -- function to check for draws
+---@param tbl table[]
+---@return boolean
 function CustomMatchGroupInput.placementCheckDraw(tbl)
 	local last
 	for _, scoreInfo in pairs(tbl) do
@@ -144,6 +157,10 @@ function CustomMatchGroupInput.placementCheckDraw(tbl)
 	return true
 end
 
+---@param data table
+---@param indexedScores table[]
+---@return table
+---@return table[]
 function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match wasn't played, set not played
 	if
@@ -185,6 +202,12 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	return data, indexedScores
 end
 
+---@param opponents table[]
+---@param winner nil
+---@param specialType nil
+---@param finished nil
+---@return table[]
+---@return number?
 function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, finished)
 	if specialType == 'draw' then
 		for key, _ in pairs(opponents) do
@@ -223,6 +246,10 @@ function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, fini
 	return opponents, winner
 end
 
+---@param tbl table
+---@param key1 string
+---@param key2 string
+---@return boolean
 function CustomMatchGroupInput.placementSortFunction(tbl, key1, key2)
 	local value1 = tonumber(tbl[key1].score or NO_SCORE) or NO_SCORE
 	local value2 = tonumber(tbl[key2].score or NO_SCORE) or NO_SCORE
@@ -230,6 +257,8 @@ function CustomMatchGroupInput.placementSortFunction(tbl, key1, key2)
 end
 
 -- Check if any opponent has a none-standard status
+---@param tbl table[]
+---@return boolean
 function CustomMatchGroupInput.placementCheckSpecialStatus(tbl)
 	return Table.any(tbl,
 		function (_, scoreinfo)
@@ -239,21 +268,29 @@ function CustomMatchGroupInput.placementCheckSpecialStatus(tbl)
 end
 
 -- function to check for forfeits
+---@param tbl table[]
+---@return boolean
 function CustomMatchGroupInput.placementCheckFF(tbl)
 	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == STATUS_FORFEIT end)
 end
 
 -- function to check for DQ's
+---@param tbl table[]
+---@return boolean
 function CustomMatchGroupInput.placementCheckDQ(tbl)
 	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == STATUS_DISQUALIFIED end)
 end
 
 -- function to check for W/L
+---@param tbl table[]
+---@return boolean
 function CustomMatchGroupInput.placementCheckWL(tbl)
 	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == STATUS_DEFAULT_LOSS end)
 end
 
 -- Get the winner when resulttype=default
+---@param tbl table[]
+---@return number
 function CustomMatchGroupInput.getDefaultWinner(tbl)
 	for index, scoreInfo in pairs(tbl) do
 		if scoreInfo.status == STATUS_DEFAULT_WIN then
@@ -266,6 +303,8 @@ end
 --
 -- match related functions
 --
+---@param match table
+---@return table
 function matchFunctions.getBestOf(match)
 	match.bestof = Logic.emptyOr(match.bestof, Variables.varDefault('bestof', DEFAULT_BESTOF))
 	Variables.varDefine('bestof', match.bestof)
@@ -276,6 +315,8 @@ end
 -- Only update an opponents result if it's
 -- 1) Not manually added
 -- 2) At least one map has a winner
+---@param match table
+---@return table
 function matchFunctions.getScoreFromMapWinners(match)
 	local newScores = {}
 	local foundScores = false
@@ -299,6 +340,9 @@ function matchFunctions.getScoreFromMapWinners(match)
 	return match
 end
 
+---comment
+---@param matchArgs table
+---@return { date: string, dateexact: boolean, timestamp: integer, timezoneId: string?, timezoneOffset: string? }
 function matchFunctions.readDate(matchArgs)
 	return MatchGroupInput.readDate(matchArgs.date, {
 		'tournament_enddate',
@@ -306,12 +350,16 @@ function matchFunctions.readDate(matchArgs)
 	})
 end
 
+---@param match table
+---@return table
 function matchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', DEFAULT_MODE))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 
+---@param match table
+---@return table
 function matchFunctions.getVodStuff(match)
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
@@ -323,6 +371,8 @@ function matchFunctions.getVodStuff(match)
 	return match
 end
 
+---@param match table
+---@return table
 function matchFunctions.getExtraData(match)
 	match.extradata = {
 		mvp = MatchGroupInput.readMvp(match),
@@ -330,6 +380,8 @@ function matchFunctions.getExtraData(match)
 	return match
 end
 
+---@param match table
+---@return table
 function matchFunctions.getOpponents(match)
 	-- read opponents and ignore empty ones
 	local opponents = {}
@@ -417,6 +469,9 @@ function matchFunctions.getOpponents(match)
 	return match
 end
 
+---@param opponents table
+---@param walkoverType string
+---@return table
 function matchFunctions._makeAllOpponentsLoseByWalkover(opponents, walkoverType)
 	for index, _ in pairs(opponents) do
 		opponents[index].score = NOT_PLAYED_SCORE
@@ -430,6 +485,8 @@ end
 --
 
 -- Parse extradata information
+---@param map table
+---@return table
 function mapFunctions.getAdditionalExtraData(map)
 	map.extradata.comment = map.comment
 	map.extradata.team1side = string.lower(map.team1side or '')
@@ -439,6 +496,9 @@ function mapFunctions.getAdditionalExtraData(map)
 end
 
 -- Parse participant information
+---@param map table
+---@param opponents table
+---@return table
 function mapFunctions.getParticipants(map, opponents)
 	local participants = {}
 	local championData = {}
@@ -477,6 +537,11 @@ function mapFunctions.getParticipants(map, opponents)
 	return mapFunctions.getAdditionalExtraData(map)
 end
 
+---@param player string
+---@param opponentIndex integer
+---@param players table[]?
+---@param participants table
+---@return table
 function mapFunctions.attachToParticipant(player, opponentIndex, players, participants, champion, kda)
 	player = mw.ext.TeamLiquidIntegration.resolve_redirect(player):gsub(' ', '_')
 	for playerIndex, item in pairs(players or {}) do
@@ -493,6 +558,8 @@ function mapFunctions.attachToParticipant(player, opponentIndex, players, partic
 end
 
 -- Calculate Score and Winner of the map
+---@param map table
+---@return table
 function mapFunctions.getScoresAndWinner(map)
 	map.scores = {}
 	local indexedScores = {}

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -203,9 +203,9 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 end
 
 ---@param opponents table[]
----@param winner nil
----@param specialType nil
----@param finished nil
+---@param winner number
+---@param specialType string?
+---@param finished boolean?
 ---@return table[]
 ---@return number?
 function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, finished)
@@ -303,6 +303,7 @@ end
 --
 -- match related functions
 --
+
 ---@param match table
 ---@return table
 function matchFunctions.getBestOf(match)
@@ -340,9 +341,8 @@ function matchFunctions.getScoreFromMapWinners(match)
 	return match
 end
 
----comment
 ---@param matchArgs table
----@return { date: string, dateexact: boolean, timestamp: integer, timezoneId: string?, timezoneOffset: string? }
+---@return {date: string, dateexact: boolean, timestamp: integer, timezoneId: string?, timezoneOffset: string? }
 function matchFunctions.readDate(matchArgs)
 	return MatchGroupInput.readDate(matchArgs.date, {
 		'tournament_enddate',
@@ -469,9 +469,9 @@ function matchFunctions.getOpponents(match)
 	return match
 end
 
----@param opponents table
+---@param opponents table[]
 ---@param walkoverType string
----@return table
+---@return table[]
 function matchFunctions._makeAllOpponentsLoseByWalkover(opponents, walkoverType)
 	for index, _ in pairs(opponents) do
 		opponents[index].score = NOT_PLAYED_SCORE
@@ -497,7 +497,7 @@ end
 
 -- Parse participant information
 ---@param map table
----@param opponents table
+---@param opponents table[]
 ---@return table
 function mapFunctions.getParticipants(map, opponents)
 	local participants = {}
@@ -541,6 +541,8 @@ end
 ---@param opponentIndex integer
 ---@param players table[]?
 ---@param participants table
+---@param champion string?
+---@param kda string?
 ---@return table
 function mapFunctions.attachToParticipant(player, opponentIndex, players, participants, champion, kda)
 	player = mw.ext.TeamLiquidIntegration.resolve_redirect(player):gsub(' ', '_')

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -20,29 +20,29 @@ local Streams = require('Module:Links/Stream')
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
 local Opponent = Lua.import('Module:Opponent')
 
-local _STATUS_SCORE = 'S'
-local _STATUS_DRAW = 'D'
-local _STATUS_DEFAULT_WIN = 'W'
-local _STATUS_FORFEIT = 'FF'
-local _STATUS_DISQUALIFIED = 'DQ'
-local _STATUS_DEFAULT_LOSS = 'L'
-local _ALLOWED_STATUSES = {
-	_STATUS_DRAW,
-	_STATUS_DEFAULT_WIN,
-	_STATUS_FORFEIT,
-	_STATUS_DISQUALIFIED,
-	_STATUS_DEFAULT_LOSS,
+local STATUS_SCORE = 'S'
+local STATUS_DRAW = 'D'
+local STATUS_DEFAULT_WIN = 'W'
+local STATUS_FORFEIT = 'FF'
+local STATUS_DISQUALIFIED = 'DQ'
+local STATUS_DEFAULT_LOSS = 'L'
+local ALLOWED_STATUSES = {
+	STATUS_DRAW,
+	STATUS_DEFAULT_WIN,
+	STATUS_FORFEIT,
+	STATUS_DISQUALIFIED,
+	STATUS_DEFAULT_LOSS,
 }
-local _MAX_NUM_OPPONENTS = 2
-local _MAX_NUM_PLAYERS = 5
-local _DEFAULT_BESTOF = 3
-local _DEFAULT_MODE = 'team'
-local _NO_SCORE = -99
-local _DUMMY_MAP = 'default'
-local _NP_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
-local _DEFAULT_RESULT_TYPE = 'default'
-local _NOT_PLAYED_SCORE = -1
-local _NO_WINNER = -1
+local MAX_NUM_OPPONENTS = 2
+local MAX_NUM_PLAYERS = 5
+local DEFAULT_BESTOF = 3
+local DEFAULT_MODE = 'team'
+local NO_SCORE = -99
+local DUMMY_MAP = 'default'
+local NP_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
+local DEFAULT_RESULT_TYPE = 'default'
+local NOT_PLAYED_SCORE = -1
+local NO_WINNER = -1
 local NOW = os.time(os.date('!*t') --[[@as osdateparam]])
 
 
@@ -76,7 +76,7 @@ end
 
 function matchFunctions.adjustMapData(match)
 	local opponents = {}
-	for opponentIndex = 1, _MAX_NUM_OPPONENTS do
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		opponents[opponentIndex] = match['opponent' .. opponentIndex]
 	end
 	local mapIndex = 1
@@ -90,7 +90,7 @@ end
 
 -- called from Module:Match/Subobjects
 function CustomMatchGroupInput.processMap(map)
-	if map.map == _DUMMY_MAP then
+	if map.map == DUMMY_MAP then
 		map.map = nil
 	end
 	map = mapFunctions.getScoresAndWinner(map)
@@ -131,7 +131,7 @@ end
 function CustomMatchGroupInput.placementCheckDraw(tbl)
 	local last
 	for _, scoreInfo in pairs(tbl) do
-		if scoreInfo.status ~= _STATUS_SCORE and scoreInfo.status ~= _STATUS_DRAW then
+		if scoreInfo.status ~= STATUS_SCORE and scoreInfo.status ~= STATUS_DRAW then
 			return false
 		end
 		if last and last ~= scoreInfo.score then
@@ -147,8 +147,8 @@ end
 function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match wasn't played, set not played
 	if
-		Table.includes(_NP_STATUSES, data.finished) or
-		Table.includes(_NP_STATUSES, data.winner)
+		Table.includes(NP_STATUSES, data.finished) or
+		Table.includes(NP_STATUSES, data.winner)
 	then
 		data.resulttype = 'np'
 		data.finished = true
@@ -161,7 +161,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
 		elseif CustomMatchGroupInput.placementCheckSpecialStatus(indexedScores) then
 			data.winner = CustomMatchGroupInput.getDefaultWinner(indexedScores)
-			data.resulttype = _DEFAULT_RESULT_TYPE
+			data.resulttype = DEFAULT_RESULT_TYPE
 			if CustomMatchGroupInput.placementCheckFF(indexedScores) then
 				data.walkover = 'ff'
 			elseif CustomMatchGroupInput.placementCheckDQ(indexedScores) then
@@ -169,7 +169,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 			elseif CustomMatchGroupInput.placementCheckWL(indexedScores) then
 				data.walkover = 'l'
 			end
-			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, _DEFAULT_RESULT_TYPE)
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, DEFAULT_RESULT_TYPE)
 		else
 			local winner
 			indexedScores, winner = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, nil, data.finished)
@@ -190,7 +190,7 @@ function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, fini
 		for key, _ in pairs(opponents) do
 			opponents[key].placement = 1
 		end
-	elseif specialType == _DEFAULT_RESULT_TYPE then
+	elseif specialType == DEFAULT_RESULT_TYPE then
 		for key, _ in pairs(opponents) do
 			if key == winner then
 				opponents[key].placement = 1
@@ -199,8 +199,8 @@ function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, fini
 			end
 		end
 	else
-		local lastScore = _NO_SCORE
-		local lastPlacement = _NO_SCORE
+		local lastScore = NO_SCORE
+		local lastPlacement = NO_SCORE
 		local counter = 0
 		for scoreIndex, opp in Table.iter.spairs(opponents, CustomMatchGroupInput.placementSortFunction) do
 			local score = tonumber(opp.score)
@@ -215,7 +215,7 @@ function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, fini
 			else
 				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement or '') or counter
 				lastPlacement = counter
-				lastScore = score or _NO_SCORE
+				lastScore = score or NO_SCORE
 			end
 		end
 	end
@@ -224,8 +224,8 @@ function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, fini
 end
 
 function CustomMatchGroupInput.placementSortFunction(tbl, key1, key2)
-	local value1 = tonumber(tbl[key1].score or _NO_SCORE) or _NO_SCORE
-	local value2 = tonumber(tbl[key2].score or _NO_SCORE) or _NO_SCORE
+	local value1 = tonumber(tbl[key1].score or NO_SCORE) or NO_SCORE
+	local value2 = tonumber(tbl[key2].score or NO_SCORE) or NO_SCORE
 	return value1 > value2
 end
 
@@ -233,41 +233,41 @@ end
 function CustomMatchGroupInput.placementCheckSpecialStatus(tbl)
 	return Table.any(tbl,
 		function (_, scoreinfo)
-			return scoreinfo.status ~= _STATUS_SCORE and String.isNotEmpty(scoreinfo.status)
+			return scoreinfo.status ~= STATUS_SCORE and String.isNotEmpty(scoreinfo.status)
 		end
 	)
 end
 
 -- function to check for forfeits
 function CustomMatchGroupInput.placementCheckFF(tbl)
-	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == _STATUS_FORFEIT end)
+	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == STATUS_FORFEIT end)
 end
 
 -- function to check for DQ's
 function CustomMatchGroupInput.placementCheckDQ(tbl)
-	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == _STATUS_DISQUALIFIED end)
+	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == STATUS_DISQUALIFIED end)
 end
 
 -- function to check for W/L
 function CustomMatchGroupInput.placementCheckWL(tbl)
-	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == _STATUS_DEFAULT_LOSS end)
+	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == STATUS_DEFAULT_LOSS end)
 end
 
 -- Get the winner when resulttype=default
 function CustomMatchGroupInput.getDefaultWinner(tbl)
 	for index, scoreInfo in pairs(tbl) do
-		if scoreInfo.status == _STATUS_DEFAULT_WIN then
+		if scoreInfo.status == STATUS_DEFAULT_WIN then
 			return index
 		end
 	end
-	return _NO_WINNER
+	return NO_WINNER
 end
 
 --
 -- match related functions
 --
 function matchFunctions.getBestOf(match)
-	match.bestof = Logic.emptyOr(match.bestof, Variables.varDefault('bestof', _DEFAULT_BESTOF))
+	match.bestof = Logic.emptyOr(match.bestof, Variables.varDefault('bestof', DEFAULT_BESTOF))
 	Variables.varDefine('bestof', match.bestof)
 	return match
 end
@@ -284,13 +284,13 @@ function matchFunctions.getScoreFromMapWinners(match)
 	while match['map'..mapIndex] do
 		local winner = tonumber(match['map'..mapIndex].winner)
 		foundScores = true
-		if winner and winner > 0 and winner <= _MAX_NUM_OPPONENTS then
+		if winner and winner > 0 and winner <= MAX_NUM_OPPONENTS then
 			newScores[winner] = (newScores[winner] or 0) + 1
 		end
 		mapIndex = mapIndex + 1
 	end
 
-	for index = 1, _MAX_NUM_OPPONENTS do
+	for index = 1, MAX_NUM_OPPONENTS do
 		if not match['opponent' .. index].score and foundScores then
 			match['opponent' .. index].score = newScores[index] or 0
 		end
@@ -307,7 +307,7 @@ function matchFunctions.readDate(matchArgs)
 end
 
 function matchFunctions.getTournamentVars(match)
-	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', _DEFAULT_MODE))
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', DEFAULT_MODE))
 	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
@@ -334,7 +334,7 @@ function matchFunctions.getOpponents(match)
 	-- read opponents and ignore empty ones
 	local opponents = {}
 	local isScoreSet = false
-	for opponentIndex = 1, _MAX_NUM_OPPONENTS do
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		-- read opponent
 		local opponent = match['opponent' .. opponentIndex]
 		if not Logic.isEmpty(opponent) then
@@ -344,11 +344,11 @@ function matchFunctions.getOpponents(match)
 			opponent.score = string.upper(opponent.score or '')
 			if Logic.isNumeric(opponent.score) then
 				opponent.score = tonumber(opponent.score)
-				opponent.status = _STATUS_SCORE
+				opponent.status = STATUS_SCORE
 				isScoreSet = true
-			elseif Table.includes(_ALLOWED_STATUSES, opponent.score) then
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
 				opponent.status = opponent.score
-				opponent.score = _NOT_PLAYED_SCORE
+				opponent.score = NOT_PLAYED_SCORE
 			end
 
 			-- get players from vars for teams
@@ -357,7 +357,7 @@ function matchFunctions.getOpponents(match)
 					match = MatchGroupInput.readPlayersOfTeam(match, opponentIndex, opponent.name, {
 						resolveRedirect = true,
 						applyUnderScores = true,
-						maxNumPlayers = _MAX_NUM_PLAYERS,
+						maxNumPlayers = MAX_NUM_PLAYERS,
 					})
 				end
 			elseif Opponent.typeIsParty(opponent.type) then
@@ -375,13 +375,13 @@ function matchFunctions.getOpponents(match)
 	match.walkover = string.upper(match.walkover or '')
 	if Logic.isNumeric(match.walkover) then
 		local winnerIndex = tonumber(match.walkover)
-		opponents = matchFunctions._makeAllOpponentsLoseByWalkover(opponents, _STATUS_DEFAULT_LOSS)
-		opponents[winnerIndex].status = _STATUS_DEFAULT_WIN
+		opponents = matchFunctions._makeAllOpponentsLoseByWalkover(opponents, STATUS_DEFAULT_LOSS)
+		opponents[winnerIndex].status = STATUS_DEFAULT_WIN
 		match.finished = true
-	elseif Logic.isNumeric(match.winner) and Table.includes(_ALLOWED_STATUSES, match.walkover) then
+	elseif Logic.isNumeric(match.winner) and Table.includes(ALLOWED_STATUSES, match.walkover) then
 		local winnerIndex = tonumber(match.winner)
 		opponents = matchFunctions._makeAllOpponentsLoseByWalkover(opponents, match.walkover)
-		opponents[winnerIndex].status = _STATUS_DEFAULT_WIN
+		opponents[winnerIndex].status = STATUS_DEFAULT_WIN
 		match.finished = true
 	end
 
@@ -419,7 +419,7 @@ end
 
 function matchFunctions._makeAllOpponentsLoseByWalkover(opponents, walkoverType)
 	for index, _ in pairs(opponents) do
-		opponents[index].score = _NOT_PLAYED_SCORE
+		opponents[index].score = NOT_PLAYED_SCORE
 		opponents[index].status = walkoverType
 	end
 	return opponents
@@ -442,8 +442,8 @@ end
 function mapFunctions.getParticipants(map, opponents)
 	local participants = {}
 	local championData = {}
-	for opponentIndex = 1, _MAX_NUM_OPPONENTS do
-		for playerIndex = 1, _MAX_NUM_PLAYERS do
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		for playerIndex = 1, MAX_NUM_PLAYERS do
 			local champ = map['t' .. opponentIndex .. 'h' .. playerIndex]
 			championData['team' .. opponentIndex .. 'champion' .. playerIndex] =
 				ChampionNames[champ and champ:lower()]
@@ -496,19 +496,19 @@ end
 function mapFunctions.getScoresAndWinner(map)
 	map.scores = {}
 	local indexedScores = {}
-	for scoreIndex = 1, _MAX_NUM_OPPONENTS do
+	for scoreIndex = 1, MAX_NUM_OPPONENTS do
 		-- read scores
 		local score = map['score' .. scoreIndex] or map['t' .. scoreIndex .. 'score']
 		local obj = {}
 		if not Logic.isEmpty(score) then
 			if Logic.isNumeric(score) then
-				obj.status = _STATUS_SCORE
+				obj.status = STATUS_SCORE
 				score = tonumber(score)
 				map['score' .. scoreIndex] = score
 				obj.score = score
-			elseif Table.includes(_ALLOWED_STATUSES, score) then
+			elseif Table.includes(ALLOWED_STATUSES, score) then
 				obj.status = score
-				obj.score = _NOT_PLAYED_SCORE
+				obj.score = NOT_PLAYED_SCORE
 			end
 			table.insert(map.scores, score)
 			indexedScores[scoreIndex] = obj

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -495,6 +495,18 @@ function mapFunctions.getAdditionalExtraData(map)
 	return map
 end
 
+---@param champion string?
+---@return string?
+function mapFunctions.getChampionName(champion)
+	if Logic.isNotEmpty(champion) then
+		local championName = ChampionNames[champion and champion:lower()]
+		assert(championName, 'Invalid hero:' .. champion)
+		return championName
+	end
+
+	return nil
+end
+
 -- Parse participant information
 ---@param map table
 ---@param opponents table[]
@@ -504,9 +516,10 @@ function mapFunctions.getParticipants(map, opponents)
 	local championData = {}
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		for playerIndex = 1, MAX_NUM_PLAYERS do
-			local champ = map['t' .. opponentIndex .. 'h' .. playerIndex]
-			championData['team' .. opponentIndex .. 'champion' .. playerIndex] =
-				ChampionNames[champ and champ:lower()]
+			local pick = mapFunctions.getChampionName(map['t' .. opponentIndex .. 'h' .. playerIndex])
+			championData['team' .. opponentIndex .. 'champion' .. playerIndex] = pick
+			local ban = mapFunctions.getChampionName(map['t' .. opponentIndex .. 'b' .. playerIndex])
+			championData['team' .. opponentIndex .. 'ban' .. playerIndex] = ban
 
 			championData['t' .. opponentIndex .. 'kda' .. playerIndex] =
 				map['t' .. opponentIndex .. 'kda' .. playerIndex]
@@ -522,13 +535,6 @@ function mapFunctions.getParticipants(map, opponents)
 					championData['team' .. opponentIndex .. 'kda' .. playerIndex]
 				)
 			end
-		end
-		local banIndex = 1
-		local currentBan = map['t' .. opponentIndex .. 'b' .. banIndex]
-		while currentBan do
-			championData['team' .. opponentIndex .. 'ban' .. banIndex] = ChampionNames[currentBan and currentBan:lower()]
-			banIndex = banIndex + 1
-			currentBan = map['t' .. opponentIndex .. 'b' .. banIndex]
 		end
 	end
 

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -446,7 +446,7 @@ function mapFunctions.getParticipants(map, opponents)
 		for playerIndex = 1, _MAX_NUM_PLAYERS do
 			local champ = map['t' .. opponentIndex .. 'h' .. playerIndex]
 			championData['team' .. opponentIndex .. 'champion' .. playerIndex] =
-				ChampionNames[champ] or champ
+				ChampionNames[champ and champ:lower()]
 
 			championData['t' .. opponentIndex .. 'kda' .. playerIndex] =
 				map['t' .. opponentIndex .. 'kda' .. playerIndex]
@@ -466,7 +466,7 @@ function mapFunctions.getParticipants(map, opponents)
 		local banIndex = 1
 		local currentBan = map['t' .. opponentIndex .. 'b' .. banIndex]
 		while currentBan do
-			championData['team' .. opponentIndex .. 'ban' .. banIndex] = ChampionNames[currentBan] or currentBan
+			championData['team' .. opponentIndex .. 'ban' .. banIndex] = ChampionNames[currentBan and currentBan:lower()]
 			banIndex = banIndex + 1
 			currentBan = map['t' .. opponentIndex .. 'b' .. banIndex]
 		end


### PR DESCRIPTION
## Summary

Make use of [Module:HeroNames](https://liquipedia.net/arenaofvalor/Module:HeroNames) to map a possible hero alias to its real "name".
Only commit 076c553aaec581c5dbe799e9397f8a629a15ed2f represents the change.

## How did you test this change?

dev
