### PR TITLE
fix(FilterButtons): Fixing hover CSS rules

### DIFF
--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -98,14 +98,12 @@ Author(s): Elysienna, Nadox
 			}
 		}
 
-		@media ( hover: hover ) {
-			&:hover {
-				color: #ffffff;
-				background-color: var( --clr-wiki-theme-primary, #1f3d7a );
+		&:hover {
+			color: #ffffff;
+			background-color: var( --clr-wiki-theme-primary, #1f3d7a );
 
-				&::after {
-					opacity: 0.24;
-				}
+			&::after {
+				opacity: 0.24;
 			}
 		}
 


### PR DESCRIPTION
## Summary

Somehow, `@media(hover...)` is not supported in less when embedded in other CSS rules. I should have caught it before but somehow I didn't see it. It broke my style on the dev env so quite a serious fix.

## How did you test this change?

On my dev env: http://killian.wiki.tldev.eu/rocketleague/MainPageTest
