### PR TITLE
feat(match2): remove support for `pagifyPlayerNames=false`

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -114,7 +114,6 @@ local contentLanguage = mw.getContentLanguage()
 ---@field maxNumPlayers integer?
 ---@field resolveRedirect boolean?
 ---@field pagifyTeamNames boolean?
----@field pagifyPlayerNames boolean?
 
 ---@class MatchGroupInputSubstituteInformation
 ---@field substitute standardPlayer
@@ -236,11 +235,9 @@ function MatchGroupInputUtil.readOpponent(match, opponentIndex, options)
 		)
 	end
 
-	if options.pagifyPlayerNames then
-		Array.forEach(opponent.players or {}, function(player)
-			player.pageName = Page.pageifyLink(player.pageName)
-		end)
-	end
+	Array.forEach(opponent.players or {}, function(player)
+		player.pageName = Page.pageifyLink(player.pageName)
+	end)
 
 	local record = MatchGroupInputUtil.mergeRecordWithOpponent(opponentInput, opponent, substitutions)
 
@@ -1133,16 +1130,9 @@ function MatchGroupInputUtil.findPlayerId(players, playerInput, playerLink)
 end
 
 ---@param name string
----@param options {pagifyPlayerNames: boolean?}?
 ---@return string
-function MatchGroupInputUtil.makeLinkFromName(name, options)
-	local link = mw.ext.TeamLiquidIntegration.resolve_redirect(name)
-
-	if (options or {}).pagifyPlayerNames then
-		link = Page.pageifyLink(link) --[[@as string]]
-	end
-
-	return link
+function MatchGroupInputUtil.makeLinkFromName(name)
+	return Page.pageifyLink(name) --[[@as string]]
 end
 
 ---@alias PlayerInputData {name: string?, link: string?}
@@ -1150,15 +1140,14 @@ end
 ---@param inputPlayers table[]
 ---@param indexToPlayer fun(playerIndex: integer): PlayerInputData?
 ---@param transform fun(playerIndex: integer, playerIdData: MGIParsedPlayer?, playerInputData: PlayerInputData): table?
----@param options {pagifyPlayerNames: boolean?}?
 ---@return table, table
-function MatchGroupInputUtil.parseParticipants(playerIds, inputPlayers, indexToPlayer, transform, options)
+function MatchGroupInputUtil.parseParticipants(playerIds, inputPlayers, indexToPlayer, transform)
 	local participants = {}
 	local unattachedParticipants = {}
 	local function parsePlayer(_, playerIndex)
 		local playerInputData = indexToPlayer(playerIndex) or {}
 		if playerInputData.name and not playerInputData.link then
-			playerInputData.link = MatchGroupInputUtil.makeLinkFromName(playerInputData.name, options)
+			playerInputData.link = MatchGroupInputUtil.makeLinkFromName(playerInputData.name)
 		end
 		local playerId = MatchGroupInputUtil.findPlayerId(playerIds, playerInputData.name, playerInputData.link)
 		local toStoreData = transform(playerIndex, playerIds[playerId] or {}, playerInputData)

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -25,7 +25,6 @@ local Streams = Lua.import('Module:Links/Stream')
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = true,
 }
 local TBD = 'TBD'
 local TBA = 'TBA'
@@ -398,8 +397,7 @@ function MapFunctions.getTeamParticipants(mapInput, opponent, opponentIndex)
 				flag = Flags.CountryName(playerIdData.flag),
 				position = playerIndex,
 			}
-		end,
-		OPPONENT_CONFIG
+		end
 	)
 
 	Array.forEach(unattachedParticipants, function(participant)

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -27,7 +27,6 @@ local CustomMatchGroupInput = {}
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = false,
 }
 
 ---@param match table
@@ -126,11 +125,9 @@ function CustomMatchGroupInput.readOpponent(match, opponentIndex, options)
 		)
 	end
 
