### PR TITLE
feat(match2): Logic.nilIfEmpty on extradata fields in match2 subtables

### DIFF
--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -268,14 +268,14 @@ function Match.encodeJson(matchRecord)
 	matchRecord.extradata = Json.stringify(matchRecord.extradata)
 
 	for _, opponentRecord in ipairs(matchRecord.match2opponents) do
-		opponentRecord.extradata = Json.stringify(opponentRecord.extradata)
+		opponentRecord.extradata = Json.stringify(Logic.nilIfEmpty(opponentRecord.extradata))
 		for _, playerRecord in ipairs(opponentRecord.match2players) do
-			playerRecord.extradata = Json.stringify(playerRecord.extradata)
+			playerRecord.extradata = Json.stringify(Logic.nilIfEmpty(playerRecord.extradata))
 		end
 	end
 	for _, gameRecord in ipairs(matchRecord.match2games) do
-		gameRecord.extradata = Json.stringify(gameRecord.extradata)
-		gameRecord.participants = Json.stringify(gameRecord.participants)
+		gameRecord.extradata = Json.stringify(Logic.nilIfEmpty(gameRecord.extradata))
+		gameRecord.participants = Json.stringify(Logic.nilIfEmpty(gameRecord.participants))
 		gameRecord.scores = Json.stringify(gameRecord.scores, {asArray = true})
 	end
 end
@@ -288,16 +288,12 @@ function Match._storeMatch2InLpdb(unsplitMatchRecord)
 	local opponentIndexes = Array.map(records.opponentRecords, function(opponentRecord, opponentIndex)
 		local playerIndexes = Array.map(records.playerRecords[opponentIndex], function(player, playerIndex)
 
-			player.extradata = Logic.nilIfEmpty(player.extradata)
-
 			return mw.ext.LiquipediaDB.lpdb_match2player(
 				matchRecord.match2id .. '_m2o_' .. string.format('%02d', opponentIndex)
 						.. '_m2p_' .. string.format('%02d', playerIndex),
 				player
 			)
 		end)
-
-		opponentRecord.extradata = Logic.nilIfEmpty(opponentRecord.extradata)
 
 		opponentRecord.match2players = table.concat(playerIndexes)
 		return mw.ext.LiquipediaDB.lpdb_match2opponent(


### PR DESCRIPTION
**I consider this a potentially breaking change and suggest to merge it monday earliest, so we are around to fix consumers who (potentially) rely on extradata/participants being non nil even if empty**

## Summary
nils the extradata (and participants) fields if they are empty.

#4548 did not work because at that point extradata/participants were already stringified

## How did you test this change?
dev