### PR TITLE
feat(opponent): make faction alias to race on craft wikis

### DIFF
--- a/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -63,18 +63,18 @@ function StarcraftOpponent.readOpponentArgs(args)
 	end
 
 	if partySize == 1 then
-		opponent.players[1].race = Faction.read(args.race)
+		opponent.players[1].race = Faction.read(args.faction or args.race)
 
 	elseif partySize then
 		opponent.isArchon = Logic.readBool(args.isarchon)
 		if opponent.isArchon then
-			local archonRace = Faction.read(args.race)
+			local archonRace = Faction.read(args.faction or args.race)
 			for _, player in ipairs(opponent.players) do
 				player.race = archonRace
 			end
 		else
 			for playerIx, player in ipairs(opponent.players) do
-				player.race = Faction.read(args['p' .. playerIx .. 'race'])
+				player.race = Faction.read(args['p' .. playerIx .. 'faction'] or args['p' .. playerIx .. 'race'])
 			end
 		end
 	end

--- a/components/opponent/wikis/warcraft/opponent_custom.lua
+++ b/components/opponent/wikis/warcraft/opponent_custom.lua
@@ -53,10 +53,10 @@ function CustomOpponent.readOpponentArgs(args)
 	end
 
 	if partySize == 1 then
-		opponent.players[1].race = Faction.read(args.race)
+		opponent.players[1].race = Faction.read(args.faction or args.race)
 	elseif partySize then
 		for playerIx, player in ipairs(opponent.players) do
-			player.race = Faction.read(args['p' .. playerIx .. 'race'])
+			player.race = Faction.read(args['p' .. playerIx .. 'faction'] or args['p' .. playerIx .. 'race'])
 		end
 	end
 


### PR DESCRIPTION
## Summary
Allow `faction` as an alternative input to `race` on warcraft, starcraft and stracraft2. First steps in a possible standardization, but allows for easier usage on commons.

## How did you test this change?
With /dev