### PR TITLE
fix(match2): pick/ban specificity

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -554,7 +554,7 @@
 	flex-basis: 100%;
 }
 
-.brkts-popup-body-element-thumbs {
+div.brkts-popup-body-element-thumbs {
 	display: inline-flex;
 	flex: 1;
 	min-width: 0.01%;


### PR DESCRIPTION
## Summary
`.brkts-popup-body-element > *` took higher prio in the CSS `.brkts-popup-body-element-thumbs`

add change the locator to `div.brkts-popup-body-element-thumbs` to bump up the specificity

## How did you test this change?
devtools