### PR TITLE
feat: darkmode support for `black` css class

### DIFF
--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -102,19 +102,19 @@ div.NavPic,
 
 /* BLACK */
 .black-text {
-	color: #272727;
+	color: var( --clr-on-surface, #272727 );
 }
 
 .black-non-text {
-	color: #2c2c2c;
+	color: var( --clr-on-surface, #2c2c2c );
 }
 
 .black-bg {
-	background-color: #272727;
+	background-color: var( --clr-on-surface, #272727 );
 }
 
 .black-border {
-	border-color: #272727;
+	border-color: var( --clr-on-surface, #272727 );
 }
 
 /* CINNABAR */


### PR DESCRIPTION

## Summary
Black classes getting variables to make anything using them work in dark-mode too.

## How did you test this change?
Chrome dev tool.

Although the issue is more compatibility testing across the whole wiki which I did not test nor do I think I could have, since the colours may have been used on non-dark-theme compliant backgrounds, so it may very well break stuff I am unaware off.