### PR TITLE
feat(match2): Add Links to Smite

### DIFF
--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -274,7 +274,7 @@ function matchFunctions.getVodStuff(match)
 	match.links = {
 		stats = match.stats,
 		smiteesports = match.smiteesports
-			and 'https://www.smiteesports.com/matches/' .. match.smiteesports or nil,
+			and ('https://www.smiteesports.com/matches/' .. match.smiteesports) or nil,
 	}
 	return match
 end

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -269,6 +269,13 @@ end
 ---@return table
 function matchFunctions.getVodStuff(match)
 	match.stream = Streams.processStreams(match)
+	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
+
+	match.links = {
+		stats = match.stats,
+		smiteesports = match.smiteesports
+			and 'https://www.smiteesports.com/matches/' .. match.smiteesports or nil,
+	}
 	return match
 end
 

--- a/components/match2/wikis/smite/match_summary.lua
+++ b/components/match2/wikis/smite/match_summary.lua
@@ -30,6 +30,15 @@ local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-tex
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 local NO_CHARACTER = 'default'
 
+local LINK_DATA = {
+	smiteesports = {
+		icon = 'File:SMITE default lightmode.png',
+		iconDark = 'File:SMITE default darkmode.png',
+		text = 'Smite Esports Match Page'
+	},
+	stats = {icon = 'File:Match_Info_Stats.png', text = 'Match Statistics'},
+}
+
 -- God Ban Class
 ---@class SmiteGodBan: MatchSummaryRowInterface
 ---@operator call: SmiteGodBan
@@ -261,6 +270,14 @@ function CustomMatchSummary._opponentGodsDisplay(opponentgodsData, numberOfGods,
 	end
 
 	return display
+end
+
+---@param match MatchGroupUtilMatch
+---@param footer MatchSummaryFooter
+---@return MatchSummaryFooter
+function CustomMatchSummary.addToFooter(match, footer)
+	footer = MatchSummary.addVodsToFooter(match, footer)
+	return footer:addLinks(LINK_DATA, match.links)
 end
 
 return CustomMatchSummary


### PR DESCRIPTION
## Summary
Adds match pages to Smite's Match2 setup. Specifically adding the SmiteEsports (Publisher) pages. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested live with dev modules
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
