### PR TITLE
fix(match2): missing return on the anoying wiki

### DIFF
--- a/components/match2/wikis/clashroyale/match_summary.lua
+++ b/components/match2/wikis/clashroyale/match_summary.lua
@@ -110,7 +110,7 @@ function CustomMatchSummary._createTeamMatchBody(match)
 	Array.forEach(subMatches, FnUtil.curry(CustomMatchSummary._getSubMatchOpponentsAndPlayers, match))
 	Array.forEach(subMatches, CustomMatchSummary._calculateSubMatchWinner)
 	return Array.map(subMatches, function(subMatch, subMatchIndex)
-		CustomMatchSummary._createSubMatch(
+		return CustomMatchSummary._createSubMatch(
 			subMatch.players,
 			subMatchIndex,
 			subMatch,


### PR DESCRIPTION
## Summary
add a missing return to properly show the team matches on clashroyale again

## How did you test this change?
dev