### PR TITLE
fix(match2): Game Tab countdowns are not working

### DIFF
--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -321,6 +321,9 @@ liquipedia.battleRoyale = {
 							this.createBottomNav( battleRoyaleId, matchContentId, index );
 						}
 					} );
+
+				// Trigger countdown initialization since we have new dates
+				liquipedia.countdown.init();
 			} );
 		} else {
 			this.updateGameTabDisplay( battleRoyaleId, matchContentId, gameTab );


### PR DESCRIPTION
## Summary

Since the new BR changes, we insert game-related data only on click. However, countdowns are not being shown on game-specific tabs since they need to be initialized.

This triggers the init flow for countdowns to take into account the new ones. This is what it looks like in a future game:
![image](https://github.com/user-attachments/assets/dcb94edb-26c7-4b9f-bdd6-0898f22a0ebd)

Double checked with Kano, the result is as expected.

## How did you test this change?

Ran `liquipedia.countdown.init()` in the console on [this page](https://liquipedia.net/apexlegends/Apex_Legends_Global_Series/2024/Championship/Bracket_Stage).
Then updated the script and tested it in the console as well on the same page.
