### PR TITLE
feat(match2): Add missing Match Copypaste

### DIFF
--- a/components/match2/wikis/clashofclans/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/clashofclans/get_match_group_copy_paste_wiki.lua
@@ -26,7 +26,7 @@ local INDENT = WikiCopyPaste.Indent
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local showScore = Logic.nilOr(Logic.readBool(args.score), bestof == 0)
+	local showScore = Logic.readBool(args.score)
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
 	local lines = Array.extendWith({},

--- a/components/match2/wikis/clashofclans/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/clashofclans/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,50 @@
+---
+-- @Liquipedia
+-- wiki=clashofclans
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class ClashofClansMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.nilOr(Logic.readBool(args.score), bestof == 0)
+	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
+
+	local lines = Array.extendWith({},
+		'{{Match',
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
+		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
+		INDENT .. '|date=',
+		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
+		end),
+		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|percent1= |score2=|percent2= |winner=}}'
+		end) or nil,
+		INDENT .. '}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/clashofclans/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/clashofclans/get_match_group_copy_paste_wiki.lua
@@ -29,7 +29,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.readBool(args.score)
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
-	local lines = Array.extendWith({},
+	local lines = Array.extend(
 		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,

--- a/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
@@ -49,17 +49,6 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		table.insert(lines, INDENT .. '|twitch=|youtube=')
 	end
 
-	---@param list string[]
-	---@param indents integer
-	---@return string?
-	local buildListLine = function(list, indents)
-		if #list == 0 then return nil end
-
-		return string.rep(INDENT, indents) .. table.concat(Array.map(list, function(elemenmt)
-			return '|' .. elemenmt:lower() .. '='
-		end))
-	end
-
 	Array.forEach(Array.range(1, bestof), function(mapIndex)
 		Array.appendWith(lines,
 			INDENT .. '|map' .. mapIndex .. '={{Map|map=' .. (mapDetails and '' or '|score1=|score2=') .. '|finished=',

--- a/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,131 @@
+---
+-- @Liquipedia
+-- wiki=criticalops
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+local Opponent = Lua.import('Module:Opponent')
+
+---@class CriticalOpsMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+local GSL_STYLE_WITH_EXTRA_MATCH_INDICATOR = 'gf'
+local GSL_WINNERS = 'winners'
+local GSL_LOSERS = 'losers'
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local streams = Logic.readBool(args.streams)
+	local showScore = Logic.readBool(args.score)
+	local mapDetails = Logic.readBool(args.detailedMap)
+	local mapDetailsOT = Logic.readBool(args.detailedMapOT)
+
+	local lines = {
+		'{{Match',
+		INDENT .. table.concat(Array.map(Array.range(1, opponents), function(opponentIndex)
+			return '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, showScore)
+		end)),
+		INDENT .. '|date= |finished=',
+	}
+
+	if streams then
+		table.insert(lines, INDENT .. '|twitch=|youtube=')
+	end
+
+	---@param list string[]
+	---@param indents integer
+	---@return string?
+	local buildListLine = function(list, indents)
+		if #list == 0 then return nil end
+
+		return string.rep(INDENT, indents) .. table.concat(Array.map(list, function(elemenmt)
+			return '|' .. elemenmt:lower() .. '='
+		end))
+	end
+
+	Array.forEach(Array.range(1, bestof), function(mapIndex)
+		Array.appendWith(lines,
+			INDENT .. '|map' .. mapIndex .. '={{Map|map=' .. (mapDetails and '' or '|score1=|score2=') .. '|finished=',
+			mapDetails and (INDENT .. INDENT .. '|t1firstside=|t1t=|t1ct=|t2t=|t2ct=') or nil,
+			mapDetails and mapDetailsOT and (INDENT .. INDENT .. '|o1t1firstside=|o1t1t=|o1t1ct=|o1t2t=|o1t2ct=') or nil
+		)
+		lines[#lines] = lines[#lines] .. '}}'
+	end)
+
+	Array.appendWith(lines,
+		INDENT .. '}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+---subfunction used to generate the code for the Opponent template, depending on the type of opponent
+---@param mode string
+---@param showScore boolean
+---@return string
+function WikiCopyPaste._getOpponent(mode, showScore)
+	local score = showScore and '|score=' or ''
+	if mode == Opponent.solo then
+		return '{{PlayerOpponent||flag=' .. score .. '}}'
+	elseif mode == Opponent.team then
+		return '{{TeamOpponent|' .. score .. '}}'
+	elseif mode == Opponent.literal then
+		return '{{LiteralOpponent|}}'
+	end
+
+	return ''
+end
+
+---@param template string
+---@param id string
+---@param modus string
+---@param args table
+---@return string
+---@return table
+function WikiCopyPaste.getStart(template, id, modus, args)
+	args.namedMatchParams = false
+	args.headersUpTop = Logic.readBool(Logic.emptyOr(args.headersUpTop, true))
+
+	local start = '{{' .. WikiCopyPaste.getMatchGroupTypeCopyPaste(modus, template) .. '|id=' .. id
+
+	local gslStyle = args.gsl
+	if modus ~= 'matchlist' or not gslStyle then
+		return start, args
+	end
+
+	args.customHeader = false
+
+	if not String.startsWith(gslStyle:lower(), GSL_STYLE_WITH_EXTRA_MATCH_INDICATOR) then
+		args.matches = 5
+		return start .. '|gsl=' .. gslStyle, args
+	end
+
+	args.matches = 6
+	if String.endsWith(gslStyle:lower(), GSL_WINNERS) then
+		start = start .. '|gsl=' .. 'winnersfirst'
+	elseif String.endsWith(gslStyle:lower(), GSL_LOSERS) then
+		start = start .. '|gsl=' .. 'losersfirst'
+	end
+	start = start .. '\n|M6header=Grand Final'
+
+	return start, args
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
@@ -26,7 +26,7 @@ local INDENT = WikiCopyPaste.Indent
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local showScore = args.score
+	local showScore = Logic.readBool(args.score)
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
 	local lines = Array.extendWith({},

--- a/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
@@ -26,7 +26,7 @@ local INDENT = WikiCopyPaste.Indent
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local showScore = args.score, bestof == 0
+	local showScore = args.score
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
 	local lines = Array.extendWith({},

--- a/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
@@ -10,19 +10,13 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
-local Opponent = Lua.import('Module:Opponent')
 
 ---@class CriticalOpsMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 local INDENT = WikiCopyPaste.Indent
-
-local GSL_STYLE_WITH_EXTRA_MATCH_INDICATOR = 'gf'
-local GSL_WINNERS = 'winners'
-local GSL_LOSERS = 'losers'
 
 --returns the Code for a Match, depending on the input
 ---@param bestof integer
@@ -32,89 +26,25 @@ local GSL_LOSERS = 'losers'
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local streams = Logic.readBool(args.streams)
-	local showScore = Logic.readBool(args.score)
-	local mapDetails = Logic.readBool(args.detailedMap)
-	local mapDetailsOT = Logic.readBool(args.detailedMapOT)
+	local showScore = args.score, bestof == 0
+	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
-	local lines = {
+	local lines = Array.extendWith({},
 		'{{Match',
-		INDENT .. table.concat(Array.map(Array.range(1, opponents), function(opponentIndex)
-			return '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, showScore)
-		end)),
-		INDENT .. '|date= |finished=',
-	}
-
-	if streams then
-		table.insert(lines, INDENT .. '|twitch=|youtube=')
-	end
-
-	Array.forEach(Array.range(1, bestof), function(mapIndex)
-		Array.appendWith(lines,
-			INDENT .. '|map' .. mapIndex .. '={{Map|map=' .. (mapDetails and '' or '|score1=|score2=') .. '|finished=',
-			mapDetails and (INDENT .. INDENT .. '|t1firstside=|t1t=|t1ct=|t2t=|t2ct=') or nil,
-			mapDetails and mapDetailsOT and (INDENT .. INDENT .. '|o1t1firstside=|o1t1t=|o1t1ct=|o1t2t=|o1t2ct=') or nil
-		)
-		lines[#lines] = lines[#lines] .. '}}'
-	end)
-
-	Array.appendWith(lines,
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
+		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
+		INDENT .. '|date=',
+		Logic.readBool(args.streams) and (INDENT .. '|youtube=|twitch=') or nil,
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
+		end),
+		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
+		end) or nil,
 		INDENT .. '}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
----subfunction used to generate the code for the Opponent template, depending on the type of opponent
----@param mode string
----@param showScore boolean
----@return string
-function WikiCopyPaste._getOpponent(mode, showScore)
-	local score = showScore and '|score=' or ''
-	if mode == Opponent.solo then
-		return '{{PlayerOpponent||flag=' .. score .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. score .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{LiteralOpponent|}}'
-	end
-
-	return ''
-end
-
----@param template string
----@param id string
----@param modus string
----@param args table
----@return string
----@return table
-function WikiCopyPaste.getStart(template, id, modus, args)
-	args.namedMatchParams = false
-	args.headersUpTop = Logic.readBool(Logic.emptyOr(args.headersUpTop, true))
-
-	local start = '{{' .. WikiCopyPaste.getMatchGroupTypeCopyPaste(modus, template) .. '|id=' .. id
-
-	local gslStyle = args.gsl
-	if modus ~= 'matchlist' or not gslStyle then
-		return start, args
-	end
-
-	args.customHeader = false
-
-	if not String.startsWith(gslStyle:lower(), GSL_STYLE_WITH_EXTRA_MATCH_INDICATOR) then
-		args.matches = 5
-		return start .. '|gsl=' .. gslStyle, args
-	end
-
-	args.matches = 6
-	if String.endsWith(gslStyle:lower(), GSL_WINNERS) then
-		start = start .. '|gsl=' .. 'winnersfirst'
-	elseif String.endsWith(gslStyle:lower(), GSL_LOSERS) then
-		start = start .. '|gsl=' .. 'losersfirst'
-	end
-	start = start .. '\n|M6header=Grand Final'
-
-	return start, args
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
@@ -39,7 +39,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
 		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
-			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'
 	)

--- a/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/criticalops/get_match_group_copy_paste_wiki.lua
@@ -29,7 +29,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.readBool(args.score)
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
-	local lines = Array.extendWith({},
+	local lines = Array.extend(
 		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,

--- a/components/match2/wikis/crossfire/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/crossfire/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,50 @@
+---
+-- @Liquipedia
+-- wiki=crossfire
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class CrossfireMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.nilOr(Logic.readBool(args.score), bestof == 0)
+	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
+
+	local lines = Array.extendWith({},
+		'{{Match',
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
+		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
+		INDENT .. '|date=',
+		Logic.readBool(args.streams) and (INDENT .. '|huya=|douyu=|youtube=|twitch=') or nil,
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
+		end),
+		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
+		end) or nil,
+		INDENT .. '}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/crossfire/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/crossfire/get_match_group_copy_paste_wiki.lua
@@ -26,7 +26,7 @@ local INDENT = WikiCopyPaste.Indent
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local showScore = Logic.nilOr(Logic.readBool(args.score), bestof == 0)
+	local showScore = Logic.readBool(args.score)
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
 	local lines = Array.extendWith({},

--- a/components/match2/wikis/crossfire/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/crossfire/get_match_group_copy_paste_wiki.lua
@@ -29,7 +29,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.readBool(args.score)
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
-	local lines = Array.extendWith({},
+	local lines = Array.extend(
 		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,

--- a/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
@@ -64,7 +64,7 @@ function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, showVod)
 				return '|t' .. opponentIndex .. 'b' .. banIndex .. '='
 			end), ' ')
 	end
-	
+
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (showVod and '|vod=' or ''),
 		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',

--- a/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
@@ -63,7 +63,7 @@ function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, vod)
 				return '|t' .. opponentIndex .. 'b' .. banIndex .. '='
 			end), ' ')
 	end
-	
+
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (vod == 'maps' and '|vod=' or ''),
 		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',

--- a/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
@@ -42,7 +42,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			args.vod == 'series' and (INDENT .. '|vod=') or nil,
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, numberOfBans, args.vod)
+			return WikiCopyPaste._getMapCode(mapIndex, numberOfBans, args.vod == 'maps')
 		end),
 		'}}'
 	)
@@ -52,9 +52,9 @@ end
 
 ---@param mapIndex integer
 ---@param numberOfBans integer
----@param vod string
+---@param showVod boolean
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, vod)
+function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, showVod)
 	numberOfBans = numberOfBans or 0
 	local getBans = function(opponentIndex)
 		if numberOfBans == 0 then
