### PR TITLE
fix(match2): missing faction normalization

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -53,6 +53,7 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 	Array.forEach(opponents, function(opponent, opponentIndex)
 		local opponentHasWon = Table.extract(opponent, 'win')
 		if not Logic.readBool(opponentHasWon) then return end
+		mw.ext.TeamLiquidIntegration.add_category('Pages with matches using `|win` in opponents')
 		match.winner = match.winner or opponentIndex
 	end)
 
@@ -180,7 +181,7 @@ end
 ---@param player table
 ---@return string
 function MatchFunctions.getPlayerFaction(player)
-	return player.extradata.faction or Faction.defaultFaction
+	return Faction.read(player.extradata.faction) or Faction.defaultFaction
 end
 
 ---@param opponents {type: OpponentType}

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -53,7 +53,7 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 	Array.forEach(opponents, function(opponent, opponentIndex)
 		local opponentHasWon = Table.extract(opponent, 'win')
 		if not Logic.readBool(opponentHasWon) then return end
-		mw.ext.TeamLiquidIntegration.add_category('Pages with matches using `|win` in opponents')
+		mw.ext.TeamLiquidIntegration.add_category('Pages with matches using `win` in opponents')
 		match.winner = match.winner or opponentIndex
 	end)
 


### PR DESCRIPTION
## Summary
Adds a misisng faction normalization in sc(2) match2 input processing.
While at it allso adds a tracking category so i can get rid of one of the unwanted aliases in the next weeks.

## How did you test this change?
live