### PR TITLE
feat(match2): add SAP logo to LoL's match pages

### DIFF
--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -6,9 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
--- todo's:
--- Team logo's are currently 50x50 => need to be 80x80. Already made preparations for this in the css.
-
 -- luacheck: ignore
 return {
 	header =

--- a/components/match2/wikis/leagueoflegends/match_page_template.lua
+++ b/components/match2/wikis/leagueoflegends/match_page_template.lua
@@ -11,6 +11,7 @@ return {
 	header =
 		[=[
 			<div class="match-bm-lol-match-header">
+				<div class="match-bm-match-header-powered-by">[[File:DataProvidedSAP.svg|link=]]</div>
 				<div class="match-bm-lol-match-header-overview">
 					<div class="match-bm-lol-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-lol-match-header-team-long">{{#page}}[[{{page}}|{{name}}]]{{/page}}</div><div class="match-bm-lol-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div>{{#seriesDots}} {{.}}{{/seriesDots}}</div>{{/opponents.1}}</div>
 					<div class="match-bm-lol-match-header-result">{{#isBestOfOne}}{{#games.1.apiInfo}}{{team1.scoreDisplay}}&ndash;{{team2.scoreDisplay}}{{/games.1.apiInfo}}{{/isBestOfOne}}{{^isBestOfOne}}{{opponents.1.score}}&ndash;{{opponents.2.score}}{{/isBestOfOne}}</div>


### PR DESCRIPTION
## Summary
Business asks us to add it to all existing LOL pages as they are all powered by SAP.

## How did you test this change?
dev
![image](https://github.com/user-attachments/assets/f1ec74ef-94ca-4038-992e-10ca82773331)
