### PR TITLE
feat(opponent): support smash participant tables

### DIFF
--- a/components/opponent/commons/opponent_display.lua
+++ b/components/opponent/commons/opponent_display.lua
@@ -17,7 +17,7 @@ local TypeUtil = require('Module:TypeUtil')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local Opponent = Lua.import('Module:Opponent')
-local PlayerDisplay = Lua.import('Module:Player/Display')
+local PlayerDisplay = Lua.import('Module:Player/Display/Custom')
 
 local zeroWidthSpace = '&#8203;'
 

--- a/components/opponent/wikis/smash/opponent_custom.lua
+++ b/components/opponent/wikis/smash/opponent_custom.lua
@@ -1,0 +1,44 @@
+---
+-- @Liquipedia
+-- wiki=smash
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local Opponent = Lua.import('Module:Opponent')
+
+local CustomOpponent = Table.deepCopy(Opponent)
+
+---@class SmashStandardPlayer:standardPlayer
+---@field chars string[]?
+---@field game string?
+
+---@class SmashStandardOpponent:standardOpponent
+---@field players SmashStandardPlayer[]
+
+---@param args table
+---@return SmashStandardOpponent?
+function CustomOpponent.readOpponentArgs(args)
+	local opponent = Opponent.readOpponentArgs(args) --[[@as SmashStandardOpponent?]]
+
+	if not opponent then return nil end
+
+	local partySize = Opponent.partySize(opponent.type)
+
+	if partySize == 1 then
+		opponent.players[1].chars = args.chars and mw.text.split(args.chars or '', ',') or nil
+		opponent.players[1].game = args.game
+	elseif partySize then
+		for _, player in ipairs(opponent.players) do
+			player.chars = args.chars and mw.text.split(args.chars or '', ',') or nil
+		end
+	end
+
+	return opponent
+end
+
+return CustomOpponent

--- a/components/opponent/wikis/smash/opponent_custom.lua
+++ b/components/opponent/wikis/smash/opponent_custom.lua
@@ -36,8 +36,8 @@ function CustomOpponent.readOpponentArgs(args)
 		opponent.players[1].chars = Array.parseCommaSeparatedString(args.chars)
 		opponent.players[1].game = args.game or Variables.varDefault('tournament_game') or Info.defaultGame
 	elseif partySize then
