### PR TITLE
fix(match2): missing nil catch, missing passalong on sc and sg

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -146,7 +146,7 @@ function StarcraftMatchGroupUtil.computeGameOpponents(game, matchOpponents)
 
 	return Array.map(game.opponents, function(mapOpponent, opponentIndex)
 		local mode = modeParts[opponentIndex]
-		local players = Array.map(mapOpponent.players, function(player, playerIndex)
+		local players = Array.map(mapOpponent.players or {}, function(player, playerIndex)
 			if Logic.isEmpty(player) then return end
 			local matchPlayer = (matchOpponents[opponentIndex].players or {})[playerIndex] or {}
 			return Table.merge({displayName = 'TBD'}, matchPlayer, {

--- a/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
+++ b/components/match2/wikis/starcraft2/legacy/match_maps_team_legacy.lua
@@ -64,7 +64,7 @@ function MatchMapsTeamLegacy._handleMaps()
 	mapWinner = _match2Args[prefix .. 'win']
 
 	if map or mapWinner then
-		_match2Args['map' .. gameIndex] = MatchMapsTeamLegacy._processSingleMap(prefix, map, mapWinner)
+		_match2Args['map' .. gameIndex] = MatchMapsTeamLegacy._processSingleMap(prefix, map, mapWinner, gameIndex)
 	end
 end
 

--- a/components/match2/wikis/warcraft/match_group_util_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_util_custom.lua
@@ -141,7 +141,7 @@ end
 ---@return WarcraftMatchGroupUtilGameOpponent[]
 function CustomMatchGroupUtil.computeGameOpponents(game, matchOpponents)
 	return Array.map(game.opponents, function(mapOpponent, opponentIndex)
-		local players = Array.map(mapOpponent.players, function(player, playerIndex)
+		local players = Array.map(mapOpponent.players or {}, function(player, playerIndex)
 			if Logic.isEmpty(player) then return end
 			local matchPlayer = (matchOpponents[opponentIndex].players or {})[playerIndex] or {}
 			return Table.merge({displayName = 'TBD'}, matchPlayer, {


### PR DESCRIPTION
## Summary
- Add a nil catch in sc(2) & stoirmgate matchGroupUtil customs
- pass along game index in an edge case on sc2 team match maps legacy wrapper

## How did you test this change?
live