### PR TITLE
refactor(squad): rename variables from `type` to `status`

### DIFF
--- a/components/squad/commons/squad_custom.lua
+++ b/components/squad/commons/squad_custom.lua
@@ -26,11 +26,11 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadType integer
+---@param squadStatus integer
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadType, customTitle)
-	return SquadUtils.defaultRunAuto(playerList, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, customTitle)
+	return SquadUtils.defaultRunAuto(playerList, squadStatus, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
 end
 
 return CustomSquad

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -48,9 +48,6 @@ SquadUtils.SquadStatusToStorageValue = {
 	[SquadUtils.SquadStatus.FORMER_INACTIVE] = 'former',
 }
 
----@enum SquadTyppe
-
-
 SquadUtils.specialTeamsTemplateMapping = {
 	retired = 'Team/retired',
 	inactive = 'Team/inactive',

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -25,28 +25,31 @@ local TransferRefs = Lua.import('Module:Transfer/References')
 
 local SquadUtils = {}
 
----@enum SquadType
-SquadUtils.SquadType = {
+---@enum SquadStatus
+SquadUtils.SquadStatus = {
 	ACTIVE = 0,
 	INACTIVE = 1,
 	FORMER = 2,
 	FORMER_INACTIVE = 3,
 }
 
----@type {string: SquadType}
-SquadUtils.StatusToSquadType = {
-	active = SquadUtils.SquadType.ACTIVE,
-	inactive = SquadUtils.SquadType.INACTIVE,
-	former = SquadUtils.SquadType.FORMER,
+---@type {string: SquadStatus}
+SquadUtils.StatusToSquadStatus = {
+	active = SquadUtils.SquadStatus.ACTIVE,
+	inactive = SquadUtils.SquadStatus.INACTIVE,
+	former = SquadUtils.SquadStatus.FORMER,
 }
 
----@type {SquadType: string}
-SquadUtils.SquadTypeToStorageValue = {
-	[SquadUtils.SquadType.ACTIVE] = 'active',
-	[SquadUtils.SquadType.INACTIVE] = 'inactive',
-	[SquadUtils.SquadType.FORMER] = 'former',
-	[SquadUtils.SquadType.FORMER_INACTIVE] = 'former',
+---@type {SquadStatus: string}
+SquadUtils.SquadStatusToStorageValue = {
+	[SquadUtils.SquadStatus.ACTIVE] = 'active',
+	[SquadUtils.SquadStatus.INACTIVE] = 'inactive',
+	[SquadUtils.SquadStatus.FORMER] = 'former',
+	[SquadUtils.SquadStatus.FORMER_INACTIVE] = 'former',
 }
+
+---@enum SquadTyppe
+
 
 SquadUtils.specialTeamsTemplateMapping = {
 	retired = 'Team/retired',
@@ -60,12 +63,12 @@ SquadUtils.validPersonTypes = {'player', 'staff'}
 SquadUtils.defaultPersonType = 'player'
 
 ---@param status string?
----@return SquadType?
-function SquadUtils.statusToSquadType(status)
+---@return SquadStatus?
+function SquadUtils.statusToSquadStatus(status)
 	if not status then
 		return
 	end
-	return SquadUtils.StatusToSquadType[status:lower()]
+	return SquadUtils.StatusToSquadStatus[status:lower()]
 end
 
 ---@param args table
@@ -139,7 +142,7 @@ function SquadUtils.readSquadPersonArgs(args)
 		leavedate = ReferenceCleaner.clean(args.leavedate),
 		inactivedate = ReferenceCleaner.clean(args.inactivedate),
 
-		status = SquadUtils.SquadTypeToStorageValue[args.type],
+		status = SquadUtils.SquadStatusToStorageValue[args.status],
 
 		extradata = {
 			loanedto = args.team,
@@ -177,22 +180,22 @@ end
 
 ---@param frame table
 ---@param squadWidget SquadWidget
----@param rowCreator fun(player: table, squadType: integer):Widget
+---@param rowCreator fun(player: table, squadStatus: integer):Widget
 ---@return Widget
 function SquadUtils.defaultRunManual(frame, squadWidget, rowCreator)
 	local args = Arguments.getArgs(frame)
 	local props = {
-		type = SquadUtils.statusToSquadType(args.status) or SquadUtils.SquadType.ACTIVE,
+		status = SquadUtils.statusToSquadStatus(args.status) or SquadUtils.SquadStatus.ACTIVE,
 		title = args.title,
 	}
 	local players = SquadUtils.parsePlayers(args)
 
-	if props.type == SquadUtils.SquadType.FORMER and SquadUtils.anyInactive(players) then
-		props.type = SquadUtils.SquadType.FORMER_INACTIVE
+	if props.status == SquadUtils.SquadStatus.FORMER and SquadUtils.anyInactive(players) then
+		props.status = SquadUtils.SquadStatus.FORMER_INACTIVE
 	end
 
 	props.children = Array.map(players, function(player)
-		return rowCreator(player, props.type)
+		return rowCreator(player, props.status)
 	end)
 
 	if Info.config.squads.hasPosition then
@@ -202,21 +205,21 @@ function SquadUtils.defaultRunManual(frame, squadWidget, rowCreator)
 end
 
 ---@param players table[]
----@param squadType SquadType
+---@param squadStatus SquadStatus
 ---@param squadWidget SquadWidget
----@param rowCreator fun(person: table, squadType: integer):Widget
+---@param rowCreator fun(person: table, squadStatus: integer):Widget
 ---@param customTitle string?
 ---@param personMapper? fun(person: table): table
 ---@return Widget
-function SquadUtils.defaultRunAuto(players, squadType, squadWidget, rowCreator, customTitle, personMapper)
+function SquadUtils.defaultRunAuto(players, squadStatus, squadWidget, rowCreator, customTitle, personMapper)
 	local props = {
-		type = squadType,
+		status = squadStatus,
 		title = customTitle
 	}
 
 	local mappedPlayers = Array.map(players, personMapper or SquadUtils.convertAutoParameters)
 	props.children = Array.map(mappedPlayers, function(player)
-		return rowCreator(player, props.type)
+		return rowCreator(player, props.status)
 	end)
 
 	if Info.config.squads.hasPosition then
@@ -226,10 +229,10 @@ function SquadUtils.defaultRunAuto(players, squadType, squadWidget, rowCreator, 
 end
 
 ---@param squadRowClass SquadRow
----@return fun(person: table, squadType: integer):Widget
+---@return fun(person: table, squadStatus: integer):Widget
 function SquadUtils.defaultRow(squadRowClass)
-	return function(person, squadType)
-		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {type = squadType}))
+	return function(person, squadStatus)
+		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
 		SquadUtils.storeSquadPerson(squadPerson)
 		local row = squadRowClass(squadPerson)
 
@@ -241,11 +244,11 @@ function SquadUtils.defaultRow(squadRowClass)
 		end
 		row:date('joindate', 'Join Date:&nbsp;')
 
-		if squadType == SquadUtils.SquadType.INACTIVE or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+		if squadStatus == SquadUtils.SquadStatus.INACTIVE or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 			row:date('inactivedate', 'Inactive Date:&nbsp;')
 		end
 
-		if squadType == SquadUtils.SquadType.FORMER or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+		if squadStatus == SquadUtils.SquadStatus.FORMER or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 			row:date('leavedate', 'Leave Date:&nbsp;')
 			row:newteam()
 		end

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -59,8 +59,8 @@ function CustomSquad.run(frame)
 	}
 end
 
-function CustomSquad._playerRow(person, squadType)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {type = squadType}))
+function CustomSquad._playerRow(person, squadStatus)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
 	squadPerson.extradata.activeteam = person.activeteam
 	squadPerson.extradata.activeteamrole = person.activeteamrole
 	SquadUtils.storeSquadPerson(squadPerson)
@@ -71,11 +71,11 @@ function CustomSquad._playerRow(person, squadType)
 	row:position()
 	row:date('joindate', 'Join Date:&nbsp;')
 
-	if squadType == SquadUtils.SquadType.INACTIVE or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+	if squadStatus == SquadUtils.SquadStatus.INACTIVE or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 		row:date('inactivedate', 'Inactive Date:&nbsp;')
 		row:activeteam()
 	end
-	if squadType == SquadUtils.SquadType.FORMER or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+	if squadStatus == SquadUtils.SquadStatus.FORMER or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 		row:date('leavedate', 'Leave Date:&nbsp;')
 		row:newteam()
 	end

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -43,7 +43,7 @@ end
 function CustomSquad.run(frame)
 	local args = Arguments.getArgs(frame)
 	local props = {
-		type = SquadUtils.statusToSquadType(args.status) or SquadUtils.SquadType.ACTIVE,
+		status = SquadUtils.statusToSquadStatus(args.status) or SquadUtils.SquadStatus.ACTIVE,
 		title = args.title,
 	}
 	local players = SquadUtils.parsePlayers(args)
@@ -51,7 +51,7 @@ function CustomSquad.run(frame)
 	local showNumber = Array.any(players, Operator.property('number'))
 
 	props.children = Array.map(players, function(player)
-		return CustomSquad._playerRow(player, props.type, showNumber)
+		return CustomSquad._playerRow(player, props.status, showNumber)
 	end)
 
 	local root = SquadContexts.RoleTitle{value = SquadUtils.positionTitle(), children = {Squad(props)}}
@@ -69,19 +69,19 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadType integer
+---@param squadStatus integer
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadType, customTitle)
-	return SquadUtils.defaultRunAuto(playerList, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, customTitle)
+	return SquadUtils.defaultRunAuto(playerList, squadStatus, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
 end
 
 ---@param person table
----@param squadType integer
+---@param squadStatus integer
 ---@param showNumber boolean
 ---@return Widget
-function CustomSquad._playerRow(person, squadType, showNumber)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {type = squadType}))
+function CustomSquad._playerRow(person, squadStatus, showNumber)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
 	squadPerson.extradata.number = person.number
 	SquadUtils.storeSquadPerson(squadPerson)
 
@@ -93,11 +93,11 @@ function CustomSquad._playerRow(person, squadType, showNumber)
 	end
 	row:name():position():date('joindate', 'Join Date:&nbsp;')
 
-	if squadType == SquadUtils.SquadType.INACTIVE or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+	if squadStatus == SquadUtils.SquadStatus.INACTIVE or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 		row:date('inactivedate', 'Inactive Date:&nbsp;')
 	end
 
-	if squadType == SquadUtils.SquadType.FORMER or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+	if squadStatus == SquadUtils.SquadStatus.FORMER or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 		row:date('leavedate', 'Leave Date:&nbsp;')
 		row:newteam()
 	end

--- a/components/squad/wikis/smash/squad_custom.lua
+++ b/components/squad/wikis/smash/squad_custom.lua
@@ -46,7 +46,7 @@ end
 function CustomSquad.run(frame)
 	local args = Arguments.getArgs(frame)
 	local props = {
-		type = SquadUtils.statusToSquadType(args.status) or SquadUtils.SquadType.ACTIVE,
+		status = SquadUtils.statusToSquadStatus(args.status) or SquadUtils.SquadStatus.ACTIVE,
 		title = args.title,
 	}
 
@@ -60,7 +60,7 @@ function CustomSquad.run(frame)
 		person.flag = Variables.varDefault('nationality') or person.flag
 		person.name = Variables.varDefault('name') or person.name
 
-		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {type = props.type}))
+		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = props.status}))
 		squadPerson.extradata.game = game
 		squadPerson.extradata.mains = mains
 		SquadUtils.storeSquadPerson(squadPerson)
