### PR TITLE
feat(infobox) Allow querying organizer prizepool by Title::baseText

### DIFF
--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -10,6 +10,7 @@ local Class = require('Module:Class')
 local Flags = require('Module:Flags')
 local Links = require('Module:Links')
 local Locale = require('Module:Locale')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local ReferenceCleaner = require('Module:ReferenceCleaner')
 local Table = require('Module:Table')
@@ -141,13 +142,14 @@ end
 
 ---@return string?
 function Company:_getOrganizerPrizepools()
+	local queryName = Logic.readBool(self.args.queryByBasename) and mw.title.getCurrentTitle().baseText or self.pagename
 	local queryData = mw.ext.LiquipediaDB.lpdb('tournament', {
 		conditions =
-			'[[organizers_organizer1::' .. self.pagename .. ']] OR ' ..
-			'[[organizers_organizer2::' .. self.pagename .. ']] OR ' ..
-			'[[organizers_organizer3::' .. self.pagename .. ']] OR ' ..
-			'[[organizers_organizer4::' .. self.pagename .. ']] OR ' ..
-			'[[organizers_organizer5::' .. self.pagename .. ']]',
+			'[[organizers_organizer1::' .. queryName .. ']] OR ' ..
+			'[[organizers_organizer2::' .. queryName .. ']] OR ' ..
+			'[[organizers_organizer3::' .. queryName .. ']] OR ' ..
+			'[[organizers_organizer4::' .. queryName .. ']] OR ' ..
+			'[[organizers_organizer5::' .. queryName .. ']]',
 		query = 'sum::prizepool'
 	})
 


### PR DESCRIPTION
## Summary
Allows to query the awarded prizepool for an organizer by `Title::baseText` instead of pagename.

Since on AoE most organizers are individuals and infobox player is preferred for the main page, the module is solely used on subpages `<Name>/Tournaments` (e.g. https://liquipedia.net/ageofempires/MembTV/Tournaments), which means the querying fails.
Adding a parameter to query by the baseText instead.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
