### PR TITLE
fix(match2): manual winner for partial unknown score overwritten with `-1`

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1113,12 +1113,12 @@ end
 function MatchGroupInput.getWinner(resultType, winnerInput,  opponents)
 	if resultType == MatchGroupInput.RESULT_TYPE.NOT_PLAYED then
 		return nil
+	elseif Logic.isNumeric(winnerInput) then
+		return tonumber(winnerInput)
 	elseif resultType == MatchGroupInput.RESULT_TYPE.DRAW then
 		return MatchGroupInput.WINNER_DRAW
 	elseif resultType == MatchGroupInput.RESULT_TYPE.DEFAULT then
 		return MatchGroupInput.getDefaultWinner(opponents)
-	elseif Logic.isNumeric(winnerInput) then
-		return tonumber(winnerInput)
 	else
 		return MatchGroupInput.getHighestScoringOpponent(opponents)
 	end


### PR DESCRIPTION
## Summary
Edge case (reported on sc2):
- one opponent has known score and the score (numeric) is entered
- one opponent has unknown score and `L` is entered as the score

Currently in this edge case the winner is determined as -1, even if manual winner input is entered.

This PR adjusts it so that if (numeric) manual winner input is evaluated before trying to determine a winner based on scores (be it as draw, via `getDefaultWinner` or `getHighestScoringOpponent`).

## How did you test this change?
dev