### PR TITLE
feat(match2): adjust fighter's match1 fields

### DIFF
--- a/components/match2/wikis/fighters/match_legacy.lua
+++ b/components/match2/wikis/fighters/match_legacy.lua
@@ -54,6 +54,9 @@ function MatchLegacy._convertParameters(match2)
 		matchsection = extradata.matchsection or '',
 	}
 
+	match.shortname = match.tournament
+	match.tournament = match.parent
+
 	local bracketData = Json.parseIfString(match2.match2bracketdata)
 	if type(bracketData) == 'table' and bracketData.type == 'bracket' and bracketData.inheritedheader then
 		match.header = (DisplayHelper.expandHeader(bracketData.inheritedheader) or {})[1]


### PR DESCRIPTION
## Summary
Smash-likes uses some core fields different in their match1 implementation. Adjust those in the legacy as well.

They also do the same for PPT, but there we add consumer side handling instead, as that should be standardized (while there is no official standard for match1).

## How did you test this change?
Live