### PR TITLE
feat: applying bg color for Primary Attribute (Hero infobox)

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -27,12 +27,15 @@ html.theme--dark .componentsinvert {
 	&_str {
 		background: var( clr-semantic-negative-40 ); // #b81414 (Old #b9500b)
 	}
+
 	&_agi {
 		background: var( clr-semantic-positive-30 ); // #1d7c1d (Old #167c13)
 	}
+
 	&_int {
 		background: var( clr-sapphire-base ); // #3a5ba9 (Old #257dae)
 	}
+
 	&_uni {
 		background: var( clr-semantic-negative-40 ); // #732b9c (Old 5d3fd3)
 	}

--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -23,6 +23,21 @@ html.theme--dark .componentsinvert {
 	font-weight: bold;
 }
 
+.primaryAttribute {
+	&_str {
+		background: var( clr-semantic-negative-40 ); // #b81414 (Old #b9500b)
+	}
+	&_agi {
+		background: var( clr-semantic-positive-30 ); // #1d7c1d (Old #167c13)
+	}
+	&_int {
+		background: var( clr-sapphire-base ); // #3a5ba9 (Old #257dae)
+	}
+	&_uni {
+		background: var( clr-semantic-negative-40 ); // #732b9c (Old 5d3fd3)
+	}
+} // Colors the Attribute base + gain section
+
 #primaryAttribute img,
 .primaryAttribute img {
 	border: 0.125rem solid #ffffff;
@@ -408,6 +423,9 @@ a.cf {
 		text-align: left;
 	}
 }
+
+// ValueColor (Will eventually move all color-related stuff to this stylesheet.
+// ValueColor section end.
 
 // $craft-related
 // This is mainly for the mini-infobox within the Spellcard.


### PR DESCRIPTION
## Summary

Colors the attribute section according to the hero's primary attribute using predefined colors.

