### PR TITLE
feat(widget): simplify injector handling

### DIFF
--- a/components/infobox/commons/infobox_basic.lua
+++ b/components/infobox/commons/infobox_basic.lua
@@ -102,13 +102,13 @@ end
 ---@param widgets Widget[]
 ---@return string
 function BasicInfobox:build(widgets)
-	return Infobox{
+	return tostring(Infobox{
 		gameName = self.wiki,
 		forceDarkMode = Logic.readBool(self.args.darkmodeforced),
 		bottomContent = self.bottomContent,
 		warnings = self.warnings,
 		children = widgets,
-	}:tryMake(self.injector) or ''
+	})
 end
 
 return BasicInfobox

--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -19,7 +19,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class BuildingInfobox: BasicInfobox
 local Building = Class.new(BasicInfobox)
@@ -36,6 +36,7 @@ end
 ---@return string
 function Building:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_campaign_mission.lua
+++ b/components/infobox/commons/infobox_campaign_mission.lua
@@ -16,8 +16,8 @@ local Widgets = require('Module:Widget/All')
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Breakdown = Widgets.Breakdown
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class CampaignMissionInfobox: BasicInfobox
 local Mission = Class.new(BasicInfobox)
@@ -33,6 +33,7 @@ end
 ---@return string
 function Mission:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Customizable{id = 'header', children = {

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -19,7 +19,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class CharacterInfobox: BasicInfobox
 local Character = Class.new(BasicInfobox)
@@ -34,6 +34,7 @@ end
 ---@return string
 function Character:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_company.lua
+++ b/components/infobox/commons/infobox_company.lua
@@ -22,8 +22,8 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 local Language = mw.getContentLanguage()
 
@@ -42,6 +42,7 @@ end
 ---@return string
 function Company:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_cosmetic.lua
+++ b/components/infobox/commons/infobox_cosmetic.lua
@@ -16,7 +16,7 @@ local BasicInfobox = Lua.import('Module:Infobox/Basic')
 local Widgets = require('Module:Widget/All')
 local Header = Widgets.Header
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class CosmeticInfobox: BasicInfobox
 local Cosmetic = Class.new(BasicInfobox)
@@ -24,6 +24,7 @@ local Cosmetic = Class.new(BasicInfobox)
 ---@return string
 function Cosmetic:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 	self:customParseArguments(args)
 
 	local widgets = {

--- a/components/infobox/commons/infobox_game.lua
+++ b/components/infobox/commons/infobox_game.lua
@@ -20,8 +20,8 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class GameInfobox: BasicInfobox
 local Game = Class.new(BasicInfobox)
@@ -37,6 +37,7 @@ end
 function Game:createInfobox()
 	local args = self.args
 	local links = Links.transform(args)
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_item.lua
+++ b/components/infobox/commons/infobox_item.lua
@@ -17,7 +17,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class ItemInfobox: BasicInfobox
 local Item = Class.new(BasicInfobox)
@@ -32,6 +32,7 @@ end
 ---@return string
 function Item:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Customizable{

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -39,9 +39,9 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local CustomizableFactory = require('Module:Widget/Customizable/Factory')
 local Builder = Widgets.Builder
 local Chronology = Widgets.Chronology
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class InfoboxLeague: BasicInfobox
 local League = Class.new(BasicInfobox)
@@ -55,7 +55,7 @@ end
 
 ---@return Html
 function League:createInfobox()
-	local Customizable = CustomizableFactory.createCustomizable(self.infobox.injector)
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 	local args = self.args
 	self:_parseArgs()
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -39,7 +39,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = require('Module:Widget/Customizable/Factory')
 local Builder = Widgets.Builder
 local Chronology = Widgets.Chronology
 
@@ -55,6 +55,7 @@ end
 
 ---@return Html
 function League:createInfobox()
+	local Customizable = CustomizableFactory.createCustomizable(self.infobox.injector)
 	local args = self.args
 	self:_parseArgs()
 

--- a/components/infobox/commons/infobox_lore.lua
+++ b/components/infobox/commons/infobox_lore.lua
@@ -16,7 +16,7 @@ local BasicInfobox = Lua.import('Module:Infobox/Basic')
 local Widgets = require('Module:Widget/All')
 local Header = Widgets.Header
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class LoreInfobox: BasicInfobox
 local Cosmetic = Class.new(BasicInfobox)
@@ -25,6 +25,7 @@ local Cosmetic = Class.new(BasicInfobox)
 function Cosmetic:createInfobox()
 	local args = self.args
 	self:customParseArguments(args)
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Customizable{

--- a/components/infobox/commons/infobox_manufacturer.lua
+++ b/components/infobox/commons/infobox_manufacturer.lua
@@ -19,8 +19,8 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class ManufacturerInfobox: BasicInfobox
 local Manufacturer = Class.new(BasicInfobox)
@@ -28,6 +28,7 @@ local Manufacturer = Class.new(BasicInfobox)
 ---@return string
 function Manufacturer:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Customizable{

--- a/components/infobox/commons/infobox_map.lua
+++ b/components/infobox/commons/infobox_map.lua
@@ -20,7 +20,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class MapInfobox:BasicInfobox
 local Map = Class.new(BasicInfobox)
@@ -36,6 +36,7 @@ end
 ---@return string
 function Map:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	self:_readCreators()
 

--- a/components/infobox/commons/infobox_patch.lua
+++ b/components/infobox/commons/infobox_patch.lua
@@ -23,8 +23,8 @@ local Title = Widgets.Title
 local Center = Widgets.Center
 local Chronology = Widgets.Chronology
 local Builder = Widgets.Builder
-local Customizable = Widgets.Customizable
 local Highlights = Widgets.Highlights
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class PatchInfobox: BasicInfobox
 local Patch = Class.new(BasicInfobox)
@@ -39,6 +39,7 @@ end
 ---@return string
 function Patch:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -31,7 +31,7 @@ local Title = Widgets.Title
 local Cell = Widgets.Cell
 local Center = Widgets.Center
 local Builder = Widgets.Builder
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class Person: BasicInfobox
 ---@field locations string[]
@@ -79,6 +79,7 @@ end
 ---@return string
 function Person:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	self.locations = self:getLocations()
 

--- a/components/infobox/commons/infobox_scene.lua
+++ b/components/infobox/commons/infobox_scene.lua
@@ -21,8 +21,8 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class SceneInfobox: BasicInfobox
 local Scene = Class.new(BasicInfobox)
@@ -37,6 +37,7 @@ end
 ---@return string
 function Scene:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_series.lua
+++ b/components/infobox/commons/infobox_series.lua
@@ -32,8 +32,8 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class SeriesInfobox: BasicInfobox
 local Series = Class.new(BasicInfobox)
@@ -48,6 +48,7 @@ end
 ---@return string
 function Series:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	-- define this here so we can use it in lpdb data and the display
 	local links = Links.transform(args)

--- a/components/infobox/commons/infobox_show.lua
+++ b/components/infobox/commons/infobox_show.lua
@@ -20,8 +20,8 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class ShowInfobox: BasicInfobox
 local Show = Class.new(BasicInfobox)
@@ -37,6 +37,7 @@ end
 ---@return string
 function Show:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_skill.lua
+++ b/components/infobox/commons/infobox_skill.lua
@@ -22,7 +22,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class SkillInfobox: BasicInfobox
 local Skill = Class.new(BasicInfobox)
@@ -37,6 +37,7 @@ end
 ---@return string
 function Skill:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	if String.isEmpty(args.informationType) then
 		error('You need to specify an informationType, e.g. "Spell", "Ability, ...')

--- a/components/infobox/commons/infobox_strategy.lua
+++ b/components/infobox/commons/infobox_strategy.lua
@@ -18,7 +18,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class StrategyInfobox: BasicInfobox
 local Strategy = Class.new(BasicInfobox)
@@ -33,6 +33,7 @@ end
 ---@return string
 function Strategy:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	if String.isEmpty(args.informationType) then
 		error('You need to specify an informationType, e.g. "Strategy", "Technique, ...')

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -35,8 +35,8 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class InfoboxTeam : BasicInfobox
 local Team = Class.new(BasicInfobox)
@@ -63,6 +63,7 @@ end
 ---@return string
 function Team:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	--- Transform data
 	-- Links

--- a/components/infobox/commons/infobox_unit.lua
+++ b/components/infobox/commons/infobox_unit.lua
@@ -19,7 +19,7 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class UnitInfobox: BasicInfobox
 local Unit = Class.new(BasicInfobox)
@@ -34,6 +34,7 @@ end
 ---@return string
 function Unit:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Customizable{

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -18,9 +18,9 @@ local Cell = Widgets.Cell
 local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
-local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
 local Breakdown = Widgets.Breakdown
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class UnofficialWorldChampionInfobox: BasicInfobox
 local UnofficialWorldChampion = Class.new(BasicInfobox)
@@ -35,6 +35,7 @@ end
 ---@return string
 function UnofficialWorldChampion:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_weapon.lua
+++ b/components/infobox/commons/infobox_weapon.lua
@@ -20,7 +20,7 @@ local Header = Widgets.Header
 local Title = Widgets.Title
 local Center = Widgets.Center
 local Builder = Widgets.Builder
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class WeaponInfobox: BasicInfobox
 local Weapon = Class.new(BasicInfobox)
@@ -35,6 +35,7 @@ end
 ---@return string
 function Weapon:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/infobox/commons/infobox_website.lua
+++ b/components/infobox/commons/infobox_website.lua
@@ -19,7 +19,7 @@ local Title = Widgets.Title
 local Cell = Widgets.Cell
 local Center = Widgets.Center
 local Builder = Widgets.Builder
-local Customizable = Widgets.Customizable
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class WebsiteInfobox: BasicInfobox
 local Website = Class.new(BasicInfobox)
@@ -34,6 +34,7 @@ end
 ---@return string
 function Website:createInfobox()
 	local args = self.args
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
 
 	local widgets = {
 		Header{

--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -608,7 +608,7 @@ function BasePrizePool:_buildTable(isAward)
 	end
 
 	local tableNode = mw.html.create('div'):css('overflow-x', 'auto')
-	tableNode:node(tbl:tryMake(self._widgetInjector))
+	tableNode:node(tostring(tbl))
 
 	return tableNode
 end

--- a/components/squad/commons/squad.lua
+++ b/components/squad/commons/squad.lua
@@ -105,12 +105,11 @@ end
 
 ---@return string
 function Squad:create()
-	local dataTable = Widget.TableNew{
+	return tostring(Widget.TableNew{
 		css = {['margin-bottom'] = '10px'},
 		classes = {'wikitable-striped', 'roster-card'},
 		children = self.rows,
-	}
-	return dataTable:tryMake(self.injector) or ''
+	})
 end
 
 return Squad

--- a/components/squad/commons/squad.lua
+++ b/components/squad/commons/squad.lua
@@ -15,6 +15,7 @@ local String = require('Module:StringUtils')
 
 local SquadUtils = Lua.import('Module:Squad/Utils')
 local Widget = Lua.import('Module:Widget/All')
+local CustomizableFactory = Lua.import('Module:Widget/Customizable/Factory')
 
 ---@class Squad
 ---@operator call:Squad
@@ -66,6 +67,8 @@ end
 
 ---@return self
 function Squad:header()
+	local Customizable = CustomizableFactory.createCustomizable(self.injector)
+
 	local isInactive = self.type == SquadUtils.SquadType.INACTIVE or self.type == SquadUtils.SquadType.FORMER_INACTIVE
 	local isFormer = self.type == SquadUtils.SquadType.FORMER or self.type == SquadUtils.SquadType.FORMER_INACTIVE
 	table.insert(self.rows, Widget.TableRowNew{
@@ -73,17 +76,17 @@ function Squad:header()
 		children = Array.append({},
 			Widget.TableCellNew{content = {'ID'}, header = true},
 			Widget.TableCellNew{header = true}, -- "Team Icon" (most commmonly used for loans)
-			Widget.Customizable{id = 'header_name',
+			Customizable{id = 'header_name',
 				children = {Widget.TableCellNew{content = {'Name'}, header = true}}
 			},
-			Widget.Customizable{id = 'header_role',
+			Customizable{id = 'header_role',
 				children = {Widget.TableCellNew{header = true}}
 			},
 			Widget.TableCellNew{content = {'Join Date'}, header = true},
-			isInactive and Widget.Customizable{id = 'header_inactive', children = {
+			isInactive and Customizable{id = 'header_inactive', children = {
 				Widget.TableCellNew{content = {'Inactive Date'}, header = true},
 			}} or nil,
-			isFormer and Widget.Customizable{id = 'header_former', children = {
+			isFormer and Customizable{id = 'header_former', children = {
 				Widget.TableCellNew{content = {'Leave Date'}, header = true},
 				Widget.TableCellNew{content = {'New Team'}, header = true},
 			}} or nil

--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -47,10 +47,6 @@ function Widget:tryMake()
 	)
 end
 
-function Widget:__tostring()
-	return self:tryMake()
-end
-
 ---@return string
 function Widget:__tostring()
 	return self:tryMake() or ''

--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local ErrorDisplay = require('Module:Error/Display')
 local Logic = require('Module:Logic')
@@ -37,8 +38,9 @@ end
 
 ---@return string|nil
 function Widget:tryMake()
+	local children = Array.map(self.children, tostring) -- Backwards compatibility
 	return Logic.tryOrElseLog(
-		function() return self:make(self.children) end,
+		function() return self:make(children) end,
 		function(error) return tostring(ErrorDisplay.InlineError(error)) end,
 		function(error)
 			error.header = 'Error occured in widget: (caught by Widget:tryMake)'

--- a/components/widget/widget_all.lua
+++ b/components/widget/widget_all.lua
@@ -12,7 +12,6 @@ local Lua = require('Module:Lua')
 
 --- Core Widgets
 Widgets.Builder = Lua.import('Module:Widget/Builder')
-Widgets.Customizable = Lua.import('Module:Widget/Customizable')
 
 --- Infobox Widgets
 Widgets.Breakdown = Lua.import('Module:Widget/Breakdown')

--- a/components/widget/widget_builder.lua
+++ b/components/widget/widget_builder.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
@@ -24,13 +25,7 @@ local Builder = Class.new(
 ---@param children string[]
 ---@return string
 function Builder:make(children)
-	return table.concat(children)
-end
-
----@param injector WidgetInjector?
----@return Widget[]?
-function Builder:makeChildren(injector)
-	return self.builder()
+	return table.concat(Array.map(self.builder(), tostring))
 end
 
 return Builder

--- a/components/widget/widget_customizable.lua
+++ b/components/widget/widget_customizable.lua
@@ -6,34 +6,32 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
 
 ---@class CustomizableWidget: Widget
----@operator call({id: string, children: Widget[]}): CustomizableWidget
+---@operator call({id: string, children: Widget[], injector:WidgetInjector?}): CustomizableWidget
 ---@field id string
+---@field children Widget[]
+---@field injector WidgetInjector?
 local Customizable = Class.new(
 	Widget,
 	function(self, input)
 		self.id = self:assertExistsAndCopy(input.id)
+		self.injector = input.injector
 	end
 )
 
----@param children string[]
 ---@return string
-function Customizable:make(children)
-	return table.concat(children)
-end
-
----@param injector WidgetInjector?
----@return Widget[]?
-function Customizable:makeChildren(injector)
-	if injector == nil then
-		return self.children
+function Customizable:make()
+	local children = self.children
+	if self.injector ~= nil then
+		children = self.injector:parse(self.id, children) or {}
 	end
-	return injector:parse(self.id, self.children)
+	return table.concat(Array.map(children, tostring))
 end
 
 return Customizable

--- a/components/widget/widget_customizable_factory.lua
+++ b/components/widget/widget_customizable_factory.lua
@@ -1,0 +1,27 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Customizable/Factory
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Customizable = Lua.import('Module:Widget/Customizable')
+
+local CustomizableFactory = {}
+
+---@param injector WidgetInjector?
+---@return fun(props: {id: string, children: Widget[]}): CustomizableWidget
+function CustomizableFactory.createCustomizable(injector)
+	return function(props)
+		return Customizable{
+			id = props.id,
+			children = props.children,
+			injector = injector,
+		}
+	end
+end
+
+return CustomizableFactory


### PR DESCRIPTION
## Summary
Customizable complicates things a lot by having the injector needed to be passed around.

Here's an idea of how it can be significantly simplified. Also simplifies the children handling for widgets a lot (no longer needs to be pass through make()).

Primary changes are in the Widget folder. The rest are just changes of the usage of customizable.

Added bonus is that Builder and injector:parse() can return non-widgets if wanted.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
