### PR TITLE
feat(match2): remove redundant score workaround on sc(2)

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -185,11 +185,6 @@ end
 ---@param opponent table
 ---@param autoScore? fun(opponentIndex: integer): integer?
 function MatchFunctions.computeOpponentScore(props, opponent, autoScore)
-	-- TODO: bot the usage away
-	if props.score == '-' then
-		props.score = 'L'
-	end
-
 	local calculatedScore
 	calculatedScore, opponent.status = MatchGroupInput.computeOpponentScore(props, autoScore)
 


### PR DESCRIPTION
## Summary
Due to removing the need for the workaround via bot runs we now can kick the workaround

## How did you test this change?
N/A