### PR TITLE
fix(infobox): max damage calculation on warcraft's unit infobox is incorrect

### DIFF
--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_building_unit_shared.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_building_unit_shared.lua
@@ -302,7 +302,7 @@ function CustomBuildingUnit.calculateMaxDamage(args, index)
 	local diceDamage = tonumber(args['dmgdice' .. index]) or 1
 	local sidesDamage = tonumber(args['dmgsides' .. index] or args.dmgsides) or 2
 
-	return baseDamage + diceDamage + sidesDamage
+	return baseDamage + (diceDamage * sidesDamage)
 end
 
 ---@param args table


### PR DESCRIPTION
## Summary
As requested on discord https://discord.com/channels/93055209017729024/268719633366777856/1234540830648172595
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
