### PR TITLE
feat(match2): handle legacy R6 bo1 input

### DIFF
--- a/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
@@ -12,7 +12,6 @@ local Lua = require('Module:Lua')
 local MatchGroupLegacy = Lua.import('Module:MatchGroup/Legacy')
 
 ---@class RainbowsixMatchGroupLegacyDefault: MatchGroupLegacy
----@field _base MatchGroupLegacy
 local MatchGroupLegacyDefault = Class.new(MatchGroupLegacy)
 
 ---@return table
@@ -48,13 +47,9 @@ function MatchGroupLegacyDefault.run(frame)
 	return MatchGroupLegacyDefault(frame):build()
 end
 
----@param match2key string
----@param match1params match1Keys
-function MatchGroupLegacyDefault:getMatch(match2key, match1params)
-	local match = self._base.getMatch(self, match2key, match1params)
-	if not match then
-		return nil
-	end
+---@param isReset boolean
+---@param match table
+function MatchGroupLegacyDefault:handleOtherMatchParams(isReset, match)
 	if not match.map1 then
 		match.map1 = {
 			map = 'Unknown',
@@ -65,7 +60,6 @@ function MatchGroupLegacyDefault:getMatch(match2key, match1params)
 	end
 	(match.opponent1 or {}).score = nil
 	(match.opponent2 or {}).score = nil
-	return match
 end
 
 return MatchGroupLegacyDefault

--- a/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
@@ -50,16 +50,22 @@ end
 ---@param isReset boolean
 ---@param match table
 function MatchGroupLegacyDefault:handleOtherMatchParams(isReset, match)
-	if not match.map1 then
-		match.map1 = {
-			map = 'Unknown',
-			finished = true,
-			score1 = (match.opponent1 or {}).score,
-			score2 = (match.opponent2 or {}).score,
-		}
+	local opp1score, opp2score = (match.opponent1 or {}).score, (match.opponent2 or {}).score
+	-- Legacy maps are Bo10 or Bo12, while >Bo5 in legacy matches are non existent
+	-- Let's assume that if the sum of the scores is less than 6, it's a a match, otherwise it's a map
+	if (opp1score or 0) + (opp2score or 0) < 6 then
+		return
 	end
+
 	(match.opponent1 or {}).score = nil
 	(match.opponent2 or {}).score = nil
+	match.map1 = match.map1 or {
+		map = 'Unknown',
+		finished = true,
+		score1 = opp1score,
+		score2 = opp2score,
+	}
+
 end
 
 return MatchGroupLegacyDefault

--- a/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
@@ -65,7 +65,6 @@ function MatchGroupLegacyDefault:handleOtherMatchParams(isReset, match)
 		score1 = opp1score,
 		score2 = opp2score,
 	}
-
 end
 
 return MatchGroupLegacyDefault

--- a/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/rainbowsix/legacy/match_group_legacy_default.lua
@@ -12,6 +12,7 @@ local Lua = require('Module:Lua')
 local MatchGroupLegacy = Lua.import('Module:MatchGroup/Legacy')
 
 ---@class RainbowsixMatchGroupLegacyDefault: MatchGroupLegacy
+---@field _base MatchGroupLegacy
 local MatchGroupLegacyDefault = Class.new(MatchGroupLegacy)
 
 ---@return table
@@ -45,6 +46,26 @@ end
 ---@return string
 function MatchGroupLegacyDefault.run(frame)
 	return MatchGroupLegacyDefault(frame):build()
+end
+
+---@param match2key string
+---@param match1params match1Keys
+function MatchGroupLegacyDefault:getMatch(match2key, match1params)
+	local match = self._base.getMatch(self, match2key, match1params)
+	if not match then
+		return nil
+	end
+	if not match.map1 then
+		match.map1 = {
+			map = 'Unknown',
+			finished = true,
+			score1 = (match.opponent1 or {}).score,
+			score2 = (match.opponent2 or {}).score,
+		}
+	end
+	(match.opponent1 or {}).score = nil
+	(match.opponent2 or {}).score = nil
+	return match
 end
 
 return MatchGroupLegacyDefault

--- a/components/match2/wikis/rainbowsix/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/rainbowsix/legacy/match_maps_legacy.lua
@@ -16,8 +16,8 @@ local Arguments = require('Module:Arguments')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
+local Table = require('Module:Table')
 local Template = require('Module:Template')
