### PR TITLE
feat(match2): use i18n over mw.messages for bracket headers

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste.lua
+++ b/components/match2/commons/get_match_group_copy_paste.lua
@@ -7,9 +7,10 @@
 --
 
 local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
 local BracketAlias = mw.loadData('Module:BracketAlias')
 local Class = require('Module:Class')
-local Array = require('Module:Array')
+local I18n = require('Module:I18n')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -104,8 +105,7 @@ function CopyPaste._getHeader(headerCode, customHeader)
 	local headerCodeArray = mw.text.split(string.gsub(headerCode, '$', '!'), '!')
 	local index = Logic.isEmpty(headerCodeArray[1]) and 2 or 1
 
-	local headerMessage = mw.message.new('brkts-header-' .. headerCodeArray[index])
-		:params(headerCodeArray[index + 1] or ''):plain()
+	local headerMessage = I18n.translate('brkts-header-' .. headerCodeArray[index], {round = headerCodeArray[index + 1]})
 	local header = mw.text.split(headerMessage, ',')[1]
 	header = '\n' .. '<!-- ' .. header .. ' -->'
 

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Date = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
+local I18n = require('Module:I18n')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -16,7 +17,6 @@ local Table = require('Module:Table')
 local Timezone = require('Module:Timezone')
 
 local Opponent = Lua.import('Module:Opponent')
-
 
 local DisplayHelper = {}
 local NONBREAKING_SPACE = '&nbsp;'
@@ -52,9 +52,7 @@ end
 function DisplayHelper.expandHeaderCode(headerCode)
 	headerCode = headerCode:gsub('$', '!')
 	local args = mw.text.split(headerCode, '!')
-	local response = mw.message.new('brkts-header-' .. args[2])
-		:params(args[3] or '')
-		:plain()
+	local response = I18n.translate('brkts-header-' .. args[2], {round = args[3]})
 	return mw.text.split(response, ',')
 end
 

--- a/components/match_ticker/commons/match_ticker_display_components.lua
+++ b/components/match_ticker/commons/match_ticker_display_components.lua
@@ -13,6 +13,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
 local DateExt = require('Module:Date/Ext')
+local I18n = require('Module:I18n')
 local Icon = require('Module:Icon')
 local LeagueIcon = require('Module:LeagueIcon')
 local Logic = require('Module:Logic')
@@ -388,9 +389,7 @@ function Match:_expandHeader(inheritedHeader)
 	end
 
 	local headerInput = 'brkts-header-' .. headerArray[index]
-	local expandedHeader = mw.message.new('brkts-header-' .. headerArray[index])
-			---@diagnostic disable-next-line: param-type-mismatch
-			:params(headerArray[index + 1] or ''):plain() --[[@as string]]
+	local expandedHeader = I18n.translate('brkts-header-' .. headerArray[index], {round = headerArray[index + 1]})
 	local failedExpandedHeader = '⧼' .. headerInput .. '⧽'
 	if Logic.isEmpty(expandedHeader) or failedExpandedHeader == expandedHeader then
 		return inheritedHeader

--- a/standard/i18n_data.lua
+++ b/standard/i18n_data.lua
@@ -8,6 +8,32 @@
 
 return {
 	en = {
+		-- Bracket Headers
+		["brkts-header-r1"] = "Grand Final,Final,GF",
+		["brkts-header-r2"] = "Semifinals,Semis,SF",
+		["brkts-header-r3"] = "Quarterfinals,Quarters,QF",
+		["brkts-header-r4"] = "Round ${round},R${round}",
 		["brkts-header-rx"] = "Round ${round},R${round}",
+
+		["brkts-header-u1"] = "Grand Final,Final,GF",
+		["brkts-header-u2"] = "Upper Bracket Final,UB Final,UBF",
+		["brkts-header-u3"] = "Upper Bracket Semifinals,UB Semifinals,UBSF",
+		["brkts-header-u4"] = "Upper Bracket Quarterfinals,UB Quarterfinals,UBQF",
+		["brkts-header-ux"] = "Upper Bracket Round ${round},UB Round ${round},UBR${round}",
+
+		["brkts-header-m1"] = "Mid Bracket Final,MB Final,MBF",
+		["brkts-header-m2"] = "Mid Bracket Semifinal,MB Semifinal,MBSF",
+		["brkts-header-m3"] = "Mid Bracket Quarterfinal,MB Quarterfinal,MBQF",
+		["brkts-header-m4"] = "Mid Bracket Round ${round},MB Round ${round},MBR${round}",
+		["brkts-header-mx"] = "Mid Bracket Round ${round},MB Round ${round},MBR${round}",
+
+		["brkts-header-l2"] = "Lower Bracket Final,LB Final,LBF",
+		["brkts-header-l3"] = "Lower Bracket Semifinal,LB Semifinal,LBSF",
+		["brkts-header-l4"] = "Lower Bracket Quarterfinals,LB Quarterfinals,LBQF",
+		["brkts-header-lx"] = "Lower Bracket Round ${round},LB Round ${round},LBR${round}",
+
+		["brkts-header-q"] = "Qualified,Qual.,Q",
+		["brkts-header-tp"] = "Third Place Match,3rd Place,3rd",
+
 	}
 }


### PR DESCRIPTION
## Summary
As LH wants us not use to `mw.messages`, moving the i18n to lua from the extension.

## How did you test this change?

/dev