@@ -64,9 +64,9 @@ function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, vod)
 				return '|t' .. opponentIndex .. 'b' .. banIndex .. '='
 			end), ' ')
 	end
-
+	
 	return table.concat(Array.extend(
-		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (vod == 'maps' and '|vod=' or ''),
+		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (showVod and '|vod=' or ''),
 		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',
 		INDENT .. INDENT .. '<!-- Hero picks -->',
 		INDENT .. INDENT .. '|t1h1= |t1h2= |t1h3= |t1h4= |t1h5=',

--- a/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
@@ -31,6 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match',
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)

--- a/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,80 @@
+---
+-- @Liquipedia
+-- wiki=honorofkings
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class HonorofkingsMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
+	local numberOfBans = tonumber(args.bans)
+
+	local lines = Array.extend(
+		'{{Match',
+		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
+		end),
+		Logic.readBool(args.hasDate) and {
+			INDENT .. '|date=',
+			INDENT .. '|twitch= |youtube= |bilibili= |douyu= |huya=',
+			args.vod == 'series' and (INDENT .. '|vod=') or nil,
+		} or nil,
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return WikiCopyPaste._getMapCode(mapIndex, numberOfBans, args.vod)
+		end),
+		'}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+---@param mapIndex integer
+---@param numberOfBans integer
+---@param vod string
+---@return string
+function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, vod)
+	numberOfBans = numberOfBans or 0
+	local getBans = function(opponentIndex)
+		if numberOfBans == 0 then
+			return nil
+		end
+		return INDENT .. INDENT .. table.concat(Array.map(Array.range(1, numberOfBans), function(banIndex)
+				return '|t' .. opponentIndex .. 'b' .. banIndex .. '='
+			end), ' ')
+	end
+	
+	return table.concat(Array.extend(
+		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (vod == 'maps' and '|vod=' or ''),
+		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',
+		INDENT .. INDENT .. '<!-- Hero picks -->',
+		INDENT .. INDENT .. '|t1h1= |t1h2= |t1h3= |t1h4= |t1h5=',
+		INDENT .. INDENT .. '|t2h1= |t2h2= |t2h3= |t2h4= |t2h5=',
+		numberOfBans > 0 and (INDENT .. INDENT .. '<!-- Hero bans-->') or nil,
+		getBans(1),
+		getBans(2),
+		INDENT .. '}}'
+	), '\n')
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
@@ -62,7 +62,7 @@ function WikiCopyPaste._getMapCode(mapIndex, bans, vod)
 		INDENT .. INDENT .. '|t2h1= |t2h2= |t2h3= |t2h4= |t2h5=',
 		bans and (INDENT .. INDENT .. '<!-- Hero bans -->') or nil,
 		bans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,