-local CustomInput = require('Module:MatchGroup/Input/Custom')
 
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')
 
@@ -26,11 +26,10 @@ local MAX_GAME_NUM = 9
 local MatchMaps = {}
 
 function MatchMaps.main(frame)
-	local args = Arguments.getArgs(frame)
-	return MatchMaps._main(args, frame)
+	return MatchMaps._main(Arguments.getArgs(frame))
 end
 
-function MatchMaps._main(args, frame)
+function MatchMaps._main(args)
 	-- Data storage (LPDB)
 	if Logic.readBool(matchlistVars:get('store')) then
 
@@ -40,7 +39,7 @@ function MatchMaps._main(args, frame)
 			local storage_args = {}
 			local details = Json.parseIfString(args.details) or {}
 
-			storage_args['title'] = args.date
+			storage_args.title = args.date
 
 			--opponents
 			for i = 1, 2 do
@@ -58,7 +57,6 @@ function MatchMaps._main(args, frame)
 					storage_args['opponent' .. i] = {
 						['type'] = 'team',
 						template = args['team' .. i],
-						score = args['games' .. i] or args['score' .. i],
 					}
 				end
 			end
@@ -72,64 +70,45 @@ function MatchMaps._main(args, frame)
 			for i = 1, MAX_GAME_NUM do
 				local prefix = 'map' .. i
 				if Logic.isNotEmpty(details[prefix]) or Logic.isNotEmpty(details[prefix ..'finished']) then
-					storage_args[prefix] = CustomInput.processMap{
-						map = details[prefix] or 'Unknown',
-						finished = details[prefix..'finished'],
-						score1 = details[prefix..'score1'],
-						score2 = details[prefix..'score2'],
-						t1ban1 = details[prefix..'t1ban1'],
-						t1ban2 = details[prefix..'t1ban2'],
-						t2ban1 = details[prefix..'t2ban1'],
-						t2ban2 = details[prefix..'t2ban2'],
-						t1firstside = details[prefix..'t1firstside'],
-						t1firstsideot = details[prefix..'o1t1firstside'],
-						t1atk = details[prefix..'t1atk'],
-						t1def = details[prefix..'t1def'],
-						t2atk = details[prefix..'t2atk'],
-						t2def = details[prefix..'t2def'],
-						t1otatk = details[prefix..'o1t1atk'],
-						t1otdef = details[prefix..'o1t1def'],
-						t2otatk = details[prefix..'o1t2atk'],
-						t2otdef = details[prefix..'o1t2def'],
-						vod = details['vod'..i],
-						winner = details[prefix .. 'win']
+					storage_args[prefix] = {
+						map = Table.extract(details, prefix) or 'Unknown',
+						finished = Table.extract(details, prefix..'finished'),
+						score1 = Table.extract(details,  prefix..'score1'),
+						score2 = Table.extract(details, prefix..'score2'),
+						t1ban1 = Table.extract(details, prefix..'t1ban1'),
+						t1ban2 = Table.extract(details, prefix..'t1ban2'),
+						t2ban1 = Table.extract(details, prefix..'t2ban1'),
+						t2ban2 = Table.extract(details, prefix..'t2ban2'),
+						t1firstside = Table.extract(details, prefix..'t1firstside'),
+						t1firstsideot = Table.extract(details, prefix..'o1t1firstside'),
+						t1atk = Table.extract(details, prefix..'t1atk'),
+						t1def = Table.extract(details, prefix..'t1def'),
+						t2atk = Table.extract(details, prefix..'t2atk'),
+						t2def = Table.extract(details, prefix..'t2def'),
+						t1otatk = Table.extract(details, prefix..'o1t1atk'),
+						t1otdef = Table.extract(details, prefix..'o1t1def'),
+						t2otatk = Table.extract(details, prefix..'o1t2atk'),
+						t2otdef = Table.extract(details, prefix..'o1t2def'),
+						vod = Table.extract(details, 'vod'..i),
+						winner = Table.extract(details, prefix .. 'win'),
 					}
-					details[prefix] = nil
-					details[prefix ..'win'] = nil
-					details[prefix ..'score'] = nil
-					details[prefix ..'t1ban1'] = nil
-					details[prefix ..'t1ban2'] = nil
-					details[prefix ..'t2ban1'] = nil
-					details[prefix ..'t2ban2'] = nil
-					details[prefix ..'t1firstside'] = nil
-					details[prefix ..'o1t1firstside'] = nil
-					details[prefix ..'t1atk'] = nil
-					details[prefix ..'t1def'] = nil
-					details[prefix ..'t2atk'] = nil
-					details[prefix ..'t2def'] = nil
-					details[prefix ..'o1t1atk'] = nil
-					details[prefix ..'o1t1def'] = nil
-					details[prefix ..'o1t2atk'] = nil
-					details[prefix ..'o1t2def'] = nil
-					details['vod'..i] = nil
+				elseif i == 1 then
+					storage_args[prefix] = {
+						map = 'Unknown',
+						finished = true,
+						score1 = args.games1,
+						score2 = args.games2,
+					}
 				else
 					break
 				end
 			end
 
-			storage_args['mapveto'] = Json.parseIfString(details.mapveto)
-			details.mapbans = nil
+			storage_args.mapveto = Json.parseIfString(Table.extract(details, 'mapveto'))
 
-			-- Add date
-			storage_args.date = details.date
-			-- If details is missing, let's assume it's finished
-			if #details == 0 then
-				storage_args.finished = true
-			else
-				storage_args.finished = details.finished
-			end
-
-			details.date = nil
+			storage_args.date = Table.extract(details, 'date')
+			-- It's legacy, let's assume it's finished
+			storage_args.finished = true
 			details.finished = nil
 
 			for key, value in pairs(details) do
@@ -141,6 +120,5 @@ function MatchMaps._main(args, frame)
 		end
 	end
 end
-
 
 return MatchMaps

--- a/components/match2/wikis/rainbowsix/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/rainbowsix/legacy/match_maps_legacy.lua
@@ -57,6 +57,7 @@ function MatchMaps._main(args)
 					storage_args['opponent' .. i] = {
 						['type'] = 'team',
 						template = args['team' .. i],
+						score = args['games' .. i],
 					}
 				end
 			end
@@ -92,13 +93,6 @@ function MatchMaps._main(args)
 						vod = Table.extract(details, 'vod'..i),
 						winner = Table.extract(details, prefix .. 'win'),
 					}
