### PR TITLE
feat(match2): add casters display to CrossFire

### DIFF
--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -286,7 +286,8 @@ end
 
 function matchFunctions.getExtraData(match)
 	match.extradata = {
-		mvp = MatchGroupInput.readMvp(match)
+		mvp = MatchGroupInput.readMvp(match),
+		casters = MatchGroupInput.readCasters(match, {noSort = true})
 	}
 	return match
 end

--- a/components/match2/wikis/crossfire/match_summary.lua
+++ b/components/match2/wikis/crossfire/match_summary.lua
@@ -8,6 +8,7 @@
 
 local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapModes = require('Module:MapModes')
@@ -77,6 +78,17 @@ function CustomMatchSummary.createBody(match)
 			body:addRow(mvp)
 		end
 
+	end
+
+	-- casters
+	if String.isNotEmpty(match.extradata.casters) then
+		local casters = Json.parseIfString(match.extradata.casters)
+		local casterRow = MatchSummary.Casters()
+		for _, caster in pairs(casters) do
+			casterRow:addCaster(caster)
+		end
+
+		body:addRow(casterRow)
 	end
 
 	return body


### PR DESCRIPTION
To allow Casters to be input and display in match summary ( `|casterX=Y` ) like this:
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/0488ee4e-8ace-4529-9486-a644753769cc)

Requested by an editor from the CrossFire wiki (the request actually includes MVP, but that one already exists): 
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/3f861b9d-bc31-4be6-9c3f-464c172a49fd)


tested on dev=1
 