### PR TITLE
fix: on rocketleague, automatically fetch team of players from participant table 

### DIFF
--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -26,7 +26,7 @@ function PlayerExtCustom.fetchTeamHistoryEntry(resolvedPageName, date)
 	local conditions = {
 		'[[opponenttype::solo]]', -- can not use Opponent.solo due to circular requires
 		'[[pagename::' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
-		'[[oppobentname::' .. resolvedPageName .. ']]',
+		'[[opponentname::' .. resolvedPageName .. ']]',
 	}
 	local placement = mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = 1,

--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -34,7 +34,7 @@ function PlayerExtCustom.fetchTeamHistoryEntry(resolvedPageName, date)
 		query = 'opponentplayers',
 	})[1] or {}
 
-local team = (placement.opponentplayers or {}).p1team
+	local team = (placement.opponentplayers or {}).p1team
 	if Logic.isNotEmpty(team) then
 		return {
 			joinDate = date,

--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -24,20 +24,22 @@ function PlayerExtCustom.fetchTeamHistoryEntry(resolvedPageName, date)
 		return
 	end
 	local conditions = {
-		'[[type::Notable]]',
+		'[[opponenttype::solo]]', -- can not use Opponent.solo due to circular requires
 		'[[pagename::' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
-		'[[name::' .. resolvedPageName .. ']]',
+		'[[oppobentname::' .. resolvedPageName .. ']]',
 	}
-	local datapoint = mw.ext.LiquipediaDB.lpdb('datapoint', {
+	local placement = mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = 1,
 		conditions = table.concat(conditions, ' AND '),
-		query = 'information',
-	})[1]
-	if datapoint and Logic.isNotEmpty(datapoint.information) then
+		query = 'opponentplayers',
+	})[1] or {}
+
+local team = (placement.opponentplayers or {}).p1team
+	if Logic.isNotEmpty(team) then
 		return {
 			joinDate = date,
 			leaveDate = date,
-			template = datapoint.information:lower(),
+			template = team:gsub('_', ' '):lower(),
 		}
 	end
 end

--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -25,7 +25,7 @@ local PlayerExtCustom = Table.copy(PlayerExt)
 ---@param resolvedPageName string
 ---@param date string|number|osdate?
 ---@return {joinDate: string|number|osdate?, leaveDate: string|number|osdate?, template: string}?
-function PlayerExtCustom.fetchTeamHistoryEntry(resolvedPageName, date)
+function PlayerExtCustom._fetchTeamFromPlacement(resolvedPageName, date)
 	if Logic.isEmpty(resolvedPageName) then
 		return
 	end
@@ -55,7 +55,7 @@ end
 ---@param date string|number|osdate?
 ---@return string?
 function PlayerExtCustom.fetchTeamTemplate(resolvedPageName, date)
-	local entry = PlayerExtCustom.fetchTeamHistoryEntry(resolvedPageName, date)
+	local entry = PlayerExtCustom._fetchTeamFromPlacement(resolvedPageName, date)
 	return entry and TeamTemplate.resolve(entry.template, date) or nil
 end
 
@@ -69,7 +69,7 @@ function PlayerExtCustom.syncTeam(pageName, template, options)
 	template = PlayerExt.syncTeam(pageName, template, options)
 	if Logic.isNotEmpty(template) or options.fetchPlayer == false then return template end
 
-	local entry = PlayerExtCustom.fetchTeamHistoryEntry(pageName, options.date) --[[@as table]]
+	local entry = PlayerExtCustom._fetchTeamFromPlacement(pageName, options.date) --[[@as table]]
 
 	if entry and not entry.isResolved then
 		entry.template = entry.template and TeamTemplate.resolve(entry.template, options.date)

--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -66,10 +66,10 @@ end
 function PlayerExtCustom.syncTeam(pageName, template, options)
 	options = options or {}
 
-	local template = PlayerExt.syncTeam(pageName, template, options)
+	template = PlayerExt.syncTeam(pageName, template, options)
 	if Logic.isNotEmpty(template) or options.fetchPlayer == false then return template end
 
-	local entry = PlayerExtCustom.fetchTeamHistoryEntry(pageName, options.date)
+	local entry = PlayerExtCustom.fetchTeamHistoryEntry(pageName, options.date) --[[@as table]]
 
 	if entry and not entry.isResolved then
 		entry.template = entry.template and TeamTemplate.resolve(entry.template, options.date)
@@ -78,8 +78,7 @@ function PlayerExtCustom.syncTeam(pageName, template, options)
 
 	local historyVar = playerVars:get(pageName .. '.teamHistory')
 	local history = historyVar and Json.parse(historyVar) or {}
-	if options.savePageVar ~= false and entry
-		and (entry and entry.template) ~= (pageVarEntry and pageVarEntry.template) then
+	if options.savePageVar ~= false and entry and entry.template then
 		if entry.isTimeless then
 			history.timeless = entry
 		else

--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -43,8 +43,7 @@ function PlayerExtCustom._fetchTeamFromPlacement(resolvedPageName, date)
 	local team = (placement.opponentplayers or {}).p1team
 	if Logic.isNotEmpty(team) then
 		return {
-			joinDate = date,
-			leaveDate = date,
+			isTimeless = true,
 			template = team:gsub('_', ' '):lower(),
 		}
 	end


### PR DESCRIPTION
it working #depends on #4247 but there is no harm in already merging it

## Summary
Use placement data instead of obsolete datapoint in Rocketleagues `PlayerExtCustom.fetchTeamHistoryEntry` fucntion so it actually can fetch teams again.
Note: this means that RLs `PlayerExtCustom.fetchTeamHistoryEntry` is still only usable directly on pages with PrizePool/ParticipantTable and still only works for solo opponents and not for duo etc.

## How did you test this change?
dev