### PR TITLE
refactor(widget): migrate Widget Table(Old) to use children instead of content

### DIFF
--- a/components/infobox/wikis/apexlegends/infobox_map_custom.lua
+++ b/components/infobox/wikis/apexlegends/infobox_map_custom.lua
@@ -79,11 +79,11 @@ end
 function CustomMap:_createRingTableHeader()
 	local headerRow = TableRow{css = {['font-weight'] = 'bold'}} -- bg needed
 	return headerRow
-		:addCell(TableCell{content = {'Ring'}})
-		:addCell(TableCell{content = {'Wait (s)'}})
-		:addCell(TableCell{content = {'Close<br>Time (s)'}})
-		:addCell(TableCell{content = {'Damage<br>per tick'}})
-		:addCell(TableCell{content = {'End Diameter (m)'}})
+		:addCell(TableCell{children = {'Ring'}})
+		:addCell(TableCell{children = {'Wait (s)'}})
+		:addCell(TableCell{children = {'Close<br>Time (s)'}})
+		:addCell(TableCell{children = {'Damage<br>per tick'}})
+		:addCell(TableCell{children = {'End Diameter (m)'}})
 end
 
 ---@param ringData string
@@ -91,7 +91,7 @@ end
 function CustomMap:_createRingTableRow(ringData)
 	local row = TableRow{}
 	for _, item in ipairs(mw.text.split(ringData, ',')) do
-		row:addCell(TableCell{content = {item}})
+		row:addCell(TableCell{children = {item}})
 	end
 	return row
 end

--- a/components/prize_pool/commons/prize_pool.lua
+++ b/components/prize_pool/commons/prize_pool.lua
@@ -54,7 +54,7 @@ end
 ---@return WidgetTableCell
 function PrizePool:placeOrAwardCell(placement)
 	local placeCell = TableCell{
-		content = {placement:getMedal() or '', NON_BREAKING_SPACE, placement:_displayPlace()},
+		children = {placement:getMedal() or '', NON_BREAKING_SPACE, placement:_displayPlace()},
 		css = {['font-weight'] = 'bolder'},
 		classes = {'prizepooltable-place'},
 	}
@@ -91,9 +91,9 @@ end
 ---@return WidgetTableRow
 function PrizePool:_toggleExpand(placeStart, placeEnd)
 	local text = 'place ' .. placeStart .. ' to ' .. placeEnd
-	local expandButton = TableCell{content = {'<div>' .. text .. '&nbsp;<i class="fa fa-chevron-down"></i></div>'}}
+	local expandButton = TableCell{children = {'<div>' .. text .. '&nbsp;<i class="fa fa-chevron-down"></i></div>'}}
 		:addClass('general-collapsible-expand-button')
-	local collapseButton = TableCell{content = {'<div>' .. text .. '&nbsp;<i class="fa fa-chevron-up"></i></div>'}}
+	local collapseButton = TableCell{children = {'<div>' .. text .. '&nbsp;<i class="fa fa-chevron-up"></i></div>'}}
 		:addClass('general-collapsible-collapse-button')
 
 	return TableRow{classes = {'ppt-toggle-expand'}}:addCell(expandButton):addCell(collapseButton)

--- a/components/prize_pool/commons/prize_pool_award.lua
+++ b/components/prize_pool/commons/prize_pool_award.lua
@@ -53,7 +53,7 @@ end
 ---@return WidgetTableCell
 function AwardPrizePool:placeOrAwardCell(placement)
 	local awardCell = TableCell{
-		content = {placement.award},
+		children = {placement.award},
 		css = {['font-weight'] = 'bolder'},
 		classes = {'prizepooltable-place'},
 	}
@@ -85,9 +85,9 @@ end
 
 ---@return WidgetTableRow
 function AwardPrizePool:_toggleExpand()
