### PR TITLE
docs(match2): Input processings commons + sc(2)

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -158,7 +158,7 @@ end
 ---and removes direct references between a match record and its subobject records.
 ---@param match table
 ---@return {matchRecord: table, gameRecords: table[], opponentRecords: table[], playerRecords: table[]}
----@overload fun(match: any): {}
+---@overload fun(match: table): {}
 function Match.splitRecordsByType(match)
 	if match == nil or type(match) ~= 'table' then
 		return {}
@@ -211,7 +211,7 @@ end
 ---to `list`. Sets the original location (so in `match`) to `nil`.
 ---@param match table
 ---@param list table[]
----@param typePrefix any
+---@param typePrefix string
 ---@return table[]
 function Match._moveRecordsFromMatchToList(match, list, typePrefix)
 	for key, item in Table.iter.pairsByPrefix(match, typePrefix) do
@@ -247,7 +247,7 @@ subobject records, while copying the other objects like match.match2bracketdata
 and opponent.extradata by reference. Assumes that subobject references have
 been normalized (in Match.normalizeSubobjectReferences).
 ]]
----@param matchRecord any
+---@param matchRecord table
 ---@return table
 function Match.copyRecords(matchRecord)
 	return Table.merge(matchRecord, {
@@ -369,8 +369,8 @@ function Match._getSection()
 	return lastHeading
 end
 
----@param matchRecord any
----@param gameRecord any
+---@param matchRecord table
+---@param gameRecord table
 function Match._prepareGameRecordForStore(matchRecord, gameRecord)
 	gameRecord.parent = matchRecord.parent
 	gameRecord.tournament = matchRecord.tournament

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -12,6 +12,19 @@ local Variables = require('Module:Variables')
 
 local MatchGroupBase = {}
 
+---@class MatchGroupBaseOptions
+---@field bracketId string
+---@field matchGroupType 'bracket'|'matchlist'
+---@field shouldWarnMissing boolean
+---@field show boolean
+---@field storeMatch1 boolean
+---@field storeMatch2 boolean
+---@field storePageVar boolean
+
+---@param args table
+---@param matchGroupType string
+---@return MatchGroupBaseOptions
+---@return string[]
 function MatchGroupBase.readOptions(args, matchGroupType)
 	local store = Logic.nilOr(Logic.readBoolOrNil(args.store),
 		not Logic.readBool(Variables.varDefault('disable_LPDB_storage')))
@@ -46,6 +59,8 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 	return options, warnings
 end
 
+---@param baseBracketId string
+---@return string
 function MatchGroupBase.readBracketId(baseBracketId)
 	assert(baseBracketId, 'Argument \'id\' is empty')
 
@@ -57,6 +72,9 @@ function MatchGroupBase.readBracketId(baseBracketId)
 	return MatchGroupBase.getBracketIdPrefix() .. baseBracketId
 end
 
+---@param baseBracketId string
+---@return boolean
+---@return string?
 function MatchGroupBase.validateBaseBracketId(baseBracketId)
 	local subbed, count = baseBracketId:gsub('[0-9a-zA-Z]', '')
 	if subbed ~= '' then
@@ -67,10 +85,9 @@ function MatchGroupBase.validateBaseBracketId(baseBracketId)
 	return true
 end
 
---[[
-Non-mainspace match groups are used for testing. Their IDs are prefixed with
-the namespace so that they don't collide with mainspace IDs.
-]]
+---Non-mainspace match groups are used for testing. Their IDs are prefixed with the namespace
+---so that they don't collide with mainspace IDs.
+---@return string
 function MatchGroupBase.getBracketIdPrefix()
 	local namespace = mw.title.getCurrentTitle().nsText
 
@@ -83,13 +100,15 @@ function MatchGroupBase.getBracketIdPrefix()
 	end
 end
 
+---@param bracketId string
+---@return string?
 function MatchGroupBase._checkBracketDuplicate(bracketId)
 	local status = mw.ext.Brackets.checkBracketDuplicate(bracketId)
 	if status ~= 'ok' then
 		local warning = 'This match group uses the duplicate ID \'' .. bracketId .. '\'.'
-		local category = '[[Category:Pages with duplicate Bracketid]]'
+		mw.ext.TeamLiquidIntegration.add_category('Pages with duplicate Bracketid')
 		mw.addWarning(warning)
-		return warning .. category
+		return warning
 	end
 end
 

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -29,6 +29,25 @@ local globalVars = PageVariableNamespace{cached = true}
 
 local MatchGroupInput = {}
 
+---@class MatchGroupContext
+---@field bracketIndex integer
+---@field groupRoundIndex number?
+---@field matchSection string?
+---@field sectionHeader string?
+---@field tournamentParent string
+
+---@class MatchGroupMvpPlayer
+---@field displayname string
+---@field name string
+---@field comment string?
+---@field team string?
+---@field template string
+
+---@class MatchGroupInputReadPlayersOfTeamOptions
+---@field maxNumPlayers integer?
+---@field resolveRedirect boolean?
+---@field applyUnderScores boolean?
+
 local GSL_GROUP_STYLE_DEFAULT_HEADERS = {
 	{default = 'Opening Matches'},
 	{},
@@ -41,18 +60,24 @@ local VALID_GSL_GROUP_STYLES = {
 	'losersfirst',
 }
 
+---@param match table
 function MatchGroupInput._applyTournamentVarsToMaps(match)
 	for mapKey, map in Table.iter.pairsByPrefix(match, 'map') do
 		match[mapKey] = MatchGroupInput.getCommonTournamentVars(map, match)
 	end
 end
 
+---@param matchArgs table
+---@return table
 function MatchGroupInput._processMatch(matchArgs)
 	local match = WikiSpecific.processMatch(matchArgs)
 	MatchGroupInput._applyTournamentVarsToMaps(match)
 	return match
 end
 
+---@param bracketId string
+---@param args table
+---@return table[]
 function MatchGroupInput.readMatchlist(bracketId, args)
 	local matchKeys = Table.mapArgumentsByPrefix(args, {'M'}, FnUtil.identity)
 
@@ -105,10 +130,17 @@ function MatchGroupInput.readMatchlist(bracketId, args)
 	)
 end
 
+---@param matchIndex integer
+---@return string
 function MatchGroupInput._matchlistMatchIdFromIndex(matchIndex)
 	return string.format('%04d', matchIndex)
 end
 
+---@param bracketId string
+---@param args table
+---@param options MatchGroupBaseOptions
+---@return table[]
+---@return string[]?
 function MatchGroupInput.readBracket(bracketId, args, options)
 	local warnings = {}
 	local templateId = args[1]
@@ -215,6 +247,9 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 end
 
 -- Retrieve bracket data from the template generated bracket on commons
+---@param templateId string
+---@param bracketId string
+---@return table<string, table>
 function MatchGroupInput._fetchBracketDatas(templateId, bracketId)
 	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateId)
 	assert(type(matches) == 'table')
@@ -260,6 +295,8 @@ function MatchGroupInput._fetchBracketDatas(templateId, bracketId)
 	end)
 end
 
