### PR TITLE
feat(tier): remove unused D-tier from Brawlhalla

### DIFF
--- a/standard/tier/wikis/brawlhalla/tier_data.lua
+++ b/standard/tier/wikis/brawlhalla/tier_data.lua
@@ -40,14 +40,6 @@ return {
 			link = 'C-Tier Tournaments',
 			category = 'C-Tier Tournaments',
 		},
-		{
-			value = '5',
-			sort = 'A5',
-			name = 'D-Tier',
-			short = 'D',
-			link = 'D-Tier Tournaments',
-			category = 'D-Tier Tournaments',
-		},
 		[-1] = {
 			value = '-1',
 			sort = 'C1',
@@ -67,7 +59,7 @@ return {
 	tierTypes = {
 		monthly = {
 			value = 'Monthly',
-			sort = 'A6',
+			sort = 'A5',
 			name = 'Monthly',
 			short = 'Mon.',
 			link = 'Monthly Tournaments',
@@ -75,7 +67,7 @@ return {
 		},
 		weekly = {
 			value = 'Weekly',
-			sort = 'A7',
+			sort = 'A6',
 			name = 'Weekly',
 			short = 'Week.',
 			link = 'Weekly Tournaments',
@@ -83,7 +75,7 @@ return {
 		},
 		qualifier = {
 			value = 'Qualifier',
-			sort = 'A8',
+			sort = 'A7',
 			name = 'Qualifier',
 			short = 'Qual.',
 			link = 'Qualifier Tournaments',
@@ -91,7 +83,7 @@ return {
 		},
 		misc = {
 			value = 'Misc',
-			sort = 'A9',
+			sort = 'A8',
 			name = 'Misc',
 			short = 'Misc',
 			link = 'Miscellaneous Tournaments',


### PR DESCRIPTION
## Summary

D tier isn't used on Brawlhalla so kicking to remove the filter option on the mainpage

## How did you test this change?

live
