### PR TITLE
fix(match2): AoE: Prevent hard error on missing team template

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -275,9 +275,9 @@ function CustomMatchGroupInput._getOpponents(match)
 			if template then
 				MatchGroupInput.readPlayersOfTeam(match, opponentIndex, template.page, {
 					resolveRedirect = true,
-					applyUnderScores = true,	
-					maxNumPlayers = MAX_NUM_PLAYERS,	
-				})	
+					applyUnderScores = true,
+					maxNumPlayers = MAX_NUM_PLAYERS,
+				})
 			end
 		end
 	end

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -271,11 +271,14 @@ function CustomMatchGroupInput._getOpponents(match)
 		match['opponent' .. opponentIndex] = opponent
 
 		if opponent.type == Opponent.team and Logic.isNotEmpty(opponent.template) then
-			MatchGroupInput.readPlayersOfTeam(match, opponentIndex, mw.ext.TeamTemplate.raw(opponent.template).page, {
-				resolveRedirect = true,
-				applyUnderScores = true,
-				maxNumPlayers = MAX_NUM_PLAYERS,
-			})
+			local template = mw.ext.TeamTemplate.raw(opponent.template)
+			if template then
+				MatchGroupInput.readPlayersOfTeam(match, opponentIndex, template.page, {
+					resolveRedirect = true,
+					applyUnderScores = true,	
+					maxNumPlayers = MAX_NUM_PLAYERS,	
+				})	
+			end
 		end
 	end
 


### PR DESCRIPTION
## Summary
The change from #4263 would lead to a hard error, preventing display of the entire bracket in case of a missing team template.
This prevents the immediate error and instead will result in the usual "Missing team template for ..." error inside the specific match.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
