### PR TITLE
feat(matchticker): add match detail button for matchpages

### DIFF
--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -122,9 +122,9 @@ function Details:create()
 	matchBottomBar:node(self:countdown())
 
 	if self.matchDetailLink then
-		matchBottomBar:node(mw.html.create('div')
+		matchBottomBar:node(mw.html.create('a')
 			:addClass('btn btn-secondary btn-new btn--match-details')
-			:attr('tabindex', '0')
+			:attr('href', self.matchDetailLink)
 			:node(mw.html.create('i')
 				:addClass('fas fa-external-link')
 			)

--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -107,7 +107,6 @@ local Details = Class.new(
 		self.hideTournament = args.hideTournament
 		self.onlyHighlightOnValue = args.onlyHighlightOnValue
 		self.match = args.match
-		self.matchDetailLink = args.matchDetailLink
 	end
 )
 
@@ -121,15 +120,22 @@ function Details:create()
 	local matchBottomBar = mw.html.create('div'):addClass('match-bottom-bar')
 	matchBottomBar:node(self:countdown())
 
-	if self.matchDetailLink then
-		matchBottomBar:node(mw.html.create('a')
+	if self.match.match2bracketdata.matchpage then
+		matchBottomBar:node(Page.makeInternalLink(tostring(mw.html.create('div')
 			:addClass('btn btn-secondary btn-new btn--match-details')
-			:attr('href', self.matchDetailLink)
+			:attr('title', 'View Match Page')
 			:node(mw.html.create('i')
 				:addClass('fas fa-external-link')
 			)
 			:wikitext('  Details')
-		)
+		), self.match.match2bracketdata.matchpage))
+	else
+		local link = 'Match:ID ' .. self.match.matchid
+		matchBottomBar:node(Page.makeInternalLink(tostring(mw.html.create('div')
+			:addClass('btn btn-new btn--add-match-details')
+				:attr('title', 'Add Match Page')
+			:wikitext('+ Add details')
+		), link))
 	end
 
 	return self.root

--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -122,7 +122,17 @@ function Details:create()
 			:node(self:tournament())
 			:node(self:streams())
 		)
-		:node(self:countdown())
+		:node(mw.html.create('div'):addClass('match-bottom-bar')
+			:node(self:countdown())
+			:node(mw.html.create('div')
+					:addClass('btn btn-secondary btn-new btn--match-details')
+					:attr('tabindex', '0')
+					:node(mw.html.create('i')
+						:addClass('fas fa-external-link')
+					)
+					:wikitext('  Details')
+	)
+		)
 end
 
 ---It will display both countdown and date of the match so the user can select which one to show

--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -129,11 +129,11 @@ function Details:create()
 			)
 			:wikitext('  Details')
 		), self.match.match2bracketdata.matchpage))
-	else
-		local link = 'Match:ID ' .. self.match.matchid
+	elseif self.match.match2id then
+		local link = 'Match:ID ' .. self.match.match2id
 		matchBottomBar:node(Page.makeInternalLink(tostring(mw.html.create('div')
-			:addClass('btn btn-new btn--add-match-details')
-				:attr('title', 'Add Match Page')
+			:addClass('btn btn-new btn--add-match-details show-when-logged-in')
+			:attr('title', 'Add Match Page')
 			:wikitext('+ Add details')
 		), link))
 	end

--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -107,6 +107,7 @@ local Details = Class.new(
 		self.hideTournament = args.hideTournament
 		self.onlyHighlightOnValue = args.onlyHighlightOnValue
 		self.match = args.match
+		self.matchDetailLink = args.matchDetailLink
 	end
 )
 
@@ -117,22 +118,26 @@ function Details:create()
 		self.root:addClass(HIGHLIGHT_CLASS)
 	end
 
+	local matchBottomBar = mw.html.create('div'):addClass('match-bottom-bar')
+	matchBottomBar:node(self:countdown())
+
+	if self.matchDetailLink then
+		matchBottomBar:node(mw.html.create('div')
+			:addClass('btn btn-secondary btn-new btn--match-details')
+			:attr('tabindex', '0')
+			:node(mw.html.create('i')
+				:addClass('fas fa-external-link')
+			)
+			:wikitext('  Details')
+		)
+	end
+
 	return self.root
 		:node(mw.html.create('div'):addClass('match-links')
 			:node(self:tournament())
 			:node(self:streams())
 		)
