### PR TITLE
feat(transfer): split transfers in transferlist based on team1_2 and team2_2 too

### DIFF
--- a/components/transfer/commons/transfer_list.lua
+++ b/components/transfer/commons/transfer_list.lua
@@ -185,10 +185,16 @@ function TransferList:fetch()
 			order = self.config.sortOrder,
 		})
 		local currentGroup
-		local currentRole2
+		local cache = {}
 		Array.forEach(transfers, function(transf)
-			if currentRole2 ~= transf.role2 then
-				currentRole2 = transf.role2
+			if
+				cache.role2 ~= transf.role2 or
+				cache.team1_2 ~= transf.extradata.fromteamsec or
+				cache.team2_2 ~= transf.extradata.toteamsec
+			then
+				cache.role2 = transf.role2
+				cache.team1_2 = transfer.extradata.fromteamsec
+				cache.team2_2 = transfer.extradata.toteamsec
 				Array.appendWith(groupedData, currentGroup)
 				currentGroup = {}
 			end


### PR DESCRIPTION
## Summary
as reported on discord transfer list should split transfers if they have different team1_2/team2_2 too

## How did you test this change?
dev