### PR TITLE
[wip] feat(infobox): remove the legacy publisher tier params

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_league_custom.lua
@@ -56,7 +56,7 @@ end
 ---@param args table
 ---@return string
 function CustomLeague:appendLiquipediatierDisplay(args)
-	return String.isNotEmpty(self.data.publishertier) and (' ' .. RIOT_ICON) or ''
+	return self.data.publishertier and (' ' .. RIOT_ICON) or ''
 end
 
 ---@param lpdbData table
@@ -66,12 +66,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.individual = String.isNotEmpty(args.participants_number) or
 			String.isNotEmpty(args.individual) and 'true' or ''
 	return lpdbData
-end
-
----@param args table
-function CustomLeague:customParseArguments(args)
-	-- line below can be kicked after conversion bot runs
-	self.data.publishertier = Logic.readBool(args.highlighted or args.riotpremier)
 end
 
 ---@param args table


### PR DESCRIPTION
bot runs still under way

## Summary
Remove the legacy publishertier input support after the bot conversions are done.

## How did you test this change?
untested