### PR TITLE
feat(opponent): sort playerNames in `toName`

### DIFF
--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -344,6 +344,7 @@ function Opponent.toName(opponent)
 		local pageNames = Array.map(opponent.players, function(player)
 			return player.pageName or player.displayName
 		end)
+		table.sort(pageNames)
 		return table.concat(pageNames, ' / ')
 	else -- opponent.type == Opponent.literal
 		return opponent.name

--- a/spec/opponent_spec.lua
+++ b/spec/opponent_spec.lua
@@ -237,7 +237,7 @@ describe('opponent', function()
 			},
 				Opponent.toLpdbStruct(Opponent.fromMatch2Record(Config.exampleMatch2RecordSolo) --[[@as standardOpponent]]))
 			assert.are_same({
-				opponentname = 'Semper / Jig',
+				opponentname = 'Jig / Semper',
 				opponenttype = Opponent.duo,
 				opponentplayers = {
 					p1 = 'Semper',


### PR DESCRIPTION
## Summary
Currently `toName` just concats the player page names in the same order as they are supplied.
To be able to easier find matches, ... for duo/trio/quad opponents this PR adjusts `toName` so that the player pagenames are sorted before concating them.
Due to that the order of input is not relevant anymore and `{{DuoOpponent|p1=Player B|p2=Player A}}` will get the same opponent name as `{{DuoOpponent|p1=Player A|p2=Player B}}`


## How did you test this change?
dev