-		Array.forEach(opponent.players, function (player)
-			player.chars = Array.parseCommaSeparatedString(args.chars)
+		Array.forEach(opponent.players, function (player, playerIndex)
+			player.chars = Array.parseCommaSeparatedString(args['chars' .. playerIndex])
 		end)
 	end
 

--- a/components/opponent/wikis/smash/opponent_custom.lua
+++ b/components/opponent/wikis/smash/opponent_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Info = require('Module:Info')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
@@ -32,12 +33,12 @@ function CustomOpponent.readOpponentArgs(args)
 	local partySize = Opponent.partySize(opponent.type)
 
 	if partySize == 1 then
-		opponent.players[1].chars = args.chars and mw.text.split(args.chars or '', ',') or nil
+		opponent.players[1].chars = Array.parseCommaSeparatedString(args.char)
 		opponent.players[1].game = args.game or Variables.varDefault('tournament_game') or Info.defaultGame
 	elseif partySize then
-		for _, player in ipairs(opponent.players) do
-			player.chars = args.chars and mw.text.split(args.chars or '', ',') or nil
-		end
+		Array.forEach(opponent.players, function (player)
+			player.chars = Array.parseCommaSeparatedString(args.char)
+		end)
 	end
 
 	return opponent

--- a/components/opponent/wikis/smash/opponent_custom.lua
+++ b/components/opponent/wikis/smash/opponent_custom.lua
@@ -6,8 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Info = require('Module:Info')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
+local Variables = require('Module:Variables')
 
 local Opponent = Lua.import('Module:Opponent')
 
@@ -31,7 +33,7 @@ function CustomOpponent.readOpponentArgs(args)
 
 	if partySize == 1 then
 		opponent.players[1].chars = args.chars and mw.text.split(args.chars or '', ',') or nil
-		opponent.players[1].game = args.game
+		opponent.players[1].game = args.game or Variables.varDefault('tournament_game') or Info.defaultGame
 	elseif partySize then
 		for _, player in ipairs(opponent.players) do
 			player.chars = args.chars and mw.text.split(args.chars or '', ',') or nil

--- a/components/opponent/wikis/smash/opponent_custom.lua
+++ b/components/opponent/wikis/smash/opponent_custom.lua
@@ -33,11 +33,11 @@ function CustomOpponent.readOpponentArgs(args)
 	local partySize = Opponent.partySize(opponent.type)
 
 	if partySize == 1 then
-		opponent.players[1].chars = Array.parseCommaSeparatedString(args.char)
+		opponent.players[1].chars = Array.parseCommaSeparatedString(args.chars)
 		opponent.players[1].game = args.game or Variables.varDefault('tournament_game') or Info.defaultGame
 	elseif partySize then
 		Array.forEach(opponent.players, function (player)
-			player.chars = Array.parseCommaSeparatedString(args.char)
+			player.chars = Array.parseCommaSeparatedString(args.chars)
 		end)
 	end
 

--- a/components/opponent/wikis/smash/player_display_custom.lua
+++ b/components/opponent/wikis/smash/player_display_custom.lua
@@ -1,0 +1,126 @@
+---
+-- @Liquipedia
+-- wiki=smash
+-- page=Module:Player/Display/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Abbreviation = require('Module:Abbreviation')
+local FnUtil = require('Module:FnUtil')
+local Characters = require('Module:Characters')
+local DisplayUtil = require('Module:DisplayUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local Opponent = Lua.import('Module:Opponent')
+local PlayerDisplay = Lua.import('Module:Player/Display')
+
+local TBD_ABBREVIATION = Abbreviation.make('TBD', 'To be determined (or to be decided)')
+local ZERO_WIDTH_SPACE = '&#8203;'
+
+---@class SmashPlayerDisplay: PlayerDisplay
+local CustomPlayerDisplay = Table.copy(PlayerDisplay)
+
+---@class SmashBlockPlayerProps: BlockPlayerProps
+---@field player SmashStandardPlayer
+
+---@class SmashInlinePlayerProps: InlinePlayerProps
+---@field player SmashStandardPlayer
+
+---@param props SmashBlockPlayerProps
+---@return Html
+function CustomPlayerDisplay.BlockPlayer(props)
+	local player = props.player
+
+	local nameNode = mw.html.create(props.dq and 's' or 'span')
+		:wikitext(
+			props.abbreviateTbd and Opponent.playerIsTbd(player) and TBD_ABBREVIATION
+			or props.showLink ~= false and player.pageName
+			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
+			or Logic.emptyOr(player.displayName, ZERO_WIDTH_SPACE)
+		)
+	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
+
+	if props.note then
+		nameNode = mw.html.create('span'):addClass('name')
+			:node(nameNode)
+			:tag('sup'):addClass('note'):wikitext(props.note):done()
+	else
+		nameNode:addClass('name')
+	end
+
+	local flagNode
+	if props.showFlag ~= false and player.flag then
+		flagNode = PlayerDisplay.Flag(player.flag)
+	end
+	mw.logObject(player.chars, 'BlockPlayer')
+
+	local characterNode = mw.html.create()
+	if player.chars then
+		Array.forEach(player.chars, function (character)
+			characterNode:node(
+				mw.html.create('span'):addClass('race'):wikitext(CustomPlayerDisplay.character(player.game, character))
+			)
+		end)
+	end
+
+	local teamNode
+	if props.showPlayerTeam and player.team and player.team:lower() ~= 'tbd' then
+		teamNode = mw.html.create('span')
+			:wikitext('&nbsp;')
+			:node(mw.ext.TeamTemplate.teampart(player.team))
+	end
+
+	return mw.html.create('div'):addClass('block-player starcraft-block-player')
+		:addClass(props.flip and 'flipped' or nil)
+		:addClass(props.showPlayerTeam and 'has-team' or nil)
+		:node(flagNode)
+		:node(characterNode)
+		:node(nameNode)
+		:node(teamNode)
+end
+
+---@param props SmashInlinePlayerProps
+---@return Html
+function CustomPlayerDisplay.InlinePlayer(props)
+	local player = props.player
+
+	local flag = props.showFlag ~= false and player.flag
+		and PlayerDisplay.Flag(player.flag)
+		or nil
+
+	local faction = player.chars
+		and table.concat(Array.map(player.chars, FnUtil.curry(CustomPlayerDisplay.character, player.game)))
+		or nil
+
+	local nameAndLink = props.showLink ~= false and player.pageName
+		and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
+		or player.displayName
+	if props.dq then
+		nameAndLink = '<s>' .. nameAndLink .. '</s>'
+	end
+
+	local text
+	if props.flip then
+		text = nameAndLink
+			.. (faction and '&nbsp;' .. faction or '')
+			.. (flag and '&nbsp;' .. flag or '')
+	else
+		text = (flag and flag .. '&nbsp;' or '')
+			.. (faction and faction .. '&nbsp;' or '')
+			.. nameAndLink
+	end
+
+	return mw.html.create('span'):addClass('starcraft-inline-player')
+		:addClass(props.flip and 'flipped' or nil)
+		:wikitext(text)
+end
+
+function CustomPlayerDisplay.character(game, character)
+	return Characters.GetIconAndName{character, game = game, large = true}
+end
+
+return CustomPlayerDisplay

--- a/standard/info/wikis/smash/info.lua
+++ b/standard/info/wikis/smash/info.lua
@@ -98,5 +98,6 @@ return {
 			allowManual = true,
 		},
 	},
+	opponentLibrary = 'Opponent/Custom',
 	match2 = 0,
 }


### PR DESCRIPTION
## Summary
Opponent Display for Smash, to support Participant Tables.

<img width="1013" alt="image" src="https://github.com/Liquipedia/Lua-Modules/assets/3426850/bee8fbd6-6a4d-4b6b-bb2e-180c3f3c9396">

## How did you test this change?
Dev