### PR TITLE
feat(participantTable): Add AoE custom with support for seedings

### DIFF
--- a/components/participant_table/wikis/ageofempires/participant_table_custom.lua
+++ b/components/participant_table/wikis/ageofempires/participant_table_custom.lua
@@ -118,9 +118,7 @@ function AoEParticipantTable:_createSeedList()
 	local display = self:_createTitle('Seeding', self.config.title or 'Participants', 2, 1, width, true)
 
 	local wrapper = mw.html.create('div')
-		:addClass('participantTable-Seeding')
-		:css('display', 'grid')
-		:css('grid-template-columns', '50px 1fr')
+		:addClass('participantTable-seeding')
 
 	local entries = Array.sortBy(
 		Array.filter(Array.flatMap(self.sections, function(section)
@@ -135,7 +133,7 @@ function AoEParticipantTable:_createSeedList()
 	Array.forEach(entries, function (entry, index)
 		wrapper
 			:tag('div')
-				:addClass('participantTable-tbd')
+				:addClass('participantTable-seed')
 				:wikitext(index)
 				:done()
 			:node(self:displayEntry(entry))

--- a/components/participant_table/wikis/ageofempires/participant_table_custom.lua
+++ b/components/participant_table/wikis/ageofempires/participant_table_custom.lua
@@ -126,9 +126,7 @@ function AoEParticipantTable:_createSeedList()
 		Array.filter(Array.flatMap(self.sections, function(section)
 			return section.entries
 		end), Logic.isNotEmpty),
-		function (element)
-			return element and element.seed or nil
-		end,
+		Operator.property('seed'),
 		function (a, b)
 			return a and b and a < b or false
 		end
@@ -170,7 +168,7 @@ function AoEParticipantTable:_createTitle(tabletitle, buttontitle, togglearea, b
 	else
 		title:css('position', 'absolute')
 	end
-	
+
 	return title:done()
 			:tag('div')
 				:addClass('participantTable-title')

--- a/components/participant_table/wikis/ageofempires/participant_table_custom.lua
+++ b/components/participant_table/wikis/ageofempires/participant_table_custom.lua
@@ -1,0 +1,181 @@
+---
+-- @Liquipedia
+-- wiki=ageofempires
+-- page=Module:ParticipantTable/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
+
+---@class AoEParticipantTableEntry: ParticipantTableEntry
+---@field seed integer?
+
+---@class AoEParticipantTableSection: ParticipantTableSection
+---@field entries AoEParticipantTableEntry[]
+
+---@class AoEParticipantTable: ParticipantTable
+---@field hasSeeds boolean
+---@field _createSeedList function
+---@field _createTitle function
+
+local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
+
+local OpponentLibrary = require('Module:OpponentLibraries')
+local Opponent = OpponentLibrary.Opponent
+
+local AoEParticipantTable = {}
+
+---@param frame Frame
+---@return Html?
+function AoEParticipantTable.run(frame)
+	local participantTable = ParticipantTable(frame) --[[@as AoEParticipantTable]]
+	participantTable.readEntry = AoEParticipantTable.readEntry
+	participantTable:read():store()
+
+	if participantTable.hasSeeds then
+		participantTable._createSeedList = AoEParticipantTable._createSeedList
+		participantTable._createTitle = AoEParticipantTable._createTitle
+		participantTable.create = AoEParticipantTable._createSeedTable
+	end
+
+	return participantTable:create()
+end
+
+---@param sectionArgs table
+---@param key string|number
+---@param index number
+---@param config ParticipantTableConfig
+---@return AoEParticipantTableEntry
+function AoEParticipantTable:readEntry(sectionArgs, key, index, config)
+	local prefix = 'p' .. index
+	local valueFromArgs = function(postfix)
+		return sectionArgs[key .. postfix] or sectionArgs[prefix .. postfix]
+	end
+
+	--if not a json assume it is a solo opponent
+	local opponentArgs = Json.parseIfTable(sectionArgs[key]) or {
+		type = Opponent.solo,
+		name = sectionArgs[key],
+		link = valueFromArgs('link'),
+		flag = valueFromArgs('flag'),
+		team = valueFromArgs('team'),
+		dq = valueFromArgs('dq'),
+		note = valueFromArgs('note'),
+		seed = valueFromArgs('seed'),
+	}
+
+	assert(Opponent.isType(opponentArgs.type) and opponentArgs.type ~= Opponent.team,
+		'Missing or unsupported opponent type for "' .. sectionArgs[key] .. '"')
+
+	local opponent = Opponent.readOpponentArgs(opponentArgs) or {}
+
+	if config.sortPlayers and opponent.players then
+		table.sort(opponent.players, function (player1, player2)
+			local name1 = (player1.displayName or player1.pageName):lower()
+			local name2 = (player2.displayName or player2.pageName):lower()
+			return name1 < name2
+		end)
+	end
+
+	if tonumber(opponentArgs.seed) then
+		self.hasSeeds = true
+	end
+
+	return {
+		dq = Logic.readBool(opponentArgs.dq),
+		note = opponentArgs.note,
+		opponent = opponent,
+		name = Opponent.toName(opponent),
+		inputIndex = index,
+		seed = tonumber(opponentArgs.seed)
+	}
+end
+
+---@return Html?
+function AoEParticipantTable:_createSeedTable()
+	local config = self.config
+
+	if not config.display then return end
+
+	self.display = self:_createTitle(self.config.title or 'Participants', 'Seeding', 1, 2)
+	Array.forEach(self.sections, function(section) self:displaySection(section) end)
+
+	return mw.html.create('div')
+		:addClass('table-responsive toggle-area toggle-area-1')
+		:attr('data-toggle-area', 1)
+		:node(self.display)
+		:node(self:_createSeedList())
+end
+
+---@return Html
+function AoEParticipantTable:_createSeedList()
+	local width = tostring(50 + (self.config.showTeams and 212 or 156)) .. 'px'
+	local display = self:_createTitle('Seeding', self.config.title or 'Participants', 2, 1, width, true)
+
+	local wrapper = mw.html.create('div')
+		:addClass('participantTable-Seeding')
+		:css('display', 'grid')
+		:css('grid-template-columns', '50px 1fr')
+
+	local entries = Array.sortBy(
+		Array.filter(Array.flatMap(self.sections, function(section)
+			return section.entries
+		end), Logic.isNotEmpty),
+		function (element)
+			return element and element.seed or nil
+		end,
+		function (a, b)
+			return a and b and a < b or false
+		end
+	)
+
+	Array.forEach(entries, function (entry, index)
+		wrapper
+			:tag('div')
+				:addClass('participantTable-tbd')
+				:wikitext(index)
+				:done()
+			:node(self:displayEntry(entry))
+	end)
+
+	return display:node(wrapper)
+end
+
+---@param togglearea integer
+---@param title string
+---@param buttonarea integer
+---@param buttontitle string
+---@return Html
+function AoEParticipantTable:_createTitle(tabletitle, buttontitle, togglearea, buttonarea, width, float)
+	local title = mw.html.create('div')
+			:addClass('participantTable')
+			:attr('data-toggle-area-content', togglearea)
+			:css('max-width', '100%!important')
+			:css('width', width or self.config.width)
+			:css('vertical-align', 'middle')
+			:tag('span')
+				:addClass('toggle-area-button btn btn-primary')
+				:attr('data-toggle-area-btn', buttonarea)
+				:css('padding-top', '2px')
+				:css('padding-bottom', '2px')
+				:wikitext(buttontitle)
+
+	if float then
+		title:css('float', 'left')
+	else
+		title:css('position', 'absolute')
+	end
+	
+	return title:done()
+			:tag('div')
+				:addClass('participantTable-title')
+				:wikitext(tabletitle)
+				:done()
+end
+
+return AoEParticipantTable

--- a/stylesheets/commons/OpponentList.less
+++ b/stylesheets/commons/OpponentList.less
@@ -30,6 +30,11 @@ Author: hjpalpha
 	flex-wrap: wrap;
 }
 
+.participantTable-seeding {
+	display: grid;
+        grid-template-columns: 50px 1fr;
+}
+
 .participantTable-entry {
 	background-color: inherit;
 	border-bottom: 1px solid var( --table-border-color, #bbbbbb );
@@ -45,6 +50,15 @@ Author: hjpalpha
 	border-right: 1px solid var( --table-border-color, #bbbbbb );
 	padding: 4px;
 	font-style: italic;
+	text-align: center;
+	width: 100%;
+}
+
+.participantTable-seed {
+	background-color: inherit;
+	border-bottom: 1px solid var( --table-border-color, #bbbbbb );
+	border-right: 1px solid var( --table-border-color, #bbbbbb );
+	padding: 8px 4px 4px;
 	text-align: center;
 	width: 100%;
 }

--- a/stylesheets/commons/OpponentList.less
+++ b/stylesheets/commons/OpponentList.less
@@ -32,7 +32,7 @@ Author: hjpalpha
 
 .participantTable-seeding {
 	display: grid;
-        grid-template-columns: 50px 1fr;
+	grid-template-columns: 50px 1fr;
 }
 
 .participantTable-entry {


### PR DESCRIPTION
## Summary
Adds a custom that supports toggeable display of seeding tables.

## How did you test this change?
via dev, css classes via inspector/direct attribute setting
Before:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/056f060b-5efa-45d7-85f4-4b1f5b5f68fe)
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/92f9a3c3-9173-4e2f-9e56-751832e15e1b)

After:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/5de8f0fc-32d4-4e4d-8010-ffa3476b184b)
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/7c730d78-4eeb-486a-92dc-0119a6b27e86)

