### PR TITLE
feat(squad): add support for organization tables

### DIFF
--- a/components/squad/commons/squad_custom.lua
+++ b/components/squad/commons/squad_custom.lua
@@ -25,13 +25,13 @@ function CustomSquad.run(frame)
 	return SquadUtils.defaultRunManual(frame, Squad, SquadUtils.defaultRow(SquadRow))
 end
 
----@param playerList table[]
+---@param players table[]
 ---@param squadStatus SquadStatus
 ---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
-	return SquadUtils.defaultRunAuto(playerList, squadStatus, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
+function CustomSquad.runAuto(players, squadStatus, squadType, customTitle)
+	return SquadUtils.defaultRunAuto(players, squadStatus, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
 end
 
 return CustomSquad

--- a/components/squad/commons/squad_custom.lua
+++ b/components/squad/commons/squad_custom.lua
@@ -26,11 +26,12 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadStatus integer
+---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, customTitle)
-	return SquadUtils.defaultRunAuto(playerList, squadStatus, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
+	return SquadUtils.defaultRunAuto(playerList, squadStatus, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
 end
 
 return CustomSquad

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -56,8 +56,8 @@ SquadUtils.SquadType = {
 
 ---@type {string: SquadType}
 SquadUtils.TypeToSquadType = {
-	active = SquadUtils.SquadType.PLAYER,
-	inactive = SquadUtils.SquadType.STAFF,
+	player = SquadUtils.SquadType.PLAYER,
+	staff = SquadUtils.SquadType.STAFF,
 }
 
 ---@type {SquadType: string}

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -208,7 +208,7 @@ function SquadUtils.defaultRunManual(frame, squadWidget, rowCreator)
 	end
 
 	props.children = Array.map(players, function(player)
-		return rowCreator(player, props.status)
+		return rowCreator(player, props.status, props.type)
 	end)
 
 	if Info.config.squads.hasPosition then
@@ -234,7 +234,7 @@ function SquadUtils.defaultRunAuto(players, squadStatus, squadType, squadWidget,
 
 	local mappedPlayers = Array.map(players, personMapper or SquadUtils.convertAutoParameters)
 	props.children = Array.map(mappedPlayers, function(player)
-		return rowCreator(player, props.status)
+		return rowCreator(player, props.status, props.type)
 	end)
 
 	if Info.config.squads.hasPosition then

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -48,16 +48,30 @@ SquadUtils.SquadStatusToStorageValue = {
 	[SquadUtils.SquadStatus.FORMER_INACTIVE] = 'former',
 }
 
+---@enum SquadType
+SquadUtils.SquadType = {
+	PLAYER = 0,
+	STAFF = 1,
+}
+
+---@type {string: SquadType}
+SquadUtils.TypeToSquadType = {
+	active = SquadUtils.SquadType.PLAYER,
+	inactive = SquadUtils.SquadType.STAFF,
+}
+
+---@type {SquadType: string}
+SquadUtils.SquadTypeToStorageValue = {
+	[SquadUtils.SquadType.PLAYER] = 'player',
+	[SquadUtils.SquadType.STAFF] = 'staff',
+}
+
 SquadUtils.specialTeamsTemplateMapping = {
 	retired = 'Team/retired',
 	inactive = 'Team/inactive',
 	['passed away'] = 'Team/passed away',
 	military = 'Team/military',
 }
-
--- TODO: Decided on all valid types
-SquadUtils.validPersonTypes = {'player', 'staff'}
-SquadUtils.defaultPersonType = 'player'
 
 ---@param status string?
 ---@return SquadStatus?
@@ -140,6 +154,7 @@ function SquadUtils.readSquadPersonArgs(args)
 		inactivedate = ReferenceCleaner.clean(args.inactivedate),
 
 		status = SquadUtils.SquadStatusToStorageValue[args.status],
+		type = SquadUtils.SquadTypeToStorageValue[args.type],
 
 		extradata = {
 			loanedto = args.team,
@@ -177,13 +192,14 @@ end
 
 ---@param frame table
 ---@param squadWidget SquadWidget
----@param rowCreator fun(player: table, squadStatus: integer):Widget
+---@param rowCreator fun(player: table, squadStatus: SquadStatus, squadType: SquadType):Widget
 ---@return Widget
 function SquadUtils.defaultRunManual(frame, squadWidget, rowCreator)
 	local args = Arguments.getArgs(frame)
 	local props = {
 		status = SquadUtils.statusToSquadStatus(args.status) or SquadUtils.SquadStatus.ACTIVE,
 		title = args.title,
+		type = SquadUtils.TypeToSquadType[args.type] or SquadUtils.SquadType.PLAYER,
 	}
 	local players = SquadUtils.parsePlayers(args)
 
@@ -203,15 +219,17 @@ end
 
 ---@param players table[]
 ---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@param squadWidget SquadWidget
----@param rowCreator fun(person: table, squadStatus: integer):Widget
+---@param rowCreator fun(person: table, squadStatus: SquadStatus, squadType: SquadType):Widget
 ---@param customTitle string?
 ---@param personMapper? fun(person: table): table
 ---@return Widget
-function SquadUtils.defaultRunAuto(players, squadStatus, squadWidget, rowCreator, customTitle, personMapper)
+function SquadUtils.defaultRunAuto(players, squadStatus, squadType, squadWidget, rowCreator, customTitle, personMapper)
 	local props = {
 		status = squadStatus,
-		title = customTitle
+		title = customTitle,
+		type = squadType,
 	}
 
 	local mappedPlayers = Array.map(players, personMapper or SquadUtils.convertAutoParameters)
@@ -226,10 +244,10 @@ function SquadUtils.defaultRunAuto(players, squadStatus, squadWidget, rowCreator
 end
 
 ---@param squadRowClass SquadRow
----@return fun(person: table, squadStatus: integer):Widget
+---@return fun(person: table, squadStatus: SquadStatus, squadType: SquadType):Widget
 function SquadUtils.defaultRow(squadRowClass)
-	return function(person, squadStatus)
-		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
+	return function(person, squadStatus, squadType)
+		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus, type = squadType}))
 		SquadUtils.storeSquadPerson(squadPerson)
 		local row = squadRowClass(squadPerson)
 

--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -59,8 +59,8 @@ function CustomSquad.run(frame)
 	}
 end
 
-function CustomSquad._playerRow(person, squadStatus)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
+function CustomSquad._playerRow(person, squadStatus, squadType)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus, type = squadType}))
 	squadPerson.extradata.activeteam = person.activeteam
 	squadPerson.extradata.activeteamrole = person.activeteamrole
 	SquadUtils.storeSquadPerson(squadPerson)

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -69,13 +69,13 @@ function CustomSquad.run(frame)
 	}
 end
 
