### PR TITLE
fix(match2): missing 1% on margin-left for win/loss icons

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -627,7 +627,7 @@ div.brkts-popup-body-element-thumbs {
 .brkts-popup-winloss-icon {
 	width: 16px;
 	line-height: 17px;
-	margin-left: %;
+	margin-left: 1%;
 	margin-right: 1%;
 }
 


### PR DESCRIPTION
## Summary
Typo missing the `1`

## How did you test this change?
dev tools