### PR TITLE
fix(transfer): logic inverted

### DIFF
--- a/components/transfer/commons/transfer_references.lua
+++ b/components/transfer/commons/transfer_references.lua
@@ -146,7 +146,7 @@ function TransferRef.makeUnique(references)
 	local refs = {}
 	Array.forEach(references, function(reference)
 		if Array.all(refs, function(ref)
-			return Logic.deepEquals(ref, reference)
+			return not Logic.deepEquals(ref, reference)
 		end) then
 			table.insert(refs, reference)
 		end


### PR DESCRIPTION
## Summary
Adds a missing `not` in the makeUnique logic for transfer refs display

## How did you test this change?
dev to live