### PR TITLE
refactor(match2): remove unused deprecated functions

### DIFF
--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -233,42 +233,4 @@ end
 
 Lua.autoInvokeEntryPoints(MatchGroup, 'Module:MatchGroup')
 
-MatchGroup.deprecatedCategory = '[[Category:Pages using deprecated Match Group functions]]'
-
--- Entry point used by Template:Bracket
----@deprecated
-function MatchGroup.bracket(frame)
-	return MatchGroup.TemplateBracket(frame) .. MatchGroup.deprecatedCategory
-end
-
----@deprecated
-function MatchGroup.luaBracket(_, args)
-	return MatchGroup.TemplateBracket(args) .. MatchGroup.deprecatedCategory
-end
-
--- Entry point used by Template:Matchlist
----@deprecated
-function MatchGroup.matchlist(frame)
-	return MatchGroup.TemplateMatchlist(frame) .. MatchGroup.deprecatedCategory
-end
-
----@deprecated
-function MatchGroup.luaMatchlist(_, args)
-	return MatchGroup.TemplateMatchlist(args) .. MatchGroup.deprecatedCategory
-end
-
--- Entry point from Template:ShowBracket and direct #invoke
----@deprecated
-function MatchGroup.Display(frame)
-	return tostring(MatchGroup.TemplateShowBracket(frame)) .. MatchGroup.deprecatedCategory
-end
-
--- Entry point from direct #invoke
----@deprecated
-function MatchGroup.DisplayDev(frame)
-	local args = Arguments.getArgs(frame)
-	args.dev = true
-	return tostring(MatchGroup.TemplateShowBracket(args)) .. MatchGroup.deprecatedCategory
-end
-
 return MatchGroup

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -7,7 +7,6 @@
 --
 
 local Logic = require('Module:Logic')
-local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
 local MatchGroupBase = {}

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -112,16 +112,4 @@ function MatchGroupBase._checkBracketDuplicate(bracketId)
 	end
 end
 
----@deprecated
-function MatchGroupBase.luaMatchlist(_, args)
-	local MatchGroup = Lua.import('Module:MatchGroup')
-	return MatchGroup.MatchList(args) .. MatchGroup.deprecatedCategory
-end
-
----@deprecated
-function MatchGroupBase.luaBracket(_, args)
-	local MatchGroup = Lua.import('Module:MatchGroup')
-	return MatchGroup.Bracket(args) .. MatchGroup.deprecatedCategory
-end
-
 return MatchGroupBase


### PR DESCRIPTION
## Summary
These functions have been deprecated from a long time. They seem to have no usage

## How did you test this change?
They are unused based on the fact that the categories are never set
https://tools.liquipedia.space/?view=pagesfordeletion&category=Pages_using_deprecated_Match_Group_functions