### PR TITLE
feat(portal players): add color for deceased status

### DIFF
--- a/components/portal_players/commons/portal_players.lua
+++ b/components/portal_players/commons/portal_players.lua
@@ -28,6 +28,7 @@ local BACKGROUND_CLASSES = {
 	inactive = 'sapphire-bg',
 	retired = 'bg-neutral',
 	banned = 'cinnabar-bg',
+	['passed away'] = 'gray-bg',
 }
 
 --- @class PortalPlayers

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -35,7 +35,7 @@ Besides these twelve there is Gray which will fit in with them very well. There 
 .gray-theme-light-alt-bg,
 ul.nav-tabs li.game-none,
 .overview.game-none {
-	background-color: #d3d3d3;
+	background-color: var( --clr-moon-80, #d3d3d3 );
 }
 
 .gray-bg-alt,


### PR DESCRIPTION
## Summary

Changes first made for https://github.com/Liquipedia/Lua-Modules/pull/4016 but that PR isn't ready for merge as per reviews. 
These changes add a background color to players who have passed away, similar to retired or inactive players, etc.
## How did you test this change?
via dev
