### PR TITLE
fix(transfer): nil role2 causes error in edgge case

### DIFF
--- a/components/transfer/commons/transfer_row_display.lua
+++ b/components/transfer/commons/transfer_row_display.lua
@@ -320,7 +320,7 @@ end
 function TransferRowDisplay:_createRole(roles, team)
 	if Logic.isEmpty(roles) then return end
 
-	local rolesText = table.concat(roles, '/')
+	local rolesText = table.concat(Array.filter(roles, Logic.isNotEmpty), '/')
 
 	local roleCell = mw.html.create('span')
 		:css('font-style', 'italic')


### PR DESCRIPTION
## Summary
If role(2) is nil but role(2)_2 is not nil table.concat errors.
To avoid that filter away the empty roles for display

## How did you test this change?
dev into live