### PR TITLE
fix(match2): ban direction on dota2

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -65,11 +65,11 @@ function HeroBan:banRow(banData, gameNumber)
 		)
 		:tag('td')
 			:attr('colspan', '2')
-			:node(CustomMatchSummary._opponentHeroesDisplay(banData[1], true))
+			:node(CustomMatchSummary._opponentHeroesDisplay(banData[1], false))
 	self.table:tag('tr')
 		:tag('td')
 			:attr('colspan', '2')
-			:node(CustomMatchSummary._opponentHeroesDisplay(banData[2], true))
+			:node(CustomMatchSummary._opponentHeroesDisplay(banData[2], false))
 	return self
 end
 


### PR DESCRIPTION
## Summary
Ban direction on dota2 seems to always been wrong. This fixes it

