### PR TITLE
feat(match2): make winner override draws for CoC

### DIFF
--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -113,7 +113,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match is marked as finished.
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
 	elseif Logic.readBool(data.finished) then
-		if tonumber(data.winner) == 0 or not Logic.isNumeric(data.winner) and MatchGroupInput.isDraw(indexedScores) then
+		if CustomMatchGroupInput.isDraw(indexedScores, tonumber(data.winner)) then
 			data.winner = 0
 			data.resulttype = 'draw'
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')
@@ -142,6 +142,15 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	end
 
 	return data, indexedScores
+end
+
+---@param indexedScores table[]
+---@param winner integer?
+---@return boolean
+function CustomMatchGroupInput.isDraw(indexedScores, winner)
+	if winner == 0 then return true end
+	if winner then return false end
+	return MatchGroupInput.isDraw(indexedScores)
 end
 
 function CustomMatchGroupInput.setPlacement(opponents, winner, specialType, finished)

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -114,7 +114,7 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
 	elseif Logic.readBool(data.finished) then
 		local winner = tonumber(data.winner)
-		if winner == 0 or not winner and MatchGroupInput.isDraw(indexedScores) then
+		if tonumber(data.winner) == 0 or not Logic.isNumeric(data.winner) and MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -113,7 +113,6 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match is marked as finished.
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
 	elseif Logic.readBool(data.finished) then
-		local winner = tonumber(data.winner)
 		if tonumber(data.winner) == 0 or not Logic.isNumeric(data.winner) and MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -113,7 +113,8 @@ function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match is marked as finished.
 	-- Calculate and set winner, resulttype, placements and walkover (if applicable for the outcome)
 	elseif Logic.readBool(data.finished) then
-		if MatchGroupInput.isDraw(indexedScores) then
+		local winner = tonumber(data.winner)
+		if winner == 0 or not winner and MatchGroupInput.isDraw(indexedScores) then
 			data.winner = 0
 			data.resulttype = 'draw'
 			indexedScores = CustomMatchGroupInput.setPlacement(indexedScores, data.winner, 'draw')


### PR DESCRIPTION
## Summary
matches in Clash of Clans can ended it a tied score, but won through other factors (being the Total score count per map, or percentage if the former is also tied)

Previously an issue caused the `|winner=` to not be able to override the tied scores, effectively causing double winners, This is to fix that issue, need some code cleanup help here

(Note: CoC also used scores manually to displayed the total star count, but its unlikely I planned to rework the match2 to force the map1 scores to display over 1/0 due to i have no clue + editors dont want 1/0 on a BO1 either)

![image](https://github.com/Liquipedia/Lua-Modules/assets/88981446/195d3231-e556-4cfa-b499-5f47fb14cb07)

## Testing
LIVE

## Side Note
World of Tanks also have the same issue, but it will be a separate PR
