### PR TITLE
feat: support widgets as nodes in mw.html

### DIFF
--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -78,4 +78,10 @@ function Widget:__tostring()
 	return self:tryMake() or ''
 end
 
+--- Here to allow for Widget to be used as a node in the third part html library (mw.html).
+---@param ret string[]
+function Widget:_build(ret)
+	table.insert(ret, self:__tostring())
+end
+
 return Widget


### PR DESCRIPTION
## Summary
With this little one tweak, adding a Widget to a mw.html's node will no longer kill everything. Rather it should work quite smoothly

## How did you test this change?
Without _build
<img width="585" alt="image" src="https://github.com/user-attachments/assets/f335e47a-56f4-4f7d-9a58-28a071a7a188">

With _build
<img width="368" alt="image" src="https://github.com/user-attachments/assets/c2416905-0370-46f7-8e36-fe866582bb32">
