### PR TITLE
feat(match2): styling and structure dota2 match page player stats

### DIFF
--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -119,7 +119,7 @@ return {
 			</div>
 			<h3>Player Performance</h3>
 			<div class="match-bm-players-wrapper">
-				<div class="match-bm-lol-players-team"><div class="match-bm-lol-players-team-header">{{&opponents.1.iconDisplay}}</div>
+				<div class="match-bm-players-team"><div class="match-bm-lol-players-team-header">{{&opponents.1.iconDisplay}}</div>
 					{{#teams.1.players}}
 						<div class="match-bm-players-player">
 							<div class="match-bm-players-player-character">
@@ -151,7 +151,7 @@ return {
 						</div>
 					{{/teams.1.players}}
 				</div>
-				<div class="match-bm-lol-players-team"><div class="match-bm-lol-players-team-header">{{&opponents.2.iconDisplay}}</div>
+				<div class="match-bm-players-team"><div class="match-bm-lol-players-team-header">{{&opponents.2.iconDisplay}}</div>
 					{{#teams.2.players}}
 						<div class="match-bm-players-player">
 							<div class="match-bm-players-player-character">

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -24,9 +24,9 @@ return {
 				<div class="match-bm-lol-match-header-date">{{&dateCountdown}}</div>
 			</div>
 			{{#isBestOfOne}}<div class="match-bm-lol-game-overview"><div class="match-bm-lol-game-summary">
-			<div class="match-bm-lol-game-summary-team">{{#games.1.teams.1.side}}[[File:Lol faction {{games.1.teams.1.side}}.png|link=|{{games.1.teams.1.side}} side]]{{/games.1.teams.1.side}}</div>
+			<div class="match-bm-lol-game-summary-team">{{#games.1.teams.1.side}}[[File:Dota2 faction {{games.1.teams.1.side}}.png|link=|{{games.1.teams.1.side}} side]]{{/games.1.teams.1.side}}</div>
 			<div class="match-bm-lol-game-summary-center"><div class="match-bm-lol-game-summary-score-holder"><div class="match-bm-lol-game-summary-length">{{games.1.length}}</div></div></div>
-			<div class="match-bm-lol-game-summary-team">{{#games.1.teams.2.side}}[[File:Lol faction {{games.1.teams.2.side}}.png|link=|{{games.1.teams.1.side}} side]]{{/games.1.teams.2.side}}</div>
+			<div class="match-bm-lol-game-summary-team">{{#games.1.teams.2.side}}[[File:Dota2 faction {{games.1.teams.2.side}}.png|link=|{{games.1.teams.1.side}} side]]{{/games.1.teams.2.side}}</div>
 			</div></div>{{/isBestOfOne}}
 			{{#extradata.mvp}}<div class="match-bm-lol-match-mvp"><b>MVP</b> {{#players}}[[{{name}}|{{displayname}}]]{{/players}}</div>{{/extradata.mvp}}
 		]=],
@@ -56,9 +56,9 @@ return {
 				<div class="match-bm-lol-game-summary">
 					<div class="match-bm-lol-game-summary-team">{{&opponents.1.iconDisplay}}</div>
 					<div class="match-bm-lol-game-summary-center">
-						<div class="match-bm-lol-game-summary-faction">{{#teams.1.side}}[[File:Lol faction {{teams.1.side}}.png|link=|{{teams.1.side}} side]]{{/teams.1.side}}</div>
+						<div class="match-bm-lol-game-summary-faction">{{#teams.1.side}}[[File:Dota2 faction {{teams.1.side}}.png|link=|{{teams.1.side}} side]]{{/teams.1.side}}</div>
 						<div class="match-bm-lol-game-summary-score-holder">{{#finished}}<div class="match-bm-lol-game-summary-score">{{teams.1.scoreDisplay}}&ndash;{{teams.2.scoreDisplay}}</div><div class="match-bm-lol-game-summary-length">{{length}}</div>{{/finished}}</div>
-						<div class="match-bm-lol-game-summary-faction">{{#teams.2.side}}[[File:Lol faction {{teams.2.side}}.png|link=|{{teams.2.side}} side]]{{/teams.2.side}}</div>
+						<div class="match-bm-lol-game-summary-faction">{{#teams.2.side}}[[File:Dota2 faction {{teams.2.side}}.png|link=|{{teams.2.side}} side]]{{/teams.2.side}}</div>
 					</div>
 					<div class="match-bm-lol-game-summary-team">{{&opponents.2.iconDisplay}}</div>
 				</div>
@@ -81,6 +81,43 @@ return {
 				</div>
 			</div>
 			<h3>Head-to-Head</h3>
+			<div class="match-bm-team-stats">
+				<div class="match-bm-team-stats-header">
+					<h4>Radiant Victory</h4>
+					<span class="match-bm-team-stats-time side--dire">25:55</span>
+				</div>
+				<div>
+					<div class="match-bm-team-stats-team">{{&opponents.1.iconDisplay}}</div>
+					<div class="match-bm-team-stats-list">
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.1.kills}}<span class="slash">/</span>{{teams.1.deaths}}<span class="slash">/</span>{{teams.1.assists}}{{/finished}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-crossbones cell--icon"></i>KDA</div>
+							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.2.kills}}<span class="slash">/</span>{{teams.2.deaths}}<span class="slash">/</span>{{teams.2.assists}}{{/finished}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.gold}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-coins cell--icon"></i>Gold</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.gold}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.objectives.towers}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-chess-rook cell--icon"></i>Towers</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.objectives.towers}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.objectives.barracks}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-warehouse cell--icon"></i>Barracks</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.objectives.barracks}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.objectives.roshans}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-cow cell--icon"></i>Roshan</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.objectives.roshans}}</div>
+						</div>
+					</div>
+					<div class="match-bm-team-stats-team">{{&opponents.2.iconDisplay}}</div>
+				</div>
+			</div>
 			<div class="match-bm-lol-h2h">
 				<div class="match-bm-lol-h2h-header">
 					<div class="match-bm-lol-h2h-header-team">{{&opponents.1.iconDisplay}}</div>
@@ -130,8 +167,8 @@ return {
 								<!-- Loadout -->
 								<div class="match-bm-players-player-loadout-items">
 									<!-- Items -->
-									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.1}}.png|24px]][[File:Lol item {{items.2}}.png|24px]][[File:Lol item {{items.3}}.png|24px]]</div>
-									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.4}}.png|24px]][[File:Lol item {{items.5}}.png|24px]][[File:Lol item {{items.6}}.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:{{items.1}} itemicon dota2 gameasset.png|24px]][[File:{{items.2}} itemicon dota2 gameasset.png|24px]][[File:{{items.3}} itemicon dota2 gameasset.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:{{items.4}} itemicon dota2 gameasset.png|24px]][[File:{{items.5}} itemicon dota2 gameasset.png|24px]][[File:{{items.6}} itemicon dota2 gameasset.png|24px]]</div>
 									<div class="match-bm-players-player-loadout-item">[[File:{{backpackitems.1}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.2}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.3}} itemicon dota2 gameasset.png|24px]]</div>
 								</div>
 								<div class="match-bm-players-player-loadout-rs-wrap">
@@ -162,8 +199,8 @@ return {
 								<!-- Loadout -->
 								<div class="match-bm-players-player-loadout-items">
 									<!-- Items -->
-									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.1}}.png|24px]][[File:Lol item {{items.2}}.png|24px]][[File:Lol item {{items.3}}.png|24px]]</div>
-									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.4}}.png|24px]][[File:Lol item {{items.5}}.png|24px]][[File:Lol item {{items.6}}.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:{{items.1}} itemicon dota2 gameasset.png|24px]][[File:{{items.2}} itemicon dota2 gameasset.png|24px]][[File:{{items.3}} itemicon dota2 gameasset.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:{{items.4}} itemicon dota2 gameasset.png|24px]][[File:{{items.5}} itemicon dota2 gameasset.png|24px]][[File:{{items.6}} itemicon dota2 gameasset.png|24px]]</div>
 									<div class="match-bm-players-player-loadout-item">[[File:{{backpackitems.1}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.2}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.3}} itemicon dota2 gameasset.png|24px]]</div>
 								</div>
 								<div class="match-bm-players-player-loadout-rs-wrap">

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -81,43 +81,6 @@ return {
 				</div>
 			</div>
 			<h3>Head-to-Head</h3>
-			<div class="match-bm-team-stats">
-				<div class="match-bm-team-stats-header">
-					<h4>Radiant Victory</h4>
-					<span class="match-bm-team-stats-time side--dire">25:55</span>
-				</div>
-				<div>
-					<div class="match-bm-team-stats-team">{{&opponents.1.iconDisplay}}</div>
-					<div class="match-bm-team-stats-list">
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.1.kills}}<span class="slash">/</span>{{teams.1.deaths}}<span class="slash">/</span>{{teams.1.assists}}{{/finished}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-crossbones cell--icon"></i>KDA</div>
-							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.2.kills}}<span class="slash">/</span>{{teams.2.deaths}}<span class="slash">/</span>{{teams.2.assists}}{{/finished}}</div>
-						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.gold}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-coins cell--icon"></i>Gold</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.gold}}</div>
-						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.objectives.towers}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-chess-rook cell--icon"></i>Towers</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.objectives.towers}}</div>
-						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.objectives.barracks}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-warehouse cell--icon"></i>Barracks</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.objectives.barracks}}</div>
-						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.objectives.roshans}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-cow cell--icon"></i>Roshan</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.objectives.roshans}}</div>
-						</div>
-					</div>
-					<div class="match-bm-team-stats-team">{{&opponents.2.iconDisplay}}</div>
-				</div>
-			</div>
 			<div class="match-bm-lol-h2h">
 				<div class="match-bm-lol-h2h-header">
 					<div class="match-bm-lol-h2h-header-team">{{&opponents.1.iconDisplay}}</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -118,32 +118,30 @@ return {
 				</div>
 			</div>
 			<h3>Player Performance</h3>
-			<div class="match-bm-lol-players-wrapper">
+			<div class="match-bm-players-wrapper">
 				<div class="match-bm-lol-players-team"><div class="match-bm-lol-players-team-header">{{&opponents.1.iconDisplay}}</div>
 					{{#teams.1.players}}
-						<div class="match-bm-lol-players-player">
-							<div class="match-bm-lol-players-player-details">
-								<div class="match-bm-lol-players-player-character">
-									<div class="match-bm-lol-players-player-avatar"><div class="match-bm-lol-players-player-icon">{{&heroIcon}}</div><div class="match-bm-lol-players-player-role">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
-									<div class="match-bm-lol-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
+						<div class="match-bm-players-player">
+							<div class="match-bm-players-player-character">
+								<div class="match-bm-lol-players-player-avatar"><div class="match-bm-lol-players-player-icon">{{&heroIcon}}</div><div class="match-bm-lol-players-player-role">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
+								<div class="match-bm-lol-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
+							</div>
+							<div class="match-bm-players-player-loadout">
+								<!-- Loadout -->
+								<div class="match-bm-players-player-loadout-items">
+									<!-- Items -->
+									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.1}}.png|24px]][[File:Lol item {{items.2}}.png|24px]][[File:Lol item {{items.3}}.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.4}}.png|24px]][[File:Lol item {{items.5}}.png|24px]][[File:Lol item {{items.6}}.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:{{backpackitems.1}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.2}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.3}} itemicon dota2 gameasset.png|24px]]</div>
 								</div>
