### PR TITLE
RL: Correctly condition opponentname in PlayerExtCustom

### DIFF
--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -32,7 +32,7 @@ function PlayerExtCustom._fetchTeamFromPlacement(resolvedPageName, date)
 	local conditions = {
 		'[[opponenttype::solo]]', -- can not use Opponent.solo due to circular requires
 		'[[pagename::' .. mw.title.getCurrentTitle().text:gsub(' ', '_') .. ']]',
-		'[[opponentname::' .. resolvedPageName .. ']]',
+		'[[opponentname::' .. resolvedPageName:gsub('_', ' ') .. ']]',
 	}
 	local placement = mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = 1,


### PR DESCRIPTION
## Summary

`Opponent.resolve` gsubs for underscores before calling to this function, but `opponentname` is stored with spaces.

## How did you test this change?

/dev