### PR TITLE
feat: implement heroes section

### DIFF
--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -91,6 +91,7 @@
 			align-items: center;
 			border-bottom: 0.5rem solid;
 			padding: 0.5rem 0;
+			margin-bottom: 0.25rem;
 
 			.category--strength & {
 				.theme--light & {
@@ -149,21 +150,21 @@
 		}
 
 		ul&-list {
-			@--bs-gutter-y: 0.5rem;
-			@--bs-gutter-x: 0.5rem;
+			@--gutter-y: 0.5rem;
+			@--gutter-x: 0.5rem;
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: center;
 			list-style: none;
-			margin: calc(-1* @--bs-gutter-y) calc(-.5* @--bs-gutter-x) 0 calc(-.5* @--bs-gutter-x);
+			margin: calc(-.5* @--gutter-y) calc(-.5* @--gutter-x) 0.5rem calc(-.5* @--gutter-x);
 
 			> li {
 				flex: 0 0 auto;
 				width: calc( 100% / 3 );
 				max-width: 100%;
-				padding-right: calc(@--bs-gutter-x* .5);
-				padding-left: calc(@--bs-gutter-x* .5);
-				margin-top: @--bs-gutter-y;
+				padding-right: calc(@--gutter-x* .5);
+				padding-left: calc(@--gutter-x* .5);
+				margin-top: @--gutter-y;
 				margin-bottom: 0;
 
 				@media ( min-width: 576px ) {
@@ -177,35 +178,30 @@
 				@media ( min-width: 1024px ) {
 					width: calc( 100% / 8 );
 				}
-
-				> img {
-					display: flex;
-					object-fit: cover;
-					width: 100%;
-					height: 100%;
-				}
-
-				> a {
-					width: 100%;
-					height: 100%;
-
-					> img {
-						display: flex;
-						object-fit: cover;
-						width: 100%;
-						height: 100%;
-					}
-				}
 			}
 		}
 	}
 
 	&__hero-card {
-		box-shadow: inset 0 0 0 0.125rem rgba(0, 0, 0, 0.7);
 		display: flex;
 		position: relative;
 		flex: 1;
 		height: 3.5rem;
+
+		&::before {
+			content: "";
+			box-shadow: inset 0 0 0 0.125rem rgba(0, 0, 0, 0.7);
+			position: absolute;
+			inset: 0;
+			z-index: 1;
+		}
+
+		> img {
+			display: flex;
+			object-fit: cover;
+			width: 100%;
+			height: 100%;
+		}
 
 		&__title {
 			color: #fff;
@@ -217,6 +213,10 @@
 			bottom: 0.25rem;
 			left: 0;
 			text-align: center;
+
+			> a {
+				color: inherit;
+			}
 		}
 	}
 }

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -1,0 +1,64 @@
+.heroes-panel {
+	&__heading {
+		display: flex;
+		align-items: center;
+		margin-bottom: 1rem;
+
+		&-title {
+			font-weight: bold;
+			display: inline-flex;
+
+			&__number {
+				font-weight: normal;
+				margin-left: 0.5rem;
+			}
+		}
+
+		ul&-links {
+			margin: 0 0 0 auto;
+			list-style: none;
+			display: inline-flex;
+
+			> li:not(:first-child) {
+				margin-left: 1.375rem;
+
+				> a {
+					&::before {
+						content: '';
+						width: 0.125rem;
+						height: 0.125rem;
+						background-color: #000;
+						border-radius: 100%;
+						display: block;
+					}
+				}
+			}
+		}
+	}
+
+	&__filter {}
+
+	&__category {
+		&.category--strength {}
+		&.category--agility {}
+		&.category--intelligence {}
+		&.category--universal {}
+		&.category--upcoming {}
+
+		&-title {
+			display: flex;
+			justify-content: center;
+			border-bottom: 0.5rem solid;
+
+			.category--strength & {
+				border-bottom-color: var( --clr-california-40 );
+			}
+		}
+
+		&__list {
+			display: grid;
+			margin: 0;
+			list-style: none;
+		}
+	}
+}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -153,6 +153,7 @@
 
 				@media ( hover: hover ) {
 					&:hover {
+						color: #fff;
 						background: linear-gradient( rgba( 0, 0, 0, 0 ), rgba( 0, 0, 0, 0.5 ) );
 					}
 				}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -38,7 +38,9 @@
 	}
 
 	&__filter {
-		&-group {}
+		&-group {
+			margin-bottom: 1rem;
+		}
 
 		&-button {
 			min-height: 2rem;
@@ -57,12 +59,19 @@
 
 			&::after {
 				content: '';
-				background-color: var( --clr-wiki-theme-primary );
 				opacity: 0.12;
 				position: absolute;
 				inset: 0;
 				z-index: -1;
 				border-radius: 0.5rem;
+
+				.theme--light & {
+					background-color: var( --clr-wiki-theme-primary );
+				}
+
+				.theme--dark & {
+					background-color: #fff;
+				}
 			}
 
 			@media ( hover: hover ) {
@@ -196,6 +205,10 @@
 			z-index: 1;
 		}
 
+		&.is--unselected {
+			filter: grayscale(1);
+		}
+
 		> img {
 			display: flex;
 			object-fit: cover;
@@ -209,13 +222,23 @@
 			text-shadow: 0 0.0625rem 0.0625rem #000000, 0 0 0.125rem #000000;
 			font-size: 0.6875rem;
 			position: absolute;
-			right: 0;
-			bottom: 0.25rem;
-			left: 0;
-			text-align: center;
+			inset: 0;
+			display: flex;
+			justify-content: space-evenly;
+			align-items: stretch;
 
-			> a {
+			& > a {
 				color: inherit;
+				display: flex;
+				align-items: flex-end;
+				padding-bottom: 0.25rem;
+
+				&::before {
+					content: '';
+					position: absolute;
+					inset: 0;
+					z-index: 1;
+				}
 			}
 		}
 	}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -78,7 +78,7 @@
 				width: calc( 100% / 3 );
 				max-width: 100%;
 				padding-right: calc( @_gutter-x* 0.5 );
-				padding-left: calc (@_gutter-x* 0.5 );
+				padding-left: calc( @_gutter-x* 0.5 );
 				margin-top: @_gutter-y;
 				margin-bottom: 0;
 

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -77,9 +77,7 @@
 				flex: 0 0 auto;
 				width: calc( 100% / 3 );
 				max-width: 100%;
-				padding-right: calc( @_gutter-x * 0.5 );
-				padding-left: calc( @_gutter-x * 0.5 );
-				margin-top: @_gutter-y;
+				padding: calc( @_gutter-x * 0.5 );
 				margin-bottom: 0;
 
 				@media ( min-width: 576px ) {

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -71,14 +71,14 @@
 			flex-wrap: wrap;
 			justify-content: center;
 			list-style: none;
-			margin: calc( -0.5* @_gutter-y ) calc( -0.5* @_gutter-x ) 0.5rem calc( -0.5* @_gutter-x );
+			margin: calc( -0.5 * @_gutter-y ) calc( -0.5 * @_gutter-x ) 0.5rem calc( -0.5 * @_gutter-x );
 
 			> li {
 				flex: 0 0 auto;
 				width: calc( 100% / 3 );
 				max-width: 100%;
-				padding-right: calc( @_gutter-x* 0.5 );
-				padding-left: calc( @_gutter-x* 0.5 );
+				padding-right: calc( @_gutter-x * 0.5 );
+				padding-left: calc( @_gutter-x * 0.5 );
 				margin-top: @_gutter-y;
 				margin-bottom: 0;
 

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -85,40 +85,138 @@
 	}
 
 	&__category {
-		&.category--strength {}
-		&.category--agility {}
-		&.category--intelligence {}
-		&.category--universal {}
-		&.category--upcoming {}
-
 		&-title {
 			display: flex;
 			justify-content: center;
+			align-items: center;
 			border-bottom: 0.5rem solid;
+			padding: 0.5rem 0;
 
 			.category--strength & {
-				border-bottom-color: var( --clr-california-40 );
+				.theme--light & {
+					border-bottom-color: var( --clr-california-40 );
+				}
+
+				.theme--dark & {
+					border-bottom-color: var( --clr-california-80 );
+				}
+			}
+
+			.category--agility & {
+				.theme--light & {
+					border-bottom-color: var( --clr-semantic-positive-40 );
+				}
+
+				.theme--dark & {
+					border-bottom-color: var( --clr-semantic-positive-80 );
+				}
+			}
+
+			.category--intelligence & {
+				.theme--light & {
+					border-bottom-color: var( --clr-sapphire-40 );
+				}
+
+				.theme--dark & {
+					border-bottom-color: var( --clr-sapphire-80 );
+				}
+			}
+
+			.category--universal & {
+				.theme--light & {
+					border-bottom-color: var( --clr-gigas-40 );
+				}
+
+				.theme--dark & {
+					border-bottom-color: var( --clr-gigas-80 );
+				}
+			}
+
+			.category--upcoming & {
+				.theme--light & {
+					border-bottom-color: var( --clr-secondary-25 );
+				}
+
+				.theme--dark & {
+					border-bottom-color: var( --clr-secondary-100 );
+				}
+			}
+
+			> a {
+				font-weight: bold;
+				margin-right: 0.5rem;
 			}
 		}
 
 		ul&-list {
-			display: grid;
-			grid-template-columns: repeat( 9, 1fr );
-			gap: 0.5rem;
-			margin: 0;
+			@--bs-gutter-y: 0.5rem;
+			@--bs-gutter-x: 0.5rem;
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
 			list-style: none;
+			margin: calc(-1* @--bs-gutter-y) calc(-.5* @--bs-gutter-x) 0 calc(-.5* @--bs-gutter-x);
 
 			> li {
-				padding: 0;
-				border: 0.125rem solid rgba( 0, 0, 0, 0.7 );
-				border-radius: 0.25rem;
-				overflow: hidden;
-			}
+				flex: 0 0 auto;
+				width: calc( 100% / 3 );
+				max-width: 100%;
+				padding-right: calc(@--bs-gutter-x* .5);
+				padding-left: calc(@--bs-gutter-x* .5);
+				margin-top: @--bs-gutter-y;
+				margin-bottom: 0;
 
-			&__title {
-				color: #fff;
-				box-shadow: 0 0.0625rem 0.0625rem 0 rgba( 0, 0, 0, 1 ), 0 0 0.125rem 0 rgba( 0, 0, 0, 1 );
+				@media ( min-width: 576px ) {
+					width: calc( 100% / 4 );
+				}
+
+				@media ( min-width: 768px ) {
+					width: calc( 100% / 6 );
+				}
+
+				@media ( min-width: 1024px ) {
+					width: calc( 100% / 8 );
+				}
+
+				> img {
+					display: flex;
+					object-fit: cover;
+					width: 100%;
+					height: 100%;
+				}
+
+				> a {
+					width: 100%;
+					height: 100%;
+
+					> img {
+						display: flex;
+						object-fit: cover;
+						width: 100%;
+						height: 100%;
+					}
+				}
 			}
+		}
+	}
+
+	&__hero-card {
+		box-shadow: inset 0 0 0 0.125rem rgba(0, 0, 0, 0.7);
+		display: flex;
+		position: relative;
+		flex: 1;
+		height: 3.5rem;
+
+		&__title {
+			color: #fff;
+			font-weight: bold;
+			text-shadow: 0 0.0625rem 0.0625rem #000000, 0 0 0.125rem #000000;
+			font-size: 0.6875rem;
+			position: absolute;
+			right: 0;
+			bottom: 0.25rem;
+			left: 0;
+			text-align: center;
 		}
 	}
 }

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -36,7 +36,24 @@
 		}
 	}
 