-								<div class="match-bm-lol-players-player-loadout">
-									<!-- Loadout -->
-									<div class="match-bm-lol-players-player-loadout-items">
-										<!-- Items -->
-										<div class="match-bm-lol-players-player-loadout-item">[[File:Lol item {{items.1}}.png|24px]][[File:Lol item {{items.2}}.png|24px]][[File:Lol item {{items.3}}.png|24px]]</div>
-										<div class="match-bm-lol-players-player-loadout-item">[[File:Lol item {{items.4}}.png|24px]][[File:Lol item {{items.5}}.png|24px]][[File:Lol item {{items.6}}.png|24px]]</div>
-										<div class="match-bm-lol-players-player-loadout-item">[[File:{{backpackitems.1}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.2}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.3}} itemicon dota2 gameasset.png|24px]]</div>
-									</div>
-									<div class="match-bm-lol-players-player-loadout-rs-wrap">
-										<!-- Runes/Spells -->
-										<div class="match-bm-lol-players-player-loadout-rs">[[File:{{neutralitem}} itemicon dota2 gameasset.png|24px]]</div>
-										<div class="match-bm-lol-players-player-loadout-rs">{{#shard}}[[File:Dota2_Aghanim's_Shard_symbol_allmode.png|24px]]{{/shard}}</div>
-										<div class="match-bm-lol-players-player-loadout-rs">{{#scepter}}[[File:Dota2_Aghanim's_Scepter_symbol_allmode.png|24px]]{{/scepter}}</div>
-									</div>
+								<div class="match-bm-players-player-loadout-rs-wrap">
+									<!-- Runes/Spells -->
+									<div class="match-bm-players-player-loadout-rs">[[File:{{neutralitem}} itemicon dota2 gameasset.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-rs">{{#shard}}[[File:Dota2_Aghanim's_Shard_symbol_allmode.png|24px]]{{/shard}}</div>
+									<div class="match-bm-players-player-loadout-rs">{{#scepter}}[[File:Dota2_Aghanim's_Scepter_symbol_allmode.png|24px]]{{/scepter}}</div>
 								</div>
 							</div>
-							<div class="match-bm-lol-players-player-stats">
+							<div class="match-bm-players-player-stats">
 								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon kda.png|link=|KDA]]KDA {{kills}}/{{deaths}}/{{assists}}</div>
 								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon dmg.png|link=|Damage]]DMG {{displayDamageDone}}</div>
 								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Last Hits / Denies]]LH/DN {{lasthits}} / {{denies}}</div>
@@ -155,29 +153,27 @@ return {
 				</div>
 				<div class="match-bm-lol-players-team"><div class="match-bm-lol-players-team-header">{{&opponents.2.iconDisplay}}</div>
 					{{#teams.2.players}}
-						<div class="match-bm-lol-players-player">
-							<div class="match-bm-lol-players-player-details">
-								<div class="match-bm-lol-players-player-character">
-									<div class="match-bm-lol-players-player-avatar"><div class="match-bm-lol-players-player-icon">{{&heroIcon}}</div><div class="match-bm-lol-players-player-role">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
-									<div class="match-bm-lol-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
+						<div class="match-bm-players-player">
+							<div class="match-bm-players-player-character">
+								<div class="match-bm-lol-players-player-avatar"><div class="match-bm-lol-players-player-icon">{{&heroIcon}}</div><div class="match-bm-lol-players-player-role">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
+								<div class="match-bm-lol-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
+							</div>
+							<div class="match-bm-players-player-loadout">
+								<!-- Loadout -->
+								<div class="match-bm-players-player-loadout-items">
+									<!-- Items -->
+									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.1}}.png|24px]][[File:Lol item {{items.2}}.png|24px]][[File:Lol item {{items.3}}.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:Lol item {{items.4}}.png|24px]][[File:Lol item {{items.5}}.png|24px]][[File:Lol item {{items.6}}.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-item">[[File:{{backpackitems.1}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.2}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.3}} itemicon dota2 gameasset.png|24px]]</div>
 								</div>
-								<div class="match-bm-lol-players-player-loadout">
-									<!-- Loadout -->
-									<div class="match-bm-lol-players-player-loadout-items">
-										<!-- Items -->
-										<div class="match-bm-lol-players-player-loadout-item">[[File:Lol item {{items.1}}.png|24px]][[File:Lol item {{items.2}}.png|24px]][[File:Lol item {{items.3}}.png|24px]]</div>
-										<div class="match-bm-lol-players-player-loadout-item">[[File:Lol item {{items.4}}.png|24px]][[File:Lol item {{items.5}}.png|24px]][[File:Lol item {{items.6}}.png|24px]]</div>
-										<div class="match-bm-lol-players-player-loadout-item">[[File:{{backpackitems.1}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.2}} itemicon dota2 gameasset.png|24px]][[File:{{backpackitems.3}} itemicon dota2 gameasset.png|24px]]</div>
-									</div>
-									<div class="match-bm-lol-players-player-loadout-rs-wrap">
-										<!-- Runes/Spells -->
-										<div class="match-bm-lol-players-player-loadout-rs">[[File:{{neutralitem}} itemicon dota2 gameasset.png|24px]]</div>
-										<div class="match-bm-lol-players-player-loadout-rs">{{#shard}}[[File:Dota2_Aghanim's_Shard_symbol_allmode.png|24px]]{{/shard}}</div>
-										<div class="match-bm-lol-players-player-loadout-rs">{{#scepter}}[[File:Dota2_Aghanim's_Scepter_symbol_allmode.png|24px]]{{/scepter}}</div>
-									</div>
+								<div class="match-bm-players-player-loadout-rs-wrap">
+									<!-- Runes/Spells -->
+									<div class="match-bm-players-player-loadout-rs">[[File:{{neutralitem}} itemicon dota2 gameasset.png|24px]]</div>
+									<div class="match-bm-players-player-loadout-rs">{{#shard}}[[File:Dota2_Aghanim's_Shard_symbol_allmode.png|24px]]{{/shard}}</div>
+									<div class="match-bm-players-player-loadout-rs">{{#scepter}}[[File:Dota2_Aghanim's_Scepter_symbol_allmode.png|24px]]{{/scepter}}</div>
 								</div>
 							</div>
-							<div class="match-bm-lol-players-player-stats">
+							<div class="match-bm-players-player-stats">
 								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon kda.png|link=|KDA]]KDA {{kills}}/{{deaths}}/{{assists}}</div>
 								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon dmg.png|link=|Damage]]DMG {{displayDamageDone}}</div>
 								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Last Hits / Denies]]LH/DN {{lasthits}} / {{denies}}</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -123,7 +123,7 @@ return {
 					{{#teams.1.players}}
 						<div class="match-bm-players-player">
 							<div class="match-bm-players-player-character">
-								<div class="match-bm-lol-players-player-avatar"><div class="match-bm-lol-players-player-icon">{{&heroIcon}}</div><div class="match-bm-lol-players-player-role">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
+								<div class="match-bm-players-player-avatar"><div class="match-bm-players-player-icon">{{&heroIcon}}</div><div class="match-bm-players-player-role role--{{teams.1.side}}">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
 								<div class="match-bm-lol-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
 							</div>
 							<div class="match-bm-players-player-loadout">
@@ -142,11 +142,11 @@ return {
 								</div>
 							</div>
 							<div class="match-bm-players-player-stats">
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon kda.png|link=|KDA]]KDA {{kills}}/{{deaths}}/{{assists}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon dmg.png|link=|Damage]]DMG {{displayDamageDone}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Last Hits / Denies]]LH/DN {{lasthits}} / {{denies}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Net Worth]]NET {{displayGold}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Gold per Minute]]GPM {{gpm}}</div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-skull-crossbones"></i>KDA</div><div class="match-bm-players-player-stat-data">{{kills}}<span class="slash">/</span>{{deaths}}<span class="slash">/</span>{{assists}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-sword"></i>DMG</div><div class="match-bm-players-player-stat-data">{{displayDamageDone}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-swords"></i>LH/DN</div><div class="match-bm-players-player-stat-data">{{lasthits}}<span class="slash">/</span>{{denies}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-coin"></i>NET</div><div class="match-bm-players-player-stat-data">{{displayGold}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-coins"></i>GPM</div><div class="match-bm-players-player-stat-data">{{gpm}}</div></div>
 							</div>
 						</div>
 					{{/teams.1.players}}
@@ -155,7 +155,7 @@ return {
 					{{#teams.2.players}}
 						<div class="match-bm-players-player">
 							<div class="match-bm-players-player-character">
-								<div class="match-bm-lol-players-player-avatar"><div class="match-bm-lol-players-player-icon">{{&heroIcon}}</div><div class="match-bm-lol-players-player-role">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
+								<div class="match-bm-players-player-avatar"><div class="match-bm-players-player-icon">{{&heroIcon}}</div><div class="match-bm-players-player-role role--{{teams.2.side}}">[[File:Dota2 facet {{facet}}.png|link=|{{facet}}]]</div></div>
 								<div class="match-bm-lol-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
 							</div>
 							<div class="match-bm-players-player-loadout">
@@ -174,11 +174,11 @@ return {
 								</div>
 							</div>
 							<div class="match-bm-players-player-stats">
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon kda.png|link=|KDA]]KDA {{kills}}/{{deaths}}/{{assists}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon dmg.png|link=|Damage]]DMG {{displayDamageDone}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Last Hits / Denies]]LH/DN {{lasthits}} / {{denies}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Net Worth]]NET {{displayGold}}</div>
-								<div class="match-bm-lol-players-player-stat">[[File:Lol stat icon cs.png|link=|Gold per Minute]]GPM {{gpm}}</div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-skull-crossbones"></i>KDA</div><div class="match-bm-players-player-stat-data">{{kills}}<span class="slash">/</span>{{deaths}}<span class="slash">/</span>{{assists}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-sword"></i>DMG</div><div class="match-bm-players-player-stat-data">{{displayDamageDone}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-swords"></i>LH/DN</div><div class="match-bm-players-player-stat-data">{{lasthits}}<span class="slash">/</span>{{denies}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-coin"></i>NET</div><div class="match-bm-players-player-stat-data">{{displayGold}}</div></div>
+								<div class="match-bm-players-player-stat"><div class="match-bm-players-player-stat-title"><i class="fas fa-coins"></i>GPM</div><div class="match-bm-players-player-stat-data">{{gpm}}</div></div>
 							</div>
 						</div>
 					{{/teams.2.players}}

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -526,6 +526,21 @@ ul.match-bm-lol-game-veto-overview-pick {
 	background: #b81414;
 }
 
+.match-bm-players-wrapper {
+	display: grid;
+	grid-template-columns: auto auto;
+	grid-gap: 1rem;
+	align-items: flex-start;
+
+	@media ( min-width: 414px ) {
+		font-size: 15px;
+	}
+
+	@media ( max-width: 413px ) {
+		font-size: 12px;
+	}
+}
+
 /* >= 834 2 column player layout */
 @media ( max-width: 833px ) {
 	.match-bm-lol-players-wrapper {
@@ -577,6 +592,82 @@ ul.match-bm-lol-game-veto-overview-pick {
 	.theme--dark & {
 		background-color: var( --clr-secondary-16 );
 		border-color: var( --clr-secondary-25 );
+	}
+}
+
+.match-bm-players-player {
+	display: grid;
+	grid-template-columns: 150px auto 152px;
+	grid-gap: 1rem;
+	padding: 1rem;
+	align-items: flex-start;
+	background: #ffffff;
+	border: 1px solid #bbbbbb;
+
+	.theme--dark & {
+		background-color: var( --clr-secondary-7 );
+		border-color: var( --clr-secondary-25 );
+	}
+
+	&-character {
+		display: flex;
+		order: 1;
+		align-items: center;
+		position: relative;
+	}
+
+	&-loadout {
+		order: 3;
+		display: flex;
+		gap: 1rem;
+
+		&-item {
+			display: flex;
+			flex-direction: row;
+			align-items: flex-start;
+			gap: 0.25rem;
+
+			img {
+				width: 2rem;
+				height: 2rem;
+				border-radius: 0.25rem;
+			}
+		}
+
+		&-items {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.25rem;
+		}
+
+		&-rs {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 2px;
+
+			img {
+				width: 2rem;
+				height: 2rem;
+				border-radius: 100%;
+			}
+		}
+
+		&-rs-wrap {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.25rem;
+		}
+	}
+
+	&-stats {
+		order: 2;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		align-items: center;
 	}
 }
 

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -540,10 +540,6 @@ ul.match-bm-lol-game-veto-overview-pick {
 		font-size: 12px;
 	}
 
-	@media ( max-width: 767px ) {
-		grid-template-columns: auto auto;
-	}
-
 	@media ( min-width: 768px ) {
 		grid-template-columns: auto auto;
 	}
@@ -580,6 +576,12 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 }
 
+.match-bm-players-team {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+}
+
 .match-bm-lol-players-team {
 	display: flex;
 	flex-direction: column;
@@ -606,20 +608,19 @@ ul.match-bm-lol-game-veto-overview-pick {
 .match-bm-players-player {
 	display: flex;
 	padding: 1rem;
-	align-items: flex-start;
+	align-items: stretch;
 	background: #ffffff;
 	border: 0.0625rem solid #bbbbbb;
 
-	@media ( max-width: 767px ) {
+	@media ( max-width: 1199px ), ( min-width: 1320px ) {
 		flex-wrap: wrap;
 		justify-content: space-between;
 	}
 
-	@media ( min-width: 768px ) {
+	@media ( min-width: 1200px ) and ( max-width: 1319px ) {
 		display: grid;
 		grid-template-columns: 9.375rem auto 9.5rem;
 		grid-gap: 1rem;
-		width: 100%;
 	}
 
 	.theme--dark & {
@@ -650,38 +651,48 @@ ul.match-bm-lol-game-veto-overview-pick {
 		align-items: center;
 		position: relative;
 
-		@media ( max-width: 767px ) {
+		@media ( max-width: 1199px ), ( min-width: 1320px ) {
 			flex: 1 0 auto;
 		}
 
-		@media ( min-width: 768px ) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ) {
 			order: 1;
 		}
 	}
 
 	&-avatar {
-		width: 4rem;
-		height: 4rem;
+		width: 3rem;
+		height: 3rem;
 		margin-right: 0.5rem;
 		position: relative;
+
+		@media ( min-width: 768px ) {
+			width: 4rem;
+			height: 4rem;
+		}
 	}
 
 	&-icon img {
-		width: 4rem;
-		height: 4rem;
+		width: 3rem;
+		height: 3rem;
 		border-radius: 100%;
+
+		@media ( min-width: 768px ) {
+			width: 4rem;
+			height: 4rem;
+		}
 	}
 
 	&-loadout {
 		display: flex;
 		gap: 1rem;
 
-		@media ( max-width: 767px ) {
+		@media ( max-width: 1199px ), ( min-width: 1320px ) {
 			flex: 0 0 7.5rem;
 		}
 
 
-		@media ( min-width: 768px ) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ) {
 			order: 3;
 		}
 
@@ -756,7 +767,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 			font-weight: bold;
 			font-size: 1rem;
 
-			@media ( min-width: 768px ) {
+			@media ( min-width: 1024px ) {
 				font-size: 1.125rem;
 			}
 
@@ -773,13 +784,12 @@ ul.match-bm-lol-game-veto-overview-pick {
 		grid-template-columns: 1fr 1fr 1fr;
 		grid-template-rows: 1fr 1fr;
 
-		@media ( max-width: 767px ) {
-			flex: 1;
+		@media ( max-width: 1199px ), ( min-width: 1320px ) {
+			flex: 1 0 100%;
 			margin-top: 1rem;
 		}
 
-
-		@media ( min-width: 768px ) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ) {
 			order: 2;
 		}
 	}

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -528,7 +528,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 
 .match-bm-players-wrapper {
 	display: grid;
-	grid-template-columns: auto auto;
+	grid-template-columns: auto;
 	grid-gap: 1rem;
 	align-items: flex-start;
 
@@ -538,6 +538,14 @@ ul.match-bm-lol-game-veto-overview-pick {
 
 	@media ( max-width: 413px ) {
 		font-size: 12px;
+	}
+
+	@media ( max-width: 767px ) {
+		grid-template-columns: auto auto;
+	}
+
+	@media ( min-width: 768px ) {
+		grid-template-columns: auto auto;
 	}
 }
 
@@ -596,30 +604,86 @@ ul.match-bm-lol-game-veto-overview-pick {
 }
 
 .match-bm-players-player {
-	display: grid;
-	grid-template-columns: 150px auto 152px;
-	grid-gap: 1rem;
+	display: flex;
 	padding: 1rem;
 	align-items: flex-start;
 	background: #ffffff;
-	border: 1px solid #bbbbbb;
+	border: 0.0625rem solid #bbbbbb;
+
+	@media ( max-width: 767px ) {
+		flex-wrap: wrap;
+		justify-content: space-between;
+	}
+
+	@media ( min-width: 768px ) {
+		display: grid;
+		grid-template-columns: 9.375rem auto 9.5rem;
+		grid-gap: 1rem;
+		width: 100%;
+	}
 
 	.theme--dark & {
 		background-color: var( --clr-secondary-7 );
 		border-color: var( --clr-secondary-25 );
 	}
 
+	&-role {
+		width: 1.25rem;
+		height: 1.25rem;
+		position: absolute;
+		inset: auto 0 0 auto;
+		border-radius: 0.25rem;
+		background-color: var( --on-background );
+		overflow: hidden;
+
+		&.role--radiant {
+			background-color: var( --clr-atlantis-40 );
+		}
+
+		&.role--dire {
+			background-color: var( --clr-california-40 );
+		}
+	}
+
 	&-character {
 		display: flex;
-		order: 1;
 		align-items: center;
+		position: relative;
+
+		@media ( max-width: 767px ) {
+			flex: 1 0 auto;
+		}
+
+		@media ( min-width: 768px ) {
+			order: 1;
+		}
+	}
+
+	&-avatar {
+		width: 4rem;
+		height: 4rem;
+		margin-right: 0.5rem;
 		position: relative;
 	}
 
+	&-icon img {
+		width: 4rem;
+		height: 4rem;
+		border-radius: 100%;
+	}
+
 	&-loadout {
-		order: 3;
 		display: flex;
 		gap: 1rem;
+
+		@media ( max-width: 767px ) {
+			flex: 0 0 7.5rem;
+		}
+
+
+		@media ( min-width: 768px ) {
+			order: 3;
+		}
 
 		&-item {
 			display: flex;
@@ -628,9 +692,14 @@ ul.match-bm-lol-game-veto-overview-pick {
 			gap: 0.25rem;
 
 			img {
-				width: 2rem;
-				height: 2rem;
+				width: 1.5rem;
+				height: 1.5rem;
 				border-radius: 0.25rem;
+
+				@media ( min-width: 768px ) {
+					width: 2rem;
+					height: 2rem;
+				}
 			}
 		}
 
@@ -645,12 +714,17 @@ ul.match-bm-lol-game-veto-overview-pick {
 			display: flex;
 			flex-direction: column;
 			align-items: flex-start;
-			gap: 2px;
+			gap: 0.125rem;
 
 			img {
-				width: 2rem;
-				height: 2rem;
+				width: 1.5rem;
+				height: 1.5rem;
 				border-radius: 100%;
+
+				@media ( min-width: 768px ) {
+					width: 2rem;
+					height: 2rem;
+				}
 			}
 		}
 
@@ -662,12 +736,52 @@ ul.match-bm-lol-game-veto-overview-pick {
 		}
 	}
 
-	&-stats {
-		order: 2;
+	&-stat {
 		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
+		flex-direction: column;
 		align-items: center;
+		gap: 0.25rem;
+
+		&-title {
+			display: flex;
+			align-items: center;
+			font-size: 0.875rem;
+
+			i {
+				margin-right: 0.5rem;
+			}
+		}
+
+		&-data {
+			font-weight: bold;
+			font-size: 1rem;
+
+			@media ( min-width: 768px ) {
+				font-size: 1.125rem;
+			}
+
+			.slash {
+				margin: 0 0.125rem;
+				opacity: 0.4;
+			}
+		}
+	}
+
+	&-stats {
+		display: grid;
+		grid-gap: 0.5rem;
+		grid-template-columns: 1fr 1fr 1fr;
+		grid-template-rows: 1fr 1fr;
+
+		@media ( max-width: 767px ) {
+			flex: 1;
+			margin-top: 1rem;
+		}
+
+
+		@media ( min-width: 768px ) {
+			order: 2;
+		}
 	}
 }
 

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -617,7 +617,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 		justify-content: space-between;
 	}
 
-	@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
+	@media ( min-width: 1200px ) and ( max-width: 1319px ), ( min-width: 1510px ) {
 		display: grid;
 		grid-template-columns: 9.375rem auto 9.5rem;
 		grid-gap: 1rem;
@@ -655,7 +655,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 			flex: 1 0 auto;
 		}
 
-		@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ), ( min-width: 1510px ) {
 			order: 1;
 		}
 	}
@@ -691,8 +691,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 			flex: 0 0 7.5rem;
 		}
 
-
-		@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ), ( min-width: 1510px ) {
 			order: 3;
 		}
 
@@ -789,7 +788,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 			margin-top: 1rem;
 		}
 
-		@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ), ( min-width: 1510px ) {
 			order: 2;
 			margin-top: unset;
 		}

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -617,7 +617,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 		justify-content: space-between;
 	}
 
-	@media ( min-width: 1200px ) and ( max-width: 1319px ) {
+	@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
 		display: grid;
 		grid-template-columns: 9.375rem auto 9.5rem;
 		grid-gap: 1rem;
@@ -655,7 +655,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 			flex: 1 0 auto;
 		}
 
-		@media ( min-width: 1200px ) and ( max-width: 1319px ) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
 			order: 1;
 		}
 	}
@@ -692,7 +692,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 		}
 
 
-		@media ( min-width: 1200px ) and ( max-width: 1319px ) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
 			order: 3;
 		}
 
@@ -789,8 +789,9 @@ ul.match-bm-lol-game-veto-overview-pick {
 			margin-top: 1rem;
 		}
 
-		@media ( min-width: 1200px ) and ( max-width: 1319px ) {
+		@media ( min-width: 1200px ) and ( max-width: 1319px ), (min-width: 1510px) {
 			order: 2;
+			margin-top: unset;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR is for updating the player stats section for various screen resolutions:

![image](https://github.com/user-attachments/assets/6dda3f8c-2523-47b9-966e-bde9a2dd0d97)
![image](https://github.com/user-attachments/assets/e7228d69-fb30-4d51-809b-47267ed67bf3)
![image](https://github.com/user-attachments/assets/c1753b70-c46b-478d-bf5e-2df2c0398233)


## How did you test this change?

On the live wiki: https://liquipedia.net/dota2/Liquipedia:ID_XLA7bhOs3l_R01-M001
