### PR TITLE
fix(match2): BattleRoyale loading panels in wrong container when there's multiple

### DIFF
--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -307,8 +307,11 @@ liquipedia.battleRoyale = {
 
 		if ( loadTemplate && !this.loadedTabs[ battleRoyaleId ][ matchContentId ] ) {
 			this.callTemplate( battleRoyaleId, matchId, gameId, matchContentId, () => {
-				this.buildBattleRoyaleMapMatchContents( battleRoyaleId, this.battleRoyaleInstances[battleRoyaleId].querySelector(
-					`[data-js-battle-royale-content-id="${ matchContentId }"]` ), true );
+				this.buildBattleRoyaleMapMatchContents(
+					battleRoyaleId, this.battleRoyaleInstances[ battleRoyaleId ].querySelector(
+						`[data-js-battle-royale-content-id="${ matchContentId }"]`
+					), true
+				);
 				this.loadedTabs[ battleRoyaleId ][ matchContentId ] = true;
 				this.updateGameTabDisplay( battleRoyaleId, matchContentId, gameTab );
 				this.makeCollapsibles( battleRoyaleId );
@@ -371,7 +374,10 @@ liquipedia.battleRoyale = {
 			wikitext += `{{ShowSingleGame|id=${ battleRoyaleId }|matchid=${ matchId }|gameidx=${ i }}}`;
 		}
 
-		const element = this.battleRoyaleInstances[battleRoyaleId].querySelector( `[data-js-battle-royale-content-id="${ matchContentId }"]` );
+		const element =
+			this.battleRoyaleInstances[ battleRoyaleId ].querySelector(
+				`[data-js-battle-royale-content-id="${ matchContentId }"]`
+			);
 
 		mw.loader.using( [ 'mediawiki.api' ] ).then( () => {
 			const api = new mw.Api();

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -307,7 +307,7 @@ liquipedia.battleRoyale = {
 
 		if ( loadTemplate && !this.loadedTabs[ battleRoyaleId ][ matchContentId ] ) {
 			this.callTemplate( battleRoyaleId, matchId, gameId, matchContentId, () => {
-				this.buildBattleRoyaleMapMatchContents( battleRoyaleId, document.querySelector(
+				this.buildBattleRoyaleMapMatchContents( battleRoyaleId, this.battleRoyaleInstances[battleRoyaleId].querySelector(
 					`[data-js-battle-royale-content-id="${ matchContentId }"]` ), true );
 				this.loadedTabs[ battleRoyaleId ][ matchContentId ] = true;
 				this.updateGameTabDisplay( battleRoyaleId, matchContentId, gameTab );
@@ -371,7 +371,7 @@ liquipedia.battleRoyale = {
 			wikitext += `{{ShowSingleGame|id=${ battleRoyaleId }|matchid=${ matchId }|gameidx=${ i }}}`;
 		}
 
-		const element = document.querySelector( `[data-js-battle-royale-content-id="${ matchContentId }"]` );
+		const element = this.battleRoyaleInstances[battleRoyaleId].querySelector( `[data-js-battle-royale-content-id="${ matchContentId }"]` );
 
 		mw.loader.using( [ 'mediawiki.api' ] ).then( () => {
 			const api = new mw.Api();


### PR DESCRIPTION
## Summary

There was a bug causing the game panels to be append to the wrong container when there were more battle royales on one page. The query is adjusted to grabbing the br instance instead of the global document.

## How did you test this change?

Live and on dev wiki
https://liquipedia.net/apexlegends/FFL/REBOOT_6
http://laura.wiki.tldev.eu/rocketleague/Apex