### PR TITLE
fix(prizepool): adjacent content data affected by size of main prize pool

### DIFF
--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -577,7 +577,7 @@ function BasePrizePool:build(isAward)
 	local tablesWrapper = mw.html.create('div'):addClass('prizepool-section-tables'):node(prizePoolTable)
 
 	if self.adjacentContent then
-		tablesWrapper:wikitext(self.adjacentContent)
+		tablesWrapper:tag('span'):wikitext(self.adjacentContent)
 	end
 
 	wrapper:node(tablesWrapper)


### PR DESCRIPTION
Added a span tag to the adjacent content so the height of the content is not determined by height of the main prize pool

## Summary
Current Adjacent Content height is affected by the height of the prize pool, as it is placed under the same tag

Before:
![before](https://github.com/user-attachments/assets/184a7b64-7e4e-41c0-b0d1-e862be1aefb0)

After:
![after](https://github.com/user-attachments/assets/326ddbe8-08ab-4ba0-8cc7-27c799ea9e3b)

## How did you test this change?

/dev in Valorant wiki
