### PR TITLE
fix(match2) Various match2 improvements on AoE

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -299,7 +299,7 @@ function CustomMatchGroupInput._mapInput(match, mapIndex)
 			end)
 			if info then
 				map.map = info.link
-				map.mapDisplayName = info.name
+				map.mapDisplayName = info.name or info.link
 			end
 		else
 			map.mapDisplayName = map.map
@@ -319,6 +319,16 @@ function CustomMatchGroupInput._mapInput(match, mapIndex)
 
 	-- determine score, resulttype, walkover and winner
 	map = CustomMatchGroupInput._mapWinnerProcessing(map)
+
+	-- Init score if match started and map info is present
+	if not match.opponent1.autoscore and not match.opponent2.autoscore
+			and map.map and map.map ~= 'TBD'
+			and match.timestamp < os.time(os.date('!*t'))
+			and String.isNotEmpty(map.civs1) and String.isNotEmpty(map.civs2) then
+		match.opponent1.autoscore = 0
+		match.opponent2.autoscore = 0
+	end
+
 	if Logic.isEmpty(map.resulttype) and map.scores[1] and map.scores[2] then
 		match.opponent1.autoscore = (match.opponent1.autoscore or 0) + map.scores[1]
 		match.opponent2.autoscore = (match.opponent2.autoscore or 0) + map.scores[2]

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -299,7 +299,7 @@ function CustomMatchGroupInput._mapInput(match, mapIndex)
 			end)
 			if info then
 				map.map = info.link
-				map.mapDisplayName = info.name or info.link
+				map.mapDisplayName = info.name
 			end
 		else
 			map.mapDisplayName = map.map

--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -52,7 +52,7 @@ end
 ---@param match MatchGroupUtilMatch
 ---@return string
 function CustomMatchSummary._determineWidth(match)
-	return CustomMatchSummary._isSolo(match) and '285px' or '550px'
+	return CustomMatchSummary._isSolo(match) and '350px' or '550px'
 end
 
 ---@param match MatchGroupUtilMatch
@@ -70,7 +70,7 @@ function CustomMatchSummary.createBody(match)
 		if not game.map and not game.winner then return end
 		local row = MatchSummary.Row()
 				:addClass('brkts-popup-body-game')
-				:css('font-size', '84%')
+				:css('font-size', '0.75rem')
 				:css('padding', '4px')
 				:css('min-height', '24px')
 
@@ -149,7 +149,6 @@ function CustomMatchSummary._createGame(row, game, props)
 			local player = CustomMatchSummary._getPlayerData(game, participantId)
 			local playerNode = PlayerDisplay.BlockPlayer{player = player, flip = flipped}
 			local factionNode = CustomMatchSummary._createFactionIcon(player.civ, normGame)
-
 			return mw.html.create('div'):css('display', 'flex'):css('align-self', flipped and 'end' or 'start')
 				:node(flipped and playerNode or factionNode)
 				:wikitext('&nbsp;')
@@ -200,8 +199,8 @@ function CustomMatchSummary._createCheckMark(winner, opponentIndex)
 	return mw.html.create('div')
 			:addClass('brkts-popup-spaced')
 			:css('line-height', '17px')
-			:css('margin-left', '1%')
-			:css('margin-right', '1%')
+			:css('margin-left', opponentIndex == 1 and '10%' or '1%')
+			:css('margin-right', opponentIndex == 2 and '10%' or '1%')
 			:wikitext(
 				winner == opponentIndex and GREEN_CHECK
 				or winner == 0 and DRAW_LINE or NO_CHECK

--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -168,12 +168,12 @@ function CustomMatchSummary._createGame(row, game, props)
 
 	row
 			:addElement(faction1)
-			:addElement(CustomMatchSummary._createCheckMark(game.winner, 1))
+			:addElement(CustomMatchSummary._createCheckMark(game.winner, 1, props.soloMode))
 			:addElement(mw.html.create('div')
 				:addClass('brkts-popup-spaced'):css('flex-grow', '1')
 				:wikitext(DisplayHelper.MapAndStatus(game))
 			)
-			:addElement(CustomMatchSummary._createCheckMark(game.winner, 2))
+			:addElement(CustomMatchSummary._createCheckMark(game.winner, 2, props.soloMode))
 			:addElement(faction2)
 end
 
@@ -195,12 +195,12 @@ end
 ---@param winner integer|string
 ---@param opponentIndex integer
 ---@return Html
-function CustomMatchSummary._createCheckMark(winner, opponentIndex)
+function CustomMatchSummary._createCheckMark(winner, opponentIndex, soloMode)
 	return mw.html.create('div')
 			:addClass('brkts-popup-spaced')
 			:css('line-height', '17px')
-			:css('margin-left', opponentIndex == 1 and '10%' or '1%')
-			:css('margin-right', opponentIndex == 2 and '10%' or '1%')
+			:css('margin-left', (opponentIndex == 1 and soloMode) and '10%' or '1%')
+			:css('margin-right', (opponentIndex == 2 and soloMode) and '10%' or '1%')
 			:wikitext(
 				winner == opponentIndex and GREEN_CHECK
 				or winner == 0 and DRAW_LINE or NO_CHECK


### PR DESCRIPTION
## Summary
- Contributors requested initialized score if match has started and a map has details entered.
- Width change necessary due do long names otherwise overflowing.
- Font and margin changes to be more similar to match1 popups.

## How did you test this change?
via dev
Visual changes, before:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/2a496af6-c395-41f8-abab-2ea36b3967d5)
After: 
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/584355b5-2ec2-4293-a0fc-fd181251099f)

