### PR TITLE
feat: Update some infoboxes to use CharacterIcon

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_person_player_custom.lua
@@ -7,8 +7,9 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
+local CharacterNames = require('Module:CharacterNames')
 local Class = require('Module:Class')
-local LegendIcon = require('Module:LegendIcon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -75,7 +76,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		local legendIcons = Array.map(caller:getAllArgsForBase(args, 'legends'), function(legend)
-			return LegendIcon.getImage{legend, size = SIZE_LEGEND}
+			return CharacterIcon.Icon{character = CharacterNames[legend:lower()], size = SIZE_LEGEND}
 		end)
 		Array.appendWith(widgets,
 			Cell{
@@ -155,7 +156,7 @@ function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 	lpdbData.extradata.retired = args.retired
 
 	for _, legend, legendIndex in Table.iter.pairsByPrefix(args, 'legends', {requireIndex = false}) do
-		lpdbData.extradata['signatureLegend' .. legendIndex] = legend
+		lpdbData.extradata['signatureLegend' .. legendIndex] = CharacterNames[legend:lower()]
 	end
 	lpdbData.type = self:_isPlayerOrStaff()
 

--- a/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/arenaofvalor/infobox_person_player_custom.lua
@@ -7,8 +7,8 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
-local HeroIcon = require('Module:HeroIcon')
 local HeroNames = mw.loadData('Module:HeroNames')
 local Lua = require('Module:Lua')
 local Role = require('Module:Role')
@@ -58,7 +58,7 @@ function CustomInjector:parse(id, widgets)
 				table.insert(caller.infobox.warnings,
 					'Invalid hero input "' .. hero .. '"[[Category:Pages with invalid hero input]]')
 			end
-			return HeroIcon.getImage{standardizedHero or hero, size = SIZE_HERO}
+			return CharacterIcon.Icon{character = standardizedHero or hero, size = SIZE_HERO}
 		end)
 
 		if Table.isEmpty(heroIcons) then return widgets end

--- a/components/infobox/wikis/dota2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_player_custom.lua
@@ -7,8 +7,9 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
-local HeroIcon = require('Module:HeroIcon')
+local HeroNames = mw.loadData('Module:HeroNames')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')
@@ -99,7 +100,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		local icons = Array.map(caller:getAllArgsForBase(args, 'hero'), function(hero)
-			return HeroIcon._getImage{hero = hero, size = SIZE_HERO}
+			return CharacterIcon.Icon{character = HeroNames[hero:lower()], size = SIZE_HERO}
 		end)
 		return {
 			Cell{name = 'Signature Hero', content = {table.concat(icons, '&nbsp;')}}
@@ -178,11 +179,12 @@ end
 function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 	lpdbData.status = lpdbData.status or 'Unknown'
 
+	for heroIndex, hero in ipairs(self:getAllArgsForBase(args, 'hero')) do
+		lpdbData.extradata['hero' .. heroIndex] = HeroNames[hero:lower()]
+	end
+
 	lpdbData.extradata.role = (self.role or {}).variable
 	lpdbData.extradata.role2 = (self.role2 or {}).variable
-	lpdbData.extradata.hero = args.hero
-	lpdbData.extradata.hero2 = args.hero2
-	lpdbData.extradata.hero3 = args.hero3
 	lpdbData.extradata['lc_id'] = self.basePageName:lower()
 	lpdbData.extradata.team2 = mw.ext.TeamLiquidIntegration.resolve_redirect(
 		not String.isEmpty(args.team2link) and args.team2link or args.team2 or '')

--- a/components/infobox/wikis/dota2/infobox_person_user_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_person_user_custom.lua
@@ -7,10 +7,11 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
+local HeroNames = mw.loadData('Module:HeroNames')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
-local Template = require('Module:Template')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local User = Lua.import('Module:Infobox/Person/User')
@@ -19,6 +20,8 @@ local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 local Center = Widgets.Center
+
+local SIZE_HERO = '44x25px'
 
 ---@class Dota2InfoboxUser: InfoboxUser
 local CustomUser = Class.new(User)
@@ -46,7 +49,7 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(widgets,
 			Cell{name = 'Gender', content = {args.gender}},
 			Cell{name = 'Languages', content = {args.languages}},
-			Cell{name = 'Favorite heroes', content = self.caller:_getFavouriteHeroes()},
+			Cell{name = 'Favorite heroes', content = {self.caller:_getFavouriteHeroes()}},
 			Cell{name = 'Favorite players', content = self.caller:_getArgsfromBaseDefault('fav-player', 'fav-players')},
 			Cell{name = 'Favorite casters', content = self.caller:_getArgsfromBaseDefault('fav-caster', 'fav-casters')},
 			Cell{name = 'Favorite teams', content = {args['fav-teams']}}
@@ -71,18 +74,13 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
----@return string[]
+---@return string
 function CustomUser:_getFavouriteHeroes()
-	local foundArgs = self:getAllArgsForBase(self.args, 'fav-hero-')
+	local icons = Array.map(self:getAllArgsForBase(self.args, 'fav-hero-'), function(hero)
+		return CharacterIcon.Icon{character = HeroNames[hero:lower()], size = SIZE_HERO}
+	end)
 
-	local heroes = {}
-	for _, item in ipairs(foundArgs) do
-		local hero = Template.safeExpand(mw.getCurrentFrame(), 'HeroBracket/' .. item:lower(), nil, '')
-		if not String.isEmpty(hero) then
-			table.insert(heroes, hero)
-		end
-	end
-	return heroes
+	return table.concat(icons, '&nbsp;')
 end
 
 return CustomUser

--- a/components/infobox/wikis/heroes/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/heroes/infobox_person_player_custom.lua
@@ -7,15 +7,18 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
+local CharacterNames = mw.loadData('Module:HeroNames')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local Template = require('Module:Template')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
+
+local SIZE_HERO = '28x28px'
 
 ---@class HeroesInfoboxPlayer: Person
 local CustomPlayer = Class.new(Player)
@@ -38,7 +41,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		local heroIcons = Array.map(self.caller:getAllArgsForBase(args, 'hero'), function(hero)
-			return Template.safeExpand(mw.getCurrentFrame(), 'HeroIcon/' .. hero)
+			return CharacterIcon.Icon{character = CharacterNames[hero:lower()], size = SIZE_HERO}
 		end)
 		table.insert(widgets, Cell{name = 'Signature Heroes', content = {table.concat(heroIcons, '&nbsp;')}})
 	elseif id == 'history' and string.match(args.retired or '', '%d%d%d%d') then

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -7,8 +7,8 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
-local HeroIcon = require('Module:HeroIcon')
 local HeroNames = mw.loadData('Module:HeroNames')
 local Lua = require('Module:Lua')
 local Region = require('Module:Region')
@@ -64,7 +64,7 @@ function CustomInjector:parse(id, widgets)
 					'Invalid hero input "' .. hero .. '"[[Category:Pages with invalid hero input]]'
 				)
 			end
-			return HeroIcon.getImage{standardizedHero or hero, size = SIZE_HERO}
+			return CharacterIcon.Icon{character = standardizedHero or hero, size = SIZE_HERO}
 		end)
 
 		table.insert(widgets, Cell{

--- a/components/infobox/wikis/naraka/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_person_player_custom.lua
@@ -7,8 +7,9 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
+local CharacterNames = mw.loadData('Module:CharacterNames')
 local Class = require('Module:Class')
-local HeroIcon = require('Module:HeroIcon')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
@@ -69,7 +70,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		local heroIcons = Array.map(caller:getAllArgsForBase(args, 'hero'), function(hero, _)
-			return HeroIcon.getImage{hero, size = SIZE_HERO}
+			return CharacterIcon.Icon{character = CharacterNames[hero:lower()], size = SIZE_HERO}
 		end)
 
 		return {
@@ -103,7 +104,7 @@ function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 	lpdbData.extradata.role2 = (self.role2 or {}).variable
 
 	for _, hero, heroIndex in Table.iter.pairsByPrefix(args, 'hero', {requireIndex = false}) do
-		lpdbData.extradata['signatureHero' .. heroIndex] = hero
+		lpdbData.extradata['signatureHero' .. heroIndex] = CharacterNames[hero:lower()]
 	end
 	lpdbData.type = self:_isPlayerOrStaff()
 

--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -8,8 +8,9 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local CharacterIcon = require('Module:CharacterIcon')
+local CharacterNames = mw.loadData('Module:CharacterNames')
 local GameAppearances = require('Module:GetGameAppearances')
-local HeroIcon = require('Module:HeroIcon')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
@@ -76,7 +77,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		local heroIcons = Array.map(caller:getAllArgsForBase(args, 'hero'), function(hero)
-			return HeroIcon.getImage{hero, size = SIZE_HERO}
+			return CharacterIcon.Icon{character = CharacterNames[hero:lower()], size = SIZE_HERO}
 		end)
 
 		Array.appendWith(widgets,
@@ -144,7 +145,7 @@ function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 
 	-- store signature heroes with standardized name
 	for heroIndex, hero in ipairs(self:getAllArgsForBase(args, 'hero')) do
-		lpdbData.extradata['signatureHero' .. heroIndex] = HeroIcon.getHeroName(hero)
+		lpdbData.extradata['signatureHero' .. heroIndex] = CharacterNames[hero:lower()]
 		if heroIndex == MAX_NUMBER_OF_SIGNATURE_HEROES then
 			break
 		end

--- a/components/infobox/wikis/overwatch/infobox_person_user_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_user_custom.lua
@@ -7,10 +7,11 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
+local CharacterNames = mw.loadData('Module:CharacterNames')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
-local Template = require('Module:Template')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local User = Lua.import('Module:Infobox/Person/User')
@@ -19,6 +20,8 @@ local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 local Center = Widgets.Center
+
+local SIZE_HERO = '25x25px'
 
 ---@class OverwatchInfoboxUser: InfoboxUser
 local CustomUser = Class.new(User)
@@ -66,7 +69,7 @@ function CustomUser:addCustomCells(widgets)
 		Cell{name = 'Gender', content = {args.gender}},
 		Cell{name = 'Languages', content = {args.languages}},
 		Cell{name = 'BattleTag', content = {args.battletag}},
-		Cell{name = 'Main Hero', content = self:_getHeroes()},
+		Cell{name = 'Main Hero', content = {self:_getHeroes()}},
 		Cell{name = 'Favorite players', content = self:_getArgsfromBaseDefault('fav-player', 'fav-players')},
 		Cell{name = 'Favorite casters', content = self:_getArgsfromBaseDefault('fav-caster', 'fav-casters')},
 		Cell{name = 'Favorite teams', content = {args['fav-teams']}}
@@ -96,18 +99,13 @@ function CustomUser:addCustomCells(widgets)
 	return widgets
 end
 
----@return string[]
+---@return string
 function CustomUser:_getHeroes()
-	local foundArgs = self:getAllArgsForBase(self.args, 'hero')
+	local icons = Array.map(self:getAllArgsForBase(self.args, 'hero'), function(hero)
+		return CharacterIcon.Icon{character = CharacterNames[hero:lower()], size = SIZE_HERO}
+	end)
 
-	local heroes = {}
-	for _, item in ipairs(foundArgs) do
-		local hero = Template.safeExpand(mw.getCurrentFrame(), 'Hero/' .. item, nil, '')
-		if not String.isEmpty(hero) then
-			table.insert(heroes, hero)
-		end
-	end
-	return heroes
+	return table.concat(icons, '&nbsp;')
 end
 
 return CustomUser

--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -7,9 +7,10 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
+local CharacterNames = require('Module:CharacterNames')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local OperatorIcon = require('Module:OperatorIcon')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -102,7 +103,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		-- Signature Operators
 		local operatorIcons = Array.map(caller:getAllArgsForBase(args, 'operator'), function(operator)
-			return OperatorIcon.getImage{operator, size = SIZE_OPERATOR}
+			return CharacterIcon.Icon{character = CharacterNames[operator:lower()], size = SIZE_OPERATOR}
 		end)
 		table.insert(widgets, Cell{
 			name = #operatorIcons > 1 and 'Signature Operators' or 'Signature Operator',
@@ -179,12 +180,9 @@ end
 function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 	lpdbData.extradata.role = (self.role or {}).variable
 	lpdbData.extradata.role2 = (self.role2 or {}).variable
-
-	lpdbData.extradata.signatureOperator1 = args.operator1 or args.operator
-	lpdbData.extradata.signatureOperator2 = args.operator2
-	lpdbData.extradata.signatureOperator3 = args.operator3
-	lpdbData.extradata.signatureOperator4 = args.operator4
-	lpdbData.extradata.signatureOperator5 = args.operator5
+	for _, operator, operatorIndex in Table.iter.pairsByPrefix(args, 'operator', {requireIndex = false}) do
+		lpdbData.extradata['signatureOperator' .. operatorIndex] = CharacterNames[operator:lower()]
+	end
 	lpdbData.type = self:_isPlayerOrStaff()
 
 	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {args.country})

--- a/components/infobox/wikis/rainbowsix/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_weapon_custom.lua
@@ -7,10 +7,11 @@
 --
 
 local Array = require('Module:Array')
+local CharacterIcon = require('Module:CharacterIcon')
+local CharacterNames = require('Module:CharacterNames')
 local Class = require('Module:Class')
 local Cell = require('Module:Infobox/Widget/Cell')
 local Lua = require('Module:Lua')
-local OperatorIcon = require('Module:OperatorIcon')
 local Table = require('Module:Table')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
@@ -46,7 +47,7 @@ end
 ---@return string
 function CustomWeapon:_getOperators()
 	local operatorIcons = Array.map(self:getAllArgsForBase(self.args, 'operator'), function(operator)
-		return OperatorIcon.getImage{operator, size = SIZE_OPERATOR}
+		return CharacterIcon.Icon{character = CharacterNames[operator:lower()], size = SIZE_OPERATOR}
 	end)
 
 	return table.concat(operatorIcons, '&nbsp;')
@@ -56,6 +57,9 @@ end
 ---@param args table
 ---@return table
 function CustomWeapon:addToLpdb(lpdbData, args)
+	local operators = Array.map(self:getAllArgsForBase(self.args, 'operator'), function(operator)
+		return CharacterNames[operator:lower()]
+	end)
 	lpdbData.extradata = Table.merge(lpdbData.extradata, {
 		desc = args.desc,
 		class = args.class,
@@ -65,7 +69,7 @@ function CustomWeapon:addToLpdb(lpdbData, args)
 		reloadspeed = args.reloadspeed,
 		rateoffire = args.rateoffire,
 		firemode = table.concat(self:getAllArgsForBase(args, 'firemode'), ';'),
-		operators = table.concat(self:getAllArgsForBase(args, 'operator'), ';'),
+		operators = table.concat(operators, ';'),
 		games = table.concat(self:getAllArgsForBase(args, 'game'), ';'),
 	})
 	return lpdbData

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -8,7 +8,8 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local ChampionIcon = require('Module:ChampionIcon')
+local ChampionNames = mw.loadData('Module:ChampionNames')
+local CharacterIcon = require('Module:CharacterIcon')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
@@ -91,7 +92,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		-- Signature Champion
 		local championIcons = Array.map(caller:getAllArgsForBase(args, 'champion'), function(champion)
-			return ChampionIcon.getImage{champion, size = SIZE_CHAMPION}
+			return CharacterIcon.Icon{character = ChampionNames[champion:lower()], size = SIZE_CHAMPION}
 		end)
 		return {Cell{
 			name = #championIcons > 1 and 'Signature Champions' or 'Signature Champions',
@@ -152,12 +153,9 @@ end
 function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 	lpdbData.extradata.role = (self.role or {}).variable
 	lpdbData.extradata.role2 = (self.role2 or {}).variable
-
-	lpdbData.extradata.signatureChampion1 = args.champion1 or args.champion
-	lpdbData.extradata.signatureChampion2 = args.champion2
-	lpdbData.extradata.signatureChampion3 = args.champion3
-	lpdbData.extradata.signatureChampion4 = args.champion4
-	lpdbData.extradata.signatureChampion5 = args.champion5
+	for index, champion in ipairs(self:getAllArgsForBase(args, 'champion')) do
+		lpdbData.extradata['signatureChampion' .. index] = ChampionNames[champion:lower()]
+	end
 	lpdbData.type = self:_isPlayerOrStaff()
 
 	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {args.country})


### PR DESCRIPTION
## Summary

Update some infoboxes to use CharacterIcon instead of wiki-specific `Module:XIcon`.
On some wikis [Module:CharacterNames](https://liquipedia.net/rainbowsix/Module:CharacterNames) was created, this module contains aliases for the characters, and maybe in the future, we could move all HeroNames, ChampionNames, etc... to this name.

Rainbowsix match2 modules can be updated in the future to use CharacterIcon and CharacterNames.

## How did you test this change?

/dev on certain wikis