@@ -70,11 +70,11 @@ function CustomSquad.run(frame)
 		row:id():name()
 		row:mains():date('joindate', 'Join Date:&nbsp;')
 
-		if props.type == SquadUtils.SquadType.INACTIVE or props.type == SquadUtils.SquadType.FORMER_INACTIVE then
+		if props.status == SquadUtils.SquadStatus.INACTIVE or props.status == SquadUtils.SquadStatus.FORMER_INACTIVE then
 			row:date('inactivedate', 'Inactive Date:&nbsp;')
 		end
 
-		if props.type == SquadUtils.SquadType.FORMER or props.type == SquadUtils.SquadType.FORMER_INACTIVE then
+		if props.status == SquadUtils.SquadStatus.FORMER or props.status == SquadUtils.SquadStatus.FORMER_INACTIVE then
 			row:date('leavedate', 'Leave Date:&nbsp;')
 			row:newteam()
 		end

--- a/components/squad/wikis/starcraft/squad_custom.lua
+++ b/components/squad/wikis/starcraft/squad_custom.lua
@@ -44,7 +44,7 @@ function CustomSquad.run(frame)
 	local tlpd = Logic.readBool(args.tlpd)
 	local SquadClass = tlpd and SquadTldb or Squad
 
-	return SquadUtils.defaultRunManual(frame, SquadClass, function(person, squadType)
+	return SquadUtils.defaultRunManual(frame, SquadClass, function(person, squadStatus)
 		local inputId = person.id --[[@as number]]
 		person.race = CustomSquad._queryTLPD(inputId, 'race') or person.race
 		person.id = CustomSquad._queryTLPD(inputId, 'name') or person.id
@@ -53,7 +53,7 @@ function CustomSquad.run(frame)
 		person.name = (CustomSquad._queryTLPD(inputId, 'name_korean') or '') .. ' ' ..
 			(CustomSquad._queryTLPD(inputId, 'name_romanized') or person.name or '')
 
-		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {type = squadType}))
+		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
 		squadPerson.extradata.eloCurrent = CustomSquad._queryTLPD(inputId, 'elo')
 		squadPerson.extradata.eloPeak = CustomSquad._queryTLPD(inputId, 'peak_elo')
 		SquadUtils.storeSquadPerson(squadPerson)
