### PR TITLE
feat(infobox): allow `player` as role on osu

### DIFF
--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -24,14 +24,18 @@ local ROLES = {
 	igl = {category = 'In-game leaders', variable = 'In-game leader'},
 	player = {category = 'Players', variable = 'Player'},
 
-	-- Staff and Talents
+	-- Team Staff (haven't yet actually)
 	analyst = {category = 'Analysts', variable = 'Analyst', staff = true},
+	coach = {category = 'Coaches', variable = 'Coach', staff = true},
+	manager = {category = 'Managers', variable = 'Manager', staff = true},
+
+	-- Tournament Talents
 	['broadcast analyst'] = {category = 'Broadcast Analysts', variable = 'Broadcast Analyst', talent = true},
 	observer = {category = 'Observers', variable = 'Observer', talent = true},
 	host = {category = 'Host', variable = 'Host', talent = true},
-	coach = {category = 'Coaches', variable = 'Coach', staff = true},
 	caster = {category = 'Casters', variable = 'Caster', talent = true},
-	manager = {category = 'Managers', variable = 'Manager', staff = true},
+
+	-- Tournament Staff (osu! unique roles)
 	referee = {category = 'Referees', variable = 'Referee', staff = true},
 	mapper = {category = 'Mappers', variable = 'Mapper', staff = true},
 	streamer = {category = 'Streamers', variable = 'Streamer', talent = true},

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -22,6 +22,7 @@ local Cell = Widgets.Cell
 local ROLES = {
 	-- Players
 	['igl'] = {category = 'In-game leaders', variable = 'In-game leader'},
+	['player'] = {category = 'Players', variable = 'Player'},
 
 	-- Staff and Talents
 	['analyst'] = {category = 'Analysts', variable = 'Analyst', staff = true},
@@ -39,6 +40,7 @@ local ROLES = {
 ---@class OsuInfoboxPlayer: Person
 ---@field role {category: string, variable: string, staff: boolean?, talent: boolean?}?
 ---@field role2 {category: string, variable: string, staff: boolean?, talent: boolean?}?
+---@field role3 {category: string, variable: string, staff: boolean?, talent: boolean?}?
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 
@@ -51,6 +53,7 @@ function CustomPlayer.run(frame)
 	player.args.history = TeamHistoryAuto.results{convertrole = true}
 	player.role = player:_getRoleData(player.args.role)
 	player.role2 = player:_getRoleData(player.args.role2)
+    player.role3 = player:_getRoleData(player.args.role3)
 
 	return player:createInfobox()
 end
@@ -69,6 +72,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Role', content = {
 				caller:_displayRole(caller.role),
 				caller:_displayRole(caller.role2),
+                caller:_displayRole(caller.role3),
 			}},
 		}
 	elseif id == 'history' then
@@ -102,6 +106,7 @@ end
 function CustomPlayer:defineCustomPageVariables(args)
 	Variables.varDefine('role', (self.role or {}).variable)
 	Variables.varDefine('role2', (self.role2 or {}).variable)
+    Variables.varDefine('role3', (self.role3 or {}).variable)
 end
 
 ---@param categories string[]
@@ -109,7 +114,8 @@ end
 function CustomPlayer:getWikiCategories(categories)
 	return Array.append(categories,
 		(self.role or {}).category,
-		(self.role2 or {}).category
+		(self.role2 or {}).category,
+        (self.role3 or {}).category
 	)
 end
 

--- a/components/infobox/wikis/osu/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/osu/infobox_person_player_custom.lua
@@ -21,26 +21,25 @@ local Cell = Widgets.Cell
 
 local ROLES = {
 	-- Players
-	['igl'] = {category = 'In-game leaders', variable = 'In-game leader'},
-	['player'] = {category = 'Players', variable = 'Player'},
+	igl = {category = 'In-game leaders', variable = 'In-game leader'},
+	player = {category = 'Players', variable = 'Player'},
 
 	-- Staff and Talents
-	['analyst'] = {category = 'Analysts', variable = 'Analyst', staff = true},
+	analyst = {category = 'Analysts', variable = 'Analyst', staff = true},
 	['broadcast analyst'] = {category = 'Broadcast Analysts', variable = 'Broadcast Analyst', talent = true},
-	['observer'] = {category = 'Observers', variable = 'Observer', talent = true},
-	['host'] = {category = 'Host', variable = 'Host', talent = true},
-	['coach'] = {category = 'Coaches', variable = 'Coach', staff = true},
-	['caster'] = {category = 'Casters', variable = 'Caster', talent = true},
-	['manager'] = {category = 'Managers', variable = 'Manager', staff = true},
-	['referee'] = {category = 'Referees', variable = 'Referee', staff = true},
-	['mapper'] = {category = 'Mappers', variable = 'Mapper', staff = true},
-	['streamer'] = {category = 'Streamers', variable = 'Streamer', talent = true},
+	observer = {category = 'Observers', variable = 'Observer', talent = true},
+	host = {category = 'Host', variable = 'Host', talent = true},
+	coach = {category = 'Coaches', variable = 'Coach', staff = true},
+	caster = {category = 'Casters', variable = 'Caster', talent = true},
+	manager = {category = 'Managers', variable = 'Manager', staff = true},
+	referee = {category = 'Referees', variable = 'Referee', staff = true},
+	mapper = {category = 'Mappers', variable = 'Mapper', staff = true},
+	streamer = {category = 'Streamers', variable = 'Streamer', talent = true},
 }
 
 ---@class OsuInfoboxPlayer: Person
 ---@field role {category: string, variable: string, staff: boolean?, talent: boolean?}?
 ---@field role2 {category: string, variable: string, staff: boolean?, talent: boolean?}?
----@field role3 {category: string, variable: string, staff: boolean?, talent: boolean?}?
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 
@@ -53,7 +52,6 @@ function CustomPlayer.run(frame)
 	player.args.history = TeamHistoryAuto.results{convertrole = true}
 	player.role = player:_getRoleData(player.args.role)
 	player.role2 = player:_getRoleData(player.args.role2)
-    player.role3 = player:_getRoleData(player.args.role3)
 
 	return player:createInfobox()
 end
@@ -72,7 +70,6 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Role', content = {
 				caller:_displayRole(caller.role),
 				caller:_displayRole(caller.role2),
-                caller:_displayRole(caller.role3),
 			}},
 		}
 	elseif id == 'history' then
