### PR TITLE
fix(match2): alignement of column content on BR

### DIFF
--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -160,7 +160,7 @@ Author(s): Elysienna
 		&-grouped {
 			display: flex;
 			align-items: center;
-			justify-content: center;
+			justify-content: inherit;
 			flex-basis: 100%;
 		}
 


### PR DESCRIPTION
## Summary
When the components were standardized between game overview and match/game summary, one css ended up incorrectly. This meant that everything was center-aligned, instead of the correct alignement.

## How did you test this change?

dev tools