### PR TITLE
fix(infobox): dota2game's cosmetic infobox market link does not work for items without defindex while having space in the name

### DIFF
--- a/components/infobox/wikis/dota2game/infobox_cosmetic_custom.lua
+++ b/components/infobox/wikis/dota2game/infobox_cosmetic_custom.lua
@@ -51,8 +51,6 @@ function CustomCosmetic.run(frame)
 	return mw.html.create():node(cosmetic:createInfobox()):node(cosmetic:_createIntroText())
 end
 
--- TODO: Store LPDB
-
 ---@param id string
 ---@param widgets Widget[]
 ---@return Widget[]
@@ -161,7 +159,7 @@ function CustomCosmetic._buyNow(marketable, defindex)
 	if marketable and defindex then
 		link = 'http://steamcommunity.com/market/search/?q=appid:570+prop_def_index:'.. defindex
 	elseif marketable then
-		link = 'http://steamcommunity.com/market/search/?q=appid:570+' .. mw.title.getCurrentTitle().fullText
+		link = 'http://steamcommunity.com/market/search/?q=appid:570+' .. (mw.title.getCurrentTitle().fullText:gsub(' ', '_'))
 	else
 		return
 	end


### PR DESCRIPTION
## Summary
Media wiki's external links requires no spaces in the name. So was causing fault links.

## How did you test this change?
Live