### PR TITLE
fix(match2): `acs` misspelled as `asc`

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -223,7 +223,7 @@ function MapFunctions.getParticipants(map, opponentCount)
 				kills = stats.kills,
 				deaths = stats.deaths,
 				assists = stats.assists,
-				asc = stats.acs,
+				acs = stats.acs,
 				player = stats.player,
 				agent = getCharacterName(stats.agent),
 			}


### PR DESCRIPTION
## Summary
Fixes typo
Reported by GodOfPog https://discord.com/channels/93055209017729024/372075546231832576/1276022319734849609

## How did you test this change?

did live patch
