### PR TITLE
feat(FilterButtons): show filter elements if filter state doesn't exist

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -240,8 +240,10 @@ liquipedia.filterButtons = {
 			filterGroup.filterableItems.forEach( ( filterableItem ) => {
 				if ( filterGroup.curated ) {
 					filterableItem.hidden = !filterableItem.curated;
-				} else {
+				} else if ( filterableItem.value in filterGroup.filterStates ) {
 					filterableItem.hidden = !filterGroup.filterStates[ filterableItem.value ];
+				} else {
+					filterableItem.hidden = false;
 				}
 			} );
 		} );


### PR DESCRIPTION
## Summary

For the new [main page design](https://liquipedia.net/dota2/User:FO-nTTaX/Sandbox/23) we want to display tournaments and matches that don't have their respective category in the filter groups. The reason is that right now, for tournaments without tier types an empty and hidden button is required (like currently done in https://liquipedia.net/dota2/Main_Page).

This is checking if there is a filter state, if not then it just shows the element by default.

## How did you test this change?

On the console with @FO-nTTaX for [this page](https://liquipedia.net/dota2/User:FO-nTTaX/Sandbox/23)
