### PR TITLE
feat(json): Check for lua errors in strings passed to Json parse actions

### DIFF
--- a/standard/json.lua
+++ b/standard/json.lua
@@ -11,6 +11,18 @@ local Json = {}
 local Arguments = require('Module:Arguments')
 local Table = require('Module:Table')
 
+local ERROR_PATTERN = '<span class="scribunto%-error" id="mw%-scribunto%-error%-%d">Lua error in .-: (.*)%.</span>'
+
+---throws if an lua script error is found in the provided string
+---@param str string?
+function Json.checkForError(str)
+	if type(str) ~= 'string' then return end
+
+	local errorMessage = string.match(str, ERROR_PATTERN)
+
+	assert(not errorMessage, errorMessage)
+end
+
 ---Json-stringifies all arguments from a supplied frame.
 ---@param frame Frame
 ---@return string
@@ -62,6 +74,7 @@ end
 ---@return table, boolean
 ---@overload fun(obj: any): {}, true
 function Json.parse(obj)
+	Json.checkForError(obj)
 	local parse = function(object) return mw.text.jsonDecode(object, mw.text.JSON_TRY_FIXING) end
 	local status, res = pcall(parse, obj);
 	if status then
@@ -95,6 +108,7 @@ end
 ---@overload fun(any: any): nil
 function Json.parseIfTable(any)
 	if type(any) == 'string' then
+		Json.checkForError(any)
 		local firstChar = any:sub(1, 1)
 		if firstChar == '{' or firstChar == '[' then
 			local result, hasError = Json.parse(any)

--- a/standard/json.lua
+++ b/standard/json.lua
@@ -11,7 +11,8 @@ local Json = {}
 local Arguments = require('Module:Arguments')
 local Table = require('Module:Table')
 
-local ERROR_PATTERN = '<span class="scribunto%-error" id="mw%-scribunto%-error%-%d">Lua error in .-: (.*)%.</span>'
+local ERROR_PATTERN = '<span class="scribunto%-error" id="mw%-scribunto%-error%-%d">Lua error%s?i?n?%s?:? (.*)%.</span>'
+local JSON_ERROR_PATTERN = 'Module:Json/?d?e?v? at line %d+: Tried to parse Lua error &quot;(.*)&quot;'
 
 ---throws if an lua script error is found in the provided string
 ---@param str string?
@@ -20,7 +21,10 @@ function Json.checkForError(str)
 
 	local errorMessage = string.match(str, ERROR_PATTERN)
 
-	assert(not errorMessage, errorMessage)
+	if not errorMessage then return end
+
+	error('Tried to parse Lua error "' ..
+		errorMessage:gsub(JSON_ERROR_PATTERN, '%1') .. '"')
 end
 
 ---Json-stringifies all arguments from a supplied frame.


### PR DESCRIPTION
## Summary
If a module/template that is supposed to return a stringified table gets parsed currently the json parse just fails without errors
this leads to outer templates/modules to error in other places (unrelated to the underlying error) and hence giving a bad user experience.

Example (from R6):
- invalid operator input in a map causes the intended lua error, it gets returned from the map template
- the match input processing tries to parse the lua error string into a table and fails
- the match input processing continues without error in that moment but errors later on due to the return of the json parse being a string/nil
- the error shown to users is basically useless

This PR adjusts Module:Json to check if the string it is supposed to parse contains a lua error string.
If it finds such a string it throws with the information of said string.
This basically passes the directly displayed error from inner to outer layer by layer.
It does not pass along the stack trace though.

## How did you test this change?
dev