### PR TITLE
feat(broadcastsTable): skip cancelled tournaments in achievements

### DIFF
--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -141,8 +141,10 @@ function BroadcastTalentTable:_fetchTournaments()
 	end
 
 	if args.isAchievementsTable then
-		conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.neq, 'cancelled')}
-		conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.neq, 'postponed')}
+		local IGNORED_STATUSES = {'cancelled', 'postponed'}
+		Array.forEach(IGNORED_STATUSES, function(ignoredStatus)
+			conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.neq, ignoredStatus)}
+		end)
 	end
 
 	-- double the limit for the query due to potentional merging of results further down the line

--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -141,7 +141,8 @@ function BroadcastTalentTable:_fetchTournaments()
 	end
 
 	if args.isAchievementsTable then
-		conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.eq, '')}
+		conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.neq, 'cancelled')}
+		conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.neq, 'postponed')}
 	end
 
 	-- double the limit for the query due to potentional merging of results further down the line

--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -37,6 +37,7 @@ local DASH = '&#8211;'
 local DEFAULT_TIERTYPE = 'General'
 local DEFAULT_ABOUT_LINK = 'Template:Weight/doc'
 local ACHIEVEMENTS_SORT_ORDER = 'weight desc, date desc'
+local ACHIEVEMENTS_IGNORED_STATUSES = {'cancelled', 'postponed'}
 local RESULTS_SORT_ORDER = 'date desc'
 
 ---@class BroadcastTalentTable
@@ -141,8 +142,7 @@ function BroadcastTalentTable:_fetchTournaments()
 	end
 
 	if args.isAchievementsTable then
-		local IGNORED_STATUSES = {'cancelled', 'postponed'}
-		Array.forEach(IGNORED_STATUSES, function(ignoredStatus)
+		Array.forEach(ACHIEVEMENTS_IGNORED_STATUSES, function(ignoredStatus)
 			conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.neq, ignoredStatus)}
 		end)
 	end

--- a/components/broadcast_talent_table/commons/broadcast_talent_table.lua
+++ b/components/broadcast_talent_table/commons/broadcast_talent_table.lua
@@ -140,6 +140,10 @@ function BroadcastTalentTable:_fetchTournaments()
 		end
 	end
 
+	if args.isAchievementsTable then
+		conditions:add{ConditionNode(ColumnName('extradata_status'), Comparator.eq, '')}
+	end
+
 	-- double the limit for the query due to potentional merging of results further down the line
 	local queryLimit = args.limit * 2
 


### PR DESCRIPTION
## Summary

Currently cancelled or postponed tournaments show up in talent's achievements tables. Not ideal imo as cancelled tournaments were usually cancelled due to being scams or something else like that.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/00831baf-0aab-4b13-b8dd-adf18e72f515)

## How did you test this change?

Tested on `/dev`

(notice `HCG Masters Season 1` missing now)
![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/3e9da656-633f-4219-9992-3d15ef794629)
