### PR TITLE
feat(ppt): fetch and store id of last match on brawlhalla

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -331,6 +331,7 @@ end
 function Import._makeEntryFromMatch(placementEntry, match)
 	local entry = {
 		date = DateExt.toYmdInUtc(match.date),
+		matchId = match.matchId,
 	}
 
 	if match.winner and 1 <= match.winner and #match.opponents == 2 then
@@ -595,7 +596,7 @@ function Import:_entryToOpponent(lpdbEntry, placement)
 		wdl = (not lpdbEntry.needsLastVs) and self:_formatGroupScore(lpdbEntry) or nil,
 		lastvs = Table.isNotEmpty(lastVs) and {lastVs} or nil,
 		lastvsscore = lastVsScore,
-		lastvsmatchid = additionalData.matchId,
+		lastvsmatchid = lpdbEntry.matchId or additionalData.matchId,
 		date = additionalData.date or lpdbEntry.date,
 	}}[1]
 end

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -595,6 +595,7 @@ function Import:_entryToOpponent(lpdbEntry, placement)
 		wdl = (not lpdbEntry.needsLastVs) and self:_formatGroupScore(lpdbEntry) or nil,
 		lastvs = Table.isNotEmpty(lastVs) and {lastVs} or nil,
 		lastvsscore = lastVsScore,
+		lastvsmatchid = additionalData.matchid,
 		date = additionalData.date or lpdbEntry.date,
 	}}[1]
 end
@@ -657,7 +658,7 @@ function Import:_groupLastVsAdditionalData(lpdbEntry)
 		self:_lastVsMatchesDataToCache(mw.ext.LiquipediaDB.lpdb('match2', {
 			conditions = conditions,
 			order = 'date desc, match2id desc',
-			query = 'date, match2opponents, winner',
+			query = 'match2id, date, match2opponents, winner',
 			limit = 1000,
 		}))
 	end
@@ -712,6 +713,7 @@ function Import._makeAdditionalDataFromMatch(opponentName, match)
 		lastVs = lastVs,
 		score = score,
 		vsScore = vsScore,
+		matchId = match.match2id,
 	}
 end
 

--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -595,7 +595,7 @@ function Import:_entryToOpponent(lpdbEntry, placement)
 		wdl = (not lpdbEntry.needsLastVs) and self:_formatGroupScore(lpdbEntry) or nil,
 		lastvs = Table.isNotEmpty(lastVs) and {lastVs} or nil,
 		lastvsscore = lastVsScore,
-		lastvsmatchid = additionalData.matchid,
+		lastvsmatchid = additionalData.matchId,
 		date = additionalData.date or lpdbEntry.date,
 	}}[1]
 end
@@ -643,7 +643,7 @@ function Import._getScore(opponentData)
 end
 
 ---@param lpdbEntry table
----@return table
+---@return {date: string?, lastVs: standardOpponent?, score:string|number?, vsScore:string|number?, matchId: string?}
 function Import:_groupLastVsAdditionalData(lpdbEntry)
 	local opponentName = Opponent.toName(lpdbEntry.opponent)
 	local matchConditions = {}
@@ -690,7 +690,7 @@ end
 
 ---@param opponentName string
 ---@param match match2
----@return table
+---@return {date: string?, lastVs: standardOpponent?, score:string|number?, vsScore:string|number?, matchId: string?}
 function Import._makeAdditionalDataFromMatch(opponentName, match)
 	-- catch unfinished or invalid match
 	local winner = tonumber(match.winner)

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -34,13 +34,11 @@ local SPECIAL_SCORES = {'W', 'FF' , 'L', 'DQ', 'D'}
 
 local _tbd_index = 0
 
---- @class PrizePoolPlacement
+--- @class PrizePoolPlacement: BasePlacement
 --- A Placement is a set of opponents who all share the same final place in the tournament.
 --- Its input is generally a table created by `Template:Slot`.
 --- It has a range from placeStart to placeEnd, for example 5 to 8, or count (slotSize)
 --- and is expected to have at maximum the same amount of opponents as the range allows (4 in the 5-8 example).
---- @field parseOpponents function
---- @field getPrizeRewardForOpponent function
 --- @field parent PrizePool
 --- @field args table
 local Placement = Class.new(BasePlacement)

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -149,6 +149,12 @@ Placement.additionalData = {
 			return {score = scores[1], vsscore = scores[2]}
 		end
 	},
+	LASTVSMATCHID = {
+		field = 'lastvsmatchid',
+		parse = function (placement, input, context)
+			return input
+		end
+	},
 }
 
 ---@param lastPlacement integer The previous placement's end

--- a/components/prize_pool/wikis/brawlhalla/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/brawlhalla/prize_pool_custom.lua
@@ -48,17 +48,21 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	)
 
 	if opponent.opponentData.type == Opponent.solo then
+		lpdbData.mode = 'singles'
 		if opponent.additionalData.LASTVS then
 			lpdbData.extradata.lastvsflag = opponent.additionalData.LASTVS.players[1].flag
 		end
 	end
 
 	if opponent.opponentData.type == Opponent.duo then
+		lpdbData.mode = 'doubles'
 		lpdbData.players = {
 			p1 = opponent.opponentData.players[1].pageName,
 			p2 = opponent.opponentData.players[2].pageName,
 		}
 	end
+
+	lpdbData.extradata.matchid = opponent.additionalData.LASTVSMATCHID
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
Smash-likes need the last match id to have the option to fetch more detail about the lastvs match. 
This PR implements the auto retrieval of last matchId in Import, and handle both manual and auto imports in PPT.

## How did you test this change?

/dev