### PR TITLE
feat(FilterButtons): refresh countdowns after expansion

### DIFF
--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -3,7 +3,15 @@
  * Author(s): FO-nTTaX, Machunki
  ******************************************************************************/
 liquipedia.countdown = {
+	timeoutFunctions: null,
+	timerObjectNodes: null,
+	lastCountdownId: null,
 	init: function() {
+		// // Cancels last countdown loop if it exists to prevent multiple countdowns running at the same time
+		if ( liquipedia.countdown.timeoutFunctions && liquipedia.countdown.lastCountdownId ) {
+			liquipedia.countdown.timeoutFunctions.clear( liquipedia.countdown.lastCountdownId );
+		}
+
 		liquipedia.countdown.timerObjectNodes = document.querySelectorAll( '.timer-object' );
 		if ( liquipedia.countdown.timerObjectNodes.length > 0 ) {
 			mw.loader.using( 'user.options', () => {
@@ -45,8 +53,6 @@ liquipedia.countdown = {
 			} );
 		}
 	},
-	timeoutFunctions: null,
-	timerObjectNodes: null,
 	parseTimerObjectNodeToDateObj: function( timerObjectNode ) {
 		if ( timerObjectNode.dataset.timestamp === 'error' ) {
 			return false;
@@ -57,7 +63,11 @@ liquipedia.countdown = {
 		liquipedia.countdown.timerObjectNodes.forEach( ( timerObjectNode ) => {
 			liquipedia.countdown.setCountdownString( timerObjectNode );
 		} );
-		liquipedia.countdown.timeoutFunctions.set( liquipedia.countdown.runCountdown, 1000 );
+
+		liquipedia.countdown.lastCountdownId = liquipedia.countdown.timeoutFunctions.set(
+			liquipedia.countdown.runCountdown,
+			1000
+		);
 	},
 	setCountdownString: function( timerObjectNode ) {
 		const streamsarr = [ ];

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -260,6 +260,7 @@ liquipedia.filterButtons = {
 
 			if ( wikitext in templateExpansion.cache ) {
 				templateExpansion.element.innerHTML = templateExpansion.cache[ wikitext ];
+				this.refreshScriptsAfterContentUpdate();
 				return;
 			}
 
@@ -279,10 +280,15 @@ liquipedia.filterButtons = {
 					if ( data.parse?.text?.[ '*' ] ) {
 						templateExpansion.element.innerHTML = data.parse.text[ '*' ];
 						templateExpansion.cache[ wikitext ] = data.parse.text[ '*' ];
+						this.refreshScriptsAfterContentUpdate();
 					}
 				} );
 			} );
 		} );
+	},
+
+	refreshScriptsAfterContentUpdate: function() {
+		liquipedia.countdown.init();
 	},
 
 	buildLocalStorageKey: function() {


### PR DESCRIPTION
## Summary

When filter buttons are triggering DOM updates, some scripts need to be rerun to consider the new HTML content (for example: countdowns).

This sets a basic setup to rerun some JS scripts after a DOM update, with the countdown implementation.

## How did you test this change?

Dev environment: http://killian.wiki.tldev.eu/rocketleague/MainPageTest
