### PR TITLE
fix(externalMediaList): unintended `[]` in `translatedtitle` display

### DIFF
--- a/components/external_media_links/external_media_list.lua
+++ b/components/external_media_links/external_media_list.lua
@@ -220,7 +220,7 @@ function MediaList._row(item, args)
 	row:node(MediaList._displayTitle(item))
 
 	if String.isNotEmpty(item.translatedtitle) then
-		row:wikitext(mw.text.nowiki('[') .. item.translatedtitle .. mw.text.nowiki(']'))
+		row:wikitext(' ' .. mw.text.nowiki('[') .. item.translatedtitle .. mw.text.nowiki(']'))
 	end
 
 	local authors = {}

--- a/components/external_media_links/external_media_list.lua
+++ b/components/external_media_links/external_media_list.lua
@@ -220,7 +220,7 @@ function MediaList._row(item, args)
 	row:node(MediaList._displayTitle(item))
 
 	if String.isNotEmpty(item.translatedtitle) then
-		row:wikitext(mw.text.nowiki('[') .. '[' .. item.translatedtitle .. ']' .. mw.text.nowiki(']'))
+		row:wikitext(mw.text.nowiki('[') .. item.translatedtitle .. mw.text.nowiki(']'))
 	end
 
 	local authors = {}


### PR DESCRIPTION
## Summary
Removes the unintended (second) `[]` around translated title display.
reported on discord by ElectricalBoy
https://discord.com/channels/93055209017729024/268719633366777856/1291372169829421118

## How did you test this change?
live