### PR TITLE
feat(match2): improve display for non-solo matches on fighters

### DIFF
--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -122,7 +122,7 @@ function CustomMatchGroupInput._processPlayerMapData(map, opponent, opponentInde
 		opponent.match2players,
 		players,
 		function(playerIndex)
-			return (opponent.match2players[playerIndex] or {}).name
+			return {name = map['t' .. opponentIndex .. 'p' .. playerIndex]}
 		end,
 		function(playerIndex, playerIdData, playerInputData)
 			local charInputs = Json.parseIfTable(map['o' .. opponentIndex .. 'p' .. playerIndex]) or {} ---@type string[]

--- a/components/match2/wikis/fighters/match_summary.lua
+++ b/components/match2/wikis/fighters/match_summary.lua
@@ -74,7 +74,8 @@ end
 function CustomMatchSummary.fetchCharactersOfPlayers(game, matchOpponents, teamIdx)
 	return Array.map(game.opponents[teamIdx].players, function (players, index)
 		if players.characters then
-			return {player = matchOpponents[teamIdx].players[index], characters = Array.map(players.characters, Operator.property('name'))}
+			local characters = Array.map(players.characters, Operator.property('name'))
+			return {player = matchOpponents[teamIdx].players[index], characters = characters}
 		end
 	end)
 end

--- a/components/match2/wikis/fighters/match_summary.lua
+++ b/components/match2/wikis/fighters/match_summary.lua
@@ -9,13 +9,18 @@
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
+local Operator = require('Module:Operator')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+local PlayerDisplay = require('Module:Player/Display')
 
 local CustomMatchSummary = {}
 
@@ -31,7 +36,16 @@ end
 ---@param match MatchGroupUtilMatch
 ---@return string
 function CustomMatchSummary._determineWidth(match)
-	return '350px'
+	return CustomMatchSummary._isSolo(match) and '400px' or '550px'
+end
+
+---@param match MatchGroupUtilMatch
+---@return boolean
+function CustomMatchSummary._isSolo(match)
+	if type(match.opponents[1]) ~= 'table' or type(match.opponents[2]) ~= 'table' then
+		return false
+	end
+	return match.opponents[1].type == Opponent.solo and match.opponents[2].type == Opponent.solo
 end
 
 ---@param match MatchGroupUtilMatch
@@ -43,6 +57,7 @@ function CustomMatchSummary.createBody(match)
 		return CustomMatchSummary._createStandardGame(game, {
 			opponents = match.opponents,
 			game = match.game,
+			soloMode = CustomMatchSummary._isSolo(match),
 		})
 	end)
 
@@ -53,20 +68,19 @@ function CustomMatchSummary.createBody(match)
 end
 
 ---@param game MatchGroupUtilGame
+---@param matchOpponents table[]
 ---@param teamIdx integer
----@return {name: string}[]
-function CustomMatchSummary.fetchCharacters(game, teamIdx)
-	local characters = {}
-	for _, playerCharacters in Table.iter.pairsByPrefix(game.participants, teamIdx .. '_', {requireIndex = true}) do
-		if playerCharacters.characters then
-			table.insert(characters, playerCharacters.characters)
+---@return {player: standardPlayer, characters: string[]}[]
+function CustomMatchSummary.fetchCharactersOfPlayers(game, matchOpponents, teamIdx)
+	return Array.map(game.opponents[teamIdx].players, function (players, index)
+		if players.characters then
+			return {player = matchOpponents[teamIdx].players[index], characters = Array.map(players.characters, Operator.property('name'))}
 		end
-	end
-	return Array.flatten(characters)
+	end)
 end
 
 ---@param game MatchGroupUtilGame
----@param props {game: string?}
+---@param props {game: string?, soloMode: boolean, opponents: table[]}
 ---@return Widget?
 function CustomMatchSummary._createStandardGame(game, props)
 	if not game or not game.participants then
