### PR TITLE
feat(participantTable): Inherit `isRandomEvent` from parent on sc & sc2

### DIFF
--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -77,7 +77,7 @@ function StarcraftParticipantTable.readConfig(args, parentConfig)
 	config.displayUnknownColumn = Logic.readBoolOrNil(args.unknowncolumn)
 	config.displayRandomColumn = Logic.readBoolOrNil(args.randomcolumn)
 	config.showCountByFaction = Logic.readBool(args.showCountByRace or args.count)
-	config.isRandomEvent = Logic.readBool(args.is_random_event)
+	config.isRandomEvent = Logic.nilOr(Logic.readBoolOrNil(args.is_random_event), parentConfig.isRandomEvent)
 	config.isQualified = Logic.nilOr(Logic.readBoolOrNil(args.isQualified), parentConfig.isQualified)
 	config.sortPlayers = true
 	--only relevant for solo case since there we need columnWidth in px since colSpan is calculated dynamically


### PR DESCRIPTION
## Summary
Inherit `isRandomEvent` from parent to section so it is enough to set it in the parent instead of in every child/section

## How did you test this change?
live