### PR TITLE
Hide infobox edit button from search

### DIFF
--- a/components/infobox/commons/infobox_widget_header.lua
+++ b/components/infobox/commons/infobox_widget_header.lua
@@ -152,6 +152,7 @@ function Header:_createInfoboxButtons()
 
 	local buttons = mw.html.create('span')
 	buttons:addClass('infobox-buttons')
+	buttons:addClass('navigation-not-searchable')
 
 	-- Quick edit link
 	buttons:node(


### PR DESCRIPTION
## Summary

This change is meant to make sure the [e][h] in the screenshot doesn't show up in search:

![image](https://github.com/Liquipedia/Lua-Modules/assets/3266537/9e43de00-f1c8-4bdb-abb7-3da5b323bf4c)


## How did you test this change?

I did not, but it is the same solution we use for navboxes.
