### PR TITLE
feat(tier): add points tier for WoT

### DIFF
--- a/standard/tier/wikis/worldoftanks/tier_data.lua
+++ b/standard/tier/wikis/worldoftanks/tier_data.lua
@@ -97,5 +97,13 @@ return {
 			link = 'Showmatches',
 			category = 'Showmatch Tournaments',
 		},
+		points = {
+			value = 'Points',
+			sort = 'B1',
+			name = 'Points',
+			short = 'Points',
+			link = 'Point Rankings',
+			category = 'Point Rankings',
+		},
 	},
 }


### PR DESCRIPTION
## Summary

Adding the Points tier for World of Tanks since there is an increase in points tables used for tournament qualification. The idea is to be able to show these in the players or teams detailed results.

## How did you test this change?