### PR TITLE
fix(match2): Handle default map win in legacy wrapper on AoE

### DIFF
--- a/components/match2/wikis/ageofempires/legacy/legacy_bracket_match_summary.lua
+++ b/components/match2/wikis/ageofempires/legacy/legacy_bracket_match_summary.lua
@@ -9,13 +9,13 @@
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Json = require('Module:Json')
+local MatchGroupInputUtil = require('Module:MatchGroup/Input/Util')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local LegacyBracketMatchSummary = {}
 
 local DEFAULT = 'default'
-local DEFAULT_WIN = 'W'
 
 ---@param args table
 ---@return table
@@ -47,7 +47,7 @@ function LegacyBracketMatchSummary._handleMaps(args)
 			map = mapInfo[1]
 			if String.startsWith(map:lower(), DEFAULT) then
 				map = nil
-				mapArgs.walkover = DEFAULT_WIN
+				mapArgs.walkover = MatchGroupInputUtil.STATUS_INPUTS.DEFAULT_WIN
 			end
 			mapArgs.map = map
 		end

--- a/components/match2/wikis/ageofempires/legacy/legacy_bracket_match_summary.lua
+++ b/components/match2/wikis/ageofempires/legacy/legacy_bracket_match_summary.lua
@@ -9,9 +9,13 @@
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Json = require('Module:Json')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local LegacyBracketMatchSummary = {}
+
+local DEFAULT = 'default'
+local DEFAULT_WIN = 'W'
 
 ---@param args table
 ---@return table
@@ -36,9 +40,16 @@ function LegacyBracketMatchSummary._handleMaps(args)
 			vod = Table.extract(args, 'vodgame' .. mapIndex),
 			date = Table.extract(args, 'date' .. mapIndex) or Table.extract(matchTeam, 'date'),
 		}
-		if mapArgs.map then
-			local mapInfo = Array.parseCommaSeparatedString(mapArgs.map, '|')
-			mapArgs.map = mapInfo[1]
+
+		local map = mapArgs.map
+		if map then
+			local mapInfo = Array.parseCommaSeparatedString(map, '|')
+			map = mapInfo[1]
+			if String.startsWith(map:lower(), DEFAULT) then
+				map = nil
+				mapArgs.walkover = DEFAULT_WIN
+			end
+			mapArgs.map = map
 		end
 
 		isValidMap = mapArgs.map ~= nil or mapArgs.winner


### PR DESCRIPTION
## Summary

When either Default win or Default is entered, we should set `|walkover=W` and disregard the map name. This will align with the current input format used for a default win in match2.

## How did you test this change?

/dev and [sandbox](https://liquipedia.net/ageofempires/User:LuckeLucky/sandbox)
