### PR TITLE
feat(prizepool): store tournament data on fighters

### DIFF
--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -11,6 +11,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Currency = require('Module:Currency')
 local Game = require('Module:Game')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -183,6 +184,8 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.circuittier = args.circuittier
 	lpdbData.extradata.circuit2 = args.circuit2
 	lpdbData.extradata.circuit2tier = args.circuit2tier
+
+	Variables.varDefine('tournament_extradata', Json.stringify(lpdbData.extradata))
 
 	return lpdbData
 end

--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -407,9 +407,8 @@ function BasePrizePool:_parseArgs(args)
 	return parsedArgs
 end
 
----@param args table
 ---@return self
-function BasePrizePool:create(args)
+function BasePrizePool:create()
 	self.options = self:_readConfig(self.args)
 	self.prizes = self:_readPrizes(self.args)
 	self:readPlacements(self.args)

--- a/components/prize_pool/wikis/fighters/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/fighters/prize_pool_custom.lua
@@ -47,9 +47,8 @@ function CustomPrizePool.run(frame)
 			return
 		end
 		local player = p.opponents[1].opponentData.players[1] --[[@as FightersStandardPlayer]]
-		return player.displayName, player.pageName, player.flag, table.concat(player.chars, ',')
+		return player.displayName, player.pageName, player.flag, table.concat(player.chars or {}, ',')
 	end
-
 	if prizePool.opponentType == Opponent.solo then
 		local tournament = Json.parseIfTable(Variables.varDefault('tournament_extradata')) or {}
 		tournament.winner, tournament.winnerlink, tournament.winnerflag, tournament.winnerheads = placementData(1)

--- a/components/prize_pool/wikis/fighters/prize_pool_custom.lua
+++ b/components/prize_pool/wikis/fighters/prize_pool_custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
+local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
@@ -33,9 +34,32 @@ function CustomPrizePool.run(frame)
 	args.syncPlayers = true
 	args.import = true
 
-	local prizePool = PrizePool(args)
+	local prizePool = PrizePool(args) ---@type PrizePool
 
-	return prizePool:create():setLpdbInjector(CustomLpdbInjector()):build()
+	local output = prizePool:create():setLpdbInjector(CustomLpdbInjector()):build()
+
+	local function placementData(placement)
+		local p = prizePool.placements[placement]
+		if not p or not p.opponents or not p.opponents[1] or not p.opponents[1].opponentData then
+			return
+		end
+		if not p.opponents[1].opponentData.players or not p.opponents[1].opponentData.players[1] then
+			return
+		end
+		local player = p.opponents[1].opponentData.players[1] --[[@as FightersStandardPlayer]]
+		return player.displayName, player.pageName, player.flag, table.concat(player.chars, ',')
+	end
+
+	if prizePool.opponentType == Opponent.solo then
+		local tournament = Json.parseIfTable(Variables.varDefault('tournament_extradata')) or {}
+		tournament.winner, tournament.winnerlink, tournament.winnerflag, tournament.winnerheads = placementData(1)
+		tournament.runnerup, tournament.runneruplink, tournament.runnerupflag, tournament.runnerupheads = placementData(2)
+		mw.ext.LiquipediaDB.lpdb_tournament('tournament_' .. Variables.varDefault('tournament_name', ''), {
+			extradata = Json.stringify(tournament)
+		})
+	end
+
+	return output
 end
 
 ---@param lpdbData placement


### PR DESCRIPTION
## Summary
Store tournament level extradata from prizepool on fighters, similar to CS. Here we are storing winner and runner up data

## How did you test this change?
Live