### PR TITLE
feat(prizepool): Add option to shift imported placements

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -53,6 +53,7 @@ local Import = Class.new(function(self, ...) self:init(...) end)
 ---@field stagePlacementsToSkip table<integer, integer>
 ---@field stageImportWinners table<integer, boolean>
 ---@field stageGroupElimStatuses table<integer, string[]>
+---@field shiftPlacementsBy integer
 
 ---@class PrizePoolImportStageConfig
 ---@field importWinners boolean
@@ -123,6 +124,7 @@ function Import._getConfig(args, placements)
 		stageGroupElimStatuses = processStagesConfig('importLimit', function(val)
 			return Array.map(mw.text.split(val, ','), String.trim)
 		end),
+		shiftPlacementsBy = tonumber(args.shiftPlacementsBy) or 0,
 	}
 end
 
@@ -483,12 +485,17 @@ end
 ---@param placements PrizePoolPlacement[]
 ---@return PrizePoolPlacement[]
 function Import:_mergePlacements(lpdbEntries, placements)
-	for placementIndex, lpdbPlacement in ipairs(lpdbEntries) do
-		placements[placementIndex] = self:_mergePlacement(
+	Array.forEach(Array.range(1, self.config.shiftPlacementsBy), function(placementIndex)
+		placements[placementIndex] = placements[placementIndex] or self:_emptyPlacement(placements[placementIndex - 1], 1)
+	end)
+
+	Array.forEach(lpdbEntries, function(lpdbPlacement, placementIndex)
+		local shiftedPlacementIndex = placementIndex + self.config.shiftPlacementsBy
+		placements[shiftedPlacementIndex] = self:_mergePlacement(
 			lpdbPlacement,
-			placements[placementIndex] or self:_emptyPlacement(placements[placementIndex - 1], #lpdbPlacement)
+			placements[shiftedPlacementIndex] or self:_emptyPlacement(placements[shiftedPlacementIndex - 1], #lpdbPlacement)
 		)
-	end
+	end)
 
 	return placements
 end


### PR DESCRIPTION
## Summary
Adds the option to shift the imported placements by a given number of slots.
This can be used to add manual entries above the imported ones.

## How did you test this change?
dev

![Screenshot 2024-06-27 165729](https://github.com/Liquipedia/Lua-Modules/assets/75081997/417c95e0-67be-4664-b685-e94f0428b7e8)