### PR TITLE
feat(participantTable): Use equal padding for `.participantTable-entry`

### DIFF
--- a/stylesheets/commons/OpponentList.less
+++ b/stylesheets/commons/OpponentList.less
@@ -39,7 +39,7 @@ Author: hjpalpha
 	background-color: inherit;
 	border-bottom: 1px solid var( --table-border-color, #bbbbbb );
 	border-right: 1px solid var( --table-border-color, #bbbbbb );
-	padding: 8px 4px 4px;
+	padding: 4px;
 	text-align: left;
 	transition: 0.5s;
 	transition-property: border-color;


### PR DESCRIPTION
## Summary

Use equal padding for `.participantTable-entry`

Before and after example:
![image](https://github.com/Liquipedia/Lua-Modules/assets/42142350/54fd882b-75e6-4004-9134-ec9dfb8026e5)

## How did you test this change?

Inspect element