### PR TITLE
fix(match2): qualified headers

### DIFF
--- a/components/match2/commons/match_group_display_bracket.lua
+++ b/components/match2/commons/match_group_display_bracket.lua
@@ -332,7 +332,7 @@ function BracketDisplay.computeHeaderRows(bracket, config)
 		if bracketData.qualWin then
 			local headerRow = getHeaderRow(matchId)
 			local roundIx = coords.roundIndex + 1 + bracketData.qualSkip
-			headerRow[roundIx] = {
+			headerRow[roundIx] = headerRow[roundIx] or {
 				header = bracketData.qualifiedHeader or config.qualifiedHeader or '!q',
 				roundIx = roundIx,
 			}

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -152,11 +152,12 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 		-- Add more fields to bracket data
 		local bracketData = bracketDatasById[matchId]
 
+		---@type MatchGroupUtilBracketData
 		match.bracketdata = Table.mergeInto(bracketData, match.bracketdata or {})
 
 		bracketData.type = 'bracket'
 		bracketData.header = args[matchKey .. 'header'] or bracketData.header
-		bracketData.qualifiedheader = args[matchKey .. 'qualifiedHeader']
+		bracketData.qualifiedheader = MatchGroupInput._readQualifiedHeader(bracketData, args, matchKey)
 		bracketData.inheritedheader = MatchGroupInput._inheritedHeader(bracketData.header)
 
 		bracketData.matchpage = match.matchPage
@@ -212,6 +213,22 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 	end
 
 	return matches, warnings
+end
+
+---@param bracketData MatchGroupUtilBracketData
+---@param args table
+---@param matchKey string
+---@return string?
+function MatchGroupInput._readQualifiedHeader(bracketData, args, matchKey)
+	if args[matchKey .. 'qualifiedHeader'] then
+		return args[matchKey .. 'qualifiedHeader']
+	end
+
+	if Logic.isEmpty(bracketData.header) or not Logic.readBool(bracketData.qualwin) then
+		return
+	end
+
+	return args.qualifiedHeader
 end
 
 -- Retrieve bracket data from the template generated bracket on commons


### PR DESCRIPTION
## Summary
Fixes the storage and display of qual headers
- currently only `R1M1qualifiedHeader` input gets stored, this PR makes it so that it falls back to `qualifiedHeader` if no cell specific qual header is entered
- currently only `qualifiedHeader` input gets evaluated for displayed (but not stored), this PR makes it so that the stored header is taken and only if that is not present it falls back to the `qualifiedHeader` input

As a side effect this now also allows different qual headers for upper and lower brackets via the `RxMy` prefix to `qualifiedHeader`
![Screenshot 2024-03-22 104430](https://github.com/Liquipedia/Lua-Modules/assets/75081997/12a2340b-3d86-4835-b202-4926ebe96338)



## How did you test this change?
dev