### PR TITLE
feat(match2): fix aspect ratio of hero avatars on dota2 matchpages

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -667,8 +667,6 @@ ul.match-bm-lol-game-veto-overview-pick {
 		height: 3rem;
 		margin-right: 0.5rem;
 		position: relative;
-		overflow: hidden;
-		border-radius: 100%;
 
 		@media ( min-width: 768px ) {
 			width: 4rem;
@@ -676,15 +674,20 @@ ul.match-bm-lol-game-veto-overview-pick {
 		}
 	}
 
-	&-icon img {
-		width: auto;
-		height: 3rem;
-		position: relative;
-		left: 50%;
-		transform: translateX( -50% );
+	&-icon {
+		overflow: hidden;
+		border-radius: 100%;
 
-		@media ( min-width: 768px ) {
-			height: 4rem;
+		img {
+			width: auto;
+			height: 3rem;
+			position: relative;
+			left: 50%;
+			transform: translateX( -50% );
+
+			@media ( min-width: 768px ) {
+				height: 4rem;
+			}
 		}
 	}
 

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -667,6 +667,8 @@ ul.match-bm-lol-game-veto-overview-pick {
 		height: 3rem;
 		margin-right: 0.5rem;
 		position: relative;
+		overflow: hidden;
+		border-radius: 100%;
 
 		@media ( min-width: 768px ) {
 			width: 4rem;
@@ -675,12 +677,13 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 
 	&-icon img {
-		width: 3rem;
+		width: auto;
 		height: 3rem;
-		border-radius: 100%;
+		position: relative;
+		left: 50%;
+		transform: translateX( -50% );
 
 		@media ( min-width: 768px ) {
-			width: 4rem;
 			height: 4rem;
 		}
 	}


### PR DESCRIPTION
## Summary

Make the avatar images look a bit better with the correct aspect ratio.

![image](https://github.com/user-attachments/assets/35958157-1100-456b-84d0-8f57c9c3d57b)



## How did you test this change?

https://liquipedia.net/dota2/Liquipedia:ID_XLA7bhOs3l_R01-M001
