### PR TITLE
refactor(match2): standardize link parsing

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -1039,9 +1039,9 @@ end
 ---@return table<string, string>
 function MatchGroupInputUtil.getLinks(match)
 	local links = Links.transform(match)
-	return Table.filter(
+	return Table.mapValues(
 		Links.makeFullLinksForTableItems(links, 'match', false),
-		String.isNotEmpty
+		String.nilIfEmpty
 	) --[[@as table<string, string>]]
 end
 

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -1039,7 +1039,7 @@ end
 ---@return { [string]: string }
 function MatchGroupInputUtil.getLinks(match)
 	local links = Links.transform(match)
-	return Links.makeFullLinksForTableItems(links, 'match')
+	return Links.makeFullLinksForTableItems(links, 'match', false)
 end
 
 --- Warning, both match and standalone match may be mutated

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -1039,9 +1039,7 @@ end
 ---@return { [string]: string }
 function MatchGroupInputUtil.getLinks(match)
 	local links = Links.transform(match)
-	return Table.map(links, function(value, key)
-		return key, Links.makeFullLink(key, value, 'match')
-	end)
+	return Links.makeFullLinksForTableItems(links, 'match')
 end
 
 --- Warning, both match and standalone match may be mutated

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -1036,10 +1036,13 @@ function MatchGroupInputUtil.prefixPartcipants(opponentIndex)
 end
 
 ---@param match table
----@return { [string]: string }
+---@return table<string, string>
 function MatchGroupInputUtil.getLinks(match)
 	local links = Links.transform(match)
-	return Links.makeFullLinksForTableItems(links, 'match', false)
+	return Table.filter(
+		Links.makeFullLinksForTableItems(links, 'match', false),
+		String.isNotEmpty
+	) --[[@as table<string, string>]]
 end
 
 --- Warning, both match and standalone match may be mutated

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -20,6 +20,7 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
+local Links = Lua.import('Module:Links')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local PlayerExt = Lua.import('Module:Player/Ext/Custom')
 
@@ -1032,6 +1033,15 @@ function MatchGroupInputUtil.prefixPartcipants(opponentIndex)
 	return function(playerIndex, data)
 		return opponentIndex .. '_' .. playerIndex, data
 	end
+end
+
+---@param match table
+---@return { [string]: string }
+function MatchGroupInputUtil.getLinks(match)
+	local links = Links.transform(match)
+	return Table.map(links, function(value, key)
+		return key, Links.makeFullLink(key, value, 'match')
+	end)
 end
 
 --- Warning, both match and standalone match may be mutated

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -90,7 +90,7 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -209,20 +209,6 @@ function MatchFunctions.getBestOf(bestofInput)
 	end
 
 	return bestof
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		preview = match.preview,
-		preview2 = match.preview2,
-		interview = match.interview,
-		interview2 = match.interview2,
-		review = match.review,
-		recap = match.recap,
-		lrthread = match.lrthread,
-	}
 end
 
 ---@param match table

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -51,6 +51,7 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 	local opponents = MatchFunctions.readOpponents(match)
 
 	local games = MatchFunctions.extractMaps(match, opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games, opponents)
@@ -90,7 +91,6 @@ function StarcraftMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -46,9 +46,9 @@ local MapFunctions = {}
 function StarcraftFfaMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, BaseMatchFunctions.readDate(match.date))
 
+	match.links = MatchGroupInputUtil.getLinks(match)
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -48,7 +48,7 @@ function StarcraftFfaMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
-	match.links = BaseMatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -74,7 +74,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.mode = Opponent.toLegacyMode(opponents[1].type, opponents[2].type)
 	match.stream = Streams.processStreams(match)
-	match.links = CustomMatchGroupInput._getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -227,23 +227,6 @@ function CustomMatchGroupInput._getMapsAndGame(match)
 	Variables.varDefine('tournament_maps', data.maps)
 
 	return match.game or data.game, Logic.emptyOr(mapsInfo, (Json.parse(data.maps)))
-end
-
----@param match table
-function CustomMatchGroupInput._getLinks(match)
-	local links = {}
-
-	match.civdraft1 = match.civdraft1 or match.civdraft
-	for key, value in Table.iter.pairsByPrefix(match, 'civdraft') do
-		links[key] = 'https://aoe2cm.net/draft/' .. value
-	end
-
-	match.mapdraft1 = match.mapdraft1 or match.mapdraft
-	for key, value in Table.iter.pairsByPrefix(match, 'mapdraft') do
-		links[key] = 'https://aoe2cm.net/draft/' .. value
-	end
-
-	return links
 end
 
 ---@param maps table[]

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -44,6 +44,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = CustomMatchGroupInput.extractMaps(match, opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and CustomMatchGroupInput.calculateMatchScore(games)
@@ -74,7 +75,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.mode = Opponent.toLegacyMode(opponents[1].type, opponents[2].type)
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -70,7 +70,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -140,20 +140,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		preview = match.preview,
-		quakehistory = match.quakehistory and ('http://www.quakehistory.com/en/matches/' .. match.quakehistory) or nil,
-		dbstats = match.dbstats and ('https://quakelife.ru/diabotical/stats/matches/?matches=' .. match.dbstats) or nil,
-		qrindr = match.qrindr and ('https://qrindr.com/match/' .. match.qrindr) or nil,
-		esl = match.esl and ('https://play.eslgaming.com/match/' .. match.esl) or nil,
-		pf = match.pf and ('https://www.plusforward.net/quake/post/' .. match.pf) or nil,
-		stats = match.stats,
-	}
 end
 
 --

