### PR TITLE
docs(standard): improve abbrevation annotation

### DIFF
--- a/components/match2/wikis/worldoftanks/match_summary.lua
+++ b/components/match2/wikis/worldoftanks/match_summary.lua
@@ -22,7 +22,7 @@ local MAP_VETO_START = '<b>Start Map Veto</b>'
 local ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]'
 local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
 local NONE = '-'
-local TBD = Abbreviation.make('TBD', 'To Be Determined') --[[@as string]]
+local TBD = Abbreviation.make('TBD', 'To Be Determined')
 
 ---@enum WoTMatchIcons
 local Icons = {

--- a/components/matches_schedule_display/commons/matches_schedule_display.lua
+++ b/components/matches_schedule_display/commons/matches_schedule_display.lua
@@ -379,7 +379,7 @@ end
 ---@param value string|number
 ---@return string
 function MatchesTable._bestof(value)
-	return Abbreviation.make('Bo' .. value, 'Best of ' .. value) --[[@as string]]
+	return Abbreviation.make('Bo' .. value, 'Best of ' .. value)
 end
 
 return MatchesTable

--- a/components/results_table/wikis/fortnite/results_table_custom.lua
+++ b/components/results_table/wikis/fortnite/results_table_custom.lua
@@ -61,7 +61,7 @@ function CustomResultsTable:processVsData(placement)
 	local lastVs = placement.lastvsdata
 
 	if String.isNotEmpty(lastVs.groupscore) then
-		return placement.groupscore, Abbreviation.make('Grp S.', 'Group Stage') --[[@as string]]
+		return placement.groupscore, Abbreviation.make('Grp S.', 'Group Stage')
 	end
 
 	-- return empty strings for non group scores since it is a BattleRoyale wiki

--- a/standard/abbreviation.lua
+++ b/standard/abbreviation.lua
@@ -14,10 +14,12 @@ local Logic = require('Module:Logic')
 ---@param text string|number
 ---@param title string|number
 ---@return string
----@overload fun(text: string|number):nil
----@overload fun(text: string|number, title: nil):nil
----@overload fun(text: nil, title: nil):nil
----@overload fun():nil
+---@overload fun(text: string|number, title: nil?):nil
+---@overload fun(text: string|number, title: ''):nil
+---@overload fun(text: nil?, title: string|number):nil
+---@overload fun(text: '', title: string|number):nil
+---@overload fun(text: nil?, title: nil?):nil
+---@overload fun(text: '', title: ''):nil
 function Abbreviation.make(text, title)
 	if Logic.isEmpty(title) or Logic.isEmpty(text) then
 		return nil


### PR DESCRIPTION
## Summary
Workaround found in https://github.com/LuaLS/lua-language-server/issues/2707#issuecomment-2163368205
It the empty string matching doesn't seem to be perfect, but it's quite good now and will only give false positives and no false negatives as far as I could tell (ie error slightly more than intended, but always on the safe side)

## How did you test this change?
IDE Intellisense