### PR TITLE
refactor(match2): cleanup player processing functions

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -118,7 +118,7 @@ function CustomMatchGroupInput.readOpponent(match, opponentIndex, options)
 		substitutions = manualPlayersInput.substitutions
 		-- Change compared to commons MatchGroupInputUtil.readOpponent
 		local template = mw.ext.TeamTemplate.raw(opponent.template or '') or {}
-		opponent.players = MatchGroupInputUtil.readPlayersOfTeamNew(
+		opponent.players = MatchGroupInputUtil.readPlayersOfTeam(
 			template.page or '',
 			manualPlayersInput,
 			options,


### PR DESCRIPTION
## Summary
All usages of `readPlayersOfTeam` (old) is now removed, change `readPlayersOfTeamNew` to just `readPlayersOfTeam`.

## How did you test this change?
/dev 