### PR TITLE
fix(infobox): matchup category lowercased in StarCraft's strategy infobox

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_strategy_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_strategy_custom.lua
@@ -105,7 +105,7 @@ function CustomStrategy:_getCategories(race, matchups)
 
 	table.insert(categories, race .. ' ' .. informationType .. 's')
 
-	matchups = (matchups or ''):lower()
+	matchups = matchups or ''
 	if informationType == 'Build Order' then
 		for _, raceMatchupItem in pairs(CustomStrategy._raceMatchups()) do
 			if String.contains(matchups, raceMatchupItem) then
@@ -122,7 +122,7 @@ function CustomStrategy._raceMatchups()
 	local raceMatchups = {}
 	for _, faction1 in pairs(Faction.coreFactions) do
 		for _, faction2 in pairs(Faction.coreFactions) do
-			table.insert(raceMatchups, faction1 .. 'v' .. faction2)
+			table.insert(raceMatchups, faction1:upper() .. 'v' .. faction2:upper())
 		end
 	end
 


### PR DESCRIPTION
## Summary

The page https://liquipedia.net/starcraft/1_Factory_Tanks_(vs._Zerg) has category "Tv**z** Builds" instead of "Tv**Z** Builds". This fixes the capitalization to use the historical categories (e.g. https://liquipedia.net/starcraft/index.php?title=Category:TvZ_Builds&action=history)

## How did you test this change?

dev
