### PR TITLE
feat(MatchTicker): add tier and tiertype filters

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -120,9 +120,7 @@ function MatchTicker:init(args)
 					local identifier = Tier.toIdentifier(tier)
 					return type(identifier) == 'number' and Tier.isValid(identifier)
 				end) or nil,
-		tierTypes = args.tiertypes and Array.filter(Array.parseCommaSeparatedString(args.tiertypes), function(tiertype)
-					return Tier.isValid(1, tiertype)
-				end) or nil,
+		tierTypes = args.tiertypes and Array.filter(Array.parseCommaSeparatedString(args.tiertypes), FnUtils.curry(Tier.isValid, 1)) or nil,
 	}
 
 	--min 1 of them has to be set; recent can not be set while any of the others is set

--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -14,6 +14,7 @@ local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local Team = require('Module:Team')
 local Tier = require('Module:Tier/Utils')
+local FnUtil = require('Module:FnUtil')
 
 local OpponentLibrary = require('Module:OpponentLibraries')
 local Opponent = OpponentLibrary.Opponent
@@ -120,7 +121,7 @@ function MatchTicker:init(args)
 					local identifier = Tier.toIdentifier(tier)
 					return type(identifier) == 'number' and Tier.isValid(identifier)
 				end) or nil,
-		tierTypes = args.tiertypes and Array.filter(Array.parseCommaSeparatedString(args.tiertypes), FnUtils.curry(Tier.isValid, 1)) or nil,
+		tierTypes = args.tiertypes and Array.filter(Array.parseCommaSeparatedString(args.tiertypes), FnUtil.curry(Tier.isValid, 1)) or nil,
 	}
 
 	--min 1 of them has to be set; recent can not be set while any of the others is set

--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -121,7 +121,9 @@ function MatchTicker:init(args)
 					local identifier = Tier.toIdentifier(tier)
 					return type(identifier) == 'number' and Tier.isValid(identifier)
 				end) or nil,
-		tierTypes = args.tiertypes and Array.filter(Array.parseCommaSeparatedString(args.tiertypes), FnUtil.curry(Tier.isValid, 1)) or nil,
+		tierTypes = args.tiertypes and Array.filter(
+					Array.parseCommaSeparatedString(args.tiertypes), FnUtil.curry(Tier.isValid, 1)
+				) or nil,
 	}
 
 	--min 1 of them has to be set; recent can not be set while any of the others is set


### PR DESCRIPTION
## Summary

To filter matches by tournament tier and tier type, this module needs to be able to filter by tournaments. This adds both tier and tier type as possible parameters.

## How did you test this change?

Dev environment: http://killian.wiki.tldev.eu/rocketleague/MainPageTest