### PR TITLE
feat(match2): manual bonus/subtract points on apex

### DIFF
--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -225,7 +225,7 @@ function MatchFunctions.getScoreFromMaps(match)
 
 	for index = 1, MAX_NUM_OPPONENTS do
 		if match['opponent' .. index] and not match['opponent' .. index].score then
-			match['opponent' .. index].score = newScores[index] or 0
+			match['opponent' .. index].score = (newScores[index] or 0) + (match['opponent' .. index].pointmodifier or 0)
 		end
 	end
 


### PR DESCRIPTION
## Summary
Add support to manually tweak (setting fully manual was already possible) the point. This is for instance if a team reiceves bonus points (eg. starts with +10 points because of seed) or have a penety and as such starts with negative points.
## How did you test this change?
/dev