### PR TITLE
feat(match2): improve score display on sc(2) submatches

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -327,6 +327,9 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 		return node:addClass('brkts-popup-sc-submatch-opponent')
 	end
 
+	local hasNonZeroScore = Array.any(submatch.scores, function(score) return score ~= 0 end)
+	local hasPlayers = Array.any(submatch.opponents, function(opponent) return Logic.isNotEmpty(opponent.players) end)
+
 	local renderScore = function(opponentIndex)
 		if submatch.resultType == 'np' then
 			return
@@ -335,7 +338,7 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 		local text
 		if submatch.resultType == 'default' then
 			text = isWinner and 'W' or submatch.walkover:upper()
-		else
+		elseif hasNonZeroScore or hasPlayers then
 			local score = submatch.scores[opponentIndex]
 			text = score and tostring(score) or ''
 		end

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -331,13 +331,12 @@ function StarcraftMatchSummary.TeamSubmatch(props)
 	local hasPlayers = Array.any(submatch.opponents, function(opponent) return Logic.isNotEmpty(opponent.players) end)
 
 	local renderScore = function(opponentIndex)
-		if submatch.resultType == 'np' then
-			return
-		end
 		local isWinner = opponentIndex == submatch.winner
 		local text
 		if submatch.resultType == 'default' then
 			text = isWinner and 'W' or submatch.walkover:upper()
+		elseif submatch.resultType == 'np' then
+			text = ''
 		elseif hasNonZeroScore or hasPlayers then
 			local score = submatch.scores[opponentIndex]
 			text = score and tostring(score) or ''


### PR DESCRIPTION
## Summary
Currently in submatches the score 0 is always show even if no player nor winner data in the maps of the submatch was entered.

This PR changes that behaviour and only displays the submatch scores if
- resultType is not `default`
- at least one of the scores is non 0
- at least one of the submatch opponents has player data entered

## How did you test this change?
dev

before:
![Screenshot 2024-08-22 082239](https://github.com/user-attachments/assets/6428b828-6195-4bdf-97c2-5197f9238f35)
with pr:
![Screenshot 2024-08-22 081539](https://github.com/user-attachments/assets/4e0171c0-ebb2-4202-9d02-a56d16cdfd6f)