### PR TITLE
feat(match2): remove flipping of character order in match sumamry

### DIFF
--- a/components/match2/wikis/clashroyale/match_summary.lua
+++ b/components/match2/wikis/clashroyale/match_summary.lua
@@ -449,7 +449,7 @@ function CustomMatchSummary._opponentCardsDisplay(args)
 				wrapperCards:node(display)
 				display = mw.html.create('div')
 					:addClass('brkts-popup-body-element-thumbs')
-					:addClass('brkts-popup-body-element-thumbs-' .. (flip and 'left' or 'right'))
+					:addClass(flip and 'brkts-popup-body-element-thumbs-right' or nil)
 			end
 
 			display:node(card)

--- a/components/match2/wikis/splatoon/match_summary.lua
+++ b/components/match2/wikis/splatoon/match_summary.lua
@@ -208,7 +208,7 @@ function CustomMatchSummary._opponentWeaponsDisplay(props)
 
 	local display = mw.html.create('div')
 		:addClass('brkts-popup-body-element-thumbs')
-		:addClass('brkts-popup-body-element-thumbs-' .. (flip and 'right' or 'left'))
+		:addClass(flip and 'brkts-popup-body-element-thumbs-right' or nil)
 
 	for _, item in ipairs(displayElements) do
 		display:node(item)

--- a/components/widget/match/summary/widget_match_summary_characters.lua
+++ b/components/widget/match/summary/widget_match_summary_characters.lua
@@ -32,8 +32,8 @@ function MatchSummaryCharacters:render()
 	return Div{
 		classes = {
 			'brkts-popup-body-element-thumbs',
-			'brkts-popup-body-element-thumbs-' .. (flipped and 'right' or 'left'),
-			'brkts-champion-icon'
+			'brkts-champion-icon',
+			flipped and 'brkts-popup-body-element-thumbs-right' or nil,
 		},
 		children = Array.map(self.props.characters, function(character)
 			return Character{

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -555,19 +555,13 @@
 }
 
 .brkts-popup-body-element-thumbs {
+	display: inline-flex;
 	flex: 1;
 	min-width: 0.01%;
 }
 
-.brkts-popup-body-element-thumbs.brkts-popup-body-element-thumbs-left {
-	display: inline-flex;
-	flex-direction: row;
-	justify-content: left;
-}
-
+/* TODO: Remove when able, but is currently needed for hero picks no to lack of wrapper */
 .brkts-popup-body-element-thumbs.brkts-popup-body-element-thumbs-right {
-	display: inline-flex;
-	flex-direction: row-reverse;
 	justify-content: right;
 }
 


### PR DESCRIPTION
## Summary
Remove the order reversal of picks and bans for the right side team.

## How did you test this change?
Dev tools