### PR TITLE
fix(infobox): dota2game's cosmetic automatic `setitems`

### DIFF
--- a/components/infobox/wikis/dota2game/infobox_cosmetic_custom.lua
+++ b/components/infobox/wikis/dota2game/infobox_cosmetic_custom.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local CosmeticIcon = require('Module:Cosmetic')
 local DateExt = require('Module:Date/Ext')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -146,7 +147,7 @@ function CustomCosmetic._createSet(setName, manualItems)
 		return manualItems
 	end
 
-	return Array.parseCommaSeparatedString((mw.ext.LiquipediaDB.lpdb('datapoint', {
+	return Json.parseIfString((mw.ext.LiquipediaDB.lpdb('datapoint', {
 		conditions = '[[type::cosmetic_item]] and [[name::'.. setName ..']]',
 		limit = 1,
 	})[1] or {extradata = {}}).extradata.setitems)


### PR DESCRIPTION
## Summary
When adding LPDB Data storage fothe cosmetic item, `setitems` were adding as an array. The template based version stored as CSV. 

## How did you test this change?

Live
