### PR TITLE
fix(match2): game comment location on wc3 and sg

### DIFF
--- a/components/match2/wikis/stormgate/match_summary.lua
+++ b/components/match2/wikis/stormgate/match_summary.lua
@@ -161,8 +161,8 @@ function CustomMatchSummary.Game(options, game)
 			},
 			showOffFactionIcons and offFactionIcons(2) or nil,
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
-			MatchSummaryWidgets.GameComment{children = game.comment, classes = {'brkts-popup-sc-game-comment'}},
-			CustomMatchSummary.DisplayHeroes(game.opponents[2], {hasHeroes = options.hasHeroes, flipped = true})
+			CustomMatchSummary.DisplayHeroes(game.opponents[2], {hasHeroes = options.hasHeroes, flipped = true}),
+			MatchSummaryWidgets.GameComment{children = game.comment, classes = {'brkts-popup-sc-game-comment'}}
 		)
 	}
 end

--- a/components/match2/wikis/warcraft/match_summary.lua
+++ b/components/match2/wikis/warcraft/match_summary.lua
@@ -162,8 +162,8 @@ function CustomMatchSummary.Game(options, game)
 			},
 			showOffFactionIcons and offFactionIcons(2) or nil,
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
-			MatchSummaryWidgets.GameComment{children = game.comment, classes = {'brkts-popup-sc-game-comment'}},
-			CustomMatchSummary.DisplayHeroes(game.opponents[2], {hasHeroes = options.hasHeroes, flipped = true})
+			CustomMatchSummary.DisplayHeroes(game.opponents[2], {hasHeroes = options.hasHeroes, flipped = true}),
+			MatchSummaryWidgets.GameComment{children = game.comment, classes = {'brkts-popup-sc-game-comment'}}
 		)
 	}
 end


### PR DESCRIPTION
## Summary
Game comment is located before 2nd team heroes, causing the display to be incorrect.
![image](https://github.com/user-attachments/assets/7bdeb3b6-b139-4fd3-a383-e06f17d97937)
This PR fixes this
## How did you test this change?
devtools