### PR TITLE
feat(match2): Legacy Wrappers for Call of Duty

### DIFF
--- a/components/match2/wikis/callofduty/legacy/legacy_bracket_match_summary.lua
+++ b/components/match2/wikis/callofduty/legacy/legacy_bracket_match_summary.lua
@@ -1,0 +1,49 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:LegacyBracketMatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Table = require('Module:Table')
+
+local MAX_NUM_MAPS = 20
+
+local LegacyBracketMatchSummary = {}
+
+---@param frame Frame
+---@return string
+function LegacyBracketMatchSummary.run(frame)
+	local args = Arguments.getArgs(frame)
+
+	---@param prefix string
+	---@return boolean
+	local mapIsNotEmpty = function(prefix)
+		return Logic.isNotEmpty(args[prefix]) or
+			Logic.isNotEmpty(args[prefix .. 'type']) or
+			Logic.isNotEmpty(args[prefix .. 'score'])
+	end
+
+	Array.forEach(Array.range(1, MAX_NUM_MAPS), function(mapIndex)
+		local prefix = 'map' .. mapIndex
+		-- make sure map is processed in `Module:MatchGroup/Legacy/Default` if any valid input for map is given
+		args[prefix .. 'win'] = args[prefix .. 'win'] or mapIsNotEmpty(prefix) and 'skip' or nil
+
+		-- convert the map score input into a format that `Module:MatchGroup/Legacy/Default` can process
+		local scorePrefix = prefix .. 'score'
+		local scoreInput = Table.extract(args, scorePrefix)
+		if Logic.isEmpty(scoreInput) then return end
+		local scores = Array.parseCommaSeparatedString(scoreInput, '-')
+		args[scorePrefix .. 1] = scores[1]
+		args[scorePrefix .. 2] = scores[2]
+	end)
+
+	return Json.stringify(args)
+end
+
+return LegacyBracketMatchSummary

