### PR TITLE
revert:"fix(tabs): static tabs without links display are wonky (#4135)"

### DIFF
--- a/standard/tabs.lua
+++ b/standard/tabs.lua
@@ -35,11 +35,9 @@ function Tabs.static(args)
 	local subTabs = mw.html.create()
 
 	Array.forEach(tabArgs, function(tab)
-		if not tab.link then
-			return
-		end
+		--if tab.name is unset tab.link is set as per `Tabs._readArguments`
 		local name = tab.name or Tabs._getDisplayNameFromLink(tab.link --[[@as string]])
-		local text = Page.makeInternalLink({}, name, tab.link)
+		local text = tab.link and Page.makeInternalLink({}, name, tab.link) or tab.name
 		tabs:tag('li'):addClass(tab.this and 'active' or nil):wikitext(text)
 		subTabs:node(tab.this and tab.tabs or nil)
 	end)


### PR DESCRIPTION
## Summary
revert #4135 as it broke several things (across lots of wikis)
- https://discord.com/channels/93055209017729024/268719633366777856/1224813148541030590
- https://discord.com/channels/93055209017729024/268719633366777856/1224941155460972598

## How did you test this change?
spazer reverted it live