### PR TITLE
fix(match2): easportsfc participant processing faulty

### DIFF
--- a/components/match2/wikis/easportsfc/match_group_input_custom.lua
+++ b/components/match2/wikis/easportsfc/match_group_input_custom.lua
@@ -180,7 +180,7 @@ function CustomMatchGroupInput.getPlayersOfMapOpponent(map, opponent, opponentIn
 			}
 		end
 	)
-	return {players = participants}
+	return participants
 end
 
 return CustomMatchGroupInput


### PR DESCRIPTION
## Summary
the mapOpponents/participants processing on easportsfc causes bad data and hence bad display
it wraps the opponentplayers additionally leading to storage like
`{players = {players = {...}, ...}` as mapOpponents
for participants data this results in data like
`{X_players = {[Y] = {players = {...}}}`

This PR removes the additional (faulty) wrapper to fix the data and hence also the display.

## How did you test this change?
live