### PR TITLE
feat(match2): standardize core body display logic

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -526,7 +526,10 @@ end
 ---@param options {teamStyle: teamStyle?, width: fun(MatchGroupUtilMatch):string?|string?, noScore:boolean?}?
 ---@return Html
 function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
-	assert(type(CustomMatchSummary.createBody) == 'function', 'Function "createBody" missing in "Module:MatchSummary"')
+	assert(
+		(type(CustomMatchSummary.createBody) == 'function' or type(CustomMatchSummary.createGame) == 'function'),
+		'createBody(match) or createGame(date, game, gameIndex) must be implemented in Module:MatchSummary'
+	)
 
 	options = options or {}
 
@@ -540,8 +543,8 @@ function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 
 	local matchSummary = MatchSummary():init(width)
 
-	--additional header for when martin adds the the css and buttons for switching between match and reset match
-	--if bracketResetMatch then
+	--additional header for when martin adds the the css and buttons for switching betwen match and reset match
+	--if bracketResetMatch the
 		--local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
 		--matchSummary:header(createHeader(match, {noScore = true, teamStyle = options.teamStyle}))
 		--here martin can add the buttons for switching between match and reset match

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -9,6 +9,8 @@
 local Abbreviation = require('Module:Abbreviation')
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
+local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -18,6 +20,7 @@ local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local Links = Lua.import('Module:Links')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
@@ -179,36 +182,6 @@ function Row:create()
 	return self.root
 end
 
----@class MatchSummaryBody
----@operator call: MatchSummaryBody
----@field root Html
-local Body = Class.new(
-	function(self)
-		self.root = mw.html.create('div')
-		self.root:addClass('brkts-popup-body')
-	end
-)
-
----@param cssClass string?
----@return MatchSummaryBody
-function Body:addClass(cssClass)
-	self.root:addClass(cssClass)
-	return self
-end
-
----@param row MatchSummaryRowInterface?
----@return MatchSummaryBody
-function Body:addRow(row)
-	if not row then return self end
-	self.root:node(row:create())
-	return self
-end
-
----@return Html
-function Body:create()
-	return self.root
-end
-
 ---@class MatchSummaryFooter
 ---@operator call: MatchSummaryFooter
 ---@field root Html
@@ -302,16 +275,10 @@ function Match:header(header)
 	return self
 end
 
----@param body MatchSummaryBody|Widget
+---@param body Widget
 ---@return MatchSummaryMatch
 function Match:body(body)
-	if type(body.create) == 'function' then
-		---@cast body MatchSummaryBody
-		self.bodyElement = body:create()
-	else
-		---@cast body Widget
-		self.bodyElement = body
-	end
+	self.bodyElement = body
 	return self
 end
 
@@ -346,7 +313,6 @@ end
 ---@class MatchSummary
 ---@operator call(string?):MatchSummary
 ---@field Header MatchSummaryHeader
----@field Body MatchSummaryBody
 ---@field Row MatchSummaryRow
 ---@field Footer MatchSummaryFooter
 ---@field Match MatchSummaryMatch
@@ -355,7 +321,6 @@ end
 ---@field root Html?
 local MatchSummary = Class.new()
 MatchSummary.Header = Header
-MatchSummary.Body = Body
 MatchSummary.Row = Row
 MatchSummary.Footer = Footer
 MatchSummary.Match = Match
@@ -425,6 +390,21 @@ function MatchSummary.createDefaultHeader(match, options)
 		:leftScore(header:createScore(match.opponents[1]))
 		:rightScore(header:createScore(match.opponents[2]))
 		:rightOpponent(header:createOpponent(match.opponents[2], 'right', teamStyle))
+end
+
+-- Default body function
+---@param match table
+---@return Widget
+function MatchSummary.createDefaultBody(match, createGame)
+	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
+
+	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
+		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
+		Array.map(match.games, FnUtil.curry(createGame, match.date)),
+		MatchSummaryWidgets.Mvp(match.extradata.mvp),
+		MatchSummaryWidgets.Casters{casters = match.extradata.casters},
+		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = match.game}))
+	)}
 end
 
 ---Default footer function
