### PR TITLE
feat(infobox): store overwatch publishertier

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -30,6 +30,7 @@ local BLIZZARD_TIERS = {
 	owl = 'Overwatch League',
 	owc = 'Overwatch Contenders',
 	owcs = 'Overwatch Champions Series',
+	owwc = 'Overwatch World Cup',
 }
 
 ---@param frame Frame

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -41,6 +41,11 @@ function CustomLeague.run(frame)
 	return league:createInfobox()
 end
 
+---@param args table
+function CustomLeague:customParseArguments(args)
+	self.data.publishertier = self:_validPublisherTier(args.blizzardtier) and args.blizzardtier:lower()
+end
+
 ---@param id string
 ---@param widgets Widget[]
 ---@return Widget[]


### PR DESCRIPTION
## Summary
as per request by ow contributors
- add storage for publishertier (it was already highlighted in infobox league, but not stored)
- add owwc as supported blizz tier

## How did you test this change?
dev