### PR TITLE
feat(match2): create team fortress support

### DIFF
--- a/components/match2/wikis/teamfortress/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/teamfortress/get_match_group_copy_paste_wiki.lua
@@ -30,28 +30,19 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local stats = Logic.readBool(args.stats)
 	local streams = Logic.readBool(args.streams)
 
-	local lines = Array.flatten({
+	local lines = Array.extend({},
 		'{{Match2',
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date= |finished=',
-	})
-
-	if streams then
-		table.insert(lines, INDENT .. '|twitch=|vod=')
-	end
-
-	if stats then
-		table.insert(lines, INDENT .. '|etf2l=|rgl=|ozf=|tftv=')
-	end
-
-	Array.forEach(Array.range(1, bestof), function(mapIndex)
-		Array.appendWith(lines, INDENT .. '|map' .. mapIndex ..
-			'={{Map|map=|score1=|score2=|finished= |logstf= |logstfgold=}}')
-	end)
-
-	table.insert(lines, '}}')
+		streams and (INDENT .. '|twitch=|vod=') or nil,
+		stats and (INDENT .. '|etf2l=|rgl=|ozf=|tftv=') or nil,
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished= |logstf= |logstfgold=}}'
+		end),
+		'}}'
+	)
 
 	return table.concat(lines, '\n')
 end

--- a/components/match2/wikis/teamfortress/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/teamfortress/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,59 @@
+---
+-- @Liquipedia
+-- wiki=teamfortress
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class TeamFortressMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.readBool(args.score)
+	local stats = Logic.readBool(args.stats)
+	local streams = Logic.readBool(args.streams)
+
+	local lines = Array.flatten({
+		'{{Match',
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
+		end),
+		INDENT .. '|date= |finished=',
+	})
+
+	if streams then
+		table.insert(lines, INDENT .. '|twitch=|vod=')
+	end
+
+	if stats then
+		table.insert(lines, INDENT .. '|etf2l=|rgl=|ozf=|tftv=')
+	end
+
+	Array.forEach(Array.range(1, bestof), function(mapIndex)
+		Array.appendWith(lines, INDENT .. '|map' .. mapIndex ..
+			'={{Map|map=|score1=|score2=|finished= |logstf= |logstfgold=}}')
+	end)
+
+	table.insert(lines, '}}')
+
+	return table.concat(lines, '\n')
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/teamfortress/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/teamfortress/get_match_group_copy_paste_wiki.lua
@@ -31,7 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local streams = Logic.readBool(args.streams)
 
 	local lines = Array.flatten({
-		'{{Match',
+		'{{Match2',
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -10,21 +10,14 @@ local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Opponent = require('Module:Opponent')
-local String = require('Module:StringUtils')
+local Operator = require('Module:Operator')
+local Streams = require('Module:Links/Stream')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
-local DateExt = require('Module:Date/Ext')
-local Streams = require('Module:Links/Stream')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
 
-local NP_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
-local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L', 'D' }
-local MAX_NUM_OPPONENTS = 2
-local MAX_NUM_MAPS = 20
-
-local NOW = os.time(os.date('!*t') --[[@as osdateparam]])
+local DEFAULT_BESTOF = 3
 
 local LINK_PREFIXES = {
 	rgl = 'https://rgl.gg/Public/Match.aspx?m=',
@@ -36,231 +29,134 @@ local LINK_PREFIXES = {
 }
 
 -- containers for process helper functions
-local matchFunctions = {}
-local mapFunctions = {}
+local MatchFunctions = {}
+local MapFunctions = {}
 
 local CustomMatchGroupInput = {}
 
--- called from Module:MatchGroup
 ---@param match table
+---@param options table?
 ---@return table
-function CustomMatchGroupInput.processMatch(match)
-	-- Count number of maps, check for empty maps to remove, and automatically count score
-	match = matchFunctions.getBestOf(match)
-	match = matchFunctions.getScoreFromMapWinners(match)
+function CustomMatchGroupInput.processMatch(match, options)
+	local finishedInput = match.finished --[[@as string?]]
+	local winnerInput = match.winner --[[@as string?]]
 
-	-- process match
 	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
-	match = matchFunctions.getOpponents(match)
-	match = matchFunctions.getTournamentVars(match)
-	return matchFunctions.getVodStuff(match)
-end
 
--- called from Module:Match/Subobjects
----@param map table
----@return table
-function CustomMatchGroupInput.processMap(map)
-	map = mapFunctions.getExtraData(map)
-	return mapFunctions.getScoresAndWinner(map)
-end
+	local opponents = Array.mapIndexes(function(opponentIndex)
+		return MatchGroupInput.readOpponent(match, opponentIndex, {})
+	end)
+	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
+	match.bestof = MatchFunctions.getBestOf(match)
 
----@param record table
----@param timestamp integer
-function CustomMatchGroupInput.processOpponent(record, timestamp)
-	local opponent = Opponent.readOpponentArgs(record)
-		or Opponent.blank()
+	local autoScoreFunction = MatchGroupInput.canUseAutoScore(match, games)
+		and MatchFunctions.calculateMatchScore(games, match.bestof)
+		or nil
+	Array.forEach(opponents, function(opponent, opponentIndex)
+		opponent.score, opponent.status = MatchGroupInput.computeOpponentScore({
+			walkover = match.walkover,
+			winner = match.winner,
+			opponentIndex = opponentIndex,
+			score = opponent.score,
+		}, autoScoreFunction)
+	end)
 
-	-- Convert byes to literals
-	if Opponent.isBye(opponent) then
-		opponent = {type = Opponent.literal, name = 'BYE'}
+	match.finished = MatchGroupInput.matchIsFinished(match, opponents)
+
+	if match.finished then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
+		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
 	end
 
-	---@type number|string
-	local teamTemplateDate = DateExt.nilIfDefaultTimestamp(timestamp) or
-		Variables.varDefaultMulti('tournament_enddate', 'tournament_startdate', NOW)
+	MatchFunctions.getTournamentVars(match)
 
-	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer = true})
-	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+	match.stream = Streams.processStreams(match)
+	match.links = Table.map(LINK_PREFIXES, function(prefix, link)
+		return prefix, match[prefix] and (link .. match[prefix]) or nil
+	end)
+
+	match.extradata = MatchFunctions.getExtraData(match)
+
+	match.games = games
+	match.opponents = opponents
+
+	return match
 end
 
--- called from Module:Match/Subobjects
-CustomMatchGroupInput.processPlayer = FnUtil.identity
-
----@param data table
----@param indexedScores table[]
----@return table
+---@param match table
+---@param opponentCount integer
 ---@return table[]
-function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
-	-- Map or Match wasn't played, set not played
-	if
-		Table.includes(NP_STATUSES, data.finished) or
-		Table.includes(NP_STATUSES, data.winner)
-	then
-		data.resulttype = 'np'
-		data.finished = true
-	-- Map or Match is marked as finished.
-	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
-	elseif Logic.readBool(data.finished) then
-		if MatchGroupInput.isDraw(indexedScores) then
-			data.winner = 0
-			data.resulttype = 'draw'
-			MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 1)
-		elseif MatchGroupInput.hasSpecialStatus(indexedScores) then
-			data.winner = MatchGroupInput.getDefaultWinner(indexedScores)
-			data.resulttype = 'default'
-			if MatchGroupInput.hasForfeit(indexedScores) then
-				data.walkover = 'ff'
-			elseif MatchGroupInput.hasDisqualified(indexedScores) then
-				data.walkover = 'dq'
-			elseif MatchGroupInput.hasDefaultWinLoss(indexedScores) then
-				data.walkover = 'l'
-			end
-			indexedScores = MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
-		else
-			--only has exactly 2 opponents, neither more or less
-			assert(#indexedScores == 2, 'Unexpected number of opponents when calculating winner')
+function CustomMatchGroupInput.extractMaps(match, opponentCount)
+	local maps = {}
+	for key, map in Table.iter.pairsByPrefix(match, 'map', {requireIndex = true}) do
+		local finishedInput = map.finished --[[@as string?]]
+		local winnerInput = map.winner --[[@as string?]]
 
-			local scores = Array.map(indexedScores, function(indexedScore)
-				return tonumber(indexedScore.score)
-			end)
-			data.winner = tonumber(data.winner) or scores[1] > scores[2] and 1 or 2
-			local winner
-			indexedScores, winner = MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
-			data.winner = data.winner or winner
+		map.extradata = MapFunctions.getExtraData(map)
+		map.finished = MatchGroupInput.mapIsFinished(map)
+
+		local opponentInfo = Array.map(Array.range(1, opponentCount), function(opponentIndex)
+			local score, status = MatchGroupInput.computeOpponentScore({
+				walkover = map.walkover,
+				winner = map.winner,
+				opponentIndex = opponentIndex,
+				score = map['score' .. opponentIndex],
+			})
+			return {score = score, status = status}
+		end)
+
+		map.scores = Array.map(opponentInfo, Operator.property('score'))
+		if map.finished then
+			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
+			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
+			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)
 		end
+
+		table.insert(maps, map)
+		match[key] = nil
 	end
 
-	--set it as finished if we have a winner
-	if Logic.isNotEmpty(data.winner) then
-		data.finished = true
-	end
-
-	return data, indexedScores
+	return maps
 end
 
----@param tbl table[]
----@param key1 integer
----@param key2 integer
----@return boolean
-function CustomMatchGroupInput.placementSortFunction(tbl, key1, key2)
-	local value1 = tonumber(tbl[key1].score) or -99
-	local value2 = tonumber(tbl[key2].score) or -99
-	return value1 > value2
-end
+CustomMatchGroupInput.processMap = FnUtil.identity
 
 --
 -- match related functions
 --
 
