### PR TITLE
fix: border radius for the new dota2 wikis main page header

### DIFF
--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -6,6 +6,7 @@
 	position: relative;
 	border-radius: 0.5rem;
 
+	.wiki-dota2 &,
 	.wiki-dota2game & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/1/19/Bgdota2.jpg ) no-repeat center / cover;

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -4,7 +4,7 @@
 	align-items: center;
 	margin-bottom: 1.5rem;
 	position: relative;
-	border-radius: 0.25rem;
+	border-radius: 0.5rem;
 
 	.wiki-dota2game & {
 		@media ( min-width: 768px ) {


### PR DESCRIPTION
## Summary

This aligns the border-radius of the main page header with the border radius of the nav pills

https://gitlab.com/teamliquid-dev/liquipedia/web/issue-bucket/-/issues/86

## How did you test this change?

Dev tools
