### PR TITLE
feat(infobox): Update stormgate infoboxes unit and skill

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -271,7 +271,7 @@ function CustomSkill:_processPatchFromId(key)
 	})
 
 	args[key] = (Array.filter(patches, function(patch)
-		return String.endsWith(patch.pagename, '/' .. input
+		return String.endsWith(patch.pagename, '/' .. input)
 	end)[1] or {}).pagename
 	assert(args[key], 'Invalid patch "' .. input .. '"')
 

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -22,7 +22,6 @@ local Skill = Lua.import('Module:Infobox/Skill')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
-local Center = Widgets.Center
 
 ---@class StormgateSkillInfobox: SkillInfobox
 ---@field faction string?
@@ -272,7 +271,7 @@ function CustomSkill:_processPatchFromId(key)
 	})
 
 	local patch = Array.filter(patches, function(patch)
-		return String.endsWith(patch.pagename, '/' .. patchName)
+		return String.endsWith(patch.pagename, '/' .. value)
 	end)[1]
 	assert(patch, 'Invalid patch "' .. value .. '"')
 

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -270,9 +270,9 @@ function CustomSkill:_processPatchFromId(key)
 		limit = 5000,
 	})
 
-	local patch = Array.filter(patches, function(patch)
+	local patch = (Array.filter(patches, function(patch)
 		return String.endsWith(patch.pagename, '/' .. value)
-	end)[1]
+	end)[1] or {}).pagename
 	assert(patch, 'Invalid patch "' .. value .. '"')
 
 	args[key] = patch

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -15,7 +15,7 @@ local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local messageBox = require('Module:Message box')
+local MessageBox = require('Module:Message box')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local Skill = Lua.import('Module:Infobox/Skill')
@@ -86,7 +86,8 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'custom' then
 		local castingTime = tonumber(args.casting_time)
-		local introduced = args.introduced and '[['.. CustomSkill._getPatchName(args.introduced) .. '|' .. args.introduced .. ']]'
+		local introduced = args.introduced and
+			Page.makeInternalLink(args.introduced,CustomSkill._getPatchName(args.introduced))
 
 		---@param arr string[]
 		---@param trimPattern string?
@@ -119,11 +120,11 @@ function CustomInjector:parse(id, widgets)
 			caller:_damageHealDisplay('heal')
 		)
 		if args.deprecated then
