### PR TITLE
fix(match2): `tournament_status` is not working

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -55,7 +55,6 @@ local NOT_PLAYED_INPUTS = {
 	'np',
 	'canceled',
 	'cancelled',
-	'postponed',
 }
 
 MatchGroupInputUtil.DEFAULT_ALLOWED_VETOES = {

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -55,6 +55,7 @@ local NOT_PLAYED_INPUTS = {
 	'np',
 	'canceled',
 	'cancelled',
+	'postponed',
 }
 
 MatchGroupInputUtil.DEFAULT_ALLOWED_VETOES = {

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -39,13 +39,7 @@ local CustomMatchGroupInput = {}
 ---@param options table?
 ---@return table
 function CustomMatchGroupInput.processMatch(match, options)
-	---@type string
-	local finishedInput = tostring(Logic.nilOr(
-		Logic.readBoolOrNil(match.finished),
-		Variables.varDefault('tournament_status'),
-		match.finished,
-		''
-	))
+	local finishedInput = Logic.nilIfEmpty(match.finished) or Variables.varDefault('tournament_status') --[[@as string?]]
 	local winnerInput = match.winner --[[@as string?]]
 
 	Table.mergeInto(match, MatchGroupInputUtil.readDate(match.date))
@@ -246,12 +240,12 @@ end
 
 ---@param match table
 ---@param opponents table[]
----@param finishedInput string
+---@param finishedInput string?
 ---@return table
 function MatchFunctions.getExtraData(match, opponents, finishedInput)
 	return {
 		mapveto = MatchGroupInputUtil.getMapVeto(match),
-		status = match.resulttype == MatchGroupInputUtil.RESULT_TYPE.NOT_PLAYED and Logic.nilIfEmpty(finishedInput) or nil,
+		status = match.resulttype == MatchGroupInputUtil.RESULT_TYPE.NOT_PLAYED and finishedInput or nil,
 		overturned = Logic.isNotEmpty(match.overturned),
 		featured = MatchFunctions.isFeatured(match, opponents),
 		hidden = Logic.readBool(Variables.varDefault('match_hidden'))

--- a/components/match2/wikis/counterstrike/match_group_input_custom.lua
+++ b/components/match2/wikis/counterstrike/match_group_input_custom.lua
@@ -42,7 +42,6 @@ function CustomMatchGroupInput.processMatch(match, options)
 	---@type string
 	local finishedInput = tostring(Logic.nilOr(
 		Logic.readBoolOrNil(match.finished),
-		Logic.nilIfEmpty(match.status),
 		Variables.varDefault('tournament_status'),
 		match.finished,
 		''


### PR DESCRIPTION
## Summary
Fix the status/finished processing on cs by applying fallbacks a bit differently and moving status processing further up.
~~Also allow `'postponed'` as valid not played input~~

## How did you test this change?
dev