### PR TITLE
feat(infobox): create storage for extra roles on hearthstone

### DIFF
--- a/components/infobox/wikis/hearthstone/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/hearthstone/infobox_person_player_custom.lua
@@ -38,7 +38,6 @@ function CustomPlayer.run(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
 	player.role = ROLES[(player.args.role or ''):lower()]
-	player.role2 = ROLES[(player.args.role2 or ''):lower()]
 
 	return player:createInfobox()
 end
@@ -58,7 +57,6 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{name = 'Role', content = {
 				caller:_displayRole(caller.role),
-				caller:_displayRole(caller.role2),
 			}},
 		}
 	end
@@ -78,8 +76,7 @@ end
 ---@return string[]
 function CustomPlayer:getWikiCategories(categories)
 	return Array.append(categories,
-		(self.role or {}).category,
-		(self.role2 or {}).category
+		(self.role or {}).category
 	)
 end
 


### PR DESCRIPTION
## Summary

Adds role storage for hearthstone. Lots of conversions have been done on tournament pages to move over to Broadcaster cards and subsequently, pages have been made for Casters.

## How did you test this change?

testing live https://liquipedia.net/hearthstone/Dragonrider
