### PR TITLE
feat(Infobox): League & Player for deadlock

### DIFF
--- a/components/infobox/wikis/deadlock/infobox_league_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_league_custom.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/infobox/wikis/deadlock/infobox_league_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_league_custom.lua
@@ -1,0 +1,77 @@
+---
+-- @Liquipedia
+-- wiki=deadlock
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+---@class DeadlockLeagueInfobox: InfoboxLeague
+local CustomLeague = Class.new(League)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		return {
+			Cell{name = 'Version', content = {self.caller:_createPatchCell(args)}},
+			Cell{name = 'Number of teams', content = {args.team_number}},
+			Cell{name = 'Number of players', content = {args.player_number}},
+		}
+	end
+
+	return widgets
+end
+
+---@param args table
+---@return boolean
+function CustomLeague:liquipediaTierHighlighted(args)
+	return Logic.readBool(args.publisherpremier)
+end
+
+---@param args table
+function CustomLeague:customParseArguments(args)
+	self.data.publishertier = tostring(Logic.readBool(args.publisherpremier))
+end
+
+
+---@param args table
+---@return string?
+function CustomLeague:_createPatchCell(args)
+	if String.isEmpty(args.patch) then
+		return nil
+	end
+
+	local displayText = '[['.. args.patch .. ']]'
+	if args.epatch then
+		displayText = displayText .. ' &ndash; [['.. args.epatch .. ']]'
+	end
+	return displayText
+end
+
+return CustomLeague

--- a/components/infobox/wikis/deadlock/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_person_player_custom.lua
@@ -1,0 +1,123 @@
+---
+-- @Liquipedia
+-- wiki=deadlock
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Infobox/Widget/Injector')
+local Player = Lua.import('Module:Infobox/Person')
+
+local Widgets = require('Module:Infobox/Widget/All')
+local Cell = Widgets.Cell
+
+local ROLES = {
+	-- Staff and Talents
+	['analyst'] = {category = 'Analysts', variable = 'Analyst', staff = true},
+	['coach'] = {category = 'Coaches', variable = 'Coach', staff = true},
+	['caster'] = {category = 'Casters', variable = 'Caster', talent = true},
+}
+
+---@class DeadlockInfoboxPlayer: Person
+---@field role {category: string, variable: string, staff: boolean?, talent: boolean?}?
+---@field role2 {category: string, variable: string, staff: boolean?, talent: boolean?}?
+local CustomPlayer = Class.new(Player)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomPlayer.run(frame)
+	local player = CustomPlayer(frame)
+	player:setWidgetInjector(CustomInjector(player))
+
+	player.args.history = TeamHistoryAuto.results{convertrole = true}
+	player.role = player:_getRoleData(player.args.role)
+	player.role2 = player:_getRoleData(player.args.role2)
+
+	return player:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args = caller.args
+
+	if id == 'status' then
+		return {
+			Cell{name = 'Status', content = caller:_getStatusContents()},
+		}
+	elseif id == 'role' then
+		return {
+			Cell{name = 'Role', content = {
+				caller:_displayRole(caller.role),
+				caller:_displayRole(caller.role2)
+			}},
+		}
+	elseif id == 'history' then
+		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+	end
+
+	return widgets
+end
+
+---@return string[]
+function CustomPlayer:_getStatusContents()
+	return {Page.makeInternalLink({onlyIfExists = true}, self.args.status) or self.args.status}
+end
+
+---@param args table
+function CustomPlayer:defineCustomPageVariables(args)
+	Variables.varDefine('role', (self.role or {}).variable)
+	Variables.varDefine('role2', (self.role2 or {}).variable)
+end
+
+---@param categories string[]
+---@return string[]
+function CustomPlayer:getWikiCategories(categories)
+	return Array.append(categories,
+		(self.role or {}).category,
+		(self.role2 or {}).category
+	)
+end
+
+---@param role string?
+---@return {category: string, variable: string, staff: boolean?, talent: boolean?}?
+function CustomPlayer:_getRoleData(role)
+	return ROLES[(role or ''):lower()]
+end
+
+---@param roleData {category: string, variable: string, staff: boolean?, talent: boolean?}?
+---@return string?
+function CustomPlayer:_displayRole(roleData)
+	if not roleData then return end
+
+	if not self:shouldStoreData(self.args) then
+		return roleData.variable
+	end
+
+	return Page.makeInternalLink(roleData.variable, ':Category:' .. roleData.category)
+end
+
+---@param args table
+---@return {store: string, category: string}
+function CustomPlayer:getPersonType(args)
+	local roleData = self.role or {}
+	if roleData.staff then
+		return {store = 'staff', category = 'Staff'}
+	elseif roleData.talent then
+		return {store = 'talent', category = 'Talent'}
+	end
+	return {store = 'player', category = 'Player'}
+end
+
+return CustomPlayer


### PR DESCRIPTION
## Summary - League
**Based from DOTA2's InfoLeague**

- Removed unused stuff about DPC 
- Replaced valvepremier with publisherpremier, for future highlighted tier usage
- Keep the patch cell intact because it probably will be usefule
- Keep the player_number input in case if they ever had an Individual event

## Summary - Player
**Basically GeoGuessr port (#4489 < this one still unmerged btw) with MatchTicker removed and some roles removed down to just the commonly used one (there are no player pages yet)**

## How did you test this change?
BOTH LIVE