### PR TITLE
feat(game): only apply default class to span if size is not supplied

### DIFF
--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -34,10 +34,10 @@ describe('Game', function()
 					Game.icon{noSpan = true})
 				assert.are_equal('<span class="span-class">' .. COMMONS_ICON .. '</span>',
 					tostring(Game.icon{spanClass = 'span-class'}))
-					assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
-						tostring(Game.icon()))
-					assert.are_equal('[[File:Liquipedia logo.png|Commons|link=lpcommons:Main Page|class=|24x24px]]',
-						tostring(Game.icon{size = '24x24px'}))
+				assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
+					tostring(Game.icon()))
+				assert.are_equal('[[File:Liquipedia logo.png|Commons|link=lpcommons:Main Page|class=|24x24px]]',
+					tostring(Game.icon{size = '24x24px'}))
 			end)
 		end)
 

--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -34,7 +34,7 @@ describe('Game', function()
 					Game.icon{noSpan = true})
 				assert.are_equal('<span class="span-class">' .. COMMONS_ICON .. '</span>',
 					tostring(Game.icon{spanClass = 'span-class'}))
-				assert.are_equal(COMMONS_ICON,
+				assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
 					tostring(Game.icon()))
 			end)
 		end)

--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -6,7 +6,7 @@ describe('Game', function()
 
 		local COMMONS_IDENTIFIER = 'commons'
 		local COMMONS_DATA = Info.games.commons
-		local COMMONS_ICON = '[[File:Liquipedia logo.png|Commons|link=lpcommons:Main Page|class=|25x25px]]'
+		local COMMONS_ICON = '[[File:Liquipedia logo.png|Commons|link=lpcommons:Main Page|class=|32x32px]]'
 		local GAME_TO_THROW = 'please throw'
 
 		describe('to identifier', function()

--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -34,8 +34,10 @@ describe('Game', function()
 					Game.icon{noSpan = true})
 				assert.are_equal('<span class="span-class">' .. COMMONS_ICON .. '</span>',
 					tostring(Game.icon{spanClass = 'span-class'}))
-				assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
-					tostring(Game.icon()))
+					assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
+						tostring(Game.icon()))
+					assert.are_equal('[[File:Liquipedia logo.png|Commons|link=lpcommons:Main Page|class=|24x24px]]',
+						tostring(Game.icon{size = '24x24px'}))
 			end)
 		end)
 

--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -34,7 +34,7 @@ describe('Game', function()
 					Game.icon{noSpan = true})
 				assert.are_equal('<span class="span-class">' .. COMMONS_ICON .. '</span>',
 					tostring(Game.icon{spanClass = 'span-class'}))
-				assert.are_equal('<span class="icon-16px">' .. COMMONS_ICON .. '</span>',
+				assert.are_equal(COMMONS_ICON,
 					tostring(Game.icon()))
 			end)
 		end)

--- a/standard/game.lua
+++ b/standard/game.lua
@@ -30,7 +30,7 @@ local Info = Lua.import('Module:Info')
 local GamesData = Info.games --[[@as table<string, GameData>]]
 
 local ICON_STRING = '[[File:${icon}|${alt}|link=${link}|class=${class}|${size}]]'
-local DEFAULT_SIZE = '25x25px'
+local DEFAULT_SIZE = '32x32px'
 local DEFAULT_SPAN_CLASS = 'icon-16px'
 local ICON_PLACEHOLDER = 'LeaguesPlaceholder.png'
 
@@ -157,7 +157,7 @@ function Game.icon(options)
 	local link = Logic.readBool(options.noLink) and '' or options.link or gameData.link
 	local spanClass = (Logic.readBool(options.noSpan) and '') or
 		(String.isNotEmpty(options.spanClass) and options.spanClass) or
-			DEFAULT_SPAN_CLASS
+		(String.isNotEmpty(options.size) and DEFAULT_SPAN_CLASS or '')
 
 	if Table.isEmpty(gameData) then
 		gameIcons = Game._createIcon{icon = ICON_PLACEHOLDER, size = options.size}

--- a/standard/game.lua
+++ b/standard/game.lua
@@ -157,7 +157,7 @@ function Game.icon(options)
 	local link = Logic.readBool(options.noLink) and '' or options.link or gameData.link
 	local spanClass = (Logic.readBool(options.noSpan) and '') or
 		(String.isNotEmpty(options.spanClass) and options.spanClass) or
-		(String.isNotEmpty(options.size) and DEFAULT_SPAN_CLASS or '')
+		(String.isEmpty(options.size) and DEFAULT_SPAN_CLASS or '')
 
 	if Table.isEmpty(gameData) then
 		gameIcons = Game._createIcon{icon = ICON_PLACEHOLDER, size = options.size}


### PR DESCRIPTION
## Summary
Currently the default span is applied in the span wrapper in Module:Game and hence making manual size inputs bnasically invalid.
This PR changes it so that if size is applied default class is not applied.
As per discussion in Module Sync meeting.

## How did you test this change?
testcases