### PR TITLE
fix(match2): missing patch information on lol match pages

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -513,6 +513,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		mode = record.mode,
 		opponents = opponents,
 		parent = record.parent,
+		patch = record.patch,
 		resultType = nilIfEmpty(record.resulttype),
 		stream = Json.parseIfString(record.stream) or {},
 		timestamp = tonumber(Table.extract(extradata, 'timestamp')),


### PR DESCRIPTION
## Summary
Patch information is not being kept when parsing a record. This PR makes it so it's kept if set.

## How did you test this change?
/dev