+---@param matches table<string, table>
+---@param args table
 function MatchGroupInput.applyOverrideArgs(matches, args)
 	local matchGroupType = matches[1].bracketData.type
 
@@ -274,6 +311,7 @@ function MatchGroupInput.applyOverrideArgs(matches, args)
 	else
 		for _, match in ipairs(matches) do
 			local _, baseMatchId = MatchGroupUtil.splitMatchId(match.matchId)
+			assert(baseMatchId, 'Invalid matchId "' .. match.matchId .. '"')
 			local matchKey = MatchGroupUtil.matchIdToKey(baseMatchId)
 			match.bracketData.header = args[matchKey .. 'header'] or match.bracketData.header
 		end
@@ -282,12 +320,13 @@ end
 
 local getContentLanguage = FnUtil.memoize(mw.getContentLanguage)
 
+---@param headerInput string?
+---@return string?
 function MatchGroupInput._inheritedHeader(headerInput)
 	local inheritedHeader = headerInput or globalVars:get('inheritedHeader')
 	globalVars:set('inheritedHeader', inheritedHeader)
 	return inheritedHeader
 end
-
 
 ---@param dateString string?
 ---@param dateFallbacks string[]?
@@ -330,10 +369,11 @@ function MatchGroupInput.readDate(dateString, dateFallbacks)
 	end
 end
 
