### PR TITLE
fix(match2): line break on R6 match summary

### DIFF
--- a/components/match2/wikis/rainbowsix/match_summary.lua
+++ b/components/match2/wikis/rainbowsix/match_summary.lua
@@ -59,18 +59,10 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		local oppositeSide = CustomMatchSummary._getOppositeSide(firstSide)
 		local oppositeSideOt = CustomMatchSummary._getOppositeSide(firstSideOt)
 		return {
-			{style = 'brkts-popup-body-match-sidewins', score = halves[firstSide], icon = ROUND_ICONS[firstSide]},
-			{style = 'brkts-popup-body-match-sidewins', score = halves[oppositeSide], icon = ROUND_ICONS[oppositeSide]},
-			{
-				style = 'brkts-popup-body-match-sidewins-overtime',
-				score = halves['ot' .. firstSideOt],
-				icon = ROUND_ICONS['ot' .. firstSideOt]
-			},
-			{
-				style = 'brkts-popup-body-match-sidewins-overtime',
-				score = halves['ot' .. oppositeSideOt],
-				icon = ROUND_ICONS['ot' .. oppositeSideOt]
-			},
+			{score = halves[firstSide], icon = ROUND_ICONS[firstSide]},
+			{score = halves[oppositeSide], icon = ROUND_ICONS[oppositeSide]},
+			{score = halves['ot' .. firstSideOt], icon = ROUND_ICONS['ot' .. firstSideOt]},
+			{score = halves['ot' .. oppositeSideOt], icon = ROUND_ICONS['ot' .. oppositeSideOt]},
 		}
 	end
 

--- a/components/widget/match/summary/widget_match_summary_detailed_score.lua
+++ b/components/widget/match/summary/widget_match_summary_detailed_score.lua
@@ -22,8 +22,13 @@ function MatchSummaryDetailedScore:render()
 	local flipped = self.props.flipped
 	local partialScores = Array.map(self.props.partialScores or {}, function(partialScore)
 		local children = {partialScore.score or '', partialScore.icon}
+
+		local styles = {'brkts-popup-body-match-sidewins'}
+		table.insert(styles, partialScore.style)
+		table.insert(styles, partialScore.icon and 'brkts-popup-body-match-sidewins-icon' or nil)
+
 		return HtmlWidgets.Td{
-			classes = {'brkts-popup-body-match-sidewins', partialScore.style},
+			classes = styles,
 			children = flipped and Array.reverse(children) or children,
 		}
 	end)

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -809,12 +809,14 @@ div.brkts-popup-body-element-thumbs {
 	font-size: 85%;
 }
 
-.brkts-popup-body-match-sidewins-overtime,
 .brkts-popup-body-match-sidewins {
 	padding: 0 0 3px 3px;
 	line-height: 11px;
 	width: 10px;
+}
 
+.brkts-popup-body-match-sidewins-icon {
+	width: 24px;
 	& img {
 		[ data-darkreader-scheme="dark" ] &,
 		.theme--dark & {

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -817,6 +817,7 @@ div.brkts-popup-body-element-thumbs {
 
 .brkts-popup-body-match-sidewins-icon {
 	width: 24px;
+
 	& img {
 		[ data-darkreader-scheme="dark" ] &,
 		.theme--dark & {


### PR DESCRIPTION
## Summary
Due to width limitation when using icon, the icon and text row breaks. Increase the width when using icon.
Also remove the `brkts-popup-body-match-sidewins-overtime` style as it's no longer needed.

## How did you test this change?
devtools