### PR TITLE
fix: dota heroes panel visited color text

### DIFF
--- a/stylesheets/commons/PanelBox/Heroes.less
+++ b/stylesheets/commons/PanelBox/Heroes.less
@@ -149,6 +149,10 @@
 					z-index: 1;
 				}
 
+				&:visited {
+					color: #ffffff;
+				}
+
 				@media ( hover: hover ) {
 					&:hover {
 						color: #ffffff;


### PR DESCRIPTION
## Summary

This PR fixes the visited link color.
![image](https://github.com/user-attachments/assets/b95f395b-7c98-4356-89fe-ee17cdd710a0)


## How did you test this change?

Live wiki