--- a/components/match2/wikis/callofduty/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/callofduty/legacy/match_group_legacy_default.lua
@@ -1,0 +1,197 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:MatchGroup/Legacy/Default
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local MatchGroupLegacyDefault = {}
+
+local String = require('Module:StringUtils')
+local Logic = require('Module:Logic')
+
+local MAX_NUMBER_OF_OPPONENTS = 2
+local MAX_NUM_MAPS = 20
+
+local roundData
+---@param templateid string
+---@param bracketType string
+---@return table
+function MatchGroupLegacyDefault.get(templateid, bracketType)
+	local lowerHeader = {}
+	local matches = mw.ext.Brackets.getCommonsBracketTemplate(templateid)
+
+	assert(type(matches) == 'table')
+	local bracketData = {}
+	roundData = roundData or {}
+	local lastRound = 0
+	for _, match in ipairs(matches) do
+		bracketData, lastRound, lowerHeader = MatchGroupLegacyDefault._getMatchMapping(match, bracketData,
+																						bracketType, lowerHeader)
+	end
+
+	for round = 1, lastRound do
+		bracketData['R' .. round .. 'M1header'] = 'R' .. round
+		if lowerHeader[round] then
+			bracketData['R' .. round .. 'M' .. lowerHeader[round] .. 'header'] = 'L' .. round
+		end
+	end
+
+	-- add reference for map mappings
+	bracketData['$$map'] = {
+		['$notEmpty$'] = 'map$1$win',
+		map = 'map$1$',
+		winner = 'map$1$win',
+		mode = 'map$1$type',
+		vod = 'vodgame$1$',
+		score1 = 'map$1$score1',
+		score2 = 'map$1$score2',
+	}
+
+	return bracketData
+end
+
+---@param prefix string
+---@param scoreKey string
+---@param bracketType string
+---@return table
+function MatchGroupLegacyDefault._readOpponent(prefix, scoreKey, bracketType)
+	return {
+		['type'] = 'type',
+		template = prefix .. 'team',
+		score = prefix .. scoreKey,
+		name = prefix,
+		displayname = prefix .. 'display',
+		flag = prefix .. 'flag',
+		win = prefix .. 'win',
+		['$notEmpty$'] = bracketType == 'team' and (prefix .. 'team') or prefix,
+	}
+end
+
+--the following variable gets mutaded by each p._getMatchMapping
+--it is needed as a basis for the next call
+local _lastRound
+---@param match table
+---@param bracketData table
+---@param bracketType string
+---@param lowerHeader table
+---@return table
+---@return number
+---@return table
+function MatchGroupLegacyDefault._getMatchMapping(match, bracketData, bracketType, lowerHeader)
+	local id = String.split(match.match2id, '_')[2] or match.match2id
+	--remove 0's and dashes from the match param
+	--e.g. R01-M001 --> R1M1
+	id = id:gsub('0*([1-9])', '%1'):gsub('%-', '')
+	local bd = match.match2bracketdata
+
+	local roundNum
+	local round
+	local reset = false
+	if id == 'RxMTP' then
+		round = _lastRound
+	elseif id == 'RxMBR' then
+		round = _lastRound
+		round.G = round.G - 2
+		round.W = round.W - 2
+		round.D = round.D - 2
+		reset = true
+	else
+		roundNum = id:match('R%d*'):gsub('R', '')
+		roundNum = tonumber(roundNum)
+		round = roundData[roundNum] or { R = roundNum, G = 0, D = 1, W = 1 }
+	end
+	round.G = round.G + 1
+
+	--if bd.header starts with '!l'
+	if string.match(bd.header or '', '^!l') then
+		lowerHeader[roundNum or ''] = round.G
+	end
+
+	local opponents = {}
+	local finished = {}
+	local scoreKey = (reset and 'score2' or 'score')
+	for opponentIndex = 1, MAX_NUMBER_OF_OPPONENTS do
+		local prefix
+		if not reset and
+			(Logic.isEmpty(bd.toupper) and opponentIndex == 1 or
+			Logic.isEmpty(bd.tolower) and opponentIndex == 2) then
+
+			prefix = 'R' .. round.R .. 'D' .. round.D
+			round.D = round.D + 1
+		else
+			prefix = 'R' .. round.R .. 'W' .. round.W
+			round.W = round.W + 1
+		end
+
+		opponents[opponentIndex] = MatchGroupLegacyDefault._readOpponent(prefix, scoreKey, bracketType)
+		finished[opponentIndex] = prefix .. 'win'
+	end
+
+	match = {
+		opponent1 = opponents[1],
+		opponent2 = opponents[2],
+		finished = finished[1] .. '|' .. finished[2],
+		-- reference to variables that shall be flattened
+		['$flatten$'] = {'R' .. round.R .. 'G' .. round.G .. 'details'}
+	}
+
+	bracketData[id] = MatchGroupLegacyDefault.addMaps(match)
+	_lastRound = round
+	roundData[round.R] = round
+
+	return bracketData, round.R, lowerHeader
+end
+
+--[[
+custom mappings are used to overwrite the default mappings
+in the cases where the default mappings do not fit the
+parameter format of the old bracket
+]]--
+
+--this can be used for custom mappings too
+---@param match table
+---@return table
+function MatchGroupLegacyDefault.addMaps(match)
+	for mapIndex = 1, MAX_NUM_MAPS do
+		match['map' .. mapIndex] = {
+			['$ref$'] = 'map',
+			['$1$'] = mapIndex
+		}
+	end
+	return match
+end
+
+--this is for custom mappings
+---@param data {opp1: string, opp2: string, details: string}
+---@param bracketType string
+---@return table
+function MatchGroupLegacyDefault.matchMappingFromCustom(data, bracketType)
+	bracketType = bracketType or 'team'
+
+	local mapping = {
+		['$flatten$'] = {data.details .. 'details'},
+		['finished'] = data.opp1 .. 'win|' .. data.opp2 .. 'win',
+		opponent1 = MatchGroupLegacyDefault._readOpponent(data.opp1, 'score', bracketType),
+		opponent2 =  MatchGroupLegacyDefault._readOpponent(data.opp2, 'score', bracketType),
+	}
+	mapping = MatchGroupLegacyDefault.addMaps(mapping)
+
+	return mapping
+end
+
+--this is for custom mappings for Reset finals matches
+--it switches score2 into the place of score
+--and sets flatten to nil
+---@param mapping table
+---@return table
+function MatchGroupLegacyDefault.matchResetMappingFromCustom(mapping)
+	local mappingReset = mw.clone(mapping)
+	mappingReset.opponent1.score = mapping.opponent1.score .. '2'
+	mappingReset.opponent2.score = mapping.opponent2.score .. '2'
+	mappingReset['$flatten$'] = nil
+	return mappingReset
+end
+
+return MatchGroupLegacyDefault

--- a/components/match2/wikis/callofduty/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/callofduty/legacy/match_group_legacy_default.lua
@@ -8,8 +8,8 @@
 
 local MatchGroupLegacyDefault = {}
 
