### PR TITLE
feat(participantsTable): display columns if only dq opponents are in them

### DIFF
--- a/components/participant_table/wikis/warcraft/participant_table_custom.lua
+++ b/components/participant_table/wikis/warcraft/participant_table_custom.lua
@@ -154,18 +154,18 @@ function CustomParticipantTable:createSoloFactionTable()
 
 	local factionColumns = Array.copy(Faction.coreFactions)
 
-	if config.displayRandomColumn or config.displayRandomColumn == nil and factioNumbers.rDisplay > 0 then
+	if config.displayRandomColumn or config.displayRandomColumn == nil and factioNumbers.r > 0 then
 		table.insert(factionColumns, Faction.read('r'))
 	end
 
 	if config.displayUnknownColumn or
-		config.displayUnknownColumn == nil and factioNumbers[Faction.defaultFaction .. 'Display'] > 0 then
+		config.displayUnknownColumn == nil and factioNumbers[Faction.defaultFaction] > 0 then
 
 		table.insert(factionColumns, Faction.defaultFaction)
 	end
 
 	if config.displayMultipleFactionColumn or
-		config.displayMultipleFactionColumn == nil and factioNumbers.mDisplay > 0 then
+		config.displayMultipleFactionColumn == nil and factioNumbers.m > 0 then
 
 		table.insert(factionColumns, Faction.read('m'))
 	end


### PR DESCRIPTION
## Summary
requested by stowka

in case in a faction column that is not shown by default only dq'd players are listed it currently does not display that column
this pr makes it so that it shows in that case too

## How did you test this change?
dev