### PR TITLE
feat(sc2 infobox player): enable automated team history & team

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -28,6 +28,7 @@ local YearsActive = require('Module:YearsActive')
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local CustomPerson = Lua.import('Module:Infobox/Person/Custom')
 local Opponent = Lua.import('Module:Opponent/Starcraft')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
 local Condition = require('Module:Condition')
 local ConditionTree = Condition.Tree
@@ -76,7 +77,16 @@ function CustomPlayer.run(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
 	player.shouldQueryData = player:shouldStoreData(player.args)
+
 	player.args.autoTeam = Logic.emptyOr(player.args.autoTeam, true)
+
+	player.args.history = Logic.nilIfEmpty(player.args.history) or TeamHistoryAuto.results{
+		player = player.pagename,
+		convertrole = true,
+		addlpdbdata = Logic.emptyOr(player.args.addlpdbdata, true),
+		cleanRoles = 'Module:TeamHistoryAuto/cleanRole',
+		specialRoles = true,
+	}
 
 	if player.shouldQueryData then
 		player:_getMatchupData(player.pagename)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -14,6 +14,7 @@ local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local Faction = require('Module:Faction')
 local Json = require('Module:Json')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Lpdb = require('Module:Lpdb')
 local MatchTicker = require('Module:MatchTicker/Custom')
@@ -75,6 +76,7 @@ function CustomPlayer.run(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
 	player.shouldQueryData = player:shouldStoreData(player.args)
+	player.args.autoTeam = Logic.emptyOr(player.args.autoTeam, true)
 
 	if player.shouldQueryData then
 		player:_getMatchupData(player.pagename)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -28,7 +28,7 @@ local YearsActive = require('Module:YearsActive')
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local CustomPerson = Lua.import('Module:Infobox/Person/Custom')
 local Opponent = Lua.import('Module:Opponent/Starcraft')
-local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local TeamHistoryAuto = Lua.import('Module:TeamHistoryAuto')
 
 local Condition = require('Module:Condition')
 local ConditionTree = Condition.Tree


### PR DESCRIPTION
## Summary
Due to conversion from manual input to THA is at a point that it is imo a good idea to enable THA by default this PR does that ;)

Manual input still wins (for now) due to still having 343 (as of writing this) pages that use manual TeamHistory input and hence still need to be converted (make sure data is available in transfer data).

As a precaution also added option to still disable autoTeam.

## How did you test this change?
/dev