### PR TITLE
refactor(standard): Have ClassicError return html instead of string

### DIFF
--- a/standard/error_display.lua
+++ b/standard/error_display.lua
@@ -100,7 +100,7 @@ end
 
 ---Builds a JSON string for use by `liquipedia.customLuaErrors` JS module with `error()`.
 ---@param error Error
----@return string
+---@return Html
 function ErrorDisplay.ClassicError(error)
 	local stackTrace = {}
 
@@ -156,11 +156,11 @@ function ErrorDisplay.ClassicError(error)
 		errorShort = errorText,
 		stackTrace = stackTrace,
 	}, {asArray = true})
-	return tostring(mw.html.create('div')
+	return mw.html.create('div')
 				:tag('strong'):addClass('error')
 				:tag('span'):addClass('scribunto-error')
 				:wikitext(jsonData):wikitext('.')
-				:allDone())
+				:allDone()
 end
 
 return ErrorDisplay

--- a/standard/lua.lua
+++ b/standard/lua.lua
@@ -162,7 +162,7 @@ function Lua.callAndDisplayErrors(fn, frame, hardErrors)
 	if #errors > 0 then
 		if hardErrors then
 			for _, error in ipairs(errors) do
-				table.insert(parts, ErrorDisplay.ClassicError(error))
+				table.insert(parts, tostring(ErrorDisplay.ClassicError(error)))
 			end
 		else
 			table.insert(parts, tostring(ErrorDisplay.ErrorList{errors = errors}))


### PR DESCRIPTION
## Summary
Align it better with other error displays 

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
