### PR TITLE
feat(match2): standardize template usage on league of legends

### DIFF
--- a/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
@@ -30,7 +30,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local bans = Logic.readBool(args.bans)
 
 	local lines = Array.extend(
-		'{{Match2', -- Template:Match is used by match1 for now. Using Template:Match2 until it has been worked away.
+		'{{Match',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)


### PR DESCRIPTION
## Summary

leagueoflegends wiki previously used [Template:Match](https://liquipedia.net/leagueoflegends/index.php?title=TemplateArchive:Match/1&redirect=no) as a local redirect for a match1 component. The uses of the legacy redirect were all cleaned up and the redirect itself was archived few days ago.
As `Template:Match` now links to the Commons version, the use of [Template:Match2](https://liquipedia.net/leagueoflegends/Template:Match2) is no longer necessary. Thus, this PR updates MatchGroup generator for LoL to start using `Template:Match`.

## How did you test this change?

dev
