### PR TITLE
fix(match2): not played input handling - step 1

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1359,7 +1359,6 @@ end
 ---@return boolean
 function MatchGroupInput.matchIsFinished(match, opponents)
 	if MatchGroupInput.isNotPlayed(match.winner, match.finished) then
-		-- decide if true or false, personally fav false
 		return false
 	end
 

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1359,7 +1359,7 @@ end
 ---@return boolean
 function MatchGroupInput.matchIsFinished(match, opponents)
 	if MatchGroupInput.isNotPlayed(match.winner, match.finished) then
-		return false
+		return true
 	end
 
 	local finished = Logic.readBoolOrNil(match.finished)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1401,7 +1401,7 @@ end
 ---@return boolean
 function MatchGroupInput.mapIsFinished(map, opponents)
 	if MatchGroupInput.isNotPlayed(map.winner, map.finished) then
-		return true
+		return false
 	end
 
 	local finished = Logic.readBoolOrNil(map.finished)

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1085,15 +1085,21 @@ function MatchGroupInput.getMapVeto(match, allowedVetoes)
 	return data
 end
 
+---@param winnerInput integer|string|nil
+---@param finishedInput string?
+---@return boolean
+function MatchGroupInput.isNotPlayed(winnerInput, finishedInput)
+	return (type(winnerInput) == 'string' and MatchGroupInput.isNotPlayedInput(winnerInput))
+		or (type(finishedInput) == 'string' and MatchGroupInput.isNotPlayedInput(finishedInput))
+end
+
 ---Should only be called on finished matches or maps
 ---@param winnerInput integer|string|nil
 ---@param finishedInput string?
 ---@param opponents {score: number?, status: string}[]
 ---@return string? #Result Type
 function MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
-	if (type(winnerInput) == 'string' and MatchGroupInput.isNotPlayedInput(winnerInput))
-		or (type(finishedInput) == 'string' and MatchGroupInput.isNotPlayedInput(finishedInput)) then
-
+	if MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
 		return MatchGroupInput.RESULT_TYPE.NOT_PLAYED
 	end
 
@@ -1352,6 +1358,11 @@ end
 ---@param opponents {score: integer?}[]
 ---@return boolean
 function MatchGroupInput.matchIsFinished(match, opponents)
+	if MatchGroupInput.isNotPlayed(match.winner, match.finished) then
+		-- decide if true or false, personally fav false
+		return false
+	end
+
 	local finished = Logic.readBoolOrNil(match.finished)
 	if finished ~= nil then
 		return finished
@@ -1390,6 +1401,10 @@ end
 ---@param opponents? {score: integer?}[]
 ---@return boolean
 function MatchGroupInput.mapIsFinished(map, opponents)
+	if MatchGroupInput.isNotPlayed(map.winner, map.finished) then
+		return true
+	end
+
 	local finished = Logic.readBoolOrNil(map.finished)
 	if finished ~= nil then
 		return finished

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1359,7 +1359,7 @@ end
 ---@return boolean
 function MatchGroupInput.matchIsFinished(match, opponents)
 	if MatchGroupInput.isNotPlayed(match.winner, match.finished) then
-		return true
+		return false
 	end
 
 	local finished = Logic.readBoolOrNil(match.finished)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -106,6 +106,9 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchGroupInput.getCommonTournamentVars(match)
@@ -162,7 +165,7 @@ end
 
 ---@param maps table[]
 ---@param opponents table[]
----@return fun(opponentIndex: integer): integer
+---@return fun(opponentIndex: integer): integer?
 function MatchFunctions.calculateMatchScore(maps, opponents)
 	return function(opponentIndex)
 		local calculatedScore = MatchGroupInput.computeMatchScoreFromMapWinners(maps, opponentIndex)
@@ -295,7 +298,7 @@ function MapFunctions.readMap(mapInput, subGroup, opponentCount)
 
 	map.scores = Array.map(opponentInfo, Operator.property('score'))
 
-	if map.finished then
+	if map.finished or MatchGroupInput.isNotPlayed(map.winner, mapInput.finished) then
 		map.resulttype = MatchGroupInput.getResultType(mapInput.winner, mapInput.finished, opponentInfo)
 		map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 		map.winner = MatchGroupInput.getWinner(map.resulttype, mapInput.winner, opponentInfo)
@@ -308,6 +311,10 @@ end
 ---@param opponentCount integer
 ---@return boolean
 function MapFunctions.isFinished(mapInput, opponentCount)
+	if MatchGroupInput.isNotPlayed(mapInput.winner, mapInput.finished) then
+		return true
+	end
+
 	local finished = Logic.readBoolOrNil(mapInput.finished)
 	if finished ~= nil then
 		return finished

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -74,6 +74,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -115,7 +118,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)
@@ -179,6 +182,7 @@ end
 
 -- Parse extradata information
 ---@param map table
+---@param opponentCount integer
 ---@return table
 function MapFunctions.getExtraData(map, opponentCount)
 	local extraData = {

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -69,6 +69,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -110,7 +113,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		map.finished = MatchGroupInput.mapIsFinished(map, opponentInfo)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -59,6 +59,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -97,7 +100,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -103,6 +103,9 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -150,7 +153,7 @@ function MatchFunctions.extractMaps(MatchParser, match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -67,6 +67,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -108,7 +111,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)
@@ -175,6 +178,8 @@ end
 
 -- Parse extradata information
 ---@param map table
+---@param opponentCount integer
+---@return table
 function MapFunctions.getExtraData(map, opponentCount)
 	local extraData = {
 		comment = map.comment,

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -103,6 +103,9 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -149,7 +152,7 @@ function MatchFunctions.extractMaps(MatchParser, match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -59,6 +59,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -101,7 +104,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -64,6 +64,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -108,7 +111,7 @@ function MatchFunctions.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -66,6 +66,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -105,7 +108,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -63,6 +63,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -103,7 +106,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -73,6 +73,9 @@ function CustomMatchGroupInput.processMatch(match, options)
 		match.walkover = MatchGroupInput.getWalkover(match.resulttype, opponents)
 		match.winner = MatchGroupInput.getWinner(match.resulttype, winnerInput, opponents)
 		MatchGroupInput.setPlacement(opponents, match.winner, 1, 2)
+	elseif MatchGroupInput.isNotPlayed(winnerInput, finishedInput) then
+		match.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponents)
+		match.winner = nil
 	end
 
 	MatchFunctions.getTournamentVars(match)
@@ -114,7 +117,7 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
-		if map.finished then
+		if map.finished or MatchGroupInput.isNotPlayed(map.winner, finishedInput) then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)
 			map.winner = MatchGroupInput.getWinner(map.resulttype, winnerInput, opponentInfo)
@@ -178,6 +181,7 @@ end
 
 -- Parse extradata information
 ---@param map table
+---@param opponentCount integer
 ---@return table
 function MapFunctions.getExtraData(map, opponentCount)
 	local extraData = {


### PR DESCRIPTION
Step 2 is #4600

## Summary
current behaviour:
- if `finished=np/skip/...` --> match is not assumed as finished and resulttype is not set properly
- if `winner=np/skip/...` --> match is assumed finished but errors on `setPlacement` because it expects a valid winner input

this PR makes it so that on `np/skip/...` input in either winner or finished **the match is assumed to _not_ be finished**
this results in the error not being able to occour
due to `np/skip` now setting the match as not finished the `resulttype` processing for these cases has to be caught too
additionally this PR fixes a few missing annos

## How did you test this change?
dev