### PR TITLE
feat: show teamnames on geroguessr's transfers

### DIFF
--- a/standard/info/wikis/geoguessr/info.lua
+++ b/standard/info/wikis/geoguessr/info.lua
@@ -35,6 +35,9 @@ return {
 		match2 = {
 			status = 0,
 		},
+		transfers = {
+			showTeamName = true,
+		},
 	},
 	defaultRoundPrecision = 0,
 }


### PR DESCRIPTION
## Summary
a lot of team in geoguessr does not have a logo so it's better that show the team name in transfer so it will not confusing the viewer and user that are editing the transfer page
## How did you test this change?
#report-bugs and checking other wiki that use that
