### PR TITLE
feat(links): add soop support

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -167,6 +167,7 @@ local PREFIXES = {
 	sk = {'https://sk-gaming.com/member/'},
 	smashboards = {'https://smashboards.com/'},
 	snapchat = {'https://www.snapchat.com/add/'},
+	soop = {'https://www.sooplive.com/'},
 	sostronk = {'https://www.sostronk.com/tournament/'},
 	['start-gg'] = {
 		'https://start.gg/',

--- a/standard/links/commons/links_priority_groups.lua
+++ b/standard/links/commons/links_priority_groups.lua
@@ -82,6 +82,7 @@ return {
 		'youtube',
 		'stream',
 		'afreeca',
+		'soop',
 		'dlive',
 		'facebook-gaming',
 		'vidio',

--- a/stylesheets/commons/Icons.less
+++ b/stylesheets/commons/Icons.less
@@ -143,6 +143,7 @@ Note: When adding a new icon, please add to
 	.icon-make-image( smash-gg, "//liquipedia.net/commons/images/3/3c/InfoboxIcon_SmashGG.png" );
 	.icon-make-image( start-gg, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_StartGG.png" );
 	.icon-make-image( snapchat, "//liquipedia.net/commons/images/f/fc/InfoboxIcon_Snapchat.png" );
+	.icon-make-image( soop, "//liquipedia.net/commons/images/c/ce/InfoboxIcon_SOOP.png" );
 	.icon-make-image( sostronk, "//liquipedia.net/commons/images/4/4e/InfoboxIcon_SoStronk.png" );
 	.icon-make-image( spotify, "//liquipedia.net/commons/images/1/14/InfoboxIcon_Spotify.png" );
 	.icon-make-image( steam, "//liquipedia.net/commons/images/d/d0/InfoboxIcon_Steam.png" );


### PR DESCRIPTION
## Summary
Adds support for soop as infobox link.
Soop is the successor of afreecatv, but for some time they will run in parallel

## How did you test this change?
N/A