### PR TITLE
refactor(widget): improve building part 4 - `Html[]` into `string`

### DIFF
--- a/components/infobox/commons/infobox.lua
+++ b/components/infobox/commons/infobox.lua
@@ -86,11 +86,7 @@ function Infobox:build(widgets)
 			error('Infobox:build can only accept Widgets')
 		end
 
-		local contentItems = WidgetFactory.work(widget, self.injector)
-
-		for _, node in ipairs(contentItems or {}) do
-			self.content:node(node)
-		end
+		self.content:node(WidgetFactory.work(widget, self.injector))
 	end
 
 	self.root:node(self.content)

--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -608,9 +608,7 @@ function BasePrizePool:_buildTable(isAward)
 	end
 
 	local tableNode = mw.html.create('div'):css('overflow-x', 'auto')
-	for _, node in ipairs(WidgetFactory.work(tbl, self._widgetInjector)) do
-		tableNode:node(node)
-	end
+	tableNode:node(WidgetFactory.work(tbl, self._widgetInjector))
 
 	return tableNode
 end

--- a/components/squad/commons/squad.lua
+++ b/components/squad/commons/squad.lua
@@ -9,7 +9,6 @@
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -109,9 +108,7 @@ function Squad:create()
 		classes = {'wikitable-striped', 'roster-card'},
 		children = self.rows,
 	}
-	local wrapper = mw.html.create()
-	wrapper:node(WidgetFactory.work(dataTable, self.injector))
-	return wrapper
+	return WidgetFactory.work(dataTable, self.injector)
 end
 
 return Squad

--- a/components/squad/commons/squad.lua
+++ b/components/squad/commons/squad.lua
@@ -101,7 +101,7 @@ function Squad:row(row)
 	return self
 end
 
----@return Html
+---@return string
 function Squad:create()
 	local dataTable = Widget.TableNew{
 		css = {['margin-bottom'] = '10px'},

--- a/components/squad/commons/squad.lua
+++ b/components/squad/commons/squad.lua
@@ -110,7 +110,7 @@ function Squad:create()
 		children = self.rows,
 	}
 	local wrapper = mw.html.create()
-	Array.forEach(WidgetFactory.work(dataTable, self.injector), FnUtil.curry(wrapper.node, wrapper))
+	wrapper:node(WidgetFactory.work(dataTable, self.injector))
 	return wrapper
 end
 

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -181,7 +181,7 @@ end
 ---@param squadClass Squad
 ---@param personFunction fun(player: table, squadType: integer):WidgetTableRowNew
 ---@param injector WidgetInjector?
----@return Html
+---@return string
 function SquadUtils.defaultRunManual(frame, squadClass, personFunction, injector)
 	local args = Arguments.getArgs(frame)
 	local injectorInstance = (injector and injector()) or
@@ -210,7 +210,7 @@ end
 ---@param customTitle string?
 ---@param injector? WidgetInjector
 ---@param personMapper? fun(person: table): table
----@return Html?
+---@return string?
 function SquadUtils.defaultRunAuto(players, squadType, squadClass, rowCreator, customTitle, injector, personMapper)
 	local args = {type = squadType, title = customTitle}
 	local injectorInstance = (injector and injector()) or

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -55,7 +55,7 @@ function ExtendedSquadRow:activeteam()
 end
 
 ---@param frame Frame
----@return Html
+---@return string
 function CustomSquad.run(frame)
 	return SquadUtils.defaultRunManual(frame, Squad, CustomSquad._playerRow, CustomInjector)
 end

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -48,7 +48,7 @@ function ExtendedSquadRow:number()
 end
 
 ---@param frame Frame
----@return Html
+---@return string
 function CustomSquad.run(frame)
 	local args = Arguments.getArgs(frame)
 	local squad = Squad(args, CustomInjector()):title()
@@ -69,7 +69,7 @@ end
 ---@param playerList table[]
 ---@param squadType integer
 ---@param customTitle string?
