### PR TITLE
fix(match2): Wrong index on match2players in CR Legacy

### DIFF
--- a/components/match2/wikis/clashroyale/match_legacy.lua
+++ b/components/match2/wikis/clashroyale/match_legacy.lua
@@ -42,7 +42,7 @@ function MatchLegacy.store(match2)
 	if opponent1.type == Opponent.solo then
 		local function handlePlayer(index)
 			local opponent = match2.match2opponents[index] or {}
-			local player = opponent.match2players or {}
+			local player = opponent.match2players[1] or {}
 			local prefix = 'opponent' .. index
 
 			match[prefix] = player.name and player.name:gsub('_', ' ') or nil


### PR DESCRIPTION
## Summary
Legacy storage would not find proper opponent data for solo
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
