### PR TITLE
fix(prizepool): error in import due to `opponentFromRecord` param change

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -707,12 +707,12 @@ function Import._makeAdditionalDataFromMatch(opponentName, match)
 	end
 
 	local score, vsScore, lastVs
-	for _, opponent in pairs(match.match2opponents) do
+	for opponentIndex, opponent in pairs(match.match2opponents) do
 		if opponent.name == opponentName then
 			score = Import._getScore(opponent)
 		else
 			vsScore = Import._getScore(opponent)
-			lastVs = MatchGroupUtil.opponentFromRecord(opponent)
+			lastVs = MatchGroupUtil.opponentFromRecord(match, opponent, opponentIndex)
 		end
 	end
 


### PR DESCRIPTION
## Summary
Due to the changed header in #4618 of `opponentFromRecord` function, and the miss that PPT Import also uses this function. 

## How did you test this change?
Live