### PR TITLE
feat(squad): use model for storing

### DIFF
--- a/components/squad/commons/squad_custom.lua
+++ b/components/squad/commons/squad_custom.lua
@@ -78,7 +78,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -10,6 +10,7 @@ local Class = require('Module:Class')
 local Flags = require('Module:Flags')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
+local Lpdb = require('Module:Lpdb')
 local Lua = require('Module:Lua')
 local OpponentLib = require('Module:OpponentLibraries')
 local Opponent = OpponentLib.Opponent
@@ -31,14 +32,14 @@ local ICON_SUBSTITUTE = Icon.makeIcon{iconName = 'substitute', hover = 'Substitu
 ---@field children Widget[]
 ---@field options {useTemplatesForSpecialTeams: boolean?}
 ---@field backgrounds string[]
----@field lpdbData table
+---@field lpdbData ModelRow
 local SquadRow = Class.new(
 	function(self, options)
 		self.options = options or {}
 		self.children = {}
 		self.backgrounds = {'Player'}
 
-		self.lpdbData = {type = SquadUtils.defaultPersonType}
+		self.lpdbData = Lpdb.SquadPlayer:new()
 	end
 )
 
@@ -55,7 +56,6 @@ function SquadRow:id(args)
 	if String.isEmpty(args[1]) then
 		error('Something is off with your input!')
 	end
-
 
 	local content = {}
 	local opponent = Opponent.resolve(
@@ -262,11 +262,10 @@ function SquadRow:setExtradata(extradata)
 	return self
 end
 
----@param objectName string
 ---@return WidgetTableRowNew
-function SquadRow:create(objectName)
+function SquadRow:create()
 	if not Logic.readBool(Variables.varDefault('disable_LPDB_storage')) then
-		mw.ext.LiquipediaDB.lpdb_squadplayer(objectName, self.lpdbData)
+		self.lpdbData:save()
 	end
 
 	return Widget.TableRowNew{

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -93,17 +93,4 @@ function SquadUtils.convertAutoParameters(player)
 	return newPlayer
 end
 
----@param player table
----@param squadType SquadType
----@return string
-function SquadUtils.defaultObjectName(player, squadType)
-	local link = mw.ext.TeamLiquidIntegration.resolve_redirect(player.link or player.id)
-
-	return mw.title.getCurrentTitle().prefixedText
-	.. '_' .. link .. '_'
-	.. ReferenceCleaner.clean(player.joindate)
-	.. (player.role and '_' .. player.role or '')
-	.. '_' .. squadType
-end
-
 return SquadUtils

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Table = require('Module:Table')
 
 local SquadAutoRefs = Lua.import('Module:SquadAuto/References')

--- a/components/squad/wikis/apexlegends/squad_custom.lua
+++ b/components/squad/wikis/apexlegends/squad_custom.lua
@@ -58,7 +58,7 @@ function CustomSquad.run(frame)
 			}
 		end
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 	end)
 
 	return squad:create()

--- a/components/squad/wikis/arenaofvalor/squad_custom.lua
+++ b/components/squad/wikis/arenaofvalor/squad_custom.lua
@@ -95,7 +95,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/counterstrike/squad_custom.lua
+++ b/components/squad/wikis/counterstrike/squad_custom.lua
@@ -58,7 +58,7 @@ function CustomSquad.run(frame)
 			}
 		end
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 	end)
 
 	return squad:create()

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -80,7 +80,7 @@ function CustomSquad.run(frame)
 			}
 		end
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 	end)
 
 	return squad:create()

--- a/components/squad/wikis/halo/squad_custom.lua
+++ b/components/squad/wikis/halo/squad_custom.lua
@@ -76,7 +76,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/leagueoflegends/squad_custom.lua
+++ b/components/squad/wikis/leagueoflegends/squad_custom.lua
@@ -79,7 +79,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/mobilelegends/squad_custom.lua
+++ b/components/squad/wikis/mobilelegends/squad_custom.lua
@@ -93,7 +93,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -123,7 +123,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/rainbowsix/squad_custom.lua
+++ b/components/squad/wikis/rainbowsix/squad_custom.lua
@@ -77,7 +77,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/rocketleague/squad_custom.lua
+++ b/components/squad/wikis/rocketleague/squad_custom.lua
@@ -51,7 +51,7 @@ function CustomSquad.run(frame)
 			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 		end
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 	end)
 
 	return squad:create()

--- a/components/squad/wikis/smash/squad_custom.lua
+++ b/components/squad/wikis/smash/squad_custom.lua
@@ -93,7 +93,7 @@ function CustomSquad.run(frame)
 			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 		end
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 
 		Variables.varDefine('nationality', '')
 		Variables.varDefine('name', '')

--- a/components/squad/wikis/smite/squad_custom.lua
+++ b/components/squad/wikis/smite/squad_custom.lua
@@ -93,7 +93,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(leaveText, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/starcraft/squad_custom.lua
+++ b/components/squad/wikis/starcraft/squad_custom.lua
@@ -116,7 +116,7 @@ function CustomSquad.run(frame)
 			end
 		end
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 	end)
 
 	return squad:create()

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -85,7 +85,7 @@ function CustomSquad.run(frame)
 			status = status,
 		}
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 	end)
 
 	return squad:create()

