### PR TITLE
Fix getCharacterName erroring

### DIFF
--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -329,7 +329,9 @@ function mapFunctions.getExtraData(map)
 	Array.forEach(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
 		map.extradata['t' .. opponentIndex .. 'bans'] = Array.map(Array.range(1, MAX_NUM_BANS), function (banIndex)
 			local ban = map['t' .. opponentIndex .. 'ban' .. banIndex]
-			return getCharacterName(ban) or ''
+			if ban~=nil and CharacterNames[ban:lower()]~=nil then
+				return getCharacterName(ban) or ''
+			return ''
 		end)
 	end)
 	return map

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -331,6 +331,7 @@ function mapFunctions.getExtraData(map)
 			local ban = map['t' .. opponentIndex .. 'ban' .. banIndex]
 			if ban~=nil and CharacterNames[ban:lower()]~=nil then
 				return getCharacterName(ban) or ''
+			mw.ext.TeamLiquidIntegration.add_category('Pages with Invalid Character Input')
 			return ''
 		end)
 	end)


### PR DESCRIPTION
## Summary

As discussed in the discord, we have been having problems with editors mispelling character names and instead of the usual behaviour of the ban just not showing up, due to the new changes it now crashes the local system giving us an error message that requires looking into the lua logs to debug, which is entirely unreasonable for our editors to be doing when filling out match details.





## How did you test this change?

tested on [/dev/](https://liquipedia.net/rainbowsix/Module:MatchGroup/Input/Custom/dev) works well.

important to note, this is super inefficient since `MatchGroupInput.getCharacterName` does all the same processing, but since the erroring is the behaviour we are trying to avoid, the only other way is to copy in the function and edit it to do the same thing without having it throw an error when it doesnt find as such:

```lua
-- Parse extradata information, particularally info about halfs and operator bans
---@param map table
---@return table
function mapFunctions.getExtraData(map)
    map.extradata = {
        comment = map.comment,
        t1firstside = {rt = map.t1firstside, ot = map.t1firstsideot},
        t1halfs = {atk = map.t1atk, def = map.t1def, otatk = map.t1otatk, otdef = map.t1otdef},
        t2halfs = {atk = map.t2atk, def = map.t2def, otatk = map.t2otatk, otdef = map.t2otdef},
        t1bans = {},
        t2bans = {},
        pick = map.pick
    }

    local getCharacterName = FnUtil.curry(mapFunctions.getCharacterName, CharacterNames)
    Array.forEach(Array.range(1, MAX_NUM_OPPONENTS), function(opponentIndex)
        map.extradata['t' .. opponentIndex .. 'bans'] = Array.map(Array.range(1, MAX_NUM_BANS), function (banIndex)
            local ban = map['t' .. opponentIndex .. 'ban' .. banIndex]
            return getCharacterName(ban) or '' end
        end)
    end)
    return map
end

[...]

---@param alias table<string, string>
---@param character string?
---@return string?
function mapfunctions.getCharacterName(alias, character)
    if Logic.isEmpty(character) then return nil end
    ---@cast character -nil

    local char = alias[character:lower()]
    if char then return char end

    mw.ext.TeamLiquidIntegration.add_category('Pages with Invalid Character Input')
    return nil
end

return CustomMatchGroupInput
```

not sure which is more acceptable though the difference really seems minimal.
