### PR TITLE
feat: add additonal roles to valorant person infobox

### DIFF
--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -27,20 +27,26 @@ local ROLES = {
 	-- Players
 	['igl'] = {category = 'In-game leaders', variable = 'In-game leader'},
 
-	-- Staff and Talents
+	-- Staff
 	['analyst'] = {category = 'Analysts', variable = 'Analyst', staff = true},
+	['coach'] = {category = 'Coaches', variable = 'Coach', staff = true},
+	['manager'] = {category = 'Managers', variable = 'Manager', staff = true},
+	
+	-- Talents
 	['broadcast analyst'] = {category = 'Broadcast Analysts', variable = 'Broadcast Analyst', talent = true},
 	['observer'] = {category = 'Observers', variable = 'Observer', talent = true},
 	['host'] = {category = 'Host', variable = 'Host', talent = true},
 	['journalist'] = {category = 'Journalists', variable = 'Journalist', talent = true},
 	['expert'] = {category = 'Experts', variable = 'Expert', talent = true},
-	['coach'] = {category = 'Coaches', variable = 'Coach', staff = true},
 	['caster'] = {category = 'Casters', variable = 'Caster', talent = true},
-	['manager'] = {category = 'Managers', variable = 'Manager', staff = true},
-	['streamer'] = {category = 'Streamers', variable = 'Streamer', talent = true},
+	['streamer'] = {category = 'Content Creators', variable = 'Streamer', talent = true},
+	['content creator'] = {category = 'Content Creators', variable = 'Content Creator', talent = true},
 	['producer'] = {category = 'Production Staff', variable = 'Producer', talent = true},
+	['stats producer'] = {category = 'Production Staff', variable = 'Stats Producer', talent = true},
 	['director'] = {category = 'Production Staff', variable = 'Director', talent = true},
 	['interviewer'] = {category = 'Interviewers', variable = 'Interviewer', talent = true},
+	['translator'] = {category = 'Production Staff', variable = 'Translator', talent = true},
+	['interpreter'] = {category = 'Production Staff', variable = 'Interpreter', talent = true},
 }
 ROLES['in-game leader'] = ROLES.igl
 
@@ -79,13 +85,13 @@ function CustomInjector:parse(id, widgets)
 			return CharacterIcon.Icon{character = agent, size = SIZE_AGENT}
 		end)
 		return {
-			Cell{name = 'Signature Hero', content = {table.concat(icons, '&nbsp;')}}
+			Cell{name = 'Signature Agent', content = {table.concat(icons, '&nbsp;')}}
 		}
 	elseif id == 'status' then
 		return {
 			Cell{name = 'Status', content = CustomPlayer._getStatusContents(args)},
 			Cell{name = 'Years Active (Player)', content = {args.years_active}},
-			Cell{name = 'Years Active (Org)', content = {args.years_active_manage}},
+			Cell{name = 'Years Active (Org)', content = {args.years_active_org}},
 			Cell{name = 'Years Active (Coach)', content = {args.years_active_coach}},
 			Cell{name = 'Years Active (Talent)', content = {args.years_active_talent}},
 		}

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -31,7 +31,6 @@ local ROLES = {
 	['analyst'] = {category = 'Analysts', variable = 'Analyst', staff = true},
 	['coach'] = {category = 'Coaches', variable = 'Coach', staff = true},
 	['manager'] = {category = 'Managers', variable = 'Manager', staff = true},
-	
 	-- Talents
 	['broadcast analyst'] = {category = 'Broadcast Analysts', variable = 'Broadcast Analyst', talent = true},
 	['observer'] = {category = 'Observers', variable = 'Observer', talent = true},

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -85,7 +85,7 @@ function CustomInjector:parse(id, widgets)
 			return CharacterIcon.Icon{character = agent, size = SIZE_AGENT}
 		end)
 		return {
-			Cell{name = 'Signature Agent', content = {table.concat(icons, '&nbsp;')}}
+			Cell{name = 'Signature Hero', content = {table.concat(icons, '&nbsp;')}}
 		}
 	elseif id == 'status' then
 		return {

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -91,7 +91,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{name = 'Status', content = CustomPlayer._getStatusContents(args)},
 			Cell{name = 'Years Active (Player)', content = {args.years_active}},
-			Cell{name = 'Years Active (Org)', content = {args.years_active_org}},
+			Cell{name = 'Years Active (<abbr title="Organisation">Org</abbr>)', content = {args.years_active_org}},
 			Cell{name = 'Years Active (Coach)', content = {args.years_active_coach}},
 			Cell{name = 'Years Active (Talent)', content = {args.years_active_talent}},
 		}


### PR DESCRIPTION
## Summary
- New roles:
1. Content Creator
2. Stats Producer
3. Translator
4. Interpreter
- 'Streamers' role category changed from 'Streamers' to 'Content Creators'
- Added abbreviation for `Years Active (Org)` - not sure if that's the best way to do it though
- `years_active_manage` param renamed to `years_active_org` - there are only a handful of usages, so it can be changed manually on the wiki once merged

## How did you test this change?
