### PR TITLE
feat(match2): add side information on deadlock

### DIFF
--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -23,6 +23,8 @@ local SIZE_HERO = '48x48px'
 local ICONS = {
 	winner = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = 'initial'},
 	loss = Icon.makeIcon{iconName = 'loss', color = 'cinnabar-text', size = 'initial'},
+	amber = Icon.makeIcon{iconName = 'amberhand', color = 'deadlock-amberhand-text', size = 'initial'},
+	sapphire = Icon.makeIcon{iconName = 'sapphireflame', color = 'deadlock-sapphireflame-text', size = 'initial'},
 	empty = '[[File:NoCheck.png|link=|16px]]',
 }
 
@@ -31,7 +33,7 @@ local CustomMatchSummary = {}
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px', teamStyle = 'bracket'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '440px', teamStyle = 'bracket'})
 end
 
 ---@param match MatchGroupUtilMatch
@@ -75,11 +77,11 @@ function CustomMatchSummary._createGame(game, gameIndex)
 	local function makeCharacterDisplay(opponentIndex)
 		return CustomMatchSummary._createCharacterDisplay(
 			CustomMatchSummary._getHeroesForOpponent(game.participants, opponentIndex),
-			extradata['team' .. opponentIndex .. 'side'],
 			opponentIndex == 2
 		)
 	end
 
+	row:addElement(CustomMatchSummary._createIcon(ICONS[extradata.team1side]))
 	row:addElement(makeCharacterDisplay(1))
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner, 1))
 	row:addElement(mw.html.create('div')
@@ -91,6 +93,7 @@ function CustomMatchSummary._createGame(game, gameIndex)
 	)
 	row:addElement(CustomMatchSummary._createCheckMark(game.winner, 2))
 	row:addElement(makeCharacterDisplay(2))
+	row:addElement(CustomMatchSummary._createIcon(ICONS[extradata.team2side]))
 
 	if Logic.isNotEmpty(game.comment) then
 		row:addElement(MatchSummary.Break():create())
@@ -100,16 +103,8 @@ function CustomMatchSummary._createGame(game, gameIndex)
 	return row
 end
 
----@param winner integer|string
----@param opponentIndex integer
----@return Html
 function CustomMatchSummary._createCheckMark(winner, opponentIndex)
-	return mw.html.create('div')
-		:addClass('brkts-popup-spaced')
-		:css('line-height', '17px')
-		:css('margin-left', '1%')
-		:css('margin-right', '1%')
-		:wikitext(
+	return CustomMatchSummary._createIcon(
 			winner == opponentIndex and ICONS.winner
 			or winner == 0 and ICONS.draw
 			or Logic.isNotEmpty(winner) and ICONS.loss
@@ -117,11 +112,22 @@ function CustomMatchSummary._createCheckMark(winner, opponentIndex)
 		)
 end
 
+---@param winner integer|string
+---@param opponentIndex integer
+---@return Html
+function CustomMatchSummary._createIcon(icon)
+	return mw.html.create('div')
+		:addClass('brkts-popup-spaced')
+		:css('line-height', '17px')
+		:css('margin-left', '1%')
+		:css('margin-right', '1%')
+		:wikitext(icon)
+end
+
 ---@param characters {name: string, active: boolean}[]?
----@param side string?
 ---@param reverse boolean?
 ---@return Html
-function CustomMatchSummary._createCharacterDisplay(characters, side, reverse)
+function CustomMatchSummary._createCharacterDisplay(characters, reverse)
 	local wrapper = mw.html.create('div')
 		:addClass('brkts-popup-body-element-thumbs')
 		:addClass('brkts-popup-body-element-thumbs-' .. (reverse and 'right' or 'left'))

--- a/standard/icon_data.lua
+++ b/standard/icon_data.lua
@@ -74,7 +74,11 @@ return {
 	-- Usage: buildtime, duration, cooldown, ...
 	time = 'far fa-clock',
 
-	-- Usage: Sqaud Table
+	-- Usage: Squad Table
 	captain = 'fas fa-crown',
 	substitute = 'fas fa-people-arrows',
+
+	-- Usage: Deadlock
+	amberhand = 'fas fa-hand-paper',
+	sapphireflame = 'fas fa-fire',
 }

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -676,6 +676,15 @@ ul.nav-tabs li.game-wiiu,
 	color: var( --clr-california-80, #f9dec7 );
 }
 
+/* Deadlock */
+.deadlock-amberhand-text {
+	color: #C09B54;
+}
+
+.deadlock-sapphireflame-text {
+	color: #5C7AE6;
+}
+
 /* OTHER */
 .transparent-bg {
 	background: transparent !important;

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -678,11 +678,11 @@ ul.nav-tabs li.game-wiiu,
 
 /* Deadlock */
 .deadlock-amberhand-text {
-	color: #C09B54;
+	color: #c09b54;
 }
 
 .deadlock-sapphireflame-text {
-	color: #5C7AE6;
+	color: #5c7ae6;
 }
 
 /* OTHER */


### PR DESCRIPTION
## Summary
Adding support for a side display in deadlock, adding icons on the outer sides of the hero select.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Tested on /dev and matchsummary previews
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
