### PR TITLE
ci: use grunt-eslint 24.x for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"devDependencies": {
 		"eslint-config-wikimedia": "*",
 		"grunt": "*",
-		"grunt-eslint": "*",
+		"grunt-eslint": "24.x.x",
 		"grunt-stylelint": "*",
 		"postcss-less": "*",
 		"stylelint-config-wikimedia": "*",


### PR DESCRIPTION
## Summary
grunt-eslint just upgrade to eslint 9 (released a couple of days ago) in v25. Several of our dependencies do not yet support eslint 9, so stopping at v24.

## How did you test this change?
Pipeline is no longer breaking