### PR TITLE
refactor(ratings): decouple ratings display

### DIFF
--- a/components/ratings/ratings_display.lua
+++ b/components/ratings/ratings_display.lua
@@ -8,56 +8,54 @@
 
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
-local Operator = require('Module:Operator')
 local RatingsStorageLpdb = require('Module:Ratings/Storage/Lpdb')
-local Table = require('Module:Table')
-local Template = require('Module:Template')
 
 --- Liquipedia Ratings (LPR) Display
 local RatingsDisplay = {}
 
 -- Settings
-local LIMIT_TEAMS_LIST = 100 -- How many teams to show in the list/table
-local LIMIT_TEAMS_GRAPH = 10 -- How many teams to show in the combined graph
-local LIMIT_TEAMS_GRAPH_SELECTED = 5 -- How many teams are preselected in the graph
-local LIMIT_LPR_SNAPSHOT = 24 -- How many historic entries is fetched for graphs (graph mode and team rating history)
+local LIMIT_HISTORIC_ENTRIES = 24 -- How many historic entries is fetched
 
 --- Entry point for the ratings display in graph display mode
 ---@param frame Frame
 ---@return string
 function RatingsDisplay.graph(frame)
-	local args = Arguments.getArgs(frame)
-
-	local teamRankings = RatingsDisplay._getTeamRankings(args.id, LIMIT_TEAMS_GRAPH, LIMIT_LPR_SNAPSHOT)
-
-	return RatingsDisplay._toGraph(teamRankings)
+	local Display = require('Module:Ratings/Display/Graph')
+	return RatingsDisplay.make(frame, Display)
 end
 
 --- Entry point for the ratings display in table list display mode
 ---@param frame Frame
 ---@return string
 function RatingsDisplay.list(frame)
+	local Display = require('Module:Ratings/Display/List')
+	return RatingsDisplay.make(frame, Display)
+end
+
+---@param frame Frame
+---@param displayClass {build: fun(playerRankings: table[]):string}
+---@return unknown
+function RatingsDisplay.make(frame, displayClass)
 	local args = Arguments.getArgs(frame)
 
-	local teamRankings = RatingsDisplay._getTeamRankings(args.id, LIMIT_TEAMS_LIST, LIMIT_LPR_SNAPSHOT)
+	local teamRankings = RatingsDisplay._getTeamRankings(args.id, LIMIT_HISTORIC_ENTRIES)
 
-	return RatingsDisplay._toList(teamRankings)
+	return displayClass.build(teamRankings)
 end
 
 ---@param id string
----@param limit integer
 ---@param progressionLimit integer
----@return table
-function RatingsDisplay._getTeamRankings(id, limit, progressionLimit)
-	local teams = RatingsStorageLpdb.getRankings(id, limit, progressionLimit)
+---@return table[]
+function RatingsDisplay._getTeamRankings(id, progressionLimit)
+	local teams = RatingsStorageLpdb.getRankings(id, progressionLimit)
 
 	teams = RatingsDisplay._enrichTeamInformation(teams)
 
 	return teams
 end
 
