### PR TITLE
fix(match2) Display games with resulttype but no winner on AoE

### DIFF
--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -15,6 +15,7 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapMode = require('Module:MapMode')
 local Operator = require('Module:Operator')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
@@ -68,7 +69,7 @@ function CustomMatchSummary.createBody(match)
 	end
 
 	Array.forEach(match.games, function(game)
-		if not game.map and not game.winner then return end
+		if not game.map and not game.winner and String.isNotEmpty(game.resulttype) then return end
 		local row = MatchSummary.Row()
 				:addClass('brkts-popup-body-game')
 				:css('font-size', '0.75rem')


### PR DESCRIPTION
## Summary
There are occasions on AoE where there are "maps" entered as skipped (=no winner, resulttype np), but the actual map is unknown and thus left empty.
This fix catches these to still display a row in the popup.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
