### PR TITLE
feat(links): Add Untapped for stormgate and remove sgworld

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -169,7 +169,6 @@ local PREFIXES = {
 		team = 'https://siege.gg/teams/',
 		player = 'https://siege.gg/players/',
 	},
-	sgworld = {'https://stormgateworld.com/players/'},
 	sk = {'https://sk-gaming.com/member/'},
 	smashboards = {'https://smashboards.com/'},
 	snapchat = {'https://www.snapchat.com/add/'},

--- a/standard/links/wikis/stormgate/links_custom_data.lua
+++ b/standard/links/wikis/stormgate/links_custom_data.lua
@@ -1,0 +1,22 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Links/CustomData
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	prefixes = {
+		untapped = {
+			'',
+			player = 'https://stormgate.untapped.gg/en/players/',
+		},
+	},
+	suffixes = {
+		untapped = {
+			'',
+			player = '/a', --completely generic, it just needs `/` and any letter behind it ...
+		},
+	},
+}

--- a/stylesheets/commons/Icons.less
+++ b/stylesheets/commons/Icons.less
@@ -72,9 +72,9 @@ Note: When adding a new icon, please add to
 	.icon-make-image( discord, "//liquipedia.net/commons/images/c/c6/InfoboxIcon_Discord.png" );
 	.icon-make-image( dlive, "//liquipedia.net/commons/images/4/43/InfoboxIcon_DLive.png" );
 	.icon-make-image( dotabuff, "//liquipedia.net/commons/images/9/90/InfoboxIcon_Dotabuff.png" );
+	.icon-make-image( douyin, "//liquipedia.net/commons/images/4/47/InfoboxIcon_TikTok.png" ); // Intended to be TikTok
 	.icon-make-image( douyu, "//liquipedia.net/commons/images/b/bc/InfoboxIcon_DouyuTV.png" );
 	.icon-make-image( douyutv, "//liquipedia.net/commons/images/b/bc/InfoboxIcon_DouyuTV.png" );
-	.icon-make-image( douyin, "//liquipedia.net/commons/images/4/47/InfoboxIcon_TikTok.png" ); // Intended to be TikTok
 	.icon-make-image( email, "//liquipedia.net/commons/images/2/2f/InfoboxIcon_Email.png" );
 	.icon-make-image( escharts, "//liquipedia.net/commons/images/9/99/InfoboxIcon_EsportsCharts.png" );
 	.icon-make-image( esea, "//liquipedia.net/commons/images/9/99/InfoboxIcon_ESEA.png" );
@@ -90,8 +90,8 @@ Note: When adding a new icon, please add to
 	.icon-make-image( flickr, "//liquipedia.net/commons/images/d/d2/InfoboxIcon_Flickr.png" );
 	.icon-make-image( gamersclub, "//liquipedia.net/commons/images/a/a5/InfoboxIcon_Gamers_Club.png" );
 	.icon-make-image( garena, "//liquipedia.net/commons/images/6/6b/InfoboxIcon_Garena.png" );
-	.icon-make-image( github, "//liquipedia.net/commons/images/f/fc/InfoboxIcon_GitHub.png" );
 	.icon-make-image( geoguessr, "//liquipedia.net/commons/images/a/a7/InfoboxIcon_GeoGuessr.png" );
+	.icon-make-image( github, "//liquipedia.net/commons/images/f/fc/InfoboxIcon_GitHub.png" );
 	.icon-make-image( google-plus, "//liquipedia.net/commons/images/4/40/InfoboxIcon_Google%2B.png" );
 	.icon-make-image( gosugamers, "//liquipedia.net/commons/images/f/f0/InfoboxIcon_GosuGamers.png" );
 	.icon-make-image( halodatahive, "//liquipedia.net/commons/images/e/e9/InfoboxIcon_HaloDataHive.png" );
@@ -104,11 +104,11 @@ Note: When adding a new icon, please add to
 	.icon-make-image( huyatv, "//liquipedia.net/commons/images/0/05/InfoboxIcon_HuyaTV.png" );
 	.icon-make-image( iccup, "//liquipedia.net/commons/images/2/2c/InfoboxIcon_ICCUP.png" );
 	.icon-make-image( instagram, "//liquipedia.net/commons/images/7/7d/InfoboxIcon_Instagram.png" );
