### PR TITLE
feat: Yellow color for bracket

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -868,6 +868,11 @@
 	padding: 2px 1px 2px 1px;
 }
 
+.brkts-popup-side-color-yellow {
+	class: bg-first !important;
+	padding: 2px 1px 2px 1px;
+}
+
 .brkts-popup-side-color-radiant {
 	background-color: #bcd985 !important;
 }


### PR DESCRIPTION
## Summary
Note: This is my first time tapping into stylesheet PRs

![image](https://github.com/user-attachments/assets/7150d59a-8ec9-43ea-a460-7a3639c182ba)
Deadlock uses Blue and Yellow as side colors, yellow is the one we don't have

I'm trying to add this one by using the existing css class, I believe the bg-first class might be usable for this occasion.

## How did you test this change?
How can I even test this? (I tried Inspect element the bg-first class on other MOBA wikis and it just doesnt display well) 
![image](https://github.com/user-attachments/assets/e534b2bd-45b3-44a7-850e-1df19b419d98)