-		bans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,
+		bans and (INDENT .. INDENT .. '|t2b1= |t2b2= |t2b3= |t2b4= |t2b5=') or nil,
 		INDENT .. '}}'
 	), '\n')
 end

--- a/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
@@ -37,9 +37,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		end),
 		Logic.readBool(args.hasDate) and {
 			INDENT .. '|date= |youtube=',
+			args.vod == 'series' and (INDENT .. '|vod=') or nil,
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, bans)
+			return WikiCopyPaste._getMapCode(mapIndex, numberOfBans, args.vod)
 		end),
 		'}}'
 	)
@@ -49,8 +50,9 @@ end
 
 ---@param mapIndex integer
 ---@param bans boolean
+---@param vod string
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, bans)
+function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, vod)
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (vod == 'maps' and '|vod=' or ''),
 		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',

--- a/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=leagueoflegends
+-- wiki=mobilelegends
 -- page=Module:GetMatchGroupCopyPaste/wiki
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,67 @@
+---
+-- @Liquipedia
+-- wiki=leagueoflegends
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class MobileLegendsMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
+	local bans = Logic.readBool(args.bans)
+
+	local lines = Array.extend(
+		'{{Match',
+		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
+		end),
+		Logic.readBool(args.hasDate) and {
+			INDENT .. '|date= |youtube=',
+		} or nil,
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return WikiCopyPaste._getMapCode(mapIndex, bans)
+		end),
+		'}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+---@param mapIndex integer
+---@param bans boolean
+---@return string
+function WikiCopyPaste._getMapCode(mapIndex, bans)
+	return table.concat(Array.extend(
+		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (vod == 'maps' and '|vod=' or ''),
+		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',
+		INDENT .. INDENT .. '<!-- Hero picks -->',
+		INDENT .. INDENT .. '|t1h1= |t1h2= |t1h3= |t1h4= |t1h5=',
+		INDENT .. INDENT .. '|t2h1= |t2h2= |t2h3= |t2h4= |t2h5=',
+		INDENT .. INDENT .. '<!-- Hero bans -->',
+		INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=',
+		INDENT .. INDENT .. '|t2b1= |t2b2= |t2b3= |t2b4= |t2b5=',
+		INDENT .. '}}'
+	), '\n')
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
@@ -27,7 +27,7 @@ local INDENT = WikiCopyPaste.Indent
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
-	local bans = Logic.readBool(args.bans)
+	local showBans = Logic.readBool(args.bans)
 
 	local lines = Array.extend(
 		'{{Match',
@@ -41,7 +41,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			args.vod == 'series' and (INDENT .. '|vod=') or nil,
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, bans, args.vod)
+			return WikiCopyPaste._getMapCode(mapIndex, showBans, args.vod == 'maps')
 		end),
 		'}}'
 	)
