### PR TITLE
feat(match2): activate pagifyPlayerNames on all refactored wikis

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -27,7 +27,7 @@ local CustomMatchGroupInput = {}
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = false,
+	pagifyPlayerNames = true,
 }
 
 ---@param match table

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -20,6 +20,12 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local DEFAULT_BESTOF = 3
 local DEFAULT_MODE = 'Duel'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -37,7 +43,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -29,6 +29,12 @@ local FIRST_PICK_CONVERSION = {
 local DEFAULT_BESTOF_MATCH = 5
 local DEFAULT_BESTOF_MAP = 3
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -45,7 +51,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date, {'tournament_enddate'}))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, opponents)
 	match.bestof = MatchFunctions.getBestOf(match)
@@ -223,7 +229,8 @@ function MapFunctions.getParticipants(map, opponents)
 					player = playerIdData.name,
 					brawler = getCharacterName(brawler),
 				}
-			end
+			end,
+			OPPONENT_CONFIG
 		)
 		Array.forEach(unattachedParticipants, function()
 			table.insert(participants, table.remove(unattachedParticipants, 1))

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -19,6 +19,12 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
 local DEFAULT_BESTOF = 3
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -35,7 +41,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match)

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -23,6 +23,12 @@ local DUMMY_MAP = 'null' -- Is set in Template:Map when |map= is empty.
 local SIDE_DEF = 'ct'
 local SIDE_ATK = 't'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -42,7 +48,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -20,6 +20,12 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local DEFAULT_BESTOF = 3
 local DEFAULT_MODE = 'team'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -37,7 +43,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -22,6 +22,12 @@ local DEFAULT_BESTOF = 3
 local DEFAULT_MODE = 'team'
 local DUMMY_MAP = 'default'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 local OPPONENT_CONFIG = {}
 
 -- containers for process helper functions

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -28,8 +28,6 @@ local OPPONENT_CONFIG = {
 	pagifyPlayerNames = true,
 }
 
-local OPPONENT_CONFIG = {}
-
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -21,6 +21,12 @@ local ALLOWED_VETOES = Array.append(MatchGroupInputUtil.DEFAULT_ALLOWED_VETOES, 
 local DEFAULT_BESTOF = 3
 local DEFAULT_MODE = 'team'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -38,7 +44,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -19,6 +19,12 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
 local DEFAULT_BESTOF = 3
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -35,7 +41,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match)

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -22,6 +22,12 @@ local MAX_NUM_BANS = 2
 local DUMMY_MAP = 'null' -- Is set in Template:Map when |map= is empty.
 local DEFAULT_MODE = 'team'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -39,7 +45,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -24,6 +24,12 @@ local Opponent = Lua.import('Module:Opponent')
 
 local DEFAULT_MODE = '3v3'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 local EARNINGS_LIMIT_FOR_FEATURED = 10000
 local CURRENT_YEAR = os.date('%Y')
 
@@ -42,7 +48,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 
@@ -126,7 +132,7 @@ end
 CustomMatchGroupInput.processMap = FnUtil.identity
 
 ---@param opponent table
----@return table?
+---@return table
 function CustomMatchGroupInput.getOpponentExtradata(opponent)
 	if not Logic.isNumeric(opponent.score2) then
 		return {}

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -20,6 +20,12 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local DEFAULT_BESTOF = 3
 local DEFAULT_MODE = 'team'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -37,7 +43,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -22,6 +22,12 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local DUMMY_MAP = 'null' -- Is set in Template:Map when |map= is empty.
 local DEFAULT_MODE = 'team'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -38,7 +44,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)
@@ -229,7 +235,8 @@ function MapFunctions.getParticipants(map, opponents)
 					player = playerIdData.name or playerInputData.name,
 					agent = getCharacterName(stats.agent),
 				}
-			end
+			end,
+			OPPONENT_CONFIG
 		)
 		Array.forEach(unattachedParticipants, function(participant)
 			table.insert(participants, participant)

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -21,6 +21,12 @@ local ALLOWED_VETOES = Array.append(MatchGroupInputUtil.DEFAULT_ALLOWED_VETOES, 
 local DEFAULT_BESTOF = 3
 local DEFAULT_MODE = 'team'
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 -- containers for process helper functions
 local MatchFunctions = {}
 local MapFunctions = {}
@@ -38,7 +44,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)

--- a/components/match2/wikis/zula/match_group_input_custom.lua
+++ b/components/match2/wikis/zula/match_group_input_custom.lua
@@ -24,6 +24,12 @@ local DUMMY_MAP = 'null' -- Is set in Template:Map when |map= is empty.
 local MatchFunctions = {}
 local MapFunctions = {}
 
+local OPPONENT_CONFIG = {
+	resolveRedirect = false,
+	pagifyTeamNames = false,
+	pagifyPlayerNames = true,
+}
+
 local CustomMatchGroupInput = {}
 
 -- called from Module:MatchGroup
@@ -39,7 +45,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
 
 	local opponents = Array.mapIndexes(function(opponentIndex)
-		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, OPPONENT_CONFIG)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)


### PR DESCRIPTION
## Summary
TeamCards always outputs players with `_`, so `_` is needed to match inputs and match2players. 

## How did you test this change?
/dev into live on valorant