### PR TITLE
feat(infobox): on stormgate, add support subfactions on buildings

### DIFF
--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -38,19 +38,14 @@ function Building:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Customizable{
-			id = 'header',
-			children = {
-				Header{
-					name = self:nameDisplay(args),
-					image = args.image,
-					imageDefault = args.default,
-					imageDark = args.imagedark or args.imagedarkmode,
-					imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-					subHeader = self:subHeaderDisplay(args),
-					size = args.imagesize,
-				},
-			}
+		Header{
+			name = self:nameDisplay(args),
+			image = args.image,
+			imageDefault = args.default,
+			imageDark = args.imagedark or args.imagedarkmode,
+			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+			subHeader = self:subHeaderDisplay(args),
+			size = args.imagesize,
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Building') .. ' Information'},

--- a/components/infobox/commons/infobox_building.lua
+++ b/components/infobox/commons/infobox_building.lua
@@ -38,13 +38,19 @@ function Building:createInfobox()
 	local args = self.args
 
 	local widgets = {
-		Header{
-			name = self:nameDisplay(args),
-			image = args.image,
-			imageDefault = args.default,
-			imageDark = args.imagedark or args.imagedarkmode,
-			imageDefaultDark = args.defaultdark or args.defaultdarkmode,
-			size = args.imagesize,
+		Customizable{
+			id = 'header',
+			children = {
+				Header{
+					name = self:nameDisplay(args),
+					image = args.image,
+					imageDefault = args.default,
+					imageDark = args.imagedark or args.imagedarkmode,
+					imageDefaultDark = args.defaultdark or args.defaultdarkmode,
+					subHeader = self:subHeaderDisplay(args),
+					size = args.imagesize,
+				},
+			}
 		},
 		Center{content = {args.caption}},
 		Title{name = (args.informationType or 'Building') .. ' Information'},
@@ -134,6 +140,13 @@ end
 
 ---@param args table
 function Building:setLpdbData(args)
+end
+
+--- Allows for overriding this functionality
+---@param args table
+---@return string?
+function Building:subHeaderDisplay(args)
+	return args.title
 end
 
 return Building

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -13,6 +13,7 @@ local Class = require('Module:Class')
 local CostDisplay = require('Module:Infobox/Extension/CostDisplay')
 local Faction = require('Module:Faction')
 local Hotkeys = require('Module:Hotkey')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
@@ -147,7 +148,9 @@ end
 ---@param args table
 ---@return string?
 function CustomBuilding:subHeaderDisplay(args)
-	if string.find(args.subfaction, '1v1') or string.find(args.subfaction, self.pagename) then return end
+	if Logic.isEmpty(args.subfaction) or
+		string.find(args.subfaction, '1v1') or
+		string.find(args.subfaction, self.pagename) then return end
 	return tostring(mw.html.create('span')
 		:css('font-size', '90%')
 		:wikitext('Hero: ' .. self:_displayCsvAsPageCsv(args.subfaction))

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -144,6 +144,16 @@ function CustomBuilding:nameDisplay(args)
 	return factionIcon .. (args.name or self.pagename)
 end
 
+---@param args table
+---@return string?
+function CustomBuilding:subHeaderDisplay(args)
+	if string.find(args.subfaction, '1v1') or string.find(args.subfaction, self.pagename) then return end
+	return tostring(mw.html.create('span')
+		:css('font-size', '90%')
+		:wikitext('Hero: ' .. self:_displayCsvAsPageCsv(args.subfaction))
+	)
+end
+
 ---@param hotkey1 string?
 ---@param hotkey2 string?
 ---@return string?
@@ -191,6 +201,7 @@ function CustomBuilding:setLpdbData(args)
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
 			deprecated = args.deprecated or '',
 			introduced = args.introduced or '',
+			subfaction = Array.parseCommaSeparatedString(args.subfaction),
 			size = tonumber(args.size),
 			sight = tonumber(args.sight),
 			luminite = tonumber(args.luminite),

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -13,6 +13,7 @@ local Class = require('Module:Class')
 local CostDisplay = require('Module:Infobox/Extension/CostDisplay')
 local Faction = require('Module:Faction')
 local Hotkeys = require('Module:Hotkey')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
@@ -155,7 +156,9 @@ end
 ---@param args table
 ---@return string?
 function CustomUnit:subHeaderDisplay(args)
-	if string.find(args.subfaction, '1v1') or string.find(args.subfaction, self.pagename) then return end
+	if Logic.isEmpty(args.subfaction) or
+		string.find(args.subfaction, '1v1') or
+		string.find(args.subfaction, self.pagename) then return end
 	return tostring(mw.html.create('span')
 		:css('font-size', '90%')
 		:wikitext('Hero: ' .. self:_displayCsvAsPageCsv(args.subfaction))


### PR DESCRIPTION
## Summary

With the latest 0.1.0 patch the first hero/subfaction-specific buildings appeared (Arkhos Arcship, Arkhos Arcstation and Arkhos Arcsfortress for hero Kastiel). Changes are identical to how Infobox/Unit is build. 

- Allow customizable header in Infobox/Building
- Add `|subfaction=` and subHeader to Infobox/Building/Custom

![grafik](https://github.com/user-attachments/assets/5138a6e4-0586-45af-b48d-690ac230aacb)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev-tools

- https://liquipedia.net/stormgate/Arkhos_Arcship
- https://liquipedia.net/commons/Module:Infobox/Building/dev/senti
- https://liquipedia.net/stormgate/Module:Infobox/Building/Custom/dev/senti

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
