### PR TITLE
feat(portalPlayers): Add color for deceased on fifa and smash

### DIFF
--- a/components/portal_players/wikis/fifa/portal_players_custom.lua
+++ b/components/portal_players/wikis/fifa/portal_players_custom.lua
@@ -28,6 +28,7 @@ local BACKGROUND_CLASSES = {
 	inactive = 'sapphire-bg',
 	retired = 'bg-neutral',
 	banned = 'cinnabar-bg',
+	['passed away'] = 'gigas-bg',
 }
 
 local CustomPortalPlayers = {}

--- a/components/portal_players/wikis/smash/portal_players_custom.lua
+++ b/components/portal_players/wikis/smash/portal_players_custom.lua
@@ -26,6 +26,7 @@ local BACKGROUND_CLASSES = {
 	inactive = 'sapphire-bg',
 	retired = 'bg-neutral',
 	banned = 'cinnabar-bg',
+	['passed away'] = 'gigas-bg',
 }
 
 local PortalPlayers = Lua.import('Module:PortalPlayers')


### PR DESCRIPTION
## Summary

Adds the gigas background to deceased persons, in line with https://github.com/Liquipedia/Lua-Modules/pull/4016
I'm leaving Formula 1 out of this PR since it only needs 3 colors

As a side note, I have added gigas to the description on each wikis player portal, similar to the other colors https://liquipedia.net/rainbowsix/Portal:Players/Europe

## How did you test this change?

N/A
