### PR TITLE
fix(match2): aov comments cut off

### DIFF
--- a/components/match2/wikis/arenaofvalor/match_summary.lua
+++ b/components/match2/wikis/arenaofvalor/match_summary.lua
@@ -229,6 +229,7 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 		local comment = mw.html.create('div')
 		comment :wikitext(game.comment)
 				:css('margin', 'auto')
+				:css('width', '100%')
 		row:addElement(comment)
 	end
 


### PR DESCRIPTION
resolves #4558 

## Summary
On aov (game) comments in a match overflow/are cut off.
This PR gives the comment div a width of 100% top fix this issue

## How did you test this change?
current:
![Screenshot 2024-08-18 120417](https://github.com/user-attachments/assets/9324e5af-3f4b-4791-8cee-d08a4965aeef)
dev:
![Screenshot 2024-08-18 120434](https://github.com/user-attachments/assets/5c225bfc-3352-4bae-b638-d12c3db94208)
