### PR TITLE
fix(match2): apex with rcircular reference when trying to Json.stringify

### DIFF
--- a/components/match2/wikis/apexlegends/match_group_input_custom.lua
+++ b/components/match2/wikis/apexlegends/match_group_input_custom.lua
@@ -247,7 +247,7 @@ function MapFunctions.getExtraData(map, opponents)
 	return {
 		dateexact = map.dateexact,
 		comment = map.comment,
-		opponents = opponents,
+		opponents = Table.deepCopy(opponents),
 	}
 end
 


### PR DESCRIPTION
## Summary
Json.stringify in Module:Match fails for apex matches due to a circular reference in the data.
This is caused by setting map.extradata.opponents as just opponents which lua makes just a reference to the original opponents table.
To solve this we need to deepCopy here instead.
Longterm storing opponents additionally in extradata can be skipped once we rely on map.opponents!

## How did you test this change?
live