### PR TITLE
fix(prizePool): Do not reuse tables in placement data - part 2

### DIFF
--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -278,7 +278,7 @@ function Placement:_getLpdbData(...)
 		}
 
 		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(opponent.opponentData))
-		lpdbData.players = lpdbData.players or lpdbData.opponentplayers
+		lpdbData.players = lpdbData.players or Table.copy(lpdbData.opponentplayers)
 
 		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
 		if Opponent.isTbd(opponent.opponentData) then

--- a/components/prize_pool/commons/prize_pool_placement.lua
+++ b/components/prize_pool/commons/prize_pool_placement.lua
@@ -278,7 +278,7 @@ function Placement:_getLpdbData(...)
 		}
 
 		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(opponent.opponentData))
-		lpdbData.players = lpdbData.players or Table.copy(lpdbData.opponentplayers)
+		lpdbData.players = lpdbData.players or Table.copy(lpdbData.opponentplayers or {})
 
 		lpdbData.objectName = self.parent:_lpdbObjectName(lpdbData, ...)
 		if Opponent.isTbd(opponent.opponentData) then

--- a/components/prize_pool/wikis/fortnite/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/fortnite/prize_pool_custom.lua
@@ -46,7 +46,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		placement.placeStart
 	)
 
-	lpdbData.players = Table.copy(lpdbData.opponentplayers)
+	lpdbData.players = Table.copy(lpdbData.opponentplayers or {})
 
 	local team = lpdbData.participant or ''
 	local lpdbPrefix = Variables.varDefault('lpdb_prefix') or ''

--- a/components/prize_pool/wikis/fortnite/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/fortnite/prize_pool_custom.lua
@@ -10,6 +10,7 @@ local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
+local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local PrizePool = Lua.import('Module:PrizePool')
@@ -45,7 +46,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		placement.placeStart
 	)
 
-	lpdbData.players = lpdbData.opponentplayers
+	lpdbData.players = Table.copy(lpdbData.opponentplayers)
 
 	local team = lpdbData.participant or ''
 	local lpdbPrefix = Variables.varDefault('lpdb_prefix') or ''

--- a/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
@@ -67,7 +67,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		seriesnumber = CustomPrizePool._seriesNumber()
 	})
 
-	lpdbData.players = lpdbData.opponentplayers
+	lpdbData.players = Table.copy(lpdbData.opponentplayers)
 
 	lpdbData.weight = Weight.calc(
 		lpdbData.individualprizemoney,

--- a/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/warcraft/prize_pool_custom.lua
@@ -67,7 +67,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 		seriesnumber = CustomPrizePool._seriesNumber()
 	})
 
-	lpdbData.players = Table.copy(lpdbData.opponentplayers)
+	lpdbData.players = Table.copy(lpdbData.opponentplayers or {})
 
 	lpdbData.weight = Weight.calc(
 		lpdbData.individualprizemoney,


### PR DESCRIPTION
## Summary
Sometimes `lpdbData.players = lpdbData.opponentplayers` is used.
This PR changes it so that it now used Table.copy to create the (deprecated) players table isntead of referencing to the opponentpayers table.
This is so that the `Json.stringify` for the wiki variable that gest set does not break.

## How did you test this change?
dev to live as bug fix