### PR TITLE
fix(match2): Warcraft factions in team matches

### DIFF
--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -347,7 +347,7 @@ function CustomMatchGroupInput._readPlayersOfTeam(match, opponentIndex, opponent
 		player.name = mw.ext.TeamLiquidIntegration.resolve_redirect(player.name):gsub(' ', '_')
 		player.flag = Flags.CountryName(player.flag)
 		player.displayname = Logic.emptyOr(player.displayname, player.displayName)
-		player.extradata = {faction = Faction.read(player.race)}
+		player.extradata = {faction = Faction.read(player.race or player.faction)}
 
 		players[player.name] = players[player.name] or {}
 		Table.deepMergeInto(players[player.name], player)


### PR DESCRIPTION
## Summary
Fix the faction reading for players in Warcaft team matches

## How did you test this change?
live as bug fix