### PR TITLE
feat(match2): remove strikethrough on resulttype=default

### DIFF
--- a/components/match2/commons/match_group_display_helper.lua
+++ b/components/match2/commons/match_group_display_helper.lua
@@ -170,7 +170,7 @@ function DisplayHelper.Map(game, config)
 	else
 		mapText = game.map or 'Unknown'
 	end
-	if game.resultType == 'np' or game.resultType == 'default' then
+	if game.resultType == 'np' then
 		mapText = '<s>' .. mapText .. '</s>'
 	end
 	return mapText


### PR DESCRIPTION
## Summary
Remove the strikethrough on "defaults". Only keep it on notplayed.

Feedback from https://discord.com/channels/93055209017729024/1209065403955806270/1303520062531047516 which I resonate with

Before the match summary refactors I believe the only wikis that used the display helper functions were the Craft wikis. So only there there's a negative impact. But they will still display the status text when there was a "default".

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
