### PR TITLE
Use small character icons for Smash

### DIFF
--- a/components/opponent/wikis/smash/player_display_custom.lua
+++ b/components/opponent/wikis/smash/player_display_custom.lua
@@ -120,7 +120,7 @@ function CustomPlayerDisplay.InlinePlayer(props)
 end
 
 function CustomPlayerDisplay.character(game, character)
-	return Characters.GetIconAndName{character, game = game, large = true}
+	return Characters.GetIconAndName{character, game = game}
 end
 
 return CustomPlayerDisplay


### PR DESCRIPTION
## Summary

Large icons are 25x25px, which is too big for most use cases (including ParticipantTable). These are intended to be 18x18px, which is the default.

## How did you test this change?

Change is live