### PR TITLE
feat(match2): map score display for walkovers on VAL

### DIFF
--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -27,6 +27,8 @@ local LINK_DATA = {
 	vlr = {icon = 'File:VLR icon.png', text = 'Matchpage and Stats on VLR'},
 }
 
+local DEFAULT_WINNER = 'W'
+
 ---@class ValorantAgents
 ---@operator call: ValorantAgents
 ---@field root Html
@@ -106,11 +108,20 @@ function Score:setRight()
 	return self
 end
 
----@param score string|number|nil
+---@param game MatchGroupUtilGame
+---@param opponentIndex integer
 ---@return self
-function Score:setMapScore(score)
+function Score:setMapScore(game, opponentIndex)
+	---@type string|number|nil
+	local score = game.scores[opponentIndex]
+	if game.walkover and game.winner == opponentIndex then
+		score = DEFAULT_WINNER
+	elseif game.walkover then
+		score = game.walkover:upper()
+	end
+
 	local mapScore = mw.html.create('td')
-	mapScore:attr('rowspan', '2')
+			:attr('rowspan', '2')
 			:css('font-size', '16px')
 			:css('width', '24px')
 			:wikitext(score or '')
@@ -387,7 +398,7 @@ function CustomMatchSummary._createMap(game)
 	score1 = Score():setLeft()
 	score2 = Score():setRight()
 
-	score1:setMapScore(game.scores[1])
+	score1:setMapScore(game, 1)
 
 	if not Table.isEmpty(extradata) then
 		-- Detailed scores
@@ -409,7 +420,7 @@ function CustomMatchSummary._createMap(game)
 		score2:addBottomRoundScore(firstSide, team2Halfs[firstSide])
 	end
 
-	score2:setMapScore(game.scores[2])
+	score2:setMapScore(game, 2)
 
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))
 	if team1Agents ~= nil then

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -27,8 +27,6 @@ local LINK_DATA = {
 	vlr = {icon = 'File:VLR icon.png', text = 'Matchpage and Stats on VLR'},
 }
 
-local DEFAULT_WINNER = 'W'
-
 ---@class ValorantAgents
 ---@operator call: ValorantAgents
 ---@field root Html
@@ -112,19 +110,14 @@ end
 ---@param opponentIndex integer
 ---@return self
 function Score:setMapScore(game, opponentIndex)
-	---@type string|number|nil
-	local score = game.scores[opponentIndex]
-	if game.walkover and game.winner == opponentIndex then
-		score = DEFAULT_WINNER
-	elseif game.walkover then
-		score = game.walkover:upper()
-	end
+	local scoreDisplay = DisplayHelper.MapScore(
+		game.scores[opponentIndex], opponentIndex, game.resultType, game.walkover, game.winner)
 
 	local mapScore = mw.html.create('td')
 			:attr('rowspan', '2')
 			:css('font-size', '16px')
 			:css('width', '24px')
-			:wikitext(score or '')
+			:wikitext(scoreDisplay)
 	self.top:node(mapScore)
 
 	return self

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -106,18 +106,14 @@ function Score:setRight()
 	return self
 end
 
----@param game MatchGroupUtilGame
----@param opponentIndex integer
+---@param score string?
 ---@return self
-function Score:setMapScore(game, opponentIndex)
-	local scoreDisplay = DisplayHelper.MapScore(
-		game.scores[opponentIndex], opponentIndex, game.resultType, game.walkover, game.winner)
-
+function Score:setMapScore(score)
 	local mapScore = mw.html.create('td')
 			:attr('rowspan', '2')
 			:css('font-size', '16px')
 			:css('width', '24px')
-			:wikitext(scoreDisplay)
+			:wikitext(score)
 	self.top:node(mapScore)
 
 	return self
@@ -391,7 +387,7 @@ function CustomMatchSummary._createMap(game)
 	score1 = Score():setLeft()
 	score2 = Score():setRight()
 
-	score1:setMapScore(game, 1)
+	score1:setMapScore(DisplayHelper.MapScore(game.scores[1], 1, game.resultType, game.walkover, game.winner))
 
 	if not Table.isEmpty(extradata) then
 		-- Detailed scores
@@ -413,7 +409,8 @@ function CustomMatchSummary._createMap(game)
 		score2:addBottomRoundScore(firstSide, team2Halfs[firstSide])
 	end
 
-	score2:setMapScore(game, 2)
+
+	score1:setMapScore(DisplayHelper.MapScore(game.scores[2], 2, game.resultType, game.walkover, game.winner))
 
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner == 1))
 	if team1Agents ~= nil then


### PR DESCRIPTION
## Summary
Currently in case of a walkover game/map in the matchsummary `-1` is displayed.
This PR make sit so that the walkover information is displayed instead.

## How did you test this change?
dev

![image](https://github.com/user-attachments/assets/5575625d-99f1-43ca-b11f-b5e8673d069e)
