### PR TITLE
feat(match2): Create hearthstone bracket match1->match2 support

### DIFF
--- a/components/match2/commons/match_group_legacy.lua
+++ b/components/match2/commons/match_group_legacy.lua
@@ -106,9 +106,22 @@ function MatchGroupLegacy._getMatchMapping(match, match2mapping, lowerHeaders, l
 	return round, round.R
 end
 
+---@param match2mapping match2mapping
+---@param lowerHeaders {[number] : number}
+---@param lastRoundIndex number
+function MatchGroupLegacy._handleHeaderMapping(match2mapping, lowerHeaders, lastRoundIndex)
+	Array.forEach(Array.range(1, lastRoundIndex), function (roundIndex)
+		match2mapping['R' .. roundIndex .. 'M1header'] = 'R' .. roundIndex
+		if lowerHeaders[roundIndex] then
+			match2mapping['R' .. roundIndex .. 'M' .. lowerHeaders[roundIndex] .. 'header'] = 'L' .. roundIndex
+		end
+	end)
+end
+
 ---@param template string
+---@param bracketType string?
 ---@return match2mapping
-function MatchGroupLegacy.get(template)
+function MatchGroupLegacy.get(template, bracketType)
 	local matches = mw.ext.Brackets.getCommonsBracketTemplate(template)
 	assert(type(matches) == 'table')
 
@@ -122,12 +135,58 @@ function MatchGroupLegacy.get(template)
 			lastRound, roundData)
 	end)
 
