### PR TITLE
ci: use stylelint 16

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,7 +16,7 @@
 		"no-duplicate-selectors": null,
 		"function-url-no-scheme-relative": null,
 		"declaration-no-important": null,
-		"stylistic/string-quotes": "single",
+		"stylistic/string-quotes": "double",
 		"function-no-unknown": null
 	}
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,8 +1,7 @@
 {
 	"extends": "stylelint-config-wikimedia",
 	"plugins": [
-		"stylelint-less",
-		"stylelint-stylistic"
+		"stylelint-less"
 	],
 	"customSyntax": "postcss-less",
 	"rules": {
@@ -17,7 +16,7 @@
 		"no-duplicate-selectors": null,
 		"function-url-no-scheme-relative": null,
 		"declaration-no-important": null,
-		"stylistic/string-quotes": "double",
+		"stylistic/string-quotes": "single",
 		"function-no-unknown": null
 	}
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,7 +16,7 @@
 		"no-duplicate-selectors": null,
 		"function-url-no-scheme-relative": null,
 		"declaration-no-important": null,
-		"stylistic/string-quotes": "double",
+		"@stylistic/string-quotes": "double",
 		"function-no-unknown": null
 	}
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"devDependencies": {
 		"eslint-config-wikimedia": "*",
 		"grunt": "*",
-		"grunt-eslint": "*",
+		"grunt-eslint": "24.x.x",
 		"grunt-stylelint": "*",
 		"jquery": "*",
 		"postcss-less": "*",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
 	"private": true,
 	"devDependencies": {
 		"eslint-config-wikimedia": "*",
+		"jquery": "*",
 		"grunt": "*",
 		"grunt-eslint": "24.x.x",
-		"grunt-stylelint": "*",
-		"jquery": "*",
-		"postcss-less": "*",
-		"stylelint-config-wikimedia": "*",
-		"stylelint-less": "*"
+		"grunt-stylelint": "^0.20.x",
+		"postcss-less": "^6.0.0",
+		"stylelint": "^16.6.1",
+		"stylelint-config-wikimedia": "^0.17.0",
+		"stylelint-less": "^3.0.1",
+		"@stylistic/stylelint-plugin": "^2.1.2"
 	},
 	"scripts": {
 		"test": "grunt main",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
 	"devDependencies": {
 		"eslint-config-wikimedia": "*",
 		"grunt": "*",
-		"grunt-eslint": "24.x.x",
-		"grunt-stylelint": "0.19.x",
-		"jquery": "3.6.1",
+		"grunt-eslint": "*",
+		"grunt-stylelint": "*",
+		"jquery": "*",
 		"postcss-less": "*",
 		"stylelint-config-wikimedia": "*",
-		"stylelint-less": "2.x.x"
+		"stylelint-less": "*"
 	},
 	"scripts": {
 		"test": "grunt main",

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -1602,9 +1602,9 @@ div.brkts-opponent-hover-active::after {
 
 .button-link {
 	background-color: #e6e6e6;
+	border: 1px solid transparent;
 	border-color: #e6e6e6;
 	border-radius: 0;
-	border: 1px solid transparent;
 	color: #212529;
 	font-size: 1rem;
 	font-weight: normal;


### PR DESCRIPTION
## Summary
All upstream dependencies now support stylelint v16, so no longer need to lock us to v15.

## How did you test this change?

Locally and pipeline
