### PR TITLE
feat(match2): improve match summaries additionally

### DIFF
--- a/components/widget/match/summary/widget_match_summary_game_team_wrapper.lua
+++ b/components/widget/match/summary/widget_match_summary_game_team_wrapper.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
@@ -24,8 +23,8 @@ MatchSummaryMatchGameTeamWrapper.defaultProps = {
 function MatchSummaryMatchGameTeamWrapper:render()
 	return HtmlWidgets.Div{
 		classes = {'brkts-popup-spaced'},
-		css = {flex = 1},
-		children = self.props.flipped and Array.reverse(self.props.children) or self.props.children
+		css = {flex = 1, ['justify-content'] = 'unset', ['flex-direction'] = self.props.flipped and 'row-reverse' or 'row'},
+		children = self.props.children
 	}
 end
 


### PR DESCRIPTION
## Summary
Followup to #5068 to improve the styling more.

From:
![image](https://github.com/user-attachments/assets/9bcecf32-32c2-426d-a587-f28e01327b45)
![image](https://github.com/user-attachments/assets/9c6cd02a-1414-40d6-969c-a30a9e00c949)
![image](https://github.com/user-attachments/assets/15eec37d-111e-4355-a0d7-f0f993a03e5e)

To:
![image](https://github.com/user-attachments/assets/4dd5af8a-16c5-497f-8057-347a38ec57bf)
![image](https://github.com/user-attachments/assets/2a009a48-e9cf-4680-a5c3-ac2b83a70c0b)
![image](https://github.com/user-attachments/assets/20c08530-7d25-49c8-a721-70fce1a75558)



## How did you test this change?
dev