### PR TITLE
ci: resolve `stylelint-less` version dependency mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 		"eslint-config-wikimedia": "*",
 		"grunt": "*",
 		"grunt-eslint": "24.x.x",
-		"grunt-stylelint": "*",
+		"grunt-stylelint": "0.19.x",
+		"jquery": "3.6.1",
 		"postcss-less": "*",
 		"stylelint-config-wikimedia": "*",
 		"stylelint-less": "2.x.x"


### PR DESCRIPTION
## Summary

`grunt-stylelint@0.20.0` requires `stylelint@16.x`, but `stylelint-less@2.x.x` requires `stylelint@15.x`. This is causing a conflicting peer dependency.

(I did attempt to push us to `stylelint-less@3.x.x`, however, that causes stylelint plugin warnings that I don't know enough about to debug.)

Also added `jquery@3.6.1` (what we current have on the wikis) to add static analysis/IDE support for it in JS modules.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/cc540304-81f4-42d7-bbd9-a6d60099ed14)

## How did you test this change?

Tested locally:

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/e5beb078-c59a-41b9-9c22-b4004d8fecf2)

