### PR TITLE
docs(match2): allow faction as input data in parseParticipants

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -1145,7 +1145,7 @@ function MatchGroupInputUtil.makeLinkFromName(name, options)
 	return link
 end
 
----@alias PlayerInputData {name: string?, link: string?}
+---@alias PlayerInputData {name: string?, link: string?, faction: string?}
 ---@param playerIds MGIParsedPlayer[]
 ---@param inputPlayers table[]
 ---@param indexToPlayer fun(playerIndex: integer): PlayerInputData?


### PR DESCRIPTION
## Summary
just so that anno warning in sc(2) MGI shuts up :)

## How did you test this change?
vscode