### PR TITLE
fix(match2): some faction issues on sc1&sc2

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -626,7 +626,7 @@ function StarcraftMatchGroupInput._getPlayersFromVariables(teamName)
 				name = name:gsub(' ', '_'),
 				displayname = Variables.varDefault(prefix .. 'dn'),
 				flag = Flags.CountryName(Variables.varDefault(prefix .. 'flag')),
-				extradata = {faction = Variables.varDefault(prefix .. 'race')}
+				extradata = {faction = Variables.varDefault(prefix .. 'faction', Variables.varDefault(prefix .. 'race'))}
 			}
 			if player.displayname then
 				Variables.varDefine(player.displayname .. '_page', player.name)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -446,14 +446,14 @@ function StarcraftMatchGroupInput.ProcessSoloOpponentInput(opponent)
 	) or ''
 	local link = Logic.emptyOr(opponent.link, Variables.varDefault(name .. '_page')) or name
 	link = mw.ext.TeamLiquidIntegration.resolve_redirect(link):gsub(' ', '_')
-	local faction = Logic.emptyOr(opponent.race, StarcraftMatchGroupInput._getFactionVariable(name))
+	local race = Logic.emptyOr(opponent.race, Variables.varDefault(name .. '_race'), '')
 	local players = {}
 	local flag = Logic.emptyOr(opponent.flag, Variables.varDefault(name .. '_flag'))
 	players[1] = {
 		displayname = name,
 		name = link,
 		flag = Flags.CountryName(flag),
-		extradata = {faction = Faction.read(faction) or Faction.defaultFaction}
+		extradata = {faction = Faction.read(race) or Faction.defaultFaction}
 	}
 
 	return {
@@ -484,11 +484,11 @@ function StarcraftMatchGroupInput.ProcessDuoOpponentInput(opponent)
 	else
 		opponent.p1race = Faction.read(Logic.emptyOr(
 				opponent.p1race,
-				StarcraftMatchGroupInput._getFactionVariable(opponent.p1)
+				Variables.varDefault(opponent.p1 .. '_race')
 			)) or Faction.defaultFaction
 		opponent.p2race = Faction.read(Logic.emptyOr(
 				opponent.p2race,
-				StarcraftMatchGroupInput._getFactionVariable(opponent.p2)
+				Variables.varDefault(opponent.p2 .. '_race')
 			)) or Faction.defaultFaction
 	end
 
@@ -532,7 +532,7 @@ function StarcraftMatchGroupInput.ProcessOpponentInput(opponent, playernumber)
 			) or playerName):gsub(' ', '_')
 		local race = Logic.emptyOr(
 			opponent['p' .. playerIndex .. 'race'],
-			StarcraftMatchGroupInput._getFactionVariable(playerName),
+			Variables.varDefault(playerName .. '_race'),
 			''
 		)
 		name = name .. (playerIndex ~= 1 and ' / ' or '') .. link
@@ -626,7 +626,7 @@ function StarcraftMatchGroupInput._getPlayersFromVariables(teamName)
 				name = name:gsub(' ', '_'),
 				displayname = Variables.varDefault(prefix .. 'dn'),
 				flag = Flags.CountryName(Variables.varDefault(prefix .. 'flag')),
-				extradata = {faction = Variables.varDefault(prefix .. 'faction', Variables.varDefault(prefix .. 'race'))}
+				extradata = {faction = Variables.varDefault(prefix .. 'race')}
 			}
 			if player.displayname then
 				Variables.varDefine(player.displayname .. '_page', player.name)
@@ -1057,14 +1057,6 @@ function StarcraftMatchGroupInput._placementSortFunction(tbl, key1, key2)
 		elseif Table.includes(DEFAULT_LOSS_STATUSES, opponent2.status) then return true
 		else return true end
 	end