@@ -50,19 +50,19 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 ---@param mapIndex integer
----@param bans boolean
----@param vod string
+---@param showBans boolean
+---@param showVod boolean
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, bans, vod)
+function WikiCopyPaste._getMapCode(mapIndex, showBans, showVod)
 	return table.concat(Array.extend(
-		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (vod == 'maps' and '|vod=' or ''),
+		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (showVod and '|vod=' or ''),
 		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',
 		INDENT .. INDENT .. '<!-- Hero picks -->',
 		INDENT .. INDENT .. '|t1h1= |t1h2= |t1h3= |t1h4= |t1h5=',
 		INDENT .. INDENT .. '|t2h1= |t2h2= |t2h3= |t2h4= |t2h5=',
-		bans and (INDENT .. INDENT .. '<!-- Hero bans -->') or nil,
-		bans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,
-		bans and (INDENT .. INDENT .. '|t2b1= |t2b2= |t2b3= |t2b4= |t2b5=') or nil,
+		showBans and (INDENT .. INDENT .. '<!-- Hero bans -->') or nil,
+		showBans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,
+		showBans and (INDENT .. INDENT .. '|t2b1= |t2b2= |t2b3= |t2b4= |t2b5=') or nil,
 		INDENT .. '}}'
 	), '\n')
 end