----@param teams table
----@return table
+---@param teams table[]
+---@return table[]
 function RatingsDisplay._enrichTeamInformation(teams)
 	-- Update team information from Team Tempalte and Team Page
 	Array.forEach(teams, function(team)
@@ -87,115 +85,6 @@ function RatingsDisplay._getTeamInfo(name)
 	end
 
 	return res[1] or {}
-end
-
----@param teamRankings table
----@return string
-function RatingsDisplay._toList(teamRankings)
-	local htmlTable = mw.html.create('table'):addClass('wikitable'):css('text-align', 'center')
-		:tag('tr'):css('font-weight', 'bold')
-			:tag('td'):wikitext('#'):done()
-			:tag('td'):wikitext('Team'):done()
-			:tag('td'):wikitext('Rating'):done()
-			:tag('td'):wikitext('Region'):done()
-			:tag('td'):wikitext('Played'):done()
-			:tag('td'):wikitext('Streak'):done()
-			:tag('td'):wikitext('History'):done()
-		:allDone()
-
-	Array.forEach(teamRankings, function(team, rank)
-		local chart = mw.ext.Charts.chart({
-			xAxis = {
-				type = 'category',
-				data = Array.map(team.progression, Operator.property('date'))
-			},
-			yAxis = {
-				type = 'value',
-				min = 1000,
-				max = 3500,
-			},
-			tooltip = {
-				trigger = 'axis'
-			},
-			grid = {
-				show = true
-			},
-			size = {
-				height = 300,
-				width = 500
-			},
-			series = {
-				{
-					data = Array.map(team.progression, Operator.property('rating')),
-					type = 'line'
-				}
-			}
-		})
-
-		local popup = Template.expandTemplate(mw.getCurrentFrame(), 'Popup', {
-			label = 'show',
-			title = 'Details for ' .. mw.ext.TeamTemplate.team(team.name),
-			content = chart,
-		})
-
-		local streakText = team.streak > 1 and team.streak .. 'W' or (team.streak < -1 and (-team.streak) .. 'L') or '-'
-		local streakClass = (team.streak > 1 and 'group-table-rank-change-up')
-				or (team.streak < -1 and 'group-table-rank-change-down')
-				or nil
-
-		htmlTable:tag('tr')
-			:tag('td'):css('font-weight', 'bold'):wikitext(rank):done()
-			:tag('td'):css('text-align', 'left'):wikitext(mw.ext.TeamTemplate.team(team.name)):done()
-			:tag('td'):wikitext(math.floor(team.rating + 0.5)):done()
-			:tag('td'):wikitext(string.upper(team.region or '')):done()
-			:tag('td'):wikitext(team.matches):done()
-			:tag('td'):css('font-weight', 'bold'):addClass(streakClass):wikitext(streakText):done()
-			:tag('td'):wikitext(popup):done()
-	end)
-	return tostring(mw.html.create('div'):addClass('table-responsive'):node(htmlTable))
-end
-
----@param teamRankings table
----@return string
-function RatingsDisplay._toGraph(teamRankings)
-	return mw.ext.Charts.chart({
-		xAxis = {
-			type = 'category',
-			data =  Array.map(teamRankings[1].progression or {}, Operator.property('date'))
-		},
-		yAxis = {
-			name = 'Rating',
-			type = 'value',
-			min = 1500,
-			max = 3500,
-			axisTick = {
-				interval = 500
-			}
-		},
-		tooltip = {
-			trigger = 'axis'
-		},
-		grid = {
-			show = true
-		},
-		size = {
-			height = 500,
-			width = 700
-		},
-		legend = {
-			show = true,
-			selected = Table.map(teamRankings, function(rank, team)
-				return team.shortName, rank <= LIMIT_TEAMS_GRAPH_SELECTED and true or false
-			end)
-		},
-		series = Array.map(teamRankings, function(team)
-			return {
-				data =  Array.map(team.progression, Operator.property('rating')),
-				type = 'line',
-				name = team.shortName
-			}
-		end)
-	})
 end
 
 return RatingsDisplay

--- a/components/ratings/ratings_display_graph.lua
+++ b/components/ratings/ratings_display_graph.lua
@@ -1,0 +1,63 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Ratings/Display/Graph
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Operator = require('Module:Operator')
+local Table = require('Module:Table')
+
+local RatingsDisplayGraph = {}
+
+local LIMIT_TEAMS = 10 -- How many teams to show in the combined graph
+local LIMIT_TEAMS_SELECTED = 5 -- How many teams are preselected in the graph
+
+---@param teamRankings table[]
+---@return string
+function RatingsDisplayGraph.build(teamRankings)
+	local teams = Array.sub(teamRankings, 1, LIMIT_TEAMS)
+
+	return mw.ext.Charts.chart({
+		xAxis = {
+			type = 'category',
+			data =  Array.map(teams[1].progression or {}, Operator.property('date'))
+		},
+		yAxis = {
+			name = 'Rating',
+			type = 'value',
+			min = 1500,
+			max = 3500,
+			axisTick = {
+				interval = 500
+			}
+		},
+		tooltip = {
+			trigger = 'axis'
+		},
+		grid = {
+			show = true
+		},
+		size = {
+			height = 500,
+			width = 700
+		},
+		legend = {
+			show = true,
+			selected = Table.map(teams, function(rank, team)
+				return team.shortName, rank <= LIMIT_TEAMS_SELECTED and true or false
+			end)
+		},
+		series = Array.map(teams, function(team)
+			return {
+				data =  Array.map(team.progression, Operator.property('rating')),
+				type = 'line',
+				name = team.shortName
+			}
+		end)
+	})
+end
+
+return RatingsDisplayGraph

--- a/components/ratings/ratings_display_graph.lua
+++ b/components/ratings/ratings_display_graph.lua
@@ -10,12 +10,13 @@ local Array = require('Module:Array')
 local Operator = require('Module:Operator')
 local Table = require('Module:Table')
 
+---@class RatingsDisplayGraph: RatingsDisplayInterface
 local RatingsDisplayGraph = {}
 
 local LIMIT_TEAMS = 10 -- How many teams to show in the combined graph
 local LIMIT_TEAMS_SELECTED = 5 -- How many teams are preselected in the graph
 
----@param teamRankings table[]
+---@param teamRankings RatingsEntry[]
 ---@return string
 function RatingsDisplayGraph.build(teamRankings)
 	local teams = Array.sub(teamRankings, 1, LIMIT_TEAMS)

--- a/components/ratings/ratings_display_list.lua
+++ b/components/ratings/ratings_display_list.lua
@@ -1,0 +1,85 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Ratings/Display/List
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Operator = require('Module:Operator')
+local Template = require('Module:Template')
+
+local RatingsDisplayList = {}
+
+local LIMIT_TEAMS = 100 -- How many teams to show in the list/table
+
+---@param teamRankings table[]
+---@return string
+function RatingsDisplayList.build(teamRankings)
+	local teams = Array.sub(teamRankings, 1, LIMIT_TEAMS)
+
+	local htmlTable = mw.html.create('table'):addClass('wikitable'):css('text-align', 'center')
+		:tag('tr'):css('font-weight', 'bold')
+			:tag('td'):wikitext('#'):done()
+			:tag('td'):wikitext('Team'):done()
+			:tag('td'):wikitext('Rating'):done()
+			:tag('td'):wikitext('Region'):done()
+			:tag('td'):wikitext('Played'):done()
+			:tag('td'):wikitext('Streak'):done()
+			:tag('td'):wikitext('History'):done()
+		:allDone()
+
+	Array.forEach(teams, function(team, rank)
+		local chart = mw.ext.Charts.chart({
+			xAxis = {
+				type = 'category',
+				data = Array.map(team.progression, Operator.property('date'))
+			},
+			yAxis = {
+				type = 'value',
+				min = 1000,
+				max = 3500,
+			},
+			tooltip = {
+				trigger = 'axis'
+			},
+			grid = {
+				show = true
+			},
+			size = {
+				height = 300,
+				width = 500
+			},
+			series = {
+				{
+					data = Array.map(team.progression, Operator.property('rating')),
+					type = 'line'
+				}
+			}
+		})
+
+		local popup = Template.expandTemplate(mw.getCurrentFrame(), 'Popup', {
+			label = 'show',
+			title = 'Details for ' .. mw.ext.TeamTemplate.team(team.name),
+			content = chart,
+		})
+
+		local streakText = team.streak > 1 and team.streak .. 'W' or (team.streak < -1 and (-team.streak) .. 'L') or '-'
+		local streakClass = (team.streak > 1 and 'group-table-rank-change-up')
+				or (team.streak < -1 and 'group-table-rank-change-down')
+				or nil
+
+		htmlTable:tag('tr')
+			:tag('td'):css('font-weight', 'bold'):wikitext(rank):done()
+			:tag('td'):css('text-align', 'left'):wikitext(mw.ext.TeamTemplate.team(team.name)):done()
+			:tag('td'):wikitext(math.floor(team.rating + 0.5)):done()
+			:tag('td'):wikitext(string.upper(team.region or '')):done()
+			:tag('td'):wikitext(team.matches):done()
+			:tag('td'):css('font-weight', 'bold'):addClass(streakClass):wikitext(streakText):done()
+			:tag('td'):wikitext(popup):done()
+	end)
+	return tostring(mw.html.create('div'):addClass('table-responsive'):node(htmlTable))
+end
+
+return RatingsDisplayList

--- a/components/ratings/ratings_display_list.lua
+++ b/components/ratings/ratings_display_list.lua
@@ -10,11 +10,12 @@ local Array = require('Module:Array')
 local Operator = require('Module:Operator')
 local Template = require('Module:Template')
 
+---@class RatingsDisplayList: RatingsDisplayInterface
 local RatingsDisplayList = {}
 
 local LIMIT_TEAMS = 100 -- How many teams to show in the list/table
 
----@param teamRankings table[]
+---@param teamRankings RatingsEntry[]
 ---@return string
 function RatingsDisplayList.build(teamRankings)
 	local teams = Array.sub(teamRankings, 1, LIMIT_TEAMS)

--- a/components/ratings/ratings_storage_lpdb.lua
+++ b/components/ratings/ratings_storage_lpdb.lua
@@ -18,6 +18,7 @@ local LIMIT_TEAMS = 100 -- How many teams to do the calculations for
 
 ---@param id string
 ---@param progressionLimit integer
+---@return table[]
 function RatingsStorageLpdb.getRankings(id, progressionLimit)
 	local snapshot = RatingsStorageLpdb._getSnapshot(id)
 	if not snapshot then

--- a/components/ratings/ratings_storage_lpdb.lua
+++ b/components/ratings/ratings_storage_lpdb.lua
@@ -1,0 +1,99 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Ratings/Storage/Lpdb
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Date = require('Module:Date/Ext')
+
+local RatingsStorageLpdb = {}
+
+-- static conditions for LPDB
+local STATIC_CONDITIONS_LPR_SNAPSHOT = '[[namespace::4]] AND [[type::LPR_SNAPSHOT]]'
+
+---@param id string
+---@param limit integer
+---@param progressionLimit integer
+function RatingsStorageLpdb.getRankings(id, limit, progressionLimit)
+	local snapshot = RatingsStorageLpdb._getSnapshot(id)
+	if not snapshot then
+		error('Could not find a Rating with this ID')
+	end
+
+	-- Merge the ranking and team data tables
+	-- Toss away teams that are lower ranked than what is interesting
+	local teams = {}
+	for rank, teamName in ipairs(snapshot.extradata.ranks) do
+		local team = snapshot.extradata.table[teamName] or {}
+		team.name = teamName
+		table.insert(teams, team)
+		if rank >= limit then
+			break
+		end
+	end
+
+	teams = RatingsStorageLpdb._addProgressionData(teams, id, progressionLimit)
+
+	return teams
+end
+
+---@param name string
+---@param offset integer?
+---@return datapoint
+function RatingsStorageLpdb._getSnapshot(name, offset)
+	return mw.ext.LiquipediaDB.lpdb(
+		'datapoint',
+		{
+			query = 'extradata, date',
+			limit = 1,
+			offset = offset,
+			order = 'date DESC',
+			conditions = STATIC_CONDITIONS_LPR_SNAPSHOT .. ' AND [[name::' .. name .. ']]'
+		}
+	)[1]
+end
+
+---@param teams table
+---@param id string
+---@param limit integer
+---@return table
+function RatingsStorageLpdb._addProgressionData(teams, id, limit)
+	-- Build rating progression with snapshots
+	for i = 0, limit do
+		local snapshot = RatingsStorageLpdb._getSnapshot(id, i)
+		if not snapshot then
+			break
+		end
+
+		local snapshotTime = os.time(Date.parseIsoDate(snapshot.date))
+
+		Array.forEach(teams, function(team)
+			local rating = (snapshot.extradata.table[team.name] or {}).rating
+			team.progression = team.progression or {}
+
+			table.insert(team.progression, RatingsStorageLpdb._createProgressionEntry(snapshotTime, rating))
+		end)
+	end
+
+	-- Put progression in the correct order (oldest to newest)
+	Array.forEach(teams, function(team)
+		team.progression = Array.reverse(team.progression)
+	end)
+
+	return teams
+end
+
+---@param timestamp integer
+---@param rating number
+---@return {date: string, rating: string}
+function RatingsStorageLpdb._createProgressionEntry(timestamp, rating)
+	return {
+		date = os.date('%Y-%m-%d', timestamp),
+		rating = rating and tostring(math.floor(rating + 0.5)) or '',
+	}
+end
+
+return RatingsStorageLpdb

--- a/components/ratings/ratings_storage_lpdb.lua
+++ b/components/ratings/ratings_storage_lpdb.lua
@@ -14,10 +14,11 @@ local RatingsStorageLpdb = {}
 -- static conditions for LPDB
 local STATIC_CONDITIONS_LPR_SNAPSHOT = '[[namespace::4]] AND [[type::LPR_SNAPSHOT]]'
 
+local LIMIT_TEAMS = 100 -- How many teams to do the calculations for
+
 ---@param id string
----@param limit integer
 ---@param progressionLimit integer
-function RatingsStorageLpdb.getRankings(id, limit, progressionLimit)
+function RatingsStorageLpdb.getRankings(id, progressionLimit)
 	local snapshot = RatingsStorageLpdb._getSnapshot(id)
 	if not snapshot then
 		error('Could not find a Rating with this ID')
@@ -30,7 +31,7 @@ function RatingsStorageLpdb.getRankings(id, limit, progressionLimit)
 		local team = snapshot.extradata.table[teamName] or {}
 		team.name = teamName
 		table.insert(teams, team)
-		if rank >= limit then
+		if rank >= LIMIT_TEAMS then
 			break
 		end
 	end
@@ -56,10 +57,10 @@ function RatingsStorageLpdb._getSnapshot(name, offset)
 	)[1]
 end
 
----@param teams table
+---@param teams table[]
 ---@param id string
 ---@param limit integer
----@return table
+---@return table[]
 function RatingsStorageLpdb._addProgressionData(teams, id, limit)
 	-- Build rating progression with snapshots
 	for i = 0, limit do


### PR DESCRIPTION
## Summary
Refactoring Ratings Display to make future things easier to implement.

## How did you test this change?
dev

Before:
![image](https://github.com/user-attachments/assets/0cf3130f-1915-4b09-bf81-548c1accbbef)
![image](https://github.com/user-attachments/assets/da5f417a-4fc0-418b-8b40-adb3c6ec8971)

After:
![image](https://github.com/user-attachments/assets/50b76da4-60c2-4ff3-b645-e16024c52871)
![image](https://github.com/user-attachments/assets/7cc379e7-b474-4187-baad-b0ee8ef0bb44)
