### PR TITLE
fix(match2): extradata for 1v1 maps in team matches incomplete on craft wikis

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -388,8 +388,8 @@ function MapFunctions.getExtraData(match, map, opponents)
 
 	---@type table[]
 	local players = {
-		Array.extractValues(map.opponents[1].players)[1],
-		Array.extractValues(map.opponents[2].players)[1],
+		Array.filter(Array.extractValues(map.opponents[1].players or {}), Logic.isNotEmpty)[1],
+		Array.filter(Array.extractValues(map.opponents[2].players or {}), Logic.isNotEmpty)[1],
 	}
 
 	extradata.opponent1 = players[1].player

--- a/components/match2/wikis/stormgate/match_group_input_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_input_custom.lua
@@ -324,8 +324,8 @@ function MapFunctions.getExtraData(match, map, opponents)
 
 	---@type table[]
 	local players = {
-		Array.extractValues(map.opponents[1].players)[1],
-		Array.extractValues(map.opponents[2].players)[1],
+		Array.filter(Array.extractValues(map.opponents[1].players or {}), Logic.isNotEmpty)[1],
+		Array.filter(Array.extractValues(map.opponents[2].players or {}), Logic.isNotEmpty)[1],
 	}
 
 	extradata.opponent1 = players[1].player

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -356,8 +356,8 @@ function MapFunctions.getExtraData(match, map, opponents)
 
 	---@type table[]
 	local players = {
-		Array.extractValues(map.opponents[1].players)[1],
-		Array.extractValues(map.opponents[2].players)[1],
+		Array.filter(Array.extractValues(map.opponents[1].players or {}), Logic.isNotEmpty)[1],
+		Array.filter(Array.extractValues(map.opponents[2].players or {}), Logic.isNotEmpty)[1],
 	}
 
 	extradata.opponent1 = players[1].player


### PR DESCRIPTION
## Summary
in team matches not always the first player is set
hence throw an array.filter on the players array to get the set player

## How did you test this change?
dev to live