### PR TITLE
fix(char icons): allow empty link

### DIFF
--- a/components/character_icon/commons/character_icon.lua
+++ b/components/character_icon/commons/character_icon.lua
@@ -51,7 +51,7 @@ function CharacterIcon._makeImage(info, size, class)
 		info.file,
 		info.display,
 		size,
-		Logic.isNotEmpty(info.link) and 'link=' .. info.link or nil,
+		info.link and ('link=' .. info.link) or nil,
 		Logic.isNotEmpty(class) and 'class=' .. class or nil
 	)
 


### PR DESCRIPTION
## Summary
allow empty link in character icons to be able to supress linking

## How did you test this change?
dev