### PR TITLE
feat(info): add GeoGuessr

### DIFF
--- a/standard/info/wikis/geoguessr/info.lua
+++ b/standard/info/wikis/geoguessr/info.lua
@@ -30,7 +30,7 @@ return {
 		squads = {
 			hasPosition = false,
 			hasSpecialTeam = false,
-			allowManual = true,
+			allowManual = false,
 		},
 		match2 = {
 			matchWidthMobile = 110,

--- a/standard/info/wikis/geoguessr/info.lua
+++ b/standard/info/wikis/geoguessr/info.lua
@@ -30,8 +30,8 @@ return {
 		squads = {
 			hasPosition = false,
 			hasSpecialTeam = false,
-			allowManual = true,
+			allowManual = false,
 		},
 	},
-	match2 = 1,
+	match2 = 0,
 }

--- a/standard/info/wikis/geoguessr/info.lua
+++ b/standard/info/wikis/geoguessr/info.lua
@@ -1,0 +1,37 @@
+---
+-- @Liquipedia
+-- wiki=geoguessr
+-- page=Module:Info
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	startYear = 2013,
+	wikiName = 'geoguessr',
+	name = 'GeoGuessr',
+	defaultGame = 'geoguessr',
+	games = {
+		geoguessr = {
+			abbreviation = 'GeoGuessr',
+			name = 'GeoGuessr',
+			link = 'GeoGuessr',
+			logo = {
+				darkMode = 'GeoGuessr allmode.png',
+				lightMode = 'GeoGuessr allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GeoGuessr allmode.png',
+				lightMode = 'GeoGuessr allmode.png',
+			},
+		},
+	},
+	config = {
+		squads = {
+			hasPosition = false,
+			hasSpecialTeam = false,
+			allowManual = true,
+		},
+	},
+	match2 = 1,
+}

--- a/standard/info/wikis/geoguessr/info.lua
+++ b/standard/info/wikis/geoguessr/info.lua
@@ -13,7 +13,7 @@ return {
 	defaultGame = 'geoguessr',
 	games = {
 		geoguessr = {
-			abbreviation = 'GeoGuessr',
+			abbreviation = 'Geo',
 			name = 'GeoGuessr',
 			link = 'GeoGuessr',
 			logo = {
@@ -30,8 +30,13 @@ return {
 		squads = {
 			hasPosition = false,
 			hasSpecialTeam = false,
-			allowManual = false,
+			allowManual = true,
+		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 190,
 		},
 	},
+	defaultRoundPrecision = 0,
 	match2 = 0,
 }

--- a/standard/info/wikis/geoguessr/info.lua
+++ b/standard/info/wikis/geoguessr/info.lua
@@ -13,7 +13,7 @@ return {
 	defaultGame = 'geoguessr',
 	games = {
 		geoguessr = {
-			abbreviation = 'Geo',
+			abbreviation = 'GeoGuessr',
 			name = 'GeoGuessr',
 			link = 'GeoGuessr',
 			logo = {
@@ -33,8 +33,6 @@ return {
 			allowManual = false,
 		},
 		match2 = {
-			matchWidthMobile = 110,
-			matchWidth = 190,
 		},
 	},
 	defaultRoundPrecision = 0,


### PR DESCRIPTION
## Summary
GeoGuessr is a newly installed wiki

## How did you test this change?
LIVE

## Side Note 
Infobox and Match2 will come shortly soon after, to set some expectation 

- Match2 will be using Team Fortress's setup aka #4333 with TF2's local links gone, which is currently in-PR, as everything matches what GeoGuessr need. 
- Infobox league will had some customization, player is always needed but there won't be one for team [team will be fine with base]

Labels are also created