### PR TITLE
fix: `listGames` doesn't filter unlisted items

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -41,4 +41,4 @@ ignore = {
 	"212" -- unused argument
 }
 
-files["spec/*_spec.lua"].read_globals = {"GoldenTest"}
+files["spec/*_spec.lua"].read_globals = {"GoldenTest", "SetActiveWiki"}

--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -1,80 +1,101 @@
 --- Triple Comment to Enable our LLS Plugin
 describe('Game', function()
-	local Game = require('Module:Game')
-	local Info = require('Module:Info')
+	insulate('Commons', function ()
+		local Game = require('Module:Game')
+		local Info = require('Module:Info')
 
-	local COMMONS_IDENTIFIER = 'commons'
-	local COMMONS_DATA = Info.games.commons
-	local COMMONS_ICON = '[[File:Liquipedia logo.png|Commons|link=lpcommons:Main Page|class=|25x25px]]'
-	local GAME_TO_THROW = 'please throw'
+		local COMMONS_IDENTIFIER = 'commons'
+		local COMMONS_DATA = Info.games.commons
+		local COMMONS_ICON = '[[File:Liquipedia logo.png|Commons|link=lpcommons:Main Page|class=|25x25px]]'
+		local GAME_TO_THROW = 'please throw'
 
-	describe('to identifier', function()
-		it('verify', function()
-			assert.are_equal(COMMONS_IDENTIFIER, Game.toIdentifier())
-			assert.is_nil(Game.toIdentifier{useDefault = false})
-			assert.is_nil(Game.toIdentifier{game = 'lp'})
-			assert.are_equal(COMMONS_IDENTIFIER, Game.toIdentifier{game = 'comMoNs'})
-		end)
-	end)
-
-	describe('data retrieve', function()
-		it('verify', function()
-			assert.are_same(COMMONS_DATA, Game.raw())
-			assert.are_equal(COMMONS_DATA.abbreviation, Game.abbreviation())
-			assert.are_equal(COMMONS_DATA.name, Game.name())
-			assert.are_equal(COMMONS_DATA.link, Game.link())
-			assert.are_same(COMMONS_DATA.defaultTeamLogo, Game.defaultTeamLogoData())
-		end)
-	end)
-
-	describe('icon', function()
-		it('verify', function()
-			assert.are_equal(COMMONS_ICON,
-				Game.icon{noSpan = true})
-			assert.are_equal('<span class="span-class">' .. COMMONS_ICON .. '</span>',
-				tostring(Game.icon{spanClass = 'span-class'}))
-			assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
-				tostring(Game.icon()))
-		end)
-	end)
-
-	describe('text', function()
-		it('verify',
-			function()
-				assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.name .. ']]', Game.text())
-				assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.name .. ']]', Game.text{})
-				assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.name .. ']]', Game.text{game = ''})
-				assert.are_equal(COMMONS_DATA.name, Game.text{noLink = true})
-				assert.are_equal('[[' .. 'ABC123' .. '|' .. COMMONS_DATA.name .. ']]', Game.text{link = 'ABC123'})
-				assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.abbreviation .. ']]',
-					Game.text{useAbbreviation = true})
-				assert.are_equal(COMMONS_DATA.abbreviation, Game.text{noLink = true, useAbbreviation = true})
-				assert.are_equal('[[' .. 'ABC123' .. '|' .. COMMONS_DATA.abbreviation .. ']]',
-					Game.text{useAbbreviation = true, link = 'ABC123'})
-				assert.are_equal('<abbr title="The specified game input is not recognized">Unknown Game</abbr>',
-					Game.text{useDefault = false})
-				assert.are_equal('<abbr title="The specified game input is not recognized">Unkwn.</abbr>',
-					Game.text{useDefault = false, useAbbreviation = true})
+		describe('to identifier', function()
+			it('verify', function()
+				assert.are_equal(COMMONS_IDENTIFIER, Game.toIdentifier())
+				assert.is_nil(Game.toIdentifier{useDefault = false})
+				assert.is_nil(Game.toIdentifier{game = 'lp'})
+				assert.are_equal(COMMONS_IDENTIFIER, Game.toIdentifier{game = 'comMoNs'})
 			end)
-	end)
+		end)
 