-			local patch = '[['.. CustomSkill._getPatchName(args.deprecated) .. '|' .. args.deprecated .. ']]'
-			local box = messageBox.main( 'ambox', {
+			local box = MessageBox.main( 'ambox', {
 				image= ICON_DEPRECATED,
 				class='ambox-red',
-				text= 'This has been removed from 1v1 with Patch ' .. patch
+				text= 'This has been removed from 1v1 with Patch ' ..
+				Page.makeInternalLink({},args.deprecated,CustomSkill._getPatchName(args.deprecated))
 			})
 			table.insert(widgets, Center{content = {box}})
 		end

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -89,15 +89,15 @@ function CustomInjector:parse(id, widgets)
 		local introduced = args.introduced and '[['.. CustomSkill._getPatchName(args.introduced) .. '|' .. args.introduced .. ']]'
 
 		---@param arr string[]
-		---@param trim string?
+		---@param trimPattern string?
 		---@return string[]
-		local makeArrayLinks = function(arr, trim)
+		local makeArrayLinks = function(arr, trimPattern)
 			return Array.map(arr, function(value)
-				local dispaly = value
-				if trim then
-					dispaly = dispaly:gsub(trim, '')
+				local display = value
+				if trimPattern then
+					display = display:gsub(trimPattern, '')
 				end
-				return Page.makeInternalLink({}, dispaly, value)
+				return Page.makeInternalLink({}, display, value)
 			end)
 		end
 

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -182,6 +182,7 @@ function CustomSkill:addToLpdb(lpdbData, args)
 	lpdbData.extradata = {
 		deprecated = args.deprecated or '',
 		introduced = args.introduced or '',
+		subfaction = Array.parseCommaSeparatedString(args.subfaction),
 		luminite = tonumber(args.luminite),
 		totalluminite = tonumber(args.totalluminite),
 		therium = tonumber(args.therium),

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -262,21 +262,20 @@ end
 ---@param key string
 function CustomSkill:_processPatchFromId(key)
 	local args = self.args
-	local value = Table.extract(args, key)
-	if String.isEmpty(value) then return end
+	local input = Table.extract(args, key)
+	if String.isEmpty(input) then return end
 
 	local patches = mw.ext.LiquipediaDB.lpdb('datapoint', {
 		conditions = '[[type::patch]]',
 		limit = 5000,
 	})
 
-	local patch = (Array.filter(patches, function(patch)
-		return String.endsWith(patch.pagename, '/' .. value)
+	args[key] = (Array.filter(patches, function(patch)
+		return String.endsWith(patch.pagename, '/' .. input
 	end)[1] or {}).pagename
-	assert(patch, 'Invalid patch "' .. value .. '"')
+	assert(args[key], 'Invalid patch "' .. input .. '"')
 
-	args[key] = patch
-	args[key .. 'Display'] = Page.makeInternalLink(args.introduced, patch)
+	args[key .. 'Display'] = Page.makeInternalLink(input, args[key])
 end
 
 ---@param patch string?

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -87,7 +87,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'custom' then
 		local castingTime = tonumber(args.casting_time)
 		local introduced = args.introduced and
-			Page.makeInternalLink(args.introduced,CustomSkill._getPatchName(args.introduced))
+		Page.makeInternalLink(args.introduced,CustomSkill._getPatchName(args.introduced))
 
 		---@param arr string[]
 		---@param trimPattern string?
@@ -272,7 +272,7 @@ function CustomSkill._getPatchName(patchName)
 		limit = 5000,
 	})
 	local patch = Array.filter(patches, function(patch)
-		return String.contains(patch.pagename, patchName)
+		return String.endsWith(patch.pagename, '/' .. patchName)
 	end)
 	return patch[1].pagename
 end

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -192,7 +192,7 @@ function CustomUnit:setLpdbData(args)
 		imagedark = args.imagedark,
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
 			deprecated = args.deprecated or '',
-			introduced = tostring(args.introduced),
+			introduced = args.introduced or '',
 			subfaction = Array.parseCommaSeparatedString(args.subfaction),
 			veterancybonushealth = Array.parseCommaSeparatedString(args.veterancybonushealth),
 			veterancybonusdamage = Array.parseCommaSeparatedString(args.veterancybonusdamage),

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -25,7 +25,6 @@ local Unit = Lua.import('Module:Infobox/Unit')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
-local Center = Widgets.Center
 
 ---@class Stormgate2UnitInfobox: UnitInfobox
 ---@field faction string?

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -18,7 +18,7 @@ local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local messageBox = require('Module:Message box')
+local MessageBox = require('Module:Message box')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local Unit = Lua.import('Module:Infobox/Unit')
@@ -100,7 +100,8 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Armor', content = caller:_getArmorDisplay()},
 		}
 	elseif id == 'custom' then
-		local introduced = args.introduced and '[['.. CustomUnit._getPatchName(args.introduced) .. '|' .. args.introduced .. ']]'
+		local introduced = args.introduced and
+			Page.makeInternalLink(args.introduced,CustomUnit._getPatchName(args.introduced))
 		Array.appendWith(widgets,
 			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
 			Cell{name = 'Sight', content = {args.sight}},
@@ -111,11 +112,11 @@ function CustomInjector:parse(id, widgets)
 		)
 
 		if args.deprecated then
-			local patch = '[['.. CustomUnit._getPatchName(args.deprecated) .. '|' .. args.deprecated .. ']]'
-			local box = messageBox.main( 'ambox', {
+			local box = MessageBox.main( 'ambox', {
 				image= ICON_DEPRECATED,
 				class='ambox-red',
-				text= 'This unit has been removed from 1v1 with Patch ' .. patch
+				text= 'This unit has been removed from 1v1 with Patch ' ..
+				Page.makeInternalLink({},args.deprecated,CustomUnit._getPatchName(args.deprecated))
 			})
 			table.insert(widgets, Center{content = {box}})
 		end

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -101,7 +101,7 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'custom' then
 		local introduced = args.introduced and
-			Page.makeInternalLink(args.introduced,CustomUnit._getPatchName(args.introduced))
+		Page.makeInternalLink(args.introduced,CustomUnit._getPatchName(args.introduced))
 		Array.appendWith(widgets,
 			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
 			Cell{name = 'Sight', content = {args.sight}},
@@ -280,7 +280,7 @@ function CustomUnit._getPatchName(patchName)
 		limit = 5000,
 	})
 	local patch = Array.filter(patches, function(patch)
-		return String.contains(patch.pagename, patchName)
+		return String.endsWith(patch.pagename, '/' .. patchName)
 	end)
 	return patch[1].pagename
 end


### PR DESCRIPTION
## Summary

Added storage and display of the introduction and deprecating patch/version for infobox unit and skill:
This allows auto removing these units from stats pages (e.g. https://liquipedia.net/stormgate/The_Human_Vanguard_Unit_Statistics).
For upgrades/abilities that are no longer present in game can be excluded from being displaying on e.g. unit pages (like https://liquipedia.net/stormgate/Vulcan) using Module:SkillCard via `{{CardList|dev=1}}`)
_Obviously that module needs to be updated after the pr is merged_

Added storage for unit veterancy in the infobox unit:
This allows  an automated overview on unit pages for the bonuses granted for each veterancy level:
![stormgate veterancy draft](https://github.com/Liquipedia/Lua-Modules/assets/143346492/54581124-5a99-44e4-9fea-856d22f5a5a6)

Added storage for subfaction flags in the infobox unit:
Units might be part of 1v1, coop, 3v3 and or hero subfaction(s). Storing this as a flag allows to only display relevant units on e.g. stat pages like https://liquipedia.net/stormgate/The_Human_Vanguard_Unit_Statistics

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

Changes were tested on the dev Modules:
https://liquipedia.net/stormgate/Module:Infobox/Unit/Custom/dev
https://liquipedia.net/stormgate/Module:Infobox/Skill/Custom/dev
https://liquipedia.net/stormgate/Module:SkillCard/dev

Storage and Display for Unit Infobox was tested here:
https://liquipedia.net/stormgate/index.php?title=Weaver&type=revision&diff=6987&oldid=6646
![2024-06-19 12_08_18-Weaver - Liquipedia Stormgate Wiki](https://github.com/Liquipedia/Lua-Modules/assets/143346492/a0f0e1bb-3fce-49f1-94f7-ba1f5ee3afbe)
![2024-06-19 12_08_09-Liquipedia DB - Liquipedia Stormgate Wiki](https://github.com/Liquipedia/Lua-Modules/assets/143346492/9bae828f-7d6c-47e2-84f4-b85741faaec5)

Storage and Display for Skill(Abilities/Upgrades) Infobox was tested here:
https://liquipedia.net/stormgate/index.php?title=Research_Jump_Jets&type=revision&diff=6888&oldid=6375
![2024-06-19 12_12_29-Research Jump Jets_ Difference between revisions - Liquipedia Stormgate Wiki](https://github.com/Liquipedia/Lua-Modules/assets/143346492/9cb423df-181f-406d-abcb-5426a7223156)
In combination with https://liquipedia.net/stormgate/Module:SkillCard/dev this upgrade is no longer displayed on the corresponding [unit page](https://liquipedia.net/stormgate/Vulcan#Upgrades)