### PR TITLE
fix(partTable): break lpdb loops

### DIFF
--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -164,7 +164,7 @@ function StarcraftParticipantTable:adjustLpdbData(lpdbData, entry, config)
 	lpdbData.qualified = isQualified and 1 or nil
 end
 
----@return table<string, true>
+---@return table<string, placement>
 function StarcraftParticipantTable:getPlacements()
 	local placements = {}
 	local maxPrizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0

--- a/components/participant_table/wikis/stormgate/participant_table_custom.lua
+++ b/components/participant_table/wikis/stormgate/participant_table_custom.lua
@@ -154,14 +154,14 @@ function StormgateParticipantTable:adjustLpdbData(lpdbData, entry, config)
 	lpdbData.qualified = isQualified and 1 or nil
 end
 
----@return table<string, true>
+---@return table<string, placement>
 function StormgateParticipantTable:getPlacements()
 	local placements = {}
 	local maxPrizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0
 
 	for prizePoolIndex = 1, maxPrizePoolIndex do
 		Array.forEach(Json.parseIfTable(prizePoolVars:get('placementRecords.' .. prizePoolIndex)) or {}, function(placement)
-			placements[placement.opponentname] = true
+			placements[placement.opponentname] = placement
 		end)
 	end
 


### PR DESCRIPTION
## Summary
Due to participant table now merging queried placement with the data inputted in the participant table we sometimes get stuck in lpdb loops.
PartTbl reads from lpdb and writes the exact same suff back to lpdb and hence overwrites changes the prize pool made to lpdb in the same page save again.

This PR restricts the data queried from lpdb_placement so that we only retireve the necessary fields and hence reduce the probability of such lpdb loops.
Due to extradata sometimes being needed it also adds a check if extradata should be saved or not and removes it from the to be stored object in the case of it not being needed

Technically in certain situations we could still get stuck in those loops but this PR should reduce the probability significantly.

## How did you test this change?
dev