### PR TITLE
fix(match2): heartstone's map copy paste for party opponents is faulty

### DIFF
--- a/components/match2/wikis/hearthstone/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/hearthstone/get_match_group_copy_paste_wiki.lua
@@ -58,13 +58,13 @@ function WikiCopyPaste._getMap(mode, opponents)
 		return '={{Map|winner=}}'
 	end
 
-	local parts = Array.extend({},
+	local parts = Array.extend({'={{Map'},
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return table.concat(Array.map(Array.range(1, Opponent.partySize(mode) --[[@as integer]]), function(playerIndex)
 				return '|o' .. opponentIndex .. 'p' .. playerIndex .. '='
 			end))
 		end),
-		'}}'
+		'|winner=}}'
 	)
 
 	return table.concat(parts)


### PR DESCRIPTION
## Summary
Map copy paste was missing some parts for the party opponent case

## How did you test this change?
live