### PR TITLE
feat(infobox): on valorant player infobox change signature title to account for plurality

### DIFF
--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -87,7 +87,7 @@ function CustomInjector:parse(id, widgets)
 			return CharacterIcon.Icon{character = agent, size = SIZE_AGENT}
 		end)
 		return {
-			Cell{name = 'Signature Agent(s)', content = {table.concat(icons, '&nbsp;')}}
+			Cell{name = 'Signature Agent' .. (#icons > 1 and 's' or ''), content = {table.concat(icons, '&nbsp;')}}
 		}
 	elseif id == 'status' then
 		return {


### PR DESCRIPTION
## Summary
Requested by GodOfPog https://discord.com/channels/93055209017729024/268719633366777856/1261307299809591388
Changes param display name to fit cases where a player has more than 1 signature operator.

## How did you test this change?

dev
