### PR TITLE
fix(partTable): resolve LPDB loops

### DIFF
--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -11,7 +11,6 @@ local Json = require('Module:Json')
 local Faction = require('Module:Faction')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
@@ -44,8 +43,6 @@ local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 local OpponentLibrary = require('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
 
-local prizePoolVars = PageVariableNamespace('PrizePool')
-
 local StarcraftParticipantTable = {}
 
 ---@param frame Frame
@@ -56,7 +53,6 @@ function StarcraftParticipantTable.run(frame)
 	participantTable.readConfig = StarcraftParticipantTable.readConfig
 	participantTable.readEntry = StarcraftParticipantTable.readEntry
 	participantTable.adjustLpdbData = StarcraftParticipantTable.adjustLpdbData
-	participantTable.getPlacements = StarcraftParticipantTable.getPlacements
 	participantTable._displaySoloFactionTableSection = StarcraftParticipantTable._displaySoloFactionTableSection
 	participantTable._displayHeader = StarcraftParticipantTable._displayHeader
 	participantTable._getFactionNumbers = StarcraftParticipantTable._getFactionNumbers
@@ -162,20 +158,6 @@ function StarcraftParticipantTable:adjustLpdbData(lpdbData, entry, config)
 	lpdbData.extradata.isqualified = tostring(isQualified)
 
 	lpdbData.qualified = isQualified and 1 or nil
-end
-
----@return table<string, true>
-function StarcraftParticipantTable:getPlacements()
-	local placements = {}
-	local maxPrizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0
-
-	for prizePoolIndex = 1, maxPrizePoolIndex do
-		Array.forEach(Json.parseIfTable(prizePoolVars:get('placementRecords.' .. prizePoolIndex)) or {}, function(placement)
-			placements[placement.opponentname] = placement
-		end)
-	end
-
-	return placements
 end
 
 ---@param sections StarcraftParticipantTableSection[]

--- a/components/participant_table/wikis/stormgate/participant_table_custom.lua
+++ b/components/participant_table/wikis/stormgate/participant_table_custom.lua
@@ -11,7 +11,6 @@ local Json = require('Module:Json')
 local Faction = require('Module:Faction')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
@@ -44,8 +43,6 @@ local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 local OpponentLibrary = require('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
 
-local prizePoolVars = PageVariableNamespace('PrizePool')
-
 local StormgateParticipantTable = {}
 
 ---@param frame Frame
@@ -56,7 +53,6 @@ function StormgateParticipantTable.run(frame)
 	participantTable.readConfig = StormgateParticipantTable.readConfig
 	participantTable.readEntry = StormgateParticipantTable.readEntry
 	participantTable.adjustLpdbData = StormgateParticipantTable.adjustLpdbData
-	participantTable.getPlacements = StormgateParticipantTable.getPlacements
 	participantTable._displaySoloFactionTableSection = StormgateParticipantTable._displaySoloFactionTableSection
 	participantTable._displayHeader = StormgateParticipantTable._displayHeader
 	participantTable._getFactionNumbers = StormgateParticipantTable._getFactionNumbers
@@ -152,20 +148,6 @@ function StormgateParticipantTable:adjustLpdbData(lpdbData, entry, config)
 	lpdbData.extradata.isqualified = tostring(isQualified)
 
 	lpdbData.qualified = isQualified and 1 or nil
-end
-
----@return table<string, placement>
-function StormgateParticipantTable:getPlacements()
-	local placements = {}
-	local maxPrizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0
-
-	for prizePoolIndex = 1, maxPrizePoolIndex do
-		Array.forEach(Json.parseIfTable(prizePoolVars:get('placementRecords.' .. prizePoolIndex)) or {}, function(placement)
-			placements[placement.opponentname] = placement
-		end)
-	end
-
-	return placements
 end
 
 ---@param sections StormgateParticipantTableSection[]

--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -13,6 +13,7 @@ local Json = require('Module:Json')
 local LeagueIcon = require('Module:LeagueIcon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
@@ -29,6 +30,8 @@ local WidgetFactory = require('Module:Infobox/Widget/Factory')
 local WidgetTable = require('Module:Widget/Table')
 local TableRow = require('Module:Widget/Table/Row')
 local TableCell = require('Module:Widget/Table/Cell')
+
+local pageVars = PageVariableNamespace('PrizePool')
 
 --- @class BasePrizePool
 local BasePrizePool = Class.new(function(self, ...) self:init(...) end)
@@ -898,6 +901,10 @@ function BasePrizePool:storeData()
 		end
 
 		Variables.varDefine(objectName .. '_placementdate', lpdbEntry.date)
+	end
+
+	if self.options.storeLpdb then
+		pageVars:set('placementRecords.' .. prizePoolIndex, Json.stringify(lpdbData))
 	end
 
 	return self

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_award_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_award_starcraft.lua
@@ -8,7 +8,6 @@
 
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
-local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_award_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_award_starcraft.lua
@@ -12,7 +12,6 @@ local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
@@ -25,18 +24,14 @@ local Opponent = OpponentLibrary.Opponent
 
 local CustomLpdbInjector = Class.new(LpdbInjector)
 
-local pageVars = PageVariableNamespace('PrizePool')
-
 local CustomPrizePool = {}
 
 local PRIZE_TYPE_POINTS = 'POINTS'
 local IS_AWARD = true
 
-local _lpdb_stash = {}
 local _series
 local _tier
 local _tournament_name
-local _series_number
 
 -- Template entry point
 ---@param frame Frame
@@ -58,21 +53,11 @@ function CustomPrizePool.run(frame)
 	-- fixed setting
 	args.resolveRedirect = true
 
-	-- stash seriesNumber
-	_series_number = CustomPrizePool._seriesNumber()
-
 	local prizePool = AwardPrizePool(args):create()
 
 	prizePool:setLpdbInjector(CustomLpdbInjector())
 
 	local builtPrizePool = prizePool:build(IS_AWARD)
-
-	if Logic.readBool(args.storelpdb) then
-		local prizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0
-
-		-- stash the lpdb_placement data so teamCards can use them
-		pageVars:set('placementRecords.' .. prizePoolIndex, Json.stringify(_lpdb_stash))
-	end
 
 	return builtPrizePool
 end
@@ -88,7 +73,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.type = Variables.varDefault('tournament_type') or lpdbData.type
 
 	Table.mergeInto(lpdbData.extradata, {
-		seriesnumber = _series_number,
+		seriesnumber = CustomPrizePool._seriesNumber(),
 
 		-- to be removed once poinst storage is standardized
 		points = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1),
@@ -100,8 +85,6 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	local prizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0
 	lpdbData.objectName = CustomPrizePool._overwriteObjectName(lpdbData, prizePoolIndex)
-
-	table.insert(_lpdb_stash, Table.deepCopy(lpdbData))
 
 	return lpdbData
 end

--- a/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
+++ b/components/prize_pool/commons/starcraft_starcraft2/prize_pool_starcraft.lua
@@ -9,11 +9,9 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Info = require('Module:Info')
-local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 local Weight = require('Module:Weight')
@@ -27,18 +25,14 @@ local Opponent = OpponentLibrary.Opponent
 
 local CustomLpdbInjector = Class.new(LpdbInjector)
 
-local pageVars = PageVariableNamespace('PrizePool')
-
 local CustomPrizePool = {}
 
 local PRIZE_TYPE_POINTS = 'POINTS'
 local SC2 = 'starcraft2'
 
-local _lpdb_stash = {}
 local _series
 local _tier
 local _tournament_name
-local _series_number
 
 -- Template entry point
 ---@param frame Frame
@@ -66,9 +60,6 @@ function CustomPrizePool.run(frame)
 	args.resolveRedirect = true
 	args.groupScoreDelimiter = '-'
 
-	-- stash seriesNumber
-	_series_number = CustomPrizePool._seriesNumber()
-
 	local prizePool = PrizePool(args)
 
 	prizePool:setConfigDefault('storeLpdb', Namespace.isMain())
@@ -82,11 +73,6 @@ function CustomPrizePool.run(frame)
 	local prizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0
 	-- set an additional wiki-var for legacy reasons so that combination with award prize pools still work
 	Variables.varDefine('prize pool table id', prizePoolIndex)
-
-	if prizePool.options.storeLpdb then
-		-- stash the lpdb_placement data so teamCards can use them
-		pageVars:set('placementRecords.' .. prizePoolIndex, Json.stringify(_lpdb_stash))
-	end
 
 	return builtPrizePool
 end
@@ -117,7 +103,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end
 
 	lpdbData.extradata = Table.mergeInto(lpdbData.extradata, {
-		seriesnumber = _series_number,
+		seriesnumber = CustomPrizePool._seriesNumber(),
 
 		-- to be removed once poinst storage is standardized
 		points = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1),
@@ -129,8 +115,6 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	local prizePoolIndex = tonumber(Variables.varDefault('prizepool_index')) or 0
 	lpdbData.objectName = CustomPrizePool._overwriteObjectName(lpdbData, prizePoolIndex)
-
-	table.insert(_lpdb_stash, Table.deepCopy(lpdbData))
 
 	return lpdbData
 end


### PR DESCRIPTION
## Summary
Due to participant table now merging queried placement with the data inputted in the participant table we sometimes get stuck in lpdb loops.
PartTbl reads from lpdb and writes the exact same suff back to lpdb and hence overwrites changes the prize pool made to lpdb in the same page save again.

This PR changes the behaviour from reading from lpdb to instead passing along wiki variables from prize pool to participant table.

As per yesterdays Modules Sync Meeting this is the prefered solutionm over #4299 where the issue was just minimized while still reading from lpdb_placement instead of inheriting the wiki variable.

## How did you test this change?
dev