-	&__filter {}
+	&__filter {
+		&-group {}
+
+		&-button {
+			@color: var( --clr-wiki-theme-primary );
+			min-height: 32px;
+			//background-color: rgba( 184, 20, 20, 0.12 );
+			background-color: fade(@color, 12%);
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			padding: 0 12px;
+			border-radius: 8px;
+			font-size: 14px;
+			font-weight: bold;
+			color: var( --clr-wiki-theme-primary );
+		}
+	}
 
 	&__category {
 		&.category--strength {}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -20,17 +20,18 @@
 			display: inline-flex;
 
 			> li:not( :first-child ) {
-				margin-left: 1.375rem;
+				margin-left: 0.5rem;
+				display: flex;
+				align-items: center;
 
-				> a {
-					&::before {
-						content: '';
-						width: 0.125rem;
-						height: 0.125rem;
-						background-color: #000;
-						border-radius: 100%;
-						display: block;
-					}
+				&::before {
+					content: '';
+					width: 0.25rem;
+					height: 0.25rem;
+					background-color: #000;
+					border-radius: 100%;
+					display: block;
+					margin-right: 0.5rem;
 				}
 			}
 		}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -19,7 +19,7 @@
 			list-style: none;
 			display: inline-flex;
 
-			> li:not(:first-child) {
+			> li:not( :first-child ) {
 				margin-left: 1.375rem;
 
 				> a {
@@ -40,18 +40,46 @@
 		&-group {}
 
 		&-button {
-			@color: var( --clr-wiki-theme-primary );
-			min-height: 32px;
-			//background-color: rgba( 184, 20, 20, 0.12 );
-			background-color: fade(@color, 12%);
+			min-height: 2rem;
 			display: inline-flex;
 			align-items: center;
 			justify-content: center;
-			padding: 0 12px;
-			border-radius: 8px;
-			font-size: 14px;
+			padding: 0 0.75rem;
+			border-radius: 0.5rem;
+			font-size: 0.875rem;
 			font-weight: bold;
 			color: var( --clr-wiki-theme-primary );
+			position: relative;
+			z-index: 0;
+			cursor: pointer;
+			margin-right: 0.5rem;
+
+			&::after {
+				content: '';
+				background-color: var( --clr-wiki-theme-primary );
+				opacity: 0.12;
+				position: absolute;
+				inset: 0;
+				z-index: -1;
+				border-radius: 0.5rem;
+			}
+
+			@media ( hover: hover ) {
+				&:hover {
+					&::after {
+						opacity: 0.24;
+					}
+				}
+			}
+
+			&.is--active {
+				background-color: var( --clr-wiki-theme-primary );
+				color: #fff;
+			}
+
+			> .icon-left {
+				margin-right: 0.25rem;
+			}
 		}
 	}
 
@@ -68,27 +96,27 @@
 			border-bottom: 0.5rem solid;
 
 			.category--strength & {
-				border-bottom-color: var(--clr-california-40);
+				border-bottom-color: var( --clr-california-40 );
 			}
 		}
 
 		ul&-list {
 			display: grid;
-			grid-template-columns: repeat(9, 1fr);
+			grid-template-columns: repeat( 9, 1fr );
 			gap: 0.5rem;
 			margin: 0;
 			list-style: none;
 
 			> li {
 				padding: 0;
-				border: 0.125rem solid rgba(0, 0, 0, 0.7);
+				border: 0.125rem solid rgba( 0, 0, 0, 0.7 );
 				border-radius: 0.25rem;
 				overflow: hidden;
 			}
 
 			&__title {
 				color: #fff;
-				box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 1), 0 0 2px 0 rgba(0, 0, 0, 1);
+				box-shadow: 0 0.0625rem 0.0625rem 0 rgba( 0, 0, 0, 1 ), 0 0 0.125rem 0 rgba( 0, 0, 0, 1 );
 			}
 		}
 	}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -51,14 +51,28 @@
 			border-bottom: 0.5rem solid;
 
 			.category--strength & {
-				border-bottom-color: var( --clr-california-40 );
+				border-bottom-color: var(--clr-california-40);
 			}
 		}
 