--- a/components/match2/wikis/arenafps/match_group_input_custom.lua
+++ b/components/match2/wikis/arenafps/match_group_input_custom.lua
@@ -40,6 +40,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
 
@@ -70,7 +71,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -43,6 +43,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)
 	games = MatchFunctions.removeUnsetMaps(games)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -70,7 +71,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -70,7 +70,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -135,12 +135,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {}
 end
 
 ---@param match table

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -66,7 +66,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -133,16 +133,6 @@ function MatchFunctions.getBestOf(match)
 	local bestof = tonumber(Logic.emptyOr(match.bestof, Variables.varDefault('bestof')))
 	Variables.varDefine('bestof', bestof)
 	return bestof or DEFAULT_BESTOF
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		reddit = match.reddit and 'https://redd.it/' .. match.reddit or nil,
-		cdl = match.cdl and 'https://callofdutyleague.com/en-us/match/' .. match.cdl or nil,
-		breakingpoint = match.breakingpoint and 'https://www.breakingpoint.gg/match/' .. match.breakingpoint or nil,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -38,6 +38,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -66,7 +67,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -47,6 +47,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -75,7 +76,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -75,7 +75,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
@@ -160,12 +160,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {}
 end
 
 --

--- a/components/match2/wikis/clashroyale/match_group_input_custom.lua
+++ b/components/match2/wikis/clashroyale/match_group_input_custom.lua
@@ -26,7 +26,6 @@ local OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
 }
-local ROYALE_API_PREFIX = 'https://royaleapi.com/'
 
 local CustomMatchGroupInput = {}
 local MatchFunctions = {}
@@ -76,7 +75,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
 	match.extradata = MatchFunctions.getExtraData(match, #games)
 
@@ -84,14 +83,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	match.opponents = opponents
 
 	return match
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		royaleapi = match.royaleapi and (ROYALE_API_PREFIX .. match.royaleapi) or nil,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/clashroyale/match_group_input_custom.lua
+++ b/components/match2/wikis/clashroyale/match_group_input_custom.lua
@@ -42,6 +42,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games, opponents)
@@ -75,7 +76,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
 	match.extradata = MatchFunctions.getExtraData(match, #games)
 

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -50,6 +50,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)
 	games = MatchFunctions.removeUnsetMaps(games)
+	match.links = MatchFunctions.getLinks(match, games)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -80,7 +81,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match, games)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -74,7 +74,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 
@@ -141,12 +141,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {}
 end
 
 ---@param match table

--- a/components/match2/wikis/criticalops/match_group_input_custom.lua
+++ b/components/match2/wikis/criticalops/match_group_input_custom.lua
@@ -46,6 +46,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)
 	games = MatchFunctions.removeUnsetMaps(games)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -74,7 +75,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.vod = Logic.emptyOr(match.vod, Variables.varDefault('vod'))
 

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -75,7 +75,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -147,12 +147,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {}
 end
 
 ---@param match table

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -47,6 +47,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -75,7 +76,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -178,15 +178,12 @@ end
 ---@param games table[]
 ---@return table
 function MatchFunctions.getLinks(match, games)
-	local links = {
-		preview = match.preview,
-		lrthread = match.lrthread,
-		recap = match.recap,
-		faceit = match.faceit and 'https://www.faceit.com/en/dota2/room/' .. match.faceit or nil,
-		stratz = {},
-		dotabuff = {},
-		datdota = {},
-	}
+	---@type table<string, string|table>
+	local links = MatchGroupInputUtil.getLinks(match)
+	links.stratz = {}
+	links.dotabuff = {}
+	links.datdota = {}
+
 	Array.forEach(
 		Array.filter(games, function(map) return map.publisherid ~= nil end),
 		function(map, mapIndex)

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -81,6 +81,7 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 	end)
 	local games = MatchFunctions.extractMaps(MatchParser, match, opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(match.bestof, games)
+	match.links = MatchFunctions.getLinks(match, games)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -110,7 +111,6 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match, games)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -70,7 +70,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -142,16 +142,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		faceit = match.faceit and ('https://www.faceit.com/en/halo_infinite/room/' .. match.faceit) or nil,
-		halodatahive = match.halodatahive and ('https://halodatahive.com/Series/Summary/' .. match.halodatahive) or nil,
-		stats = match.stats,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -40,6 +40,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
 
