### PR TITLE
feat(match2): better warning for section preview

### DIFF
--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -48,7 +48,8 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 	end
 
 	if not Variables.varDefault('tournament_parent') then
-		table.insert(warnings, 'Missing tournament context. Ensure the page has a InfoboxLeague or a HiddenDataBox.')
+		table.insert(warnings, 'Missing tournament context. Ensure the page has a InfoboxLeague or a HiddenDataBox.'
+			.. 'If you only see this in a section preview, please ignore this warning.')
 		mw.ext.TeamLiquidIntegration.add_category('Pages with missing tournament context')
 	end
 


### PR DESCRIPTION
## Summary
As per Fo's suggestion on discord add a sentence about section preview to the missing tournament context warning.

## How did you test this change?
not tested, but just appending text to the warning