---[[
-Parses the match group context. The match group context describes where a match
-group is relative to the tournament page.
-]]
+---Parses the match group context.
+---The match group context describes where a match group is relative to the tournament page.
+---@param matchArgs table
+---@param matchGroupArgs table
+---@return MatchGroupContext
 function MatchGroupInput.readContext(matchArgs, matchGroupArgs)
 	return {
 		bracketIndex = tonumber(globalVars:get('match2bracketindex')) or 0,
@@ -344,6 +384,9 @@ function MatchGroupInput.readContext(matchArgs, matchGroupArgs)
 	}
 end
 
+---@param matchArgs table
+---@param matchGroupArgs table
+---@return number?
 function MatchGroupInput.readGroupRoundIndex(matchArgs, matchGroupArgs)
 	if matchArgs.round then
 		return tonumber(matchArgs.round)
@@ -358,19 +401,17 @@ function MatchGroupInput.readGroupRoundIndex(matchArgs, matchGroupArgs)
 	return roundIndex and tonumber(roundIndex)
 end
 
---[[
-Saves changes to the match group context, as set by match group args, in page variables.
-]]
+---Saves changes to the match group context, as set by match group args, in page variables.
+---@param context MatchGroupContext
 function MatchGroupInput.persistContextChanges(context)
 	globalVars:set('bracket_header', context.sectionHeader)
 	globalVars:set('matchsection', context.matchSection)
 end
 
---[[
-Fetches the LPDB records of a match group containing standalone matches.
-Standalone matches are specified from individual match pages in the Match
-namespace.
-]]
+---Fetches the LPDB records of a match group containing standalone matches.
+---Standalone matches are specified from individual match pages in the Match namespace.
+---@param bracketId string
+---@return match2[]
 MatchGroupInput.fetchStandaloneMatchGroup = FnUtil.memoize(function(bracketId)
 	return mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = '[[namespace::130]] AND [[match2bracketid::' .. bracketId .. ']]',
@@ -378,13 +419,14 @@ MatchGroupInput.fetchStandaloneMatchGroup = FnUtil.memoize(function(bracketId)
 	})
 end)
 
---[[
-Fetches the LPDB record of a standalone match.
-
-matchId is a full match ID, such as MATCH_wec2CbLWRx_0001
-]]
+---Fetches the LPDB record of a standalone match.
+---
+---matchId is a full match ID, such as MATCH_wec2CbLWRx_0001
+---@param matchId string
+---@return match2?
 function MatchGroupInput.fetchStandaloneMatch(matchId)
 	local bracketId, _ = MatchGroupUtil.splitMatchId(matchId)
+	assert(bracketId, 'Invalid matchId "' .. matchId .. '"')
 	local matches = MatchGroupInput.fetchStandaloneMatchGroup(bracketId)
 	return Array.find(matches, function(match)
 		return match.match2id == matchId
@@ -398,6 +440,9 @@ If any property exists in both the record and opponent struct, the value from th
 The opponent struct is retrieved programmatically via Module:Opponent, by using the team template extension.
 Using the team template extension, the opponent struct is standardised and not user input dependant, unlike the record.
 ]]
