### PR TITLE
feat(match2): add new options for Rainbow 6's Match2 Copy/Paste

### DIFF
--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -16,7 +16,7 @@ local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 ---@class RainbowsixMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 
-local INDENT = '\t'
+local INDENT = WikiCopyPaste.Indent
 
 local VETOES = {
 	[0] = '',

--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -34,6 +34,7 @@ local VETOES = {
 --returns the Code for a Match, depending on the input
 ---@param bestof integer
 ---@param mode string
+---@param index integer
 ---@param opponents integer
 ---@param args table
 ---@return string

--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -34,17 +34,16 @@ local VETOES = {
 --returns the Code for a Match, depending on the input
 ---@param bestof integer
 ---@param mode string
----@param index integer
 ---@param opponents integer
 ---@param args table
 ---@return string
-function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, opponents, args)
 	local casters = Logic.readBool(args.casters)
 	local mapDetails = Logic.readBool(args.detailedMap)
 	local mapDetailsOT = Logic.readBool(args.detailedMapOT)
 	local mapScore = Logic.readBool(args.mapScore)
 	local mapVeto = Logic.readBool(args.mapVeto)
-	local matchMatchpages = args.matchMatchpages and Array.unique(mw.text.split(args.matchMatchpages, ', ')) or {}
+	local matchLinks = args.matchLinks and Array.unique(mw.text.split(args.matchLinks, ', ')) or {}
 	local mvps = Logic.readBool(args.mvp)
 	local showScore = Logic.readBool(args.score)
 	local streams = Logic.readBool(args.streams)
@@ -64,7 +63,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match',
 		INDENT .. '|date=|finished=',
 		streams and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.appendWith(buildListLine(matchMatchpages, 1)),
+		buildListLine(matchLinks, 1),
 		casters and (INDENT .. '|caster1=|caster2=') or nil,
 		mvps and (INDENT .. '|mvp=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)

--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -44,7 +44,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local mapDetailsOT = Logic.readBool(args.detailedMapOT)
 	local mapScore = Logic.readBool(args.mapScore)
 	local mapVeto = Logic.readBool(args.mapVeto)
-	local matchLinks = args.matchLinks and Array.unique(mw.text.split(args.matchLinks, ', ')) or {}
+	local matchLinks = args.matchLinks and Array.unique(Array.parseCommaSeparatedString(args.matchLinks)) or {}
 	local mvps = Logic.readBool(args.mvp)
 	local showScore = Logic.readBool(args.score)
 	local streams = Logic.readBool(args.streams)

--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -39,14 +39,15 @@ local VETOES = {
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local showScore = Logic.readBool(args.score)
-	local mapScore = Logic.readBool(args.mapScore)
+	local casters = Logic.readBool(args.casters)
 	local mapDetails = Logic.readBool(args.detailedMap)
 	local mapDetailsOT = Logic.readBool(args.detailedMapOT)
+	local mapScore = Logic.readBool(args.mapScore)
 	local mapVeto = Logic.readBool(args.mapVeto)
 	local matchMatchpages = args.matchMatchpages and Array.unique(mw.text.split(args.matchMatchpages, ', ')) or {}
+	local mvps = Logic.readBool(args.mvp)
+	local showScore = Logic.readBool(args.score)
 	local streams = Logic.readBool(args.streams)
-	local casters = Logic.readBool(args.casters)
 
 	---@param list string[]
 	---@param indents integer
@@ -65,6 +66,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		streams and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		Array.appendWith(buildListLine(matchMatchpages, 1)),
 		casters and (INDENT .. '|caster1=|caster2=') or nil,
+		mvps and (INDENT .. '|mvp=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end)

--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -37,7 +37,7 @@ local VETOES = {
 ---@param opponents integer
 ---@param args table
 ---@return string
-function WikiCopyPaste.getMatchCode(bestof, mode, opponents, args)
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local casters = Logic.readBool(args.casters)
 	local mapDetails = Logic.readBool(args.detailedMap)
 	local mapDetailsOT = Logic.readBool(args.detailedMapOT)


### PR DESCRIPTION
## Summary
Adds a bunch of new things to the Rainbow Six Copy/Paste generator

- Ability to add casters based off Bool (currently only supports 2 casters)
- Ability to add Match Pages based off a selection list (supports R6Esports, LPL, OPL, Challengermode, ESL, FACEIT)
- Separates the score parameters to either the match, or the maps themselves
- Adds MVP parameter based off Bool

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Dev modules/templates/forms
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
