### PR TITLE
feat(infobox) AoE: Disable region cell in Infobox team

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -55,6 +55,8 @@ function CustomInjector:parse(id, widgets)
 	if id == 'earnings' then
 		---@diagnostic disable-next-line: inject-field
 		widgets[1].name = 'Approx. Total Winnings'
+	elseif id == 'region' then
+		return {}
 	elseif id == 'custom' then
 		table.insert(widgets, Cell{name = 'Games', content = self.caller:_getGames()})
 	end


### PR DESCRIPTION
## Summary
Removes the region cell from the infobox, as AoE esports is not divided into regions and the information therefore only duplicates the info from location cells.

## How did you test this change?
/dev
