### PR TITLE
chore: space cleanup

### DIFF
--- a/components/broadcaster_card/commons/broadcaster_card.lua
+++ b/components/broadcaster_card/commons/broadcaster_card.lua
@@ -134,7 +134,7 @@ end
 function BroadcasterCard._display(broadcaster, options)
 	local displayName = broadcaster.displayName or broadcaster.name
 
-	if String.isNotEmpty(displayName)  and (options.alwaysShowName or displayName ~= broadcaster.id) then
+	if String.isNotEmpty(displayName) and (options.alwaysShowName or displayName ~= broadcaster.id) then
 		displayName = ('&nbsp;(' .. displayName ..')')
 	else
 		displayName = ''

--- a/components/faction/wikis/ageofempires/faction_data.lua
+++ b/components/faction/wikis/ageofempires/faction_data.lua
@@ -16,102 +16,102 @@ local AOM_SUFFIX = '/Age of Mythology'
 local AOEO_SUFFIX = '/Age of Empires Online'
 
 local factionPropsAoE1 = {
-    assyrians = {
-        index = 1,
-        name = 'Assyrians',
-        faction = 'assyrians',
-    },
-    babylonians = {
-        index = 2,
-        name = 'Babylonians',
-        pageName = 'Babylonians' .. AOE1_SUFFIX,
-        faction = 'babylonians',
-    },
-    carthaginians = {
-        index = 3,
-        name = 'Carthaginians',
-        faction = 'carthaginians',
-    },
-    choson = {
-        index = 4,
-        name = 'Choson',
-        faction = 'choson',
-    },
-    egyptians = {
-        index = 5,
-        name = 'Egyptians',
-        pageName = 'Egyptians' .. AOE1_SUFFIX,
-        faction = 'egyptians',
-    },
-    greeks = {
-        index = 6,
-        name = 'Greeks',
-        pageName = 'Greeks' .. AOE1_SUFFIX,
-        faction = 'greeks',
-    },
-    hittites = {
-        index = 7,
-        name = 'Hittites',
-        faction = 'hittites',
-    },
-    macedonians = {
-        index = 8,
-        name = 'Macedonians',
-        faction = 'macedonians',
-    },
-    minoans = {
-        index = 9,
-        name = 'Minoans',
-        faction = 'minoans',
-    },
-    palmyrans = {
-        index = 10,
-        name = 'Palmyrans',
-        faction = 'palmyrans',
-    },
-    persians = {
-        index = 11,
-        name = 'Persians',
-        pageName = 'Persians' .. AOE1_SUFFIX,
-        faction = 'persians',
-    },
-    phoenicians = {
-        index = 12,
-        name = 'Phoenicians',
-        faction = 'phoenicians',
-    },
-    romans = {
-        index = 13,
-        name = 'Romans',
-        pageName = 'Romans' .. AOE1_SUFFIX,
-        faction = 'romans',
-    },
-    shang = {
-        index = 14,
-        name = 'Shang',
-        faction = 'shang',
-    },
-    sumerians = {
-        index = 15,
-        name = 'Sumerians',
-        faction = 'sumerians',
-    },
-    yamato = {
-        index = 16,
-        name = 'Yamato',
-        faction = 'yamato',
-    },
-    lacviet = {
-        index = 17,
-        name = 'Lac Viet',
-        faction = 'lacviet',
-    },
+	assyrians = {
+		index = 1,
+		name = 'Assyrians',
+		faction = 'assyrians',
+	},
+	babylonians = {
+		index = 2,
+		name = 'Babylonians',
+		pageName = 'Babylonians' .. AOE1_SUFFIX,
+		faction = 'babylonians',
+	},
+	carthaginians = {
+		index = 3,
+		name = 'Carthaginians',
+		faction = 'carthaginians',
+	},
+	choson = {
+		index = 4,
+		name = 'Choson',
+		faction = 'choson',
+	},
+	egyptians = {
+		index = 5,
+		name = 'Egyptians',
+		pageName = 'Egyptians' .. AOE1_SUFFIX,
+		faction = 'egyptians',
+	},
+	greeks = {
+		index = 6,
+		name = 'Greeks',
+		pageName = 'Greeks' .. AOE1_SUFFIX,
+		faction = 'greeks',
+	},
+	hittites = {
+		index = 7,
+		name = 'Hittites',
+		faction = 'hittites',
+	},
+	macedonians = {
+		index = 8,
+		name = 'Macedonians',
+		faction = 'macedonians',
+	},
+	minoans = {
+		index = 9,
+		name = 'Minoans',
+		faction = 'minoans',
+	},
+	palmyrans = {
+		index = 10,
+		name = 'Palmyrans',
+		faction = 'palmyrans',
+	},
+	persians = {
+		index = 11,
+		name = 'Persians',
+		pageName = 'Persians' .. AOE1_SUFFIX,
+		faction = 'persians',
+	},
+	phoenicians = {
+		index = 12,
+		name = 'Phoenicians',
+		faction = 'phoenicians',
+	},
+	romans = {
+		index = 13,
+		name = 'Romans',
+		pageName = 'Romans' .. AOE1_SUFFIX,
+		faction = 'romans',
+	},
+	shang = {
+		index = 14,
+		name = 'Shang',
+		faction = 'shang',
+	},
+	sumerians = {
+		index = 15,
+		name = 'Sumerians',
+		faction = 'sumerians',
+	},
+	yamato = {
+		index = 16,
+		name = 'Yamato',
+		faction = 'yamato',
+	},
+	lacviet = {
+		index = 17,
+		name = 'Lac Viet',
+		faction = 'lacviet',
+	},
 
-    unknown = {
-        index = 18,
-        name = 'Unknown',
-        faction = 'unknown',
-    },
+	unknown = {
+		index = 18,
+		name = 'Unknown',
+		faction = 'unknown',
+	},
 }
 
 local factionPropsAoE2 = {
@@ -367,138 +367,138 @@ local factionPropsAoE2 = {
 }
 
 local factionPropsAoE3 = {
-    aztecs = {
+	aztecs = {
 		index = 1,
 		name = 'Aztecs',
 		pageName = 'Aztecs' .. AOE3_SUFFIX,
 		faction = 'aztecs',
 	},
-    british = {
+	british = {
 		index = 2,
 		name = 'British',
 		faction = 'british',
 	},
-    chinese = {
+	chinese = {
 		index = 3,
 		name = 'Chinese',
 		pageName = 'Chinese' .. AOE3_SUFFIX,
 		faction = 'chinese',
 	},
-    dutch = {
+	dutch = {
 		index = 4,
 		name = 'Dutch',
 		faction = 'dutch',
 	},
-    ethiopians = {
+	ethiopians = {
 		index = 5,
 		name = 'Ethiopians',
 		pageName = 'Ethiopians' .. AOE3_SUFFIX,
 		faction = 'ethiopians',
 	},
-    french = {
+	french = {
 		index = 6,
 		name = 'French',
 		faction = 'french',
 	},
-    germans = {
+	germans = {
 		index = 7,
 		name = 'Germans',
 		faction = 'germans',
 	},
-    haudenosaunee = {
+	haudenosaunee = {
 		index = 8,
 		name = 'Haudenosaunee',
 		faction = 'haudenosaunee',
 	},
-    hausa = {
+	hausa = {
 		index = 9,
 		name = 'Hausa',
 		faction = 'hausa',
 	},
-    incas = {
+	incas = {
 		index = 10,
 		name = 'Incas',
 		pageName = 'Incas' .. AOE3_SUFFIX,
 		faction = 'incas',
 	},
-    indians = {
+	indians = {
 		index = 11,
 		name = 'Indians',
 		pageName = 'Indians' .. AOE3_SUFFIX,
 		faction = 'indians',
 	},
-    italians = {
+	italians = {
 		index = 12,
 		name = 'Italians',
 		pageName = 'Italians' .. AOE3_SUFFIX,
 		faction = 'italians',
 	},
-    japanese = {
+	japanese = {
 		index = 13,
 		name = 'Japanese',
 		pageName = 'Japanese' .. AOE3_SUFFIX,
 		faction = 'japanese',
 	},
-    lakota = {
+	lakota = {
 		index = 14,
 		name = 'Lakota',
 		faction = 'lakota',
 	},
-    maltese = {
+	maltese = {
 		index = 15,
 		name = 'Maltese',
 		pageName = 'Maltese' .. AOE3_SUFFIX,
 		faction = 'maltese',
 	},
-    mexicans = {
+	mexicans = {
 		index = 16,
 		name = 'Mexicans',
 		faction = 'mexicans',
 	},
-    ottomans = {
+	ottomans = {
 		index = 17,
 		name = 'Ottomans',
 		pageName = 'Ottomans' .. AOE3_SUFFIX,
 		faction = 'ottomans',
 	},
-    portuguese = {
+	portuguese = {
 		index = 18,
 		name = 'Portuguese',
 		pageName = 'Portuguese' .. AOE3_SUFFIX,
 		faction = 'portuguese',
 	},
-    russians = {
+	russians = {
 		index = 19,
 		name = 'Russians',
 		faction = 'russians',
 	},
-    spanish = {
+	spanish = {
 		index = 20,
 		name = 'Spanish',
 		pageName = 'Spanish' .. AOE3_SUFFIX,
 		faction = 'spanish',
 	},
-    swedes = {
+	swedes = {
 		index = 21,
 		name = 'Swedes',
 		faction = 'swedes',
 	},
-    unitedstates = {
+	unitedstates = {
 		index = 22,
 		name = 'United States',
 		faction = 'unitedstates',
 	},
-    random = {
+	random = {
 		index = 23,
 		name = 'Random',
 		faction = 'random',
 	},
 
-    unknown = {
-        index = 24,
-        name = 'Unknown',
-        faction = 'unknown',
-    },
+	unknown = {
+		index = 24,
+		name = 'Unknown',
+		faction = 'unknown',
+	},
 }
 
 local factionPropsAoE4 = {
@@ -591,10 +591,10 @@ local factionPropsAoE4 = {
 	},
 
 	unknown = {
-        index = 17,
-        name = 'Unknown',
-        faction = 'unknown',
-    },
+		index = 17,
+		name = 'Unknown',
+		faction = 'unknown',
+	},
 }
 
 local factionPropsAoM = {
@@ -722,10 +722,10 @@ local factionPropsAoM = {
 	},
 
 	unknown = {
-        index = 24,
-        name = 'Unknown',
-        faction = 'unknown',
-    },
+		index = 24,
+		name = 'Unknown',
+		faction = 'unknown',
+	},
 }
 
 local factionPropsAoEO = {
@@ -779,104 +779,104 @@ local factionPropsAoEO = {
 	},
 
 	unknown = {
-        index = 9,
-        name = 'Unknown',
-        faction = 'unknown',
-    },
+		index = 9,
+		name = 'Unknown',
+		faction = 'unknown',
+	},
 }
 
 return {
-    factionProps = {
-        aoe1 = factionPropsAoE1,
-        aoe2 = factionPropsAoE2,
-        aoe3 = factionPropsAoE3,
-        aoe4 = factionPropsAoE4,
+	factionProps = {
+		aoe1 = factionPropsAoE1,
+		aoe2 = factionPropsAoE2,
+		aoe3 = factionPropsAoE3,
+		aoe4 = factionPropsAoE4,
 		aom = factionPropsAoM,
 		aoeo = factionPropsAoEO,
-    },
-    defaultFaction = 'unknown',
-    factions = {
-        aoe1 = Array.extractKeys(factionPropsAoE1),
-        aoe2 = Array.extractKeys(factionPropsAoE2),
-        aoe3 = Array.extractKeys(factionPropsAoE3),
-        aoe4 = Array.extractKeys(factionPropsAoE4),
-        aom = Array.extractKeys(factionPropsAoM),
-        aoeo = Array.extractKeys(factionPropsAoEO),
-    },
-    aliases = {
-        aoe1 = {
-            asr = 'assyrians',
-            asy = 'assyrians',
-            bab = 'babylonians',
-            car = 'carthaginians',
-            cho = 'choson',
-            egy = 'egyptians',
-            gre = 'greeks',
-            hit = 'hittites',
-            mac = 'macedonians',
-            min = 'minoans',
-            pal = 'palmyrans',
-            per = 'persians',
-            pho = 'phoenicians',
-            rom = 'romans',
-            sha = 'shang',
-            sum = 'sumerians',
-            yam = 'yamato',
-            lac = 'lacviet',
-            lv = 'lacviet',
-            ['lac viet'] = 'lacviet',
-         },
-        aoe2 = {
-            arm = 'armenians',
-            azt = 'aztecs',
-            ber = 'berbers',
-            ben = 'bengalis',
-            boh = 'bohemians',
-            bri = 'britons',
-            bul = 'bulgarians',
-            brg = 'burgundians',
-            bur = 'burmese',
-            byz = 'byzantines',
-            cel = 'celts',
-            chi = 'chinese',
-            cms = 'cumans',
-            cum = 'cumans',
-            dra = 'dravidians',
-            eth = 'ethiopians',
-            fra = 'franks',
-            geo = 'georgians',
-            got = 'goths',
-            gur = 'gurjaras',
-            hin = 'hindustanis',
-            hun = 'huns',
-            inc = 'incas',
-            ind = 'indians',
-            ita = 'italians',
-            jap = 'japanese',
-            jpn = 'japanese',
-            khm = 'khmer',
-            kor = 'koreans',
-            lit = 'lithuanians',
-            mag = 'magyars',
-            mly = 'malay',
-            mal = 'malians',
-            mli = 'malians',
-            may = 'mayans',
-            mon = 'mongols',
-            per = 'persians',
-            pol = 'poles',
-            por = 'portuguese',
-            rom = 'romans',
-            sar = 'saracens',
-            sic = 'sicilians',
-            sla = 'slavs',
-            spa = 'spanish',
-            tat = 'tatars',
-            teu = 'teutons',
-            tur = 'turks',
-            vie = 'vietnamese',
-            vik = 'vikings',
-        },
+	},
+	defaultFaction = 'unknown',
+	factions = {
+		aoe1 = Array.extractKeys(factionPropsAoE1),
+		aoe2 = Array.extractKeys(factionPropsAoE2),
+		aoe3 = Array.extractKeys(factionPropsAoE3),
+		aoe4 = Array.extractKeys(factionPropsAoE4),
+		aom = Array.extractKeys(factionPropsAoM),
+		aoeo = Array.extractKeys(factionPropsAoEO),
+	},
+	aliases = {
+		aoe1 = {
+			asr = 'assyrians',
+			asy = 'assyrians',
+			bab = 'babylonians',
+			car = 'carthaginians',
+			cho = 'choson',
+			egy = 'egyptians',
+			gre = 'greeks',
+			hit = 'hittites',
+			mac = 'macedonians',
+			min = 'minoans',
+			pal = 'palmyrans',
+			per = 'persians',
+			pho = 'phoenicians',
+			rom = 'romans',
+			sha = 'shang',
+			sum = 'sumerians',
+			yam = 'yamato',
+			lac = 'lacviet',
+			lv = 'lacviet',
+			['lac viet'] = 'lacviet',
+		 },
+		aoe2 = {
+			arm = 'armenians',
+			azt = 'aztecs',
+			ber = 'berbers',
+			ben = 'bengalis',
+			boh = 'bohemians',
+			bri = 'britons',
+			bul = 'bulgarians',
+			brg = 'burgundians',
+			bur = 'burmese',
+			byz = 'byzantines',
+			cel = 'celts',
+			chi = 'chinese',
+			cms = 'cumans',
+			cum = 'cumans',
+			dra = 'dravidians',
+			eth = 'ethiopians',
+			fra = 'franks',
+			geo = 'georgians',
+			got = 'goths',
+			gur = 'gurjaras',
+			hin = 'hindustanis',
+			hun = 'huns',
+			inc = 'incas',
+			ind = 'indians',
+			ita = 'italians',
+			jap = 'japanese',
+			jpn = 'japanese',
+			khm = 'khmer',
+			kor = 'koreans',
+			lit = 'lithuanians',
+			mag = 'magyars',
+			mly = 'malay',
+			mal = 'malians',
+			mli = 'malians',
+			may = 'mayans',
+			mon = 'mongols',
+			per = 'persians',
+			pol = 'poles',
+			por = 'portuguese',
+			rom = 'romans',
+			sar = 'saracens',
+			sic = 'sicilians',
+			sla = 'slavs',
+			spa = 'spanish',
+			tat = 'tatars',
+			teu = 'teutons',
+			tur = 'turks',
+			vie = 'vietnamese',
+			vik = 'vikings',
+		},
 		aoe3 = {
 			azt = 'aztecs',
 			brt = 'british',
@@ -952,5 +952,5 @@ return {
 			per = 'persians',
 			rom = 'romans',
 		}
-    },
+	},
 }

--- a/components/faction/wikis/ageofempires/faction_icon_data.lua
+++ b/components/faction/wikis/ageofempires/faction_icon_data.lua
@@ -7,59 +7,59 @@
 --
 
 local byFactionAoE1 = {
-    assyrians = {
+	assyrians = {
 		icon = 'File:Assyrian AOE DE ROR icon.webp',
 	},
-    babylonians = {
+	babylonians = {
 		icon = 'File:Babylonian AOE DE ROR icon.webp',
 	},
-    carthaginians = {
+	carthaginians = {
 		icon = 'File:Carthaginian AOE DE ROR icon.webp',
 	},
-    choson = {
+	choson = {
 		icon = 'File:Choson AOE DE ROR icon.webp',
 	},
-    egyptians = {
+	egyptians = {
 		icon = 'File:Egyptian AOE DE ROR icon.webp',
 	},
-    greeks = {
+	greeks = {
 		icon = 'File:Greek AOE DE ROR icon.webp',
 	},
-    hittites = {
+	hittites = {
 		icon = 'File:Hittite AOE DE ROR icon.webp',
 	},
-    macedonians = {
+	macedonians = {
 		icon = 'File:Macedonian AOE DE ROR icon.webp',
 	},
-    minoans = {
+	minoans = {
 		icon = 'File:Minoan AOE DE ROR icon.webp',
 	},
-    palmyrans = {
+	palmyrans = {
 		icon = 'File:Palmyran AOE DE ROR icon.webp',
 	},
-    persians = {
+	persians = {
 		icon = 'File:Persian AOE DE ROR icon.webp',
 	},
-    phoenicians = {
+	phoenicians = {
 		icon = 'File:Phoenician AOE DE ROR icon.webp',
 	},
-    romans = {
+	romans = {
 		icon = 'File:Roman AOE DE ROR icon.webp',
 	},
-    shang = {
+	shang = {
 		icon = 'File:Shang AOE DE ROR icon.webp',
 	},
-    sumerians = {
+	sumerians = {
 		icon = 'File:Sumerian AOE DE ROR icon.webp',
 	},
-    yamato = {
+	yamato = {
 		icon = 'File:Yamato AOE DE ROR icon.webp',
 	},
-    lacviet = {
+	lacviet = {
 		icon = 'File:Lac Viet AOE DE ROR icon.webp',
 	},
 
-    unknown = {
+	unknown = {
 		icon = 'File:Char head filler.png',
 	},
 }
@@ -210,77 +210,77 @@ local byFactionAoE2 = {
 }
 
 local byFactionAoE3 = {
-    aztecs = {
+	aztecs = {
 		icon = 'File:Aztecs AoE3 icon.png',
 	},
-    british = {
+	british = {
 		icon = 'File:British AoE3 icon.png',
 	},
-    chinese = {
+	chinese = {
 		icon = 'File:Chinese AoE3 icon.png',
 	},
-    dutch = {
+	dutch = {
 		icon = 'File:Dutch AoE3 icon.png',
 	},
-    ethiopians = {
+	ethiopians = {
 		icon = 'File:Ethiopians AoE3 icon.png',
 	},
-    french = {
+	french = {
 		icon = 'File:French AoE3 icon.png',
 	},
-    germans = {
+	germans = {
 		icon = 'File:Germans AoE3 icon.png',
 	},
-    haudenosaunee = {
+	haudenosaunee = {
 		icon = 'File:Haudenosaunee AoE3 icon.png',
 	},
-    hausa = {
+	hausa = {
 		icon = 'File:Hausa AoE3 icon.png',
 	},
-    incas = {
+	incas = {
 		icon = 'File:Incas AoE3 icon.png',
 	},
-    indians = {
+	indians = {
 		icon = 'File:Indians AoE3 icon.png',
 	},
-    italians = {
+	italians = {
 		icon = 'File:Italians AoE3 icon.png',
 	},
-    japanese = {
+	japanese = {
 		icon = 'File:Japanese AoE3 icon.png',
 	},
-    lakota = {
+	lakota = {
 		icon = 'File:Lakota AoE3 icon.png',
 	},
-    maltese = {
+	maltese = {
 		icon = 'File:Maltese AoE3 icon.png',
 	},
-    mexicans = {
+	mexicans = {
 		icon = 'File:Mexicans AoE3 icon.png',
 	},
-    ottomans = {
+	ottomans = {
 		icon = 'File:Ottomans AoE3 icon.png',
 	},
-    portuguese = {
+	portuguese = {
 		icon = 'File:Portuguese AoE3 icon.png',
 	},
-    russians = {
+	russians = {
 		icon = 'File:Russians AoE3 icon.png',
 	},
-    spanish = {
+	spanish = {
 		icon = 'File:Spanish AoE3 icon.png',
 	},
-    swedes = {
+	swedes = {
 		icon = 'File:Swedes AoE3 icon.png',
 	},
-    unitedstates = {
+	unitedstates = {
 		icon = 'File:United States AoE3 icon.png',
 	},
-    random = {
+	random = {
 		icon = 'File:Random AoE3 icon.png',
 	},
 
-    unknown = {
+	unknown = {
 		icon = 'File:Char head filler.png',
 	},
 }

--- a/components/infobox/extensions/commons/infobox_placement_stats.lua
+++ b/components/infobox/extensions/commons/infobox_placement_stats.lua
@@ -104,7 +104,7 @@ end
 ---@param baseConditions string
 ---@param placementData InfoboxPlacementStatsData
 function PlacementStats._fetchForTier(tier, baseConditions, placementData)
-	placementData.tiers[tier] =  {top3 = 0, all = 0, placement = {}}
+	placementData.tiers[tier] = {top3 = 0, all = 0, placement = {}}
 
 	local queryData = mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = 5000,

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -108,7 +108,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'hotkey' then
 		if not args.hotkey and not args.macro_key then return {} end
 		local hotkeyName = table.concat(Array.append({},
-			args.hotkey and 'Hotkeys',  args.macro_key and 'Macrokeys'
+			args.hotkey and 'Hotkeys', args.macro_key and 'Macrokeys'
 		), HOTKEY_SEPERATOR)
 		local hotkeys = table.concat(Array.append({},
 			args.hotkey and CustomBuilding._hotkeys(args.hotkey, args.hotkey2),
@@ -226,7 +226,7 @@ function CustomBuilding:setLpdbData(args)
 			respawn = tonumber(args.respawn),
 			creeps = Array.parseCommaSeparatedString(args.creeps),
 			capturepoint = args.capture_point,
-			globalbuff =  args.global_buff,
+			globalbuff = args.global_buff,
 		},
 	})
 end

--- a/components/infobox/wikis/stormgate/infobox_map_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_map_custom.lua
@@ -83,7 +83,7 @@ function CustomMap._parseArgs(args)
 		local value = tonumber(args[key])
 		args[key] = value ~= 0 and value or nil
 	end)
-	args.types =  Array.map(mw.text.split((args.type or ManualMapTypes.MISC):upper(), ','), String.trim)
+	args.types = Array.map(mw.text.split((args.type or ManualMapTypes.MISC):upper(), ','), String.trim)
 
 	--check for invalid type input
 	assert(

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -97,7 +97,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'hotkey' then
 		if not args.hotkey and not args.macro_key then return {} end
 		local hotkeyName = table.concat(Array.append({},
-			args.hotkey and 'Hotkeys',  args.macro_key and 'Macrokeys'
+			args.hotkey and 'Hotkeys', args.macro_key and 'Macrokeys'
 		), HOTKEY_SEPERATOR)
 		local hotkeys = table.concat(Array.append({},
 			args.hotkey and CustomUnit._hotkeys(args.hotkey, args.hotkey2),

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -397,7 +397,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.participantsnumber = participantsNumber
 	lpdbData.sortdate = self.data.startTime.startTime
 		and (self.data.startTime.startTime .. (self.data.startTime.timeZone or ''))
-		or self.data.firstMatch or  self.data.startDate
+		or self.data.firstMatch or self.data.startDate
 	lpdbData.mode = self:_getMode()
 	lpdbData.extradata.seriesnumber = self.data.number
 

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -98,7 +98,7 @@ function MatchGroup.MatchPage(args)
 	matchId = args.matchid or matchId
 	local fullMatchId = bracketId .. '_' .. matchId
 
-	local options = {storeMatch1 = false,  storeMatch2 = true, storePageVar = true, bracketId = bracketId}
+	local options = {storeMatch1 = false, storeMatch2 = true, storePageVar = true, bracketId = bracketId}
 	local matches = MatchGroupInput.readMatchpage(bracketId, matchId, args)
 	Match.storeMatchGroup(matches, options)
 

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -158,7 +158,7 @@ end
 ---@param walkover string?
 ---@param winner integer?
 ---@return string
-function DisplayHelper.MapScore(score, opponentIndex, resultType,  walkover, winner)
+function DisplayHelper.MapScore(score, opponentIndex, resultType, walkover, winner)
 	if resultType == 'default' then
 		return opponentIndex == winner and 'W' or string.upper(walkover or '')
 	end

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -745,7 +745,7 @@ end
 ---@param winnerInput integer|string|nil
 ---@param opponents {score: number, status: string}[]
 ---@return integer? # Winner
-function MatchGroupInputUtil.getWinner(resultType, winnerInput,  opponents)
+function MatchGroupInputUtil.getWinner(resultType, winnerInput, opponents)
 	if resultType == MatchGroupInputUtil.RESULT_TYPE.NOT_PLAYED then
 		return nil
 	elseif Logic.isNumeric(winnerInput) then

--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -289,7 +289,7 @@ function MatchGroupLegacy:getMatch(match2key, match1params)
 	self:handleFinished(isReset, match)
 	self:handleOtherMatchParams(isReset, match)
 	Array.forEach(Array.range(1, MAX_NUMBER_OF_OPPONENTS), function (opponentIndex)
-		local opponent =  match['opponent' .. opponentIndex] or {}
+		local opponent = match['opponent' .. opponentIndex] or {}
 		match.winner = match.winner or opponent.win and opponentIndex or nil
 		isValidReset = isValidReset or Logic.isNotEmpty(opponent.score)
 	end)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -434,7 +434,7 @@ end
 ---@param displayName string
 ---@return integer
 function MapFunctions.getPlayerIndex(players, name, displayName)
-	local playerIndex =  Array.indexOf(players, function(player) return player.name == name end)
+	local playerIndex = Array.indexOf(players, function(player) return player.name == name end)
 
 	if playerIndex ~= 0 then
 		return playerIndex

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -87,7 +87,7 @@ function StarcraftMatchSummary.MatchSummaryContainer(args)
 
 	local matchSummary = MatchSummary():init()
 		:addClass('brkts-popup-sc')
-		:addClass(match.opponentMode ~= UNIFORM_MATCH  and 'brkts-popup-sc-team-match' or nil)
+		:addClass(match.opponentMode ~= UNIFORM_MATCH and 'brkts-popup-sc-team-match' or nil)
 
 	--additional header for when martin adds the the css and buttons for switching between match and reset match
 	--if bracketResetMatch then

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -60,7 +60,7 @@ return {
 							</div>
 							{{/teams.1.picks}}
 						</div>
-						<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
+						<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
 							{{#teams.1.bans}}
 							<div class="match-bm-game-veto-overview-team-veto-row-item">
 								<div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div>
@@ -81,7 +81,7 @@ return {
 							</div>
 							{{/teams.2.picks}}
 						</div>
-						<div class="match-bm-game-veto-overview-team-veto-row  match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
+						<div class="match-bm-game-veto-overview-team-veto-row match-bm-game-veto-overview-team-veto-row--ban" aria-labelledby="bans">
 							{{#teams.2.bans}}
 							<div class="match-bm-game-veto-overview-team-veto-row-item">
 								<div class="match-bm-game-veto-overview-team-veto-row-item-icon">{{&heroIcon}}</div>

--- a/components/match2/wikis/easportsfc/match_group_input_custom.lua
+++ b/components/match2/wikis/easportsfc/match_group_input_custom.lua
@@ -491,7 +491,7 @@ function CustomMatchGroupInput._processTeamPlayerMapData(players, opponentIndex,
 			playerData = Table.merge(playerData, {name = player:gsub(' ', '_'), displayname = map[playerKey] or player})
 		end
 
-		participants[opponentIndex .. '_' .. match2playerIndex] =  playerData
+		participants[opponentIndex .. '_' .. match2playerIndex] = playerData
 	end
 end
 

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -26,7 +26,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MAX_NUM_BANS = 3
 local NUM_CHAMPIONS_PICK = 5
 
-local GREEN_CHECK  = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
+local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 local NO_CHARACTER = 'default'
 local MAP_VETO_START = '<b>Start Map Veto</b>'

--- a/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/rainbowsix/get_match_group_copy_paste_wiki.lua
@@ -96,7 +96,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	end
 
 	Array.forEach(Array.range(1, bestof), function(mapIndex)
-		local firstMapLine = INDENT .. '|map' .. mapIndex .. '={{Map|map=' .. score  .. '|finished='
+		local firstMapLine = INDENT .. '|map' .. mapIndex .. '={{Map|map=' .. score .. '|finished='
 		if not mapDetails then
 			Array.appendWith(lines, firstMapLine .. '}}')
 			return

--- a/components/match2/wikis/stormgate/match_group_util_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_util_custom.lua
@@ -48,7 +48,7 @@ CustomMatchGroupUtil.types.GameOpponent = TypeUtil.struct({
 })
 
 ---@class StormgateMatchGroupUtilGame: MatchGroupUtilGame
----@field opponents  StormgateMatchGroupUtilGameOpponent[]
+---@field opponents StormgateMatchGroupUtilGameOpponent[]
 ---@field offFactions table<integer, string[]>?
 
 ---@class StormgateMatchGroupUtilVeto
@@ -89,7 +89,7 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 		game.opponents = CustomMatchGroupUtil.computeGameOpponents(game, match.opponents)
 	end
 
-	match.isUniformMode = Array.all(match.opponents, function(opponent) return opponent.type  ~= Opponent.team end)
+	match.isUniformMode = Array.all(match.opponents, function(opponent) return opponent.type ~= Opponent.team end)
 
 	local extradata = match.extradata
 	---@cast extradata table

--- a/components/match2/wikis/warcraft/match_group_util_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_util_custom.lua
@@ -36,7 +36,7 @@ local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 ---@field score number?
 
 ---@class WarcraftMatchGroupUtilGame: MatchGroupUtilGame
----@field opponents  WarcraftMatchGroupUtilGameOpponent[]
+---@field opponents WarcraftMatchGroupUtilGameOpponent[]
 ---@field offfactions table<integer, string[]>?
 
 ---@class WarcraftMatchGroupUtilVeto

--- a/components/participant_table/commons/participant_table_import.lua
+++ b/components/participant_table/commons/participant_table_import.lua
@@ -80,7 +80,7 @@ end
 ---@return ParticipantTableEntry?
 function ParticipantTableImport._entryFromOpponentRecord(opponentRecord)
 	local opponent = Opponent.fromMatch2Record(opponentRecord) --[[@as standardOpponent]]
-	if  Opponent.isTbd(opponent) then
+	if Opponent.isTbd(opponent) then
 		return
 	end
 	return {

--- a/components/ratings/ratings_display_graph.lua
+++ b/components/ratings/ratings_display_graph.lua
@@ -24,7 +24,7 @@ function RatingsDisplayGraph.build(teamRankings)
 	return mw.ext.Charts.chart({
 		xAxis = {
 			type = 'category',
-			data =  Array.map(teams[1].progression or {}, Operator.property('date'))
+			data = Array.map(teams[1].progression or {}, Operator.property('date'))
 		},
 		yAxis = {
 			name = 'Rating',
@@ -53,7 +53,7 @@ function RatingsDisplayGraph.build(teamRankings)
 		},
 		series = Array.map(teams, function(team)
 			return {
-				data =  Array.map(team.progression, Operator.property('rating')),
+				data = Array.map(team.progression, Operator.property('rating')),
 				type = 'line',
 				name = team.shortName
 			}

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -121,7 +121,7 @@ function SquadUtils.readSquadPersonArgs(args)
 	end
 
 	local id = assert(String.nilIfEmpty(args.id), 'Something is off with your input!')
-	local person =  Lpdb.SquadPlayer:new{
+	local person = Lpdb.SquadPlayer:new{
 		id = id,
 		link = mw.ext.TeamLiquidIntegration.resolve_redirect(args.link or id),
 		name = String.nilIfEmpty(args.name),

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -465,7 +465,7 @@ function StatisticsPortal.prizepoolBreakdown(args)
 	local colIndex = 1
 
 	for _, yearValue in pairs(defaultYearTable) do
-		local conditions =  StatisticsPortal._returnBaseConditions()
+		local conditions = StatisticsPortal._returnBaseConditions()
 
 		if args.game then
 			conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, args.game)}
@@ -782,7 +782,7 @@ function StatisticsPortal.playerAgeTable(args)
 			:tag('td')
 				:node(OpponentDisplay.BlockOpponent{
 					opponent = StatisticsPortal._toOpponent(player),
-					showPlayerTeam  = true,
+					showPlayerTeam = true,
 				}):done()
 			:tag('td')
 				:wikitext(yearAge .. ' years, ' .. dayAge .. ' days')
@@ -1042,7 +1042,7 @@ function StatisticsPortal._cacheOpponentPlacementData(args)
 		local placement = string.sub(item.placement, 1, 1)
 		for _, opponent in pairs(makeOpponentTable(item) or {}) do
 			if not data[opponent] then
-				data[opponent] = {['1'] = 0, ['2'] =  0, ['3'] = 0, showWins = 0, sWinData = {}}
+				data[opponent] = {['1'] = 0, ['2'] = 0, ['3'] = 0, showWins = 0, sWinData = {}}
 			end
 			if placement == FIRST and item.liquipediatier == TIER1 and item.liquipediatiertype ~= SHOWMATCH then
 				table.insert(data[opponent].sWinData, {

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -328,7 +328,7 @@ end
 ---@return number|string
 function mw.language:formatDate(format, timestamp, localTime)
 	local function localTimezoneOffset(ts)
-		local utcDt   = os.date("!*t", ts)
+		local utcDt = os.date("!*t", ts)
 		local localDt = os.date("*t", ts)
 		localDt.isdst = false
 		return os.difftime(os.time(localDt --[[@as osdateparam]]), os.time(utcDt --[[@as osdateparam]]))
@@ -794,14 +794,14 @@ mw.ustring = {}
 
 ---Returns individual bytes; identical to string.byte().
 ---@see string.byte
----@param s  string|number
+---@param s string|number
 ---@param i? integer
 ---@param j? integer
 ---@return integer ...
 function mw.ustring.byte(s, i, j) end
 
 ---Returns the byte offset of a character in the string. The default for both l and i is 1. i may be negative, in which case it counts from the end of the string.
----@param s  string|number
+---@param s string|number
 ---@param l? integer
 ---@param i? integer
 ---@return integer ...
@@ -815,7 +815,7 @@ function mw.ustring.char(...) end
 
 ---Much like string.byte(), except that the return values are codepoints and the offsets are characters rather than bytes.
 ---@see string.byte
----@param s  string|number
+---@param s string|number
 ---@param i? integer
 ---@param j? integer
 ---@return integer ...
@@ -823,10 +823,10 @@ function mw.ustring.codepoint(s, i, j) end
 
 ---Much like string.find(), except that the pattern is extended as described in Ustring patterns and the init offset is in characters rather than bytes.
 ---@see string.find
----@param s       string|number
+---@param s string|number
 ---@param pattern string|number
----@param init?   integer
----@param plain?  boolean
+---@param init? integer
+---@param plain? boolean
 ---@return integer|nil start
 ---@return integer|nil end
 ---@return any|nil ... captured
@@ -840,7 +840,7 @@ function mw.ustring.find(s, pattern, init, plain) end
 function mw.ustring.format(format, ...) end
 
 ---Returns three values for iterating over the codepoints in the string. i defaults to 1, and j to -1. This is intended for use in the iterator form of for:
----@param s  string|number
+---@param s string|number
 ---@param i? integer
 ---@param j? integer
 ---@return string
@@ -848,17 +848,17 @@ function mw.ustring.gcodepoint(s, i, j) end
 
 ---Much like string.gmatch(), except that the pattern is extended as described in Ustring patterns.
 ---@see string.gmatch
----@param s       string|number
+---@param s string|number
 ---@param pattern string|number
 ---@return fun():string, ...
 function mw.ustring.gmatch(s, pattern) end
 
 ---Much like string.gmatch(), except that the pattern is extended as described in Ustring patterns.
 ---@see string.gsub
----@param s       string|number
+---@param s string|number
 ---@param pattern string|number
----@param repl    string|number|table|function
----@param n?      integer
+---@param repl string|number|table|function
+---@param n? integer
 ---@return string
 ---@return integer count
 function mw.ustring.gsub(s, pattern, repl, n) end
@@ -887,44 +887,44 @@ end
 
 ---Much like string.match(), except that the pattern is extended as described in Ustring patterns and the init offset is in characters rather than bytes.
 ---@see string.match
----@param s       string|number
+---@param s string|number
 ---@param pattern string|number
----@param init?   integer
+---@param init? integer
 ---@return any ...
 function mw.ustring.match(s, pattern, init) end
 
 ---Identical to string.rep().
 ---@see string.rep
----@param s    string|number
----@param n    integer
+---@param s string|number
+---@param n integer
 ---@return string
 function mw.ustring.rep(s, n) end
 
 ---Identical to string.sub().
 ---@see string.sub
----@param s  string|number
----@param i  integer
+---@param s string|number
+---@param i integer
 ---@param j? integer
 ---@return string
 function mw.ustring.sub(s, i, j) end
 
 ---Converts the string to Normalization Form C (also known as Normalization Form Canonical Composition). Returns nil if the string is not valid UTF-8.
----@param s  string|number
+---@param s string|number
 ---@return string?
 function mw.ustring.toNFC(s) return tostring(s) end
 
 ---Converts the string to Normalization Form D (also known as Normalization Form Canonical Decomposition). Returns nil if the string is not valid UTF-8.
----@param s  string|number
+---@param s string|number
 ---@return string?
 function mw.ustring.toNFD(s) return tostring(s) end
 
 ---Converts the string to Normalization Form KC (also known as Normalization Form Compatibility Composition). Returns nil if the string is not valid UTF-8.
----@param s  string|number
+---@param s string|number
 ---@return string?
 function mw.ustring.toNFKC(s) return tostring(s) end
 
 ---Converts the string to Normalization Form KD (also known as Normalization Form Compatibility Decomposition). Returns nil if the string is not valid UTF-8.
----@param s  string|number
+---@param s string|number
 ---@return string?
 function mw.ustring.toNFKD(s) return tostring(s) end
 

--- a/plugins/sumneko_plugin.lua
+++ b/plugins/sumneko_plugin.lua
@@ -55,14 +55,14 @@ function liquipedia.annotate(text, diffs)
 end
 
 ---@class diff
----@field start  integer # The number of bytes at the beginning of the replacement
+---@field start integer # The number of bytes at the beginning of the replacement
 ---@field finish integer # The number of bytes at the end of the replacement
----@field text   string  # What to replace
+---@field text string # What to replace
 
 -- luacheck: push ignore
 -- setting non-standard global variable 'OnSetText' (but it's mandatory)
----@param  uri  string # The uri of file
----@param  text string # The content of file
+---@param uri string # The uri of file
+---@param text string # The content of file
 ---@return nil|diff[]
 ---@diagnostic disable-next-line: global-element
 function OnSetText(uri, text)

--- a/standard/error_display.lua
+++ b/standard/error_display.lua
@@ -116,7 +116,7 @@ function ErrorDisplay.ClassicError(error)
 			stackEntry.content = mw.text.trim(table.concat(frameSplit, ':', 2))
 		elseif frameSplit[1]:sub(1, 3) == 'mw.' then
 			stackEntry.prefix = table.concat(frameSplit, ':', 1, 2)
-			stackEntry.content =  table.concat(frameSplit, ':', 3)
+			stackEntry.content = table.concat(frameSplit, ':', 3)
 		elseif frameSplit[1] == 'Module' then
 			local wiki = not Page.exists(table.concat(frameSplit, ':', 1, 2)) and 'commons'
 				or mw.text.split(mw.title.getCurrentTitle():canonicalUrl(), '/', true)[4] or 'commons'


### PR DESCRIPTION
## Summary
searched for double space in vscode (`  `) and replaced most of them with single space or tabs

## How did you test this change?
N/A