### PR TITLE
fix(prizepool): Honor tiertype on AoE in weight calculation

### DIFF
--- a/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/ageofempires/prize_pool_custom.lua
@@ -54,7 +54,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		lpdbData.prizemoney,
 		Variables.varDefault('tournament_liquipediatier'),
 		placement.placeStart,
-		Variables.varDefault('tournament_type')
+		Variables.varDefault('tournament_type'),
+		Variables.varDefault('tournament_liquipediatiertype')
 	)
 	if opponent.opponentData.type == Opponent.solo then
 		-- legacy extradata, to be removed once unused
@@ -98,13 +99,17 @@ end
 ---@param tier string?
 ---@param place integer
 ---@param type string?
+---@param tiertype string?
 ---@return integer
-function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type)
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type, tiertype)
 	if Logic.isEmpty(tier) then
 		return 0
 	end
 
 	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier) or ''] or 1
+	if tiertype == QUALIFIER then
+		tierValue = tierValue * 0.1
+	end
 	local onlineFactor = type == 'Online' and 0.65 or 1
 
 	return tierValue * math.max(prizeMoney, 0.001) / place * onlineFactor


### PR DESCRIPTION
## Summary
Previously, tiertype was ignored in weight calculation.
While this is fine for most types, it leads to weird behavior with qualifiers:
The placement from a qualified team (place=1) gets a heigher weight than the actual result in the tournament.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
