### PR TITLE
feat(match2): add display option switching between bracket and matchlist

### DIFF
--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -190,7 +190,7 @@ function MatchGroup.TemplateShowBracket(frame)
 	return MatchGroup.MatchGroupById(args)
 end
 
--- Entry point of Template:ShowBracket, Template:DisplayMatchGroup
+-- Entry point of Template:BracketMatchlistToggle
 ---@param frame Frame
 ---@return string|Html?
 function MatchGroup.TemplateBracketMatchlistToggle(frame)
@@ -202,7 +202,7 @@ function MatchGroup.TemplateBracketMatchlistToggle(frame)
 	return MatchGroup.BracketMatchlistToggle(Table.merge(args, {id = MatchGroupBase.readBracketId(args.id)}))
 end
 
--- Entry point of Template:ShowBracket, Template:DisplayMatchGroup
+-- Entry point of Template:ShowBracketMatchlistToggle
 ---@param frame Frame
 ---@return string|Html?
 function MatchGroup.TemplateShowBracketMatchlistToggle(frame)

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -223,7 +223,11 @@ function MatchGroup.BracketMatchlistToggle(args)
 		content1 = MatchGroup.MatchGroupById(args),
 		content2 = mw.html.create()
 			:node(args.gtl)
-			:node(MatchGroup.MatchGroupById(Table.merge(args, {forceMatchList = true}))),
+			:node(MatchGroup.MatchGroupById(Table.merge(args, {
+				forceMatchList = true,
+				collapsed = Logic.nilOr(Logic.readBoolOrNil(args.collapsed), Logic.isNotEmpty(args.gtl)),
+				attached = Logic.nilOr(Logic.readBoolOrNil(args.attached), Logic.isNotEmpty(args.gtl)),
+			}))),
 	}
 end
 

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -213,7 +213,8 @@ end
 ---@param args table
 ---@return string|Html?
 function MatchGroup.BracketMatchlistToggle(args)
-	--for the poc just use tabs dynamic, for live preferably use a toggle button
+	--for now use tabs dynamic, goal is to use toggle buttons for this,
+	--but they clash with rounds in GTL input (if the GTL has rounds set), so would need some additional js
 	return Tabs.dynamic{
 		['hide-showall'] = true,
 		This = args.This,

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -12,6 +12,7 @@ local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+local Tabs = require('Module:Tabs')
 local WarningBox = require('Module:WarningBox')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
@@ -187,6 +188,42 @@ end
 function MatchGroup.TemplateShowBracket(frame)
 	local args = Arguments.getArgs(frame)
 	return MatchGroup.MatchGroupById(args)
+end
+
+-- Entry point of Template:ShowBracket, Template:DisplayMatchGroup
+---@param frame Frame
+---@return string|Html?
+function MatchGroup.TemplateBracketMatchlistToggle(frame)
+	local args = Arguments.getArgs(frame)
+
+	-- build the brackets variables and storage
+	MatchGroup.Bracket(args)
+
+	return MatchGroup.BracketMatchlistToggle(Table.merge(args, {id = MatchGroupBase.readBracketId(args.id)}))
+end
+
+-- Entry point of Template:ShowBracket, Template:DisplayMatchGroup
+---@param frame Frame
+---@return string|Html?
+function MatchGroup.TemplateShowBracketMatchlistToggle(frame)
+	local args = Arguments.getArgs(frame)
+	return MatchGroup.BracketMatchlistToggle(args)
+end
+
+---@param args table
+---@return string|Html?
+function MatchGroup.BracketMatchlistToggle(args)
+	--for the poc just use tabs dynamic, for live preferably use a toggle button
+	return Tabs.dynamic{
+		['hide-showall'] = true,
+		This = args.This,
+		name1 = 'Bracket',
+		name2 = 'Matchlist',
+		content1 = MatchGroup.MatchGroupById(args),
+		content2 = mw.html.create()
+			:node(args.gtl)
+			:node(MatchGroup.MatchGroupById(Table.merge(args, {forceMatchList = true}))),
+	}
 end
 
 if FeatureFlag.get('perf') then


### PR DESCRIPTION
## Summary
Add an additional display mode that displays a bracket both as bracket and matchlist (optionally with GTL).
The display is done via Tabs dynamic.

requested by kano

## How did you test this change?
dev

examples:
- entering bracket data: https://liquipedia.net/starcraft2/User:Hjpalpha/wip6
- retrieving from lpdb: https://liquipedia.net/starcraft2/User:Hjpalpha/wip7

## Remark
Long term the display should be switched to toggle buttons.
But if i use `data-toggle-area-btn`, `data-toggle-area-content` etc it clashes with GTL which uses the same for its round/week/day/... dropdown display.
Hence i assume it would need additional/changed JS to support this. Since i don't have the time (nor passion) to look into js atm leaving it using tabs dynamic instead.

## Remark2:
After we standardized GTL we could make it so that the input into `gtl` param is a Json and build the display by directly calling it and hence reduce include size for that quite a bit