### PR TITLE
feat(match2): shorter header titles in mobile view to save width

### DIFF
--- a/components/match2/wikis/apexlegends/match_summary.lua
+++ b/components/match2/wikis/apexlegends/match_summary.lua
@@ -102,6 +102,7 @@ local MATCH_STANDING_COLUMNS = {
 		iconClass = 'fas fa-star',
 		header = {
 			value = 'Total Points',
+			mobileValue = 'Pts.',
 		},
 		sortVal = {
 			value = function (opponent, idx)
@@ -203,6 +204,7 @@ local GAME_STANDINGS_COLUMNS = {
 		iconClass = 'fas fa-star',
 		header = {
 			value = 'Total Points',
+			mobileValue = 'Pts.',
 		},
 		sortVal = {
 			value = function (opponent, idx)
@@ -553,9 +555,15 @@ function CustomMatchSummary._createMatchStandings(match)
 						:addClass('panel-table__cell-icon')
 						:addClass(column.iconClass)
 						:done()
-				:tag('span')
-						:wikitext(column.header.value)
-						:done()
+		local span = groupedCell:tag('span')
+				:wikitext(column.header.value)
+		if column.header.mobileValue then
+				span:addClass('d-none d-md-block')
+				groupedCell:tag('span')
+						:wikitext(column.header.mobileValue)
+						:addClass('d-block d-md-none')
+		end
+		span:done()
 		if (column.sortable and column.sortType) then
 			cell:attr('data-sort-type', column.sortType)
 			groupedCell:tag('div')

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -9,19 +9,10 @@ liquipedia.battleRoyale = {
 	ICON_SORT: 'fa-arrows-alt-v',
 	ICON_SORT_UP: 'fa-long-arrow-alt-up',
 	ICON_SORT_DOWN: 'fa-long-arrow-alt-down',
-	TEXT_VALUE_MOBILE_TOTAL_POINTS: 'Pts.',
 	instancesLoaded: {},
 	battleRoyaleInstances: {},
 	battleRoyaleMap: {},
 	gameWidth: parseFloat( getComputedStyle( document.documentElement ).fontSize ) * 9.25,
-
-	replaceTotalPointsText: function( instanceId ) {
-		const elements = this.battleRoyaleInstances[ instanceId ]
-			.querySelectorAll( '[data-js-battle-royale="header-row"] [data-sort-type="total-points"] span' );
-		elements.forEach( ( element ) => {
-			element.innerText = this.TEXT_VALUE_MOBILE_TOTAL_POINTS;
-		} );
-	},
 
 	isMobile: function() {
 		return window.matchMedia( '(max-width: 767px)' ).matches;
@@ -487,9 +478,6 @@ liquipedia.battleRoyale = {
 
 			this.attachHandlers( instanceId );
 			this.makeCollapsibles( instanceId );
-			if ( this.isMobile() ) {
-				this.replaceTotalPointsText( instanceId );
-			}
 			if ( !this.isMobile() ) {
 				this.makeSideScrollElements( instanceId );
 				this.makeTableScrollHint( instanceId );

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -9,10 +9,16 @@ liquipedia.battleRoyale = {
 	ICON_SORT: 'fa-arrows-alt-v',
 	ICON_SORT_UP: 'fa-long-arrow-alt-up',
 	ICON_SORT_DOWN: 'fa-long-arrow-alt-down',
+	TEXT_VALUE_MOBILE_TOTAL_POINTS: 'Total Pts.',
 	instancesLoaded: {},
 	battleRoyaleInstances: {},
 	battleRoyaleMap: {},
 	gameWidth: parseFloat( getComputedStyle( document.documentElement ).fontSize ) * 9.25,
+
+	replaceTotalPointsText: function( instanceId ) {
+		const elements = this.battleRoyaleInstances[ instanceId ].querySelectorAll( '[data-js-battle-royale="header-row"] [data-sort-type="total-points"] span' );
+		elements.forEach( element => element.innerText = this.TEXT_VALUE_MOBILE_TOTAL_POINTS );
+	},
 
 	isMobile: function() {
 		return window.matchMedia( '(max-width: 767px)' ).matches;
@@ -478,6 +484,9 @@ liquipedia.battleRoyale = {
 
 			this.attachHandlers( instanceId );
 			this.makeCollapsibles( instanceId );
+			if ( this.isMobile() ) {
+				this.replaceTotalPointsText( instanceId );
+			}
 			if ( !this.isMobile() ) {
 				this.makeSideScrollElements( instanceId );
 				this.makeTableScrollHint( instanceId );

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -9,7 +9,7 @@ liquipedia.battleRoyale = {
 	ICON_SORT: 'fa-arrows-alt-v',
 	ICON_SORT_UP: 'fa-long-arrow-alt-up',
 	ICON_SORT_DOWN: 'fa-long-arrow-alt-down',
-	TEXT_VALUE_MOBILE_TOTAL_POINTS: 'Total Pts.',
+	TEXT_VALUE_MOBILE_TOTAL_POINTS: 'Pts.',
 	instancesLoaded: {},
 	battleRoyaleInstances: {},
 	battleRoyaleMap: {},

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -19,7 +19,7 @@ liquipedia.battleRoyale = {
 		const elements = this.battleRoyaleInstances[ instanceId ]
 			.querySelectorAll( '[data-js-battle-royale="header-row"] [data-sort-type="total-points"] span' );
 		elements.forEach( ( element ) => {
-			element.innerText = this.TEXT_VALUE_MOBILE_TOTAL_POINTS
+			element.innerText = this.TEXT_VALUE_MOBILE_TOTAL_POINTS;
 		} );
 	},
 

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -16,8 +16,11 @@ liquipedia.battleRoyale = {
 	gameWidth: parseFloat( getComputedStyle( document.documentElement ).fontSize ) * 9.25,
 
 	replaceTotalPointsText: function( instanceId ) {
-		const elements = this.battleRoyaleInstances[ instanceId ].querySelectorAll( '[data-js-battle-royale="header-row"] [data-sort-type="total-points"] span' );
-		elements.forEach( element => element.innerText = this.TEXT_VALUE_MOBILE_TOTAL_POINTS );
+		const elements = this.battleRoyaleInstances[ instanceId ]
+			.querySelectorAll( '[data-js-battle-royale="header-row"] [data-sort-type="total-points"] span' );
+		elements.forEach( ( element ) => {
+			element.innerText = this.TEXT_VALUE_MOBILE_TOTAL_POINTS
+		} );
 	},
 
 	isMobile: function() {

--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -374,7 +374,7 @@ Author(s): Elysienna
 			font-weight: bold;
 
 			@media ( max-width: 767px ) {
-				flex-basis: 5.25rem;
+				flex-basis: 4.25rem;
 			}
 		}
 

--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -104,6 +104,16 @@ Author(s): Elysienna
 				& .cell--game-container-nav-holder {
 					min-width: 15.875rem;
 				}
+
+				& .cell--rank,
+				& .cell--team,
+				& .cell--total-points {
+					.panel-table__cell-icon {
+						@media ( max-width: 767px ) {
+							display: none;
+						}
+					}
+				}
 			}
 
 			&--navigate {
@@ -341,6 +351,10 @@ Author(s): Elysienna
 
 		&--rank {
 			flex-basis: 6.375rem;
+
+			@media ( max-width: 767px ) {
+				flex-basis: 4.6875rem;
+			}
 		}
 
 		&--team {
@@ -349,7 +363,7 @@ Author(s): Elysienna
 			overflow: hidden;
 
 			@media ( max-width: 767px ) {
-				flex-basis: 9rem;
+				flex-basis: 8.375rem;
 			}
 		}
 
@@ -358,6 +372,10 @@ Author(s): Elysienna
 			flex-grow: 0;
 			justify-content: flex-end;
 			font-weight: bold;
+
+			@media ( max-width: 767px ) {
+				flex-basis: 5.25rem;
+			}
 		}
 
 		&--placements {


### PR DESCRIPTION
## Summary

Mobile optimizations:
- Remove icons from Rank, Team and Total points
- Abbreviate Total points to Pts.

Closes [ticket](https://gitlab.com/teamliquid-dev/liquipedia/web/issue-bucket/-/issues/54)

## How did you test this change?

Tested it on the live site.