### PR TITLE
feat(infobox_extensions): create automated game appearances for players

### DIFF
--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -12,7 +12,6 @@ local Game = require('Module:Game')
 local MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
 
 local Appearances = {}
-local HashSet = {}
 
 ---@class GameAppearancesArgs
 ---@field player string?

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -21,10 +21,20 @@ function Appearances.player(args)
 	if not args or not args.player then return end
 	local numberOfPlayersInPlacement = args.numberOfPlayersInPlacement or DEFAULT_MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT
 
-	local conditions = Array.map(Array.range(1, numberOfPlayersInPlacement), function(index)
-		return '[[opponentplayers_p' .. index .. '::' .. args.player .. ']]'
+	local player = args.player:gsub(' ', '_')
+	local playerWithoutUnderscores = args.player:gsub('_', ' ')
+
+	local conditions = {
+		'[[opponentname::' .. player .. ']]',
+		'[[opponentname::' .. playerWithoutUnderscores .. ']]',
+	}
+
+	Array.forEach(Array.range(1, numberOfPlayersInPlacement), function(index)
+		Array.appenWith(conditions,
+			'[[opponentplayers_p' .. index .. '::' .. player .. ']]',
+			'[[opponentplayers_p' .. index .. '::' .. playerWithoutUnderscores .. ']]'
+		)
 	end)
-	table.insert(conditions, '[[opponentname::' .. args.player .. ']]')
 
 	local queriedGames = Table.map(mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = table.concat(conditions, ' OR '),

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -26,15 +26,15 @@ function Appearances.player(args)
 	end)
 	table.insert(conditions, '[[opponentname::' .. args.player .. ']]')
 
-	local queriedGames = Array.map(mw.ext.LiquipediaDB.lpdb('placement', {
+	local queriedGames = Table.map(mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = table.concat(conditions, ' OR '),
 		query = 'game',
 		groupby = 'game asc',
 		limit = 1000,
-	}), function(item) return item.game end)
+	}), function(_, item) return Game.toIdentifier{game = item.game, useDefault = false}, true end)
 
 	local orderedGames = Array.filter(Game.listGames{ordered = true}, function(game)
-		return Table.includes(queriedGames, game)
+		return queriedGames[game]
 	end)
 
 	return Array.map(orderedGames, function(game)

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Game = require('Module:Game')
+local Table = require('Module:Table')
 
 local DEFAULT_MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
 
@@ -25,18 +26,20 @@ function Appearances.player(args)
 	end)
 	table.insert(conditions, '[[opponentname::' .. args.player .. ']]')
 
-	local data = mw.ext.LiquipediaDB.lpdb('placement', {
+	local queriedGames = Array.map(mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = table.concat(conditions, ' OR '),
 		query = 'game',
 		groupby = 'game asc',
 		limit = 1000,
-	})
+	}), function(item) return item.game end)
 
-	local games = Array.unique(Array.map(data, function(item)
-		return Game.name{game = item.game}
-	end))
-	table.sort(games)
-	return games
+	local orderedGames = Array.filter(Game.listGames{ordered = true}, function(game)
+		return Table.includes(queriedGames, game)
+	end)
+
+	return Array.map(orderedGames, function(game)
+		return Game.name{game = game}
+	end)
 end
 
 return Appearances

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local Class = require('Module:Class')
 local Game = require('Module:Game')
 
 local MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
@@ -15,9 +14,10 @@ local MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
 local Appearances = {}
 
 ----Provide a list of games compete by a player
----@param args GameApperancesArgs
----@return string?
+---@param args GameAppearancesArgs
+---@return table?
 function Appearances.player(args)
+
 	if not args or not args.player then return end
 
 	local conditions = Array.map(Array.range(1, MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT), function(index)
@@ -32,7 +32,7 @@ function Appearances.player(args)
 		limit = 1000,
 	})
 
