### PR TITLE
fix(infobox): typo in chronology fallback

### DIFF
--- a/components/widget/infobox/widget_infobox_chronology.lua
+++ b/components/widget/infobox/widget_infobox_chronology.lua
@@ -98,7 +98,7 @@ function Chronology:_createChronologyRow(previous, next)
 
 	return Div{
 		children = {
-			prevSlot() or Div{classes = 'infobox-cell-2'},
+			prevSlot() or Div{classes = {'infobox-cell-2'}},
 			nextSlot(),
 		}
 	}


### PR DESCRIPTION
## Summary
Typo in the class wrapper (string, not table)

## How did you test this change?
Live