-	.icon-make-image( king-kong, "//liquipedia.net/commons/images/4/43/InfoboxIcon_King_Kong.png" );
 	.icon-make-image( kick, "//liquipedia.net/commons/images/5/57/InfoboxIcon_Kick.png" );
+	.icon-make-image( king-kong, "//liquipedia.net/commons/images/4/43/InfoboxIcon_King_Kong.png" );
 	.icon-make-image( kuaishou, "//liquipedia.net/commons/images/f/f9/InfoboxIcon_Kuaishou.png" );
-	.icon-make-image( letsplaylive-old, "//liquipedia.net/commons/images/2/2c/InfoboxIcon_LetsPlay.Live.png" );
 	.icon-make-image( letsplaylive, "//liquipedia.net/commons/images/f/fa/InfoboxIcon_letsplay.live.png" );
+	.icon-make-image( letsplaylive-old, "//liquipedia.net/commons/images/2/2c/InfoboxIcon_LetsPlay.Live.png" );
 	.icon-make-image( linkedin, "//liquipedia.net/commons/images/9/97/InfoboxIcon_LinkedIn.png" );
 	.icon-make-image( liquipedia, "//liquipedia.net/commons/images/d/de/InfoboxIcon_Liquipedia.png" );
 	.icon-make-image( loco, "//liquipedia.net/commons/images/0/06/InfoboxIcon_Loco.png" );
@@ -142,11 +142,11 @@ Note: When adding a new icon, please add to
 	.icon-make-image( smashboards, "//liquipedia.net/commons/images/a/aa/InfoboxIcon_SmashBoards.png" );
 	.icon-make-image( smashcast, "//liquipedia.net/commons/images/d/db/InfoboxIcon_Smashcast.png" );
 	.icon-make-image( smash-gg, "//liquipedia.net/commons/images/3/3c/InfoboxIcon_SmashGG.png" );
