### PR TITLE
fix(match2): missing nil catch

### DIFF
--- a/components/match2/wikis/clashroyale/match_group_input_custom.lua
+++ b/components/match2/wikis/clashroyale/match_group_input_custom.lua
@@ -240,7 +240,7 @@ end
 function MapFunctions.getCardsExtradata(mapOpponents)
 	local extradata = {}
 	for opponentIndex, opponent in ipairs(mapOpponents) do
-		for playerIndex, player in pairs(opponent.players) do
+		for playerIndex, player in pairs(opponent.players or {}) do
 			local prefix = 't' .. opponentIndex .. 'p' .. playerIndex
 			extradata[prefix .. 'tower'] = player.cards.tower
 			-- participant.cards is an array plus the tower value ....


### PR DESCRIPTION
## Summary
on the annoying wiki the input processing errors on mapopponentplayers being nil when trying to loop over them
to avoid that add a simple nil catch
mind alternatively to this pr could just refactor that mgi to be up to current standard (i currently don't have the time for it)
- new parseMapOpponentPlayers stuff
- use the standard map parsing function from commons

## How did you test this change?
live