### PR TITLE
feat(match2): parse bestof on easportsfc

### DIFF
--- a/components/match2/wikis/easportsfc/match_group_input_custom.lua
+++ b/components/match2/wikis/easportsfc/match_group_input_custom.lua
@@ -56,6 +56,7 @@ function CustomMatchGroupInput.processMatch(match, options)
 		}, autoScoreFunction)
 	end)
 
+	match.bestof = tonumber(match.bestof)
 	match.finished = MatchGroupInputUtil.matchIsFinished(match, opponents)
 
 	if match.finished then


### PR DESCRIPTION
## Summary
Currently bestof gets not parsed at all on fifa.
This will lead to it being a string if there is input for it and hence causing errors in some edge cases.

reported on discord by omarion:
https://discord.com/channels/93055209017729024/1209065403955806270/1296184431358509067
investigated by enuaj and found a solution that ignored annos but pointed me to the fact that bestof was not parsed:
https://discord.com/channels/93055209017729024/1209065403955806270/1296200399354724373

## How did you test this change?
dev