### PR TITLE
fix(bigmatch): make icons white monochrome on dark theme

### DIFF
--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -4324,6 +4324,10 @@ ul.match-bm-lol-game-veto-overview-pick {
 	justify-content: flex-start;
 	gap: 4px;
 	width: 88px;
+
+	.theme--dark & > img {
+		filter: invert( 1 );
+	}
 }
 
 .match-bm-lol-h2h {
@@ -4380,6 +4384,10 @@ ul.match-bm-lol-game-veto-overview-pick {
 
 .match-bm-lol-h2h-stat-title {
 	width: 80px;
+
+	.theme--dark & > img {
+		filter: invert( 1 );
+	}
 }
 
 .match-bm-lol-game-overview {


### PR DESCRIPTION
## Summary

The icons are still in their original color on dark theme. 
Since they are png's the CSS filter invert changes them to white when dark theme is activated.

## How did you test this change?

Devtools
