### PR TITLE
feat(match2): move wiki (size) config into Info

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -9,7 +9,7 @@
 local Array = require('Module:Array')
 local Date = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
-local Json = require('Module:Json')
+local Info = require('Module:Info')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
@@ -184,7 +184,7 @@ function DisplayHelper.DefaultMatchPageContainer(props)
 	return MatchPageModule.getByMatchId(props)
 end
 
----Retrieves the wiki specific global bracket config specified in MediaWiki:BracketConfig.
+---Retrieves the wiki specific global bracket config.
 ---@return table
 DisplayHelper.getGlobalConfig = FnUtil.memoize(function()
 	local defaultConfig = {
@@ -192,17 +192,16 @@ DisplayHelper.getGlobalConfig = FnUtil.memoize(function()
 		headerHeight = 25,
 		headerMargin = 8,
 		lineWidth = 2,
-		matchHeight = 44, -- deprecated
 		matchWidth = 150,
-		matchWidthMobile = 90,
+		matchWidthMobile = 88,
 		opponentHeight = 24,
 		roundHorizontalMargin = 20,
-		scoreWidth = 20,
+		scoreWidth = 22,
 	}
-	local rawConfig = Json.parse(tostring(mw.message.new('BracketConfig')))
+	local wikiConfig = Info.config.match2
 	local config = {}
 	for paramName, defaultValue in pairs(defaultConfig) do
-		config[paramName] = tonumber(rawConfig[paramName]) or defaultValue
+		config[paramName] = wikiConfig[paramName] or defaultValue
 	end
 	return config
 end)

--- a/standard/info/commons/info.lua
+++ b/standard/info/commons/info.lua
@@ -31,6 +31,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/ageofempires/info.lua
+++ b/standard/info/wikis/ageofempires/info.lua
@@ -99,6 +99,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+		},
 	},
 	match2 = 1,
 }

--- a/standard/info/wikis/apexlegends/info.lua
+++ b/standard/info/wikis/apexlegends/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = true,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 1,
 	defaultRoundPrecision = 0,

--- a/standard/info/wikis/arenafps/info.lua
+++ b/standard/info/wikis/arenafps/info.lua
@@ -409,6 +409,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	match2 = 1,
 }

--- a/standard/info/wikis/arenaofvalor/info.lua
+++ b/standard/info/wikis/arenaofvalor/info.lua
@@ -73,6 +73,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 190,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/artifact/info.lua
+++ b/standard/info/wikis/artifact/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/autochess/info.lua
+++ b/standard/info/wikis/autochess/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/battalion/info.lua
+++ b/standard/info/wikis/battalion/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/battlerite/info.lua
+++ b/standard/info/wikis/battlerite/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/brawlhalla/info.lua
+++ b/standard/info/wikis/brawlhalla/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 1,
 }

--- a/standard/info/wikis/brawlstars/info.lua
+++ b/standard/info/wikis/brawlstars/info.lua
@@ -32,6 +32,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 150,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/callofduty/info.lua
+++ b/standard/info/wikis/callofduty/info.lua
@@ -344,6 +344,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 100,
+			matchWidth = 190,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/clashofclans/info.lua
+++ b/standard/info/wikis/clashofclans/info.lua
@@ -32,6 +32,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 200,
+		},
 	},
 	match2 = 1,
 }

--- a/standard/info/wikis/clashroyale/info.lua
+++ b/standard/info/wikis/clashroyale/info.lua
@@ -32,6 +32,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 170,
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/counterstrike/info.lua
+++ b/standard/info/wikis/counterstrike/info.lua
@@ -118,6 +118,11 @@ local infoData = {
 			hasSpecialTeam = true,
 			allowManual = true,
 		},
+		match2 = {
+			opponentHeight = 26,
+			scoreWidth = 26,
+			matchWidth = 200,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/criticalops/info.lua
+++ b/standard/info/wikis/criticalops/info.lua
@@ -32,6 +32,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/crossfire/info.lua
+++ b/standard/info/wikis/crossfire/info.lua
@@ -58,6 +58,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 190,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 1,

--- a/standard/info/wikis/dota2/info.lua
+++ b/standard/info/wikis/dota2/info.lua
@@ -45,6 +45,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/easportsfc/info.lua
+++ b/standard/info/wikis/easportsfc/info.lua
@@ -435,6 +435,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 180,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/fighters/info.lua
+++ b/standard/info/wikis/fighters/info.lua
@@ -1670,6 +1670,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	opponentLibrary = 'Opponent/Custom',
 	match2 = 1,

--- a/standard/info/wikis/formula1/info.lua
+++ b/standard/info/wikis/formula1/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/fortnite/info.lua
+++ b/standard/info/wikis/fortnite/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/freefire/info.lua
+++ b/standard/info/wikis/freefire/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 0,

--- a/standard/info/wikis/goals/info.lua
+++ b/standard/info/wikis/goals/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/halo/info.lua
+++ b/standard/info/wikis/halo/info.lua
@@ -110,6 +110,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = false,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 180,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/hearthstone/info.lua
+++ b/standard/info/wikis/hearthstone/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/heroes/info.lua
+++ b/standard/info/wikis/heroes/info.lua
@@ -32,6 +32,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 190,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 1,

--- a/standard/info/wikis/leagueoflegends/info.lua
+++ b/standard/info/wikis/leagueoflegends/info.lua
@@ -32,6 +32,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 200,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/magic/info.lua
+++ b/standard/info/wikis/magic/info.lua
@@ -58,6 +58,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/mobilelegends/info.lua
+++ b/standard/info/wikis/mobilelegends/info.lua
@@ -32,6 +32,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 190,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/naraka/info.lua
+++ b/standard/info/wikis/naraka/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/omegastrikers/info.lua
+++ b/standard/info/wikis/omegastrikers/info.lua
@@ -32,6 +32,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/osu/info.lua
+++ b/standard/info/wikis/osu/info.lua
@@ -45,6 +45,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/overwatch/info.lua
+++ b/standard/info/wikis/overwatch/info.lua
@@ -45,6 +45,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/paladins/info.lua
+++ b/standard/info/wikis/paladins/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/pokemon/info.lua
+++ b/standard/info/wikis/pokemon/info.lua
@@ -227,6 +227,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 190,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/pubg/info.lua
+++ b/standard/info/wikis/pubg/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 0,

--- a/standard/info/wikis/pubgmobile/info.lua
+++ b/standard/info/wikis/pubgmobile/info.lua
@@ -71,6 +71,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 0,

--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -45,6 +45,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = false,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/rocketleague/info.lua
+++ b/standard/info/wikis/rocketleague/info.lua
@@ -45,6 +45,9 @@ return {
 			hasSpecialTeam = true,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 150,
+		},
 	},
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 	match2 = 2,

