### PR TITLE
fix(tabs): edge cases failing

### DIFF
--- a/components/match2/wikis/leagueoflegends/big_match.lua
+++ b/components/match2/wikis/leagueoflegends/big_match.lua
@@ -298,7 +298,7 @@ end
 function BigMatch.render(model)
 	return mw.html.create('div')
 		:wikitext(BigMatch.header(model))
-		:wikitext(BigMatch.games(model))
+		:node(BigMatch.games(model))
 		:wikitext(BigMatch.footer(model))
 end
 

--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -230,8 +230,8 @@ function Tabs._single(tab, showHeader)
 	local header
 	if showHeader then
 		header = mw.html.create()
-			:newline()
 			:tag('h6'):wikitext(tab.name):done()
+			:newline()
 	end
 	return mw.html.create()
 		:node(header)

--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -58,7 +58,6 @@ end
 function Tabs.dynamic(args)
 	args = args or {}
 
-	args.This = tonumber(args.This) or 1
 	local tabArgs = Tabs._readArguments(args, {removeEmptyTabs = Logic.readBool(args.removeEmptyTabs)})
 	local tabCount = #tabArgs
 	if tabCount == 0 then return end
@@ -73,6 +72,10 @@ function Tabs.dynamic(args)
 
 	local tabs = mw.html.create('ul')
 		:addClass('nav nav-tabs tabs tabs' .. tabCount)
+
+	if not Array.any(tabArgs, Operator.property('this')) then
+		tabArgs[1].this = true
+	end
 
 	---@param obj Html
 	---@param elementType string

--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -69,7 +69,7 @@ function Tabs.dynamic(args)
 		return Logic.isEmpty(tab.content) end)
 	assert(hasContent or allEmpty, 'Some of the tabs have contents while others do not')
 
-	if tabCount == 1 and hasContent then return Tabs._single(tabArgs[1]) end
+	if tabCount == 1 and hasContent then return Tabs._single(tabArgs[1], not Logic.readBool(args.suppressHeader)) end
 
 	local tabs = mw.html.create('ul')
 		:addClass('nav nav-tabs tabs tabs' .. tabCount)
@@ -221,10 +221,17 @@ function Tabs._buildContentDiv(hasContent, hybridTabs, noPadding)
 end
 
 ---@param tab {name: string?, link: string?, content: string|Html?, tabs: string|Html?, this: boolean}
+---@param showHeader boolean
 ---@return Html
-function Tabs._single(tab)
+function Tabs._single(tab, showHeader)
+	local header
+	if showHeader then
+		header = mw.html.create()
+			:newline()
+			:tag('h6'):wikitext(tab.name):done()
+	end
 	return mw.html.create()
-		:tag('h6'):wikitext(tab.name):done()
+		:node(header)
 		:node(tab.content)
 end
 


### PR DESCRIPTION
## Summary
- git consumers now accept html returns instead of only strings
- `this` edge case (if first tab is empty in tabs dynamic)
- misisng new line in `_single`
- option to suppress header in `_single`

## How did you test this change?
dev