### PR TITLE
feat(match2): remove temp workarounds on sc(2) MGI

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -32,10 +32,6 @@ local TBD = 'TBD'
 local TBA = 'TBA'
 local MODE_MIXED = 'mixed'
 
---- only temp needed until bot job finishes
-local TEMP_WORKAROUND = {['-'] = 'L'}
-local TEMP_WORKAROUND2 = {['draw'] = 0}
-
 local StarcraftMatchGroupInput = {}
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -53,8 +49,6 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 	local opponents = Array.mapIndexes(function(opponentIndex)
 		return MatchGroupInput.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
-
-	match.winner = TEMP_WORKAROUND2[string.lower(match.winner or '')] or match.winner
 
 	-- TODO: check how we can get rid of this legacy stuff ...
 	Array.forEach(opponents, function(opponent, opponentIndex)
@@ -85,7 +79,7 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 			walkover = match.walkover,
 			winner = match.winner,
 			opponentIndex = opponentIndex,
-			score = TEMP_WORKAROUND[opponent.score] or opponent.score,
+			score = opponent.score,
 		}, autoScoreFunction)
 	end)
 


### PR DESCRIPTION
## Summary
Remove the temp. workarounds form sc(2) MatchInput processing after the need for them has been resolved by bot jobs.

## How did you test this change?
N/A