### PR TITLE
refactor(match2): remove unused wiki-customs functions

### DIFF
--- a/components/match2/wikis/arenafps/match_summary.lua
+++ b/components/match2/wikis/arenafps/match_summary.lua
@@ -67,27 +67,9 @@ function CustomMatchSummary.createBody(match)
 end
 
 ---@param game MatchGroupUtilGame
----@param opponentIndex integer
----@return Html
-function CustomMatchSummary._gameScore(game, opponentIndex)
-	return mw.html.create('div'):wikitext(game.scores[opponentIndex])
-end
-
----@param game MatchGroupUtilGame
 ---@return MatchSummaryRow
 function CustomMatchSummary._createMapRow(game)
 	local row = MatchSummary.Row()
-
-	-- Add Header
-	if Logic.isNotEmpty(game.header) then
-		local mapHeader = mw.html.create('div')
-			:wikitext(game.header)
-			:css('font-weight','bold')
-			:css('font-size','85%')
-			:css('margin','auto')
-		row:addElement(mapHeader)
-		row:addElement(MatchSummary.Break():create())
-	end
 
 	local centerNode = mw.html.create('div')
 		:addClass('brkts-popup-spaced')

--- a/components/match2/wikis/battlerite/match_summary.lua
+++ b/components/match2/wikis/battlerite/match_summary.lua
@@ -25,13 +25,6 @@ function CustomMatchSummary.getByMatchId(args)
 end
 
 ---@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	return MatchSummary.addVodsToFooter(match, footer)
-end
-
----@param match MatchGroupUtilMatch
 ---@return Widget
 function CustomMatchSummary.createBody(match)
 	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp

--- a/components/match2/wikis/brawlhalla/match_summary.lua
+++ b/components/match2/wikis/brawlhalla/match_summary.lua
@@ -73,15 +73,6 @@ function CustomMatchSummary.createBody(match)
 end
 
 ---@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	return footer
-end
-
----@param match MatchGroupUtilMatch
 ---@return boolean
 function CustomMatchSummary._isSolo(match)
 	if type(match.opponents[1]) ~= 'table' or type(match.opponents[2]) ~= 'table' then

--- a/components/match2/wikis/clashofclans/match_summary.lua
+++ b/components/match2/wikis/clashofclans/match_summary.lua
@@ -28,13 +28,6 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
----@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	return MatchSummary.addVodsToFooter(match, footer)
-end
-
 function CustomMatchSummary.createHeader(match)
 	local header = MatchSummary.Header()
 

--- a/components/match2/wikis/fighters/match_summary.lua
+++ b/components/match2/wikis/fighters/match_summary.lua
@@ -78,15 +78,6 @@ function CustomMatchSummary._displayGames(match)
 	end)
 end
 
----@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	return footer
-end
-
 ---@param game MatchGroupUtilGame
 ---@param teamIdx integer
 ---@return {name: string}[]

--- a/components/match2/wikis/geoguessr/match_summary.lua
+++ b/components/match2/wikis/geoguessr/match_summary.lua
@@ -30,13 +30,6 @@ function CustomMatchSummary.getByMatchId(args)
 end
 
 ---@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	return MatchSummary.addVodsToFooter(match, footer)
-end
-
----@param match MatchGroupUtilMatch
 ---@return MatchSummaryBody
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()

--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -77,15 +77,6 @@ function CustomMatchSummary.createBody(match)
 end
 
 ---@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	return footer
-end
-
----@param match MatchGroupUtilMatch
 ---@return boolean
 function CustomMatchSummary._isSolo(match)
 	if type(match.opponents[1]) ~= 'table' or type(match.opponents[2]) ~= 'table' then

--- a/components/match2/wikis/heroes/match_summary.lua
+++ b/components/match2/wikis/heroes/match_summary.lua
@@ -13,7 +13,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
-local ExternalLinks = require('Module:ExternalLinks')
 local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -56,19 +55,6 @@ end
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '480px'})
-end
-
----@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	if Table.isNotEmpty(match.links) then
-		footer:addElement(ExternalLinks.print(match.links))
-	end
-
-	return footer
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/honorofkings/match_summary.lua
+++ b/components/match2/wikis/honorofkings/match_summary.lua
@@ -11,11 +11,9 @@ local CustomMatchSummary = {}
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
-local ExternalLinks = require('Module:ExternalLinks')
 local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
@@ -28,19 +26,6 @@ local NUM_CHAMPIONS_PICK = 5
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px', teamStyle = 'bracket'})
-end
-
----@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	if Table.isNotEmpty(match.links) then
-		footer:addElement(ExternalLinks.print(match.links))
-	end
-
-	return footer
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/mobilelegends/match_summary.lua
+++ b/components/match2/wikis/mobilelegends/match_summary.lua
@@ -11,12 +11,10 @@ local CustomMatchSummary = {}
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
-local ExternalLinks = require('Module:ExternalLinks')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
@@ -29,19 +27,6 @@ local NUM_CHAMPIONS_PICK = 5
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px', teamStyle = 'bracket'})
-end
-
----@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	if Table.isNotEmpty(match.links) then
-		footer:addElement(ExternalLinks.print(match.links))
-	end
-
-	return footer
 end
 
 ---@param match MatchGroupUtilMatch

--- a/components/match2/wikis/omegastrikers/match_summary.lua
+++ b/components/match2/wikis/omegastrikers/match_summary.lua
@@ -117,13 +117,6 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	return MatchSummary.addVodsToFooter(match, footer)
-end
-
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()
 

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -30,19 +30,6 @@ function CustomMatchSummary.getByMatchId(args)
 end
 
 ---@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	if Logic.isNotEmpty(match.links) then
-		footer:addElement(ExternalLinks.print(match.links))
-	end
-
-	return footer
-end
-
----@param match MatchGroupUtilMatch
 ---@return MatchSummaryBody
 function CustomMatchSummary.createBody(match)
 	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp

--- a/components/match2/wikis/pokemon/match_summary.lua
+++ b/components/match2/wikis/pokemon/match_summary.lua
@@ -11,7 +11,6 @@ local CustomMatchSummary = {}
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
-local ExternalLinks = require('Module:ExternalLinks')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -144,13 +144,6 @@ function CustomMatchSummary.createHeader(match, options)
 end
 
 ---@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	return MatchSummary.addVodsToFooter(match, footer)
-end
-
----@param match MatchGroupUtilMatch
 ---@return MatchSummaryBody
 function CustomMatchSummary.createBody(match)
 	local body = MatchSummary.Body()

--- a/components/match2/wikis/wildrift/match_summary.lua
+++ b/components/match2/wikis/wildrift/match_summary.lua
@@ -12,8 +12,6 @@ local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
-local ExternalLinks = require('Module:ExternalLinks')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
@@ -27,19 +25,6 @@ local NUM_CHAMPIONS_PICK = 5
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '420px'})
-end
-
----@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
-	footer = MatchSummary.addVodsToFooter(match, footer)
-
-	if Table.isNotEmpty(match.links) then
-		footer:addElement(ExternalLinks.print(match.links))
-	end
-
-	return footer
 end
 
 ---@param match MatchGroupUtilMatch


### PR DESCRIPTION
## Summary
Removed unused addFooters (commons already does this).

Non of the moba's had anything in their ExternalLinks other than stuff like reddit and preview, which is on commons' link support already

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
