### PR TITLE
fix(match2): dota2 matchpage team logo stretching 

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -94,14 +94,12 @@ Author(s): Rathoz
 		img {
 			max-width: 4rem;
 			max-height: 4rem;
-			width: 4rem;
-			height: 4rem;
+			width: auto;
+			height: auto;
 
 			@media ( min-width: 768px ) {
 				max-width: 5rem;
 				max-height: 5rem;
-				width: 5rem;
-				height: 5rem;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR removes the specific width and heights on the team logo's.

## How did you test this change?

devtools
