### PR TITLE
feat(infobox): rename header on F1 person infobox

### DIFF
--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -90,7 +90,7 @@ function CustomPlayer:addCustomCells(widgets)
 	end
 
 	return Array.extendWith(widgets,
-		{Title{name = 'Driver Statistics'}},
+		{Title{name = 'F1 Driver Statistics'}},
 		Array.map(statisticsCells, function(cellData)
 			return Cell{name = cellData.name, content = {args[cellData.key]}}
 		end)


### PR DESCRIPTION
## Summary

Rename the header to clarify which stats are being displayed. Since there are multiple series other than F1
fwiw I do plan on eventually moving stats out of the infoboxes and into a subpage where we can track all series

## How did you test this change?

dev 
