### PR TITLE
feat(infobox person custom osu!): remove status cell overwrite

### DIFF
--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -80,11 +80,6 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
----@return string[]
-function CustomPlayer:_getStatusContents()
-	return {Page.makeInternalLink({onlyIfExists = true}, self.args.status) or self.args.status}
-end
-
 ---@param role string?
 ---@return {category: string, variable: string, staff: boolean?, talent: boolean?}?
 function CustomPlayer:_getRoleData(role)

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -63,7 +63,7 @@ function CustomInjector:parse(id, widgets)
 	local args = caller.args
 
 	if id == 'status' then
-			table.insert(widgets, Cell{name = 'Years Active', content = {args.years_active}})
+		table.insert(widgets, Cell{name = 'Years Active', content = {args.years_active}})
 	elseif id == 'role' then
 		return {
 			Cell{name = 'Role', content = {

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -62,10 +62,8 @@ function CustomInjector:parse(id, widgets)
 	local caller = self.caller
 	local args = caller.args
 
-	if id == 'custom' then
-		return {
-			Cell{name = 'Years Active', content = {args.years_active}},
-		}
+	if id == 'status' then
+			table.insert(widgets, Cell{name = 'Years Active', content = {args.years_active}})
 	elseif id == 'role' then
 		return {
 			Cell{name = 'Role', content = {

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -62,9 +62,8 @@ function CustomInjector:parse(id, widgets)
 	local caller = self.caller
 	local args = caller.args
 
-	if id == 'status' then
+	if id == 'custom' then
 		return {
-			Cell{name = 'Status', content = caller:_getStatusContents()},
 			Cell{name = 'Years Active', content = {args.years_active}},
 		}
 	elseif id == 'role' then


### PR DESCRIPTION
## Summary
Removes status cell overwrite so `Banned` can be displayed in infobox as a valid status. https://github.com/Liquipedia/Lua-Modules/pull/4107 meets the rest of the requested changes
Brought up here: https://discord.com/channels/93055209017729024/1164213669324927096/1218721711768207440
Discussion with hjp: https://discord.com/channels/93055209017729024/874304000718172200/1219815338632417343



## How did you test this change?
dev https://liquipedia.net/osu/Natsuko