### PR TITLE
fix(countdown): resolve platforms to special pages

### DIFF
--- a/standard/links_stream.lua
+++ b/standard/links_stream.lua
@@ -42,6 +42,11 @@ StreamLinks.countdownPlatformNames = {
 	TLNET_STREAM,
 }
 
+local PLATFORM_TO_SPECIAL_PAGE = {
+	afreeca = 'afreecatv',
+	cc = 'cc163',
+}
+
 ---@param key string
 ---@return boolean
 ---@overload fun(key: any): false
@@ -65,9 +70,16 @@ end
 ---@param streamValue string
 ---@return string
 function StreamLinks.resolve(platformName, streamValue)
+	platformName = StreamLinks.reaolvePlatform(platformName)
 	local streamLink = mw.ext.StreamPage.resolve_stream(platformName, streamValue)
 
 	return (string.gsub(streamLink, 'Special:Stream/' .. platformName, ''))
+end
+
+---@param platform string
+---@return string
+function StreamLinks.reaolvePlatform(platform)
+	return PLATFORM_TO_SPECIAL_PAGE[platform] or platform
 end
 
 --[[
@@ -148,6 +160,8 @@ function StreamLinks.displaySingle(platform, streamValue)
 
 	local streamLink = StreamLinks.resolve(platform, streamValue)
 	if not streamLink then return nil end
+
+	platform = StreamLinks.reaolvePlatform(platform)
 
 	return Page.makeInternalLink({}, icon, 'Special:Stream/' .. platform .. '/' .. streamValue)
 end


### PR DESCRIPTION
## Summary
To match the names of the special pages we have to normalize the platform before passing it to building the special page or resolving the stream.

Reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1269537138504892477

## How did you test this change?
dev