### PR TITLE
feat(infobox): prepare clean up of more complicated publishertier cases

### DIFF
--- a/components/infobox/wikis/tft/infobox_league_custom.lua
+++ b/components/infobox/wikis/tft/infobox_league_custom.lua
@@ -77,7 +77,8 @@ function CustomLeague:customParseArguments(args)
 	args.mode = args.mode and GAME_MODES[string.lower(args.mode):gsub('s$', '')] or DEFAULT_MODE
 
 	self.data.mode = string.lower(args.mode)
-	self.data.publishertier = Logic.readBool(args['riot-sponsored']) and 'sponsored' or nil
+	self.data.publishertier = Logic.nilIfEmpty(args.publishertier)
+		or Logic.readBool(args['riot-sponsored']) and 'sponsored' or nil
 end
 
 ---@param args table

--- a/components/infobox/wikis/valorant/infobox_league_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_league_custom.lua
@@ -44,7 +44,8 @@ end
 ---@param args table
 function CustomLeague:customParseArguments(args)
 	self.data.mode = (args.individual or args.player_number) and '1v1' or 'team'
-	self.data.publishertier = Logic.readBool(args['riot-highlighted']) and 'highlighted'
+	self.data.publishertier = Logic.nilIfEmpty(args.publishertier)
+		or Logic.readBool(args['riot-highlighted']) and 'highlighted'
 		or Logic.readBool(args['riot-sponsored']) and 'sponsored'
 		or nil
 end


### PR DESCRIPTION
## Summary
- val: switch from `riot-highlighted` and `riot-sponsored` bools to `|publishertier=` string input (`highlighted`/`sponsored`)
- tft: switch from 
- clashofclans: to be done`riot-sponsored` bool input to `|publishertier=` string input (`sponsored`)
- brawlstars: to be done
- apex: to be done

## Bot jobs
- val:
  - `\|\s*riot-highlighted\s*=\s*true` --> `|publishertier=highlighted` (18)
  - `\|\s*riot-sponsored\s*=\s*true` --> `|publishertier=sponsored` (~1.9k)
- tft
 - `\|\s*riot-sponsored\s*=\s*true` --> `|publishertier=sponsored` (~900)
- 

## How did you test this change?
to be done after discussion if this is wanted