### PR TITLE
feat(match2): add darkmode support for r6 matchsummary

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -807,6 +807,17 @@
 	line-height: 11px;
 }
 
+[ data-darkreader-scheme="dark" ],
+.theme--dark {
+	& .brkts-popup-body-match-sidewins img {
+		filter: invert( 1 );
+	}
+
+	& .brkts-popup-body-match-sidewins-overtime img {
+		filter: invert( 1 );
+	}
+}
+
 .brkts-popup-body-operator-bans {
 	position: relative;
 	margin-top: -8px;
@@ -830,22 +841,22 @@
 
 .brkts-popup-body-gradient-left {
 	padding: 4px 0;
-	background: linear-gradient( to left, #fbdfdf 35%, #ffffff 35%, #ffffff 65%, #ddf4dd 65% ) !important;
+	background: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 35%, var( --table-background-color, #ffffff ) 35%, var( --table-background-color, #ffffff ) 65%, var( --clr-forestgreen-background-color, #ddf4dd ) 65% ) !important;
 }
 
 .brkts-popup-body-gradient-right {
 	padding: 4px 0;
-	background: linear-gradient( to right, #fbdfdf 35%, #ffffff 35%, #ffffff 65%, #ddf4dd 65% ) !important;
+	background: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 35%, var( --table-background-color, #ffffff ) 35%, var( --table-background-color, #ffffff ) 65%, var( --clr-forestgreen-background-color, #ddf4dd ) 65% ) !important;
 }
 
 .brkts-popup-body-gradient-draw {
 	padding: 4px 0;
-	background: linear-gradient( to left, #f9f9c7 35%, #ffffff 35%, #ffffff 65%, #f9f9c7 65% ) !important;
+	background: linear-gradient( to left, var( --clr-pear-background-color, #f9f9c7 ) 35%, var( --table-background-color, #ffffff ) 35%, var( --table-background-color, #ffffff ) 65%, var( --clr-pear-background-color, #f9f9c7 ) 65% ) !important;
 }
 
 .brkts-popup-body-gradient-default {
 	padding: 4px 0;
-	background: #ffffff !important;
+	background: var( --table-background-color, #ffffff ) !important;
 }
 
 .brkts-popup-side-color-blue {

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -806,7 +806,7 @@
 	}
 }
 
-.brkts-popup-body-match-sidewins .skin-lakesideview {
+.skin-lakesideview .brkts-popup-body-match-sidewins {
 	font-weight: 800;
 }
 

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -800,21 +800,24 @@
 	.skin-lakesideview & {
 		font-weight: 800;
 	}
+
+	& img {
+		[ data-darkreader-scheme="dark" ] &,
+		.theme--dark & {
+			filter: invert( 1 );
+		}
+	}
 }
 
 .brkts-popup-body-match-sidewins-overtime {
 	padding: 0 0 3px 3px;
 	line-height: 11px;
-}
 
-[ data-darkreader-scheme="dark" ],
-.theme--dark {
-	& .brkts-popup-body-match-sidewins img {
-		filter: invert( 1 );
-	}
-
-	& .brkts-popup-body-match-sidewins-overtime img {
-		filter: invert( 1 );
+	& img {
+		[ data-darkreader-scheme="dark" ] &,
+		.theme--dark & {
+			filter: invert( 1 );
+		}
 	}
 }
 

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -806,7 +806,7 @@
 	}
 }
 
-.brkts-popup-body-match-sidewins .skin-lakesideview & {
+.brkts-popup-body-match-sidewins .skin-lakesideview {
 	font-weight: 800;
 }
 

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -793,13 +793,10 @@
 	font-size: 85%;
 }
 
+.brkts-popup-body-match-sidewins-overtime,
 .brkts-popup-body-match-sidewins {
 	padding: 0 0 3px 3px;
 	line-height: 11px;
-
-	.skin-lakesideview & {
-		font-weight: 800;
-	}
 
 	& img {
 		[ data-darkreader-scheme="dark" ] &,
@@ -809,16 +806,8 @@
 	}
 }
 
-.brkts-popup-body-match-sidewins-overtime {
-	padding: 0 0 3px 3px;
-	line-height: 11px;
-
-	& img {
-		[ data-darkreader-scheme="dark" ] &,
-		.theme--dark & {
-			filter: invert( 1 );
-		}
-	}
+.brkts-popup-body-match-sidewins .skin-lakesideview & {
+	font-weight: 800;
 }
 
 .brkts-popup-body-operator-bans {


### PR DESCRIPTION
i think it resolves /skins/lakesideview#121

## Summary
add darkmode support for classes used in r6 matchsummary

## How did you test this change?
browser dev tools

before:
![image](https://github.com/user-attachments/assets/96e2fdd1-177e-4571-a5c0-2f741c853906)

after:
![image](https://github.com/user-attachments/assets/57e1fa81-ac7a-421f-a709-374f581a9c09)
