### PR TITLE
fix(infobox): return false instead of nil for custom Publisherpremier

### DIFF
--- a/components/infobox/wikis/brawlstars/infobox_league_custom.lua
+++ b/components/infobox/wikis/brawlstars/infobox_league_custom.lua
@@ -77,7 +77,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args['supercell-sponsored']
+	self.data.publishertier = Logic.readBool(args['supercell-sponsored'])
 end
 
 ---@param args table

--- a/components/infobox/wikis/callofduty/infobox_league_custom.lua
+++ b/components/infobox/wikis/callofduty/infobox_league_custom.lua
@@ -74,7 +74,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args['atvi-sponsored']
+	self.data.publishertier = Logic.readBool(args['atvi-sponsored'])
 	self.data.mode = args.player_number and 'solo' or self.data.mode
 end
 

--- a/components/infobox/wikis/clashofclans/infobox_league_custom.lua
+++ b/components/infobox/wikis/clashofclans/infobox_league_custom.lua
@@ -60,7 +60,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBool(args['supercell-sponsored']) and 'true' or nil
+	self.data.publishertier = Logic.readBool(args['supercell-sponsored'])
 end
 
 return CustomLeague

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -126,7 +126,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = (self.valveTier or {}).name
+	self.data.publishertier = (self.valveTier or {}).name or ''
 	if String.isNotEmpty(args.localcurrency) and String.isNotEmpty(args.prizepool) then
 		local currency = string.upper(args.localcurrency)
 		local prize = InfoboxPrizePool._cleanValue(args.prizepool)

--- a/components/infobox/wikis/crossfire/infobox_league_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_league_custom.lua
@@ -77,7 +77,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args.cfpremier
+	self.data.publishertier = Logic.readBool(args['cfpremier']) and 'true' or false
 end
 
 ---@param args table

--- a/components/infobox/wikis/crossfire/infobox_league_custom.lua
+++ b/components/infobox/wikis/crossfire/infobox_league_custom.lua
@@ -77,7 +77,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBool(args['cfpremier']) and 'true' or false
+	self.data.publishertier = Logic.readBool(args.cfpremier)
 end
 
 ---@param args table

--- a/components/infobox/wikis/fortnite/infobox_league_custom.lua
+++ b/components/infobox/wikis/fortnite/infobox_league_custom.lua
@@ -49,7 +49,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args.epicpremier
+	self.data.publishertier = Logic.readBool(args.epicpremier)
 end
 
 ---@param args table

--- a/components/infobox/wikis/halo/infobox_league_custom.lua
+++ b/components/infobox/wikis/halo/infobox_league_custom.lua
@@ -102,7 +102,7 @@ end
 ---@param args table
 function CustomLeague:customParseArguments(args)
 	self.data.mode = args.player_number and 'solo' or self.data.mode
-	self.data.publishertier = args['hcs-sponsored']
+	self.data.publishertier = Logic.readBool(args['hcs-sponsored'])
 end
 
 ---@param args table

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -82,7 +82,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBool(args.riotpremier) and '1' or false
+	self.data.publishertier = Logic.readBool(args.riotpremier)
 end
 
 ---@param args table

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -82,7 +82,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBool(args.riotpremier) and '1' or nil
+	self.data.publishertier = Logic.readBool(args.riotpremier) and '1' or false
 end
 
 ---@param args table

--- a/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
@@ -60,7 +60,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBool(args['moonton-sponsored']) and 'true' or nil
+	self.data.publishertier = Logic.readBool(args['moonton-sponsored']) and 'true' or false
 end
 
 ---@param args table

--- a/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_league_custom.lua
@@ -60,7 +60,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBool(args['moonton-sponsored']) and 'true' or false
+	self.data.publishertier = Logic.readBool(args['moonton-sponsored'])
 end
 
 ---@param args table

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 
 local Injector = Lua.import('Module:Widget/Injector')

--- a/components/infobox/wikis/naraka/infobox_league_custom.lua
+++ b/components/infobox/wikis/naraka/infobox_league_custom.lua
@@ -65,7 +65,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args.narakapremier
+	self.data.publishertier = Logic.readBool(args.narakapremier)
 end
 
 ---@param lpdbData table

--- a/components/infobox/wikis/pokemon/infobox_league_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_league_custom.lua
@@ -73,7 +73,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args.pokemonpremier
+	self.data.publishertier = Logic.readBool(args.pokemonpremier)
 	self.data.mode = self:_getGameMode()
 end
 

--- a/components/infobox/wikis/pubg/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubg/infobox_league_custom.lua
@@ -113,7 +113,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args.pubgpremier
+	self.data.publishertier = Logic.readBool(args.pubgpremier)
 end
 
 ---@param args table

--- a/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
+++ b/components/infobox/wikis/pubgmobile/infobox_league_custom.lua
@@ -98,7 +98,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = args.pubgpremier
+	self.data.publishertier = Logic.readBool(args.pubgpremier)
 end
 
 ---@param args table

--- a/components/infobox/wikis/warcraft/infobox_league_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_league_custom.lua
@@ -96,7 +96,7 @@ end
 function CustomLeague:customParseArguments(args)
 	self.data.game = self:_determineGame(args.game)
 	self.data.status = self:_getStatus(args)
-	self.data.publishertier = ESL_TIERS[(args.eslprotier or ''):lower()] and args.eslprotier:lower() or nil
+	self.data.publishertier = ESL_TIERS[(args.eslprotier or ''):lower()] and args.eslprotier:lower() or false
 	self.data.raceBreakDown = RaceBreakdown.run(args, BREAKDOWN_RACES) or {}
 	self.data.maps = self:_getMaps('map', args)
 	self.data.number = tonumber(args.number)

--- a/components/infobox/wikis/wildrift/infobox_league_custom.lua
+++ b/components/infobox/wikis/wildrift/infobox_league_custom.lua
@@ -60,7 +60,7 @@ end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBool(args.riotpremier) and 'true' or nil
+	self.data.publishertier = Logic.readBool(args.riotpremier)
 end
 
 ---@param args table


### PR DESCRIPTION
## Summary
Several wikis uses a different param for highlighted tiers (e.g. `riotpremier` `valve-sponsored`) which means a local implementation

these wikis apparently returns **nil** if its unset, in #4852 after the TeamCard Storage changes publishertier storage to **false** which meant now if it returns **nil** = it causes the highlight to triggered anyway

![image](https://github.com/user-attachments/assets/cd9e6dc4-f78a-46a7-b21c-edcaf0440165)

## Side Note
There are wikis that still returns **nil** but the issue does not occured (e.g. Dota2) I will leave those untouched