### PR TITLE
fix(match2): on age of empires, manual width is ignored in Legacy mode

### DIFF
--- a/components/match2/wikis/ageofempires/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/ageofempires/legacy/match_maps_legacy.lua
@@ -129,6 +129,7 @@ function MatchMapsLegacy.showmatch(frame)
 	return MatchGroup.MatchByMatchId({
 		id = MatchGroupBase.getBracketIdPrefix() .. id,
 		matchid = 'R1M1',
+		width = args.width
 	})
 end
 


### PR DESCRIPTION
## Summary
A lot of LegacySingleMatches have width set, as the default width is too narrow for teams leading to display issues.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
