### PR TITLE
fix(GTL button): button padding in match2 based GTL

### DIFF
--- a/stylesheets/commons/GroupTableLeague.less
+++ b/stylesheets/commons/GroupTableLeague.less
@@ -58,8 +58,8 @@ Author: warnull
 	text-align: center;
 }
 
-.group-table .dropdown-box-button {
-	padding: 2px 0 !important;
+.main-content-column .group-table .dropdown-box-button {
+	padding: 2px 0;
 }
 
 .group-table .dropdown-box {
@@ -67,9 +67,9 @@ Author: warnull
 	padding: 0;
 }
 
-.group-table .dropdown-box > div {
+.main-content-column .group-table .dropdown-box > div {
 	border-top-width: 0;
-	padding: 2px 0 !important;
+	padding: 2px 0;
 }
 
 .group-table-header-row,

--- a/stylesheets/commons/GroupTableLeague.less
+++ b/stylesheets/commons/GroupTableLeague.less
@@ -59,7 +59,7 @@ Author: warnull
 }
 
 .group-table .dropdown-box-button {
-	padding: 2px 0;
+	padding: 2px 0 !important;
 }
 
 .group-table .dropdown-box {
@@ -69,7 +69,7 @@ Author: warnull
 
 .group-table .dropdown-box > div {
 	border-top-width: 0;
-	padding: 2px 0;
+	padding: 2px 0 !important;
 }
 
 .group-table-header-row,


### PR DESCRIPTION
## Summary
Fix the button (and dropdown) padding in the match2 based GTL.
Due to a somewhat recent change to button styles (probably [this](https://discord.com/channels/321003439431745537/321641676579930112/1242837025430704152)) the padding applied by the `dropdown-box-button` / `dropdown-box` class gets overwritten.
This PR changes specificity on those classes so that they get applied properly again.

## How did you test this change?
broswer dev tools