### PR TITLE
feat(streams): re-order streams based on previous priority

### DIFF
--- a/standard/links_stream.lua
+++ b/standard/links_stream.lua
@@ -23,6 +23,9 @@ local TLNET_STREAM = 'stream'
 
 --List of streaming platforms supported in Module:Countdown.
 StreamLinks.countdownPlatformNames = {
+	'twitch',
+	'youtube',
+	'kick',
 	'afreeca',
 	'bilibili',
 	'cc',
@@ -31,15 +34,12 @@ StreamLinks.countdownPlatformNames = {
 	'facebook',
 	'huomao',
 	'huya',
-	'kick',
 	'loco',
 	'mildom',
 	'nimo',
-	TLNET_STREAM,
 	'tl',
 	'trovo',
-	'twitch',
-	'youtube',
+	TLNET_STREAM,
 }
 
 ---@param key string


### PR DESCRIPTION
## Summary

Before the stream changes away from JavaScript doing more of the work, we had twitch and youtube ordered first as the most common platforms. Now we are back to alphabetical order:

![image](https://github.com/user-attachments/assets/e5769a8c-b0b5-4867-bc1a-78615495e832)


Moved twitch, youtube, and kick to be first as the current "go-to" english platforms and moved TL stream to the end as basically legacy item.

## How did you test this change?

Tested on `/dev`.

![image](https://github.com/user-attachments/assets/06ae393e-7e6b-4301-a86d-943d219ff9c0)

