### PR TITLE
feat(opponnet): add `StarcraftPlayerExt.TemplateStorePlayerLink`

### DIFF
--- a/components/opponent/commons/starcraft_starcraft2/player_ext_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/player_ext_starcraft.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local Faction = require('Module:Faction')
@@ -202,15 +203,27 @@ end
 ---so that editors do not have to duplicate the same info later on.
 ---@param player StarcraftStandardPlayer
 function StarcraftPlayerExt.saveToPageVars(player)
-	if player.pageName then
-		globalVars:set(player.displayName .. '_page', player.pageName)
-	end
-	if player.flag then
-		globalVars:set(player.displayName .. '_flag', player.flag)
-	end
 	if player.faction and player.faction ~= Faction.defaultFaction then
 		globalVars:set(player.displayName .. '_faction', player.faction)
 	end
+
+	PlayerExt.saveToPageVars(player)
+end
+
+---@param frame Frame
+function StarcraftPlayerExt.TemplateStorePlayerLink(frame)
+	local args = Arguments.getArgs(frame)
+
+	if not args[1] then return end
+
+	local pageName, displayName = PlayerExt.extractFromLink(args[1])
+
+	StarcraftPlayerExt.saveToPageVars{
+		displayName = displayName,
+		pageName = args.link or pageName or displayName,
+		flag = String.nilIfEmpty(Flags.CountryName(args.flag)),
+		faction = Faction.read(args.faction or args.race) or Faction.defaultFaction,
+	}
 end
 
 return StarcraftPlayerExt


### PR DESCRIPTION
resolves #1160 (except for gtl/stl which imo is out of scope for this issue/PR)

## Summary
Add `StarcraftPlayerExt.TemplateStorePlayerLink` function to be able to adjust
- https://liquipedia.net/starcraft/Template:StorePlayerLink
- https://liquipedia.net/starcraft2/Template:StorePlayerLink

and hence be able to kick
- https://liquipedia.net/commons/Module:Player/Ext/downstream
- https://liquipedia.net/commons/Module:Player/Display/downstream
- https://liquipedia.net/commons/Module:Player/Ext/Starcraft/downstream
- https://liquipedia.net/commons/Module:Player/Display/Starcraft/downstream
- https://liquipedia.net/commons/Module:TeamTemplate/Named

## How did you test this change?
dev