### PR TITLE
feat(ExternalMediaLinks): Add `trans_title` support to wrapper

### DIFF
--- a/components/external_media_links/external_media_link.lua
+++ b/components/external_media_links/external_media_link.lua
@@ -251,6 +251,7 @@ function ExternalMediaLink.wrapper(args)
 		language = args.language,
 		translation = args.translation,
 		translator = args.translator,
+		trans_title = args.trans_title,
 	}
 
 	if args.authors then


### PR DESCRIPTION
## Summary
feat(ExternalMediaLinks): Add `trans_title` support to wrapper as per request on discord
https://discord.com/channels/93055209017729024/268719633366777856/1288674347845812296

mind this will only adjust the module the form has to be adjusted afterwards too (on each wiki)

## How did you test this change?
not tested, just a super easy 1:1 map