### PR TITLE
fix(match2): align team logo on dota2 match pages

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -29,6 +29,7 @@ Author(s): Rathoz
 
 	@media ( min-width: 768px ) {
 		flex-direction: row;
+		gap: 1.5rem;
 	}
 
 	&:first-child {
@@ -66,12 +67,18 @@ Author(s): Rathoz
 		}
 	}
 
-	.team-template-image-icon {
-		width: 4rem;
-		height: 4rem;
+	.team-template-team-icon {
 		display: flex;
 		align-items: center;
 		justify-content: center;
+	}
+
+	.team-template-image-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 4rem;
+		height: 4rem;
 
 		@media ( min-width: 768px ) {
 			height: 5rem;
@@ -79,13 +86,20 @@ Author(s): Rathoz
 		}
 
 		a {
-			width: 4rem;
-			height: 4rem;
 			display: flex;
 			align-items: center;
 			justify-content: center;
+		}
+
+		img {
+			max-width: 4rem;
+			max-height: 4rem;
+			width: 4rem;
+			height: 4rem;
 
 			@media ( min-width: 768px ) {
+				max-width: 5rem;
+				max-height: 5rem;
 				width: 5rem;
 				height: 5rem;
 			}


### PR DESCRIPTION
## Summary

Changed up some css to make sure the dark theme version looks the same as light theme. Also forced the icons to be 80x80 on desktop and 64x64 on mobile.

## How did you test this change?

Live
