### PR TITLE
feat(infobox): allowed manually input `dps` param on `deadlock` wiki

### DIFF
--- a/components/infobox/wikis/deadlock/infobox_character_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_character_custom.lua
@@ -29,7 +29,7 @@ function CustomHero.run(frame)
 	character:setWidgetInjector(CustomInjector(character))
 	character.args.informationType = 'Hero'
 	if character.args.damagebullet and character.args.bps then
-		character.args.dps = character.args.damagebullet * character.args.bps
+		character.args.dps = character.args.dps or character.args.damagebullet * character.args.bps
 	end
 
 	return character:createInfobox()

--- a/components/infobox/wikis/deadlock/infobox_character_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_character_custom.lua
@@ -29,7 +29,7 @@ function CustomHero.run(frame)
 	character:setWidgetInjector(CustomInjector(character))
 	character.args.informationType = 'Hero'
 	if character.args.damagebullet and character.args.bps then
-		character.args.dps = character.args.dps or character.args.damagebullet * character.args.bps
+		character.args.dps = character.args.dps or (character.args.damagebullet * character.args.bps)
 	end
 
 	return character:createInfobox()


### PR DESCRIPTION
## Summary

Some heroes (i.e. `mo & krill`, `abrams`, `pocket`, `shiv`, `yamato`) using shotguns, so their in-game dps dosen't apply foluma.

![mo & krill have 76dps, but calculation result are ~20 dps](https://github.com/user-attachments/assets/c2bf493f-3da1-47ec-bd5e-1f8bf20bdc6b)

*mo & krill have 76dps, but calculation result are ~20 dps*

So we decided to allowed contributer manually input `|dps=` parm, if they haven't input anything ,then still using calculation result.

[Discord discussion context](https://discord.com/channels/93055209017729024/1278051336889438218/1278276460980736083)

-->

## How did you test this change?

We adding an dev version of influenced module , [links](https://liquipedia.net/deadlock/Module:Infobox/Character/Custom/dev)

Then test this module in a hero page , [changes](https://liquipedia.net/deadlock/index.php?title=Mo_%26_Krill&type=revision&diff=630&oldid=628)