-	local games = {}	
+	local games = {}
 	Array.forEach(data, function(item)
 		local game = Game.name{game = item.game}
 		if game then
@@ -44,12 +44,12 @@ function Appearances.player(args)
 end
 
 function Appearances.removeDuplicates(games)
-    hashSet = {}
+    HashSet = {}
 	Array.forEach(games, function(game)
-		hashSet[game] = true
+		HashSet[game] = true
 	end)
 
-	games = Array.extractKeys(hashSet)
+	games = Array.extractKeys(HashSet)
 	table.sort(games)
 
 	return games

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Infobox/Extension/GameApperances
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Game = require('Module:Game')
+
+local MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
+
+local Appearances = {}
+
+----Provide a list of games compete by a player
+---@param args GameApperancesArgs
+---@return string?
+function Appearances.player(args)
+	if not args or not args.player then return end
+
+	local conditions = Array.map(Array.range(1, MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT), function(index)
+		return '[[opponentplayers_p' .. index .. '::' .. args.player .. ']]'
+	end)
+	table.insert(conditions, '[[opponentname::' .. args.player .. ']]')
+
+	local data = mw.ext.LiquipediaDB.lpdb('placement', {
+		conditions = table.concat(conditions, ' OR '),
+		query = 'game',
+		groupby = 'game asc',
+		limit = 1000,
+	})
+
+	local games = {}	
+	Array.forEach(data, function(item)
+		local game = Game.name{game = item.game}
+		if game then
+			table.insert(games, '[[' .. game .. ']]')
+		end
+	end)
+
+	return Appearances.removeDuplicates(games)
+end
+
+function Appearances.removeDuplicates(games)
+    hashSet = {}
+	Array.forEach(games, function(game)
+		hashSet[game] = true
+	end)
+
+	games = Array.extractKeys(hashSet)
+	table.sort(games)
+
+	return games
+end
+
+return Appearances

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -12,12 +12,15 @@ local Game = require('Module:Game')
 local MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
 
 local Appearances = {}
+local HashSet = {}
+
+---@class GameAppearancesArgs
+---@field player string?
 
 ----Provide a list of games compete by a player
 ---@param args GameAppearancesArgs
----@return table?
+---@return string[]
 function Appearances.player(args)
-
 	if not args or not args.player then return end
 
 	local conditions = Array.map(Array.range(1, MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT), function(index)
@@ -32,27 +35,13 @@ function Appearances.player(args)
 		limit = 1000,
 	})
 
-	local games = {}
-	Array.forEach(data, function(item)
-		local game = Game.name{game = item.game}
-		if game then
-			table.insert(games, '[[' .. game .. ']]')
-		end
-	end)
-
-	return Appearances.removeDuplicates(games)
-end
-
-function Appearances.removeDuplicates(games)
-    HashSet = {}
-	Array.forEach(games, function(game)
-		HashSet[game] = true
-	end)
-
-	games = Array.extractKeys(HashSet)
+	local games = Array.unique(Array.map(data, function(item)
+		return Game.name{game = item.game}
+	end))
 	table.sort(games)
-
-	return games
+	return Array.map(games, function(game)
+		return game
+	end)
 end
 
 return Appearances

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -18,7 +18,7 @@ local Appearances = {}
 
 ----Provide a list of games compete by a player
 ---@param args GameAppearancesArgs
----@return string[]
+---@return string[] | nil
 function Appearances.player(args)
 	if not args or not args.player then return end
 

--- a/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
+++ b/components/infobox/extensions/commons/infobox_extension_game_appearances.lua
@@ -9,20 +9,18 @@
 local Array = require('Module:Array')
 local Game = require('Module:Game')
 
-local MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
+local DEFAULT_MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
 
 local Appearances = {}
 
----@class GameAppearancesArgs
----@field player string?
-
 ----Provide a list of games compete by a player
----@param args GameAppearancesArgs
----@return string[] | nil
+---@param args {player: string?, numberOfPlayersInPlacement}?
+---@return string[]?
 function Appearances.player(args)
 	if not args or not args.player then return end
+	local numberOfPlayersInPlacement = args.numberOfPlayersInPlacement or DEFAULT_MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT
 
-	local conditions = Array.map(Array.range(1, MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT), function(index)
+	local conditions = Array.map(Array.range(1, numberOfPlayersInPlacement), function(index)
 		return '[[opponentplayers_p' .. index .. '::' .. args.player .. ']]'
 	end)
 	table.insert(conditions, '[[opponentname::' .. args.player .. ']]')
@@ -38,9 +36,7 @@ function Appearances.player(args)
 		return Game.name{game = item.game}
 	end))
 	table.sort(games)
-	return Array.map(games, function(game)
-		return game
-	end)
+	return games
 end
 
 return Appearances


### PR DESCRIPTION
## Summary
This is part of #4177, as the module that's appeared locally are suggested to be made as proper Extension module instead

This is a port from `Module:GetGameAppearances` that appears in couple wikis, I renamed it to `GameAppearances` 

this module's intention is to be used on Infobox Player, where a list of Games the player had compete in that wiki can be displayed

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/b626b26f-8bee-4e0e-9017-3610551f99b9)

## How did you test this change?
https://liquipedia.net/simracing/Jarno_Opmeer

## Note 
Since this is a local module turned into commons module, Help on Annotation and cleanup is surely needed because I can't get through one myself
