### PR TITLE
fix: stylelint not enabled for less files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,12 @@
 		".busted": "lua",
 		".luacov": "lua"
 	},
+	"stylelint.validate": [
+		"css",
+		"postcss",
+		"less",
+		"scss"
+	],
 	"css.validate": false,
 	"less.validate": false,
 	"scss.validate": false


### PR DESCRIPTION
## Summary
Since we changed the extension from `.css` to `.less`, stylelint was not running in VSCode. This enable it to process `.less` files, and future proofs with `.scss`.

## How did you test this change?
In mine and @liquidely's vscodes