### PR TITLE
feat(match2): handle match/legacy errors

### DIFF
--- a/components/match2/commons/display_util.lua
+++ b/components/match2/commons/display_util.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local ErrorDisplay = require('Module:Error/Display')
 local FeatureFlag = require('Module:FeatureFlag')
 local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
@@ -53,11 +52,12 @@ end
 ---The error is caught and displayed using classic error style.
 ---@param Component function
 ---@param props table
+---@param other? fun(error: Error): any
 ---@return Html
-function DisplayUtil.TryPureComponent(Component, props)
+function DisplayUtil.TryPureComponent(Component, props, other)
 	return Logic.tryOrElseLog(
 		function() return Component(props) end,
-		ErrorDisplay.ClassicError,
+		other,
 		function(error)
 			error.header = 'Error occured in display component: (caught by DisplayUtil.TryPureComponent)'
 			return error

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -117,7 +117,7 @@ function Match.storeMatchGroup(matchRecords, options)
 
 	if LegacyMatch then
 		Array.forEach(matchRecordsCopy, function(matchRecord)
-			LegacyMatch.storeMatch(matchRecord, options)
+			Logic.wrapTryOrLog(LegacyMatch.storeMatch)(matchRecord, options)
 		end)
 	end
 end

--- a/standard/error_display.lua
+++ b/standard/error_display.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local ErrorExt = require('Module:Error/Ext')
 local Json = require('Module:Json')

--- a/standard/error_display.lua
+++ b/standard/error_display.lua
@@ -44,18 +44,6 @@ function ErrorDisplay.ErrorList(props)
 	return boxesNode
 end
 
----Entry point of Template:StashedErrors
----@deprecated # I think the template is not used anymore
----@param frame Frame
----@return Html
-function ErrorDisplay.TemplateStashedErrors(frame)
-	local args = Arguments.getArgs(frame)
-	return ErrorDisplay.ErrorList{
-		errors = ErrorExt.Stash.retrieve(),
-		limit = tonumber(args.limit),
-	}
-end
-
 ---@param props {hasDetails: boolean?, loggedInOnly: boolean?, text: string}
 ---@return Html
 function ErrorDisplay.Box(props)

--- a/standard/error_display.lua
+++ b/standard/error_display.lua
@@ -45,6 +45,7 @@ function ErrorDisplay.ErrorList(props)
 end
 
 ---Entry point of Template:StashedErrors
+---@deprecated # I think the template is not used anymore
 ---@param frame Frame
 ---@return Html
 function ErrorDisplay.TemplateStashedErrors(frame)


### PR DESCRIPTION
## Summary
With this change, an error Match/Legacy will not have a cascading effect to affect all of match2, rest of the match is still stored and displayed
<img width="815" alt="image" src="https://github.com/user-attachments/assets/5aa918b6-79d4-4cf1-855b-aa15b2281fd3">


## How did you test this change?
dev
