### PR TITLE
feat(match2): Support for Marvel Rivals

### DIFF
--- a/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
@@ -26,12 +26,12 @@ local INDENT = WikiCopyPaste.Indent
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local showScore = Logic.nilOr(Logic.readBool(args.score), bestof == 0)
+	local showScore = Logic.readBool(args.score), bestof == 0
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
 	local lines = Array.extendWith({},
 		'{{Match',
-		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
+		Logic.readBool(args.isFinished) and (INDENT .. '|finished=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)

--- a/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
@@ -26,7 +26,7 @@ local INDENT = WikiCopyPaste.Indent
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
-	local showScore = Logic.readBool(args.score), bestof == 0
+	local showScore = bestof == 0
 	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
 
 	local lines = Array.extendWith({},

--- a/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
@@ -31,7 +31,6 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extendWith({},
 		'{{Match',
-		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
@@ -39,7 +38,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
 		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
-			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'
 	)

--- a/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
@@ -31,7 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extendWith({},
 		'{{Match',
-		Logic.readBool(args.isFinished) and (INDENT .. '|finished=') or nil,
+		showScore and (INDENT .. '|finished=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)

--- a/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/marvelrivals/get_match_group_copy_paste_wiki.lua
@@ -1,0 +1,50 @@
+---
+-- @Liquipedia
+-- wiki=marvelrivals
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class MarvelRivalsMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.nilOr(Logic.readBool(args.score), bestof == 0)
+	local opponent = WikiCopyPaste.getOpponent(mode, showScore)
+
+	local lines = Array.extendWith({},
+		'{{Match',
+		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
+		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
+		INDENT .. '|date=',
+		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
+		end),
+		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
+		end) or nil,
+		INDENT .. '}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+return WikiCopyPaste

--- a/components/match2/wikis/marvelrivals/match_group_input_custom.lua
+++ b/components/match2/wikis/marvelrivals/match_group_input_custom.lua
@@ -1,0 +1,89 @@
+---
+-- @Liquipedia
+-- wiki=marvelrivals
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Variables = require('Module:Variables')
+
+local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
+
+local DEFAULT_BESTOF = 3
+
+local CustomMatchGroupInput = {}
+local MatchFunctions = {}
+local MapFunctions = {}
+
+MatchFunctions.DEFAULT_MODE = 'team'
+
+---@param match table
+---@param options table?
+---@return table
+function CustomMatchGroupInput.processMatch(match, options)
+	return MatchGroupInputUtil.standardProcessMatch(match, MatchFunctions)
+end
+
+--
+-- match related functions
+--
+---@param match table
+---@param opponents table[]
+---@return table[]
+function MatchFunctions.extractMaps(match, opponents)
+	return MatchGroupInputUtil.standardProcessMaps(match, opponents, MapFunctions)
+end
+
+---@param games table[]
+---@return table[]
+function MatchFunctions.removeUnsetMaps(games)
+	return Array.filter(games, function(map)
+		return map.map ~= nil
+	end)
+end
+
+---@param maps table[]
+---@return fun(opponentIndex: integer): integer?
+function MatchFunctions.calculateMatchScore(maps)
+	return function(opponentIndex)
+		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
+	end
+end
+
+---@param bestofInput string|integer?
+---@return integer?
+function MatchFunctions.getBestOf(bestofInput)
+	local bestof = tonumber(Logic.emptyOr(bestofInput, Variables.varDefault('bestof')))
+	Variables.varDefine('bestof', bestof)
+	return bestof or DEFAULT_BESTOF
+end
+
+---@param match table
+---@param games table[]
+---@param opponents table[]
+---@return table
+function MatchFunctions.getExtraData(match, games, opponents)
+	return {
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
+	}
+end
+
+--
+-- map related functions
+--
+
+---@param match table
+---@param map table
+---@param opponents table[]
+---@return table
+function MapFunctions.getExtraData(match, map, opponents)
+	return {
+		comment = map.comment,
+	}
+end
+
+return CustomMatchGroupInput

--- a/components/match2/wikis/marvelrivals/match_group_input_custom.lua
+++ b/components/match2/wikis/marvelrivals/match_group_input_custom.lua
@@ -20,6 +20,7 @@ local MatchFunctions = {}
 local MapFunctions = {}
 
 MatchFunctions.DEFAULT_MODE = 'team'
+MatchFunctions.getBestOf = MatchGroupInputUtil.getBestOf
 
 ---@param match table
 ---@param options table?
@@ -38,38 +39,12 @@ function MatchFunctions.extractMaps(match, opponents)
 	return MatchGroupInputUtil.standardProcessMaps(match, opponents, MapFunctions)
 end
 
----@param games table[]
----@return table[]
-function MatchFunctions.removeUnsetMaps(games)
-	return Array.filter(games, function(map)
-		return map.map ~= nil
-	end)
-end
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer?
 function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param bestofInput string|integer?
----@return integer?
-function MatchFunctions.getBestOf(bestofInput)
-	local bestof = tonumber(Logic.emptyOr(bestofInput, Variables.varDefault('bestof')))
-	Variables.varDefine('bestof', bestof)
-	return bestof or DEFAULT_BESTOF
-end
-
----@param match table
----@param games table[]
----@param opponents table[]
----@return table
-function MatchFunctions.getExtraData(match, games, opponents)
-	return {
-		mvp = MatchGroupInputUtil.readMvp(match, opponents),
-	}
 end
 
 --

--- a/components/match2/wikis/marvelrivals/match_group_input_custom.lua
+++ b/components/match2/wikis/marvelrivals/match_group_input_custom.lua
@@ -11,11 +11,11 @@ local Lua = require('Module:Lua')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
 local CustomMatchGroupInput = {}
-local MatchFunctions = {}
+local MatchFunctions = {
+	DEFAULT_MODE = 'team',
+	getBestOf = MatchGroupInputUtil.getBestOf,
+}
 local MapFunctions = {}
-
-MatchFunctions.DEFAULT_MODE = 'team'
-MatchFunctions.getBestOf = MatchGroupInputUtil.getBestOf
 
 ---@param match table
 ---@param options table?

--- a/components/match2/wikis/marvelrivals/match_group_input_custom.lua
+++ b/components/match2/wikis/marvelrivals/match_group_input_custom.lua
@@ -6,14 +6,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Variables = require('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-
-local DEFAULT_BESTOF = 3
 
 local CustomMatchGroupInput = {}
 local MatchFunctions = {}

--- a/components/match2/wikis/marvelrivals/match_summary.lua
+++ b/components/match2/wikis/marvelrivals/match_summary.lua
@@ -1,0 +1,51 @@
+---
+-- @Liquipedia
+-- wiki=marvelrivals
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
+local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local CustomMatchSummary = {}
+
+---@param args table
+---@return Html
+function CustomMatchSummary.getByMatchId(args)
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
+end
+
+---@param date string
+---@param game MatchGroupUtilGame
+---@param gameIndex integer
+---@return Widget?
+function CustomMatchSummary.createGame(date, game, gameIndex)
+	if not game.map then
+		return
+	end
+
+	local function makeTeamSection(opponentIndex)
+		return {
+			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = opponentIndex},
+			DisplayHelper.MapScore(game.scores[opponentIndex], opponentIndex, game.resultType, game.walkover, game.winner)
+		}
+	end
+
+	return MatchSummaryWidgets.Row{
+		classes = {'brkts-popup-body-game'},
+		children = WidgetUtil.collect(
+			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
+			MatchSummaryWidgets.GameCenter{children = DisplayHelper.Map(game)},
+			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(2), flipped = true},
+			MatchSummaryWidgets.GameComment{children = game.comment}
+		)
+	}
+end
+
+return CustomMatchSummary

--- a/standard/info/wikis/marvelrivals/info.lua
+++ b/standard/info/wikis/marvelrivals/info.lua
@@ -12,7 +12,7 @@ return {
 	name = 'Marvel Rivals',
 	defaultGame = 'Marvel Rivals',
 	games = {
-		['Marvel Rivals'] = {
+		marvelrivals = {
 			abbreviation = 'Marvel Rivals',
 			name = 'Marvel Rivals',
 			link = 'Marvel Rivals',
@@ -34,6 +34,7 @@ return {
 		},
 		match2 = {
 			status = 0,
+			matchWidth = 180,
 		},
 	},
 	defaultRoundPrecision = 0,

--- a/standard/info/wikis/marvelrivals/info.lua
+++ b/standard/info/wikis/marvelrivals/info.lua
@@ -1,0 +1,40 @@
+---
+-- @Liquipedia
+-- wiki=marvelrivals
+-- page=Module:Info
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	startYear = 2024,
+	wikiName = 'marvelrivals',
+	name = 'Marvel Rivals',
+	defaultGame = 'Marvel Rivals',
+	games = {
+		['Marvel Rivals'] = {
+			abbreviation = 'Marvel Rivals',
+			name = 'Marvel Rivals',
+			link = 'Marvel Rivals',
+			logo = {
+				darkMode = 'Marvel Rivals darkmode.png',
+				lightMode = 'Marvel Rivals lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Marvel Rivals darkmode.png',
+				lightMode = 'Marvel Rivals lightmode.png',
+			},
+		},
+	},
+	config = {
+		squads = {
+			hasPosition = true,
+			hasSpecialTeam = false,
+			allowManual = false,
+		},
+		match2 = {
+			status = 0,
+		},
+	},
+	defaultRoundPrecision = 0,
+}

--- a/standard/info/wikis/marvelrivals/info.lua
+++ b/standard/info/wikis/marvelrivals/info.lua
@@ -33,7 +33,7 @@ return {
 			allowManual = false,
 		},
 		match2 = {
-			status = 0,
+			status = 2,
 			matchWidth = 180,
 		},
 	},


### PR DESCRIPTION
## Summary
New Wiki: Marvel Rivals

the game is basically Overwatch but Marvel, however the Match2 port here starts with clean COD wiki port with no changes outside removing Mode icon calls for now, because the game has multiple modes, but doesnt have mode icons in the game. (Fortunately no one map is played on two modes)

**Includes Info module as well**

## How did you test this change?
https://liquipedia.net/marvelrivals/User:Hesketh2/Match2_Test
