### PR TITLE
feat(Infobox): Remove outdated player ratings on AoE

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -43,7 +43,6 @@ local CustomInjector = Class.new(Injector)
 
 local RATINGCONFIG = {
 	aoe2 = {
-		--{text = 'RM [[Age of Empires II/Definitive Edition|DE]]', id = 'aoe2net_id', game = 'aoe2de'},
 		{
 			text = Page.makeExternalLink('Tournament', 'https://aoe-elo.com/players'),
 			id = 'aoe-elo.com_id',
@@ -52,11 +51,7 @@ local RATINGCONFIG = {
 		{text = 'RM [[Voobly]]', id = 'voobly_elo'},
 	},
 	aoe3 = {
-		--{text = 'Supremacy [[Age of Empires III/Definitive Edition|DE]]', id = 'aoe3net_id', game = 'aoe3de'},
 		{text = 'Supremacy', id = 'aoe3_elo'},
-	},
-	aoe4 = {
-		--{text = 'QM', id = 'aoe4net_id', game = 'aoe4'},
 	},
 	aom = {
 		{text = 'Elo [[Voobly]]', id = 'aom_voobly_elo'},

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -43,7 +43,7 @@ local CustomInjector = Class.new(Injector)
 
 local RATINGCONFIG = {
 	aoe2 = {
-		{text = 'RM [[Age of Empires II/Definitive Edition|DE]]', id = 'aoe2net_id', game = 'aoe2de'},
+		--{text = 'RM [[Age of Empires II/Definitive Edition|DE]]', id = 'aoe2net_id', game = 'aoe2de'},
 		{
 			text = Page.makeExternalLink('Tournament', 'https://aoe-elo.com/players'),
 			id = 'aoe-elo.com_id',
@@ -52,11 +52,11 @@ local RATINGCONFIG = {
 		{text = 'RM [[Voobly]]', id = 'voobly_elo'},
 	},
 	aoe3 = {
-		{text = 'Supremacy [[Age of Empires III/Definitive Edition|DE]]', id = 'aoe3net_id', game = 'aoe3de'},
+		--{text = 'Supremacy [[Age of Empires III/Definitive Edition|DE]]', id = 'aoe3net_id', game = 'aoe3de'},
 		{text = 'Supremacy', id = 'aoe3_elo'},
 	},
 	aoe4 = {
-		{text = 'QM', id = 'aoe4net_id', game = 'aoe4'},
+		--{text = 'QM', id = 'aoe4net_id', game = 'aoe4'},
 	},
 	aom = {
 		{text = 'Elo [[Voobly]]', id = 'aom_voobly_elo'},
@@ -157,10 +157,10 @@ function CustomInjector:parse(id, widgets)
 			-- Games & Inactive Games
 			Cell{name = 'Games', content = Array.map(args.gameList, function(game)
 				return game.name .. (game.active and '' or '&nbsp;<small>(inactive)</small>')
-			end)},
-			--Elo ratings
-			Title{name = 'Ratings'}
+			end)}
 		)
+		--Elo ratings
+		local ratingCells = {}
 		for game, ratings in Table.iter.spairs(RATINGCONFIG) do
 			game = Game.raw{game = game}
 			Array.forEach(ratings, function(rating)
@@ -179,8 +179,14 @@ function CustomInjector:parse(id, widgets)
 					bestRating = bestRating .. '&nbsp;<small>(highest)</small>'
 					table.insert(content, bestRating)
 				end
-				table.insert(widgets, Cell{name = rating.text .. ' (' .. game.abbreviation .. ')', content = content})
+				if Logic.isNotEmpty(content) then
+					table.insert(ratingCells, Cell{name = rating.text .. ' (' .. game.abbreviation .. ')', content = content})
+				end
 			end)
+		end
+		if Logic.isNotEmpty(ratingCells) then
+			table.insert(widgets, Title{name = 'Ratings'})
+			Array.extendWith(widgets, ratingCells)
 		end
 	elseif id == 'status' then
 		table.insert(widgets, Cell{


### PR DESCRIPTION
## Summary
Fetching new ratings is not possible for quite a while now due to API changes that need to be implemented in the extension.
Leaving the config commented out for easier enabling once https://gitlab.com/teamliquid-dev/liquipedia/web/issue-bucket/-/issues/64 is done.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