--- a/components/squad/wikis/stormgate/squad_custom.lua
+++ b/components/squad/wikis/stormgate/squad_custom.lua
@@ -95,7 +95,7 @@ function CustomSquad._playerRow(player, squadType)
 
 	row:setExtradata{faction = faction}
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/valorant/squad_custom.lua
+++ b/components/squad/wikis/valorant/squad_custom.lua
@@ -88,7 +88,7 @@ function CustomSquad._playerRow(player, squadType)
 		}
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/components/squad/wikis/warcraft/squad_custom.lua
+++ b/components/squad/wikis/warcraft/squad_custom.lua
@@ -52,7 +52,7 @@ function CustomSquad.run(frame)
 			row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 		end
 
-		squad:row(row:create(SquadUtils.defaultObjectName(player, squad.type)))
+		squad:row(row:create())
 	end)
 
 	return squad:create()

--- a/components/squad/wikis/wildrift/squad_custom.lua
+++ b/components/squad/wikis/wildrift/squad_custom.lua
@@ -94,7 +94,7 @@ function CustomSquad._playerRow(player, squadType)
 		row:date(player.inactivedate, 'Inactive Date:&nbsp;', 'inactivedate')
 	end
 
-	return row:create(SquadUtils.defaultObjectName(player, squadType))
+	return row:create()
 end
 
 return CustomSquad

--- a/spec/squad_spec.lua
+++ b/spec/squad_spec.lua
@@ -20,22 +20,30 @@ describe('Squad', function()
 			local row = SquadRow()
 			row:id{'Baz', 'se'}
 					:name{name = 'Foo Bar'}
+					:status(2)
 					:role{}
 					:date('2022-01-01', 'Join Date:&nbsp;', 'joindate')
 					:date('2022-03-03', 'Inactive Date:&nbsp;', 'inactivedate')
 					:date('2022-05-01', 'Leave Date:&nbsp;', 'leavedate')
 
-			GoldenTest('squad_row', tostring(row:create('foo_bar_baz'):tryMake()[1]))
+			GoldenTest('squad_row', tostring(row:create():tryMake()[1]))
 
-			assert.stub(LpdbSquadStub).was.called_with('foo_bar_baz', {
+			assert.stub(LpdbSquadStub).was.called_with('Baz_2022-01-01__former', {
 				id = 'Baz',
-				name = 'Foo Bar',
 				inactivedate = '2022-03-03',
 				joindate = '2022-01-01',
 				leavedate = '2022-05-01',
 				link = 'Baz',
+				name = 'Foo Bar',
 				nationality = '',
 				type = 'player',
+				newteam = '',
+				newteamtemplate = '',
+				position = '',
+				role = '',
+				status = 'former',
+				teamtemplate = '',
+				extradata = {},
 			})
 		end)
 	end)

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -258,4 +258,30 @@ Lpdb.Placement = Model('placement', {
 	{name = 'extradata', fieldType = 'struct', default = {}},
 })
 
+---@class SquadPlayerModel:Model
+Lpdb.SquadPlayer = Model('squadplayer', {
+	{
+		name = 'objectname',
+		fieldType = 'string',
+		default = function(fields)
+			return fields.link .. '_' .. (fields.joindate or '') .. '_' .. (fields.role or '') .. '_' .. (fields.status or '')
+		end
+	},
+	{name = 'id', fieldType = 'string'},
+	{name = 'link', fieldType = 'string'},
+	{name = 'name', fieldType = 'string', default = ''},
+	{name = 'nationality', fieldType = 'string', default = ''},
+	{name = 'position', fieldType = 'string', default = ''},
+	{name = 'role', fieldType = 'string', default = ''},
+	{name = 'type', fieldType = 'string', default = 'player'},
+	{name = 'newteam', fieldType = 'string', default = ''},
+	{name = 'teamtemplate', fieldType = 'string', default = ''},
+	{name = 'newteamtemplate', fieldType = 'string', default = ''},
+	{name = 'status', fieldType = 'string'},
+	{name = 'joindate', fieldType = 'string', default = ''},
+	{name = 'leavedate', fieldType = 'string', default = ''},
+	{name = 'inactivedate', fieldType = 'string', default = ''},
+	{name = 'extradata', fieldType = 'struct', default = {}},
+})
+
 return Lpdb


### PR DESCRIPTION
## Summary
Use ORM instead of direct function. Gives some validation on key fields and automatic filling on some other fields

## How did you test this change?
dev

Two minor changes to LPDB storage,
extradata will always exist (as empty)
teamname dropped from objectname (unneeded)

LPDB Before:
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/11e7abb9-413e-463e-9959-eaeda1382464)

LPDB After:
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/cf9bdf30-cdd9-4993-885d-7dc72435e9e2)

