### PR TITLE
fix(match2): not played input handling - step 2

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1085,15 +1085,21 @@ function MatchGroupInput.getMapVeto(match, allowedVetoes)
 	return data
 end
 
+---@param winnerInput integer|string|nil
+---@param finishedInput string?
+---@return boolean
+function MatchGroupInput.isNotPlayed(winnerInput, finishedInput)
+	return (type(winnerInput) == 'string' and MatchGroupInput.isNotPlayedInput(winnerInput))
+		or (type(finishedInput) == 'string' and MatchGroupInput.isNotPlayedInput(finishedInput))
+end
+
 ---Should only be called on finished matches or maps
 ---@param winnerInput integer|string|nil
 ---@param finishedInput string?
 ---@param opponents {score: number?, status: string}[]
 ---@return string? #Result Type
 function MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
-	if (type(winnerInput) == 'string' and MatchGroupInput.isNotPlayedInput(winnerInput))
-		or (type(finishedInput) == 'string' and MatchGroupInput.isNotPlayedInput(finishedInput)) then
-
+	if MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
 		return MatchGroupInput.RESULT_TYPE.NOT_PLAYED
 	end
 
@@ -1312,9 +1318,10 @@ end
 ---@param winner integer?
 ---@param placementWinner integer
 ---@param placementLoser integer
+---@param resultType string
 ---@return table[]
-function MatchGroupInput.setPlacement(opponents, winner, placementWinner, placementLoser)
-	if not opponents or #opponents ~= 2 then
+function MatchGroupInput.setPlacement(opponents, winner, placementWinner, placementLoser, resultType)
+	if not opponents or #opponents ~= 2 or resultType == MatchGroupInput.RESULT_TYPE.NOT_PLAYED then
 		return opponents
 	end
 

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1318,7 +1318,7 @@ end
 ---@param winner integer?
 ---@param placementWinner integer
 ---@param placementLoser integer
----@param resultType string
+---@param resultType string?
 ---@return table[]
 function MatchGroupInput.setPlacement(opponents, winner, placementWinner, placementLoser, resultType)
 	if not opponents or #opponents ~= 2 or resultType == MatchGroupInput.RESULT_TYPE.NOT_PLAYED then

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1359,6 +1359,10 @@ end
 ---@param opponents {score: integer?}[]
 ---@return boolean
 function MatchGroupInput.matchIsFinished(match, opponents)
+	if MatchGroupInput.isNotPlayed(match.winner, match.finished) then
+		return true
+	end
+
 	local finished = Logic.readBoolOrNil(match.finished)
 	if finished ~= nil then
 		return finished

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1397,6 +1397,10 @@ end
 ---@param opponents? {score: integer?}[]
 ---@return boolean
 function MatchGroupInput.mapIsFinished(map, opponents)
+	if MatchGroupInput.isNotPlayed(map.winner, map.finished) then
+		return true
+	end
+
 	local finished = Logic.readBoolOrNil(map.finished)
 	if finished ~= nil then
 		return finished

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -308,6 +308,10 @@ end
 ---@param opponentCount integer
 ---@return boolean
 function MapFunctions.isFinished(mapInput, opponentCount)
+	if MatchGroupInput.isNotPlayed(mapInput.winner, mapInput.finished) then
+		return true
+	end
+
 	local finished = Logic.readBoolOrNil(mapInput.finished)
 	if finished ~= nil then
 		return finished

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -105,7 +105,7 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchGroupInput.getCommonTournamentVars(match)
@@ -162,7 +162,7 @@ end
 
 ---@param maps table[]
 ---@param opponents table[]
----@return fun(opponentIndex: integer): integer
+---@return fun(opponentIndex: integer): integer?
 function MatchFunctions.calculateMatchScore(maps, opponents)
 	return function(opponentIndex)
 		local calculatedScore = MatchGroupInput.computeMatchScoreFromMapWinners(maps, opponentIndex)

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -73,7 +73,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -179,6 +179,7 @@ end
 
 -- Parse extradata information
 ---@param map table
+---@param opponentCount integer
 ---@return table
 function MapFunctions.getExtraData(map, opponentCount)
 	local extraData = {

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -68,7 +68,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -58,7 +58,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -102,7 +102,7 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -66,7 +66,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -175,6 +175,8 @@ end
 
 -- Parse extradata information
 ---@param map table
+---@param opponentCount integer
+---@return table
 function MapFunctions.getExtraData(map, opponentCount)
 	local extraData = {
 		comment = map.comment,

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -102,7 +102,7 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -58,7 +58,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -63,7 +63,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -65,7 +65,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -62,7 +62,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -72,7 +72,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
-		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -178,6 +178,7 @@ end
 
 -- Parse extradata information
 ---@param map table
+---@param opponentCount integer
 ---@return table
 function MapFunctions.getExtraData(map, opponentCount)
 	local extraData = {


### PR DESCRIPTION
Follow up to #4601 - This PR changes `np` to be `finished`

## Summary
current behaviour:
- if `finished=np/skip/...` --> match is not assumed as finished and resulttype is not set properly
- if `winner=np/skip/...` --> match is assumed finished but errors on `setPlacement` because it expects a valid winner input

this PR makes it so that on `np/skip/...` input in either winner or finished **the match is assumed to be finished**
it also fixes the above mentioned error in `setPlacement`
additionally it fixes a few annos

## How did you test this change?
dev