### PR TITLE
feat(infobox): show the stay22 accommodation button on events with multiple venues in same city

### DIFF
--- a/components/infobox/commons/infobox_league.lua
+++ b/components/infobox/commons/infobox_league.lua
@@ -231,8 +231,8 @@ function League:createInfobox()
 					return
 				end
 				local locations = Locale.formatLocations(args)
-				-- If more than one venue, don't show the accommodation section, as it is unclear which one the link is for
-				if locations.venue2 or locations.city2 then
+				-- If more than one city, don't show the accommodation section, as it is unclear which one the link is for
+				if locations.city2 then
 					return
 				end
 				-- Must have a venue or a city to show the accommodation section
@@ -256,7 +256,8 @@ function League:createInfobox()
 				end
 
 				local addressParts = {}
-				table.insert(addressParts, locations.venue1)
+				-- Only add the venue if there is exactly one venue, otherwise we'll only use the city + country
+				table.insert(addressParts, not locations.venue2 and locations.venue1 or nil)
 				table.insert(addressParts, locations.city1)
 				table.insert(addressParts, Flags.CountryName(locations.country1 or locations.region1))
 


### PR DESCRIPTION
## Summary
Currently the accommodation button is set to only display in events with one single venue. We propose to also display it for events with multiple venues in the same city, adjusting the URL to only account for city + country input, disregarding the venue input.

## How did you test this change?
/dev