### PR TITLE
feat(match2): add vodgameX support in sc(2) legacy wrappers

### DIFF
--- a/components/match2/wikis/starcraft/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/starcraft/legacy/match_group_legacy_default.lua
@@ -41,7 +41,8 @@ function MatchGroupLegacyDefault:getMap()
 		map = 'map$1$',
 		winner = 'map$1$win',
 		race1 = 'map$1$p1race',
-		race2 = 'map$1$p2race'
+		race2 = 'map$1$p2race',
+		vod = 'vodgame$1$',
 	}
 end
 

--- a/components/match2/wikis/starcraft/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/starcraft/legacy/match_maps_legacy.lua
@@ -189,6 +189,7 @@ function MatchMapsLegacy._handleMaps(match)
 			winner = match['map' .. gameIndex .. 'win'],
 			race1 = match['map' .. gameIndex .. 'p1race'],
 			race2 = match['map' .. gameIndex .. 'p2race'],
+			vod = match['vodgame' .. gameIndex],
 		}
 
 		match['map' .. gameIndex .. 'win'] = nil

--- a/components/match2/wikis/starcraft2/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_group_legacy_default.lua
@@ -41,7 +41,8 @@ function MatchGroupLegacyDefault:getMap()
 		map = 'map$1$',
 		winner = 'map$1$win',
 		race1 = 'map$1$p1race',
-		race2 = 'map$1$p2race'
+		race2 = 'map$1$p2race',
+		vod = 'vodgame$1$',
 	}
 end
 

--- a/components/match2/wikis/starcraft2/legacy/match_maps_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_maps_legacy.lua
@@ -108,6 +108,7 @@ function MatchMapsLegacy._handleMaps()
 			winner = mapWinner,
 			race1 = storageArgs['map' .. gameIndex .. 'p1race'],
 			race2 = storageArgs['map' .. gameIndex .. 'p2race'],
+			vod = storageArgs['vodgame' .. gameIndex],
 		}
 
 		storageArgs['map' .. gameIndex .. 'win'] = nil

--- a/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
@@ -51,7 +51,7 @@ function MatchMapsTeamLegacy._handleMaps()
 	local mapWinner = _match2Args[prefix .. 'win']
 
 	while map or mapWinner do
-		_match2Args['map' .. gameIndex] = MatchMapsTeamLegacy._processSingleMap(prefix, map, mapWinner)
+		_match2Args['map' .. gameIndex] = MatchMapsTeamLegacy._processSingleMap(prefix, map, mapWinner, gameIndex)
 
 		gameIndex = gameIndex + 1
 		prefix = 'm' .. gameIndex
@@ -68,12 +68,13 @@ function MatchMapsTeamLegacy._handleMaps()
 	end
 end
 
-function MatchMapsTeamLegacy._processSingleMap(prefix, map, mapWinner)
+function MatchMapsTeamLegacy._processSingleMap(prefix, map, mapWinner, gameIndex)
 	local archon = Logic.readBool(_match2Args[prefix .. 'archon'])
 
 	local mapArgs = {
 		map = map or 'unknown',
 		winner = mapWinner,
+		vod = _match2Args['vodgame' .. gameIndex],
 	}
 	mapArgs = MatchMapsTeamLegacy._processMapOpponent(1, prefix, mapArgs, archon)
 	mapArgs = MatchMapsTeamLegacy._processMapOpponent(2, prefix, mapArgs, archon)


### PR DESCRIPTION
## Summary
Was lost due to the refactors.
Mind as currently enuaj is converting all the pages that use legacy wrapper to use the new input we will probably be able to kick these modules completely in some months (hence not bothering with annos)

## How did you test this change?
dev