### PR TITLE
fix(opponent): in bo1 handling we sometimes show `nil` as score

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -613,7 +613,7 @@ function MatchGroupUtil.opponentFromRecord(matchRecord, record, opponentIndex)
 	local score = tonumber(record.score)
 	local bestof = tonumber(matchRecord.bestof)
 	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and (matchRecord.match2games or {})[1] then
-		score = matchRecord.match2games[1].scores[opponentIndex] or ''
+		score = matchRecord.match2games[1].scores[opponentIndex] or score
 	end
 
 	return {

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -613,7 +613,7 @@ function MatchGroupUtil.opponentFromRecord(matchRecord, record, opponentIndex)
 	local score = tonumber(record.score)
 	local bestof = tonumber(matchRecord.bestof)
 	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and (matchRecord.match2games or {})[1] then
-		score = matchRecord.match2games[1].scores[opponentIndex]
+		score = matchRecord.match2games[1].scores[opponentIndex] or ''
 	end
 
 	return {

--- a/components/opponent/commons/opponent_display.lua
+++ b/components/opponent/commons/opponent_display.lua
@@ -469,10 +469,10 @@ end
 ---@return string
 function OpponentDisplay.InlineScore(opponent)
 	if opponent.status == 'S' then
-		if (opponent.score or 0) == 0 and Opponent.isTbd(opponent) then
+		if opponent.score == 0 and Opponent.isTbd(opponent) then
 			return ''
 		else
-			return opponent.score and opponent.score ~= -1 and tostring(opponent.score) or ''
+			return opponent.score ~= -1 and tostring(opponent.score) or ''
 		end
 	else
 		return opponent.status or ''

--- a/components/opponent/commons/opponent_display.lua
+++ b/components/opponent/commons/opponent_display.lua
@@ -469,10 +469,10 @@ end
 ---@return string
 function OpponentDisplay.InlineScore(opponent)
 	if opponent.status == 'S' then
-		if opponent.score == 0 and Opponent.isTbd(opponent) then
+		if (opponent.score or 0) == 0 and Opponent.isTbd(opponent) then
 			return ''
 		else
-			return opponent.score ~= -1 and tostring(opponent.score) or ''
+			return opponent.score and opponent.score ~= -1 and tostring(opponent.score) or ''
 		end
 	else
 		return opponent.status or ''


### PR DESCRIPTION
## Summary
reported on discord:
https://discord.com/channels/93055209017729024/372075546231832576/1284885694224797708

## How did you test this change?
dev