### PR TITLE
fix(match2) Prevent matches with default date to be automatically marked as finished

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
 local Faction = require('Module:Faction')
 local Game = require('Module:Game')
 local Json = require('Module:Json')
@@ -94,7 +95,7 @@ end
 ---@param match table
 function CustomMatchGroupInput._updateFinished(match)
 	match.finished = Logic.nilOr(Logic.readBoolOrNil(match.finished), Logic.isNotEmpty(match.winner))
-	if match.finished then
+	if match.finished or match.timestamp == DateExt.minTimestamp then
 		return
 	end
 

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -95,7 +95,7 @@ end
 ---@param match table
 function CustomMatchGroupInput._updateFinished(match)
 	match.finished = Logic.nilOr(Logic.readBoolOrNil(match.finished), Logic.isNotEmpty(match.winner))
-	if match.finished or match.timestamp == DateExt.minTimestamp then
+	if match.finished or match.timestamp == DateExt.defaultTimestamp then
 		return
 	end
 


### PR DESCRIPTION
## Summary
Matches were marked as finished if a certain time has passed since their dates.
This lead to all matches without a known date yet to be marked as finished.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
