### PR TITLE
fix(opponent): Missing alias for faction in solo opponents on wc3

### DIFF
--- a/components/opponent/wikis/warcraft/opponent_custom.lua
+++ b/components/opponent/wikis/warcraft/opponent_custom.lua
@@ -37,7 +37,7 @@ function CustomOpponent.readOpponentArgs(args)
 	end
 
 	if partySize == 1 then
-		opponent.players[1].faction = Faction.read(args.faction or args.race)
+		opponent.players[1].faction = Faction.read(args.faction or args.race or args.p1race)
 	elseif partySize then
 		for playerIx, player in ipairs(opponent.players) do
 			player.faction = Faction.read(args['p' .. playerIx .. 'faction'] or args['p' .. playerIx .. 'race'])


### PR DESCRIPTION
## Summary
Due to it being used widely in match2 and some other places re-add the `p1race` alias for faction in solo opponnets.

## How did you test this change?
live