### PR TITLE
fix(match2): display on bracket templates broken

### DIFF
--- a/components/match2/commons/bracket_template.lua
+++ b/components/match2/commons/bracket_template.lua
@@ -16,6 +16,7 @@ local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 local Match = Lua.import('Module:Match')
 local MatchGroupCoordinates = Lua.import('Module:MatchGroup/Coordinates')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
+local Opponent = Lua.import('Module:Opponent')
 
 ---@class BracketTemplateBracket
 ---@field bracketDatasById table<string,MatchGroupUtilBracketBracketData>
@@ -54,8 +55,12 @@ end
 ---@param props {bracketId: string, config: table?}
 ---@return Html
 function BracketTemplate.BracketContainer(props)
+	local bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId) --[[@as MatchGroupUtilBracket]]
+	Array.forEach(bracket.matches or {}, function(match)
+		match.opponents = {Opponent.blank()}
+	end)
 	return BracketDisplay.Bracket({
-		bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId) --[[@as MatchGroupUtilBracket]],
+		bracket = bracket,
 		config = Table.merge(props.config, {
 			OpponentEntry = function() return mw.html.create('div'):addClass('brkts-opponent-entry') end,
 			matchHasDetails = function() return false end,


### PR DESCRIPTION
## Summary
live:
![image](https://github.com/user-attachments/assets/5e80c488-40b2-4779-a5b2-c36e1ac71c8f)

dev:
![image](https://github.com/user-attachments/assets/9aeb7556-064e-43b9-b274-71265c5d21c1)


## How did you test this change?
dev