### PR TITLE
fix(countdown): Remove countdown init call on all update

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -215,7 +215,6 @@ liquipedia.filterButtons = {
 		this.updateFromFilterStates();
 		this.setLocalStorage();
 		this.updateDOM();
-		this.refreshScriptsAfterContentUpdate();
 	},
 
 	updateFromFilterStates: function() {
@@ -298,6 +297,7 @@ liquipedia.filterButtons = {
 			} );
 			if ( isDefault ) {
 				templateExpansion.element.innerHTML = templateExpansion.cache.default;
+				this.refreshScriptsAfterContentUpdate();
 				return;
 			}
 			const parameters = templateExpansion.groups.map( ( group ) => {
@@ -314,6 +314,7 @@ liquipedia.filterButtons = {
 
 			if ( wikitext in templateExpansion.cache ) {
 				templateExpansion.element.innerHTML = templateExpansion.cache[ wikitext ];
+				this.refreshScriptsAfterContentUpdate();
 				return;
 			}
 
@@ -333,6 +334,7 @@ liquipedia.filterButtons = {
 					if ( data.parse?.text?.[ '*' ] ) {
 						templateExpansion.element.innerHTML = data.parse.text[ '*' ];
 						templateExpansion.cache[ wikitext ] = data.parse.text[ '*' ];
+						this.refreshScriptsAfterContentUpdate();
 					}
 				} );
 			} );


### PR DESCRIPTION
## Summary

Quick fix to avoid having broken countdown on pages with filter buttons. This only recalls the countdown when the content from the filter buttons is repopulated. It doesn't solve the core issue but it is a fix that works for divs that have their DOM updated, as tested on: 
- https://liquipedia.net/dota2/Main_Page
- https://liquipedia.net/dota2/User:FO-nTTaX/Sandbox/23

## How did you test this change?

By testing it on prod on:
- https://liquipedia.net/dota2/Main_Page
- https://liquipedia.net/dota2/User:FO-nTTaX/Sandbox/23