----@param playerList table[]
+---@param players table[]
 ---@param squadStatus SquadStatus
 ---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
-	return SquadUtils.defaultRunAuto(playerList, squadStatus, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
+function CustomSquad.runAuto(players, squadStatus, squadType, customTitle)
+	return SquadUtils.defaultRunAuto(players, squadStatus, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
 end
 
 ---@param person table

--- a/components/squad/wikis/overwatch/squad_custom.lua
+++ b/components/squad/wikis/overwatch/squad_custom.lua
@@ -45,13 +45,14 @@ function CustomSquad.run(frame)
 	local props = {
 		status = SquadUtils.statusToSquadStatus(args.status) or SquadUtils.SquadStatus.ACTIVE,
 		title = args.title,
+		type = SquadUtils.TypeToSquadType[args.type] or SquadUtils.SquadType.PLAYER,
 	}
 	local players = SquadUtils.parsePlayers(args)
 
 	local showNumber = Array.any(players, Operator.property('number'))
 
 	props.children = Array.map(players, function(player)
-		return CustomSquad._playerRow(player, props.status, showNumber)
+		return CustomSquad._playerRow(player, props.status, props.type, showNumber)
 	end)
 
 	local root = SquadContexts.RoleTitle{value = SquadUtils.positionTitle(), children = {Squad(props)}}
@@ -69,19 +70,21 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadStatus integer
+---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, customTitle)
-	return SquadUtils.defaultRunAuto(playerList, squadStatus, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
+	return SquadUtils.defaultRunAuto(playerList, squadStatus, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
 end
 
 ---@param person table
----@param squadStatus integer
+---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@param showNumber boolean
 ---@return Widget
-function CustomSquad._playerRow(person, squadStatus, showNumber)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
+function CustomSquad._playerRow(person, squadStatus, squadType, showNumber)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus, type = squadType}))
 	squadPerson.extradata.number = person.number
 	SquadUtils.storeSquadPerson(squadPerson)
 

--- a/components/squad/wikis/smash/squad_custom.lua
+++ b/components/squad/wikis/smash/squad_custom.lua
@@ -48,6 +48,7 @@ function CustomSquad.run(frame)
 	local props = {
 		status = SquadUtils.statusToSquadStatus(args.status) or SquadUtils.SquadStatus.ACTIVE,
 		title = args.title,
+		type = SquadUtils.TypeToSquadType[args.type] or SquadUtils.SquadType.PLAYER,
 	}
 
 	local tableGame = args.game
