### PR TITLE
fix(match2): Don't try to build class icon if is empty on hearthstone

### DIFF
--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -151,14 +151,14 @@ end
 ---@return Html?
 function CustomMatchSummary._displayOpponents(isTeamMatch, players, flip)
 	local playerDisplays = Array.map(players, function (player)
-		local char = HtmlWidgets.Div{
+		local char = player.class and HtmlWidgets.Div{
 			classes = {'brkts-champion-icon'},
 			children = MatchSummaryWidgets.Character{
 				character = player.class,
 				showName = not isTeamMatch,
 				flipped = flip,
 			}
-		}
+		} or nil
 		return HtmlWidgets.Div{
 			css = {
 				display = 'flex',

--- a/components/match2/wikis/hearthstone/match_summary.lua
+++ b/components/match2/wikis/hearthstone/match_summary.lua
@@ -151,7 +151,7 @@ end
 ---@return Html?
 function CustomMatchSummary._displayOpponents(isTeamMatch, players, flip)
 	local playerDisplays = Array.map(players, function (player)
-		local char = player.class and HtmlWidgets.Div{
+		local char = Logic.isNotEmpty(player.class) and HtmlWidgets.Div{
 			classes = {'brkts-champion-icon'},
 			children = MatchSummaryWidgets.Character{
 				character = player.class,


### PR DESCRIPTION
## Summary

If player class is empty don't build the class icon.

## How did you test this change?

/dev