@@ -106,7 +103,6 @@ end
 function CustomPlayer:defineCustomPageVariables(args)
 	Variables.varDefine('role', (self.role or {}).variable)
 	Variables.varDefine('role2', (self.role2 or {}).variable)
-    Variables.varDefine('role3', (self.role3 or {}).variable)
 end
 
 ---@param categories string[]
@@ -114,8 +110,7 @@ end
 function CustomPlayer:getWikiCategories(categories)
 	return Array.append(categories,
 		(self.role or {}).category,
-		(self.role2 or {}).category,
-        (self.role3 or {}).category
+		(self.role2 or {}).category
 	)
 end
 


### PR DESCRIPTION

## Summary

Some notable players are both players, talents and staffs, so we adding "players" as optional choose in `|role=`.
we also add support for `|role3=` in rare case people both have achievement in players, talents or staffs. 

the above solution was [discussed](https://discord.com/channels/93055209017729024/1164213669324927096/1277272216131735664) in dc with other majorly contributer: 

## How did you test this change?

By Made an dev version of this [module](https://liquipedia.net/osu/Module:Infobox/Person/Player/Custom/dev) then test in a page using preview in both [sandbox page](https://liquipedia.net/osu/User:RushFTK/Module_Sandbox) and [real page](https://liquipedia.net/osu/ChillierPear)

## Future discussion (solved)
After future discussed, we decided not implement `|role=3` unless we really need add player who really notable at all three ascpect. currently, osu! haven't professional orgainze so no notable staffs yet (we record tournament staff as staff instead of pro-teams)