### PR TITLE
feat(FilterButtons): Adding new filter styles

### DIFF
--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -1,6 +1,6 @@
 /*******************************************************************************
 Template(s): Filter buttons
-Author(s): Elysienna
+Author(s): Elysienna, Nadox
 *******************************************************************************/
 .filter-category--hidden {
 	clip: rect( 0 0 0 0 );
@@ -73,13 +73,13 @@ Author(s): Elysienna
 		align-items: center;
 		border-radius: 8px;
 		padding: 6px 12px;
-		font-weight: 700;
+		font-weight: bold;
 		flex-grow: initial;
 
 		.theme--light & {
-			color: var(--clr-on-primary-container,#ffffff);
-			background-color: var(--clr-primary-container,#1f3d7a);
-			border-color: var(--clr-primary-container,#1f3d7a);
+			color: var( --clr-on-primary-container, #ffffff );
+			background-color: var( --clr-primary-container, #1f3d7a );
+			border-color: var( --clr-primary-container, #1f3d7a );
 		}
 
 		.theme--dark & {
@@ -87,20 +87,11 @@ Author(s): Elysienna
 			background-color: var( --clr-surface-3, #282828 );
 			border-color: var( --clr-surface-3, #282828 );
 		}
-	}
 
-	.filter-button--active {
-
-		.theme--light & {
+		&.filter-button--active {
+			background-color: var( --clr-wiki-theme-primary, #1f3d7a );
+			border-color: var( --clr-wiki-theme-primary, #1f3d7a );
 			color: #ffffff;
-			background-color: var(--clr-wiki-primary,#1f3d7a);
-			border-color: var(--clr-wiki-primary,#1f3d7a);
-		}
-
-		.theme--dark & {
-			color: #ffffff;
-			background-color: var(--clr-wiki-theme-primary,#1f3d7a);
-			border-color: var(--clr-wiki-theme-primary,#1f3d7a);
 		}
 	}
 }

--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -58,6 +58,53 @@ Author(s): Elysienna
 	animation-duration: 0.8s;
 }
 
+.dota2-test {
+	.filter-buttons {
+		display: flex;
+		justify-content: start;
+		flex-flow: row wrap;
+		font-size: 10pt;
+		margin: 0.125rem;
+		align-items: center;
+	}
+
+	.filter-button {
+		display: flex;
+		align-items: center;
+		border-radius: 8px;
+		padding: 6px 12px;
+		font-weight: 700;
+		flex-grow: initial;
+
+		.theme--light & {
+			color: var(--clr-on-primary-container,#ffffff);
+			background-color: var(--clr-primary-container,#1f3d7a);
+			border-color: var(--clr-primary-container,#1f3d7a);
+		}
+
+		.theme--dark & {
+			color: #ffffff;
+			background-color: var( --clr-surface-3, #282828 );
+			border-color: var( --clr-surface-3, #282828 );
+		}
+	}
+
+	.filter-button--active {
+
+		.theme--light & {
+			color: #ffffff;
+			background-color: var(--clr-wiki-primary,#1f3d7a);
+			border-color: var(--clr-wiki-primary,#1f3d7a);
+		}
+
+		.theme--dark & {
+			color: #ffffff;
+			background-color: var(--clr-wiki-theme-primary,#1f3d7a);
+			border-color: var(--clr-wiki-theme-primary,#1f3d7a);
+		}
+	}
+}
+
 /* Keyframes filter effects */
 
 @keyframes fadeIn {

--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -63,7 +63,7 @@ Author(s): Elysienna, Nadox
 		display: flex;
 		justify-content: start;
 		flex-flow: row wrap;
-		font-size: 10pt;
+		font-size: 0.825rem;
 		margin: 0.125rem;
 		align-items: center;
 	}
@@ -71,8 +71,8 @@ Author(s): Elysienna, Nadox
 	.filter-button {
 		display: flex;
 		align-items: center;
-		border-radius: 8px;
-		padding: 6px 12px;
+		border-radius: 0.5rem;
+		padding: 0.375rem 0.75rem;
 		font-weight: bold;
 		flex-grow: initial;
 

--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -59,38 +59,56 @@ Author(s): Elysienna, Nadox
 }
 
 .dota2-test {
-	.filter-buttons {
-		display: flex;
-		justify-content: start;
-		flex-flow: row wrap;
-		font-size: 0.825rem;
-		margin: 0.125rem;
-		align-items: center;
-	}
-
 	.filter-button {
 		display: flex;
 		align-items: center;
 		border-radius: 0.5rem;
-		padding: 0.375rem 0.75rem;
+		padding: 0 0.75rem;
 		font-weight: bold;
 		flex-grow: initial;
+		position: relative;
+		border: 0;
+		min-height: 2rem;
+		color: #3366cc;
+		font-size: 0.875rem;
 
 		.theme--light & {
-			color: var( --clr-on-primary-container, #ffffff );
-			background-color: var( --clr-primary-container, #1f3d7a );
-			border-color: var( --clr-primary-container, #1f3d7a );
+			color: var( --clr-wiki-theme-primary );
 		}
-
 		.theme--dark & {
 			color: #ffffff;
-			background-color: var( --clr-surface-3, #282828 );
-			border-color: var( --clr-surface-3, #282828 );
 		}
+		
+		&:not( .is--active )::after {
+			content: '';
+			opacity: 0.12;
+			position: absolute;
+			inset: 0;
+			z-index: -1;
+			border-radius: 0.5rem;
+			background-color: #c1cee8;
 
+			.theme--light & {
+				background-color: var( --clr-wiki-theme-primary );
+			}
+			.theme--dark & {
+				background-color: #fff;
+			}
+		}
+		
+		@media ( hover: hover ) {
+			&:hover {
+				color: #ffffff;
+				background-color: var( --clr-wiki-theme-primary, #1f3d7a );
+
+				&::after {
+					opacity: 0.24;
+				}
+			}
+		}
+		
 		&.filter-button--active {
 			background-color: var( --clr-wiki-theme-primary, #1f3d7a );
-			border-color: var( --clr-wiki-theme-primary, #1f3d7a );
 			color: #ffffff;
 		}
 	}

--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -75,10 +75,11 @@ Author(s): Elysienna, Nadox
 		.theme--light & {
 			color: var( --clr-wiki-theme-primary );
 		}
+
 		.theme--dark & {
 			color: #ffffff;
 		}
-		
+
 		&:not( .is--active )::after {
 			content: '';
 			opacity: 0.12;
@@ -91,11 +92,12 @@ Author(s): Elysienna, Nadox
 			.theme--light & {
 				background-color: var( --clr-wiki-theme-primary );
 			}
+
 			.theme--dark & {
-				background-color: #fff;
+				background-color: #ffffff;
 			}
 		}
-		
+
 		@media ( hover: hover ) {
 			&:hover {
 				color: #ffffff;
@@ -106,7 +108,7 @@ Author(s): Elysienna, Nadox
 				}
 			}
 		}
-		
+
 		&.filter-button--active {
 			background-color: var( --clr-wiki-theme-primary, #1f3d7a );
 			color: #ffffff;

--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -81,7 +81,7 @@ Author(s): Elysienna, Nadox
 		}
 
 		&:not( .is--active )::after {
-			content: '';
+			content: "";
 			opacity: 0.12;
 			position: absolute;
 			inset: 0;


### PR DESCRIPTION
## Summary

We want to implement a new design for the filter buttons, which will be tested with the new Dota2 Main page. This gives the new rules for the filter buttons which give the following outcome:

![image](https://github.com/Liquipedia/Lua-Modules/assets/32543621/1dac70e5-c7d8-4ec6-b0e2-fc36da7895da)
![image](https://github.com/Liquipedia/Lua-Modules/assets/32543621/85bfb663-dda5-4772-ba8c-41374753754d)

## How did you test this change?

On my dev env: http://killian.wiki.tldev.eu/rocketleague/MainPageTest
