### PR TITLE
fix(match2): on sc(2), faction fallback in participants data is missing

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -403,16 +403,18 @@ function MapFunctions.getTeamParticipants(mapInput, opponent, opponentIndex)
 			table.insert(players, {
 				name = isTBD and TBD or link,
 				displayname = isTBD and TBD or nameInput,
-				extradata = {faction = participantInput.faction},
+				extradata = {faction = participantInput.faction or Faction.defaultFaction},
 			})
 			playerIndex = #players
 		end
 
+		local player = players[playerIndex]
+
 		participants[opponentIndex .. '_' .. playerIndex] = {
-			faction = participantInput.faction,
+			faction = participantInput.faction or player.extradata.faction,
 			player = link,
 			position = position,
-			flag = Flags.CountryName(players[playerIndex].flag),
+			flag = Flags.CountryName(player.flag),
 		}
 	end)
 


### PR DESCRIPTION
## Summary
in team matches
when faction is not specified in the map data for a player it should fall back the data of that player available in match2players
currently that doesn't happen
this pr fixes that

## How did you test this change?
not tested but a simple change