### PR TITLE
feat(infobox): accommodation button in infobox league

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -231,12 +231,22 @@ function League:createInfobox()
 				end
 				local venues = League._parseVenues(args)
 				-- If more than one venue, don't show the accommodation section, as it is unclear which one the link is for
-				if #venues ~= 1 then
+				if #venues > 1 then
 					return
 				end
-				local venueName = venues[1].id
-				if not venueName then
-					return
+				local location = (venues[1] or {}).id
+
+				-- If the event has no known venue, show based on the city instead, if there's only one city
+				if not location then
+					local locations = Locale.formatLocations(args)
+					if not locations.city1 or locations.city2 then
+						return
+					end
+					if locations.country1 or locations.region1 then
+						location = locations.city1 .. ', ' .. Flags.CountryName(locations.country1 or locations.region1)
+					else
+						location = locations.city1
+					end
 				end
 				-- Start date for the accommodation should be the day before the event, but at most 4 days before the event
 				-- End date for the accommodation should be 1 day after the event
@@ -270,7 +280,7 @@ function League:createInfobox()
 							variant = 'primary',
 							size = 'md',
 							link = buildStay22Link(
-								venueName,
+								location,
 								DateExt.toYmdInUtc(osdateStart),
 								DateExt.toYmdInUtc(osdateEnd)
 							),

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -33,6 +33,8 @@ local TextSanitizer = Lua.import('Module:TextSanitizer')
 
 local INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia ${tierMode}'
 local VENUE_DESCRIPTION = '<br><small><small>(${desc})</small></small>'
+local STAY22_LINK = 'https://www.stay22.com/allez/roam?aid=liquipedia&campaign=infobox'..
+	'&address=${address}&checkin=${checkin}&checkout=${checkout}'
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
@@ -42,6 +44,8 @@ local Center = Widgets.Center
 local Customizable = Widgets.Customizable
 local Builder = Widgets.Builder
 local Chronology = Widgets.Chronology
+local Button = Lua.import('Module:Widget/Basic/Button')
+local IconFa = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 
 ---@class InfoboxLeague: BasicInfobox
 local League = Class.new(BasicInfobox)
@@ -153,15 +157,9 @@ function League:createInfobox()
 		}}},
 		Builder{
 			builder = function()
-				local venues = {}
-				for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue', {requireIndex = false}) do
-					local description
-					if String.isNotEmpty(args[prefix .. 'desc']) then
-						description = String.interpolate(VENUE_DESCRIPTION, {desc = args[prefix .. 'desc']})
-					end
-
-					table.insert(venues, self:createLink(venueName, args[prefix .. 'name'], args[prefix .. 'link'], description))
-				end
+				local venues = Array.map(League._parseVenues(args), function(venue)
+					return self:createLink(venue.id, venue.name, venue.link, venue.description)
+				end)
 
 				return {Cell{
 					name = 'Venue',
@@ -221,6 +219,72 @@ function League:createInfobox()
 				}
 			}
 		},
+		Builder{
+			builder = function()
+				local startDate, endDate = self.data.startDate, self.data.endDate
+				if not startDate or not endDate then
+					return
+				end
+				local onlineOrOffline = tostring(args.type or ''):lower()
+				if not onlineOrOffline:match('offline') then
+					return
+				end
+				local venues = League._parseVenues(args)
+				-- If more than one venue, don't show the accommodation section, as it is unclear which one the link is for
+				if #venues ~= 1 then
+					return
+				end
+				local venueName = venues[1].id
+				if not venueName then
+					return
+				end
+				-- Start date for the accommodation should be the day before the event, but at most 4 days before the event
+				-- End date for the accommodation should be 1 day after the event
+				local osdateEnd = DateExt.parseIsoDate(endDate)
+				osdateEnd.day = osdateEnd.day + 1
+				local osdateFictiveStart = DateExt.parseIsoDate(endDate)
+				osdateFictiveStart.day = osdateFictiveStart.day - 4
+				local osdateRealStart = DateExt.parseIsoDate(startDate)
+				osdateRealStart.day = osdateRealStart.day - 1
+
+				local osdateStart
+				if os.difftime(os.time(osdateFictiveStart), os.time(osdateRealStart)) > 0 then
+					osdateStart = osdateFictiveStart
+				else
+					osdateStart = osdateRealStart
+				end
+
+				local function buildStay22Link(address, checkin, checkout)
+					return String.interpolate(STAY22_LINK, {
+						address = address,
+						checkin = checkin,
+						checkout = checkout,
+					})
+				end
+
+				return {
+					Title{children = 'Accommodation'},
+					Center{children = {
+						Button{
+							linktype = 'external',
+							variant = 'primary',
+							size = 'md',
+							link = buildStay22Link(
+								venueName,
+								DateExt.toYmdInUtc(osdateStart),
+								DateExt.toYmdInUtc(osdateEnd)
+							),
+							children = {
+								IconFa{iconName = 'accommodation'},
+								' ',
+								'Find My Accommodation',
+							}
+						},
+						Center{children = 'Bookings earn Liquipedia a small commission.'}
+					}}
+				}
+			end
+		}
 	}
 
 	self.name = TextSanitizer.stripHTML(self.name)