-				elseif i == 1 then
-					storage_args[prefix] = {
-						map = 'Unknown',
-						finished = true,
-						score1 = args.games1,
-						score2 = args.games2,
-					}
 				else
 					break
 				end
@@ -115,7 +109,23 @@ function MatchMaps._main(args)
 				storage_args[key] = value
 			end
 
-			-- Store the processed args for later usage
+			local opp1score, opp2score = storage_args.opponent1.score, storage_args.opponent2.score
+			-- Legacy maps are Bo10 or Bo12, while >Bo5 in legacy matches are non existent
+			-- Let's assume that if the sum of the scores is less than 6, it's a a match, otherwise it's a map
+			if (opp1score or 0) + (opp2score or 0) < 6 then
+				Template.stashReturnValue(storage_args, 'LegacyMatchlist')
+				return
+			end
+
+			storage_args.opponent1.score = nil
+			storage_args.opponent2.score = nil
+			storage_args.map1 = storage_args.map1 or {
+				map = 'Unknown',
+				finished = true,
+				score1 = opp1score,
+				score2 = opp2score,
+			}
+
 			Template.stashReturnValue(storage_args, 'LegacyMatchlist')
 		end
 	end


### PR DESCRIPTION
## Summary
Handle this kind of Bo1 input in legacy
```
{{MatchMaps
|team1=vitality|team2=supremacy |winner=1
|games1=6 |games2=2
|details={{BracketMatchSummary
|date=July 5, 2018 - 20:00 {{Abbr/CEST}}|finished=true
|twitch=rainbow six
|youtube=rainbow six pro league
|map1t1ban1=Ying|map1t1ban2=Mute|map1t2ban1=Hibana|map1t2ban2=Mira
|map1t1firstside=def|map1t1atk=2|map1t1def=4|map1t2atk=1|map1t2def=1
|map1=Oregon |map1score= |map1win=1
|siegegg=129
|esl=35999855
|vod=https://youtu.be/UjHXesurcbU
}}
```
Where the bo1 score is also the match score. 

This PR handles it by removing the match level score from legacy (as to let match2 calculate match level score automatically). Additionally, if map1 is missing, it adds in a dummy map1 with the previous match score.

## How did you test this change?
Dev ->  live