### PR TITLE
refactor(widget): children rework - part 7&8 for breakdown widget

### DIFF
--- a/components/infobox/commons/infobox_campaign_mission.lua
+++ b/components/infobox/commons/infobox_campaign_mission.lua
@@ -48,10 +48,10 @@ function Mission:createInfobox()
 		Center{content = {args.caption}},
 		Title{name = 'Mission Information'},
 		Breakdown{
-			content = {'Mission Objective'},
+			children = {'Mission Objective'},
 			classes = {'infobox-header', 'wiki-backgroundcolor-light', 'infobox-header-3'}
 		},
-		Breakdown{content = { args.objective }},
+		Breakdown{children = { args.objective }},
 		Customizable{id = 'custom', children = {}},
 		Center{content = {args.footnotes}},
 	}

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -75,7 +75,7 @@ function UnofficialWorldChampion:createInfobox()
 					builder = function()
 						return Array.map(
 							self:getAllArgsForBase(args, 'most defences against '),
-							function (value) return Breakdown{content = {value}} end
+							function (value) return Breakdown{children = {value}} end
 						)
 					end
 				},

--- a/components/infobox/extensions/wikis/warcraft/infobox_extension_building_unit_shared.lua
+++ b/components/infobox/extensions/wikis/warcraft/infobox_extension_building_unit_shared.lua
@@ -144,7 +144,7 @@ function CustomBuildingUnit.attackDisplay(args)
 		if Array.all(data, Logic.isEmpty) then
 			return nil
 		end
-		return BreakDown{contentClasses = {content1 = {'infobox-description'}}, content = {desc, unpack(data)}}
+		return BreakDown{contentClasses = {content1 = {'infobox-description'}}, children = {desc, unpack(data)}}
 	end
 
 	return Array.append({Title{name = 'Combat'}},

--- a/components/infobox/wikis/leagueoflegends/infobox_unit_champion_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_unit_champion_custom.lua
@@ -71,7 +71,7 @@ function CustomInjector:parse(id, widgets)
 			toBreakDownCell('secondaryrole', 'Secondary Role', 'ClassIcon')
 		)
 		return {
-			Breakdown{classes = {'infobox-center'}, content = breakDownContents},
+			Breakdown{classes = {'infobox-center'}, children = breakDownContents},
 			Cell{name = 'Real Name', content = {args.realname}},
 		}
 	elseif id == 'cost' then

--- a/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_item_custom.lua
@@ -59,7 +59,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'header' then
 		if String.isNotEmpty(args.itemcost) then
 			table.insert(widgets, Breakdown{
-				content = caller:_getCostDisplay(),
+				children = caller:_getCostDisplay(),
 				classes = {
 					'infobox-header',
 					'wiki-backgroundcolor-light',

--- a/components/infobox/wikis/mobilelegends/infobox_unit_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_unit_hero_custom.lua
@@ -69,7 +69,7 @@ function CustomInjector:parse(id, widgets)
 			toBreakDownCell('secondaryrole', 'Secondary Role')
 		)
 		return {
-			Breakdown{classes = {'infobox-center'}, content = breakDownContents},
+			Breakdown{classes = {'infobox-center'}, children = breakDownContents},
 		}
 	elseif id == 'cost' then
 		local cost = Array.append({},

--- a/components/infobox/wikis/overwatch/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/overwatch/infobox_unofficial_world_champion_custom.lua
@@ -47,7 +47,7 @@ function CustomInjector:parse(id, widgets)
 		for regionKey, region in Table.iter.pairsByPrefix(args, 'region') do
 			Array.appendWith(widgets,
 				Cell{name = (args[regionKey .. ' no'] or '') .. ' champions', content = {region}},
-				Breakdown{content = {args[regionKey .. ' champions']}}
+				Breakdown{children = {args[regionKey .. ' champions']}}
 			)
 		end
 	end

--- a/components/infobox/wikis/smite/infobox_unit_god_custom.lua
+++ b/components/infobox/wikis/smite/infobox_unit_god_custom.lua
@@ -72,7 +72,7 @@ function CustomInjector:parse(id, widgets)
 				toBreakDownCell('powertype', 'Power Type', 'PowerTypeIcon')
 			)
 		return {
-			Breakdown{classes = {'infobox-center'}, content = breakDownContents},
+			Breakdown{classes = {'infobox-center'}, children = breakDownContents},
 			Cell{name = 'Real Name', content = {args.realname}},
 		}
 	elseif id == 'cost' then

--- a/components/infobox/wikis/starcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_league_custom.lua
@@ -155,7 +155,7 @@ function CustomInjector:parse(id, widgets)
 				Title{name = 'Participants'},
 				Cell{name = 'Number of Players', content = {self.caller.data.raceBreakDown.total}},
 				Cell{name = 'Number of Teams', content = {args.team_number}},
-				Breakdown{content = self.caller.data.raceBreakDown.display or {}, classes = { 'infobox-center' }}
+				Breakdown{children = self.caller.data.raceBreakDown.display or {}, classes = { 'infobox-center' }}
 			)
 		end
 

--- a/components/infobox/wikis/starcraft/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_team_custom.lua
@@ -89,7 +89,7 @@ function CustomInjector:parse(id, widgets)
 			Array.appendWith(widgets,
 				Title{name = 'Player Breakdown'},
 				Cell{name = 'Number of Players', content = {raceBreakdown.total}},
-				Breakdown{content = raceBreakdown.display, classes = { 'infobox-center' }}
+				Breakdown{children = raceBreakdown.display, classes = { 'infobox-center' }}
 			)
 		end
 	elseif id == 'history' then

--- a/components/infobox/wikis/starcraft2/infobox_league_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_league_custom.lua
@@ -179,7 +179,7 @@ function CustomInjector:parse(id, widgets)
 				Title{name = 'Participants'},
 				Cell{name = 'Number of Players', content = {args.raceBreakDown.total}},
 				Cell{name = 'Number of Teams', content = {args.team_number}},
-				Breakdown{content = args.raceBreakDown.display or {}, classes = { 'infobox-center' }}
+				Breakdown{children = args.raceBreakDown.display or {}, classes = { 'infobox-center' }}
 			)
 		end
 

