### PR TITLE
feat(widget): let Link Widget fallback to using link as display text

### DIFF
--- a/components/widget/basic/widget_basic_link.lua
+++ b/components/widget/basic/widget_basic_link.lua
@@ -45,7 +45,7 @@ function Link:render()
 			'[[',
 			self.props.link,
 			'|',
-			unpack(self.props.children),
+			unpack(self.props.children) or self.props.link,
 			']]'
 		)
 	}

--- a/components/widget/misc/widget_misc_inline_icon_and_text.lua
+++ b/components/widget/misc/widget_misc_inline_icon_and_text.lua
@@ -37,7 +37,7 @@ function InlineIconAndText:render()
 		Link{
 			link = self.props.link,
 			linktype = 'internal',
-			children = {self.props.text}
+			children = {self.props.text or self.props.link}
 		},
 	}
 

--- a/components/widget/misc/widget_misc_inline_icon_and_text.lua
+++ b/components/widget/misc/widget_misc_inline_icon_and_text.lua
@@ -37,7 +37,7 @@ function InlineIconAndText:render()
 		Link{
 			link = self.props.link,
 			linktype = 'internal',
-			children = {self.props.text or self.props.link}
+			children = {self.props.text}
 		},
 	}
 


### PR DESCRIPTION
## Summary
Migration of Widget/Chronology to this broke occasions that did not include a pipe character and both link and text.
Let me know if you prefer to have this fallback in the Chronology widget instead.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
