### PR TITLE
Change class name for banner

### DIFF
--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -1,4 +1,4 @@
-.banner {
+.header-banner {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -6,8 +6,13 @@
 	position: relative;
 	border-radius: 0.25rem;
 
+	&.wiki--dota2 {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/1/19/Bgdota2.jpg ) no-repeat center / cover;
+		}
+	}
+
 	@media ( min-width: 768px ) {
-		background: url( https://liquipedia.net/commons/images/1/19/Bgdota2.jpg ) no-repeat center / cover;
 		box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
 		height: 8.875rem;
 		flex-direction: row;

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -6,7 +6,7 @@
 	position: relative;
 	border-radius: 0.25rem;
 
-	&.wiki--dota2 {
+	&.wiki--dota2game {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/1/19/Bgdota2.jpg ) no-repeat center / cover;
 		}

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -6,7 +6,7 @@
 	position: relative;
 	border-radius: 0.25rem;
 
-	&.wiki--dota2game {
+	.wiki-dota2game & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/1/19/Bgdota2.jpg ) no-repeat center / cover;
 		}


### PR DESCRIPTION
## Summary

The current class name conflicts with a class name of the same name that already exists. 
This MR changes the banner class name to a more specific. It uses the modifier class `wiki-dota2game` from the body to add the specific background-image.

After merge the class names needs to be edited here: https://liquipedia.net/dota2game/User:Elysienna/Main_Page

## How did you test this change?

[dev wiki ](http://laura.wiki.tldev.eu/rocketleague/User:Elysienna/Main_Page)
