### PR TITLE
fix(match2): shortened brackets with 3rd place match erroring

### DIFF
--- a/components/match2/commons/match_group_shorten_bracket.lua
+++ b/components/match2/commons/match_group_shorten_bracket.lua
@@ -45,6 +45,8 @@ function ShortenBracket.adjustMatchesAndBracketId(props)
 		bracketDatasById
 	)
 
+	-- in case of a third place match we need to adjust that after the finals match was processed
+	-- as we need the data of the processed finals match, hence adjust it here
 	newMatches = ShortenBracket._adjustThirdPlaceMatch(newMatches)
 
 	assert(newMatches[1], 'The provided id and shortTemplate values leave an empty bracket')


### PR DESCRIPTION
## Summary
If a Bracket with a set (and filled in) thiord place match is shown with `Template:ShowBracket` in combination with shortening the bracket an error was caused.
This is due to the `match2bracketdata.coordinates` of the third place match not being adjusted.
This PR fixes that by adjusting the coordinates data of the third place match.

## How did you test this change?
dev to live as bug fix