### PR TITLE
fix(countdown): Catch inexact dates

### DIFF
--- a/standard/countdown.lua
+++ b/standard/countdown.lua
@@ -25,6 +25,7 @@ end
 ---@param args table
 ---@return string
 function Countdown._create(args)
+	args = args or {}
 	if Logic.isEmpty(args.date) and not args.timestamp then
 		return ''
 	end
@@ -40,7 +41,7 @@ function Countdown._create(args)
 	end
 
 	-- Timestamp
-	local timestamp = args.timestamp or DateExt.readTimestampOrNil(args.date) or 'error'
+	local timestamp = args.timestamp or args.date:find('data%-tz="[%+%-]?%d') and DateExt.readTimestampOrNil(args.date) or 'error'
 	wrapper:attr('data-timestamp', timestamp)
 
 	local streams


### PR DESCRIPTION
## Summary
Countdown did not catch inexact dates and displayed a countdown nonetheless.
This PR adds a check for inexact dates, so that the countdown isn't displayed for them anymore.
As before the refactor plain input is displayed in that case again.

Also catch a potential nil.

## How did you test this change?
dev