### PR TITLE
fix(infobox): fix upcoming tournaments sometimes not working on Valorant

### DIFF
--- a/components/infobox/wikis/valorant/infobox_team_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_team_custom.lua
@@ -55,7 +55,7 @@ function CustomTeam:createBottomContent()
 		return Template.expandTemplate(
 			mw.getCurrentFrame(),
 			'Upcoming and ongoing tournaments of',
-			{team = self.name or self.pagename}
+			{team = self.pagename}
 		)
 	end
 end


### PR DESCRIPTION
## Summary

Putting Martin's fix into PR as suggested https://discord.com/channels/93055209017729024/268719633366777856/1246923785173467146
I did a quick check via Insource and didn't see any other usage

## How did you test this change?

Martin did a fix live
