### PR TITLE
feat(widget): allow for non-arrays as children

### DIFF
--- a/components/widget/infobox/widget_infobox_title.lua
+++ b/components/widget/infobox/widget_infobox_title.lua
@@ -14,16 +14,7 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
 ---@class TitleWidget: Widget
 ---@operator call(table): TitleWidget
-local Title = Class.new(
-	Widget,
-	function(self)
-		-- Legacy support for single string children, convert to array
-		-- Widget v2.1 will have this support added to the base class
-		if type(self.props.children) == 'string' then
-			self.props.children = {self.props.children}
-		end
-	end
-)
+local Title = Class.new(Widget)
 
 ---@return string?
 function Title:render()

--- a/components/widget/widget.lua
+++ b/components/widget/widget.lua
@@ -5,10 +5,11 @@
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
+
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local FnUtil = require('Module:FnUtil')
 local ErrorDisplay = require('Module:Error/Display')
+local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -20,7 +21,11 @@ local Table = require('Module:Table')
 ---@field injector WidgetInjector?
 local Widget = Class.new(function(self, props)
 	self.props = Table.copy(props) or {}
-	self.props.children = self.props.children or {}
+
+	if not Array.isArray(self.props.children) then
+		self.props.children = {self.props.children}
+	end
+
 	self.context = {} -- Populated by the parent
 end)
 


### PR DESCRIPTION
## Summary
To allow for each inputs, the `children` special prop no longer needs to be an array on input. It will be automatically converted into an array if not. A non-array children is automatically wrapped into an array of length 1.

## How did you test this change?
dev