### PR TITLE
fix details of the IDR currency

### DIFF
--- a/standard/currency_data.lua
+++ b/standard/currency_data.lua
@@ -333,9 +333,9 @@ return {
 	},
 	idr = {
 		code = 'IDR',
-		name = 'Indonesian Rupee',
+		name = 'Indonesian rupiah',
 		symbol = {
-			hasSpace = true,
+			hasSpace = false,
 			isAfter = false,
 			text = 'Rp',
 		},


### PR DESCRIPTION
## Summary
Fixing details of the IDR currency. The name of the currency is Indonesian rupiah, and there is no space after the currency symbol.
https://en.wikipedia.org/wiki/Indonesian_rupiah
## How did you test this change?
via /dev