### PR TITLE
feat(infobox): Show participant count in individual tournament infoboxes on RL

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_league_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_league_custom.lua
@@ -81,6 +81,12 @@ function CustomInjector:parse(id, widgets)
 				name = 'Number of teams',
 				content = {args.team_number}
 			})
+		elseif not String.isEmpty(args.player_number) then
+			table.insert(widgets, Title{children = 'Players'})
+			table.insert(widgets, Cell{
+				name = 'Number of players',
+				content = {args.player_number}
+			})
 		end
 	end
 	return widgets


### PR DESCRIPTION
## Summary

Originally only supported the `team_number` arg for team tournaments, extend to the `player_number` arg for individual tournaments

## How did you test this change?

/dev