-local String = require('Module:StringUtils')
 local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
 
 local MAX_NUMBER_OF_OPPONENTS = 2
 local MAX_NUM_MAPS = 20
@@ -174,7 +174,7 @@ function MatchGroupLegacyDefault.matchMappingFromCustom(data, bracketType)
 		['$flatten$'] = {data.details .. 'details'},
 		['finished'] = data.opp1 .. 'win|' .. data.opp2 .. 'win',
 		opponent1 = MatchGroupLegacyDefault._readOpponent(data.opp1, 'score', bracketType),
-		opponent2 =  MatchGroupLegacyDefault._readOpponent(data.opp2, 'score', bracketType),
+		opponent2 = MatchGroupLegacyDefault._readOpponent(data.opp2, 'score', bracketType),
 	}
 	mapping = MatchGroupLegacyDefault.addMaps(mapping)
 

--- a/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
@@ -92,7 +92,7 @@ function MatchMapsLegacy._readOpponents(matchArgs)
 		matchArgs['opponent' .. opponentIndex] = {
 			template = template,
 			type = template == TBD and Opponent.literal or Opponent.team,
-			score = tonumber(Table.extract(matchArgs, 'games' .. opponentIndex)) or
+			score = Logic.nilIfEmpty(Table.extract(matchArgs, 'games' .. opponentIndex)) or
 				(walkover and walkover ~= 0 and (walkover == opponentIndex and DEFAULT_WIN or DEFAULT_LOSS))
 		}
 	end)

--- a/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=callofduty
--- page=Module:MatchMaps/Legacy/Store
+-- page=Module:MatchMaps/Legacy
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --

--- a/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
@@ -45,7 +45,7 @@ function MatchMapsLegacy.init(frame)
 	matchlistVars:set('bracketid', args.id)
 	matchlistVars:set('matchListTitle', args.title or args[1] or 'Match List')
 	matchlistVars:set('width', args.width)
-	matchlistVars:set('hide', args.hide or 'true' )
+	matchlistVars:set('hide', args.hide or 'true')
 	matchlistVars:set('store', store and 'true' or nil)
 end
 
@@ -57,6 +57,7 @@ function MatchMapsLegacy.match(frame)
 
 	Template.stashReturnValue(matchArgs, 'LegacyMatchlist')
 end
+
 ---@param args table
 ---@return table
 function MatchMapsLegacy._mergeDetailsIntoArgs(args)
@@ -114,7 +115,7 @@ function MatchMapsLegacy.close()
 		matchListArgs['M' .. matchIndex] = Match.makeEncodedJson(match)
 	end)
 
-	if matchlistVars:get('hide') == 'true' then
+	if Logic.readBool(matchlistVars:get('hide')) then
 		matchListArgs.collapsed = true
 		matchListArgs.attached = true
 	else

--- a/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
@@ -63,7 +63,10 @@ end
 function MatchMapsLegacy._mergeDetailsIntoArgs(args)
 	local details = Json.parseIfTable(Table.extract(args, 'details')) or {}
 
-	return Table.merge({}, details, args)
+	return Table.merge(details, args, {
+		date = details.date or args.date,
+		dateheader = Logic.isNotEmpty(args.date)
+	})
 end
 
 ---@param matchArgs table

