### PR TITLE
fix(match2): error when using ShowBracket

### DIFF
--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -348,11 +348,11 @@ function MatchGroupInput.applyOverrideArgs(matches, args)
 	end
 end
 
----@param matches {match2opponents: table[]}[]
+---@param matches {match2opponents: table[]?, opponents: table[]?}[]
 ---@return integer
 function MatchGroupInput.getMaxOpponentCount(matches)
 	return Array.reduce(matches, function(cur, match)
-		return math.max(#match.match2opponents, cur)
+		return math.max(#(match.match2opponents or match.opponents or {}), cur)
 	end, 0)
 end
 

--- a/components/match2/commons/match_group_input.lua
+++ b/components/match2/commons/match_group_input.lua
@@ -352,6 +352,8 @@ end
 ---@return integer
 function MatchGroupInput.getMaxOpponentCount(matches)
 	return Array.reduce(matches, function(cur, match)
+		-- If the match comes from ShowBracket then it's opponents, otherwise it's match2opponents
+		-- Which is stupid, and needs to be fixed
 		return math.max(#(match.match2opponents or match.opponents or {}), cur)
 	end, 0)
 end


### PR DESCRIPTION
## Summary

If the match comes from ShowBracket then it's opponents, otherwise it's match2opponents
Which is stupid, and needs to be same in the future.
Add a comment sayign the same.

## How did you test this change?
live