### PR TITLE
feat(match2): remove flex-grow on characters display

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -567,7 +567,6 @@
 
 div.brkts-popup-body-element-thumbs {
 	display: inline-flex;
-	flex: 1;
 	min-width: 0.01%;
 }
 


### PR DESCRIPTION
## Summary
The flex-grow on the character display causes display issues at times. The center piece should be the growing one.

## How did you test this change?
Tested in devtools on Heroes, Valorant, dota2 and Warcraft. Which should cover all cases