--- a/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/callofduty/legacy/match_maps_legacy.lua
@@ -1,0 +1,149 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:MatchMaps/Legacy/Store
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
+local Table = require('Module:Table')
+local Template = require('Module:Template')
+
+local Match = Lua.import('Module:Match')
+local MatchGroup = Lua.import('Module:MatchGroup')
+local MatchSubobjects = Lua.import('Module:Match/Subobjects')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+
+local globalVars = PageVariableNamespace()
+local matchlistVars = PageVariableNamespace('LegacyMatchlist')
+
+local MAX_NUMBER_OF_OPPONENTS = 2
+local MAX_NUM_MAPS = 20
+local TBD = 'tbd'
+local DEFAULT_WIN = 'W'
+local DEFAULT_LOSS = 'L'
+
+local MatchMapsLegacy = {}
+
+---@param frame Frame
+function MatchMapsLegacy.init(frame)
+	local args = Arguments.getArgs(frame)
+
+	local store = Logic.nilOr(
+		Logic.readBoolOrNil(args.store),
+		not Logic.readBool(globalVars:get('disable_LPDB_storage'))
+	)
+
+	matchlistVars:set('bracketid', args.id)
+	matchlistVars:set('matchListTitle', args.title or args[1] or 'Match List')
+	matchlistVars:set('width', args.width)
+	matchlistVars:set('hide', args.hide or 'true' )
+	matchlistVars:set('store', store and 'true' or nil)
+end
+
+---@param frame Frame
+function MatchMapsLegacy.match(frame)
+	local matchArgs = MatchMapsLegacy._mergeDetailsIntoArgs(Arguments.getArgs(frame))
+	MatchMapsLegacy._readMaps(matchArgs)
+	MatchMapsLegacy._readOpponents(matchArgs)
+
+	Template.stashReturnValue(matchArgs, 'LegacyMatchlist')
+end
+---@param args table
+---@return table
+function MatchMapsLegacy._mergeDetailsIntoArgs(args)
+	local details = Json.parseIfTable(Table.extract(args, 'details')) or {}
+
+	return Table.merge({}, details, args)
+end
+
+---@param matchArgs table
+function MatchMapsLegacy._readMaps(matchArgs)
+	Array.forEach(Array.range(1, MAX_NUM_MAPS), function(mapIndex)
+		local prefix = 'map' .. mapIndex
+		local mapArgs = {
+			map = Table.extract(matchArgs, prefix),
+			winner = Table.extract(matchArgs, prefix .. 'win'),
+			mode = Table.extract(matchArgs, prefix .. 'type'),
+			vod = Table.extract(matchArgs, 'vodgame' .. mapIndex),
+			score1 = Table.extract(matchArgs, prefix .. 'score1'),
+			score2 = Table.extract(matchArgs, prefix .. 'score2'),
+		}
+		matchArgs[prefix] = Logic.isNotEmpty(mapArgs) and MatchSubobjects.luaGetMap(mapArgs) or nil
+	end)
+end
+
+---@param matchArgs table
+function MatchMapsLegacy._readOpponents(matchArgs)
+	local walkover = tonumber(Table.extract(matchArgs, 'walkover'))
+
+	Array.forEach(Array.range(1, MAX_NUMBER_OF_OPPONENTS), function(opponentIndex)
+		local template = string.lower(Logic.nilIfEmpty(Table.extract(matchArgs, 'team' .. opponentIndex)) or TBD)
+
+		matchArgs['opponent' .. opponentIndex] = {
+			template = template,
+			type = template == TBD and Opponent.literal or Opponent.team,
+			score = tonumber(Table.extract(matchArgs, 'games' .. opponentIndex)) or
+				(walkover and walkover ~= 0 and (walkover == opponentIndex and DEFAULT_WIN or DEFAULT_LOSS))
+		}
+	end)
+end
+
+---@return string?
+function MatchMapsLegacy.close()
+	local bracketid = matchlistVars:get('bracketid')
+	if Logic.isEmpty(bracketid) then return end
+
+	local matchListArgs = {
+		id = bracketid,
+		title = matchlistVars:get('matchListTitle'),
+		width = matchlistVars:get('width'),
+		isLegacy = true,
+	}
+
+	local matches = Template.retrieveReturnValues('LegacyMatchlist') --[[@as table]]
+	Array.forEach(matches, function(match, matchIndex)
+		matchListArgs['M' .. matchIndex] = Match.makeEncodedJson(match)
+	end)
+
+	if matchlistVars:get('hide') == 'true' then
+		matchListArgs.collapsed = true
+		matchListArgs.attached = true
+	else
+		matchListArgs.collapsed = false
+	end
+	if Logic.readBool(matchlistVars:get('store')) then
+		matchListArgs.store = true
+	else
+		matchListArgs.noDuplicateCheck = true
+		matchListArgs.store = false
+	end
+
+	-- store matches
+	local matchHtml = MatchGroup.MatchList(matchListArgs)
+
+	MatchMapsLegacy._resetVars()
+
+	return matchHtml
+end
+
+function MatchMapsLegacy._resetVars()
+	globalVars:set('match2bracketindex', (globalVars:get('match2bracketindex') or 0) + 1)
+	globalVars:set('match_number', 0)
+	globalVars:delete('matchsection')
+	matchlistVars:delete('store')
+	matchlistVars:delete('bracketid')
+	matchlistVars:delete('matchListTitle')
+	matchlistVars:delete('hide')
+	matchlistVars:delete('width')
+end
+
+return MatchMapsLegacy


### PR DESCRIPTION
## Summary
Add Legacy Wrappers for Bracket and Matchlist to be able to bot convert match1 templates into storing match2 data

## How did you test this change?
"live" + [test page](https://liquipedia.net/callofduty/User:Hesketh2/Legacy), not in use as of now