### PR TITLE
fix(match2): incorrect scores shown when using showmatch on apex

### DIFF
--- a/components/match2/wikis/apexlegends/match_summary.lua
+++ b/components/match2/wikis/apexlegends/match_summary.lua
@@ -118,12 +118,12 @@ local MATCH_STANDING_COLUMNS = {
 		},
 		sortVal = {
 			value = function (opponent, idx)
-				return opponent.score
+				return OpponentDisplay.InlineScore(opponent)
 			end,
 		},
 		row = {
 			value = function (opponent, idx)
-				return opponent.score
+				return OpponentDisplay.InlineScore(opponent)
 			end,
 		},
 	},


### PR DESCRIPTION
## Summary
When using {{ShowMatch}} the score is currently shown as `-1`. 

Change the raw usage of opponent.score to using `OpponentDisplay.InlineScore` to display it

## How did you test this change?

/dev