### PR TITLE
chore: Update match2 status on some wikis

### DIFF
--- a/standard/info/wikis/ageofempires/info.lua
+++ b/standard/info/wikis/ageofempires/info.lua
@@ -100,7 +100,7 @@ return {
 			allowManual = true,
 		},
 		match2 = {
-			status = 1,
+			status = 2,
 			matchWidthMobile = 110,
 		},
 	},

--- a/standard/info/wikis/hearthstone/info.lua
+++ b/standard/info/wikis/hearthstone/info.lua
@@ -33,7 +33,7 @@ return {
 			allowManual = true,
 		},
 		match2 = {
-			status = 1,
+			status = 2,
 		},
 	},
 }

--- a/standard/info/wikis/smite/info.lua
+++ b/standard/info/wikis/smite/info.lua
@@ -46,7 +46,7 @@ return {
 			allowManual = true,
 		},
 		match2 = {
-			status = 0,
+			status = 2,
 		},
 		transfers = {
 			showTeamName = true,


### PR DESCRIPTION
## Summary

All of this wikis have match2 or match2 and wrappers in m1 brackets/matchlists (this doesn't include ffa stuff)

