### PR TITLE
feat: improve useful articles on dota2 main page

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -1063,12 +1063,14 @@ div.heroentrytext {
 .useful-articles-layout {
 	display: flex;
 	flex-wrap: wrap;
+	justify-content: space-between;
 }
 
 .useful-articles-layout > div {
 	flex: 0 0 33%;
 	max-width: 33%;
 	word-wrap: break-word;
+	min-width: 160px;
 }
 
 .useful-articles-layout > div > div:first-child {


### PR DESCRIPTION

## Summary
min-width to ensure the width on mobile devices are not too narrow. This change is needed at the moment. 
space between is just to make the columns look a tiny bit nicer. This is just my preference, so this is not needed.

## How did you test this change?
In google chrome dev tools on the main page and game hub on dota 2 only across a variety of window sizes to test the . I am not aware that this code is used on any other wiki at the moment. 