### PR TITLE
feat(faction): add `Celestial` and `Neutral` as factions on stormgate

### DIFF
--- a/components/faction/wikis/stormgate/faction_data.lua
+++ b/components/faction/wikis/stormgate/faction_data.lua
@@ -23,15 +23,27 @@ local factionProps = {
 		pageName = 'Infernal Host',
 		faction = 'i',
 	},
+	c = {
+		bgClass = 'stormgate-celestial',
+		index = 3,
+		name = 'Celestial',
+		pageName = 'Celestial Armada',
+		faction = 'c',
+	},
 	r = {
 		bgClass = 'Random',
-		index = 3,
+		index = 4,
 		name = 'Random',
 		pageName = 'Random',
 		faction = 'r',
 	},
+	n = {
+		index = 5,
+		name = 'Neutral',
+		faction = 'n',
+	},
 	u = {
-		index = 4,
+		index = 6,
 		name = 'Unknown',
 		faction = 'u',
 	},
@@ -44,16 +56,17 @@ return {
 	},
 	defaultFaction = 'u',
 	factions = {
-		[Info.defaultGame] = {'v', 'i', 'r', 'u'},
+		[Info.defaultGame] = {'v', 'i', 'c', 'r', 'u'},
 	},
-	knownFactions = {'v', 'i', 'r'},
-	coreFactions = {'v', 'i'},
+	knownFactions = {'v', 'i', 'c', 'r'},
+	coreFactions = {'v', 'i', 'c'},
 	aliases = {
 		[Info.defaultGame] = {
 			human = 'v',
 			van = 'v',
 			host = 'i',
 			inf = 'i',
+			cel = 'c',
 		},
 	}
 }

--- a/components/faction/wikis/stormgate/faction_icon_data.lua
+++ b/components/faction/wikis/stormgate/faction_icon_data.lua
@@ -10,13 +10,19 @@ local Info = mw.loadData('Module:Info')
 
 local byFaction = {
 	v = {
-		icon = 'File:Stormgate_Human_Vanguard_default_allmode.png',
+		icon = 'File:Stormgate Human Vanguard default allmode.png',
 	},
 	i = {
-		icon = 'File:Stormgate_Infernal_Host_default_allmode.png',
+		icon = 'File:Stormgate Infernal Host default allmode.png',
+	},
+	c = {
+		icon = 'File:Stormgate Celestial Armada default allmode.png',
 	},
 	r = {
 		icon = 'File:Random race icon.png',
+	},
+	n = {
+		icon = 'File:Space filler race.png',
 	},
 	u = {
 		icon = 'File:Space filler race.png',

--- a/stylesheets/commons/Faction.less
+++ b/stylesheets/commons/Faction.less
@@ -52,8 +52,11 @@ Author(s): hjpalpha
 }
 
 .warcraft-undead,
+.stormgate-celestial,
 .warcraft-undead th,
-.warcraft-undead td {
+.stormgate-celestial th,
+.warcraft-undead td,
+.stormgate-celestial td {
 	background: var( --clr-vividviolet-90, #f1d2fa ) !important;
 }
 


### PR DESCRIPTION
## Summary
Add `Celestial` and `Neutral` as factions for Stormgate wiki.
(Celestial was announced officially and hence can be added now, also since we now know that c is taken for the faction we named neutral/creep as Neutral.)

## How did you test this change?
live for data, browser dev tools for styles