### PR TITLE
feat: support more date inputs

### DIFF
--- a/spec/date_ext_spec.lua
+++ b/spec/date_ext_spec.lua
@@ -20,8 +20,17 @@ describe('Date', function()
 			DateExt.readTimestamp('2021-10-17 17:40 <abbr data-tz="-4:00">EDT</abbr>')
 			assert.stub(FormatDateSpy).was.called_with(mw.language, 'U', '20211017 17:40 -4:00')
 
+			DateExt.readTimestamp('2021-10-17 17:40 - <abbr data-tz="-4:00">EDT</abbr>')
+			assert.stub(FormatDateSpy).was.called_with(mw.language, 'U', '20211017 17:40 -4:00')
+
 			DateExt.readTimestamp('2021-10-17 21:40')
 			assert.stub(FormatDateSpy).was.called_with(mw.language, 'U', '20211017 21:40')
+
+			DateExt.readTimestamp('2024-11-24T15:38:01')
+			assert.stub(FormatDateSpy).was.called_with(mw.language, 'U', '2024112415:38:01')
+
+			DateExt.readTimestamp('2024-11-24T15:38:01.999Z')
+			assert.stub(FormatDateSpy).was.called_with(mw.language, 'U', '2024112415:38:01.999Z')
 		end)
 	end)
 

--- a/spec/date_ext_spec.lua
+++ b/spec/date_ext_spec.lua
@@ -20,7 +20,7 @@ describe('Date', function()
 			DateExt.readTimestamp('2021-10-17 17:40 <abbr data-tz="-4:00">EDT</abbr>')
 			assert.stub(FormatDateSpy).was.called_with(mw.language, 'U', '20211017 17:40 -4:00')
 
-			DateExt.readTimestamp('2021-10-17 17:40 - <abbr data-tz="-4:00">EDT</abbr>')
+			DateExt.readTimestamp('2021-10-17 - 17:40 <abbr data-tz="-4:00">EDT</abbr>')
 			assert.stub(FormatDateSpy).was.called_with(mw.language, 'U', '20211017 17:40 -4:00')
 
 			DateExt.readTimestamp('2021-10-17 21:40')

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -54,8 +54,7 @@ function DateExt.readTimestamp(dateInput)
 	local tzTemplateOffset = dateInput:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
 	local datePart = (mw.text.split(dateInput, '<', true)[1])
 		:gsub('-', '')
-		:gsub('T', '') -- is used as sep in forms datepicker if time is entered
-		:gsub('Z$', '') -- gets appended in forms datepicker if time is entered
+		:gsub('T', '')
 	local timestampString = mw.getContentLanguage():formatDate('U', datePart .. (tzTemplateOffset or ''))
 	return tonumber(timestampString)
 end

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -52,7 +52,10 @@ function DateExt.readTimestamp(dateInput)
 
 	-- Extracts the '-4:00' out of <abbr data-tz="-4:00" title="Eastern Daylight Time (UTC-4)">EDT</abbr>
 	local tzTemplateOffset = dateInput:match('data%-tz%=[\"\']([%d%-%+%:]+)[\"\']')
-	local datePart = (mw.text.split(dateInput, '<', true)[1]):gsub('-', '')
+	local datePart = (mw.text.split(dateInput, '<', true)[1])
+		:gsub('-', '')
+		:gsub('T', '') -- is used as sep in forms datepicker if time is entered
+		:gsub('Z$', '') -- gets appended in forms datepicker if time is entered
 	local timestampString = mw.getContentLanguage():formatDate('U', datePart .. (tzTemplateOffset or ''))
 	return tonumber(timestampString)
 end


### PR DESCRIPTION
## Summary
On Overwatch they have a form that uses date picker with time (in addition to the date).
Form passes the dateTime as `YYYY-MM-DDTHH:mm:ss.ssssZ` (e.g. `2024-11-24T15:38:01.999Z`) to the template/module.
Hence it results in DateExt.readTimestamp erroring.
This PR adds support to also parse such dateTime strings so we can support date picker with dateTime in forms properly with standardized modules.

## How did you test this change?
dev