### PR TITLE
fix(squad): newteamdate is not working

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -172,7 +172,7 @@ function SquadRow:newteam()
 			return content
 		end
 
-		local date = self.model.extradata.newteamdate or self.model.leavedate
+		local date = String.isNotEmpty(self.model.extradata.newteamdate) and self.model.extradata.newteamdate or self.model.leavedate
 		table.insert(content, mw.ext.TeamTemplate.team(newTeam, date))
 
 		if hasNewTeamRole then

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -172,7 +172,8 @@ function SquadRow:newteam()
 			return content
 		end
 
-		local date = String.isNotEmpty(self.model.extradata.newteamdate) and self.model.extradata.newteamdate or self.model.leavedate
+		local date = String.isNotEmpty(self.model.extradata.newteamdate) and self.model.extradata.newteamdate
+			or self.model.leavedate
 		table.insert(content, mw.ext.TeamTemplate.team(newTeam, date))
 
 		if hasNewTeamRole then

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -172,8 +172,7 @@ function SquadRow:newteam()
 			return content
 		end
 
-		local date = String.isNotEmpty(self.model.extradata.newteamdate) and self.model.extradata.newteamdate
-			or self.model.leavedate
+		local date = self.model.extradata.newteamdate or self.model.leavedate
 		table.insert(content, mw.ext.TeamTemplate.team(newTeam, date))
 
 		if hasNewTeamRole then

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -172,7 +172,7 @@ function SquadRow:newteam()
 			return content
 		end
 
-		local date = self.model.newteamdate or self.model.leavedate
+		local date = self.model.extradata.newteamdate or self.model.leavedate
 		table.insert(content, mw.ext.TeamTemplate.team(newTeam, date))
 
 		if hasNewTeamRole then

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -146,7 +146,7 @@ function SquadUtils.readSquadPersonArgs(args)
 		extradata = {
 			loanedto = args.team,
 			loanedtorole = args.teamrole,
-			newteamdate = args.newteamdate,
+			newteamdate = ReferenceCleaner.clean(args.newteamdate),
 			faction = Faction.read(args.faction or args.race),
 		},
 	}

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -146,7 +146,7 @@ function SquadUtils.readSquadPersonArgs(args)
 		extradata = {
 			loanedto = args.team,
 			loanedtorole = args.teamrole,
-			newteamdate = ReferenceCleaner.clean(args.newteamdate),
+			newteamdate = String.nilIfEmpty(ReferenceCleaner.clean(args.newteamdate)),
 			faction = Faction.read(args.faction or args.race),
 		},
 	}


### PR DESCRIPTION
## Summary
As the date is put into extradata during parsing, but wasn't read from there:
https://github.com/Liquipedia/Lua-Modules/blob/e5d02d4fac624a979586cbba1136ae0e61b8e82e/components/squad/commons/squad_utils.lua#L149
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
