### PR TITLE
feat(infobox): Update Unit, Building and Skill Infoboxes for Stormgate (Griffin patch)

### DIFF
--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_cost_display.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_cost_display.lua
@@ -32,13 +32,17 @@ local ICONS = {
 	animus = {
 		default = Abbreviation.make('Ani', 'Animus'),
 	},
+	power = {
+		default = Abbreviation.make('Pow', 'Power'),
+	},
 }
 local ORDER = {
 	'luminite',
 	'therium',
 	'supply',
-	'buildTime',
 	'animus',
+	'power',
+	'buildTime',
 }
 local CONCAT_VALUE = '&nbsp;'
 
@@ -49,16 +53,19 @@ local CONCAT_VALUE = '&nbsp;'
 ---@field buildTime string|number?
 ---@field supply string|number?
 ---@field animus string|number?
+---@field power string|number?
 ---@field luminiteForced boolean?
 ---@field theriumForced boolean?
 ---@field buildTimeForced boolean?
 ---@field supplyForced boolean?
 ---@field animusForced boolean?
+---@field powerForced boolean?
 ---@field luminiteTotal string|number?
 ---@field theriumTotal string|number?
 ---@field buildTimeTotal string|number?
 ---@field supplyTotal string|number?
 ---@field animusTotal string|number?
+---@field powerTotal string|number?
 
 ---@param args StormgateCostDisplayArgsValues
 ---@return string?

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -80,6 +80,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'cost' then
 		return {
 			Cell{name = 'Cost', content = {caller:_costDisplay()}},
+			Cell{name = 'Recharge Time', content = {args.charge_time and (args.charge_time .. 's') or nil}},
 		}
 	elseif id == 'duration' then
 		return {
@@ -189,8 +190,11 @@ function CustomSkill:addToLpdb(lpdbData, args)
 		totaltherium = tonumber(args.totaltherium),
 		buildtime = tonumber(args.buildtime),
 		totalbuildtime = tonumber(args.totalbuildtime),
+		rechargetime = tonumber(args.charge_time),
 		animus = tonumber(args.animus),
 		totalanimus = tonumber(args.totalanimus),
+		power = tonumber(args.power),
+		totalpower = tonumber(args.totalpower),
 		techrequirements = Array.parseCommaSeparatedString(args.tech_requirement),
 		buildingrequirements = Array.parseCommaSeparatedString(args.building_requirement),
 		targets = Array.parseCommaSeparatedString(args.target),
@@ -243,6 +247,8 @@ function CustomSkill:_costDisplay()
 			animusTotal = args.totalanimus,
 			buildTime = args.buildtime,
 			buildTimeTotal = args.totalbuildtime,
+			power = args.power,
+			powerTotal = args.totalpower,
 		},
 		energy ~= 0 and (ENERGY_ICON .. '&nbsp;' .. energy) or nil,
 		args.special_cost

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -63,16 +63,16 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'type' then
 		return {
-			Cell{name = 'Type', content = {caller:_displayCommaSeparatedString(args.type)}},
+			Cell{name = 'Type', content = {caller:_displayCsvAsPageCsv(args.type)}},
 		}
 	elseif id == 'builtfrom' then
 		return {
-			Cell{name = 'Built From', content = {caller:_displayCommaSeparatedString(args.built)}},
+			Cell{name = 'Built From', content = caller:_csvToPageList(args.built)},
 		}
 	elseif id == 'requirements' then
 		return {
-			Cell{name = 'Tech. Requirement', content = {caller:_displayCommaSeparatedString(args.tech_requirement)}},
-			Cell{name = 'Building Requirement', content = {caller:_displayCommaSeparatedString(args.building_requirement)}},
+			Cell{name = 'Tech. Requirement', content = {caller:_displayCsvAsPageCsv(args.tech_requirement)}},
+			Cell{name = 'Building Requirement', content = {caller:_displayCsvAsPageCsv(args.building_requirement)}},
 		}
 	elseif id == 'cost' then
 		return {
@@ -108,14 +108,14 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'defense' then
 		return {
 			Cell{name = 'Defense', content = {caller:_getDefenseDisplay()}},
-			Cell{name = 'Attributes', content = {caller:_displayCommaSeparatedString(args.armor_type)}}
+			Cell{name = 'Attributes', content = {caller:_displayCsvAsPageCsv(args.armor_type)}}
 		}
 	elseif id == 'custom' then
 		Array.appendWith(widgets,
 			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
 			Cell{name = 'Sight', content = {args.sight}},
 			Cell{name = 'Speed', content = {args.speed}},
-			Cell{name = 'Upgrades To', content = {caller:_displayCommaSeparatedString(args.upgrades_to)}},
+			Cell{name = 'Upgrades To', content = {caller:_displayCsvAsPageCsv(args.upgrades_to)}},
 			Cell{name = 'Introduced', content = {args.introducedDisplay}}
 		)
 		-- moved to the bottom due to having headers that would look ugly if in place where attack is set in commons
@@ -205,7 +205,7 @@ function CustomUnit:setLpdbData(args)
 			subfaction = Array.parseCommaSeparatedString(args.subfaction),
 			veterancybonushealth = Array.parseCommaSeparatedString(args.veterancybonushealth),
 			veterancybonusdamage = Array.parseCommaSeparatedString(args.veterancybonusdamage),
-			veterancybonusattackspeed = Array.parseCommaSeparatedString(args.veterancybonusattackspeed),
+			veterancyspecialbonus = Array.parseCommaSeparatedString(args.veterancyspecialbonus),
 			veterancyxp = Array.parseCommaSeparatedString(args.veterancyxp),
 			type = Array.parseCommaSeparatedString(args.type),
 			builtfrom = Array.parseCommaSeparatedString(args.built),
@@ -269,13 +269,17 @@ function CustomUnit._hotkeys(hotkey1, hotkey2)
 end
 
 ---@param inputString string?
+---@return string[]
+function CustomUnit:_csvToPageList(inputString)
+	return Array.map(Array.parseCommaSeparatedString(inputString), function(value)
+		return Page.makeInternalLink(value)
+	end)
+end
+
+---@param input string?
 ---@return string
-function CustomUnit:_displayCommaSeparatedString(inputString)
-	return table.concat(Array.map(Array.parseCommaSeparatedString(inputString),
-		function(value)
-			return Page.makeInternalLink(value)
-		end
-	), ', ')
+function CustomUnit:_displayCsvAsPageCsv(input)
+	return table.concat(self:_csvToPageList(input), ', ')
 end
 
 ---@param key string


### PR DESCRIPTION
## Summary

Changes due to Stormgate EA release (Griffin patch)

- Replace `|veterancybonusattackspeed=` with `|veterancyspecialbonus=` in `infobox_unit_custom`
- Add `|power=` to `infobox_building_custom` and `infobox_skill_custom`
- Add `|charge_time=` to `infobox_skill_custom`
- Add `|deprecated=` to `infobox_building_custom`

...and some follow-up changes in the appearance of the infoboxes. 

![grafik](https://github.com/user-attachments/assets/6d15998b-1969-43dd-a7c5-2537fc3abc4d)![grafik](https://github.com/user-attachments/assets/d8b86c85-db98-4c35-ac2d-604c56ef80ef)

![grafik](https://github.com/user-attachments/assets/da64a7b7-4db7-4557-b729-baea036cb03f)

![grafik](https://github.com/user-attachments/assets/622d3f82-5981-432a-954b-2ff424be1dce)

## How did you test this change?

dev tools

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
