### PR TITLE
fix(match2): uncalculated mode for games with missing opponents

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -162,7 +162,7 @@ end
 
 ---@param maps table[]
 ---@param opponents table[]
----@return fun(opponentIndex: integer): integer
+---@return fun(opponentIndex: integer): integer?
 function MatchFunctions.calculateMatchScore(maps, opponents)
 	return function(opponentIndex)
 		local calculatedScore = MatchGroupInput.computeMatchScoreFromMapWinners(maps, opponentIndex)
@@ -477,8 +477,8 @@ end
 ---@param opponents table[]
 ---@return string
 function MapFunctions.getMode(mapInput, participants, opponents)
-	---@type (string|integer)[]
-	local playerCounts = {}
+	-- assume we have a min of 2 opponents in a game
+	local playerCounts = {0, 0}
 	for key in pairs(participants) do
 		local parsedOpponentIndex = key:match('(%d+)_%d+')
 		local opponetIndex = tonumber(parsedOpponentIndex) --[[@as integer]]


### PR DESCRIPTION
## Summary
if participants was empty it did not calculate any numbers leading to en empty map mode which then got overwritten by `MatchGroupInput._applyTournamentVarsToMaps` with the mode of the match, leading to a display bug

This PR adjusts it so that we assume we have 2 oppoennts if no participants data is found and sets the mode accordingly to `literalvliteral` as it was intended.

## How did you test this change?
dev to live