### PR TITLE
fix(seriesMedalTables): fix endDate condition

### DIFF
--- a/components/series_medal_stats/series_medal_stats.lua
+++ b/components/series_medal_stats/series_medal_stats.lua
@@ -163,8 +163,7 @@ function MedalStats:_getConditions()
 	addOrCondition('placement', config.placements)
 	addOrCondition('opponenttype', config.opponentTypes)
 
-	local endDate = config.endDate or TODAY
-	addOrCondition('date', {endDate, '<' .. endDate})
+	conditions:add{ConditionNode(ColumnName('date'), Comparator.lt, (config.endDate or TODAY) .. 'T23:59:59')}
 
 	if not config.external then
 		conditions:add{ConditionNode(ColumnName('prizepoolindex'), Comparator.eq, 1)}


### PR DESCRIPTION
## Summary
Due to the recent change in prize pool date storage from import (#4306) the end date condition in `Module:SeriesMedalStats` doesn't include the day of the end date anymore.
This PR adjusts the condition so that it includes the day of the end date again.

## How did you test this change?
dev