@@ -60,7 +61,7 @@ function CustomSquad.run(frame)
 		person.flag = Variables.varDefault('nationality') or person.flag
 		person.name = Variables.varDefault('name') or person.name
 
-		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = props.status}))
+		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = props.status, type = props.type}))
 		squadPerson.extradata.game = game
 		squadPerson.extradata.mains = mains
 		SquadUtils.storeSquadPerson(squadPerson)

--- a/components/squad/wikis/starcraft/squad_custom.lua
+++ b/components/squad/wikis/starcraft/squad_custom.lua
@@ -44,7 +44,7 @@ function CustomSquad.run(frame)
 	local tlpd = Logic.readBool(args.tlpd)
 	local SquadClass = tlpd and SquadTldb or Squad
 
-	return SquadUtils.defaultRunManual(frame, SquadClass, function(person, squadStatus)
+	return SquadUtils.defaultRunManual(frame, SquadClass, function(person, squadStatus, squadType)
 		local inputId = person.id --[[@as number]]
 		person.race = CustomSquad._queryTLPD(inputId, 'race') or person.race
 		person.id = CustomSquad._queryTLPD(inputId, 'name') or person.id
@@ -53,7 +53,7 @@ function CustomSquad.run(frame)
 		person.name = (CustomSquad._queryTLPD(inputId, 'name_korean') or '') .. ' ' ..
 			(CustomSquad._queryTLPD(inputId, 'name_romanized') or person.name or '')
 
-		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
+		local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus, type = squadType}))
 		squadPerson.extradata.eloCurrent = CustomSquad._queryTLPD(inputId, 'elo')
 		squadPerson.extradata.eloPeak = CustomSquad._queryTLPD(inputId, 'peak_elo')
 		SquadUtils.storeSquadPerson(squadPerson)

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -24,13 +24,15 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadStatus integer
+---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
 	return SquadUtils.defaultRunAuto(
 		playerList,
 		squadStatus,
+		squadType,
 		Squad,
 		CustomSquad._playerRow,
 		customTitle,
@@ -47,10 +49,11 @@ function CustomSquad.personMapper(person)
 end
 
 ---@param person table
----@param squadStatus integer
+---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@return Widget
-function CustomSquad._playerRow(person, squadStatus)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
+function CustomSquad._playerRow(person, squadStatus, squadType)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus, type = squadType}))
 	local squadArgs = Arguments.getArgs(mw.getCurrentFrame())
 
 	if squadStatus == SquadUtils.SquadStatus.ACTIVE then

--- a/components/squad/wikis/starcraft2/squad_custom.lua
+++ b/components/squad/wikis/starcraft2/squad_custom.lua
@@ -23,14 +23,14 @@ function CustomSquad.run(frame)
 	return SquadUtils.defaultRunManual(frame, Squad, CustomSquad._playerRow)
 end
 
----@param playerList table[]
+---@param players table[]
 ---@param squadStatus SquadStatus
 ---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
+function CustomSquad.runAuto(players, squadStatus, squadType, customTitle)
 	return SquadUtils.defaultRunAuto(
-		playerList,
+		players,
 		squadStatus,
 		squadType,
 		Squad,

--- a/components/squad/wikis/stormgate/squad_custom.lua
+++ b/components/squad/wikis/stormgate/squad_custom.lua
@@ -22,14 +22,14 @@ function CustomSquad.run(frame)
 	return SquadUtils.defaultRunManual(frame, Squad, CustomSquad._playerRow)
 end
 
----@param playerList table[]
+---@param players table[]
 ---@param squadStatus SquadStatus
 ---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
+function CustomSquad.runAuto(players, squadStatus, squadType, customTitle)
 	return SquadUtils.defaultRunAuto(
-		playerList,
+		players,
 		squadStatus,
 		squadType,
 		Squad,

--- a/components/squad/wikis/stormgate/squad_custom.lua
+++ b/components/squad/wikis/stormgate/squad_custom.lua
@@ -23,13 +23,15 @@ function CustomSquad.run(frame)
 end
 
 ---@param playerList table[]
----@param squadStatus integer
+---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@param customTitle string?
 ---@return Widget
-function CustomSquad.runAuto(playerList, squadStatus, customTitle)
+function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
 	return SquadUtils.defaultRunAuto(
 		playerList,
 		squadStatus,
+		squadType,
 		Squad,
 		CustomSquad._playerRow,
 		customTitle,
@@ -46,10 +48,11 @@ function CustomSquad.personMapper(person)
 end
 
 ---@param person table
----@param squadStatus integer
+---@param squadStatus SquadStatus
+---@param squadType SquadType
 ---@return Widget
-function CustomSquad._playerRow(person, squadStatus)
-	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus}))
+function CustomSquad._playerRow(person, squadStatus, squadType)
+	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus, type = squadType}))
 	if Logic.isEmpty(squadPerson.newteam) then
 		if Logic.readBool(person.retired) then
 			squadPerson.newteamspecial = 'retired'

