### PR TITLE
fix(match2): Display input for unknown maps, log missing map on AoE

### DIFF
--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -277,7 +277,12 @@ function CustomMatchGroupInput._getMapName(map, mapsInfo)
 	---@cast mapsInfo -nil
 	local info = Array.find(mapsInfo, function(m)
 		return m.name == map.map or m.link == map.map
-	end) or {}
+	end)
+	if not info then
+		mw.ext.TeamLiquidIntegration.add_category('Pages with maps missing in infobox')
+		mw.logObject('Missing map: ' .. map.map)
+		return mw.ext.TeamLiquidIntegration.resolve_redirect(map.map or ''), map.map
+	end
 	return info.link, info.name
 end
 


### PR DESCRIPTION
## Summary
match2 requires to set the maplink/name in the infobox, but sometimes a map is overlooked. This adds a tracking category to find and clean up these, as well as displaying the map input instead of `Unknown`.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
