### PR TITLE
chore(match2): prep for requested wiki var name change

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -124,6 +124,7 @@ end
 function MatchFunctions.readDate(dateInput)
 	local dateProps = MatchGroupInputUtil.readDate(dateInput, {
 		'matchDate',
+		'match_date',
 		'tournament_startdate',
 		'tournament_enddate',
 	})

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -130,6 +130,7 @@ function MatchFunctions.readDate(dateInput)
 	})
 	if dateProps.dateexact then
 		Variables.varDefine('matchDate', dateProps.date)
+		Variables.varDefine('match_date', dateProps.date)
 	end
 	return dateProps
 end

--- a/components/match2/wikis/stormgate/match_group_input_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_input_custom.lua
@@ -116,12 +116,14 @@ end
 function MatchFunctions.readDate(matchArgs)
 	local dateProps = MatchGroupInputUtil.readDate(matchArgs.date, {
 		'matchDate',
+		'match_date',
 		'tournament_startdate',
 		'tournament_enddate'
 	})
 
 	if dateProps.dateexact then
 		Variables.varDefine('matchDate', dateProps.date)
+		Variables.varDefine('match_date', dateProps.date)
 	end
 
 	return dateProps

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -130,11 +130,13 @@ function MatchFunctions.readDate(matchArgs)
 			matchArgs.date and dateProps.dateexact or false
 		)
 		Variables.varDefine('matchDate', dateProps.date)
+		Variables.varDefine('match_date', dateProps.date)
 		return dateProps
 	end
 
 	return MatchGroupInputUtil.readDate(nil, {
 		'matchDate',
+		'match_date',
 		'tournament_startdate',
 		'tournament_enddate',
 	})


### PR DESCRIPTION
## Summary
enable reading from current and intended wiki var

## Next steps (after merge)
- adjust other templates & modules on warcraft, stormgate broodwar and sc2 accordingly
- adjust usage of the wiki var on content pages
- open a pr to remove the currently used one

## How did you test this change?
N/A