-end
-
--- temporary function for switching wiki vars from race to faction
----@param prefix string
----@return string?
-function StarcraftMatchGroupInput._getFactionVariable(prefix)
-	prefix = prefix .. (noUnderScore and '' or '_')
-	return Variables.varDefault(prefix .. 'faction', Variables.varDefault(prefix .. 'race'))
 end
 
 return StarcraftMatchGroupInput

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -446,14 +446,14 @@ function StarcraftMatchGroupInput.ProcessSoloOpponentInput(opponent)
 	) or ''
 	local link = Logic.emptyOr(opponent.link, Variables.varDefault(name .. '_page')) or name
 	link = mw.ext.TeamLiquidIntegration.resolve_redirect(link):gsub(' ', '_')
-	local race = Logic.emptyOr(opponent.race, Variables.varDefault(name .. '_race'), '')
+	local faction = Logic.emptyOr(opponent.race, StarcraftMatchGroupInput._getFactionVariable(name))
 	local players = {}
 	local flag = Logic.emptyOr(opponent.flag, Variables.varDefault(name .. '_flag'))
 	players[1] = {
 		displayname = name,
 		name = link,
 		flag = Flags.CountryName(flag),
-		extradata = {faction = Faction.read(race) or Faction.defaultFaction}
+		extradata = {faction = Faction.read(faction) or Faction.defaultFaction}
 	}
 
 	return {
@@ -484,11 +484,11 @@ function StarcraftMatchGroupInput.ProcessDuoOpponentInput(opponent)
 	else
 		opponent.p1race = Faction.read(Logic.emptyOr(
 				opponent.p1race,
-				Variables.varDefault(opponent.p1 .. '_race')
+				StarcraftMatchGroupInput._getFactionVariable(opponent.p1)
 			)) or Faction.defaultFaction
 		opponent.p2race = Faction.read(Logic.emptyOr(
 				opponent.p2race,
-				Variables.varDefault(opponent.p2 .. '_race')
+				StarcraftMatchGroupInput._getFactionVariable(opponent.p2)
 			)) or Faction.defaultFaction
 	end
 
@@ -532,7 +532,7 @@ function StarcraftMatchGroupInput.ProcessOpponentInput(opponent, playernumber)
 			) or playerName):gsub(' ', '_')
 		local race = Logic.emptyOr(
 			opponent['p' .. playerIndex .. 'race'],
-			Variables.varDefault(playerName .. '_race'),
+			StarcraftMatchGroupInput._getFactionVariable(playerName),
 			''
 		)
 		name = name .. (playerIndex ~= 1 and ' / ' or '') .. link
@@ -1057,6 +1057,14 @@ function StarcraftMatchGroupInput._placementSortFunction(tbl, key1, key2)
 		elseif Table.includes(DEFAULT_LOSS_STATUSES, opponent2.status) then return true
 		else return true end
 	end
+end
+
+-- temporary function for switching wiki vars from race to faction
+---@param prefix string
+---@return string?
+function StarcraftMatchGroupInput._getFactionVariable(prefix)
+	prefix = prefix .. (noUnderScore and '' or '_')
+	return Variables.varDefault(prefix .. 'faction', Variables.varDefault(prefix .. 'race'))
 end
 
 return StarcraftMatchGroupInput

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -245,11 +245,11 @@ function StarcraftMatchSummary.Game(game, options)
 		local opponent = game.opponents ~= nil and game.opponents[opponentIndex] or nil
 
 		if offFactions and opponent and opponent.isArchon then
-			return StarcraftMatchSummary.offFactionIcons({offFactions[1]})
+			return StarcraftMatchSummary.OffFactionIcons({offFactions[1]})
 		elseif offFactions and opponent then
-			return StarcraftMatchSummary.offFactionIcons(offFactions)
+			return StarcraftMatchSummary.OffFactionIcons(offFactions)
 		elseif showOffFactionIcons then
-			return StarcraftMatchSummary.offFactionIcons({})
+			return StarcraftMatchSummary.OffFactionIcons({})
 		else
 			return nil
 		end


### PR DESCRIPTION
## Summary

* Fix Lua errors that appeared on https://liquipedia.net/starcraft2/World_Team_League/2024/Summer/Code_A#Results (discussed here: https://discord.com/channels/93055209017729024/213614988647071744/1237518343930515538)
* The fix is simply changing a lowercase 'o' to an uppercase 'O' three times.

## How did you test this change?

I edited the module on Commons and tested that the Lua errors disappeared on the SC2 wiki page.