### PR TITLE
fix(match2): opponent extradata is empty array instead of null

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -287,12 +287,17 @@ function Match._storeMatch2InLpdb(unsplitMatchRecord)
 
 	local opponentIndexes = Array.map(records.opponentRecords, function(opponentRecord, opponentIndex)
 		local playerIndexes = Array.map(records.playerRecords[opponentIndex], function(player, playerIndex)
+
+			player.extradata = Logic.nilIfEmpty(player.extradata)
+
 			return mw.ext.LiquipediaDB.lpdb_match2player(
 				matchRecord.match2id .. '_m2o_' .. string.format('%02d', opponentIndex)
 						.. '_m2p_' .. string.format('%02d', playerIndex),
 				player
 			)
 		end)
+
+		opponentRecord.extradata = Logic.nilIfEmpty(opponentRecord.extradata)
 
 		opponentRecord.match2players = table.concat(playerIndexes)
 		return mw.ext.LiquipediaDB.lpdb_match2opponent(

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -587,10 +587,7 @@ function MatchGroupInput.mergeRecordWithOpponent(record, opponent, substitutions
 
 	record.name = Opponent.toName(opponent)
 	record.type = opponent.type
-	record.extradata = Logic.nilIfEmpty(Table.merge(
-		record.extradata or {},
-		{substitutions = Logic.nilIfEmpty(substitutions)}
-	))
+	record.extradata = Table.merge(record.extradata or {}, {substitutions = Logic.nilIfEmpty(substitutions)})
 
 	return record
 end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -587,7 +587,10 @@ function MatchGroupInput.mergeRecordWithOpponent(record, opponent, substitutions
 
 	record.name = Opponent.toName(opponent)
 	record.type = opponent.type
-	record.extradata = Logic.nilIfEmpty(Table.merge(record.extradata or {}, {substitutions = Logic.nilIfEmpty(substitutions)}))
+	record.extradata = Logic.nilIfEmpty(Table.merge(
+		record.extradata or {},
+		{substitutions = Logic.nilIfEmpty(substitutions)}
+	))
 
 	return record
 end

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -587,7 +587,7 @@ function MatchGroupInput.mergeRecordWithOpponent(record, opponent, substitutions
 
 	record.name = Opponent.toName(opponent)
 	record.type = opponent.type
-	record.extradata = Table.merge(record.extradata or {}, {substitutions = Logic.nilIfEmpty(substitutions)})
+	record.extradata = Logic.nilIfEmpty(Table.merge(record.extradata or {}, {substitutions = Logic.nilIfEmpty(substitutions)}))
 
 	return record
 end


### PR DESCRIPTION
## Summary
Introduced in #4511, opponent extradata was always set to an empty table if not otherwise created, which leads to bad serialization in LPDB (json array instead of object).

Reported on discord: https://discord.com/channels/93055209017729024/443856413052239882/1273905924775346198
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
tbd
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
