### PR TITLE
fix(infobox): usd broken on fighters and sc2

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -282,7 +282,7 @@ function League:_parseArgs()
 
 	self.data = data
 
-	self.prizepoolDisplay, self.data.prizepoolUsd, self.data.localCurrency = League._parsePrizePool(args, data.endDate)
+	self.prizepoolDisplay, self.data.prizepoolUsd, self.data.localCurrency = self:_parsePrizePool(args, data.endDate)
 
 	data.icon, data.iconDark, self.iconDisplay = self:getIcons{
 		displayManualIcons = Logic.readBool(args.display_series_icon_from_manual_input),
@@ -300,14 +300,14 @@ end
 ---@param args table
 ---@param endDate string?
 ---@return number|string?, number?, string?
-function League._parsePrizePool(args, endDate)
+function League:_parsePrizePool(args, endDate)
 	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
 		return
 	end
 
 	--need to get the display here since it sets variables we want/need to get the clean values
 	--overwritable since sometimes display is supposed to look a bit different
-	return League.displayPrizePool(args, endDate),
+	return self:displayPrizePool(args, endDate),
 		tonumber(Variables.varDefault('tournament_prizepoolusd')) or 0,
 		Variables.varDefault('tournament_currency', args.localcurrency)
 end
@@ -315,7 +315,7 @@ end
 ---@param args table
 ---@param endDate string?
 ---@return number|string?
-function League.displayPrizePool(args, endDate)
+function League:displayPrizePool(args, endDate)
 	return InfoboxPrizePool.display{
 		prizepool = args.prizepool,
 		prizepoolusd = args.prizepoolusd,

--- a/components/infobox/wikis/fighters/infobox_league_custom.lua
+++ b/components/infobox/wikis/fighters/infobox_league_custom.lua
@@ -94,7 +94,7 @@ end
 ---@param args table
 ---@param endDate string?
 ---@return number|string?
-function CustomLeague.displayPrizePool(args, endDate)
+function CustomLeague:displayPrizePool(args, endDate)
 	local localCurrency = args.localcurrency
 	local prizePoolUSD = args.prizepoolusd
 	local prizePool = args.prizepool --[[@as number|string|nil]]

--- a/components/infobox/wikis/smash/infobox_league_custom.lua
+++ b/components/infobox/wikis/smash/infobox_league_custom.lua
@@ -142,7 +142,7 @@ function CustomLeague:customParseArguments(args)
 		local doubleArgs = Table.copy(args)
 		doubleArgs.setvariables = false
 		doubleArgs.prizepool, doubleArgs.prizepoolusd = args.doublesprizepool, args.doublesprizepoolusd
-		self.doublePrizepoolDisplay = CustomLeague._parsePrizePool(doubleArgs, self.data.endDate)
+		self.doublePrizepoolDisplay = self:_parsePrizePool(doubleArgs, self.data.endDate)
 	end
 end
 

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -219,7 +219,7 @@ end
 ---@param args table
 ---@param endDate string?
 ---@return number|string?
-function CustomLeague.displayPrizePool(args, endDate)
+function CustomLeague:displayPrizePool(args, endDate)
 	if String.isEmpty(args.prizepool) and String.isEmpty(args.prizepoolusd) then
 		return
 	end


### PR DESCRIPTION
## Summary
Introduced in #4425, USD-only prizepools broke on fighters and SC2. Caused by insufficient testing

## How did you test this change?
Live