### PR TITLE
feat: new portal pills styling

### DIFF
--- a/stylesheets/commons/NavigationCard.less
+++ b/stylesheets/commons/NavigationCard.less
@@ -1,9 +1,13 @@
 .navigation-cards {
 	display: grid;
-	grid-template-columns: 1fr 1fr 1fr;
+	grid-template-columns: repeat( 3, 1fr );
 	gap: 0.5rem;
 	margin-bottom: 1rem;
 	position: relative;
+
+	@media ( min-width: 576px ) {
+		grid-template-columns: repeat( 4, 1fr );
+	}
 
 	@media ( min-width: 768px ) {
 		grid-template-columns: repeat( 5, 1fr );
@@ -37,11 +41,6 @@
 		border-radius: 0.5rem 0.5rem 0 0;
 		display: flex;
 		position: relative;
-
-		a {
-			width: 100%;
-			height: 100%;
-		}
 
 		img {
 			display: flex;


### PR DESCRIPTION
## Summary

This MR sets up the styling for the new portal pills. For the new implementation I renamed them to 'navigation cards' since the current html of the portal pills need some cleanup and I thought it might be easier to roll it out this way. But correct me if I'm wrong.

HTML setup:
```
<div class="navigation-cards">
	<div class="navigation-card">
		<div class="navigation-card__image">[[File:Morphling_Large.png|200x80px|link=]]</div>
		<span class="navigation-card__title">[[Heroes|Heroes]]</span>
		<span class="navigation-card__subtitle">231</span>
	</div>
</div>
```

`navigation-cards`: container for the cards
`navigation-card`: individual cards
`navigation-card__image`: container for the image.
`navigation-card__title`: Title of the cards
`navigation-card__subtitle`: Text below the title

## Responsivity
Amount of horizontal cards grows with the screen size:
- Mobile: 3 cards
- Min-width 576px: 4 cards
- Min-width 768px: 5 cards
- Min-width 1024px: all cards

Screenshots:
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/c1073845-44a4-4507-aa58-9f7d248cc722)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/2b35e4df-3703-4983-b68f-da2a2302009f)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/e5e90ead-5381-43ba-8124-44aa1f7309d2)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/b11a1a73-03a8-4ffe-b32c-ee4fb7f3d745)


## How did you test this change?

https://liquipedia.net/dota2game/User:Elysienna/Main_Page

Closes https://gitlab.com/teamliquid-dev/liquipedia/web/extensions/teamliquidintegration/-/issues/132