### PR TITLE
feat(filterButtons): add self-hiding groups

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -99,7 +99,7 @@ liquipedia.filterButtons = {
 				defaultCurated: buttonsDiv.dataset.filterDefaultCurated === 'true'
 			};
 
-			buttonsDiv.querySelectorAll( ':scope > .filter-button' ).forEach(
+			Array.from( buttonsDiv.querySelectorAll( ':scope > .filter-button' ) ).forEach(
 				( /** @type {HTMLElement} */ buttonElement ) => {
 					const filterOn = buttonElement.dataset.filterOn ?? '';
 					const defaultState = !(
@@ -131,7 +131,7 @@ liquipedia.filterButtons = {
 	},
 
 	generateFilterableObjects: function() {
-		document.querySelectorAll( '[data-filter-category]' ).forEach(
+		Array.from( document.querySelectorAll( '[data-filter-category]' ) ).forEach(
 			/** @param {HTMLElement} filterableItem */
 			( filterableItem ) => {
 				const filterGroup = this.filterGroups[ filterableItem.dataset.filterGroup ?? this.fallbackFilterGroup ];
@@ -144,7 +144,7 @@ liquipedia.filterButtons = {
 			}
 		);
 
-		document.querySelectorAll( '[data-filter-expansion-template]' ).forEach(
+		Array.from( document.querySelectorAll( '[data-filter-expansion-template]' ) ).forEach(
 			/** @param {HTMLElement} templateExpansion */
 			( templateExpansion ) => {
 				this.templateExpansions.push( {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -67,7 +67,7 @@ liquipedia.filterButtons = {
 	hideableGroups: [],
 
 	init: function() {
-		const filterButtonGroups = document.querySelectorAll( '.filter-buttons[data-filter]' );
+		const filterButtonGroups = Array.from( document.querySelectorAll( '.filter-buttons[data-filter]' ) );
 		if ( filterButtonGroups.length === 0 ) {
 			return;
 		}
@@ -80,7 +80,7 @@ liquipedia.filterButtons = {
 	},
 
 	/**
-	 * @param {NodeListOf<HTMLElement>} filterButtonGroups
+	 * @param {HTMLElement[]} filterButtonGroups
 	 */
 	generateFilterGroups: function( filterButtonGroups ) {
 		const localStorage = this.getLocalStorage();
@@ -100,7 +100,7 @@ liquipedia.filterButtons = {
 			};
 
 			buttonsDiv.querySelectorAll( ':scope > .filter-button' ).forEach(
-				( /** @type HTMLElement */ buttonElement ) => {
+				( /** @type {HTMLElement} */ buttonElement ) => {
 					const filterOn = buttonElement.dataset.filterOn ?? '';
 					const defaultState = !(
 						buttonElement.dataset.filterDefault === 'false' ||
@@ -131,18 +131,22 @@ liquipedia.filterButtons = {
 	},
 
 	generateFilterableObjects: function() {
-		document.querySelectorAll( '[data-filter-category]' ).forEach( ( /** @type HTMLElement */ filterableItem ) => {
-			const filterGroup = this.filterGroups[ filterableItem.dataset.filterGroup ?? this.fallbackFilterGroup ];
-			filterGroup.filterableItems.push( {
-				element: filterableItem,
-				value: filterableItem.dataset.filterCategory,
-				curated: filterableItem.dataset.curated !== undefined,
-				hidden: false
-			} );
-		} );
+		document.querySelectorAll( '[data-filter-category]' ).forEach(
+			/** @param {HTMLElement} filterableItem */
+			( filterableItem ) => {
+				const filterGroup = this.filterGroups[ filterableItem.dataset.filterGroup ?? this.fallbackFilterGroup ];
+				filterGroup.filterableItems.push( {
+					element: filterableItem,
+					value: filterableItem.dataset.filterCategory,
+					curated: filterableItem.dataset.curated !== undefined,
+					hidden: false
+				} );
+			}
+		);
 
 		document.querySelectorAll( '[data-filter-expansion-template]' ).forEach(
-			( /** @type HTMLElement */ templateExpansion ) => {
+			/** @param {HTMLElement} templateExpansion */
+			( templateExpansion ) => {
 				this.templateExpansions.push( {
 					element: templateExpansion,
 					groups: templateExpansion.dataset.filterGroups.split( ',' ),

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -100,7 +100,8 @@ liquipedia.filterButtons = {
 			};
 
 			Array.from( buttonsDiv.querySelectorAll( ':scope > .filter-button' ) ).forEach(
-				( /** @type {HTMLElement} */ buttonElement ) => {
+				/** @param {HTMLElement} buttonElement */
+				( buttonElement ) => {
 					const filterOn = buttonElement.dataset.filterOn ?? '';
 					const defaultState = !(
 						buttonElement.dataset.filterDefault === 'false' ||

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -269,7 +269,7 @@ liquipedia.filterButtons = {
 		this.hideableGroups.forEach( ( hideableGroup ) => {
 			const groupElement = hideableGroup.element;
 			const filterableItems = this.getTopLevelFilterableItems( groupElement );
-			if ( !filterableItems.every( this.isFilterableVisible, this ) ) {
+			if ( !filterableItems.some( this.isFilterableVisible, this ) ) {
 				groupElement.classList.remove( hideableGroup.effectClass );
 				groupElement.classList.add( 'filter-category--hidden-group' );
 				hideableGroup.fallbackItem?.classList.add( hideableGroup.effectClass );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -150,6 +150,7 @@ liquipedia.filterButtons = {
 
 		this.templateExpansions = Array.from(
 			document.querySelectorAll( '[data-filter-expansion-template]' ),
+			/** @param {HTMLElement} templateExpansion */
 			( templateExpansion ) => ( {
 				element: templateExpansion,
 				groups: templateExpansion.dataset.filterGroups.split( ',' ),
@@ -162,6 +163,7 @@ liquipedia.filterButtons = {
 
 		this.hideableGroups = Array.from(
 			document.querySelectorAll( '[data-filter-hideable-group]' ),
+			/** @param {HTMLElement} hideableGroup */
 			( hideableGroup ) => ( {
 				element: hideableGroup,
 				effectClass: 'filter-effect-' + ( hideableGroup.dataset.filterEffect ?? this.fallbackFilterEffect ),

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -3,40 +3,56 @@
  Author(s): Elysienna (original), iMarbot (refactor), SyntacticSalt (template expansion)
  *******************************************************************************/
 /**
- * Usage of module:
- *
- * Filter buttons:
+ * ### Liquipedia Filter Buttons
+ * #### Filter buttons/groups
+ * ```html
  * <span data-filter data-filter-effect="fade" data-filter-group="group1">
  *   <span data-filter-on="all">All</span>
  *   <span data-filter-on="cat1" class="filter-button--active">Category 1</span>
  *   <span data-filter-on="cat2">Category 2</span>
  * </span>
+ * ```
  *
- * - data-filter (required): property on the container to group the buttons within into the given group
- * - data-filter-group (encouraged): a unique identifier given to this group, to be used later on the items so the controls know which items to filter.
+ * - `data-filter` (required): property on the container to group the buttons within into the given group
+ * - `data-filter-group` (encouraged): unique identifier for group, used to determine which items to filter on the page.
  *     Note: this attribute is technically not required as long as one instance of the module is being used.
  *           When using multiple on a single page, ALWAYS use this attribute to distinguish between button/item groups
- * - data-filter-effect (optional): options are [fade,bounce,none]. When omitted, no effect is used.
- * - data-filter-on (required): clicking this element will toggle the items with the passed category
- *     (matching on data-filter-category on the items). Can also be 'all' to toggle all items.
+ * - `data-filter-effect` (optional): options are [fade,bounce,none]. When omitted, no effect is used.
+ * - `data-filter-on` (required): clicking this element will toggle the items with the passed category
+ *     (matching on `data-filter-category` on the items). Can also be 'all' to toggle all items.
  * Note: the class 'filter-button--active' may be given to pre-filter items on load.
  *
- * Filterable items:
+ * #### Filterable items
+ * ```html
  * <span data-filter-group="group1" data-filter-category="cat1">cat1</span>
  * <span data-filter-group="group1" data-filter-category="cat2">cat2</span>
+ * ```
  *
- * - data-filter-group (encouraged): group identifier for which the button group can interact with the item.
+ * - `data-filter-group` (encouraged): group identifier for which the button group can interact with the item.
  *     Note: See data-filter-group in Filter buttons above as to why it is encouraged to always provide.
- * - data-filter-category (required): identifier for 'data-filter-on'
+ * - `data-filter-category` (required): identifier for 'data-filter-on'
  *
- * Replacement by Template with filter options:
+ * #### Replacement by template with filter options
+ * ```html
  * <div data-filter-expansion-template="TemplateName" data-filter-groups="group1,group2">Default content</div>
+ * ```
  *
- * - data-filter-expansion-template (required): The template to expand with the current filter options.
+ * - `data-filter-expansion-template` (required): The template to expand with the current filter options.
  *   Expanded template will replace default content.
- * - data-filter-groups (required): Identify the groups of filterbuttons the template should receive the current parameters from.
+ * - `data-filter-groups` (required): Identify which filter groups the template will receive current parameters from.
  *   Should correspond to appropriate filter button groups used on the page.
  *   For each group, the template will receive a parameter groupName holding the currently active group settings.
+ *
+ * #### Self-hiding filterable item groups
+ * Just adding this data attribute (no actual value needed) will create a group of filterable items. This group will
+ * then hide itself entierly if all the items contained within it are also hidden. Useful to hide categorizing heading
+ * items. Optionally can also add an effect type as with items which will be used on the whole group as well.
+ * ```html
+ * <div data-filter-hideable-group data-filter-effect="fade">
+ *   <span data-filter-group="group1" data-filter-category="cat1">cat1</span>
+ *   <span data-filter-group="group1" data-filter-category="cat2">cat2</span>
+ * </div>
+ * ```
  */
 
 liquipedia.filterButtons = {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -58,7 +58,7 @@ liquipedia.filterButtons = {
 
 		this.localStorageKey = this.buildLocalStorageKey();
 		this.generateFilterGroups( filterButtonGroups );
-		this.generateFilterableItems();
+		this.generateFilterableObjects();
 		this.initializeButtons();
 		this.performUpdate();
 	},
@@ -114,7 +114,7 @@ liquipedia.filterButtons = {
 		} );
 	},
 
-	generateFilterableItems: function() {
+	generateFilterableObjects: function() {
 		document.querySelectorAll( '[data-filter-category]' ).forEach( ( /** @type HTMLElement */ filterableItem ) => {
 			const filterGroup = this.filterGroups[ filterableItem.dataset.filterGroup ?? this.fallbackFilterGroup ];
 			filterGroup.filterableItems.push( {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -141,16 +141,18 @@ liquipedia.filterButtons = {
 			} );
 		} );
 
-		document.querySelectorAll( '[data-filter-expansion-template]' ).forEach( ( /** @type HTMLElement */ templateExpansion ) => {
-			this.templateExpansions.push( {
-				element: templateExpansion,
-				groups: templateExpansion.dataset.filterGroups.split( ',' ),
-				template: templateExpansion.dataset.filterExpansionTemplate,
-				cache: {
-					default: templateExpansion.innerHTML
-				}
-			} );
-		} );
+		document.querySelectorAll( '[data-filter-expansion-template]' ).forEach(
+			( /** @type HTMLElement */ templateExpansion ) => {
+				this.templateExpansions.push( {
+					element: templateExpansion,
+					groups: templateExpansion.dataset.filterGroups.split( ',' ),
+					template: templateExpansion.dataset.filterExpansionTemplate,
+					cache: {
+						default: templateExpansion.innerHTML
+					}
+				} );
+			}
+		);
 
 		this.hideableGroups = Array.from( document.querySelectorAll( '[data-filter-hideable-group]' ) );
 	},
@@ -272,7 +274,9 @@ liquipedia.filterButtons = {
 				if ( filterGroup.curated || filterGroup.defaultCurated ) {
 					return filterGroup.curated === filterGroup.defaultCurated;
 				}
-				return Object.keys( filterGroup.filterStates ).every( ( filterState ) => filterGroup.filterStates[ filterState ] === filterGroup.defaultStates[ filterState ] );
+				return Object.keys( filterGroup.filterStates ).every(
+					( filter ) => filterGroup.filterStates[ filter ] === filterGroup.defaultStates[ filter ]
+				);
 			} );
 			if ( isDefault ) {
 				templateExpansion.element.innerHTML = templateExpansion.cache.default;

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -145,18 +145,16 @@ liquipedia.filterButtons = {
 			}
 		);
 
-		Array.from( document.querySelectorAll( '[data-filter-expansion-template]' ) ).forEach(
-			/** @param {HTMLElement} templateExpansion */
-			( templateExpansion ) => {
-				this.templateExpansions.push( {
-					element: templateExpansion,
-					groups: templateExpansion.dataset.filterGroups.split( ',' ),
-					template: templateExpansion.dataset.filterExpansionTemplate,
-					cache: {
-						default: templateExpansion.innerHTML
-					}
-				} );
-			}
+		this.templateExpansions = Array.from(
+			document.querySelectorAll( '[data-filter-expansion-template]' ),
+			( templateExpansion ) => ( {
+				element: templateExpansion,
+				groups: templateExpansion.dataset.filterGroups.split( ',' ),
+				template: templateExpansion.dataset.filterExpansionTemplate,
+				cache: {
+					default: templateExpansion.innerHTML
+				}
+			} )
 		);
 
 		this.hideableGroups = Array.from( document.querySelectorAll( '[data-filter-hideable-group]' ) );

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -46,11 +46,15 @@
  * #### Self-hiding filterable item groups
  * Just adding this data attribute (no actual value needed) will create a group of filterable items. This group will
  * then hide itself entierly if all the items contained within it are also hidden. Useful to hide categorizing heading
- * items. Optionally can also add an effect type as with items which will be used on the whole group as well.
+ * items. Optionally can also add an effect type as with items which will be used on the whole group as well. The groups
+ * can also be nested, but, this will still check filterable items and not whether child groups themselves are hidden.
+ * Can also add a fallback item as a direct child of the group using `data-filter-hideable-group-fallback`; this item
+ * will instead be shown when the group is determined to be hidden instead of hiding the actual group element.
  * ```html
  * <div data-filter-hideable-group data-filter-effect="fade">
  *   <span data-filter-group="group1" data-filter-category="cat1">cat1</span>
  *   <span data-filter-group="group1" data-filter-category="cat2">cat2</span>
+ *   <span data-filter-hideable-group-fallback>DEFAULT CONTENT</span>
  * </div>
  * ```
  */

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -63,7 +63,6 @@ liquipedia.filterButtons = {
 
 	filterGroups: {},
 	templateExpansions: [],
-	/** @type {HTMLElement[]} */
 	hideableGroups: [],
 
 	init: function() {
@@ -157,7 +156,14 @@ liquipedia.filterButtons = {
 			} )
 		);
 
-		this.hideableGroups = Array.from( document.querySelectorAll( '[data-filter-hideable-group]' ) );
+		this.hideableGroups = Array.from(
+			document.querySelectorAll( '[data-filter-hideable-group]' ),
+			( hideableGroup ) => ( {
+				element: hideableGroup,
+				effectClass: 'filter-effect-' + ( hideableGroup.dataset.filterEffect ?? this.fallbackFilterEffect ),
+				fallbackItem: hideableGroup.querySelector( ':scope > [data-filter-hideable-group-fallback]' )
+			} )
+		);
 	},
 
 	initializeButtons: function() {
@@ -261,13 +267,15 @@ liquipedia.filterButtons = {
 		} );
 
 		this.hideableGroups.forEach( ( hideableGroup ) => {
-			const filerableItems = this.getTopLevelFilterableItems( hideableGroup );
-			const effectClass = 'filter-effect-' + ( hideableGroup.dataset.filterEffect ?? this.fallbackFilterEffect );
+			const groupElement = hideableGroup.element;
+			const filerableItems = this.getTopLevelFilterableItems( groupElement );
 			if ( !filerableItems.every( this.isFilterableVisible, this ) ) {
-				hideableGroup.classList.remove( effectClass );
-				hideableGroup.classList.add( this.hiddenCategoryClass );
+				groupElement.classList.remove( hideableGroup.effectClass );
+				groupElement.classList.add( 'filter-category--hidden-group' );
+				hideableGroup.fallbackItem?.classList.add( hideableGroup.effectClass );
 			} else {
-				hideableGroup.classList.replace( this.hiddenCategoryClass, effectClass );
+				groupElement.classList.replace( 'filter-category--hidden-group', hideableGroup.effectClass );
+				hideableGroup.fallbackItem?.classList.remove( hideableGroup.effectClass );
 			}
 		} );
 

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -268,8 +268,8 @@ liquipedia.filterButtons = {
 
 		this.hideableGroups.forEach( ( hideableGroup ) => {
 			const groupElement = hideableGroup.element;
-			const filerableItems = this.getTopLevelFilterableItems( groupElement );
-			if ( !filerableItems.every( this.isFilterableVisible, this ) ) {
+			const filterableItems = this.getTopLevelFilterableItems( groupElement );
+			if ( !filterableItems.every( this.isFilterableVisible, this ) ) {
 				groupElement.classList.remove( hideableGroup.effectClass );
 				groupElement.classList.add( 'filter-category--hidden-group' );
 				hideableGroup.fallbackItem?.classList.add( hideableGroup.effectClass );
@@ -372,14 +372,14 @@ liquipedia.filterButtons = {
 	},
 
 	/**
-	 * @param {HTMLElement} filerableItem
+	 * @param {HTMLElement} filterableItem
 	 * @return {boolean}
 	 */
-	isFilterableVisible: function ( filerableItem ) {
-		if ( filerableItem.classList.contains( this.hiddenCategoryClass ) ) {
+	isFilterableVisible: function ( filterableItem ) {
+		if ( filterableItem.classList.contains( this.hiddenCategoryClass ) ) {
 			return false;
 		} else {
-			const filterableChildren = this.getTopLevelFilterableItems( filerableItem );
+			const filterableChildren = this.getTopLevelFilterableItems( filterableItem );
 			return filterableChildren.length === 0 ? true : filterableChildren.some( this.isFilterableVisible, this );
 		}
 	}

--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -2,7 +2,9 @@
 Template(s): Filter buttons
 Author(s): Elysienna, Nadox
 *******************************************************************************/
-.filter-category--hidden {
+.filter-category--hidden,
+.filter-category--hidden-group > :not( [ data-filter-hideable-group-fallback ] ),
+:not( .filter-category--hidden-group ) > [ data-filter-hideable-group-fallback ] {
 	clip: rect( 0 0 0 0 );
 	clip-path: inset( 50% );
 	height: 1px;


### PR DESCRIPTION
## Summary

Add ability to define groups that can hide themselves if all their filterable-item children are hidden. Also refactored some of the code to clean up jsdoc warnings and formatted the module documentation.

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/6e910f3d-ace0-4ea7-85e6-5ae848df0d0d)

Currently we can get this scenario where you can empty out an entire section of filterable items and then you are left with an empty heading:

![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/8c5b9b80-2502-4a6b-9b81-5f0dd830f23d)

## How did you test this change?

Tested on the dev wiki (http://darkrai.wiki.tldev.eu/rocketleague/Main_Page):
| With Ongoing Tournament(s) | Without Ongoing Tournament(s) |
|--------|--------|
| ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/eebfaa01-4614-4c9d-8932-97a698da4393) | ![image](https://github.com/Liquipedia/Lua-Modules/assets/5881994/23b81f44-68c1-432e-9dd1-b09e960e38b8) | 


