### PR TITLE
feat(match2): improve name and displayName processing

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -755,8 +755,8 @@ function MatchGroupInput.extractManualPlayersInput(match, opponentIndex, opponen
 
 	for playerPrefix, playerName in Table.iter.pairsByPrefix(playersData, 'p') do
 		table.insert(manualInput.players, {
-			pageName = playerName,
-			displayName = playersData[playerPrefix .. 'dn'],
+			pageName = playersData[playerPrefix .. 'link'] or playerName,
+			displayName = playersData[playerPrefix .. 'dn'] or playerName,
 			flag = playersData[playerPrefix .. 'flag'],
 			faction = playersData[playerPrefix .. 'faction'] or playersData[playerPrefix .. 'race'],
 		})


### PR DESCRIPTION
## Summary
- some wikis use `pX` as displayName with `pXlink` being the link overwrite
- some wikis use `pX` as the link with `pXdn` being the displayName overwrite

This PR makes it so that
- the displayName is actually read
- the above mentioned cases are both covered

## How did you test this change?
dev to live