### PR TITLE
fix(match2): prep walkover consumers for walkover value fix

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -138,11 +138,11 @@ function DisplayHelper.MapAndStatus(game, config)
 
 	local statusText = nil
 	if game.resultType == 'default' then
-		if game.walkover == 'L' then
+		if game.walkover == 'l' then
 			statusText = NONBREAKING_SPACE .. '<i>(w/o)</i>'
-		elseif game.walkover == 'FF' then
+		elseif game.walkover == 'ff' then
 			statusText = NONBREAKING_SPACE .. '<i>(ff)</i>'
-		elseif game.walkover == 'DQ' then
+		elseif game.walkover == 'dq' then
 			statusText = NONBREAKING_SPACE .. '<i>(dq)</i>'
 		else
 			statusText = NONBREAKING_SPACE .. '<i>(def.)</i>'

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -192,8 +192,8 @@ MatchGroupUtil.types.GameOpponent = TypeUtil.struct({
 
 ---@alias ResultType 'default'|'draw'|'np'
 MatchGroupUtil.types.ResultType = TypeUtil.literalUnion('default', 'draw', 'np')
----@alias WalkoverType 'L'|'FF'|'DQ'
-MatchGroupUtil.types.Walkover = TypeUtil.literalUnion('L', 'FF', 'DQ')
+---@alias WalkoverType 'l'|'ff'|'dq'
+MatchGroupUtil.types.Walkover = TypeUtil.literalUnion('l', 'ff', 'dq')
 
 ---@class MatchGroupUtilGame
 ---@field comment string?
@@ -503,6 +503,8 @@ function MatchGroupUtil.matchFromRecord(record)
 			or MatchGroupUtil.autoAssignLowerEdges(#bracketData.lowerMatchIds, #opponents)
 	end
 
+	local walkover = nilIfEmpty(record.walkover)
+
 	return {
 		bestof = tonumber(record.bestof) or 0,
 		bracketData = bracketData,
@@ -528,7 +530,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		tournament = record.tournament,
 		type = nilIfEmpty(record.type) or 'literal',
 		vod = nilIfEmpty(record.vod),
-		walkover = nilIfEmpty(record.walkover),
+		walkover = walkover and walkover:lower() or nil,
 		winner = tonumber(record.winner),
 	}
 end
@@ -649,6 +651,9 @@ end
 ---@return MatchGroupUtilGame
 function MatchGroupUtil.gameFromRecord(record)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
+
+	local walkover = nilIfEmpty(record.walkover)
+
 	return {
 		comment = nilIfEmpty(Table.extract(extradata, 'comment')),
 		date = record.date,
@@ -665,7 +670,7 @@ function MatchGroupUtil.gameFromRecord(record)
 		subgroup = tonumber(record.subgroup),
 		type = nilIfEmpty(record.type),
 		vod = nilIfEmpty(record.vod),
-		walkover = nilIfEmpty(record.walkover),
+		walkover = walkover and walkover:lower() or nil,
 		winner = tonumber(record.winner),
 	}
 end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -331,7 +331,7 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 		local isWinner = opponentIndex == submatch.winner
 		local text
 		if submatch.resultType == 'default' then
-			text = isWinner and 'W' or submatch.walkover
+			text = isWinner and 'W' or submatch.walkover:upper()
 		else
 			local score = submatch.scores[opponentIndex]
 			text = score and tostring(score) or ''

--- a/components/match2/wikis/ageofempires/match_legacy.lua
+++ b/components/match2/wikis/ageofempires/match_legacy.lua
@@ -95,6 +95,7 @@ function MatchLegacy._convertParameters(match2)
 		end
 	end
 
+	match.walkover = match.walkover and string.upper(match.walkover) or nil
 	if match.walkover == 'FF' or match.walkover == 'DQ' then
 		match.resulttype = match.walkover:lower()
 		match.walkover = match.winner

--- a/components/match2/wikis/brawlhalla/match_legacy.lua
+++ b/components/match2/wikis/brawlhalla/match_legacy.lua
@@ -37,6 +37,7 @@ function MatchLegacy._convertParameters(match2)
 		end
 	end
 
+	match.walkover = match.walkover and string.upper(match.walkover) or nil
 	if match.walkover == 'FF' or match.walkover == 'DQ' then
 		match.resulttype = match.walkover:lower()
 		match.walkover = match.winner

--- a/components/match2/wikis/fighters/match_legacy.lua
+++ b/components/match2/wikis/fighters/match_legacy.lua
@@ -78,6 +78,7 @@ function MatchLegacy._convertParameters(match2)
 		return not String.startsWith(key, 'match2')
 	end)
 
+	match.walkover = match.walkover and string.upper(match.walkover) or nil
 	if match.walkover == 'FF' or match.walkover == 'DQ' then
 		match.resulttype = match.walkover:lower()
 		match.walkover = match.winner


### PR DESCRIPTION
## Summary
Currently several wikis store walkovers uppercased, while they should be lower cased.
This PR adjusts the consumers on the repo in a way that they can handle both upper and lower case so we can fix the storage with the refactors.

## How did you test this change?
dev