### PR TITLE
feat(match2): entering map-score on rocketleague should finish the map, unless `|finished=false`

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -105,6 +105,10 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 		end)
 
 		map.scores = Array.map(opponentInfo, Operator.property('score'))
+		if Logic.readBoolOrNil(finishedInput) == nil and Logic.isNotEmpty(map.scores) then
+			map.finished = true
+		end
+
 		if map.finished then
 			map.resulttype = MatchGroupInput.getResultType(winnerInput, finishedInput, opponentInfo)
 			map.walkover = MatchGroupInput.getWalkover(map.resulttype, opponentInfo)


### PR DESCRIPTION
## Summary
Rocket League maps are assumed to be completed once scores are entered, unless finished is explicitly set to false.
## How did you test this change?
Preview in dev