### PR TITLE
feat(squad) Allow dota2 to use ActiveOrganizationAuto

### DIFF
--- a/components/squad/wikis/dota2/squad_custom.lua
+++ b/components/squad/wikis/dota2/squad_custom.lua
@@ -59,6 +59,15 @@ function CustomSquad.run(frame)
 	}
 end
 
+---@param playerList table[]
+---@param squadStatus integer
+---@param squadType SquadType
+---@param customTitle string?
+---@return Widget
+function CustomSquad.runAuto(playerList, squadStatus, squadType, customTitle)
+	return SquadUtils.defaultRunAuto(playerList, squadStatus, squadType, Squad, SquadUtils.defaultRow(SquadRow), customTitle)
+end
+
 function CustomSquad._playerRow(person, squadStatus, squadType)
 	local squadPerson = SquadUtils.readSquadPersonArgs(Table.merge(person, {status = squadStatus, type = squadType}))
 	squadPerson.extradata.activeteam = person.activeteam


### PR DESCRIPTION
## Summary
Reported on [discord](https://discord.com/channels/93055209017729024/268719633366777856/1307275622598443008)
dota2 has a handful of pages using ActiveOrganizationAuto, but Squad/Custom wasn't setup for it.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
