### PR TITLE
fix(match2): `opponentIsHighlightable` sometimes being wrong on sc(2)/wc/sg

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -32,7 +32,9 @@ function DisplayHelper.opponentIsHighlightable(opponent)
 		return opponent.template and opponent.template ~= 'tbd' or false
 	else
 		return 0 < #opponent.players
-			and Array.all(opponent.players, function(player) return player.pageName ~= '' and player.displayName ~= 'TBD' end)
+			and Array.all(opponent.players, function(player)
+				return Logic.isNotEmpty(player.pageName) and Logic.isNotEmpty(player.displayName) and player.displayName ~= 'TBD'
+			end)
 	end
 end
 


### PR DESCRIPTION
## Summary
Currently `opponentIsHighlightable` fails on sc2 for empty party opponents due to the filled in default faction.
After thinking about removing defaultFaction in empty player cases it was noticed that for an party opponent with filled in flag/faction it would still cause the same issue again.
Hence adjust the commons check a bit so it also checks on the displayName not being empty instead.
Additionally move away from checking against not being empty string and use `Logic.isNotEmpty` instead.

## How did you test this change?
dev