@@ -68,10 +68,10 @@ function CustomSquad.run(frame)
 			row:role()
 			row:date('joindate', 'Join Date:&nbsp;')
 
-			if squadType == SquadUtils.SquadType.FORMER then
+			if squadStatus == SquadUtils.SquadStatus.FORMER then
 				row:date('leavedate', 'Leave Date:&nbsp;')
 				row:newteam()
-			elseif squadType == SquadUtils.SquadType.INACTIVE then
+			elseif squadStatus == SquadUtils.SquadStatus.INACTIVE then
 				row:date('inactivedate', 'Inactive Date:&nbsp;')
 			end
 		end

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -24,13 +24,13 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadType integer
+---@param squadStatus integer
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadType, customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, customTitle)
 	return SquadUtils.defaultRunAuto(
 		playerList,
-		squadType,
+		squadStatus,
 		Squad,
 		CustomSquad._playerRow,
 		customTitle,
@@ -47,13 +47,13 @@ function CustomSquad.personMapper(person)
 end
 
 ---@param person table
----@param squadType integer
+---@param squadStatus integer
 ---@return Widget
-function CustomSquad._playerRow(person, squadType)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {type = squadType}))
+function CustomSquad._playerRow(person, squadStatus)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
 	local squadArgs = Arguments.getArgs(mw.getCurrentFrame())
 
