### PR TITLE
refactor(widget): move most widgets from `Infobox/Widget` to `Widget`

### DIFF
--- a/components/infobox/commons/infobox_widget_all.lua
+++ b/components/infobox/commons/infobox_widget_all.lua
@@ -11,18 +11,18 @@ local Widgets = {}
 local Lua = require('Module:Lua')
 
 --- Core Widgets
-Widgets.Builder = Lua.import('Module:Infobox/Widget/Builder')
-Widgets.Customizable = Lua.import('Module:Infobox/Widget/Customizable')
+Widgets.Builder = Lua.import('Module:Widget/Builder')
+Widgets.Customizable = Lua.import('Module:Widget/Customizable')
 
 --- Infobox Widgets
-Widgets.Breakdown = Lua.import('Module:Infobox/Widget/Breakdown')
-Widgets.Cell = Lua.import('Module:Infobox/Widget/Cell')
-Widgets.Center = Lua.import('Module:Infobox/Widget/Center')
-Widgets.Chronology = Lua.import('Module:Infobox/Widget/Chronology')
-Widgets.Header = Lua.import('Module:Infobox/Widget/Header')
-Widgets.Highlights = Lua.import('Module:Infobox/Widget/Highlights')
-Widgets.Links = Lua.import('Module:Infobox/Widget/Links')
-Widgets.Title = Lua.import('Module:Infobox/Widget/Title')
+Widgets.Breakdown = Lua.import('Module:Widget/Breakdown')
+Widgets.Cell = Lua.import('Module:Widget/Cell')
+Widgets.Center = Lua.import('Module:Widget/Center')
+Widgets.Chronology = Lua.import('Module:Widget/Chronology')
+Widgets.Header = Lua.import('Module:Widget/Header')
+Widgets.Highlights = Lua.import('Module:Widget/Highlights')
+Widgets.Links = Lua.import('Module:Widget/Links')
+Widgets.Title = Lua.import('Module:Widget/Title')
 
 --- Table Widgets (div-table) (might be removed)
 Widgets.Table = Lua.import('Module:Widget/Table')

--- a/components/infobox/commons/infobox_widget_factory.lua
+++ b/components/infobox/commons/infobox_widget_factory.lua
@@ -10,7 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class WidgetFactory
 local WidgetFactory = Class.new()

--- a/components/infobox/wikis/brawlhalla/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/brawlhalla/infobox_person_player_custom.lua
@@ -31,8 +31,9 @@ local CLEAN_OTHER_ROLES = {
 
 local CURRENT_YEAR = tonumber(os.date('%Y'))
 
+local Widgets = require('Module:Infobox/Widget/All')
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
-local Cell = require('Module:Infobox/Widget/Cell')
+local Cell = Widgets.Cell
 
 ---@class BrawlhallaInfoboxPlayer: Person
 local CustomPlayer = Class.new(Player)

--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget
+-- page=Module:Widget
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --

--- a/components/widget/widget_breakdown.lua
+++ b/components/widget/widget_breakdown.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Breakdown
+-- page=Module:Widget/Breakdown
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class BreakdownWidget: Widget
 ---@operator call({content:(string|number)[],classes:string[],contentClasses:table<integer,string[]>}):BreakdownWidget

--- a/components/widget/widget_builder.lua
+++ b/components/widget/widget_builder.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Builder
+-- page=Module:Widget/Builder
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -10,7 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory')
 
 ---@class BuilderWidget: Widget

--- a/components/widget/widget_cell.lua
+++ b/components/widget/widget_cell.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Cell
+-- page=Module:Widget/Cell
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class CellWidgetOptions
 ---@field columns number?

--- a/components/widget/widget_center.lua
+++ b/components/widget/widget_center.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Center
+-- page=Module:Widget/Center
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -10,7 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class CentereWidget: Widget
 ---@operator call({content: (string|number)[], classes: string[]}): CentereWidget

--- a/components/widget/widget_chronology.lua
+++ b/components/widget/widget_chronology.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Chronology
+-- page=Module:Widget/Chronology
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -10,7 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class ChronologyWidget: Widget
 ---@operator call({content: table<string, string|number|nil>}): ChronologyWidget

--- a/components/widget/widget_customizable.lua
+++ b/components/widget/widget_customizable.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Customizable
+-- page=Module:Widget/Customizable
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class CustomizableWidget: Widget
 ---@operator call({id: string, children: Widget[]}): CustomizableWidget

--- a/components/widget/widget_header.lua
+++ b/components/widget/widget_header.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Header
+-- page=Module:Widget/Header
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class HeaderWidget: Widget
 ---@operator call(table): HeaderWidget

--- a/components/widget/widget_highlights.lua
+++ b/components/widget/widget_highlights.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Highlights
+-- page=Module:Widget/Highlights
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -10,7 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class HighlightsWidget: Widget
 ---@operator call({content: (string|number)[]?}):HighlightsWidget

--- a/components/widget/widget_links.lua
+++ b/components/widget/widget_links.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Links
+-- page=Module:Widget/Links
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -11,7 +11,7 @@ local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
 local UtilLinks = Lua.import('Module:Links')
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class LinksWidget: Widget
 ---@operator call({content: table<string, string>, variant: string?}): LinksWidget

--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -10,7 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory')
 
 ---@class WidgetTableInput

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class WidgetCellInput
 ---@field content (string|number|table|Html)[]?

--- a/components/widget/widget_table_cell_new.lua
+++ b/components/widget/widget_table_cell_new.lua
@@ -12,7 +12,7 @@ local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class WidgetCellInputNew
 ---@field content (string|number|table|Html)[]?

--- a/components/widget/widget_table_new.lua
+++ b/components/widget/widget_table_new.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory')
 
 ---@class WidgetTableNewInput

--- a/components/widget/widget_table_row.lua
+++ b/components/widget/widget_table_row.lua
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory')
 
 ---@class WidgetTableRowInput

--- a/components/widget/widget_table_row_new.lua
+++ b/components/widget/widget_table_row_new.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 local WidgetFactory = Lua.import('Module:Infobox/Widget/Factory')
 
 ---@class WidgetTableRowNewInput

--- a/components/widget/widget_title.lua
+++ b/components/widget/widget_title.lua
@@ -1,7 +1,7 @@
 ---
 -- @Liquipedia
 -- wiki=commons
--- page=Module:Infobox/Widget/Title
+-- page=Module:Widget/Title
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -9,7 +9,7 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local Widget = Lua.import('Module:Infobox/Widget')
+local Widget = Lua.import('Module:Widget')
 
 ---@class TitleWidget: Widget
 ---@operator call({name: string|number|nil}): TitleWidget


### PR DESCRIPTION
## Summary
Move all Widgets except `/All`, `/Factory` and `/Injector` from Infobox/Widget to Widget. Those 3 will be done in other PRs due to being directly imported instead of going via /All.

## How did you test this change?
