### PR TITLE
feat(match2): on dota2 match pages add winnerName prop

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -244,6 +244,8 @@ MatchGroupUtil.types.Game = TypeUtil.struct({
 ---@field opponents standardOpponent[]
 ---@field resultType ResultType?
 ---@field stream table
+---@field tickername string?
+---@field tournament string?
 ---@field type string?
 ---@field vod string?
 ---@field walkover WalkoverType?
@@ -265,6 +267,8 @@ MatchGroupUtil.types.Match = TypeUtil.struct({
 	opponents = TypeUtil.array(MatchGroupUtil.types.Opponent),
 	resultType = 'string?',
 	stream = 'table',
+	tickername = 'string?',
+	tournament = 'string?',
 	type = 'string?',
 	vod = 'string?',
 	walkover = 'string?',

--- a/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
@@ -479,7 +479,7 @@ function CustomMatchGroupInputMatchPage.getLength(map)
 end
 
 function CustomMatchGroupInputMatchPage.getSide(map, opponentIndex)
-	return (map['team' .. opponentIndex] or {}).color
+	return (map['team' .. opponentIndex] or {}).side
 end
 
 function CustomMatchGroupInputMatchPage.getParticipants(map, opponentIndex)

--- a/components/match2/wikis/dota2/match_page.lua
+++ b/components/match2/wikis/dota2/match_page.lua
@@ -29,10 +29,10 @@ local NOT_PLAYED = 'np'
 local DEFAULT_ITEM = 'EmptyIcon'
 local DEFAULT_BACKPACK_ITEM = 'EmptyIcon'
 local TEAMS = Array.range(1, 2)
-local AVAILABLE_FOR_TIERS = {1}
 local ITEMS_TO_SHOW = 6
 local BACKPACK_ITEMS_TO_SHOW = 3
 
+local AVAILABLE_FOR_TIERS = {1}
 local MATCH_PAGE_START_TIME = 1725148800 -- September 1st 2024 midnight
 
 ---@param match table
@@ -44,6 +44,7 @@ end
 
 ---@class Dota2MatchPageViewModelGame: MatchGroupUtilGame
 ---@field finished boolean
+---@field winnerName string?
 ---@field teams table[]
 
 ---@class Dota2MatchPageViewModelOpponent: standardOpponent
@@ -113,6 +114,9 @@ function MatchPage.getByMatchId(props)
 
 			return team
 		end)
+		if game.finished and viewModel.opponents[game.winner] then
+			game.winnerName = viewModel.opponents[game.winner].name
+		end
 	end)
 
 	-- Add more opponent data field
@@ -168,24 +172,28 @@ function MatchPage.getByMatchId(props)
 		}
 	end
 
-	local displayTitle
-	if viewModel.opponents[1].shortname or viewModel.opponents[2].shortname then
-		local team1name = viewModel.opponents[1].shortname or 'TBD'
-		local team2name = viewModel.opponents[2].shortname or 'TBD'
-		local tournamentName = viewModel.tickername
-		displayTitle = team1name .. ' vs. ' .. team2name
-		if tournamentName then
-			displayTitle = displayTitle .. ' @ ' .. tournamentName
-		end
-	else
-		local tournamentName = viewModel.tickername
-		displayTitle = table.concat({'Match in', tournamentName}, ' ')
-	end
+	local displayTitle = MatchPage.makeDisplayTitle(viewModel)
 	if String.isNotEmpty(displayTitle) then
 		mw.getCurrentFrame():preprocess(table.concat{'{{DISPLAYTITLE:', displayTitle, '}}'})
 	end
 
 	return MatchPage.render(viewModel)
+end
+
+function MatchPage.makeDisplayTitle(viewModel)
+	if not viewModel.opponents[1].shortname and viewModel.opponents[2].shortname then
+		return table.concat({'Match in', viewModel.tickername}, ' ')
+	end
+
+	local team1name = viewModel.opponents[1].shortname or 'TBD'
+	local team2name = viewModel.opponents[2].shortname or 'TBD'
+	local tournamentName = viewModel.tickername
+	local displayTitle = team1name .. ' vs. ' .. team2name
+	if tournamentName then
+		displayTitle = displayTitle .. ' @ ' .. tournamentName
+	end
+
+	return displayTitle
 end
 
 ---@param tbl table

--- a/components/match2/wikis/dota2/match_page.lua
+++ b/components/match2/wikis/dota2/match_page.lua
@@ -189,11 +189,11 @@ function MatchPage.makeDisplayTitle(viewModel)
 	local team2name = viewModel.opponents[2].shortname or 'TBD'
 	local tournamentName = viewModel.tickername
 	local displayTitle = team1name .. ' vs. ' .. team2name
-	if tournamentName then
-		displayTitle = displayTitle .. ' @ ' .. tournamentName
+	if not tournamentName then
+		return displayTitle
 	end
 
-	return displayTitle
+	return displayTitle .. ' @ ' .. tournamentName
 end
 
 ---@param tbl table


### PR DESCRIPTION
## Summary
Add winnerName proper to the VM.
Also fix a typo in the parsing
Some refactoring

## How did you test this change?
dev
<img width="1575" alt="image" src="https://github.com/user-attachments/assets/32c29ba8-e95e-4ec7-b7e3-334376640356">
