### PR TITLE
refactor(info): remove deprected fields - part 1

### DIFF
--- a/standard/info/commons/info.lua
+++ b/standard/info/commons/info.lua
@@ -26,7 +26,5 @@ return {
 	},
 	defaultGame = 'commons',
 
-	defaultTeamLogo = 'Liquipedia logo.png', ---@deprecated
-	defaultTeamLogoDark = 'Liquipedia logo.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/ageofempires/info.lua
+++ b/standard/info/wikis/ageofempires/info.lua
@@ -93,7 +93,5 @@ return {
 	},
 	defaultGame = 'Age of Empires II',
 
-	defaultTeamLogo = 'Age of Empires default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Age of Empires default allmode.png', ---@deprecated
 	match2 = 1,
 }

--- a/standard/info/wikis/apexlegends/info.lua
+++ b/standard/info/wikis/apexlegends/info.lua
@@ -27,7 +27,5 @@ return {
 	},
 	defaultGame = 'apexlegends',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Apex Legends default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Apex Legends default darkmode.png', ---@deprecated
 	match2 = 1,
 }

--- a/standard/info/wikis/arenafps/info.lua
+++ b/standard/info/wikis/arenafps/info.lua
@@ -403,7 +403,5 @@ return {
 		},
 	},
 	defaultGame = 'qc',
-	defaultTeamLogo = 'Quake default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Quake default darkmode.png', ---@deprecated
 	match2 = 1,
 }

--- a/standard/info/wikis/arenaofvalor/info.lua
+++ b/standard/info/wikis/arenaofvalor/info.lua
@@ -67,13 +67,5 @@ return {
 	},
 	defaultGame = 'aov',
 
-	defaultTeamLogo = {
-		aov = 'Arena of ValorLogo.png', --Arena of Valor
-		hok = 'Honor of Kings 2018-12-24 Logo.png', --Honor of Kings
-	}, ---@deprecated
-	defaultTeamLogoDark = {
-		aov = 'Arena of ValorLogo.png', --Arena of Valor
-		hok = 'Honor of Kings 2018-12-24 Logo.png', --Honor of Kings
-	}, ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/artifact/info.lua
+++ b/standard/info/wikis/artifact/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'artifact',
-	defaultTeamLogo = 'Artifact allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Artifact allmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/autochess/info.lua
+++ b/standard/info/wikis/autochess/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'autochess',
-	defaultTeamLogo = 'Auto Chess lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Auto Chess darkmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/battalion/info.lua
+++ b/standard/info/wikis/battalion/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'battalion',
-	defaultTeamLogo = 'Battalion 1944 default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Battalion 1944 default darkmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/battlerite/info.lua
+++ b/standard/info/wikis/battlerite/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'battlerite',
-	defaultTeamLogo = 'Battlerite default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Battlerite default allmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/brawlhalla/info.lua
+++ b/standard/info/wikis/brawlhalla/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'brawl',
-	defaultTeamLogo = 'Brawlhalla Default logo.png', ---@deprecated
-	defaultTeamLogoDark = 'Brawlhalla Default logo.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/brawlstars/info.lua
+++ b/standard/info/wikis/brawlstars/info.lua
@@ -27,7 +27,5 @@ return {
 	},
 	defaultGame = 'brawlstars',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Brawl Stars Default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Brawl Stars Default allmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/callofduty/info.lua
+++ b/standard/info/wikis/callofduty/info.lua
@@ -339,7 +339,5 @@ return {
 	},
 	defaultGame = 'cod',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Call of Duty Default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Call of Duty Default darkmode.png', ---@deprecated
 	match2 = 1,
 }

--- a/standard/info/wikis/clashofclans/info.lua
+++ b/standard/info/wikis/clashofclans/info.lua
@@ -27,7 +27,5 @@ return {
 	},
 	defaultGame = 'clashofclans',
 
-	defaultTeamLogo = 'Clash of Clans default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Clash of Clans default allmode.png', ---@deprecated
 	match2 = 1,
 }

--- a/standard/info/wikis/clashroyale/info.lua
+++ b/standard/info/wikis/clashroyale/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'cr',
-	defaultTeamLogo = 'Clash Royale.png', ---@deprecated
-	defaultTeamLogoDark = 'Clash Royale.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/criticalops/info.lua
+++ b/standard/info/wikis/criticalops/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'cops',
-	defaultTeamLogo = 'Critical Ops allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Critical Ops allmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/crossfire/info.lua
+++ b/standard/info/wikis/crossfire/info.lua
@@ -53,7 +53,5 @@ return {
 	},
 	defaultGame = 'cf',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Crossfire default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Crossfire default darkmode.png', ---@deprecated
 	match2 = 1,
 }

--- a/standard/info/wikis/dota2/info.lua
+++ b/standard/info/wikis/dota2/info.lua
@@ -40,7 +40,5 @@ return {
 	},
 	defaultGame = 'dota2',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Dota2 logo.png', ---@deprecated
-	defaultTeamLogoDark = 'Dota2 logo.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/fifa/info.lua
+++ b/standard/info/wikis/fifa/info.lua
@@ -417,7 +417,5 @@ return {
 	},
 	defaultGame = 'fifa',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'FIFA lightmode logo.png', ---@deprecated
-	defaultTeamLogoDark = 'FIFA darkmode logo.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -1651,7 +1651,5 @@ return {
 		},
 	},
 	defaultGame = 'fighters',
-	defaultTeamLogo = 'Fighters default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Fighters default darkmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/formula1/info.lua
+++ b/standard/info/wikis/formula1/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'formula1',
-	defaultTeamLogo = 'Sim Racing default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Sim Racing default darkmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/fortnite/info.lua
+++ b/standard/info/wikis/fortnite/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'fortnite',
-	defaultTeamLogo = 'Fortnite default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Fortnite default allmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/freefire/info.lua
+++ b/standard/info/wikis/freefire/info.lua
@@ -27,7 +27,5 @@ return {
 	},
 	defaultGame = 'freefire',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Freefire Default Logo.png', ---@deprecated
-	defaultTeamLogoDark = 'Freefire Default Logo.png', ---@deprecated
 	match2 = 0,
 }


### PR DESCRIPTION
## Summary
Remove deprected fields from info modules - part 1
(removed remaining usage i coud find via https://tools.liquipedia.space/?view=search)

## How did you test this change?
N/A