### PR TITLE
refactor: remove usage of deprecated `Module:Games`

### DIFF
--- a/components/infobox/extensions/commons/metadata_generator.lua
+++ b/components/infobox/extensions/commons/metadata_generator.lua
@@ -10,7 +10,7 @@ local AnOrA = require('Module:A or an')
 local Class = require('Module:Class')
 local Date = require('Module:Date/Ext')
 local Flags = require('Module:Flags')
-local Games = mw.loadData('Module:Games')
+local Game = require('Module:Game')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Tier = require('Module:Tier/Utils')
@@ -58,12 +58,7 @@ function MetadataGenerator.tournament(args)
 	local teams = args.team_number
 	local players = args.player_number
 
-	local game
-	if type(Games.abbr) == 'table' and args.primarygame and String.isNotEmpty(args.game)
-		and args.game == args.primarygame then
-
-		game = Games.abbr[args.game]
-	end
+	local game = Game.abbreviation({game = args.game, useDefault = true})
 
 	local prizepoolusd = args.prizepoolusd and ('$' .. args.prizepoolusd .. ' USD') or nil
 	local prizepool = prizepoolusd or (args.prizepool and args.localcurrency and

--- a/spec/metadata_generator_spec.lua
+++ b/spec/metadata_generator_spec.lua
@@ -1,9 +1,15 @@
 --- Triple Comment to Enable our LLS Plugin
 describe('metadata generator', function()
+	SetActiveWiki('counterstrike')
 	local MetadataGenerator = require('components.infobox.extensions.commons.metadata_generator')
 
+	teardown(function ()
+		SetActiveWiki('')
+	end)
+
 	it('generate', function()
-		local EXPECTED_RESULT = 'Intel Extreme Masters XVI - Cologne is an offline German tournament organized by ESL.' ..
+		local EXPECTED_RESULT =
+				'Intel Extreme Masters XVI - Cologne is an offline German CS:GO tournament organized by ESL.' ..
 				' This S-Tier tournament took place from Jul 06 to 18 2021 featuring 24 teams competing' ..
 				' over a total prize pool of $1,000,000 USD.'
 

--- a/spec/test_helper.lua
+++ b/spec/test_helper.lua
@@ -169,11 +169,6 @@ return function(busted, helper, options)
 				}
 			end
 
-			-- TODO Work away this usage
-			if newName == 'games' then
-				return {abbr = {}, name = {}}
-			end
-
 			if fileExists(newName) then
 				return require_original(newName)
 			end


### PR DESCRIPTION
## Summary
Module:Games is an old data module, being a subset of what's available in Module:Info (with help of Module:Game).
This is now this only non-AoE module using it.

After merge, remove https://liquipedia.net/commons/Module:Games (AoE has its own local version)

## How did you test this change?
Only with busted 