### PR TITLE
feat(participantTable): store dq indicator

### DIFF
--- a/components/participant_table/commons/participant_table_base.lua
+++ b/components/participant_table/commons/participant_table_base.lua
@@ -268,8 +268,11 @@ function ParticipantTable:store()
 		if placements[lpdbData.opponentname] or section.config.noStorage or
 			Opponent.isTbd(entry.opponent) or Opponent.isEmpty(entry.opponent) then return end
 
-
-		lpdbData = Table.merge(lpdbTournamentData, lpdbData, {date = section.config.resolveDate, extradata = {}})
+		lpdbData = Table.merge(
+			lpdbTournamentData,
+			lpdbData,
+			{date = section.config.resolveDate, extradata = {dq = entry.dq and 'true' or nil}}
+		)
 
 		self:adjustLpdbData(lpdbData, entry, section.config)
 


### PR DESCRIPTION
## Summary
Store dq indicator in participant table to be able to differentiate between participants that actually played in the event and e.g. participants who forfeited after being invited.

## How did you test this change?
dev