### PR TITLE
fix: use different class to target collapsible panel body content

### DIFF
--- a/stylesheets/commons/Panels.less
+++ b/stylesheets/commons/Panels.less
@@ -45,7 +45,7 @@ Author(s): FO-nTTaX
 				}
 			}
 
-			.panel-box-body {
+			.panel-box-collabsible-content {
 				display: none;
 			}
 		}

--- a/stylesheets/commons/Panels.less
+++ b/stylesheets/commons/Panels.less
@@ -45,7 +45,7 @@ Author(s): FO-nTTaX
 				}
 			}
 
-			.panel-box-collabsible-content {
+			.panel-box-collapsible-content {
 				display: none;
 			}
 		}


### PR DESCRIPTION
## Summary

The original class wasn't always available, so I added a new class for this purpose.

## How did you test this change?

dev tools
