### PR TITLE
fix(match2): Clash Royale card display for duo opponents

### DIFF
--- a/components/match2/wikis/clashroyale/match_summary.lua
+++ b/components/match2/wikis/clashroyale/match_summary.lua
@@ -387,7 +387,7 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 	local date = args.date
 
 	local color = flip and CARD_COLOR_2 or CARD_COLOR_1
-	
+
 	local sideWrapper = mw.html.create('div')
 		:css('display', 'flex')
 		:css('flex-direction', 'column')
@@ -401,7 +401,7 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 		local wrapperCards = mw.html.create('div')
 			:css('display', 'flex')
 			:css('flex-direction', 'column')
-		
+
 		local cardDisplays = {}
 		for _, card in ipairs(cardData) do
 			table.insert(cardDisplays, mw.html.create('div')
@@ -441,7 +441,7 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 						})
 			wrapper:node(towerCardDisplay)
 		end
-		
+
 		sideWrapper:node(wrapper)
 	end
 

--- a/components/match2/wikis/clashroyale/match_summary.lua
+++ b/components/match2/wikis/clashroyale/match_summary.lua
@@ -387,17 +387,21 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 	local date = args.date
 
 	local color = flip and CARD_COLOR_2 or CARD_COLOR_1
-	local wrapper = mw.html.create('div')
-		:css('flex-basis', '1px')
-		:css('display', 'inline-flex')
-		:css('flex-direction', (flip and 'row' or 'row-reverse'))
-		:css('align-items', 'center')
-
-	local wrapperCards = mw.html.create('div')
+	
+	local sideWrapper = mw.html.create('div')
 		:css('display', 'flex')
 		:css('flex-direction', 'column')
 
 	for _, cardData in ipairs(cardDataSets) do
+		local wrapper = mw.html.create('div')
+			:css('flex-basis', '1px')
+			:css('display', 'inline-flex')
+			:css('flex-direction', (flip and 'row' or 'row-reverse'))
+			:css('align-items', 'center')
+		local wrapperCards = mw.html.create('div')
+			:css('display', 'flex')
+			:css('flex-direction', 'column')
+		
 		local cardDisplays = {}
 		for _, card in ipairs(cardData) do
 			table.insert(cardDisplays, mw.html.create('div')
@@ -437,9 +441,11 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 						})
 			wrapper:node(towerCardDisplay)
 		end
+		
+		sideWrapper:node(wrapper)
 	end
 
-	return wrapper
+	return sideWrapper
 end
 
 return CustomMatchSummary


### PR DESCRIPTION
## Summary
Fixes the card display for games with more than one player.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
via dev.

Before:
![image](https://github.com/user-attachments/assets/dd4550fc-d87e-4d77-9dec-0dd07f96e1d8)
After:
![image](https://github.com/user-attachments/assets/2e3acde5-47bf-4691-a122-633562a6af43)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