----@param match table
----@return table
-function matchFunctions.getBestOf(match)
-	match.bestof = #Array.filter(Array.range(1, MAX_NUM_MAPS), function(idx) return match['map'.. idx] end)
-	return match
+---@param maps table[]
+---@param bestOf integer
+---@return fun(opponentIndex: integer): integer?
+function MatchFunctions.calculateMatchScore(maps, bestOf)
+	return function(opponentIndex)
+		return MatchGroupInput.computeMatchScoreFromMapWinners(maps, opponentIndex)
+	end
 end
 
--- Calculate the match scores based on the map results (counting map wins)
--- Only update a teams result if it's
--- 1) Not manually added
--- 2) At least one map has a winner
 ---@param match table
----@return table
-function matchFunctions.getScoreFromMapWinners(match)
-	local opponentNumber = 0
-	for index = 1, MAX_NUM_OPPONENTS do
-		if String.isEmpty(match['opponent' .. index]) then
-			break
-		end
-		opponentNumber = index
-	end
-	local newScores = {}
-	local foundScores = false
-
-	for _, map in Table.iter.pairsByPrefix(match, 'map') do
-		local winner = tonumber(map.winner)
-		foundScores = true
-		if winner and winner > 0 and winner <= opponentNumber then
-			newScores[winner] = (newScores[winner] or 0) + 1
-		end
-	end
-
-	Array.forEach(Array.range(1, opponentNumber), function(index)
-		if not match['opponent' .. index].score and foundScores then
-			match['opponent' .. index].score = newScores[index] or 0
-		end
-	end)
-
-	return match
+---@return integer
+function MatchFunctions.getBestOf(match)
+	local bestof = tonumber(Logic.emptyOr(match.bestof, Variables.varDefault('bestof')))
+	Variables.varDefine('bestof', bestof)
+	return bestof or DEFAULT_BESTOF
 end
 
 ---@param match table
 ---@return table
-function matchFunctions.getTournamentVars(match)
-	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', '6v6'))
+function MatchFunctions.getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
 	return MatchGroupInput.getCommonTournamentVars(match)
 end
 
 ---@param match table
 ---@return table
-function matchFunctions.getVodStuff(match)
-	match.stream = Streams.processStreams(match)
-	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
-
-	match.links = Table.map(LINK_PREFIXES, function(prefix, link)
-		return prefix, match[prefix] and (link .. match[prefix]) or nil
-	end)
-
-	return match
-end
-
----@param match table
----@return table
-function matchFunctions.getOpponents(match)
-	-- read opponents and ignore empty ones
-	local opponents = {}
-	local isScoreSet = false
-	Array.forEach(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
-		-- read opponent
-		local opponent = match['opponent' .. opponentIndex]
-		if Logic.isEmpty(opponent) then return end
-		CustomMatchGroupInput.processOpponent(opponent, match.timestamp)
-
-		-- apply status
-		if Logic.isNumeric(opponent.score) then
-			opponent.status = 'S'
-			isScoreSet = true
-		elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
-			opponent.status = opponent.score
-			opponent.score = -1
-		end
-		opponents[opponentIndex] = opponent
-	end)
-
-	-- see if match should actually be finished if bestof limit was reached
-	match.finished = Logic.readBool(match.finished)
-		or isScoreSet and (
-			Array.any(opponents, function(opponent) return (tonumber(opponent.score) or 0) > match.bestof/2 end)
-			or Array.all(opponents, function(opponent) return (tonumber(opponent.score) or 0) == match.bestof/2 end)
-		)
-
-	-- see if match should actually be finished if score is set
-	if isScoreSet and not Logic.readBool(match.finished) and match.timestamp ~= DateExt.defaultTimestamp then
-		local threshold = match.dateexact and 30800 or 86400
-		if match.timestamp + threshold < NOW then
-			match.finished = true
-		end
-	end
-
-	-- apply placements and winner if finshed
-	if String.isNotEmpty(match.winner) or Logic.readBool(match.finished) then
-		match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
-	end
-
-	-- Update all opponents with new values
-	for opponentIndex, opponent in pairs(opponents) do
-		match['opponent' .. opponentIndex] = opponent
-	end
-	return match
+function MatchFunctions.getExtraData(match)
+	return {
+		mvp = MatchGroupInput.readMvp(match),
+	}
 end
 
 --
@@ -270,43 +166,13 @@ end
 -- Parse extradata information
 ---@param map table
 ---@return table
-function mapFunctions.getExtraData(map)
-	map.extradata = {
+function MapFunctions.getExtraData(map)
+	return {
 		comment = map.comment,
 		header = map.header,
 		logstf = Logic.isNotEmpty(map.logstf) and ('https://logs.tf/' .. map.logstf) or nil,
 		logstfgold = Logic.isNotEmpty(map.logstfgold) and ('https://logs.tf/' .. map.logstfgold) or nil,
 	}
-
-	return map
-end
-
--- Calculate Score and Winner of the map
----@param map table
----@return table
-function mapFunctions.getScoresAndWinner(map)
-	map.scores = {}
-	local indexedScores = {}
-	for scoreIndex = 1, MAX_NUM_OPPONENTS do
-		-- read scores
-		local score = map['score' .. scoreIndex] or map['t' .. scoreIndex .. 'score']
-		local obj = {}
-		if not Logic.isEmpty(score) then
-			if Logic.isNumeric(score) then
-				obj.status = 'S'
-				obj.score = score
-			elseif Table.includes(ALLOWED_STATUSES, score) then
-				obj.status = score
-				obj.score = -1
-			end
-			table.insert(map.scores, score)
-			indexedScores[scoreIndex] = obj
-		else
-			break
-		end
-	end
-
-	return CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
 end
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -69,6 +69,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match, games)
+	match.extradata = MatchFunctions.getExtraData(match)
 	match.games = games
 	match.opponents = opponents
 
@@ -153,6 +154,14 @@ function MatchFunctions.getLinks(match, games)
 	end)
 
 	return links
+end
+
+---@param match table
+---@return table
+function MatchFunctions.getExtraData(match)
+	return {
+		comment = match.comment,
+	}
 end
 
 --

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -221,15 +221,11 @@ function matchFunctions.getScoreFromMapWinners(match)
 	local newScores = {}
 	local foundScores = false
 
-	for _, map, i in Table.iter.pairsByPrefix(match, 'map') do
-		if match['map'..i] then
-			local winner = tonumber(match['map'..i].winner)
-			foundScores = true
-			if winner and winner > 0 and winner <= opponentNumber then
-				newScores[winner] = (newScores[winner] or 0) + 1
-			end
-		else
-			break
+	for _, map in Table.iter.pairsByPrefix(match, 'map') do
+    	local winner = tonumber(map.winner)
+		foundScores = true
+    	if winner and winner > 0 and winner <= opponentNumber then
+        	newScores[winner] = (newScores[winner] or 0) + 1
 		end
 	end
 

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -266,7 +266,7 @@ function matchFunctions.getVodStuff(match)
 	match.links = {}
 	local links = match.links
 
-	for key, prefix in pairs(LINK_PREFIXES) do
+	for key, _prefix in pairs(LINK_PREFIXES) do
 		if match[key] then links[key] = LINK_PREFIXES[key] .. match[key] end
 	end
 

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -17,7 +17,6 @@ local Variables = require('Module:Variables')
 
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
 
-local DEFAULT_BESTOF = 3
 local DEFAULT_MODE = 'team'
 
 -- containers for process helper functions
@@ -39,11 +38,12 @@ function CustomMatchGroupInput.processMatch(match, options)
 		return MatchGroupInput.readOpponent(match, opponentIndex, {})
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
-	match.bestof = MatchFunctions.getBestOf(match)
+	match.bestof = MatchGroupInput.getBestOf(match.bestof, games)
 
 	local autoScoreFunction = MatchGroupInput.canUseAutoScore(match, games)
-		and MatchFunctions.calculateMatchScore(games, match.bestof)
+		and MatchFunctions.calculateMatchScore(games)
 		or nil