-	.icon-make-image( start-gg, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_StartGG.png" );
 	.icon-make-image( snapchat, "//liquipedia.net/commons/images/f/fc/InfoboxIcon_Snapchat.png" );
 	.icon-make-image( soop, "//liquipedia.net/commons/images/c/ce/InfoboxIcon_SOOP.png" );
 	.icon-make-image( sostronk, "//liquipedia.net/commons/images/4/4e/InfoboxIcon_SoStronk.png" );
 	.icon-make-image( spotify, "//liquipedia.net/commons/images/1/14/InfoboxIcon_Spotify.png" );
+	.icon-make-image( start-gg, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_StartGG.png" );
 	.icon-make-image( steam, "//liquipedia.net/commons/images/d/d0/InfoboxIcon_Steam.png" );
 	.icon-make-image( stratz, "//liquipedia.net/commons/images/3/3e/InfoboxIcon_Stratz.png" );
 	.icon-make-image( stream, "//liquipedia.net/commons/images/c/c2/InfoboxIcon_Stream.png" );
@@ -159,9 +159,9 @@ Note: When adding a new icon, please add to
 	.icon-make-image( tiktok, "//liquipedia.net/commons/images/4/47/InfoboxIcon_TikTok.png" );
 	.icon-make-image( tlpd, "//liquipedia.net/commons/images/0/07/InfoboxIcon_TLPDInt.png" );
 	.icon-make-image( tlpd-hots, "//liquipedia.net/commons/images/e/e3/InfoboxIcon_TLPDHoTS.png" );
+	.icon-make-image( tlpd-sospa, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_TLPDSonic.png" );
 	.icon-make-image( tlpd-wol, "//liquipedia.net/commons/images/0/07/InfoboxIcon_TLPDInt.png" );
 	.icon-make-image( tlpd-wol-korea, "//liquipedia.net/commons/images/7/78/InfoboxIcon_TLPDKor.png" );
-	.icon-make-image( tlpd-sospa, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_TLPDSonic.png" );
 	.icon-make-image( tlprofile, "//liquipedia.net/commons/images/f/f3/InfoboxIcon_TLProfile.png" );
 	.icon-make-image( tlstream, "//liquipedia.net/commons/images/b/b3/InfoboxIcon_TLStream.png" );
 	.icon-make-image( tonamel, "//liquipedia.net/commons/images/e/e1/InfoboxIcon_Tonamel.png" );
@@ -174,10 +174,10 @@ Note: When adding a new icon, please add to
 	.icon-make-image( twitter, "//liquipedia.net/commons/images/1/19/InfoboxIcon_Twitter.png" );
 	.icon-make-image( untapped, "//https://liquipedia.net/commons/images/9/91/InfoboxIcon_UntappedGG.png" );
 	.icon-make-image( vidio, "//liquipedia.net/commons/images/6/62/InfoboxIcon_Vidio.png" );
-	.icon-make-image( vod, "//liquipedia.net/commons/images/5/56/InfoboxIcon_Vod.png" );
 	.icon-make-image( vk, "//liquipedia.net/commons/images/d/d7/InfoboxIcon_VK.png" );
 	.icon-make-image( vkontakte, "//liquipedia.net/commons/images/d/d7/InfoboxIcon_VK.png" );
 	.icon-make-image( vlr, "//liquipedia.net/commons/images/f/f7/InfoboxIcon_VLR.png" );
+	.icon-make-image( vod, "//liquipedia.net/commons/images/5/56/InfoboxIcon_Vod.png" );
 	.icon-make-image( weibo, "//liquipedia.net/commons/images/9/92/InfoboxIcon_Weibo.png" );
 	.icon-make-image( yandexefir, "//liquipedia.net/commons/images/6/6c/InfoboxIcon_Yandex_Efir.png" );
 	.icon-make-image( youku, "//liquipedia.net/commons/images/8/8e/InfoboxIcon_Youku.png" );

--- a/stylesheets/commons/Icons.less
+++ b/stylesheets/commons/Icons.less
@@ -172,6 +172,7 @@ Note: When adding a new icon, please add to
 	.icon-make-image( twitch, "//liquipedia.net/commons/images/6/61/InfoboxIcon_Twitch.png" );
 	.icon-make-image( twitch2, "//liquipedia.net/commons/images/6/61/InfoboxIcon_Twitch.png" );
 	.icon-make-image( twitter, "//liquipedia.net/commons/images/1/19/InfoboxIcon_Twitter.png" );
+	.icon-make-image( untapped, "//https://liquipedia.net/commons/images/9/91/InfoboxIcon_UntappedGG.png" );
 	.icon-make-image( vidio, "//liquipedia.net/commons/images/6/62/InfoboxIcon_Vidio.png" );
 	.icon-make-image( vod, "//liquipedia.net/commons/images/5/56/InfoboxIcon_Vod.png" );
 	.icon-make-image( vk, "//liquipedia.net/commons/images/d/d7/InfoboxIcon_VK.png" );

--- a/stylesheets/commons/Icons.less
+++ b/stylesheets/commons/Icons.less
@@ -137,7 +137,6 @@ Note: When adding a new icon, please add to
 	.icon-make-image( rules, "//liquipedia.net/commons/images/d/d0/InfoboxIcon_Rules.png" );
 	.icon-make-image( shift, "//liquipedia.net/commons/images/6/61/InfoboxIcon_Shift.png" );
 	.icon-make-image( siegegg, "//liquipedia.net/commons/images/e/e2/InfoboxIcon_SiegeGG.png" );
-	.icon-make-image( sgworld, "//liquipedia.net/commons/images/c/c7/InfoboxIcon_Stormgate_World.png" );
 	.icon-make-image( skgaming, "//liquipedia.net/commons/images/0/01/InfoboxIcon_SK.png" );
 	.icon-make-image( skype, "//liquipedia.net/commons/images/2/29/InfoboxIcon_Skype.png" );
 	.icon-make-image( smashboards, "//liquipedia.net/commons/images/a/aa/InfoboxIcon_SmashBoards.png" );


### PR DESCRIPTION
## Summary
- sgworld is basically dead, hence remove it
- add untapped support for stormgate
  - untapped technically has support for several games (from what i see we do not have them as wikis though), they have game specific subdomains, hence push it into the sg custom
- alphab sorting in `Icons.less`

## How did you test this change?
the newly added module live (can't use dev due to the module not existing yet), moved it to dev afterwards