### PR TITLE
fix(matchticker): matches starting same minute as render are not shown

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -293,7 +293,12 @@ function MatchTicker:dateConditions()
 
 		if config.upcoming then return dateConditions end
 
-		return dateConditions:add{ConditionNode(ColumnName('date'), Comparator.lt, NOW)}
+		return dateConditions:add{
+			ConditionTree(BooleanOperator.any):add{
+				ConditionNode(ColumnName('date'), Comparator.lt, NOW),
+				ConditionNode(ColumnName('date'), Comparator.eq, NOW),
+			}
+		}
 	end
 
 	--case upcoming


### PR DESCRIPTION
## Summary
When the page would be rendered in the exact minute a game starts, it would disappear from the matchticker as all conditions would be LT or GT NOW, but not EQ.

Noticed on valorant, where the bot conversion runs on :00 and therefore often triggered this: https://discord.com/channels/93055209017729024/372075546231832576/1273192019497451561
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