+
 	Array.forEach(opponents, function(opponent, opponentIndex)
 		opponent.score, opponent.status = MatchGroupInput.computeOpponentScore({
 			walkover = match.walkover,
@@ -115,20 +115,11 @@ CustomMatchGroupInput.processMap = FnUtil.identity
 --
 
 ---@param maps table[]
----@param bestOf integer
----@return fun(opponentIndex: integer): integer?
-function MatchFunctions.calculateMatchScore(maps, bestOf)
+---@return fun(opponentIndex: integer): integer
+function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInput.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return integer
-function MatchFunctions.getBestOf(match)
-	local bestof = tonumber(Logic.emptyOr(match.bestof, Variables.varDefault('bestof')))
-	Variables.varDefine('bestof', bestof)
-	return bestof or DEFAULT_BESTOF
 end
 
 ---@param match table

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -1,0 +1,385 @@
+---
+-- @Liquipedia
+-- wiki=teamfortress
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Opponent = require('Module:Opponent')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local TypeUtil = require('Module:TypeUtil')
+local Variables = require('Module:Variables')
+local DateExt = require('Module:Date/Ext')
+local Streams = require('Module:Links/Stream')
+
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
+
+local NP_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
+local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban', 'protect'}
+local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L', 'D' }
+local MAX_NUM_OPPONENTS = 2
+local MAX_NUM_MAPS = 20
+local DEFAULT_BESTOF = 3
+
+local NOW = os.time(os.date('!*t') --[[@as osdateparam]])
+
+-- containers for process helper functions
+local matchFunctions = {}
+local mapFunctions = {}
+
+local CustomMatchGroupInput = {}
+
+-- called from Module:MatchGroup
+---@param match table
+---@return table
+function CustomMatchGroupInput.processMatch(match)
+	-- Count number of maps, check for empty maps to remove, and automatically count score
+	match = matchFunctions.getBestOf(match)
+	match = matchFunctions.getScoreFromMapWinners(match)
+
+	-- process match
+	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
+	match = matchFunctions.getOpponents(match)
+	match = matchFunctions.getTournamentVars(match)
+	match = matchFunctions.getVodStuff(match)
+	match = matchFunctions.getExtraData(match)
+
+	return match
+end
+
+-- called from Module:Match/Subobjects
+---@param map table
+---@return table
+function CustomMatchGroupInput.processMap(map)
+	map = mapFunctions.getExtraData(map)
+	map = mapFunctions.getScoresAndWinner(map)
+
+	return map
+end
+
+---@param record table
+---@param timestamp integer
+function CustomMatchGroupInput.processOpponent(record, timestamp)
+	local opponent = Opponent.readOpponentArgs(record)
+		or Opponent.blank()
+
+	-- Convert byes to literals
+	if Opponent.isBye(opponent) then
+		opponent = {type = Opponent.literal, name = 'BYE'}
+	end
+
+	---@type number|string
+	local teamTemplateDate = timestamp
+	-- If date is default date, resolve using tournament dates instead
+	-- default date indicates that the match is missing a date
+	-- In order to get correct child team template, we will use an approximately date and not the default date
+	if teamTemplateDate == DateExt.defaultTimestamp then
+		teamTemplateDate = Variables.varDefaultMulti('tournament_enddate', 'tournament_startdate', NOW)
+	end
+
+	Opponent.resolve(opponent, teamTemplateDate, {syncPlayer = true})
+	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
+end
+
+-- called from Module:Match/Subobjects
+---@param player table
+---@return table
+function CustomMatchGroupInput.processPlayer(player)
+	return player
+end
+
+---@param data table
+---@param indexedScores table[]
+---@return table
+---@return table[]
+function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
+	-- Map or Match wasn't played, set not played
+	if
+		Table.includes(NP_STATUSES, data.finished) or
+		Table.includes(NP_STATUSES, data.winner)
+	then
+		data.resulttype = 'np'
+		data.finished = true
+	-- Map or Match is marked as finished.
+	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
+	elseif Logic.readBool(data.finished) then
+		if MatchGroupInput.isDraw(indexedScores) then
+			data.winner = 0
+			data.resulttype = 'draw'
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
+		elseif MatchGroupInput.hasSpecialStatus(indexedScores) then
+			data.winner = MatchGroupInput.getDefaultWinner(indexedScores)
+			data.resulttype = 'default'
+			if MatchGroupInput.hasForfeit(indexedScores) then
+				data.walkover = 'ff'
+			elseif MatchGroupInput.hasDisqualified(indexedScores) then
+				data.walkover = 'dq'
+			elseif MatchGroupInput.hasDefaultWinLoss(indexedScores) then
+				data.walkover = 'l'
+			end
+			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'default')
+		else
+			local winner
+			indexedScores, winner = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, nil, data.finished)
+			data.winner = data.winner or winner
+		end
+	end
+
+	--set it as finished if we have a winner
+	if Logic.isNotEmpty(data.winner) then
+		data.finished = true
+	end
+
+	return data, indexedScores
+end
+
+---@param opponents table[]
+---@param winner integer?
+---@param specialType string?
+---@param finished boolean|string?
+---@return table[]
+---@return integer?
+function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, finished)
+	if specialType == 'draw' then
+		for key, _ in pairs(opponents) do
+			opponents[key].placement = 1
+		end
+	elseif specialType == 'default' then
+		for key, _ in pairs(opponents) do
+			if key == winner then
+				opponents[key].placement = 1
+			else
+				opponents[key].placement = 2
+			end
+		end
+	else
+		local temporaryScore
+		local temporaryPlace = -99
+		local counter = 0
+		for scoreIndex, opp in Table.iter.spairs(opponents, CustomMatchGroupInput.placementSortFunction) do
+			local score = tonumber(opp.score) or ''
+			counter = counter + 1
+			if counter == 1 and Logic.isEmpty(winner) then
+				if finished then
+					winner = scoreIndex
+				end
+			end
+			if temporaryScore == score then
+				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or temporaryPlace
+			else
+				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or counter
+				temporaryPlace = counter
+				temporaryScore = score
+			end
+		end
+	end
+
+	return opponents, winner
+end
+
+---@param tbl table[]
+---@param key1 integer
+---@param key2 integer
+---@return boolean
+function CustomMatchGroupInput.placementSortFunction(tbl, key1, key2)
+	local value1 = tonumber(tbl[key1].score) or -99
+	local value2 = tonumber(tbl[key2].score) or -99
+	return value1 > value2
+end
+
+--
+-- match related functions
+--
+
+---@param match table
+---@return table
+function matchFunctions.getBestOf(match)
+	match.bestof = Logic.emptyOr(match.bestof, Variables.varDefault('bestof', DEFAULT_BESTOF))
+	Variables.varDefine('bestof', match.bestof)
+	return match
+end
+
+-- Calculate the match scores based on the map results (counting map wins)
+-- Only update a teams result if it's
+-- 1) Not manually added
+-- 2) At least one map has a winner
+---@param match table
+---@return table
+function matchFunctions.getScoreFromMapWinners(match)
+	local opponentNumber = 0
+	for index = 1, MAX_NUM_OPPONENTS do
+		if String.isEmpty(match['opponent' .. index]) then
+			break
+		end
+		opponentNumber = index
+	end
+	local newScores = {}
+	local foundScores = false
+
+	for i = 1, MAX_NUM_MAPS do
+		if match['map'..i] then
+			local winner = tonumber(match['map'..i].winner)
+			foundScores = true
+			if winner and winner > 0 and winner <= opponentNumber then
+				newScores[winner] = (newScores[winner] or 0) + 1
+			end
+		else
+			break
+		end
+	end
+
+	for index = 1, opponentNumber do
+		if not match['opponent' .. index].score and foundScores then
+			match['opponent' .. index].score = newScores[index] or 0
+		end
+	end
+
+	return match
+end
+
+---@param match table
+---@return table
+function matchFunctions.getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode', 'team'))
+	match.publishertier = Logic.emptyOr(match.publishertier, Variables.varDefault('tournament_publishertier'))
+	return MatchGroupInput.getCommonTournamentVars(match)
+end
+
+---@param match table
+---@return table
+function matchFunctions.getVodStuff(match)
+	match.stream = Streams.processStreams(match)
+	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
+
+	match.links = {}
+	local links = match.links
+
+	if match.rgl then links.rgl = 'https://rgl.gg/Public/Match.aspx?m=' .. match.rgl end
+	if match.ozf then links.ozf = 'https://warzone.ozfortress.com/matches/' .. match.ozf end
+	if match.etf2l then links.etf2l = 'http://etf2l.org/matches/' .. match.etf2l end
+	if match.tftv then links.tftv = 'http://tf.gg/' .. match.tftv end
+	if match.esl then links.esl = 'https://play.eslgaming.com/match/' .. match.esl end
+	if match.esea then links.esea = 'https://play.esea.net/match/' .. match.esea end
+
+	return match
+end
+
+---@param match table
+---@return table
+function matchFunctions.getExtraData(match)
+	match.extradata = {
+		mvp = MatchGroupInput.readMvp(match),
+		mapveto = MatchGroupInput.getMapVeto(match, ALLOWED_VETOES),
+		casters = MatchGroupInput.readCasters(match),
+	}
+	return match
+end
+
+---@param match table
+---@return table
+function matchFunctions.getOpponents(match)
+	-- read opponents and ignore empty ones
+	local opponents = {}
+	local isScoreSet = false
+	for opponentIndex = 1, MAX_NUM_OPPONENTS do
+		-- read opponent
+		local opponent = match['opponent' .. opponentIndex]
+		if not Logic.isEmpty(opponent) then
+			CustomMatchGroupInput.processOpponent(opponent, match.timestamp)
+
+			-- apply status
+			if TypeUtil.isNumeric(opponent.score) then
+				opponent.status = 'S'
+				isScoreSet = true
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
+				opponent.status = opponent.score
+				opponent.score = -1
+			end
+			opponents[opponentIndex] = opponent
+		end
+	end
+
+	-- see if match should actually be finished if bestof limit was reached
+	if isScoreSet and not Logic.readBool(match.finished) then
+		local firstTo = math.ceil(match.bestof/2)
+		for _, item in pairs(opponents) do
+			if (tonumber(item.score) or 0) >= firstTo then
+				match.finished = true
+				break
+			end
+		end
+	end
+
+	-- see if match should actually be finished if score is set
+	if isScoreSet and not Logic.readBool(match.finished) and match.timestamp ~= DateExt.defaultTimestamp then
+		local threshold = match.dateexact and 30800 or 86400
+		if match.timestamp + threshold < NOW then
+			match.finished = true
+		end
+	end
+
+	-- apply placements and winner if finshed
+	if not String.isEmpty(match.winner) or Logic.readBool(match.finished) then
+		match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
+	end
+
+	-- Update all opponents with new values
+	for opponentIndex, opponent in pairs(opponents) do
+		match['opponent' .. opponentIndex] = opponent
+	end
+	return match
+end
+
+--
+-- map related functions
+--
+
+-- Parse extradata information
+---@param map table
+---@return table
+function mapFunctions.getExtraData(map)
+	map.extradata = {
+		comment = map.comment,
+		header = map.header,
+		logstf = Logic.isNotEmpty(map.logstf) and ('https://logs.tf/' .. map.logstf) or nil,
+		logstfgold = Logic.isNotEmpty(map.logstfgold) and ('https://logs.tf/' .. map.logstfgold) or nil,
+	}
+
+	return map
+end
+
+-- Calculate Score and Winner of the map
+---@param map table
+---@return table
+function mapFunctions.getScoresAndWinner(map)
+	map.scores = {}
+	local indexedScores = {}
+	for scoreIndex = 1, MAX_NUM_OPPONENTS do
+		-- read scores
+		local score = map['score' .. scoreIndex] or map['t' .. scoreIndex .. 'score']
+		local obj = {}
+		if not Logic.isEmpty(score) then
+			if TypeUtil.isNumeric(score) then
+				obj.status = 'S'
+				obj.score = score
+			elseif Table.includes(ALLOWED_STATUSES, score) then
+				obj.status = score
+				obj.score = -1
+			end
+			table.insert(map.scores, score)
+			indexedScores[scoreIndex] = obj
+		else
+			break
+		end
+	end
+
+	map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
+
+	return map
+end
+
+return CustomMatchGroupInput

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -13,7 +13,6 @@ local Lua = require('Module:Lua')
 local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local TypeUtil = require('Module:TypeUtil')
 local Variables = require('Module:Variables')
 local DateExt = require('Module:Date/Ext')
 local Streams = require('Module:Links/Stream')
