### PR TITLE
feat(match2): dota2 match page picks and bans

### DIFF
--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -64,18 +64,50 @@ return {
 				</div>
 			</div>{{/isBestOfOne}}
 			<h3>Picks and Bans</h3>
-			<div class="match-bm-lol-game-veto collapsed general-collapsible">
+			<div class="match-bm-game-veto-wrapper">
 				<div class="match-bm-lol-game-veto-overview">
-					<div class="match-bm-lol-game-veto-overview-team"><div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
-						<div class="match-bm-lol-game-veto-overview-team-veto">
-							<ul class="match-bm-lol-game-veto-overview-pick" aria-labelledby="picks">{{#teams.1.picks}}<li class="match-bm-lol-game-veto-overview-item">{{vetoNumber}}{{&heroIcon}}<div class="match-bm-lol-game-veto-pick-bar-{{teams.1.side}}"></div></li>{{/teams.1.picks}}</ul>
-							<ul class="match-bm-lol-game-veto-overview-ban" aria-labelledby="bans">{{#teams.1.bans}}<li class="match-bm-lol-game-veto-overview-item">{{vetoNumber}}{{&heroIcon}}</li>{{/teams.1.bans}}</ul>
+					<div class="match-bm-lol-game-veto-overview-team">
+						<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
+							<div class="match-bm-game-veto-overview-team-veto">
+								<div class="match-bm-game-veto-overview match-bm-game-veto-overview-pick--{{teams.1.side}}" aria-labelledby="picks">
+									{{#teams.1.picks}}
+									<div class="match-bm-game-veto-overview-item">
+										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
+										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
+									</div>
+									{{/teams.1.picks}}
+								</div>
+								<div class="match-bm-game-veto-overview  match-bm-game-veto-overview-ban" aria-labelledby="bans">
+									{{#teams.1.bans}}
+									<div class="match-bm-game-veto-overview-item">
+										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
+										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
+									</div>
+									{{/teams.1.bans}}
+								</div>
+							</div>
 						</div>
 					</div>
-					<div class="match-bm-lol-game-veto-overview-team"><div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
-						<div class="match-bm-lol-game-veto-overview-team-veto">
-							<ul class="match-bm-lol-game-veto-overview-pick" aria-labelledby="picks">{{#teams.2.picks}}<li class="match-bm-lol-game-veto-overview-item">{{vetoNumber}}{{&heroIcon}}<div class="match-bm-lol-game-veto-pick-bar-{{teams.2.side}}"></div></li>{{/teams.2.picks}}</ul>
-							<ul class="match-bm-lol-game-veto-overview-ban" aria-labelledby="bans">{{#teams.2.bans}}<li class="match-bm-lol-game-veto-overview-item">{{vetoNumber}}{{&heroIcon}}</li>{{/teams.2.bans}}</ul>
+					<div class="match-bm-lol-game-veto-overview-team">
+						<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
+							<div class="match-bm-game-veto-overview-team-veto">
+								<div class="match-bm-game-veto-overview match-bm-game-veto-overview-pick--{{teams.2.side}}" aria-labelledby="picks">
+									{{#teams.2.picks}}
+									<div class="match-bm-game-veto-overview-item">
+										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
+										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
+									</div>
+									{{/teams.2.picks}}
+								</div>
+								<div class="match-bm-game-veto-overview  match-bm-game-veto-overview-ban" aria-labelledby="bans">
+									{{#teams.2.bans}}
+									<div class="match-bm-game-veto-overview-item">
+										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
+										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
+									</div>
+									{{/teams.2.bans}}
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -66,7 +66,7 @@ return {
 			<h3>Draft</h3>
 			<div class="match-bm-game-veto-wrapper">
 				<div class="match-bm-lol-game-veto-overview-team">
-					<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
+					<div class="match-bm-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
 					<div class="match-bm-game-veto-overview-team-veto">
 						<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.1.side}}" aria-labelledby="picks">
 							{{#teams.1.picks}}
@@ -87,7 +87,7 @@ return {
 					</div>
 				</div>
 				<div class="match-bm-lol-game-veto-overview-team">
-					<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
+					<div class="match-bm-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
 					<div class="match-bm-game-veto-overview-team-veto">
 						<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.2.side}}" aria-labelledby="picks">
 							{{#teams.2.picks}}

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -69,21 +69,11 @@ return {
 					<div class="match-bm-lol-game-veto-overview-team">
 						<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
 							<div class="match-bm-game-veto-overview-team-veto">
-								<div class="match-bm-game-veto-overview match-bm-game-veto-overview-pick--{{teams.1.side}}" aria-labelledby="picks">
-									{{#teams.1.picks}}
-									<div class="match-bm-game-veto-overview-item">
-										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
-										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
-									</div>
-									{{/teams.1.picks}}
+								<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.1.side}}" aria-labelledby="picks">
+									{{#teams.1.picks}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.1.picks}}
 								</div>
-								<div class="match-bm-game-veto-overview  match-bm-game-veto-overview-ban" aria-labelledby="bans">
-									{{#teams.1.bans}}
-									<div class="match-bm-game-veto-overview-item">
-										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
-										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
-									</div>
-									{{/teams.1.bans}}
+								<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
+									{{#teams.1.bans}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.1.bans}}
 								</div>
 							</div>
 						</div>
@@ -91,21 +81,11 @@ return {
 					<div class="match-bm-lol-game-veto-overview-team">
 						<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
 							<div class="match-bm-game-veto-overview-team-veto">
-								<div class="match-bm-game-veto-overview match-bm-game-veto-overview-pick--{{teams.2.side}}" aria-labelledby="picks">
-									{{#teams.2.picks}}
-									<div class="match-bm-game-veto-overview-item">
-										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
-										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
-									</div>
-									{{/teams.2.picks}}
+								<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.2.side}}" aria-labelledby="picks">
+									{{#teams.2.picks}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.2.picks}}
 								</div>
-								<div class="match-bm-game-veto-overview  match-bm-game-veto-overview-ban" aria-labelledby="bans">
-									{{#teams.2.bans}}
-									<div class="match-bm-game-veto-overview-item">
-										<div class="match-bm-game-veto-overview-item-icon">{{&heroIcon}}</div>
-										<div class="match-bm-game-veto-overview-item-text">#{{vetoNumber}}</div>
-									</div>
-									{{/teams.2.bans}}
+								<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
+									{{#teams.2.bans}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.2.bans}}
 								</div>
 							</div>
 						</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -65,29 +65,45 @@ return {
 			</div>{{/isBestOfOne}}
 			<h3>Draft</h3>
 			<div class="match-bm-game-veto-wrapper">
-				<div class="match-bm-lol-game-veto-overview">
-					<div class="match-bm-lol-game-veto-overview-team">
-						<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
-							<div class="match-bm-game-veto-overview-team-veto">
-								<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.1.side}}" aria-labelledby="picks">
-									{{#teams.1.picks}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.1.picks}}
-								</div>
-								<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
-									{{#teams.1.bans}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.1.bans}}
-								</div>
+				<div class="match-bm-lol-game-veto-overview-team">
+					<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.1.iconDisplay}}</div>
+					<div class="match-bm-game-veto-overview-team-veto">
+						<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.1.side}}" aria-labelledby="picks">
+							{{#teams.1.picks}}
+							<div class="match-bm-game-veto-overview-team-veto-row-item">
+								<div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div>
+								<div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div>
 							</div>
+							{{/teams.1.picks}}
+						</div>
+						<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
+							{{#teams.1.bans}}
+							<div class="match-bm-game-veto-overview-team-veto-row-item">
+								<div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div>
+								<div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div>
+							</div>
+							{{/teams.1.bans}}
 						</div>
 					</div>
-					<div class="match-bm-lol-game-veto-overview-team">
-						<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
-							<div class="match-bm-game-veto-overview-team-veto">
-								<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.2.side}}" aria-labelledby="picks">
-									{{#teams.2.picks}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.2.picks}}
-								</div>
-								<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
-									{{#teams.2.bans}}<div class="match-bm-game-veto-overview-team-veto-row-item"><div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div><div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div></div>{{/teams.2.bans}}
-								</div>
+				</div>
+				<div class="match-bm-lol-game-veto-overview-team">
+					<div class="match-bm-lol-game-veto-overview-team-header">{{&opponents.2.iconDisplay}}</div>
+					<div class="match-bm-game-veto-overview-team-veto">
+						<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--{{teams.2.side}}" aria-labelledby="picks">
+							{{#teams.2.picks}}
+							<div class="match-bm-game-veto-overview-team-veto-row-item">
+								<div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div>
+								<div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div>
 							</div>
+							{{/teams.2.picks}}
+						</div>
+						<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
+							{{#teams.2.bans}}
+							<div class="match-bm-game-veto-overview-team-veto-row-item">
+								<div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div>
+								<div class="match-bm-game-veto-overview-team-veto-row-item-text">#{{vetoNumber}}</div>
+							</div>
+							{{/teams.2.bans}}
 						</div>
 					</div>
 				</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -63,7 +63,7 @@ return {
 					<div class="match-bm-lol-game-summary-team">{{&opponents.2.iconDisplay}}</div>
 				</div>
 			</div>{{/isBestOfOne}}
-			<h3>Picks and Bans</h3>
+			<h3>Draft</h3>
 			<div class="match-bm-game-veto-wrapper">
 				<div class="match-bm-lol-game-veto-overview">
 					<div class="match-bm-lol-game-veto-overview-team">

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -798,7 +798,11 @@ ul.match-bm-lol-game-veto-overview-pick {
 }
 
 .match-bm-game-veto-overview-team-header {
-	border-bottom: 0.0625rem solid var( --clr-secondary-25 );
+	border-bottom: 0.0625rem solid #bbbbbb;
+
+	.theme--dark & {
+		border-color: var( --clr-secondary-25 );
+	}
 }
 
 .match-bm-game-veto-overview-team-veto {

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -804,14 +804,14 @@ ul.match-bm-lol-game-veto-overview-pick {
 	align-items: center;
 	gap: 0.5rem;
 
-	.match-bm-game-veto-overview {
+	&-row {
 		display: flex;
 		gap: 0.125rem;
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
 
-		.match-bm-game-veto-overview-item {
+		&-item {
 			display: flex;
 			flex-direction: column;
 
@@ -826,7 +826,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 				}
 			}
 
-			.match-bm-game-veto-overview-item-text {
+			&-text {
 				display: flex;
 				justify-content: center;
 				align-items: center;
@@ -835,29 +835,23 @@ ul.match-bm-lol-game-veto-overview-pick {
 			}
 		}
 
-		&.match-bm-game-veto-overview-pick--radiant {
-			.match-bm-game-veto-overview-item {
-				.match-bm-game-veto-overview-item-text {
-					background-color: #7eac20;
-				}
+		&--radiant {
+			.match-bm-game-veto-overview-team-veto-row-item-text {
+				background-color: #7eac20;
 			}
 		}
 
-		&.match-bm-game-veto-overview-pick--dire {
-			.match-bm-game-veto-overview-item {
-				.match-bm-game-veto-overview-item-text {
-					background-color: #cc6500;
-				}
+		&--dire {
+			.match-bm-game-veto-overview-team-veto-row-item-text {
+				background-color: #cc6500;
 			}
 		}
 
-		&.match-bm-game-veto-overview-ban {
+		&--ban {
 			opacity: 0.5;
 
-			.match-bm-game-veto-overview-item {
-				.match-bm-game-veto-overview-item-text {
-					background-color: #121212;
-				}
+			.match-bm-game-veto-overview-team-veto-row-item-text {
+				background-color: #121212;
 			}
 		}
 	}

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -526,6 +526,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	background: #b81414;
 }
 
+.match-bm-game-veto-wrapper,
 .match-bm-players-wrapper {
 	display: grid;
 	grid-template-columns: auto;
@@ -791,6 +792,73 @@ ul.match-bm-lol-game-veto-overview-pick {
 		@media ( min-width: 1200px ) and ( max-width: 1319px ), ( min-width: 1510px ) {
 			order: 2;
 			margin-top: unset;
+		}
+	}
+}
+
+.match-bm-game-veto-overview-team-veto {
+	padding: 1rem 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 0.5rem;
+
+	.match-bm-game-veto-overview {
+		display: flex;
+		gap: 0.125rem;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+
+		.match-bm-game-veto-overview-item {
+			display: flex;
+			flex-direction: column;
+
+			img {
+				border-radius: 0.25rem 0.25rem 0 0;
+				width: 3.75rem;
+				height: 2.5rem;
+
+				@media ( min-width: 834px ) {
+					width: 4.5rem;
+					height: 3rem;
+				}
+			}
+
+			.match-bm-game-veto-overview-item-text {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				font-weight: bold;
+				border-radius: 0 0 0.25rem 0.25rem;
+			}
+		}
+
+		&.match-bm-game-veto-overview-pick--radiant {
+			.match-bm-game-veto-overview-item {
+				.match-bm-game-veto-overview-item-text {
+					background-color: #7eac20;
+				}
+			}
+		}
+
+		&.match-bm-game-veto-overview-pick--dire {
+			.match-bm-game-veto-overview-item {
+				.match-bm-game-veto-overview-item-text {
+					background-color: #cc6500;
+				}
+			}
+		}
+
+		&.match-bm-game-veto-overview-ban {
+			opacity: 0.5;
+
+			.match-bm-game-veto-overview-item {
+				.match-bm-game-veto-overview-item-text {
+					background-color: #121212;
+				}
+			}
 		}
 	}
 }

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -320,6 +320,7 @@ Author(s): Rathoz
 	}
 }
 
+.match-bm-game-veto-overview-team-header,
 .match-bm-lol-game-veto-overview-team-header {
 	display: flex;
 	flex-direction: row;
@@ -796,6 +797,10 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 }
 
+.match-bm-game-veto-overview-team-header {
+	border-bottom: 0.0625rem solid var( --clr-secondary-25 );
+}
+
 .match-bm-game-veto-overview-team-veto {
 	padding: 1rem 0;
 	display: flex;
@@ -803,6 +808,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	justify-content: center;
 	align-items: center;
 	gap: 0.5rem;
+	color: #ffffff;
 
 	&-row {
 		display: flex;


### PR DESCRIPTION
## Summary

This sets the picks and bans section for the Dota2 match page with the following result:

Desktop:
![image](https://github.com/user-attachments/assets/c5363eee-673f-4d89-b1af-4a30ae6dd803)

Mobile:
![image](https://github.com/user-attachments/assets/35855d14-5422-4030-a446-21f5983321cb)


## How did you test this change?

On [this page](https://liquipedia.net/dota2/Liquipedia:ID_XLA7bhOs3l_R01-M001)