### PR TITLE
feat(statistics): improve game stats performance

### DIFF
--- a/components/statistics/count.lua
+++ b/components/statistics/count.lua
@@ -37,7 +37,7 @@ function Count.match2(args)
 end
 
 
----Counts the number of matches played on a wiki - querying lpdb_match2
+---Counts the number of matches played on a wiki - querying lpdb_match2game
 ---@param args table?
 ---@return integer
 function Count.match2game(args)

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -251,7 +251,7 @@ function StatisticsPortal._coverageMatchTableRow(args, parameters)
 	local gameCountValue
 
 	if Info.config.match2.status == 2 then
-		matchCountValue = Count.match2gamesData(parameters)
+		matchCountValue = Count.match2game(parameters)
 		gameCountValue = Count.match2(parameters)
 	else
 		matchCountValue = Count.matches(parameters)


### PR DESCRIPTION
## Summary
The query variant that fetches match2.match2games would run out of memory on AoE: https://liquipedia.net/ageofempires/Portal:Statistics, so instead directly count match2games instead. Not sure why this wasn't done immediately.

Issue surfaced due to change of match2 status.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