@@ -227,7 +226,7 @@ function matchFunctions.getOpponents(match)
 		CustomMatchGroupInput.processOpponent(opponent, match.timestamp)
 
 		-- apply status
-		if TypeUtil.isNumeric(opponent.score) then
+		if Logic.isNumeric(opponent.score) then
 			opponent.status = 'S'
 			isScoreSet = true
 		elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
@@ -253,7 +252,7 @@ function matchFunctions.getOpponents(match)
 	end
 
 	-- apply placements and winner if finshed
-	if not String.isEmpty(match.winner) or Logic.readBool(match.finished) then
+	if String.isNotEmpty(match.winner) or Logic.readBool(match.finished) then
 		match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
 	end
 
@@ -293,7 +292,7 @@ function mapFunctions.getScoresAndWinner(map)
 		local score = map['score' .. scoreIndex] or map['t' .. scoreIndex .. 'score']
 		local obj = {}
 		if not Logic.isEmpty(score) then
-			if TypeUtil.isNumeric(score) then
+			if Logic.isNumeric(score) then
 				obj.status = 'S'
 				obj.score = score
 			elseif Table.includes(ALLOWED_STATUSES, score) then

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -15,7 +15,7 @@ local Streams = require('Module:Links/Stream')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
-local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
+local MatchGroupInput = Lua.import('Module:MatchGroup/Input/Util')
 
 local DEFAULT_MODE = 'team'
 
@@ -60,6 +60,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -125,6 +125,13 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 			end
 			indexedScores = MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
 		else
+			--only has exactly 2 opponents, neither more or less
+			assert(#indexedScores == 2, 'Unexpected number of opponents when calculating winner')
+
+			local scores = Array.map(indexedScores, function(indexedScore)
+				return tonumber(indexedScore.score)
+			end)
+			data.winner = tonumber(data.winner) or scores[1] > scores[2] and 1 or 2
 			local winner
 			indexedScores, winner = MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
 			data.winner = data.winner or winner
@@ -137,50 +144,6 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	end
 
 	return data, indexedScores
-end
-
----@param opponents table[]
----@param winner integer?
----@param specialType string?
----@param finished boolean|string?
----@return table[]
----@return integer?
-function MatchGroupInput.setPlacement(opponents, winner, specialType, finished)
-	if specialType == 'draw' then
-		for key, _ in pairs(opponents) do
-			opponents[key].placement = 1
-		end
-	elseif specialType == 'default' then
-		for key, _ in pairs(opponents) do
-			if key == winner then
-				opponents[key].placement = 1
-			else
-				opponents[key].placement = 2
-			end
-		end
-	else
-		local temporaryScore
-		local temporaryPlace = -99
-		local counter = 0
-		for scoreIndex, opp in Table.iter.spairs(opponents, CustomMatchGroupInput.placementSortFunction) do
-			local score = tonumber(opp.score) or ''
-			counter = counter + 1
-			if counter == 1 and Logic.isEmpty(winner) then
-				if finished then
-					winner = scoreIndex
-				end
-			end
-			if temporaryScore == score then
-				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or temporaryPlace
-			else
-				opponents[scoreIndex].placement = tonumber(opponents[scoreIndex].placement) or counter
-				temporaryPlace = counter
-				temporaryScore = score
-			end
-		end
-	end
-
-	return opponents, winner
 end
 
 ---@param tbl table[]

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -266,7 +266,7 @@ function matchFunctions.getVodStuff(match)
 	match.links = {}
 	local links = match.links
 
-	for key, _prefix in pairs(LINK_PREFIXES) do
+	for key in pairs(LINK_PREFIXES) do
 		if match[key] then links[key] = LINK_PREFIXES[key] .. match[key] end
 	end
 

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -15,7 +15,7 @@ local Streams = require('Module:Links/Stream')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
-local MatchGroupInput = Lua.import('Module:MatchGroup/Input/Util')
+local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
 local DEFAULT_MODE = 'team'
 
@@ -32,20 +32,20 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local finishedInput = match.finished --[[@as string?]]
 	local winnerInput = match.winner --[[@as string?]]
 
-	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
+	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInput.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
-	match.bestof = MatchGroupInput.getBestOf(match.bestof, games)
+	match.bestof = MatchGroupInputUtil.getBestOf(match.bestof, games)
 
-	local autoScoreFunction = MatchGroupInput.canUseAutoScore(match, games)
+	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
 		or nil
 
 	Array.forEach(opponents, function(opponent, opponentIndex)
-		opponent.score, opponent.status = MatchGroupInput.computeOpponentScore({
+		opponent.score, opponent.status = MatchGroupInputUtil.computeOpponentScore({
 			walkover = match.walkover,
 			winner = match.winner,
 			opponentIndex = opponentIndex,
@@ -53,16 +53,13 @@ function CustomMatchGroupInput.processMatch(match, options)
 		}, autoScoreFunction)
 	end)
 
-	match.finished = MatchGroupInput.matchIsFinished(match, opponents)
+	match.finished = MatchGroupInputUtil.matchIsFinished(match, opponents)
 
 	if match.finished then
-		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
-		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
-		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
-	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
-		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
-		match.winner = nil
+		match.resulttype = MatchGroupInputUtil.getResultType(winnerInput, finishedInput, opponents)
+		match.walkover = MatchGroupInputUtil.getWalkover(match.resulttype, opponents)
+		match.winner = MatchGroupInputUtil.getWinner(match.resulttype, winnerInput, opponents)
+		MatchGroupInputUtil.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -86,10 +83,10 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		local winnerInput = map.winner --[[@as string?]]
 
 		map.extradata = MapFunctions.getExtraData(map)
-		map.finished = MatchGroupInput.mapIsFinished(map)
+		map.finished = MatchGroupInputUtil.mapIsFinished(map)
 
 		local opponentInfo = Array.map(Array.range(1, opponentCount), function(opponentIndex)
-			local score, status = MatchGroupInput.computeOpponentScore({
+			local score, status = MatchGroupInputUtil.computeOpponentScore({
 				walkover = map.walkover,
 				winner = map.winner,
 				opponentIndex = opponentIndex,
@@ -100,9 +97,9 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
 		if map.finished then
-			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
-			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
-			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)
+			map.resulttype = MatchGroupInputUtil.getResultType(winnerInput, finishedInput, opponentInfo)
+			map.walkover = MatchGroupInputUtil.getWalkover(map.resulttype, opponentInfo)
+			map.winner = MatchGroupInputUtil.getWinner(map.resulttype, winnerInput, opponentInfo)
 		end
 
 		table.insert(maps, map)
@@ -122,7 +119,7 @@ CustomMatchGroupInput.processMap = FnUtil.identity
 ---@return fun(opponentIndex: integer): integer
 function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
-		return MatchGroupInput.computeMatchScoreFromMapWinners(maps, opponentIndex)
+		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
 end
 
@@ -130,7 +127,7 @@ end
 ---@return table
 function MatchFunctions.getTournamentVars(match)
 	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode'), DEFAULT_MODE)
-	return MatchGroupInput.getCommonTournamentVars(match)
+	return MatchGroupInputUtil.getCommonTournamentVars(match)
 end
 
 ---@param match table

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -222,10 +222,10 @@ function matchFunctions.getScoreFromMapWinners(match)
 	local foundScores = false
 
 	for _, map in Table.iter.pairsByPrefix(match, 'map') do
-    	local winner = tonumber(map.winner)
+		local winner = tonumber(map.winner)
 		foundScores = true
-    	if winner and winner > 0 and winner <= opponentNumber then
-        	newScores[winner] = (newScores[winner] or 0) + 1
+		if winner and winner > 0 and winner <= opponentNumber then
+			newScores[winner] = (newScores[winner] or 0) + 1
 		end
 	end
 

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Opponent = require('Module:Opponent')
@@ -53,9 +54,7 @@ function CustomMatchGroupInput.processMatch(match)
 	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
 	match = matchFunctions.getOpponents(match)
 	match = matchFunctions.getTournamentVars(match)
-	match = matchFunctions.getVodStuff(match)
-
-	return match
+	return matchFunctions.getVodStuff(match)
 end
 
 -- called from Module:Match/Subobjects
@@ -63,9 +62,7 @@ end
 ---@return table
 function CustomMatchGroupInput.processMap(map)
 	map = mapFunctions.getExtraData(map)
-	map = mapFunctions.getScoresAndWinner(map)
-
-	return map
+	return mapFunctions.getScoresAndWinner(map)
 end
 
 ---@param record table
@@ -88,11 +85,7 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 end
 
 -- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
+CustomMatchGroupInput.processPlayer = FnUtil.identity
 
 ---@param data table
 ---@param indexedScores table[]
@@ -314,9 +307,7 @@ function mapFunctions.getScoresAndWinner(map)
 		end
 	end
 
-	map = CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
-
-	return map
+	return CustomMatchGroupInput.getResultTypeAndWinner(map, indexedScores)
 end
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -68,7 +68,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match.links = MatchFunctions.getLinks(match, games)
 	match.games = games
 	match.opponents = opponents
-	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end
@@ -151,14 +150,6 @@ function MatchFunctions.getLinks(match, games)
 	end)
 
 	return links
-end
-
----@param match table
----@return table
-function MatchFunctions.getExtraData(match)
-	return {
-		comment = match.comment,
-	}
 end
 
 --

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -19,13 +19,21 @@ local Streams = require('Module:Links/Stream')
 local MatchGroupInput = Lua.import('Module:MatchGroup/Input')
 
 local NP_STATUSES = {'skip', 'np', 'canceled', 'cancelled'}
-local ALLOWED_VETOES = {'decider', 'pick', 'ban', 'defaultban', 'protect'}
 local ALLOWED_STATUSES = { 'W', 'FF', 'DQ', 'L', 'D' }
 local MAX_NUM_OPPONENTS = 2
 local MAX_NUM_MAPS = 20
 local DEFAULT_BESTOF = 3
 
 local NOW = os.time(os.date('!*t') --[[@as osdateparam]])
+
+local LINK_PREFIXES = {
+	rgl = 'https://rgl.gg/Public/Match.aspx?m=',
+	ozf = 'https://warzone.ozfortress.com/matches/',
+	etf2l = 'http://etf2l.org/matches/',
+	tftv = 'http://tf.gg/',
+	esl = 'https://play.eslgaming.com/match/',
+	esea = 'https://play.esea.net/match/',
+}
 
 -- containers for process helper functions
 local matchFunctions = {}
@@ -258,12 +266,9 @@ function matchFunctions.getVodStuff(match)
 	match.links = {}
 	local links = match.links
 
-	if match.rgl then links.rgl = 'https://rgl.gg/Public/Match.aspx?m=' .. match.rgl end
-	if match.ozf then links.ozf = 'https://warzone.ozfortress.com/matches/' .. match.ozf end
-	if match.etf2l then links.etf2l = 'http://etf2l.org/matches/' .. match.etf2l end
-	if match.tftv then links.tftv = 'http://tf.gg/' .. match.tftv end
-	if match.esl then links.esl = 'https://play.eslgaming.com/match/' .. match.esl end
-	if match.esea then links.esea = 'https://play.esea.net/match/' .. match.esea end
+	for key, prefix in pairs(LINK_PREFIXES) do
+		if match[key] then links[key] = LINK_PREFIXES[key] .. match[key] end
+	end
 
 	return match
 end
@@ -273,7 +278,6 @@ end
 function matchFunctions.getExtraData(match)
 	match.extradata = {
 		mvp = MatchGroupInput.readMvp(match),
-		mapveto = MatchGroupInput.getMapVeto(match, ALLOWED_VETOES),
 		casters = MatchGroupInput.readCasters(match),
 	}
 	return match

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -66,9 +66,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match, games)
-
-	match.extradata = MatchFunctions.getExtraData(match)
-
 	match.games = games
 	match.opponents = opponents
 
@@ -157,20 +154,11 @@ function MatchFunctions.getLinks(match, games)
 	}
 
 	Array.forEach(games or {}, function(game, gameIndex)
-			links.logstf[gameIndex] = game.logstf and ('https://logs.tf/' .. game.logstf) or nil
-			links.logstfgold[gameIndex] = game.logstfgold and ('https://logs.tf/' .. game.logstfgold) or nil
+		links.logstf[gameIndex] = game.logstf and ('https://logs.tf/' .. game.logstf) or nil
+		links.logstfgold[gameIndex] = game.logstfgold and ('https://logs.tf/' .. game.logstfgold) or nil
 	end)
 
 	return links
-end
-
-
----@param match table
----@return table
-function MatchFunctions.getExtraData(match)
-	return {
-		mvp = MatchGroupInput.readMvp(match),
-	}
 end
 
 --
@@ -183,7 +171,6 @@ end
 function MapFunctions.getExtraData(map)
 	return {
 		comment = map.comment,
-		header = map.header,
 	}
 end
 

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -118,7 +118,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 		if MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'
-			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
+			indexedScores = MatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
 		elseif MatchGroupInput.hasSpecialStatus(indexedScores) then
 			data.winner = MatchGroupInput.getDefaultWinner(indexedScores)
 			data.resulttype = 'default'
@@ -129,10 +129,10 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 			elseif MatchGroupInput.hasDefaultWinLoss(indexedScores) then
 				data.walkover = 'l'
 			end
-			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'default')
+			indexedScores = MatchGroupInput.setPlacement(indexedScores, data.winner, 'default')
 		else
 			local winner
-			indexedScores, winner = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, nil, data.finished)
+			indexedScores, winner = MatchGroupInput.setPlacement(indexedScores, data.winner, nil, data.finished)
 			data.winner = data.winner or winner
 		end
 	end
@@ -151,7 +151,7 @@ end
 ---@param finished boolean|string?
 ---@return table[]
 ---@return integer?
-function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, finished)
+function MatchGroupInput.setPlacement(opponents, winner, specialType, finished)
 	if specialType == 'draw' then
 		for key, _ in pairs(opponents) do
 			opponents[key].placement = 1
@@ -168,7 +168,7 @@ function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, fini
 		local temporaryScore
 		local temporaryPlace = -99
 		local counter = 0
-		for scoreIndex, opp in Table.iter.spairs(opponents, CustomMatchGroupInput.placementSortFunction) do
+		for scoreIndex, opp in Table.iter.spairs(opponents, MatchGroupInput.placementSortFunction) do
 			local score = tonumber(opp.score) or ''
 			counter = counter + 1
 			if counter == 1 and Logic.isEmpty(winner) then

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -167,7 +167,7 @@ function MatchGroupInput.setPlacement(opponents, winner, specialType, finished)
 		local temporaryScore
 		local temporaryPlace = -99
 		local counter = 0
-		for scoreIndex, opp in Table.iter.spairs(opponents, MatchGroupInput.placementSortFunction) do
+		for scoreIndex, opp in Table.iter.spairs(opponents, CustomMatchGroupInput.placementSortFunction) do
 			local score = tonumber(opp.score) or ''
 			counter = counter + 1
 			if counter == 1 and Logic.isEmpty(winner) then

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -69,9 +69,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match, games)
-	match.extradata = MatchFunctions.getExtraData(match)
 	match.games = games
 	match.opponents = opponents
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -117,7 +117,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 		if MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'
-			indexedScores = MatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
+			MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 1)
 		elseif MatchGroupInput.hasSpecialStatus(indexedScores) then
 			data.winner = MatchGroupInput.getDefaultWinner(indexedScores)
 			data.resulttype = 'default'
