### PR TITLE
fix(squad): header order on overwatch

### DIFF
--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -25,7 +25,7 @@ local HAS_NUMBER = false
 
 function CustomInjector:parse(id, widgets)
 	if id == 'header_name' and HAS_NUMBER then
-		table.insert(widgets, Widget.TableCellNew{content = {'Number'}, header = true})
+		table.insert(widgets, 1, Widget.TableCellNew{content = {'Number'}, header = true})
 	end
 
 	return self._base:parse(id, widgets)


### PR DESCRIPTION
## Summary
`Number` inserted in the wrong place
![image](https://github.com/Liquipedia/Lua-Modules/assets/3426850/1993666b-3b61-4309-91eb-beca64a8ff94)

This PR fixed it
