### PR TITLE
feat(countdown): display `completed` for completed matches in new style

### DIFF
--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -118,7 +118,7 @@ function Details:create()
 	end
 
 	return self.root
-		:node(self:streams())
+			:node(self:streams())
 		:node(self:tournament())
 		:node(self:countdown())
 end
@@ -139,7 +139,8 @@ function Details:countdown()
 
 	local countdownArgs = {
 		date = dateString,
-		finished = match.finished
+		finished = match.finished,
+		showCompleted = true
 	}
 
 	local countdownDisplay = mw.html.create('span')

--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -118,7 +118,7 @@ function Details:create()
 	end
 
 	return self.root
-			:node(self:streams())
+		:node(self:streams())
 		:node(self:tournament())
 		:node(self:countdown())
 end

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -119,21 +119,21 @@ liquipedia.countdown = {
 		const differenceInSeconds =
 			Math.floor( parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 ) );
 
-		if ( differenceInSeconds <= 0 ) {
-			if ( differenceInSeconds > -43200 && timerObjectNode.dataset.finished !== 'finished' ) {
-				countdownElem.classList.add( 'timer-object-countdown-live' );
+		if ( differenceInSeconds > 0 ) {
+			return this.formatTimeDifference( differenceInSeconds );
+		}
 
-				if ( typeof timerObjectNode.dataset.countdownEndText !== 'undefined' ) {
-					return timerObjectNode.dataset.countdownEndText;
-				}
-
-				return 'LIVE';
-			}
-
+		if ( differenceInSeconds <= -43200 || timerObjectNode.dataset.finished === 'finished' ) {
 			return '';
 		}
 
-		return this.formatTimeDifference( differenceInSeconds );
+		countdownElem.classList.add( 'timer-object-countdown-live' );
+
+		if ( typeof timerObjectNode.dataset.countdownEndText !== 'undefined' ) {
+			return timerObjectNode.dataset.countdownEndText;
+		}
+
+		return 'LIVE';
 	},
 	formatTimeDifference: function ( differenceInSeconds ) {
 		const weeks = Math.floor( differenceInSeconds / 604800 );

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -100,9 +100,7 @@ liquipedia.countdown = {
 		const countdownElem = timerObjectNode.querySelector( '.timer-object-countdown' );
 		let datestr = '';
 
-		if ( timerObjectNode.dataset.timestamp === 'error' ) {
-			datestr = '';
-		} else {
+		if ( timerObjectNode.dataset.timestamp !== 'error' ) {
 			datestr = this.calculateCountdownString( timerObjectNode, countdownElem );
 		}
 

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -104,35 +104,40 @@ liquipedia.countdown = {
 			live = timerObjectNode.dataset.countdownEndText;
 		}
 		if ( timerObjectNode.dataset.timestamp !== 'error' ) {
-			const differenceInSeconds = Math.floor(
-				parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 )
-			);
-
-			if ( differenceInSeconds <= 0 ) {
-				if ( differenceInSeconds > -43200 && timerObjectNode.dataset.finished !== 'finished' ) {
-					countdownElem.classList.add( 'timer-object-countdown-live' );
-					datestr = live;
-				}
+			if ( timerObjectNode.dataset.finished === 'finished' && timerObjectNode.dataset.showCompleted === 'true' ) {
+				countdownElem.classList.add( 'timer-object-countdown-completed' );
+				datestr = 'COMPLETED';
 			} else {
-				let differenceInSecondsMath = differenceInSeconds;
-				const weeks = Math.floor( differenceInSecondsMath / 604800 );
-				differenceInSecondsMath = differenceInSecondsMath % 604800;
-				const days = Math.floor( differenceInSecondsMath / 86400 );
-				differenceInSecondsMath = differenceInSecondsMath % 86400;
-				const hours = Math.floor( differenceInSecondsMath / 3600 );
-				differenceInSecondsMath = differenceInSecondsMath % 3600;
-				const minutes = Math.floor( differenceInSecondsMath / 60 );
-				const seconds = Math.floor( differenceInSecondsMath % 60 );
-				if ( differenceInSeconds >= 604800 ) {
-					datestr = weeks + 'w ' + days + 'd';
-				} else if ( differenceInSeconds >= 86400 ) {
-					datestr = days + 'd ' + hours + 'h ' + minutes + 'm';
-				} else if ( differenceInSeconds >= 3600 ) {
-					datestr = hours + 'h ' + minutes + 'm ' + seconds + 's';
-				} else if ( differenceInSeconds >= 60 ) {
-					datestr = minutes + 'm ' + seconds + 's';
+				const differenceInSeconds = Math.floor(
+					parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 )
+				);
+
+				if ( differenceInSeconds <= 0 ) {
+					if ( differenceInSeconds > -43200 && timerObjectNode.dataset.finished !== 'finished' ) {
+						countdownElem.classList.add( 'timer-object-countdown-live' );
+						datestr = live;
+					}
 				} else {
-					datestr = seconds + 's';
+					let differenceInSecondsMath = differenceInSeconds;
+					const weeks = Math.floor( differenceInSecondsMath / 604800 );
+					differenceInSecondsMath = differenceInSecondsMath % 604800;
+					const days = Math.floor( differenceInSecondsMath / 86400 );
+					differenceInSecondsMath = differenceInSecondsMath % 86400;
+					const hours = Math.floor( differenceInSecondsMath / 3600 );
+					differenceInSecondsMath = differenceInSecondsMath % 3600;
+					const minutes = Math.floor( differenceInSecondsMath / 60 );
+					const seconds = Math.floor( differenceInSecondsMath % 60 );
+					if ( differenceInSeconds >= 604800 ) {
+						datestr = weeks + 'w ' + days + 'd';
+					} else if ( differenceInSeconds >= 86400 ) {
+						datestr = days + 'd ' + hours + 'h ' + minutes + 'm';
+					} else if ( differenceInSeconds >= 3600 ) {
+						datestr = hours + 'h ' + minutes + 'm ' + seconds + 's';
+					} else if ( differenceInSeconds >= 60 ) {
+						datestr = minutes + 'm ' + seconds + 's';
+					} else {
+						datestr = seconds + 's';
+					}
 				}
 			}
 		} else {

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -101,7 +101,12 @@ liquipedia.countdown = {
 		let datestr = '';
 
 		if ( timerObjectNode.dataset.timestamp !== 'error' ) {
-			datestr = this.calculateCountdownString( timerObjectNode, countdownElem );
+			const countdownContent = this.getCountdownStringAndClassName( timerObjectNode, countdownElem );
+			datestr = countdownContent.text;
+
+			if ( countdownContent.className !== '' ) {
+				countdownElem.classList.add( countdownContent.className );
+			}
 		}
 
 		let html = `<span class="timer-object-countdown-time">${ datestr }</span>`;
@@ -110,30 +115,42 @@ liquipedia.countdown = {
 		}
 		countdownElem.innerHTML = html;
 	},
-	calculateCountdownString: function ( timerObjectNode, countdownElem ) {
+	getCountdownStringAndClassName: function ( timerObjectNode ) {
 		if ( timerObjectNode.dataset.finished === 'finished' && timerObjectNode.dataset.showCompleted === 'true' ) {
-			countdownElem.classList.add( 'timer-object-countdown-completed' );
-			return 'COMPLETED';
+			return {
+				text: 'COMPLETED',
+				className: 'timer-object-countdown-completed'
+			};
 		}
 
 		const differenceInSeconds =
 			Math.floor( parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 ) );
 
 		if ( differenceInSeconds > 0 ) {
-			return this.formatTimeDifference( differenceInSeconds );
+			return {
+				text: this.formatTimeDifference( differenceInSeconds ),
+				className: ''
+			};
 		}
 
 		if ( differenceInSeconds <= -43200 || timerObjectNode.dataset.finished === 'finished' ) {
-			return '';
+			return {
+				text: '',
+				className: ''
+			};
 		}
-
-		countdownElem.classList.add( 'timer-object-countdown-live' );
 
 		if ( typeof timerObjectNode.dataset.countdownEndText !== 'undefined' ) {
-			return timerObjectNode.dataset.countdownEndText;
+			return {
+				text: timerObjectNode.dataset.countdownEndText,
+				className: 'timer-object-countdown-live'
+			};
 		}
 
-		return 'LIVE';
+		return {
+			text: 'LIVE',
+			className: 'timer-object-countdown-live'
+		};
 	},
 	formatTimeDifference: function ( differenceInSeconds ) {
 		const weeks = Math.floor( differenceInSeconds / 604800 );

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -101,11 +101,11 @@ liquipedia.countdown = {
 		let datestr = '';
 
 		if ( timerObjectNode.dataset.timestamp !== 'error' ) {
-			const countdownContent = this.getCountdownStringAndClassName( timerObjectNode, countdownElem );
-			datestr = countdownContent.text;
+			const { text, className } = this.getCountdownStringAndClassName( timerObjectNode, countdownElem );
+			datestr = text;
 
-			if ( countdownContent.className !== '' ) {
-				countdownElem.classList.add( countdownContent.className );
+			if ( className !== '' ) {
+				countdownElem.classList.add( className );
 			}
 		}
 

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -98,56 +98,63 @@ liquipedia.countdown = {
 	},
 	setCountdownString: function ( timerObjectNode ) {
 		const countdownElem = timerObjectNode.querySelector( '.timer-object-countdown' );
-		let datestr = '', live = 'LIVE';
+		let datestr = '';
 
-		if ( typeof timerObjectNode.dataset.countdownEndText !== 'undefined' ) {
-			live = timerObjectNode.dataset.countdownEndText;
-		}
-		if ( timerObjectNode.dataset.timestamp !== 'error' ) {
-			if ( timerObjectNode.dataset.finished === 'finished' && timerObjectNode.dataset.showCompleted === 'true' ) {
-				countdownElem.classList.add( 'timer-object-countdown-completed' );
-				datestr = 'COMPLETED';
-			} else {
-				const differenceInSeconds = Math.floor(
-					parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 )
-				);
-
-				if ( differenceInSeconds <= 0 ) {
-					if ( differenceInSeconds > -43200 && timerObjectNode.dataset.finished !== 'finished' ) {
-						countdownElem.classList.add( 'timer-object-countdown-live' );
-						datestr = live;
-					}
-				} else {
-					let differenceInSecondsMath = differenceInSeconds;
-					const weeks = Math.floor( differenceInSecondsMath / 604800 );
-					differenceInSecondsMath = differenceInSecondsMath % 604800;
-					const days = Math.floor( differenceInSecondsMath / 86400 );
-					differenceInSecondsMath = differenceInSecondsMath % 86400;
-					const hours = Math.floor( differenceInSecondsMath / 3600 );
-					differenceInSecondsMath = differenceInSecondsMath % 3600;
-					const minutes = Math.floor( differenceInSecondsMath / 60 );
-					const seconds = Math.floor( differenceInSecondsMath % 60 );
-					if ( differenceInSeconds >= 604800 ) {
-						datestr = weeks + 'w ' + days + 'd';
-					} else if ( differenceInSeconds >= 86400 ) {
-						datestr = days + 'd ' + hours + 'h ' + minutes + 'm';
-					} else if ( differenceInSeconds >= 3600 ) {
-						datestr = hours + 'h ' + minutes + 'm ' + seconds + 's';
-					} else if ( differenceInSeconds >= 60 ) {
-						datestr = minutes + 'm ' + seconds + 's';
-					} else {
-						datestr = seconds + 's';
-					}
-				}
-			}
+		if ( timerObjectNode.dataset.timestamp === 'error' ) {
+			datestr = '';
 		} else {
-			datestr = ''; // DATE ERROR!
+			datestr = this.calculateCountdownString( timerObjectNode, countdownElem );
 		}
-		let html = '<span class="timer-object-countdown-time">' + datestr + '</span>';
+
+		let html = `<span class="timer-object-countdown-time">${ datestr }</span>`;
 		if ( datestr.length > 0 && timerObjectNode.dataset.hasstreams === 'true' ) {
 			html += ' - ';
 		}
 		countdownElem.innerHTML = html;
+	},
+	calculateCountdownString: function ( timerObjectNode, countdownElem ) {
+		if ( timerObjectNode.dataset.finished === 'finished' && timerObjectNode.dataset.showCompleted === 'true' ) {
+			countdownElem.classList.add( 'timer-object-countdown-completed' );
+			return 'COMPLETED';
+		}
+
+		const differenceInSeconds =
+			Math.floor( parseInt( timerObjectNode.dataset.timestamp ) - ( Date.now().valueOf() / 1000 ) );
+
+		if ( differenceInSeconds <= 0 ) {
+			if ( differenceInSeconds > -43200 && timerObjectNode.dataset.finished !== 'finished' ) {
+				countdownElem.classList.add( 'timer-object-countdown-live' );
+
+				if ( typeof timerObjectNode.dataset.countdownEndText !== 'undefined' ) {
+					return timerObjectNode.dataset.countdownEndText;
+				}
+
+				return 'LIVE';
+			}
+
+			return '';
+		}
+
+		return this.formatTimeDifference( differenceInSeconds );
+	},
+	formatTimeDifference: function ( differenceInSeconds ) {
+		const weeks = Math.floor( differenceInSeconds / 604800 );
+		const days = Math.floor( ( differenceInSeconds % 604800 ) / 86400 );
+		const hours = Math.floor( ( differenceInSeconds % 86400 ) / 3600 );
+		const minutes = Math.floor( ( differenceInSeconds % 3600 ) / 60 );
+		const seconds = Math.floor( differenceInSeconds % 60 );
+
+		if ( differenceInSeconds >= 604800 ) {
+			return `${ weeks }w ${ days }d`;
+		} else if ( differenceInSeconds >= 86400 ) {
+			return `${ days }d ${ hours }h ${ minutes }m`;
+		} else if ( differenceInSeconds >= 3600 ) {
+			return `${ hours }h ${ minutes }m ${ seconds }s`;
+		} else if ( differenceInSeconds >= 60 ) {
+			return `${ minutes }m ${ seconds }s`;
+		} else {
+			return `${ seconds }s`;
+		}
 	},
 	timeZoneAbbr: new Map( [
 		[ 'Acre Time', 'ACT' ],

--- a/standard/countdown.lua
+++ b/standard/countdown.lua
@@ -60,6 +60,9 @@ function Countdown._create(args)
 		wrapper:attr('data-hasstreams', 'true')
 	end
 
+	if Logic.readBool(args.showCompleted) then
+		wrapper:attr('data-show-completed', 'true')
+	end
 
 	if args.text then
 		wrapper:attr('data-countdown-end-text', args.text)


### PR DESCRIPTION
## Summary

We want to show a COMPLETED pill for the new style of the match ticker. To do so without affecting all countdowns, this adds a flag to indicate to add this pill.

Results:
![image](https://github.com/user-attachments/assets/d3c782fc-9cb5-455e-aac1-611e9160ca16)


## How did you test this change?

On my [dev env](http://killian.wiki.tldev.eu/rocketleague/Dota2MainPageSandbox)