### PR TITLE
added darkmode icon for R6+updated lightmode icon name

### DIFF
--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -17,8 +17,8 @@ return {
 			name = 'Tom Clancy\'s Rainbow Six Siege',
 			link = 'Rainbow Six Siege',
 			logo = {
-				darkMode = 'Rainbow Six Siege gameicon lightmode.png',
-				lightMode = 'Rainbow Six Siege gameicon darkmode.png',
+				darkMode = 'Rainbow Six Siege gameicon darkmode.png',
+				lightMode = 'Rainbow Six Siege gameicon lightmode.png',
 			},
 			defaultTeamLogo = {
 				darkMode = 'Rainbow Six Siege Logo darkmode.png',

--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -17,8 +17,8 @@ return {
 			name = 'Tom Clancy\'s Rainbow Six Siege',
 			link = 'Rainbow Six Siege',
 			logo = {
-				darkMode = 'R6S icon.png',
-				lightMode = 'R6S icon.png',
+				darkMode = 'Rainbow Six Siege gameicon lightmode.png',
+				lightMode = 'Rainbow Six Siege gameicon darkmode.png',
 			},
 			defaultTeamLogo = {
 				darkMode = 'Rainbow Six Siege Logo darkmode.png',


### PR DESCRIPTION
## Summary

Added darkmode version for the game icon: https://liquipedia.net/commons/File:Rainbow_Six_Siege_gameicon_darkmode.png

+in addition updated the name of the lightmode icon: https://liquipedia.net/commons/File:Rainbow_Six_Siege_gameicon_lightmode.png

## How did you test this change?

