### PR TITLE
feat(infobox): add 2 game modes for Hearthstone

### DIFF
--- a/components/infobox/wikis/hearthstone/infobox_league_custom.lua
+++ b/components/infobox/wikis/hearthstone/infobox_league_custom.lua
@@ -27,6 +27,8 @@ local MODES = {
 	standard = 'Standard',
 	wild = 'Wild',
 	battlegrounds = 'Battlegrounds',
+	arena = 'Arena',
+	duels = 'Duels',
 }
 
 ---@param frame Frame


### PR DESCRIPTION
## Summary

We already have Standard, Wild and Battlegrounds, these are 2 additional - Arena and Duels. 
There are tournaments played in Arena (last was a couple of days ago), were Duels events.
If this pull request will be merged, we can have pages about this modes with dynamic event list.

## How did you test this change?

Tested in userspace - https://liquipedia.net/hearthstone/User:Nikita_r28/Solary_Lich 
This pull request will not break anything