### PR TITLE
feat(infobox): add national restriction for CS league infobox

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -90,17 +90,17 @@ local VALVE_TIERS = {
 }
 
 local RESTRICTIONS = {
-	['female'] = {
+	female = {
 		name = 'Female Players Only',
 		link = 'Female Tournaments',
 		data = 'female',
 	},
-	['academy'] = {
+	academy = {
 		name = 'Academy Teams Only',
 		link = 'Academy Tournaments',
 		data = 'academy',
 	},
-	['national'] = {
+	national = {
 		name = 'National Teams Only',
 		link = 'National Tournaments',
 		data = 'national',

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -99,6 +99,11 @@ local RESTRICTIONS = {
 		name = 'Academy Teams Only',
 		link = 'Academy Tournaments',
 		data = 'academy',
+	},
+	['national'] = {
+		name = 'National Teams Only',
+		link = 'National Tournaments',
+		data = 'national',
 	}
 }
 


### PR DESCRIPTION
## Summary

Add new restriction type (`national`) for CS league infobox.

## How did you test this change?

Tested using branch deploy.
![image](https://github.com/user-attachments/assets/9f330ed5-cb29-4f59-8cfe-5f3fbbad6593)
