### PR TITLE
fix(prizepool): Do not reuse tables in placement data

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -877,17 +877,24 @@ function BasePrizePool:storeData()
 		icondark = Variables.varDefault('tournament_icondark'),
 		game = Variables.varDefault('tournament_game'),
 		prizepoolindex = prizePoolIndex,
-		lastvsdata = {},
-		opponentplayers = {},
-		players = {},
-		extradata = {},
 	}
 
 	local lpdbData = {}
 	for _, placement in ipairs(self.placements) do
 		local lpdbEntries = placement:_getLpdbData(prizePoolIndex, self.options.lpdbPrefix)
 
-		lpdbEntries = Array.map(lpdbEntries, function(lpdbEntry) return Table.merge(lpdbTournamentData, lpdbEntry) end)
+		lpdbEntries = Array.map(lpdbEntries, function(lpdbEntry)
+			return Table.merge(
+				lpdbTournamentData,
+				{
+					lastvsdata = {},
+					opponentplayers = {},
+					players = {},
+					extradata = {},
+				},
+				lpdbEntry
+			)
+		end)
 
 		Array.extendWith(lpdbData, lpdbEntries)
 	end


### PR DESCRIPTION
## Summary
#4319 introduced an issue where the stringification failed due to "circular references".
Instead of copying existing tables, create new ones for every placement.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
via dev, another fix is currently active on live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
