### PR TITLE
feat(infobox): cleanup header image display

### DIFF
--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -7,7 +7,7 @@
 --
 
 local Class = require('Module:Class')
-local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Infobox/Widget')
@@ -93,7 +93,7 @@ end
 ---@param size number|string|nil
 ---@return Html?
 function Header:_image(fileName, fileNameDark, default, defaultDark, size)
-	if Logic.isEmpty(fileName) and Logic.isEmpty(default) then
+	if String.isEmpty(fileName) and String.isEmpty(default) then
 		return nil
 	end
 

--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -103,7 +103,7 @@ function Header:_image(fileName, fileNameDark, default, defaultDark, size)
 	end
 
 	if imageName == imageDarkname then
-		return mw.html.create('div'):node(Header:_makeSizedImage(imageName, size))
+		imageDarkname  = nil
 	end
 
 	local infoboxImage = Header:_makeSizedImage(imageName, size, 'lightmode')

--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -125,7 +125,7 @@ function Header:_makeSizedImage(imageName, size, mode)
 	if Logic.isNumeric(size) then
 		infoboxImage:addClass('infobox-fixed-size-image')
 	else
-		size = 600
+		size = '600x1000px'
 	end
 
 	infoboxImage:wikitext(Image.display(imageName, nil, {size = size}))

--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -7,8 +7,10 @@
 --
 
 local Class = require('Module:Class')
-local String = require('Module:StringUtils')
+local Image = require('Module:Image')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 
 local Widget = Lua.import('Module:Infobox/Widget')
 
@@ -93,12 +95,12 @@ end
 ---@param size number|string|nil
 ---@return Html?
 function Header:_image(fileName, fileNameDark, default, defaultDark, size)
-	if String.isEmpty(fileName) and String.isEmpty(default) then
+	local imageName = fileName or default
+	local imageDarkname = fileNameDark or fileName or defaultDark or default
+
+	if String.isEmpty(imageName) and String.isEmpty(imageDarkname) then
 		return nil
 	end
-
-	local imageName = fileName or default --[[@as string]]
-	local imageDarkname = fileNameDark or fileName or defaultDark or default --[[@as string]]
 
 	if imageName == imageDarkname then
 		return mw.html.create('div'):node(Header:_makeSizedImage(imageName, size))
@@ -110,33 +112,23 @@ function Header:_image(fileName, fileNameDark, default, defaultDark, size)
 	return mw.html.create('div'):node(infoboxImage):node(infoboxImageDark)
 end
 
----@param imageName string
+---@param imageName string?
 ---@param size number|string|nil
 ---@param mode string?
----@return Html
+---@return Html?
 function Header:_makeSizedImage(imageName, size, mode)
-	local infoboxImage = mw.html.create('div'):addClass('infobox-image'):addClass(mode)
-
-	-- Number (interpret as pixels)
-	size = size or ''
-	if tonumber(size) then
-		size = tonumber(size) .. 'px'
-		infoboxImage:addClass('infobox-fixed-size-image')
-	-- Percentage (interpret as scaling)
-	elseif size:find('%%') then
-		local scale = size:gsub('%%', '')
-		local scaleNumber = tonumber(scale)
-		if scaleNumber then
-			size = 'frameless|upright=' .. (scaleNumber / 100)
-			infoboxImage:addClass('infobox-fixed-size-image')
-		end
-	-- Default
-	else
-		size = '600px'
+	if String.isEmpty(imageName) then
+		return
 	end
 
-	local fullFileName = '[[File:' .. imageName .. '|' .. size .. ']]'
-	infoboxImage:wikitext(fullFileName)
+	local infoboxImage = mw.html.create('div'):addClass('infobox-image'):addClass(mode)
+	if Logic.isNumeric(size) then
+		infoboxImage:addClass('infobox-fixed-size-image')
+	else
+		size = 600
+	end
+
+	infoboxImage:wikitext(Image.display(imageName, nil, {size = size}))
 
 	return infoboxImage
 end

--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Infobox/Widget')
@@ -92,28 +93,29 @@ end
 ---@param size number|string|nil
 ---@return Html?
 function Header:_image(fileName, fileNameDark, default, defaultDark, size)
-	if (fileName == nil or fileName == '') and (default == nil or default == '') then
+	if Logic.isEmpty(fileName) and Logic.isEmpty(default) then
 		return nil
 	end
 
-	local imageName = fileName or default
-	---@cast imageName -nil
-	local infoboxImage = Header:_makeSizedImage(imageName, fileName, size, 'lightmode')
+	local imageName = fileName or default --[[@as string]]
+	local imageDarkname = fileNameDark or fileName or defaultDark or default --[[@as string]]
 
-	imageName = fileNameDark or fileName or defaultDark or default
-	---@cast imageName -nil
-	local infoboxImageDark = Header:_makeSizedImage(imageName, fileNameDark or fileName, size, 'darkmode')
+	if imageName == imageDarkname then
+		return mw.html.create('div'):node(Header:_makeSizedImage(imageName, size))
+	end
+
+	local infoboxImage = Header:_makeSizedImage(imageName, size, 'lightmode')
+	local infoboxImageDark = Header:_makeSizedImage(imageDarkname, size, 'darkmode')
 
 	return mw.html.create('div'):node(infoboxImage):node(infoboxImageDark)
 end
 
 ---@param imageName string
----@param fileName string?
 ---@param size number|string|nil
----@param mode string
+---@param mode string?
 ---@return Html
-function Header:_makeSizedImage(imageName, fileName, size, mode)
-	local infoboxImage = mw.html.create('div'):addClass('infobox-image ' .. mode)
+function Header:_makeSizedImage(imageName, size, mode)
+	local infoboxImage = mw.html.create('div'):addClass('infobox-image'):addClass(mode)
 
 	-- Number (interpret as pixels)
 	size = size or ''
@@ -133,7 +135,7 @@ function Header:_makeSizedImage(imageName, fileName, size, mode)
 		size = '600px'
 	end
 
-	local fullFileName = '[[File:' .. imageName .. '|center|' .. size .. ']]'
+	local fullFileName = '[[File:' .. imageName .. '|' .. size .. ']]'
 	infoboxImage:wikitext(fullFileName)
 
 	return infoboxImage

--- a/stylesheets/commons/Infobox.less
+++ b/stylesheets/commons/Infobox.less
@@ -125,6 +125,7 @@ Author(s): FO-nTTaX
 }
 
 .fo-nttax-infobox > div > div.infobox-image {
+	text-align: center;
 	padding: 0;
 	width: 100%;
 }


### PR DESCRIPTION
## Summary

Cleaned up the output for infobox header images a bit so that it doesn't end up producing two of the same image when there is no need. Also removed some unnecessary `div` wrappers by moving their functionality into existing css classes.

| HTML | `darkmode`/`lightmode` | `allmode` |
|--------|--------|--------|
| Old | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/f9ee6c65-9cba-4dff-ac01-653d5c106243) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/b14da93a-f195-47ae-86e7-96010060b8fc) |
| New | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/198e79ca-38b2-493b-abaa-2508d0861a6b) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/42068d31-400d-4b33-87c4-c4b3c412a8b5) | 

## How did you test this change?

Tested on dev.
