### PR TITLE
fix(match2): map names on brawlhalla are not centered

### DIFF
--- a/components/match2/wikis/brawlhalla/match_summary.lua
+++ b/components/match2/wikis/brawlhalla/match_summary.lua
@@ -20,7 +20,7 @@ local Opponent = OpponentLibraries.Opponent
 
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = 'initial'}
 local DRAW_LINE = Icon.makeIcon{iconName = 'draw', color = 'bright-sun-text', size = 'initial'}
-local NO_CHECK = '[[File:NoCheck.png|link=]]'
+local NO_CHECK = '[[File:NoCheck.png|link=|16px]]'
 
 local CustomMatchSummary = {}
 


### PR DESCRIPTION
## Summary
Map name is not fully aligned, but rather depends on who won. This is because the checkmark is 16px while the filler is 14px. Increasing the filler to 16px.

## How did you test this change?
Live