### PR TITLE
ci: improve "forkpoint" to determine branch changes

### DIFF
--- a/.github/workflows/deploy test.yml
+++ b/.github/workflows/deploy test.yml
@@ -17,13 +17,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: nrwl/nx-set-shas@v4
-        id: last_successful_commit_push
+      - uses: younited/detect-branch-changes-action@v0.2.0
+        id: forkpoint
 
       - id: changed-files
         uses: tj-actions/changed-files@v45
         with:
-          base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
+          base_sha: ${{ steps.forkpoint.outputs.fork_point_sha }}
           files: |
             components/**/*.lua
             standard/**/*.lua


### PR DESCRIPTION
## Summary
The previous action (nx-set-shas) would try to find a workflow run of deploy-personal on the main branch, not find one, and thus default to the latest commit on main:
> WARNING: Unable to find a successful workflow run on 'origin/main', or the latest successful workflow was connected to a commit which no longer exists on that branch (e.g. if that branch was rebased)
We are therefore defaulting to use HEAD~1 on 'origin/main'

When then additional changes exist on main, the changed-files action would diff the current main and the branch commits, which would list the files changed on main as changed files, thus overdeploying files. (fwiw, nx-set-shas could have been completely replaced by just setting `base_sha: main` in the changed-files config)

The new action extracts the fork point of the selected branch, which is then passed as base to changed-files to correctly find the files and only the files that the branch changes when compared to main, and not files that are changed on either main or the branch

For example, the forkpoint of this PR should be 2e1edea5bec7c50ece9a4f9db0bdcf39f2b1974d unless this PR is rebased.
Note that this solution will likely break in case of stacked PRs, but these wouldn't have been properly supported before either.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
basic testing in a fork, might not have covered all potential usecases
- Multiple commits on branch -> would deploy all files changed on branch
- multiple commits on branch, commit on main -> would deploy only files changed on branch, ignore those on main
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
