### PR TITLE
feat(match2): BR/FFA Sidescrolling behavior not working properly on chrome

### DIFF
--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -496,7 +496,7 @@ Author(s): Elysienna
 			min-width: 15.875rem;
 
 			@media ( min-width: 768px ) {
-				overflow-x: hidden;
+				overflow: hidden;
 				scroll-behavior: smooth;
 			}
 		}


### PR DESCRIPTION
## Summary

For some weird reason it works in chrome by removing `-x` from overflow...

## How did you test this change?

Live and dev wiki
https://liquipedia.net/apexlegends/Octane_Collegiate/Season_2/Stage_2/Playoffs

Closes https://gitlab.com/teamliquid-dev/liquipedia/issue-bucket/-/issues/142
