### PR TITLE
fix(match2): Dupe types in Osu match copypaste

### DIFF
--- a/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
@@ -56,7 +56,7 @@ end
 ---@param bestof integer
 ---@return string[]?
 function WikiCopyPaste._getVetoes(args, bestof)
-	local vetoTypes = VETOES[bestof]
+	local vetoTypes = Array.copy(VETOES[bestof])
 	if not Logic.readBool(args.mapVeto) or not vetoTypes then return nil end
 	if Logic.readBool(args.protect) then
 		table.insert(vetoTypes, 1, 'protect')

--- a/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
@@ -56,8 +56,8 @@ end
 ---@param bestof integer
 ---@return string[]?
 function WikiCopyPaste._getVetoes(args, bestof)
-	local vetoTypes = Array.copy(VETOES[bestof])
-	if not Logic.readBool(args.mapVeto) or not vetoTypes then return nil end
+	local vetoTypes = Array.copy(VETOES[bestof] or {})
+	if not Logic.readBool(args.mapVeto) or Logic.isEmpty(vetoTypes) then return nil end
 	if Logic.readBool(args.protect) then
 		table.insert(vetoTypes, 1, 'protect')
 	end

--- a/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
@@ -56,11 +56,8 @@ end
 ---@param bestof integer
 ---@return string[]?
 function WikiCopyPaste._getVetoes(args, bestof)
-	local vetoTypes = Array.copy(VETOES[bestof] or {})
 	if not Logic.readBool(args.mapVeto) or not VETOES[bestof] then return nil end
-	if Logic.readBool(args.protect) then
-		table.insert(vetoTypes, 1, 'protect')
-	end
+	local vetoTypes = Array.extend(Logic.readBool(args.protect) and 'protect' or nil, VETOES[bestof])
 
 	return Array.extend({},
 		INDENT .. '|mapveto={{MapVeto',

--- a/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/osu/get_match_group_copy_paste_wiki.lua
@@ -57,7 +57,7 @@ end
 ---@return string[]?
 function WikiCopyPaste._getVetoes(args, bestof)
 	local vetoTypes = Array.copy(VETOES[bestof] or {})
-	if not Logic.readBool(args.mapVeto) or Logic.isEmpty(vetoTypes) then return nil end
+	if not Logic.readBool(args.mapVeto) or not VETOES[bestof] then return nil end
 	if Logic.readBool(args.protect) then
 		table.insert(vetoTypes, 1, 'protect')
 	end


### PR DESCRIPTION
## Summary
If Protect field is set to true, on a bracket that contains one more match, every subsequent match adds a duped `protect` type and extra `tXmap` which stacks the longer the bracket goes

this PR is fixing that, so protect should always just appear only once, as first type and only a single extra set of tXmap is added
![image](https://github.com/user-attachments/assets/59f4a21e-6068-4b8f-b438-bd100ac63ad6)

LIVE
