### PR TITLE
fix(match2): error sometimes on bigmatch on lol

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -63,9 +63,11 @@ function CustomMatchGroupInput.processMatch(match, options)
 	-- process match
 	Table.mergeInto(match, MatchGroupInput.readDate(match.date))
 
-	local standaloneMatchId = 'MATCH_' .. match.bracketid .. '_' .. match.matchid
+	local standaloneMatchId = match.matchid and match.bracketid
+		and ('MATCH_' .. match.bracketid .. '_' .. match.matchid)
+		or nil
 	--set it already here so in winner and result type processing we know it will get enriched later on
-	match.standaloneMatch = MatchGroupInput.fetchStandaloneMatch(standaloneMatchId)
+	match.standaloneMatch = standaloneMatchId and MatchGroupInput.fetchStandaloneMatch(standaloneMatchId) or nil
 
 	match = matchFunctions.getBestOf(match)
 	match = matchFunctions.getScoreFromMapWinners(match)


### PR DESCRIPTION
## Summary
due to only testing in userspace and hence having to provide matchId and BracketId anyways it wasn't noticed in #4390 that those could be nil on bigmatch pages when trying to concat them.

This PR adds the necessary nil checks so that the concat nil error doesn't occour.

## How did you test this change?
dev + testing it on a page in main space