### PR TITLE
feat(infobox): show status cell on valorant player infobox

### DIFF
--- a/components/infobox/wikis/valorant/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_person_player_custom.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Abbreviation = reqiuire('Module:Abbreviation')
+local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
 local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')


### PR DESCRIPTION
## Summary

Same thing as https://github.com/Liquipedia/Lua-Modules/pull/4113 removes the status cell overwrite so that `Banned` can be displayed as a Status and be recognized in the player portal

Asked about by GodOfPog https://discord.com/channels/93055209017729024/268719633366777856/1263267196646326322

## How did you test this change?

dev https://liquipedia.net/valorant/Norsin
