### PR TITLE
fix(match2): fix broken 1v1 matches

### DIFF
--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -115,7 +115,7 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 		teamTemplateDate = Variables.varDefaultMulti('tournament_enddate', 'tournament_startdate', NOW)
 	end
 
-	Opponent.resolve(opponent, teamTemplateDate)
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer=true})
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
@@ -361,7 +361,7 @@ function matchFunctions.getOpponents(match)
 						maxNumPlayers = _MAX_NUM_PLAYERS,
 					})
 				end
-			elseif Opponent.typeIsParty(opponent) then
+			elseif Opponent.typeIsParty(opponent.type) then
 				opponent.match2players = Json.parseIfString(opponent.match2players) or {}
 				opponent.match2players[1].name = opponent.name
 			elseif opponent.type ~= Opponent.literal then


### PR DESCRIPTION
## Summary
We had several 1v1 tournaments for the ML Wiki, but this module doesn't support SoloOpponent. I replaced `typeIsParty(opponent)` with `typeIsParty(opponent.type)` to make it work.
## How did you test this change?
dev https://liquipedia.net/mobilelegends/User:MatryoshX/Sandbox
