### PR TITLE
Order achievements by date in PortalStatistics

### DIFF
--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -1022,6 +1022,7 @@ function StatisticsPortal._cacheOpponentPlacementData(args)
 			.. 'opponentplayers, opponentname, opponenttype',
 		conditions = conditions:toString(),
 		limit = 1000,
+		order = 'date asc',
 	}
 
 	local function makeOpponentTable(item)


### PR DESCRIPTION
## Summary

Order achievements by date in `PortalStatistics`, so that the tournament icons are in chronological order.

## How did you test this change?

/dev