### PR TITLE
feat(match2): remove autocalculating bestof on rocketleague

### DIFF
--- a/components/match2/wikis/rocketleague/match_group_input_custom.lua
+++ b/components/match2/wikis/rocketleague/match_group_input_custom.lua
@@ -25,7 +25,7 @@ local EARNINGS_LIMIT_FOR_FEATURED = 10000
 local CURRENT_YEAR = os.date('%Y')
 MatchFunctions.DEFAULT_MODE = '3v3'
 MatchFunctions.DATE_FALLBACKS = {'tournament_enddate'}
-MatchFunctions.getBestOf = MatchGroupInputUtil.getBestOf
+MatchFunctions.getBestOf = function (bestOfInput, maps) return tonumber(bestOfInput) end
 
 ---@param match table
 ---@param options table?


### PR DESCRIPTION
## Summary

A series' best-of length cannot be calculated by the number of maps, so this logic is removed.

## How did you test this change?

/dev