### PR TITLE
feat(match2): add handling for wikis that have both normal and br matchlists/brackets

### DIFF
--- a/components/match2/commons/brkts_wiki_specific_base.lua
+++ b/components/match2/commons/brkts_wiki_specific_base.lua
@@ -52,8 +52,7 @@ Called from MatchGroup
 -- @returns module
 ]]
 function WikiSpecificBase.getMatchGroupContainer(matchGroupType)
-	-- TODO Add a check if opponent count is > 2
-	if Lua.moduleExists('Module:GameSummary') then
+	if matchGroupType == 'horizontallist' then
 		local Horizontallist = Lua.import('Module:MatchGroup/Display/Horizontallist')
 		return Horizontallist.BracketContainer
 	elseif matchGroupType == 'matchlist' then

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -37,8 +37,9 @@ function MatchGroup.MatchList(args)
 
 	local matchlistNode
 	if options.show then
+		local matchGroupType = #matches[1].match2opponents > 2 and 'horizontallist' or 'matchlist'
 		local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist')
-		local MatchlistContainer = WikiSpecific.getMatchGroupContainer('matchlist')
+		local MatchlistContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
 		matchlistNode = MatchlistContainer({
 			bracketId = options.bracketId,
 			config = MatchlistDisplay.configFromArgs(args),
@@ -62,8 +63,9 @@ function MatchGroup.Bracket(args)
 
 	local bracketNode
 	if options.show then
+		local matchGroupType = #matches[1].match2opponents > 2 and 'horizontallist' or 'bracket'
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
-		local BracketContainer = WikiSpecific.getMatchGroupContainer('bracket')
+		local BracketContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
 		bracketNode = BracketContainer({
 			bracketId = options.bracketId,
 			config = BracketDisplay.configFromArgs(args),
@@ -146,6 +148,7 @@ function MatchGroup.MatchGroupById(args)
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 		config = BracketDisplay.configFromArgs(args)
 	end
+	local matchGroupDisplayType = #matches[1].opponents > 2 and 'horizontallist' or matchGroupType
 
 	if Logic.readBool(args.suppressDetails) then
 		config.matchHasDetails = function() return false end
@@ -153,7 +156,7 @@ function MatchGroup.MatchGroupById(args)
 
 	Logic.wrapTryOrLog(MatchGroupInput.applyOverrideArgs)(matches, args)
 
-	local MatchGroupContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
+	local MatchGroupContainer = WikiSpecific.getMatchGroupContainer(matchGroupDisplayType)
 	return MatchGroupContainer({
 		bracketId = bracketId,
 		config = config,

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -37,8 +37,7 @@ function MatchGroup.MatchList(args)
 
 	local matchlistNode
 	if options.show then
-		local matchGroupType = options.forcedMatchGroupType or
-			#matches[1].match2opponents > 2 and 'horizontallist' or 'matchlist'
+		local matchGroupType = MatchGroupBase.getMatchGroupDisplayType(matches, 'matchlist', options.forcedMatchGroupType)
 		local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist')
 		local MatchlistContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
 		matchlistNode = MatchlistContainer({
@@ -64,8 +63,7 @@ function MatchGroup.Bracket(args)
 
 	local bracketNode
 	if options.show then
-		local matchGroupType = options.forcedMatchGroupType or
-			#matches[1].match2opponents > 2 and 'horizontallist' or 'bracket'
+		local matchGroupType = MatchGroupBase.getMatchGroupDisplayType(matches, 'bracket', options.forcedMatchGroupType)
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 		local BracketContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
 		bracketNode = BracketContainer({
@@ -150,15 +148,6 @@ function MatchGroup.MatchGroupById(args)
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 		config = BracketDisplay.configFromArgs(args)
 	end
-	local inputtedMatchGroupType = args.matchGroupType
-	local matchGroupDisplayType
-	if inputtedMatchGroupType then
-		assert(inputtedMatchGroupType == matchGroupType or inputtedMatchGroupType == 'horizontallist',
-			'Invalid "|matchGroupType=" specified'
-		)
-		matchGroupDisplayType = inputtedMatchGroupType
-	end
-	matchGroupDisplayType = matchGroupDisplayType or #matches[1].opponents > 2 and 'horizontallist' or matchGroupType
 
 	if Logic.readBool(args.suppressDetails) then
 		config.matchHasDetails = function() return false end
@@ -166,6 +155,7 @@ function MatchGroup.MatchGroupById(args)
 
 	Logic.wrapTryOrLog(MatchGroupInput.applyOverrideArgs)(matches, args)
 
+	local matchGroupDisplayType = MatchGroupBase.getMatchGroupDisplayType(matches, matchGroupType, args.matchGroupType)
 	local MatchGroupContainer = WikiSpecific.getMatchGroupContainer(matchGroupDisplayType)
 	return MatchGroupContainer({
 		bracketId = bracketId,
@@ -176,7 +166,7 @@ end
 -- Displays a singleMatch specified by a bracket ID and matchID.
 ---@param args table
 ---@return Html
-function MatchGrop.MatchByMatchId(args)
+function MatchGroup.MatchByMatchId(args)
 	local bracketId = args.id
 	local matchId = args.matchid
 	assert(bracketId, 'Missing bracket ID')

--- a/components/match2/commons/match_group.lua
+++ b/components/match2/commons/match_group.lua
@@ -37,7 +37,8 @@ function MatchGroup.MatchList(args)
 
 	local matchlistNode
 	if options.show then
-		local matchGroupType = #matches[1].match2opponents > 2 and 'horizontallist' or 'matchlist'
+		local matchGroupType = options.forcedMatchGroupType or
+			#matches[1].match2opponents > 2 and 'horizontallist' or 'matchlist'
 		local MatchlistDisplay = Lua.import('Module:MatchGroup/Display/Matchlist')
 		local MatchlistContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
 		matchlistNode = MatchlistContainer({
@@ -63,7 +64,8 @@ function MatchGroup.Bracket(args)
 
 	local bracketNode
 	if options.show then
-		local matchGroupType = #matches[1].match2opponents > 2 and 'horizontallist' or 'bracket'
+		local matchGroupType = options.forcedMatchGroupType or
+			#matches[1].match2opponents > 2 and 'horizontallist' or 'bracket'
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 		local BracketContainer = WikiSpecific.getMatchGroupContainer(matchGroupType)
 		bracketNode = BracketContainer({
@@ -148,7 +150,15 @@ function MatchGroup.MatchGroupById(args)
 		local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 		config = BracketDisplay.configFromArgs(args)
 	end
-	local matchGroupDisplayType = #matches[1].opponents > 2 and 'horizontallist' or matchGroupType
+	local inputtedMatchGroupType = args.matchGroupType
+	local matchGroupDisplayType
+	if inputtedMatchGroupType then
+		assert(inputtedMatchGroupType == matchGroupType or inputtedMatchGroupType == 'horizontallist',
+			'Invalid "|matchGroupType=" specified'
+		)
+		matchGroupDisplayType = inputtedMatchGroupType
+	end
+	matchGroupDisplayType = matchGroupDisplayType or #matches[1].opponents > 2 and 'horizontallist' or matchGroupType
 
 	if Logic.readBool(args.suppressDetails) then
 		config.matchHasDetails = function() return false end
@@ -166,7 +176,7 @@ end
 -- Displays a singleMatch specified by a bracket ID and matchID.
 ---@param args table
 ---@return Html
-function MatchGroup.MatchByMatchId(args)
+function MatchGrop.MatchByMatchId(args)
 	local bracketId = args.id
 	local matchId = args.matchid
 	assert(bracketId, 'Missing bracket ID')

--- a/components/match2/commons/match_group_base.lua
+++ b/components/match2/commons/match_group_base.lua
@@ -36,7 +36,12 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 		storeMatch1 = Logic.nilOr(Logic.readBoolOrNil(args.storeMatch1), store),
 		storeMatch2 = Logic.nilOr(Logic.readBoolOrNil(args.storeMatch2), store),
 		storePageVar = Logic.nilOr(Logic.readBoolOrNil(args.storePageVar), show),
+
 	}
+
+	if args.matchGroupType and (args.matchGroupType == matchGroupType or matchGroupType == 'horizontallist') then
+		options.forcedMatchGroupType = args.matchGroupType
+	end
 
 	local warnings = {}
 

--- a/components/match2/commons/match_group_display_horizontallist.lua
+++ b/components/match2/commons/match_group_display_horizontallist.lua
@@ -35,11 +35,11 @@ local PHASE_ICONS = {
 
 ---@class HorizontallistProps
 ---@field bracketId string
----@field config HorizontallistConfigOptions?
+---@field config HorizontallistConfigOptions|BracketConfigOptions|MatchlistConfigOptions?
 
 ---@class HorizontallistBracket
 ---@field bracket MatchGroupUtilMatchGroup
----@field config HorizontallistConfigOptions?
+---@field config HorizontallistConfigOptions|BracketConfigOptions|MatchlistConfigOptions?
 ---@field bracketId string
 
 ---@param args table
@@ -112,6 +112,7 @@ function HorizontallistDisplay.Bracket(props)
 			:node(matchNode)
 end
 
+---@param bracketId string
 ---@param bracket [string, MatchGroupUtilBracketBracketData][]
 ---@return integer
 function HorizontallistDisplay.findMatchClosestInTime(bracketId, bracket)

--- a/standard/info/wikis/apexlegends/info.lua
+++ b/standard/info/wikis/apexlegends/info.lua
@@ -34,6 +34,7 @@ return {
 		},
 		match2 = {
 			status = 1,
+			defaultDisplayMode = 'horizontallist',
 		},
 	},
 	defaultRoundPrecision = 0,

--- a/standard/info/wikis/freefire/info.lua
+++ b/standard/info/wikis/freefire/info.lua
@@ -34,6 +34,7 @@ return {
 		},
 		match2 = {
 			status = 0,
+			defaultDisplayMode = 'horizontallist',
 		},
 		transfers = {
 			showTeamName = true,

--- a/standard/info/wikis/pubg/info.lua
+++ b/standard/info/wikis/pubg/info.lua
@@ -34,6 +34,7 @@ return {
 		},
 		match2 = {
 			status = 1,
+			defaultDisplayMode = 'horizontallist',
 		},
 	},
 	defaultRoundPrecision = 0,

--- a/standard/info/wikis/pubgmobile/info.lua
+++ b/standard/info/wikis/pubgmobile/info.lua
@@ -73,6 +73,7 @@ return {
 		},
 		match2 = {
 			status = 1,
+			defaultDisplayMode = 'horizontallist',
 		},
 		transfers = {
 			showTeamName = true,

--- a/standard/info/wikis/starcraft/info.lua
+++ b/standard/info/wikis/starcraft/info.lua
@@ -36,6 +36,7 @@ return {
 			status = 1,
 			matchWidthMobile = 120,
 			matchWidth = 170,
+			defaultDisplayMode = 'default', -- kick after preping sc2 matchsummary etc
 		},
 	},
 	maximumNumberOfPlayersInPlacements = 35,

--- a/standard/info/wikis/starcraft2/info.lua
+++ b/standard/info/wikis/starcraft2/info.lua
@@ -62,6 +62,7 @@ return {
 			status = 2,
 			matchWidthMobile = 110,
 			matchWidth = 150,
+			defaultDisplayMode = 'default', -- kick after preping sc2 matchsummary etc
 		},
 	},
 	opponentLibrary = 'Opponent/Starcraft',


### PR DESCRIPTION
## Summary
adds support to be able to use both normal and horizontallist display
- supports specifying a default in module:info (as per request from yesterdays module sync)
- supports overwriting the display via an input param (as per request from yesterdays module sync)
- if none of the 2 options above are used it will determine which to use based on the number of opponents present in the matches (if any match has >2 opponents it assumes to use the BR display)

## How did you test this change?
to be done