+---@param record table
+---@param opponent standardOpponent
+---@return standardOpponent
 function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 	if opponent.type == Opponent.team then
 		record.template = opponent.template or record.template
@@ -422,6 +467,9 @@ function MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
 -- Retrieves Common Tournament Variables used inside match2 and match2game
+---@param obj table
+---@param parent table?
+---@return table
 function MatchGroupInput.getCommonTournamentVars(obj, parent)
 	parent = parent or {}
 	obj.game = Logic.emptyOr(obj.game, parent.game, Variables.varDefault('tournament_game'))
@@ -449,6 +497,8 @@ function MatchGroupInput.getCommonTournamentVars(obj, parent)
 	return obj
 end
 
+---@param match table
+---@return {players: MatchGroupMvpPlayer[], points: integer}?
 function MatchGroupInput.readMvp(match)
 	if not match.mvp then return end
 	local mvppoints = match.mvppoints or 1
@@ -478,11 +528,6 @@ function MatchGroupInput.readMvp(match)
 
 	return {players = parsedPlayers, points = mvppoints}
 end
-
----@class MatchGroupInputReadPlayersOfTeamOptions
----@field maxNumPlayers integer?
----@field resolveRedirect boolean?
----@field applyUnderScores boolean?
 
 ---reads the players of a team from input and wiki variables
 ---@param match table

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -14,13 +14,19 @@ local Lua = require('Module:Lua')
 
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 
+local ENTRY_POINT_NAMES = {'getMap', 'getPlayer', 'getRound'}
+
 local MatchSubobjects = {}
 
+---@param frame Frame
+---@return string
 function MatchSubobjects.getMap(frame)
 	local args = Arguments.getArgs(frame)
 	return Json.stringify(MatchSubobjects.luaGetMap(args))
 end
 
+---@param args table
+---@return table?
 function MatchSubobjects.luaGetMap(args)
 	-- dont save map if 'map' is not filled in
 	if Logic.isEmpty(args.map) then
@@ -41,32 +47,39 @@ function MatchSubobjects.luaGetMap(args)
 	end
 end
 
+---@param frame Frame
+---@return string
 function MatchSubobjects.getRound(frame)
 	local args = Arguments.getArgs(frame)
 	return Json.stringify(MatchSubobjects.luaGetRound(frame, args))
 end
 
+---@param frame Frame
+---@param args table
+---@return table
 function MatchSubobjects.luaGetRound(frame, args)
 	return args
 end
 
+---@param frame Frame
+---@return table
 function MatchSubobjects.getPlayer(frame)
 	local args = Arguments.getArgs(frame)
 	return Json.stringify(MatchSubobjects.luaGetPlayer(args))
 end
 
+---@param args table
+---@return table
 function MatchSubobjects.luaGetPlayer(args)
 	return WikiSpecific.processPlayer(args)
 end
 
-local _ENTRY_POINT_NAMES = {'getMap', 'getPlayer', 'getRound'}
-
 if FeatureFlag.get('perf') then
 	local Match = Lua.import('Module:Match')
 	MatchSubobjects.perfConfig = Match.perfConfig
-	require('Module:Performance/Util').setupEntryPoints(MatchSubobjects, _ENTRY_POINT_NAMES)
+	require('Module:Performance/Util').setupEntryPoints(MatchSubobjects, ENTRY_POINT_NAMES)
 end
 
-Lua.autoInvokeEntryPoints(MatchSubobjects, 'Module:Match/Subobjects', _ENTRY_POINT_NAMES)
+Lua.autoInvokeEntryPoints(MatchSubobjects, 'Module:Match/Subobjects', ENTRY_POINT_NAMES)
 
 return MatchSubobjects


### PR DESCRIPTION
## Summary
Add annos for input processing parts of match2 on commons and sc(2).
Ignores the FFA stuff for sc(2) due to it to be replaced eventually anyways

## How did you test this change?
/dev (#4098, #4100 and #4102 together)