### PR TITLE
fix(MatchTicker): empty tiertype match alway disappears when using tiertype filters

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -258,6 +258,8 @@ function MatchTicker:buildQueryConditions()
 			tierTypeConditions:add { ConditionNode(ColumnName('liquipediatiertype'), Comparator.eq, tierType) }
 		end)
 
+		tierTypeConditions:add { ConditionNode(ColumnName('liquipediatiertype'), Comparator.eq, '') }
+
 		conditions:add(tierTypeConditions)
 	end
 


### PR DESCRIPTION
## Summary

Nick flagged this bug:
"(I added CCT tiertype Monthly) the tiertype 'overwrites' the non-tiertype, not sure if this is intended, just that previously it shows non-tiertype and tiertype (the filter for tournaments);  when all kinds of tier is checked except tier 4, it seems normal, when tier 4 is checked, it just shows tiertype"
![image](https://github.com/user-attachments/assets/5a97d9c7-74be-4dae-930e-129aa853421d)

This is due to tiertype filter not taking into account matches without tiertypes. To solve this, we added the condition that empty tiertypes are added into the list when triggering any filter

## How did you test this change?

With a [dev page](https://liquipedia.net/dota2/Template:NewDota2MainPage_matches/dev)
