### PR TITLE
fix(match2): lol matchMaps legacy not accoutning for empty maps

### DIFF
--- a/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/leagueoflegends/legacy/match_maps_legacy.lua
@@ -109,7 +109,11 @@ end
 function MatchMapsLegacy.handleDetails(args, details)
 	local getMapFromDetails = function (index)
 		local prefix = 'map' .. index
-		if not details[prefix] then
+		local mapDetails = Table.filterByKey(details, function(key)
+			return key == prefix or
+				string.find(key, '^' .. prefix .. '[^%d]') ~= nil
+		end)
+		if Logic.isEmpty(mapDetails) then
 			return nil
 		end
 		local map = {}


### PR DESCRIPTION
## Summary
currently it fails to process the details correctly if map name is unset
this pr changes it to not check on set map name but if the input for the map is non empty

## How did you test this change?
dev