### PR TITLE
fix(switchButtons): Fix countdown double init + logic linked to refresh buttons

### DIFF
--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -58,8 +58,8 @@ liquipedia.countdown = {
 			} );
 		}
 	},
-	setupCountdownsIfSwitchToggleExists: function () {
-		const switchToggleGroup = liquipedia.switchButtons.getSwitchGroup( 'countdown' );
+	setupCountdownsIfSwitchToggleExists: async function () {
+		const switchToggleGroup = await liquipedia.switchButtons.getSwitchGroup( 'countdown' );
 		if ( !switchToggleGroup || switchToggleGroup.type !== 'toggle' || switchToggleGroup.value === null ) {
 			return;
 		}

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -70,7 +70,7 @@ liquipedia.countdown = {
 		// Reacting state switch
 		switchToggleGroup.nodes.forEach( ( switchNode ) => {
 			switchNode.addEventListener( liquipedia.switchButtons.triggerEventName, ( event ) => {
-				liquipedia.countdown.toggleCountdowns( event.detail.value );
+				liquipedia.countdown.toggleCountdowns( event.detail.data.value );
 			} );
 		} );
 	},

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -342,7 +342,6 @@ liquipedia.filterButtons = {
 
 	refreshScriptsAfterContentUpdate: function() {
 		liquipedia.countdown.init();
-		liquipedia.switchButtons.init();
 	},
 
 	buildLocalStorageKey: function() {

--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -342,6 +342,7 @@ liquipedia.filterButtons = {
 
 	refreshScriptsAfterContentUpdate: function() {
 		liquipedia.countdown.init();
+		liquipedia.switchButtons.init();
 	},
 
 	buildLocalStorageKey: function() {

--- a/javascript/commons/SwitchButtons.js
+++ b/javascript/commons/SwitchButtons.js
@@ -55,12 +55,14 @@ liquipedia.switchButtons = {
 	baseLocalStorageKey: null,
 	triggerEventName: 'switchButtonChanged',
 	switchGroups: {},
+	isInitialized: false,
 
 	init: function () {
 		this.switchGroups = {};
 		this.baseLocalStorageKey = this.buildLocalStorageKey();
 		this.initSwitchElements( 'toggle', '.switch-toggle', 'switch-toggle-active' );
 		this.initSwitchElements( 'pill', '.switch-pill', 'switch-pill-active' );
+		this.isInitialized = true;
 	},
 
 	initSwitchElements: function ( type, selector, activeClassName ) {
@@ -193,10 +195,32 @@ liquipedia.switchButtons = {
 		node.dispatchEvent( customEvent );
 	},
 
-	// Accessed by other components, thus triggering init if necessary
-	getSwitchGroup: function ( groupName ) {
-		this.init();
-		return this.switchGroups[ groupName ];
+	/*
+	 * Get the switch group object by name.
+	 * This function is asynchronous, because the switch buttons are initialized asynchronously.
+	 * Waits up to 1 second for the switch buttons to be initialized, otherwise returns null.
+	 */
+	getSwitchGroup: async function ( groupName ) {
+		if ( this.isInitialized ) {
+			return this.switchGroups[ groupName ];
+		}
+
+		return new Promise( ( resolve ) => {
+			let interval = null;
+
+			const timeout = setTimeout( () => {
+				clearInterval( interval );
+				resolve( null );
+			}, 2000 );
+
+			interval = setInterval( () => {
+				if ( this.isInitialized ) {
+					clearInterval( interval );
+					clearTimeout( timeout );
+					resolve( this.switchGroups[ groupName ] );
+				}
+			}, 100 );
+		} );
 	}
 };
 

--- a/javascript/commons/SwitchButtons.js
+++ b/javascript/commons/SwitchButtons.js
@@ -52,24 +52,15 @@
  */
 
 liquipedia.switchButtons = {
-	isInitialized: false,
-	isBeingInitialized: false,
 	baseLocalStorageKey: null,
 	triggerEventName: 'switchButtonChanged',
 	switchGroups: {},
 
 	init: function () {
-		if ( this.isBeingInitialized || this.isInitialized ) {
-			return;
-		}
-		this.isBeingInitialized = true;
-
+		this.switchGroups = {};
 		this.baseLocalStorageKey = this.buildLocalStorageKey();
 		this.initSwitchElements( 'toggle', '.switch-toggle', 'switch-toggle-active' );
 		this.initSwitchElements( 'pill', '.switch-pill', 'switch-pill-active' );
-
-		this.isBeingInitialized = false;
-		this.isInitialized = true;
 	},
 
 	initSwitchElements: function ( type, selector, activeClassName ) {


### PR DESCRIPTION
## Summary

On [this page](https://liquipedia.net/dota2/User:FO-nTTaX/Sandbox/23) the "Show countdown" switch has to be clicked twice due to the init function being called multiple times. This makes the init function called once and changes the way other scripts can access switch button dependencies by waiting for the init to be done.

## How did you test this change?

On my dev env: http://killian.wiki.tldev.eu/rocketleague/Dota2MainPageSandbox
