### PR TITLE
feat(match2): add match vods on match pages

### DIFF
--- a/components/match2/wikis/dota2/match_page.lua
+++ b/components/match2/wikis/dota2/match_page.lua
@@ -145,6 +145,11 @@ function MatchPage.getByMatchId(props)
 			vod = game.vod,
 		} or ''
 	end)
+	if String.isNotEmpty(viewModel.vod) then
+		table.insert(viewModel.vods, 1, VodLink.display{
+			vod = viewModel.vod,
+		})
+	end
 
 	-- Create an object array for links
 	local function processLink(site, link)

--- a/components/match2/wikis/leagueoflegends/match_page.lua
+++ b/components/match2/wikis/leagueoflegends/match_page.lua
@@ -163,6 +163,11 @@ function MatchPage.getByMatchId(props)
 			} or ''
 		end)
 	}
+	if String.isNotEmpty(viewModel.vod) then
+		table.insert(viewModel.vods, 1, VodLink.display{
+			vod = viewModel.vod,
+		})
+	end
 
 	viewModel.heroIcon = function(self)
 		local character = self


### PR DESCRIPTION
## Summary
Currently on (big) match pages the vod is not displayed. This PR adds that.

## How did you test this change?
dev on dota2