### PR TITLE
fix(transfer): missing icon fallback for icon2 from icon1

### DIFF
--- a/components/transfer/commons/transfer_row.lua
+++ b/components/transfer/commons/transfer_row.lua
@@ -274,6 +274,8 @@ function TransferRow:readIconsAndPosition(playerIndex)
 		return iconInput .. '_Substitute'
 	end)
 
+	icons[2] = icons[2] or icons[1]
+
 	return icons, positions
 end
 


### PR DESCRIPTION
## Summary
Add a missing icon fallback for icon2 from icon1 in transfer row processing

## How did you test this change?
dev into live