### PR TITLE
fix(infobox): incorrect category naming on Brawl Stars's player infobox

### DIFF
--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -206,4 +206,13 @@ function CustomPlayer:defineCustomPageVariables(args)
 	end
 end
 
+---@param categories string[]
+---@return string[]
+function CustomPlayer:getWikiCategories(categories)
+	if self.role2 then
+		table.insert(categories, self.role2.category .. 's')
+	end
+	return categories
+end
+
 return CustomPlayer

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -26,14 +26,14 @@ local Cell = Widgets.Cell
 
 local ROLES = {
 	-- staff
-	coach = {category = 'Coaches', variable = 'Coach', isplayer = false, personType = 'staff'},
+	coach = {category = 'Coache', variable = 'Coach', isplayer = false, personType = 'staff'},
 	manager = {category = 'Manager', variable = 'Manager', isplayer = false, personType = 'staff'},
 
 	-- talent
-	analyst = {category = 'Analysts', variable = 'Analyst', isplayer = false, personType = 'talent'},
-	caster = {category = 'Casters', variable = 'Caster', isplayer = false, personType = 'talent'},
+	analyst = {category = 'Analyst', variable = 'Analyst', isplayer = false, personType = 'talent'},
+	caster = {category = 'Caster', variable = 'Caster', isplayer = false, personType = 'talent'},
 	['content creator'] = {
-		category = 'Content Creators', variable = 'Content Creator', isplayer = false, personType = 'talent'},
+		category = 'Content Creator', variable = 'Content Creator', isplayer = false, personType = 'talent'},
 	host = {category = 'Host', variable = 'Host', isplayer = false, personType = 'talent'},
 }
 ROLES['assistant coach'] = ROLES.coach
@@ -205,15 +205,6 @@ function CustomPlayer:defineCustomPageVariables(args)
 		Variables.varDefine('role2', self.role2.variable)
 		Variables.varDefine('type2', self.role2.personType)
 	end
-end
-
----@param categories string[]
----@return string[]
-function CustomPlayer:getWikiCategories(categories)
-	return Array.append(categories,
-		(self.role or {}).category,
-		(self.role2 or {}).category
-	)
 end
 
 return CustomPlayer


### PR DESCRIPTION
## Summary
In addition, the plain category was added in both the custom as well as the base, removed that.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
via dev: 
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/fe95cf29-57ff-4a3a-9c21-5b4adfb59bce)
![image](https://github.com/Liquipedia/Lua-Modules/assets/16326643/3239f5c7-4c63-4e5e-bb16-64489f0cd2ff)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
