### PR TITLE
fix(match2): brawlhalla's char list in match1 is not working

### DIFF
--- a/components/match2/wikis/brawlhalla/match_legacy.lua
+++ b/components/match2/wikis/brawlhalla/match_legacy.lua
@@ -61,13 +61,12 @@ function MatchLegacy._convertParameters(match2)
 	-- Handle Opponents
 	local headList = function (participant)
 		local heads = Set{}
-		local games = match2.match2games or {}
-		for _, game in ipairs(games) do
+		Array.forEach(match2.match2games or {}, function(game)
 			local participants = Json.parseIfString(game.participants) or {}
 			if participants[participant] then
 				heads:add(participants[participant].char)
 			end
-		end
+		end)
 		return heads:toArray()
 	end
 

--- a/components/match2/wikis/brawlhalla/match_legacy.lua
+++ b/components/match2/wikis/brawlhalla/match_legacy.lua
@@ -11,6 +11,7 @@ local MatchLegacy = {}
 local Array = require('Module:Array')
 local Json = require('Module:Json')
 local Lua = require('Module:Lua')
+local Set = require('Module:Set')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
@@ -58,6 +59,18 @@ function MatchLegacy._convertParameters(match2)
 	end
 
 	-- Handle Opponents
+	local headList = function (participant)
+		local heads = Set{}
+		local games = match2.match2games or {}
+		for _, game in ipairs(games) do
+			local participants = Json.parseIfString(game.participants) or {}
+			if participants[participant] then
+				heads:add(participants[participant].char)
+			end
+		end
+		return heads:toArray()
+	end
+
 	local handleOpponent = function(index)
 		local prefix = 'opponent' .. index
 		local opponent = match2.match2opponents[index] or {}
@@ -68,7 +81,7 @@ function MatchLegacy._convertParameters(match2)
 			match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix .. 'flag'] = player.flag
 			match.extradata[prefix .. 'displayname'] = player.displayname
-			match.extradata[prefix .. 'heads'] = player.char
+			match.extradata[prefix .. 'heads'] = table.concat(headList(index .. '_1'), ',')
 			if match2.winner == index then
 				match.winner = player.name
 			end
@@ -82,6 +95,7 @@ function MatchLegacy._convertParameters(match2)
 				match.extradata[teamPrefix .. playerPrefix] = player.name or ''
 				match.extradata[teamPrefix .. playerPrefix .. 'flag'] = player.flag or ''
 				match.extradata[teamPrefix .. playerPrefix .. 'displayname'] = player.displayname or ''
+				match.extradata[teamPrefix .. playerPrefix .. 'heads'] = table.concat(headList(index .. '_' .. i), ',')
 			end
 			match[prefix..'players'] = mw.ext.LiquipediaDB.lpdb_create_json(opponentPlayers)
 			match[prefix] = table.concat(Array.extractValues(opponentPlayers), '/')


### PR DESCRIPTION
## Summary
In the match1 conversion, the character / heads list was not being made properly, as the source is game for this match level field.

## How did you test this change?
Live