-	describe('list games', function()
-		it('verify', function()
-			assert.are_equal(COMMONS_IDENTIFIER, Game.listGames()[1])
-			assert.are_equal(COMMONS_IDENTIFIER, Game.listGames{ordered = true}[1])
-			assert.are_equal(COMMONS_IDENTIFIER, Game.listGames{ordered = false}[1])
+		describe('data retrieve', function()
+			it('verify', function()
+				assert.are_same(COMMONS_DATA, Game.raw())
+				assert.are_equal(COMMONS_DATA.abbreviation, Game.abbreviation())
+				assert.are_equal(COMMONS_DATA.name, Game.name())
+				assert.are_equal(COMMONS_DATA.link, Game.link())
+				assert.are_same(COMMONS_DATA.defaultTeamLogo, Game.defaultTeamLogoData())
+			end)
+		end)
+
+		describe('icon', function()
+			it('verify', function()
+				assert.are_equal(COMMONS_ICON,
+					Game.icon{noSpan = true})
+				assert.are_equal('<span class="span-class">' .. COMMONS_ICON .. '</span>',
+					tostring(Game.icon{spanClass = 'span-class'}))
+				assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
+					tostring(Game.icon()))
+			end)
+		end)
+
+		describe('text', function()
+			it('verify',
+				function()
+					assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.name .. ']]', Game.text())
+					assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.name .. ']]', Game.text{})
+					assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.name .. ']]', Game.text{game = ''})
+					assert.are_equal(COMMONS_DATA.name, Game.text{noLink = true})
+					assert.are_equal('[[' .. 'ABC123' .. '|' .. COMMONS_DATA.name .. ']]', Game.text{link = 'ABC123'})
+					assert.are_equal('[[' .. COMMONS_DATA.link .. '|' .. COMMONS_DATA.abbreviation .. ']]',
+						Game.text{useAbbreviation = true})
+					assert.are_equal(COMMONS_DATA.abbreviation, Game.text{noLink = true, useAbbreviation = true})
+					assert.are_equal('[[' .. 'ABC123' .. '|' .. COMMONS_DATA.abbreviation .. ']]',
+						Game.text{useAbbreviation = true, link = 'ABC123'})
+					assert.are_equal('<abbr title="The specified game input is not recognized">Unknown Game</abbr>',
+						Game.text{useDefault = false})
+					assert.are_equal('<abbr title="The specified game input is not recognized">Unkwn.</abbr>',
+						Game.text{useDefault = false, useAbbreviation = true})
+				end)
+		end)
+
+		describe('list games', function()
+			it('verify', function()
+				assert.are_equal(COMMONS_IDENTIFIER, Game.listGames()[1])
+				assert.are_equal(COMMONS_IDENTIFIER, Game.listGames{ordered = true}[1])
+				assert.are_equal(COMMONS_IDENTIFIER, Game.listGames{ordered = false}[1])
+			end)
+		end)
+
+		describe('default team logo', function()
+			it('verify', function()
+				assert.is_true(Game.isDefaultTeamLogo{logo = 'Liquipedia logo.png'})
+				assert.is_false(Game.isDefaultTeamLogo{logo = 'Liquipedia logo.jpg'})
+				assert.is_false(Game.isDefaultTeamLogo{logo = 'bviarBRVNUI.jpg'})
+
+				assert.error(function()
+					Game.isDefaultTeamLogo{logo = 'Liquipedia logo.png', game = GAME_TO_THROW}
+				end, 'Invalid game input "' .. GAME_TO_THROW .. '"')
+			end)
 		end)
 	end)
 
-	describe('default team logo', function()
-		it('verify', function()
-			assert.are_equal(true, Game.isDefaultTeamLogo{logo = 'Liquipedia logo.png'})
-			assert.are_equal(false, Game.isDefaultTeamLogo{logo = 'Liquipedia logo.jpg'})
-			assert.are_equal(false, Game.isDefaultTeamLogo{logo = 'bviarBRVNUI.jpg'})
-
-			assert.error(function()
-				Game.isDefaultTeamLogo{logo = 'Liquipedia logo.png', game = GAME_TO_THROW}
-			end, 'Invalid game input "' .. GAME_TO_THROW .. '"')
+	insulate('counterstrike', function ()
+		local Game
+		setup(function()
+			SetActiveWiki('counterstrike')
+			Game = require('Module:Game')
+		end)
+		teardown(function()
+			SetActiveWiki()
+		end)
+		describe('list games hiddens', function ()
+			it('default', function ()
+				assert.are_same({'cs1', 'css', 'cscz', 'cs2', 'csgo', 'cs16', 'cs', 'cso'}, Game.listGames())
+			end)
+			it('ordered', function ()
+				-- TODO
+			end)
 		end)
 	end)
 end)

--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -94,7 +94,7 @@ describe('Game', function()
 				assert.are_same({'cs1', 'css', 'cscz', 'cs2', 'csgo', 'cs16', 'cs', 'cso'}, Game.listGames())
 			end)
 			it('ordered', function ()
-				-- TODO
+				assert.are_same({'cs1', 'cs', 'cs16', 'cscz', 'css', 'cso', 'csgo', 'cs2'}, Game.listGames{ordered = true})
 			end)
 		end)
 	end)

