### PR TITLE
fix(match2): unset status causing `hasSpecialStatus` to be true

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1251,7 +1251,8 @@ end
 ---@param opponents {status: string}[]
 ---@return boolean
 function MatchGroupInput.hasSpecialStatus(opponents)
-	return Array.any(opponents, function (opponent) return opponent.status ~= MatchGroupInput.STATUS.SCORE end)
+	return Array.any(opponents, function (opponent)
+			return opponent.status and opponent.status ~= MatchGroupInput.STATUS.SCORE end)
 end
 
 ---@param opponents {status: string?}[]


### PR DESCRIPTION
## Summary
`hasSpecialStatus` currently returns true if any of the opponnents has an unset status.
This (among other things) causes the finiuched checks in the refactors to always return true if no manual input is given.
This PR adds a nil check on the status check in `hasSpecialStatus`.

## How did you test this change?
dev