### PR TITLE
fix(css) recent-matches-publishertier darkmode compatibility

### DIFF
--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -4442,15 +4442,15 @@ Author(s): hjpalpha
 }
 
 .recent-matches-left-publishertier {
-	background-image: linear-gradient( to left, #fbdfdf 25%, #ffffcc 45%, #ffffff 55%, #ddf4dd 75% ) !important;
+	background-image: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --publisher-premier-highlight-background-color, #ffffcc ) 45%, var( --publisher-premier-highlight-background-color, #ffffcc ) 55%, var( --clr-forestgreen-background-color, #ddf4dd ) 75% ) !important;
 }
 
 .recent-matches-right-publishertier {
-	background-image: linear-gradient( to right, #fbdfdf 25%, #ffffcc 45%, #ffffff 55%, #ddf4dd 75% ) !important;
+	background-image: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --publisher-premier-highlight-background-color, #ffffcc ) 45%, var( --publisher-premier-highlight-background-color, #ffffcc ) 55%, var( --clr-forestgreen-background-color, #ddf4dd ) 75% ) !important;
 }
 
 .recent-matches-draw-publishertier {
-	background-image: linear-gradient( to left, #f9f9c7 25%, #ffffcc 45%, #ffffff 55%, #f9f9c7 75% ) !important;
+	background-image: linear-gradient( to left, var( --clr-pear-background-color, #f9f9c7 ) 25%, var( --publisher-premier-highlight-background-color, #ffffcc ) 45%, var( --publisher-premier-highlight-background-color, #ffffcc ) 55%, var( --clr-pear-background-color, #f9f9c7 ) 75% ) !important;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
## Summary
Some matchtickers (e.g. valorant) apply highlighting to publishertier matches.
This makes the already defined classes darkmode compatible, using the same variables as the non-publishertier versions combined with the usual highlighting color.

## How did you test this change?
inspector:
Before:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/89b8fe28-e5de-4654-8231-c8a3d72b60fa)
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/4ba404f2-0e81-42af-9972-708fb5493b26)
After:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/3eedceff-f1c8-482a-8b68-f7f698901ac3)
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/0613834f-b6f7-4c78-8d1e-6cebbed2d3f1)