-		:node(mw.html.create('div'):addClass('match-bottom-bar')
-			:node(self:countdown())
-			:node(mw.html.create('div')
-					:addClass('btn btn-secondary btn-new btn--match-details')
-					:attr('tabindex', '0')
-					:node(mw.html.create('i')
-						:addClass('fas fa-external-link')
-					)
-					:wikitext('  Details')
-	)
-		)
+		:node(matchBottomBar)
 end
 
 ---It will display both countdown and date of the match so the user can select which one to show

--- a/stylesheets/commons/MatchTicker.less
+++ b/stylesheets/commons/MatchTicker.less
@@ -104,8 +104,30 @@ Author(s): Nadox
 				align-items: center;
 				justify-content: space-between;
 
-				.btn--match-details {
+				> a {
+					flex-shrink: 0;
+
+					&:hover {
+						.btn--match-details,
+						.btn--add-match-details {
+							.theme--light & {
+								background-color: rgba( 0, 0, 0, 0.4 );
+							}
+
+							.theme--dark & {
+								background-color: rgba( 255, 255, 255, 0.4 );
+							}
+						}
+					}
+				}
+
+				.btn--match-details,
+				.btn--add-match-details {
 					padding: 0.3125rem 0.75rem;
+				}
+
+				.btn--match-details {
+					color: inherit;
 				}
 			}
 

--- a/stylesheets/commons/MatchTicker.less
+++ b/stylesheets/commons/MatchTicker.less
@@ -99,6 +99,16 @@ Author(s): Nadox
 				}
 			}
 
+			.match-bottom-bar {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+
+				.btn--match-details {
+					padding: 0.3125rem 0.75rem;
+				}
+			}
+
 			.match-countdown {
 				display: flex;
 				justify-content: center;

--- a/stylesheets/commons/MatchTicker.less
+++ b/stylesheets/commons/MatchTicker.less
@@ -106,17 +106,18 @@ Author(s): Nadox
 
 				> a {
 					flex-shrink: 0;
+				}
 
-					&:hover {
-						.btn--match-details,
-						.btn--add-match-details {
-							.theme--light & {
-								background-color: rgba( 0, 0, 0, 0.4 );
-							}
+				> a:hover {
+					.btn--add-match-details {
+						.theme--light & {
+							background-color: rgba( 0, 0, 0, 0.4 );
+							color: #0d61a4;
+						}
 
-							.theme--dark & {
-								background-color: rgba( 255, 255, 255, 0.4 );
-							}
+						.theme--dark & {
+							background-color: rgba( 255, 255, 255, 0.4 );
+							color: var(--clr-primary-80);
 						}
 					}
 				}
@@ -127,7 +128,17 @@ Author(s): Nadox
 				}
 
 				.btn--match-details {
-					color: inherit;
+					background-color: transparent;
+				}
+
+				.btn--add-match-details {
+					.theme--light & {
+						color: #0d61a4;
+					}
+
+					.theme--dark & {
+						color: var(--clr-primary-80);
+					}
 				}
 			}
 

--- a/stylesheets/commons/MatchTicker.less
+++ b/stylesheets/commons/MatchTicker.less
@@ -117,7 +117,7 @@ Author(s): Nadox
 
 						.theme--dark & {
 							background-color: rgba( 255, 255, 255, 0.4 );
-							color: var(--clr-primary-80);
+							color: var( --clr-primary-80 );
 						}
 					}
 				}
@@ -137,7 +137,7 @@ Author(s): Nadox
 					}
 
 					.theme--dark & {
-						color: var(--clr-primary-80);
+						color: var( --clr-primary-80 );
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

This PR implements the design for the match detail button
- Add match detail button to the overview when the `match.match2bracketdata.matchpage` exists
- Add a button to add match detail page when you're logged in and there is no `match.match2bracketdata.matchpage`

## How did you test this change?

On https://liquipedia.net/dota2/User:Elysienna

## Info
Closes https://gitlab.com/teamliquid-dev/liquipedia/web/issue-bucket/-/issues/121
