### PR TITLE
fix(match2): display on bracket template pages still off

### DIFF
--- a/components/match2/commons/bracket_template.lua
+++ b/components/match2/commons/bracket_template.lua
@@ -55,10 +55,12 @@ end
 ---@param props {bracketId: string, config: table?}
 ---@return Html
 function BracketTemplate.BracketContainer(props)
-	local bracket = MatchGroupUtil.fetchMatchGroup(props.bracketId) --[[@as MatchGroupUtilBracket]]
-	Array.forEach(bracket.matches or {}, function(match)
-		match.opponents = {Opponent.blank()}
+	local matchRecords = MatchGroupUtil.fetchMatchRecords(props.bracketId)
+	Array.forEach(matchRecords, function(match)
+		match.match2opponents = {{type = Opponent.literal, name = '', match2players = {}}}
 	end)
+	local bracket = MatchGroupUtil.makeMatchGroup(matchRecords) --[[@as MatchGroupUtilBracket]]
+
 	return BracketDisplay.Bracket({
 		bracket = bracket,
 		config = Table.merge(props.config, {


### PR DESCRIPTION
## Summary
need to insert the opponents before making the records a match group so that coordinates for the lines between matches get drawn properly
can not use plain opponnet.blank due to:
- match2players has to be a table or else `MatchGroupUtil.makeMatchGroup` errors
- additionally at that point it isn't an opponent but a `match2opponent:LpdbBaseData` object

## How did you test this change?
dev to live