----@return Html?
+---@return string?
 function CustomSquad.runAuto(playerList, squadType, customTitle)
 	return SquadUtils.defaultRunAuto(playerList, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
 end

--- a/components/squad/wikis/smash/squad_custom.lua
+++ b/components/squad/wikis/smash/squad_custom.lua
@@ -54,7 +54,7 @@ function ExtendedSquadRow:mains()
 end
 
 ---@param frame Frame
----@return Html
+---@return string
 function CustomSquad.run(frame)
 	local args = Arguments.getArgs(frame)
 	local squad = Squad(args, CustomInjector()):title():header()

--- a/components/squad/wikis/starcraft/squad_custom.lua
+++ b/components/squad/wikis/starcraft/squad_custom.lua
@@ -59,7 +59,7 @@ function ExtendedSquadRow:elo()
 end
 
 ---@param frame Frame
----@return Html
+---@return string
 function CustomSquad.run(frame)
 	local args = Arguments.getArgs(frame)
 	local tlpd = Logic.readBool(args.tlpd)

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -18,7 +18,7 @@ local SquadUtils = Lua.import('Module:Squad/Utils')
 local CustomSquad = {}
 
 ---@param frame Frame
----@return Html
+---@return string
 function CustomSquad.run(frame)
 	return SquadUtils.defaultRunManual(frame, Squad, CustomSquad._playerRow)
 end
@@ -26,7 +26,7 @@ end
 ---@param playerList table[]
 ---@param squadType integer
 ---@param customTitle string?
----@return Html?
+---@return string?
 function CustomSquad.runAuto(playerList, squadType, customTitle)
 	return SquadUtils.defaultRunAuto(
 		playerList,

--- a/components/squad/wikis/stormgate/squad_custom.lua
+++ b/components/squad/wikis/stormgate/squad_custom.lua
@@ -17,7 +17,7 @@ local SquadUtils = Lua.import('Module:Squad/Utils')
 local CustomSquad = {}
 
 ---@param frame Frame
----@return Html
+---@return string
 function CustomSquad.run(frame)
 	return SquadUtils.defaultRunManual(frame, Squad, CustomSquad._playerRow)
 end
@@ -25,7 +25,7 @@ end
 ---@param playerList table[]
 ---@param squadType integer
 ---@param customTitle string?
----@return Html?
+---@return string?
 function CustomSquad.runAuto(playerList, squadType, customTitle)
 	return SquadUtils.defaultRunAuto(
 		playerList,

--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -22,13 +22,13 @@ function Widget:assertExistsAndCopy(value)
 end
 
 ---@param injector WidgetInjector?
----@return Widget[]|Html|nil
+---@return Widget[]|string|nil
 function Widget:make(injector)
 	error('A Widget must override the make() function!')
 end
 
 ---@param injector WidgetInjector?
----@return Widget[]|Html|nil
+---@return Widget[]|string|nil
 function Widget:tryMake(injector)
 	return Logic.tryOrElseLog(
 		function() return self:make(injector) end,

--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -22,13 +22,13 @@ function Widget:assertExistsAndCopy(value)
 end
 
 ---@param injector WidgetInjector?
----@return Widget[]|Html[]|nil
+---@return Widget[]|Html|nil
 function Widget:make(injector)
 	error('A Widget must override the make() function!')
 end
 
 ---@param injector WidgetInjector?
----@return Widget[]|Html[]|nil
+---@return Widget[]|Html|nil
 function Widget:tryMake(injector)
 	return Logic.tryOrElseLog(
 		function() return self:make(injector) end,

--- a/components/widget/widget_breakdown.lua
+++ b/components/widget/widget_breakdown.lua
@@ -26,9 +26,9 @@ local Breakdown = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return {[1]: Html?}
+---@return Html?
 function Breakdown:make(injector)
-	return {Breakdown:_breakdown(self.contents, self.classes, self.contentClasses)}
+	return Breakdown:_breakdown(self.contents, self.classes, self.contentClasses)
 end
 
 ---@param contents (string|number)[]

--- a/components/widget/widget_breakdown.lua
+++ b/components/widget/widget_breakdown.lua
@@ -26,9 +26,9 @@ local Breakdown = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Breakdown:make(injector)
-	return Breakdown:_breakdown(self.contents, self.classes, self.contentClasses)
+	return tostring(Breakdown:_breakdown(self.contents, self.classes, self.contentClasses))
 end
 
 ---@param contents (string|number)[]

--- a/components/widget/widget_breakdown.lua
+++ b/components/widget/widget_breakdown.lua
@@ -28,13 +28,13 @@ local Breakdown = Class.new(
 ---@param injector WidgetInjector?
 ---@return string?
 function Breakdown:make(injector)
-	return tostring(Breakdown:_breakdown(self.contents, self.classes, self.contentClasses))
+	return Breakdown:_breakdown(self.contents, self.classes, self.contentClasses)
 end
 
 ---@param contents (string|number)[]
 ---@param classes string[]
 ---@param contentClasses table<integer, string[]> --can have gaps in the outer table
----@return Html?
+---@return string?
 function Breakdown:_breakdown(contents, classes, contentClasses)
 	if type(contents) ~= 'table' or contents == {} then
 		return nil
@@ -54,7 +54,7 @@ function Breakdown:_breakdown(contents, classes, contentClasses)
 		div:node(infoboxCustomCell)
 	end
 
-	return div
+	return tostring(div)
 end
 
 return Breakdown

--- a/components/widget/widget_builder.lua
+++ b/components/widget/widget_builder.lua
@@ -23,14 +23,14 @@ local Builder = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html
+---@return string
 function Builder:make(injector)
 	local children = self.builder()
 	local builtChildren = mw.html.create()
 	for _, child in ipairs(children or {}) do
 		builtChildren:node(WidgetFactory.work(child, injector))
 	end
-	return builtChildren
+	return tostring(builtChildren)
 end
 
 return Builder

--- a/components/widget/widget_builder.lua
+++ b/components/widget/widget_builder.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 

--- a/components/widget/widget_builder.lua
+++ b/components/widget/widget_builder.lua
@@ -24,14 +24,14 @@ local Builder = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Widget[]
+---@return Html
 function Builder:make(injector)
 	local children = self.builder()
-	local widgets = {}
+	local builtChildren = mw.html.create()
 	for _, child in ipairs(children or {}) do
-		Array.extendWith(widgets, WidgetFactory.work(child, injector))
+		builtChildren:node(WidgetFactory.work(child, injector))
 	end
-	return widgets
+	return builtChildren
 end
 
 return Builder

--- a/components/widget/widget_cell.lua
+++ b/components/widget/widget_cell.lua
@@ -90,19 +90,19 @@ function Cell:_content(...)
 end
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Cell:make(injector)
 	self:_new(self.name)
 	self:_class(unpack(self.classes or {}))
 	self:_content(unpack(self.content))
 
 	if self.contentDiv == nil then
-		return {}
+		return
 	end
 
 	self.root	:node(self.description)
 				:node(self.contentDiv)
-	return self.root
+	return tostring(self.root)
 end
 
 return Cell

--- a/components/widget/widget_cell.lua
+++ b/components/widget/widget_cell.lua
@@ -90,7 +90,7 @@ function Cell:_content(...)
 end
 
 ---@param injector WidgetInjector?
----@return {[1]: Html?}
+---@return Html?
 function Cell:make(injector)
 	self:_new(self.name)
 	self:_class(unpack(self.classes or {}))
@@ -102,9 +102,7 @@ function Cell:make(injector)
 
 	self.root	:node(self.description)
 				:node(self.contentDiv)
-	return {
-		self.root
-	}
+	return self.root
 end
 
 return Cell

--- a/components/widget/widget_center.lua
+++ b/components/widget/widget_center.lua
@@ -27,12 +27,12 @@ local Center = Class.new(
 ---@param injector WidgetInjector?
 ---@return string?
 function Center:make(injector)
-	return tostring(Center:_create(self.content, self.classes))
+	return Center:_create(self.content, self.classes)
 end
 
 ---@param content (string|number)[]
 ---@param classes string[]
----@return Html?
+---@return string?
 function Center:_create(content, classes)
 	if Table.isEmpty(content) then
 		return nil
@@ -47,7 +47,7 @@ function Center:_create(content, classes)
 		centered:wikitext(item)
 	end
 
-	return mw.html.create('div'):node(centered)
+	return tostring(mw.html.create('div'):node(centered))
 end
 
 return Center

--- a/components/widget/widget_center.lua
+++ b/components/widget/widget_center.lua
@@ -25,9 +25,9 @@ local Center = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return {[1]: Html?}
+---@return Html?
 function Center:make(injector)
-	return {Center:_create(self.content, self.classes)}
+	return Center:_create(self.content, self.classes)
 end
 
 ---@param content (string|number)[]

--- a/components/widget/widget_center.lua
+++ b/components/widget/widget_center.lua
@@ -25,9 +25,9 @@ local Center = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Center:make(injector)
-	return Center:_create(self.content, self.classes)
+	return tostring(Center:_create(self.content, self.classes))
 end
 
 ---@param content (string|number)[]

--- a/components/widget/widget_chronology.lua
+++ b/components/widget/widget_chronology.lua
@@ -23,26 +23,26 @@ local Chronology = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html[]
+---@return Html?
 function Chronology:make(injector)
 	return Chronology:_chronology(self.links)
 end
 
 ---@param links table<string, string|number|nil>
----@return Html[]
+---@return Html?
 function Chronology:_chronology(links)
 	if links == nil or Table.size(links) == 0 then
-		return self
+		return
 	end
 
-	local chronologyContent = {}
-	chronologyContent[1] = self:_createChronologyRow(links['previous'], links['next'])
+	local chronologyContent = mw.html.create()
+	chronologyContent:node(self:_createChronologyRow(links['previous'], links['next']))
 
 	local index = 2
 	local previous = links['previous' .. index]
 	local next = links['next' .. index]
 	while (previous ~= nil or next ~= nil) do
-		chronologyContent[index] = self:_createChronologyRow(previous, next)
+		chronologyContent:node(self:_createChronologyRow(previous, next))
 
 		index = index + 1
 		previous = links['previous' .. index]

--- a/components/widget/widget_chronology.lua
+++ b/components/widget/widget_chronology.lua
@@ -25,11 +25,11 @@ local Chronology = Class.new(
 ---@param injector WidgetInjector?
 ---@return string?
 function Chronology:make(injector)
-	return tostring(Chronology:_chronology(self.links))
+	return Chronology:_chronology(self.links)
 end
 
 ---@param links table<string, string|number|nil>
----@return Html?
+---@return string?
 function Chronology:_chronology(links)
 	if links == nil or Table.size(links) == 0 then
 		return
@@ -49,7 +49,7 @@ function Chronology:_chronology(links)
 		next = links['next' .. index]
 	end
 
-	return chronologyContent
+	return tostring(chronologyContent)
 end
 
 ---@param previous string|number|nil

--- a/components/widget/widget_chronology.lua
+++ b/components/widget/widget_chronology.lua
@@ -23,9 +23,9 @@ local Chronology = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Chronology:make(injector)
-	return Chronology:_chronology(self.links)
+	return tostring(Chronology:_chronology(self.links))
 end
 
 ---@param links table<string, string|number|nil>

--- a/components/widget/widget_factory.lua
+++ b/components/widget/widget_factory.lua
@@ -14,25 +14,21 @@ local WidgetFactory = Class.new()
 
 ---@param widget Widget
 ---@param injector WidgetInjector?
----@return Html
+---@return string
 function WidgetFactory.work(widget, injector)
 	local children = widget:tryMake(injector)
 
 	if not children then
-		return mw.html.create()
+		return ''
 	end
 
-	if Array.isArray(children) then
-		---@cast children Widget[]
-		local wrapper = mw.html.create()
-		Array.forEach(children, function(child)
-			wrapper:node(WidgetFactory.work(child, injector))
-		end)
-		return wrapper
+	if type(children) == 'string' then
+		return children
 	end
 
-	---@cast children Html
-	return children
+	return table.concat(Array.map(children, function(child)
+		return WidgetFactory.work(child, injector)
+	end))
 end
 
 return WidgetFactory

--- a/components/widget/widget_factory.lua
+++ b/components/widget/widget_factory.lua
@@ -17,20 +17,22 @@ local WidgetFactory = Class.new()
 ---@return Html
 function WidgetFactory.work(widget, injector)
 	local children = widget:tryMake(injector)
+
 	if not children then
 		return mw.html.create()
 	end
-	if not Array.isArray(children) then
-		---@cast children Html
-		return children
+
+	if Array.isArray(children) then
+		---@cast children Widget[]
+		local wrapper = mw.html.create()
+		Array.forEach(children, function(child)
+			wrapper:node(WidgetFactory.work(child, injector))
+		end)
+		return wrapper
 	end
 
-	---@cast children Widget[]
-	local wrapper = mw.html.create()
-	Array.forEach(children, function(child)
-		wrapper:node(WidgetFactory.work(child, injector))
-	end)
-	return wrapper
+	---@cast children Html
+	return children
 end
 
 return WidgetFactory

--- a/components/widget/widget_header.lua
+++ b/components/widget/widget_header.lua
@@ -59,7 +59,11 @@ function Header:make(injector)
 		table.insert(header, 2, subHeader)
 	end
 
-	return header
+	local wrapper = mw.html.create()
+	for _, element in ipairs(header) do
+		wrapper:node(element)
+	end
+	return wrapper
 end
 
 ---@param name string?

--- a/components/widget/widget_header.lua
+++ b/components/widget/widget_header.lua
@@ -36,7 +36,7 @@ local Header = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html[]
+---@return string
 function Header:make(injector)
 	local header = {
 		Header:_name(self.name),
@@ -63,7 +63,7 @@ function Header:make(injector)
 	for _, element in ipairs(header) do
 		wrapper:node(element)
 	end
-	return wrapper
+	return tostring(wrapper)
 end
 
 ---@param name string?

--- a/components/widget/widget_highlights.lua
+++ b/components/widget/widget_highlights.lua
@@ -23,7 +23,7 @@ local Highlights = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}?
+---@return Html?
 function Highlights:make(injector)
 	return Highlights:_highlights(self.list)
 end
@@ -44,7 +44,7 @@ function Highlights:_highlights(list)
 
 	div:node(highlights)
 
-	return {div}
+	return div
 end
 
 return Highlights

--- a/components/widget/widget_highlights.lua
+++ b/components/widget/widget_highlights.lua
@@ -23,9 +23,9 @@ local Highlights = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Highlights:make(injector)
-	return Highlights:_highlights(self.list)
+	return tostring(Highlights:_highlights(self.list))
 end
 
 ---@param list (string|number)[]?

--- a/components/widget/widget_highlights.lua
+++ b/components/widget/widget_highlights.lua
@@ -25,11 +25,11 @@ local Highlights = Class.new(
 ---@param injector WidgetInjector?
 ---@return string?
 function Highlights:make(injector)
-	return tostring(Highlights:_highlights(self.list))
+	return Highlights:_highlights(self.list)
 end
 
 ---@param list (string|number)[]?
----@return Html?
+---@return string?
 function Highlights:_highlights(list)
 	if list == nil or Table.size(list) == 0 then
 		return nil
@@ -44,7 +44,7 @@ function Highlights:_highlights(list)
 
 	div:node(highlights)
 
-	return div
+	return tostring(div)
 end
 
 return Highlights

--- a/components/widget/widget_links.lua
+++ b/components/widget/widget_links.lua
@@ -28,7 +28,7 @@ local Links = Class.new(
 local PRIORITY_GROUPS = Lua.import('Module:Links/PriorityGroups', {loadData = true})
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function Links:make(injector)
 	local infoboxLinks = mw.html.create('div')
 	infoboxLinks	:addClass('infobox-center')
@@ -56,9 +56,7 @@ function Links:make(injector)
 		infoboxLinks:wikitext(' ' .. self:_makeLink(key, value))
 	end
 
-	return {
-		mw.html.create('div'):node(infoboxLinks)
-	}
+	return mw.html.create('div'):node(infoboxLinks)
 end
 
 ---@param key string

--- a/components/widget/widget_links.lua
+++ b/components/widget/widget_links.lua
@@ -28,7 +28,7 @@ local Links = Class.new(
 local PRIORITY_GROUPS = Lua.import('Module:Links/PriorityGroups', {loadData = true})
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Links:make(injector)
 	local infoboxLinks = mw.html.create('div')
 	infoboxLinks	:addClass('infobox-center')
@@ -56,7 +56,7 @@ function Links:make(injector)
 		infoboxLinks:wikitext(' ' .. self:_makeLink(key, value))
 	end
 
-	return mw.html.create('div'):node(infoboxLinks)
+	return tostring(mw.html.create('div'):node(infoboxLinks))
 end
 
 ---@param key string

--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -50,7 +50,7 @@ function Table:addClass(class)
 end
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function Table:make(injector)
 	local displayTable = mw.html.create('div'):addClass('csstable-widget')
 	displayTable:css{
@@ -69,7 +69,7 @@ function Table:make(injector)
 		end
 	end
 
-	return {displayTable}
+	return displayTable
 end
 
 ---@return integer?

--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -64,9 +64,7 @@ function Table:make(injector)
 	displayTable:css(self.css)
 
 	for _, row in ipairs(self.rows) do
-		for _, node in ipairs(WidgetFactory.work(row, injector)) do
-			displayTable:node(node)
-		end
+		displayTable:node(WidgetFactory.work(row, injector))
 	end
 
 	return displayTable

--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -50,7 +50,7 @@ function Table:addClass(class)
 end
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Table:make(injector)
 	local displayTable = mw.html.create('div'):addClass('csstable-widget')
 	displayTable:css{
@@ -67,7 +67,7 @@ function Table:make(injector)
 		displayTable:node(WidgetFactory.work(row, injector))
 	end
 
-	return displayTable
+	return tostring(displayTable)
 end
 
 ---@return integer?

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -57,7 +57,7 @@ function TableCell:addCss(key, value)
 end
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function TableCell:make(injector)
 	local cell = mw.html.create('div'):addClass('csstable-widget-cell')
 	cell:css{
@@ -73,7 +73,7 @@ function TableCell:make(injector)
 
 	cell:node(self:_concatContent())
 
-	return {cell}
+	return cell
 end
 
 ---@return string

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -57,7 +57,7 @@ function TableCell:addCss(key, value)
 end
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function TableCell:make(injector)
 	local cell = mw.html.create('div'):addClass('csstable-widget-cell')
 	cell:css{
@@ -73,7 +73,7 @@ function TableCell:make(injector)
 
 	cell:node(self:_concatContent())
 
-	return cell
+	return tostring(cell)
 end
 
 ---@return string

--- a/components/widget/widget_table_cell_new.lua
+++ b/components/widget/widget_table_cell_new.lua
@@ -43,7 +43,7 @@ local TableCell = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function TableCell:make(injector)
 	local cell = mw.html.create(self.isHeader and 'th' or 'td')
 	cell:attr('colspan', self.colSpan)
@@ -55,7 +55,7 @@ function TableCell:make(injector)
 
 	cell:node(self:_content())
 
-	return cell
+	return tostring(cell)
 end
 
 ---@return string

--- a/components/widget/widget_table_cell_new.lua
+++ b/components/widget/widget_table_cell_new.lua
@@ -43,7 +43,7 @@ local TableCell = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function TableCell:make(injector)
 	local cell = mw.html.create(self.isHeader and 'th' or 'td')
 	cell:attr('colspan', self.colSpan)
@@ -55,7 +55,7 @@ function TableCell:make(injector)
 
 	cell:node(self:_content())
 
-	return {cell}
+	return cell
 end
 
 ---@return string

--- a/components/widget/widget_table_new.lua
+++ b/components/widget/widget_table_new.lua
@@ -34,7 +34,7 @@ local Table = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Table:make(injector)
 	local wrapper = mw.html.create('div'):addClass('table-responsive')
 	local output = mw.html.create('table'):addClass('wikitable')
@@ -48,7 +48,7 @@ function Table:make(injector)
 	end)
 
 	wrapper:node(output)
-	return wrapper
+	return tostring(wrapper)
 end
 
 return Table

--- a/components/widget/widget_table_new.lua
+++ b/components/widget/widget_table_new.lua
@@ -34,7 +34,7 @@ local Table = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function Table:make(injector)
 	local wrapper = mw.html.create('div'):addClass('table-responsive')
 	local output = mw.html.create('table'):addClass('wikitable')
@@ -48,7 +48,7 @@ function Table:make(injector)
 	end)
 
 	wrapper:node(output)
-	return {wrapper}
+	return wrapper
 end
 
 return Table

--- a/components/widget/widget_table_new.lua
+++ b/components/widget/widget_table_new.lua
@@ -44,7 +44,7 @@ function Table:make(injector)
 	output:css(self.css)
 
 	Array.forEach(self.children, function(child)
-		Array.forEach(WidgetFactory.work(child, injector), FnUtil.curry(output.node, output))
+		output:node(WidgetFactory.work(child, injector))
 	end)
 
 	wrapper:node(output)

--- a/components/widget/widget_table_row.lua
+++ b/components/widget/widget_table_row.lua
@@ -59,7 +59,7 @@ function TableRow:getCellCount()
 end
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function TableRow:make(injector)
 	local row = mw.html.create('div'):addClass('csstable-widget-row')
 
@@ -75,7 +75,7 @@ function TableRow:make(injector)
 		end
 	end
 
-	return {row}
+	return row
 end
 
 return TableRow

--- a/components/widget/widget_table_row.lua
+++ b/components/widget/widget_table_row.lua
@@ -59,7 +59,7 @@ function TableRow:getCellCount()
 end
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function TableRow:make(injector)
 	local row = mw.html.create('div'):addClass('csstable-widget-row')
 
@@ -73,7 +73,7 @@ function TableRow:make(injector)
 		row:node(WidgetFactory.work(cell, injector))
 	end
 
-	return row
+	return tostring(row)
 end
 
 return TableRow

--- a/components/widget/widget_table_row.lua
+++ b/components/widget/widget_table_row.lua
@@ -70,9 +70,7 @@ function TableRow:make(injector)
 	row:css(self.css)
 
 	for _, cell in ipairs(self.cells) do
-		for _, node in ipairs(WidgetFactory.work(cell, injector)) do
-			row:node(node)
-		end
+		row:node(WidgetFactory.work(cell, injector))
 	end
 
 	return row

--- a/components/widget/widget_table_row_new.lua
+++ b/components/widget/widget_table_row_new.lua
@@ -34,7 +34,7 @@ local TableRow = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function TableRow:make(injector)
 	local row = mw.html.create('tr')
 
@@ -46,7 +46,7 @@ function TableRow:make(injector)
 		Array.forEach(WidgetFactory.work(child, injector), FnUtil.curry(row.node, row))
 	end)
 
-	return {row}
+	return row
 end
 
 return TableRow

--- a/components/widget/widget_table_row_new.lua
+++ b/components/widget/widget_table_row_new.lua
@@ -34,7 +34,7 @@ local TableRow = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function TableRow:make(injector)
 	local row = mw.html.create('tr')
 
@@ -46,7 +46,7 @@ function TableRow:make(injector)
 		row:node(WidgetFactory.work(child, injector))
 	end)
 
-	return row
+	return tostring(row)
 end
 
 return TableRow

--- a/components/widget/widget_table_row_new.lua
+++ b/components/widget/widget_table_row_new.lua
@@ -43,7 +43,7 @@ function TableRow:make(injector)
 	row:css(self.css)
 
 	Array.forEach(self.children, function(child)
-		Array.forEach(WidgetFactory.work(child, injector), FnUtil.curry(row.node, row))
+		row:node(WidgetFactory.work(child, injector))
 	end)
 
 	return row

--- a/components/widget/widget_title.lua
+++ b/components/widget/widget_title.lua
@@ -22,9 +22,9 @@ local Title = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return {[1]: Html}
+---@return Html?
 function Title:make(injector)
-	return {Title:_create(self.content)}
+	return Title:_create(self.content)
 end
 
 ---@param infoDescription string|number|nil

--- a/components/widget/widget_title.lua
+++ b/components/widget/widget_title.lua
@@ -24,18 +24,18 @@ local Title = Class.new(
 ---@param injector WidgetInjector?
 ---@return string?
 function Title:make(injector)
-	return tostring(Title:_create(self.content))
+	return Title:_create(self.content)
 end
 
 ---@param infoDescription string|number|nil
----@return Html
+---@return string
 function Title:_create(infoDescription)
 	local header = mw.html.create('div')
 	header	:addClass('infobox-header')
 			:addClass('wiki-backgroundcolor-light')
 			:addClass('infobox-header-2')
 			:wikitext(infoDescription)
-	return mw.html.create('div'):node(header)
+	return tostring(mw.html.create('div'):node(header))
 end
 
 return Title

--- a/components/widget/widget_title.lua
+++ b/components/widget/widget_title.lua
@@ -22,9 +22,9 @@ local Title = Class.new(
 )
 
 ---@param injector WidgetInjector?
----@return Html?
+---@return string?
 function Title:make(injector)
-	return Title:_create(self.content)
+	return tostring(Title:_create(self.content))
 end
 
 ---@param infoDescription string|number|nil


### PR DESCRIPTION
## Summary
Currently `make()` has effectively 3 different return values.
* 1-`Html` obj wrapped in an array (most common)
* `Html`-array (just in two)
* `Widget`-array

The end goal is to have just one return value.

Other PRs will remove the `Widget`-array return value, by doing that logic as preprocessing instead. 

So this PR is focused on the two `Html` cases. After some POC-ing, I found that `string` was the best return value.
So this PR changes the 2 cases of `Html`-array into single `Html`, and then does `tostring` on basically all return values from all Widgets.

This PR in independent of Parts 1, 2 & 3. Part 3 and Part 4 together are both required to make 5.

## How did you test this change?
Tested on some tournament and team pages on dota2
