### PR TITLE
feat(match2): Support team players in hearthstone

### DIFF
--- a/components/match2/wikis/hearthstone/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/hearthstone/get_match_group_copy_paste_wiki.lua
@@ -53,7 +53,7 @@ end
 ---@return string
 function WikiCopyPaste._getMap(mode, opponents)
 	if mode == Opponent.team then
-		return '={{Map|o1p1=|o2p1=|o1p1char=|o2p1char=|winner=}}'
+		return '={{Map|o1p1=|o2p1=|o1c1=|o2c1=|winner=}}'
 	elseif mode == Opponent.literal then
 		return '={{Map|winner=}}'
 	end
@@ -61,7 +61,7 @@ function WikiCopyPaste._getMap(mode, opponents)
 	local parts = Array.extend({'={{Map'},
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return table.concat(Array.map(Array.range(1, Opponent.partySize(mode) --[[@as integer]]), function(playerIndex)
-				return '|o' .. opponentIndex .. 'p' .. playerIndex .. '='
+				return '|o' .. opponentIndex .. 'c' .. playerIndex .. '='
 			end))
 		end),
 		'|winner=}}'

--- a/components/match2/wikis/hearthstone/legacy/match_group_legacy_default.lua
+++ b/components/match2/wikis/hearthstone/legacy/match_group_legacy_default.lua
@@ -57,8 +57,8 @@ function MatchGroupLegacyDefault:getMap()
 	return {
 		['$notEmpty$'] = 'win$1$',
 		winner = 'win$1$',
-		o1p1 = 'p1class$1$',
-		o2p1 = 'p2class$1$',
+		o1c1 = 'p1class$1$',
+		o2c1 = 'p2class$1$',
 		vod = 'vodgame$1$'
 	}
 end

--- a/components/match2/wikis/hearthstone/match_group_input_custom.lua
+++ b/components/match2/wikis/hearthstone/match_group_input_custom.lua
@@ -162,8 +162,6 @@ function MapFunctions.getPartyParticipants(mapInput, opponent, opponentIndex)
 	end)
 end
 
----@param input string?
----@return string?
-MapFunctions.readCharacter = FnUtil.curry(MatchGroupInputUtil.getCharacterName, CharacterStandardization)
+MapFunctions.readCharacter = FnUtil.curry(MatchGroupInputUtil.getCharacterName, CharacterStandardization) --[[@as fun(class: string): string]]
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/hearthstone/match_group_input_custom.lua
+++ b/components/match2/wikis/hearthstone/match_group_input_custom.lua
@@ -18,9 +18,7 @@ local Opponent = OpponentLibraries.Opponent
 
 local CustomMatchGroupInput = {}
 local MatchFunctions = {}
-local MapFunctions = {
-	ADD_SUB_GROUP = true,
-}
+local MapFunctions = {}
 MatchFunctions.OPPONENT_CONFIG = {
 	resolveRedirect = true,
 	pagifyTeamNames = true,
@@ -53,19 +51,6 @@ end
 ---@return integer?
 function MatchFunctions.getBestOf(bestofInput)
 	return tonumber(bestofInput)
-end
-
----@param match table
----@param games table[]
----@param opponents table[]
----@return table
-function MatchFunctions.getExtraData(match, games, opponents)
-	local extradata = {}
-	Array.forEach(games, function(_, subGroupIndex)
-		extradata['subGroup' .. subGroupIndex .. 'header'] = Logic.nilIfEmpty(match['submatch' .. subGroupIndex .. 'header'])
-	end)
-
-	return extradata
 end
 
 ---@param match table

--- a/components/match2/wikis/hearthstone/match_group_input_custom.lua
+++ b/components/match2/wikis/hearthstone/match_group_input_custom.lua
@@ -162,6 +162,7 @@ function MapFunctions.getPartyParticipants(mapInput, opponent, opponentIndex)
 	end)
 end
 
-MapFunctions.readCharacter = FnUtil.curry(MatchGroupInputUtil.getCharacterName, CharacterStandardization) --[[@as fun(class: string): string]]
+MapFunctions.readCharacter = FnUtil.curry(MatchGroupInputUtil.getCharacterName,
+	CharacterStandardization) --[[@as fun(class: string): string]]
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/hearthstone/match_group_input_custom.lua
+++ b/components/match2/wikis/hearthstone/match_group_input_custom.lua
@@ -26,7 +26,6 @@ MatchFunctions.OPPONENT_CONFIG = {
 	pagifyTeamNames = true,
 	pagifyPlayerNames = true,
 }
