### PR TITLE
feat: set match1 bracket width for Fortnite

### DIFF
--- a/stylesheets/commons/Bracket.less
+++ b/stylesheets/commons/Bracket.less
@@ -775,6 +775,10 @@ Author(s): FO-nTTaX, salle
 	width: 330px;
 }
 
+.wiki-fortnite .bracket-popup-wrapper.bracket-popup-team {
+	width: 330px;
+}
+
 .wiki-hearthstone .bracket-popup-wrapper.bracket-popup-player {
 	width: 300px;
 }


### PR DESCRIPTION
Since Fortnite will have a chunk of Match1-brackets to be covered on wiki (for EWC), bracket width in the CSS are needed