### PR TITLE
feat(locale): Allow single country regions

### DIFF
--- a/spec/locale_spec.lua
+++ b/spec/locale_spec.lua
@@ -31,8 +31,8 @@ describe('Variables', function()
 			local result4 = {country1 = 'cn', region1 = 'China'}
 
 			-- Normal region
-			local test5 = {country1 = 'Asia-Pacific'}
-			local result5 = {region1 = 'apac'}
+			local test5 = {country1 = 'apac'}
+			local result5 = {region1 = 'Asia-Pacific'}
 
 			assert.are_same(result1, Locale.formatLocations(test1))
 			assert.are_same(result2, Locale.formatLocations(test2))

--- a/spec/locale_spec.lua
+++ b/spec/locale_spec.lua
@@ -22,8 +22,24 @@ describe('Variables', function()
 			local test2 = {venue = 'Abc', country1 = 'Sweden', region1 = 'Europe', venuelink = 'https://lmgtfy.app/'}
 			local result2 = {country1 = 'se', region1 = 'Europe', venue1 = 'Abc', venuelink1 = 'https://lmgtfy.app/'}
 
+			-- Special region that also has alpha2-code
+			local test3 = {country1 = 'Europe'}
+			local result3 = {region1 = 'Europe'}
+
+			-- Region that is a a country
+			local test4 = {country1 = 'China'}
+			local result4 = {country1 = 'cn', region1 = 'China'}
+
+			-- Normal region
+			local test5 = {country1 = 'Asia-Pacific'}
+			local result5 = {region1 = 'apac'}
+
+
 			assert.are_same(result1, Locale.formatLocations(test1))
 			assert.are_same(result2, Locale.formatLocations(test2))
+			assert.are_same(result3, Locale.formatLocations(test3))
+			assert.are_same(result4, Locale.formatLocations(test4))
+			assert.are_same(result5, Locale.formatLocations(test5))
 			assert.are_same({}, Locale.formatLocations{dummy = true})
 		end)
 	end)

--- a/spec/locale_spec.lua
+++ b/spec/locale_spec.lua
@@ -26,14 +26,13 @@ describe('Variables', function()
 			local test3 = {country1 = 'Europe'}
 			local result3 = {region1 = 'Europe'}
 
-			-- Region that is a a country
+			-- Region that also is a country
 			local test4 = {country1 = 'China'}
 			local result4 = {country1 = 'cn', region1 = 'China'}
 
 			-- Normal region
 			local test5 = {country1 = 'Asia-Pacific'}
 			local result5 = {region1 = 'apac'}
-
 
 			assert.are_same(result1, Locale.formatLocations(test1))
 			assert.are_same(result2, Locale.formatLocations(test2))

--- a/standard/locale.lua
+++ b/standard/locale.lua
@@ -9,9 +9,14 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Flags = require('Module:Flags')
+local FnUtil = require('Module:FnUtil')
+local Operator = require('Module:Operator')
 local Region = require('Module:Region')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
+
+-- ISO 3166-1 alpha-2 Exceptional Reservations
+local EXCEPTIONAL_RESERVATIONS = {'eu', 'un'}
 
 local Locale = {}
 
@@ -64,6 +69,11 @@ function Locale.formatLocations(args)
 		-- Convert country to alpha2
 		if location.country then
 			location.country = String.nilIfEmpty(Flags.CountryCode(location.country))
+		end
+
+		-- Remove country if it is actually a region
+		if Array.find(EXCEPTIONAL_RESERVATIONS, FnUtil.curry(Operator.eq, location.country)) then
+			location.country = nil
 		end
 
 		-- Always normalize region name

--- a/standard/locale.lua
+++ b/standard/locale.lua
@@ -59,25 +59,24 @@ function Locale.formatLocations(args)
 			return
 		end
 
-		-- Always normalize region name
-		if not location.region and location.country then
-			-- Check if the country provided is actually a region
-			location.region = String.nilIfEmpty(Region.name{region = location.country})
-
-			-- If it actually was a region, it's no longer a country, otherwise get the Region from the country
-			if location.region then
-				location.country = nil
-			else
-				location.region = String.nilIfEmpty(Region.name{country = location.country})
-			end
-
-		elseif location.region then
-			location.region = String.nilIfEmpty(Region.name{region = location.region})
-		end
-
+		-- Keep unresolved country as it might be a region instead
+		local unresolvedCountry = location.country
 		-- Convert country to alpha2
 		if location.country then
 			location.country = String.nilIfEmpty(Flags.CountryCode(location.country))
+		end
+
+		-- Always normalize region name
+		if not location.region and unresolvedCountry then
+			-- Check if the country provided is actually a region
+			location.region = String.nilIfEmpty(Region.name{region = unresolvedCountry})
+
+			-- Get the Region from the country if still unknown
+			if not location.region then
+				location.region = String.nilIfEmpty(Region.name{country = location.country})
+			end
+		elseif location.region then
+			location.region = String.nilIfEmpty(Region.name{region = location.region})
 		end
 
 		return location


### PR DESCRIPTION
## Summary
Closes #4323 

Previously, input of `country=cn` or similar would lead to removed country from the output as it would get parsed as region.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
via dev:
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/6a63a1ba-92b6-4205-9cfe-66de5cfd4894)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
