### PR TITLE
feat(match2): improve character pick and ban display

### DIFF
--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -107,12 +107,10 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Character Bans
 	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS, NO_CHARACTER)
-	if characterBansData then
-		body.root:node(MatchSummaryWidgets.CharacterBanTable{
-			bans = characterBansData,
-			date = match.date,
-		})
-	end
+	body.root:node(MatchSummaryWidgets.CharacterBanTable{
+		bans = characterBansData,
+		date = match.date,
+	})
 
 	-- Add the Map Vetoes
 	body:addRow(MatchSummary.defaultMapVetoDisplay(match, MapVeto()))

--- a/components/match2/wikis/honorofkings/match_summary.lua
+++ b/components/match2/wikis/honorofkings/match_summary.lua
@@ -77,12 +77,10 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Character Bans
 	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS, NO_CHARACTER)
-	if characterBansData then
-		body.root:node(MatchSummaryWidgets.CharacterBanTable{
-			bans = characterBansData,
-			date = match.date,
-		})
-	end
+	body.root:node(MatchSummaryWidgets.CharacterBanTable{
+		bans = characterBansData,
+		date = match.date,
+	})
 
 	return body
 end
@@ -106,8 +104,6 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 			championsData[2][champIndex] = extradata['team2champion' .. champIndex]
 			championsDataIsEmpty = false
 		end
-		championsData[1].color = extradata.team1side
-		championsData[2].color = extradata.team2side
 	end
 
 	if

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -82,12 +82,10 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Character Bans
 	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS, NO_CHARACTER)
-	if characterBansData then
-		body.root:node(MatchSummaryWidgets.CharacterBanTable{
-			bans = characterBansData,
-			date = match.date,
-		})
-	end
+	body.root:node(MatchSummaryWidgets.CharacterBanTable{
+		bans = characterBansData,
+		date = match.date,
+	})
 
 	return body
 end

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -80,12 +80,10 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Character Bans
 	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS, NO_CHARACTER)
-	if characterBansData then
-		body.root:node(MatchSummaryWidgets.CharacterBanTable{
-			bans = characterBansData,
-			date = match.date,
-		})
-	end
+	body.root:node(MatchSummaryWidgets.CharacterBanTable{
+		bans = characterBansData,
+		date = match.date,
+	})
 
 	return body
 end

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -79,12 +79,10 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Character Bans
 	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS, NO_CHARACTER)
-	if characterBansData then
-		body.root:node(MatchSummaryWidgets.CharacterBanTable{
-			bans = characterBansData,
-			date = match.date,
-		})
-	end
+	body.root:node(MatchSummaryWidgets.CharacterBanTable{
+		bans = characterBansData,
+		date = match.date,
+	})
 
 	return body
 end
@@ -105,8 +103,6 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 	end
 	local championsData = Array.map(Array.range(1, 2), getChampsForTeam)--[[@as table]]
 	local championsDataIsEmpty = Array.all(championsData, Table.isEmpty)
-	championsData[1].color = extradata.team1side
-	championsData[2].color = extradata.team2side
 
 	if Table.isEmpty(game.scores) and Logic.isEmpty(game.winner) and championsDataIsEmpty then
 		return nil

--- a/components/match2/wikis/smite/match_summary.lua
+++ b/components/match2/wikis/smite/match_summary.lua
@@ -64,12 +64,10 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Character Bans
 	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS, NO_CHARACTER)
-	if characterBansData then
-		body.root:node(MatchSummaryWidgets.CharacterBanTable{
-			bans = characterBansData,
-			date = match.date,
-		})
-	end
+	body.root:node(MatchSummaryWidgets.CharacterBanTable{
+		bans = characterBansData,
+		date = match.date,
+	})
 
 	return body
 end
@@ -95,8 +93,6 @@ function CustomMatchSummary._createGame(game, gameIndex, date)
 		if String.isNotEmpty(extradata['team2god' .. godIndex]) then
 			godsData[2][godIndex] = extradata['team2god' .. godIndex]
 		end
-		godsData[1].side = extradata.team1side
-		godsData[2].side = extradata.team2side
 	end
 
 	row:addClass('brkts-popup-body-game')

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -77,12 +77,10 @@ function CustomMatchSummary.createBody(match)
 
 	-- Add the Character Bans
 	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS, NO_CHARACTER)
-	if characterBansData then
-		body.root:node(MatchSummaryWidgets.CharacterBanTable{
-			bans = characterBansData,
-			date = match.date,
-		})
-	end
+	body.root:node(MatchSummaryWidgets.CharacterBanTable{
+		bans = characterBansData,
+		date = match.date,
+	})
 
 	return body
 end
@@ -105,8 +103,6 @@ function CustomMatchSummary._createGame(game, gameIndex)
 			championsData[2][champIndex] = extradata['team2champion' .. champIndex]
 			championsDataIsEmpty = false
 		end
-		championsData[1].color = extradata.team1side
-		championsData[2].color = extradata.team2side
 	end
 
 	if

--- a/components/widget/match/summary/widget_match_summary_character_ban_table.lua
+++ b/components/widget/match/summary/widget_match_summary_character_ban_table.lua
@@ -25,6 +25,9 @@ MatchSummaryCharacterBanTable.defaultProps = {
 
 ---@return Widget[]?
 function MatchSummaryCharacterBanTable:render()
+	if not self.props.bans then
+		return nil
+	end
 	local rows = Array.map(self.props.bans, function(banData, gameNumber)
 		return Tr{
 			children = {

--- a/components/widget/match/summary/widget_match_summary_characters.lua
+++ b/components/widget/match/summary/widget_match_summary_characters.lua
@@ -24,6 +24,9 @@ MatchSummaryCharacters.defaultProps = {
 
 ---@return Widget[]?
 function MatchSummaryCharacters:render()
+	if not self.props.characters then
+		return nil
+	end
 	local flipped = self.props.flipped
 
 	return Div{

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -882,21 +882,24 @@
 }
 
 .brkts-champion-icon img {
-	height: auto;
+	height: 24px;
 	width: 24px;
+	object-fit: cover;
 }
 
 @media only screen and ( max-width: 768px ) {
 	img.brkts-champion-icon {
-		height: auto;
+		height: 20px;
 		width: 20px;
+		object-fit: cover;
 	}
 }
 
 @media ( max-width: 768px ) {
 	.brkts-champion-icon img {
-		height: auto;
+		height: 20px;
 		width: 20px;
+		object-fit: cover;
 	}
 }
 
@@ -905,6 +908,7 @@
 		-ms-transform: scale( 2.5, 2.5 );
 		-webkit-transform: scale( 2.5, 2.5 );
 		transform: scale( 2.5, 2.5 );
+		object-fit: contain;
 	}
 }
 


### PR DESCRIPTION
## Summary
* Add some empty checking into the Widgets (remove checks on match summaries)
* Tweak the CSS to get a better display on dota2 (for other wikis this is no change in their display)

## How did you test this change?
CSS in devtools, empty checking is partially live