### PR TITLE
fix(HDB): write capitalized participant variables

### DIFF
--- a/components/hidden_data_box/commons/hidden_data_box.lua
+++ b/components/hidden_data_box/commons/hidden_data_box.lua
@@ -26,6 +26,8 @@ local INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia '
 local INVALID_PARENT = '${parent} is not a Liquipedia Tournament[[Category:Pages with invalid parent]]'
 local DEFAULT_TIER_TYPE = 'general'
 
+local Language = mw.getContentLanguage()
+
 local OpponentLibraries = Lua.import('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
 
@@ -177,6 +179,8 @@ end
 ---@param key string
 ---@param value string|number
 function HiddenDataBox._setWikiVariableForParticipantKey(participant, participantResolved, key, value)
+	Variables.varDefine(participant .. '_' .. key, value)
+	participant = Language:ucfirst(participant)
 	Variables.varDefine(participant .. '_' .. key, value)
 	if participant ~= participantResolved then
 		Variables.varDefine(participantResolved .. '_' .. key, value)


### PR DESCRIPTION
## Summary

Currently, match2 code looks for participants (teams) with capitalized first letters due to resolving redirects. HDB was not setting these properly and instead using direct passed data from LPDB (which comes from TT database).

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/7e9302f6-d951-4275-be20-1b92d9dac033)

## How did you test this change?

`/dev`

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/cbe0e388-dada-4bf5-86ed-239034f65cbc)