-	Array.forEach(Array.range(1, lastRoundIndex), function (roundIndex)
-		match2mapping['R' .. roundIndex .. 'M1header'] = 'R' .. roundIndex
-		if lowerHeaders[roundIndex] then
-			match2mapping['R' .. roundIndex .. 'M' .. lowerHeaders[roundIndex] .. 'header'] = 'L' .. roundIndex
+	MatchGroupLegacy._handleHeaderMapping(match2mapping, lowerHeaders, lastRoundIndex)
+
+	return match2mapping
+end
+
+---@param template string
+---@param bracketType string?
+---@return match2mapping
+function MatchGroupLegacy.getAlt(template, bracketType)
+	local matches = mw.ext.Brackets.getCommonsBracketTemplate(template)
+	assert(type(matches) == 'table')
+
+	local match2mapping = {}
+	local lowerHeaders = {}
+	local lastRoundIndex = matches[1].match2bracketdata.coordinates.roundCount
+	local countMatchesInLower = 0
+	Array.forEach(matches, function (match)
+		local _, baseMatchId = MatchGroupUtil.splitMatchId(match.match2id)
+		---@cast baseMatchId -nil
+		local id = MatchGroupUtil.matchIdToKey(baseMatchId)
+		local bd = match.match2bracketdata
+
+		local roundNum = lastRoundIndex
+		local matchKey
+		if id == THIRD_PLACE_MATCH then
+			matchKey = 'l' .. roundNum .. 'm1'
+			match2mapping[THIRD_PLACE_MATCH .. 'header'] = 'L' .. roundNum
+		elseif id == RESET_MATCH then
+			matchKey = 'r' .. roundNum .. 'm1'
+		else
+			roundNum = id:match('R%d*'):gsub('R', '')
+			if bd.bracketsection == 'upper' then
+				countMatchesInLower = 0
+				matchKey = id:lower()
+			elseif bd.bracketsection == 'lower' then
+				if bd.coordinates.matchIndexInRound == 0 then
+					countMatchesInLower = 0
+				end
+				countMatchesInLower = countMatchesInLower + 1
+				matchKey = 'l' .. roundNum .. 'm' .. countMatchesInLower
+			end
 		end
+
+		if string.match(bd.header or '', '^!l') then
+			lowerHeaders[roundNum or ''] = roundNum
+		end
+
+
+		match2mapping[id] = {opp1 = matchKey .. 'p1', opp2 = matchKey .. 'p2', details = matchKey}
 	end)
+
+	MatchGroupLegacy._handleHeaderMapping(match2mapping, lowerHeaders, lastRoundIndex)
 
 	return match2mapping
 end
@@ -323,13 +382,13 @@ end
 ---@param templateid string
 ---@param oldTemplateid string?
 ---@return table
-function MatchGroupLegacy._get(templateid, oldTemplateid)
+function MatchGroupLegacy:_get(templateid, oldTemplateid)
 	if Lua.moduleExists('Module:MatchGroup/Legacy/' .. templateid) then
 		mw.log('Module:MatchGroup/Legacy/' .. templateid .. ' exists')
 		return (require('Module:MatchGroup/Legacy/' .. templateid)[oldTemplateid] or function() return nil end)()
-			or MatchGroupLegacy.get(templateid)
+			or self.get(templateid, self.bracketType)
 	else
-		return MatchGroupLegacy.get(templateid)
+		return self.get(templateid, self.bracketType)
 	end
 end
 
@@ -352,9 +411,9 @@ function MatchGroupLegacy:build()
 
 	local args = self.args
 
-	local match2mapping = MatchGroupLegacy._get(args.template, args.templateOld)
-
 	self.bracketType = args.type
+	local match2mapping = self:_get(args.template, args.templateOld)
+
 	self.newArgs = {
 		args.template,
 		id = args.id,

--- a/components/match2/wikis/hearthstone/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/hearthstone/legacy/match_group_legacy_default.lua
@@ -1,0 +1,79 @@
+---
+-- @Liquipedia
+-- wiki=hearthstone
+-- page=Module:MatchGroup/Legacy/Default
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local String = require('Module:StringUtils')
+
+local MatchGroupLegacy = Lua.import('Module:MatchGroup/Legacy')
+
+---@class HearthstoneMatchGroupLegacyDefault: MatchGroupLegacy
+local MatchGroupLegacyDefault = Class.new(MatchGroupLegacy)
+
+---@param template string
+---@param bracketType string?
+---@return match2mapping
+function MatchGroupLegacyDefault.get(template, bracketType)
+	return MatchGroupLegacy.getAlt(template)
+end
+
+---@param prefix string
+---@param scoreKey string
+---@return table
+function MatchGroupLegacyDefault:getOpponent(prefix, scoreKey)
+	return {
+		['$notEmpty$'] = prefix,
+		score = prefix .. scoreKey,
+		name = prefix ,
+		displayname = prefix .. 'display',
+		flag = prefix .. 'flag',
+	}
+end
+
+---@param isReset boolean
+---@param prefix string
+---@return table
+function MatchGroupLegacyDefault:getDetails(isReset, prefix)
+	local details = MatchGroupLegacy.getDetails(self, false, prefix)
+
+	Table.iter.forEachPair(self.args, function (key)
+		if not tonumber(key) and String.startsWith(key, prefix) then
+			details[key:gsub(prefix, '')] = self.args[key]
+		end
+	end)
+
+	return details
+end
+
+---@return table
+function MatchGroupLegacyDefault:getMap()
+	return {
+		['$notEmpty$'] = 'win$1$',
+		winner = 'win$1$',
+		o1p1 = 'p1class$1$',
+		o2p1 = 'p2class$1$',
+		vod = 'vodgame$1$'
+	}
+end
+
+
+---@param isReset boolean?
+---@param match table
+function MatchGroupLegacyDefault:handleOtherMatchParams(isReset, match)
+	match['winner'] = Table.extract(match, 'win')
+	match['finished'] = Table.extract(match, 'finished') or Logic.isNotEmpty(match['winner'])
+end
+
+---@param frame Frame
+function MatchGroupLegacyDefault.run(frame)
+	return MatchGroupLegacyDefault(frame):build()
+end
+
+return MatchGroupLegacyDefault

--- a/components/match2/wikis/hearthstone/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/hearthstone/legacy/match_group_legacy_default.lua
@@ -9,8 +9,8 @@
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local MatchGroupLegacy = Lua.import('Module:MatchGroup/Legacy')
 


### PR DESCRIPTION
## Summary

Added a new function to legacy to map old rXmY..
Legacy default will only be used to convert solo brackets, team brackets or brackets using RX(DW)Y inputs will be handled on a case-by-case basis.

## How did you test this change?

[8DEBracket](https://liquipedia.net/hearthstone/Stone_League_2015/Season_1/Code_S#Playoffs)
[4SEBracket](https://liquipedia.net/hearthstone/ONOG_Summer_Circuit_Finals#Results)