### PR TITLE
feat(FilterButtons): filter buttons alignment

### DIFF
--- a/components/tournaments_list/filter_buttons.lua
+++ b/components/tournaments_list/filter_buttons.lua
@@ -24,6 +24,7 @@ local DROPDOWN_ARROW = '&#8203;▼&#8203;'
 ---@field transform? fun(item: string): string
 ---@field expandKey string?
 ---@field expandable boolean?
+---@field additionalClass string?
 ---@field order? fun(a: string, b: string): boolean
 ---@field load? fun(cat: FilterButtonCategory): FilterButtonCategory
 
@@ -83,6 +84,10 @@ function FilterButtons.getButtonRow(category)
 			:wikitext('All')
 			:done()
 
+	if String.isNotEmpty(category.additionalClass) then
+		buttons:addClass(category.additionalClass)
+	end
+
 	for _, value in ipairs(category.items or {}) do
 		local text = category.transform and category.transform(value) or value
 		local button = mw.html.create('span')
@@ -110,6 +115,11 @@ function FilterButtons.getButtonRow(category)
 				:addClass('filter-button')
 				:css('display','none')
 				:attr('data-filter-on', 'all'))
+
+		if String.isNotEmpty(category.additionalClass) then
+			dropdownButton:addClass(category.additionalClass)
+		end
+
 		buttons:node(dropdownButton)
 	end
 

--- a/stylesheets/commons/FilterButtons.less
+++ b/stylesheets/commons/FilterButtons.less
@@ -22,6 +22,14 @@ Author(s): Elysienna, Nadox
 	justify-content: center;
 	align-items: center;
 	flex-flow: row wrap;
+
+	&.filter-buttons--left {
+		justify-content: left;
+	}
+
+	&.filter-buttons--right {
+		justify-content: right;
+	}
 }
 
 .filter-button {


### PR DESCRIPTION
## Summary

We want to have the filter buttons being left aligned on [this page](https://liquipedia.net/dota2/User:FO-nTTaX/Sandbox/23). To do so, this adds a field that is configurable from the config to use additional CSS rules in the filter buttons.

## How did you test this change?

On my dev env: http://killian.wiki.tldev.eu/rocketleague/Dota2MainPageSandbox
