### PR TITLE
feat(transfer): RL rumour specialities

### DIFF
--- a/components/transfer/commons/transfer_row.lua
+++ b/components/transfer/commons/transfer_row.lua
@@ -21,7 +21,7 @@ local Variables = require('Module:Variables')
 
 local PlayerExt = Lua.import('Module:Player/Ext/Custom')
 local PositionConvert = Lua.requireIfExists('Module:PositionName/data', {loadData = true})
-local TransferRowDisplay = Lua.import('Module:TransferRow/Display')
+local TransferRowDisplay = Lua.import('Module:TransferRow/Display/Custom')
 local References = Lua.import('Module:Transfer/References')
 
 local HAS_PLATFORM_ICONS = Lua.moduleExists('Module:Platform/data')

--- a/components/transfer/commons/transfer_row_display_custom.lua
+++ b/components/transfer/commons/transfer_row_display_custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:TransferRow/Display/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local TransferDisplay = Lua.import('Module:TransferRow/Display')
+
+return TransferDisplay

--- a/components/transfer/wikis/rocketleague/transfer_row_custom.lua
+++ b/components/transfer/wikis/rocketleague/transfer_row_custom.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague
+-- page=Module:TransferRow/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Flags = require('Module:Flags')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local PlayerExt = Lua.import('Module:Player/Ext/Custom')
+local TransferRow = Lua.import('Module:TransferRow')
+
+---@class rlTransfer: transfer
+---@field players2 standardPlayer[]?
+
+---@class RLCustomTransferRow: TransferRow
+---@field transfers rlTransfer
+local CustomTransferRow = Class.new(TransferRow)
+
+---@param frame Frame
+---@return Html?
+function CustomTransferRow.transfer(frame)
+	return CustomTransferRow(Arguments.getArgs(frame)):read():store():build()
+end
+
+---@param frame Frame
+---@return Html?
+function CustomTransferRow.rumour(frame)
+	local args = Arguments.getArgs(frame)
+	args.isRumour = true
+	return CustomTransferRow(args):read():store():readPlayers2():build()
+end
+
+---@return self
+function CustomTransferRow:readPlayers2()
+	local args = self.args
+
+	local players = {}
+	for prefix, displayName in Table.iter.pairsByPrefix(args, 'team2p') do
+		table.insert(players, PlayerExt.populatePlayer{
+			displayName = displayName,
+			flag = Logic.nilIfEmpty(Flags.CountryName(args[prefix .. 'flag'])),
+			pageName = args[prefix .. 'link'] or displayName,
+		})
+	end
+
+	self.transfers[1].players2 = players
+
+	return self
+end
+
+return CustomTransferRow

--- a/components/transfer/wikis/rocketleague/transfer_row_display_custom.lua
+++ b/components/transfer/wikis/rocketleague/transfer_row_display_custom.lua
@@ -1,0 +1,71 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague
+-- page=Module:TransferRow/Display/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local TransferDisplay = Lua.import('Module:TransferRow/Display')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
+---@class RLTransferRowDisplay: TransferRowDisplay
+---@field players2 standardPlayer[]?
+local CustomTransferDisplay = Class.new(TransferDisplay, function(self, transfers)
+		self.players2 = transfers[1].players2
+		return self
+end)
+
+---@return self
+function CustomTransferDisplay:to()
+	if Logic.isEmpty(self.transfer.to.teams) and Logic.isNotEmpty(self.players2) then
+		self.display:node(self:_displayPlayers2())
+	else
+		self.display:node(self:_displayTeam{
+			data = self.transfer.to,
+			date = self.transfer.date,
+			isOldTeam = false,
+		})
+	end
+
+	return self
+end
+
+---@return Html
+function CustomTransferDisplay:_displayPlayers2()
+	local players = self.players2
+	---@cast players -nil
+
+	-- build a fake opponent for display purposes
+	---@type standardOpponent
+	local opponent = {players = players, type = Opponent.quad}
+
+	local showTeamName = self.config.showTeamName
+	local cell = mw.html.create('div')
+		:addClass('divCell Team NewTeam')
+
+	if showTeamName then
+		cell:css('text-align', 'left')
+	end
+
+	cell:node(OpponentDisplay.BlockPlayers{
+		opponent = opponent
+	})
+
+	if Logic.isEmpty(self.transfer.to.roles) then
+		return cell
+	end
+
+	return cell
+		:wikitext('<br>')
+		:node(self:_createRole(self.transfer.to.roles, ''))
+end
+
+return CustomTransferDisplay


### PR DESCRIPTION
## Summary
As per complaints on discord add some special stuff to RL rumour row

They have `team2pX` input which generates a list of players instead of team2 display in case team2 is not set

![image](https://github.com/user-attachments/assets/63af074e-d77c-4fbf-948c-a4e84d63f559)

## How did you test this change?
dev