### PR TITLE
feat(infobox): Update Eastern Naming Country Order List

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -46,6 +46,8 @@ local COUNTRIES_EASTERN_NAME_ORDER = {
 	'Vietnam',
 	'South Korea',
 	'Cambodia'
+	'Macau'
+	'Singapore'
 }
 
 ---@enum PlayerStatus

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -45,9 +45,9 @@ local COUNTRIES_EASTERN_NAME_ORDER = {
 	'Hong Kong',
 	'Vietnam',
 	'South Korea',
-	'Cambodia'
-	'Macau'
-	'Singapore'
+	'Cambodia',
+	'Macau',
+	'Singapore',
 }
 
 ---@enum PlayerStatus


### PR DESCRIPTION
Adding in Macau and Singapore to follow the eastern naming order. Macau seemed to be missed and should commonly use eastern order. Singapore is often a mix, but since we don't allow for a swap from western to eastern with nonameflip=true, might be handier to default singapore to eastern as well

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
