### PR TITLE
fix(match2): improve style on dota2's matchpage footer 

### DIFF
--- a/components/match2/wikis/dota2/big_match_template.lua
+++ b/components/match2/wikis/dota2/big_match_template.lua
@@ -37,15 +37,11 @@ return {
 					<div class="match-bm-match-additional-section">
 						<div class="match-bm-match-additional-section-header">VODs</div>
 						<div class="match-bm-match-additional-section-body">{{#vods}}{{&.}}{{/vods}}</div>
-					</div>
-				{{/vods.1}}
-				{{#links.1}}
+					</div>{{/vods.1}}{{#links.1}}
 					<div class="match-bm-match-additional-section">
 						<div class="match-bm-match-additional-section-header">Socials</div>
 						<div class="match-bm-match-additional-section-body">{{#links}}[[File:{{icon}}|link={{link}}|15px|{{text}}]]{{/links}}</div>
-					</div>
-				{{/links.1}}
-				{{#patch}}
+					</div>{{/links.1}}{{#patch}}
 					<div class="match-bm-match-additional-section">
 						<div class="match-bm-match-additional-section-header">Patch</div>
 						<div class="match-bm-match-additional-section-body">[[Patch {{patch}}]]</div>

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -882,7 +882,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 
 	&-section {
-		flex: 1 0 auto;
+		flex: 1 0 20%;
 		border: 0.0625rem solid #bbbbbb;
 
 		.theme--dark & {


### PR DESCRIPTION
As discussed:
- prevent media wiki from creating additional p tags
- change flex basis 