### PR TITLE
feat(match2): support for hero bans on deadlock

### DIFF
--- a/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
@@ -24,7 +24,6 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	
 	local lines = Array.extend(
 		'{{Match|bestof=' .. (bestof ~= 0 and bestof or ''),
-		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)

--- a/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
@@ -29,7 +29,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		INDENT .. '|date=|finished=',
+		INDENT .. '|date=',
 		INDENT .. '|twitch=|youtube=|vod=',
 		Array.map(Array.range(1, bestof), function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, bans)

--- a/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
@@ -20,15 +20,20 @@ local INDENT = WikiCopyPaste.Indent
 
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil, bestof == 0)
-
+	local bans = Logic.readBool(args.bans)
+	
 	local lines = Array.extend(
 		'{{Match|bestof=' .. (bestof ~= 0 and bestof or ''),
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
+		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date=|finished=',
 		INDENT .. '|twitch=|youtube=|vod=',
-		Array.map(Array.range(1, bestof), WikiCopyPaste._getMapCode),
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return WikiCopyPaste._getMapCode(mapIndex, bans)
+		end),
 		'}}'
 	)
 
@@ -36,13 +41,19 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 ---@param mapIndex integer
+---@param bans boolean
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex)
+function WikiCopyPaste._getMapCode(mapIndex, bans)
 	return table.concat(Array.extend(
-		INDENT .. '|map' .. mapIndex .. '={{Map|length=|winner=|vod=',
-		INDENT .. INDENT .. '|team1side=|team2side=',
+		INDENT .. '|map' .. mapIndex .. '={{Map',
+		INDENT .. INDENT .. '|team1side=',
 		INDENT .. INDENT .. '|t1h1=|t1h2=|t1h3=|t1h4=|t1h5=|t1h6=',
+		bans and (INDENT .. INDENT .. '|t1b1=|t1b2=|t1b3=|t1b4=|t1b5=|t1b6=') or nil,
+		INDENT .. INDENT .. '|team2side=',
 		INDENT .. INDENT .. '|t2h1=|t2h2=|t2h3=|t2h4=|t2h5=|t2h6=',
+		bans and (INDENT .. INDENT .. '|t2b1=|t2b2=|t2b3=|t2b4=|t2b5=|t2b6=') or nil,
+		INDENT .. INDENT .. '|length=|winner=|matchid=|vod=',
+		INDENT .. '|matchid'.. mapIndex ..'=',
 		INDENT .. '}}'
 	), '\n')
 end

--- a/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
@@ -53,7 +53,6 @@ function WikiCopyPaste._getMapCode(mapIndex, bans)
 		INDENT .. INDENT .. '|t2h1=|t2h2=|t2h3=|t2h4=|t2h5=|t2h6=',
 		bans and (INDENT .. INDENT .. '|t2b1=|t2b2=|t2b3=|t2b4=|t2b5=|t2b6=') or nil,
 		INDENT .. INDENT .. '|length=|winner=|matchid=|vod=',
-		INDENT .. '|matchid'.. mapIndex ..'=',
 		INDENT .. '}}'
 	), '\n')
 end

--- a/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/deadlock/get_match_group_copy_paste_wiki.lua
@@ -21,7 +21,7 @@ local INDENT = WikiCopyPaste.Indent
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil, bestof == 0)
 	local bans = Logic.readBool(args.bans)