@@ -70,7 +71,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -45,6 +45,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -74,7 +75,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -74,7 +74,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -139,14 +139,6 @@ function MatchFunctions.getBestOf(match)
 	local bestOf = tonumber(Logic.emptyOr(match.bestof, Variables.varDefault('bestof')))
 	Variables.varDefine('bestof', bestOf)
 	return bestOf or DEFAULT_BESTOF
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		reddit = match.reddit
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/honorofkings/match_group_input_custom.lua
+++ b/components/match2/wikis/honorofkings/match_group_input_custom.lua
@@ -52,6 +52,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -81,7 +82,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/honorofkings/match_group_input_custom.lua
+++ b/components/match2/wikis/honorofkings/match_group_input_custom.lua
@@ -81,7 +81,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -149,14 +149,6 @@ function MatchFunctions.getBestOf(match)
 	local bestOf = tonumber(Logic.emptyOr(match.bestof, Variables.varDefault('bestof')))
 	Variables.varDefine('bestof', bestOf)
 	return bestOf or DEFAULT_BESTOF
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		reddit = match.reddit,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -109,7 +109,7 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -166,16 +166,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		reddit = match.reddit and 'https://redd.it/' .. match.reddit or nil,
-		gol = match.gol and 'https://gol.gg/game/stats/' .. match.gol .. '/page-game/' or nil,
-		factor = match.factor and 'https://www.factor.gg/match/' .. match.factor or nil,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -80,6 +80,7 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 	end)
 	local games = MatchFunctions.extractMaps(MatchParser, match, opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(match.bestof, games)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -109,7 +110,6 @@ function CustomMatchGroupInput.processMatchWithoutStandalone(MatchParser, match)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -71,7 +71,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -148,18 +148,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	local links = {preview = match.preview}
-
-	for key, linkPart in Table.iter.pairsByPrefix(match, 'mplink', {requireIndex = false}) do
-		links[key] = 'https://osu.ppy.sh/community/matches/' .. linkPart
-	end
-
-	return links
 end
 
 ---@param match table

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -41,6 +41,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
 
@@ -71,7 +72,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -66,7 +66,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -137,21 +137,6 @@ function MatchFunctions.getBestOf(match)
 	local bestof = tonumber(Logic.emptyOr(match.bestof, Variables.varDefault('bestof')))
 	Variables.varDefine('bestof', bestof)
 	return bestof or DEFAULT_BESTOF
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		owl = match.owl and 'https://web.archive.org/web/overwatchleague.com/en-us/match/' .. match.owl or nil,
-		jcg = match.jcg and 'https://web.archive.org/web/ow.j-cg.com/compe/view/match/' .. match.jcg or nil,
-		tespa = match.tespa and 'https://web.archive.org/web/compete.tespa.org/tournament/' .. match.tespa or nil,
-		overgg = match.overgg and 'http://www.over.gg/' .. match.overgg or nil,
-		pf = match.pf and 'http://www.plusforward.net/overwatch/post/' .. match.pf or nil,
-		wl = match.wl and 'https://www.winstonslab.com/matches/match.php?id=' .. match.wl or nil,
-		faceit = match.faceit and 'https://www.faceit.com/en/ow2/room/' .. match.faceit or nil,
-		stats = match.stats,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -38,6 +38,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -66,7 +67,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -43,6 +43,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)
 	games = MatchFunctions.removeUnsetMaps(games)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -71,7 +72,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -71,7 +71,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -136,23 +136,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		stats = match.stats,
-		siegegg = match.siegegg and 'https://siege.gg/matches/' .. match.siegegg or nil,
-		opl = match.opl and 'https://www.opleague.eu/match/' .. match.opl or nil,
-		esl = match.esl and 'https://play.eslgaming.com/match/' .. match.esl or nil,
-		faceit = match.faceit and 'https://www.faceit.com/en/rainbow_6/room/' .. match.faceit or nil,
-		lpl = match.lpl and 'https://old.letsplay.live/match/' .. match.lpl or nil,
-		r6esports = match.r6esports
-			and 'https://www.ubisoft.com/en-us/esports/rainbow-six/siege/match/' .. match.r6esports or nil,
-		challengermode = match.challengermode and 'https://www.challengermode.com/games/' .. match.challengermode or nil,
-		ebattle = match.ebattle and 'https://www.ebattle.gg/turnier/match/' .. match.ebattle or nil,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -73,7 +73,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -192,24 +192,6 @@ function MatchFunctions._checkForNonEmptyOpponent(opponent)
 	end
 	-- Literal and Teams can use the default function, player's can not because of match2player vs player list names
 	return not Opponent.isTbd(opponent)
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	local links = {}
-
-	-- Shift (formerly Octane)
-	for key, shift in Table.iter.pairsByPrefix(match, 'shift', {requireIndex = false}) do
-		links[key] = 'https://www.shiftrle.gg/matches/' .. shift
-	end
-
-	-- Ballchasing
-	for key, ballchasing in Table.iter.pairsByPrefix(match, 'ballchasing', {requireIndex = false}) do
-		links[key] = 'https://ballchasing.com/group/' .. ballchasing
-	end
-
-	return links
 end
 
 ---@param opponents table[]

