### PR TITLE
fix(match2): Don't fill score when empty in legacy maps on valorant

### DIFF
--- a/components/match2/wikis/valorant/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/valorant/legacy/match_group_legacy_default.lua
@@ -27,7 +27,8 @@ function MatchGroupLegacyDefault:getMap()
 		t1firstsideot = 'map$1$t1firstsideot',
 		finished = 'map$1$finished',
 		length = 'map$1$length',
-		vod = 'map$1$vod'
+		vod = 'map$1$vod',
+		winner = 'map$1$winner'
 	}
 
 	Array.forEach(Array.range(1, MAX_NUMBER_OF_OPPONENTS), function (oppIndex)

--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -26,6 +26,7 @@ local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')
 
 local DECIDER = 'decider'
+local DRAW = 'draw'
 local SKIP = 'skip'
 local DEFAULT_WIN = 'W'
 local DEFAULT_LOSS = 'L'
@@ -85,7 +86,7 @@ function MatchMapsLegacy._handleMaps(args)
 		args[prefix .. 'finished'] = (winner == SKIP and SKIP) or
 			(not Logic.isEmpty(winner) and 'true') or 'false'
 
-		if Logic.isNumeric(winner) then
+		if Logic.isNumeric(winner) or winner == DRAW then
 			args[prefix .. 'winner'] = winner
 		end
 

--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -87,7 +87,7 @@ function MatchMapsLegacy._handleMaps(args)
 			(not Logic.isEmpty(winner) and 'true') or 'false'
 
 		if Logic.isNumeric(winner) or winner == DRAW then
-			args[prefix .. 'winner'] = winner
+			args[prefix .. 'winner'] = winner == DRAW and 0 or winner
 		end
 
 		args[prefix .. 't1firstsideot'] = Table.extract(args, prefix .. 'o1t1firstside')

--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -76,23 +76,18 @@ function MatchMapsLegacy._handleMaps(args)
 			return false
 		end
 
-		local score1
-		local score2
 		if Logic.isNotEmpty(score) then
 			local splitedScore = mw.text.split(score, '-')
-			score1 = splitedScore[1]
-			score2 = splitedScore[2]
-		end
-		if not score1 and not score2 and winner ~= SKIP then
-			local winnerInt = tonumber(winner)
-			score1 = winnerInt == 1 and DEFAULT_WIN or DEFAULT_LOSS
-			score2 = winnerInt == 2 and DEFAULT_WIN or DEFAULT_LOSS
+			args[prefix .. 'score1'] = mw.text.trim(splitedScore[1] or '')
+			args[prefix .. 'score2'] = mw.text.trim(splitedScore[2] or '')
 		end
 
-		args[prefix .. 'score1'] = mw.text.trim(score1 or '')
-		args[prefix .. 'score2'] = mw.text.trim(score2 or '')
 		args[prefix .. 'finished'] = (winner == SKIP and SKIP) or
 			(not Logic.isEmpty(winner) and 'true') or 'false'
+
+		if Logic.isNumeric(winner) then
+			args[prefix .. 'winner'] = winner
+		end
 
 		args[prefix .. 't1firstsideot'] = Table.extract(args, prefix .. 'o1t1firstside')
 		args[prefix .. 't1otatk'] = Table.extract(args, prefix .. 'o1t1atk')

--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -79,8 +79,8 @@ function MatchMapsLegacy._handleMaps(args)
 
 		if Logic.isNotEmpty(score) then
 			local splitedScore = Array.parseCommaSeparatedString(score, '-')
-			args[prefix .. 'score1'] = splitedScore[1] or ''
-			args[prefix .. 'score2'] = splitedScore[2] or ''
+			args[prefix .. 'score1'] = splitedScore[1]
+			args[prefix .. 'score2'] = splitedScore[2]
 		end
 
 		args[prefix .. 'finished'] = (winner == SKIP and SKIP) or

--- a/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/valorant/legacy/match_maps_legacy.lua
@@ -78,9 +78,9 @@ function MatchMapsLegacy._handleMaps(args)
 		end
 
 		if Logic.isNotEmpty(score) then
-			local splitedScore = mw.text.split(score, '-')
-			args[prefix .. 'score1'] = mw.text.trim(splitedScore[1] or '')
-			args[prefix .. 'score2'] = mw.text.trim(splitedScore[2] or '')
+			local splitedScore = Array.parseCommaSeparatedString(score, '-')
+			args[prefix .. 'score1'] = splitedScore[1] or ''
+			args[prefix .. 'score2'] = splitedScore[2] or ''
 		end
 
 		args[prefix .. 'finished'] = (winner == SKIP and SKIP) or


### PR DESCRIPTION
## Summary

Old:
![image](https://github.com/user-attachments/assets/6605a663-3347-4ee5-8310-74b7c57da04a)

New:
![image](https://github.com/user-attachments/assets/ee369efc-dd65-46f6-a6f4-6c5020702669)



## How did you test this change?

/dev
