### PR TITLE
feat(match2): parse participant into arrays

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -169,32 +169,6 @@ function DisplayHelper.MapScore(score, opponentIndex, resultType, walkover, winn
 	return score and tostring(score) or ''
 end
 
----@param allParticipants table<string, table>
----@param opponentIndex integer
----@return table[]
-function DisplayHelper.getParticipantsOfOpponent(allParticipants, opponentIndex)
-	local prefix = opponentIndex .. '_'
-	local function indexFromKey(key)
-		if String.startsWith(key, prefix) then
-			return tonumber(string.sub(key, #prefix + 1))
-		else
-			return nil
-		end
-	end
-	local participantsOfOpponent = Array.extractValues(Table.mapArguments(
-		allParticipants,
-		indexFromKey,
-		function (key, index)
-			if Logic.isEmpty(allParticipants[key]) then
-				return nil
-			end
-			return Table.merge({playerId = index}, allParticipants[key])
-		end,
-		true
-	))
-	return Array.sortBy(participantsOfOpponent, Operator.property('playerId'))
-end
-
 --[[
 Display component showing the detailed summary of a match. The component will
 appear as a popup from the Matchlist and Bracket components. This is a

--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -13,8 +13,6 @@ local I18n = require('Module:I18n')
 local Info = require('Module:Info')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Operator = require('Module:Operator')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Timezone = require('Module:Timezone')
 

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -667,6 +667,7 @@ end
 function MatchGroupUtil.gameFromRecord(record)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 
+	local participants = Json.parseIfString(record.participants) or {}
 	local walkover = nilIfEmpty(record.walkover)
 
 	local function getParticipantsOfOpponent(allParticipants, opponentIndex)
@@ -694,7 +695,7 @@ function MatchGroupUtil.gameFromRecord(record)
 
 	-- TODO: Dynamic range based on number of opponents
 	local opponents = Array.map(Array.range(1, 2), function (_, index)
-		return {players = getParticipantsOfOpponent(Json.parseIfString(record.participants) or {}, index)}
+		return {players = getParticipantsOfOpponent(participants, index)}
 	end)
 
 	return {
@@ -708,7 +709,7 @@ function MatchGroupUtil.gameFromRecord(record)
 		mapDisplayName = nilIfEmpty(Table.extract(extradata, 'displayname')),
 		mode = nilIfEmpty(record.mode),
 		opponents = opponents,
-		participants = Json.parseIfString(record.participants) or {},
+		participants = participants,
 		resultType = nilIfEmpty(record.resulttype),
 		scores = Json.parseIfString(record.scores) or {},
 		subgroup = tonumber(record.subgroup),

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -502,7 +502,7 @@ end
 function MatchGroupUtil.matchFromRecord(record)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 	local opponents = Array.map(record.match2opponents, FnUtil.curry(MatchGroupUtil.opponentFromRecord, record))
-	local games = Array.map(record.match2games, MatchGroupUtil.gameFromRecord)
+	local games = Array.map(record.match2games, function(game) return MatchGroupUtil.gameFromRecord(game, #opponents) end)
 	local bracketData = MatchGroupUtil.bracketDataFromRecord(Json.parseIfString(record.match2bracketdata))
 	if bracketData.type == 'bracket' then
 		bracketData.lowerEdges = bracketData.lowerEdges
@@ -663,8 +663,9 @@ function MatchGroupUtil.playerFromRecord(record)
 end
 
 ---@param record table
+---@param opponentCount integer?
 ---@return MatchGroupUtilGame
-function MatchGroupUtil.gameFromRecord(record)
+function MatchGroupUtil.gameFromRecord(record, opponentCount)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
 
 	local participants = Json.parseIfString(record.participants) or {}
@@ -693,8 +694,7 @@ function MatchGroupUtil.gameFromRecord(record)
 		return Array.sortBy(participantsOfOpponent, Operator.property('playerId'))
 	end
 
-	-- TODO: Dynamic range based on number of opponents
-	local opponents = Array.map(Array.range(1, 2), function (_, index)
+	local opponents = Array.map(Array.range(1, opponentCount or 2), function (_, index)
 		return {players = getParticipantsOfOpponent(participants, index)}
 	end)
 

--- a/components/match2/wikis/leagueoflegends/match_page.lua
+++ b/components/match2/wikis/leagueoflegends/match_page.lua
@@ -57,7 +57,6 @@ end)
 local NO_CHARACTER = 'default'
 local NOT_PLAYED = 'np'
 local DEFAULT_ITEM = 'EmptyIcon'
-local TEAMS = Array.range(1, 2)
 local AVAILABLE_FOR_TIERS = {1, 2, 3}
 local ITEMS_TO_SHOW = 6
 
@@ -87,13 +86,13 @@ function MatchPage.getByMatchId(props)
 	-- Update the view model with game and team data
 	Array.forEach(viewModel.games, function(game)
 		game.finished = game.winner ~= nil and game.winner ~= -1
-		game.teams = Array.map(TEAMS, function(teamIdx)
+		game.teams = Array.map(game.opponents, function(opponent, teamIdx)
 			local team = {players = {}}
 
 			team.scoreDisplay = game.winner == teamIdx and 'W' or game.finished and 'L' or '-'
 			team.side = String.nilIfEmpty(game.extradata['team' .. teamIdx ..'side'])
 
-			for _, player in Table.iter.pairsByPrefix(game.participants, teamIdx .. '_') do
+			for _, player in ipairs(opponent.players) do
 				table.insert(team.players, Table.mergeInto(player, {
 					roleIcon = player.role .. ' ' .. team.side,
 					items = Array.map(Array.range(1, ITEMS_TO_SHOW), function(idx)

--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -83,11 +83,10 @@ function MatchLegacy.storeGames(match, match2)
 				game.extradata['t'..teamId..'a'..playerId] = data.agent
 			end
 		end
-		local participants = Json.parseIfString(game2.participants) or {}
-		for team = 1, 2 do
-			local participantsOfTeam = DisplayHelper.getParticipantsOfOpponent(participants, team)
-			for player = 1, 5 do
-				addPlayer(team, player, participantsOfTeam[player])
+		local opponents = Json.parseIfString(game2.opponents) or {}
+		for teamId, opponent in ipairs(opponents) do
+			for playerId, player in ipairs(opponent.players)  do
+				addPlayer(teamId, playerId, player)
 			end
 		end
 		-- Other stuff

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -361,10 +361,10 @@ function CustomMatchSummary._createMap(game)
 
 	local team1Agents = Agents():setLeft()
 	local team2Agents = Agents():setRight()
-	for _, playerStats in ipairs((game.opponents[1] or {}).players or {}) do
+	for _, playerStats in ipairs((game.opponents[1] or {}).players) do
 		team1Agents:add(playerStats.agent)
 	end
-	for _, playerStats in ipairs((game.opponents[2] or {}).players or {}) do
+	for _, playerStats in ipairs((game.opponents[2] or {}).players) do
 		team2Agents:add(playerStats.agent)
 	end
 

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -359,25 +359,18 @@ end
 function CustomMatchSummary._createMap(game)
 	local row = MatchSummary.Row()
 
-	local team1Agents, team2Agents
-
-	if not Table.isEmpty(game.participants) then
-		team1Agents = Agents():setLeft()
-		team2Agents = Agents():setRight()
-
-		for _, playerStats in ipairs(DisplayHelper.getParticipantsOfOpponent(game.participants, 1)) do
-			team1Agents:add(playerStats.agent)
-		end
-		for _, playerStats in ipairs(DisplayHelper.getParticipantsOfOpponent(game.participants, 2)) do
-			team2Agents:add(playerStats.agent)
-		end
+	local team1Agents = Agents():setLeft()
+	local team2Agents = Agents():setRight()
+	for _, playerStats in ipairs((game.opponents[1] or {}).players or {}) do
+		team1Agents:add(playerStats.agent)
+	end
+	for _, playerStats in ipairs((game.opponents[2] or {}).players or {}) do
+		team2Agents:add(playerStats.agent)
 	end
 
-	local score1, score2
-
 	local extradata = game.extradata or {}
-	score1 = Score():setLeft()
-	score2 = Score():setRight()
+	local score1 = Score():setLeft()
+	local score2 = Score():setRight()
 
 	score1:setMapScore(DisplayHelper.MapScore(game.scores[1], 1, game.resultType, game.walkover, game.winner))
 


### PR DESCRIPTION
## Summary
When retrieving a game record, automatically parse `participants` into a easy usage solution of two arrays calleds `opponents`. 

## How did you test this change?

Tested on lol and val