### PR TITLE
feat: implement dota 2 banner header

### DIFF
--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -35,8 +35,15 @@
 		position: relative;
 
 		img {
-			max-height: 36px;
 			width: auto;
+
+			@media ( max-width: 767px ) {
+				max-height: 2.375rem;
+			}
+
+			@media ( min-width: 768px ) {
+				max-height: 3.25rem;
+			}
 		}
 
 		.logo--light-theme {

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -3,22 +3,21 @@
 	flex-direction: column;
 	align-items: center;
 	margin-bottom: 1.5rem;
-	height: 8.875rem;
 	position: relative;
 	border-radius: 0.25rem;
 	overflow: hidden;
-	box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
 
-	&__logo {
-		position: relative;
-		z-index: 1;
+	@media ( min-width: 768px ) {
+		background: url("https://liquipedia.net/commons/images/1/19/Bgdota2.jpg") no-repeat center / cover;
+		box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
+		height: 8.875rem;
+		flex-direction: row;
+		justify-content: space-between;
+		padding: 0 2.5rem;
 	}
 
-	&__bg {
-		position: absolute;
-		inset: 0;
-
-		&::before {
+	&::before {
+		@media ( min-width: 768px ) {
 			content: '';
 			background-color: #000000;
 			opacity: 0.5;
@@ -26,11 +25,34 @@
 			inset: 0;
 			z-index: 0;
 		}
+	}
 
-		> img {
-			object-fit: cover;
-			width: 100%;
-			height: 100%;
+	> * {
+		z-index: 1;
+	}
+
+	&__logo {
+		position: relative;
+
+		img {
+			max-height: 36px;
+			width: auto;
+		}
+	}
+
+	.searchbox {
+		@media ( max-width: 768px ) {
+			margin-top: 1.5rem;
+		}
+
+		@media ( min-width: 768px ) {
+			margin-top: 0;
+		}
+
+		&-text {
+			@media ( min-width: 768px ) {
+				width: 25rem;
+			}
 		}
 	}
 }

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -7,7 +7,7 @@
 	border-radius: 0.25rem;
 
 	@media ( min-width: 768px ) {
-		background: url("https://liquipedia.net/commons/images/1/19/Bgdota2.jpg") no-repeat center / cover;
+		background: url( https://liquipedia.net/commons/images/1/19/Bgdota2.jpg ) no-repeat center / cover;
 		box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
 		height: 8.875rem;
 		flex-direction: row;
@@ -18,7 +18,7 @@
 
 	&::before {
 		@media ( min-width: 768px ) {
-			content: '';
+			content: "";
 			background-color: #000000;
 			opacity: 0.5;
 			position: absolute;

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -5,7 +5,6 @@
 	margin-bottom: 1.5rem;
 	position: relative;
 	border-radius: 0.25rem;
-	overflow: hidden;
 
 	@media ( min-width: 768px ) {
 		background: url("https://liquipedia.net/commons/images/1/19/Bgdota2.jpg") no-repeat center / cover;
@@ -14,6 +13,7 @@
 		flex-direction: row;
 		justify-content: space-between;
 		padding: 0 2.5rem;
+		overflow: hidden;
 	}
 
 	&::before {
@@ -38,10 +38,32 @@
 			max-height: 36px;
 			width: auto;
 		}
+
+		.logo--light-theme {
+			display: none;
+
+			.theme--light & {
+				@media ( max-width: 767px ) {
+					display: block;
+				}
+			}
+		}
+
+		.logo--dark-theme {
+			display: block;
+
+			.theme--light & {
+				@media ( max-width: 767px ) {
+					display: none;
+				}
+			}
+		}
 	}
 
-	.searchbox {
-		@media ( max-width: 768px ) {
+	form.searchbox {
+		display: flex;
+
+		@media ( max-width: 767px ) {
 			margin-top: 1.5rem;
 		}
 
@@ -49,10 +71,27 @@
 			margin-top: 0;
 		}
 
-		&-text {
+		// needed higher specificity to override the default input styles
+		input.searchbox-text:not( .search-input ):not( .oo-ui-inputWidget-input ) {
+			min-height: 2.75rem;
+			border-radius: 0.5rem;
+			box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
+			border: 0.0625rem solid rgba( 0, 0, 0, 0.12 );
+
+			@media ( max-width: 767px ) {
+				flex-grow: 1;
+			}
+
 			@media ( min-width: 768px ) {
 				width: 25rem;
 			}
+		}
+
+		button.searchbox-button {
+			min-height: 2.75rem;
+			margin-left: 0.5rem;
+			padding: 0 1rem;
+			border: 0;
 		}
 	}
 }

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -1,0 +1,36 @@
+.banner {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin-bottom: 1.5rem;
+	height: 8.875rem;
+	position: relative;
+	border-radius: 0.25rem;
+	overflow: hidden;
+	box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
+
+	&__logo {
+		position: relative;
+		z-index: 1;
+	}
+
+	&__bg {
+		position: absolute;
+		inset: 0;
+
+		&::before {
+			content: '';
+			background-color: #000000;
+			opacity: 0.5;
+			position: absolute;
+			inset: 0;
+			z-index: 0;
+		}
+
+		> img {
+			object-fit: cover;
+			width: 100%;
+			height: 100%;
+		}
+	}
+}

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -72,6 +72,7 @@
 
 		@media ( max-width: 767px ) {
 			margin-top: 1.5rem;
+			width: 100%;
 		}
 
 		@media ( min-width: 768px ) {
@@ -91,6 +92,11 @@
 
 			@media ( min-width: 768px ) {
 				width: 25rem;
+			}
+
+			.theme--dark & {
+				background-color: #ffffff;
+				color: var( --clr-secondary-7 );
 			}
 		}
 


### PR DESCRIPTION
## Summary

Add the styling for the dota2 mainpage banner.
https://liquipedia.net/dota2game/User:Elysienna/Main_Page

![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/e8191a0e-14f8-4bc8-8368-a4ca23791079)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/94517d09-9343-486a-8d42-a40365b4cf9f)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/85743d14-a764-4dbb-ab00-ecdf63481424)
![image](https://github.com/Liquipedia/Lua-Modules/assets/105433238/29335e36-0289-4d96-b10b-bbf965e20e0c)

## How did you test this change?
On the live wiki

## Closes 
https://gitlab.com/teamliquid-dev/liquipedia/web/extensions/teamliquidintegration/-/issues/131
https://gitlab.com/teamliquid-dev/liquipedia/web/extensions/teamliquidintegration/-/issues/130