@@ -128,10 +128,10 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 			elseif MatchGroupInput.hasDefaultWinLoss(indexedScores) then
 				data.walkover = 'l'
 			end
-			indexedScores = MatchGroupInput.setPlacement(indexedScores, data.winner, 'default')
+			indexedScores = MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
 		else
 			local winner
-			indexedScores, winner = MatchGroupInput.setPlacement(indexedScores, data.winner, nil, data.finished)
+			indexedScores, winner = MatchGroupInput.setPlacement(indexedScores, data.winner, 1, 2)
 			data.winner = data.winner or winner
 		end
 	end

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -9,7 +9,6 @@
 local MatchLegacy = {}
 
 local Json = require('Module:Json')
-local Lua = require('Module:Lua')
 local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -13,17 +13,6 @@ local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-function MatchLegacy.storeMatch(match2, options)
-	if not options.storeMatch1 then
-		return
-	end
-
-	return mw.ext.LiquipediaDB.lpdb_match(
-		'legacymatch_' .. match2.match2id,
-		MatchLegacy._convertParameters(match2)
-	)
-end
-
 function MatchLegacy._convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -13,6 +13,13 @@ local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
+function MatchLegacy.storeMatch(match2)
+	return mw.ext.LiquipediaDB.lpdb_match(
+		'legacymatch_' .. match2.match2id,
+		MatchLegacy._convertParameters(match2)
+	)
+end
+
 function MatchLegacy._convertParameters(match2)
 	local match = Table.deepCopy(match2)
 	for key, _ in pairs(match) do

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -34,9 +34,6 @@ function MatchLegacy.storeGames(match, match2)
 	for gameIndex, game2 in ipairs(match2.match2games or {}) do
 		local game = Table.deepCopy(game2)
 		local scores = game2.scores or {}
