### PR TITLE
feat(match2): show bo1  score on zula cops and crossfire

### DIFF
--- a/standard/info/wikis/criticalops/info.lua
+++ b/standard/info/wikis/criticalops/info.lua
@@ -35,6 +35,7 @@ return {
 		match2 = {
 			status = 2,
 			matchWidth = 180,
+			gameScoresIfBo1 = true,
 		},
 	},
 }

--- a/standard/info/wikis/crossfire/info.lua
+++ b/standard/info/wikis/crossfire/info.lua
@@ -62,6 +62,7 @@ return {
 			status = 1,
 			matchWidthMobile = 110,
 			matchWidth = 190,
+			gameScoresIfBo1 = true,
 		},
 	},
 	defaultRoundPrecision = 0,

--- a/standard/info/wikis/zula/info.lua
+++ b/standard/info/wikis/zula/info.lua
@@ -75,6 +75,7 @@ return {
 			status = 2,
 			matchWidthMobile = 110,
 			matchWidth = 200,
+			gameScoresIfBo1 = true,
 		},
 	},
 }


### PR DESCRIPTION
## Summary

Zula and COps had it before. Crossfire puts it in manually in bo1 as match score..