### PR TITLE
fix(infobox): issues on dota2 cosmetic infobox

### DIFF
--- a/components/infobox/wikis/dota2/infobox_cosmetic_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_cosmetic_custom.lua
@@ -100,13 +100,13 @@ function CustomInjector:parse(id, widgets)
 				}
 			end},
 			Center{children = {args.description}},
-			Center{name = '[[Trading|Tradable]]', classes = {'infobox-cosmetic-tradeable'}, content = {
+			Center{name = '[[Trading|Tradable]]', classes = {'infobox-cosmetic-tradeable'}, children = {
 				CustomCosmetic._ableText('TRADEABLE', args.tradeable, args.marketlock)
 			}},
-			Center{name = '[[Steam Community Market|Marketable]]', classes = {'infobox-cosmetic-marketable'}, content = {
+			Center{name = '[[Steam Community Market|Marketable]]', classes = {'infobox-cosmetic-marketable'}, children = {
 				CustomCosmetic._ableText('MARKETABLE', args.marketable, args.marketlock)
 			}},
-			Center{name = '[[Deleting|Deletable]]', classes = {'infobox-cosmetic-deletable'}, content = {
+			Center{name = '[[Deleting|Deletable]]', classes = {'infobox-cosmetic-deletable'}, children = {
 				CustomCosmetic._ableText('DELETABLE', args.deletable)
 			}}
 		)

--- a/components/widget/infobox/widget_infobox_header.lua
+++ b/components/widget/infobox/widget_infobox_header.lua
@@ -164,7 +164,7 @@ function Header:_makeImageText(text)
 		return
 	end
 
-	return Div{classes = 'infobox-image-text', children = {text}}
+	return Div{classes = {'infobox-image-text'}, children = {text}}
 end
 
 return Header


### PR DESCRIPTION
## Summary
Two small issues affecting the dota2 cosmetic infobox. 
Incorrect setup class for ImageText on the Header, causing error
Incorrect usage of the Center widget, causing those elements not to be displayed

## How did you test this change?
Lvie
