### PR TITLE
feat(standard): add Boosty to Links Module

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -44,6 +44,7 @@ local PREFIXES = {
 		stream = 'https://live.bilibili.com/',
 	},
 	['bilibili-stream'] = {'https://live.bilibili.com/'},
+	boosty = {'https://boosty.to/'},
 	booyah = {'https://booyah.live/'},
 	bracket = {''},
 	cc = {'https://cc.163.com/'},


### PR DESCRIPTION
## Summary
Allow content creators from CIS countries (and beyond) to use Boosty profile links without using `|website=` or other 

## How did you test this change?
Haven't tested this, but I'm pretty sure it works correctly, sorry >.<
