### PR TITLE
refactor(teamcard): move qualifier text parsing from external module

### DIFF
--- a/components/team_card/team_card_storage.lua
+++ b/components/team_card/team_card_storage.lua
@@ -13,8 +13,6 @@ local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local Custom = Lua.import('Module:TeamCard/Custom')
--- TODO: Once the Template calls are not needed (when RL has been moved to Module), deprecate Qualifier Module
-local Qualifier = require('Module:TeamCard/Qualifier')
 
 local OpponentLibrary = require('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
@@ -89,7 +87,7 @@ function TeamCardStorage._addStandardLpdbFields(lpdbData, team, args, lpdbPrefix
 	lpdbData.date = args.date
 		or Variables.varDefault(lpdbData.objectName .. '_placementdate')
 		or endDate
-	lpdbData.qualifier, lpdbData.qualifierpage, lpdbData.qualifierurl = Qualifier.parseQualifier(args.qualifier)
+	lpdbData.qualifier, lpdbData.qualifierpage, lpdbData.qualifierurl = TeamCardStorage._parseQualifier(args.qualifier)
 
 	if team ~= 'TBD' then
 		lpdbData.image = args.image1
@@ -125,5 +123,45 @@ function TeamCardStorage._getLpdbObjectName(team, lpdbPrefix)
 	end
 	return storageName
 end
+
+--- Link internal and link external is mutually exclusive
+---@param rawQualifier string?
+---@return string? #link text
+---@return string? #internal link
+---@return string? #external link
+function TeamCardStorage._parseQualifier(rawQualifier)
+	if not rawQualifier then
+		return nil, nil, nil
+	end
+
+	local cleanQualifier = rawQualifier:gsub('%[', ''):gsub('%]', '')
+	if cleanQualifier:find('|') then
+		-- Internal link
+		local qualifier = mw.text.split(cleanQualifier, '|', true)
+		local qualifierLink, qualifierText = qualifier[1], qualifier[2]
+
+		if qualifierLink:sub(1, 1) == '/' then
+			-- Relative link
+			qualifierLink = mw.title.getCurrentTitle().fullText .. qualifierLink
+		end
+		qualifierLink = qualifierLink:gsub(' ', '_')
+		return qualifierText, qualifierLink, nil
+
+	elseif rawQualifier:sub(1, 1) == '[' then
+		-- Not internal link, but a link -> must be external link
+		local qualifier = mw.text.split(cleanQualifier, ' ', true)
+		local qualifierLink = qualifier[1]
+
+		table.remove(qualifier, 1)
+		local qualifierText = table.concat(qualifier, ' ')
+
+		return qualifierText, nil, qualifierLink
+
+	else
+		-- Just text
+		return rawQualifier, nil, nil
+	end
+end
+
 
 return TeamCardStorage

--- a/spec/team_card_storage_spec.lua
+++ b/spec/team_card_storage_spec.lua
@@ -43,4 +43,54 @@ describe('Team Card Storage', function()
 		assert.are_equal('participant_tbd_1', TCStorage._getLpdbObjectName('TBD'))
 		assert.are_equal('participant_tbd_2', TCStorage._getLpdbObjectName('TBD'))
 	end)
+
+	describe('qualifier parsing', function()
+		it('raw text', function()
+			local test = 'Foo Bar'
+			local text, internal, external = TCStorage._parseQualifier(test)
+			assert.are_equal('Foo Bar', text)
+			assert.is_nil(internal)
+			assert.is_nil(external)
+		end)
+
+		it('SimpleInternalLink', function()
+			local test = '[[Foo_Bar/2022|Foo Bar]]'
+			local text, internal, external = TCStorage._parseQualifier(test)
+			assert.are_equal('Foo Bar', text)
+			assert.are_equal('Foo_Bar/2022', internal)
+			assert.is_nil(external)
+		end)
+
+		it('RelativeInternalLink', function()
+			local test = '[[/2022|Foo Bar]]'
+			local text, internal, external = TCStorage._parseQualifier(test)
+			assert.are_equal('Foo Bar', text)
+			assert.are_equal('FakePage/2022', internal)
+			assert.is_nil(external)
+		end)
+
+		it('FixingSpaceInternalLink', function()
+			local test = '[[Foo Bar/2022|Foo Bar]]'
+			local text, internal, external = TCStorage._parseQualifier(test)
+			assert.are_equal('Foo Bar', text)
+			assert.are_equal('Foo_Bar/2022', internal)
+			assert.is_nil(external)
+		end)
+
+		it('ExternalLink', function()
+			local test = '[https://foo.bar Foo Bar]'
+			local text, internal, external = TCStorage._parseQualifier(test)
+			assert.are_equal('Foo Bar', text)
+			assert.is_nil(internal)
+			assert.are_equal('https://foo.bar', external)
+		end)
+
+		it('ExternalLinkNoSpace', function()
+			local test = '[https://foo.bar]'
+			local text, internal, external = TCStorage._parseQualifier(test)
+			assert.are_equal('', text)
+			assert.is_nil(internal)
+			assert.are_equal('https://foo.bar', external)
+		end)
+	end)
 end)


### PR DESCRIPTION
## Summary
Merge `Module:TeamCard/Qualifier` into `Module:TeamCard/Storage` as initially intended (but wasn't possible at the time).
Also migrate the testcases to busted automated testing

## How did you test this change?
Automated testing