### PR TITLE
refactor(match2): caster row on all wikis

### DIFF
--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -46,7 +46,7 @@ function CustomMatchSummary.createBody(match)
 		Array.map(match.games, CustomMatchSummary._createGame),
 		MatchSummaryWidgets.Mvp(match.extradata.mvp),
 		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date},
-		MatchSummaryWidgets.Casters{casters = Json.parseIfString(match.extradata.casters)}
+		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
 	)}
 end
 

--- a/components/match2/wikis/dota2/match_summary.lua
+++ b/components/match2/wikis/dota2/match_summary.lua
@@ -10,7 +10,6 @@ local CustomMatchSummary = {}
 
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
-local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -55,7 +55,7 @@ function CustomMatchSummary.createBody(match)
 		Array.map(match.games, FnUtil.curry(CustomMatchSummary._createGame, match.date)),
 		MatchSummaryWidgets.Mvp(match.extradata.mvp),
 		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date},
-		MatchSummaryWidgets.Casters{casters = Json.parseIfString(match.extradata.casters)}
+		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
 	)}
 end
 

--- a/components/match2/wikis/smite/match_summary.lua
+++ b/components/match2/wikis/smite/match_summary.lua
@@ -39,7 +39,7 @@ function CustomMatchSummary.createBody(match)
 		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
 		Array.map(match.games, FnUtil.curry(CustomMatchSummary._createGame, match.date)),
 		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date},
-		MatchSummaryWidgets.Casters{casters = Json.parseIfString(match.extradata.casters)}
+		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
 	)}
 end
 


### PR DESCRIPTION
## Summary
Apply the caster row from #4937 to all wikis, similiar to how MVP was done
Fix the double stringify being done

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
