### PR TITLE
fix(match2): AoE walkover handling

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -157,7 +157,7 @@ function CustomMatchGroupInput._calculateWinner(match)
 				local walkover = tonumber(match.walkover)
 				if walkover == opponentIndex then
 					match.winner = opponentIndex
-					match.walkover = 'L'
+					match.walkover = 'FF'
 					opponent.status = 'W'
 				elseif walkover == 0 then
 					match.winner = 0

--- a/components/match2/wikis/ageofempires/match_legacy.lua
+++ b/components/match2/wikis/ageofempires/match_legacy.lua
@@ -95,9 +95,10 @@ function MatchLegacy._convertParameters(match2)
 		end
 	end
 
-	if match.walkover == 'ff' or match.walkover == 'dq' then
+	if match.walkover == 'FF' or match.walkover == 'DQ' then
+		match.resulttype = match.walkover:lower()
 		match.walkover = match.winner
-	elseif match.walkover == 'l' then
+	elseif match.walkover == 'L' then
 		match.walkover = nil
 	end
 


### PR DESCRIPTION
## Summary
resulttype was missing in legacy storage, causing consumers to show 0:0 instead of W:FF

## How did you test this change?
live, bugfix