--- a/components/widget/squad/widget_squad_core.lua
+++ b/components/widget/squad/widget_squad_core.lua
@@ -24,11 +24,24 @@ local DataTable, Tr, Th = Widgets.DataTable, Widgets.Tr, Widgets.Th
 local Squad = Class.new(Widget)
 Squad.defaultProps = {
 	status = SquadUtils.SquadStatus.ACTIVE,
+	type = SquadUtils.SquadType.PLAYER,
+}
+
+local SquadStatusToDisplay = {
+	[SquadUtils.SquadStatus.ACTIVE] = '',
+	[SquadUtils.SquadStatus.INACTIVE] = 'Inactive',
+	[SquadUtils.SquadStatus.FORMER] = 'Former',
+	[SquadUtils.SquadStatus.FORMER_INACTIVE] = 'Former',
+}
+
+local SquadTypeToDisplay = {
+	[SquadUtils.SquadType.PLAYER] = 'Players',
+	[SquadUtils.SquadType.STAFF] = 'Organization',
 }
 
 ---@return WidgetDataTable
 function Squad:render()
-	local title = self:_title(self.props.status, self.props.title)
+	local title = self:_title(self.props.status, self.props.title, self.props.type)
 	local header = self:_header(self.props.status)
 
 	local allChildren = WidgetUtil.collect(title, header, unpack(self.props.children))
@@ -40,15 +53,20 @@ function Squad:render()
 	}
 end
 
----@param status SquadStatus
+---@param squadStatus SquadStatus
 ---@param title string?
+---@param squadType SquadType
 ---@return Widget?
-function Squad:_title(status, title)
+function Squad:_title(squadStatus, title, squadType)
 	local defaultTitle
-	if status == SquadUtils.SquadStatus.FORMER or status == SquadUtils.SquadStatus.FORMER_INACTIVE then
+	-- TODO: Work away this special case
+	if squadType == SquadUtils.SquadType.PLAYER and
+		(squadStatus == SquadUtils.SquadStatus.FORMER or squadStatus == SquadUtils.SquadStatus.FORMER_INACTIVE) then
+
 		defaultTitle = 'Former Squad'
-	elseif status == SquadUtils.SquadStatus.INACTIVE then
-		defaultTitle = 'Inactive Players'
+	-- No default title for Active tables
+	elseif squadStatus ~= SquadUtils.SquadStatus.ACTIVE then
+		defaultTitle = SquadStatusToDisplay[squadStatus]  .. ' ' .. SquadTypeToDisplay[squadType]
 	end
 
 	local titleText = Logic.emptyOr(title, defaultTitle)

--- a/components/widget/squad/widget_squad_core_tldb.lua
+++ b/components/widget/squad/widget_squad_core_tldb.lua
@@ -18,7 +18,7 @@ local SquadTldb = Class.new(SquadWidget)
 
 ---@param status SquadStatus
 ---@return Widget
-function SquadTldb:header(status)
+function SquadTldb:_header(status)
 	return Widgets.Tr{
 		classes = {'HeaderRow'},
 		cells = {
@@ -31,10 +31,11 @@ function SquadTldb:header(status)
 	}
 end
 
----@param status SquadStatus
+---@param squadStatus SquadStatus
 ---@param title string?
+---@param squadType SquadType
 ---@return Widget?
-function SquadTldb:_title(status, title)
+function SquadTldb:_title(squadStatus, title, squadType)
 	return nil
 end
 


### PR DESCRIPTION
## Summary
Add support in Squad Tables to be used for Organizations. This allows for the standardization of org tables. Doing this will allow a significant code simplification of SquadAuto (which currently uses standardized Squad for display of players, while custom table for display of staff). 

This Squad Auto change needs to be put live when this PR is merged.
https://liquipedia.net/commons/index.php?title=Module%3ASquadAuto%2Fdev%2Frath&type=revision&diff=789940&oldid=789920

When this PR is merged, and the SquadAuto change is live, all Auto Org tables will be swapped over to the new. However there's still a significant usage of ManualOrg tables across the wikis, almost all wikis have and use them to some capacity. Apex is also a special case where they got some strange setup. So Manual tables will not be automatically deployed, but rather significant bot running will be done to do those.

## How did you test this change?
Auto on R6, Manual on CS