--- a/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
@@ -40,7 +40,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			args.vod == 'series' and (INDENT .. '|vod=') or nil,
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, numberOfBans, args.vod)
+			return WikiCopyPaste._getMapCode(mapIndex, bans, args.vod)
 		end),
 		'}}'
 	)
@@ -52,16 +52,16 @@ end
 ---@param bans boolean
 ---@param vod string
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, vod)
+function WikiCopyPaste._getMapCode(mapIndex, bans, vod)
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (vod == 'maps' and '|vod=' or ''),
 		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',
 		INDENT .. INDENT .. '<!-- Hero picks -->',
 		INDENT .. INDENT .. '|t1h1= |t1h2= |t1h3= |t1h4= |t1h5=',
 		INDENT .. INDENT .. '|t2h1= |t2h2= |t2h3= |t2h4= |t2h5=',
-		INDENT .. INDENT .. '<!-- Hero bans -->',
-		INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=',
-		INDENT .. INDENT .. '|t2b1= |t2b2= |t2b3= |t2b4= |t2b5=',
+		bans and (INDENT .. INDENT .. '<!-- Hero bans -->') or nil,
+		bans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,
+		bans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,
 		INDENT .. '}}'
 	), '\n')
 end

--- a/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/mobilelegends/get_match_group_copy_paste_wiki.lua
@@ -31,6 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match',
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)

--- a/components/match2/wikis/smite/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/smite/get_match_group_copy_paste_wiki.lua
@@ -60,8 +60,8 @@ function WikiCopyPaste._getMapCode(mapIndex, bans)
 	if bans then
 		Array.appendWith(lines,
 			INDENT .. INDENT .. '<!-- God bans -->',
-			INDENT .. INDENT .. '|t1b1=|t1b2=|t1b3=|t1b4=|t1b5=',
-			INDENT .. INDENT .. '|t2b1=|t2b2=|t2b3=|t2b4=|t2b5='
+			INDENT .. INDENT .. '|t1b1=',
+			INDENT .. INDENT .. '|t2b1='
 		)
 	end
 	Array.appendWith(lines, INDENT .. '}}')

--- a/components/match2/wikis/smite/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/smite/get_match_group_copy_paste_wiki.lua
@@ -27,18 +27,21 @@ local INDENT = WikiCopyPaste.Indent
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
-	local bans = Logic.readBool(args.bans)
+	local showBans = Logic.readBool(args.bans)
 
 	local lines = Array.extend(
 		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|youtube=|twitch='} or {},
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
+		Logic.readBool(args.hasDate) and {
+			INDENT .. '|date= |youtube= |twitch=',
+			args.vod == 'series' and (INDENT .. '|vod=') or nil,
+		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, bans)
+			return WikiCopyPaste._getMapCode(mapIndex, showBans, args.vod == 'maps')
 		end),
 		'}}'
 	)
