### PR TITLE
fix(infobox): do not error when player has team1 but not team2

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -182,7 +182,7 @@ end
 ---@return string?
 function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
-		local teamPage = String.isNotEmpty(self.args.team) and Team.page(mw.getCurrentFrame(), self.args.team) or nil
+		local teamPage = Team.page(mw.getCurrentFrame(), self.args.team)
 		local team2Page = String.isNotEmpty(self.args.team2) and Team.page(mw.getCurrentFrame(), self.args.team2) or nil
 		return
 			tostring(MatchTicker.player{recentLimit = 3}) ..

--- a/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_person_player_custom.lua
@@ -182,8 +182,8 @@ end
 ---@return string?
 function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
-		local teamPage = Team.page(mw.getCurrentFrame(), self.args.team)
-		local team2Page = Team.page(mw.getCurrentFrame(), self.args.team2)
+		local teamPage = String.isNotEmpty(self.args.team) and Team.page(mw.getCurrentFrame(), self.args.team) or nil
+		local team2Page = String.isNotEmpty(self.args.team2) and Team.page(mw.getCurrentFrame(), self.args.team2) or nil
 		return
 			tostring(MatchTicker.player{recentLimit = 3}) ..
 			Template.safeExpand(


### PR DESCRIPTION
## Summary
Team.page would error if the team was nil, as reported on discord https://discord.com/channels/93055209017729024/268719633366777856/1272900297647456297

Issue introduced in #4484 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
