### PR TITLE
feat(match2): replace non working `brkts-template-container`

### DIFF
--- a/components/match2/commons/bracket_template.lua
+++ b/components/match2/commons/bracket_template.lua
@@ -44,10 +44,9 @@ function BracketTemplate.BracketDocumentation(props)
 		BracketTemplate.BracketContainer({bracketId = props.templateId}),
 		[[
 
-==Template==
-Refresh the page to generate a new ID.
+==Copy-Paste==
+For copy-pastable code please use <code>Special:RunQuery/BracketCopyPaste</code> on the respective wiki(s).
 ]],
-		mw.html.create('pre'):addClass('brkts-template-container'),
 	}
 	return table.concat(Array.map(parts, tostring))
 end


### PR DESCRIPTION
## Summary
`brkts-template-container` doesn't work for quite some time now.
This PR replaces its usage by just referencing to `Special:RunQuery/BracketCopyPaste` instead.
The Form has more options anyways and hence is **imo** preferable.

## How did you test this change?
dev + [test page](https://liquipedia.net/starcraft2/User:Hjpalpha/wip31)