--- a/spec/test_helper.lua
+++ b/spec/test_helper.lua
@@ -22,25 +22,35 @@ local function resetMediawiki()
 	mw.ext.VariablesLua.variablesStorage = {}
 end
 
+function SetActiveWiki(wiki)
+	package.preload = {}
+	local paths = {}
+	table.insert(paths, '?.lua')
+	table.insert(paths, 'standard/?.lua')
+	if wiki then
+		table.insert(paths, 'standard/info/wikis/'.. wiki ..'/?.lua')
+	end
+	table.insert(paths, 'components/match2/commons/?.lua')
+	table.insert(paths, 'components/prize_pool/commons/?.lua')
+	table.insert(paths, 'components/infobox/commons/?.lua')
+	table.insert(paths, 'components/infobox/commons/custom/?.lua')
+	table.insert(paths, 'components/opponent/commons/?.lua')
+	table.insert(paths, 'components/hidden_data_box/commons/?.lua')
+	table.insert(paths, 'components/squad/commons/?.lua')
+	table.insert(paths, 'components/standings/commons/?.lua')
+	table.insert(paths, 'components/team_card/?.lua')
+	table.insert(paths, 'standard/info/commons/?.lua')
+	table.insert(paths, 'standard/region/commons/?.lua')
+	table.insert(paths, 'standard/tier/commons/?.lua')
+	table.insert(paths, 'components/widget/?.lua')
+
+	package.path = table.concat(paths, ';')
+end
+
 local function setupForTesting()
 	require('definitions.mw')
 
-	package.path = '?.lua;' ..
-			'standard/?.lua;' ..
-			'components/match2/commons/?.lua;' ..
-			'components/prize_pool/commons/?.lua;' ..
-			'components/infobox/commons/?.lua;' ..
-			'components/infobox/commons/custom/?.lua;' ..
-			'components/opponent/commons/?.lua;' ..
-			'components/hidden_data_box/commons/?.lua;' ..
-			'components/squad/commons/?.lua;' ..
-			'components/standings/commons/?.lua;' ..
-			'components/team_card/?.lua;' ..
-			'standard/info/commons/?.lua;' ..
-			'standard/region/commons/?.lua;' ..
-			'standard/tier/commons/?.lua;' ..
-			'components/widget/?.lua;' ..
-			package.path
+	SetActiveWiki()
 
 	local require_original = require
 	local Plugin = require_original('plugins.sumneko_plugin')

--- a/standard/game.lua
+++ b/standard/game.lua
@@ -97,14 +97,14 @@ function Game.listGames(options)
 	end
 
 	local gamesList = Array.extractKeys(GamesData)
-	---@cast gamesList GameData[]
+
+	gamesList = Array.filter(gamesList, function(gameIdentifier)
+		return not GamesData[gameIdentifier].unlisted
+	end)
+
 	if Logic.readBool(options.ordered) and Array.all(gamesList, getGameOrder) then
 		return Array.sortBy(gamesList, getGameOrder)
 	end
-
-	Array.filter(gamesList, function(game)
-		return not game.unlisted
-	end)
 
 	return gamesList
 end


### PR DESCRIPTION
## Summary

There were a number of issues with this method:

- The casting was wrong
- The filtered array wasn't being used
- The filtering didn't work anyway due to misleading casting.
- Ordered lists didn't even reach filtering code

PR address them all, and I think it should work properly now.

## How did you test this change?

Tested with dev on CS wiki.
| Before Fix | After Fix |
|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/4e7068dd-8f03-42ec-93f0-6b5665e031bd) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/9ea81656-6b97-40fe-809a-de4a480c20cc) | 