### PR TITLE
fix(prize pool): error on literals with empty name

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -319,7 +319,7 @@ function Import:_computeBracketPlacementEntries(matchRecords, options)
 			return not (
 				entry.opponent
 				and entry.opponent.type == Opponent.literal
-				and Opponent.toName(entry.opponent):lower() == BYE_OPPONENT_NAME
+				and (not Opponent.toName(entry.opponent) or (Opponent.toName(entry.opponent) or ''):lower() == BYE_OPPONENT_NAME)
 			) and (not self.config.ignoreNonScoreEliminations or not entry.opponent or entry.opponent.status == SCORE_STATUS)
 		end)
 	end


### PR DESCRIPTION
## Summary
Currently if ppt import tries to process a literal without name it errors.
This PR adds a nil check for that

## How did you test this change?
dev