@@ -525,7 +505,8 @@ function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 	local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
 	match:header(createHeader(matchData, options))
 
-	match:body(CustomMatchSummary.createBody(matchData))
+	local createBody = CustomMatchSummary.createBody or MatchSummary.createDefaultBody
+	match:body(createBody(matchData, CustomMatchSummary.createGame))
 
 	local substituteComment = MatchSummary.createSubstitutesComment(matchData)
 

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -543,8 +543,8 @@ function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 
 	local matchSummary = MatchSummary():init(width)
 
-	--additional header for when martin adds the the css and buttons for switching betwen match and reset match
-	--if bracketResetMatch the
+	--additional header for when martin adds the the css and buttons for switching between match and reset match
+	--if bracketResetMatch then
 		--local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
 		--matchSummary:header(createHeader(match, {noScore = true, teamStyle = options.teamStyle}))
 		--here martin can add the buttons for switching between match and reset match

--- a/components/match2/wikis/arenafps/match_summary.lua
+++ b/components/match2/wikis/arenafps/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -16,7 +14,6 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -26,22 +23,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----@param match MatchGroupUtilMatch
----@return Widget
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMapRow(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/battlerite/match_summary.lua
+++ b/components/match2/wikis/battlerite/match_summary.lua
@@ -8,12 +8,9 @@
 
 local CustomMatchSummary = {}
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
@@ -24,21 +21,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px', teamStyle = 'bracket'})
 end
 
----@param match MatchGroupUtilMatch
----@return Widget
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createGame)
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
 ---@param gameIndex integer
----@return MatchSummaryRow
-function CustomMatchSummary._createGame(game, gameIndex)
+---@return Widget?
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	return MatchSummaryWidgets.Row{
 		classes = {'brkts-popup-body-game'},
 		css = {['font-size'] = '80%', padding = '4px'},

--- a/components/match2/wikis/callofduty/match_summary.lua
+++ b/components/match2/wikis/callofduty/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapModes = require('Module:MapModes')
@@ -16,7 +14,6 @@ local String = require('Module:StringUtils')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -24,18 +21,6 @@ local CustomMatchSummary = {}
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
-end
-
----@param match MatchGroupUtilMatch
----@return Widget
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp)
-	)}
 end
 
 ---@param game MatchGroupUtilGame
@@ -47,9 +32,11 @@ function CustomMatchSummary._gameScore(game, opponentIndex)
 	return mw.html.create('div'):wikitext(scoreDisplay)
 end
 
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMapRow(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/clashofclans/match_summary.lua
+++ b/components/match2/wikis/clashofclans/match_summary.lua
@@ -7,8 +7,6 @@
 --
 
 local Abbreviation = require('Module:Abbreviation')
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
@@ -16,7 +14,6 @@ local Table = require('Module:Table')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -47,16 +44,6 @@ function CustomMatchSummary.createHeader(match)
 		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
 
 	return header
-end
-
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp)
-	)}
 end
 
 function CustomMatchSummary._gameScore(game, opponentIndex)
@@ -93,7 +80,11 @@ function CustomMatchSummary._time(game, opponentIndex)
 		:wikitext(Abbreviation.make('(' .. os.date('%M:%S', time) .. ')', 'Total Time'))
 end
 
-function CustomMatchSummary._createMapRow(game, gameIndex)
+---@param date string
+---@param game MatchGroupUtilGame
+---@param gameIndex integer
+---@return Html?
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if Table.isEmpty(game.scores) then
 		return
 	end

--- a/components/match2/wikis/criticalops/match_summary.lua
+++ b/components/match2/wikis/criticalops/match_summary.lua
@@ -6,16 +6,13 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 -- Score Class
 ---@class CriticalopsScore
@@ -105,21 +102,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMap),
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = match.game}))
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMap(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/crossfire/match_summary.lua
+++ b/components/match2/wikis/crossfire/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapModes = require('Module:MapModes')
@@ -16,7 +14,6 @@ local String = require('Module:StringUtils')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -26,22 +23,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMapRow(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/geoguessr/match_summary.lua
+++ b/components/match2/wikis/geoguessr/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -15,7 +13,6 @@ local Page = require('Module:Page')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -23,17 +20,6 @@ local CustomMatchSummary = {}
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
-end
-
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow)
-	)}
 end
 
 ---@param game MatchGroupUtilGame
