### PR TITLE
feat(match2): always set score on BR/FFA matches, even on upcoming matches

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -1301,9 +1301,7 @@ function MatchGroupInputUtil.standardProcessFfaMatch(match, Parser, mapProps)
 
 	local games = Parser.extractMaps(match, opponents, settings.score)
 
-	local autoScoreFunction = Parser.calculateMatchScore and MatchGroupInputUtil.canUseAutoScore(match, games)
-		and Parser.calculateMatchScore(opponents, games)
-		or nil
+	local autoScoreFunction = Parser.calculateMatchScore and Parser.calculateMatchScore(opponents, games) or nil
 	Array.forEach(opponents, function(opponent, opponentIndex)
 		opponent.extradata = opponent.extradata or {}
 		opponent.extradata.startingpoints = tonumber(opponent.startingpoints)


### PR DESCRIPTION
## Summary
Always use AutoScore if available. Mainly so that bonus/penelties are shown before the first game starts.

## How did you test this change?
/dev