### PR TITLE
Change single-tab behaviour

### DIFF
--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -68,7 +68,8 @@ function Tabs.dynamic(args)
 		return Logic.isEmpty(tab.content) end)
 	assert(hasContent or allEmpty, 'Some of the tabs have contents while others do not')
 
-	if tabCount == 1 and hasContent then return Tabs._single(tabArgs[1], not Logic.readBool(args.suppressHeader)) end
+	local isSingular = tabCount == 1 and hasContent
+	if isSingular and Logic.readBool(args.reduceSingle) then return Tabs._single(tabArgs[1], not Logic.readBool(args.suppressHeader)) end
 
 	local tabs = mw.html.create('ul')
 		:addClass('nav nav-tabs tabs tabs' .. tabCount)

--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -97,7 +97,7 @@ function Tabs.dynamic(args)
 		build(tabs, 'li', tabData.name, 'tab' .. tabIndex, tabData.this)
 	end)
 
-	if Logic.nilOr(Logic.readBoolOrNil(args['hide-showall']), true) then
+	if not isSingular and Logic.nilOr(Logic.readBoolOrNil(args['hide-showall']), true) then
 		tabs:tag('li')
 			:addClass('show-all')
 			:wikitext('Show All')


### PR DESCRIPTION
## Summary

Change the new tab behaviour to be opt-in.
* Keeps tab sections of a standardised format across pages on a wiki regardless of whether there is only one dynamic tab.

Only show "show all" if there is more to show.
* Reduces redundancy.

## How did you test this change?

/dev