--- a/standard/info/wikis/runeterra/info.lua
+++ b/standard/info/wikis/runeterra/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/sideswipe/info.lua
+++ b/standard/info/wikis/sideswipe/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/simracing/info.lua
+++ b/standard/info/wikis/simracing/info.lua
@@ -812,6 +812,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/smash/info.lua
+++ b/standard/info/wikis/smash/info.lua
@@ -97,6 +97,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	opponentLibrary = 'Opponent/Custom',
 	match2 = 0,

--- a/standard/info/wikis/smite/info.lua
+++ b/standard/info/wikis/smite/info.lua
@@ -45,6 +45,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/splatoon/info.lua
+++ b/standard/info/wikis/splatoon/info.lua
@@ -58,6 +58,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 190,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/splitgate/info.lua
+++ b/standard/info/wikis/splitgate/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/squadrons/info.lua
+++ b/standard/info/wikis/squadrons/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/starcraft/info.lua
+++ b/standard/info/wikis/starcraft/info.lua
@@ -32,6 +32,10 @@ return {
 			hasSpecialTeam = true,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 120,
+			matchWidth = 170,
+		},
 	},
 	maximumNumberOfPlayersInPlacements = 35,
 	opponentLibrary = 'Opponent/Starcraft',

--- a/standard/info/wikis/starcraft2/info.lua
+++ b/standard/info/wikis/starcraft2/info.lua
@@ -58,6 +58,10 @@ return {
 			hasSpecialTeam = true,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 150,
+		},
 	},
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',

--- a/standard/info/wikis/stormgate/info.lua
+++ b/standard/info/wikis/stormgate/info.lua
@@ -32,6 +32,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 150,
+		},
 	},
 	defaultRoundPrecision = 0,
 	opponentLibrary = 'Opponent/Custom',

--- a/standard/info/wikis/teamfortress/info.lua
+++ b/standard/info/wikis/teamfortress/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/tetris/info.lua
+++ b/standard/info/wikis/tetris/info.lua
@@ -448,6 +448,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 180,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/tft/info.lua
+++ b/standard/info/wikis/tft/info.lua
@@ -45,6 +45,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 0,

--- a/standard/info/wikis/trackmania/info.lua
+++ b/standard/info/wikis/trackmania/info.lua
@@ -149,6 +149,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	opponentLibrary = 'Opponent',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',

--- a/standard/info/wikis/underlords/info.lua
+++ b/standard/info/wikis/underlords/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/valorant/info.lua
+++ b/standard/info/wikis/valorant/info.lua
@@ -32,6 +32,9 @@ return {
 			hasSpecialTeam = true,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 180,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/warcraft/info.lua
+++ b/standard/info/wikis/warcraft/info.lua
@@ -58,6 +58,10 @@ return {
 			hasSpecialTeam = true,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 150,
+		},
 	},
 	opponentLibrary = 'Opponent/Custom',
 	opponentDisplayLibrary = 'OpponentDisplay/Custom',

--- a/standard/info/wikis/wildrift/info.lua
+++ b/standard/info/wikis/wildrift/info.lua
@@ -32,6 +32,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 200,
+		},
 	},
 	match2 = 2,
 }

--- a/standard/info/wikis/worldoftanks/info.lua
+++ b/standard/info/wikis/worldoftanks/info.lua
@@ -71,6 +71,9 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidth = 190,
+		},
 	},
 	defaultRoundPrecision = 0,
 	match2 = 2,

--- a/standard/info/wikis/worldofwarcraft/info.lua
+++ b/standard/info/wikis/worldofwarcraft/info.lua
@@ -32,6 +32,8 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+		},
 	},
 	match2 = 0,
 }

--- a/standard/info/wikis/zula/info.lua
+++ b/standard/info/wikis/zula/info.lua
@@ -71,6 +71,10 @@ return {
 			hasSpecialTeam = false,
 			allowManual = true,
 		},
+		match2 = {
+			matchWidthMobile = 110,
+			matchWidth = 200,
+		},
 	},
 	match2 = 2,
 }


### PR DESCRIPTION
## Summary
Move the wiki match/bracket sizes from MediaWiki:BracketConfig into the wiki's Config section of Module:Info.

As basically every wiki had scoreWidth = 22, I changed the default width to that instead of 20. The only ones without 22 were the ones that didn't make any customizations at all. 
Since mobileWidth = 88 (instead of 90) was extremely common as well, change the default as well, many wikis still override it to other values, with the most common being 110. 

In the future will look at standardizing the values. I know CS did a lot of work finding very pleasant values, so might switch to that.

## How did you test this change?

/dev on dota2