### PR TITLE
fix(transfer): flag processing not perfect

### DIFF
--- a/components/transfer/commons/transfer_row.lua
+++ b/components/transfer/commons/transfer_row.lua
@@ -234,7 +234,7 @@ function TransferRow:_convertToTransferStructure(data)
 
 	return Table.merge(self.baseData, {
 		player = player.pageIsResolved and player.pageName or mw.ext.TeamLiquidIntegration.resolve_redirect(player.pageName),
-		nationality = Flags.CountryCode(player.flag, 'alpha3'),
+		nationality = Flags.CountryName(player.flag),
 		role1 = self.baseData.role1 or self.baseData.fromteam and subs[1] and 'Substitute' or nil,
 		role2 = self.baseData.role2 or self.baseData.toteam and subs[2] and 'Substitute' or nil,
 		reference = self.references[data.index] or self.references.all or {reference1 = ''},

--- a/components/transfer/commons/transfer_row_display.lua
+++ b/components/transfer/commons/transfer_row_display.lua
@@ -18,7 +18,7 @@ local Table = require('Module:Table')
 local IconModule = Lua.requireIfExists('Module:PositionIcon/data', {loadData = true})
 local Info = Lua.import('Module:Info', {loadData = true})
 local Platform = Lua.import('Module:Platform')
-local PlayerDisplay = Lua.requireIfExists('Module:Player/Display/Custom')
+local PlayerDisplay = Lua.import('Module:Player/Display/Custom')
 local TransferRef = Lua.import('Module:Transfer/References')
 
 local HAS_PLATFORM_ICONS = Lua.moduleExists('Module:Platform/data')

--- a/spec/transfer_spec.lua
+++ b/spec/transfer_spec.lua
@@ -37,7 +37,7 @@ insulate('Transfer', function()
 				{
 					objectname = 'transfer_2024-10-11_000000',
 					player = 'Supr',
-					nationality = 'usa',
+					nationality = 'United States',
 					fromteam = '', --'Team Liquid',
 					toteam = '', --'mousesports',
 					fromteamtemplate = '', --'team liquid 2024',
@@ -85,7 +85,7 @@ insulate('Transfer', function()
 				{
 					objectname = 'transfer_2024-10-11_000000',
 					player = 'Clem',
-					nationality = 'fra',
+					nationality = 'France',
 					fromteam = '', --'Team Liquid',
 					toteam = '', --'mousesports',
 					fromteamtemplate = '', --'team liquid 2024',


### PR DESCRIPTION
## Summary
- shut up an anno warning in transfer display
- switch from countrycode to countryname for storage/processing
  - can't use alpha2 country code due to it not supporting the shitty uk sub flag stuff
  - can't use alpha3 country code due to it not supporting:
```lua
--   ISO 3166-1 alpha-2 User-assigned Code Elements
['xk'] = 'kosovo',
['xx'] = 'nonrepresenting',
```
alternative solution would be to add user assigned alpha3 country codes for those 2 cases... ([xkx for Kosovo](https://en.wikipedia.org/wiki/XK_(user_assigned_code)) and xxx for non rep)
lmk if that is prefered

## How did you test this change?
untested on wki, don't have the time atm
golden/smoke tests should be enough