### PR TITLE
feat(infobox): show accomodation button only on non finished events

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -226,7 +226,7 @@ function League:createInfobox()
 					return
 				end
 				local onlineOrOffline = tostring(args.type or ''):lower()
-				if not onlineOrOffline:match('offline') then
+				if Logic.readBool(args['event-without-crowd']) or not onlineOrOffline:match('offline') then
 					return
 				end
 				local locations = Locale.formatLocations(args)
@@ -236,6 +236,13 @@ function League:createInfobox()
 				end
 				-- Must have a venue or a city to show the accommodation section
 				if not locations.venue1 and not locations.city1 then
+					return
+				end
+
+				-- if the event is finished do not show the button
+				local osdateCuttoff = DateExt.parseIsoDate(endDate)
+				osdateCuttoff.day = osdateCuttoff.day + 2
+				if os.difftime(os.time(), os.time(osdateCuttoff)) > 0 then
 					return
 				end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -241,7 +241,6 @@ function League:createInfobox()
 
 				-- if the event is finished do not show the button
 				local osdateCutoff = DateExt.parseIsoDate(endDate)
-				osdateCutoff.day = osdateCutoff.day + 2
 				if os.difftime(os.time(), os.time(osdateCutoff)) > 0 then
 					return
 				end

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -241,6 +241,7 @@ function League:createInfobox()
 
 				-- if the event is finished do not show the button
 				local osdateCutoff = DateExt.parseIsoDate(endDate)
+				osdateCutoff.day = osdateCutoff.day + 1
 				if os.difftime(os.time(), os.time(osdateCutoff)) > 0 then
 					return
 				end

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -240,9 +240,9 @@ function League:createInfobox()
 				end
 
 				-- if the event is finished do not show the button
-				local osdateCuttoff = DateExt.parseIsoDate(endDate)
-				osdateCuttoff.day = osdateCuttoff.day + 2
-				if os.difftime(os.time(), os.time(osdateCuttoff)) > 0 then
+				local osdateCutoff = DateExt.parseIsoDate(endDate)
+				osdateCutoff.day = osdateCutoff.day + 2
+				if os.difftime(os.time(), os.time(osdateCutoff)) > 0 then
 					return
 				end
 

--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -226,7 +226,7 @@ function League:createInfobox()
 					return
 				end
 				local onlineOrOffline = tostring(args.type or ''):lower()
-				if Logic.readBool(args['event-without-crowd']) or not onlineOrOffline:match('offline') then
+				if not onlineOrOffline:match('offline') then
 					return
 				end
 				local locations = Locale.formatLocations(args)


### PR DESCRIPTION
## Summary
once the event has finished (assumed once the end date has been exceeded by 24h) do not display th ebutton anymore
reason: the button seems useless for finished events

## How did you test this change?
dev