### PR TITLE
fix(infobox): brawlstars role check

### DIFF
--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -209,7 +209,7 @@ end
 ---@param categories string[]
 ---@return string[]
 function CustomPlayer:getWikiCategories(categories)
-	if (self.role2 or {}).category then
+	if self.role2.category then
 		table.insert(categories, self.role2.category .. 's')
 	end
 	return categories

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -39,8 +39,8 @@ ROLES['assistant coach'] = ROLES.coach
 ROLES.commentator = ROLES.caster
 
 ---@class BrawlstarsInfoboxPlayer: Person
----@field role {category: string, variable: string, isplayer: boolean?, personType: string}?
----@field role2 {category: string, variable: string, isplayer: boolean?, personType: string}?
+---@field role {category?: string, variable: string?, isplayer: boolean?, personType: string?}
+---@field role2 {category?: string, variable: string?, isplayer: boolean?, personType: string?}
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -209,7 +209,7 @@ end
 ---@param categories string[]
 ---@return string[]
 function CustomPlayer:getWikiCategories(categories)
-	if self.role2 then
+	if self.role2.category then
 		table.insert(categories, self.role2.category .. 's')
 	end
 	return categories

--- a/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_person_player_custom.lua
@@ -209,7 +209,7 @@ end
 ---@param categories string[]
 ---@return string[]
 function CustomPlayer:getWikiCategories(categories)
-	if self.role2.category then
+	if (self.role2 or {}).category then
 		table.insert(categories, self.role2.category .. 's')
 	end
 	return categories


### PR DESCRIPTION
## Summary
Issue introduced in #4334, I've overlooked that `self.role2` is in fact an empty table by default instead of nil.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
