### PR TITLE
fix(match2): mapscore started auto calcing too early on R6

### DIFF
--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -222,7 +222,7 @@ end
 ---@return fun(opponentIndex: integer): integer?
 function MapFunctions.calculateMapScore(map)
 	return function(opponentIndex)
-		if not map['t'.. opponentIndex ..'atk'] and map['t'.. opponentIndex ..'def'] then
+		if not map['t'.. opponentIndex ..'atk'] and not map['t'.. opponentIndex ..'def'] then
 			return
 		end
 		return (tonumber(map['t'.. opponentIndex ..'atk']) or 0)


### PR DESCRIPTION
## Summary
A missing `not` made the condition incorrect

## How did you test this change?
Tested with /dev on valorant