@@ -45,9 +31,11 @@ function CustomMatchSummary._gameScore(game, opponentIndex)
 	return mw.html.create('div'):wikitext(scoreDisplay)
 end
 
+---@param date string
 ---@param game MatchGroupUtilGame
----@return Html
-function CustomMatchSummary._createMapRow(game)
+---@param gameIndex integer
+---@return Html?
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	local row = MatchSummary.Row()
 
 	local centerNode = mw.html.create('div')

--- a/components/match2/wikis/halo/match_summary.lua
+++ b/components/match2/wikis/halo/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapModes = require('Module:MapModes')
@@ -16,7 +14,6 @@ local String = require('Module:StringUtils')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -26,22 +23,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMapRow(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/magic/match_summary.lua
+++ b/components/match2/wikis/magic/match_summary.lua
@@ -6,11 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
@@ -23,16 +20,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createGame)
-	)}
-end
-
-function CustomMatchSummary._createGame(game)
+---@param date string
+---@param game MatchGroupUtilGame
+---@param gameIndex integer
+---@return Html?
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	return MatchSummaryWidgets.Row{
 		classes = {'brkts-popup-body-game'},
 		css = {['font-size'] = '80%', padding = '4px'},

--- a/components/match2/wikis/overwatch/match_summary.lua
+++ b/components/match2/wikis/overwatch/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -16,7 +14,6 @@ local MapModes = require('Module:MapModes')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -24,19 +21,6 @@ local CustomMatchSummary = {}
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
-end
-
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
-	)}
 end
 
 ---@param game MatchGroupUtilGame
@@ -51,9 +35,11 @@ function CustomMatchSummary._gameScore(game, opponentIndex)
 	return mw.html.create('div'):wikitext(scoreDisplay)
 end
 
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMapRow(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
@@ -16,7 +15,6 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local POSITION_LEFT = 1
 local POSITION_RIGHT = 2
@@ -185,23 +183,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMap),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters},
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = 'siege'}))
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMap(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/rocketleague/match_summary.lua
+++ b/components/match2/wikis/rocketleague/match_summary.lua
@@ -6,10 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Abbreviation = require('Module:Abbreviation')
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -20,7 +18,6 @@ local Table = require('Module:Table')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 local OpponentDisplay = Lua.import('Module:OpponentDisplay')
 
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
@@ -197,21 +194,11 @@ function CustomMatchSummary.createHeader(match, options)
 		:rightOpponentTeam(header:soloOpponentTeam(match.opponents[2], match.date))
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createGame),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createGame(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/sideswipe/match_summary.lua
+++ b/components/match2/wikis/sideswipe/match_summary.lua
@@ -6,10 +6,8 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Abbreviation = require('Module:Abbreviation')
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
@@ -17,10 +15,8 @@ local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 local OpponentDisplay = Lua.import('Module:OpponentDisplay')
 
 local GREEN_CHECK = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'}
@@ -171,20 +167,11 @@ function CustomMatchSummary.createHeader(match, options)
 		:rightOpponentTeam(header:soloOpponentTeam(match.opponents[2], match.date))
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createGame)
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createGame(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/splatoon/match_summary.lua
+++ b/components/match2/wikis/splatoon/match_summary.lua
@@ -9,7 +9,6 @@
 local CustomMatchSummary = {}
 
 local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapTypeIcon = require('Module:MapType')
@@ -20,7 +19,6 @@ local WeaponIcon = require('Module:WeaponIcon')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local NON_BREAKING_SPACE = '&nbsp;'
 
@@ -30,22 +28,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '490px', teamStyle = 'bracket'})
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createGame),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto))
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
----@return Html
-function CustomMatchSummary._createGame(game)
+---@param gameIndex integer
+---@return Html?
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	local row = MatchSummary.Row()
 
 	if Logic.isNotEmpty(game.header) then

