### PR TITLE
feat(fountain): Missing the two hyphens for the predefined colors.

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -25,27 +25,32 @@ html.theme--dark .componentsinvert {
 
 .primaryAttribute {
 	&_str {
-		background: var( clr-semantic-negative-40 ); // #b81414 (Old #b9500b)
+		background: var( --clr-semantic-negative-40 ); // #b81414 (Old #b9500b)
 	}
 
 	&_agi {
-		background: var( clr-semantic-positive-30 ); // #1d7c1d (Old #167c13)
+		background: var( --clr-semantic-positive-30 ); // #1d7c1d (Old #167c13)
 	}
 
 	&_int {
-		background: var( clr-sapphire-base ); // #3a5ba9 (Old #257dae)
+		background: var( --clr-sapphire-base ); // #3a5ba9 (Old #257dae)
 	}
 
 	&_uni {
-		background: var( clr-semantic-negative-40 ); // #732b9c (Old 5d3fd3)
+		background: var( --clr-semantic-negative-40 ); // #732b9c (Old 5d3fd3)
 	}
 } // Colors the Attribute base + gain section
 
 #primaryAttribute img,
 .primaryAttribute img {
-	border: 0.125rem solid #ffffff;
+	border: 0.125rem solid var( --clr-primary-100 ); // #fff
 	border-radius: 50%;
 } // Circles the Primary Attribute.
+
+.secondaryAttribute img {
+	border: 0.125rem solid var( --clr-secondary-7 ); // #121212
+	border-radius: 50%;
+} // Circles the Secondary Attribute.
 
 .ib-tooltip {
 	border-width: 0.1875rem 0.0625rem 0.0625rem 0.0625rem;


### PR DESCRIPTION
## Summary

- I missed `--` for #4671 the `var(--color)`.
- Adding secondary attributes img properties as well, this will help the icons pop-up better with the colored bg.

Apologies for the second merge request. Thank you!
