### PR TITLE
refactor(widget): improve building part 6 - remove injector from make()

### DIFF
--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -26,10 +26,9 @@ function Widget:assertExistsAndCopy(value)
 	return assert(String.nilIfEmpty(value), 'Tried to set a nil value to a mandatory property')
 end
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string|nil
-function Widget:make(injector, children)
+function Widget:make(children)
 	error('A Widget must override the make() function!')
 end
 
@@ -38,7 +37,7 @@ end
 function Widget:tryMake(injector)
 	local processedChildren = self:tryChildren(injector)
 	return Logic.tryOrElseLog(
-		function() return self:make(injector, processedChildren) end,
+		function() return self:make(processedChildren) end,
 		function(error) return tostring(ErrorDisplay.InlineError(error)) end,
 		function(error)
 			error.header = 'Error occured in widget: (caught by Widget:tryMake)'

--- a/components/widget/widget_breakdown.lua
+++ b/components/widget/widget_breakdown.lua
@@ -24,10 +24,9 @@ local Breakdown = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Breakdown:make(injector, children)
+function Breakdown:make(children)
 	return Breakdown:_breakdown(children, self.classes, self.contentClasses)
 end
 

--- a/components/widget/widget_builder.lua
+++ b/components/widget/widget_builder.lua
@@ -21,10 +21,9 @@ local Builder = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string
-function Builder:make(injector, children)
+function Builder:make(children)
 	return table.concat(children)
 end
 

--- a/components/widget/widget_cell.lua
+++ b/components/widget/widget_cell.lua
@@ -88,10 +88,9 @@ function Cell:_content(...)
 	return self
 end
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Cell:make(injector, children)
+function Cell:make(children)
 	self:_new(self.name)
 	self:_class(unpack(self.classes or {}))
 	self:_content(unpack(children))

--- a/components/widget/widget_center.lua
+++ b/components/widget/widget_center.lua
@@ -23,10 +23,9 @@ local Center = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Center:make(injector, children)
+function Center:make(children)
 	return Center:_create(children, self.classes)
 end
 

--- a/components/widget/widget_chronology.lua
+++ b/components/widget/widget_chronology.lua
@@ -22,10 +22,9 @@ local Chronology = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Chronology:make(injector, children)
+function Chronology:make(children)
 	return Chronology:_chronology(self.links)
 end
 

--- a/components/widget/widget_customizable.lua
+++ b/components/widget/widget_customizable.lua
@@ -21,10 +21,9 @@ local Customizable = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string
-function Customizable:make(injector, children)
+function Customizable:make(children)
 	return table.concat(children)
 end
 

--- a/components/widget/widget_div.lua
+++ b/components/widget/widget_div.lua
@@ -23,10 +23,9 @@ local Div = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Div:make(injector, children)
+function Div:make(children)
 	local div = mw.html.create('div')
 	Array.forEach(self.classes, FnUtil.curry(div.addClass, div))
 	Array.forEach(children, FnUtil.curry(div.node, div))

--- a/components/widget/widget_header.lua
+++ b/components/widget/widget_header.lua
@@ -35,10 +35,9 @@ local Header = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string
-function Header:make(injector, children)
+function Header:make(children)
 	local header = {
 		Header:_name(self.name),
 		Header:_image(

--- a/components/widget/widget_highlights.lua
+++ b/components/widget/widget_highlights.lua
@@ -21,10 +21,9 @@ local Highlights = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Highlights:make(injector, children)
+function Highlights:make(children)
 	return Highlights:_highlights(children)
 end
 

--- a/components/widget/widget_links.lua
+++ b/components/widget/widget_links.lua
@@ -27,10 +27,9 @@ local Links = Class.new(
 
 local PRIORITY_GROUPS = Lua.import('Module:Links/PriorityGroups', {loadData = true})
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Links:make(injector, children)
+function Links:make(children)
 	local infoboxLinks = mw.html.create('div')
 	infoboxLinks	:addClass('infobox-center')
 					:addClass('infobox-icons')

--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -47,10 +47,9 @@ function Table:addClass(class)
 	return self
 end
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Table:make(injector, children)
+function Table:make(children)
 	local displayTable = mw.html.create('div'):addClass('csstable-widget')
 	displayTable:css{
 		['grid-template-columns'] = 'repeat(' .. (self.columns or self:_getMaxCells()) .. ', auto)',

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -55,10 +55,9 @@ function TableCell:addCss(key, value)
 	return self
 end
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function TableCell:make(injector, children)
+function TableCell:make(children)
 	local cell = mw.html.create('div'):addClass('csstable-widget-cell')
 	cell:css{
 		['grid-row'] = self.rowSpan and 'span ' .. self.rowSpan or nil,

--- a/components/widget/widget_table_cell_new.lua
+++ b/components/widget/widget_table_cell_new.lua
@@ -41,10 +41,9 @@ local TableCell = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function TableCell:make(injector, children)
+function TableCell:make(children)
 	local cell = mw.html.create(self.isHeader and 'th' or 'td')
 	cell:attr('colspan', self.colSpan)
 	cell:attr('rowspan', self.rowSpan)

--- a/components/widget/widget_table_new.lua
+++ b/components/widget/widget_table_new.lua
@@ -30,10 +30,9 @@ local Table = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Table:make(injector, children)
+function Table:make(children)
 	local wrapper = mw.html.create('div'):addClass('table-responsive')
 	local output = mw.html.create('table'):addClass('wikitable')
 

--- a/components/widget/widget_table_row.lua
+++ b/components/widget/widget_table_row.lua
@@ -56,10 +56,9 @@ function TableRow:getCellCount()
 	return #self.children
 end
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function TableRow:make(injector, children)
+function TableRow:make(children)
 	local row = mw.html.create('div'):addClass('csstable-widget-row')
 
 	for _, class in ipairs(self.classes) do

--- a/components/widget/widget_table_row_new.lua
+++ b/components/widget/widget_table_row_new.lua
@@ -30,10 +30,9 @@ local TableRow = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function TableRow:make(injector, children)
+function TableRow:make(children)
 	local row = mw.html.create('tr')
 
 	Array.forEach(self.classes, FnUtil.curry(row.addClass, row))

--- a/components/widget/widget_title.lua
+++ b/components/widget/widget_title.lua
@@ -20,10 +20,9 @@ local Title = Class.new(
 	end
 )
 
----@param injector WidgetInjector?
 ---@param children string[]
 ---@return string?
-function Title:make(injector, children)
+function Title:make(children)
 	return Title:_create(children[1])
 end
 


### PR DESCRIPTION
## Summary
Requires Part 3. No widget's `make()` function uses injector anymore, so we can remove it entirely. All injector logic is now in tryChildren().

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
