### PR TITLE
refactor(info): remove deprected fields - part 3

### DIFF
--- a/standard/info/wikis/smash/info.lua
+++ b/standard/info/wikis/smash/info.lua
@@ -91,7 +91,5 @@ return {
 		},
 	},
 	defaultGame = 'melee',
-	defaultTeamLogo = 'Smashlogo std.png', ---@deprecated
-	defaultTeamLogoDark = 'Smashlogo std.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/smite/info.lua
+++ b/standard/info/wikis/smite/info.lua
@@ -39,7 +39,5 @@ return {
 		},
 	},
 	defaultGame = 'smite',
-	defaultTeamLogo = 'SMITE default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'SMITE default darkmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/splatoon/info.lua
+++ b/standard/info/wikis/splatoon/info.lua
@@ -52,7 +52,5 @@ return {
 		},
 	},
 	defaultGame = '1',
-	defaultTeamLogo = 'Splatoon default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Splatoon default darkmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/splitgate/info.lua
+++ b/standard/info/wikis/splitgate/info.lua
@@ -27,9 +27,5 @@ return {
 	},
 	defaultGame = 'splitgate',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Splitgate allmode.png (2019) Change date '
-		.. '(2021-06-01) Splitgate 2021 lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Splitgate allmode.png (2019) Change date '
-		.. '(2021-06-01) Splitgate 2021 darkmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/squadrons/info.lua
+++ b/standard/info/wikis/squadrons/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'squadrons',
-	defaultTeamLogo = 'Star Wars Squadrons allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Star Wars Squadrons allmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/starcraft/info.lua
+++ b/standard/info/wikis/starcraft/info.lua
@@ -27,8 +27,6 @@ return {
 		},
 	},
 	defaultGame = 'bw',
-	defaultTeamLogo = 'StarCraft default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'StarCraft default allmode.png', ---@deprecated
 
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',

--- a/standard/info/wikis/starcraft2/info.lua
+++ b/standard/info/wikis/starcraft2/info.lua
@@ -52,8 +52,6 @@ return {
 		},
 	},
 	defaultGame = 'wol',
-	defaultTeamLogo = 'StarCraft 2 Default logo.png', ---@deprecated
-	defaultTeamLogoDark = 'StarCraft 2 Default logo.png', ---@deprecated
 
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',

--- a/standard/info/wikis/stormgate/info.lua
+++ b/standard/info/wikis/stormgate/info.lua
@@ -27,8 +27,6 @@ return {
 	},
 	defaultGame = 'stormgate',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Stormgate default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Stormgate default darkmode.png', ---@deprecated
 	opponentLibrary = 'Opponent/Custom',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 	match2 = 2,

--- a/standard/info/wikis/teamfortress/info.lua
+++ b/standard/info/wikis/teamfortress/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'tf2',
-	defaultTeamLogo = 'Team Fortress logo.png', ---@deprecated
-	defaultTeamLogoDark = 'Team Fortress logo.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/tetris/info.lua
+++ b/standard/info/wikis/tetris/info.lua
@@ -443,7 +443,5 @@ return {
 	},
 	defaultGame = 'tetris',
 
-	defaultTeamLogo = 'Tetris default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Tetris default allmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/tft/info.lua
+++ b/standard/info/wikis/tft/info.lua
@@ -40,7 +40,5 @@ return {
 	},
 	defaultGame = 'tft',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'Teamfight Tactics Double Up lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Teamfight Tactics Double Up darkmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/trackmania/info.lua
+++ b/standard/info/wikis/trackmania/info.lua
@@ -143,8 +143,6 @@ return {
 		},
 	},
 	defaultGame = 'tm',
-	defaultTeamLogo = 'Trackmania logo lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Trackmania logo darkmode.png', ---@deprecated
 	opponentLibrary = 'Opponent',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 	match2 = 1,

--- a/standard/info/wikis/underlords/info.lua
+++ b/standard/info/wikis/underlords/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'underlords',
-	defaultTeamLogo = 'Dota Underlords lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Dota Underlords darkmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/valorant/info.lua
+++ b/standard/info/wikis/valorant/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'val',
-	defaultTeamLogo = 'VALORANT allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'VALORANT allmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/warcraft/info.lua
+++ b/standard/info/wikis/warcraft/info.lua
@@ -52,8 +52,6 @@ return {
 		},
 	},
 	defaultGame = 'reforged',
-	defaultTeamLogo = 'Warcraft III default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Warcraft III default allmode.png', ---@deprecated
 	opponentLibrary = 'Opponent/Custom',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 	match2 = 2,

--- a/standard/info/wikis/wildrift/info.lua
+++ b/standard/info/wikis/wildrift/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'wildrift',
-	defaultTeamLogo = 'Wild Rift Teamcard.png', ---@deprecated
-	defaultTeamLogoDark = 'Wild Rift Teamcard.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/worldoftanks/info.lua
+++ b/standard/info/wikis/worldoftanks/info.lua
@@ -66,7 +66,5 @@ return {
 	},
 	defaultGame = 'worldoftanks',
 	defaultRoundPrecision = 0,
-	defaultTeamLogo = 'World of Tanks default lightmode.png', ---@deprecated
-	defaultTeamLogoDark = 'World of Tanks default darkmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/worldofwarcraft/info.lua
+++ b/standard/info/wikis/worldofwarcraft/info.lua
@@ -26,7 +26,5 @@ return {
 		},
 	},
 	defaultGame = 'wow',
-	defaultTeamLogo = 'WoWlogo Default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'WoWlogo Default allmode.png', ---@deprecated
 	match2 = 0,
 }

--- a/standard/info/wikis/zula/info.lua
+++ b/standard/info/wikis/zula/info.lua
@@ -64,9 +64,7 @@ return {
 			},
 		},
 	},
-	defaultGame = 'zula',
+	defaultGame = 'zula',+
 
-	defaultTeamLogo = 'Zula Global default allmode.png', ---@deprecated
-	defaultTeamLogoDark = 'Zula Global default allmode.png', ---@deprecated
 	match2 = 2,
 }

--- a/standard/info/wikis/zula/info.lua
+++ b/standard/info/wikis/zula/info.lua
@@ -64,7 +64,7 @@ return {
 			},
 		},
 	},
-	defaultGame = 'zula',+
+	defaultGame = 'zula',
 
 	match2 = 2,
 }


### PR DESCRIPTION
## Summary
Remove deprected fields from info modules - part 3
(removed remaining usage i coud find via https://tools.liquipedia.space/?view=search)

## How did you test this change?
N/A