### PR TITLE
feat: limit SignatureHeroes on OW Player Infobox

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -76,13 +76,10 @@ function CustomInjector:parse(id, widgets)
 	local args = caller.args
 
 	if id == 'custom' then
-		local heroIcons = Array.map(caller:getAllArgsForBase(args, 'hero'), function(hero)
+		local heroes = Array.sub(caller:getAllArgsForBase(args, 'hero'), 1, MAX_NUMBER_OF_SIGNATURE_HEROES)
+		local heroIcons = Array.map(heroes, function(hero)
 			return CharacterIcon.Icon{character = CharacterNames[hero:lower()], size = SIZE_HERO}
 		end)
-
-		if #heroIcons > MAX_NUMBER_OF_SIGNATURE_HEROES then
-			heroIcons = {unpack(heroIcons, 1, MAX_NUMBER_OF_SIGNATURE_HEROES)}
-		end
 
 		Array.appendWith(widgets,
 			Cell{

--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -80,6 +80,10 @@ function CustomInjector:parse(id, widgets)
 			return CharacterIcon.Icon{character = CharacterNames[hero:lower()], size = SIZE_HERO}
 		end)
 
+		if #heroIcons > MAX_NUMBER_OF_SIGNATURE_HEROES then
+        		heroIcons = {unpack(heroIcons, 1, MAX_NUMBER_OF_SIGNATURE_HEROES)}
+   		end
+
 		Array.appendWith(widgets,
 			Cell{
 				name = #heroIcons > 1 and 'Signature Heroes' or 'Signature Hero',

--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -81,8 +81,8 @@ function CustomInjector:parse(id, widgets)
 		end)
 
 		if #heroIcons > MAX_NUMBER_OF_SIGNATURE_HEROES then
-        		heroIcons = {unpack(heroIcons, 1, MAX_NUMBER_OF_SIGNATURE_HEROES)}
-   		end
+			heroIcons = {unpack(heroIcons, 1, MAX_NUMBER_OF_SIGNATURE_HEROES)}
+		end
 
 		Array.appendWith(widgets,
 			Cell{


### PR DESCRIPTION
## Summary
Currently the Player Infobox for Overwatch allows users to list a players signature heroes. However, the Overwatch wiki gets spammed with edits on these signature heroes, so a while ago, we limited the saving of these signature heroes into LPDB to 3. There are currently players on the wiki with more than 6 signautre heroes listed. This limits the display of the signature heroes to 3 to bring it in line with LPDB saving. 

Player example with many Signature Heroes being displayed
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/ebb71516-ea11-4b7e-a186-3264eac63a6f)
Same player LPDB data
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/b3bfb9de-db49-4c19-a39d-d097c98d6390)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
[Player ](https://liquipedia.net/overwatch/Stellar) (shown above) page using dev modules
![image](https://github.com/Liquipedia/Lua-Modules/assets/58013431/4ee13889-0206-4c92-a266-a584f25aa4f5)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
