### PR TITLE
fix(opponent): wrong key for faction page var

### DIFF
--- a/components/opponent/commons/starcraft_starcraft2/player_ext_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/player_ext_starcraft.lua
@@ -212,7 +212,7 @@ function StarcraftPlayerExt.saveToPageVars(player, options)
 	local overwrite = options.overwritePageVars
 
 	if PlayerExt.shouldWritePageVar(displayName .. '_faction', player.faction, overwrite) then
-		globalVars:set(displayName .. '_faction', player.pageName)
+		globalVars:set(displayName .. '_faction', player.faction)
 	end
 
 	PlayerExt.saveToPageVars(player, options)

--- a/components/opponent/wikis/stormgate/player_ext_custom.lua
+++ b/components/opponent/wikis/stormgate/player_ext_custom.lua
@@ -128,7 +128,7 @@ function CustomPlayerExt.saveToPageVars(player, options)
 	local overwrite = options.overwritePageVars
 
 	if PlayerExt.shouldWritePageVar(displayName .. '_faction', player.faction, overwrite) then
-		globalVars:set(displayName .. '_faction', player.pageName)
+		globalVars:set(displayName .. '_faction', player.faction)
 	end
 
 	PlayerExt.saveToPageVars(player, options)

--- a/components/opponent/wikis/warcraft/player_ext_custom.lua
+++ b/components/opponent/wikis/warcraft/player_ext_custom.lua
@@ -128,7 +128,7 @@ function CustomPlayerExt.saveToPageVars(player, options)
 	local overwrite = options.overwritePageVars
 
 	if PlayerExt.shouldWritePageVar(displayName .. '_faction', player.faction, overwrite) then
-		globalVars:set(displayName .. '_faction', player.pageName)
+		globalVars:set(displayName .. '_faction', player.faction)
 	end
 
 	PlayerExt.saveToPageVars(player, options)


### PR DESCRIPTION
## Summary
merging #4662 broke the 4 faction wikis because it used the wrong key in setting the faction page vars
this pr fixes that key

## How did you test this change?
live