### PR TITLE
fix(infobox): publishertier not working

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -110,7 +110,7 @@ end
 ---@param args table
 function CustomLeague:customParseArguments(args)
 	self.data.rlcsPremier = args.series == SERIES_RLCS and 1 or 0
-	self.data.publishertier = tostring(args.series == SERIES_RLCS and self.data.liquipediatier == TIER_1)
+	self.data.publishertier = tostring(args.series == SERIES_RLCS and tonumber(self.data.liquipediatier) == TIER_1)
 end
 
 ---@param args table


### PR DESCRIPTION
## Summary
In #4320 i forgot to parse the tier to a number which leads to currently no events having set publ tier as true.
This PR adds the `tonumber` to fix that.

## How did you test this change?
dev to live