### PR TITLE
feat(links): add `douyin_page` support

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -291,7 +291,7 @@ local ICON_KEYS_TO_RENAME = {
 	tlpdint = 'tlpd',
 	tlpdkr = 'tlpd-wol-korea',
 	tlpdsospa = 'tlpd-sospa',
-	douyin_page = 'douyib',
+	douyin_page = 'douyin',
 }
 
 ---@param links {[string]: string}

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -74,6 +74,7 @@ local PREFIXES = {
 		team = 'https://www.dotabuff.com/esports/teams/'
 	},
 	douyin = {'https://live.douyin.com/'},
+	douyin_page = {'https://v.douyin.com/'},
 	douyu = {'https://www.douyu.com/'},
 	esea = {
 		'https://play.esea.net/events/',
@@ -290,6 +291,7 @@ local ICON_KEYS_TO_RENAME = {
 	tlpdint = 'tlpd',
 	tlpdkr = 'tlpd-wol-korea',
 	tlpdsospa = 'tlpd-sospa',
+	douyin_page = 'douyib',
 }
 
 ---@param links {[string]: string}

--- a/standard/links/commons/links_priority_groups.lua
+++ b/standard/links/commons/links_priority_groups.lua
@@ -75,7 +75,8 @@ return {
 		'tiktok',
 		'twitter',
 		'vk',
-		'weibo'
+		'weibo',
+		'douyin_page',
 	},
 	streams = {
 		'twitch',


### PR DESCRIPTION
## Summary
Adds support for `douyin_page`.
It is supposed to link to douyin user page. It needs to be available in addition to the douyin links that link to streams as both will get used on player/team pages.

requested by zeropochan on discord

## How did you test this change?
dev