### PR TITLE
fix(medals): remove file prefix in data

### DIFF
--- a/standard/medals_data.lua
+++ b/standard/medals_data.lua
@@ -9,26 +9,26 @@
 return {
 	{
 		title = 'First Place',
-		file = 'File:Gold.png',
+		file = 'Gold.png',
 	},
 	{
 		title = 'Second Place',
-		file = 'File:Silver.png',
+		file = 'Silver.png',
 	},
 	{
 		title = 'Third Place',
-		file = 'File:Bronze.png',
+		file = 'Bronze.png',
 	},
 	{
 		title = 'Fourth Place',
-		file = 'File:Copper.png',
+		file = 'Copper.png',
 	},
 	['3-4'] = {
 		title = 'Semifinalist(s)',
-		file = 'File:SF.png',
+		file = 'SF.png',
 	},
 	qualified = {
 		title = 'Qualified',
-		file = 'File:Medal Icon qualified.png',
+		file = 'Medal Icon qualified.png',
 	},
 }


### PR DESCRIPTION
## Summary
Due to using `Module:Image` the `File:` prefix is not needed and causes red links instead of images

## How did you test this change?
live as bug fix