### PR TITLE
feat(match2): in legacy mode, handle third place headers

### DIFF
--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -62,6 +62,7 @@ function MatchGroupLegacy._getMatchMapping(match, match2mapping, lowerHeaders, l
 	local isReset = false
 	if id == THIRD_PLACE_MATCH then
 		round = lastRound
+		match2mapping[THIRD_PLACE_MATCH .. 'header'] = 'L' .. round.R
 	elseif id == RESET_MATCH then
 		round = lastRound
 		round.G = round.G - 2


### PR DESCRIPTION
## Summary

Third place match headers are ignored :(
This pr fixes that.

## How did you test this change?

/dev
