### PR TITLE
Add Infobox Icons & Links for `Rooter` and `CFS`

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -55,6 +55,7 @@ local PREFIXES = {
 	chzzk = {'https://chzzk.naver.com/live/'},
 	cntft = {'https://lol.qq.com/tft/#/masterDetail/'},
 	corestrike = {'https://corestrike.gg/lookup/'},
+	cfs = {'https://www.crossfirestars.com/'},
 	datdota = {
 		'https://www.datdota.com/leagues/',
 		player = 'https://www.datdota.com/players/',
@@ -153,6 +154,7 @@ local PREFIXES = {
 		team = 'https://rgl.gg/Public/Team?t=',
 		player = 'https://rgl.gg/Public/PlayerProfile?p=',
 	},
+	rooter = {'https://rooter.gg/'},
 	royaleapi = {'https://royaleapi.com/player/'},
 	rules = {''},
 	shift = {'https://www.shiftrle.gg/events/'},

--- a/standard/links/commons/links_priority_groups.lua
+++ b/standard/links/commons/links_priority_groups.lua
@@ -19,6 +19,7 @@ return {
 		'apexlegendsstatus',
 		'battlefy',
 		'b5csgo',
+		'cfs',
 		'challengermode',
 		'challonge',
 		'cybergamer',
@@ -100,5 +101,6 @@ return {
 		'steamtv',
 		'yandexefir',
 		'zhanqitv',
+		'rooter',
 	},
 }

--- a/stylesheets/commons/Icons.less
+++ b/stylesheets/commons/Icons.less
@@ -60,6 +60,7 @@ Note: When adding a new icon, please add to
 	.icon-make-image( cafe-daum, "//liquipedia.net/commons/images/c/c9/InfoboxIcon_Daum.png" );
 	.icon-make-image( caffeine, "//liquipedia.net/commons/images/4/4b/InfoboxIcon_Caffeine.png" );
 	.icon-make-image( cc, "//liquipedia.net/commons/images/4/46/InfoboxIcon_cc.png" );
+	.icon-make-image( cfs, "//liquipedia.net/commons/images/1/1e/InfoboxIcon_CFS.png" );
 	.icon-make-image( challengermode, "//liquipedia.net/commons/images/1/19/InfoboxIcon_Challengermode.png" );
 	.icon-make-image( challonge, "//liquipedia.net/commons/images/c/cd/InfoboxIcon_Challonge.png" );
 	.icon-make-image( chzzk, "//liquipedia.net/commons/images/7/71/InfoboxIcon_CHZZK.png" );
@@ -129,6 +130,7 @@ Note: When adding a new icon, please add to
 	.icon-make-image( reddit, "//liquipedia.net/commons/images/5/59/InfoboxIcon_Reddit.png" );
 	.icon-make-image( replay, "//liquipedia.net/commons/images/5/52/InfoboxIcon_Replay.png" );
 	.icon-make-image( rgl, "//liquipedia.net/commons/images/9/91/InfoboxIcon_RGL.png" );
+	.icon-make-image( rooter, "//liquipedia.net/commons/images/f/f7/InfoboxIcon_Rooter.png" );
 	.icon-make-image( royaleapi, "//liquipedia.net/commons/images/7/74/InfoboxIcon_RoyaleAPI.png" );
 	.icon-make-image( rules, "//liquipedia.net/commons/images/d/d0/InfoboxIcon_Rules.png" );
 	.icon-make-image( shift, "//liquipedia.net/commons/images/6/61/InfoboxIcon_Shift.png" );


### PR DESCRIPTION
## Summary
These are two separate requests that happens on same time 

- Rooter is a streaming platform
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/6a3a0006-8dac-49f2-8d36-00de3bdf94a1)

- CFS is the official site for CrossFire events, editors requested this to be a separate icon as sometime it needs a usage over a 2nd website parameter
- while the full site is named `crossfirestars` the param was decided to be just `cfs` the site's official shortname
![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/a18e6053-3506-493c-baf1-4377e7fd9b99)

this PR adds the icons and links for both

File needs to be added to CSS by someone else because I cannot edit the .css

https://liquipedia.net/commons/File:InfoboxIcon_Rooter.png
https://liquipedia.net/commons/File:InfoboxIcon_CFS.png
