### PR TITLE
fix(match2): pkmn legacy macth storage has underscores in opponent names

### DIFF
--- a/components/match2/wikis/pokemon/match_legacy.lua
+++ b/components/match2/wikis/pokemon/match_legacy.lua
@@ -83,7 +83,7 @@ function MatchLegacy._convertParameters(match2)
 		local opponent = match2.match2opponents[index] or {}
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == 'team' then
-			match[prefix] = opponent.name
+			match[prefix] = opponent.name and opponent.name:gsub('_', ' ')
 			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			local opponentplayers = {}
 			for i = 1, 10 do
@@ -95,7 +95,7 @@ function MatchLegacy._convertParameters(match2)
 			match[prefix..'players'] = opponentplayers
 		elseif opponent.type == 'solo' then
 			local player = opponentmatch2players[1] or {}
-			match[prefix] = player.name
+			match[prefix] = player.name and player.name:gsub('_', ' ')
 			match[prefix..'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix..'flag'] = player.flag
 		elseif opponent.type == 'literal' then


### PR DESCRIPTION
## Summary
For legacy reasons switch opponent names in legacy match1 storage to have spaces instead of underscores

## How did you test this change?
dev into live