### PR TITLE
refactor: code style improvements

### DIFF
--- a/components/automatic_points_table/commons/automatic_points_table.lua
+++ b/components/automatic_points_table/commons/automatic_points_table.lua
@@ -23,7 +23,7 @@ local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
-local _POINTS_TYPE = {
+local POINTS_TYPE = {
 	MANUAL = 'MANUAL',
 	PRIZE = 'PRIZE',
 	SECURED = 'SECURED'
@@ -303,7 +303,7 @@ function AutomaticPointsTable:calculatePointsForTournament(placement, manualPoin
 	if manualPoints ~= nil then
 		return {
 			amount = manualPoints,
-			type = _POINTS_TYPE.MANUAL
+			type = POINTS_TYPE.MANUAL
 		}
 	-- placement points get next priority
 	elseif placement ~= nil then
@@ -312,14 +312,14 @@ function AutomaticPointsTable:calculatePointsForTournament(placement, manualPoin
 		if prizePoints ~= nil then
 			return {
 				amount = prizePoints,
-				type = _POINTS_TYPE.PRIZE
+				type = POINTS_TYPE.PRIZE
 			}
 		-- secured points are the points that are guaranteed for a team in a tournament
 		-- a team with X secured points will get X or more points at the end of the tournament
 		elseif securedPoints ~= nil then
 			return {
 				amount = securedPoints,
-				type = _POINTS_TYPE.SECURED
+				type = POINTS_TYPE.SECURED
 			}
 		end
 	end

--- a/components/automatic_points_table/commons/automatic_points_table_display.lua
+++ b/components/automatic_points_table/commons/automatic_points_table_display.lua
@@ -12,7 +12,7 @@ local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local _POINTS_TYPE = {
+local POINTS_TYPE = {
 	MANUAL = 'MANUAL',
 	PRIZE = 'PRIZE',
 	SECURED = 'SECURED'
@@ -153,7 +153,7 @@ function TableRow:pointsCell(points, tournament)
 	local finished = Logic.readBool(tournament.finished)
 	local pointString = points.amount ~= nil and points.amount or (finished and '-' or '')
 	local pointsCell = self:baseCell(pointString)
-	if points.type == _POINTS_TYPE.SECURED then
+	if points.type == POINTS_TYPE.SECURED then
 		pointsCell:css('font-weight', 'lighter'):css('font-style', 'italic')
 	end
 	table.insert(self.cells, pointsCell)

--- a/components/mvp_table/commons/mvp_table.lua
+++ b/components/mvp_table/commons/mvp_table.lua
@@ -20,8 +20,6 @@ local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
-local _PAGENAME = mw.title.getCurrentTitle().text
-
 local MvpTable = {}
 
 ---Entry point for MvpTable.
@@ -110,7 +108,7 @@ function MvpTable._parseArgs(args)
 	end
 
 	if Table.isEmpty(parsedArgs.matchGroupIds) and Table.isEmpty(parsedArgs.tournaments) then
-		table.insert(parsedArgs.tournaments, _PAGENAME)
+		table.insert(parsedArgs.tournaments, mw.title.getCurrentTitle().text)
 	end
 
 	return parsedArgs

--- a/components/tournaments_summary_table/commons/tournaments_summary_table.lua
+++ b/components/tournaments_summary_table/commons/tournaments_summary_table.lua
@@ -56,7 +56,7 @@ TournamentsSummaryTable.upcomingType = conditionTypes.upcoming
 TournamentsSummaryTable.ongoingType = conditionTypes.ongoing
 TournamentsSummaryTable.recentType = conditionTypes.recent
 
-local _TYPE_TO_TITLE = {
+local TYPE_TO_TITLE = {
 	'Upcoming',
 	'Ongoing',
 	'Completed',
@@ -95,7 +95,7 @@ function TournamentsSummaryTable.run(args)
 		error('No type parameter (upcoming, ongoing, recent) specified')
 	end
 
-	local title = mw.language.getContentLanguage():ucfirst(args.title or _TYPE_TO_TITLE[type])
+	local title = mw.language.getContentLanguage():ucfirst(args.title or TYPE_TO_TITLE[type])
 	local limit = args.limit and tonumber(args.limit) or TournamentsSummaryTable.defaultLimit
 	local sort = args.sort or (type == TournamentsSummaryTable.recentType and 'end' or 'start')
 	local order = args.order or (type == TournamentsSummaryTable.recentType and 'desc' or 'asc')

--- a/standard/hotkey.lua
+++ b/standard/hotkey.lua
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Hotkeys = {}
 
-local _SEPERATORS = {
+local SEPERATORS = {
 	['->'] = '&nbsp;→&nbsp;',
 	['then'] = '&nbsp;→&nbsp;',
 	['arrow'] = '&nbsp;→&nbsp;',
@@ -41,7 +41,7 @@ end
 function Hotkeys.hotkey2(hotkey1, hotkey2, seperator)
 	hotkey1 = Hotkeys.hotkey(hotkey1)
 	hotkey2 = Hotkeys.hotkey(hotkey2)
-	seperator = _SEPERATORS[string.lower(seperator or '')] or
+	seperator = SEPERATORS[string.lower(seperator or '')] or
 		seperator or ''
 
 	return '<b>' .. hotkey1 .. seperator .. hotkey2 .. '</b>'

--- a/standard/league_icon.lua
+++ b/standard/league_icon.lua
@@ -12,7 +12,7 @@ local Template = require('Module:Template')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 
-local _FILLER = '<span class="league-icon-small-image">[[File:Logo filler event.png|link=]]</span>'
+local FILLER = '<span class="league-icon-small-image">[[File:Logo filler event.png|link=]]</span>'
 local NO_ICON_BUT_ICONDARK_TRACKING_CATEGORY = '[[Category:Pages with only icondark]]'
 
 ---@class LeagueIconDisplayArgs
@@ -55,7 +55,7 @@ function LeagueIcon.display(args)
 
 	--if icon and iconDark are not given and can not be retrieved return filler icon
 	if String.isEmpty(icon) and String.isEmpty(iconDark) then
-		return _FILLER
+		return FILLER
 	end
 
 	if String.isEmpty(icon) then


### PR DESCRIPTION
## Summary
Remove leading underscores of const vars outside of match2 folder to be in line with code style.
(For match2 folder it will happen step by step when annotating it in the next weeks.)

## How did you test this change?
N/A