-		&__list {
+		ul&-list {
 			display: grid;
+			grid-template-columns: repeat(9, 1fr);
+			gap: 0.5rem;
 			margin: 0;
 			list-style: none;
+
+			> li {
+				padding: 0;
+				border: 0.125rem solid rgba(0, 0, 0, 0.7);
+				border-radius: 0.25rem;
+				overflow: hidden;
+			}
+
+			&__title {
+				color: #fff;
+				box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 1), 0 0 2px 0 rgba(0, 0, 0, 1);
+			}
 		}
 	}
 }

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -1,98 +1,4 @@
 .heroes-panel {
-	&__heading {
-		display: flex;
-		align-items: center;
-		margin-bottom: 1rem;
-
-		&-title {
-			font-weight: bold;
-			display: inline-flex;
-
-			&__number {
-				font-weight: normal;
-				margin-left: 0.5rem;
-			}
-		}
-
-		ul&-links {
-			margin: 0 0 0 auto;
-			list-style: none;
-			display: inline-flex;
-
-			> li:not( :first-child ) {
-				margin-left: 0.5rem;
-				display: flex;
-				align-items: center;
-
-				&::before {
-					content: '';
-					width: 0.25rem;
-					height: 0.25rem;
-					background-color: #000;
-					border-radius: 100%;
-					display: block;
-					margin-right: 0.5rem;
-				}
-			}
-		}
-	}
-
-	&__filter {
-		&-group {
-			margin-bottom: 1rem;
-		}
-
-		&-button {
-			min-height: 2rem;
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			padding: 0 0.75rem;
-			border-radius: 0.5rem;
-			font-size: 0.875rem;
-			font-weight: bold;
-			color: var( --clr-wiki-theme-primary );
-			position: relative;
-			z-index: 0;
-			cursor: pointer;
-			margin-right: 0.5rem;
-
-			&::after {
-				content: '';
-				opacity: 0.12;
-				position: absolute;
-				inset: 0;
-				z-index: -1;
-				border-radius: 0.5rem;
-
-				.theme--light & {
-					background-color: var( --clr-wiki-theme-primary );
-				}
-
-				.theme--dark & {
-					background-color: #fff;
-				}
-			}
-
-			@media ( hover: hover ) {
-				&:hover {
-					&::after {
-						opacity: 0.24;
-					}
-				}
-			}
-
-			&.is--active {
-				background-color: var( --clr-wiki-theme-primary );
-				color: #fff;
-			}
-
-			> .icon-left {
-				margin-right: 0.25rem;
-			}
-		}
-	}
-
 	&__category {
 		&-title {
 			display: flex;
@@ -159,21 +65,21 @@
 		}
 
 		ul&-list {
-			@--gutter-y: 0.5rem;
-			@--gutter-x: 0.5rem;
+			@_gutter-y: 0.5rem;
+			@_gutter-x: 0.5rem;
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: center;
 			list-style: none;
-			margin: calc(-.5* @--gutter-y) calc(-.5* @--gutter-x) 0.5rem calc(-.5* @--gutter-x);
+			margin: calc(-.5* @_gutter-y) calc(-.5* @_gutter-x) 0.5rem calc(-.5* @_gutter-x);
 
 			> li {
 				flex: 0 0 auto;
 				width: calc( 100% / 3 );
 				max-width: 100%;
-				padding-right: calc(@--gutter-x* .5);
-				padding-left: calc(@--gutter-x* .5);
-				margin-top: @--gutter-y;
+				padding-right: calc(@_gutter-x* .5);
+				padding-left: calc(@_gutter-x* .5);
+				margin-top: @_gutter-y;
 				margin-bottom: 0;
 
 				@media ( min-width: 576px ) {
@@ -191,11 +97,12 @@
 		}
 	}
 
-	&__hero-card {
+	div.heroes-panel &__hero-card {
+		@_border-radius: 0.25rem;
 		display: flex;
 		position: relative;
-		flex: 1;
 		height: 3.5rem;
+		border-radius: @_border-radius;
 
 		&::before {
 			content: "";
@@ -203,10 +110,11 @@
 			position: absolute;
 			inset: 0;
 			z-index: 1;
+			border-radius: @_border-radius;
 		}
 
 		&.is--unselected {
-			filter: grayscale(1);
+			filter: grayscale( 1 );
 		}
 
 		> img {
@@ -214,6 +122,7 @@
 			object-fit: cover;
 			width: 100%;
 			height: 100%;
+			border-radius: @_border-radius;
 		}
 
 		&__title {
@@ -228,16 +137,24 @@
 			align-items: stretch;
 
 			& > a {
-				color: inherit;
+				color: #fff;
 				display: flex;
 				align-items: flex-end;
 				padding-bottom: 0.25rem;
+				flex: 1;
+				justify-content: center;
 
 				&::before {
 					content: '';
 					position: absolute;
 					inset: 0;
 					z-index: 1;
+				}
+
+				@media ( hover: hover ) {
+					&:hover {
+						background: linear-gradient( rgba( 0, 0, 0, 0 ), rgba( 0, 0, 0, 0.5 ) );
+					}
 				}
 			}
 		}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -71,14 +71,14 @@
 			flex-wrap: wrap;
 			justify-content: center;
 			list-style: none;
-			margin: calc(-.5* @_gutter-y) calc(-.5* @_gutter-x) 0.5rem calc(-.5* @_gutter-x);
+			margin: calc( -0.5* @_gutter-y ) calc( -0.5* @_gutter-x ) 0.5rem calc( -0.5* @_gutter-x );
 
 			> li {
 				flex: 0 0 auto;
 				width: calc( 100% / 3 );
 				max-width: 100%;
-				padding-right: calc(@_gutter-x* .5);
-				padding-left: calc(@_gutter-x* .5);
+				padding-right: calc( @_gutter-x* 0.5 );
+				padding-left: calc (@_gutter-x* 0.5 );
 				margin-top: @_gutter-y;
 				margin-bottom: 0;
 
@@ -126,7 +126,7 @@
 		}
 
 		&__title {
-			color: #fff;
+			color: #ffffff;
 			font-weight: bold;
 			text-shadow: 0 0.0625rem 0.0625rem #000000, 0 0 0.125rem #000000;
 			font-size: 0.6875rem;
@@ -137,7 +137,7 @@
 			align-items: stretch;
 
 			& > a {
-				color: #fff;
+				color: #ffffff;
 				display: flex;
 				align-items: flex-end;
 				padding-bottom: 0.25rem;
@@ -145,7 +145,7 @@
 				justify-content: center;
 
 				&::before {
-					content: '';
+					content: "";
 					position: absolute;
 					inset: 0;
 					z-index: 1;
@@ -153,7 +153,7 @@
 
 				@media ( hover: hover ) {
 					&:hover {
-						color: #fff;
+						color: #ffffff;
 						background: linear-gradient( rgba( 0, 0, 0, 0 ), rgba( 0, 0, 0, 0.5 ) );
 					}
 				}

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -106,7 +106,7 @@
 
 		&::before {
 			content: "";
-			box-shadow: inset 0 0 0 0.125rem rgba(0, 0, 0, 0.7);
+			box-shadow: inset 0 0 0 0.125rem rgba( 0, 0, 0, 0.7 );
 			position: absolute;
 			inset: 0;
 			z-index: 1;

--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -6,7 +6,7 @@
 			align-items: center;
 			border-bottom: 0.5rem solid;
 			padding: 0.5rem 0;
-			margin-bottom: 0.25rem;
+			margin-bottom: 0.5rem;
 
 			.category--strength & {
 				.theme--light & {


### PR DESCRIPTION
## Summary

Add the styling for the heroes section. The filters are left out for now as mentioned in the [ticket](https://gitlab.com/teamliquid-dev/liquipedia/web/extensions/teamliquidintegration/-/issues/134).

The hero rows are scaling based on the viewport width and they have a subtle hover effect.
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/a54657d6-c7ff-49c3-a078-16d4bb094207)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/facc9c45-deaf-438b-9ee0-340652d22cf8)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/ade93129-0e60-407d-b302-28fb1c952703)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/5bde16bf-4858-4280-8077-ec4426239fe4)

## How did you test this change?

On the live wiki: 
https://liquipedia.net/dota2game/User:Elysienna/Main_Page

## AI
Some autocompleting
