### PR TITLE
feat(squad): drop the requirement of `id`

### DIFF
--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -43,6 +43,7 @@ function SquadRow:id()
 			link = self.model.link,
 			faction = self.model.extradata.faction,
 			type = Opponent.solo,
+			showLink = self.model.link and true or false,
 		},
 		nil, {syncPlayer = true}
 	)

--- a/components/squad/commons/squad_row.lua
+++ b/components/squad/commons/squad_row.lua
@@ -43,7 +43,6 @@ function SquadRow:id()
 			link = self.model.link,
 			faction = self.model.extradata.faction,
 			type = Opponent.solo,
-			showLink = self.model.link and true or false,
 		},
 		nil, {syncPlayer = true}
 	)

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -132,11 +132,11 @@ function SquadUtils.readSquadPersonArgs(args)
 		return mw.ext.TeamTemplate.raw(page)[property]
 	end
 
-	local id = assert(String.nilIfEmpty(args.id), 'Something is off with your input!')
+	local id, name = String.nilIFEmpty(args.id), String.nilIfEmpty(args.name)
 	local person = Lpdb.SquadPlayer:new{
-		id = id,
+		id = id or name,
 		link = mw.ext.TeamLiquidIntegration.resolve_redirect(args.link or id),
-		name = String.nilIfEmpty(args.name),
+		name = name,
 		nationality = Flags.CountryName(args.flag),
 
 		position = String.nilIfEmpty(args.position),

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -110,7 +110,7 @@ function SquadUtils.convertAutoParameters(player)
 	newPlayer.leavedate = (player.leavedatedisplay or player.leavedate) .. ' ' .. leaveReference
 	newPlayer.inactivedate = newPlayer.leavedate
 
-	newPlayer.link = player.page
+	newPlayer.link = String.nilIfEmpty(player.page)
 	newPlayer.role = player.thisTeam.role
 	newPlayer.position = player.thisTeam.position
 	newPlayer.team = player.thisTeam.role == 'Loan' and player.oldTeam.team
@@ -132,11 +132,13 @@ function SquadUtils.readSquadPersonArgs(args)
 		return mw.ext.TeamTemplate.raw(page)[property]
 	end
 
-	local id, name = String.nilIfEmpty(args.id), String.nilIfEmpty(args.name)
-	local linkInput = args.link or id
+	local name = String.nilIfEmpty(args.name)
+	local id = String.nilIfEmpty(args.id) or name
+	assert(id, 'id or name is required')
+
 	local person = Lpdb.SquadPlayer:new{
-		id = id or name,
-		link = linkInput and mw.ext.TeamLiquidIntegration.resolve_redirect(linkInput) or nil,
+		id = id,
+		link = mw.ext.TeamLiquidIntegration.resolve_redirect(args.link or id),
 		name = name,
 		nationality = Flags.CountryName(args.flag),
 

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -132,7 +132,7 @@ function SquadUtils.readSquadPersonArgs(args)
 		return mw.ext.TeamTemplate.raw(page)[property]
 	end
 
-	local id, name = String.nilIFEmpty(args.id), String.nilIfEmpty(args.name)
+	local id, name = String.nilIfEmpty(args.id), String.nilIfEmpty(args.name)
 	local person = Lpdb.SquadPlayer:new{
 		id = id or name,
 		link = mw.ext.TeamLiquidIntegration.resolve_redirect(args.link or id),

--- a/components/squad/commons/squad_utils.lua
+++ b/components/squad/commons/squad_utils.lua
@@ -133,9 +133,10 @@ function SquadUtils.readSquadPersonArgs(args)
 	end
 
 	local id, name = String.nilIfEmpty(args.id), String.nilIfEmpty(args.name)
+	local linkInput = args.link or id
 	local person = Lpdb.SquadPlayer:new{
 		id = id or name,
-		link = mw.ext.TeamLiquidIntegration.resolve_redirect(args.link or id),
+		link = linkInput and mw.ext.TeamLiquidIntegration.resolve_redirect(linkInput) or nil,
 		name = name,
 		nationality = Flags.CountryName(args.flag),
 


### PR DESCRIPTION
## Summary
We do not always know the `id` (gamer tag) of org staff. So let's drop that as a requirement, and use either `id` or `name` (realname). 

## How did you test this change?
dev