### PR TITLE
fix(opponent): stormgate's faction sync

### DIFF
--- a/components/opponent/wikis/stormgate/opponent_custom.lua
+++ b/components/opponent/wikis/stormgate/opponent_custom.lua
@@ -130,7 +130,7 @@ function CustomOpponent.resolve(opponent, date, options)
 					player.team,
 					{date = date, savePageVar = savePageVar}
 				)
-				player.faction = (hasFaction and player.faction ~= Faction.defaultFaction) and player.faction or nil
+				player.faction = (hasFaction or player.faction ~= Faction.defaultFaction) and player.faction or nil
 			else
 				PlayerExt.populatePageName(player)
 			end


### PR DESCRIPTION
## Summary
`Opponent.resolve` should retrieve the faction and only not apply it if it isn't default faction AND not set already.
The current condition makes it so that if either of the above conditions is fulfilled it is not applied.
This PR fixes that behaviour by switching the `and` to an `or`.

## How did you test this change?
dev into live