### PR TITLE
feat(match2): improve map score display on R6 and OW

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -152,6 +152,19 @@ function DisplayHelper.MapAndStatus(game, config)
 	return mapText .. (statusText or '')
 end
 
+---@param score string|number|nil
+---@param opponentIndex integer
+---@param resultType string?
+---@param walkover string?
+---@param winner integer?
+---@return string
+function DisplayHelper.MapScore(score, opponentIndex, resultType,  walkover, winner)
+	if resultType == 'default' then
+		return opponentIndex == winner and 'W' or string.upper(walkover or '')
+	end
+	return score and tostring(score) or ''
+end
+
 --[[
 Display component showing the detailed summary of a match. The component will
 appear as a popup from the Matchlist and Bracket components. This is a

--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -101,7 +101,8 @@ function CustomMatchSummary._gameScore(game, opponentIndex)
 	if score and game.mode == 'Push' then
 		score = score .. 'm'
 	end
-	return htmlCreate('div'):wikitext(score)
+	local scoreDisplay = DisplayHelper.MapScore(score, opponentIndex, game.resultType, game.walkover, game.winner)
+	return htmlCreate('div'):wikitext(scoreDisplay)
 end
 
 ---@param game MatchGroupUtilGame

--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -476,7 +476,7 @@ function CustomMatchSummary._createMap(game)
 	local team2Score = Score():setRight()
 
 	-- Score Team 1
-	team1Score:setMapScore(game.scores[1])
+	team1Score:setMapScore(DisplayHelper.MapScore(game.scores[1], 1, game.resultType, game.walkover, game.winner))
 
 	-- Detailed scores
 	local team1Halfs = extradata.t1halfs or {}
@@ -512,7 +512,7 @@ function CustomMatchSummary._createMap(game)
 	end
 
 	-- Score Team 2
-	team2Score:setMapScore(game.scores[2])
+	team2Score:setMapScore(DisplayHelper.MapScore(game.scores[1], 1, game.resultType, game.walkover, game.winner))
 
 	-- Operator bans
 	local operatorBans = {team1 = extradata.t1bans or {}, team2 = extradata.t2bans or {}}


### PR DESCRIPTION
## Summary
Currently on R6 and OW, default resultTypes are displaying the score as `-1`. This will change it to show `W` and walkoverType (often `L`)

## How did you test this change?
/dev