### PR TITLE
feat: Remove background color from `.spellcard`

### DIFF
--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -596,7 +596,6 @@ Author(s): FO-nTTaX, Rapture
 	clear: both;
 	border-width: 1px;
 	border-style: solid;
-	background-color: var( --clr-surface-2, #eeeeee );
 	margin-right: 1em;
 }
 


### PR DESCRIPTION
## Summary

I'm removing some hardcoded colors from the Wildrift wiki and the `.spellcard` class calls a background color. This pr removes it. Disclaimer: I have no idea if this will remove the page from the hardcoded colors category. 
Before
![image_2024-10-07_090903648](https://github.com/user-attachments/assets/c2272033-60a3-4674-abba-9094a865e4dc)
After
![Screenshot 2024-10-07 090926](https://github.com/user-attachments/assets/48b554ea-3fa0-4c0a-a0f3-ad08dbc6b352)


## How did you test this change?

Inspect tools
