### PR TITLE
fix(infobox) Typo in hearthstone infobox league

### DIFF
--- a/components/infobox/wikis/hearthstone/infobox_league_custom.lua
+++ b/components/infobox/wikis/hearthstone/infobox_league_custom.lua
@@ -62,7 +62,7 @@ function CustomInjector:parse(id, widgets)
 					prizepool = args.bin,
 					prizepoolusd = args.binusd,
 					currency = args.localcurrency,
-					setVariables = false,
+					setvariables = false,
 				}
 			}})
 		end


### PR DESCRIPTION
## Summary
Issue reported in discord.
As per https://github.com/Liquipedia/Lua-Modules/blob/baed407c7c5912c954c7ccd4ad59fb5d788faec4/components/infobox/extensions/commons/infobox_extensions_prize_pool.lua#L44
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
