### PR TITLE
feat(infobox): on pokemon, store in LPDB for player history

### DIFF
--- a/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/pokemon/infobox_person_player_custom.lua
@@ -55,6 +55,7 @@ function CustomInjector:parse(id, widgets)
 		local manualHistory = args.history
 		local automatedHistory = TeamHistoryAuto.results{
 			convertrole = true,
+			addlpdbdata = true,
 			player = caller.pagename
 		}
 


### PR DESCRIPTION
## Summary
Allow player's stored transfer data to be stored as datapoints which can then allow automatic team icon on Individual tournaments. We've run into a situation where player didnt have the corresponding team icon applied on their 1v1 events, when they should have it. 

Given Pokemon has very very little amount of Team Transfers that is for the 1v1 scene. This should be very helpful to avoid manual addition of those (incl. Minuscule amount of transfer cleanup needed)


## Test Bed
https://liquipedia.net/pokemon/index.php?title=User:Hesketh2/Test&action=edit (Sejun has T1 icon in the imported prize pool by auto)

