### PR TITLE
feat(broodwar): add module missing on git

### DIFF
--- a/components/prize_pool/wikis/starcraft/prize_pool_import_custom.lua
+++ b/components/prize_pool/wikis/starcraft/prize_pool_import_custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- wiki=starcraft
+-- page=Module:PrizePool/Import/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+-- default custom that only "redirects" to the Base with dev option
+
+local Lua = require('Module:Lua')
+return Lua.import('Module:PrizePool/Import/Starcraft')


### PR DESCRIPTION
## Summary

I was checking pages for edit protection (list coming soon) and noticed this one wasn't on the git even though it has a git header. Not sure how important it is since it looks like it just redirects to the base version. but just thought I'd bring it up just in case^^
Also I removed the `Require dev if enabled` part since I'm kinda sure it's redundant
https://liquipedia.net/starcraft/Module:PrizePool/Import/Custom

## How did you test this change?

live
