### PR TITLE
feat(matchTable): support redirected pages that are not set in the team templates

### DIFF
--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -244,8 +244,12 @@ function MatchTable:getOpponentAliases(mode, opponent)
 	Array.forEach(opponentNames, function(name)
 		name = name:gsub(' ', '_')
 		local nameWithSpaces = name:gsub('_', ' ')
+		local pagifiedName = Page.pageifyLink(name)
+		local pagifiedNameWithSpaces = pagifiedName:gsub('_', ' ')
 		aliases[name] = true
 		aliases[nameWithSpaces] = true
+		aliases[pagifiedName] = true
+		aliases[pagifiedNameWithSpaces] = true
 	end)
 
 	return aliases


### PR DESCRIPTION
## Summary
currently in some edge cases matchTable doesn't retrieve the wanted matches.
mentioned on discord: https://discord.com/channels/93055209017729024/268719633366777856/1309935673842864129

cause of this:
- matchTable retrieves the page names from (historical) TeamTemplate(s)
- there exists a (page) redirect from (at least) one of the pages set in the team template to a page that is not among the pages listed in the team templates
- the match stores them redirect resolved
- hence the condition will never meet what is stored in matches

This PR makes it so that conditions in matchTable gets adjusted so that it also checks for resolve redirected versions.

## How did you test this change?
dev