### PR TITLE
feat(match2): support light/dark theme for BR display

### DIFF
--- a/stylesheets/commons/BattleRoyale/NavigationTabs.less
+++ b/stylesheets/commons/BattleRoyale/NavigationTabs.less
@@ -36,18 +36,26 @@ Author(s): Elysienna
 			font-size: 0.75rem;
 		}
 
+		.theme--dark & {
+			border-color: var( --clr-secondary-16 );
+		}
+
 		&:not( :first-child ) {
 			margin-left: 0.5rem;
 		}
 
 		&.tab--active {
-			background-color: var( --clr-wiki-primary-container );
+			background-color: var( --clr-wiki-theme-primary, var( --clr-wiki-primary-container ) );
 			color: #ffffff;
 		}
 
 		@media ( hover: hover ) {
 			&:not( .tab--active ):hover {
 				background-color: #f5f5f5;
+
+				.theme--dark & {
+					background-color: var( --clr-secondary-9 );
+				}
 			}
 		}
 

--- a/stylesheets/commons/BattleRoyale/Panel.less
+++ b/stylesheets/commons/BattleRoyale/Panel.less
@@ -145,6 +145,10 @@ Author(s): Elysienna
 			.panel-content__collapsible.is--collapsed & {
 				&:hover {
 					background-color: rgba( 0, 0, 0, 0.08 );
+
+					.theme--dark & {
+						background-color: rgba( 255, 255, 255, .08 );
+					}
 				}
 			}
 		}
@@ -300,6 +304,10 @@ Author(s): Elysienna
 			cursor: pointer;
 			font-weight: bold;
 
+			.theme--dark & {
+				color: var( --clr-on-background );
+			}
+
 			&.navigate--left {
 				flex-direction: row-reverse;
 			}
@@ -310,11 +318,15 @@ Author(s): Elysienna
 		}
 
 		&__icon {
-			color: var( --clr-wiki-on-primary );
+			color: var( --clr-wiki-theme-primary, var( --clr-wiki-on-primary ) );
 			width: 1.5rem;
 			display: flex;
 			justify-content: center;
 			margin: 0 0.5rem;
+
+			.theme--dark & {
+				color: var( --clr-secondary-70 );
+			}
 		}
 	}
 }

--- a/stylesheets/commons/BattleRoyale/Panel.less
+++ b/stylesheets/commons/BattleRoyale/Panel.less
@@ -147,7 +147,7 @@ Author(s): Elysienna
 					background-color: rgba( 0, 0, 0, 0.08 );
 
 					.theme--dark & {
-						background-color: rgba( 255, 255, 255, .08 );
+						background-color: rgba( 255, 255, 255, 0.08 );
 					}
 				}
 			}

--- a/stylesheets/commons/BattleRoyale/Panel.less
+++ b/stylesheets/commons/BattleRoyale/Panel.less
@@ -33,11 +33,22 @@ Author(s): Elysienna
 			font-size: 0.75rem;
 		}
 
+		.theme--dark & {
+			background-color: var( --clr-secondary-9 );
+			border-bottom-color: var( --clr-secondary-16 );
+		}
+
 		&.is--active {
-			background-color: #ffffff;
+			background-color: var( --clr-background, #ffffff );
 			color: #282828;
 			border-color: rgba( 0, 0, 0, 0.2 );
 			border-bottom-color: transparent;
+
+			.theme--dark & {
+				color: var( --clr-secondary-70 );
+				border-color: var( --clr-secondary-16 );
+				border-bottom-color: transparent;
+			}
 		}
 
 		&:not( :first-child ) {
@@ -47,6 +58,10 @@ Author(s): Elysienna
 		@media ( hover: hover ) {
 			&:hover:not( .is--active ) {
 				background-color: rgba( 0, 0, 0, 0.08 );
+
+				.theme--dark & {
+					background-color: var( --clr-secondary-16 );
+				}
 			}
 		}
 	}
@@ -69,6 +84,11 @@ Author(s): Elysienna
 		margin: 0;
 		padding: 0;
 		color: inherit;
+
+		html.theme--light &,
+		html.theme--dark & {
+			color: var( --clr-on-background );
+		}
 	}
 }
 
@@ -79,6 +99,11 @@ Author(s): Elysienna
 
 	@media ( max-width: 767px ) {
 		font-size: 0.75rem;
+	}
+
+	.theme--dark & {
+		border-color: var( --clr-secondary-16 );
+		box-shadow: 0 -0.0625rem 0 0 var( --clr-secondary-16 );
 	}
 
 	&.is--hidden {
@@ -126,6 +151,11 @@ Author(s): Elysienna
 
 		@media ( max-width: 767px ) {
 			font-size: 0.8125rem;
+		}
+
+		html.theme--light &,
+		html.theme--dark & {
+			color: var( --clr-on-background );
 		}
 
 		&-icon {

--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -49,10 +49,14 @@ Author(s): Elysienna
 
 	&__sort {
 		margin-left: 0.25rem;
-		color: var( --clr-wiki-on-primary );
+		color: var( --clr-wiki-theme-primary, var( --clr-wiki-on-primary ) );
 		cursor: pointer;
 		width: 1.25rem;
 		text-align: center;
+
+		.theme--dark & {
+			color: var( --clr-on-background );
+		}
 	}
 
 	&__navigate {


### PR DESCRIPTION
## Summary

This MR updates the colors for Battle Royale on Lakesideview wikis. Way back when we created BR there was never a dark theme design so that's why we need to update it now.

## How did you test this change?

On the live site, for example https://liquipedia.net/apexlegends/BLGS/2024/Qualifier_3/APAC_North/Bracket

## Closes
https://gitlab.com/teamliquid-dev/liquipedia/issue-bucket/-/issues/159