-	
+
 	local lines = Array.extend(
 		'{{Match|bestof=' .. (bestof ~= 0 and bestof or ''),
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,

--- a/components/match2/wikis/deadlock/match_group_input_custom.lua
+++ b/components/match2/wikis/deadlock/match_group_input_custom.lua
@@ -79,6 +79,7 @@ end
 
 ---@param match table
 ---@param opponents table[]
+---@param opponentCount integer
 ---@return table[]
 function MatchFunctions.extractMaps(match, opponents)
 	local maps = {}
@@ -88,7 +89,7 @@ function MatchFunctions.extractMaps(match, opponents)
 
 		map.map = nil
 		map.participants = MapFunctions.getParticipants(map, opponents)
-		map.extradata = MapFunctions.getExtraData(map)
+		map.extradata = MapFunctions.getExtraData(map, #opponents)
 
 		map.finished = MatchGroupInputUtil.mapIsFinished(map)
 		local opponentInfo = Array.map(opponents, function(_, opponentIndex)
@@ -132,15 +133,26 @@ function MatchFunctions.getExtraData(match)
 end
 
 ---@param map table
+---@param opponentCount integer
 ---@return table
-function MapFunctions.getExtraData(map)
-	local extraData = {
+function MapFunctions.getExtraData(map, opponentCount)
+	local extradata = {
 		comment = map.comment,
 		team1side = map.team1side,
 		team2side = map.team2side,
 	}
 
-	return extraData
+	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, HeroNames)
+	for opponentIndex = 1, opponentCount do
+		for _, ban, banIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'b') do
+			extradata['team' .. opponentIndex .. 'ban' .. banIndex] = getCharacterName(ban)
+		end
+		for _, pick, pickIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'h') do
+			extradata['team' .. opponentIndex .. 'hero' .. pickIndex] = getCharacterName(pick)
+		end
+	end
+
+	return extradata
 end
 
 ---@param map table

--- a/components/match2/wikis/deadlock/match_group_input_custom.lua
+++ b/components/match2/wikis/deadlock/match_group_input_custom.lua
@@ -79,7 +79,6 @@ end
 
 ---@param match table
 ---@param opponents table[]
----@param opponentCount integer
 ---@return table[]
 function MatchFunctions.extractMaps(match, opponents)
 	local maps = {}

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -136,15 +136,15 @@ function CustomMatchSummary.createBody(match)
 		end
 
 		if numberOfBans > 0 then
-			HeroBanData[gameIndex] = banData
+			heroBanData[gameIndex] = banData
 		end
 	end
 
 	-- Add the Hero Bans
-	if not Table.isEmpty(HeroBanData) then
+	if not Table.isEmpty(heroBanData) then
 		local heroBan = HeroBan()
 
-		for gameIndex, banData in ipairs(HeroBanData) do
+		for gameIndex, banData in ipairs(heroBanData) do
 			heroBan:banRow(banData, gameIndex)
 		end
 

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -147,13 +147,13 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Hero Bans
 	if not Table.isEmpty(HeroBanData) then
-		local HeroBan = HeroBan()
+		local heroBan = HeroBan()
 
 		for gameIndex, banData in ipairs(HeroBanData) do
-			HeroBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
+			heroBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
 		end
 
-		body:addRow(HeroBan)
+		body:addRow(heroBan)
 	end
 
 	return body

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -56,10 +56,8 @@ end
 
 ---@param banData {numberOfBans: integer, [1]: table, [2]: table}
 ---@param gameNumber integer
----@param numberOfBans integer
----@param date string
 ---@return self
-function HeroBan:banRow(banData, gameNumber, numberOfBans, date)
+function HeroBan:banRow(banData, gameNumber)
 	self.table:tag('tr')
 		:tag('td'):css('float', 'left')
 			:node(CustomMatchSummary._createCharacterDisplay(banData[1], false))

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -145,7 +145,7 @@ function CustomMatchSummary.createBody(match)
 		local heroBan = HeroBan()
 
 		for gameIndex, banData in ipairs(HeroBanData) do
-			heroBan:banRow(banData, gameIndex, banData.numberOfBans, match.date)
+			heroBan:banRow(banData, gameIndex)
 		end
 
 		body:addRow(heroBan)

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -213,5 +213,4 @@ function CustomMatchSummary._createIcon(icon)
 		:wikitext(icon)
 end
 
-
 return CustomMatchSummary

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -119,7 +119,7 @@ function CustomMatchSummary.createBody(match)
 	end
 
 	-- Pre-Process Hero Ban Data
-	local HeroBanData = {}
+	local heroBanData = {}
 	for gameIndex, game in ipairs(match.games) do
 		local extradata = game.extradata or {}
 		local banData = {{}, {}}

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -13,7 +13,6 @@ local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -103,21 +103,6 @@ function CustomMatchSummary.createBody(match)
 		end
 	end
 
-	-- Add Match MVP(s)
-	if match.extradata.mvp then
-		local mvpData = match.extradata.mvp
-		if not Table.isEmpty(mvpData) and mvpData.players then
-			local mvp = MatchSummary.Mvp()
-			for _, player in ipairs(mvpData.players) do
-				mvp:addPlayer(player)
-			end
-			mvp:setPoints(mvpData.points)
-
-			body:addRow(mvp)
-		end
-
-	end
-
 	-- Pre-Process Hero Ban Data
 	local heroBanData = {}
 	for gameIndex, game in ipairs(match.games) do

--- a/components/match2/wikis/deadlock/match_summary.lua
+++ b/components/match2/wikis/deadlock/match_summary.lua
@@ -136,9 +136,6 @@ function CustomMatchSummary.createBody(match)
 		end
 
 		if numberOfBans > 0 then
-			banData[1].color = extradata.team1side
-			banData[2].color = extradata.team2side
-			banData.numberOfBans = numberOfBans
 			HeroBanData[gameIndex] = banData
 		end
 	end


### PR DESCRIPTION
## Summary
Adding support for Hero Bans in Deadlock

The number of bans/ban format is currently community driven, so the current display supporting up to 6 bans should be future proof
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Dev modules:
https://liquipedia.net/deadlock/Module:MatchGroup/Input/Custom/dev/kano
https://liquipedia.net/deadlock/Module:MatchSummary/dev/kano
Test page:
https://liquipedia.net/deadlock/User:Kanoodles/test

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
