### PR TITLE
fix(opponent): fix `TemplatePlayer`

### DIFF
--- a/components/opponent/commons/starcraft_starcraft2/player_display_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/player_display_starcraft.lua
@@ -98,15 +98,18 @@ function StarcraftPlayerDisplay.TemplatePlayer(frame)
 	local pageName
 	local displayName
 	if not args.noclean then
-		pageName, displayName = StarcraftPlayerExt.extractFromLink(args[1])
-		if args.link == 'true' then
+		pageName, displayName = StarcraftPlayerExt.extractFromLink(args[1] or '')
+		local showLink = Logic.readBoolOrNil(args.link)
+		if showLink == true then
 			pageName = displayName
-		elseif args.link then
-			pageName = args.link
+		elseif showLink == false then
+			pageName = nil
+		else
+			pageName = args.link or pageName or displayName
 		end
 	else
 		pageName = args.link
-		displayName = args[1]
+		displayName = args[1] or ''
 	end
 
 	local player = {


### PR DESCRIPTION
## Summary
the old version did not parse `|link=false` properly, this PR fixes that
additionally it does a nil catch for missing `args[1]`

## How did you test this change?
live