### PR TITLE
feat(match2): improve centering on match2

### DIFF
--- a/components/widget/match/summary/widget_match_summary_game_team_wrapper.lua
+++ b/components/widget/match/summary/widget_match_summary_game_team_wrapper.lua
@@ -24,6 +24,7 @@ MatchSummaryMatchGameTeamWrapper.defaultProps = {
 function MatchSummaryMatchGameTeamWrapper:render()
 	return HtmlWidgets.Div{
 		classes = {'brkts-popup-spaced'},
+		css = {flex = 1},
 		children = self.props.flipped and Array.reverse(self.props.children) or self.props.children
 	}
 end


### PR DESCRIPTION
## Summary
Improves alignment on 18 wikis (arenafps, bs, cod, coc, cf, geo, halo, os, osu, ow, rl, ss, splitgate, tf, tetris, tft, val, wot). The current non-alignment comes when the size of the content on left/right are not the same.

## How did you test this change?
devtools and /dev on geo and val