### PR TITLE
refactor(notability): use standardized fields over deprecated fields

### DIFF
--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -98,7 +98,7 @@ function NotabilityChecker._calculateTeamNotability(team)
 	local data = mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = Config.PLACEMENT_LIMIT,
 		conditions = '[[participant::' .. team .. ']]',
-		query = Config.PLACEMENT_QUERY,
+		query = 'pagename, tournament, date, placement, liquipediatier, liquipediatiertype, extradata, mode',
 	})
 
 	return NotabilityChecker._calculateWeight(data)

--- a/components/notability/commons/notability_checker.lua
+++ b/components/notability/commons/notability_checker.lua
@@ -113,10 +113,10 @@ function NotabilityChecker._calculatePersonNotability(person)
 	for _, name in pairs({person, (person:gsub(' ', '_'))}) do
 		table.insert(conditions, '[[participant::' .. name .. ']]')
 		for i = 1, Config.MAX_NUMBER_OF_PARTICIPANTS do
-			table.insert(conditions, '[[players_p' .. tostring(i) .. '::' .. name .. ']]')
+			table.insert(conditions, '[[opponentplayers_p' .. tostring(i) .. '::' .. name .. ']]')
 		end
 		for i = 1, Config.MAX_NUMBER_OF_COACHES do
-			table.insert(conditions, '[[players_c' .. tostring(i) .. '::' .. name .. ']]')
+			table.insert(conditions, '[[opponentplayers_c' .. tostring(i) .. '::' .. name .. ']]')
 		end
 	end
 

--- a/components/notability/wikis/ageofempires/notability_checker_config.lua
+++ b/components/notability/wikis/ageofempires/notability_checker_config.lua
@@ -29,11 +29,6 @@ Config.MAX_NUMBER_OF_PARTICIPANTS = 10
 -- How many coaches can be in a team?
 Config.MAX_NUMBER_OF_COACHES = 1
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 1600 -- Essentially disabled since NOTABILITY_THRESHOLD_NOTABLE is checked first
 Config.NOTABILITY_THRESHOLD_NOTABLE = 1600

--- a/components/notability/wikis/ageofempires/notability_checker_config.lua
+++ b/components/notability/wikis/ageofempires/notability_checker_config.lua
@@ -32,7 +32,7 @@ Config.MAX_NUMBER_OF_COACHES = 1
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 1600 -- Essentially disabled since NOTABILITY_THRESHOLD_NOTABLE is checked first

--- a/components/notability/wikis/apexlegends/notability_checker_config.lua
+++ b/components/notability/wikis/apexlegends/notability_checker_config.lua
@@ -25,7 +25,7 @@ Config.PLACEMENT_LIMIT = 2000
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 20

--- a/components/notability/wikis/apexlegends/notability_checker_config.lua
+++ b/components/notability/wikis/apexlegends/notability_checker_config.lua
@@ -22,11 +22,6 @@ Config.MAX_NUMBER_OF_COACHES = 2
 -- How many placements should we retrieve from LPDB for a team/player?
 Config.PLACEMENT_LIMIT = 2000
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 20
 Config.NOTABILITY_THRESHOLD_NOTABLE = 25

--- a/components/notability/wikis/brawlstars/notability_checker_config.lua
+++ b/components/notability/wikis/brawlstars/notability_checker_config.lua
@@ -25,7 +25,7 @@ Config.PLACEMENT_LIMIT = 5000
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 12

--- a/components/notability/wikis/brawlstars/notability_checker_config.lua
+++ b/components/notability/wikis/brawlstars/notability_checker_config.lua
@@ -22,11 +22,6 @@ Config.MAX_NUMBER_OF_COACHES = 3
 -- How many placements should we retrieve from LPDB for a team/player?
 Config.PLACEMENT_LIMIT = 5000
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 12
 Config.NOTABILITY_THRESHOLD_NOTABLE = 15

