### PR TITLE
fix(match2): misisng empty check in legacy storage

### DIFF
--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -87,8 +87,10 @@ function MatchLegacy.storeGames(match, match2)
 		for teamId, opponent in ipairs(opponents) do
 			local counter = 0
 			for _, player in pairs(opponent.players)  do
-				counter = counter + 1
-				addPlayer(teamId, counter, player)
+				if Logic.isNotEmpty(player) then
+					counter = counter + 1
+					addPlayer(teamId, counter, player)
+				end
 			end
 		end
 		-- Other stuff


### PR DESCRIPTION
## Summary
`opponent.players` sometimes contains empty tables, this PR accounts for that when looping through them for legacy storage

## How did you test this change?
live