### PR TITLE
fix(info): Merge Warzone games for COD

### DIFF
--- a/standard/info/wikis/callofduty/info.lua
+++ b/standard/info/wikis/callofduty/info.lua
@@ -300,24 +300,11 @@ return {
 		},
 		wz = {
 			abbreviation = 'WZ',
-			name = 'Warzone 1.0',
+			name = 'Warzone',
 			link = 'Call of Duty: Warzone',
 			logo = {
 				darkMode = 'COD Warzone 1.0 default darkmode.png',
 				lightMode = 'COD Warzone 1.0 default lightmode.png',
-			},
-			defaultTeamLogo = {
-				darkMode = 'Call of Duty Default darkmode.png',
-				lightMode = 'Call of Duty Default lightmode.png',
-			},
-		},
-		wz2 = {
-			abbreviation = 'WZ2',
-			name = 'Warzone 2.0',
-			link = 'Call of Duty: Warzone 2.0',
-			logo = {
-				darkMode = 'COD Warzone 2.0 default allmode.png',
-				lightMode = 'COD Warzone 2.0 default allmode.png',
 			},
 			defaultTeamLogo = {
 				darkMode = 'Call of Duty Default darkmode.png',


### PR DESCRIPTION
## Summary
WZ1 and WZ2 eventually wasnt used by standard for COD/Acitivision, they just keep calling all versions as "Warzone" only. So merging both into one single entry make sense (this is also because after the 3rd warzone coming out last year, they stop using the numbers and just called it Warzone only, no 2.0/3.0)