-	if squadType == SquadUtils.SquadType.ACTIVE then
+	if squadStatus == SquadUtils.SquadStatus.ACTIVE then
 		local isMain = Logic.readBool(squadArgs.main) or Logic.isEmpty(squadArgs.squad)
 		squadPerson.extradata = Table.merge({ismain = tostring(isMain)}, squadPerson.extradata)
 	end
@@ -67,10 +67,10 @@ function CustomSquad._playerRow(person, squadType)
 
 	row:id():name():role():date('joindate', 'Join Date:&nbsp;')
 
-	if squadType == SquadUtils.SquadType.INACTIVE or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+	if squadStatus == SquadUtils.SquadStatus.INACTIVE or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 		row:date('inactivedate', 'Inactive Date:&nbsp;')
 	end
-	if squadType == SquadUtils.SquadType.FORMER or squadType == SquadUtils.SquadType.FORMER_INACTIVE then
+	if squadStatus == SquadUtils.SquadStatus.FORMER or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE then
 		row:date('leavedate', 'Leave Date:&nbsp;')
 		row:newteam()
 	end

--- a/components/squad/wikis/stormgate/squad_custom.lua
+++ b/components/squad/wikis/stormgate/squad_custom.lua
@@ -23,13 +23,13 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadType integer
+---@param squadStatus integer
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadType, customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, customTitle)
 	return SquadUtils.defaultRunAuto(
 		playerList,
-		squadType,
+		squadStatus,
 		Squad,
 		CustomSquad._playerRow,
 		customTitle,
@@ -46,10 +46,10 @@ function CustomSquad.personMapper(person)
 end
 
 ---@param person table
----@param squadType integer
+---@param squadStatus integer
 ---@return Widget
-function CustomSquad._playerRow(person, squadType)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {type = squadType}))
+function CustomSquad._playerRow(person, squadStatus)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
 	if Logic.isEmpty(squadPerson.newteam) then
 		if Logic.readBool(person.retired) then
 			squadPerson.newteamspecial = 'retired'
@@ -65,10 +65,10 @@ function CustomSquad._playerRow(person, squadType)
 	row:role()
 	row:date('joindate', 'Join Date:&nbsp;')
 
