### PR TITLE
fix(match2): unattached participants attaching not always working on fighters

### DIFF
--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Game = require('Module:Game')
 local Json = require('Module:Json')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
@@ -99,16 +100,21 @@ function MapFunctions._processPlayerMapData(map, opponent, opponentIndex)
 
 				return {name = character}
 			end)
-			return {
+			local participant = {
 				characters = characters,
 				player = playerIdData.name,
 			}
+			return Logic.isNotDeepEmpty(participant) and participant or nil
 		end
 	)
-	Array.forEach(unattachedParticipants, function(participant)
-		table.insert(participants, participant)
+
+	-- fill up participants with empty data to avoid errors
+	Array.forEach(opponent.match2players, function(_, playerIndex)
+		participants[playerIndex] = participants[playerIndex] or {characters = {}}
 	end)
-	return participants
+
+	-- append actually unattached participants
+	return Array.extendWith(participants, unattachedParticipants)
 end
 
 ---@param map table


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/268719633366777856/1307090277059526676
sometimes the participant processing is faulty and leaves unintended gaps and hence also causes wrong displays
basically the table.insert is not always inserting in correct order

this fix first ignores not inputted players and instead fills in the gaps in participant/mapOpponent data before attaching the unattached players

## How did you test this change?
dev