### PR TITLE
feat(hdb): simplify phase logic on brawlhalla

### DIFF
--- a/components/hidden_data_box/wikis/brawlhalla/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/brawlhalla/hidden_data_box_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 local Tier = require('Module:Tier/Custom')
 local Variables = require('Module:Variables')
@@ -29,14 +28,8 @@ end
 ---@param args table
 ---@param queryResult table
 function CustomHiddenDataBox.addCustomVariables(args, queryResult)
-	local offsetTime = DateExt.readTimestampOrNil(
-		Variables.varDefault('tournament_enddate') or Variables.varDefault('tournament_startdate')
-	)
-	if offsetTime then
-		if tonumber(args.phase) then
-			offsetTime = offsetTime + 7200 * tonumber(args.phase)
-		end
-		Variables.varDefine('match_date', DateExt.formatTimestamp('F j, Y - H:i:s', offsetTime))
+	if tonumber(args.phase) then
+		Variables.varDefine('num_missing_dates', 7200 * tonumber(args.phase))
 	end
 
 	Variables.varDefine('tournament_sdate', Variables.varDefault('tournament_startdate'))


### PR DESCRIPTION
## Summary
Simplify the phase logic (1 phase = 2h offset), by increasing the `num_missing_dates` counter directly. Each `num_missing_dates` is 1s offset.

https://github.com/Liquipedia/Lua-Modules/blob/7b611e80e3ff2c7d04e1c91ea5ac02dea59411dd/components/match2/commons/match_group_input.lua#L370-L372

## How did you test this change?

Live