### PR TITLE
feat(standard): set a different category for userspace errors

### DIFF
--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -167,7 +167,11 @@ function Lua.callAndDisplayErrors(fn, frame, hardErrors)
 		else
 			table.insert(parts, tostring(ErrorDisplay.ErrorList{errors = errors}))
 		end
-		mw.ext.TeamLiquidIntegration.add_category('Pages with script errors')
+		if mw.title.getCurrentTitle().namespace == 2 then
+			mw.ext.TeamLiquidIntegration.add_category('User pages with script errors')
+		else
+			mw.ext.TeamLiquidIntegration.add_category('Pages with script errors')
+		end
 	end
 
 	return table.concat(parts)


### PR DESCRIPTION
## Summary
A new and different category for caught lua errors in userspace
## How did you test this change?
/dev