### PR TITLE
fix(match2): prevent applying winner class for draws in MatchList

### DIFF
--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -216,8 +216,8 @@ function MatchlistDisplay.Opponent(props)
 		:addClass('brkts-matchlist-cell-content')
 	return mw.html.create('div')
 		:addClass('brkts-matchlist-cell brkts-matchlist-opponent')
-		:addClass(props.opponent.placement == 1 and props.resultType ~= 'draw' and 'brkts-matchlist-slot-winner' or nil)
-		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
+		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or
+			props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
 		:node(contentNode)
 end
 

--- a/components/match2/commons/match_group_display_matchlist.lua
+++ b/components/match2/commons/match_group_display_matchlist.lua
@@ -216,7 +216,7 @@ function MatchlistDisplay.Opponent(props)
 		:addClass('brkts-matchlist-cell-content')
 	return mw.html.create('div')
 		:addClass('brkts-matchlist-cell brkts-matchlist-opponent')
-		:addClass(props.opponent.placement == 1 and 'brkts-matchlist-slot-winner' or nil)
+		:addClass(props.opponent.placement == 1 and props.resultType ~= 'draw' and 'brkts-matchlist-slot-winner' or nil)
 		:addClass(props.resultType == 'draw' and 'brkts-matchlist-slot-bold bg-draw' or nil)
 		:node(contentNode)
 end

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -448,10 +448,6 @@
 	background-color: #ddf4dd;
 }
 
-.theme--dark .brkts-matchlist-slot-winner:not( .bg-draw ) {
-	box-shadow: inset 0 0 0 2px var( --table-green-border-color, transparent );
-}
-
 .brkts-matchlist-slot-winner .flag + .name {
 	margin-left: -1px;
 }


### PR DESCRIPTION
## Summary
For draws, the `brkts-matchlist-slot-winner` was applied, but lead to weird display cause only parts were overridden by the `bg-draw` class.

## How did you test this change?
via dev:
Before:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/75abfacf-269e-4c18-b64d-0d4c3ac2eb2b)

After:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/8dec6f9f-57fd-4adb-bc61-78eaaea79ad8)

