### PR TITLE
fix(infobox): drop non-themed infobox header colors

### DIFF
--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -523,6 +523,7 @@ ul.nav-tabs li.game-64,
 .bright-theme-light-alt-bg,
 .bg-s,
 .bg-stay,
+.fo-nttax-infobox-wrapper.infobox-cs1 .infobox-header,
 .fo-nttax-infobox-wrapper.infobox-cs16 .infobox-header {
 	background-color: var( --clr-sun-background-color, #f9f0c7 );
 }

--- a/stylesheets/commons/Infobox.less
+++ b/stylesheets/commons/Infobox.less
@@ -222,26 +222,6 @@ Author(s): FO-nTTaX
 	line-height: 0.1px;
 }
 
-.fo-nttax-infobox-wrapper .infobox-color-always {
-	background-color: #ccffcc;
-}
-
-.fo-nttax-infobox-wrapper .infobox-color-very.often {
-	background-color: #eeffaa;
-}
-
-.fo-nttax-infobox-wrapper .infobox-color-often {
-	background-color: #ffff99;
-}
-
-.fo-nttax-infobox-wrapper .infobox-color-seldom {
-	background-color: #ffddaa;
-}
-
-.fo-nttax-infobox-wrapper .infobox-color-never {
-	background-color: #ffcccc;
-}
-
 .fo-nttax-infobox-wrapper.popout {
 	position: absolute;
 	top: 0;
@@ -251,10 +231,6 @@ Author(s): FO-nTTaX
 /** Game colors **/
 
 /* StarCraft II - Wings of Liberty */
-.fo-nttax-infobox-wrapper.infobox-wol .infobox-header {
-	background-color: #b6cfe5;
-}
-
 .theme--light .fo-nttax-infobox-wrapper.infobox-wol .infobox-header {
 	background-color: var( --clr-sapphire-90 );
 }
@@ -264,10 +240,6 @@ Author(s): FO-nTTaX
 }
 
 /* StarCraft II - Heart of the Swarm */
-.fo-nttax-infobox-wrapper.infobox-hots .infobox-header {
-	background-color: #deb0b0;
-}
-
 .theme--light .fo-nttax-infobox-wrapper.infobox-hots .infobox-header {
 	background-color: var( --clr-cinnabar-90 );
 }
@@ -277,10 +249,6 @@ Author(s): FO-nTTaX
 }
 
 /* Starcraft II - Legacy of the Void */
-.fo-nttax-infobox-wrapper.infobox-lotv .infobox-header {
-	background-color: #b0deb0;
-}
-
 .theme--light .fo-nttax-infobox-wrapper.infobox-lotv .infobox-header {
 	background-color: var( --clr-forestgreen-90 );
 }
@@ -290,10 +258,6 @@ Author(s): FO-nTTaX
 }
 
 /* Starcraft II - Custom mods */
-.fo-nttax-infobox-wrapper.infobox-mod .infobox-header {
-	background-color: #f2e8b8;
-}
-
 .theme--light .fo-nttax-infobox-wrapper.infobox-mod .infobox-header {
 	background-color: var( --clr-sun-80 );
 }
@@ -325,24 +289,6 @@ Author(s): FO-nTTaX
 
 .fo-nttax-infobox-wrapper.infobox-ultimate .infobox-header {
 	background-color: #e5b6d5;
-}
-
-/* Counter-Strike */
-.fo-nttax-infobox-wrapper.infobox-csgo .infobox-header {
-	background-color: #cde5b6;
-}
-
-.fo-nttax-infobox-wrapper.infobox-css .infobox-header {
-	background-color: #deb0b0;
-}
-
-.fo-nttax-infobox-wrapper.infobox-cs16 .infobox-header,
-.fo-nttax-infobox-wrapper.infobox-cs1 .infobox-header {
-	background-color: #f2e8b8;
-}
-
-.fo-nttax-infobox-wrapper.infobox-cscz .infobox-header {
-	background-color: #b6cfe5;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
## Summary

These are all defined using vars in [`Colours.less`](https://github.com/Liquipedia/Lua-Modules/blob/main/stylesheets/commons/Colours.less) so there should be no issue in removing them for either theme.

They're causing darkmode issues too currently.
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/c881bdd8-c8ed-46d0-9e1a-baa142184084)


## How did you test this change?

Browser dev tools.

When removed:

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/879c6214-cba4-4a73-8a4c-e20c28ed2bc4)

