### PR TITLE
feat(match2) Allow to disregard transfer dates for players of team

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -104,6 +104,7 @@ local contentLanguage = mw.getContentLanguage()
 ---@field maxNumPlayers integer?
 ---@field resolveRedirect boolean?
 ---@field pagifyTeamNames boolean?
+---@field dontCheckTransferDates boolean?
 
 ---@class MatchGroupInputSubstituteInformation
 ---@field substitute standardPlayer
@@ -466,7 +467,7 @@ function MatchGroupInputUtil.readPlayersOfTeam(teamName, manualPlayersInput, opt
 	while name do
 		if options.maxNumPlayers and (playersIndex >= options.maxNumPlayers) then break end
 
-		if wasPresentInMatch(varPrefix) then
+		if options.dontCheckTransferDates or wasPresentInMatch(varPrefix) then
 			insertIntoPlayers{
 				pageName = name,
 				displayName = globalVars:get(varPrefix .. 'dn'),

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -104,7 +104,7 @@ local contentLanguage = mw.getContentLanguage()
 ---@field maxNumPlayers integer?
 ---@field resolveRedirect boolean?
 ---@field pagifyTeamNames boolean?
----@field dontCheckTransferDates boolean?
+---@field disregardTransferDates boolean?
 
 ---@class MatchGroupInputSubstituteInformation
 ---@field substitute standardPlayer
@@ -467,7 +467,7 @@ function MatchGroupInputUtil.readPlayersOfTeam(teamName, manualPlayersInput, opt
 	while name do
 		if options.maxNumPlayers and (playersIndex >= options.maxNumPlayers) then break end
 
-		if options.dontCheckTransferDates or wasPresentInMatch(varPrefix) then
+		if options.disregardTransferDates or wasPresentInMatch(varPrefix) then
 			insertIntoPlayers{
 				pageName = name,
 				displayName = globalVars:get(varPrefix .. 'dn'),

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -19,7 +19,7 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local CustomMatchGroupInput = {}
 local MatchFunctions = {
 	OPPONENT_CONFIG = {
-		dontCheckTransferDates = true,
+		disregardTransferDates = true,
 	}
 }
 local MapFunctions = {}

--- a/components/match2/wikis/valorant/match_group_input_custom.lua
+++ b/components/match2/wikis/valorant/match_group_input_custom.lua
@@ -17,7 +17,11 @@ local Table = require('Module:Table')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
 local CustomMatchGroupInput = {}
-local MatchFunctions = {}
+local MatchFunctions = {
+	OPPONENT_CONFIG = {
+		dontCheckTransferDates = true,
+	}
+}
 local MapFunctions = {}
 
 MatchFunctions.DEFAULT_MODE = 'team'


### PR DESCRIPTION
## Summary
Seemed like the easiest way to mitigate the issues occuring on valorant, where transfer dates are based on the official announcement and often vary from actual date.

Other option would be to first check all maps of a match, extract player input, and override the date variables to include the matchdate in the custom(s).
Let me know what you'd prefer.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
