### PR TITLE
feat(match2): store player and agent info on valorant

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -578,7 +578,7 @@ function mapFunctions.getParticipantsData(map)
 					participants[o .. '_' .. player] = participant
 
 					Table.iter.forEachPair(participant, function (key, val)
-						map.extradata[opstringNormal .. (key ~= 'player' and key or '')] = val
+						map.extradata[opstringNormal .. (key == 'player' and '' or key)] = val
 					end)
 				end
 			end

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -6,7 +6,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local AgentNames = require('Module:AgentNames')
 local DateExt = require('Module:Date/Ext')
+local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -548,7 +550,7 @@ end
 ---@return table
 function mapFunctions.getParticipantsData(map)
 	local participants = map.participants or {}
-
+	local getCharacterName = FnUtil.curry(MatchGroupInput.getCharacterName, AgentNames)
 	-- fill in stats
 	for o = 1, MAX_NUM_OPPONENTS do
 		for player = 1, MAX_NUM_PLAYERS do
@@ -575,11 +577,10 @@ function mapFunctions.getParticipantsData(map)
 				participant.player = Logic.isEmpty(playerName) and participant.player or playerName
 
 				if not Table.isEmpty(participant) then
+					participant.agent = getCharacterName(participant.agent)
 					participants[o .. '_' .. player] = participant
-
-					Table.iter.forEachPair(participant, function (key, val)
-						map.extradata[opstringNormal .. (key == 'player' and '' or key)] = val
-					end)
+					map.extradata[opstringNormal] = participant.player
+					map.extradata[opstringNormal .. 'agent'] = participant.agent
 				end
 			end
 		end

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -576,6 +576,10 @@ function mapFunctions.getParticipantsData(map)
 
 				if not Table.isEmpty(participant) then
 					participants[o .. '_' .. player] = participant
+
+					Table.iter.forEachPair(participant, function (key, val)
+						map.extradata[opstring_normal .. (key ~= 'player' and key or '')] = val
+					end)
 				end
 			end
 		end

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -553,9 +553,9 @@ function mapFunctions.getParticipantsData(map)
 	for o = 1, MAX_NUM_OPPONENTS do
 		for player = 1, MAX_NUM_PLAYERS do
 			local participant = participants[o .. '_' .. player] or {}
-			local opstring_big = 'opponent' .. o .. '_p' .. player
-			local opstring_normal = 't' .. o .. 'p' .. player
-			local stats = map[opstring_big .. 'stats'] or map[opstring_normal]
+			local opstringBig = 'opponent' .. o .. '_p' .. player
+			local opstringNormal = 't' .. o .. 'p' .. player
+			local stats = map[opstringBig .. 'stats'] or map[opstringNormal]
 
 			if stats then
 				stats = Json.parse(stats)
@@ -578,7 +578,7 @@ function mapFunctions.getParticipantsData(map)
 					participants[o .. '_' .. player] = participant
 
 					Table.iter.forEachPair(participant, function (key, val)
-						map.extradata[opstring_normal .. (key ~= 'player' and key or '')] = val
+						map.extradata[opstringNormal .. (key ~= 'player' and key or '')] = val
 					end)
 				end
 			end


### PR DESCRIPTION
## Summary

It's impossible to query for player/agent inside match2games.participants so we need to move the data we want to query to extradata.
![image](https://github.com/user-attachments/assets/0f242734-13fa-45cd-a5f1-f611cdf40fdc)

In the future we expect to have the possibilty to query match2games.participants.

## How did you test this change?

/dev and [sandbox](https://liquipedia.net/valorant/User:LuckeLucky/sandbox/2)
