### PR TITLE
Update match_summary.lua

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -105,21 +105,35 @@ function CustomMatchSummary.createBody(match)
 			DisplayHelper.MatchCountdownBlock(match)
 		))
 	end
-
-	if BigMatch.isEnabledFor(match) then
-		local matchPageElement = mw.html.create('center')
-		matchPageElement:wikitext('[[Match:ID_' .. match.matchId .. '|Match Page]]')
-						:css('display', 'block')
-						:css('margin', 'auto')
-		body:addRow(MatchSummary.Row():css('font-size', '85%'):addElement(matchPageElement):addClass('brkts-popup-mvp'))
-	end
-
+	
 	-- Iterate each map
 	for gameIndex, game in ipairs(match.games) do
 		local rowDisplay = CustomMatchSummary._createGame(game, gameIndex, match.date)
 		body:addRow(rowDisplay)
 	end
-
+	
+	-- Add Match Page link
+	if BigMatch.isEnabledFor(match) then
+		local matchPageElement = mw.html.create('center')
+		matchPageElement:wikitext('[[Match:ID_' .. match.matchId .. '|')
+						:css('display', 'block')
+						:css('margin', 'auto')
+						:tag('span')
+							:addClass('fa-stack')
+							:css('font-size','10px')
+							:css('vertical-align','text-bottom')
+							:tag('i')
+								:addClass('fad fa-file fa-stack-2x')
+								:done()
+							:tag('i')
+								:addClass('fas fa-info fa-stack-1x')
+								:done()
+							:done()
+						:wikitext('MATCH PAGE')
+						:wikitext(']]')
+		body:addRow(MatchSummary.Row():css('font-size', '14px'):css('font-weight','600'):css('line-height','2em'):addElement(matchPageElement))
+	end
+	
 	-- Add Match MVP(s)
 	if match.extradata.mvp then
 		local mvpData = match.extradata.mvp


### PR DESCRIPTION
Trying to make the Match Page link more visible but also less intrusive in the match card layout. instead of having it look like a potential header for the match hopefully it's now more obvious that it is a link.

## Summary
Old branch from @salle that never was made into a PR, is it still relevant?

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
