### PR TITLE
fix(match2): hearthstone erroring on empty maps

### DIFF
--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -78,7 +78,7 @@ end
 ---@param game MatchGroupUtilGame
 ---@return Html?
 function CustomMatchSummary._createGame(game)
-	if not game.map and not game.winner then return end
+	if not game.map and not game.winner then return nil end
 	local row = MatchSummary.Row()
 			:addClass('brkts-popup-body-game')
 			:css('font-size', '0.75rem')


### PR DESCRIPTION
if we like #4967 this PR (4966) becomes obsolete

## Summary
Array.map requires actual nil return instead of undefined return, else it errors.

## How did you test this change?
live