### PR TITLE
Enable syncPlayer for CoC Processing

### DIFF
--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -97,7 +97,7 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 		teamTemplateDate = Variables.varDefaultMulti('tournament_enddate', 'tournament_startdate', NOW)
 	end
 
-	Opponent.resolve(opponent, teamTemplateDate)
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer=true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 


### PR DESCRIPTION
This is for events that using Duo or Solo opponents, to have flags automatically tracked on brackets or matchlists. As Clash of Clans start having more non-team events 

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/7dfaded5-ecec-4e7c-afee-2fd4ce253365)
