### PR TITLE
fix(match2): Handle display of games with no bans and length on heroes

### DIFF
--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -48,8 +48,7 @@ local VETO_TYPE_TO_TEXT = {
 ---@field root Html
 ---@field table Html
 local ChampionBan = Class.new(
-	function(self, options)
-		options = options or {}
+	function(self)
 		self.root = mw.html.create('div'):addClass('brkts-popup-mapveto')
 		self.table = self.root:tag('table')
 			:addClass('wikitable-striped'):addClass('collapsible'):addClass('collapsed')

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -45,13 +45,11 @@ local VETO_TYPE_TO_TEXT = {
 -- Champion Ban Class
 ---@class HeroesOfTheStormHeroBan: MatchSummaryRowInterface
 ---@operator call: HeroesOfTheStormHeroBan
----@field isBan boolean
 ---@field root Html
 ---@field table Html
 local ChampionBan = Class.new(
 	function(self, options)
 		options = options or {}
-		self.isBan = options.isBan
 		self.root = mw.html.create('div'):addClass('brkts-popup-mapveto')
 		self.table = self.root:tag('table')
 			:addClass('wikitable-striped'):addClass('collapsible'):addClass('collapsed')
@@ -292,7 +290,7 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Champion Bans
 	if not Table.isEmpty(championBanData) then
-		local championBan = ChampionBan({isBan = true})
+		local championBan = ChampionBan()
 
 		Array.forEach(match.games,function (_, gameIndex)
 			championBan:banRow(championBanData[gameIndex], gameIndex, match.date)

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -375,7 +375,7 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 
 	-- Add Comment
 	if Logic.isNotEmpty(game.length) then
-		local lengthComment = '<small>Match Duration: '.. game.length ..'</small>'
+		local lengthComment = '<small>Match Duration: ' .. game.length .. '</small>'
 		game.comment = game.comment and (lengthComment .. '<br>' .. game.comment) or lengthComment
 	end
 	if not Logic.isEmpty(game.comment) then

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -292,8 +292,11 @@ function CustomMatchSummary.createBody(match)
 	if not Table.isEmpty(championBanData) then
 		local championBan = ChampionBan({isBan = true})
 
-		for gameIndex, banData in ipairs(championBanData) do
-			championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
+		for gameIndex in ipairs(match.games) do
+			local banData = championBanData[gameIndex]
+			if banData then
+				championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
+			end
 		end
 
 		body:addRow(championBan)

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -83,7 +83,7 @@ function ChampionBan:banRow(banData, gameNumber, date)
 			:node(mw.html.create('div')
 				:wikitext(Abbreviation.make(
 							'Game ' .. gameNumber,
-							(self.isBan and 'Bans' or 'Picks') .. ' in game ' .. gameNumber
+							'Bans in game ' .. gameNumber
 						)
 					)
 				)

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -373,17 +373,18 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 2))
 	row:addElement(CustomMatchSummary._opponentChampionsDisplay(championsData[2], NUM_CHAMPIONS_PICK, date, true))
 
-	-- Add Comment
-	if Logic.isNotEmpty(game.length) then
-		local lengthComment = '<small>Match Duration: ' .. game.length .. '</small>'
-		game.comment = game.comment and (lengthComment .. '<br>' .. game.comment) or lengthComment
-	end
-	if not Logic.isEmpty(game.comment) then
-		row:addElement(MatchSummary.Break():create())
-		local comment = mw.html.create('div')
-		comment :wikitext(game.comment)
+	if Logic.isNotEmpty(game.comment) or Logic.isNotEmpty(game.length) then
+		game.length = Logic.nilIfEmpty(game.length)
+		local commentContents = Array.append({},
+			Logic.nilIfEmpty(game.comment),
+			game.length and tostring(mw.html.create('span'):wikitext('Match Duration: ' .. game.length)) or nil
+		)
+		row
+			:addElement(MatchSummary.Break():create())
+			:addElement(mw.html.create('div')
 				:css('margin', 'auto')
-		row:addElement(comment)
+				:wikitext(table.concat(commentContents, '<br>'))
+			)
 	end
 
 	return row

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -374,6 +374,10 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 	row:addElement(CustomMatchSummary._opponentChampionsDisplay(championsData[2], NUM_CHAMPIONS_PICK, date, true))
 
 	-- Add Comment
+	if Logic.isNotEmpty(game.length) then
+		local lengthComment = '<small>Match Duration: '.. game.length ..'</small>'
+		game.comment = game.comment and (lengthComment .. '<br>' .. game.comment) or lengthComment
+	end
 	if not Logic.isEmpty(game.comment) then
 		row:addElement(MatchSummary.Break():create())
 		local comment = mw.html.create('div')

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -70,13 +70,15 @@ end
 
 ---@param banData {numberOfBans: integer, [1]: table, [2]: table}
 ---@param gameNumber integer
----@param numberOfBans integer
 ---@param date string
 ---@return HeroesOfTheStormHeroBan
-function ChampionBan:banRow(banData, gameNumber, numberOfBans, date)
+function ChampionBan:banRow(banData, gameNumber, date)
+	if Logic.isEmpty(banData) then
+		return self
+	end
 	self.table:tag('tr')
 		:tag('td')
-			:node(CustomMatchSummary._opponentChampionsDisplay(banData[1], numberOfBans, date, false, true))
+			:node(CustomMatchSummary._opponentChampionsDisplay(banData[1], banData.numberOfBans, date, false, true))
 		:tag('td')
 			:node(mw.html.create('div')
 				:wikitext(Abbreviation.make(
@@ -86,7 +88,7 @@ function ChampionBan:banRow(banData, gameNumber, numberOfBans, date)
 					)
 				)
 		:tag('td')
-			:node(CustomMatchSummary._opponentChampionsDisplay(banData[2], numberOfBans, date, true, true))
+			:node(CustomMatchSummary._opponentChampionsDisplay(banData[2], banData.numberOfBans, date, true, true))
 	return self
 end
 
@@ -292,12 +294,9 @@ function CustomMatchSummary.createBody(match)
 	if not Table.isEmpty(championBanData) then
 		local championBan = ChampionBan({isBan = true})
 
-		for gameIndex in ipairs(match.games) do
-			local banData = championBanData[gameIndex]
-			if banData then
-				championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
-			end
-		end
+		Array.forEach(match.games,function (_, gameIndex)
+			championBan:banRow(championBanData[gameIndex], gameIndex, match.date)
+		end)
 
 		body:addRow(championBan)
 	end


### PR DESCRIPTION
## Summary

Iterate bans using match.games, this allows to display bans even if game 1 has no bans.
Add game length display.

## How did you test this change?
/dev
