### PR TITLE
fix(match2): GameComment overflowing matchsummary box

### DIFF
--- a/components/widget/match/summary/widget_match_summary_game_comment.lua
+++ b/components/widget/match/summary/widget_match_summary_game_comment.lua
@@ -25,7 +25,7 @@ function MatchSummaryGameComment:render()
 	end
 	return HtmlWidgets.Fragment{children = {
 		MatchSummaryBreak{},
-		HtmlWidgets.Div{css = {margin = 'auto'}, classes = self.props.classes, children = self.props.children},
+		HtmlWidgets.Div{css = {margin = 'auto', ['max-width'] = '100%'}, classes = self.props.classes, children = self.props.children},
 	}}
 end
 

--- a/components/widget/match/summary/widget_match_summary_game_comment.lua
+++ b/components/widget/match/summary/widget_match_summary_game_comment.lua
@@ -25,7 +25,11 @@ function MatchSummaryGameComment:render()
 	end
 	return HtmlWidgets.Fragment{children = {
 		MatchSummaryBreak{},
-		HtmlWidgets.Div{css = {margin = 'auto', ['max-width'] = '100%'}, classes = self.props.classes, children = self.props.children},
+		HtmlWidgets.Div{
+			css = {margin = 'auto', ['max-width'] = '100%'},
+			classes = self.props.classes,
+			children = self.props.children
+		},
 	}}
 end
 


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1317037207072149535

- long came comments overflow the MS box
- adjust the max-width of game comments to 100% so that they do not overflow anymore

## How did you test this change?
dev