### PR TITLE
fix(match2): wrong prefix for pick/ban input on pokemon

### DIFF
--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -172,10 +172,10 @@ function MapFunctions.getExtraData(map, opponentCount)
 
 	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, ChampionNames)
 	for opponentIndex = 1, opponentCount do
-		for _, ban, banIndex in Table.iter.pairsByPrefix(map, 'team' .. opponentIndex .. 'b') do
+		for _, ban, banIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'b') do
 			extradata['team' .. opponentIndex .. 'ban' .. banIndex] = getCharacterName(ban)
 		end
-		for _, pick, pickIndex in Table.iter.pairsByPrefix(map, 'team' .. opponentIndex .. 'h') do
+		for _, pick, pickIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'h') do
 			extradata['team' .. opponentIndex .. 'champion' .. pickIndex] = getCharacterName(pick)
 		end
 	end


### PR DESCRIPTION
## Summary
During refactor the prefix of the pick/ban input was mixed up.
This PR fixes the prefix.

## How did you test this change?
dev into live