### PR TITLE
fix(opponent): wrong var name & passed to wrong function

### DIFF
--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -301,7 +301,7 @@ options.syncPlayer: Whether to fetch player information from variables or LPDB. 
 ]]
 ---@param opponent standardOpponent
 ---@param date string|number|nil
----@param options {syncPlayer: boolean?, overwriteVars: boolean?}?
+---@param options {syncPlayer: boolean?, overwritePageVars: boolean?}?
 ---@return standardOpponent
 function Opponent.resolve(opponent, date, options)
 	options = options or {}
@@ -314,7 +314,7 @@ function Opponent.resolve(opponent, date, options)
 				local savePageVar = not Opponent.playerIsTbd(player)
 				PlayerExt.syncPlayer(player, {
 					savePageVar = savePageVar,
-					overwriteVars = options.overwriteVars,
+					overwritePageVars = options.overwritePageVars,
 				})
 				player.team = PlayerExt.syncTeam(
 					player.pageName:gsub(' ', '_'),

--- a/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_starcraft.lua
@@ -126,7 +126,7 @@ options.syncPlayer: Whether to fetch player information from variables or LPDB. 
 ]]
 ---@param opponent StarcraftStandardOpponent
 ---@param date string|number|osdate|nil
----@param options {syncPlayer: boolean?, overwriteVars: boolean?}
+---@param options {syncPlayer: boolean?, overwritePageVars: boolean?}
 ---@return StarcraftStandardOpponent
 function StarcraftOpponent.resolve(opponent, date, options)
 	options = options or {}
@@ -140,7 +140,7 @@ function StarcraftOpponent.resolve(opponent, date, options)
 				StarcraftPlayerExt.syncPlayer(player, {
 					savePageVar = savePageVar,
 					date = date,
-					overwriteVars = options.overwriteVars,
+					overwritePageVars = options.overwritePageVars,
 				})
 				player.team = PlayerExt.syncTeam(
 					player.pageName:gsub(' ', '_'),

--- a/components/opponent/wikis/stormgate/opponent_custom.lua
+++ b/components/opponent/wikis/stormgate/opponent_custom.lua
@@ -115,7 +115,7 @@ end
 
 ---@param opponent StormgateStandardOpponent
 ---@param date string|number|nil
----@param options {syncPlayer: boolean?, overwriteVars: boolean?}
+---@param options {syncPlayer: boolean?, overwritePageVars: boolean?}
 ---@return StormgateStandardOpponent
 function CustomOpponent.resolve(opponent, date, options)
 	options = options or {}
@@ -124,14 +124,17 @@ function CustomOpponent.resolve(opponent, date, options)
 			if options.syncPlayer then
 				local hasFaction = String.isNotEmpty(player.faction)
 				local savePageVar = not Opponent.playerIsTbd(player)
-				PlayerExt.syncPlayer(player, {date = date, savePageVar = savePageVar})
+				PlayerExt.syncPlayer(player, {
+					date = date,
+					savePageVar = savePageVar,
+					overwritePageVars = options.overwritePageVars,
+				})
 				player.team = PlayerExt.syncTeam(
 					player.pageName:gsub(' ', '_'),
 					player.team,
 					{
 							date = date,
 							savePageVar = savePageVar,
-							overwriteVars = options.overwriteVars,
 						}
 				)
 				player.faction = (hasFaction or player.faction ~= Faction.defaultFaction) and player.faction or nil

--- a/components/opponent/wikis/warcraft/opponent_custom.lua
+++ b/components/opponent/wikis/warcraft/opponent_custom.lua
@@ -100,7 +100,7 @@ end
 
 ---@param opponent WarcraftStandardOpponent
 ---@param date string|number|nil
----@param options {syncPlayer: boolean?, overwriteVars: boolean?}?
+---@param options {syncPlayer: boolean?, overwritePageVars: boolean?}?
 ---@return WarcraftStandardOpponent
 function CustomOpponent.resolve(opponent, date, options)
 	options = options or {}
@@ -111,14 +111,17 @@ function CustomOpponent.resolve(opponent, date, options)
 			if options.syncPlayer then
 				local hasFaction = String.isNotEmpty(player.faction)
 				local savePageVar = not Opponent.playerIsTbd(player)
-				PlayerExt.syncPlayer(player, {savePageVar = savePageVar, date = date})
+				PlayerExt.syncPlayer(player, {
+					savePageVar = savePageVar,
+					date = date,
+					overwritePageVars = options.overwritePageVars,
+				})
 				player.team = PlayerExt.syncTeam(
 					player.pageName:gsub(' ', '_'),
 					player.team,
 					{
 							date = date,
 							savePageVar = savePageVar,
-							overwriteVars = options.overwriteVars,
 						}
 				)
 				player.faction = (hasFaction or player.faction ~= Faction.defaultFaction) and player.faction or nil


### PR DESCRIPTION
## Summary
In `Module:Opponent` the option key is `overwriteVars` while in Player/ext it is `overwritePageVars`.
And on WC/SG the option param was passed to the wrong function

## How did you test this change?
live