### PR TITLE
fix(match2): league of legend's vetophase character name normalization

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -581,7 +581,7 @@ function MapFunctions.getParticipants(MatchParser, map, opponents)
 	end
 
 	extradata.vetophase = MatchParser.getVetoPhase(map)
-	Array.forEach(map.vetophase or {}, function(veto)
+	Array.forEach(extradata.vetophase or {}, function(veto)
 		veto.character = getCharacterName(veto.character)
 	end)
 


### PR DESCRIPTION
## Summary
Due to typo, the normalization of characters was not done

## How did you test this change?
/dev