### PR TITLE
feat(infobox): show platform on valorant

### DIFF
--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -50,7 +50,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	Cell{name = 'Platform', content = {PageLink.makeInternalLink(
+	self.data.platform = Cell{name = 'Platform', content = {PageLink.makeInternalLink(
 		self.data.platform,
 		self.data.platform and (':Category:' .. self.data.platform) or nil)
 	}}

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -105,18 +105,6 @@ function CustomLeague:getWikiCategories(args)
 	)
 end
 
----@param args table
----@return string?
-function CustomLeague:_createPlatformCell(args)
-	local platform = self.data.platform(args.platform)
-
-	if String.isNotEmpty(platform) then
-		return PageLink.makeInternalLink({}, platform, ':Category:'..platform)
-	else
-		return nil
-	end
-end
-
 ---@param lpdbData table
 ---@param args table
 ---@return table

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -50,7 +50,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.platform = Cell{name = 'Platform', content = {PageLink.makeInternalLink(
+	self.data.platform = PLATFORMS[(args.platform or ''):lower()] or DEFAULT_PLATFORM
 		self.data.platform,
 		self.data.platform and (':Category:' .. self.data.platform) or nil)
 	}}

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -50,6 +50,10 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
+	Cell{name = 'Platform', content = {PageLink.makeInternalLink(
+		self.data.platform,
+		self.data.platform and (':Category:' .. self.data.platform) or nil)
+	}}
 	self.data.mode = (args.individual or args.player_number) and '1v1' or 'team'
 	self.data.publishertier = Logic.readBool(args['riot-highlighted']) and 'highlighted'
 		or Logic.readBool(args['riot-sponsored']) and 'sponsored'
@@ -64,7 +68,6 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Platform', content = {self.caller:_createPlatformCell(args)}},
 			Cell{name = 'Teams', content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
 			Cell{name = 'Players', content = {args.player_number}}
 		)
@@ -95,35 +98,15 @@ end
 ---@param args table
 ---@return string[]
 function CustomLeague:getWikiCategories(args)
-	local categories = {}
-
-	if Logic.readBool(args.female) then
-		table.insert(categories, 'Female Tournaments')
-		return categories
-	end
-	local platform = self:_platformLookup(args.platform)
-
-	return {
-		platform and (platform .. ' Tournaments') or nil,
-	}
-
-end
-
----@param platform string?
----@return string?
-function CustomLeague:_platformLookup(platform)
-	if String.isEmpty(platform) then
-		platform = DEFAULT_PLATFORM
-	end
-	---@cast platform -nil
-
-	return PLATFORM_ALIAS[platform:lower()]
+	return Array.append({self.data.platform .. ' Tournaments'},
+		Logic.readBool(args.female) and 'Female Tournaments' or nil
+	)
 end
 
 ---@param args table
 ---@return string?
 function CustomLeague:_createPlatformCell(args)
-	local platform = self:_platformLookup(args.platform)
+	local platform = self.data.platform(args.platform)
 
 	if String.isNotEmpty(platform) then
 		return PageLink.makeInternalLink({}, platform, ':Category:'..platform)
@@ -137,11 +120,11 @@ end
 ---@return table
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.maps = table.concat(self:getAllArgsForBase(args, 'map'), ';')
-
 	lpdbData.extradata.region = Template.safeExpand(mw.getCurrentFrame(), 'Template:Player region', {args.country})
 	lpdbData.extradata.startdate_raw = args.sdate or args.date
 	lpdbData.extradata.enddate_raw = args.edate or args.date
 	lpdbData.extradata.female = args.female or 'false'
+	lpdbData.extradata.platform = args.platform
 
 	return lpdbData
 end

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -68,7 +68,7 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(widgets,
 			Cell{name = 'Platform', content = {PageLink.makeInternalLink(
 				caller.data.platform,
-				caller.data.platform and (':Category:' .. self.data.platform) or nil)
+				caller.data.platform and (':Category:' .. caller.data.platform) or nil)
 			}},
 			Cell{name = 'Teams', content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
 			Cell{name = 'Players', content = {args.player_number}}

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -61,14 +61,15 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
+	local caller = self.caller
+	local args = caller.args
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
 			Cell{name = 'Platform', content = {PageLink.makeInternalLink(
 				caller.data.platform,
 				caller.data.platform and (':Category:' .. self.data.platform) or nil)
-			)}},
+			}},
 			Cell{name = 'Teams', content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
 			Cell{name = 'Players', content = {args.player_number}}
 		)

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -124,7 +124,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.startdate_raw = args.sdate or args.date
 	lpdbData.extradata.enddate_raw = args.edate or args.date
 	lpdbData.extradata.female = args.female or 'false'
-	lpdbData.extradata.platform = args.platform
+	lpdbData.extradata.platform = self.data.platform
 
 	return lpdbData
 end

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -30,7 +30,7 @@ local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
 
 local DEFAULT_PLATFORM = 'PC'
-local PLATFORM_ALIAS = {
+local PLATFORMS = {
 	console = 'Console',
 	pc = 'PC',
 }
@@ -51,9 +51,6 @@ end
 ---@param args table
 function CustomLeague:customParseArguments(args)
 	self.data.platform = PLATFORMS[(args.platform or ''):lower()] or DEFAULT_PLATFORM
-		self.data.platform,
-		self.data.platform and (':Category:' .. self.data.platform) or nil)
-	}}
 	self.data.mode = (args.individual or args.player_number) and '1v1' or 'team'
 	self.data.publishertier = Logic.readBool(args['riot-highlighted']) and 'highlighted'
 		or Logic.readBool(args['riot-sponsored']) and 'sponsored'
@@ -68,6 +65,8 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
+			Cell{name = 'Platform', content = {PageLink.makeInternalLink(args.platform)
+		}},
 			Cell{name = 'Teams', content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
 			Cell{name = 'Players', content = {args.player_number}}
 		)

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -65,8 +65,10 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Platform', content = {PageLink.makeInternalLink(args.platform)
-		}},
+			Cell{name = 'Platform', content = {PageLink.makeInternalLink(
+				caller.data.platform,
+				caller.data.platform and (':Category:' .. self.data.platform) or nil)
+			)}},
 			Cell{name = 'Teams', content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
 			Cell{name = 'Players', content = {args.player_number}}
 		)


### PR DESCRIPTION
## Summary
Adds platform param to use for Console tournaments (by default set to PC)

There has been discussion in the Valorant channel about whether or not they should cover Console tournaments since they don't have a way to differentiate. 
Convo: https://discord.com/channels/93055209017729024/684060921898860569/1270099131913867284

I will open this pr then ask the Valorant channel if they want any other aliases added (imo it is best just to use 1)


# How did you test this change?

dev 
