### PR TITLE
feat(match2): normalize caster input and display on sc/sc2

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/get_match_group_copy_paste_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/get_match_group_copy_paste_starcraft.lua
@@ -64,8 +64,9 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
-		args.needsWinner == 'true' and INDENT .. '|winner=' or nil,
-		args.hasDate == 'true' and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
+		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
+		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
+		Logic.readBool(args.casters) and '|caster1=|caster2=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -159,7 +159,7 @@ function StarcraftMatchGroupInput._getExtraData(match)
 	end
 
 	extradata = {
-		casters = match.casters,
+		casters = MatchGroupInput.readCasters(match, {noSort = true}),
 		headtohead = match.headtohead,
 		ffa = 'false',
 	}

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -178,7 +178,7 @@ function StarcraftMatchSummary.createBody(match)
 	end)
 
 	if match.casters then
-		body:addRow(MatchSummary.Row():addClass('brkts-popup-sc-game-comment'):addElement('Caster(s): ' .. match.casters))
+		body:addRow(MatchSummary.makeCastersRow(match.casters))
 	end
 
 	return body


### PR DESCRIPTION
## Summary
Currently sc/sc2 has its own casters input processing and display.
This PR normalizes it to use the commons funcctions instead.

## How did you test this change?
Due to bot conversion runs being needed i pushed an intermediate version live that currently supports both input variants.
A bot run is under way to change the old inputs to the new pattern.
Once that bot run is finished this PR can be merged.