### PR TITLE
fix(opponent): missing padding between name and characters on fighters

### DIFF
--- a/components/opponent/wikis/fighters/player_display_custom.lua
+++ b/components/opponent/wikis/fighters/player_display_custom.lua
@@ -58,7 +58,7 @@ function CustomPlayerDisplay.BlockPlayer(props)
 		flagNode = PlayerDisplay.Flag(player.flag)
 	end
 
-	local characterNode = mw.html.create('div')
+	local characterNode = mw.html.create()
 	if player.chars then
 		Array.forEach(player.chars, function (character)
 			characterNode:node(


### PR DESCRIPTION
## Summary
Extra div causes no padding to be added after the characters, which was unintended

## How did you test this change?
Devtools -> Live