### PR TITLE
feat(match2): do not show popup if only h2h link is present on sc(2)

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -328,9 +328,12 @@ end
 ---@param match StarcraftMatchGroupUtilMatch
 ---@return boolean
 function StarcraftMatchGroupUtil.matchHasDetails(match)
+	local linksWithoutH2H = Table.filterByKey(match.links, function(key)
+		return key ~= 'headtohead'
+	end)
 	return match.dateIsExact
 		or String.isNotEmpty(match.vod)
-		or not Table.isEmpty(match.links)
+		or not Table.isEmpty(linksWithoutH2H)
 		or String.isNotEmpty(match.comment)
 		or String.isNotEmpty(match.casters)
 		or 0 < #match.vetoes


### PR DESCRIPTION
## Summary
As per request on discord (sc2 channel): do not show the popup if h2h is the only link

## How did you test this change?
dev