### PR TITLE
fix(match2): BYE opponents dropping score input

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -189,7 +189,7 @@ function MatchGroupInputUtil.readOpponent(match, opponentIndex, options)
 	--- or Opponent.blank() is only needed because readOpponentArg can return nil for team opponents
 	local opponent = Opponent.readOpponentArgs(opponentInput) or Opponent.blank()
 	if Opponent.isBye(opponent) then
-		return {type = Opponent.literal, name = 'BYE'}
+		return {type = Opponent.literal, name = 'BYE', score = opponentInput.score}
 	end
 
 	---@type number|string?


### PR DESCRIPTION
## Summary
Currently for BYE opponents the score is not processed.
This is due to the score not getting returned in `MatchGroupInputUtil.readOpponent` in the BYE case.
This PR fixes that.

## How did you test this change?
dev into live