### PR TITLE
fix(match2): brawlstars legacy storage erroring on empty opponents

### DIFF
--- a/components/match2/wikis/brawlhalla/match_legacy.lua
+++ b/components/match2/wikis/brawlhalla/match_legacy.lua
@@ -74,7 +74,7 @@ function MatchLegacy._convertParameters(match2)
 		local opponentmatch2players = opponent.match2players or {}
 		if opponent.type == Opponent.solo then
 			local player = opponentmatch2players[1] or {}
-			match[prefix] = player.name:gsub(' ', '_')
+			match[prefix] = (player.name or ''):gsub(' ', '_')
 			match[prefix .. 'score'] = (tonumber(opponent.score) or 0) > 0 and opponent.score or 0
 			match[prefix .. 'flag'] = player.flag
 			match.extradata[prefix .. 'displayname'] = player.displayname


### PR DESCRIPTION
## Summary
add a nil catch needed for empty opponent case

## How did you test this change?
live