--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -44,6 +44,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		return MatchGroupInputUtil.readOpponent(match, opponentIndex, {})
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	Array.forEach(opponents, function(opponent, opponentIndex)
 		opponent.extradata = CustomMatchGroupInput.getOpponentExtradata(opponent)
@@ -73,7 +74,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -77,7 +77,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -124,15 +124,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		stats = match.stats,
-		smiteesports = match.smiteesports and ('https://www.smiteesports.com/matches/' .. match.smiteesports) or nil,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -49,6 +49,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -77,7 +78,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -70,7 +70,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -142,15 +142,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		esl = match.esl and ('https://play.eslgaming.com/match/' .. match.esl) or nil,
-		stats = match.stats,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -40,6 +40,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
 
@@ -70,7 +71,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -129,16 +129,10 @@ end
 ---@param games table[]
 ---@return table
 function MatchFunctions.getLinks(match, games)
-	local links = {
-		rgl = match.rgl and 'https://rgl.gg/Public/Match.aspx?m=' .. match.rgl or nil,
-		ozf = match.ozf and 'https://warzone.ozfortress.com/matches/' .. match.ozf or nil,
-		etf2l = match.etf2l and 'http://etf2l.org/matches/' .. match.etf2l or nil,
-		tftv = match.tftv and'http://tf.gg/' .. match.tftv or nil,
-		esl = match.esl and 'https://play.eslgaming.com/match/' .. match.esl or nil,
-		esea = match.esea and 'https://play.esea.net/match/' .. match.esea or nil,
-		logstf = {},
-		logstfgold = {},
-	}
+	---@type table<string, string|table>
+	local links = MatchGroupInputUtil.getLinks(match)
+	links.logstf = {}
+	links.logstfgold = {}
 
 	Array.forEach(games or {}, function(game, gameIndex)
 		links.logstf[gameIndex] = game.logstf and ('https://logs.tf/' .. game.logstf) or nil

--- a/components/match2/wikis/teamfortress/match_group_input_custom.lua
+++ b/components/match2/wikis/teamfortress/match_group_input_custom.lua
@@ -38,6 +38,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(match.bestof, games)
+	match.links = MatchFunctions.getLinks(match, games)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -67,7 +68,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match, games)
 	match.games = games
 	match.opponents = opponents
 

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -42,6 +42,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = CustomMatchGroupInput.extractMaps(match, opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)
 	games = MatchFunctions.removeUnsetMaps(games)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -70,7 +71,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -70,7 +70,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -137,14 +137,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		vlr = match.vlr and 'https://vlr.gg/' .. match.vlr or nil,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -70,6 +70,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games, opponents)
