### PR TITLE
feat(match2): sort dota2 extradata hero picks in pick order

### DIFF
--- a/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom_match_page.lua
@@ -110,9 +110,10 @@ end
 ---@param opponentIndex integer
 ---@return string[]?
 function CustomMatchGroupInputMatchPage.getHeroPicks(map, opponentIndex)
-	local team = map['team' .. opponentIndex] ---@type dota2MatchTeam?
-	if not team then return end
-	return Array.map(team.players or {}, Operator.property('heroName'))
+	if not map.heroVeto then return end
+	local teamVeto = map.heroVeto['team' .. opponentIndex] ---@type dota2TeamVeto?
+	if not teamVeto then return end
+	return Array.map(teamVeto.picks or {}, Operator.property('hero'))
 end
 
 ---@param map dota2MatchDataExtended


### PR DESCRIPTION
## Summary
Feature request that for match page matches, heroes on the match summary should be in hero pick order. This will be done if they are provided from the dep injection in getHeroes in that order. So let's pick them from the veto instead of player list.

## How did you test this change?
dev