### PR TITLE
feat(participantTable): merge instead of skip for `duplicate` placements

### DIFF
--- a/components/participant_table/commons/participant_table_base.lua
+++ b/components/participant_table/commons/participant_table_base.lua
@@ -275,14 +275,20 @@ function ParticipantTable:store()
 	Array.forEach(self.sections, function(section) Array.forEach(section.entries, function(entry)
 		local lpdbData = Opponent.toLpdbStruct(entry.opponent)
 
-		if placements[lpdbData.opponentname] or section.config.noStorage or
-			Opponent.isTbd(entry.opponent) or Opponent.isEmpty(entry.opponent) then return end
+		if section.config.noStorage or Opponent.isTbd(entry.opponent) or Opponent.isEmpty(entry.opponent) then return end
 
-		lpdbData = Table.merge(
-			lpdbTournamentData,
-			lpdbData,
-			{date = section.config.resolveDate, extradata = {dq = entry.dq and 'true' or nil}}
-		)
+		if placements[lpdbData.opponentname] then
+			lpdbData = Table.deepMerge(
+				lpdbData,
+				placements[lpdbData.opponentname]
+			)
+		else
+			lpdbData = Table.merge(
+				lpdbTournamentData,
+				lpdbData,
+				{date = section.config.resolveDate, extradata = {dq = entry.dq and 'true' or nil}}
+			)
+		end
 
 		self:adjustLpdbData(lpdbData, entry, section.config)
 
@@ -299,7 +305,7 @@ function ParticipantTable:getPlacements()
 	Array.forEach(mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = 5000,
 		conditions = '[[placement::!]] AND [[pagename::' .. string.gsub(mw.title.getCurrentTitle().text, ' ', '_') .. ']]',
-	}), function(placement) placements[placement.opponentname] = true end)
+	}), function(placement) placements[placement.opponentname] = placement end)
 
 	return placements
 end
@@ -307,6 +313,9 @@ end
 ---@param lpdbData table
 ---@return string
 function ParticipantTable:objectName(lpdbData)
+	local objectName = Logic.emptyOr(lpdbData.objectName, lpdbData.objectname)
+	if objectName then return objectName end
+
 	local lpdbPrefix = self.config.lpdbPrefix and ('_' .. self.config.lpdbPrefix) or ''
 	return 'ranking' .. lpdbPrefix .. lpdbData.prizepoolindex .. '_' .. lpdbData.opponentname
 end

--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -171,7 +171,7 @@ function StarcraftParticipantTable:getPlacements()
 
 	for prizePoolIndex = 1, maxPrizePoolIndex do
 		Array.forEach(Json.parseIfTable(prizePoolVars:get('placementRecords.' .. prizePoolIndex)) or {}, function(placement)
-			placements[placement.opponentname] = true
+			placements[placement.opponentname] = placement
 		end)
 	end
 


### PR DESCRIPTION
## Summary
Currently ParticipantTable skips storage for entries that already have a placement on the page.
This PR changes this behaviour into merging the data from ParticipantTable into the one of the Placement it finds.

This PR is needed for another follow up PR for RLs Player/Ext/Custom

## How did you test this change?
dev