### PR TITLE
feat(match2): ignore empty string scores

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -1180,7 +1180,7 @@ function MatchGroupInput.computeOpponentScore(props, autoScore)
 		return MatchGroupInput.opponentWalkover(props.walkover, winner == props.opponentIndex)
 	end
 	local score = props.score
-	if not score and autoScore then
+	if Logic.isEmpty(score) and autoScore then
 		score = autoScore(props.opponentIndex)
 	end
 
@@ -1191,9 +1191,10 @@ end
 ---@return integer? #SCORE
 ---@return string? #STATUS
 function MatchGroupInput.parseScoreInput(scoreInput)
-	if not scoreInput then
+	if Logic.isEmpty(scoreInput) then
 		return
 	end
+	---@cast scoreInput -nil
 
 	if Logic.isNumeric(scoreInput) then
 		return tonumber(scoreInput), MatchGroupInput.STATUS.SCORE


### PR DESCRIPTION
## Summary
Temporary fix needed for Match1 Legacy input, as sometimes we get empty-string-scores from it, which are causing havoc.

## How did you test this change?
Live for a couple of days