### PR TITLE
fix(match2): dota2 matchpage various minor styling fixes

### DIFF
--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -151,9 +151,15 @@ return {
 								<!-- Loadout -->
 								<div class="match-bm-players-player-loadout-items">
 									<!-- Items -->
-									<div class="match-bm-players-player-loadout-item">{{&items.1}}{{&items.2}}{{&items.3}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.4}}{{&items.5}}{{&items.6}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&backpackitems.1}}{{&backpackitems.2}}{{&backpackitems.3}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.1}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.2}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.3}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.4}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.5}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.6}}</div>
+									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.1}}</div>
+									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
+									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
 								</div>
 								<div class="match-bm-players-player-loadout-rs-wrap">
 									<!-- Special Items -->
@@ -183,9 +189,15 @@ return {
 								<!-- Loadout -->
 								<div class="match-bm-players-player-loadout-items">
 									<!-- Items -->
-									<div class="match-bm-players-player-loadout-item">{{&items.1}}{{&items.2}}{{&items.3}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.4}}{{&items.5}}{{&items.6}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&backpackitems.1}}{{&backpackitems.2}}{{&backpackitems.3}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.1}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.2}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.3}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.4}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.5}}</div>
+									<div class="match-bm-players-player-loadout-item">{{&items.6}}</div>
+									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.1}}</div>
+									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
+									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
 								</div>
 								<div class="match-bm-players-player-loadout-rs-wrap">
 									<!-- Special Items -->

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -14,7 +14,7 @@ return {
 	header =
 		[=[
 			<div class="match-bm-lol-match-header">
-				<div class="match-bm-match-header-powered-by">[[File:SAP logo.svg|link=]]</div>
+				<div class="match-bm-match-header-powered-by">[[File:DataProvidedSAP.svg|link=]]</div>
 				<div class="match-bm-lol-match-header-overview">
 					<div class="match-bm-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-match-header-team-group"><div class="match-bm-match-header-team-long">{{#page}}[[{{page}}|{{name}}]]{{/page}}</div><div class="match-bm-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div class="match-bm-lol-match-header-round-results">{{#seriesDots}}<div class="match-bm-lol-match-header-round-result result--{{.}}"></div>{{/seriesDots}}</div>{{/opponents.1}}</div></div>
 					<div class="match-bm-match-header-result">{{#isBestOfOne}}{{#games.1.apiInfo}}{{team1.scoreDisplay}}&ndash;{{team2.scoreDisplay}}{{/games.1.apiInfo}}{{/isBestOfOne}}{{^isBestOfOne}}{{opponents.1.score}}&ndash;{{opponents.2.score}}{{/isBestOfOne}}<div class="match-bm-match-header-result-text">{{statusText}}</div></div>
@@ -151,15 +151,8 @@ return {
 								<!-- Loadout -->
 								<div class="match-bm-players-player-loadout-items">
 									<!-- Items -->
-									<div class="match-bm-players-player-loadout-item">{{&items.1}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.2}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.3}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.4}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.5}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.6}}</div>
-									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.1}}</div>
-									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
-									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
+									{{#items}}<div class="match-bm-players-player-loadout-item">{{&.}}</div>{{/items}}
+									{{#backpackitems}}<div class="match-bm-players-player-loadout-item item--backpack">{{&.}}</div>{{/backpackitems}}
 								</div>
 								<div class="match-bm-players-player-loadout-rs-wrap">
 									<!-- Special Items -->
@@ -188,16 +181,8 @@ return {
 							<div class="match-bm-players-player-loadout">
 								<!-- Loadout -->
 								<div class="match-bm-players-player-loadout-items">
-									<!-- Items -->
-									<div class="match-bm-players-player-loadout-item">{{&items.1}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.2}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.3}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.4}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.5}}</div>
-									<div class="match-bm-players-player-loadout-item">{{&items.6}}</div>
-									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.1}}</div>
-									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
-									<div class="match-bm-players-player-loadout-item item--backpack">{{&backpackitems.3}}</div>
+									{{#items}}<div class="match-bm-players-player-loadout-item">{{&.}}</div>{{/items}}
+									{{#backpackitems}}<div class="match-bm-players-player-loadout-item item--backpack">{{&.}}</div>{{/backpackitems}}
 								</div>
 								<div class="match-bm-players-player-loadout-rs-wrap">
 									<!-- Special Items -->

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -847,15 +847,22 @@ ul.match-bm-lol-game-veto-overview-pick {
 			display: flex;
 			flex-direction: column;
 
-			img {
+			&-icon {
 				border-radius: 0.25rem 0.25rem 0 0;
 				width: 3.75rem;
 				height: 2.5rem;
+				overflow: hidden;
 
 				@media ( min-width: 834px ) {
 					width: 4.5rem;
 					height: 3rem;
 				}
+			}
+
+			img {
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
 			}
 
 			&-text {

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -541,7 +541,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 
 	@media ( min-width: 768px ) {
-		grid-template-columns: auto auto;
+		grid-template-columns: 1fr 1fr
 	}
 }
 
@@ -699,9 +699,10 @@ ul.match-bm-lol-game-veto-overview-pick {
 	&-loadout {
 		display: flex;
 		gap: 1rem;
+		flex: 0 0 7.5rem;
 
-		@media ( max-width: 1199px ), ( min-width: 1320px ) {
-			flex: 0 0 7.5rem;
+		@media ( min-width: 768px ) {
+			flex: 0 0 9.5rem;
 		}
 
 		@media ( min-width: 1200px ) and ( max-width: 1319px ), ( min-width: 1510px ) {
@@ -712,42 +713,52 @@ ul.match-bm-lol-game-veto-overview-pick {
 			display: flex;
 			flex-direction: row;
 			align-items: flex-start;
-			gap: 0.25rem;
+			width: 1.5rem;
+			height: 1.5rem;
+			border-radius: 0.25rem;
+			overflow: hidden;
+
+			&.item--backpack {
+				opacity: 0.4;
+			}
+
+			@media ( min-width: 768px ) {
+				width: 2rem;
+				height: 2rem;
+			}
 
 			img {
-				width: 1.5rem;
-				height: 1.5rem;
-				border-radius: 0.25rem;
-
-				@media ( min-width: 768px ) {
-					width: 2rem;
-					height: 2rem;
-				}
+				object-fit: cover;
+				height: 100%;
+				width: 100%;
 			}
 		}
 
 		&-items {
 			display: flex;
-			flex-direction: column;
 			align-items: flex-start;
 			gap: 0.25rem;
+			flex-wrap: wrap;
 		}
 
 		&-rs {
 			display: flex;
 			flex-direction: column;
 			align-items: flex-start;
-			gap: 0.125rem;
+			width: 1.5rem;
+			height: 1.5rem;
+			border-radius: 100%;
+			overflow: hidden;
+
+			@media ( min-width: 768px ) {
+				width: 2rem;
+				height: 2rem;
+			}
 
 			img {
-				width: 1.5rem;
-				height: 1.5rem;
-				border-radius: 100%;
-
-				@media ( min-width: 768px ) {
-					width: 2rem;
-					height: 2rem;
-				}
+				object-fit: cover;
+				height: 100%;
+				width: 100%;
 			}
 		}
 

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -541,7 +541,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 
 	@media ( min-width: 768px ) {
-		grid-template-columns: 1fr 1fr
+		grid-template-columns: 1fr 1fr;
 	}
 }
 


### PR DESCRIPTION
## Summary

In this PR:
- item images are wrapped in a div to fix the ratio
- add opacity to backpack items.
- fix layout shift of the two player performance columns
- fix loadout display on specific screen sizes
- fix hero image ratio
- update to new SAP logo

## How did you test this change?

Live wiki https://liquipedia.net/dota2/Match:ID_PDc51bykFj_R04-M002
