### PR TITLE
fix(match2): mapScore calc on heroes, pokemon and wildrift

### DIFF
--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -101,14 +101,13 @@ function MapFunctions.getExtraData(match, map, opponents)
 	return extraData
 end
 
----@param winnerInput string|integer|nil
----@param finished boolean
+---@param map table
 ---@return fun(opponentIndex: integer): integer?
-function MapFunctions.calculateMapScore(winnerInput, finished)
-	local winner = tonumber(winnerInput)
+function MapFunctions.calculateMapScore(map)
+	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner and not map.finished then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -102,14 +102,13 @@ function MapFunctions.getExtraData(match, map, opponents)
 	return extradata
 end
 
----@param winnerInput string|integer|nil
----@param finished boolean
+---@param map table
 ---@return fun(opponentIndex: integer): integer?
-function MapFunctions.calculateMapScore(winnerInput, finished)
-	local winner = tonumber(winnerInput)
+function MapFunctions.calculateMapScore(map)
+	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner and not map.finished then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/tft/match_group_input_custom.lua
+++ b/components/match2/wikis/tft/match_group_input_custom.lua
@@ -76,18 +76,18 @@ function MapFunctions.getExtraData(match, map, opponents)
 	}
 end
 
----@param winnerInput string|integer|nil
----@param finished boolean
+---@param map table
 ---@return fun(opponentIndex: integer): integer?
-function MapFunctions.calculateMapScore(winnerInput, finished)
-	local winner = tonumber(winnerInput)
+function MapFunctions.calculateMapScore(map)
+	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner and not map.finished then
 			return
 		end
 		return winner == opponentIndex and 1 or 0
 	end
 end
+
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -102,14 +102,13 @@ function MapFunctions.getExtraData(match, map, opponents)
 	return extraData
 end
 
----@param winnerInput string|integer|nil
----@param finished boolean
+---@param map table
 ---@return fun(opponentIndex: integer): integer?
-function MapFunctions.calculateMapScore(winnerInput, finished)
-	local winner = tonumber(winnerInput)
+function MapFunctions.calculateMapScore(map)
+	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner and not map.finished then
 			return
 		end
 		return winner == opponentIndex and 1 or 0


### PR DESCRIPTION
## Summary
Nothing major as the scores are not used for display. (doesn't error). But it's not working as intended without this

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
