### PR TITLE
fix(filterButtons): default by class unintentionally ignored

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -73,6 +73,10 @@ liquipedia.filterButtons = {
 			buttonsDiv.querySelectorAll( ':scope > .filter-button' ).forEach(
 				( /** @type HTMLElement */ buttonElement ) => {
 					const filterOn = buttonElement.dataset.filterOn ?? '';
+					const defaultState = !(
+						buttonElement.dataset.filterDefault === 'false' ||
+							!buttonElement.classList.contains( 'filter-button--active' )
+					);
 					const button = {
 						element: buttonElement,
 						filter: filterOn,
@@ -86,8 +90,7 @@ liquipedia.filterButtons = {
 						default:
 							filterGroupEntry.buttons[ filterOn ] = button;
 							filterGroupEntry.filterStates[ filterOn ] =
-								filterGroupEntry.filterStates[ filterOn ] ??
-									!( buttonElement.dataset.filterDefault === 'false' );
+								filterGroupEntry.filterStates[ filterOn ] ?? defaultState;
 					}
 					buttonElement.setAttribute( 'tabindex', '0' );
 				}


### PR DESCRIPTION
## Summary

Due to a regression in #4040, filter buttons written to expect the previous javascript code (i.e., non-commons tournamentlists) would no longer have their default states respected.

Added intermediary const value which respects both old and new ways of setting default state. (Technically, if `buttonElement.dataset.filterDefault` is `false` but `filter-button--active` is present, then the false is ignored - not ideal, but that would only happen if someone incorrectly applied either the false value or the class.)

## How did you test this change?

Pushed live on commons.
