### PR TITLE
feat: Add the tileset category to infobox map for starcraft

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_map_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_map_custom.lua
@@ -109,10 +109,19 @@ end
 ---@param args table
 ---@return string[]
 function CustomMap:getWikiCategories(args)
-	local players = args.players or self:_tlpdMap(args.id, 'players')
-	if String.isEmpty(players) then return {} end
+	local categories = {}
 
-	return {'Maps (' .. players .. ' Players)'}
+	local players = args.players or self:_tlpdMap(args.id, 'players')
+	if not String.isEmpty(players) then
+		table.insert(categories, 'Maps (' .. players .. ' Players)')
+	end
+
+	local tileset = args.tileset or self:_tlpdMap(args.id, 'tileset')
+	if not String.isEmpty(tileset) then
+		table.insert(categories, tileset .. ' Tileset')
+	end
+
+	return categories
 end
 
 return CustomMap

--- a/components/infobox/wikis/starcraft/infobox_map_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_map_custom.lua
@@ -109,19 +109,13 @@ end
 ---@param args table
 ---@return string[]
 function CustomMap:getWikiCategories(args)
-	local categories = {}
-
 	local players = args.players or self:_tlpdMap(args.id, 'players')
-	if not String.isEmpty(players) then
-		table.insert(categories, 'Maps (' .. players .. ' Players)')
-	end
-
 	local tileset = args.tileset or self:_tlpdMap(args.id, 'tileset')
-	if not String.isEmpty(tileset) then
-		table.insert(categories, tileset .. ' Tileset')
-	end
 
-	return categories
+	return Array.append({},
+		String.isNotEmpty(players) and ('Maps (' .. players .. ' Players)') or nil,
+		String.isNotEmpty(tileset) and (tileset .. ' Tileset') or nil
+	)
 end
 
 return CustomMap


### PR DESCRIPTION
## Summary

All tileset categories are empty on the StarCraft: Brood War wiki: https://liquipedia.net/starcraft/Category:Tilesets
For example, https://liquipedia.net/starcraft/Category:Jungle_World_Tileset should include https://liquipedia.net/starcraft/Python

## How did you test this change?

I edited https://liquipedia.net/starcraft/Module:Infobox/Map/Custom/dev and previewed the page https://liquipedia.net/starcraft/Python with `|dev=1` to check that the category "Jungle World Tileset" was added.
