### PR TITLE
feat(match2): Add MVP to copypaste for HoK

### DIFF
--- a/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
@@ -39,6 +39,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.hasDate) and {
 			INDENT .. '|date=',
 			INDENT .. '|twitch= |youtube= |bilibili= |douyu= |huya=',
+			INDENT .. '|mvp=',
 			args.vod == 'series' and (INDENT .. '|vod=') or nil,
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)


### PR DESCRIPTION
## Summary
(the bracketdata error is unrelated)
![image](https://github.com/user-attachments/assets/aaa28ed9-2b80-4f14-8874-b94b5f30d901)

## How did you test this change?
LIVE, Form now adjusted to have MVP fields which is missing in Bracket Paste but is exist in Matchlist Paste