--- a/components/match2/wikis/splitgate/match_summary.lua
+++ b/components/match2/wikis/splitgate/match_summary.lua
@@ -6,15 +6,12 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -24,18 +21,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow)
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMapRow(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/teamfortress/match_summary.lua
+++ b/components/match2/wikis/teamfortress/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -15,7 +13,6 @@ local Page = require('Module:Page')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -23,17 +20,6 @@ local CustomMatchSummary = {}
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
-end
-
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow)
-	)}
 end
 
 ---@param game MatchGroupUtilGame
@@ -45,9 +31,11 @@ function CustomMatchSummary._gameScore(game, opponentIndex)
 	return mw.html.create('div'):wikitext(scoreDisplay)
 end
 
+---@param date string
 ---@param game MatchGroupUtilGame
----@return Html
-function CustomMatchSummary._createMapRow(game)
+---@param gameIndex integer
+---@return Html?
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	local row = MatchSummary.Row()
 
 	local centerNode = mw.html.create('div')

--- a/components/match2/wikis/tetris/match_summary.lua
+++ b/components/match2/wikis/tetris/match_summary.lua
@@ -6,15 +6,11 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -24,17 +20,6 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createGame)
-	)}
-end
-
 ---@param game MatchGroupUtilGame
 ---@param opponentIndex integer
 ---@return Html
@@ -42,9 +27,11 @@ function CustomMatchSummary._gameScore(game, opponentIndex)
 	return mw.html.create('div'):wikitext(game.scores[opponentIndex])
 end
 
+---@param date string
 ---@param game MatchGroupUtilGame
----@return Html
-function CustomMatchSummary._createGame(game)
+---@param gameIndex integer
+---@return Html?
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	local row = MatchSummary.Row()
 
 	row:addClass('brkts-popup-body-game')

--- a/components/match2/wikis/tft/match_summary.lua
+++ b/components/match2/wikis/tft/match_summary.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -15,7 +13,6 @@ local Page = require('Module:Page')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CustomMatchSummary = {}
 
@@ -25,22 +22,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMapRow),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMapRow(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/trackmania/match_summary.lua
+++ b/components/match2/wikis/trackmania/match_summary.lua
@@ -7,17 +7,13 @@
 --
 
 local Abbreviation = require('Module:Abbreviation')
-local Array = require('Module:Array')
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Icon = require('Module:Icon')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 local OpponentLibrary = require('Module:OpponentLibraries')
 local OpponentDisplay = OpponentLibrary.OpponentDisplay
 
@@ -147,22 +143,11 @@ function CustomMatchSummary.createHeader(match, options)
 		:rightOpponent(header:createOpponent(match.opponents[2], 'right'))
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createGame),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters}
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createGame(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/valorant/match_summary.lua
+++ b/components/match2/wikis/valorant/match_summary.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
@@ -16,7 +15,6 @@ local Operator = require('Module:Operator')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class ValorantScore
 ---@operator call: ValorantScore
@@ -102,23 +100,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '500px', teamStyle = 'bracket'})
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMap),
-		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.Casters{casters = match.extradata.casters},
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto))
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMap(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end

--- a/components/match2/wikis/zula/match_summary.lua
+++ b/components/match2/wikis/zula/match_summary.lua
@@ -6,16 +6,13 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
-local DateExt = require('Module:Date/Ext')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 -- Score Class
 ---@class ZulaScore
@@ -105,21 +102,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
----@param match MatchGroupUtilMatch
----@return MatchSummaryBody
-function CustomMatchSummary.createBody(match)
-	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
-
-	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
-		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		Array.map(match.games, CustomMatchSummary._createMap),
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto))
-	)}
-end
-
+---@param date string
 ---@param game MatchGroupUtilGame
+---@param gameIndex integer
 ---@return Html?
-function CustomMatchSummary._createMap(game)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	if not game.map then
 		return
 	end


### PR DESCRIPTION
## Summary
Create a standardized createBody, and use it where it can be used.

Want to expand it to add character bans, but currently that's depends on a max num of bans, which varies by game.

## How did you test this change?
/dev on R6