### PR TITLE
feat(prizePool): Store dateTime from import

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -235,7 +235,7 @@ function Import:_computeGroupTablePlacementEntries(standingRecords, options)
 	for _, record in ipairs(standingRecords) do
 		if options.importWinners or Table.includes(options.groupElimStatuses, record.currentstatus) then
 			local entry = {
-				date = record.extradata.enddate and DateExt.toYmdInUtc(record.extradata.enddate),
+				date = record.extradata.enddate,
 				hasDraw = record.hasDraw,
 				hasOvertime = record.hasOvertime,
 			}
@@ -330,7 +330,7 @@ end
 ---@return table
 function Import._makeEntryFromMatch(placementEntry, match)
 	local entry = {
-		date = DateExt.toYmdInUtc(match.date),
+		date = match.date,
 		matchId = match.matchId,
 	}
 


### PR DESCRIPTION
## Summary
As per [discussion on discord](https://discord.com/channels/93055209017729024/874304000718172200/1246521662036250624) store the dateTime in placement data if importing from match2/standings tables.

Additionally this solves an inconsistency where atm on wikis that use lastvs oppnent data for group finishes where it already stoired the full untruncated date.

## How did you test this change?
dev on sc2