### PR TITLE
feat(infobox): Add impact storage on Stormgate's Skill Infobox

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -85,15 +85,15 @@ function CustomInjector:parse(id, widgets)
 		local castingTime = tonumber(args.casting_time)
 
 		---@param arr string[]
-		---@param trim string?
+		---@param trimPattern string?
 		---@return string[]
-		local makeArrayLinks = function(arr, trim)
+		local makeArrayLinks = function(arr, trimPattern)
 			return Array.map(arr, function(value)
-				local dispaly = value
-				if trim then
-					dispaly = dispaly:gsub(trim, '')
+				local display = value
+				if trimPattern then
+					display = display:gsub(trimPattern, '')
 				end
-				return Page.makeInternalLink({}, dispaly, value)
+				return Page.makeInternalLink({}, display, value)
 			end)
 		end
 

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -208,7 +208,8 @@ function CustomSkill:addToLpdb(lpdbData, args)
 		healthtotal = args.healthTotal,
 		healthdps = args.healthDps,
 		healthovertime = args.health_over_time,
-		specialcost = args.special_cost
+		specialcost = args.special_cost,
+		impact = Array.parseCommaSeparatedString(args.impact),
 	}
 
 	return lpdbData

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -83,9 +83,20 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'custom' then
 		local castingTime = tonumber(args.casting_time)
-		local makeArrayLinks = function(arr)
-			return Array.map(arr, function(value) return Page.makeInternalLink({}, value) end)
+
+		---@param arr string[]
+		---@param trim string?
+		---@return string[]
+		local makeArrayLinks = function(arr, trim)
+			return Array.map(arr, function(value)
+				local dispaly = value
+				if trim then
+					dispaly = dispaly:gsub(trim, '')
+				end
+				return Page.makeInternalLink({}, dispaly, value)
+			end)
 		end
+
 		Array.extendWith(widgets, {
 				Cell{name = 'Researched From', content = {Page.makeInternalLink({}, args.from)}},
 				Cell{name = 'Upgrade Target', content = makeArrayLinks(Array.parseCommaSeparatedString(args.upgrade_target))},
@@ -95,7 +106,7 @@ function CustomInjector:parse(id, widgets)
 				Cell{name = 'Unlocks', content = makeArrayLinks(Array.parseCommaSeparatedString(args.unlocks))},
 				Cell{name = 'Target', content = makeArrayLinks(Array.parseCommaSeparatedString(args.target))},
 				Cell{name = 'Casting Time', content = {castingTime and (castingTime .. 's') or nil}},
-				Cell{name = 'Effect', content = makeArrayLinks(Array.parseCommaSeparatedString(args.effect))},
+				Cell{name = 'Effect', content = makeArrayLinks(Array.parseCommaSeparatedString(args.effect), ' %(effect%)$')},
 				Cell{name = 'Trigger', content = {args.trigger}},
 				Cell{name = 'Invulnerable', content = makeArrayLinks(Array.parseCommaSeparatedString(args.invulnerable))},
 			},


### PR DESCRIPTION
## Summary
Adds storage for impact.
Impact does not need dispaly it is "just" for conditioning in queries.
Also make the effect display a bit more pretty

## How did you test this change?
dev