### PR TITLE
fix(match2): pass wrong var to `canUseAutoScore`

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -76,7 +76,7 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 
 	local games = MatchFunctions.extractMaps(match, opponents)
 
-	local autoScoreFunction = MatchGroupInput.canUseAutoScore(match, opponents)
+	local autoScoreFunction = MatchGroupInput.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games, opponents)
 		or nil
 


### PR DESCRIPTION
## Summary

## How did you test this change?
live