### PR TITLE
refactor(match2): Add often used functions to commons

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -13,6 +13,7 @@ local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -761,22 +762,13 @@ function MatchGroupInput.getMapVeto(match, allowedVetoes)
 	return data
 end
 
----@param tbl table
+---@param opponents table[]
 ---@return boolean
-function MatchGroupInput.isDraw(tbl)
-	local last
-	for _, scoreInfo in pairs(tbl) do
-		if scoreInfo.status ~= 'S' and scoreInfo.status ~= 'D' then
-			return false
-		end
-		if last and last ~= scoreInfo.score then
-			return false
-		else
-			last = scoreInfo.score
-		end
+function MatchGroupInput.isDraw(opponents)
+	if Array.any(opponents, function (opponent) return opponent.status ~= 'S' or opponent.status ~= 'D' end) then
+		return false
 	end
-
-	return true
+	return #Array.unique(Array.map(opponents, Operator.property('score'))) == 1
 end
 
 -- Check if any opponent has a none-standard status
@@ -787,24 +779,24 @@ function MatchGroupInput.hasSpecialStatus(opponents)
 end
 
 -- function to check for forfeits
----@param tbl table
+---@param opponents table[]
 ---@return boolean
-function MatchGroupInput.placementCheckFF(tbl)
-	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == 'FF' end)
+function MatchGroupInput.hasForfeit(opponents)
+	return Array.any(opponents, function (opponent) return opponent.status == 'FF' end)
 end
 
 -- function to check for DQ's
----@param tbl table
+---@param opponents table[]
 ---@return boolean
-function MatchGroupInput.placementCheckDQ(tbl)
-	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == 'DQ' end)
+function MatchGroupInput.hasDisqualified(opponents)
+	return Array.any(opponents, function (opponent) return opponent.status == 'DQ' end)
 end
 
 -- function to check for W/L
----@param tbl table
+---@param opponents table[]
 ---@return boolean
-function MatchGroupInput.placementCheckWL(tbl)
-	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status == 'L' end)
+function MatchGroupInput.hasDefaultWinLoss(opponents)
+	return Array.any(opponents, function (opponent) return opponent.status == 'L' end)
 end
 
 -- Get the winner when resulttype=default

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -781,10 +781,10 @@ function MatchGroupInput.placementCheckDraw(tbl)
 end
 
 -- Check if any team has a none-standard status
----@param tbl table
+---@param opponents table[]
 ---@return boolean
-function MatchGroupInput.placementCheckSpecialStatus(tbl)
-	return Table.any(tbl, function (_, scoreinfo) return scoreinfo.status ~= 'S' end)
+function MatchGroupInput.hasSpecialStatus(opponents)
+	return Array.any(tbl, function (opponent) return opponent.status ~= 'S' end)
 end
 
 -- function to check for forfeits

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -780,7 +780,7 @@ function MatchGroupInput.placementCheckDraw(tbl)
 	return true
 end
 
--- Check if any team has a none-standard status
+-- Check if any opponent has a none-standard status
 ---@param opponents table[]
 ---@return boolean
 function MatchGroupInput.hasSpecialStatus(opponents)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -763,7 +763,7 @@ end
 
 ---@param tbl table
 ---@return boolean
-function MatchGroupInput.placementCheckDraw(tbl)
+function MatchGroupInput.isDraw(tbl)
 	local last
 	for _, scoreInfo in pairs(tbl) do
 		if scoreInfo.status ~= 'S' and scoreInfo.status ~= 'D' then
@@ -783,7 +783,7 @@ end
 ---@param opponents table[]
 ---@return boolean
 function MatchGroupInput.hasSpecialStatus(opponents)
-	return Array.any(tbl, function (opponent) return opponent.status ~= 'S' end)
+	return Array.any(opponents, function (opponent) return opponent.status ~= 'S' end)
 end
 
 -- function to check for forfeits
@@ -808,15 +808,11 @@ function MatchGroupInput.placementCheckWL(tbl)
 end
 
 -- Get the winner when resulttype=default
----@param tbl table
+---@param opponents table[]
 ---@return integer
-function MatchGroupInput.getDefaultWinner(tbl)
-	for index, scoreInfo in pairs(tbl) do
-		if scoreInfo.status == 'W' then
-			return index
-		end
-	end
-	return -1
+function MatchGroupInput.getDefaultWinner(opponents)
+	local idx = Array.indexOf(opponents, function(opponent) return opponent.status == 'W' end)
+	return idx > 0 and idx or -1
 end
 
 -- Set the field 'placement' for the two participants in the opponenets list.

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -726,7 +726,7 @@ function MatchGroupInput._getCasterInformation(name, flag, displayName)
 	}
 end
 
--- function for parsing mapVeto input
+-- Parse map veto input
 ---@param match table
 ---@param allowedVetoes string[]?
 ---@return {type:string, team1: string?, team2:string?, decider:string?, vetostart:string?}[]?

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -738,14 +738,14 @@ function MatchGroupInput.getMapVeto(match, allowedVetoes)
 
 	match.mapveto = Json.parseIfString(match.mapveto)
 
-	local vetoTypes = mw.text.split(match.mapveto.types or '', ',')
-	local deciders = mw.text.split(match.mapveto.decider or '', ',')
+	local vetoTypes = Array.parseCommaSeparatedString(match.mapveto.types)
+	local deciders = Array.parseCommaSeparatedString(match.mapveto.decider)
 	local vetoStart = match.mapveto.firstpick or ''
 	local deciderIndex = 1
 
 	local data = {}
 	for index, vetoType in ipairs(vetoTypes) do
-		vetoType = mw.text.trim(vetoType):lower()
+		vetoType = vetoType:lower()
 		if not Table.includes(allowedVetoes, vetoType) then
 			return nil -- Any invalid input will not store (ie hide) all vetoes.
 		end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -761,7 +761,6 @@ function MatchGroupInput.getMapVeto(match, allowedVetoes)
 	return data
 end
 
--- function to check for draws
 ---@param tbl table
 ---@return boolean
 function MatchGroupInput.placementCheckDraw(tbl)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -765,7 +765,7 @@ end
 ---@param opponents table[]
 ---@return boolean
 function MatchGroupInput.isDraw(opponents)
-	if Array.any(opponents, function (opponent) return opponent.status ~= 'S' or opponent.status ~= 'D' end) then
+	if Array.any(opponents, function (opponent) return opponent.status ~= 'S' and opponent.status ~= 'D' end) then
 		return false
 	end
 	return #Array.unique(Array.map(opponents, Operator.property('score'))) == 1


### PR DESCRIPTION
## Summary
Add functions that are often repeated in match2 custom input processing to commons `Module:MatchGroup/Input`.

The idea is to extend #4118 and #4120 to also remove those duplicate code snipets and use the in this PR added commons functions instead if they are identical.

## How did you test this change?
N/A, copied from R6 and not used anywhere as of now