### PR TITLE
refactor: use arrow functions in js

### DIFF
--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -412,9 +412,7 @@ liquipedia.battleRoyale = {
 					this.changeButtonStyle( b, 'default' );
 				}
 				this.changeButtonStyle( button, newOrder );
-				const sorted = sortableRows.sort( function( a, b ) {
-					return this.comparator( a, b, newOrder, sortType );
-				}.bind( this ) );
+				const sorted = sortableRows.sort( ( a, b ) => this.comparator( a, b, newOrder, sortType ) );
 
 				sorted.forEach( ( element, index ) => {
 					if ( element.style.order ) {
@@ -484,7 +482,7 @@ liquipedia.battleRoyale = {
 			this.makeSortableTable( instance );
 		} );
 
-		Object.keys( this.battleRoyaleInstances ).forEach( function ( instanceId ) {
+		Object.keys( this.battleRoyaleInstances ).forEach( ( instanceId ) => {
 			// create object based on id
 			this.buildBattleRoyaleMap( instanceId );
 
@@ -518,7 +516,7 @@ liquipedia.battleRoyale = {
 				this.implementScrollWheelEvent();
 			}
 
-		}.bind( this ) );
+		} );
 	}
 };
 liquipedia.core.modules.push( 'battleRoyale' );

--- a/javascript/commons/Bracket.js
+++ b/javascript/commons/Bracket.js
@@ -44,7 +44,7 @@ liquipedia.bracket = {
 		init: function() {
 			liquipedia.bracket.highlighting.createBinds();
 			liquipedia.bracket.highlighting.createHoverCache();
-			document.querySelectorAll( 'tr.match-row' ).forEach( function( element ) {
+			document.querySelectorAll( 'tr.match-row' ).forEach( ( element ) => {
 				element.addEventListener( 'mouseover', function() {
 					this.classList.add( 'bracket-hover' );
 				} );
@@ -52,10 +52,10 @@ liquipedia.bracket = {
 					this.classList.remove( 'bracket-hover' );
 				} );
 			} );
-			document.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-team-middle, .bracket-team-inner, .bracket-player-top, .bracket-player-bottom, .bracket-player-middle, .bracket-player-inner, .matchlistslot, .matchslot, .grouptableslot' ).forEach( function( element ) {
-				element.addEventListener( 'mouseover', function() {
+			document.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-team-middle, .bracket-team-inner, .bracket-player-top, .bracket-player-bottom, .bracket-player-middle, .bracket-player-inner, .matchlistslot, .matchslot, .grouptableslot' ).forEach( ( element ) => {
+				element.addEventListener( 'mouseover', () => {
 					if ( !liquipedia.bracket.highlighting.filteredSelectors.includes( element.dataset.highlightingkey ) ) {
-						liquipedia.bracket.highlighting.hoverCache[ element.dataset.highlightingkey ].forEach( function( node ) {
+						liquipedia.bracket.highlighting.hoverCache[ element.dataset.highlightingkey ].forEach( ( node ) => {
 							node.classList.add( 'bracket-hover' );
 							if ( typeof node.dataset.backgroundColorHover !== 'undefined' ) {
 								node.style.backgroundColor = node.dataset.backgroundColorHover;
@@ -63,8 +63,8 @@ liquipedia.bracket = {
 						} );
 					}
 				} );
-				element.addEventListener( 'mouseleave', function() {
-					liquipedia.bracket.highlighting.hoverCache[ element.dataset.highlightingkey ].forEach( function( node ) {
+				element.addEventListener( 'mouseleave', () => {
+					liquipedia.bracket.highlighting.hoverCache[ element.dataset.highlightingkey ].forEach( ( node ) => {
 						node.classList.remove( 'bracket-hover' );
 						if ( typeof node.dataset.backgroundColor !== 'undefined' ) {
 							node.style.backgroundColor = node.dataset.backgroundColor;
@@ -87,7 +87,7 @@ liquipedia.bracket = {
 		getTextSelector: function( node ) {
 			const clonedNode = node.cloneNode( true );
 			const children = clonedNode.querySelectorAll( 'div.bracket-score, div.team-template-team-bracket' );
-			children.forEach( function( child ) {
+			children.forEach( ( child ) => {
 				clonedNode.removeChild( child );
 			} );
 			let value = clonedNode.innerHTML;
@@ -99,7 +99,7 @@ liquipedia.bracket = {
 		binds: { },
 		createBinds: function() {
 			const bindingtemplates = document.querySelectorAll( '.bind-highlighting' );
-			bindingtemplates.forEach( function( element ) {
+			bindingtemplates.forEach( ( element ) => {
 				const from = element.querySelector( '.bind-highlighting-from' );
 				const to = element.querySelector( '.bind-highlighting-to' );
 				const fromteamicon = from.querySelector( '.team-template-image img' );
@@ -131,7 +131,7 @@ liquipedia.bracket = {
 		},
 		hoverCache: { },
 		createHoverCache: function() {
-			document.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-team-middle, .bracket-team-inner, .bracket-player-top, .bracket-player-bottom, .bracket-player-middle, .bracket-player-inner, .matchlistslot, .matchslot, .grouptableslot' ).forEach( function( element ) {
+			document.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-team-middle, .bracket-team-inner, .bracket-player-top, .bracket-player-bottom, .bracket-player-middle, .bracket-player-inner, .matchlistslot, .matchslot, .grouptableslot' ).forEach( ( element ) => {
 				const teamicon = element.querySelector( '.team-template-image img' );
 				let selector;
 				if ( teamicon === null ) {
@@ -191,7 +191,7 @@ liquipedia.bracket = {
 		},
 		popupBox: null,
 		createIcons: function() {
-			document.querySelectorAll( '.bracket-game' ).forEach( function( element ) {
+			document.querySelectorAll( '.bracket-game' ).forEach( ( element ) => {
 				const popupwrapper = element.querySelector( '.bracket-popup-wrapper' );
 				if ( popupwrapper !== null ) {
 					const icon = document.createElement( 'div' );
@@ -204,13 +204,13 @@ liquipedia.bracket = {
 						icon.style.right = '16px';
 					}
 					element.appendChild( icon );
-					element.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-player-top, .bracket-player-bottom' ).forEach( function( node ) {
+					element.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-player-top, .bracket-player-bottom' ).forEach( ( node ) => {
 						node.style.cursor = 'pointer';
 						node.title = 'Click for further information';
 					} );
 				}
 			} );
-			document.querySelectorAll( '.match-row' ).forEach( function( element ) {
+			document.querySelectorAll( '.match-row' ).forEach( ( element ) => {
 				const popupwrapper = element.querySelector( '.bracket-popup-wrapper' );
 				if ( popupwrapper !== null ) {
 					const icon = document.createElement( 'div' );
@@ -220,7 +220,7 @@ liquipedia.bracket = {
 					icon.appendChild( iconinner );
 					let iconHolder;
 					let i = 0;
-					element.childNodes.forEach( function( node ) {
+					element.childNodes.forEach( ( node ) => {
 						if ( typeof node.tagName !== 'undefined' && node.tagName.toLowerCase() === 'td' ) {
 							i++;
 							if ( i === 3 ) {
@@ -229,17 +229,17 @@ liquipedia.bracket = {
 						}
 					} );
 					iconHolder.insertBefore( icon, iconHolder.firstChild );
-					element.querySelectorAll( '.matchlistslot' ).forEach( function( node ) {
+					element.querySelectorAll( '.matchlistslot' ).forEach( ( node ) => {
 						node.style.cursor = 'pointer';
 						node.title = 'Click for further information';
-						node.querySelectorAll( 'a' ).forEach( function( link ) {
+						node.querySelectorAll( 'a' ).forEach( ( link ) => {
 							link.href = '#';
 							link.classList.remove( 'new' );
 						} );
 					} );
 				}
 			} );
-			document.querySelectorAll( '.table-battleroyale-results-round' ).forEach( function( element ) {
+			document.querySelectorAll( '.table-battleroyale-results-round' ).forEach( ( element ) => {
 				const popupwrapper = element.querySelector( '.bracket-popup-wrapper' );
 				if ( popupwrapper !== null ) {
 					const icon = document.createElement( 'div' );
@@ -252,7 +252,7 @@ liquipedia.bracket = {
 			} );
 		},
 		createToggles: function() {
-			document.querySelector( 'html' ).addEventListener( 'click', function( ev ) {
+			document.querySelector( 'html' ).addEventListener( 'click', ( ev ) => {
 				if ( ev.target.closest( '.bracket-popup-wrapper' ) === null ) {
 					if ( liquipedia.bracket.popup.popupBox !== null ) {
 						liquipedia.bracket.popup.popupBox.querySelector( '.bracket-popup-wrapper' ).style.display = 'none';
@@ -261,13 +261,13 @@ liquipedia.bracket = {
 					}
 				}
 			} );
-			document.querySelectorAll( '.bracket-popup-wrapper' ).forEach( function( el ) {
-				el.addEventListener( 'click', function( ev ) {
+			document.querySelectorAll( '.bracket-popup-wrapper' ).forEach( ( el ) => {
+				el.addEventListener( 'click', ( ev ) => {
 					ev.stopPropagation();
 				} );
 			} );
-			document.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-team-inner, .bracket-player-top, .bracket-player-bottom, .bracket-player-inner, .bracket-game .icon' ).forEach( function( element ) {
-				element.addEventListener( 'click', function( event ) {
+			document.querySelectorAll( '.bracket-team-top, .bracket-team-bottom, .bracket-team-inner, .bracket-player-top, .bracket-player-bottom, .bracket-player-inner, .bracket-game .icon' ).forEach( ( element ) => {
+				element.addEventListener( 'click', ( event ) => {
 					const newPopupWrapper = element.closest( '.bracket-game' );
 					if ( liquipedia.bracket.popup.popupBox !== null ) {
 						liquipedia.bracket.popup.popupBox.querySelector( '.bracket-popup-wrapper' ).style.display = 'none';
@@ -288,8 +288,8 @@ liquipedia.bracket = {
 					event.stopPropagation();
 				} );
 			} );
-			document.querySelectorAll( '.match-row' ).forEach( function( element ) {
-				element.addEventListener( 'click', function( event ) {
+			document.querySelectorAll( '.match-row' ).forEach( ( element ) => {
+				element.addEventListener( 'click', ( event ) => {
 					const newPopupWrapper = element;
 					if ( liquipedia.bracket.popup.popupBox !== null ) {
 						liquipedia.bracket.popup.popupBox.querySelector( '.bracket-popup-wrapper' ).style.display = 'none';
@@ -310,8 +310,8 @@ liquipedia.bracket = {
 					event.stopPropagation();
 				} );
 			} );
-			document.querySelectorAll( '.table-battleroyale-results-round' ).forEach( function( element ) {
-				element.addEventListener( 'click', function( event ) {
+			document.querySelectorAll( '.table-battleroyale-results-round' ).forEach( ( element ) => {
+				element.addEventListener( 'click', ( event ) => {
 					const newPopupWrapper = element;
 					if ( liquipedia.bracket.popup.popupBox !== null ) {
 						liquipedia.bracket.popup.popupBox.querySelector( '.bracket-popup-wrapper' ).style.display = 'none';
@@ -428,7 +428,7 @@ liquipedia.bracket = {
 					bruinenBracketScroll.addEventListener( 'scroll', liquipedia.bracket.popup.positionBracketPopup );
 				}
 				window.addEventListener( 'resize', liquipedia.bracket.popup.positionBracketPopup );
-				document.querySelectorAll( '.bracket-wrapper' ).forEach( function( element ) {
+				document.querySelectorAll( '.bracket-wrapper' ).forEach( ( element ) => {
 					element.addEventListener( 'scroll', liquipedia.bracket.popup.positionBracketPopup );
 				} );
 			}

--- a/javascript/commons/Collapse.js
+++ b/javascript/commons/Collapse.js
@@ -4,7 +4,7 @@
  ******************************************************************************/
 liquipedia.collapse = {
 	init: function() {
-		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( function( table, index ) {
+		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( ( table, index ) => {
 			if ( table.classList.contains( 'autocollapse' ) && index >= 1 ) {
 				table.classList.add( 'collapsed' );
 			}
@@ -17,7 +17,7 @@ liquipedia.collapse = {
 		liquipedia.collapse.setupCollapsibleNavFrameButtons();
 	},
 	setupCollapsibleButtons: function() {
-		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( function( collapsible ) {
+		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( ( collapsible ) => {
 			const row = collapsible.querySelector( 'tr' );
 			if ( row !== null ) {
 				const collapseShowButton = document.createElement( 'span' );
@@ -64,7 +64,7 @@ liquipedia.collapse = {
 		// For xss safety, only the child nodes and class name are copied over.
 		function replaceWithAnchor( button ) {
 			const anchor = document.createElement( 'a' );
-			button.childNodes.forEach( function ( node ) {
+			button.childNodes.forEach( ( node ) => {
 				anchor.append( node );
 			} );
 			anchor.className = button.className;
@@ -73,13 +73,13 @@ liquipedia.collapse = {
 			return anchor;
 		}
 
-		document.querySelectorAll( '#mw-content-text .general-collapsible' ).forEach( function( collapsible ) {
+		document.querySelectorAll( '#mw-content-text .general-collapsible' ).forEach( ( collapsible ) => {
 			const collapseButton = collapsible.querySelector( '.general-collapsible-collapse-button' );
 			const expandButton = collapsible.querySelector( '.general-collapsible-expand-button' );
 
 			if ( expandButton ) {
 				const anchor = replaceWithAnchor( expandButton );
-				anchor.addEventListener( 'click', function( event ) {
+				anchor.addEventListener( 'click', ( event ) => {
 					collapsible.classList.remove( 'collapsed' );
 					event.preventDefault();
 				} );
@@ -87,7 +87,7 @@ liquipedia.collapse = {
 
 			if ( collapseButton ) {
 				const anchor = replaceWithAnchor( collapseButton );
-				anchor.addEventListener( 'click', function( event ) {
+				anchor.addEventListener( 'click', ( event ) => {
 					collapsible.classList.add( 'collapsed' );
 					event.preventDefault();
 				} );
@@ -95,7 +95,7 @@ liquipedia.collapse = {
 		} );
 	},
 	setupCollapsibleMapsButtons: function() {
-		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( function( collapsible ) {
+		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( ( collapsible ) => {
 			const row = collapsible.querySelector( 'tr' );
 			if ( row !== null && collapsible.querySelector( '.maprow' ) !== null ) {
 				const collapseShowButton = document.createElement( 'span' );
@@ -130,7 +130,7 @@ liquipedia.collapse = {
 		} );
 	},
 	setupCollapsibleNavFrameButtons: function() {
-		document.querySelectorAll( '#mw-content-text .NavFrame' ).forEach( function( navFrame ) {
+		document.querySelectorAll( '#mw-content-text .NavFrame' ).forEach( ( navFrame ) => {
 			const head = navFrame.querySelector( '.NavHead' );
 			if ( head !== null ) {
 				const collapseShowButton = document.createElement( 'span' );
@@ -165,7 +165,7 @@ liquipedia.collapse = {
 		} );
 	},
 	setupToggleGroups: function() {
-		document.querySelectorAll( '#mw-content-text .toggle-group' ).forEach( function( toggleGroup ) {
+		document.querySelectorAll( '#mw-content-text .toggle-group' ).forEach( ( toggleGroup ) => {
 			let showAllText;
 			if ( toggleGroup.dataset.showAllText !== undefined ) {
 				showAllText = toggleGroup.dataset.showAllText;
@@ -189,20 +189,20 @@ liquipedia.collapse = {
 					toggleGroup.classList.remove( 'toggle-state-hide' );
 					toggleGroup.classList.add( 'toggle-state-show' );
 					this.innerHTML = showAllText;
-					toggleGroup.querySelectorAll( '.collapsible, .general-collapsible' ).forEach( function( collapsible ) {
+					toggleGroup.querySelectorAll( '.collapsible, .general-collapsible' ).forEach( ( collapsible ) => {
 						collapsible.classList.add( 'collapsed' );
 					} );
-					toggleGroup.querySelectorAll( '.brkts-matchlist-collapsible' ).forEach( function( collapsible ) {
+					toggleGroup.querySelectorAll( '.brkts-matchlist-collapsible' ).forEach( ( collapsible ) => {
 						collapsible.classList.add( 'brkts-matchlist-collapsed' );
 					} );
 				} else {
 					toggleGroup.classList.remove( 'toggle-state-show' );
 					toggleGroup.classList.add( 'toggle-state-hide' );
 					this.innerHTML = hideAllText;
-					toggleGroup.querySelectorAll( '.collapsible, .general-collapsible' ).forEach( function( collapsible ) {
+					toggleGroup.querySelectorAll( '.collapsible, .general-collapsible' ).forEach( ( collapsible ) => {
 						collapsible.classList.remove( 'collapsed' );
 					} );
-					toggleGroup.querySelectorAll( '.brkts-matchlist-collapsible' ).forEach( function( collapsible ) {
+					toggleGroup.querySelectorAll( '.brkts-matchlist-collapsible' ).forEach( ( collapsible ) => {
 						collapsible.classList.remove( 'brkts-matchlist-collapsed' );
 					} );
 				}
@@ -212,29 +212,29 @@ liquipedia.collapse = {
 	},
 	setupDropdownBox: function() {
 		let toggleActive = false;
-		document.querySelector( 'html' ).addEventListener( 'click', function( ev ) {
+		document.querySelector( 'html' ).addEventListener( 'click', ( ev ) => {
 			if ( ev.target.closest( '.dropdown-box' ) === null ) {
 				if ( toggleActive ) {
-					document.querySelectorAll( '.dropdown-box-visible' ).forEach( function( box ) {
+					document.querySelectorAll( '.dropdown-box-visible' ).forEach( ( box ) => {
 						box.classList.remove( 'dropdown-box-visible' );
 					} );
 					toggleActive = false;
 				}
 			}
 		} );
-		document.querySelectorAll( '#mw-content-text .dropdown-box-wrapper' ).forEach( function( dropdownBox ) {
+		document.querySelectorAll( '#mw-content-text .dropdown-box-wrapper' ).forEach( ( dropdownBox ) => {
 			const dropdownButton = dropdownBox.querySelector( '.dropdown-box-button' );
 			dropdownButton.onclick = function( ev ) {
 				ev.stopPropagation();
-				dropdownBox.querySelectorAll( '.dropdown-box' ).forEach( function ( box ) {
+				dropdownBox.querySelectorAll( '.dropdown-box' ).forEach( ( box ) => {
 					if ( box.classList.contains( 'dropdown-box-visible' ) ) {
 						box.classList.remove( 'dropdown-box-visible' );
 						toggleActive = false;
 					} else {
 						box.classList.add( 'dropdown-box-visible' );
 						toggleActive = true;
-						box.querySelectorAll( '.btn' ).forEach( function( btn ) {
-							btn.addEventListener( 'click', function() {
+						box.querySelectorAll( '.btn' ).forEach( ( btn ) => {
+							btn.addEventListener( 'click', () => {
 								dropdownButton.innerHTML = btn.textContent + ' <span class="caret"></span>';
 								box.classList.remove( 'dropdown-box-visible' );
 								toggleActive = false;

--- a/javascript/commons/Commons_mainpage.js
+++ b/javascript/commons/Commons_mainpage.js
@@ -8,7 +8,7 @@ liquipedia.commonsmainpage = {
 		liquipedia.commonsmainpage.showRecentUploads();
 	},
 	redirectUpload: function() {
-		window.addEventListener( 'load', function() {
+		window.addEventListener( 'load', () => {
 			if ( ( mw.config.get( 'wgPageName' ) === 'Special:Upload' ) && ( mw.config.get( 'wgNamespaceNumber' ) === -1 ) && ( typeof mw.user.isAnon === 'function' ) && ( mw.user.isAnon() ) ) {
 				let url = document.querySelector( '#mw-content-text a' ).href;
 				if ( !url.startsWith( 'http' ) ) {
@@ -19,7 +19,7 @@ liquipedia.commonsmainpage = {
 		} );
 	},
 	showRecentUploads: function() {
-		mw.loader.using( 'mediawiki.api' ).then( function() {
+		mw.loader.using( 'mediawiki.api' ).then( () => {
 			const latestUploads = document.getElementById( 'latest-uploads' );
 			if ( latestUploads !== null ) {
 				const api = new mw.Api();
@@ -30,9 +30,9 @@ liquipedia.commonsmainpage = {
 					lelimit: 20,
 					continue: '',
 					format: 'json'
-				} ).done( function( logEntries ) {
+				} ).done( ( logEntries ) => {
 					const imageNames = [ ];
-					logEntries.query.logevents.forEach( function( title ) {
+					logEntries.query.logevents.forEach( ( title ) => {
 						imageNames.push( title.title );
 					} );
 					api.get( {
@@ -42,12 +42,12 @@ liquipedia.commonsmainpage = {
 						iiprop: 'url',
 						iiurlheight: 150,
 						format: 'json'
-					} ).done( function( imageData ) {
+					} ).done( ( imageData ) => {
 						// let imageUrls = [ ];
 						// imageUrls = imageUrls.reverse();
 						let output = '';
 						let counter = 0;
-						Object.keys( imageData.query.pages ).reverse().forEach( function( key ) {
+						Object.keys( imageData.query.pages ).reverse().forEach( ( key ) => {
 							const image = imageData.query.pages[ key ];
 							if ( typeof image.imageinfo !== 'undefined' ) {
 								if ( counter++ < 10 ) {

--- a/javascript/commons/Commons_tools.js
+++ b/javascript/commons/Commons_tools.js
@@ -33,7 +33,7 @@ liquipedia.commonstools = {
 			const api = new mw.ForeignApi( '/api.php' );
 			api.get( {
 				action: 'listwikis'
-			} ).done( function( data ) {
+			} ).done( ( data ) => {
 				liquipedia.commonstools.wikis = data.allwikis;
 				callback();
 			} );
@@ -43,7 +43,7 @@ liquipedia.commonstools = {
 	},
 	checkForPageExistence: function( ev ) {
 		ev.preventDefault();
-		mw.loader.using( [ 'mediawiki.ForeignApi', 'mediawiki.api' ], function() {
+		mw.loader.using( [ 'mediawiki.ForeignApi', 'mediawiki.api' ], () => {
 			liquipedia.commonstools.setupWikisWithCallback( liquipedia.commonstools.checkForPageExistenceReal );
 		} );
 	},
@@ -76,7 +76,7 @@ liquipedia.commonstools = {
 			format: 'json',
 			formatversion: 2,
 			titles: title
-		} ).done( function( data ) {
+		} ).done( ( data ) => {
 			if ( !Object.prototype.hasOwnProperty.call( data, 'query' ) ) {
 				listElement.innerHTML = '<span style="color:#0000ff;">You need to put in a valid page title</span>';
 			} else {
@@ -110,7 +110,7 @@ liquipedia.commonstools = {
 	},
 	checkPageText: function( ev ) {
 		ev.preventDefault();
-		mw.loader.using( [ 'mediawiki.ForeignApi', 'mediawiki.api' ], function() {
+		mw.loader.using( [ 'mediawiki.ForeignApi', 'mediawiki.api' ], () => {
 			liquipedia.commonstools.setupWikisWithCallback( liquipedia.commonstools.checkPageTextReal );
 		} );
 	},
@@ -133,7 +133,7 @@ liquipedia.commonstools = {
 				format: 'json',
 				formatversion: 2,
 				titles: title
-			} ).done( function( data ) {
+			} ).done( ( data ) => {
 				if ( !Object.prototype.hasOwnProperty.call( data, 'query' ) ) {
 					listElement.innerHTML = '<span style="color:#0000ff;">You need to put in a valid page title</span>';
 				} else {
@@ -170,7 +170,7 @@ liquipedia.commonstools = {
 			format: 'json',
 			formatversion: 2,
 			titles: title
-		} ).done( function( data ) {
+		} ).done( ( data ) => {
 			if ( !Object.prototype.hasOwnProperty.call( data, 'query' ) ) {
 				listElement.innerHTML = '<span style="color:#0000ff;">You need to put in a valid page title</span>';
 			} else {
@@ -203,12 +203,12 @@ liquipedia.commonstools = {
 						listElement.append( postButton );
 					}
 				}
-				postButton.addEventListener( 'click', function() {
+				postButton.addEventListener( 'click', () => {
 					const api2 = new mw.Api( { ajax: { url: wikiData.api } } );
 					api2.get( {
 						action: 'query',
 						meta: 'tokens'
-					} ).done( function( data2 ) {
+					} ).done( ( data2 ) => {
 						const editToken = data2.query.tokens.csrftoken;
 						if ( editToken === '+\\' ) {
 							const errorMessage = document.createElement( 'p' );
@@ -221,7 +221,7 @@ liquipedia.commonstools = {
 								title: title,
 								text: liquipedia.commonstools.checkPageTextRealSourceText,
 								token: editToken
-							} ).done( function() {
+							} ).done( () => {
 								const successMessage = document.createElement( 'p' );
 								successMessage.style.color = '#006400';
 								successMessage.innerHTML = 'Transferred!';
@@ -234,12 +234,12 @@ liquipedia.commonstools = {
 		} );
 	},
 	timeoutPageExistenceApi: function( i, wiki, wikiData, title, listElement ) {
-		setTimeout( function() {
+		setTimeout( () => {
 			liquipedia.commonstools.checkForPageExistenceApiCall( wiki, wikiData, title, listElement );
 		}, i * 1000 );
 	},
 	timeoutPageTextApi: function( i, wiki, wikiData, title, sourceWiki, listElement ) {
-		setTimeout( function() {
+		setTimeout( () => {
 			liquipedia.commonstools.checkPageTextApiCall( wiki, wikiData, title, sourceWiki, listElement );
 		}, i * 1000 );
 	}

--- a/javascript/commons/CopyToClipboard.js
+++ b/javascript/commons/CopyToClipboard.js
@@ -4,7 +4,7 @@
  ******************************************************************************/
 liquipedia.copytoclipboard = {
 	init: function() {
-		document.querySelectorAll( '.copy-to-clipboard' ).forEach( function( copy ) {
+		document.querySelectorAll( '.copy-to-clipboard' ).forEach( ( copy ) => {
 			const button = copy.querySelector( '.see-this' );
 			if ( button !== null ) {
 				button.addEventListener( 'click', liquipedia.copytoclipboard.buttonEventListener );
@@ -56,7 +56,7 @@ liquipedia.copytoclipboard = {
 			trigger: 'manual'
 		} );
 		$copy.tooltip( 'show' );
-		window.setTimeout( function() {
+		window.setTimeout( () => {
 			$copy.tooltip( 'hide' );
 		}, timeout );
 	}

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -6,8 +6,8 @@ liquipedia.countdown = {
 	init: function() {
 		liquipedia.countdown.timerObjectNodes = document.querySelectorAll( '.timer-object' );
 		if ( liquipedia.countdown.timerObjectNodes.length > 0 ) {
-			mw.loader.using( 'user.options', function() {
-				liquipedia.countdown.timerObjectNodes.forEach( function( timerObjectNode ) {
+			mw.loader.using( 'user.options', () => {
+				liquipedia.countdown.timerObjectNodes.forEach( ( timerObjectNode ) => {
 					const dateObject = liquipedia.countdown.parseTimerObjectNodeToDateObj( timerObjectNode );
 					const dateChild = document.createElement( 'span' );
 					if ( typeof dateObject === 'object' ) {
@@ -38,7 +38,7 @@ liquipedia.countdown = {
 					timerObjectNode.appendChild( countdownChild );
 				} );
 				// Only run when the window is actually in the front, not in background tabs (on browsers that support it)
-				mw.loader.using( 'mediawiki.visibleTimeout' ).then( function( require ) {
+				mw.loader.using( 'mediawiki.visibleTimeout' ).then( ( require ) => {
 					liquipedia.countdown.timeoutFunctions = require( 'mediawiki.visibleTimeout' );
 					liquipedia.countdown.runCountdown();
 				} );
@@ -54,7 +54,7 @@ liquipedia.countdown = {
 		return new Date( 1000 * parseInt( timerObjectNode.dataset.timestamp ) );
 	},
 	runCountdown: function() {
-		liquipedia.countdown.timerObjectNodes.forEach( function( timerObjectNode ) {
+		liquipedia.countdown.timerObjectNodes.forEach( ( timerObjectNode ) => {
 			liquipedia.countdown.setCountdownString( timerObjectNode );
 		} );
 		liquipedia.countdown.timeoutFunctions.set( liquipedia.countdown.runCountdown, 1000 );
@@ -294,7 +294,7 @@ liquipedia.countdown = {
 		const dateTimeFormat = new Intl.DateTimeFormat( 'en', { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone, timeZoneName: 'long' } );
 		if ( typeof Intl.DateTimeFormat.prototype.formatToParts === 'function' ) {
 			date = dateTimeFormat.formatToParts( dateObject );
-			date.forEach( function( element ) {
+			date.forEach( ( element ) => {
 				if ( element.type === 'timeZoneName' ) {
 					result = element.value;
 				}

--- a/javascript/commons/Crosstable.js
+++ b/javascript/commons/Crosstable.js
@@ -4,8 +4,8 @@
  ******************************************************************************/
 liquipedia.crosstable = {
 	init: function() {
-		document.querySelectorAll( '.crosstable' ).forEach( function( crosstable ) {
-			crosstable.querySelectorAll( 'td, th' ).forEach( function( cell ) {
+		document.querySelectorAll( '.crosstable' ).forEach( ( crosstable ) => {
+			crosstable.querySelectorAll( 'td, th' ).forEach( ( cell ) => {
 				cell.onmouseover = function() {
 					const row = this.closest( 'tr' );
 					crosstable.classList.add( 'crosstable-row-' + ( row.rowIndex + 1 ) );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -240,9 +240,7 @@ liquipedia.filterButtons = {
 				if ( filterGroup.curated || filterGroup.defaultCurated ) {
 					return filterGroup.curated === filterGroup.defaultCurated;
 				}
-				return Object.keys( filterGroup.filterStates ).every( ( filterState ) => {
-					return filterGroup.filterStates[ filterState ] === filterGroup.defaultStates[ filterState ];
-				} );
+				return Object.keys( filterGroup.filterStates ).every( ( filterState ) => filterGroup.filterStates[ filterState ] === filterGroup.defaultStates[ filterState ] );
 			} );
 			if ( isDefault ) {
 				templateExpansion.element.innerHTML = templateExpansion.cache.default;

--- a/javascript/commons/Mainpage.js
+++ b/javascript/commons/Mainpage.js
@@ -13,13 +13,13 @@ liquipedia.mainpage = {
 			liquipedia.mainpage.getData( month, day );
 		}
 		/* Birthday link */
-		document.querySelectorAll( '.share-birthday' ).forEach( function( birthdayIcon ) {
+		document.querySelectorAll( '.share-birthday' ).forEach( ( birthdayIcon ) => {
 			birthdayIcon.style.cursor = 'pointer';
 			birthdayIcon.onclick = liquipedia.mainpage.shareBirthday;
 		} );
 	},
 	getData: function( month, day ) {
-		mw.loader.using( [ 'mediawiki.api', 'mediawiki.util' ] ).then( function() {
+		mw.loader.using( [ 'mediawiki.api', 'mediawiki.util' ] ).then( () => {
 			const api = new mw.Api();
 			api.get( {
 				action: 'parse',
@@ -28,7 +28,7 @@ liquipedia.mainpage = {
 				page: 'Liquipedia:This_day/' + month + '/' + day,
 				disablelimitreport: true,
 				format: 'json'
-			} ).done( function( data ) {
+			} ).done( ( data ) => {
 				liquipedia.mainpage.useData( data, month, day );
 			} );
 		} );
@@ -38,11 +38,11 @@ liquipedia.mainpage = {
 			document.getElementById( 'this-day-date' ).innerHTML = '(' + liquipedia.mainpage.getMonthName( month ) + ' ' + liquipedia.mainpage.getOrdinal( day ) + ')';
 			document.getElementById( 'this-day-trivialink' ).innerHTML = 'Add trivia about this day <a href="' + mw.util.getUrl( 'Liquipedia:This_day/' + month + '/' + day ) + '" title="Liquipedia:This day/' + month + '/' + day + '">here</a>.';
 			document.getElementById( 'this-day-facts' ).innerHTML = data.parse.text[ '*' ].replace( '<p><br />\n</p>', '' );
-			document.querySelectorAll( '.age' ).forEach( function( age ) {
+			document.querySelectorAll( '.age' ).forEach( ( age ) => {
 				age.innerHTML = ( new Date() ).getFullYear() - age.dataset.year;
 			} );
 			/* Birthday link */
-			document.getElementById( 'this-day-facts' ).querySelectorAll( '.share-birthday' ).forEach( function( birthdayIcon ) {
+			document.getElementById( 'this-day-facts' ).querySelectorAll( '.share-birthday' ).forEach( ( birthdayIcon ) => {
 				birthdayIcon.style.cursor = 'pointer';
 				birthdayIcon.onclick = liquipedia.mainpage.shareBirthday;
 			} );
@@ -78,7 +78,7 @@ liquipedia.mainpage = {
 	shareBirthday: function( event ) {
 		event.stopPropagation();
 		const button = this;
-		mw.loader.using( 'mediawiki.util' ).then( function() {
+		mw.loader.using( 'mediawiki.util' ).then( () => {
 			const url = mw.config.get( 'wgServer' ) + mw.config.get( 'wgArticlePath' ).replace( '$1', mw.util.wikiUrlencode( button.dataset.page ) );
 			const twitterhandlearr = button.dataset.url.replace( '#!/', '' ).replace( '[', '' ).replace( ']', '' ).split( ' ' )[ 0 ].split( 'twitter.com/' );
 			const twitterhandle = twitterhandlearr[ twitterhandlearr.length - 1 ];

--- a/javascript/commons/Miscellaneous.js
+++ b/javascript/commons/Miscellaneous.js
@@ -19,7 +19,7 @@ liquipedia.core.modules.push( 'timeline' );
 liquipedia.teamcard = {
 	init: function() {
 		let teamcardsopened = false;
-		document.querySelectorAll( '.teamcard-toggle-button' ).forEach( function( wrap ) {
+		document.querySelectorAll( '.teamcard-toggle-button' ).forEach( ( wrap ) => {
 			let showplayers;
 			if ( wrap.dataset.showAllText !== undefined ) {
 				showplayers = wrap.dataset.showAllText;
@@ -34,21 +34,21 @@ liquipedia.teamcard = {
 			}
 			const button = document.createElement( 'button' );
 			button.innerHTML = showplayers;
-			button.addEventListener( 'click', function() {
+			button.addEventListener( 'click', () => {
 				if ( teamcardsopened ) {
 					teamcardsopened = false;
-					document.querySelectorAll( '.teamcard-toggle-button button' ).forEach( function( btn ) {
+					document.querySelectorAll( '.teamcard-toggle-button button' ).forEach( ( btn ) => {
 						btn.innerHTML = showplayers;
 					} );
-					document.querySelectorAll( '.teamcard' ).forEach( function( teamcard ) {
+					document.querySelectorAll( '.teamcard' ).forEach( ( teamcard ) => {
 						teamcard.classList.remove( 'teamcard-opened' );
 					} );
 				} else {
 					teamcardsopened = true;
-					document.querySelectorAll( '.teamcard-toggle-button button' ).forEach( function( btn ) {
+					document.querySelectorAll( '.teamcard-toggle-button button' ).forEach( ( btn ) => {
 						btn.innerHTML = hideplayers;
 					} );
-					document.querySelectorAll( '.teamcard' ).forEach( function( teamcard ) {
+					document.querySelectorAll( '.teamcard' ).forEach( ( teamcard ) => {
 						teamcard.classList.add( 'teamcard-opened' );
 					} );
 				}
@@ -61,7 +61,7 @@ liquipedia.teamcard = {
 		const showsubs = 'Show Substitutes';
 		const hidesubs = 'Hide Substitutes';
 		const showsubsShort = 'Subs';
-		document.querySelectorAll( '.teamcard-former-toggle-button' ).forEach( function( wrap ) {
+		document.querySelectorAll( '.teamcard-former-toggle-button' ).forEach( ( wrap ) => {
 			const teamcard = wrap.closest( '.teamcard' );
 			const button = document.createElement( 'button' );
 			let width = 156;
@@ -77,9 +77,9 @@ liquipedia.teamcard = {
 			}
 			button.style.width = width + 'px';
 			button.dataset.width = width;
-			button.addEventListener( 'click', function() {
+			button.addEventListener( 'click', () => {
 				if ( teamcard.classList.contains( 'teamcard-former-opened' ) ) {
-					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( ( btn ) => {
 						if ( typeof btn.dataset.width !== 'undefined' ) {
 							const btnWidth = parseInt( btn.dataset.width );
 							if ( btnWidth < 156 ) {
@@ -91,10 +91,10 @@ liquipedia.teamcard = {
 					} );
 					teamcard.classList.remove( 'teamcard-former-opened' );
 				} else {
-					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( ( btn ) => {
 						btn.innerHTML = hideformer;
 					} );
-					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( ( btn ) => {
 						if ( typeof btn.dataset.width !== 'undefined' ) {
 							const btnWidth = parseInt( btn.dataset.width );
 							if ( btnWidth < 156 ) {
@@ -111,7 +111,7 @@ liquipedia.teamcard = {
 			wrap.appendChild( button );
 		} );
 
-		document.querySelectorAll( '.teamcard-subs-toggle-button' ).forEach( function( wrap ) {
+		document.querySelectorAll( '.teamcard-subs-toggle-button' ).forEach( ( wrap ) => {
 			const teamcard = wrap.closest( '.teamcard' );
 			const button = document.createElement( 'button' );
 			let width = 156;
@@ -127,9 +127,9 @@ liquipedia.teamcard = {
 			}
 			button.style.width = width + 'px';
 			button.dataset.width = width;
-			button.addEventListener( 'click', function() {
+			button.addEventListener( 'click', () => {
 				if ( teamcard.classList.contains( 'teamcard-subs-opened' ) ) {
-					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( ( btn ) => {
 						if ( typeof btn.dataset.width !== 'undefined' ) {
 							const btnWidth = parseInt( btn.dataset.width );
 							if ( btnWidth < 156 ) {
@@ -141,10 +141,10 @@ liquipedia.teamcard = {
 					} );
 					teamcard.classList.remove( 'teamcard-subs-opened' );
 				} else {
-					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( ( btn ) => {
 						btn.innerHTML = hidesubs;
 					} );
-					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( ( btn ) => {
 						if ( typeof btn.dataset.width !== 'undefined' ) {
 							const btnWidth = parseInt( btn.dataset.width );
 							if ( btnWidth < 156 ) {
@@ -162,7 +162,7 @@ liquipedia.teamcard = {
 		} );
 		const showactive = 'Show Active';
 		const showactiveShort = 'Active';
-		document.querySelectorAll( '.teamcard-active-toggle-button' ).forEach( function( wrap ) {
+		document.querySelectorAll( '.teamcard-active-toggle-button' ).forEach( ( wrap ) => {
 			const teamcard = wrap.closest( '.teamcard' );
 			const button = document.createElement( 'button' );
 			let width = 156;
@@ -178,11 +178,11 @@ liquipedia.teamcard = {
 			}
 			button.style.width = width + 'px';
 			button.dataset.width = width;
-			button.addEventListener( 'click', function() {
+			button.addEventListener( 'click', () => {
 				if ( teamcard.classList.contains( 'teamcard-former-opened' ) || teamcard.classList.contains( 'teamcard-subs-opened' ) ) {
 					teamcard.classList.remove( 'teamcard-former-opened' );
 					teamcard.classList.remove( 'teamcard-subs-opened' );
-					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-former-toggle-button button' ).forEach( ( btn ) => {
 						if ( typeof btn.dataset.width !== 'undefined' ) {
 							const btnWidth = parseInt( btn.dataset.width );
 							if ( btnWidth < 156 ) {
@@ -192,7 +192,7 @@ liquipedia.teamcard = {
 							}
 						}
 					} );
-					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( function( btn ) {
+					teamcard.querySelectorAll( '.teamcard-subs-toggle-button button' ).forEach( ( btn ) => {
 						if ( typeof btn.dataset.width !== 'undefined' ) {
 							const btnWidth = parseInt( btn.dataset.width );
 							if ( btnWidth < 156 ) {
@@ -217,7 +217,7 @@ liquipedia.core.modules.push( 'teamcard' );
 liquipedia.tournamentstable = {
 	init: function() {
 		if ( document.querySelector( '.tournamentstable' ) !== null ) {
-			mw.loader.using( 'jquery.tablesorter' ).then( function() {
+			mw.loader.using( 'jquery.tablesorter' ).then( () => {
 				if ( $.fn.tablesorter ) {
 					$( '.tournamentstable' ).tablesorter( { sortList: [ { 1: 'desc' }, { 0: 'desc' } ] } );
 				} else {
@@ -237,7 +237,7 @@ liquipedia.core.modules.push( 'tournamentstable' );
 liquipedia.participantstable = {
 	init: function() {
 		if ( document.querySelector( '.participants-table-scroller' ) !== null ) {
-			document.querySelectorAll( '.participants-table-button-left' ).forEach( function( buttonLeft ) {
+			document.querySelectorAll( '.participants-table-button-left' ).forEach( ( buttonLeft ) => {
 				buttonLeft.classList.add( 'inactive' );
 				buttonLeft.addEventListener( 'click', function() {
 					if ( window.innerWidth < 600 ) {
@@ -246,7 +246,7 @@ liquipedia.participantstable = {
 					}
 				} );
 			} );
-			document.querySelectorAll( '.participants-table-button-right' ).forEach( function( buttonRight ) {
+			document.querySelectorAll( '.participants-table-button-right' ).forEach( ( buttonRight ) => {
 				buttonRight.addEventListener( 'click', function() {
 					if ( window.innerWidth < 600 ) {
 						const scroller = this.closest( '.participants-table-wrapper' ).querySelector( '.participants-table-scroller' );
@@ -254,7 +254,7 @@ liquipedia.participantstable = {
 					}
 				} );
 			} );
-			document.querySelectorAll( '.participants-table-scroller' ).forEach( function( scroller ) {
+			document.querySelectorAll( '.participants-table-scroller' ).forEach( ( scroller ) => {
 				scroller.addEventListener( 'scroll', function() {
 					const buttonLeft = this.closest( '.participants-table-wrapper' ).querySelector( '.participants-table-button-left' );
 					buttonLeft.classList.remove( 'inactive' );
@@ -279,7 +279,7 @@ liquipedia.core.modules.push( 'participantstable' );
  ******************************************************************************/
 liquipedia.heroesportal = {
 	init: function() {
-		document.querySelectorAll( '.hexagon-button' ).forEach( function( button ) {
+		document.querySelectorAll( '.hexagon-button' ).forEach( ( button ) => {
 			button.addEventListener( 'click', function() {
 				const hexagon = this.closest( '.hexagon' );
 				if ( hexagon.classList.contains( 'show-' + this.dataset.show ) ) {
@@ -300,7 +300,7 @@ liquipedia.core.modules.push( 'heroesportal' );
 liquipedia.decktables = {
 	init: function() {
 		if ( document.querySelector( '.decktable' ) !== null ) {
-			mw.loader.using( 'jquery.tablesorter' ).then( function() {
+			mw.loader.using( 'jquery.tablesorter' ).then( () => {
 				if ( $.fn.tablesorter ) {
 					$( '.decktable' ).tablesorter( { sortList: [ { 3: 'asc' }, { 2: 'asc' } ] } );
 				} else {
@@ -322,7 +322,7 @@ liquipedia.talenttemplate = {
 		let talent = document.getElementById( 'talent-1' );
 		if ( talent !== null ) {
 			let talentContent = document.getElementById( 'talent-1-content' );
-			document.querySelectorAll( '.talent' ).forEach( function( element ) {
+			document.querySelectorAll( '.talent' ).forEach( ( element ) => {
 				element.addEventListener( 'mouseover', function() {
 					this.style.cursor = 'pointer';
 					this.style.border = '4px solid #e5c83e';
@@ -357,8 +357,8 @@ liquipedia.core.modules.push( 'talenttemplate' );
 liquipedia.creepspot = {
 	init: function() {
 		if ( document.querySelector( '.creep-spot' ) !== null ) {
-			mw.loader.using( 'skins.bruinen.scripts' ).then( function() {
-				document.querySelectorAll( '.creep-spot' ).forEach( function( cs ) {
+			mw.loader.using( 'skins.bruinen.scripts' ).then( () => {
+				document.querySelectorAll( '.creep-spot' ).forEach( ( cs ) => {
 					const $this = $( cs );
 					const options = {
 						content: $this.find( '.creep-spot-popup-body' ).html(),
@@ -385,9 +385,9 @@ liquipedia.core.modules.push( 'creepspot' );
  ******************************************************************************/
 liquipedia.togglearea = {
 	init: function() {
-		document.querySelectorAll( '.toggle-area' ).forEach( function( area ) {
-			area.querySelectorAll( '.toggle-area-button' ).forEach( function( btn ) {
-				btn.addEventListener( 'click', function() {
+		document.querySelectorAll( '.toggle-area' ).forEach( ( area ) => {
+			area.querySelectorAll( '.toggle-area-button' ).forEach( ( btn ) => {
+				btn.addEventListener( 'click', () => {
 					area.classList.remove( 'toggle-area-' + area.dataset.toggleArea );
 					area.dataset.toggleArea = btn.dataset.toggleAreaBtn;
 					area.classList.add( 'toggle-area-' + btn.dataset.toggleAreaBtn );
@@ -508,211 +508,211 @@ liquipedia.tracker = {
 		}
 	},
 	setup: function() {
-		document.querySelectorAll( '#sidebar-toc a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#sidebar-toc a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Sidebar TOC item clicked', true );
 			} );
 		} );
-		document.querySelectorAll( '#scroll-wrapper-toc a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#scroll-wrapper-toc a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Mobile TOC item clicked', true );
 			} );
 		} );
-		document.querySelectorAll( '#toc a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#toc a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'In Content TOC item clicked', true );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked', true );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share a[data-type=twitter], .lakesideview-menu-share a[data-type=twitter]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share a[data-type=twitter], .lakesideview-menu-share a[data-type=twitter]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked (twitter)' );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share a[data-type=facebook], .lakesideview-menu-share a[data-type=facebook]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share a[data-type=facebook], .lakesideview-menu-share a[data-type=facebook]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked (facebook)' );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share a[data-type=reddit], .lakesideview-menu-share a[data-type=reddit]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share a[data-type=reddit], .lakesideview-menu-share a[data-type=reddit]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked (reddit)' );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share a[data-type=qq], .lakesideview-menu-share a[data-type=qq]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share a[data-type=qq], .lakesideview-menu-share a[data-type=qq]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked (qq)' );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share a[data-type=vk], .lakesideview-menu-share a[data-type=vk]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share a[data-type=vk], .lakesideview-menu-share a[data-type=vk]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked (vk)' );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share a[data-type=weibo], .lakesideview-menu-share a[data-type=weibo]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share a[data-type=weibo], .lakesideview-menu-share a[data-type=weibo]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked (weibo)' );
 			} );
 		} );
-		document.querySelectorAll( '.bruinen-menu-share a[data-type=whatsapp], .lakesideview-menu-share a[data-type=whatsapp]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.bruinen-menu-share a[data-type=whatsapp], .lakesideview-menu-share a[data-type=whatsapp]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Share link clicked (whatsapp)' );
 			} );
 		} );
-		document.querySelectorAll( '#mw-fr-submit-accept' ).forEach( function( node ) {
+		document.querySelectorAll( '#mw-fr-submit-accept' ).forEach( ( node ) => {
 			if ( !node.disabled ) {
-				node.addEventListener( 'click', function() {
+				node.addEventListener( 'click', () => {
 					liquipedia.tracker.track( 'Revision accepted' );
 				} );
 			}
 		} );
-		document.querySelectorAll( '#ca-purge a, #ca-purge-mobile a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#ca-purge a, #ca-purge-mobile a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Page manually purged' );
 			} );
 		} );
-		document.querySelectorAll( 'input[name=wpUpload]' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( 'input[name=wpUpload]' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'File Upload initiated' );
 			} );
 		} );
-		document.querySelectorAll( '.editButtons #wpPreview' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.editButtons #wpPreview' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Preview button clicked' );
 			} );
 		} );
-		document.querySelectorAll( '.editButtons #wpSave' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.editButtons #wpSave' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Save button clicked' );
 			} );
 		} );
-		document.querySelectorAll( '.nav a.dropdown-toggle' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '.nav a.dropdown-toggle' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Navbar toggle clicked' );
 			} );
 		} );
-		document.querySelectorAll( '#todo-list a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#todo-list a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'TODO list item clicked' );
 			} );
 		} );
-		document.addEventListener( 'keypress', function( event ) {
+		document.addEventListener( 'keypress', ( event ) => {
 			if ( event.keyCode === 116 ) {
 				liquipedia.tracker.track( 'F5 Button pressed', true );
 			}
 		} );
-		document.querySelectorAll( '#brand-logo' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#brand-logo' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Liquipedia logo clicked' );
 			} );
 		} );
-		document.querySelectorAll( '#pt-createaccount a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#pt-createaccount a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Create account link clicked' );
 			} );
 		} );
-		document.querySelectorAll( '#pt-createaccount-mobile a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#pt-createaccount-mobile a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Create account link clicked (mobile)' );
 			} );
 		} );
-		document.querySelectorAll( '#pt-login a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#pt-login a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Login link clicked' );
 			} );
 		} );
-		document.querySelectorAll( '#pt-login-mobile a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#pt-login-mobile a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Login link clicked (mobile)' );
 			} );
 		} );
-		document.querySelectorAll( '#searchInput' ).forEach( function( node ) {
-			node.addEventListener( 'keypress', function() {
+		document.querySelectorAll( '#searchInput' ).forEach( ( node ) => {
+			node.addEventListener( 'keypress', () => {
 				liquipedia.tracker.track( 'Search term entered' );
 			} );
 		} );
-		document.querySelectorAll( '#searchInput-mobile' ).forEach( function( node ) {
-			node.addEventListener( 'keypress', function() {
+		document.querySelectorAll( '#searchInput-mobile' ).forEach( ( node ) => {
+			node.addEventListener( 'keypress', () => {
 				liquipedia.tracker.track( 'Search term entered (mobile)' );
 			} );
 		} );
-		document.querySelectorAll( '#brand-menu-toggle' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#brand-menu-toggle' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Brand menu toggled' );
 			} );
 		} );
-		document.querySelectorAll( '#brand-menu a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#brand-menu a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Brand menu link clicked' );
 			} );
 		} );
-		document.querySelectorAll( '#trending-pages-menu-toggle' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#trending-pages-menu-toggle' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Trending pages menu toggled' );
 			} );
 		} );
-		document.querySelectorAll( '#trending-pages-menu a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#trending-pages-menu a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Trending pages menu link clicked' );
 			} );
 		} );
-		document.querySelectorAll( '#tournaments-menu-toggle' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#tournaments-menu-toggle' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Tournaments menu toggled' );
 			} );
 		} );
-		document.querySelectorAll( '#tournaments-menu-upcoming a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#tournaments-menu-upcoming a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Tournaments menu link clicked (upcoming)' );
 			} );
 		} );
-		document.querySelectorAll( '#tournaments-menu-ongoing a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#tournaments-menu-ongoing a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Tournaments menu link clicked (ongoing)' );
 			} );
 		} );
-		document.querySelectorAll( '#tournaments-menu-completed a' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#tournaments-menu-completed a' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Tournaments menu link clicked (completed)' );
 			} );
 		} );
-		document.querySelectorAll( '#contribute-menu-toggle' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#contribute-menu-toggle' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Contribute menu toggled' );
 			} );
 		} );
-		document.querySelectorAll( '#contribute-menu-edit-an-article' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#contribute-menu-edit-an-article' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Contribute menu link clicked (edit an article)' );
 			} );
 		} );
-		document.querySelectorAll( '#contribute-menu-create-an-article' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#contribute-menu-create-an-article' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Contribute menu link clicked (create an article)' );
 			} );
 		} );
-		document.querySelectorAll( '#contribute-menu-help-portal' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#contribute-menu-help-portal' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Contribute menu link clicked (help portal)' );
 			} );
 		} );
-		document.querySelectorAll( '#contribute-menu-chat-with-us' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#contribute-menu-chat-with-us' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Contribute menu link clicked (chat with us)' );
 			} );
 		} );
-		document.querySelectorAll( '#contribute-menu-feedback-thread' ).forEach( function( node ) {
-			node.addEventListener( 'click', function() {
+		document.querySelectorAll( '#contribute-menu-feedback-thread' ).forEach( ( node ) => {
+			node.addEventListener( 'click', () => {
 				liquipedia.tracker.track( 'Contribute menu link clicked (feedback thread)' );
 			} );
 		} );
 		if ( mw.config.get( 'wgNamespaceNumber' ) === -1 && mw.config.get( 'wgCanonicalSpecialPageName' ) === 'StreamPage' ) {
-			document.querySelectorAll( '#refresh' ).forEach( function( node ) {
-				node.addEventListener( 'click', function() {
+			document.querySelectorAll( '#refresh' ).forEach( ( node ) => {
+				node.addEventListener( 'click', () => {
 					liquipedia.tracker.track( 'Refresh button clicked (Special:StreamPage)' );
 				} );
 			} );
@@ -734,7 +734,7 @@ liquipedia.core.modules.push( 'tracker' );
  ******************************************************************************/
 liquipedia.customLuaErrors = {
 	init: function() {
-		mw.loader.using( 'jquery.ui', function() {
+		mw.loader.using( 'jquery.ui', () => {
 			const $dialog = $( '<div>' ).dialog( {
 				title: 'Script error',
 				autoOpen: false
@@ -743,7 +743,7 @@ liquipedia.customLuaErrors = {
 				try {
 					const parsedError = JSON.parse( this.innerHTML.toString().replace( /Lua error(: | in )/, '' ).slice( 0, -1 ) );
 					const $backtraceList = $( '<ol>' ).addClass( 'scribunto-trace' );
-					parsedError.stackTrace.forEach( function( stackItem ) {
+					parsedError.stackTrace.forEach( ( stackItem ) => {
 						const $backtraceItem = $( '<li>' );
 						const $prefix = $( '<b>' );
 						const prefixText = $( '<div>' ).html( stackItem.prefix ).text();
@@ -769,7 +769,7 @@ liquipedia.customLuaErrors = {
 					);
 					const $newError = $( '<span>' ).text( parsedError.errorShort ).addClass( 'scribunto-error' );
 					$( this ).replaceWith( $newError );
-					$newError.on( 'click', function( e ) {
+					$newError.on( 'click', ( e ) => {
 						$dialog.dialog( 'close' ).html( $errorDiv ).dialog( 'option', 'position', [ e.clientX + 5, e.clientY + 5 ] ).dialog( 'open' );
 					} );
 				} catch ( ignored ) {}

--- a/javascript/commons/Prizepooltable.js
+++ b/javascript/commons/Prizepooltable.js
@@ -4,7 +4,7 @@
  ******************************************************************************/
 liquipedia.prizepooltable = {
 	init: function() {
-		document.querySelectorAll( '.prizepooltable' ).forEach( function( prizepooltable ) {
+		document.querySelectorAll( '.prizepooltable' ).forEach( ( prizepooltable ) => {
 			let cutAfter;
 			if ( typeof prizepooltable.dataset.cutafter !== 'undefined' ) {
 				cutAfter = parseInt( prizepooltable.dataset.cutafter );
@@ -32,7 +32,7 @@ liquipedia.prizepooltable = {
 				}
 			}
 		} );
-		document.querySelectorAll( '.prizepooltabletoggle' ).forEach( function( prizepooltabletogglebutton ) {
+		document.querySelectorAll( '.prizepooltabletoggle' ).forEach( ( prizepooltabletogglebutton ) => {
 			prizepooltabletogglebutton.onclick = function() {
 				this.closest( '.prizepooltable' ).classList.toggle( 'collapsed' );
 			};

--- a/javascript/commons/Selectall.js
+++ b/javascript/commons/Selectall.js
@@ -4,7 +4,7 @@
  ******************************************************************************/
 liquipedia.selectall = {
 	init: function() {
-		document.querySelectorAll( '.selectall' ).forEach( function( selectall ) {
+		document.querySelectorAll( '.selectall' ).forEach( ( selectall ) => {
 			const wrapper = document.createElement( 'div' );
 			wrapper.classList.add( 'selectall-wrapper' );
 			const buttonwrapper = document.createElement( 'div' );

--- a/javascript/commons/Tabs.js
+++ b/javascript/commons/Tabs.js
@@ -4,7 +4,7 @@
  ******************************************************************************/
 liquipedia.tabs = {
 	init: function() {
-		document.querySelectorAll( '.tabs-dynamic' ).forEach( function( tabs ) {
+		document.querySelectorAll( '.tabs-dynamic' ).forEach( ( tabs ) => {
 			const tabItems = [];
 			const tabContents = [];
 			for ( let i = 0; i < tabs.children.length; i++ ) {
@@ -20,33 +20,33 @@ liquipedia.tabs = {
 					}
 				}
 			}
-			tabContents.forEach( function( tabContent, i ) {
+			tabContents.forEach( ( tabContent, i ) => {
 				const heading = document.createElement( 'h6' );
 				heading.style.display = 'none';
 				heading.innerHTML = tabItems[ i ].innerHTML;
 				tabContent.insertAdjacentElement( 'afterbegin', heading );
 			} );
-			tabItems.forEach( function( tabItem, i ) {
+			tabItems.forEach( ( tabItem, i ) => {
 				if ( tabItem.classList.contains( 'active' ) ) {
 					tabContents[ i ].classList.add( 'active' );
 				}
 				tabItem.innerHTML = '<a href="#">' + tabItem.innerHTML + '</a>';
 				tabItem.addEventListener( 'click', function( ev ) {
 					ev.preventDefault();
-					tabItems.forEach( function( element ) {
+					tabItems.forEach( ( element ) => {
 						element.classList.remove( 'active' );
 					} );
 					this.classList.add( 'active' );
-					tabContents.forEach( function( element ) {
+					tabContents.forEach( ( element ) => {
 						element.classList.remove( 'active' );
 					} );
 					if ( !this.classList.contains( 'show-all' ) ) {
 						tabContents[ parseInt( this.dataset.count ) - 1 ].classList.add( 'active' );
-						tabContents.forEach( function( tabContent ) {
+						tabContents.forEach( ( tabContent ) => {
 							tabContent.querySelector( 'h6:first-child' ).style.display = 'none';
 						} );
 					} else {
-						tabContents.forEach( function( tabContent ) {
+						tabContents.forEach( ( tabContent ) => {
 							tabContent.classList.add( 'active' );
 							tabContent.querySelector( 'h6:first-child' ).style.display = 'block';
 						} );
@@ -90,16 +90,16 @@ liquipedia.tabs = {
 		}
 		if ( scrolltoelement !== null ) {
 			const tabs = scrolltoelement.closest( '.tabs-dynamic' );
-			tabs.querySelectorAll( '.nav-tabs li' ).forEach( function( listelement ) {
+			tabs.querySelectorAll( '.nav-tabs li' ).forEach( ( listelement ) => {
 				listelement.classList.remove( 'active' );
 			} );
 			tabs.querySelector( '.nav-tabs .tab' + tabno ).classList.add( 'active' );
-			tabs.querySelectorAll( '.tabs-content > div' ).forEach( function( contentelement ) {
+			tabs.querySelectorAll( '.tabs-content > div' ).forEach( ( contentelement ) => {
 				contentelement.classList.remove( 'active' );
 			} );
 			tabs.querySelector( '.tabs-content > .content' + tabno ).classList.add( 'active' );
 			if ( scrollto !== null ) {
-				setTimeout( function() {
+				setTimeout( () => {
 					if ( typeof window.scrollY !== 'undefined' ) {
 						window.scrollTo( 0, scrolltoelement.getBoundingClientRect().top + window.scrollY );
 					} else {
@@ -108,12 +108,12 @@ liquipedia.tabs = {
 				}, 500 );
 			}
 		} else {
-			document.querySelectorAll( '.tabs-dynamic' ).forEach( function( tabs ) {
-				tabs.querySelectorAll( '.nav-tabs li' ).forEach( function( listelement ) {
+			document.querySelectorAll( '.tabs-dynamic' ).forEach( ( tabs ) => {
+				tabs.querySelectorAll( '.nav-tabs li' ).forEach( ( listelement ) => {
 					listelement.classList.remove( 'active' );
 				} );
 				tabs.querySelector( '.nav-tabs .tab' + tabno ).classList.add( 'active' );
-				tabs.querySelectorAll( '.tabs-content > div' ).forEach( function( contentelement ) {
+				tabs.querySelectorAll( '.tabs-content > div' ).forEach( ( contentelement ) => {
 					contentelement.classList.remove( 'active' );
 				} );
 				tabs.querySelector( '.tabs-content > .content' + tabno ).classList.add( 'active' );

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"grunt-stylelint": "0.19.x",
 		"jquery": "3.6.1",
 		"postcss-less": "*",
-		"stylelint-config-wikimedia": "*",
+		"stylelint-config-wikimedia": "0.16.x",
 		"stylelint-less": "2.x.x"
 	},
 	"scripts": {


### PR DESCRIPTION
## Summary
Upstream eslint config `eslint-config-wikimedia` changed their configs in their 0.28 last night. https://github.com/wikimedia/eslint-config-wikimedia/releases/tag/v0.28.0

Arrow functions are now mandated after their release and I see no reason not to follow 

Also `stylelint-config-wikimedia` updated their configs in their release to [0.17](https://github.com/wikimedia/stylelint-config-wikimedia/releases/tag/v0.17.0) last night. That requires stylelint 16. I think all our dependencies now support stylelint 16, leaving that for later to upgrade.

## How did you test this change?
Locally and pipeline
