### PR TITLE
ci: deploy the entire branch instead of just last commit

### DIFF
--- a/.github/workflows/deploy test.yml
+++ b/.github/workflows/deploy test.yml
@@ -15,11 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
+
+      - uses: nrwl/nx-set-shas@v4
+        id: last_successful_commit_push
+        with:
+          workflow-id: 'deploy test.yml'
 
       - id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v45
         with:
+          base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
           files: |
             components/**/*.lua
             standard/**/*.lua

--- a/.github/workflows/deploy test.yml
+++ b/.github/workflows/deploy test.yml
@@ -19,8 +19,6 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v4
         id: last_successful_commit_push
-        with:
-          workflow-id: 'deploy%20test.yml'
 
       - id: changed-files
         uses: tj-actions/changed-files@v45

--- a/.github/workflows/deploy test.yml
+++ b/.github/workflows/deploy test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
         id: last_successful_commit_push
         with:
-          workflow-id: 'deploy test.yml'
+          workflow-id: 'deploy%20test.yml'
 
       - id: changed-files
         uses: tj-actions/changed-files@v45


### PR DESCRIPTION
## Summary
Currently the CI  will only take the last commit of the branch. Now it should take all diffs compared to main. However it's important to rebase/merge with main before deploying! (otherwise extra files will be deployed)

## How did you test this change?
Tested in #4633 (https://github.com/Liquipedia/Lua-Modules/actions/runs/10735333412), with some minor tweaks afterwards
