### PR TITLE
chore: fix issue with changelog script when there's two PR numbers in the commit

### DIFF
--- a/scripts/generate_changelog_local.sh
+++ b/scripts/generate_changelog_local.sh
@@ -33,7 +33,7 @@ trap 'echo "An error occurred at line $LINENO. Exiting."' ERR
 # Path to the Git repository (current directory)
 REPO_DIR="."
 CHANGELOG_FILE="$REPO_DIR/CHANGELOG.md"
-GITHUB_REPO_URL=$(git remote get-url origin 2>/dev/null | sed 's/\.git$//')
+GITHUB_REPO_URL=$(git remote get-url origin 2>/dev/null | sed "s/\.git$//")
 if [ -z "$GITHUB_REPO_URL" ]; then
 	GITHUB_REPO_URL=0
 fi
@@ -96,10 +96,10 @@ print_tag() {
 			echo "Listing commits for category: $CATEGORY_NAME under tag $2"
 			echo "$CATEGORY_COMMITS" | while read -r COMMIT; do
 				HASH=$(echo $COMMIT | awk '{print $1}')
-				MESSAGE=$(echo $COMMIT | sed -E "s/^$HASH $KEY(\(.*\))?: //")
-				PR_NUMBER=$(echo $MESSAGE | grep -oE "#[0-9]+" | tr -d '#')
-				MESSAGE=$(echo $MESSAGE | sed -E "s/ \(#$PR_NUMBER\)//")
-				SCOPE=$(echo $COMMIT | sed -E "s/^$HASH $KEY(\((.*?)\))?: .*/\2/")
+				MESSAGE=$(echo $COMMIT | sed -E 's/^$HASH $KEY(\(.*\))?: //')
+				PR_NUMBER=$(echo $MESSAGE | grep -oE '#[0-9]+' | tr -d '#')
+				MESSAGE=$(echo $MESSAGE | sed -E '$s/ \(#$PR_NUMBER\)//')
+				SCOPE=$(echo $COMMIT | sed -E 's/^$HASH $KEY(\((.*?)\))?: .*/\2/')
 				if [ "$GITHUB_REPO_URL" != "0" ]; then
 					if [ -n "$SCOPE" ]; then
 						echo "- ($SCOPE) $MESSAGE ($GITHUB_REPO_URL/pull/$PR_NUMBER)" >> $CHANGELOG_FILE
@@ -124,8 +124,8 @@ print_tag() {
 		echo "$OTHER_COMMITS" | while read -r COMMIT; do
 			HASH=$(echo $COMMIT | awk '{print $1}')
 			MESSAGE=$(echo $COMMIT | sed -E 's/^[^ ]* //')
-			PR_NUMBER=$(echo $MESSAGE | grep -oE "#[0-9]+" | tr -d '#')
-			MESSAGE=$(echo $MESSAGE | sed -E "s/ \(#$PR_NUMBER\)//")
+			PR_NUMBER=$(echo $MESSAGE | grep -oE '#[0-9]+' | tr -d '#')
+			MESSAGE=$(echo $MESSAGE | sed -E '$s/ \(#$PR_NUMBER\)//')
 			if [ "$GITHUB_REPO_URL" != "0" ]; then
 				echo "- $MESSAGE ($GITHUB_REPO_URL/pull/$PR_NUMBER)" >> $CHANGELOG_FILE
 			else

--- a/scripts/generate_changelog_local.sh
+++ b/scripts/generate_changelog_local.sh
@@ -96,10 +96,10 @@ print_tag() {
 			echo "Listing commits for category: $CATEGORY_NAME under tag $2"
 			echo "$CATEGORY_COMMITS" | while read -r COMMIT; do
 				HASH=$(echo $COMMIT | awk '{print $1}')
-				MESSAGE=$(echo $COMMIT | sed -E 's/^$HASH $KEY(\(.*\))?: //')
+				MESSAGE=$(echo $COMMIT | sed -E "s/^$HASH $KEY(\(.*\))?: //")
 				PR_NUMBER=$(echo $MESSAGE | grep -oE '#[0-9]+' | tr -d '#')
 				MESSAGE=$(echo $MESSAGE | sed -E '$s/ \(#$PR_NUMBER\)//')
-				SCOPE=$(echo $COMMIT | sed -E 's/^$HASH $KEY(\((.*?)\))?: .*/\2/')
+				SCOPE=$(echo $COMMIT | sed -E "s/^$HASH $KEY(\((.*?)\))?: .*/\2/")
 				if [ "$GITHUB_REPO_URL" != "0" ]; then
 					if [ -n "$SCOPE" ]; then
 						echo "- ($SCOPE) $MESSAGE ($GITHUB_REPO_URL/pull/$PR_NUMBER)" >> $CHANGELOG_FILE


### PR DESCRIPTION
## Summary
If a Commit message mentioned another PR than itself, the changelog script would fail. This fixes it by only matching the correct number PR (final) instead of both