### PR TITLE
fix(infobox): league of legends storing incorrect data for player history

### DIFF
--- a/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_person_player_custom.lua
@@ -52,7 +52,7 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
+		local automatedHistory = TeamHistoryAuto.results{
 			convertrole = true,
 			addlpdbdata = true,
 			player = self.caller.pagename

--- a/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_person_player_custom.lua
@@ -40,8 +40,8 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
+		local automatedHistory = TeamHistoryAuto.results{
+			convertrole = true,
 			player = self.caller.pagename
 		}
 

--- a/components/infobox/wikis/formula1/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/formula1/infobox_person_player_custom.lua
@@ -49,7 +49,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'history' then
 		return {
 			Title{name = 'History'},
-			Center{content = {TeamHistoryAuto._results{
+			Center{content = {TeamHistoryAuto.results{
 				convertrole = true,
 				addlpdbdata = true
 			}}},

--- a/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_person_player_custom.lua
@@ -74,7 +74,7 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
+		local automatedHistory = TeamHistoryAuto.results{
 			addlpdbdata = true,
 			convertrole = true,
 			player = self.caller.pagename

--- a/components/infobox/wikis/freefire/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/freefire/infobox_person_player_custom.lua
@@ -73,8 +73,8 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
+		local automatedHistory = TeamHistoryAuto.results{
+			convertrole = true,
 			player = caller.pagename
 		}
 

--- a/components/infobox/wikis/halo/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/halo/infobox_person_player_custom.lua
@@ -54,8 +54,8 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Game Appearances', content = GameAppearances.player({player = caller.pagename})},
 		}
 	elseif id == 'history' then
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
+		local automatedHistory = TeamHistoryAuto.results{
+			convertrole = true,
 			player = caller.pagename
 		}
 

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -70,11 +70,11 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = Logic.emptyOr(player.args.history, TeamHistoryAuto._results{
-		hiderole = 'true',
+	player.args.history = String.nilIfEmpty(player.args.history) or TeamHistoryAuto.results{
+		hiderole = true,
 		iconModule = 'Module:PositionIcon/data',
-		addlpdbdata = 'true'
-	})
+		addlpdbdata = true,
+	}
 	player.args.autoTeam = true
 	player.role = player:_getRoleData(player.args.role)
 	player.role2 = player:_getRoleData(player.args.role2)

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')

--- a/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_person_player_custom.lua
@@ -73,8 +73,8 @@ function CustomInjector:parse(id, widgets)
 		})
 	elseif id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
+		local automatedHistory = TeamHistoryAuto.results{
+			convertrole = true,
 			iconModule = 'Module:PositionIcon/data',
 			player = caller.pagename
 		}

--- a/components/infobox/wikis/naraka/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_person_player_custom.lua
@@ -53,7 +53,7 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
+	player.args.history = TeamHistoryAuto.results{addlpdbdata = true}
 	player.args.autoTeam = true
 	player.role = player:_getRoleData(player.args.role)
 	player.role2 = player:_getRoleData(player.args.role2)

--- a/components/infobox/wikis/omegastrikers/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/omegastrikers/infobox_person_player_custom.lua
@@ -45,7 +45,7 @@ function CustomPlayer.run(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
 	player.args.autoTeam = true
-	player.args.history = TeamHistoryAuto._results{
+	player.args.history = TeamHistoryAuto.results{
 		convertrole = true,
 		player = player.pagename
 	}

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -48,7 +48,7 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
+	player.args.history = TeamHistoryAuto.results{convertrole = true}
 	player.role = player:_getRoleData(player.args.role)
 	player.role2 = player:_getRoleData(player.args.role2)
 

--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -53,8 +53,8 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
+		local automatedHistory = TeamHistoryAuto.results{
+			convertrole = true,
 			player = caller.pagename
 		}
 

--- a/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_person_player_custom.lua
@@ -66,8 +66,8 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
+		local automatedHistory = TeamHistoryAuto.results{
+			convertrole = true,
 			player = caller.pagename
 		}
 

--- a/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rainbowsix/infobox_person_player_custom.lua
@@ -78,7 +78,7 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true', specialRoles = 'true'}
+	player.args.history = TeamHistoryAuto.results{addlpdbdata = true, specialRoles = true}
 	-- Automatic achievements
 	player.args.achievements = Achievements.player{
 		baseConditions = ACHIEVEMENTS_BASE_CONDITIONS

--- a/components/infobox/wikis/smite/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/smite/infobox_person_player_custom.lua
@@ -46,7 +46,7 @@ function CustomPlayer.run(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
 	player.args.autoTeam = true
-	player.args.history = TeamHistoryAuto._results{
+	player.args.history = TeamHistoryAuto.results{
 		convertrole = true,
 		iconModule = 'Module:PositionIcon/data',
 		player = player.pagename

--- a/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/splatoon/infobox_person_player_custom.lua
@@ -36,7 +36,7 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
+	player.args.history = TeamHistoryAuto.results{convertrole = true}
 
 	player.role = Role.run{role = player.args.role}
 	player.role2 = Role.run{role = player.args.role2}

--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -63,7 +63,7 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
+	player.args.history = TeamHistoryAuto.results{convertrole = true}
 	player.args.autoTeam = true
 	player.args.agents = SignaturePlayerAgents.get{player = player.pagename, top = 3}
 	player.role = player:_getRoleData(player.args.role)

--- a/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_person_player_custom.lua
@@ -73,7 +73,7 @@ function CustomPlayer.run(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
 	if String.isEmpty(player.args.history) then
-		player.args.history = TeamHistoryAuto._results{addlpdbdata = 'true'}
+		player.args.history = TeamHistoryAuto.results{addlpdbdata = true}
 	end
 	player.args.autoTeam = true
 	player.role = player:_getRoleData(player.args.role)

--- a/components/infobox/wikis/worldoftanks/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/worldoftanks/infobox_person_player_custom.lua
@@ -46,7 +46,7 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = TeamHistoryAuto._results{convertrole = 'true'}
+	player.args.history = TeamHistoryAuto.results{convertrole = true}
 	player.role = player:_getRoleData(player.args.role)
 	player.role2 = player:_getRoleData(player.args.role2)
 

--- a/components/infobox/wikis/zula/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/zula/infobox_person_player_custom.lua
@@ -47,8 +47,8 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'history' then
 		local manualHistory = args.history
-		local automatedHistory = TeamHistoryAuto._results{
-			convertrole = 'true',
+		local automatedHistory = TeamHistoryAuto.results{
+			convertrole = true,
 			player = self.caller.pagename
 		}
 


### PR DESCRIPTION
## Summary
- fix a bug on lol where if manual TH input was present the THA was stored anyways.
- use `.result` instead of `._result` (was adjusted in the `TeamHistoryAuto` module some time ago to be able to call `.result` from lua)
- use `true` over `'true'` due to `Module:TeamHistoryAuto` using `Logic.readBool` nowadays

## How did you test this change?
dev to live for lol
N/A for the rest