### PR TITLE
refactor(match2): cleanup space usage

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -18,7 +18,7 @@ local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
-local Links =  Lua.import('Module:Links')
+local Links = Lua.import('Module:Links')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -160,7 +160,7 @@ function StarcraftMatchSummary.Game(options, game)
 		css = {width = options.isPartOfSubMatch and '100%' or nil},
 		children = WidgetUtil.collect(
 			game.header and {
-				HtmlWidgets.Div{css = {margin = 'auto'},  children = {game.header}},
+				HtmlWidgets.Div{css = {margin = 'auto'}, children = {game.header}},
 				MatchSummaryWidgets.Break{},
 			} or nil,
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
@@ -196,7 +196,7 @@ function StarcraftMatchSummary.TeamSubmatch(submatch)
 		classes = {'brkts-popup-body-game'},
 		children = WidgetUtil.collect(
 			submatch.header and {
-				HtmlWidgets.Div{css = {margin = 'auto', ['font-weight'] = 'bold'},  children = {submatch.header}},
+				HtmlWidgets.Div{css = {margin = 'auto', ['font-weight'] = 'bold'}, children = {submatch.header}},
 				MatchSummaryWidgets.Break{},
 			} or nil,
 			StarcraftMatchSummary.TeamSubMatchOpponnetRow(submatch),

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -256,7 +256,7 @@ function CustomMatchGroupInput.getHeadToHeadLink(match, opponents)
 	if not Logic.readBool(Logic.emptyOr(match.headtohead, Variables.varDefault('tournament_headtohead'))) then
 		return nil
 	end
-	if  Opponent.isEmpty(opponents[1]) or Opponent.isEmpty(opponents[2]) then
+	if Opponent.isEmpty(opponents[1]) or Opponent.isEmpty(opponents[2]) then
 		return nil
 	end
 

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -85,8 +85,8 @@ function CustomMatchSummary._createMapRow(game)
 		end
 		local flipped = opponentIndex == 2
 		if flipped then
-            return '(' .. points .. ') ' .. score
-        end
+			return '(' .. points .. ') ' .. score
+		end
 		return score .. ' (' .. points .. ')'
 	end
 

--- a/components/match2/wikis/rainbowsix/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/rainbowsix/legacy/match_maps_legacy.lua
@@ -74,7 +74,7 @@ function MatchMaps._main(args)
 					storage_args[prefix] = {
 						map = Table.extract(details, prefix) or 'Unknown',
 						finished = Table.extract(details, prefix..'finished'),
-						score1 = Table.extract(details,  prefix..'score1'),
+						score1 = Table.extract(details, prefix..'score1'),
 						score2 = Table.extract(details, prefix..'score2'),
 						t1ban1 = Table.extract(details, prefix..'t1ban1'),
 						t1ban2 = Table.extract(details, prefix..'t1ban2'),

--- a/components/match2/wikis/valorant/match_legacy.lua
+++ b/components/match2/wikis/valorant/match_legacy.lua
@@ -87,7 +87,7 @@ function MatchLegacy.storeGames(match, match2)
 		local opponents = Json.parseIfString(game2.opponents) or {}
 		for teamId, opponent in ipairs(opponents) do
 			local counter = 0
-			for _, player in pairs(opponent.players)  do
+			for _, player in pairs(opponent.players) do
 				if Logic.isNotEmpty(player) then
 					counter = counter + 1
 					addPlayer(teamId, counter, player)

--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -134,7 +134,7 @@ function ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, pref
 		local parsedPrefix = 'map' .. mapIndex
 		parsedArgs[parsedPrefix] = map
 		parsedArgs[parsedPrefix .. 'subgroup'] = submatchIndex
-		parsedArgs[parsedPrefix .. 'finished']  = true
+		parsedArgs[parsedPrefix .. 'finished'] = true
 
 		local winner = tonumber(args[prefix .. 'win' .. submatchMapIndex])
 		parsedArgs[parsedPrefix .. 'win'] = winner
@@ -170,7 +170,7 @@ function ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, pref
 	parsedArgs[parsedPrefix .. 'p2score'] = score2
 	parsedArgs[parsedPrefix .. 'walkover'] = score1 == DEFAULT_WIN and 1 or score2 == DEFAULT_WIN and 2 or nil
 	parsedArgs[parsedPrefix] = submatchIsNotDefaultWin and 'Submatch Score Fix' or 'Submatch'
-	parsedArgs[parsedPrefix .. 'finished']  = true
+	parsedArgs[parsedPrefix .. 'finished'] = true
 
 	Array.forEach(playersArrays, function(players, opponentIndex)
 		Array.forEach(players, function(player, playerIndex)

--- a/components/match2/wikis/warcraft/match_summary.lua
+++ b/components/match2/wikis/warcraft/match_summary.lua
@@ -150,7 +150,7 @@ function CustomMatchSummary.Game(options, game)
 		css = {width = options.isPartOfSubMatch and '100%' or nil},
 		children = WidgetUtil.collect(
 			game.header and {
-				HtmlWidgets.Div{css = {margin = 'auto'},  children = {game.header}},
+				HtmlWidgets.Div{css = {margin = 'auto'}, children = {game.header}},
 				MatchSummaryWidgets.Break{},
 			} or nil,
 			CustomMatchSummary.DispalyHeroes(game.opponents[1], {hasHeroes = options.hasHeroes}),

--- a/components/widget/match/summary/widget_match_summary_map_veto_start.lua
+++ b/components/widget/match/summary/widget_match_summary_map_veto_start.lua
@@ -26,7 +26,7 @@ function MatchSummaryMapVetoStart:render()
 		return
 	end
 
-	local format = self.props.vetoFormat and  ('Veto Format: ' .. self.props.vetoFormat) or ''
+	local format = self.props.vetoFormat and ('Veto Format: ' .. self.props.vetoFormat) or ''
 	local children = {}
 	if self.props.firstVeto == 1 then
 		children = {


### PR DESCRIPTION
## Summary
Clean up some double space occourances (found via search in vscode) to either single space or tabs (in case of indents).

## How did you test this change?
N/A