### PR TITLE
fix(match2) AoE: walkover status, playerData

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -161,11 +161,11 @@ function CustomMatchGroupInput._calculateWinner(match)
 					opponent.status = 'W'
 				elseif walkover == 0 then
 					match.winner = 0
-					match.walkover = 'L'
-					opponent.status = 'L'
+					match.walkover = 'FF'
+					opponent.status = 'FF'
 				else
 					local score = string.upper(opponent.score or '')
-					opponent.status = CONVERT_STATUS_INPUT[score] or 'L'
+					opponent.status = CONVERT_STATUS_INPUT[score] or 'FF'
 				end
 			elseif Table.includes(ALLOWED_STATUSES, string.upper(match.walkover)) then
 				if tonumber(match.winner or 0) == opponentIndex then
@@ -473,12 +473,11 @@ function CustomMatchGroupInput._processTeamMapData(opponentPlayers, map, opponen
 
 		participants[opponentIndex .. '_' .. playerIndex] = {
 			civ = civ,
-			displayName = playerData.displayname,
-			pageName = playerData.name,
+			displayName = playerData.displayName,
+			pageName = playerData.pageName,
 			flag = playerData.flag,
 		}
 	end
-
 	return participants
 end
 


### PR DESCRIPTION
## Summary
Fixes two issues with aoe match2:
- Faulty walkover handling for `walkover=2` (was W-FF for input 1, but L-W for input 2)
- Missing playerData in preview/without TC due to typo

## How did you test this change?
via dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
