### PR TITLE
fix(infobox): remove duplicate `cooldown reduction` cell on mlbb

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
@@ -92,7 +92,6 @@ function CustomInjector:parse(id, widgets)
 			{name = 'Magic Resistance', parameter = 'magicresist'},
 			{name = 'Status Resistance', parameter = 'statusresist', funct = '_positivePercentDisplay'},
 			{name = 'Attack Speed', parameter = 'attackspeed'},
-			{name = 'Cooldown Reduction', parameter = 'cdreduction'},
 			{name = 'Magic Power', parameter = 'mp'},
 			{name = 'Attack Damage', parameter = 'ad'},
 			{name = 'Physical Attack', parameter = 'physatk'},


### PR DESCRIPTION
## Summary
Removing duplicate 'cooldown reduction' parameter
## How did you test this change?
via /dev
