### PR TITLE
feat(infobox): Show automated team history for logged out users on AoE

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -80,12 +80,21 @@ function CustomPlayer.run(frame)
 		player.args.history = automatedHistory
 	else
 		args.history = tostring(mw.html.create('div')
-			:addClass("show-when-logged-in")
-			:addClass("navigation-not-searchable")
-			:tag('big'):wikitext("Automated History"):done()
-			:wikitext(automatedHistory)
-			:tag('big'):wikitext("Manual History"):done())
-			.. args.history
+			:tag('div')
+				:tag('big')
+					:addClass("show-when-logged-in")
+					:addClass("navigation-not-searchable")
+					:wikitext("Automated History")
+					:done()
+				:wikitext(automatedHistory)
+				:done()
+			:tag('div')
+				:addClass("show-when-logged-in")
+				:addClass("navigation-not-searchable")
+				:tag('big'):wikitext("Manual History"):done()
+				:wikitext(args.history)
+				:done()
+			)
 	end
 
 	-- Automatic achievements


### PR DESCRIPTION
## Summary
Most history entries from recent years are automated by now, so editors suggested to switch this around to only show that to logged-out users.
Manual history still exists on some 200 pages, so show that for logged-in users to help migrating them.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
