### PR TITLE
fix(match2) Iterate without requiring index for AoE matchlinks

### DIFF
--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -102,7 +102,7 @@ function CustomMatchSummary.addToFooter(match, footer)
 			mw.log('Unknown link: ' .. linkType)
 			return
 		end
-		for _, link in Table.iter.pairsByPrefix(match.links, linkType) do
+		for _, link in Table.iter.pairsByPrefix(match.links, linkType, {requireIndex = false}) do
 			footer:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text)
 		end
 	end


### PR DESCRIPTION
## Summary
Introduced with #4880 which removed that entries of mapdraft and civdraft would always be indexed in the links table.
From an API point of view i'd prefer to get the index back, should i remap these params somewhere in MGI?
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
