### PR TITLE
fix(match2): missing links for COD

### DIFF
--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -145,8 +145,8 @@ end
 function MatchFunctions.getLinks(match)
 	return {
 		reddit = match.reddit and 'https://redd.it/' .. match.reddit or nil,
-		gol = match.gol and 'https://gol.gg/game/stats/' .. match.gol .. '/page-game/' or nil,
-		factor = match.factor and 'https://www.factor.gg/match/' .. match.factor or nil,
+		cdl = match.cdl and 'https://callofdutyleague.com/en-us/match/' .. match.cdl or nil,
+		breakingpoint = match.breakingpoint and 'https://www.breakingpoint.gg/match/' .. match.breakingpoint or nil,
 	}
 end
 


### PR DESCRIPTION
## Summary
This two was replaced by GOL and Factor (which is for the LoL wiki) following the refactor changes, This is to brought back the accidentally replaced ones

![image](https://github.com/user-attachments/assets/91a716f4-3edc-4fc7-8850-95adbc853130)
(Pic is pre-refactoring)

## How did you test this change?
LIVE