### PR TITLE
fix(infobox): correctly abbreviate Approx. Total Winnings or not

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -124,11 +124,13 @@ function Team:createInfobox()
 		Customizable{
 			id = 'earnings',
 			children = {
-				Cell{name = Abbreviation.make(
-					'Approx. Total Winnings',
-					'Includes individual player earnings won&#10;while representing this team'
-				),
-				content = {self.totalEarnings > 0 and '$' .. Language:formatNum(self.totalEarnings) or nil}}
+				Cell{
+					name = Logic.readBool(args.doNotIncludePlayerEarnings) and Abbreviation.make(
+						'Approx. Total Winnings',
+						'Includes individual player earnings won&#10;while representing this team'
+					) or 'Approx. Total Winnings',
+					content = {self.totalEarnings > 0 and '$' .. Language:formatNum(self.totalEarnings) or nil}
+				}
 			}
 		},
 		Customizable{id = 'custom', children = {}},

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -127,7 +127,7 @@ function Team:createInfobox()
 				Cell{
 					name = not Logic.readBool(args.doNotIncludePlayerEarnings) and Abbreviation.make(
 						'Approx. Total Winnings',
-						'Includes individual player earnings won&#10;while representing this team'
+						'Includes individual player winnings&#10;while representing this team'
 					) or 'Approx. Total Winnings',
 					content = {self.totalEarnings > 0 and '$' .. Language:formatNum(self.totalEarnings) or nil}
 				}

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -125,7 +125,7 @@ function Team:createInfobox()
 			id = 'earnings',
 			children = {
 				Cell{
-					name = Logic.readBool(args.doNotIncludePlayerEarnings) and Abbreviation.make(
+					name = not Logic.readBool(args.doNotIncludePlayerEarnings) and Abbreviation.make(
 						'Approx. Total Winnings',
 						'Includes individual player earnings won&#10;while representing this team'
 					) or 'Approx. Total Winnings',

--- a/components/infobox/wikis/ageofempires/infobox_team_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_team_custom.lua
@@ -52,10 +52,7 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	if id == 'earnings' then
-		---@diagnostic disable-next-line: inject-field
-		widgets[1].name = 'Approx. Total Winnings'
-	elseif id == 'region' then
+	if id == 'region' then
 		return {}
 	elseif id == 'custom' then
 		table.insert(widgets, Cell{name = 'Games', content = self.caller:_getGames()})

--- a/components/infobox/wikis/counterstrike/infobox_team_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_team_custom.lua
@@ -53,9 +53,6 @@ function CustomInjector:parse(id, widgets)
 			widgets[1], -- Coaches
 			Cell{name = 'Analysts', content = {args.analysts}},
 		}
-	elseif id == 'earnings' then
-		---@diagnostic disable-next-line: inject-field
-		widgets[1].name = 'Approx. Total Winnings'
 	elseif id == 'custom' then
 		return {Cell {
 			name = 'Games',


### PR DESCRIPTION
## Summary

The old implementation was broken at some point and I wasn't sure how to fix it. Instead just made commons set the title correctly whether the player earnings arg was set to true or not.

![image](https://github.com/user-attachments/assets/2857a323-e829-4426-aed5-8028d5d10148)

Removed it from AoE too because again it wasn't working, but also it seems the template on AoE didn't even set the arg to true, idk.

## How did you test this change?

Tested via dev deploy.

![image](https://github.com/user-attachments/assets/432f1c5d-28c6-41ab-be32-004b895dfef4)

![image](https://github.com/user-attachments/assets/d9bcaa4e-35a0-489f-bf55-cbe10fa72774)

