### PR TITLE
fix(participant table): missing index passalong in readEntry

### DIFF
--- a/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
+++ b/components/participant_table/commons/starcraft_starcraft2/participant_table_starcraft.lua
@@ -140,6 +140,7 @@ function StarcraftParticipantTable:readEntry(sectionArgs, key, index, config)
 		opponent = opponent,
 		name = Opponent.toName(opponent),
 		isQualified = Logic.nilOr(Logic.readBoolOrNil(sectionArgs[key .. 'qualified']), config.isQualified),
+		inputIndex = index,
 	}
 end
 


### PR DESCRIPTION
## Summary
Pass along the input index for sorting purposes (in case alphab sorting gets disabled)


## How did you test this change?
dev