### PR TITLE
refactor: switch to using `faction` wiki var instead of `race` wiki var

### DIFF
--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -360,7 +360,7 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 		insertIntoPlayers{
 			name = name,
 			displayName = Variables.varDefault(varPrefix .. 'dn'),
-			race = Variables.varDefault(varPrefix .. 'race'),
+			faction = Variables.varDefault(varPrefix .. 'faction'),
 			flag = Variables.varDefault(varPrefix .. 'flag'),
 		}
 		playerIndex = playerIndex + 1
@@ -378,13 +378,13 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 		insertIntoPlayers({
 			name = playerName,
 			displayName = playersData[playerPrefix .. 'dn'],
-			race = playersData[playerPrefix .. 'race'],
+			faction = playersData[playerPrefix .. 'faction'],
 			flag = playersData[playerPrefix .. 'flag'],
 		})
 	end
 
 	opponent.match2players = Array.extractValues(players)
-	--set default race for unset races
+	--set default faction for unset factions
 	Array.forEach(opponent.match2players, function(player)
 		player.extradata.faction = player.extradata.faction or Faction.defaultFaction
 	end)
@@ -395,18 +395,18 @@ end
 ---@param opponent table
 ---@return table
 function CustomMatchGroupInput.ProcessLiteralOpponentInput(opponent)
-	local race = opponent.race
+	local faction = opponent.race
 	local flag = opponent.flag
 	local name = opponent.name or opponent[1]
 	local extradata = opponent.extradata
 
 	local players = {}
-	if String.isNotEmpty(race) or String.isNotEmpty(flag) then
+	if String.isNotEmpty(faction) or String.isNotEmpty(flag) then
 		players[1] = {
 			displayname = name,
 			name = TBD:upper(),
 			flag = Flags.CountryName(flag),
-			extradata = {faction = Faction.read(race) or Faction.defaultFaction}
+			extradata = {faction = Faction.read(faction) or Faction.defaultFaction}
 		}
 		extradata.hasFactionOrFlag = true
 	end
@@ -444,7 +444,7 @@ function CustomMatchGroupInput.processPartyOpponentInput(opponent, partySize)
 				)),
 			extradata = {faction = Faction.read(Logic.emptyOr(
 					opponent['p' .. playerIndex .. 'race'],
-					Variables.varDefault(name .. '_race')
+					Variables.varDefault(name .. '_faction')
 				)) or Faction.defaultFaction}
 		})
 	end
@@ -504,7 +504,7 @@ function CustomMatchGroupInput._mapInput(match, mapIndex, subGroupIndex)
 	map = CustomMatchGroupInput._mapWinnerProcessing(map)
 
 	-- get participants data for the map + get map mode + winnerfaction and loserfaction
-	--(w/l race stuff only for 1v1 maps)
+	--(w/l faction stuff only for 1v1 maps)
 	CustomMatchGroupInput.ProcessPlayerMapData(map, match, 2)
 
 	--adjust sumscore for winner opponent