@@ -80,60 +94,74 @@ function CustomMatchSummary._createStandardGame(game, props)
 		css = {['font-size'] = '0.75rem', padding = '4px'},
 		children = WidgetUtil.collect(
 			CustomMatchSummary._createCharacterDisplay(
-				CustomMatchSummary.fetchCharacters(game, 1),
+				CustomMatchSummary.fetchCharactersOfPlayers(game, props.opponents, 1),
 				props.game,
-				false
+				false,
+				not props.soloMode
 			),
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
 			MatchSummaryWidgets.GameCenter{children = scoreDisplay, css = {['flex-grow'] = 1}},
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
 			CustomMatchSummary._createCharacterDisplay(
-				CustomMatchSummary.fetchCharacters(game, 2),
+				CustomMatchSummary.fetchCharactersOfPlayers(game, props.opponents, 2),
 				props.game,
-				true
+				true,
+				not props.soloMode
 			)
 		)
 	}
 end
 
----@param characters {name: string}[]?
+---@param players {player: standardPlayer, characters: string[]}[]
 ---@param game string?
 ---@param reverse boolean?
+---@param displayPlayerNames boolean?
 ---@return Html
-function CustomMatchSummary._createCharacterDisplay(characters, game, reverse)
+function CustomMatchSummary._createCharacterDisplay(players, game, reverse, displayPlayerNames)
 	local CharacterIcons = mw.loadData('Module:CharacterIcons/' .. (game or ''))
-	local wrapper = mw.html.create('div')
-		:css('flex-basis', '30%')
-		:css('text-align', reverse and 'right' or 'left')
+	local wrapper = mw.html.create('div'):css('flex-basis', '40%')
 
-	if Table.isEmpty(characters) then
+	if Logic.isDeepEmpty(players) then
 		return wrapper
 	end
-	---@cast characters -nil
 
-	if #characters == 1 then
-		local characterDisplay = mw.html.create('span'):addClass('draft faction')
-		local character = characters[1]
-		if reverse then
-			characterDisplay:wikitext(character.name):wikitext('&nbsp;'):wikitext(CharacterIcons[character.name])
-		else
-			characterDisplay:wikitext(CharacterIcons[character.name]):wikitext('&nbsp;'):wikitext(character.name)
+	local playerDisplays = Array.map(players, function (player)
+		local characters = player.characters
+		if #characters == 0 then
+			return
 		end
-		wrapper:node(characterDisplay)
-		return wrapper
-	end
+		local playerWrapper = mw.html.create('div')
+			:css('display', 'flex')
+			:css('flex-direction', reverse and 'row' or 'row-reverse')
+		local playerNode = PlayerDisplay.BlockPlayer{player = player.player, flip = not reverse}
 
-	local characterDisplays = Array.map(characters, function (character, index)
-		local characterDisplay = mw.html.create('span'):addClass('draft faction')
-		characterDisplay:wikitext(CharacterIcons[character.name])
-		return characterDisplay
+		if #characters == 1 and not displayPlayerNames then
+			local characterDisplay = mw.html.create('div'):addClass('brkts-popup-body-element-thumbs')
+			local character = characters[1]
+			if reverse then
+				characterDisplay:wikitext(CharacterIcons[character]):wikitext('&nbsp;'):wikitext(character)
+			else
+				characterDisplay:wikitext(character):wikitext('&nbsp;'):wikitext(CharacterIcons[character])
+			end
+			playerWrapper:node(characterDisplay)
+			return playerWrapper
+		end
+
+		local characterDisplays = Array.map(characters, function (character)
+			local characterDisplay = mw.html.create('div'):addClass('brkts-popup-body-element-thumbs')
+			characterDisplay:wikitext(CharacterIcons[character])
+			return characterDisplay
+		end)
+		if displayPlayerNames then
+			table.insert(characterDisplays, '&nbsp;')
+			table.insert(characterDisplays, playerNode)
+		end
+
+		Array.forEach(characterDisplays, FnUtil.curry(playerWrapper.node, playerWrapper))
+		return playerWrapper
 	end)
 
-	if reverse then
-		characterDisplays = Array.reverse(characterDisplays)
-	end
-
-	Array.forEach(characterDisplays, FnUtil.curry(wrapper.node, wrapper))
+	Array.forEach(playerDisplays, FnUtil.curry(wrapper.node, wrapper))
 
 	return wrapper
 end


### PR DESCRIPTION
## Summary
With new and improved looks:

Team Game (also applies to non-solo parties):
![image](https://github.com/user-attachments/assets/b126ab2a-f842-4c17-80bb-ecd6acca184e)

Solo Game (minor tweaks):
![image](https://github.com/user-attachments/assets/01cf8354-3740-4daf-8093-4c87f47ba42d)


## How did you test this change?
dev
