### PR TITLE
refactor(match2): remove processPlayer layer

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -14,7 +14,6 @@ local Lua = require('Module:Lua')
 local WikiSpecificBase = {}
 
 -- called from Module:MatchGroup
--- called after processMap/processPlayer
 -- used to alter match related parameters, e.g. automatically setting the winner
 -- @parameter match - a match
 -- @returns the match after changes have been applied
@@ -33,17 +32,6 @@ WikiSpecificBase.processMap = FnUtil.lazilyDefineFunction(function()
 	local InputModule = Lua.import('Module:MatchGroup/Input/Custom')
 	return InputModule and InputModule.processMap
 		or error('Function "processMap" not implemented on wiki in "Module:MatchGroup/Input/Custom"')
-end)
-
--- called from Module:Match/Subobjects
--- used to transform wiki-specific input of templates to the generalized
--- format that is required by Module:MatchGroup
--- @parameter player - a player
--- @returns the player after changes have been applied
-WikiSpecificBase.processPlayer = FnUtil.lazilyDefineFunction(function()
-	local InputModule = Lua.import('Module:MatchGroup/Input/Custom')
-	return InputModule and InputModule.processPlayer
-		or error('Function "processPlayer" not implemented on wiki in "Module:MatchGroup/Input/Custom"')
 end)
 
 --[[

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -61,19 +61,6 @@ function MatchSubobjects.luaGetRound(frame, args)
 	return args
 end
 
----@param frame Frame
----@return table
-function MatchSubobjects.getPlayer(frame)
-	local args = Arguments.getArgs(frame)
-	return Json.stringify(MatchSubobjects.luaGetPlayer(args))
-end
-
----@param args table
----@return table
-function MatchSubobjects.luaGetPlayer(args)
-	return WikiSpecific.processPlayer(args)
-end
-
 if FeatureFlag.get('perf') then
 	local Match = Lua.import('Module:Match')
 	MatchSubobjects.perfConfig = Match.perfConfig

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -14,7 +14,7 @@ local Lua = require('Module:Lua')
 
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 
-local ENTRY_POINT_NAMES = {'getMap', 'getPlayer', 'getRound'}
+local ENTRY_POINT_NAMES = {'getMap'}
 
 local MatchSubobjects = {}
 
@@ -45,20 +45,6 @@ function MatchSubobjects.luaGetMap(args)
 
 		return args
 	end
-end
-
----@param frame Frame
----@return string
-function MatchSubobjects.getRound(frame)
-	local args = Arguments.getArgs(frame)
-	return Json.stringify(MatchSubobjects.luaGetRound(frame, args))
-end
-
----@param frame Frame
----@param args table
----@return table
-function MatchSubobjects.luaGetRound(frame, args)
-	return args
 end
 
 if FeatureFlag.get('perf') then

--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -70,7 +70,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 end
 
 CustomMatchGroupInput.processMap = FnUtil.identity
-CustomMatchGroupInput.processPlayer = FnUtil.identity
 
 ---@param record table
 ---@param timestamp number

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -88,9 +88,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
-CustomMatchGroupInput.processPlayer = FnUtil.identity
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Streams = require('Module:Links/Stream')

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -128,13 +128,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -112,13 +112,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -93,13 +93,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 --
 --
 -- function to sort out winner/placements

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -84,13 +84,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -100,11 +100,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 function CustomMatchGroupInput.getResultTypeAndWinner(data, indexedScores)
 	-- Map or Match wasn't played, set not played
 	if Table.includes(FINISHED_INDICATORS, data.finished) or Table.includes(FINISHED_INDICATORS, data.winner) then

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -90,13 +90,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 --
 --
 -- function to check for draws

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -104,13 +104,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 -- function to check for draws
 ---@param tbl table
 ---@return boolean

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -85,13 +85,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -155,8 +155,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
-CustomMatchGroupInput.processPlayer = FnUtil.identity
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -86,13 +86,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -128,13 +128,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -153,8 +153,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
-CustomMatchGroupInput.processPlayer = FnUtil.identity
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -127,13 +127,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/omegastrikers/match_group_input_custom.lua
+++ b/components/match2/wikis/omegastrikers/match_group_input_custom.lua
@@ -107,13 +107,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 -- function to sort out winner/placements
 ---@param tbl table[]
 ---@param key1 integer

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -85,13 +85,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -85,13 +85,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -127,13 +127,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -88,13 +88,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 --- Fetch information about the tournament
 ---@param data table
 ---@return table

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -105,13 +105,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	end
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 -- function to sort out winner/placements
 ---@param tbl table[]
 ---@param key1 integer

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -88,13 +88,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 --
 --
 -- function to sort out winner/placements

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -107,13 +107,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -121,13 +121,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -84,13 +84,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/stormgate/brkts_wiki_specific.lua
+++ b/components/match2/wikis/stormgate/brkts_wiki_specific.lua
@@ -22,7 +22,6 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 end)
 
 WikiSpecific.processMap = FnUtil.identity
-WikiSpecific.processPlayer = FnUtil.identity
 
 ---Determine if a match has details that should be displayed via popup
 ---@param match table

--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -99,13 +99,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	end
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param op1 table
 ---@param op2 table
 ---@param op1norm boolean

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -99,13 +99,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 -- Set the field 'placement' for the two participants in the opponenets list.
 -- Set the placementWinner field to the winner, and placementLoser to the other team
 -- Special cases:

--- a/components/match2/wikis/warcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/warcraft/brkts_wiki_specific.lua
@@ -20,7 +20,6 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 end)
 
 WikiSpecific.processMap = FnUtil.identity
-WikiSpecific.processPlayer = FnUtil.identity
 
 ---Determine if a match has details that should be displayed via popup
 ---@param match table

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -126,13 +126,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -85,13 +85,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 ---@param data table
 ---@param indexedScores table[]
 ---@return table

--- a/components/match2/wikis/zula/match_group_input_custom.lua
+++ b/components/match2/wikis/zula/match_group_input_custom.lua
@@ -102,13 +102,6 @@ function CustomMatchGroupInput.processOpponent(record, timestamp)
 	MatchGroupInput.mergeRecordWithOpponent(record, opponent)
 end
 
--- called from Module:Match/Subobjects
----@param player table
----@return table
-function CustomMatchGroupInput.processPlayer(player)
-	return player
-end
-
 -- function to check for draws
 ---@param tbl table
 ---@return boolean


### PR DESCRIPTION
## Summary
There's only two usages of what was processPlayer, both on rocket league. The template has been changed to a json stringify, which is basically what the old call did anyhow.

https://liquipedia.net/commons/index.php?title=Template%3ABrktsPlayer&type=revision&diff=733844&oldid=278959