-	if squadType == SquadUtils.SquadType.FORMER then
+	if squadStatus == SquadUtils.SquadStatus.FORMER then
 		row:date('leavedate', 'Leave Date:&nbsp;')
 		row:newteam()
-	elseif squadType == SquadUtils.SquadType.INACTIVE then
+	elseif squadStatus == SquadUtils.SquadStatus.INACTIVE then
 		row:date('inactivedate', 'Inactive Date:&nbsp;')
 	end
 

--- a/components/widget/squad/widget_squad_core.lua
+++ b/components/widget/squad/widget_squad_core.lua
@@ -23,13 +23,13 @@ local DataTable, Tr, Th = Widgets.DataTable, Widgets.Tr, Widgets.Th
 ---@operator call(table): SquadWidget
 local Squad = Class.new(Widget)
 Squad.defaultProps = {
-	type = SquadUtils.SquadType.ACTIVE,
+	status = SquadUtils.SquadStatus.ACTIVE,
 }
 
 ---@return WidgetDataTable
 function Squad:render()
-	local title = self:_title(self.props.type, self.props.title)
-	local header = self:_header(self.props.type)
+	local title = self:_title(self.props.status, self.props.title)
+	local header = self:_header(self.props.status)
 
 	local allChildren = WidgetUtil.collect(title, header, unpack(self.props.children))
 
@@ -40,14 +40,14 @@ function Squad:render()
 	}
 end
 
----@param type SquadType
+---@param status SquadStatus
 ---@param title string?
 ---@return Widget?
-function Squad:_title(type, title)
+function Squad:_title(status, title)
 	local defaultTitle
-	if type == SquadUtils.SquadType.FORMER or type == SquadUtils.SquadType.FORMER_INACTIVE then
+	if status == SquadUtils.SquadStatus.FORMER or status == SquadUtils.SquadStatus.FORMER_INACTIVE then
 		defaultTitle = 'Former Squad'
-	elseif type == SquadUtils.SquadType.INACTIVE then
+	elseif status == SquadUtils.SquadStatus.INACTIVE then
 		defaultTitle = 'Inactive Players'
 	end
 
@@ -62,11 +62,11 @@ function Squad:_title(type, title)
 	}
 end
 
----@param type SquadType
+---@param status SquadStatus
 ---@return Widget
-function Squad:_header(type)
-	local isInactive = type == SquadUtils.SquadType.INACTIVE or type == SquadUtils.SquadType.FORMER_INACTIVE
-	local isFormer = type == SquadUtils.SquadType.FORMER or type == SquadUtils.SquadType.FORMER_INACTIVE
+function Squad:_header(status)
+	local isInactive = status == SquadUtils.SquadStatus.INACTIVE or status == SquadUtils.SquadStatus.FORMER_INACTIVE
+	local isFormer = status == SquadUtils.SquadStatus.FORMER or status == SquadUtils.SquadStatus.FORMER_INACTIVE
 
 	local name = self:useContext(SquadContexts.NameSection, {Th{children = {'Name'}}})
 	local inactive = isInactive and self:useContext(SquadContexts.InactiveSection, {

--- a/components/widget/squad/widget_squad_core_tldb.lua
+++ b/components/widget/squad/widget_squad_core_tldb.lua
@@ -16,9 +16,9 @@ local SquadWidget = Lua.import('Module:Widget/Squad/Core')
 ---@operator call:SquadTldbWidget
 local SquadTldb = Class.new(SquadWidget)
 
----@param type SquadType
+---@param status SquadStatus
 ---@return Widget
-function SquadTldb:header(type)
+function SquadTldb:header(status)
 	return Widgets.Tr{
 		classes = {'HeaderRow'},
 		cells = {
@@ -31,10 +31,10 @@ function SquadTldb:header(type)
 	}
 end
 
----@param type SquadType
+---@param status SquadStatus
 ---@param title string?
 ---@return Widget?
-function SquadTldb:_title(type, title)
+function SquadTldb:_title(status, title)
 	return nil
 end
 


### PR DESCRIPTION
## Summary
It should be called `status`, the input is `status`, the field it stores into is `status`, no idea why it ended up being called `type` in the code. Now that I'm looking at using the `type` field (#5094), it's hightime change the name so it makes sence

2 small changes in SquadAuto is needed `SquadUtils.SquadType.ACTIVE` to `SquadUtils.SquadStatus.ACTIVE`

## How did you test this change?
dev on r6 (auto) and cs (manual)