### PR TITLE
feat(match2): Create GeoGuessr support

### DIFF
--- a/components/match2/wikis/geoguessr/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/geoguessr/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,48 @@
+---
+-- @Liquipedia
+-- wiki=geoguessr
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class GeoGuessrMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.readBool(args.score)
+	local streams = Logic.readBool(args.streams)
+
+	local lines = Array.extend({},
+		'{{Match',
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
+		end),
+		INDENT .. '|date= |finished=',
+		streams and (INDENT .. '|twitch=|vod=') or nil,
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=}}'
+		end),
+		'}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/geoguessr/match_group_input_custom.lua
+++ b/components/match2/wikis/geoguessr/match_group_input_custom.lua
@@ -1,0 +1,151 @@
+---
+-- @Liquipedia
+-- wiki=geoguessr
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local FnUtil = require('Module:FnUtil')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
+local Streams = require('Module:Links/Stream')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
+
+local DEFAULT_MODE = '1v1'
+
+-- containers for process helper functions
+local MatchFunctions = {}
+local MapFunctions = {}
+
+local CustomMatchGroupInput = {}
+
+---@param match table
+---@param options table?
+---@return table
+function CustomMatchGroupInput.processMatch(match, options)
+	local finishedInput = match.finished --[[@as string?]]
+	local winnerInput = match.winner --[[@as string?]]
+
+	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
+
+	local opponents = Array.mapIndexes(function(opponentIndex)
+		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
+	end)
+	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
+	match.bestof = MatchGroupInputUtil.getBestOf(match.bestof, games)
+
+	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
+		and MatchFunctions.calculateMatchScore(games)
+		or nil
+
+	Array.forEach(opponents, function(opponent, opponentIndex)
+		opponent.score, opponent.status = MatchGroupInputUtil.computeOpponentScore({
+			walkover = match.walkover,
+			winner = match.winner,
+			opponentIndex = opponentIndex,
+			score = opponent.score,
+		}, autoScoreFunction)
+	end)
+
+	match.finished = MatchGroupInputUtil.matchIsFinished(match, opponents)
+
+	if match.finished then
+		match.resulttype = MatchGroupInputUtil.getResultType(winnerInput, finishedInput, opponents)
+		match.walkover = MatchGroupInputUtil.getWalkover(match.resulttype, opponents)
+		match.winner = MatchGroupInputUtil.getWinner(match.resulttype, winnerInput, opponents)
+		MatchGroupInputUtil.setPlacement(opponents, match.winner, 1, 2, match.resulttype)
+	end
+
+	MatchFunctions.getTournamentVars(match)
+
+	match.stream = Streams.processStreams(match)
+	match.links = MatchFunctions.getLinks(match, games)
+	match.games = games
+	match.opponents = opponents
+
+	return match
+end
+
+---@param match table
+---@param opponentCount integer
+---@return table[]
+function CustomMatchGroupInput.extractMaps(match, opponentCount)
+	local maps = {}
+	for key, map in Table.iter.pairsByPrefix(match, 'map', {requireIndex = true}) do
+		local finishedInput = map.finished --[[@as string?]]
+		local winnerInput = map.winner --[[@as string?]]
+
+		map.extradata = MapFunctions.getExtraData(map)
+		map.finished = MatchGroupInputUtil.mapIsFinished(map)
+
+		local opponentInfo = Array.map(Array.range(1, opponentCount), function(opponentIndex)
+			local score, status = MatchGroupInputUtil.computeOpponentScore({
+				walkover = map.walkover,
+				winner = map.winner,
+				opponentIndex = opponentIndex,
+				score = map['score' .. opponentIndex],
+			})
+			return {score = score, status = status}
+		end)
+
+		map.scores = Array.map(opponentInfo, Operator.property('score'))
+		if map.finished then
+			map.resulttype = MatchGroupInputUtil.getResultType(winnerInput, finishedInput, opponentInfo)
+			map.walkover = MatchGroupInputUtil.getWalkover(map.resulttype, opponentInfo)
+			map.winner = MatchGroupInputUtil.getWinner(map.resulttype, winnerInput, opponentInfo)
+		end
+
+		table.insert(maps, map)
+		match[key] = nil
+	end
+
+	return maps
+end
+
+CustomMatchGroupInput.processMap = FnUtil.identity
+
+--
+-- match related functions
+--
+
+---@param maps table[]
+---@return fun(opponentIndex: integer): integer
+function MatchFunctions.calculateMatchScore(maps)
+	return function(opponentIndex)
+		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
+	end
+end
+
+---@param match table
+---@return table
+function MatchFunctions.getLinks(match)
+	return {}
+end
+
+---@param match table
+---@return table
+function MatchFunctions.getTournamentVars(match)
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault('tournament_mode'), DEFAULT_MODE)
+	return MatchGroupInputUtil.getCommonTournamentVars(match)
+end
+
+--
+-- map related functions
+--
+
+-- Parse extradata information
+---@param map table
+---@return table
+function MapFunctions.getExtraData(map)
+	return {
+		comment = map.comment,
+	}
+end
+
+return CustomMatchGroupInput

--- a/components/match2/wikis/geoguessr/match_group_input_custom.lua
+++ b/components/match2/wikis/geoguessr/match_group_input_custom.lua
@@ -65,7 +65,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	MatchFunctions.getTournamentVars(match)
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match, games)
 	match.games = games
 	match.opponents = opponents
 
