### PR TITLE
fix(match2): error when mixing input modes on lol match pages

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_group_input_custom_match_page.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom_match_page.lua
@@ -96,6 +96,7 @@ function CustomMatchGroupInputMatchPage.getHeroBans(map, opponentIndex)
 end
 
 function CustomMatchGroupInputMatchPage.getVetoPhase(map)
+	if not map.championVeto then return end
 	return Array.map(map.championVeto, function(veto)
 		veto.character = veto.champion
 		veto.champion = nil


### PR DESCRIPTION
## Summary
When using manual input on a match page page, `championVeto` would be nil and error in the iterator. 

## How did you test this change?
Live