### PR TITLE
feat(infobox): Use standard MatchTicker on LoL player pages

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local MatchTicker = require('Module:MatchTicker/Custom')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Team = require('Module:Team')
@@ -174,8 +175,8 @@ end
 function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
 		local teamPage = Team.page(mw.getCurrentFrame(),self.args.team)
-		return Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing matches of', {team = teamPage}) ..
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
+		return tostring(MatchTicker.participant({team=teamPage}))
+			.. Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
 	end
 end
 

--- a/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_person_player_custom.lua
@@ -175,7 +175,7 @@ end
 function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
 		local teamPage = Team.page(mw.getCurrentFrame(),self.args.team)
-		return tostring(MatchTicker.participant({team=teamPage}))
+		return tostring(MatchTicker.participant({team = teamPage}))
 			.. Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
 	end
 end


### PR DESCRIPTION
## Summary
Makes the ticker darkmode compliant

## How did you test this change?
via dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
