### PR TITLE
fix(infobox): wc item infobox showing `table` at teh bottom

### DIFF
--- a/components/infobox/wikis/warcraft/infobox_item_custom.lua
+++ b/components/infobox/wikis/warcraft/infobox_item_custom.lua
@@ -93,12 +93,12 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'custom' then
-		return {
+		return Array.append(
 			args.desc and Title{children = 'Description'} or nil,
 			Center{children = {args.desc}},
 			args.history and Title{children = 'Item History'} or nil,
 			Center{children = {args.history}}
-		}
+		)
 	elseif id == 'info' then
 		return {
 			Title{children = 'Item Information'},


### PR DESCRIPTION
## Summary
Use Array.append instead of a plain table so that nil elements get removed inbetween

## How did you test this change?
dev into live