### PR TITLE
fix(match2): typo in MGI on Val

### DIFF
--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -135,7 +135,7 @@ end
 ---@param opponent table
 ---@param opponentIndex integer
 ---@return table[]
-function CustomMatchGroupInput.getPlayersOfMapOpponent(map, opponent, opponentIndex)
+function MapFunctions.getPlayersOfMapOpponent(map, opponent, opponentIndex)
 	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, AgentNames)
 
 	local players = Array.mapIndexes(function(playerIndex)


### PR DESCRIPTION
## Summary
Function was put in the wrong container

## How did you test this change?
Live