### PR TITLE
chore(standard): remove factor link

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -115,7 +115,6 @@ local PREFIXES = {
 	['faceit-c'] = {'https://www.faceit.com/en/championship/'},
 	['faceit-hub'] = {'https://www.faceit.com/en/hub/'},
 	['faceit-org'] = {'https://www.faceit.com/en/organizers/'},
-	factor = {match = 'https://www.factor.gg/match/'},
 	fanclub = {''},
 	geoguessr = {'https://www.geoguessr.com/'},
 	gol = {match = 'https://gol.gg/game/stats/'},


### PR DESCRIPTION
## Summary
Remove the factror links that were added with #4880 (after being removed with #3462)
As per [discord discussion](https://discord.com/channels/93055209017729024/268719633366777856/1297878614582362142) factor is dead.
4880 probably added them because they were still stored on lol in matches, but not displayed anymore


## How did you test this change?
untested