### PR TITLE
feat(filterButtons): support template expansions

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -126,7 +126,8 @@ liquipedia.filterButtons = {
 			this.templateExpansions.push( {
 				element: templateExpansion,
 				groups: templateExpansion.dataset.filterGroups.split( ',' ),
-				template: templateExpansion.dataset.filterExpansionTemplate
+				template: templateExpansion.dataset.filterExpansionTemplate,
+				defaultContent: templateExpansion.innerHTML
 			} );
 		} );
 	},
@@ -232,20 +233,21 @@ liquipedia.filterButtons = {
 		} );
 
 		this.templateExpansions.forEach( ( templateExpansion ) => {
-			const isDefault = this.templateExpansion.groups.every( ( group ) => {
+			const isDefault = !templateExpansion.groups.some( ( group ) => {
 				const filterGroup = this.filterGroups[ group ];
-				if ( filterGroup.curated === filterGroup.defaultCurated ) {
+				if ( filterGroup.curated !== filterGroup.defaultCurated ) {
 					return true;
 				}
-				return Object.keys( filterGroup.filterStates ).every( ( filterState ) => {
-					return filterGroup.filterStates[ filterState ] === filterGroup.defaultStates[ filterState ];
+				return Object.keys( filterGroup.filterStates ).some( ( filterState ) => {
+					return filterGroup.filterStates[ filterState ] !== filterGroup.defaultStates[ filterState ];
 				} );
 			} );
 			if ( isDefault ) {
+				templateExpansion.element.innerHTML = templateExpansion.defaultContent;
 				return;
 			}
 			const parameters = templateExpansion.groups.map( ( group ) => {
-				if ( group.curated ) {
+				if ( this.filterGroups[ group ].curated ) {
 					return group + '=curated';
 				}
 

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -233,13 +233,13 @@ liquipedia.filterButtons = {
 		} );
 
 		this.templateExpansions.forEach( ( templateExpansion ) => {
-			const isDefault = !templateExpansion.groups.some( ( group ) => {
+			const isDefault = templateExpansion.groups.every( ( group ) => {
 				const filterGroup = this.filterGroups[ group ];
 				if ( filterGroup.curated !== filterGroup.defaultCurated ) {
-					return true;
+					return false;
 				}
-				return Object.keys( filterGroup.filterStates ).some( ( filterState ) => {
-					return filterGroup.filterStates[ filterState ] !== filterGroup.defaultStates[ filterState ];
+				return Object.keys( filterGroup.filterStates ).every( ( filterState ) => {
+					return filterGroup.filterStates[ filterState ] === filterGroup.defaultStates[ filterState ];
 				} );
 			} );
 			if ( isDefault ) {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -235,8 +235,8 @@ liquipedia.filterButtons = {
 		this.templateExpansions.forEach( ( templateExpansion ) => {
 			const isDefault = templateExpansion.groups.every( ( group ) => {
 				const filterGroup = this.filterGroups[ group ];
-				if ( filterGroup.curated !== filterGroup.defaultCurated ) {
-					return false;
+				if ( filterGroup.curated || filterGroup.defaultCurated ) {
+					return filterGroup.curated === filterGroup.defaultCurated;
 				}
 				return Object.keys( filterGroup.filterStates ).every( ( filterState ) => {
 					return filterGroup.filterStates[ filterState ] === filterGroup.defaultStates[ filterState ];

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -36,7 +36,7 @@
  *   Expanded template will replace default content.
  * - data-filter-group (required): Identify the groups of filterbuttons the template should receive the current parameters from.
  *   Should correspond to appropriate filter button groups used on the page.
- *	 For each group, the template will receive a parameter groupName holding the currently active group settings.
+ *   For each group, the template will receive a parameter groupName holding the currently active group settings.
  */
 
 liquipedia.filterButtons = {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -30,11 +30,11 @@
  * - data-filter-category (required): identifier for 'data-filter-on'
  *
  * Replacement by Template with filter options:
- * <div data-filter-expansion-template="TemplateName" data-filter-groups="group1 group2">Default content</div>
+ * <div data-filter-expansion-template="TemplateName" data-filter-groups="group1,group2">Default content</div>
  *
  * - data-filter-expansion-template (required): The template to expand with the current filter options.
  *   Expanded template will replace default content.
- * - data-filter-group (required): Identify the groups of filterbuttons the template should receive the current parameters from.
+ * - data-filter-groups (required): Identify the groups of filterbuttons the template should receive the current parameters from.
  *   Should correspond to appropriate filter button groups used on the page.
  *   For each group, the template will receive a parameter groupName holding the currently active group settings.
  */
@@ -122,7 +122,7 @@ liquipedia.filterButtons = {
 		document.querySelectorAll( '[data-filter-expansion-template]' ).forEach( ( /** @type HTMLElement */ templateExpansion ) => {
 			this.templateExpansions.push( {
 				element: templateExpansion,
-				groups: templateExpansion.dataset.filterGroups.split( ' ' ),
+				groups: templateExpansion.dataset.filterGroups.split( ',' ),
 				template: templateExpansion.dataset.filterExpansionTemplate
 			} );
 		} );
@@ -235,7 +235,7 @@ liquipedia.filterButtons = {
 				return group + '=' + activeFilters.toString();
 			} );
 			const wikitext = '{{' + templateExpansion.template + '|' + parameters.join( '|' ) + '}}';
-			mw.loader.using( [ 'mediawiki.api', 'mediawiki.util' ] ).then( () => {
+			mw.loader.using( [ 'mediawiki.api' ] ).then( () => {
 				const api = new mw.Api();
 				api.get( {
 					action: 'parse',
@@ -247,7 +247,7 @@ liquipedia.filterButtons = {
 					prop: 'text',
 					text: wikitext
 				} ).done( ( data ) => {
-					if ( data.parse && data.parse.text && data.parse.text[ '*' ] ) {
+					if ( data.parse?.text?.[ '*' ] ) {
 						templateExpansion.element.innerHTML = data.parse.text[ '*' ];
 					}
 				} );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -91,7 +91,7 @@ liquipedia.filterButtons = {
 					const button = {
 						element: buttonElement,
 						filter: filterOn,
-						active: true,
+						active: true
 					};
 					switch ( filterOn ) {
 						case 'curated':
@@ -234,10 +234,10 @@ liquipedia.filterButtons = {
 		this.templateExpansions.forEach( ( templateExpansion ) => {
 			const isDefault = this.templateExpansion.groups.every( ( group ) => {
 				const filterGroup = this.filterGroups[ group ];
-				if ( filterGroup.curated === filterGroup.defaultCurated) {
+				if ( filterGroup.curated === filterGroup.defaultCurated ) {
 					return true;
 				}
-				return Object.keys(filterGroup.filterStates).every( ( filterState ) => {
+				return Object.keys( filterGroup.filterStates ).every( ( filterState ) => {
 					return filterGroup.filterStates[ filterState ] === filterGroup.defaultStates[ filterState ];
 				} );
 			} );
@@ -246,7 +246,7 @@ liquipedia.filterButtons = {
 			}
 			const parameters = templateExpansion.groups.map( ( group ) => {
 				if ( group.curated ) {
-					return group + '=curated'
+					return group + '=curated';
 				}
 
 				const filterStates = this.filterGroups[ group ].filterStates;

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -46,7 +46,7 @@ liquipedia.filterButtons = {
 	fallbackFilterGroup: 'filter-group-fallback-common',
 
 	filterGroups: {},
-	templateExpansions : [],
+	templateExpansions: [],
 
 	init: function() {
 		const filterButtonGroups = document.querySelectorAll( '.filter-buttons[data-filter]' );
@@ -122,7 +122,7 @@ liquipedia.filterButtons = {
 		document.querySelectorAll( '[data-filter-expansion-template]' ).forEach( ( /** @type HTMLElement */ templateExpansion ) => {
 			this.templateExpansions.push( {
 				element: templateExpansion,
-				groups: templateExpansion.dataset.filterGroups.split(' '),
+				groups: templateExpansion.dataset.filterGroups.split( ' ' ),
 				template: templateExpansion.dataset.filterExpansionTemplate
 			} );
 		} );
@@ -230,13 +230,13 @@ liquipedia.filterButtons = {
 
 		this.templateExpansions.forEach( ( templateExpansion ) => {
 			const parameters = templateExpansion.groups.map( ( group ) => {
-				const filterStates = this.filterGroups[group].filterStates
-				const activeFilters = Object.keys(filterStates).filter( k => filterStates[k] )
-				return group + '=' + activeFilters.toString()
-			} )
-			const wikitext = '{{' + templateExpansion.template + '|' + parameters.join('|') + '}}'
-			mw.loader.using( ['mediawiki.api', 'mediawiki.util'] ).then( () => {
-				var api = new mw.Api();
+				const filterStates = this.filterGroups[ group ].filterStates;
+				const activeFilters = Object.keys( filterStates ).filter( ( k ) => filterStates[ k ] );
+				return group + '=' + activeFilters.toString();
+			} );
+			const wikitext = '{{' + templateExpansion.template + '|' + parameters.join( '|' ) + '}}';
+			mw.loader.using( [ 'mediawiki.api', 'mediawiki.util' ] ).then( () => {
+				const api = new mw.Api();
 				api.get( {
 					action: 'parse',
 					format: 'json',
@@ -246,11 +246,11 @@ liquipedia.filterButtons = {
 					disablelimitreport: true,
 					prop: 'text',
 					text: wikitext
-				} ).done( data => {
-					if (data.parse && data.parse.text && data.parse.text['*']) {
-						templateExpansion.element.innerHTML = data.parse.text['*'];
+				} ).done( ( data ) => {
+					if ( data.parse && data.parse.text && data.parse.text[ '*' ] ) {
+						templateExpansion.element.innerHTML = data.parse.text[ '*' ];
 					}
-				});
+				} );
 			} );
 		} );
 	},


### PR DESCRIPTION
## Summary
Adds the functionality for template expansion upon filter button change.

Usage:
`<div data-filter-expansion-template="TemplateName" data-filter-groups="group1,group2">Default content</div>`
will lead to wikitext of `{{TemplateName|group1=options|group2=options}}` where `options` is a comma-separated list of all active filters for that group. 

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
http://darkrai.wiki.tldev.eu/rocketleague/User:SyntacticSalt/Test (http://darkrai.wiki.tldev.eu/commons/MediaWiki:Common.js/FilterButtons.js)
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
