### PR TITLE
fix(infobox): remove overwatch game-specific map links

### DIFF
--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -94,26 +94,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	return lpdbData
 end
 
----@param base string
----@return string[]
-function CustomLeague:_makeBasedListFromArgs(base)
-	local firstArg = self.args[base .. '1']
-	local foundArgs = {PageLink.makeInternalLink({}, firstArg)}
-	local index = 2
-
-	while String.isNotEmpty(self.args[base .. index]) do
-		local currentArg = self.args[base .. index]
-		table.insert(foundArgs, '&nbsp;• ' ..
-			tostring(self:_createNoWrappingSpan(
-				PageLink.makeInternalLink({}, currentArg)
-			))
-		)
-		index = index + 1
-	end
-
-	return foundArgs
-end
-
 ---@param publishertier string?
 ---@return string?
 function CustomLeague:_validPublisherTier(publishertier)

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -13,6 +13,7 @@ local Lua = require('Module:Lua')
 local PageLink = require('Module:Page')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
+local Logic = require('Module:Logic')
 
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
 local League = Lua.import('Module:Infobox/League')

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -47,25 +47,6 @@ function CustomLeague:customParseArguments(args)
 	self.data.publishertier = self:_validPublisherTier(args.blizzardtier) and args.blizzardtier:lower()
 end
 
----@param date string
----@return string
-function compareDates(date1, date2)
-    return date1 > date2
-end
-
-function getGame(args)
-    local endDate = Variables.varDefault('tournament_enddate')
-    if String.isNotEmpty(args.game) then
-        return args.game
-    else
-        if compareDates(endDate, '2022-10-04') then
-            return 'overwatch2'
-        else
-            return 'overwatch'
-        end
-    end
-end
-
 ---@param id string
 ---@param widgets Widget[]
 ---@return Widget[]

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -61,7 +61,13 @@ function CustomInjector:parse(id, widgets)
 	)
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.map1) then
-			table.insert(widgets, Center{content = self.caller:_makeBasedListFromArgs('map')})
+			local maps = Array.map(self.caller:getAllArgsForBase(args, 'map'), function(map)
+				return PageLink.makeInternalLink(map)
+			end)
+			Array.appendWith(widgets,
+				Logic.isNotEmpty(maps) and table.insert(widgets, Title{name = 'Maps'}) or nil,
+				Center{content = table.concat(maps, '&nbsp;• ')}
+			)
 		end
 	elseif id == 'liquipediatier' then
 		if self.caller:_validPublisherTier(args.blizzardtier) then

--- a/components/infobox/wikis/overwatch/infobox_league_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_league_custom.lua
@@ -61,7 +61,6 @@ function CustomInjector:parse(id, widgets)
 	)
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.map1) then
-			table.insert(widgets, Title{name = 'Maps'})
 			table.insert(widgets, Center{content = self.caller:_makeBasedListFromArgs('map')})
 		end
 	elseif id == 'liquipediatier' then


### PR DESCRIPTION
## Summary

Overwatch does not have different map pages for OW1 and OW2, this removes the [[Map/game]] format; copied from apex

## How did you test this change?

dev