--- a/components/notability/wikis/halo/notability_checker_config.lua
+++ b/components/notability/wikis/halo/notability_checker_config.lua
@@ -28,11 +28,6 @@ Config.PLACEMENT_LIMIT = 2000
 Config.MAX_NUMBER_OF_PARTICIPANTS = 10
 Config.MAX_NUMBER_OF_COACHES = 5
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 600
 Config.NOTABILITY_THRESHOLD_NOTABLE = 800

--- a/components/notability/wikis/halo/notability_checker_config.lua
+++ b/components/notability/wikis/halo/notability_checker_config.lua
@@ -31,7 +31,7 @@ Config.MAX_NUMBER_OF_COACHES = 5
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 600

--- a/components/notability/wikis/pubgmobile/notability_checker_config.lua
+++ b/components/notability/wikis/pubgmobile/notability_checker_config.lua
@@ -27,7 +27,7 @@ Config.PLACEMENT_LIMIT = 2000
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 12

--- a/components/notability/wikis/pubgmobile/notability_checker_config.lua
+++ b/components/notability/wikis/pubgmobile/notability_checker_config.lua
@@ -24,11 +24,6 @@ Config.MAX_NUMBER_OF_COACHES = 2
 -- How many placements should we retrieve from LPDB for a team/player?
 Config.PLACEMENT_LIMIT = 2000
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 12
 Config.NOTABILITY_THRESHOLD_NOTABLE = 15

--- a/components/notability/wikis/rainbowsix/notability_checker_config.lua
+++ b/components/notability/wikis/rainbowsix/notability_checker_config.lua
@@ -27,7 +27,7 @@ Config.MAX_NUMBER_OF_COACHES = 5
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 600

--- a/components/notability/wikis/rainbowsix/notability_checker_config.lua
+++ b/components/notability/wikis/rainbowsix/notability_checker_config.lua
@@ -24,11 +24,6 @@ Config.PLACEMENT_LIMIT = 2000
 Config.MAX_NUMBER_OF_PARTICIPANTS = 10
 Config.MAX_NUMBER_OF_COACHES = 5
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 600
 Config.NOTABILITY_THRESHOLD_NOTABLE = 700

--- a/components/notability/wikis/rocketleague/notability_checker_config.lua
+++ b/components/notability/wikis/rocketleague/notability_checker_config.lua
@@ -28,7 +28,7 @@ Config.MAX_NUMBER_OF_COACHES = 0
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 400

--- a/components/notability/wikis/rocketleague/notability_checker_config.lua
+++ b/components/notability/wikis/rocketleague/notability_checker_config.lua
@@ -25,11 +25,6 @@ Config.PLACEMENT_LIMIT = 2000
 Config.MAX_NUMBER_OF_PARTICIPANTS = 10
 Config.MAX_NUMBER_OF_COACHES = 0
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 400
 Config.NOTABILITY_THRESHOLD_NOTABLE = 500

--- a/components/notability/wikis/trackmania/notability_checker_config.lua
+++ b/components/notability/wikis/trackmania/notability_checker_config.lua
@@ -23,11 +23,6 @@ Config.MAX_NUMBER_OF_COACHES = 2
 -- How many placements should we retrieve from LPDB for a team/player?
 Config.PLACEMENT_LIMIT = 2000
 
--- Which LPDB placement parameters do we care about?
-Config.PLACEMENT_QUERY =
-	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, extradata, mode'
-
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 80
 Config.NOTABILITY_THRESHOLD_NOTABLE = 100

--- a/components/notability/wikis/trackmania/notability_checker_config.lua
+++ b/components/notability/wikis/trackmania/notability_checker_config.lua
@@ -26,7 +26,7 @@ Config.PLACEMENT_LIMIT = 2000
 -- Which LPDB placement parameters do we care about?
 Config.PLACEMENT_QUERY =
 	'pagename, tournament, date, placement, liquipediatier, ' ..
-	'liquipediatiertype, players, extradata, mode'
+	'liquipediatiertype, extradata, mode'
 
 -- These are the notability thresholds needed by a team/player
 Config.NOTABILITY_THRESHOLD_MIN = 80


### PR DESCRIPTION
## Summary
- use `opponentplayers` over `players` in condition building
- kick `players` in the query due to it not being used anywhere

## How did you test this change?
untested