--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -94,7 +94,7 @@ function CustomInjector:parse(id, widgets)
 			Array.appendWith(widgets,
 				Title{name = 'Player Breakdown'},
 				Cell{name = 'Number of Players', content = {raceBreakdown.total}},
-				Breakdown{content = raceBreakdown.display, classes = {'infobox-center'}}
+				Breakdown{children = raceBreakdown.display, classes = {'infobox-center'}}
 			)
 		end
 

--- a/components/infobox/wikis/starcraft2/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_unofficial_world_champion_custom.lua
@@ -58,7 +58,7 @@ function CustomInjector:parse(id, widgets)
 		Array.extendWith(widgets,
 			{
 				raceBreakdown and Title{name = 'Racial Distribution of Champions'} or nil,
-				raceBreakdown and Breakdown{content = raceBreakdown.display, classes = { 'infobox-center' }} or nil,
+				raceBreakdown and Breakdown{children = raceBreakdown.display, classes = { 'infobox-center' }} or nil,
 			},
 			self.caller:_buildCellsFromBase('countries with multiple champions', 'Countries with Multiple Champions'),
 			self.caller:_buildCellsFromBase('teams with multiple champions', 'Teams with Multiple Champions')

--- a/components/infobox/wikis/stormgate/infobox_league_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_league_custom.lua
@@ -107,7 +107,7 @@ function CustomInjector:parse(id, widgets)
 			Array.appendWith(widgets,
 				Title{name = 'Player Breakdown'},
 				Cell{name = 'Number of Players', content = {args.raceBreakDown.total}},
-				Breakdown{content = args.raceBreakDown.display, classes = { 'infobox-center' }}
+				Breakdown{children = args.raceBreakDown.display, classes = { 'infobox-center' }}
 			)
 		end
 

--- a/components/infobox/wikis/stormgate/infobox_team_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_team_custom.lua
@@ -60,7 +60,7 @@ function CustomInjector:parse(id, widgets)
 			Array.appendWith(widgets,
 				Title{name = 'Player Breakdown'},
 				Cell{name = 'Number of Players', content = {raceBreakdown.total}},
-				Breakdown{content = raceBreakdown.display, classes = { 'infobox-center' }}
+				Breakdown{children = raceBreakdown.display, classes = { 'infobox-center' }}
 			)
 		end
 

--- a/components/infobox/wikis/warcraft/infobox_character_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_character_custom.lua
@@ -73,12 +73,12 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return Array.append(widgets,
 			Title{name = 'Attributes'},
-			BreakDown{content = {
+			BreakDown{children = {
 				self.caller:_basicAttribute('str'),
 				self.caller:_basicAttribute('agi'),
 				self.caller:_basicAttribute('int'),
 			}, classes = {'infobox-center'}},
-			BreakDown{content = {
+			BreakDown{children = {
 				self.caller:_getDamageAttribute(),
 				self.caller:_getArmorAttribute(),
 				self.caller:_getPrimaryAttribute(),
@@ -97,7 +97,7 @@ function CustomInjector:parse(id, widgets)
 			args.icon and Title{name = 'Icon'} or nil,
 			Center{content = {self.caller:_displayIcon()}},
 			Title{name = 'Level Changes'},
-			BreakDown{content = {'[[Experience|Level]]:', 1, 5, 10}, contentClasses = LEVEL_CHANGE_CLASSES},
+			BreakDown{children = {'[[Experience|Level]]:', 1, 5, 10}, contentClasses = LEVEL_CHANGE_CLASSES},
 			BreakDown(CustomCharacter._toLevelChangesRow(
 				function(gainFactor) return self.caller:_calculateHitPoints(gainFactor) end, '[[Hit Points]]:')),
 			BreakDown(CustomCharacter._toLevelChangesRow(function(gainFactor)
@@ -345,7 +345,7 @@ end
 ---@param title string
 ---@return {content: table, contentClasses: table}}
 function CustomCharacter._toLevelChangesRow(funct, title)
-	return {content = {title, funct(0), funct(4), funct(9)}, contentClasses = LEVEL_CHANGE_CLASSES}
+	return {children = {title, funct(0), funct(4), funct(9)}, contentClasses = LEVEL_CHANGE_CLASSES}
 end
 
 return CustomCharacter

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -272,7 +272,7 @@ function CustomInjector:parse(id, widgets)
 		if playerNumber then
 			Array.appendWith(widgets,
 				Cell{name = 'Number of Players', content = {playerNumber}},
-				Breakdown{content = caller.data.raceBreakDown.display or {}, classes = { 'infobox-center' }}
+				Breakdown{children = caller.data.raceBreakDown.display or {}, classes = { 'infobox-center' }}
 			)
 		end
 

--- a/components/infobox/wikis/wildrift/infobox_item_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_item_custom.lua
@@ -59,7 +59,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'header' then
 		if String.isNotEmpty(args.itemcost) then
 			table.insert(widgets, Breakdown{
-				content = caller:_getCostDisplay(),
+				children = caller:_getCostDisplay(),
 				classes = {
 					'infobox-header',
 					'wiki-backgroundcolor-light',
@@ -78,7 +78,7 @@ function CustomInjector:parse(id, widgets)
 		if not CustomItem._hasAttributes(args) then return {} end
 
 		if not (String.isEmpty(args.str) and String.isEmpty(args.agi) and String.isEmpty(args.int)) then
-			table.insert(widgets, Breakdown{classes = {'infobox-center'}, content = {
+			table.insert(widgets, Breakdown{classes = {'infobox-center'}, children = {
 				caller:_attributeIcons('str'),
 				caller:_attributeIcons('agi'),
 				caller:_attributeIcons('int'),

--- a/components/infobox/wikis/wildrift/infobox_unit_champion_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_unit_champion_custom.lua
@@ -70,7 +70,7 @@ function CustomInjector:parse(id, widgets)
 			toBreakDownCell('secondaryrole', 'Secondary Role', 'ClassIcon')
 		)
 		return {
-			Breakdown{classes = {'infobox-center'}, content = breakDownContents},
+			Breakdown{classes = {'infobox-center'}, children = breakDownContents},
 			Cell{name = 'Real Name', content = {args.realname}},
 		}
 	elseif id == 'cost' then

--- a/components/widget/widget_breakdown.lua
+++ b/components/widget/widget_breakdown.lua
@@ -18,7 +18,6 @@ local Widget = Lua.import('Module:Widget')
 local Breakdown = Class.new(
 	Widget,
 	function(self, input)
-		self.children = input.children or input.content
 		self.classes = input.classes
 		self.contentClasses = input.contentClasses or {}
 	end


### PR DESCRIPTION
## Summary
Migrate legacy inputs for children to children. 
This PR is for the Breakdown Widget.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
