### PR TITLE
fix(match2) Fix matchsummary using sparse arrays

### DIFF
--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -14,6 +14,7 @@ local Lua = require('Module:Lua')
 local MapMode = require('Module:MapMode')
 local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
@@ -107,12 +108,14 @@ function CustomMatchSummary._createGame(game, props)
 		end
 		local function createOpponentDisplay(opponentId)
 			local display = mw.html.create('div'):css('display', 'flex'):css('flex-direction', 'column'):css('width', '35%')
-			Array.forEach(
-				Array.sortBy(game.opponents[opponentId].players, Operator.property('index')),
-				function(player)
-					display:node(createParticipant(player, opponentId == 1))
-				end
-			)
+		
+			local ordering = function(tbl, a, b)
+				return tbl[a].index < tbl[b].index
+			end
+			
+			for _, player in Table.iter.spairs(game.opponents[opponentId].players, ordering) do
+				display:node(createParticipant(player, opponentId == 1))
+			end
 			return display
 		end
 

--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -12,7 +12,6 @@ local Faction = require('Module:Faction')
 local Game = require('Module:Game')
 local Lua = require('Module:Lua')
 local MapMode = require('Module:MapMode')
-local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
@@ -108,11 +107,11 @@ function CustomMatchSummary._createGame(game, props)
 		end
 		local function createOpponentDisplay(opponentId)
 			local display = mw.html.create('div'):css('display', 'flex'):css('flex-direction', 'column'):css('width', '35%')
-		
+
 			local ordering = function(tbl, a, b)
 				return tbl[a].index < tbl[b].index
 			end
-			
+
 			for _, player in Table.iter.spairs(game.opponents[opponentId].players, ordering) do
 				display:node(createParticipant(player, opponentId == 1))
 			end


### PR DESCRIPTION
## Summary
likely introduced with #5084 match2game.opponents.players could be sparse "Arrays", where e.g. keys 1, 3, 4, 5 are used.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev to live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
