### PR TITLE
feat(infobox) add support for passive abilities (traits) in stormgate infobox skill

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -33,6 +33,7 @@ local ICON_DEPRECATED = '[[File:Cancelled Tournament.png|link=]]'
 local VALID_SKILLS = {
 	'Spell',
 	'Ability',
+	'Trait',
 	'Upgrade',
 	'Effect',
 }


### PR DESCRIPTION
## Summary

Allow another category of skills in `infobox_skill` for better sorting and display in SkillCards.
Some units (especially heroes) have a lot of active and passive abilities. Being able to group them into (active) abilities and (passive) traits helps with clarity.

![image](https://github.com/user-attachments/assets/1872367f-28cf-4883-996d-53690e6da4aa)


<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev tools

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
