### PR TITLE
fix(squad): error on league of legends

### DIFF
--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -113,7 +113,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(row:create(SquadUtils.defaultObjectName(player, squadType)))
+	return row:create(SquadUtils.defaultObjectName(player, squadType))
 end
 
 return CustomSquad


### PR DESCRIPTION
## Summary
When refactoring the objectnames, league of legends apparently ended up with two row:create(), instead of one. 
IDE would have caught this if it wasn't for ExtendedSquad() being in use.

## How did you test this change?

Live