-		if type(scores) == 'string' then
-			scores = Json.parse(scores)
-		end
 		local res = mw.ext.LiquipediaDB.lpdb_game(
 			'legacygame_' .. match2.match2id .. gameIndex,
 			Json.stringifySubTables(game)
@@ -64,8 +61,7 @@ function MatchLegacy._convertParameters(match2)
 
 	-- Handle extradata fields
 	match.extradata = {}
-	local extradata = Json.parseIfString(match2.extradata)
-
+	
 	local bracketData = Json.parseIfString(match2.match2bracketdata)
 	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
 		if bracketData.inheritedheader then

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -19,28 +19,10 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy._convertParameters(match2)
 
-	if options.storeMatch1 then
-		match.games = MatchLegacy.storeGames(match, match2)
-
 		return mw.ext.LiquipediaDB.lpdb_match(
 			'legacymatch_' .. match2.match2id,
 			match
 		)
-	end
-end
-
-function MatchLegacy.storeGames(match, match2)
-	local games = ''
-	for gameIndex, game2 in ipairs(match2.match2games or {}) do
-		local game = Table.deepCopy(game2)
-		local scores = game2.scores or {}
-		local res = mw.ext.LiquipediaDB.lpdb_game(
-			'legacygame_' .. match2.match2id .. gameIndex,
-			Json.stringifySubTables(game)
-		)
-		games = games .. res
-	end
-	return games
 end
 
 function MatchLegacy._convertParameters(match2)
@@ -59,16 +41,6 @@ function MatchLegacy._convertParameters(match2)
 
 	match.staticid = match2.match2id
 
-	-- Handle extradata fields
-	match.extradata = {}
-	
-	local bracketData = Json.parseIfString(match2.match2bracketdata)
-	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
-		if bracketData.inheritedheader then
-			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
-		end
-	end
-
 	-- Handle Opponents
 	local handleOpponent = function (index)
 		local prefix = 'opponent'..index
@@ -76,9 +48,9 @@ function MatchLegacy._convertParameters(match2)
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == Opponent.team then
 			match[prefix] = opponent.name
-			match[prefix..'score'] = tonumber(opponent.score) or 0 >= 0 and opponent.score or 0
+			match[prefix..'score'] = tonumber(opponent.score) or 0 > 0 and opponent.score or 0
 			local opponentplayers = {}
-			for i = 1, 10 do
+			for i = 1, 6 do
 				local player = opponentmatch2players[i] or {}
 				opponentplayers['p' .. i] = player.name or ''
 				opponentplayers['p' .. i .. 'flag'] = player.flag or ''
@@ -88,7 +60,7 @@ function MatchLegacy._convertParameters(match2)
 		elseif opponent.type == Opponent.solo then
 			local player = opponentmatch2players[1] or {}
 			match[prefix] = player.name
-			match[prefix..'score'] = tonumber(opponent.score) or 0 >= 0 and opponent.score or 0
+			match[prefix..'score'] = tonumber(opponent.score) or 0 > 0 and opponent.score or 00
 			match[prefix..'flag'] = player.flag
 		elseif opponent.type == Opponent.literal then
 			match[prefix] = 'TBD'

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -14,15 +14,13 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 function MatchLegacy.storeMatch(match2, options)
-	local match = MatchLegacy._convertParameters(match2)
-
-	if options.storeMatch1 then
-		match.games = match2
+	if not options.storeMatch1 then
+		return
 	end
 
 	return mw.ext.LiquipediaDB.lpdb_match(
 		'legacymatch_' .. match2.match2id,
-		match
+		MatchLegacy._convertParameters(match2)
 	)
 end
 

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -16,10 +16,14 @@ local Table = require('Module:Table')
 function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy._convertParameters(match2)
 
-		return mw.ext.LiquipediaDB.lpdb_match(
-			'legacymatch_' .. match2.match2id,
-			match
-		)
+	if options.storeMatch1 then
+		match.games = match2
+	end
+	
+	return mw.ext.LiquipediaDB.lpdb_match(
+		'legacymatch_' .. match2.match2id,
+		match
+	)
 end
 
 function MatchLegacy._convertParameters(match2)
@@ -45,7 +49,7 @@ function MatchLegacy._convertParameters(match2)
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == Opponent.team then
 			match[prefix] = opponent.name
-			match[prefix..'score'] = tonumber(opponent.score) or 0 > 0 and opponent.score or 0
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1, 6 do
 				local player = opponentmatch2players[i] or {}
@@ -57,7 +61,7 @@ function MatchLegacy._convertParameters(match2)
 		elseif opponent.type == Opponent.solo then
 			local player = opponentmatch2players[1] or {}
 			match[prefix] = player.name
-			match[prefix..'score'] = tonumber(opponent.score) or 0 > 0 and opponent.score or 00
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix..'flag'] = player.flag
 		elseif opponent.type == Opponent.literal then
 			match[prefix] = 'TBD'

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -14,8 +14,6 @@ local Opponent = require('Module:Opponent')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
-
 function MatchLegacy.storeMatch(match2, options)
 	local match = MatchLegacy._convertParameters(match2)
 

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -1,0 +1,130 @@
+---
+-- @Liquipedia
+-- wiki=teamfortress
+-- page=Module:Match/Legacy
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local MatchLegacy = {}
+
+local Json = require('Module:Json')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+
+function MatchLegacy.storeMatch(match2, options)
+	local match = MatchLegacy._convertParameters(match2)
+
+	if options.storeMatch1 then
+		match.games = MatchLegacy.storeGames(match, match2)
+
+		return mw.ext.LiquipediaDB.lpdb_match(
+			'legacymatch_' .. match2.match2id,
+			match
+		)
+	end
+end
+
+function MatchLegacy.storeGames(match, match2)
+	local games = ''
+	for gameIndex, game2 in ipairs(match2.match2games or {}) do
+		local game = Table.deepCopy(game2)
+		-- Extradata
+		game.extradata = {}
+		game.extradata.gamenumber = gameIndex
+		-- Other stuff
+		game.opponent1 = match.opponent1
+		game.opponent2 = match.opponent2
+		game.opponent1flag = match.opponent1flag
+		game.opponent2flag = match.opponent2flag
+		game.date = match.date
+		local scores = game2.scores or {}
+		if type(scores) == 'string' then
+			scores = Json.parse(scores)
+		end
+		game.opponent1score = scores[1] or 0
+		game.opponent2score = scores[2] or 0
+		local res = mw.ext.LiquipediaDB.lpdb_game(
+			'legacygame_' .. match2.match2id .. gameIndex,
+			Json.stringifySubTables(game)
+		)
+		games = games .. res
+	end
+	return games
+end
+
+function MatchLegacy._convertParameters(match2)
+	local match = Table.deepCopy(match2)
+	for key, _ in pairs(match) do
+		if String.startsWith(key, 'match2') then
+			match[key] = nil
+		end
+	end
+
+	if match.walkover == 'ff' or match.walkover == 'dq' then
+		match.walkover = match.winner
+	elseif match.walkover == 'l' then
+		match.walkover = nil
+	end
+
+	match.staticid = match2.match2id
+
+	-- Handle extradata fields
+	match.extradata = {}
+	local extradata = Json.parseIfString(match2.extradata)
+
+	local mvp = Json.parseIfString(extradata.mvp)
+	if mvp and mvp.players then
+		local players = {}
+		for _, player in ipairs(mvp.players) do
+			table.insert(players, player.name .. '|' .. player.displayname)
+		end
+		match.extradata.mvp = table.concat(players, ',')
+		match.extradata.mvp = match.extradata.mvp .. ';' .. mvp.points
+	end
+
+	match.extradata.matchsection = extradata.matchsection
+	match.extradata.bestofx = match2.bestof ~= 0 and tostring(match2.bestof) or ''
+	local bracketData = Json.parseIfString(match2.match2bracketdata)
+	if type(bracketData) == 'table' and bracketData.type == 'bracket' then
+		if bracketData.inheritedheader then
+			match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]
+		end
+	end
+
+	-- Handle Opponents
+	local handleOpponent = function (index)
+		local prefix = 'opponent'..index
+		local opponent = match2.match2opponents[index] or {}
+		local opponentmatch2players = opponent.match2players or {}
+		if opponent.type == 'team' then
+			match[prefix] = mw.ext.TeamTemplate.teampage(opponent.template)
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
+			local opponentplayers = {}
+			for i = 1,10 do
+				local player = opponentmatch2players[i] or {}
+				opponentplayers['p' .. i] = player.name or ''
+				opponentplayers['p' .. i .. 'flag'] = player.flag or ''
+				opponentplayers['p' .. i .. 'dn'] = player.displayname or ''
+			end
+			match[prefix..'players'] = opponentplayers
+		elseif opponent.type == 'solo' then
+			local player = opponentmatch2players[1] or {}
+			match[prefix] = player.name
+			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
+			match[prefix..'flag'] = player.flag
+		elseif opponent.type == 'literal' then
+			match[prefix] = 'TBD'
+		end
+	end
+
+	handleOpponent(1)
+	handleOpponent(2)
+
+	return Json.stringifySubTables(match)
+end
+
+return MatchLegacy

--- a/components/match2/wikis/teamfortress/match_legacy.lua
+++ b/components/match2/wikis/teamfortress/match_legacy.lua
@@ -19,7 +19,7 @@ function MatchLegacy.storeMatch(match2, options)
 	if options.storeMatch1 then
 		match.games = match2
 	end