@@ -624,15 +624,15 @@ function CustomMatchGroupInput.ProcessPlayerMapData(map, match, numberOfOpponent
 		return
 	end
 
-	local opponentRaces, playerNameArray, heroesData
+	local opponentFactions, playerNameArray, heroesData
 		= CustomMatchGroupInput._fetchOpponentMapParticipantData(participants)
 	map.extradata = Table.merge(map.extradata, heroesData)
 	if tonumber(map.winner) == 1 then
-		map.extradata.winnerfaction = opponentRaces[1]
-		map.extradata.loserfaction = opponentRaces[2]
+		map.extradata.winnerfaction = opponentFactions[1]
+		map.extradata.loserfaction = opponentFactions[2]
 	elseif tonumber(map.winner) == 2 then
-		map.extradata.winnerfaction = opponentRaces[2]
-		map.extradata.loserfaction = opponentRaces[1]
+		map.extradata.winnerfaction = opponentFactions[2]
+		map.extradata.loserfaction = opponentFactions[1]
 	end
 	map.extradata.opponent1 = playerNameArray[1]
 	map.extradata.opponent2 = playerNameArray[2]
@@ -643,19 +643,19 @@ end
 ---@return table<integer, string>
 ---@return table<string, string>
 function CustomMatchGroupInput._fetchOpponentMapParticipantData(participants)
-	local opponentRaces, playerNameArray, heroesData = {}, {}, {}
+	local opponentFactions, playerNameArray, heroesData = {}, {}, {}
 	for participantKey, participantData in pairs(participants) do
 		local opponentIndex = tonumber(string.sub(participantKey, 1, 1))
 		-- opponentIndex can not be nil due to the format of the participants keys
 		---@cast opponentIndex -nil
-		opponentRaces[opponentIndex] = participantData.faction
+		opponentFactions[opponentIndex] = participantData.faction
 		playerNameArray[opponentIndex] = participantData.player
 		Array.forEach(participantData.heroes or {}, function(hero, heroIndex)
 			heroesData['opponent' .. opponentIndex .. 'hero' .. heroIndex] = hero
 		end)
 	end
 
-	return opponentRaces, playerNameArray, heroesData
+	return opponentFactions, playerNameArray, heroesData
 end
 
 ---@param players table[]

--- a/components/opponent/commons/starcraft_starcraft2/player_ext_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/player_ext_starcraft.lua
@@ -174,7 +174,7 @@ function StarcraftPlayerExt.syncPlayer(player, options)
 		or match2Player() and match2Player().flag
 
 	player.faction = player.faction
-		or globalVars:get(player.displayName .. '_race')
+		or globalVars:get(player.displayName .. '_faction')
 		or options.fetchPlayer ~= false and StarcraftPlayerExt.fetchPlayerFaction(player.pageName, options.date)
 		or match2Player() and match2Player().faction
 		or Faction.defaultFaction
@@ -205,7 +205,7 @@ function StarcraftPlayerExt.saveToPageVars(player)
 		globalVars:set(player.displayName .. '_flag', player.flag)
 	end
 	if player.faction and player.faction ~= Faction.defaultFaction then
-		globalVars:set(player.displayName .. '_race', player.faction)
+		globalVars:set(player.displayName .. '_faction', player.faction)
 	end
 end
 

--- a/components/opponent/wikis/warcraft/player_ext_custom.lua
+++ b/components/opponent/wikis/warcraft/player_ext_custom.lua
@@ -99,7 +99,7 @@ function CustomPlayerExt.syncPlayer(player, options)
 	player = PlayerExt.syncPlayer(player, options) --[[@as WarcraftStandardPlayer]]
 
 	player.faction = player.faction
-		or globalVars:get(player.displayName .. '_race')
+		or globalVars:get(player.displayName .. '_faction')
 		or options.fetchPlayer ~= false and CustomPlayerExt.fetchPlayerFaction(player.pageName, options.date)
 		or Faction.defaultFaction
 
@@ -110,10 +110,18 @@ function CustomPlayerExt.syncPlayer(player, options)
 	return player
 end
 
+---Same as PlayerExt.syncPlayer, except it does not save the player's flag to page variables.
+---@param player WarcraftStandardPlayer
+---@param options {fetchPlayer: boolean, fetchMatch2Player: boolean, date: string?}?
+---@return WarcraftStandardPlayer
+function CustomPlayerExt.populatePlayer(player, options)
+	return CustomPlayerExt.syncPlayer(player, Table.merge(options, {savePageVar = false}))
+end
+
 ---@param player WarcraftStandardPlayer
 function CustomPlayerExt.saveToPageVars(player)
 	if player.faction and player.faction ~= Faction.defaultFaction then
-		globalVars:set(player.displayName .. '_race', player.faction)
+		globalVars:set(player.displayName .. '_faction', player.faction)
 	end
 
 	PlayerExt.saveToPageVars(player)

--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -125,7 +125,7 @@ function StarcraftParticipantTable:readEntry(sectionArgs, key, index, config)
 
 	--unset wiki var for random events to not read players as random if prize pool already sets them as random
 	if config.isRandomEvent and opponentArgs.type == Opponent.solo then
-		Variables.varDefine(opponentArgs.name .. '_race', '')
+		Variables.varDefine(opponentArgs.name .. '_faction', '')
 	end
 
 	local opponent = Opponent.readOpponentArgs(opponentArgs) or {}
@@ -171,7 +171,7 @@ function StarcraftParticipantTable:getPlacements()
 
 	for prizePoolIndex = 1, maxPrizePoolIndex do
 		Array.forEach(Json.parseIfTable(prizePoolVars:get('placementRecords.' .. prizePoolIndex)) or {}, function(placement)
-			placements[placement.opponentname] = true
+			placements[placement.opponentname] = placement
 		end)
 	end
 
@@ -315,7 +315,7 @@ end
 ---@param config StarcraftParticipantTableConfig
 function StarcraftParticipantTable:setCustomPageVariables(entry, config)
 	if config.isRandomEvent then
-		Variables.varDefine(entry.opponent.players[1].displayName .. '_race', Faction.read('r'))
+		Variables.varDefine(entry.opponent.players[1].displayName .. '_faction', Faction.read('r'))
 	end
 end
 

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -208,9 +208,9 @@ function StandingsStorage.fromTemplateEntry(frame)
 			flag = data.participantflag or data.flag,
 			team = data.team
 		}
-		local race = string.match(data.player, '&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
-		if String.isNotEmpty(race) then
-			opponentArgs.race = race:sub(1, 1):lower()
+		local faction = string.match(data.player, '&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
+		if String.isNotEmpty(faction) then
+			opponentArgs.faction = faction:sub(1, 1):lower()
 		end
 
 	elseif data.team then

--- a/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
+++ b/components/standings/commons/starcraft_starcraft2/standings_storage_starcraft_legacy.lua
@@ -131,11 +131,11 @@ function Wrapper._processPlayer(playerInput, opponentArgs, prefix)
 	opponentArgs[prefix .. 'link'] = link
 	opponentArgs[prefix .. 'flag'] = playerInput:match('<span class="flag">%[%[File:[^|]-%.png|36x24px|([^|]-)|')
 
-	-- get the race
+	-- get the faction
 	-- first remove the flag so that only 1 image is left
 	playerInput = playerInput:gsub('<span class="flag">.-</span>', '')
-	-- now read the race from the remaining file
-	opponentArgs[prefix .. 'race'] = playerInput:match('&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
+	-- now read the faction from the remaining file
+	opponentArgs[prefix .. 'faction'] = playerInput:match('&nbsp;%[%[File:[^]]-|([^|]-)%]%]')
 end
 
 ---@param args table


### PR DESCRIPTION
## Summary
- switch to using `faction` wiki vars instead of `race` wiki vars
- additionally it fixes a compatibility bug with HDB
 - currently HDB only sets `faction` wiki vars while most modules still expect the `race` ones
 - this PR switches all git components to use the `faction` ones instead and hence fixes the above mentioned issue
- clean up some (lua) variable names

(Non git modules & templates should by now be able to work with both vars, after this PR i will remove the support for the race one)

## How did you test this change?
dev