### PR TITLE
feat(match2): extra border width to the game columns on battle royale

### DIFF
--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -317,7 +317,7 @@ Author(s): Elysienna
 			padding: 0;
 			flex-wrap: wrap;
 			align-items: stretch;
-			border-left: 0.125rem solid rgba( 0, 0, 0, 0.08 );
+			border-left: 0.0625rem solid rgba( 0, 0, 0, 0.08 );
 			border-right-width: 0.0625rem;
 		}
 

--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -317,6 +317,8 @@ Author(s): Elysienna
 			padding: 0;
 			flex-wrap: wrap;
 			align-items: stretch;
+			border-left: 0.125rem solid rgba( 0, 0, 0, 0.08 );
+			border-right-width: 0.0625rem;
 		}
 
 		&--status {


### PR DESCRIPTION
## Summary

Increase the border width between games to separate them.
Closes [ticket](https://gitlab.com/teamliquid-dev/liquipedia/web/issue-bucket/-/issues/55)

![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/4021d193-728e-4aed-b6fe-63f3a7926abf)


## How did you test this change?

devtools
