### PR TITLE
feat(match2): fetch name and link from LPDB on dota2 matchpages

### DIFF
--- a/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
@@ -53,9 +53,18 @@ function CustomMatchGroupInputMatchPage.getParticipants(map, opponentIndex)
 			image = item.image,
 		}
 	end
+	local function fetchLpdbPlayer(playerId)
+		if not playerId then return end
+		return mw.ext.LiquipediaDB.lpdb('player', {
+			conditions = '[[extradata_playerid::' .. playerId .. ']]',
+			query = 'pagename, id',
+		})[1]
+	end
 	local players = Array.map(team.players, function(player)
+		local playerData = fetchLpdbPlayer(player.playerId) or {}
 		return {
-			player = player.name,
+			player = playerData.pagename or player.name,
+			name = playerData.id,
 			role = player.position,
 			facet = player.facet,
 			character = player.heroName,

--- a/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
@@ -61,7 +61,7 @@ function CustomMatchGroupInputMatchPage.getParticipants(map, opponentIndex)
 		})[1]
 	end
 	local players = Array.map(team.players, function(player)
-		local playerData = fetchLpdbPlayer(player.playerId) or {}
+		local playerData = fetchLpdbPlayer(player.id) or {}
 		return {
 			player = playerData.pagename or player.name,
 			name = playerData.id,

--- a/components/match2/wikis/dota2/match_page.lua
+++ b/components/match2/wikis/dota2/match_page.lua
@@ -82,6 +82,8 @@ function MatchPage.getByMatchId(props)
 
 			for _, player in Table.iter.pairsByPrefix(game.participants, teamIdx .. '_') do
 				local newPlayer = Table.mergeInto(player, {
+					displayName = player.name or player.player,
+					link = player.player,
 					items = Array.map(player.items or {}, makeItemDisplay),
 					backpackitems = Array.map(player.backpackitems or {}, makeItemDisplay),
 					neutralitem = makeItemDisplay(player.neutralitem or {}),

--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -146,7 +146,7 @@ return {
 						<div class="match-bm-players-player">
 							<div class="match-bm-players-player-character">
 								<div class="match-bm-players-player-avatar"><div class="match-bm-players-player-icon">{{&heroIcon}}</div><div class="match-bm-players-player-role role--{{teams.1.side}}">[[File:Dota2 {{facet}} facet icon darkmode.png|link=|{{facet}}]]</div></div>
-								<div class="match-bm-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
+								<div class="match-bm-players-player-name">[[{{link}}|{{displayName}}]]<i>{{character}}</i></div>
 							</div>
 							<div class="match-bm-players-player-loadout">
 								<!-- Loadout -->
@@ -177,7 +177,7 @@ return {
 						<div class="match-bm-players-player">
 							<div class="match-bm-players-player-character">
 								<div class="match-bm-players-player-avatar"><div class="match-bm-players-player-icon">{{&heroIcon}}</div><div class="match-bm-players-player-role role--{{teams.2.side}}">[[File:Dota2 {{facet}} facet icon darkmode.png|link=|{{facet}}]]</div></div>
-								<div class="match-bm-players-player-name">[[{{player}}]]<i>{{character}}</i></div>
+								<div class="match-bm-players-player-name">[[{{link}}|{{displayName}}]]<i>{{character}}</i></div>
 							</div>
 							<div class="match-bm-players-player-loadout">
 								<!-- Loadout -->


### PR DESCRIPTION
## Summary
Player Names from the API are sometimes a bit garbage.
<img width="199" alt="image" src="https://github.com/user-attachments/assets/c7c85b1e-23aa-43a5-8769-0b883aada402">

Use the player.id to lookup the actual player data and fetch the link/name from that.
<img width="150" alt="image" src="https://github.com/user-attachments/assets/fc230ff2-199b-4727-84ea-edbb6e4ad7f5">

Use the old names as fallback incase that of no return from lpdb.

## How did you test this change?
/dev/rath

