### PR TITLE
feat(Infobox): add Character for Marvel Rivals

### DIFF
--- a/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
+++ b/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
@@ -16,7 +16,6 @@ local Character = Lua.import('Module:Infobox/Character')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
-local Title = Widgets.Title
 
 ---@class MarvelRivalsHeroInfobox: CharacterInfobox
 local CustomHero = Class.new(Character)

--- a/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
+++ b/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
@@ -1,0 +1,77 @@
+---
+-- @Liquipedia
+-- wiki=marvelrivals
+-- page=Module:Infobox/Character/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+
+local Lua = require('Module:Lua')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Character = Lua.import('Module:Infobox/Character')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+
+---@class MarvelRivalsHeroInfobox: CharacterInfobox
+local CustomHero = Class.new(Character)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomHero.run(frame)
+	local character = CustomHero(frame)
+	character:setWidgetInjector(CustomInjector(character))
+	character.args.informationType = 'Hero'
+
+	return character:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+	if id == 'custom' then
+		Array.appendWith(
+			widgets,
+			Cell{name = 'Age', content = {args.age}},
+			Cell{name = 'Affiliation', content = {args.affiliation}},
+			Cell{name = 'Voice Actor(s)', content = {args.voiceactor}}
+		)
+
+		Array.appendWith(
+			widgets,
+			Title{children = 'Gameplay Information'},
+			Cell{name = 'Health', content = {args.health}},
+			Cell{name = 'Movespeed', content = {args.movespeed}},
+			Cell{name = 'Difficulty', content = {args.difficulty}}
+		)
+		return widgets
+	end
+
+	return widgets
+end
+
+---@param lpdbData table
+---@param args table
+function CustomHero:addToLpdb(lpdbData, args)
+	lpdbData.information = args.name
+	lpdbData.image = args.image
+	lpdbData.date = args.released
+	lpdbData.extradata = {
+		name = args.name,
+		health = args.health,
+		movespeed = args.movespeed,
+		dificulty = args.difficulty,
+	}
+
+	return lpdbData
+end
+
+return CustomHero

--- a/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
+++ b/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
@@ -58,7 +58,6 @@ function CustomHero:addToLpdb(lpdbData, args)
 	lpdbData.image = args.image
 	lpdbData.date = args.released
 	lpdbData.extradata = {
-		name = args.name,
 		health = args.health,
 		movespeed = args.movespeed,
 		dificulty = args.difficulty,

--- a/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
+++ b/components/infobox/wikis/marvelrivals/infobox_character_custom.lua
@@ -40,17 +40,11 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Age', content = {args.age}},
-			Cell{name = 'Affiliation', content = {args.affiliation}},
-			Cell{name = 'Voice Actor(s)', content = {args.voiceactor}}
-		)
-
-		Array.appendWith(
-			widgets,
-			Title{children = 'Gameplay Information'},
 			Cell{name = 'Health', content = {args.health}},
 			Cell{name = 'Movespeed', content = {args.movespeed}},
-			Cell{name = 'Difficulty', content = {args.difficulty}}
+			Cell{name = 'Difficulty', content = {args.difficulty}},
+			Cell{name = 'Affiliation', content = {args.affiliation}},
+			Cell{name = 'Voice Actor(s)', content = {args.voiceactor}}
 		)
 		return widgets
 	end


### PR DESCRIPTION
## Summary
New Wiki, Character Infobox

Used Deadlock's character infobox as basis with some parameters to fit the details provided inside the game

## How did you test this change?
https://liquipedia.net/marvelrivals/Iron_Man 

Updated
![image](https://github.com/user-attachments/assets/0ce34caf-00e4-41ec-a86d-40e97836df03)

