### PR TITLE
fix(matchtable): Display stats scores

### DIFF
--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -792,11 +792,11 @@ function MatchTable:displayStats()
 			data.l .. 'L'
 		), ' : ')
 
-		local percentage = Math.round((data.w + 0.5 * data.d) / sum, 2)
+		local percentage = Math.round((data.w + 0.5 * data.d) / sum, 4) * 100
 
 		local parts = {
 			scoreText,
-			'(' .. percentage .. '1)',
+			'(' .. percentage .. '%)',
 			'in',
 			statsType,
 		}


### PR DESCRIPTION
## Summary
Range [0,1] to [0, 100] and remove the extra `1`

`102W : 147L (0.411) in matches and 225W : 287L (0.441) in games` to `102W : 147L (41%) in matches and 225W : 287L (44%) in games`
## How did you test this change?

tested live, before weekly resync
