### PR TITLE
feat(styles): darkmode support for `.gvt-el-significant`

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -823,7 +823,7 @@ div.gameplay_nav ul li ul li {
 
 /* Template:GameVersionTableElement */
 .gvt-el-significant {
-	background: #ffffcc;
+	background-color: var( --publisher-premier-highlight-background-color, #ffffcc );
 }
 
 /* Template:Talent table el */


### PR DESCRIPTION
## Summary
Add darkmode support for `.gvt-el-significant` in fountain.less

## How did you test this change?
browser dev tools