### PR TITLE
fix(match2): type of dota2 publisherid

### DIFF
--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -225,7 +225,7 @@ end
 ---@return table
 function MapFunctions.getExtraData(MatchParser, map, opponentCount)
 	local extraData = {
-		publisherid = map.publisherid or '',
+		publisherid = tonumber(map.publisherid),
 		comment = map.comment,
 	}
 	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, HeroNames)


### PR DESCRIPTION
## Summary
Currently a matchpage dota2 game will have publisherid as type `number` while a non-matchpage one will have it as a `string`.

Since the dota2 pubid will always be a number, we now want to force it to a number always.