### PR TITLE
feat(infobox): add imageDefaultDark on infobox person

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -133,6 +133,7 @@ function Person:createInfobox()
 			name = self:nameDisplay(args),
 			image = args.image,
 			imageDefault = args.default,
+			imageDefaultDark = args.defaultDark,
 			subHeader = self:subHeaderDisplay(args),
 			size = args.imagesize,
 		},


### PR DESCRIPTION
## Summary

Adds param to be called on `Template:Infobox player` to use a default dark mode image alongside a light mode version for the placeholder image on player profiles.
Example: https://liquipedia.net/rainbowsix/index.php?title=Template:Infobox_player&diff=734681&oldid=734675

**Old**
![image](https://github.com/user-attachments/assets/0df49752-a7ee-4655-b61b-4ce2c9721bd9)

**New**
![image](https://github.com/user-attachments/assets/e49f281d-8ff5-433a-b85b-0ee086e27a9d)
![Screenshot 2024-11-12 204152](https://github.com/user-attachments/assets/5dc7971c-287c-4b60-a180-8dc85ccd5527)

I can update the template on all wikis that use image placeholders for player photos

## How did you test this change?

live on R6 https://liquipedia.net/rainbowsix/Aziz