@@ -120,12 +119,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {}
 end
 
 ---@param match table

--- a/components/match2/wikis/geoguessr/match_summary.lua
+++ b/components/match2/wikis/geoguessr/match_summary.lua
@@ -16,9 +16,6 @@ local Page = require('Module:Page')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 
-local htmlCreate = mw.html.create
-
----@enum GeoguessrMatchIcons
 local Icons = {
 	CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = 'initial'},
 	EMPTY = '[[File:NoCheck.png|link=]]',
@@ -66,7 +63,7 @@ end
 function CustomMatchSummary._gameScore(game, opponentIndex)
 	local score = game.scores[opponentIndex]
 	local scoreDisplay = DisplayHelper.MapScore(score, opponentIndex, game.resultType, game.walkover, game.winner)
-	return htmlCreate('div'):wikitext(scoreDisplay)
+	return mw.html.create('div'):wikitext(scoreDisplay)
 end
 
 ---@param game MatchGroupUtilGame

--- a/components/match2/wikis/geoguessr/match_summary.lua
+++ b/components/match2/wikis/geoguessr/match_summary.lua
@@ -1,0 +1,127 @@
+---
+-- @Liquipedia
+-- wiki=geoguessr
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
+local Icon = require('Module:Icon')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
+
+local htmlCreate = mw.html.create
+
+---@enum GeoguessrMatchIcons
+local Icons = {
+	CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = 'initial'},
+	EMPTY = '[[File:NoCheck.png|link=]]',
+}
+
+local CustomMatchSummary = {}
+
+---@param args table
+---@return Html
+function CustomMatchSummary.getByMatchId(args)
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
+end
+
+---@param match MatchGroupUtilMatch
+---@param footer MatchSummaryFooter
+---@return MatchSummaryFooter
+function CustomMatchSummary.addToFooter(match, footer)
+	return MatchSummary.addVodsToFooter(match, footer)
+end
+
+---@param match MatchGroupUtilMatch
+---@return MatchSummaryBody
+function CustomMatchSummary.createBody(match)
+	local body = MatchSummary.Body()
+
+	if not DateExt.isDefaultTimestamp(match.timestamp) then
+		-- dateIsExact means we have both date and time. Show countdown
+		-- if match is not default timestamp, we have a date, so display the date
+		body:addRow(MatchSummary.Row():addElement(
+			DisplayHelper.MatchCountdownBlock(match)
+		))
+	end
+
+	-- Iterate each map
+	Array.forEach(match.games, function(game)
+		body:addRow(CustomMatchSummary._createMapRow(game))
+	end)
+
+	return body
+end
+
+---@param game MatchGroupUtilGame
+---@param opponentIndex integer
+---@return Html
+function CustomMatchSummary._gameScore(game, opponentIndex)
+	local score = game.scores[opponentIndex]
+	local scoreDisplay = DisplayHelper.MapScore(score, opponentIndex, game.resultType, game.walkover, game.winner)
+	return htmlCreate('div'):wikitext(scoreDisplay)
+end
+
+---@param game MatchGroupUtilGame
+---@return MatchSummaryRow
+function CustomMatchSummary._createMapRow(game)
+	local row = MatchSummary.Row()
+
+	local centerNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:wikitext(Page.makeInternalLink(game.map))
+		:css('text-align', 'center')
+
+	if game.resultType == 'np' then
+		centerNode:addClass('brkts-popup-spaced-map-skip')
+	end
+
+	local leftNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 1, Icons.CHECK))
+		:node(CustomMatchSummary._gameScore(game, 1))
+		:css('width', '20%')
+
+	local rightNode = mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:node(CustomMatchSummary._gameScore(game, 2))
+		:node(CustomMatchSummary._createCheckMarkOrCross(game.winner == 2, Icons.CHECK))
+		:css('width', '20%')
+
+	row:addElement(leftNode)
+		:addElement(centerNode)
+		:addElement(rightNode)
+
+	row:addClass('brkts-popup-body-game')
+		:css('overflow', 'hidden')
+
+	-- Add Comment
+	if Logic.isNotEmpty(game.comment) then
+		row:addElement(MatchSummary.Break():create())
+		local comment = mw.html.create('div')
+			:wikitext(game.comment)
+			:css('margin', 'auto')
+		row:addElement(comment)
+	end
+
+	return row
+end
+
+---@param showIcon boolean?
+---@param icon strings?
+---@return Html
+function CustomMatchSummary._createCheckMarkOrCross(showIcon, icon)
+	return mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:css('line-height', '27px')
+		:node(showIcon and icon or Icons.EMPTY)
+end
+
+return CustomMatchSummary


### PR DESCRIPTION
## Summary
For New wiki: **GeoGuessr**

the setup is simple, this is #4333 (Team Fortress) Match2 as both version were developed at the same time,
(its also why Geo didnt had M2 pr up until now, I was waiting for TF to be merged)

Match structure for Geo is similar to TF just more Solo/Indivs than Teams and theres event with the other three types of Duos, Trios and Quads (I think theres even some FFA-style event before but eventually decide to exclude coverage for now)

## Differences vs TF setup
- The custom per map links from TF are also being removed because it's not needed here
- Stats from the Generator is removed
- Geo do had usage of all opponent type: **Team, Solo, Duo, Trio, Quad** but with both the setup and the generator all 5 works with no issue already.

-  everything else should be outright same as 4333

## How did you test this change?
LIVE