### PR TITLE
fix(countdown): remove completed state for countdown

### DIFF
--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -104,40 +104,35 @@ liquipedia.countdown = {
 			live = timerObjectNode.dataset.countdownEndText;
 		}
 		if ( timerObjectNode.dataset.timestamp !== 'error' ) {
-			if ( timerObjectNode.dataset.finished === 'finished' ) {
-				countdownElem.classList.add( 'timer-object-countdown-completed' );
-				datestr = 'COMPLETED';
-			} else {
-				const differenceInSeconds = Math.floor(
-					parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 )
-				);
+			const differenceInSeconds = Math.floor(
+				parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 )
+			);
 
-				if ( differenceInSeconds <= 0 ) {
-					if ( differenceInSeconds > -43200 && timerObjectNode.dataset.finished !== 'finished' ) {
-						countdownElem.classList.add( 'timer-object-countdown-live' );
-						datestr = live;
-					}
+			if ( differenceInSeconds <= 0 ) {
+				if ( differenceInSeconds > -43200 && timerObjectNode.dataset.finished !== 'finished' ) {
+					countdownElem.classList.add( 'timer-object-countdown-live' );
+					datestr = live;
+				}
+			} else {
+				let differenceInSecondsMath = differenceInSeconds;
+				const weeks = Math.floor( differenceInSecondsMath / 604800 );
+				differenceInSecondsMath = differenceInSecondsMath % 604800;
+				const days = Math.floor( differenceInSecondsMath / 86400 );
+				differenceInSecondsMath = differenceInSecondsMath % 86400;
+				const hours = Math.floor( differenceInSecondsMath / 3600 );
+				differenceInSecondsMath = differenceInSecondsMath % 3600;
+				const minutes = Math.floor( differenceInSecondsMath / 60 );
+				const seconds = Math.floor( differenceInSecondsMath % 60 );
+				if ( differenceInSeconds >= 604800 ) {
+					datestr = weeks + 'w ' + days + 'd';
+				} else if ( differenceInSeconds >= 86400 ) {
+					datestr = days + 'd ' + hours + 'h ' + minutes + 'm';
+				} else if ( differenceInSeconds >= 3600 ) {
+					datestr = hours + 'h ' + minutes + 'm ' + seconds + 's';
+				} else if ( differenceInSeconds >= 60 ) {
+					datestr = minutes + 'm ' + seconds + 's';
 				} else {
-					let differenceInSecondsMath = differenceInSeconds;
-					const weeks = Math.floor( differenceInSecondsMath / 604800 );
-					differenceInSecondsMath = differenceInSecondsMath % 604800;
-					const days = Math.floor( differenceInSecondsMath / 86400 );
-					differenceInSecondsMath = differenceInSecondsMath % 86400;
-					const hours = Math.floor( differenceInSecondsMath / 3600 );
-					differenceInSecondsMath = differenceInSecondsMath % 3600;
-					const minutes = Math.floor( differenceInSecondsMath / 60 );
-					const seconds = Math.floor( differenceInSecondsMath % 60 );
-					if ( differenceInSeconds >= 604800 ) {
-						datestr = weeks + 'w ' + days + 'd';
-					} else if ( differenceInSeconds >= 86400 ) {
-						datestr = days + 'd ' + hours + 'h ' + minutes + 'm';
-					} else if ( differenceInSeconds >= 3600 ) {
-						datestr = hours + 'h ' + minutes + 'm ' + seconds + 's';
-					} else if ( differenceInSeconds >= 60 ) {
-						datestr = minutes + 'm ' + seconds + 's';
-					} else {
-						datestr = seconds + 's';
-					}
+					datestr = seconds + 's';
 				}
 			}
 		} else {


### PR DESCRIPTION
## Summary

This removes the COMPLETED countdown string when a match is finished. This is a hotfix for the current bug, a future PR will be made to enable this behavior on the new dota2 main page design.

## How did you test this change?

On my [dev env](http://killian.wiki.tldev.eu/rocketleague/Dota2MainPageTest)
