### PR TITLE
fix(match2): warcraft legacyBrackets erroring on map walkovers

### DIFF
--- a/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
+++ b/components/match2/wikis/warcraft/legacy/match_group_legacy_convert_map_data.lua
@@ -168,7 +168,6 @@ function ConvertMapData._convertSubmatch(opponentPlayers, parsedArgs, args, pref
 	parsedArgs[parsedPrefix .. 'subgroup'] = submatchIndex
 	parsedArgs[parsedPrefix .. 'p1score'] = score1
 	parsedArgs[parsedPrefix .. 'p2score'] = score2
-	parsedArgs[parsedPrefix .. 'walkover'] = score1 == DEFAULT_WIN and 1 or score2 == DEFAULT_WIN and 2 or nil
 	parsedArgs[parsedPrefix] = submatchIsNotDefaultWin and 'Submatch Score Fix' or 'Submatch'
 	parsedArgs[parsedPrefix .. 'finished'] = true
 


### PR DESCRIPTION
## Summary
the removed line is not needed anyways ...

reported on discord by kover: https://discord.com/channels/93055209017729024/372075546231832576/1317177083117699083

## How did you test this change?
dev to live