### PR TITLE
feat(match2): dota2 match page team stats section

### DIFF
--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -83,7 +83,7 @@ return {
 			<h3>Team Stats</h3>
 			<div class="match-bm-team-stats">
 				<div class="match-bm-team-stats-header">
-					<h4 class="match-bm-team-stats-header-title">{{opponents.{{winner}}.name}} Victory</h4>
+					<h4 class="match-bm-team-stats-header-title">{{winnerName}} Victory</h4>
 				</div>
 				<div class="match-bm-team-stats-container">
 					<div class="match-bm-team-stats-team">
@@ -94,7 +94,7 @@ return {
 					<div class="match-bm-team-stats-list">
 						<div class="match-bm-team-stats-list-row">
 							<div class="match-bm-team-stats-list-cell">{{#finished}}{{teams.1.kills}}<span class="slash">/</span>{{teams.1.deaths}}<span class="slash">/</span>{{teams.1.assists}}{{/finished}}</div>
-							<div class="match-bm-team-stats-list-cell"><i class="fas fa-skull-crossbones cell--icon"></i>KDA</div>
+							<div class="match-bm-team-stats-list-cell cell--middle"><i class="fas fa-skull-crossbones cell--icon"></i>KDA</div>
 							<div class="match-bm-team-stats-list-cell">{{#finished}}{{teams.2.kills}}<span class="slash">/</span>{{teams.2.deaths}}<span class="slash">/</span>{{teams.2.assists}}{{/finished}}</div>
 						</div>
 						<div class="match-bm-team-stats-list-row">
@@ -114,7 +114,7 @@ return {
 						</div>
 						<div class="match-bm-team-stats-list-row">
 							<div class="match-bm-team-stats-list-cell">{{teams.1.objectives.roshans}}</div>
-							<div class="match-bm-team-stats-list-cell cell--middle"><i class="fas fa-skull-cow cell--icon"></i>Roshan</div>
+							<div class="match-bm-team-stats-list-cell cell--middle"><span class="liquipedia-custom-icon liquipedia-custom-icon-roshan"></span>Roshan</div>
 							<div class="match-bm-team-stats-list-cell">{{teams.2.objectives.roshans}}</div>
 						</div>
 					</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -125,42 +125,6 @@ return {
 					</div>
 				</div>
 			</div>
-			<div class="match-bm-lol-h2h">
-				<div class="match-bm-lol-h2h-header">
-					<div class="match-bm-lol-h2h-header-team">{{&opponents.1.iconDisplay}}</div>
-					<div class="match-bm-lol-h2h-stat-title"></div>
-					<div class="match-bm-lol-h2h-header-team">{{&opponents.2.iconDisplay}}</div>
-				</div>
-				<div class="match-bm-lol-h2h-section">
-					<div class="match-bm-lol-h2h-stat">
-						<div>{{#finished}}{{teams.1.kills}}/{{teams.1.deaths}}/{{teams.1.assists}}{{/finished}}</div>
-						<div class="match-bm-lol-h2h-stat-title">[[File:Lol stat icon kda.png|link=]]<br>KDA</div>
-						<div>{{#finished}}{{teams.2.kills}}/{{teams.2.deaths}}/{{teams.2.assists}}{{/finished}}</div>
-					</div>
-					<div class="match-bm-lol-h2h-stat">
-						<div>{{teams.1.gold}}</div>
-						<div class="match-bm-lol-h2h-stat-title">[[File:Lol stat icon gold.png|link=]]<br>Gold</div>
-						<div>{{teams.2.gold}}</div>
-					</div>
-				</div>
-				<div class="match-bm-lol-h2h-section">
-				<div class="match-bm-lol-h2h-stat">
-						<div>{{teams.1.objectives.towers}}</div>
-						<div class="match-bm-lol-h2h-stat-title">[[File:Lol stat icon tower.png|link=]]<br>Towers</div>
-						<div>{{teams.2.objectives.towers}}</div>
-					</div>
-					<div class="match-bm-lol-h2h-stat">
-						<div>{{teams.1.objectives.barracks}}</div>
-						<div class="match-bm-lol-h2h-stat-title">[[File:Lol stat icon inhibitor.png|link=]]<br>Barracks</div>
-						<div>{{teams.2.objectives.barracks}}</div>
-					</div>
-					<div class="match-bm-lol-h2h-stat">
-						<div>{{teams.1.objectives.roshans}}</div>
-						<div class="match-bm-lol-h2h-stat-title">[[File:Lol stat icon baron.png|link=]]<br>Roshan</div>
-						<div>{{teams.2.objectives.roshans}}</div>
-					</div>
-				</div>
-			</div>
 			<h3>Player Performance</h3>
 			<div class="match-bm-players-wrapper">
 				<div class="match-bm-players-team"><div class="match-bm-lol-players-team-header">{{&opponents.1.iconDisplay}}</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -80,7 +80,52 @@ return {
 					</div>
 				</div>
 			</div>
-			<h3>Head-to-Head</h3>
+			<h3>Team Stats</h3>
+			<div class="match-bm-team-stats">
+				<div class="match-bm-team-stats-header">
+					<h4>Radiant Victory</h4>
+					<div class="match-bm-team-stats-time side--dire">25:55</div>
+				</div>
+				<div>
+					<div class="match-bm-team-stats-team">
+						<div class="match-bm-team-stats-team-logo">{{&opponents.1.iconDisplay}}</div>
+						<div class="match-bm-team-stats-team-side">{{&opponents.1.side}}</div>
+						<div class="match-bm-team-stats-team-state">{{teams.1.scoreDisplay}}</div>
+					</div>
+					<div class="match-bm-team-stats-list">
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.1.kills}}<span class="slash">/</span>{{teams.1.deaths}}<span class="slash">/</span>{{teams.1.assists}}{{/finished}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-crossbones cell--icon"></i>KDA</div>
+							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.2.kills}}<span class="slash">/</span>{{teams.2.deaths}}<span class="slash">/</span>{{teams.2.assists}}{{/finished}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.gold}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-coins cell--icon"></i>Gold</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.gold}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.objectives.towers}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-chess-rook cell--icon"></i>Towers</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.objectives.towers}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.objectives.barracks}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-warehouse cell--icon"></i>Barracks</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.objectives.barracks}}</div>
+						</div>
+						<div class="match-bm-stats-list-row">
+							<div class="match-bm-stats-list-cell">{{teams.1.objectives.roshans}}</div>
+							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-cow cell--icon"></i>Roshan</div>
+							<div class="match-bm-stats-list-cell">{{teams.2.objectives.roshans}}</div>
+						</div>
+					</div>
+					<div class="match-bm-team-stats-team">
+						<div class="match-bm-team-stats-team-logo">{{&opponents.2.iconDisplay}}</div>
+						<div class="match-bm-team-stats-team-side">{{&opponents.2.side}}</div>
+						<div class="match-bm-team-stats-team-state">{{teams.2.scoreDisplay}}</div>
+					</div>
+				</div>
+			</div>
 			<div class="match-bm-lol-h2h">
 				<div class="match-bm-lol-h2h-header">
 					<div class="match-bm-lol-h2h-header-team">{{&opponents.1.iconDisplay}}</div>

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -83,8 +83,7 @@ return {
 			<h3>Team Stats</h3>
 			<div class="match-bm-team-stats">
 				<div class="match-bm-team-stats-header">
-					<h4 class="match-bm-team-stats-header-title">Radiant Victory</h4>
-					<div class="match-bm-team-stats-header-time"><i class="fas fa-caret-left"></i><div>Insert time here</div><i class="fas fa-caret-right"></i></div>
+					<h4 class="match-bm-team-stats-header-title">{{opponents.{{winner}}.name}} Victory</h4>
 				</div>
 				<div class="match-bm-team-stats-container">
 					<div class="match-bm-team-stats-team">

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -83,8 +83,8 @@ return {
 			<h3>Team Stats</h3>
 			<div class="match-bm-team-stats">
 				<div class="match-bm-team-stats-header">
-					<h4>Radiant Victory</h4>
-					<span class="match-bm-team-stats-time side--dire">25:55</span>
+					<h4 class="match-bm-team-stats-header-title">Radiant Victory</h4>
+					<div class="match-bm-team-stats-header-time><i class="fas fa-caret-left icon--left"></i><div>25:55</div><i class="fas fa-caret-right icon--right"></i></div>
 				</div>
 				<div class="match-bm-team-stats-container">
 					<div class="match-bm-team-stats-team">

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -84,7 +84,7 @@ return {
 			<div class="match-bm-team-stats">
 				<div class="match-bm-team-stats-header">
 					<h4 class="match-bm-team-stats-header-title">Radiant Victory</h4>
-					<div class="match-bm-team-stats-header-time><i class="fas fa-caret-left icon--left"></i><div>25:55</div><i class="fas fa-caret-right icon--right"></i></div>
+					<div class="match-bm-team-stats-header-time"><i class="fas fa-caret-left"></i><div>Insert time here</div><i class="fas fa-caret-right"></i></div>
 				</div>
 				<div class="match-bm-team-stats-container">
 					<div class="match-bm-team-stats-team">

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -83,7 +83,8 @@ return {
 			<h3>Team Stats</h3>
 			<div class="match-bm-team-stats">
 				<div class="match-bm-team-stats-header">
-					<h4 class="match-bm-team-stats-header-title">{{winnerName}} Victory</h4>
+					{{#winnerName}}<h4 class="match-bm-team-stats-header-title">{{winnerName}} Victory</h4>{{/winnerName}}
+					{{^winnerName}}<h4 class="match-bm-team-stats-header-title">No winner determined yet</h4>{{/winnerName}}
 				</div>
 				<div class="match-bm-team-stats-container">
 					<div class="match-bm-team-stats-team">

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -84,45 +84,45 @@ return {
 			<div class="match-bm-team-stats">
 				<div class="match-bm-team-stats-header">
 					<h4>Radiant Victory</h4>
-					<div class="match-bm-team-stats-time side--dire">25:55</div>
+					<span class="match-bm-team-stats-time side--dire">25:55</span>
 				</div>
-				<div>
+				<div class="match-bm-team-stats-container">
 					<div class="match-bm-team-stats-team">
 						<div class="match-bm-team-stats-team-logo">{{&opponents.1.iconDisplay}}</div>
-						<div class="match-bm-team-stats-team-side">{{&opponents.1.side}}</div>
-						<div class="match-bm-team-stats-team-state">{{teams.1.scoreDisplay}}</div>
+						<div class="match-bm-team-stats-team-side">{{&teams.1.side}}</div>
+						<div class="match-bm-team-stats-team-state state--{{teams.1.scoreDisplay}}">{{teams.1.scoreDisplay}}</div>
 					</div>
 					<div class="match-bm-team-stats-list">
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.1.kills}}<span class="slash">/</span>{{teams.1.deaths}}<span class="slash">/</span>{{teams.1.assists}}{{/finished}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-crossbones cell--icon"></i>KDA</div>
-							<div class="match-bm-stats-list-cell">{{#finished}}{{teams.2.kills}}<span class="slash">/</span>{{teams.2.deaths}}<span class="slash">/</span>{{teams.2.assists}}{{/finished}}</div>
+						<div class="match-bm-team-stats-list-row">
+							<div class="match-bm-team-stats-list-cell">{{#finished}}{{teams.1.kills}}<span class="slash">/</span>{{teams.1.deaths}}<span class="slash">/</span>{{teams.1.assists}}{{/finished}}</div>
+							<div class="match-bm-team-stats-list-cell"><i class="fas fa-skull-crossbones cell--icon"></i>KDA</div>
+							<div class="match-bm-team-stats-list-cell">{{#finished}}{{teams.2.kills}}<span class="slash">/</span>{{teams.2.deaths}}<span class="slash">/</span>{{teams.2.assists}}{{/finished}}</div>
 						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.gold}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-coins cell--icon"></i>Gold</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.gold}}</div>
+						<div class="match-bm-team-stats-list-row">
+							<div class="match-bm-team-stats-list-cell">{{teams.1.gold}}</div>
+							<div class="match-bm-team-stats-list-cell cell--middle"><i class="fas fa-coins cell--icon"></i>Gold</div>
+							<div class="match-bm-team-stats-list-cell">{{teams.2.gold}}</div>
 						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.objectives.towers}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-chess-rook cell--icon"></i>Towers</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.objectives.towers}}</div>
+						<div class="match-bm-team-stats-list-row">
+							<div class="match-bm-team-stats-list-cell">{{teams.1.objectives.towers}}</div>
+							<div class="match-bm-team-stats-list-cell cell--middle"><i class="fas fa-chess-rook cell--icon"></i>Towers</div>
+							<div class="match-bm-team-stats-list-cell">{{teams.2.objectives.towers}}</div>
 						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.objectives.barracks}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-warehouse cell--icon"></i>Barracks</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.objectives.barracks}}</div>
+						<div class="match-bm-team-stats-list-row">
+							<div class="match-bm-team-stats-list-cell">{{teams.1.objectives.barracks}}</div>
+							<div class="match-bm-team-stats-list-cell cell--middle"><i class="fas fa-warehouse cell--icon"></i>Barracks</div>
+							<div class="match-bm-team-stats-list-cell">{{teams.2.objectives.barracks}}</div>
 						</div>
-						<div class="match-bm-stats-list-row">
-							<div class="match-bm-stats-list-cell">{{teams.1.objectives.roshans}}</div>
-							<div class="match-bm-stats-list-cell"><i class="fas fa-skull-cow cell--icon"></i>Roshan</div>
-							<div class="match-bm-stats-list-cell">{{teams.2.objectives.roshans}}</div>
+						<div class="match-bm-team-stats-list-row">
+							<div class="match-bm-team-stats-list-cell">{{teams.1.objectives.roshans}}</div>
+							<div class="match-bm-team-stats-list-cell cell--middle"><i class="fas fa-skull-cow cell--icon"></i>Roshan</div>
+							<div class="match-bm-team-stats-list-cell">{{teams.2.objectives.roshans}}</div>
 						</div>
 					</div>
 					<div class="match-bm-team-stats-team">
 						<div class="match-bm-team-stats-team-logo">{{&opponents.2.iconDisplay}}</div>
-						<div class="match-bm-team-stats-team-side">{{&opponents.2.side}}</div>
-						<div class="match-bm-team-stats-team-state">{{teams.2.scoreDisplay}}</div>
+						<div class="match-bm-team-stats-team-side">{{&teams.2.side}}</div>
+						<div class="match-bm-team-stats-team-state state--{{teams.2.scoreDisplay}}">{{teams.2.scoreDisplay}}</div>
 					</div>
 				</div>
 			</div>

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1162,6 +1162,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 
 .match-bm-team-stats {
 	border: 0.0625rem solid #bbbbbb;
+	margin-bottom: 1rem;
 
 	&-header {
 		display: flex;
@@ -1169,5 +1170,86 @@ ul.match-bm-lol-game-veto-overview-pick {
 		align-items: center;
 		background: #eaecf0;
 		border-bottom: 0.0625rem solid #bbbbbb;
+	}
+
+	&-container {
+		display: flex;
+		padding: 1rem 0;
+		flex-wrap: wrap;
+	}
+
+	&-team {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 1rem;
+		padding: 1rem 0;
+
+		@media ( max-width: 767px ) {
+			flex: 1 0 50%;
+			order: 1;
+		}
+
+		&-side {
+			font-weight: bold;
+			text-transform: uppercase;
+		}
+
+		&-state {
+			background-color: var(--clr-on-background);
+			border-radius: 0.75rem;
+			min-height: 1.5rem;
+			color: #ffffff;
+			padding: 0 0.5rem;
+			text-transform: uppercase;
+			font-weight: bold;
+
+			&.state--winner {
+				background-color: var(--clr-semantic-positive-40);
+			}
+
+			&.state--loser {
+				background-color: var(--clr-semantic-negative-40);
+			}
+		}
+	}
+
+	&-list {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+
+		@media ( max-width: 767px ) {
+			flex: 1 0 100%;
+			order: 2;
+		}
+
+		&-row {
+			display: flex;
+
+			&:not(:last-child) {
+				border-bottom: 0.0625rem solid #bbbbbb;
+			}
+		}
+
+		&-cell {
+			display: flex;
+			justify-content: center;
+			flex: 1;
+			align-items: center;
+			min-height: 2.75rem;
+			gap: 0.5rem;
+			font-weight: bold;
+
+			&.cell--middle {
+				font-weight: normal;
+			}
+
+			.slash {
+				opacity: 0.4;
+			}
+		}
 	}
 }

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1164,6 +1164,10 @@ ul.match-bm-lol-game-veto-overview-pick {
 	border: 0.0625rem solid #bbbbbb;
 	margin-bottom: 1rem;
 
+	.theme--dark & {
+		border-color: var( --clr-secondary-25 );
+	}
+
 	&-header {
 		display: flex;
 		flex-direction: column;
@@ -1172,6 +1176,11 @@ ul.match-bm-lol-game-veto-overview-pick {
 		border-bottom: 0.0625rem solid #bbbbbb;
 		padding: 1rem 0;
 		gap: 0.5rem;
+
+		.theme--dark & {
+			background-color: var( --clr-secondary-16 );
+			border-color: var( --clr-secondary-25 );
+		}
 
 		html h4&-title {
 			font-weight: bold;
@@ -1248,6 +1257,10 @@ ul.match-bm-lol-game-veto-overview-pick {
 
 			&:not(:last-child) {
 				border-bottom: 0.0625rem solid #bbbbbb;
+
+				.theme--dark & {
+					border-color: var( --clr-secondary-25 );
+				}
 			}
 		}
 

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1170,6 +1170,22 @@ ul.match-bm-lol-game-veto-overview-pick {
 		align-items: center;
 		background: #eaecf0;
 		border-bottom: 0.0625rem solid #bbbbbb;
+		padding: 1rem 0;
+		gap: 0.5rem;
+
+		html h4&-title {
+			font-weight: bold;
+			text-transform: uppercase;
+			color: var( --clr-on-background )!important;
+			margin: 0;
+			padding: 0;
+		}
+
+		&-time {
+			display: flex;
+			gap: 0.5rem;
+			align-items: center;
+		}
 	}
 
 	&-container {

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1185,6 +1185,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 			display: flex;
 			gap: 0.5rem;
 			align-items: center;
+			justify-content: center;
 		}
 	}
 

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1185,7 +1185,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 		html h4&-title {
 			font-weight: bold;
 			text-transform: uppercase;
-			color: var( --clr-on-background )!important;
+			color: var( --clr-on-background ) !important;
 			margin: 0;
 			padding: 0;
 		}
@@ -1224,7 +1224,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 		}
 
 		&-state {
-			background-color: var(--clr-on-background);
+			background-color: var( --clr-on-background );
 			border-radius: 0.75rem;
 			min-height: 1.5rem;
 			color: #ffffff;
@@ -1233,11 +1233,11 @@ ul.match-bm-lol-game-veto-overview-pick {
 			font-weight: bold;
 
 			&.state--winner {
-				background-color: var(--clr-semantic-positive-40);
+				background-color: var( --clr-semantic-positive-40 );
 			}
 
 			&.state--loser {
-				background-color: var(--clr-semantic-negative-40);
+				background-color: var( --clr-semantic-negative-40 );
 			}
 		}
 	}
@@ -1255,7 +1255,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 		&-row {
 			display: flex;
 
-			&:not(:last-child) {
+			&:not( :last-child ) {
 				border-bottom: 0.0625rem solid #bbbbbb;
 
 				.theme--dark & {

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1159,3 +1159,15 @@ ul.match-bm-lol-game-veto-overview-pick {
 		border-color: var( --clr-secondary-25 );
 	}
 }
+
+.match-bm-team-stats {
+	border: 0.0625rem solid #bbbbbb;
+
+	&-header {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		background: #eaecf0;
+		border-bottom: 0.0625rem solid #bbbbbb;
+	}
+}


### PR DESCRIPTION
## Summary

Add the team stats section. Only missing is the team name that should work with `{{winnerName}}`

![image](https://github.com/user-attachments/assets/a4289a13-4752-4134-a94f-4d102c4ba0ee)
![image](https://github.com/user-attachments/assets/ed3a4314-4aed-4cc7-a1ad-e36d6aafa575)


## How did you test this change?

[Here](https://liquipedia.net/dota2/Liquipedia:ID_XLA7bhOs3l_R01-M001)
