### PR TITLE
fix(match2): sorting on (ffa) game tabs

### DIFF
--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -322,6 +322,11 @@ liquipedia.battleRoyale = {
 						}
 					} );
 
+				Object.entries( this.battleRoyaleMap[ battleRoyaleId ].gamePanels[ matchContentId ] )
+					.forEach( ( [ , panel ] ) => {
+						this.makeSortableTableFromElement( panel );
+					} );
+
 				// Trigger countdown initialization since we have new dates
 				liquipedia.countdown.init();
 			} );
@@ -605,9 +610,15 @@ liquipedia.battleRoyale = {
 		}
 	},
 
-	makeSortableTable: function( battleRoyaleElement ) {
-		const sortButtons =
-			battleRoyaleElement.querySelectorAll( '[data-js-battle-royale="header-row"] > [data-sort-type]' );
+	makeSortableTable: function( battleRoyaleId ) {
+		this.battleRoyaleMap[ battleRoyaleId ].matchContents.forEach( ( matchContentElement ) => {
+			this.makeSortableTableFromElement( matchContentElement );
+		} );
+	},
+
+	makeSortableTableFromElement: function( targetElement ) {
+		const sortButtons = targetElement
+			.querySelectorAll( '[data-js-battle-royale="header-row"] > [data-sort-type]' );
 
 		sortButtons.forEach( ( button ) => {
 			button.addEventListener( 'click', () => {
@@ -690,7 +701,6 @@ liquipedia.battleRoyale = {
 	init: function() {
 		Array.from( document.querySelectorAll( '[ data-js-battle-royale-id ]' ) ).forEach( ( battleRoyaleElement ) => {
 			this.battleRoyaleInstances[ battleRoyaleElement.dataset.jsBattleRoyaleId ] = battleRoyaleElement;
-			this.makeSortableTable( battleRoyaleElement );
 		} );
 
 		Object.keys( this.battleRoyaleInstances ).forEach( ( battleRoyaleId ) => {
@@ -701,6 +711,8 @@ liquipedia.battleRoyale = {
 
 			this.attachHandlers( battleRoyaleId );
 			this.makeCollapsibles( battleRoyaleId );
+			this.makeSortableTable( battleRoyaleId );
+
 			if ( !this.isMobile() ) {
 				this.makeSideScrollElements( battleRoyaleId );
 				this.makeTableScrollHint( battleRoyaleId );


### PR DESCRIPTION
## Summary

Since we load game tabs using transclusion, we need to retrigger the sorting arrow hydration so they can work.

## How did you test this change?

In the console for [this page](https://liquipedia.net/apexlegends/BLGS/2024/Qualifier_3/APAC_North/Bracket) + by updating the commons file & mediawiki message article