### PR TITLE
create(player infobox): Add already existing custom

### DIFF
--- a/components/infobox/wikis/geoguessr/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/geoguessr/infobox_person_player_custom.lua
@@ -26,7 +26,7 @@ local ROLES = {
 	['coach'] = {category = 'Coaches', variable = 'Coach', staff = true},
 	['caster'] = {category = 'Casters', variable = 'Caster', talent = true},
 	['host'] = {category = 'Host', variable = 'Host', talent = true},
-	['manager'] = {category = 'Manager', variable = 'Manager', talent = true},
+	['manager'] = {category = 'Manager', variable = 'Manager', staff = true},
 }
 
 ---@class GeoguessrInfoboxPlayer: Person


### PR DESCRIPTION
## Summary

The module is already live on the wiki. Two new roles, the host and manager roles, were requested to be added. https://discord.com/channels/93055209017729024/1270721461988102246/1291421453006274623

## How did you test this change?

live
