### PR TITLE
feat(highlight_condtions): add CS custom logic

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -19,7 +19,6 @@ local Variables = require('Module:Variables')
 
 local Currency = Lua.import('Module:Currency')
 local Game = Lua.import('Module:Game')
-local HighlightConditions = Lua.import('Module:HighlightConditions')
 local InfoboxPrizePool = Lua.import('Module:Infobox/Extensions/PrizePool')
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
@@ -177,7 +176,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{
 				name = Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox') .. ' Tier',
 				content = {self.caller:_createValveTierCell()},
-				classes = {HighlightConditions.tournament(args) and 'valvepremier-highlighted' or ''}
+				classes = {'valvepremier-highlighted'}
 			}
 		)
 	elseif id == 'gamesettings' then

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -19,6 +19,7 @@ local Variables = require('Module:Variables')
 
 local Currency = Lua.import('Module:Currency')
 local Game = Lua.import('Module:Game')
+local HighlightConditions = Lua.import('Module:HighlightConditions')
 local InfoboxPrizePool = Lua.import('Module:Infobox/Extensions/PrizePool')
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
@@ -176,7 +177,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{
 				name = Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox') .. ' Tier',
 				content = {self.caller:_createValveTierCell()},
-				classes = {'valvepremier-highlighted'}
+				classes = {HighlightConditions.tournament(args) and 'valvepremier-highlighted' or ''}
 			}
 		)
 	elseif id == 'gamesettings' then

--- a/standard/highlight_conditions/wikis/counterstrike/highlight_conditions.lua
+++ b/standard/highlight_conditions/wikis/counterstrike/highlight_conditions.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Logic = require('Module:Logic')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 

--- a/standard/highlight_conditions/wikis/counterstrike/highlight_conditions.lua
+++ b/standard/highlight_conditions/wikis/counterstrike/highlight_conditions.lua
@@ -1,0 +1,39 @@
+---
+-- @Liquipedia
+-- wiki=counterstrike
+-- page=Module:HighlightConditions
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local HighlightConditions = {}
+
+local DEFAULT_HIGHLIGHTABLE_VALUES = {
+	'Major Championship',
+	'Minor Championship',
+	'Major Qualifier',
+	'RMR Event'
+}
+
+--- Check arguments or queryData if the tournament should be highlighted
+---@param data table
+---@param options table
+---@return boolean
+function HighlightConditions.tournament(data, options)
+	data.extradata = data.extradata or {}
+	options = options or {}
+
+	if options.onlyHighlightOnValue then
+		return data.publishertier == options.onlyHighlightOnValue
+	elseif options.highlightOnAnyValue then
+		return String.isNotEmpty(data.publishertier)
+	end
+
+	return String.isNotEmpty(data.publishertier) and Table.includes(DEFAULT_HIGHLIGHTABLE_VALUES, data.publishertier)
+end
+
+return HighlightConditions


### PR DESCRIPTION
## Summary

Enforce default highlight values for publisher tier for CS wiki as we only want sponsored events to be highlighted now whereas Valve have introduced some other tiers too now that aren't sponsored.

## How did you test this change?

Tested in combination with #4976 via dev deploy.