-	
+
 	return mw.ext.LiquipediaDB.lpdb_match(
 		'legacymatch_' .. match2.match2id,
 		match

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -1,0 +1,360 @@
+---
+-- @Liquipedia
+-- wiki=teamfortress
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Abbreviation = require('Module:Abbreviation')
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
+local Icon = require('Module:Icon')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local Table = require('Module:Table')
+local String = require('Module:StringUtils')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
+
+local MAP_VETO_START = '<b>Start Map Veto</b>'
+local ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]'
+local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
+local NONE = '-'
+local TBD = Abbreviation.make('TBD', 'To Be Determined') --[[@as string]]
+
+---@enum TFMatchIcons
+local Icons = {
+	CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'},
+	EMPTY = '[[File:NoCheck.png|link=]]',
+}
+
+local LINK_DATA = {
+	logstf = {icon = 'File:Logstf_icon.png', text = 'logs.tf Match Page '},
+	logstfgold = {icon = 'File:Logstf_gold_icon.png', text = 'logs.tf Match Page (Golden Cap) '},
+	esl = {
+		icon = 'File:ESL 2019 icon lightmode.png',
+		iconDark = 'File:ESL 2019 icon darkmode.png',
+		text = 'ESL matchpage'
+	},
+	esea = {icon = 'File:ESEA icon allmode.png', text = 'ESEA Match Page'},
+	etf2l = {icon = 'File:ETF2L.png', text = 'ETF2L Match Page'},
+	rgl = {icon = 'File:RGL_Logo.png', text = 'RGL Match Page'},
+	ozf = {icon = 'File:ozfortress-icon.png‎', text = 'ozfortress Match Page'},
+	tftv = {icon = 'File:Teamfortress.tv.png', text = 'TFTV Match Page'},
+}
+
+local VETO_TYPE_TO_TEXT = {
+	ban = 'BAN',
+	pick = 'PICK',
+	decider = 'DECIDER',
+	defaultban = 'DEFAULT BAN',
+}
+
+local CustomMatchSummary = {}
+
+-- Map Veto Class
+---@class TeamFortressMapVeto: MatchSummaryRowInterface
+---@operator call: self
+---@field root Html
+---@field table Html
+local MapVeto = Class.new(
+	function(self)
+		self.root = mw.html.create('div'):addClass('brkts-popup-mapveto')
+		self.table = self.root:tag('table')
+			:addClass('wikitable-striped'):addClass('collapsible'):addClass('collapsed')
+		self:createHeader()
+	end
+)
+
+---@return self
+function MapVeto:createHeader()
+	self.table:tag('tr')
+		:tag('th'):css('width','33%'):done()
+		:tag('th'):css('width','34%'):wikitext('Map Veto'):done()
+		:tag('th'):css('width','33%'):done()
+	return self
+end
+
+---@param firstVeto number?
+---@param format string?
+---@return self
+function MapVeto:vetoStart(firstVeto, format)
+	format = format and ('Veto format: ' .. format) or nil
+	local textLeft
+	local textCenter
+	local textRight
+	if firstVeto == 1 then
+		textLeft = MAP_VETO_START
+		textCenter = ARROW_LEFT
+		textRight = format
+	elseif firstVeto == 2 then
+		textLeft = format
+		textCenter = ARROW_RIGHT
+		textRight = MAP_VETO_START
+	else return self end
+
+	self.table:tag('tr'):addClass('brkts-popup-mapveto-vetostart')
+		:tag('th'):wikitext(textLeft):done()
+		:tag('th'):wikitext(textCenter):done()
+		:tag('th'):wikitext(textRight):done()
+
+	return self
+end
+
+---@param map1 string?
+---@param map2 string?
+---@return string, string
+function MapVeto._displayMaps(map1, map2)
+	if Logic.isEmpty(map1) and Logic.isEmpty(map2) then
+		return TBD, TBD
+	end
+
+	return Page.makeInternalLink(map1) or NONE,
+		Page.makeInternalLink(map2) or NONE
+end
+
+---@param map string?
+---@return self
+function MapVeto:addDecider(map)
+	map = Page.makeInternalLink(map) or TBD
+	local row = mw.html.create('tr'):addClass('brkts-popup-mapveto-vetoround')
+
+	self:addColumnVetoType(row, 'brkts-popup-mapveto-decider', 'DECIDER')
+	self:addColumnVetoMap(row, map)
+	self:addColumnVetoType(row, 'brkts-popup-mapveto-decider', 'DECIDER')
+
+	self.table:node(row)
+	return self
+end
+
+---@param vetoType string?
+---@param map1 string?
+---@param map2 string?
+---@return self
+function MapVeto:addRound(vetoType, map1, map2)
+	map1, map2 = MapVeto._displayMaps(map1, map2)
+
+	local vetoText = VETO_TYPE_TO_TEXT[vetoType]
+
+	if not vetoText then return self end
+
+	local class = 'brkts-popup-mapveto-' .. vetoType
+
+	local row = mw.html.create('tr'):addClass('brkts-popup-mapveto-vetoround')
+
+	self:addColumnVetoMap(row, map1)
+	self:addColumnVetoType(row, class, vetoText)
+	self:addColumnVetoMap(row, map2)
+
+	self.table:node(row)
+	return self
+end
+
+---@param row Html
+---@param styleClass string
+---@param vetoText string
+---@return self
+function MapVeto:addColumnVetoType(row, styleClass, vetoText)
+	row:tag('td')
+		:tag('span')
+			:addClass(styleClass)
+			:addClass('brkts-popup-mapveto-vetotype')
+			:wikitext(vetoText)
+	return self
+end
+
+---@param row Html
+---@param map string
+---@return self
+function MapVeto:addColumnVetoMap(row, map)
+	row:tag('td'):wikitext(map):done()
+	return self
+end
+
+---@return Html
+function MapVeto:create()
+	return self.root
+end
+
+---@param args table
+---@return Html
+function CustomMatchSummary.getByMatchId(args)
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
+end
+
+---@param match MatchGroupUtilMatch
+---@param footer MatchSummaryFooter
+---@return MatchSummaryFooter
+function CustomMatchSummary.addToFooter(match, footer)
+	footer = MatchSummary.addVodsToFooter(match, footer)
+		:addLinks(LINK_DATA, match.links)
+
+	---@param link string?
+	---@param linkType string 
+	---@param gameIndex integer
+	local addLink = function(link, linkType, gameIndex)
+		if Logic.isEmpty(link) then return end
+		local linkData = LINK_DATA[linkType]
+		footer:addLink(link, linkData.icon, linkData.iconDark, linkData.text .. 'for game ' .. gameIndex)
+	end
+
+	Array.forEach(match.games or {}, function(game, gameIndex)
+		local extradata = game.extradata or {}
+		addLink(extradata.logstf, 'logstf', gameIndex)
+		addLink(extradata.logstfgold, 'logstfgold', gameIndex)
+		--add further such game specific stuff here if there is ...
+	end)
+
+	return footer
+end
+
+---@param match MatchGroupUtilMatch
+---@return MatchSummaryBody
+function CustomMatchSummary.createBody(match)
+	local body = MatchSummary.Body()
+
+	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
+		-- dateIsExact means we have both date and time. Show countdown
+		-- if match is not epoch=0, we have a date, so display the date
+		body:addRow(MatchSummary.Row():addElement(
+			DisplayHelper.MatchCountdownBlock(match)
+		))
+	end
+
+	-- Iterate each map
+	for _, game in ipairs(match.games) do
+		if game.map then
+			body:addRow(CustomMatchSummary._createMapRow(game))
+		end
+	end
+
+	-- Add Match MVP(s)
+	if match.extradata.mvp then
+		local mvpData = match.extradata.mvp
+		if not Table.isEmpty(mvpData) and mvpData.players then
+			local mvp = MatchSummary.Mvp()
+			for _, player in ipairs(mvpData.players) do
+				mvp:addPlayer(player)
+			end
+			mvp:setPoints(mvpData.points)
+
+			body:addRow(mvp)
+		end
+
+	end
+
+	-- Add casters
+	if String.isNotEmpty(match.extradata.casters) then
+		local casters = Json.parseIfString(match.extradata.casters)
+		local casterRow = MatchSummary.Casters()
+		for _, caster in pairs(casters) do
+			casterRow:addCaster(caster)
+		end
+
+		body:addRow(casterRow)
+	end
+
+	-- Add the Map Vetoes
+	if match.extradata.mapveto then
+		local vetoData = match.extradata.mapveto
+		if vetoData then
+			local mapVeto = MapVeto()
+
+			for _,vetoRound in ipairs(vetoData) do
+				if vetoRound.vetostart then
+					mapVeto:vetoStart(tonumber(vetoRound.vetostart))
+				end
+				if vetoRound.type == 'decider' then
+					mapVeto:addDecider(vetoRound.decider)
+				else
+					mapVeto:addRound(vetoRound.type, vetoRound.team1, vetoRound.team2)
+				end
+			end
+
+			body:addRow(mapVeto)
+		end
+	end
+
+	return body
+end
+---@param game MatchGroupUtilGame
+---@param opponentIndex integer
+---@return Html
+function CustomMatchSummary._gameScore(game, opponentIndex)
+	return mw.html.create('div'):wikitext(game.scores[opponentIndex])
+end
+
+---@param game MatchGroupUtilGame
+---@return MatchSummaryRow
+function CustomMatchSummary._createMapRow(game)
+	local row = MatchSummary.Row()
+
+	-- Add Header
+	if Logic.isNotEmpty(game.header) then
+		local mapHeader = mw.html.create('div')
+			:wikitext(game.header)
+			:css('font-weight','bold')
+			:css('font-size','85%')
+			:css('margin','auto')
+		row:addElement(mapHeader)
+		row:addElement(MatchSummary.Break():create())
+	end
+
+	local centerNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:wikitext(Page.makeInternalLink(game.map))
+		:css('text-align', 'center')
+
+	if game.resultType == 'np' then
+		centerNode:addClass('brkts-popup-spaced-map-skip')
+	end
+
+	local leftNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 1, Icons.CHECK))
+		:node(CustomMatchSummary._gameScore(game, 1))
+		:css('width', '20%')
+
+	local rightNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(CustomMatchSummary._gameScore(game, 2))
+		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 2, Icons.CHECK))
+		:css('width', '20%')
+
+	row:addElement(leftNode)
+		:addElement(centerNode)
+		:addElement(rightNode)
+
+	row:addClass('brkts-popup-body-game')
+		:css('overflow', 'hidden')
+
+	-- Add Comment
+	if Logic.isNotEmpty(game.comment) then
+		row:addElement(MatchSummary.Break():create())
+		local comment = mw.html.create('div')
+			:wikitext(game.comment)
+			:css('margin', 'auto')
+		row:addElement(comment)
+	end
+
+	return row
+end
+
+---@param showIcon boolean?
+---@param iconType TeamFortressMatchIcons?
+---@return Html
+function CustomMatchSummary._createCheckMarkOrCross(showIcon, iconType)
+	local container = mw.html.create('div'):addClass('brkts-popup-spaced'):css('line-height', '27px')
+
+	if showIcon then
+		return container:node(iconType)
+	end
+	return container:node(Icons.EMPTY)
+end
+
+return CustomMatchSummary

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -84,11 +84,10 @@ function CustomMatchSummary.createBody(match)
 	end
 
 	-- Iterate each map
