### PR TITLE
feat(infobox): create Team infobox for World of Tanks

### DIFF
--- a/components/infobox/wikis/worldoftanks/infobox_team_custom.lua
+++ b/components/infobox/wikis/worldoftanks/infobox_team_custom.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- wiki=worldoftanks
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local MatchTicker = require('Module:MatchTicker/Custom')
+
+local Team = Lua.import('Module:Infobox/Team', {requireDevIfEnabled = true})
+
+local CustomTeam = Class.new()
+
+---@param frame Frame
+---@return Html
+function CustomTeam.run(frame)
+	local team = Team(frame)
+	team.createBottomContent = CustomTeam.createBottomContent
+	return team:createInfobox()
+end
+
+---@return Html
+function CustomTeam:createBottomContent()
+	return MatchTicker.participant{team = self.pagename}
+end
+
+return CustomTeam


### PR DESCRIPTION
## Summary
LIVE, it actually got merged within #3532 https://github.com/Liquipedia/Lua-Modules/pull/3532/files#diff-0817a28586d50f520bd76ef0754d9dcf1353fb20af7cbbe3aa65134048214e69 but for some reason this specific file was never added tho the LiquipediaBot actually picked up the version control on that page. File is just not there, idk why