### PR TITLE
fix(match2): error on missing game.extradata on dota2

### DIFF
--- a/components/match2/wikis/dota2/match_legacy.lua
+++ b/components/match2/wikis/dota2/match_legacy.lua
@@ -121,7 +121,7 @@ function MatchLegacy.storeGames(match, match2)
 		local game = Table.deepCopy(game2)
 
 		-- Extradata
-		local extradata = Json.parseIfString(game2.extradata)
+		local extradata = Json.parseIfString(game2.extradata) or {}
 		game.extradata = {}
 		game.extradata.gamenumber = gameIndex
 		for key, item in pairs(extradata) do


### PR DESCRIPTION
## Summary
In certain situations, game2.extradata can be nil

## How did you test this change?

Live