### PR TITLE
fix(team logo gallery): incorrect text when skipping an image

### DIFF
--- a/standard/team_logo_gallery.lua
+++ b/standard/team_logo_gallery.lua
@@ -53,17 +53,19 @@ function TeamLogoGallery._getImageData(name, showPresentLogo)
 
 	local finalName = presentImageData.raw.name
 
-	return Array.map(imageDatas, function(imageData, index)
+	local filteredImageDatas = Array.filter(imageDatas, function(imageData, index)
 		local image = Logic.emptyOr(imageData.raw.image, imageData.raw.legacyimage)
 		if not image or Game.isDefaultTeamLogo{logo = image} then
-			return nil
+			return false
 		end
 
 		local previous = imageDatas[index - 1] or {raw = {}}
 		local previousImage = Logic.emptyOr(previous.raw.image, previous.raw.legacyimage)
-		if previousImage == image then
-			return nil
-		end
+		return previousImage ~= image
+	end)
+
+	return Array.map(filteredImageDatas, function(imageData, index)
+		local image = Logic.emptyOr(imageData.raw.image, imageData.raw.legacyimage)
 
 		local caption, below = TeamLogoGallery._makeCaptionAndBelow(imageData, index, finalName)
 


### PR DESCRIPTION
## Summary
Currently if images are removed due to being the same as the one before the index used for building the caption is increasedc nonetheless, resulting in jumping "numbering" in captions.
![Capture](https://github.com/Liquipedia/Lua-Modules/assets/75081997/f534c4df-952c-4257-96d4-7962d538d709)
This PR resolves that by first filtering the imageDatas and only after that building the captions (via mapping them).

## How did you test this change?
dev

