### PR TITLE
fix(match2): crossfire is not storing players

### DIFF
--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -311,6 +311,13 @@ function matchFunctions.getOpponents(match)
 				opponent.score = -1
 			end
 			opponents[opponentIndex] = opponent
+
+			-- get players from vars for teams
+			if opponent.type == Opponent.team and not Logic.isEmpty(opponent.name) then
+				match = MatchGroupInput.readPlayersOfTeam(match, opponentIndex, opponent.name, {
+					maxNumPlayers = 5, resolveRedirect = true, applyUnderScores = true
+				})
+			end
 		end
 	end
 

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -322,7 +322,7 @@ function matchFunctions.getOpponents(match)
 	end
 
 	-- see if match should actually be finished if bestof limit was reached
-	 match.finished = Logic.readBool(match.finished)
+	match.finished = Logic.readBool(match.finished)
 		or isScoreSet and (
 			Array.any(opponents, function(opponent) return (tonumber(opponent.score) or 0) > match.bestof/2 end)
 			or Array.all(opponents, function(opponent) return (tonumber(opponent.score) or 0) == match.bestof/2 end)


### PR DESCRIPTION
## Summary
currently crossfire match2 does not store any player data whatsoever from the looks of it
to fix that fetch player data from TeamCards as done on most wikis using the commons function

## How did you test this change?
dev