### PR TITLE
fix(Countdown): toggle data parsing & extended filter button refresh

### DIFF
--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -70,7 +70,7 @@ liquipedia.countdown = {
 		// Reacting state switch
 		switchToggleGroup.nodes.forEach( ( switchNode ) => {
 			switchNode.addEventListener( liquipedia.switchButtons.triggerEventName, ( event ) => {
-				liquipedia.countdown.toggleCountdowns( event.detail.value );
+				liquipedia.countdown.toggleCountdowns( event.detail.data.value );
 			} );
 		} );
 	},

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -342,6 +342,7 @@ liquipedia.filterButtons = {
 
 	refreshScriptsAfterContentUpdate: function() {
 		liquipedia.countdown.init();
+		liquipedia.switchButtons.init();
 	},
 
 	buildLocalStorageKey: function() {

--- a/javascript/commons/SwitchButtons.js
+++ b/javascript/commons/SwitchButtons.js
@@ -52,24 +52,15 @@
  */
 
 liquipedia.switchButtons = {
-	isInitialized: false,
-	isBeingInitialized: false,
 	baseLocalStorageKey: null,
 	triggerEventName: 'switchButtonChanged',
 	switchGroups: {},
 
 	init: function () {
-		if ( this.isBeingInitialized || this.isInitialized ) {
-			return;
-		}
-		this.isBeingInitialized = true;
-
+		this.switchGroups = {};
 		this.baseLocalStorageKey = this.buildLocalStorageKey();
 		this.initSwitchElements( 'toggle', '.switch-toggle', 'switch-toggle-active' );
 		this.initSwitchElements( 'pill', '.switch-pill', 'switch-pill-active' );
-
-		this.isBeingInitialized = false;
-		this.isInitialized = true;
 	},
 
 	initSwitchElements: function ( type, selector, activeClassName ) {


### PR DESCRIPTION
## Summary

This MR has 2 purposes:
- Fix the value parsing for the countdown refresh on the toggle (data was wrongly passed)
- Extend the JS refresh on dynamic template expansion to re-init switch buttons

To note: I wanted to add the refresh of _data-toggle-area_ as well but couldn't figure out where the js logic is.

## How did you test this change?

In console in [this page](https://liquipedia.net/dota2/User:Nadox/Dota2MainPage2)