### PR TITLE
fix(squad): tlpd not working on broodwar

### DIFF
--- a/components/squad/wikis/starcraft/squad_custom.lua
+++ b/components/squad/wikis/starcraft/squad_custom.lua
@@ -23,7 +23,7 @@ local TlpdSquad = Class.new(Squad)
 
 ---@return self
 function TlpdSquad:header()
-	table.insert(self.children, Widget.TableRowNew{
+	table.insert(self.rows, Widget.TableRowNew{
 		classes = {'HeaderRow'},
 		cells = {
 			Widget.TableCellNew{content = {'ID'}, header = true},


### PR DESCRIPTION
## Summary
Currently squads on broodwar wiki error due to trying to insert into `self.children` which does not exist.
This PR fixes the key from `children` to `rows` so that squads work again on broodwar.

## How did you test this change?
live as bug fix