### PR TITLE
fix(infobox): misc publisher tier and highlight fixes

### DIFF
--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -21,14 +21,15 @@ local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
 
 ---@class Dota2LeagueInfobox: InfoboxLeague
+---@field publisherTier {meta: string, name: string, link: string}?
 local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
 
 local VALVE_TIERS = {
 	['international'] = {meta = '', name = 'The International', link = 'The International'},
-	['major'] = {meta = 'Dota Major Championship', name = 'Dota Major Championship', link = 'Dota Major Championships'},
+	['major'] = {meta = 'Major Championship', name = 'Dota Major Championship', link = 'Dota Major Championships'},
 	['dpc major'] = {meta = 'DPC Major', name = 'DPC Major', link = 'Dota Major Championships'},
-	['dpc minor'] = {meta = 'DPC Minor', name = 'DPC Major', link = 'Dota Minor Championships'},
+	['dpc minor'] = {meta = 'DPC Minor', name = 'DPC Minor', link = 'Dota Minor Championships'},
 	['dpc league'] = {meta = 'DPC Regional League', name = 'DPC Regional League', link = 'Regional League'}
 }
 

--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -27,7 +27,7 @@ local CustomInjector = Class.new(Injector)
 
 local VALVE_TIERS = {
 	['international'] = {meta = '', name = 'The International', link = 'The International'},
-	['major'] = {meta = 'Major Championship', name = 'Dota Major Championship', link = 'Dota Major Championships'},
+	['major'] = {meta = 'Dota Major Championship', name = 'Major Championship', link = 'Dota Major Championships'},
 	['dpc major'] = {meta = 'DPC Major', name = 'DPC Major', link = 'Dota Major Championships'},
 	['dpc minor'] = {meta = 'DPC Minor', name = 'DPC Minor', link = 'Dota Minor Championships'},
 	['dpc league'] = {meta = 'DPC Regional League', name = 'DPC Regional League', link = 'Regional League'}

--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -56,10 +56,7 @@ end
 ---@param args table
 ---@return string
 function CustomLeague:appendLiquipediatierDisplay(args)
-	if self.data.publishertier then
-		return ' ' .. RIOT_ICON
-	end
-	return ''
+	return String.isNotEmpty(self.data.publishertier) and (' ' .. RIOT_ICON) or ''
 end
 
 ---@param lpdbData table
@@ -69,14 +66,14 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.individual = String.isNotEmpty(args.participants_number) or
 			String.isNotEmpty(args.individual) and 'true' or ''
 
-	lpdbData.extradata['is riot premier'] = lpdbData.publishertier and 'true' or ''
+	lpdbData.extradata['is riot premier'] = lpdbData.publishertier
 
 	return lpdbData
 end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	self.data.publishertier = Logic.readBoolOrNil(args.riotpremier) or nil
+	self.data.publishertier = Logic.readBool(args.riotpremier) or ''
 end
 
 ---@param args table

--- a/standard/highlight_conditions/wikis/counterstrike/highlight_conditions.lua
+++ b/standard/highlight_conditions/wikis/counterstrike/highlight_conditions.lua
@@ -23,7 +23,6 @@ local DEFAULT_HIGHLIGHTABLE_VALUES = {
 ---@param options table
 ---@return boolean
 function HighlightConditions.tournament(data, options)
-	data.extradata = data.extradata or {}
 	options = options or {}
 
 	if options.onlyHighlightOnValue then


### PR DESCRIPTION
## Summary

Misc fixes to #4976 and #5035.

Biggest issue is LoL where extradata is set wrong:

![image](https://github.com/user-attachments/assets/76f69cf3-2444-4a8f-a444-e2c448bc9fd6)


## How did you test this change?

Via dev deploy

![image](https://github.com/user-attachments/assets/60def1c7-998e-4506-b4ef-85471e3f00ac)