-	local expandButton = TableCell{content = {'<div>Show more Awards&nbsp;<i class="fa fa-chevron-down"></i></div>'}}
+	local expandButton = TableCell{children = {'<div>Show more Awards&nbsp;<i class="fa fa-chevron-down"></i></div>'}}
 		:addClass('general-collapsible-expand-button')
-	local collapseButton = TableCell{content = {'<div>Show less Awards&nbsp;<i class="fa fa-chevron-up"></i></div>'}}
+	local collapseButton = TableCell{children = {'<div>Show less Awards&nbsp;<i class="fa fa-chevron-up"></i></div>'}}
 		:addClass('general-collapsible-collapse-button')
 
 	return TableRow{classes = {'ppt-toggle-expand'}}:addCell(expandButton):addCell(collapseButton)

--- a/components/prize_pool/commons/prize_pool_base.lua
+++ b/components/prize_pool/commons/prize_pool_base.lua
@@ -149,7 +149,7 @@ BasePrizePool.prizeTypes = {
 
 		headerDisplay = function (data)
 			local currencyText = Currency.display(BASE_CURRENCY)
-			return TableCell{content = {currencyText}}
+			return TableCell{children = {currencyText}}
 		end,
 
 		row = BASE_CURRENCY:lower() .. 'prize',
@@ -158,7 +158,7 @@ BasePrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {
+				return TableCell{children = {
 					Currency.display(BASE_CURRENCY, data,
 						{formatValue = true, formatPrecision = headerData.roundPrecision, displayCurrencyCode = false})
 				}}
@@ -188,7 +188,7 @@ BasePrizePool.prizeTypes = {
 			}
 		end,
 		headerDisplay = function (data)
-			return TableCell{content = {Currency.display(data.currency)}}
+			return TableCell{children = {Currency.display(data.currency)}}
 		end,
 
 		row = 'localprize',
@@ -197,7 +197,7 @@ BasePrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {
+				return TableCell{children = {
 					Currency.display(headerData.currency, data,
 					{formatValue = true, formatPrecision = headerData.roundPrecision, displayCurrencyCode = false})
 				}}
@@ -226,7 +226,7 @@ BasePrizePool.prizeTypes = {
 			return {title = 'Percentage'}
 		end,
 		headerDisplay = function (data)
-			return TableCell{content = {data.title}}
+			return TableCell{children = {data.title}}
 		end,
 
 		row = 'percentage',
@@ -240,7 +240,7 @@ BasePrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if String.isNotEmpty(data) then
-				return TableCell{content = {data .. '%'}}
+				return TableCell{children = {data .. '%'}}
 			end
 		end,
 	},
@@ -266,7 +266,7 @@ BasePrizePool.prizeTypes = {
 			}
 		end,
 		headerDisplay = function (data)
-			return TableCell{content = {'Qualifies To'}}
+			return TableCell{children = {'Qualifies To'}}
 		end,
 
 		row = 'qualified',
@@ -339,7 +339,7 @@ BasePrizePool.prizeTypes = {
 				table.insert(headerDisplay, text)
 			end
 
-			return TableCell{content = {table.concat(headerDisplay)}}
+			return TableCell{children = {table.concat(headerDisplay)}}
 		end,
 
 		row = 'points',
@@ -348,7 +348,7 @@ BasePrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if data > 0 then
-				return TableCell{content = {LANG:formatNum(data)}}
+				return TableCell{children = {LANG:formatNum(data)}}
 			end
 		end,
 	},
@@ -360,7 +360,7 @@ BasePrizePool.prizeTypes = {
 			return {title = input}
 		end,
 		headerDisplay = function (data)
-			return TableCell{content = {data.title}}
+			return TableCell{children = {data.title}}
 		end,
 
 		row = 'freetext',
@@ -369,7 +369,7 @@ BasePrizePool.prizeTypes = {
 		end,
 		rowDisplay = function (headerData, data)
 			if String.isNotEmpty(data) then
-				return TableCell{content = {data}}
+				return TableCell{children = {data}}
 			end
 		end,
 	}
@@ -618,7 +618,7 @@ end
 function BasePrizePool:_buildHeader(isAward)
 	local headerRow = TableRow{classes = {'prizepooltable-header'}, css = {['font-weight'] = 'bold'}}
 
-	headerRow:addCell(TableCell{content = {isAward and 'Award' or 'Place'}, css = {['min-width'] = '80px'}})
+	headerRow:addCell(TableCell{children = {isAward and 'Award' or 'Place'}, css = {['min-width'] = '80px'}})
 
 	local previousOfType = {}
 	for _, prize in ipairs(self.prizes) do
@@ -631,7 +631,7 @@ function BasePrizePool:_buildHeader(isAward)
 		end
 	end
 
-	headerRow:addCell(TableCell{content = {'Participant'}, classes = {'prizepooltable-col-team'}})
+	headerRow:addCell(TableCell{children = {'Participant'}, classes = {'prizepooltable-col-team'}})
 
 	return headerRow
 end
@@ -702,7 +702,7 @@ function BasePrizePool:_buildRows()
 			})
 			local opponentCss = {['justify-content'] = 'start'}
 
-			row:addCell(TableCell{content = {opponentDisplay}, css = opponentCss})
+			row:addCell(TableCell{children = {opponentDisplay}, css = opponentCss})
 		end
 
 		table.insert(rows, row)
@@ -813,7 +813,7 @@ end
 --- Creates an empty table cell
 ---@return WidgetTableCell
 function BasePrizePool._emptyCell()
-	return TableCell{content = {DASH}}
+	return TableCell{children = {DASH}}
 end
 
 --- Remove all non-numeric characters from an input and changes it to a number.

--- a/components/widget/widget_table.lua
+++ b/components/widget/widget_table.lua
@@ -13,7 +13,7 @@ local Lua = require('Module:Lua')
 local Widget = Lua.import('Module:Widget')
 
 ---@class WidgetTableInput
----@field rows WidgetTableRow[]?
+---@field children WidgetTableRow[]?
 ---@field classes string[]?
 ---@field css {[string]: string|number|nil}?
 ---@field columns integer?
@@ -26,7 +26,6 @@ local Widget = Lua.import('Module:Widget')
 local Table = Class.new(
 	Widget,
 	function(self, input)
-		self.children = input.children or input.rows or {}
 		self.classes = input.classes or {}
 		self.css = input.css or {}
 		self.columns = input.columns

--- a/components/widget/widget_table_cell.lua
+++ b/components/widget/widget_table_cell.lua
@@ -14,7 +14,7 @@ local Lua = require('Module:Lua')
 local Widget = Lua.import('Module:Widget')
 
 ---@class WidgetCellInput
----@field content (string|number|table|Html)[]?
+---@field children (string|number|table|Html)[]?
 ---@field classes string[]?
 ---@field css {[string]: string|number}?
 
@@ -27,7 +27,6 @@ local Widget = Lua.import('Module:Widget')
 local TableCell = Class.new(
 	Widget,
 	function(self, input)
-		self.children = input.children or input.content or {}
 		self.classes = input.classes or {}
 		self.css = input.css or {}
 	end

--- a/components/widget/widget_table_row.lua
+++ b/components/widget/widget_table_row.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 local Widget = Lua.import('Module:Widget')
 
 ---@class WidgetTableRowInput
----@field cells Widget[]?
+---@field children Widget[]?
 ---@field classes string[]?
 ---@field css {[string]: string|number|nil}?
 
@@ -23,7 +23,6 @@ local Widget = Lua.import('Module:Widget')
 local TableRow = Class.new(
 	Widget,
 	function(self, input)
-		self.children = input.children or input.cells or {}
 		self.classes = input.classes or {}
 		self.css = input.css or {}
 	end


### PR DESCRIPTION
## Summary
For row and full-table, there were no cases of instantiated at creation, only using the `addCell` and `addRow` functions.
