### PR TITLE
fix(bigmatch): add exception to boxes with a color class

### DIFF
--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -4095,7 +4095,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	font-weight: bold;
 	font-size: 12px;
 
-	.theme--dark & {
+	.theme--dark &:not( .match-bm-lol-game-veto-order-step-blue ):not( .match-bm-lol-game-veto-order-step-red ) {
 		background-color: var( --clr-secondary-39 );
 	}
 }


### PR DESCRIPTION
## Summary

The boxes with the red and blue color were also being overwritten with a dark theme color. With this exception that no longer happens.

## How did you test this change?

On the live website.