### PR TITLE
feat(matchticker): update toggle slider disabled background color

### DIFF
--- a/stylesheets/commons/SwitchButtons.less
+++ b/stylesheets/commons/SwitchButtons.less
@@ -36,7 +36,7 @@
 				background-color: #191f2b;
 
 				.theme--light & {
-					background-color: var( --clr-wiki-theme-primary );
+					background-color: #000000;
 				}
 
 				.theme--dark & {


### PR DESCRIPTION
## Summary

Based on design feedback, the background color of the slider has been changed to a darker state to not look like it is disabled.
How it will look like:
![image](https://github.com/user-attachments/assets/2ba9c72a-90f1-4b75-be68-53d066856139)

## How did you test this change?

Console on this page](https://liquipedia.net/dota2/Main_Page)