### PR TITLE
fix(match2): restore behaviour of `isDraw`

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -782,6 +782,7 @@ end
 ---@param opponents table[]
 ---@return boolean
 function MatchGroupInput.isDraw(opponents)
+	if Logic.isEmpty(opponents) then return true end
 	if Array.any(opponents, function (opponent) return opponent.status ~= 'S' and opponent.status ~= 'D' end) then
 		return false
 	end

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -106,25 +106,6 @@ function CustomMatchGroupInput.processPlayer(player)
 	return player
 end
 
---
---
--- function to check for draws
-function CustomMatchGroupInput.placementCheckDraw(tbl)
-	local last
-	for _, scoreInfo in pairs(tbl) do
-		if scoreInfo.status ~= 'S' and scoreInfo.status ~= 'D' then
-			return false
-		end
-		if last and not Table.deepEquals(last, scoreInfo) then
-			return false
-		else
-			last = scoreInfo
-		end
-	end
-
-	return true
-end
-
 function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match wasn't played, set not played
 	if Table.includes(FINISHED_INDICATORS, data.finished) or Table.includes(FINISHED_INDICATORS, data.winner) then
@@ -133,7 +114,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match is marked as finished.
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
 	elseif Logic.readBool(data.finished) then
-		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
+		if MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -135,25 +135,6 @@ function CustomMatchGroupInput.processPlayer(player)
 	return player
 end
 
--- function to check for draws
----@param tbl table
----@return boolean
-function CustomMatchGroupInput.placementCheckDraw(tbl)
-	local last
-	for _, scoreInfo in pairs(tbl) do
-		if scoreInfo.status ~= STATUS_SCORE and scoreInfo.status ~= STATUS_DRAW then
-			return false
-		end
-		if last and last ~= scoreInfo.score then
-			return false
-		else
-			last = scoreInfo.score
-		end
-	end
-
-	return true
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table
@@ -169,7 +150,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match is marked as finished.
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
 	elseif Logic.readBool(data.finished) then
-		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
+		if MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -114,27 +114,6 @@ function CustomMatchGroupInput.processPlayer(player)
 	return player
 end
 
---
--- function to check for draws
---
----@param scoreTable table[]
----@return boolean
-function CustomMatchGroupInput.placementCheckDraw(scoreTable)
-	local last
-	for _, scoreInfo in pairs(scoreTable) do
-		if scoreInfo.status ~= STATUS_SCORE and scoreInfo.status ~= STATUS_DRAW then
-			return false
-		end
-		if last and last ~= scoreInfo.score then
-			return false
-		else
-			last = scoreInfo.score
-		end
-	end
-
-	return true
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table
@@ -150,7 +129,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match is marked as finished.
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
 	elseif Logic.readBool(data.finished) then
-		if CustomMatchGroupInput.placementCheckDraw(indexedScores) then
+		if MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, STATUS_DRAW)


### PR DESCRIPTION
## Summary
The old `placementCheckDraw` did return `true` in case of an empty Array of scores getting passed to it.
With #4120 & #4118 it started to return false in that case, resulting in errors on R6 wiki.
This PR changes the behaviour of `isDraw` to match that of the old `placementCheckDraw` again.

Longterm we probably should think about if we actually want it to return true in that edge case.
If not we also would have to adjust the `getResultTypeAndWinner` accordingly.

Additionally this PR adjusts 3 more wikis to use the `isDraw` function from commons.

## How did you test this change?
dev into live