### PR TITLE
feat: Array.map should handle no return same as nil return

### DIFF
--- a/spec/array_spec.lua
+++ b/spec/array_spec.lua
@@ -40,6 +40,10 @@ describe('array', function()
 			assert.are_same({2, 4, 6}, Array.map(a, function(x)
 				return 2 * x
 			end))
+			assert.are_same({false, false, false}, Array.map(a, function(x)
+				return false
+			end))
+			assert.are_same({}, Array.map(a, function() end))
 		end)
 	end)
 

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -88,7 +88,7 @@ end
 function Array.map(elements, funct)
 	local mappedArray = {}
 	for index, element in ipairs(elements) do
-		table.insert(mappedArray, funct(element, index))
+		table.insert(mappedArray, funct(element, index) or nil)
 	end
 	return mappedArray
 end

--- a/standard/array.lua
+++ b/standard/array.lua
@@ -88,7 +88,8 @@ end
 function Array.map(elements, funct)
 	local mappedArray = {}
 	for index, element in ipairs(elements) do
-		table.insert(mappedArray, funct(element, index) or nil)
+		local mappedElement = funct(element, index)
+		table.insert(mappedArray, mappedElement)
 	end
 	return mappedArray
 end


### PR DESCRIPTION
## Summary
Currently Array.map errors if we have an undefined return (`return end`). It needs explicit `nil` as return value.
This PR changes the behaviour of Array.map so that it doesn't need the nil return but also eats the undefined return.

## How did you test this change?
dev + busted