### PR TITLE
fix(match2): on AoV bans are not shown unless previous game(s) have a bans

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -162,7 +162,7 @@ function CustomMatchSummary.createBody(match)
 	if not Table.isEmpty(championBanData) then
 		local championBan = ChampionBan()
 
-		for gameIndex, banData in ipairs(championBanData) do
+		for gameIndex, banData in pairs(championBanData) do
 			championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
 		end
 

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -163,7 +163,9 @@ function CustomMatchSummary.createBody(match)
 		local championBan = ChampionBan()
 
 		for gameIndex, banData in ipairs(championBanData) do
-			championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
+			if banData.numberOfBans ~= 0 then
+				championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
+			end
 		end
 
 		body:addRow(championBan)

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -153,17 +153,19 @@ function CustomMatchSummary.createBody(match)
 		if numberOfBans > 0 then
 			banData[1].color = extradata.team1side
 			banData[2].color = extradata.team2side
+			banData.numberOfBans = numberOfBans
+			table.insert(championBanData, banData)
+		else
+			table.insert(championBanData, {})
 		end
-		banData.numberOfBans = numberOfBans
-		championBanData[gameIndex] = banData
 	end
 
 	-- Add the Champion Bans
-	if not Table.isEmpty(championBanData) then
+	if Array.any(championBanData, Table.isNotEmpty) then
 		local championBan = ChampionBan()
 
 		for gameIndex, banData in ipairs(championBanData) do
-			if banData.numberOfBans ~= 0 then
+			if Table.isNotEmpty(banData) then
 				championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
 			end
 		end

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -153,16 +153,16 @@ function CustomMatchSummary.createBody(match)
 		if numberOfBans > 0 then
 			banData[1].color = extradata.team1side
 			banData[2].color = extradata.team2side
-			banData.numberOfBans = numberOfBans
-			championBanData[gameIndex] = banData
 		end
+		banData.numberOfBans = numberOfBans
+		championBanData[gameIndex] = banData
 	end
 
 	-- Add the Champion Bans
 	if not Table.isEmpty(championBanData) then
 		local championBan = ChampionBan()
 
-		for gameIndex, banData in pairs(championBanData) do
+		for gameIndex, banData in ipairs(championBanData) do
 			championBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
 		end
 

--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -135,7 +135,7 @@ function CustomMatchSummary.createBody(match)
 
 	-- Pre-Process Champion Ban Data
 	local championBanData = {}
-	for gameIndex, game in ipairs(match.games) do
+	for _, game in ipairs(match.games) do
 		local extradata = game.extradata or {}
 		local banData = {{}, {}}
 		local numberOfBans = 0


### PR DESCRIPTION
## Summary
As reported on discord: https://discord.com/channels/93055209017729024/268719633366777856/1271440466214129746
When a game has no ban information entered, subsequent games would not have their bans shown.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev on https://liquipedia.net/arenaofvalor/User:Lolliftw/Sandbox/3
before:
![image](https://github.com/user-attachments/assets/cd0acc54-a94d-4fa3-8b5a-d46b2f43403a)

after:
![image](https://github.com/user-attachments/assets/5c1cbda9-dac9-48c8-bcc0-bd188f8aa934)



<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
