### PR TITLE
fix(opponent): long player names with notes do not ellipsis

### DIFF
--- a/components/opponent/commons/player_display.lua
+++ b/components/opponent/commons/player_display.lua
@@ -49,7 +49,7 @@ function PlayerDisplay.BlockPlayer(props)
 	local player = props.player
 
 	local zeroWidthSpace = '&#8203;'
-	local nameNode = mw.html.create(props.dq and 's' or 'span')
+	local nameNode = mw.html.create(props.dq and 's' or 'span'):addClass('name')
 		:wikitext(props.abbreviateTbd and Opponent.playerIsTbd(player) and TBD_ABBREVIATION
 			or props.showLink ~= false and Logic.isNotEmpty(player.pageName)
 			and '[[' .. player.pageName .. '|' .. player.displayName .. ']]'
@@ -57,12 +57,9 @@ function PlayerDisplay.BlockPlayer(props)
 		)
 	DisplayUtil.applyOverflowStyles(nameNode, props.overflow or 'ellipsis')
 
+	local noteNode
 	if props.note then
-		nameNode = mw.html.create('span'):addClass('name')
-			:node(nameNode)
-			:tag('sup'):addClass('note'):wikitext(props.note):done()
-	else
-		nameNode:addClass('name')
+		noteNode = mw.html.create('sup'):addClass('note'):wikitext(props.note)
 	end
 
 	local flagNode
@@ -82,6 +79,7 @@ function PlayerDisplay.BlockPlayer(props)
 		:addClass(props.showPlayerTeam and 'has-team' or nil)
 		:node(flagNode)
 		:node(nameNode)
+		:node(noteNode)
 		:node(teamNode)
 end
 

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -1153,12 +1153,6 @@ img.brkts-champion-icon,
 	font-size: smaller;
 	line-height: 1;
 	margin-left: 4px;
-}
-
-.block-player > .note,
-.block-team > .note,
-.block-literal > .note {
-	align-self: flex-start;
 	font-weight: bold;
 }
 

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -1153,7 +1153,6 @@ img.brkts-champion-icon,
 	font-size: smaller;
 	line-height: 1;
 	margin-left: 4px;
-	font-weight: bold;
 }
 
 .block-team {


### PR DESCRIPTION
## Summary
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/8d2c0dc1-665e-473e-b9e4-2467e32d6d94">

## How did you test this change?
Qucik dev preview test