@@ -235,7 +299,24 @@ function League:createInfobox()
 
 	return mw.html.create()
 		:node(self:build(widgets))
-		:node(Logic.readBool(args.autointro) and ('<br>' .. self:seoText(args)) or nil)
+		:node(Logic.readBool(args.autointro) and ('br>' .. self:seoText(args)) or nil)
+end
+
+---@param args table
+---@return {id: string?, name: string?, link: string?, description: string?}[]
+function League._parseVenues(args)
+	local venues = {}
+	for prefix, venueName in Table.iter.pairsByPrefix(args, 'venue', {requireIndex = false}) do
+		local name = args[prefix .. 'name']
+		local link = args[prefix .. 'link']
+		local description
+		if String.isNotEmpty(args[prefix .. 'desc']) then
+			description = String.interpolate(VENUE_DESCRIPTION, {desc = args[prefix .. 'desc']})
+		end
+
+		table.insert(venues, {id = venueName, name = name, link = link, description = description})
+	end
+	return venues
 end
 
 function League:_parseArgs()

--- a/components/widget/basic/widget_basic_link.lua
+++ b/components/widget/basic/widget_basic_link.lua
@@ -26,13 +26,16 @@ Link.defaultProps = {
 	linktype = 'internal',
 }
 
----@return Widget
+---@return Widget?
 function Link:render()
+	if not self.props.link then
+		return
+	end
 	if self.props.linktype == 'external' then
 		return Fragment{
 			children = WidgetUtil.collect(
 				'[',
-				self.props.link,
+				(self.props.link:gsub(' ', '%%20')),
 				' ',
 				unpack(self.props.children),
 				']'

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -82,7 +82,7 @@ function DateExt.formatTimestamp(format, timestamp)
 end
 
 --- Converts a date string or timestamp into a format that can be used in the date param to Module:Countdown.
----@param dateOrTimestamp string|integer|osdate
+---@param dateOrTimestamp string|integer|osdate|osdateparam
 ---@return string
 function DateExt.toCountdownArg(dateOrTimestamp)
 	local timestamp = DateExt.readTimestamp(dateOrTimestamp)
@@ -91,20 +91,20 @@ end
 
 --- Truncates the time of day in a date string or timestamp, and returns the date formatted as yyyy-mm-dd.
 --- The time of day is truncated in the UTC timezone. The time of day and timezone are discarded.
----@param dateOrTimestamp string|integer|osdate
+---@param dateOrTimestamp string|integer|osdate|osdateparam
 ---@return string|number
 function DateExt.toYmdInUtc(dateOrTimestamp)
 	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp) or '')
 end
 
----@param dateString string|integer|osdate
+---@param dateString string|integer|osdate|osdateparam
 ---@return boolean
 function DateExt.isDefaultTimestamp(dateString)
 	return DateExt.readTimestamp(dateString) == DateExt.defaultTimestamp
 end
 
----@param dateString string|integer|osdate
----@return string|integer|osdate?
+---@param dateString string|integer|osdate|osdateparam
+---@return string|integer|osdate|osdateparam?
 function DateExt.nilIfDefaultTimestamp(dateString)
 	return not DateExt.isDefaultTimestamp(dateString) and dateString or nil
 end
@@ -128,8 +128,7 @@ end
 --- YYYY is required, MM and DD are optional. They are assumed to be 1 if not supplied.
 ---@param str string
 ---@return osdateparam
----@overload fun():nil
----@overload fun(nil):nil
+---@overload fun(str: nil?):nil
 function DateExt.parseIsoDate(str)
 	if not str then
 		return

--- a/standard/icon_data.lua
+++ b/standard/icon_data.lua
@@ -84,4 +84,7 @@ return {
 	-- Usage: Deadlock
 	amberhand = 'fas fa-hand-paper',
 	sapphireflame = 'fas fa-fire',
+
+	-- Usage: Accommodations
+	accommodation = 'far fa-home-alt',
 }


### PR DESCRIPTION
## Summary
Add accommodation button for offline tournaments with ONE known venue. If there are ZERO venues, fallback to use the CITY if there's exactly ONE city.

Look on CS (and highlighted)
![image](https://github.com/user-attachments/assets/1575547b-9808-4cce-b8d7-ce0b9539dc5f)
Look on Dota2
![image](https://github.com/user-attachments/assets/4a491dfc-9099-4d34-8e2d-ba51ed57acd7)


## How did you test this change?
/dev