-	for _, game in ipairs(match.games) do
-		if game.map then
-			body:addRow(CustomMatchSummary._createMapRow(game))
-		end
-	end
+	Array.forEach(match.games, function(game)
+		if not game.map then return end
+		body:addRow(CustomMatchSummary._createMapRow(game))
+	end)
 
 	return body
 end
@@ -159,11 +158,10 @@ end
 ---@param icon strings?
 ---@return Html
 function CustomMatchSummary._createCheckMarkOrCross(showIcon, icon)
-	local container = mw.html.create('div'):addClass('brkts-popup-spaced'):css('line-height', '27px')
-	if showIcon then
-		return container:node(icon)
-	end
-	return container:node(Icons.EMPTY)
+	return mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:css('line-height', '27px')
+		:node(showIcon and icon or Icons.EMPTY)
 end
 
 return CustomMatchSummary

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -84,9 +84,10 @@ function CustomMatchSummary.createBody(match)
 	end
 
 	-- Iterate each map
-	for gameIndex, game in ipairs(match.games) do
-		local rowDisplay = CustomMatchSummary._createMapRow(game, gameIndex, match.date)
-		body:addRow(rowDisplay)
+	for _, game in ipairs(match.games) do
+		if game.map then
+			body:addRow(CustomMatchSummary._createMapRow(game))
+		end
 	end
 
 	return body

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -62,7 +62,7 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or DateExt.isDefaultTimestamp(match.timestamp) then
+	if not DateExt.isDefaultTimestamp(match.timestamp) then
 		-- dateIsExact means we have both date and time. Show countdown
 		-- if match is not default timestamp, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -20,7 +20,7 @@ local htmlCreate = mw.html.create
 
 ---@enum TFMatchIcons
 local Icons = {
-	CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'},
+	CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = 'initial'},
 	EMPTY = '[[File:NoCheck.png|link=]]',
 }
 
@@ -83,7 +83,7 @@ end
 ---@param opponentIndex integer
 ---@return Html
 function CustomMatchSummary._gameScore(game, opponentIndex)
-	local score = game.scores[opponentIndex] --[[@as number|string?]]
+	local score = game.scores[opponentIndex]
 	local scoreDisplay = DisplayHelper.MapScore(score, opponentIndex, game.resultType, game.walkover, game.winner)
 	return htmlCreate('div'):wikitext(scoreDisplay)
 end

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -6,16 +6,13 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
-local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local Table = require('Module:Table')
-local String = require('Module:StringUtils')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
@@ -69,7 +66,6 @@ function CustomMatchSummary.addToFooter(match, footer)
 		local extradata = game.extradata or {}
 		addLink(extradata.logstf, 'logstf', gameIndex)
 		addLink(extradata.logstfgold, 'logstfgold', gameIndex)
-		--add further such game specific stuff here if there is ...
 	end)
 
 	return footer

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -93,17 +93,6 @@ end
 function CustomMatchSummary._createMapRow(game)
 	local row = MatchSummary.Row()
 
-	-- Add Header
-	if Logic.isNotEmpty(game.header) then
-		local mapHeader = mw.html.create('div')
-			:wikitext(game.header)
-			:css('font-weight','bold')
-			:css('font-size','85%')
-			:css('margin','auto')
-		row:addElement(mapHeader)
-		row:addElement(MatchSummary.Break():create())
-	end
-
 	local centerNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')
 		:wikitext(Page.makeInternalLink(game.map))

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -52,15 +52,6 @@ function CustomMatchSummary.addToFooter(match, footer)
 	footer = MatchSummary.addVodsToFooter(match, footer)
 		:addLinks(LINK_DATA, match.links)
 
-	---@param link string?
-	---@param linkType string
-	---@param gameIndex integer
-	local addLink = function(link, linkType, gameIndex)
-		if Logic.isEmpty(link) then return end
-		local linkData = LINK_DATA[linkType]
-		footer:addLink(link, linkData.icon, linkData.iconDark, linkData.text .. 'for game ' .. gameIndex)
-	end
-
 	return footer
 end
 

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -90,24 +90,6 @@ function CustomMatchSummary.createBody(match)
 		body:addRow(rowDisplay)
 	end
 
-	-- Add Match MVP(s)
-	if match.extradata.mvp then
-		local mvpData = match.extradata.mvp
-		if not Table.isEmpty(mvpData) and mvpData.players then
-			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData.players) do
-				mvp:addPlayer(player)
-			end
-			mvp:setPoints(mvpData.points)
-
-			body:addRow(mvp)
-		end
-
-	end
-
-	-- Add casters
-	body:addRow(MatchSummary.makeCastersRow(match.extradata.casters))
-
 	return body
 end
 ---@param game MatchGroupUtilGame

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -75,9 +75,9 @@ end
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 
-	if match.dateIsExact or match.timestamp ~= DateExt.defaultTimestamp then
+	if match.dateIsExact or DateExt.isDefaultTimestamp(match.timestamp) then
 		-- dateIsExact means we have both date and time. Show countdown
-		-- if match is not epoch=0, we have a date, so display the date
+		-- if match is not default timestamp, we have a date, so display the date
 		body:addRow(MatchSummary.Row():addElement(
 			DisplayHelper.MatchCountdownBlock(match)
 		))
@@ -156,7 +156,7 @@ function CustomMatchSummary._createMapRow(game)
 end
 
 ---@param showIcon boolean?
----@param iconType TFMatchIcons?
+---@param iconType strings?
 ---@return Html
 function CustomMatchSummary._createCheckMarkOrCross(showIcon, iconType)
 	local container = mw.html.create('div'):addClass('brkts-popup-spaced'):css('line-height', '27px')

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -72,7 +72,6 @@ function CustomMatchSummary.createBody(match)
 
 	-- Iterate each map
 	Array.forEach(match.games, function(game)
-		if not game.map then return end
 		body:addRow(CustomMatchSummary._createMapRow(game))
 	end)
 

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -195,7 +195,7 @@ function CustomMatchSummary.addToFooter(match, footer)
 		:addLinks(LINK_DATA, match.links)
 
 	---@param link string?
-	---@param linkType string 
+	---@param linkType string
 	---@param gameIndex integer
 	local addLink = function(link, linkType, gameIndex)
 		if Logic.isEmpty(link) then return end

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -16,6 +16,8 @@ local Page = require('Module:Page')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 
+local htmlCreate = mw.html.create
+
 ---@enum TFMatchIcons
 local Icons = {
 	CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'},
@@ -76,11 +78,14 @@ function CustomMatchSummary.createBody(match)
 
 	return body
 end
+
 ---@param game MatchGroupUtilGame
 ---@param opponentIndex integer
 ---@return Html
 function CustomMatchSummary._gameScore(game, opponentIndex)
-	return mw.html.create('div'):wikitext(game.scores[opponentIndex])
+	local score = game.scores[opponentIndex] --[[@as number|string?]]
+	local scoreDisplay = DisplayHelper.MapScore(score, opponentIndex, game.resultType, game.walkover, game.winner)
+	return htmlCreate('div'):wikitext(scoreDisplay)
 end
 
 ---@param game MatchGroupUtilGame

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -12,7 +12,6 @@ local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
-local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -156,13 +156,12 @@ function CustomMatchSummary._createMapRow(game)
 end
 
 ---@param showIcon boolean?
----@param iconType strings?
+---@param icon strings?
 ---@return Html
-function CustomMatchSummary._createCheckMarkOrCross(showIcon, iconType)
+function CustomMatchSummary._createCheckMarkOrCross(showIcon, icon)
 	local container = mw.html.create('div'):addClass('brkts-popup-spaced'):css('line-height', '27px')
-
 	if showIcon then
-		return container:node(iconType)
+		return container:node(icon)
 	end
 	return container:node(Icons.EMPTY)
 end

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -61,12 +61,6 @@ function CustomMatchSummary.addToFooter(match, footer)
 		footer:addLink(link, linkData.icon, linkData.iconDark, linkData.text .. 'for game ' .. gameIndex)
 	end
 
-	Array.forEach(match.games or {}, function(game, gameIndex)
-		local extradata = game.extradata or {}
-		addLink(extradata.logstf, 'logstf', gameIndex)
-		addLink(extradata.logstfgold, 'logstfgold', gameIndex)
-	end)
-
 	return footer
 end
 


### PR DESCRIPTION
## Summary
**Match2 for Team Fortress wiki**, they are one of wikis that hasnt got one but also pretty similar to existing setups we have.

**Base**
- The first revision is a paste from World of Tanks (which Tanks itself is then a cleaner/updated version based on COD)
- a Match of TF behaves similar to those, Have Maps and Scores
 
**Custom**
- Due to Team Fortress has quite a lot of custom links that needs to be added back, there are more than usual here
- **logstf and logstfgold** are suggested to be added as Per Map instead of a single link. Similar to **stats** in CS Match2, because of this both logstf does get stored in Extradatas.
- **_Vetos/MVP may be removed later, I'm still waiting response from the editors if they want it_** 

## How did you test this change?
LIVE on Several pages : https://liquipedia.net/teamfortress/ETF2L/Season_31/Highlander/Premiership/Preseason_Playoffs

## Sidenote 
Because there are the **{{match}} vs {{match/old}}** thing that needs to be converted, the Copypaste Generator is not included here, will make a separate PR when the conversion for that is done