### PR TITLE
feat(infobox): add creep camp support in stormgate infobox building

### DIFF
--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -48,7 +48,7 @@ function Building:createInfobox()
 			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
-		Title{name = 'Building Information'},
+		Title{name = (args.informationType or 'Building') .. ' Information'},
 		Cell{name = 'Built by', content = {args.builtby}},
 		Customizable{
 			id = 'cost',

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -24,6 +24,7 @@ local Building = Lua.import('Module:Infobox/Building')
 
 local Widgets = require('Module:Infobox/Widget/All')
 local Cell = Widgets.Cell
+local Title = Widgets.Title
 
 ---@class StormgateBuildingInfobox: BuildingInfobox
 ---@field faction string?
@@ -36,6 +37,7 @@ local ICON_ARMOR = '[[File:Icon_Armor.png|link=Armor]]'
 local ICON_ENERGY = '[[File:EnergyIcon.gif|link=]]'
 local ICON_DEPRECATED = '[[File:Cancelled Tournament.png|link=]]'
 local HOTKEY_SEPERATOR = '&nbsp;&nbsp;/&nbsp;&nbsp;'
+local CREEP = 'Camp'
 
 ---@param frame Frame
 ---@return Html
@@ -61,6 +63,10 @@ end
 function CustomInjector:parse(id, widgets)
 	local caller = self.caller
 	local args = caller.args
+
+	if args.informationType == CREEP then
+		return caller:_parseForCreeps(id, widgets)
+	end
 
 	if id == 'custom' then
 		Array.appendWith(
@@ -167,15 +173,34 @@ end
 ---@param args table
 ---@return string[]
 function CustomBuilding:getWikiCategories(args)
-	if not self.faction then
-		return {}
-	end
-
-	return {Faction.toName(self.faction) .. ' Buildings'}
+	local factionName = Faction.toName(self.faction)
+	return Array.append({},
+		factionName and (factionName .. ' Buildings') or nil,
+		args.informationType == CREEP and 'Camps' or nil
+	)
 end
 
 ---@param args table
 function CustomBuilding:setLpdbData(args)
+	
+	if args.informationType == CREEP then
+		mw.ext.LiquipediaDB.lpdb_datapoint('building_' .. self.pagename, {
+			name = args.name or self.pagename,
+			type = (args.informationType or 'building'):lower(),
+			information = self.faction,
+			image = args.image,
+			imagedark = args.imagedark,
+			extradata = mw.ext.LiquipediaDB.lpdb_create_json{
+				startlevel = tonumber(args.start_level),
+				respawn = tonumber(args.respawn),
+				creeps = Array.parseCommaSeparatedString(args.creeps),
+				capturepoint = args.capture_point,
+				globalbuff =  args.global_buff,
+			},
+		})
+		return
+	end
+	
 	mw.ext.LiquipediaDB.lpdb_datapoint('building_' .. self.pagename, {
 		name = args.name or self.pagename,
 		type = 'building',
@@ -227,11 +252,11 @@ function CustomBuilding:_getDefenseDisplay()
 	local armor = tonumber(args.armor)
 
 	return table.concat(Array.append({},
-		health and ICON_HP or nil,
-		health,
+		ICON_HP,
+		health or 0,
 		extraHealth and ('(+' .. extraHealth .. ')') or nil,
-		armor and ICON_ARMOR or nil,
-		armor
+		ICON_ARMOR,
+		armor or 0
 	), '&nbsp;')
 end
 
@@ -278,6 +303,54 @@ function CustomBuilding._deprecatedWarning(patch)
 		class='ambox-red',
 		text= 'This has been removed from 1v1 with Patch ' .. patch,
 	})
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomBuilding:_parseForCreeps(id, widgets)
+	local args = self.args
+	local startLevel = args.start_level == '1' and args.start_level or args.start_level and "'''" .. args.start_level .. "'''"
+
+	local creeps = {}
+	Array.forEach(Array.parseCommaSeparatedString(args.creeps), function(creep)
+		local unit = mw.ext.LiquipediaDB.lpdb('datapoint', {
+			conditions = '[[information::n]] AND [[type::Unit]] AND [[name::' .. creep .. ']]',
+			limit = 1,
+		})[1] or {}
+		Array.appendWith(creeps, unit)
+	end)
+
+	if id ~= 'custom' then return end
+
+	return {
+		Cell{name = 'Start Level', content = {startLevel}},
+		Cell{name = 'Defenders', content = {self._displayCreepDefenders(creeps)}},
+		Cell{name = 'Respawn', content = {args.respawn and args.respawn .. 's'}},
+		Title{name = 'Tower Rewards'},
+		Cell{name = 'Capture Point', content = {args.capture_point}},
+		Cell{name = 'Global Buff', content = {args.global_buff}},
+	}
+end
+
+---@param creeps table
+---@return string
+function CustomBuilding._displayCreepDefenders(creeps)
+	local display = {}
+	local groupedCreeps = Array.groupBy(creeps, function(creep) return creep.name end)
+
+	Array.forEach(groupedCreeps, function(group)
+		local bounty = CostDisplay.run{
+			luminite = group[1].extradata.bountyluminite or 0,
+			therium = group[1].extradata.bountytherium or 0,
+		}
+		Array.appendWith(display,
+			Page.makeInternalLink(group[1].name) ..
+			(bounty and (' (' .. bounty .. ')') or '') ..
+			(#group > 1 and ' x' .. #group or ''))
+	end)
+
+	return table.concat(display, '<br>')
 end
 
 return CustomBuilding

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -182,27 +182,9 @@ end
 
 ---@param args table
 function CustomBuilding:setLpdbData(args)
-	if args.informationType == CREEP then
-		mw.ext.LiquipediaDB.lpdb_datapoint('building_' .. self.pagename, {
-			name = args.name or self.pagename,
-			type = (args.informationType or 'building'):lower(),
-			information = self.faction,
-			image = args.image,
-			imagedark = args.imagedark,
-			extradata = mw.ext.LiquipediaDB.lpdb_create_json{
-				startlevel = tonumber(args.start_level),
-				respawn = tonumber(args.respawn),
-				creeps = Array.parseCommaSeparatedString(args.creeps),
-				capturepoint = args.capture_point,
-				globalbuff =  args.global_buff,
-			},
-		})
-		return
-	end
-
 	mw.ext.LiquipediaDB.lpdb_datapoint('building_' .. self.pagename, {
 		name = args.name or self.pagename,
-		type = 'building',
+		type = (args.informationType or 'building'):lower(),
 		information = self.faction,
 		image = args.image,
 		imagedark = args.imagedark,
@@ -239,6 +221,12 @@ function CustomBuilding:setLpdbData(args)
 			energy = tonumber(args.energy),
 			energyrate = tonumber(args.energy_rate),
 			energydesc = args.energy_desc,
+			--extradata for creep camps
+			startlevel = tonumber(args.start_level),
+			respawn = tonumber(args.respawn),
+			creeps = Array.parseCommaSeparatedString(args.creeps),
+			capturepoint = args.capture_point,
+			globalbuff =  args.global_buff,
 		},
 	})
 end

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -346,7 +346,7 @@ function CustomBuilding._displayCreepDefenders(creeps)
 		Array.appendWith(display,
 			Page.makeInternalLink(group[1].name) ..
 			(bounty and (' (' .. bounty .. ')') or '') ..
-			(#group > 1 and ' x' .. #group or ''))
+			(#group > 1 and (' x' .. #group) or ''))
 	end)
 
 	return table.concat(display, '<br>')

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -182,7 +182,6 @@ end
 
 ---@param args table
 function CustomBuilding:setLpdbData(args)
-	
 	if args.informationType == CREEP then
 		mw.ext.LiquipediaDB.lpdb_datapoint('building_' .. self.pagename, {
 			name = args.name or self.pagename,
@@ -200,7 +199,7 @@ function CustomBuilding:setLpdbData(args)
 		})
 		return
 	end
-	
+
 	mw.ext.LiquipediaDB.lpdb_datapoint('building_' .. self.pagename, {
 		name = args.name or self.pagename,
 		type = 'building',
@@ -310,8 +309,8 @@ end
 ---@return Widget[]
 function CustomBuilding:_parseForCreeps(id, widgets)
 	local args = self.args
-	local startLevel = args.start_level == '1' and args.start_level or args.start_level and "'''" .. args.start_level .. "'''"
-
+	local startLevel = args.start_level == '1' and args.start_level or
+		args.start_level and "'''" .. args.start_level .. "'''"
 	local creeps = {}
 	Array.forEach(Array.parseCommaSeparatedString(args.creeps), function(creep)
 		local unit = mw.ext.LiquipediaDB.lpdb('datapoint', {

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -237,6 +237,8 @@ function CustomUnit:setLpdbData(args)
 			passive = Array.parseCommaSeparatedString(args.passive),
 			armortypes = Array.parseCommaSeparatedString(args.armor_type),
 			upgradesto = Array.parseCommaSeparatedString(args.upgrades_to),
+			bountyluminite = tonumber(args.bounty_luminite),
+			bountytherium = tonumber(args.bounty_therium),
 		},
 	})
 end


### PR DESCRIPTION
## Summary

- Add support for Creep Camps to `Module:Infobox:Building/Custom`
- Add bounties for luminite and therium to `Module:Infobox:Unit/Custom` storage (for creep units)

Example:
![image](https://github.com/user-attachments/assets/f0691850-b32d-494f-8c03-5f85df1dc5d7)


<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev tools

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
