### PR TITLE
feat(MatchTicker): move date and countdown to a new row in new style

### DIFF
--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -118,8 +118,10 @@ function Details:create()
 	end
 
 	return self.root
-		:node(self:streams())
-		:node(self:tournament())
+		:node(mw.html.create('div'):addClass('match-links')
+			:node(self:tournament())
+			:node(self:streams())
+		)
 		:node(self:countdown())
 end
 

--- a/stylesheets/commons/MatchTicker.less
+++ b/stylesheets/commons/MatchTicker.less
@@ -18,7 +18,7 @@ Author(s): Nadox
 
 	.match {
 		border-bottom: 1px solid var( --table-border-color, var( --clr-border, #bbbbbb ) );
-		padding: 0.75rem 1rem;
+		padding: 0.75rem 0;
 		font-size: 0.875rem;
 
 		.match-scoreboard {
@@ -65,11 +65,11 @@ Author(s): Nadox
 
 		.match-details {
 			display: flex;
-			justify-content: space-between;
-			align-items: center;
+			flex-direction: column;
 			padding: 0.5rem 0.75rem;
 			border-radius: 0.5rem;
 			font-size: 0.75rem;
+			gap: 0.5rem;
 
 			.theme--light & {
 				background-color: #0000000a;
@@ -79,66 +79,77 @@ Author(s): Nadox
 				background-color: #ffffff0a;
 			}
 
-			.match-streams {
+			.match-links {
 				display: flex;
-				align-items: center;
-				justify-content: center;
-				gap: 0.25rem;
+				justify-content: space-between;
+				flex: 1;
+
+				.match-streams {
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					gap: 0.25rem;
+				}
+
+				.match-tournament {
+					display: flex;
+					gap: 0.5rem;
+					justify-content: center;
+					align-items: center;
+				}
 			}
 
-			.match-tournament {
+			.match-countdown {
 				display: flex;
-				gap: 0.5rem;
 				justify-content: center;
-				align-items: center;
+
+				.timer-object-countdown,
+				.timer-object-date {
+					padding: 0.25rem 0.5rem;
+					border-radius: 0.25rem;
+					font-weight: bold;
+	
+					&.timer-object-countdown-live {
+						.theme--light & {
+							color: #ffffff;
+							background-color: #b81414;
+						}
+	
+						.theme--dark & {
+							color: #2e0505;
+							background-color: #f5a3a3;
+						}
+					}
+	
+					&.timer-object-countdown-completed {
+						.theme--light & {
+							color: #ffffff;
+							background-color: #1d7c1d;
+						}
+	
+						.theme--dark & {
+							color: #0a290a;
+							background-color: #adebad;
+						}
+					}
+	
+					&:not( .timer-object-countdown-live, .timer-object-countdown-completed ) {
+						color: var( --clr-on-background );
+	
+						.theme--light & {
+							background-color: #00000014;
+						}
+	
+						.theme--dark & {
+							background-color: #ffffff14;
+						}
+					}
+				}
+
+				.timer-object-separator {
+					display: none;
+				}
 			}
-
-			.timer-object-countdown,
-			.timer-object-date {
-				padding: 0.25rem 0.5rem;
-				border-radius: 0.25rem;
-				font-weight: bold;
-
-				&.timer-object-countdown-live {
-					.theme--light & {
-						color: #ffffff;
-						background-color: #b81414;
-					}
-
-					.theme--dark & {
-						color: #2e0505;
-						background-color: #f5a3a3;
-					}
-				}
-
-				&.timer-object-countdown-completed {
-					.theme--light & {
-						color: #ffffff;
-						background-color: #1d7c1d;
-					}
-
-					.theme--dark & {
-						color: #0a290a;
-						background-color: #adebad;
-					}
-				}
-
-				&:not( .timer-object-countdown-live, .timer-object-countdown-completed ) {
-					color: var( --clr-on-background );
-
-					.theme--light & {
-						background-color: #00000014;
-					}
-
-					.theme--dark & {
-						background-color: #ffffff14;
-					}
-				}
-			}
-		}
-
-		.timer-object-separator {
-			display: none;
 		}
 	}
 }

--- a/stylesheets/commons/MatchTicker.less
+++ b/stylesheets/commons/MatchTicker.less
@@ -108,38 +108,38 @@ Author(s): Nadox
 					padding: 0.25rem 0.5rem;
 					border-radius: 0.25rem;
 					font-weight: bold;
-	
+
 					&.timer-object-countdown-live {
 						.theme--light & {
 							color: #ffffff;
 							background-color: #b81414;
 						}
-	
+
 						.theme--dark & {
 							color: #2e0505;
 							background-color: #f5a3a3;
 						}
 					}
-	
+
 					&.timer-object-countdown-completed {
 						.theme--light & {
 							color: #ffffff;
 							background-color: #1d7c1d;
 						}
-	
+
 						.theme--dark & {
 							color: #0a290a;
 							background-color: #adebad;
 						}
 					}
-	
+
 					&:not( .timer-object-countdown-live, .timer-object-countdown-completed ) {
 						color: var( --clr-on-background );
-	
+
 						.theme--light & {
 							background-color: #00000014;
 						}
-	
+
 						.theme--dark & {
 							background-color: #ffffff14;
 						}


### PR DESCRIPTION
## Summary

Due to the new style, all info does not fit in the match ticker. As a result, we decided to put the date/countdown into a new row to make the information more visible.

Results:
![image](https://github.com/user-attachments/assets/6e8ff804-aa7f-4472-8f66-5e915910b690)


## How did you test this change?

On my [dev env](http://killian.wiki.tldev.eu/rocketleague/Dota2MainPageSandbox)