-local TBD = 'TBD'
 
 ---@param match table
 ---@param options table?

--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
-local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -47,7 +46,6 @@ function CustomMatchSummary.createBody(match)
 	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
 		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
 		Array.map(match.games, function (game, gameIndex)
-			game.header = match.extradata['subGroup' .. gameIndex .. 'header']
 			if isTeamMatch and String.startsWith(game.map or '', 'Submatch') then
 				return CustomMatchSummary._createSubmatch(game)
 			else
@@ -111,10 +109,6 @@ function CustomMatchSummary._createSubmatch(game)
 		classes = {'brkts-popup-header-dev'},
 		css = {['justify-content'] = 'center', margin = 'auto'},
 		children = WidgetUtil.collect(
-			game.header and {
-				HtmlWidgets.Div{css = {margin = 'auto'}, children = {game.header}},
-				MatchSummaryWidgets.Break{},
-			} or nil,
 			HtmlWidgets.Div{
 				classes = {'brkts-popup-header-opponent', 'brkts-popup-header-opponent-left'},
 				children = {
@@ -142,10 +136,6 @@ function CustomMatchSummary._createGame(isTeamMatch, game, gameIndex)
 		classes = {'brkts-popup-body-game'},
 		css = {padding = '4px', ['min-height'] = '24px'},
 		children = WidgetUtil.collect(
-			game.header and {
-				HtmlWidgets.Div{css = {margin = 'auto'}, children = {game.header}},
-				MatchSummaryWidgets.Break{},
-			} or nil,
 			CustomMatchSummary._displayOpponents(isTeamMatch, game.opponents[1].players, true),
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
 			MatchSummaryWidgets.GameCenter{css = {['font-size'] = '80%'}, children = 'Game ' .. gameIndex},

--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -8,16 +8,22 @@
 
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
+local FnUtil = require('Module:FnUtil')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Operator = require('Module:Operator')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local OpponentLibraries = require('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local PlayerDisplay = require('Module:Player/Display')
 
 local CustomMatchSummary = {}
 
@@ -32,39 +38,170 @@ end
 function CustomMatchSummary.createBody(match)
 	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
 
+	CustomMatchSummary._fixGameOpponents(match.games, match.opponents)
+
+	local isTeamMatch = Array.any(match.opponents, function(opponent)
+		return opponent.type == Opponent.team
+	end)
+
 	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
 		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
-		CustomMatchSummary._isSolo(match) and Array.map(match.games, CustomMatchSummary._createGame) or nil
+		Array.map(match.games, function (game, gameIndex)
+			game.header = match.extradata['subGroup' .. gameIndex .. 'header']
+			if isTeamMatch and String.startsWith(game.map or '', 'Submatch') then
+				return CustomMatchSummary._createSubmatch(game)
+			else
+				return CustomMatchSummary._createGame(isTeamMatch, game, gameIndex)
+			end
+		end)
 	)}
 end
 
----@param match MatchGroupUtilMatch
----@return boolean
-function CustomMatchSummary._isSolo(match)
-	if type(match.opponents[1]) ~= 'table' or type(match.opponents[2]) ~= 'table' then
-		return false
-	end
-	return match.opponents[1].type == Opponent.solo and match.opponents[2].type == Opponent.solo
+---@param games MatchGroupUtilGame
+---@param opponents standardOpponent[]
+function CustomMatchSummary._fixGameOpponents(games, opponents)
+	Array.forEach(games, function (game)
+		game.opponents = Array.map(game.opponents, function (opponent, opponentIndex)
+			return Table.merge(opponent, {
+				players = Array.map(game.opponents[opponentIndex].players,function (player, playerIndex)
+					if Logic.isEmpty(player) then return nil end
+					return Table.merge(opponents[opponentIndex].players[playerIndex] or {}, player)
+				end)
+			})
+		end)
+	end)
 end
 
 ---@param game MatchGroupUtilGame
----@return Widget?
-function CustomMatchSummary._createGame(game)
-	if not game.winner then return end
+---@return Widget
+function CustomMatchSummary._createSubmatch(game)
+	local opponents = game.opponents or {{}, {}}
+	local createOpponent = function(opponentIndex)
+		local players = (opponents[opponentIndex] or {}).players or {}
+		if Logic.isEmpty(players) then
+			players = Opponent.tbd(Opponent.solo).players
+		end
+		return OpponentDisplay.BlockOpponent{
+			flip = opponentIndex == 1,
+			opponent = {players = players, type = Opponent.partyTypes[math.max(#players, 1)]},
+			showLink = true,
+			overflow = 'ellipsis',
+		}
+	end
 
-	local team1Characters = Array.map((game.opponents[1] or {}).players or {}, Operator.property('character'))
-	local team2Characters = Array.map((game.opponents[2] or {}).players or {}, Operator.property('character'))
+	---@param opponentIndex any
+	---@return Html
+	local createScore = function(opponentIndex)
+		local isWinner = opponentIndex == game.winner or game.resultType == 'draw'
+		if game.resultType == 'default' then
+			return OpponentDisplay.BlockScore{
+				isWinner = isWinner,
+				scoreText = isWinner and 'W' or string.upper(game.walkover),
+			}
+		end
 
-	return MatchSummaryWidgets.Row{
-		classes = {'brkts-popup-body-game'},
-		css = {['font-size'] = '80%', padding = '4px', ['min-height'] = '24px'},
+		local score = game.resultType ~= 'np' and (game.scores or {})[opponentIndex] or nil
+		return OpponentDisplay.BlockScore{
+			isWinner = isWinner,
+			scoreText = score,
+		}
+	end
+
+	return HtmlWidgets.Div{
+		classes = {'brkts-popup-header-dev'},
+		css = {['justify-content'] = 'center', margin = 'auto'},
 		children = WidgetUtil.collect(
-			MatchSummaryWidgets.Characters{characters = team1Characters, flipped = false},
-			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
-			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
-			MatchSummaryWidgets.Characters{characters = team2Characters, flipped = true}
+			game.header and {
+				HtmlWidgets.Div{css = {margin = 'auto'}, children = {game.header}},
+				MatchSummaryWidgets.Break{},
+			} or nil,
+			HtmlWidgets.Div{
+				classes = {'brkts-popup-header-opponent', 'brkts-popup-header-opponent-left'},
+				children = {
+					createOpponent(1),
+					createScore(1):addClass('brkts-popup-header-opponent-score-left'),
+				},
+			},
+			HtmlWidgets.Div{
+				classes = {'brkts-popup-header-opponent', 'brkts-popup-header-opponent-right'},
+				children = {
+					createScore(2):addClass('brkts-popup-header-opponent-score-right'),
+					createOpponent(2),
+				},
+			}
 		)
 	}
+end
+
+---@param isTeamMatch boolean
+---@param game MatchGroupUtilGame
+---@param gameIndex number
+---@return Widget
+function CustomMatchSummary._createGame(isTeamMatch, game, gameIndex)
+	return MatchSummaryWidgets.Row{
+		classes = {'brkts-popup-body-game'},
+		css = {padding = '4px', ['min-height'] = '24px'},
+		children = WidgetUtil.collect(
+			game.header and {
+				HtmlWidgets.Div{css = {margin = 'auto'}, children = {game.header}},
+				MatchSummaryWidgets.Break{},
+			} or nil,
+			CustomMatchSummary._displayOpponents(isTeamMatch, game.opponents[1].players, true),
+			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
+			MatchSummaryWidgets.GameCenter{css = {['font-size'] = '80%', ['flex'] = 1}, children = 'Game ' .. gameIndex},
+			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
+			CustomMatchSummary._displayOpponents(isTeamMatch, game.opponents[2].players)
+		)
+	}
+end
+
+---@param isTeamMatch boolean
+---@param players table[]
+---@param flip boolean?
+---@return Html?
+function CustomMatchSummary._displayOpponents(isTeamMatch, players, flip)
+	local wrapper = mw.html.create('div'):css{
+		display = 'flex',
+		['align-items'] = 'flex-start',
+		['flex-direction'] = 'column',
+		flex = 2
+	}
+
+	if Logic.isDeepEmpty(players) then
+		return wrapper
+	end
+
+	local playerDisplays = Array.map(players, function (player)
+		local class = player.class
+		if Logic.isEmpty(class) then
+			return
+		end
+		local playerWrapper = mw.html.create('div')
+			:css('display', 'flex')
+			:css('flex-direction', flip and 'row-reverse' or 'row')
+			:css('gap', '2px')
+			:css('width', '100%')
+
+		playerWrapper:node(HtmlWidgets.Div{
+			classes = {'brkts-champion-icon'},
+			children = MatchSummaryWidgets.Character{
+				character = class,
+				showName = not isTeamMatch,
+				flipped = flip,
+			}
+		})
+
+		if isTeamMatch then
+			playerWrapper:node(PlayerDisplay.BlockPlayer{player = player, flip = flip})
+		end
+
+
+		return playerWrapper
+	end)
+
+	Array.forEach(playerDisplays, FnUtil.curry(wrapper.node, wrapper))
+
+	return wrapper
 end
 
 return CustomMatchSummary

--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -148,7 +148,7 @@ function CustomMatchSummary._createGame(isTeamMatch, game, gameIndex)
 			} or nil,
 			CustomMatchSummary._displayOpponents(isTeamMatch, game.opponents[1].players, true),
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
-			MatchSummaryWidgets.GameCenter{css = {['font-size'] = '80%', ['flex'] = 1}, children = 'Game ' .. gameIndex},
+			MatchSummaryWidgets.GameCenter{css = {['font-size'] = '80%'}, children = 'Game ' .. gameIndex},
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
 			CustomMatchSummary._displayOpponents(isTeamMatch, game.opponents[2].players)
 		)
@@ -160,17 +160,6 @@ end
 ---@param flip boolean?
 ---@return Html?
 function CustomMatchSummary._displayOpponents(isTeamMatch, players, flip)
-	local wrapper = mw.html.create('div'):css{
-		display = 'flex',
-		['align-items'] = 'flex-start',
-		['flex-direction'] = 'column',
-		flex = 2
-	}
-
-	if Logic.isDeepEmpty(players) then
-		return wrapper
-	end
-
 	local playerDisplays = Array.map(players, function (player)
 		local class = player.class
 		if Logic.isEmpty(class) then
@@ -195,13 +184,13 @@ function CustomMatchSummary._displayOpponents(isTeamMatch, players, flip)
 			playerWrapper:node(PlayerDisplay.BlockPlayer{player = player, flip = flip})
 		end
 
-
 		return playerWrapper
 	end)
 
-	Array.forEach(playerDisplays, FnUtil.curry(wrapper.node, wrapper))
-
-	return wrapper
+	return MatchSummaryWidgets.GameTeamWrapper{
+		flipped = flip,
+		children = playerDisplays
+	}
 end
 
 return CustomMatchSummary

--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -151,30 +151,26 @@ end
 ---@return Html?
 function CustomMatchSummary._displayOpponents(isTeamMatch, players, flip)
 	local playerDisplays = Array.map(players, function (player)
-		local class = player.class
-		if Logic.isEmpty(class) then
-			return
-		end
-		local playerWrapper = mw.html.create('div')
-			:css('display', 'flex')
-			:css('flex-direction', flip and 'row-reverse' or 'row')
-			:css('gap', '2px')
-			:css('width', '100%')
-
-		playerWrapper:node(HtmlWidgets.Div{
+		local char = HtmlWidgets.Div{
 			classes = {'brkts-champion-icon'},
 			children = MatchSummaryWidgets.Character{
-				character = class,
+				character = player.class,
 				showName = not isTeamMatch,
 				flipped = flip,
 			}
-		})
-
-		if isTeamMatch then
-			playerWrapper:node(PlayerDisplay.BlockPlayer{player = player, flip = flip})
-		end
-
-		return playerWrapper
+		}
+		return HtmlWidgets.Div{
+			css = {
+				display = 'flex',
+				['flex-direction'] = flip and 'row-reverse' or 'row',
+				gap = '2px',
+				width = '100%'
+			},
+			children = {
+				char,
+				isTeamMatch and PlayerDisplay.BlockPlayer{player = player, flip = flip} or nil,
+			},
+		}
 	end)
 
 	return MatchSummaryWidgets.GameTeamWrapper{


### PR DESCRIPTION
## Summary

Add support for team players in hearthstone.
The input for class was changed from `oXpY` to `oXcY` this will require a bot run to fix match2 inputs. `oXpY`will be used for player input in team games.

## How did you test this change?

/dev and [sandbox](https://liquipedia.net/hearthstone/User:LuckeLucky/sandbox)

