### PR TITLE
fix(match2): mvp processing does not have access to opponents

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -328,8 +328,9 @@ function MatchGroupInputUtil.getTournamentContext(obj, parent)
 end
 
 ---@param match table
+---@param opponents? table[]
 ---@return {players: MatchGroupMvpPlayer[], points: integer}?
-function MatchGroupInputUtil.readMvp(match)
+function MatchGroupInputUtil.readMvp(match, opponents)
 	if not match.mvp then return end
 	local mvppoints = match.mvppoints or 1
 
@@ -337,7 +338,7 @@ function MatchGroupInputUtil.readMvp(match)
 	local players = mw.text.split(match.mvp, ',')
 
 	-- parse the players to get their information
-	local opponents = MatchGroupUtil.normalizeSubtype(match, 'opponent')
+	opponents = Logic.isNotDeepEmpty(opponents) and opponents or MatchGroupUtil.normalizeSubtype(match, 'opponent')
 	local parsedPlayers = Array.map(players, function(player, playerIndex)
 		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(mw.text.split(player, '|')[1]):gsub(' ', '_')
 		for _, opponent in ipairs(opponents) do

--- a/components/match2/wikis/battlerite/match_group_input_custom.lua
+++ b/components/match2/wikis/battlerite/match_group_input_custom.lua
@@ -57,10 +57,12 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -110,10 +110,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/callofduty/match_group_input_custom.lua
+++ b/components/match2/wikis/callofduty/match_group_input_custom.lua
@@ -63,10 +63,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/clashofclans/match_group_input_custom.lua
+++ b/components/match2/wikis/clashofclans/match_group_input_custom.lua
@@ -39,10 +39,12 @@ end
 --
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/clashroyale/match_group_input_custom.lua
+++ b/components/match2/wikis/clashroyale/match_group_input_custom.lua
@@ -88,10 +88,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	local extradata = {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 
 	local prefix = 'subgroup%d+'

--- a/components/match2/wikis/crossfire/match_group_input_custom.lua
+++ b/components/match2/wikis/crossfire/match_group_input_custom.lua
@@ -72,10 +72,12 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
 	}
 end

--- a/components/match2/wikis/dota2/match_group_input_custom.lua
+++ b/components/match2/wikis/dota2/match_group_input_custom.lua
@@ -166,10 +166,12 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
 	}
 end

--- a/components/match2/wikis/halo/match_group_input_custom.lua
+++ b/components/match2/wikis/halo/match_group_input_custom.lua
@@ -70,10 +70,12 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match),
 	}
 end

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -62,11 +62,13 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
 		mapveto = MatchGroupInputUtil.getMapVeto(match),
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match),
 	}
 end

--- a/components/match2/wikis/honorofkings/match_group_input_custom.lua
+++ b/components/match2/wikis/honorofkings/match_group_input_custom.lua
@@ -68,10 +68,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -121,10 +121,12 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/mobilelegends/match_group_input_custom.lua
+++ b/components/match2/wikis/mobilelegends/match_group_input_custom.lua
@@ -95,10 +95,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
 	}
 end

--- a/components/match2/wikis/osu/match_group_input_custom.lua
+++ b/components/match2/wikis/osu/match_group_input_custom.lua
@@ -99,10 +99,12 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		mapveto = MatchGroupInputUtil.getMapVeto(match, ALLOWED_VETOES),
 		casters = MatchGroupInputUtil.readCasters(match),
 	}

--- a/components/match2/wikis/overwatch/match_group_input_custom.lua
+++ b/components/match2/wikis/overwatch/match_group_input_custom.lua
@@ -93,10 +93,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
 	}
 end

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -67,10 +67,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/rainbowsix/match_group_input_custom.lua
+++ b/components/match2/wikis/rainbowsix/match_group_input_custom.lua
@@ -56,11 +56,13 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
 		mapveto = MatchGroupInputUtil.getMapVeto(match),
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
 	}
 end

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -82,11 +82,13 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
 		mapveto = MatchGroupInputUtil.getMapVeto(match),
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/splitgate/match_group_input_custom.lua
+++ b/components/match2/wikis/splitgate/match_group_input_custom.lua
@@ -67,10 +67,12 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/tft/match_group_input_custom.lua
+++ b/components/match2/wikis/tft/match_group_input_custom.lua
@@ -34,10 +34,12 @@ function MatchFunctions.extractMaps(match, opponents)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match),
 	}
 end

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -89,11 +89,13 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
 		mapveto = MatchGroupInputUtil.getMapVeto(match),
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
 	}
 end

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -66,10 +66,12 @@ function MatchFunctions.getBestOf(bestofInput)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 	}
 end
 

--- a/components/match2/wikis/worldoftanks/match_group_input_custom.lua
+++ b/components/match2/wikis/worldoftanks/match_group_input_custom.lua
@@ -63,10 +63,12 @@ function MatchFunctions.calculateMatchScore(maps)
 end
 
 ---@param match table
+---@param games table[]
+---@param opponents table[]
 ---@return table
-function MatchFunctions.getExtraData(match)
+function MatchFunctions.getExtraData(match, games, opponents)
 	return {
-		mvp = MatchGroupInputUtil.readMvp(match),
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		mapveto = MatchGroupInputUtil.getMapVeto(match),
 		casters = MatchGroupInputUtil.readCasters(match),
 	}


### PR DESCRIPTION
## Summary
as per report on discord the mvp data is missing flags and teams on purged/edited pages
this seems to come from a lack of access to opponents data during the processing due to the changes with the recent refactors

this pr passes along the opponents data to the `readMvp` function so that it processes mvps properly again

## How did you test this change?
dev on hok