### PR TITLE
fix(FilterButton): issues with default filters

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -215,6 +215,7 @@ liquipedia.filterButtons = {
 		this.updateFromFilterStates();
 		this.setLocalStorage();
 		this.updateDOM();
+		this.refreshScriptsAfterContentUpdate();
 	},
 
 	updateFromFilterStates: function() {
@@ -313,7 +314,6 @@ liquipedia.filterButtons = {
 
 			if ( wikitext in templateExpansion.cache ) {
 				templateExpansion.element.innerHTML = templateExpansion.cache[ wikitext ];
-				this.refreshScriptsAfterContentUpdate();
 				return;
 			}
 
@@ -333,7 +333,6 @@ liquipedia.filterButtons = {
 					if ( data.parse?.text?.[ '*' ] ) {
 						templateExpansion.element.innerHTML = data.parse.text[ '*' ];
 						templateExpansion.cache[ wikitext ] = data.parse.text[ '*' ];
-						this.refreshScriptsAfterContentUpdate();
 					}
 				} );
 			} );


### PR DESCRIPTION
## Summary

The `refreshScriptsAfterContentUpdate` method was called only in some scenarios while it should be triggered after every update (even on init). It caused issues on the [new main page](https://liquipedia.net/dota2/User:FO-nTTaX/Sandbox/23) when the filters were the default ones.

This moves the call of the `refreshScriptsAfterContentUpdate` method on performUpdate.

## How did you test this change?

Directly on the console.