### PR TITLE
feat(match2) Allow multiple drafts for AoE

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -106,10 +106,15 @@ end
 
 ---@param match table
 function CustomMatchGroupInput._getLinks(match)
-	match.links = {
-		civdraft = match.civdraft and ('https://aoe2cm.net/draft/' .. match.civdraft) or nil,
-		mapdraft = match.mapdraft and ('https://aoe2cm.net/draft/' .. match.mapdraft) or nil,
-	}
+	match.links = {}
+	match.civdraft1 = match.civdraft1 or match.civdraft
+	for key, value in Table.iter.pairsByPrefix(match, 'civdraft') do
+		match.links[key] = 'https://aoe2cm.net/draft/' .. value
+	end
+	match.mapdraft1 = match.mapdraft1 or match.mapdraft
+	for key, value in Table.iter.pairsByPrefix(match, 'mapdraft') do
+		match.links[key] = 'https://aoe2cm.net/draft/' .. value
+	end
 end
 
 ---@param match table

--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -91,7 +91,19 @@ end
 function CustomMatchSummary.addToFooter(match, footer)
 	footer = MatchSummary.addVodsToFooter(match, footer)
 
-	footer:addLinks(LINKDATA, match.links)
+	local addLinks = function(linkType)
+		local currentLinkData = LINKDATA[linkType]
+		if not currentLinkData then
+			mw.log('Unknown link: ' .. linkType)
+			return
+		end
+		for _, link in Table.iter.pairsByPrefix(match.links, linkType) do
+			footer:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text)
+		end
+	end
+	
+	addLinks('mapdraft')
+	addLinks('civdraft')
 
 	if not Logic.readBool(match.extradata.headtohead) or not CustomMatchSummary._isSolo(match) then
 		return footer

--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -101,7 +101,7 @@ function CustomMatchSummary.addToFooter(match, footer)
 			footer:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text)
 		end
 	end
-	
+
 	addLinks('mapdraft')
 	addLinks('civdraft')
 


### PR DESCRIPTION
## Summary
Some tournaments have multiple map- or civdrafts for a single match (especially AoE4 ones), this adds support for adding them.
Also ensures mapdrafts are listed before civdrafts.

## How did you test this change?
dev
