### PR TITLE
fix(match2): regression in counterstrike bruinen support

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -283,6 +283,7 @@
 
 .brkts-cs-score-color-t {
 	color: #ff0000;
+
 	.theme--light & {
 		color: var( --clr-sun-30, #ff0000 );
 	}
@@ -799,6 +800,7 @@
 .brkts-popup-body-match-sidewins {
 	padding: 0 0 3px 3px;
 	line-height: 11px;
+
 	.skin-lakesideview & {
 		font-weight: 800;
 	}

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -282,6 +282,7 @@
 }
 
 .brkts-cs-score-color-t {
+	color: #ff0000;
 	.theme--light & {
 		color: var( --clr-sun-30, #ff0000 );
 	}
@@ -798,7 +799,9 @@
 .brkts-popup-body-match-sidewins {
 	padding: 0 0 3px 3px;
 	line-height: 11px;
-	font-weight: 800;
+	.skin-lakesideview & {
+		font-weight: 800;
+	}
 }
 
 .brkts-popup-body-match-sidewins-overtime {


### PR DESCRIPTION
## Summary

Support for Bruinen skin regressed in #4190 as we overlooked that the old skin is still in use.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/ede30d42-dd47-4dd8-a6ee-db0b4047593b)


## How did you test this change?

Browser dev tools
| Bruinen | Lakesideview |
|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/0707adbd-409b-4cf3-9902-c43441804a2d) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/c76ad3a2-533d-4340-a530-ffa7943c5fd0) | 


