### PR TITLE
feat(match2): improve fighters match summary alignment

### DIFF
--- a/components/match2/wikis/fighters/match_summary.lua
+++ b/components/match2/wikis/fighters/match_summary.lua
@@ -115,14 +115,14 @@ function CustomMatchSummary._createGame(row, game, props)
 		true
 	)
 
-	row:addElement(chars1)
+	row:addElement(chars1):css('flex-basis', '30%')
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner, 1))
 	row:addElement(mw.html.create('div')
-			:addClass('brkts-popup-spaced'):css('flex-grow', '1')
+			:addClass('brkts-popup-spaced'):css('flex', '1 0 auto')
 			:wikitext(game.scores[1]):wikitext('&nbsp;-&nbsp;'):wikitext(game.scores[2])
 	)
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner, 2))
-	row:addElement(chars2)
+	row:addElement(chars2):css('flex-basis', '30%'):css('text-align', 'right')
 end
 
 ---@param characters {name: string, active: boolean}[]?

--- a/components/match2/wikis/fighters/match_summary.lua
+++ b/components/match2/wikis/fighters/match_summary.lua
@@ -115,14 +115,14 @@ function CustomMatchSummary._createGame(row, game, props)
 		true
 	)
 
-	row:addElement(chars1):css('flex-basis', '30%')
+	row:addElement(chars1:css('flex-basis', '30%'))
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner, 1))
 	row:addElement(mw.html.create('div')
 			:addClass('brkts-popup-spaced'):css('flex', '1 0 auto')
 			:wikitext(game.scores[1]):wikitext('&nbsp;-&nbsp;'):wikitext(game.scores[2])
 	)
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner, 2))
-	row:addElement(chars2):css('flex-basis', '30%'):css('text-align', 'right')
+	row:addElement(chars2:css('flex-basis', '30%'):css('text-align', 'right'))
 end
 
 ---@param characters {name: string, active: boolean}[]?


### PR DESCRIPTION
## Summary
Before
![image](https://github.com/user-attachments/assets/bbfc6f01-13be-4bbc-b3cc-f5e435123666)

After
![image](https://github.com/user-attachments/assets/4fbc479a-c5fe-4a75-9638-1d4b370498ff)

## How did you test this change?
Dev
