### PR TITLE
fix(colours): add dark-theme appropriate gray background color

### DIFF
--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -35,7 +35,14 @@ Besides these twelve there is Gray which will fit in with them very well. There 
 .gray-theme-light-alt-bg,
 ul.nav-tabs li.game-none,
 .overview.game-none {
-	background-color: var( --clr-moon-80, #ababab );
+	background-color: var( --clr-moon-80, #d3d3d3 );
+}
+[ data-darkreader-scheme="dark" ] &,
+.theme--dark & {
+	.overview.game-none {
+		background: var( --clr-moon-20 );
+	}
+}
 }
 
 .gray-bg-alt,

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -35,7 +35,7 @@ Besides these twelve there is Gray which will fit in with them very well. There 
 .gray-theme-light-alt-bg,
 ul.nav-tabs li.game-none,
 .overview.game-none {
-	background-color: var( --clr-moon-80, #d3d3d3 );
+	background-color: var( --clr-moon-80, #ababab );
 }
 
 .gray-bg-alt,

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -43,7 +43,6 @@ ul.nav-tabs li.game-none,
 		background: var( --clr-moon-20 );
 	}
 }
-}
 
 .gray-bg-alt,
 .matchlistdate,

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -37,6 +37,7 @@ ul.nav-tabs li.game-none,
 .overview.game-none {
 	background-color: var( --clr-moon-80, #d3d3d3 );
 }
+
 [ data-darkreader-scheme="dark" ] &,
 .theme--dark & {
 	.overview.game-none {

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -36,12 +36,9 @@ Besides these twelve there is Gray which will fit in with them very well. There 
 ul.nav-tabs li.game-none,
 .overview.game-none {
 	background-color: var( --clr-moon-80, #d3d3d3 );
-}
 
-[ data-darkreader-scheme="dark" ] &,
-.theme--dark & {
-	.overview.game-none {
-		background: var( --clr-moon-20 );
+	.theme--dark & {
+		background: var( --clr-moon-30 );
 	}
 }
 


### PR DESCRIPTION
## Summary
https://github.com/Liquipedia/Lua-Modules/pull/4180 Added a color for deceased players in the player portal and it doesn't seem to work very well. 

I just changed it to a darker hex code, not sure about the best way to do this tho
If anyone is able to test this for me it would be appreciated

![Screen Shot 2024-04-25 at 11 24 06 PM](https://github.com/Liquipedia/Lua-Modules/assets/145709809/4292ecd7-24ad-476a-922c-04f00728d721)
https://liquipedia.net/rainbowsix/Portal:Players/Asia_Pacific#_Australia

## How did you test this change?
N/A
