### PR TITLE
fix(countdown): Make `init()` js method idempotent

### DIFF
--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -20,8 +20,7 @@ liquipedia.countdown = {
 					const dateObject = liquipedia.countdown.parseTimerObjectNodeToDateObj( timerObjectNode );
 					const dateChild = document.createElement( 'span' );
 					if ( typeof dateObject === 'object' ) {
-						const disableTimeZoneAdjust = mw.user.options.get( 'teamliquidintegration-disable-countdown-timezone-adjust' ) === '1' || mw.user.options.get( 'teamliquidintegration-disable-countdown-timezone-adjust' ) === 1;
-						if ( disableTimeZoneAdjust ) {
+						if ( mw.user.options.get( 'teamliquidintegration-disable-countdown-timezone-adjust' ) ) {
 							dateChild.innerHTML = timerObjectNode.innerHTML;
 						} else {
 							dateChild.innerHTML = liquipedia.countdown.getCorrectTimeZoneString( dateObject );

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -18,17 +18,21 @@ liquipedia.countdown = {
 			mw.loader.using( 'user.options', () => {
 				liquipedia.countdown.timerObjectNodes.forEach( ( timerObjectNode ) => {
 					const dateObject = liquipedia.countdown.parseTimerObjectNodeToDateObj( timerObjectNode );
-					const dateChild = document.createElement( 'span' );
-					if ( typeof dateObject === 'object' ) {
-						if ( mw.user.options.get( 'teamliquidintegration-disable-countdown-timezone-adjust' ) ) {
+					let dateChild;
+					if ( timerObjectNode.firstChild instanceof HTMLSpanElement ) {
+						dateChild = timerObjectNode.firstChild;
+					} else {
+						dateChild = document.createElement( 'span' );
+						if (
+							mw.user.options.get( 'teamliquidintegration-disable-countdown-timezone-adjust' ) ||
+							typeof dateObject !== 'object'
+						) {
 							dateChild.innerHTML = timerObjectNode.innerHTML;
 						} else {
 							dateChild.innerHTML = liquipedia.countdown.getCorrectTimeZoneString( dateObject );
 						}
-					} else {
-						dateChild.innerHTML = timerObjectNode.innerHTML;
+						dateChild.classList.add( 'timer-object-date' );
 					}
-					dateChild.classList.add( 'timer-object-date' );
 					timerObjectNode.innerHTML = '';
 					timerObjectNode.appendChild( dateChild );
 					let separatorChild;


### PR DESCRIPTION
## Summary

Twice now we've had issues with this not being idempotent, so it's just easier to make it so instead of adding workarounds every time it happens. Not even sure when/where the last breakage was.

## How did you test this change?

Browser dev tools.
