### PR TITLE
feat(infobox): make the Campaign ID dynamic for the Stay22 accommodation button

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local Game = require('Module:Game')
+local Info = require('Module:Info')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -34,7 +35,7 @@ local TextSanitizer = Lua.import('Module:TextSanitizer')
 
 local INVALID_TIER_WARNING = '${tierString} is not a known Liquipedia ${tierMode}'
 local VENUE_DESCRIPTION = '<br><small><small>(${desc})</small></small>'
-local STAY22_LINK = 'https://www.stay22.com/allez/roam?aid=liquipedia&campaign=infobox'..
+local STAY22_LINK = 'https://www.stay22.com/allez/roam?aid=liquipedia&campaign=${wiki}_${page}'..
 	'&address=${address}&checkin=${checkin}&checkout=${checkout}'
 
 local Widgets = require('Module:Widget/All')
@@ -278,6 +279,8 @@ function League:createInfobox()
 
 				local function buildStay22Link(address, checkin, checkout)
 					return String.interpolate(STAY22_LINK, {
+						wiki = Info.wikiName,
+						page = self.data.name,
 						address = address,
 						checkin = checkin,
 						checkout = checkout,


### PR DESCRIPTION
## Summary
In order to segregate click performance of the button across different events for business research purposes, Stay22 suggested using a separate campaign ID for each event the button is displayed in.

## How did you test this change?
/dev