### PR TITLE
fix(match2): unattached participant attaching faulty

### DIFF
--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -225,8 +225,8 @@ function MapFunctions.getParticipants(map, opponents)
 				}
 			end
 		)
-		Array.forEach(unattachedParticipants, function()
-			table.insert(participants, table.remove(unattachedParticipants, 1))
+		Array.forEach(unattachedParticipants, function(participant)
+			table.insert(participants, participant)
 		end)
 		Table.mergeInto(allParticipants, Table.map(participants, MatchGroupInputUtil.prefixPartcipants(opponentIndex)))
 	end)


### PR DESCRIPTION
## Summary
due to the `table.remove` during looping through the array the array shrinks and the later indexes are never reached

## How did you test this change?
dev into live