### PR TITLE
fix(match2): extradata processing has no access to opponents

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -110,10 +110,11 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
 	match.links = MatchFunctions.getLinks(match)
-	match.extradata = MatchFunctions.getExtraData(match, #games)
 
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match, #games)
 
 	return match
 end

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -83,10 +83,11 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
-	match.extradata = MatchFunctions.getExtraData(match)
 
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -78,10 +78,10 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 
-	match.extradata = MatchFunctions.getExtraData(match)
-
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -69,10 +69,10 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
 
-	match.extradata = MatchFunctions.getExtraData(match)
-
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/deadlock/match_group_input_custom.lua
+++ b/components/match2/wikis/deadlock/match_group_input_custom.lua
@@ -70,10 +70,11 @@ function CustomMatchGroupInput.processMatch(match, options)
 	MatchGroupInputUtil.getCommonTournamentVars(match)
 
 	match.stream = Streams.processStreams(match)
-	match.extradata = MatchFunctions.getExtraData(match)
 
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -112,10 +112,11 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match, games)
-	match.extradata = MatchFunctions.getExtraData(match)
 
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -76,10 +76,11 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
-	match.extradata = MatchFunctions.getExtraData(match)
 
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -112,10 +112,11 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
-	match.extradata = MatchFunctions.getExtraData(match)
 
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -69,10 +69,10 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
 
-	match.extradata = MatchFunctions.getExtraData(match)
-
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -74,10 +74,10 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
 
-	match.extradata = MatchFunctions.getExtraData(match)
-
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -76,10 +76,10 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
 
-	match.extradata = MatchFunctions.getExtraData(match, opponents)
-
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match, opponents)
 
 	return match
 end

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -73,10 +73,10 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
 
-	match.extradata = MatchFunctions.getExtraData(match)
-
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -82,10 +82,11 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.links = MatchFunctions.getLinks(match)
-	match.extradata = MatchFunctions.getExtraData(match)
 
 	match.games = games
 	match.opponents = opponents
+
+	match.extradata = MatchFunctions.getExtraData(match)
 
 	return match
 end


### PR DESCRIPTION
## Summary
Currently in the customs `MatchFunctions.getExtraData` is called before opponents are available in the match table.
This leads to `MatchGroupInputUtil.readMvp` (called from `getExtraData` on quite a few wikis) not being able to access the opponents (notably not match2players inside the opponents) and hence mvp data not being filled in correctly.

This PR moves the `getExtraData` to after attaching the opponents to the match table to solve that issue.

## How did you test this change?
dev on lol, rst untested