### PR TITLE
Add light/dark theme css for btn-theme in teamcard

### DIFF
--- a/stylesheets/commons/Teamcard.less
+++ b/stylesheets/commons/Teamcard.less
@@ -5,6 +5,17 @@ Author(s): ???
 .teamcard {
 	position: relative;
 	width: 200px;
+
+	.btn.btn-theme {
+		background-color: var( --clr-surface-4, #e6e6e6 );
+		color: var( --clr-on-background, #212529 );
+
+		@media ( hover: hover ) {
+			&:hover {
+				background-color: var( --clr-surface-3, lightgrey );
+			}
+		}
+	}
 }
 
 .teamcard > center {
@@ -200,7 +211,7 @@ Author(s): ???
 
 	& .team-template-team-part,
 	& span.team-template-image-icon,
-	& span.team-template-image-legacy, {
+	& span.team-template-image-legacy {
 		width: 40px;
 		height: 20px;
 	}


### PR DESCRIPTION
## Summary

In the teamcard, staff and substitutes buttons are using a class that didn't have light/dark theme styling yet.
Closes [ticket](https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/issues/91)

## How did you test this change?

Added it to commons.
