### PR TITLE
fix(match2): rocketleague's non-empty-participant check does not work on party opponents

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -189,7 +189,10 @@ end
 ---@return boolean
 function MatchFunctions._checkForNonEmptyOpponent(opponent)
 	if Opponent.typeIsParty(opponent.type) then
-		return not Array.all(opponent.match2players, Opponent.playerIsTbd)
+		local playerIsTbd = function (player)
+			return String.isEmpty(player.displayname) or player.displayname:upper() == 'TBD'
+		end
+		return not Array.all(opponent.match2players, playerIsTbd)
 	end
 	-- Literal and Teams can use the default function, player's can not because of match2player vs player list names
 	return not Opponent.isTbd(opponent)

--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -191,8 +191,7 @@ end
 ---@param player standardPlayer
 ---@return boolean
 function Opponent.playerIsTbd(player)
-	local displayName = player.displayName or player.displayname
-	return String.isEmpty(displayName) or displayName:upper() == 'TBD'
+	return String.isEmpty(player.displayName) or player.displayName:upper() == 'TBD'
 end
 
 ---Checks if a provided string is an opponent type

--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -191,7 +191,8 @@ end
 ---@param player standardPlayer
 ---@return boolean
 function Opponent.playerIsTbd(player)
-	return String.isEmpty(player.displayName) or player.displayName:upper() == 'TBD'
+	local displayName = player.displayName or player.displayname
+	return String.isEmpty(displayName) or displayName:upper() == 'TBD'
 end
 
 ---Checks if a provided string is an opponent type


### PR DESCRIPTION
## Summary

Check for alternative storage names of "display name" since they are not always the same

## How did you test this change?

/dev