### PR TITLE
fix: color of navigation card links

### DIFF
--- a/stylesheets/commons/NavigationCard.less
+++ b/stylesheets/commons/NavigationCard.less
@@ -66,7 +66,7 @@
 		margin-top: 0.5rem;
 
 		> a {
-			color: inherit;
+			color: inherit !important;
 
 			&::after {
 				content: "";


### PR DESCRIPTION
## Summary

The specificity of the navigation card link colors is not high enough, so I made it `!important`

## How did you test this change?

dev tools