@@ -109,7 +110,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
-	match.links = MatchGroupInputUtil.getLinks(match)
 	match.extradata = MatchFunctions.getExtraData(match, #games)
 
 	match.games = games

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -109,7 +109,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 
 	match.stream = Streams.processStreams(match)
 	match.vod = Logic.nilIfEmpty(match.vod)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 	match.extradata = MatchFunctions.getExtraData(match, #games)
 
 	match.games = games
@@ -215,16 +215,6 @@ function MatchFunctions.getBestOf(bestofInput)
 	end
 
 	return bestof
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		preview = match.preview,
-		review = match.review,
-		recap = match.recap,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -79,7 +79,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -143,14 +143,6 @@ function MatchFunctions.getBestOf(match)
 	local bestOf = tonumber(Logic.emptyOr(match.bestof, Variables.varDefault('bestof')))
 	Variables.varDefine('bestof', bestOf)
 	return bestOf or DEFAULT_BESTOF
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {
-		reddit = match.reddit,
-	}
 end
 
 ---@param match table

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -50,6 +50,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 	local games = CustomMatchGroupInput.extractMaps(match, #opponents)
 	match.bestof = MatchFunctions.getBestOf(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -79,7 +80,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -71,7 +71,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -143,12 +143,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {}
 end
 
 ---@param match table

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -41,6 +41,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	end)
 
 	local games = MatchFunctions.extractMaps(match, #opponents)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.bestof = MatchFunctions.getBestOf(match.bestof)
 
@@ -71,7 +72,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/components/match2/wikis/zula/match_group_input_custom.lua
+++ b/components/match2/wikis/zula/match_group_input_custom.lua
@@ -71,7 +71,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchFunctions.getLinks(match)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents
@@ -136,12 +136,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param match table
----@return table
-function MatchFunctions.getLinks(match)
-	return {}
 end
 
 ---@param match table

--- a/components/match2/wikis/zula/match_group_input_custom.lua
+++ b/components/match2/wikis/zula/match_group_input_custom.lua
@@ -43,6 +43,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 	local games = MatchFunctions.extractMaps(match, #opponents)
 	match.bestof = MatchGroupInputUtil.getBestOf(nil, games)
 	games = MatchFunctions.removeUnsetMaps(games)
+	match.links = MatchGroupInputUtil.getLinks(match)
 
 	local autoScoreFunction = MatchGroupInputUtil.canUseAutoScore(match, games)
 		and MatchFunctions.calculateMatchScore(games)
@@ -71,7 +72,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	Table.mergeInto(match, MatchGroupInputUtil.getTournamentContext(match))
 
 	match.stream = Streams.processStreams(match)
-	match.links = MatchGroupInputUtil.getLinks(match)
 
 	match.games = games
 	match.opponents = opponents

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -397,9 +397,9 @@ end
 ---@param platform string
 ---@param id string?
 ---@param variant string?
----@param fallbaseToBase boolean? #defaults to true
+---@param fallbackToBase boolean? #defaults to true
 ---@return string
-function Links.makeFullLink(platform, id, variant, fallbaseToBase)
+function Links.makeFullLink(platform, id, variant, fallbackToBase)
 	if id == nil or id == '' then
 		return ''
 	end
@@ -414,7 +414,7 @@ function Links.makeFullLink(platform, id, variant, fallbaseToBase)
 
 	local prefix = prefixData[variant]
 	local suffix = suffixData[variant]
-	if fallbaseToBase ~= false then
+	if fallbackToBase ~= false then
 		prefix = prefix or prefixData[1]
 		suffix = suffix or suffixData[1]
 	end
@@ -428,11 +428,11 @@ end
 
 ---@param links {[string]: string}
 ---@param variant string?
----@param fallbaseToBase boolean? #defaults to true
+---@param fallbackToBase boolean? #defaults to true
 ---@return {[string]: string}
-function Links.makeFullLinksForTableItems(links, variant, fallbaseToBase)
+function Links.makeFullLinksForTableItems(links, variant, fallbackToBase)
 	return Table.map(links, function(key, item)
-		return key, Links.makeFullLink(Links.removeAppendedNumber(key), item, variant, fallbaseToBase)
+		return key, Links.makeFullLink(Links.removeAppendedNumber(key), item, variant, fallbackToBase)
 	end)
 end
 

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -136,7 +136,7 @@ local PREFIXES = {
 	huyatv = {'https://www.huya.com/'},
 	iccup = {'http://www.iccup.com/starcraft/gamingprofile/'},
 	instagram = {'https://www.instagram.com/'},
-	interview = {''},
+	interview = {'', match = ''},
 	jcg = {match = 'https://web.archive.org/web/ow.j-cg.com/compe/view/match/'},
 	kick = {'https://www.kick.com/'},
 	kuaishou = {'https://live.kuaishou.com/u/'},
@@ -154,7 +154,7 @@ local PREFIXES = {
 	linkedin = {'https://www.linkedin.com/in/'},
 	loco = {'https://loco.gg/streamers/'},
 	lolchess = {'https://lolchess.gg/profile/'},
-	lrthread = {''},
+	lrthread = {'', match = ''},
 	mapdraft = {match = 'https://aoe2cm.net/draft/'},
 	matcherino = {'https://matcherino.com/tournaments/'},
 	matcherinolink = {'https://matcherino.com/t/'},
@@ -183,7 +183,7 @@ local PREFIXES = {
 	patreon = {'https://www.patreon.com/'},
 	pf = {match = 'https://www.plusforward.net/quake/post/'},
 	playlist = {''},
-	preview = {''},
+	preview = {'', match = ''},
 	qrindr = {match = 'https://qrindr.com/match/'},
 	quakehistory = {match = 'http://www.quakehistory.com/en/matches/'},
 	r6esports = {
@@ -194,8 +194,8 @@ local PREFIXES = {
 		match = 'https://redd.it/',
 	},
 	replay = {''},
-	recap = {''},
-	review = {''},
+	recap = {'', match = ''},
+	review = {'', match = ''},
 	rgl = {
 		'https://rgl.gg/Public/LeagueTable?s=',
 		team = 'https://rgl.gg/Public/Team?t=',
@@ -235,7 +235,7 @@ local PREFIXES = {
 	smiteesports = {match = 'https://www.smiteesports.com/matches/'},
 	spotify = {'https://open.spotify.com/'},
 	steamalternative = {'https://steamcommunity.com/profiles/'},
-	stats = {''},
+	stats = {'', match = ''},
 	stratz = {
 		'https://stratz.com/leagues/',
 		player = 'https://stratz.com/players/',
@@ -397,8 +397,9 @@ end
 ---@param platform string
 ---@param id string?
 ---@param variant string?
+---@param fallbaseToBase boolean? #defaults to true
 ---@return string
-function Links.makeFullLink(platform, id, variant)
+function Links.makeFullLink(platform, id, variant, fallbaseToBase)
 	if id == nil or id == '' then
 		return ''
 	end
@@ -409,20 +410,29 @@ function Links.makeFullLink(platform, id, variant)
 		return ''
 	end
 
-	local prefix = prefixData[variant] or prefixData[1]
-
 	local suffixData = SUFFIXES[platform] or {}
-	local suffix = suffixData[variant] or suffixData[1] or ''
 
-	return prefix .. id .. suffix
+	local prefix = prefixData[variant]
+	local suffix = suffixData[variant]
+	if fallbaseToBase ~= false then
+		prefix = prefix or prefixData[1]
+		suffix = suffix or suffixData[1]
+	end
+
+	if not prefix then
+		return ''
+	end
+
+	return prefix .. id .. (suffix or '')
 end
 
 ---@param links {[string]: string}
 ---@param variant string?
+---@param fallbaseToBase boolean? #defaults to true
 ---@return {[string]: string}
-function Links.makeFullLinksForTableItems(links, variant)
+function Links.makeFullLinksForTableItems(links, variant, fallbaseToBase)
 	return Table.map(links, function(key, item)
-		return key, Links.makeFullLink(Links.removeAppendedNumber(key), item, variant)
+		return key, Links.makeFullLink(Links.removeAppendedNumber(key), item, variant, fallbaseToBase)
 	end)
 end
 
@@ -442,5 +452,6 @@ function Links.makeIcon(key, size)
 	return '<i class="lp-icon lp-' .. (ICON_KEYS_TO_RENAME[key] or key)
 		.. (size and (' lp-icon-' .. size) or '') .. '></i>'
 end
+
 
 return Class.export(Links, {frameOnly = true})

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -50,7 +50,8 @@ local PREFIXES = {
 	challengermode = {
 		'https://www.challengermode.com/tournaments/',
 		player = 'https://www.challengermode.com/users/',
-		team = 'https://www.challengermode.com/teams/'
+		team = 'https://www.challengermode.com/teams/',
+		match = 'https://www.challengermode.com/games/',
 	},
 	challonge = {
 		'',
@@ -76,6 +77,7 @@ local PREFIXES = {
 	douyin = {'https://live.douyin.com/'},
 	douyin_page = {'https://v.douyin.com/'},
 	douyu = {'https://www.douyu.com/'},
+	ebattle = {match = 'https://www.ebattle.gg/turnier/match/'},
 	esea = {
 		'https://play.esea.net/events/',
 		player = 'https://play.esea.net/users/',
@@ -86,6 +88,7 @@ local PREFIXES = {
 		'',
 		team = 'https://play.eslgaming.com/team/',
 		player = 'https://play.eslgaming.com/player/',
+		match = 'https://play.eslgaming.com/match/',
 	},
 	esportal = {'https://esportal.com/tournament/'},
 	etf2l = {
@@ -132,6 +135,7 @@ local PREFIXES = {
 		'https://gg.letsplay.live/tournament/',
 		team = 'https://gg.letsplay.live/view-team/',
 		player = 'https://gg.letsplay.live/profile/view-stats/',
+		match = 'https://old.letsplay.live/match/',
 	},
 	linkedin = {'https://www.linkedin.com/in/'},
 	loco = {'https://loco.gg/streamers/'},
@@ -147,12 +151,18 @@ local PREFIXES = {
 		player = 'https://nwc3l.com/profile/',
 	},
 	openrec = {'https://www.openrec.tv/live/'},
+	opl = {
+		match = 'https://www.opleague.eu/match/'
+	},
 	osu = {
 		'https://osu.ppy.sh/',
 		player = 'https://osu.ppy.sh/users/',
 	},
 	patreon = {'https://www.patreon.com/'},
 	playlist = {''},
+	r6esports = {
+		match = 'https://www.ubisoft.com/en-us/esports/rainbow-six/siege/match/',
+	},
 	reddit = {'https://www.reddit.com/user/'},
 	replay = {''},
 	rgl = {
@@ -168,6 +178,7 @@ local PREFIXES = {
 		'https://siege.gg/competitions/',
 		team = 'https://siege.gg/teams/',
 		player = 'https://siege.gg/players/',
+		match = 'https://siege.gg/matches/',
 	},
 	sk = {'https://sk-gaming.com/member/'},
 	smashboards = {'https://smashboards.com/'},
@@ -185,6 +196,7 @@ local PREFIXES = {
 	pubsteam = {'https://steamcommunity.com/groups/'},
 	spotify = {'https://open.spotify.com/'},
 	steamalternative = {'https://steamcommunity.com/profiles/'},
+	stats = {''},
 	stratz = {
 		'https://stratz.com/leagues/',
 		player = 'https://stratz.com/players/',

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -46,7 +46,9 @@ local PREFIXES = {
 	['bilibili-stream'] = {'https://live.bilibili.com/'},
 	booyah = {'https://booyah.live/'},
 	bracket = {''},
+	breakingpoint = {match = 'https://www.breakingpoint.gg/match/'},
 	cc = {'https://cc.163.com/'},
+	cdl = {match = 'https://callofdutyleague.com/en-us/match/'},
 	challengermode = {
 		'https://www.challengermode.com/tournaments/',
 		player = 'https://www.challengermode.com/users/',
@@ -58,6 +60,7 @@ local PREFIXES = {
 		player = 'https://challonge.com/users/',
 	},
 	chzzk = {'https://chzzk.naver.com/live/'},
+	civdraft = {match = 'https://aoe2cm.net/draft/'},
 	cntft = {'https://lol.qq.com/tft/#/masterDetail/'},
 	corestrike = {'https://corestrike.gg/lookup/'},
 	cfs = {'https://www.crossfirestars.com/'},
@@ -67,6 +70,7 @@ local PREFIXES = {
 		team = 'https://www.datdota.com/teams/'
 	},
 	daumcafe = {'http://cafe.daum.net/'},
+	dbstats = {match = 'https://quakelife.ru/diabotical/stats/matches/?matches='},
 	discord = {'https://discord.gg/'},
 	dlive = {'https://www.dlive.tv/'},
 	dotabuff = {
@@ -124,6 +128,7 @@ local PREFIXES = {
 	huyatv = {'https://www.huya.com/'},
 	iccup = {'http://www.iccup.com/starcraft/gamingprofile/'},
 	instagram = {'https://www.instagram.com/'},
+	interview = {''},
 	kick = {'https://www.kick.com/'},
 	kuaishou = {'https://live.kuaishou.com/u/'},
 	['letsplaylive-old'] = {
@@ -140,6 +145,8 @@ local PREFIXES = {
 	linkedin = {'https://www.linkedin.com/in/'},
 	loco = {'https://loco.gg/streamers/'},
 	lolchess = {'https://lolchess.gg/profile/'},
+	lrthread = {''},
+	mapdraft = {match = 'https://aoe2cm.net/draft/'},
 	matcherino = {'https://matcherino.com/tournaments/'},
 	matcherinolink = {'https://matcherino.com/t/'},
 	mildom = {'https://www.mildom.com/'},
@@ -159,19 +166,31 @@ local PREFIXES = {
 		player = 'https://osu.ppy.sh/users/',
 	},
 	patreon = {'https://www.patreon.com/'},
+	pf = {match = 'https://www.plusforward.net/quake/post/'},
 	playlist = {''},
+	preview = {''},
+	qrindr = {match = 'https://qrindr.com/match/'},
+	quakehistory = {match = 'http://www.quakehistory.com/en/matches/'},
 	r6esports = {
 		match = 'https://www.ubisoft.com/en-us/esports/rainbow-six/siege/match/',
 	},
-	reddit = {'https://www.reddit.com/user/'},
+	reddit = {
+		'https://www.reddit.com/user/',
+		match = 'https://redd.it/',
+	},
 	replay = {''},
+	recap = {''},
+	review = {''},
 	rgl = {
 		'https://rgl.gg/Public/LeagueTable?s=',
 		team = 'https://rgl.gg/Public/Team?t=',
 		player = 'https://rgl.gg/Public/PlayerProfile?p=',
 	},
 	rooter = {'https://rooter.gg/'},
-	royaleapi = {'https://royaleapi.com/player/'},
+	royaleapi = {
+		'https://royaleapi.com/player/',
+		match = 'https://royaleapi.com/'
+	},
 	rules = {''},
 	shift = {'https://www.shiftrle.gg/events/'},
 	siegegg = {

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -38,6 +38,9 @@ local PREFIXES = {
 		player = 'https://www.b5csgo.com/personalCenter/',
 		team = 'https://www.b5csgo.com/clan/'
 	},
+	ballchasing = {
+		match = 'https://ballchasing.com/group/',
+	},
 	battlefy = {'https://www.battlefy.com/'},
 	bilibili = {
 		'https://space.bilibili.com/',
@@ -85,7 +88,8 @@ local PREFIXES = {
 	esea = {
 		'https://play.esea.net/events/',
 		player = 'https://play.esea.net/users/',
-		team = 'https://play.esea.net/teams/'
+		team = 'https://play.esea.net/teams/',
+		match = 'https://play.esea.net/match/',
 	},
 	['esea-d'] = {'https://play.esea.net/league/standings?divisionId='},
 	esl = {
@@ -99,6 +103,7 @@ local PREFIXES = {
 		'',
 		team = 'https://etf2l.org/teams/',
 		player = 'https://etf2l.org/forum/user/',
+		match = 'https://etf2l.org/matches/',
 	},
 	facebook = {'https://facebook.com/'},
 	['facebook-gaming'] = {'https://fb.gg/'},
@@ -110,14 +115,17 @@ local PREFIXES = {
 	['faceit-c'] = {'https://www.faceit.com/en/championship/'},
 	['faceit-hub'] = {'https://www.faceit.com/en/hub/'},
 	['faceit-org'] = {'https://www.faceit.com/en/organizers/'},
+	factor = {match = 'https://www.factor.gg/match/'},
 	fanclub = {''},
 	geoguessr = {'https://www.geoguessr.com/'},
+	gol = {match = 'https://gol.gg/game/stats/'},
 	gosugamers = {''},
 	gplus = {'http://plus.google.com/-plus'},
 	halodatahive = {
 		'https://halodatahive.com/Tournament/Detail/',
 		team = 'https://halodatahive.com/Team/Detail/',
 		player = 'https://halodatahive.com/Player/Detail/',
+		match = 'https://halodatahive.com/Series/Summary/',
 	},
 	home = {''},
 	haojiao = {
@@ -129,6 +137,7 @@ local PREFIXES = {
 	iccup = {'http://www.iccup.com/starcraft/gamingprofile/'},
 	instagram = {'https://www.instagram.com/'},
 	interview = {''},
+	jcg = {match = 'https://web.archive.org/web/ow.j-cg.com/compe/view/match/'},
 	kick = {'https://www.kick.com/'},
 	kuaishou = {'https://live.kuaishou.com/u/'},
 	['letsplaylive-old'] = {
@@ -150,6 +159,7 @@ local PREFIXES = {
 	matcherino = {'https://matcherino.com/tournaments/'},
 	matcherinolink = {'https://matcherino.com/t/'},
 	mildom = {'https://www.mildom.com/'},
+	mplink = {match = 'https://osu.ppy.sh/community/matches/'}, -- Should this key be renamed?
 	niconico = {'https://www.nicovideo.jp/'},
 	nimotv = {'https://www.nimo.tv/'},
 	['nwc3l'] = {
@@ -165,6 +175,11 @@ local PREFIXES = {
 		'https://osu.ppy.sh/',
 		player = 'https://osu.ppy.sh/users/',
 	},
+	overgg = {match = 'https://www.over.gg/'},
+	owl = {
+		match = 'https://web.archive.org/web/overwatchleague.com/en-us/match/',
+	},
+	ozf = {match = 'https://warzone.ozfortress.com/matches/'},
 	patreon = {'https://www.patreon.com/'},
 	pf = {match = 'https://www.plusforward.net/quake/post/'},
 	playlist = {''},
@@ -185,6 +200,7 @@ local PREFIXES = {
 		'https://rgl.gg/Public/LeagueTable?s=',
 		team = 'https://rgl.gg/Public/Team?t=',
 		player = 'https://rgl.gg/Public/PlayerProfile?p=',
+		match = 'https://rgl.gg/Public/Match.aspx?m=',
 	},
 	rooter = {'https://rooter.gg/'},
 	royaleapi = {
@@ -192,7 +208,10 @@ local PREFIXES = {
 		match = 'https://royaleapi.com/'
 	},
 	rules = {''},
-	shift = {'https://www.shiftrle.gg/events/'},
+	shift = {
+		'https://www.shiftrle.gg/events/',
+		match = 'https://www.shiftrle.gg/matches/',
+	},
 	siegegg = {
 		'https://siege.gg/competitions/',
 		team = 'https://siege.gg/teams/',
@@ -213,6 +232,7 @@ local PREFIXES = {
 	strikr = {'https://strikr.pro/pilot/'},
 	privsteam = {'https://steamcommunity.com/groups/'},
 	pubsteam = {'https://steamcommunity.com/groups/'},
+	smiteesports = {match = 'https://www.smiteesports.com/matches/'},
 	spotify = {'https://open.spotify.com/'},
 	steamalternative = {'https://steamcommunity.com/profiles/'},
 	stats = {''},
@@ -223,9 +243,11 @@ local PREFIXES = {
 	},
 	stream = {''},
 	telegram = {'https://t.me/'},
+	tespa = {match = 'https://web.archive.org/web/compete.tespa.org/tournament/'},
 	tftv = {
 		'https://www.teamfortress.tv/',
 		player = 'https://www.teamfortress.tv/user/',
+		match = 'http://tf.gg/',
 	},
 	tiktok = {'https://tiktok.com/@'},
 	tlpd = {''},
@@ -260,10 +282,12 @@ local PREFIXES = {
 	vlr = {
 		'https://www.vlr.gg/event/',
 		team = 'https://www.vlr.gg/team/',
-		player = 'https://www.vlr.gg/player/'
+		player = 'https://www.vlr.gg/player/',
+		match = 'https://vlr.gg/',
 	},
 	vod = {''},
 	weibo = {'https://weibo.com/'},
+	wl = {match = 'https://www.winstonslab.com/matches/match.php?id='},
 	yandexefir = {'https://yandex.ru/efir?stream_channel='},
 	youtube = {'https://www.youtube.com/'},
 	zhangyutv = {'http://www.zhangyu.tv/'},
@@ -279,6 +303,7 @@ local SUFFIXES = {
 		'',
 		stream = '/live',
 	},
+	gol = {match = '/page-game/'},
 	iccup = {'.html'},
 	['faceit-c'] = {'/'},
 	['faceit-hub'] = {'/'},

--- a/standard/links/wikis/dota2/links_custom_data.lua
+++ b/standard/links/wikis/dota2/links_custom_data.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=overwatch
+-- wiki=dota2
 -- page=Module:Links/CustomData
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -8,15 +8,11 @@
 
 return {
 	prefixes = {
-		['faceit-l'] = {
-			'https://www.faceit.com/en//league//88c7f7ec-4cb8-44d3-a5db-6e808639c232/',
-		},
 		faceit = {
 			'',
 			team = 'https://www.faceit.com/en/teams/',
 			player = 'https://www.faceit.com/en/players/',
-			match = 'https://www.faceit.com/en/ow2/room/',
+			match = 'https://www.faceit.com/en/dota2/room/',
 		},
-		pf = {match = 'http://www.plusforward.net/overwatch/post/'},
 	}
 }

--- a/standard/links/wikis/halo/links_custom_data.lua
+++ b/standard/links/wikis/halo/links_custom_data.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=overwatch
+-- wiki=halo
 -- page=Module:Links/CustomData
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -8,15 +8,11 @@
 
 return {
 	prefixes = {
-		['faceit-l'] = {
-			'https://www.faceit.com/en//league//88c7f7ec-4cb8-44d3-a5db-6e808639c232/',
-		},
 		faceit = {
 			'',
 			team = 'https://www.faceit.com/en/teams/',
 			player = 'https://www.faceit.com/en/players/',
-			match = 'https://www.faceit.com/en/ow2/room/',
+			match = 'https://www.faceit.com/en/halo_infinite/room/',
 		},
-		pf = {match = 'http://www.plusforward.net/overwatch/post/'},
 	}
 }

--- a/standard/links/wikis/rainbowsix/links_custom_data.lua
+++ b/standard/links/wikis/rainbowsix/links_custom_data.lua
@@ -12,6 +12,7 @@ return {
 			'https://www.faceit.com/en/championship/',
 			team = 'https://www.faceit.com/en/teams/',
 			player = 'https://www.faceit.com/en/players/',
+			match = 'https://www.faceit.com/en/rainbow_6/room/',
 		}
 	},
 }


### PR DESCRIPTION
## Summary
Resolves #2135, or at least partially (still needs to be automated on match summaries).

CS will still have its own fully own link parsing; dota2 and TF uses partially their own

## How did you test this change?
Tested on R6