### PR TITLE
feat(match2): render match summmary characters at an appropriate size

### DIFF
--- a/components/widget/match/summary/widget_match_summary_character.lua
+++ b/components/widget/match/summary/widget_match_summary_character.lua
@@ -15,8 +15,6 @@ local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
-
-
 ---@class MatchSummaryCharacter: Widget
 ---@operator call(table): MatchSummaryCharacter
 local MatchSummaryCharacter = Class.new(Widget)

--- a/components/widget/match/summary/widget_match_summary_character.lua
+++ b/components/widget/match/summary/widget_match_summary_character.lua
@@ -15,20 +15,23 @@ local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
+
+
 ---@class MatchSummaryCharacter: Widget
 ---@operator call(table): MatchSummaryCharacter
 local MatchSummaryCharacter = Class.new(Widget)
+
 MatchSummaryCharacter.defaultProps = {
 	showName = false,
 	flipped = false,
 }
-
 
 ---@return Widget[]?
 function MatchSummaryCharacter:render()
 	local characterIcon = CharacterIcon.Icon{
 		character = self.props.character,
 		date = self.props.date,
+		size = self.props.size
 	}
 	local children = { characterIcon }
 	if self.props.showName then

--- a/components/widget/match/summary/widget_match_summary_characters.lua
+++ b/components/widget/match/summary/widget_match_summary_characters.lua
@@ -15,15 +15,15 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Character = Lua.import('Module:Widget/Match/Summary/Character')
 
-local BASE_SIZE = 24 -- From brkts-champion-icon in Brackets.leess
-local HOOVER_MODIFIER = 2.5 -- From brkts-champion-icon in Brackets.leess
+local BASE_SIZE = 24 -- From brkts-champion-icon in Brackets.less
+local HOVER_MODIFIER = 2.5 -- From brkts-champion-icon in Brackets.less
 
 ---@class MatchSummaryCharacters: Widget
 ---@operator call(table): MatchSummaryCharacters
 local MatchSummaryCharacters = Class.new(Widget)
 MatchSummaryCharacters.defaultProps = {
 	flipped = false,
-	size = BASE_SIZE * HOOVER_MODIFIER,
+	size = BASE_SIZE * HOVER_MODIFIER,
 }
 
 ---@return Widget[]?

--- a/components/widget/match/summary/widget_match_summary_characters.lua
+++ b/components/widget/match/summary/widget_match_summary_characters.lua
@@ -23,7 +23,7 @@ local HOOVER_MODIFIER = 2.5 -- From brkts-champion-icon in Brackets.leess
 local MatchSummaryCharacters = Class.new(Widget)
 MatchSummaryCharacters.defaultProps = {
 	flipped = false,
-	size = BASE_SIZE*HOOVER_MODIFIER,
+	size = BASE_SIZE * HOOVER_MODIFIER,
 }
 
 ---@return Widget[]?

--- a/components/widget/match/summary/widget_match_summary_characters.lua
+++ b/components/widget/match/summary/widget_match_summary_characters.lua
@@ -15,11 +15,15 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Character = Lua.import('Module:Widget/Match/Summary/Character')
 
+local BASE_SIZE = 24 -- From brkts-champion-icon in Brackets.leess
+local HOOVER_MODIFIER = 2.5 -- From brkts-champion-icon in Brackets.leess
+
 ---@class MatchSummaryCharacters: Widget
 ---@operator call(table): MatchSummaryCharacters
 local MatchSummaryCharacters = Class.new(Widget)
 MatchSummaryCharacters.defaultProps = {
 	flipped = false,
+	size = BASE_SIZE*HOOVER_MODIFIER,
 }
 
 ---@return Widget[]?
@@ -42,6 +46,7 @@ function MatchSummaryCharacters:render()
 				bg = self.props.bg,
 				showName = #self.props.characters == 1,
 				flipped = flipped,
+				size = self.props.size .. 'px',
 			}
 		end)
 	}


### PR DESCRIPTION
## Summary
Don't need to render at fullsize, use a thumbnail version that's the size of the hoover.

## How did you test this change?
dev