### PR TITLE
feat(match2): don't show match summary for inexact datetime on brawlhalla

### DIFF
--- a/components/match2/wikis/apexlegends/brkts_wiki_specific.lua
+++ b/components/match2/wikis/apexlegends/brkts_wiki_specific.lua
@@ -1,0 +1,21 @@
+---
+-- @Liquipedia
+-- wiki=apexlegends
+-- page=Module:Brkts/WikiSpecific
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local BaseWikiSpecific = Lua.import('Module:Brkts/WikiSpecific/Base')
+
+---@class ApexlegendsBrktsWikiSpecific: BrktsWikiSpecific
+local WikiSpecific = Table.copy(BaseWikiSpecific)
+
+function WikiSpecific.getMatchGroupContainer(matchGroupType)
+	return Lua.import('Module:MatchGroup/Display/Horizontallist').BracketContainer
+end
+
+return WikiSpecific

--- a/components/match2/wikis/apexlegends/brkts_wiki_specific.lua
+++ b/components/match2/wikis/apexlegends/brkts_wiki_specific.lua
@@ -14,8 +14,11 @@ local BaseWikiSpecific = Lua.import('Module:Brkts/WikiSpecific/Base')
 ---@class ApexlegendsBrktsWikiSpecific: BrktsWikiSpecific
 local WikiSpecific = Table.copy(BaseWikiSpecific)
 
+---@param matchGroupType string
+---@return function
 function WikiSpecific.getMatchGroupContainer(matchGroupType)
-	return Lua.import('Module:MatchGroup/Display/Horizontallist').BracketContainer
+	local Horizontallist = Lua.import('Module:MatchGroup/Display/Horizontallist')
+	return Horizontallist.BracketContainer
 end
 
 return WikiSpecific

--- a/components/match2/wikis/brawlhalla/brkts_wiki_specific.lua
+++ b/components/match2/wikis/brawlhalla/brkts_wiki_specific.lua
@@ -1,24 +1,26 @@
 ---
 -- @Liquipedia
--- wiki=apexlegends
+-- wiki=brawlhalla
 -- page=Module:Brkts/WikiSpecific
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
 local BaseWikiSpecific = Lua.import('Module:Brkts/WikiSpecific/Base')
 
----@class ApexlegendsBrktsWikiSpecific: BrktsWikiSpecific
+---@class BrawlHallaBrktsWikiSpecific: BrktsWikiSpecific
 local WikiSpecific = Table.copy(BaseWikiSpecific)
 
----@param matchGroupType string
----@return function
-function WikiSpecific.getMatchGroupContainer(matchGroupType)
-	local Horizontallist = Lua.import('Module:MatchGroup/Display/Horizontallist')
-	return Horizontallist.BracketContainer
+function WikiSpecific.defaultMatchHasDetails(match)
+	return match.dateIsExact
+		or Logic.isNotEmpty(match.vod)
+		or not Table.isEmpty(match.links)
+		or Logic.isNotEmpty(match.comment)
+		or 0 < #match.games
 end
 
 return WikiSpecific

--- a/components/match2/wikis/brawlhalla/brkts_wiki_specific.lua
+++ b/components/match2/wikis/brawlhalla/brkts_wiki_specific.lua
@@ -15,6 +15,8 @@ local BaseWikiSpecific = Lua.import('Module:Brkts/WikiSpecific/Base')
 ---@class BrawlHallaBrktsWikiSpecific: BrktsWikiSpecific
 local WikiSpecific = Table.copy(BaseWikiSpecific)
 
+---@param match table
+---@return boolean
 function WikiSpecific.defaultMatchHasDetails(match)
 	return match.dateIsExact
 		or Logic.isNotEmpty(match.vod)


### PR DESCRIPTION
## Summary

Smash-likes don't want the match summary to show when it's only triggered by the existence of an approximate datetime


## How did you test this change?

Live
