### PR TITLE
feat(match2): remove finished check on apex for bg

### DIFF
--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -323,9 +323,7 @@ function MatchFunctions.getOpponents(match)
 		match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
 	end
 
-	if match.finished then
-		opponents = MatchFunctions.setBgForOpponents(opponents, match.statusSettings)
-	end
+	opponents = MatchFunctions.setBgForOpponents(opponents, match.statusSettings)
 
 	-- Update all opponents with new values
 	for opponentIndex, opponent in pairs(opponents) do

--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -323,7 +323,9 @@ function MatchFunctions.getOpponents(match)
 		match, opponents = CustomMatchGroupInput.getResultTypeAndWinner(match, opponents)
 	end
 
-	opponents = MatchFunctions.setBgForOpponents(opponents, match.statusSettings)
+	if match.finished then
+		opponents = MatchFunctions.setBgForOpponents(opponents, match.statusSettings)
+	end
 
 	-- Update all opponents with new values
 	for opponentIndex, opponent in pairs(opponents) do

--- a/components/match2/wikis/apexlegends/match_summary.lua
+++ b/components/match2/wikis/apexlegends/match_summary.lua
@@ -626,7 +626,7 @@ function CustomMatchSummary._createMatchStandings(match)
 					:addClass('panel-table__cell')
 					:addClass('cell--status')
 					:addClass('bg-' .. (opponentMatch.advanceBg or ''))
-					:node(CustomMatchSummary._getStatusIcon(opponentMatch.advanceBg))
+					:node(CustomMatchSummary._getStatusIcon(match.extradata.status[index]))
 		end
 
 		Array.forEach(MATCH_STANDING_COLUMNS, function(column)


### PR DESCRIPTION
## Summary
Currently the bg and icon of the "status" column will only show up once the match is finished. 
This PR changes it so the icon will always show up, while the bg will only be there when it's finished.

![image](https://github.com/user-attachments/assets/b59c7bcb-0f57-405c-8761-6cf38b182591)


## How did you test this change?
/dev