### PR TITLE
fix(tabs): static tabs without links display are wonky

### DIFF
--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -39,7 +39,7 @@ function Tabs.static(args)
 			return
 		end
 		local name = tab.name or Tabs._getDisplayNameFromLink(tab.link --[[@as string]])
-		local text = tab.link and Page.makeInternalLink({}, name, tab.link) or tab.name
+		local text = Page.makeInternalLink({}, name, tab.link)
 		tabs:tag('li'):addClass(tab.this and 'active' or nil):wikitext(text)
 		subTabs:node(tab.this and tab.tabs or nil)
 	end)

--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -35,7 +35,9 @@ function Tabs.static(args)
 	local subTabs = mw.html.create()
 
 	Array.forEach(tabArgs, function(tab)
-		--if tab.name is unset tab.link is set as per `Tabs._readArguments`
+		if not tab.link then
+			return
+		end
 		local name = tab.name or Tabs._getDisplayNameFromLink(tab.link --[[@as string]])
 		local text = tab.link and Page.makeInternalLink({}, name, tab.link) or tab.name
 		tabs:tag('li'):addClass(tab.this and 'active' or nil):wikitext(text)


### PR DESCRIPTION
## Summary
Static Tabs without a link displays completely bonkers. They should be hidden

## How did you test this change?

Live