### PR TITLE
refactor(match2): remove deprecated processMap, simplify subobjects

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -24,17 +24,6 @@ WikiSpecificBase.processMatch = FnUtil.lazilyDefineFunction(function()
 		or error('Function "processMatch" not implemented on wiki in "Module:MatchGroup/Input/Custom"')
 end)
 
--- called from Module:Match/Subobjects
--- used to transform wiki-specific input of templates to the generalized
--- format that is required by Module:MatchGroup
--- @parameter map - a map
--- @returns the map after changes have been applied
-WikiSpecificBase.processMap = FnUtil.lazilyDefineFunction(function()
-	local InputModule = Lua.import('Module:MatchGroup/Input/Custom')
-	return InputModule and InputModule.processMap
-		or error('Function "processMap" not implemented on wiki in "Module:MatchGroup/Input/Custom"')
-end)
-
 --[[
 Converts a match record to a structurally typed table with the appropriate data
 types for field values. The match record is either a match created in the store

--- a/components/match2/commons/match.lua
+++ b/components/match2/commons/match.lua
@@ -385,9 +385,9 @@ end
 function Match._prepareGameRecordForStore(matchRecord, gameRecord)
 	gameRecord.parent = matchRecord.parent
 	gameRecord.tournament = matchRecord.tournament
-	if not gameRecord.participants and gameRecord.opponents then
+	if not gameRecord.participants then
 		gameRecord.participants = {}
-		for opponentId, opponent in ipairs(gameRecord.opponents) do
+		for opponentId, opponent in ipairs(gameRecord.opponents or {}) do
 			for playerId, player in pairs(opponent.players) do
 				-- Deep copy have to be used here, otherwise a json.stringify complains about circular references
 				-- between participants and opponents

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -12,8 +12,6 @@ local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
-local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
-
 local ENTRY_POINT_NAMES = {'getMap'}
 
 local MatchSubobjects = {}
@@ -32,17 +30,6 @@ function MatchSubobjects.luaGetMap(args)
 	if Logic.isEmpty(args.map) then
 		return nil
 	else
-		args = WikiSpecific.processMap(args)
-
-		args.participants = args.participants or {}
-		for key, item in pairs(args.participants) do
-			if not key:match('%d_%d') then
-				error('Key \'' .. key .. '\' in match2game.participants has invalid format: \'<number>_<number>\' expected')
-			elseif type(item) ~= 'table' then
-				error('Item \'' .. tostring(item) .. '\' in match2game.participants has invalid format: table expected')
-			end
-		end
-
 		return args
 	end
 end

--- a/components/match2/commons/match_subobjects.lua
+++ b/components/match2/commons/match_subobjects.lua
@@ -29,9 +29,8 @@ function MatchSubobjects.luaGetMap(args)
 	-- dont save map if 'map' is not filled in
 	if Logic.isEmpty(args.map) then
 		return nil
-	else
-		return args
 	end
+	return args
 end
 
 if FeatureFlag.get('perf') then

--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -91,8 +91,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param match table
 ---@param opponents table[]
 ---@param scoreSettings table

--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -77,8 +77,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 local Streams = require('Module:Links/Stream')

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -80,8 +80,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/brawlhalla/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlhalla/match_group_input_custom.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local CharacterStandardization = mw.loadData('Module:CharacterStandardization')
-local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')

--- a/components/match2/wikis/brawlhalla/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlhalla/match_group_input_custom.lua
@@ -73,8 +73,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param match table
 ---@param matchOpponents table[]
 ---@return table[]

--- a/components/match2/wikis/brawlhalla/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlhalla/match_group_input_custom.lua
@@ -93,9 +93,6 @@ function CustomMatchGroupInput.extractMaps(match, matchOpponents)
 		map.opponents = Array.map(matchOpponents, function(opponent, opponentIndex)
 			return CustomMatchGroupInput.getParticipantsOfOpponent(map, opponent, opponentIndex)
 		end)
-		-- Match/Subobjects:luaGetMap sets a empty table as default value for participants.
-		-- Once subobjects have been refactored away this can be removed.
-		map.participants = nil
 
 		local opponentInfo = Array.map(matchOpponents, function(_, opponentIndex)
 			local score, status = MatchGroupInputUtil.computeOpponentScore({

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -124,8 +124,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -111,8 +111,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -86,8 +86,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MathUtil = require('Module:MathUtil')

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -8,7 +8,6 @@
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local EarningsOf = require('Module:Earnings of')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
@@ -90,8 +89,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	return match
 end
-
-CustomMatchGroupInput.processMap = FnUtil.identity
 
 --
 -- match related functions

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -86,8 +86,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MathUtil = require('Module:MathUtil')

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -84,8 +84,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/deadlock/match_group_input_custom.lua
+++ b/components/match2/wikis/deadlock/match_group_input_custom.lua
@@ -113,8 +113,6 @@ function MatchFunctions.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer
 function MatchFunctions.calculateMatchScore(maps)

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -164,8 +164,6 @@ function MatchFunctions.extractMaps(MatchParser, match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer
 function MatchFunctions.calculateMatchScore(maps)

--- a/components/match2/wikis/easportsfc/match_group_input_custom.lua
+++ b/components/match2/wikis/easportsfc/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Ordinal = require('Module:Ordinal')
@@ -131,7 +130,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 
 	return maps
 end
-CustomMatchGroupInput.processMap = FnUtil.identity
 
 --- TODO: Investigate if some parts of this should be a display rather than storage.
 --- If penalties is supplied, than one map MUST have the penalty flag set to true.

--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Game = require('Module:Game')
 local Json = require('Module:Json')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -98,9 +98,6 @@ function CustomMatchGroupInput.extractMaps(match, matchOpponents)
 		map.opponents = Array.map(matchOpponents, function(opponent, opponentIndex)
 			return CustomMatchGroupInput.getParticipantsOfOpponent(map, opponent, opponentIndex)
 		end)
-		-- Match/Subobjects:luaGetMap sets a empty table as default value for participants.
-		-- Once subobjects have been refactored away this can be removed.
-		map.participants = nil
 
 		local opponentInfo = Array.map(matchOpponents, function(_, opponentIndex)
 			local score, status = MatchGroupInputUtil.computeOpponentScore({

--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -126,8 +126,6 @@ function CustomMatchGroupInput.extractMaps(match, matchOpponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer
 function CustomMatchGroupInput.calculateMatchScore(maps)

--- a/components/match2/wikis/geoguessr/match_group_input_custom.lua
+++ b/components/match2/wikis/geoguessr/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/geoguessr/match_group_input_custom.lua
+++ b/components/match2/wikis/geoguessr/match_group_input_custom.lua
@@ -108,8 +108,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -79,8 +79,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -123,8 +123,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 
 --
 -- match related functions

--- a/components/match2/wikis/honorofkings/match_group_input_custom.lua
+++ b/components/match2/wikis/honorofkings/match_group_input_custom.lua
@@ -129,8 +129,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -163,8 +163,6 @@ function MatchFunctions.extractMaps(MatchParser, match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer
 function MatchFunctions.calculateMatchScore(maps)

--- a/components/match2/wikis/magic/match_group_input_custom.lua
+++ b/components/match2/wikis/magic/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/magic/match_group_input_custom.lua
+++ b/components/match2/wikis/magic/match_group_input_custom.lua
@@ -123,8 +123,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer
 function CustomMatchGroupInput.calculateMatchScore(maps)

--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -115,8 +115,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/omegastrikers/match_group_input_custom.lua
+++ b/components/match2/wikis/omegastrikers/match_group_input_custom.lua
@@ -113,8 +113,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -80,8 +80,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -115,8 +115,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -80,8 +80,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -9,7 +9,6 @@
 local CustomMatchGroupInput = {}
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -124,8 +124,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param opponent table
 ---@return table
 function CustomMatchGroupInput.getOpponentExtradata(opponent)

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -9,7 +9,6 @@
 local CustomMatchGroupInput = {}
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/sideswipe/match_group_input_custom.lua
+++ b/components/match2/wikis/sideswipe/match_group_input_custom.lua
@@ -107,8 +107,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -86,8 +86,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -122,8 +122,6 @@ function MatchFunctions.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -79,8 +79,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/starcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft/brkts_wiki_specific.lua
@@ -62,8 +62,4 @@ WikiSpecific.matchHasDetails = FnUtil.lazilyDefineFunction(function()
 	return StarcraftMatchGroupUtil.matchHasDetails
 end)
 
--- useless functions that should be present for some default checks
--- would get called from Module:Match/Subobjects if we wouldn't circumvent that module completly
-WikiSpecific.processMap = FnUtil.identity
-
 return WikiSpecific

--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -62,8 +62,4 @@ WikiSpecific.matchHasDetails = FnUtil.lazilyDefineFunction(function()
 	return StarcraftMatchGroupUtil.matchHasDetails
 end)
 
--- useless functions that should be present for some default checks
--- would get called from Module:Match/Subobjects if we wouldn't circumvent that module completly
-WikiSpecific.processMap = FnUtil.identity
-
 return WikiSpecific

--- a/components/match2/wikis/stormgate/brkts_wiki_specific.lua
+++ b/components/match2/wikis/stormgate/brkts_wiki_specific.lua
@@ -21,8 +21,6 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 	return CustomMatchGroupUtil.matchFromRecord
 end)
 
-WikiSpecific.processMap = FnUtil.identity
-
 ---Determine if a match has details that should be displayed via popup
 ---@param match table
 ---@return boolean

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -109,8 +109,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -125,8 +125,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer
 function CustomMatchGroupInput.calculateMatchScore(maps)

--- a/components/match2/wikis/tft/match_group_input_custom.lua
+++ b/components/match2/wikis/tft/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 local Table = require('Module:Table')
@@ -22,8 +21,6 @@ local DEFAULT_MODE = 'team'
 local CustomMatchGroupInput = {}
 local MatchFunctions = {}
 local MapFunctions = {}
-
-CustomMatchGroupInput.processMap = FnUtil.identity
 
 ---@param match table
 ---@param options table?

--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -9,7 +9,6 @@
 local CustomMatchGroupInput = {}
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/trackmania/match_group_input_custom.lua
+++ b/components/match2/wikis/trackmania/match_group_input_custom.lua
@@ -110,8 +110,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 ---@param opponent table
 ---@return table
 function CustomMatchGroupInput.getOpponentExtradata(opponent)

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -90,9 +90,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 		local winnerInput = map.winner --[[@as string?]]
 
 		map.opponents = MapFunctions.getParticipants(map, opponents)
-		-- Match/Subobjects:luaGetMap sets a empty table as default value for participants.
-		-- Once subobjects have been refactored away this can be removed.
-		map.participants = nil
 		map.extradata = MapFunctions.getExtraData(map, map.opponents)
 		map.finished = MatchGroupInputUtil.mapIsFinished(map)
 

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -120,8 +120,6 @@ function CustomMatchGroupInput.extractMaps(match, opponents)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/warcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/warcraft/brkts_wiki_specific.lua
@@ -19,8 +19,6 @@ WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
 	return CustomMatchGroupUtil.matchFromRecord
 end)
 
-WikiSpecific.processMap = FnUtil.identity
-
 ---Determine if a match has details that should be displayed via popup
 ---@param match table
 ---@return boolean

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -128,8 +128,6 @@ function CustomMatchGroupInput.extractMaps(match, opponentCount)
 	return maps
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -80,8 +80,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --

--- a/components/match2/wikis/zula/match_group_input_custom.lua
+++ b/components/match2/wikis/zula/match_group_input_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')

--- a/components/match2/wikis/zula/match_group_input_custom.lua
+++ b/components/match2/wikis/zula/match_group_input_custom.lua
@@ -81,8 +81,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	return match
 end
 
-CustomMatchGroupInput.processMap = FnUtil.identity
-
 --
 -- match related functions
 --


### PR DESCRIPTION
## Summary
ProcessMap is no longer used 

## How did you test this change?
dev on r6 and val