-	if options.pagifyPlayerNames then
-		Array.forEach(opponent.players or {}, function(player)
-			player.pageName = Page.pageifyLink(player.pageName)
-		end)
-	end
+	Array.forEach(opponent.players or {}, function(player)
+		player.pageName = Page.pageifyLink(player.pageName)
+	end)
 
 	local record = MatchGroupInputUtil.mergeRecordWithOpponent(opponentInput, opponent, substitutions)
 
@@ -325,8 +322,7 @@ function CustomMatchGroupInput._participants(opponentPlayers, map, opponentIndex
 				pageName = playerIdData.name or playerInputData.name,
 				flag = playerIdData.flag,
 			}
-		end,
-		OPPONENT_CONFIG
+		end
 	)
 	Array.forEach(unattachedParticipants, function(participant)
 		table.insert(participants, participant)

--- a/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
+++ b/components/match2/wikis/arenaofvalor/match_group_input_custom.lua
@@ -26,7 +26,6 @@ local DUMMY_MAP = 'default'
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = false,
-	pagifyPlayerNames = true,
 	maxNumPlayers = 5,
 }
 

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -19,7 +19,6 @@ local DUMMY_MAP = 'default' -- Is set in Template:Map when |map= is empty.
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = true,
 	maxNumPlayers = 15,
 }
 

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -23,7 +23,6 @@ local DEFAULT_MODE = 'team'
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = true,
 }
 
 -- containers for process helper functions

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -22,7 +22,6 @@ local DEFAULT_MODE = 'team'
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = true,
 	maxNumPlayers = 5
 }
 

--- a/components/match2/wikis/deadlock/match_group_input_custom.lua
+++ b/components/match2/wikis/deadlock/match_group_input_custom.lua
@@ -19,7 +19,6 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = true,
 	maxNumPlayers = 10,
 }
 

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -23,7 +23,6 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = false,
-	pagifyPlayerNames = true,
 	maxNumPlayers = 15,
 }
 local DEFAULT_MODE = 'team'
@@ -280,8 +279,8 @@ function MapFunctions.getParticipants(MatchParser, map, opponents)
 				local participant = participantList[playerIndex]
 				participant.character = getCharacterName(participant.character)
 				return participant
-			end,
-			OPPONENT_CONFIG)
+			end
+		)
 		Array.forEach(unattachedParticipants, function(participant)
 			table.insert(participants, participant)
 		end)

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -23,7 +23,6 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = false,
-	pagifyPlayerNames = true,
 	maxNumPlayers = 15,
 }
 local DEFAULT_MODE = 'team'
@@ -261,8 +260,8 @@ function MapFunctions.getParticipants(MatchParser, map, opponents)
 				local participant = participantList[playerIndex]
 				participant.character = getCharacterName(participant.character)
 				return participant
-			end,
-			OPPONENT_CONFIG)
+			end
+		)
 		Array.forEach(unattachedParticipants, function(participant)
 			table.insert(participants, participant)
 		end)

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -126,7 +126,7 @@ end
 CustomMatchGroupInput.processMap = FnUtil.identity
 
 ---@param opponent table
----@return table?
+---@return table
 function CustomMatchGroupInput.getOpponentExtradata(opponent)
 	if not Logic.isNumeric(opponent.score2) then
 		return {}

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -25,7 +25,6 @@ local MAX_NUM_PLAYERS = 15
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = true,
 	maxNumPlayers = MAX_NUM_PLAYERS,
 }
 

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -27,7 +27,6 @@ local Streams = Lua.import('Module:Links/Stream')
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
-	pagifyPlayerNames = true,
 }
 local TBD = 'TBD'
 local NEUTRAL_HERO_FACTION = 'neutral'

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -26,7 +26,6 @@ local DUMMY_MAP = 'default'
 local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = false,
-	pagifyPlayerNames = true,
 }
 
 -- containers for process helper functions


### PR DESCRIPTION
## Summary
TeamCards always outputs players with `_`, so `_` is always need to match match2players.

## How did you test this change?
Tested on valorant