@@ -47,28 +50,21 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 ---@param mapIndex integer
----@param bans boolean
+---@param showBans boolean
+---@param showVod boolean
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, bans)
-	local lines = {
-		INDENT .. '|map' .. mapIndex .. '={{Map',
-		INDENT .. INDENT .. '|team1side=|team2side=|length=|winner=',
+function WikiCopyPaste._getMapCode(mapIndex, showBans, showVod)
+	return table.concat(Array.extend(
+		INDENT .. '|map' .. mapIndex .. '={{Map' ..  (showVod and '|vod=' or ''),
+		INDENT .. INDENT .. '|team1side= |team2side= |length= |winner=',
 		INDENT .. INDENT .. '<!-- God picks -->',
-		INDENT .. INDENT .. '|t1g1=|t1g2=|t1g3=|t1g4=|t1g5=',
-		INDENT .. INDENT .. '|t2g1=|t2g2=|t2g3=|t2g4=|t2g5=',
-	}
-
-	if bans then
-		Array.appendWith(lines,
-			INDENT .. INDENT .. '<!-- God bans -->',
-			INDENT .. INDENT .. '|t1b1=',
-			INDENT .. INDENT .. '|t2b1='
-		)
-	end
-	Array.appendWith(lines, INDENT .. '}}')
-
-	return table.concat(lines, '\n')
-
+		INDENT .. INDENT .. '|t1g1= |t1g2= |t1g3= |t1g4= |t1g5=',
+		INDENT .. INDENT .. '|t2g1= |t2g2= |t2g3= |t2g4= |t2g5=',
+		showBans and (INDENT .. INDENT .. '<!-- God bans -->') or nil,
+		showBans and (INDENT .. INDENT .. '|t1b1=') or nil,
+		showBans and (INDENT .. INDENT .. '|t2b1=') or nil,
+		INDENT .. '}}'
+	), '\n')
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/smite/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/smite/get_match_group_copy_paste_wiki.lua
@@ -31,6 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match',
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|youtube=|twitch='} or {},
 		Array.map(Array.range(1, opponents), function(opponentIndex)

--- a/components/match2/wikis/zula/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/zula/get_match_group_copy_paste_wiki.lua
@@ -29,7 +29,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.readBool(args.score)
 	local streams = Logic.readBool(args.streams)
 
-	local lines = Array.extend({},
+	local lines = Array.extend(
 		'{{Match',
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
@@ -37,7 +37,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT .. '|date= |finished=',
 		streams and (INDENT .. '|twitch=|vod=') or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|score2=|finished=}}'
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=}}'
 		end),
 		'}}'
 	)

--- a/components/match2/wikis/zula/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/zula/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,48 @@
+---
+-- @Liquipedia
+-- wiki=zula
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class ZulaMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.readBool(args.score)
+	local streams = Logic.readBool(args.streams)
+
+	local lines = Array.extend({},
+		'{{Match',
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
+		end),
+		INDENT .. '|date= |finished=',
+		streams and (INDENT .. '|twitch=|vod=') or nil,
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|score2=|finished=}}'
+		end),
+		'}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+return WikiCopyPaste


### PR DESCRIPTION
## Summary
Some of the MOBA and other wikis never had one on git, so I'm updating these to match the newest version possible

some might have differences due to its unique per wiki usage, but will try to result in the generated bracket/matchlist remains no different from the old one

## List of what I do

- **HOK**: LoL Base, Requires a setup for dynamic ban numbers + |vod= within a map which is the common input pattern on wiki _(note: the vod thing wasnt my addition, another editor adds it yesterday)_

- **MLBB**: use HoK but keep the static 5 bans over dynamic bans

- **SMITE**: already exist, Decrease to only 1 ban input, reflects SMITE 2's 1 ban instead of 5

- **CrossFire and Clash of Clans**: COD Port _(both wikis match2 originally derived from COD base)_

- **Zula**: GOALS Port _(to reflect the standardized setup recently adjusted on wiki)_

- **Critical Ops**: ~~CS Port but removing matchpages, stats and hltv thing~~ uses CrossFire

