### PR TITLE
fix(transfer): uk sub flags not showing

### DIFF
--- a/components/transfer/commons/transfer_row.lua
+++ b/components/transfer/commons/transfer_row.lua
@@ -234,7 +234,7 @@ function TransferRow:_convertToTransferStructure(data)
 
 	return Table.merge(self.baseData, {
 		player = player.pageIsResolved and player.pageName or mw.ext.TeamLiquidIntegration.resolve_redirect(player.pageName),
-		nationality = Flags.CountryCode(player.flag),
+		nationality = Flags.CountryCode(player.flag, 'alpha3'),
 		role1 = self.baseData.role1 or self.baseData.fromteam and subs[1] and 'Substitute' or nil,
 		role2 = self.baseData.role2 or self.baseData.toteam and subs[2] and 'Substitute' or nil,
 		reference = self.references[data.index] or self.references.all or {reference1 = ''},

--- a/spec/transfer_spec.lua
+++ b/spec/transfer_spec.lua
@@ -71,7 +71,7 @@ insulate('Transfer', function()
 		starcraft2 = {
 			input = {
 				name = 'Clem',
-				flag = 'fra',
+				flag = 'fr',
 				faction = 't',
 				team1 = 'team liquid',
 				team2 = 'mouz',
@@ -85,7 +85,7 @@ insulate('Transfer', function()
 				{
 					objectname = 'transfer_2024-10-11_000000',
 					player = 'Clem',
-					nationality = 'fr',
+					nationality = 'fra',
 					fromteam = '', --'Team Liquid',
 					toteam = '', --'mousesports',
 					fromteamtemplate = '', --'team liquid 2024',

--- a/spec/transfer_spec.lua
+++ b/spec/transfer_spec.lua
@@ -37,7 +37,7 @@ insulate('Transfer', function()
 				{
 					objectname = 'transfer_2024-10-11_000000',
 					player = 'Supr',
-					nationality = 'us',
+					nationality = 'usa',
 					fromteam = '', --'Team Liquid',
 					toteam = '', --'mousesports',
 					fromteamtemplate = '', --'team liquid 2024',
@@ -71,7 +71,7 @@ insulate('Transfer', function()
 		starcraft2 = {
 			input = {
 				name = 'Clem',
-				flag = 'fr',
+				flag = 'fra',
 				faction = 't',
 				team1 = 'team liquid',
 				team2 = 'mouz',


### PR DESCRIPTION
## Summary
Currently we process (and store) uksc etc as alpha2, which converts them to uk. (which would be totally fine for me...)
Due to complaints on discord this PR proposes to switch it to alpha 3 to support the uk sub flag stuff.

## How did you test this change?
dev (on mobile)