### PR TITLE
feat(match2): use ffa base ms on starcraft(2)

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft_ffa.lua
@@ -192,6 +192,7 @@ function MapFunctions.readMap(mapInput, opponentCount, hasScores)
 
 	if mapInput.date then
 		Table.mergeInto(map, MatchGroupInputUtil.readDate(map.date))
+		map.extradata = map.dateexact
 	end
 
 	if MatchGroupInputUtil.isNotPlayed(mapInput.winner, mapInput.finished) then

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft_ffa.lua
@@ -6,7 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local StarcraftMatchSummary = {}
+local StarcraftMatchSummaryFfa = {}
 
 local Array = require('Module:Array')
 local Logic = require('Module:Logic')
@@ -28,7 +28,7 @@ local Parser = {}
 
 ---@param props {bracketId: string, matchId: string}
 ---@return Widget
-function StarcraftMatchSummary.getByMatchId(props)
+function StarcraftMatchSummaryFfa.getByMatchId(props)
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
 	---@cast match StarcraftMatchGroupUtilMatch
 
@@ -40,7 +40,7 @@ function StarcraftMatchSummary.getByMatchId(props)
 			matchId = match.matchId,
 			idx = 0,
 			children = {
-				StarcraftMatchSummary._schedule(match),
+				StarcraftMatchSummaryFfa._schedule(match),
 				BaseMatchSummary.standardMatch(match, Parser),
 			}
 		}
@@ -49,7 +49,7 @@ end
 
 ---@param match StarcraftMatchGroupUtilMatch
 ---@return Widget
-function StarcraftMatchSummary._schedule(match)
+function StarcraftMatchSummaryFfa._schedule(match)
 	local dates = Array.map(match.games, Operator.property('date'))
 	if Array.any(dates, function(date) return date ~= match.date end) then
 		return MatchSummaryWidgets.GamesSchedule{games = match.games}
@@ -107,4 +107,4 @@ function Parser.adjustGameOverviewColumns(columns)
 end
 
 
-return StarcraftMatchSummary
+return StarcraftMatchSummaryFfa

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft_ffa.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft_ffa.lua
@@ -6,474 +6,105 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local StarcraftMatchSummaryFfa = {}
+local StarcraftMatchSummary = {}
 
 local Array = require('Module:Array')
-local Date = require('Module:Date/Ext')
-local FnUtil = require('Module:FnUtil')
-local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Ordinal = require('Module:Ordinal')
+local Operator = require('Module:Operator')
 local Table = require('Module:Table')
-local Timezone = require('Module:Timezone')
-local VodLink = require('Module:VodLink')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
-local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local OpponentLibraries = require('Module:OpponentLibraries')
 local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
-local TBD = 'TBD'
-local UTC = Timezone.getTimezoneString('UTC')
+local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
+local BaseMatchSummary = Lua.import('Module:MatchSummary/Base/Ffa')
 
-local PHASE_ICONS = {
-	finished = {iconName = 'concluded', color = 'icon--green'},
-	ongoing = {iconName = 'live', color = 'icon--red'},
-	upcoming = {iconName = 'upcomingandongoing'},
-}
+local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/Ffa/All')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
-local PLACEMENT_BG = {
-	'cell--gold',
-	'cell--silver',
-	'cell--bronze',
-	'cell--copper',
-}
+---@type FfaMatchSummaryParser
+local Parser = {}
 
-local TROPHY_COLOR = {
-	'icon--gold',
-	'icon--silver',
-	'icon--bronze',
-	'icon--copper',
-}
+---@param props {bracketId: string, matchId: string}
+---@return Widget
+function StarcraftMatchSummary.getByMatchId(props)
+	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
+	---@cast match StarcraftMatchGroupUtilMatch
 
-local STATUS_ICONS = {
-	advances = 'fas fa-chevron-double-up',
-	eliminated = 'fas fa-skull',
-}
+	BaseMatchSummary.updateMatchOpponents(match)
 
-local MATCH_STANDING_COLUMNS = {
-	{
-		class = 'cell--status',
-		--iconClass = 'fas fa-hashtag',
-		show = {
-			value = function(match)
+	return HtmlWidgets.Fragment{children = {
+		MatchSummaryWidgets.Header{matchId = match.matchId, games = match.games},
+		MatchSummaryWidgets.Tab{
+			matchId = match.matchId,
+			idx = 0,
+			children = {
+				StarcraftMatchSummary._schedule(match),
+				BaseMatchSummary.standardMatch(match, Parser),
+			}
+		}
+	}}
+end
+
+---@param match StarcraftMatchGroupUtilMatch
+---@return Widget
+function StarcraftMatchSummary._schedule(match)
+	local dates = Array.map(match.games, Operator.property('date'))
+	if Array.any(dates, function(date) return date ~= match.date end) then
+		return MatchSummaryWidgets.GamesSchedule{games = match.games}
+	end
+	return MatchSummaryWidgets.MatchSchedule{match = match}
+end
+
+---@param columns table[]
+---@return table[]
+function Parser.adjustMatchColumns(columns)
+	return Array.map(columns, function(column)
+		if column.id == 'status' then
+			column.show = function(match)
 				return match.finished and #Array.filter(match.opponents, function(opponent)
 					return Logic.readBool(opponent.advances)
 				end) > 1
 			end
-		},
-		row = {
-			value = function (opponent, idx)
-				local statusIcon = Logic.readBool(opponent.advances) and STATUS_ICONS.advances or STATUS_ICONS.eliminated
-				return mw.html.create('i')
-					:addClass(statusIcon)
-			end,
-		},
-	},
-	{
-		class = 'cell--rank',
-		iconClass = 'fas fa-hashtag',
-		header = {
-			value = 'Rank',
-		},
-		row = {
-			value = function (opponent, idx)
-				local place = opponent.placement ~= -1 and opponent.placement or idx
-				local worstPlace = opponent.extradata.worstPlace
-				local icon, color = StarcraftMatchSummaryFfa._getTrophy(place)
-				return mw.html.create()
-						:tag('i'):addClass('panel-table__cell-icon'):addClass(icon):addClass(color):done()
-						:tag('span'):wikitext(StarcraftMatchSummaryFfa._displayRank(place, worstPlace)):done()
-			end,
-		},
-	},
-	{
-		class = 'cell--team',
-		iconClass = 'fas fa-users',
-		header = {
-			value = 'Participant',
-		},
-		row = {
-			value = function (opponent, idx)
-				return StarcraftMatchSummaryFfa._displayOpponent(opponent)
-			end,
-		},
-	},
-	{
-		class = 'cell--total-points',
-		iconClass = 'fas fa-star',
-		header = {
-			value = 'Total Points',
-			mobileValue = 'Pts.',
-		},
-		show = {
-			value = function(match)
-				return not Logic.readBool(match.noScore)
-			end
-		},
-		row = {
-			value = function (opponent, idx)
-				return OpponentDisplay.InlineScore(opponent)
-			end,
-		},
-	},
-	game = {
-		{
-			class = 'panel-table__cell__game-placement',
-			iconClass = 'fas fa-trophy-alt',
-			header = {
-				value = 'Place',
-				mobileValue = 'P.',
-			},
-			row = {
-				class = function (opponent)
-					return PLACEMENT_BG[opponent.placement]
+			column.row = {
+				value = function (opponent, idx)
+					local statusIcon = Logic.readBool(opponent.advances)
+						and BaseMatchSummary.STATUS_ICONS.advances
+						or BaseMatchSummary.STATUS_ICONS.eliminated
+					return mw.html.create('i')
+						:addClass(statusIcon)
 				end,
-				value = function (opponent)
-					local placementDisplay
-					if opponent.status and opponent.status ~= 'S' then
-						placementDisplay = opponent.status or '-'
-					else
-						placementDisplay = StarcraftMatchSummaryFfa._displayRank(opponent.placement)
-					end
-					local icon, color = StarcraftMatchSummaryFfa._getTrophy(opponent.placement)
-					return mw.html.create()
-							:tag('i')
-								:addClass('panel-table__cell-icon')
-								:addClass(icon)
-								:addClass(color)
-								:done()
-							:tag('span'):addClass('panel-table__cell-game__text')
-									:wikitext(placementDisplay):done()
-				end,
-			},
-		},
-		{
-			class = 'panel-table__cell__game-kills',
-			iconClass = 'fas fa-star',
-			show = {
-				value = function(match)
-					return not Logic.readBool(match.noScore)
-				end
-			},
-			header = {
-				value = 'Points',
-				mobileValue = 'Pts.',
-			},
-			row = {
-				value = function (opponent)
-					return OpponentDisplay.InlineScore(Table.merge({extradata = {}, score = ''}, opponent))
-				end,
-			},
-		},
-	}
-}
-
----@param props {match: StarcraftMatchGroupUtilMatch, bracketResetMatch: StarcraftMatchGroupUtilMatch?, config: table?}
----@return Html
-function StarcraftMatchSummaryFfa.getByMatchId(props)
-	local match = StarcraftMatchSummaryFfa._opponents(props.match)
-
-	return StarcraftMatchSummaryFfa._createOverallPage(match)
-end
-
-function StarcraftMatchSummaryFfa._opponents(match)
-	-- Add match opponent data to game opponent and the other way around
-	Array.forEach(match.games, function (game)
-		game.extradata.opponents = Array.map(game.opponents, function (opponent, opponentIdx)
-			return Table.merge(opponent, {
-				placement = opponent.placement,
-				status = opponent.status or 'S',
-				score = opponent.score or (game.scores or {})[opponentIdx],
-			})
-		end)
-	end)
-
-	Array.forEach(match.opponents, function (opponent, opponentIdx)
-		opponent.games = Array.map(match.games, function (game)
-			return game.extradata.opponents[opponentIdx]
-		end)
-	end)
-
-	local placementSortFunction = function(opponent1, opponent2)
-		local place1 = opponent1.placement or math.huge
-		local place2 = opponent2.placement or math.huge
-		if place1 ~= place2 then
-			return place1 < place2
-		end
-		if opponent1.status ~= 'S' and opponent2.status == 'S' then
-			return false
-		end
-		if opponent2.status ~= 'S' and opponent1.status == 'S' then
-			return true
-		end
-		if opponent1.score and opponent2.score and opponent1.score ~= opponent2.score then
-			return opponent1.score > opponent2.score
-		end
-		return (opponent1.name or ''):lower() < (opponent2.name or ''):lower()
-	end
-
-	-- Sort match level based on placement
-	Array.sortInPlaceBy(match.opponents, FnUtil.identity, placementSortFunction)
-
-	if not match.finished then
-		return match
-	end
-	local cache = {
-		index = #match.opponents,
-		currentWorst = #match.opponents
-	}
-	Array.forEach(Array.reverse(match.opponents), function(opponent)
-		local place = opponent.placement
-		opponent.extradata.worstPlace = cache.currentWorst
-		if place == cache.index then
-			cache.currentWorst = place - 1
-		end
-		cache.index = cache.index - 1
-	end)
-
-	return match
-end
-
----@param match table
----@return Html
-function StarcraftMatchSummaryFfa._createOverallPage(match)
-	local page = mw.html.create('div')
-			:addClass('brkts-match-info-popup-sc-ffa')
-			:addClass('panel-content')
-			:attr('data-js-battle-royale', 'panel-content'):attr('id', 'panel0')
-
-	local schedule = page:tag('div')
-
-	local scheduleList = schedule:tag('div')
-			:addClass('panel-content__container')
-			:attr('role', 'tabpanel')
-			:tag('ul')
-					:addClass('panel-content__game-schedule')
-
-	scheduleList:tag('li')
-			:node(StarcraftMatchSummaryFfa._countdownIcon(match, 'panel-content__game-schedule__icon'))
-			:tag('span')
-					:addClass('panel-content__game-schedule__title')
-					:wikitext('Match:')
-					:done()
-			:tag('div')
-				:addClass('panel-content__game-schedule__container')
-				:node(StarcraftMatchSummaryFfa._countdown(match))
-
-	return page:node(StarcraftMatchSummaryFfa._createMatchStandings(match))
-end
-
-
----@param match table
----@return Html
-function StarcraftMatchSummaryFfa._createMatchStandings(match)
-	local wrapper = mw.html.create('div')
-			:addClass('panel-table')
-			:attr('data-js-battle-royale', 'table')
-
-	local header = wrapper:tag('div')
-			:addClass('panel-table__row')
-			:addClass('row--header')
-			:attr('data-js-battle-royale', 'header-row')
-
-	Array.forEach(MATCH_STANDING_COLUMNS, function(column)
-		if column.show and not column.show.value(match) then
+			}
+		elseif column.id == 'opponent' then
+			column.header = {value = 'Participant'}
+		elseif column.id == 'totalPoints' then
+			column.show = function(match) return not Logic.readBool(match.noScore) end
+		elseif column.id == 'matchPoints' then
 			return
 		end
+		return column
+	end)
+end
 
-		local cell = header:tag('div')
-				:addClass('panel-table__cell')
-				:addClass(column.class)
-		local groupedCell = cell:tag('div'):addClass('panel-table__cell-grouped')
-				:tag('i')
-						:addClass('panel-table__cell-icon')
-						:addClass(column.iconClass)
-						:done()
-		local span = groupedCell:tag('span')
-				:wikitext((column.header or {}).value)
-		if (column.header or {}).mobileValue then
-				span:addClass('d-none d-md-block')
-				groupedCell:tag('span')
-						:wikitext((column.header or {}).mobileValue)
-						:addClass('d-block d-md-none')
+---@param columns table[]
+---@return table[]
+function Parser.adjustGameOverviewColumns(columns)
+	Array.forEach(columns, function(column)
+		if column.id == 'placement' then
+			column.show = function(match) return not Logic.readBool(match.noScore) end
+		elseif column.id == 'kills' then
+			return
+		elseif column.id == 'points' then
+			column.show = function(match) return true end
+			column.row = {value = function(opponent)
+				return OpponentDisplay.InlineScore(Table.merge({extradata = {}, score = ''}, opponent))
+			end}
 		end
-		span:done()
 	end)
 
-	local gameCollectionContainerNavHolder = header:tag('div')
-			:addClass('panel-table__cell')
-			:addClass('cell--game-container-nav-holder')
-			:attr('data-js-battle-royale', 'game-nav-holder')
-			:css('overflow', 'visible')
-	local gameCollectionContainer = gameCollectionContainerNavHolder:tag('div')
-			:addClass('panel-table__cell')
-			:addClass('cell--game-container')
-			:attr('data-js-battle-royale', 'game-container')
-			:css('overflow-x', 'visible')
-
-	Array.forEach(match.games, function (game, idx)
-		local gameContainer = gameCollectionContainer:tag('div')
-				:addClass('panel-table__cell')
-				:addClass('cell--game')
-
-		gameContainer:tag('div')
-				:addClass('panel-table__cell__game-head')
-				:css('text-align', 'left')
-				:tag('div')
-						:addClass('panel-table__cell__game-title')
-						:css('justify-content', 'flex-start')
-						:node(StarcraftMatchSummaryFfa._countdownIcon(game, 'panel-table__cell-icon'))
-						:tag('span')
-								:addClass('panel-table__cell-text')
-								:wikitext('Game ', idx)
-								:done()
-						:done()
-						:node(StarcraftMatchSummaryFfa._countdown(game))
-						:node(StarcraftMatchSummaryFfa._map(game))
-						:done()
-
-		local gameDetails = gameContainer:tag('div'):addClass('panel-table__cell__game-details')
-		Array.forEach(MATCH_STANDING_COLUMNS.game, function(column)
-			if column.show and not column.show.value(match) then
-				return
-			end
-			gameDetails:tag('div')
-					:addClass(column.class)
-					:tag('i')
-							:addClass('panel-table__cell-icon')
-							:addClass(column.iconClass)
-							:done()
-					:tag('span')
-							:wikitext(column.header.value)
-							:done()
-		end)
-	end)
-
-	Array.forEach(match.opponents, function (opponentMatch, index)
-		local row = wrapper:tag('div'):addClass('panel-table__row'):attr('data-js-battle-royale', 'row')
-
-		Array.forEach(MATCH_STANDING_COLUMNS, function(column)
-			if column.show and not column.show.value(match) then
-				return
-			end
-
-			row:tag('div')
-					:addClass('panel-table__cell')
-					:addClass(column.class)
-					:node(column.row.value(opponentMatch, index))
-		end)
-
-		local gameRowContainer = row:tag('div')
-				:addClass('panel-table__cell')
-				:addClass('cell--game-container')
-				:css('overflow-x', 'unset')
-				:attr('data-js-battle-royale', 'game-container')
-
-		Array.forEach(opponentMatch.games, function(opponent)
-			local gameRow = gameRowContainer:tag('div'):addClass('panel-table__cell'):addClass('cell--game')
-
-			Array.forEach(MATCH_STANDING_COLUMNS.game, function(column)
-				if column.show and not column.show.value(match) then
-					return
-				end
-				gameRow:tag('div')
-						:node(column.row.value(opponent))
-						:addClass(column.class)
-						:addClass(column.row.class and column.row.class(opponent) or nil)
-			end)
-		end)
-	end)
-
-	return mw.html.create('div')
-		:css('overflow-x', 'auto')
-		:node(wrapper)
+	return columns
 end
 
----@param game table
----@return Html
-function StarcraftMatchSummaryFfa._map(game)
-	return mw.html.create()
-		:tag('i')
-			:addClass('far fa-map')
-			:addClass('panel-content__game-schedule__icon')
-			:done()
-		:node(DisplayHelper.Map(game, {noLink = (game.map or ''):upper() == TBD}))
-end
 
----@param game table
----@return boolean
-function StarcraftMatchSummaryFfa._isFinished(game)
-	return game.winner ~= nil
-end
-
----@param game table
----@param additionalClass string
----@return string?
-function StarcraftMatchSummaryFfa._countdownIcon(game, additionalClass)
-	local iconData = PHASE_ICONS[MatchGroupUtil.computeMatchPhase(game)] or {}
-	return Icon.makeIcon{iconName = iconData.iconName, color = iconData.color, additionalClasses = {additionalClass}}
-end
-
----Creates a countdown block for a given game
----Attaches any VODs of the game as well
----@param game table
----@return Html?
-function StarcraftMatchSummaryFfa._countdown(game)
-	if not game.extradata.timezoneid then
-		return
-	end
-
-	local timestamp = Date.readTimestamp(game.date) + (Timezone.getOffset(game.extradata.timezoneid) or 0)
-	local dateString = Date.formatTimestamp('F j, Y - H:i', timestamp) .. ' '
-			.. (Timezone.getTimezoneString(game.extradata.timezoneid) or UTC)
-
-	local stream = Table.merge(game.stream, {
-		date = dateString,
-		finished = StarcraftMatchSummaryFfa._isFinished(game) and 'true' or nil,
-	})
-
-	return mw.html.create('div'):addClass('match-countdown-block')
-			:node(require('Module:Countdown')._create(stream))
-			:node(game.vod and VodLink.display{vod = game.vod} or nil)
-end
-
----@param placementStart string|number|nil
----@param placementEnd string|number|nil
----@return string
-function StarcraftMatchSummaryFfa._displayRank(placementStart, placementEnd)
-	local places = {}
-
-	if placementStart then
-		table.insert(places, Ordinal.toOrdinal(placementStart))
-	end
-
-	if placementStart and placementEnd and placementEnd > placementStart then
-		table.insert(places, Ordinal.toOrdinal(placementEnd))
-	end
-
-	return table.concat(places, ' - ')
-end
-
----@param place integer
----@return string? icon
----@return string? iconColor
-function StarcraftMatchSummaryFfa._getTrophy(place)
-	if TROPHY_COLOR[place] then
-		return 'fas fa-trophy', TROPHY_COLOR[place]
-	end
-end
-
----@param opponent standardOpponent
----@return Html
-function StarcraftMatchSummaryFfa._displayOpponent(opponent)
-	return OpponentDisplay.BlockOpponent{
-		opponent = opponent,
-		showLink = true,
-		overflow = 'ellipsis',
-		teamStyle = 'hybrid',
-	}
-end
-
-return StarcraftMatchSummaryFfa
+return StarcraftMatchSummary

--- a/components/match2/wikis/starcraft/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft/brkts_wiki_specific.lua
@@ -29,7 +29,10 @@ end)
 ---@param maxOpponentCount integer
 ---@return function
 function WikiSpecific.getMatchGroupContainer(matchGroupType, maxOpponentCount)
-	if matchGroupType == 'matchlist' then
+	if maxOpponentCount > 2 then
+		local Horizontallist = Lua.import('Module:MatchGroup/Display/Horizontallist')
+		return Horizontallist.BracketContainer
+	elseif matchGroupType == 'matchlist' then
 		local MatchList = Lua.import('Module:MatchGroup/Display/Matchlist')
 		return WikiSpecific.adjustMatchGroupContainerConfig(MatchList.MatchlistContainer)
 	end

--- a/components/match2/wikis/starcraft/match_summary_ffa.lua
+++ b/components/match2/wikis/starcraft/match_summary_ffa.lua
@@ -1,0 +1,13 @@
+---
+-- @Liquipedia
+-- wiki=starcraft
+-- page=Module:MatchSummary/Ffa
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local StarcraftFfaMatchSummary = Lua.import('Module:MatchSummary/Starcraft/Ffa')
+
+return StarcraftFfaMatchSummary

--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -29,7 +29,10 @@ end)
 ---@param maxOpponentCount integer
 ---@return function
 function WikiSpecific.getMatchGroupContainer(matchGroupType, maxOpponentCount)
-	if matchGroupType == 'matchlist' then
+	if maxOpponentCount > 2 then
+		local Horizontallist = Lua.import('Module:MatchGroup/Display/Horizontallist')
+		return Horizontallist.BracketContainer
+	elseif matchGroupType == 'matchlist' then
 		local MatchList = Lua.import('Module:MatchGroup/Display/Matchlist')
 		return WikiSpecific.adjustMatchGroupContainerConfig(MatchList.MatchlistContainer)
 	end

--- a/components/match2/wikis/starcraft2/match_summary_ffa.lua
+++ b/components/match2/wikis/starcraft2/match_summary_ffa.lua
@@ -1,0 +1,13 @@
+---
+-- @Liquipedia
+-- wiki=starcraft2
+-- page=Module:MatchSummary/Ffa
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local StarcraftFfaMatchSummary = Lua.import('Module:MatchSummary/Starcraft/Ffa')
+
+return StarcraftFfaMatchSummary

--- a/components/widget/match/summary/ffa/widget_match_summary_ffa_all.lua
+++ b/components/widget/match/summary/ffa/widget_match_summary_ffa_all.lua
@@ -16,6 +16,7 @@ Widgets.GameCountdown = Lua.import('Module:Widget/Match/Summary/Ffa/GameCountdow
 Widgets.GameDetails = Lua.import('Module:Widget/Match/Summary/Ffa/GameDetails')
 Widgets.GamesSchedule = Lua.import('Module:Widget/Match/Summary/Ffa/GamesSchedule')
 Widgets.Header = Lua.import('Module:Widget/Match/Summary/Ffa/Header')
+Widgets.MatchSchedule = Lua.import('Module:Widget/Match/Summary/Ffa/MatchSchedule')
 Widgets.PointsDistribution = Lua.import('Module:Widget/Match/Summary/Ffa/PointsDistribution')
 Widgets.RankRange = Lua.import('Module:Widget/Match/Summary/Ffa/RankRange')
 Widgets.Tab = Lua.import('Module:Widget/Match/Summary/Ffa/Tab')

--- a/components/widget/match/summary/ffa/widget_match_summary_ffa_match_schedule.lua
+++ b/components/widget/match/summary/ffa/widget_match_summary_ffa_match_schedule.lua
@@ -1,0 +1,39 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Match/Summary/Ffa/MatchSchedule
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Widget')
+local ContentItemContainer = Lua.import('Module:Widget/Match/Summary/Ffa/ContentItemContainer')
+local CountdownIcon = Lua.import('Module:Widget/Match/Summary/Ffa/CountdownIcon')
+local GameCountdown = Lua.import('Module:Widget/Match/Summary/Ffa/GameCountdown')
+
+---@class MatchSummaryFfaMatchSchedule: Widget
+---@operator call(table): MatchSummaryFfaMatchSchedule
+local MatchSummaryFfaMatchSchedule = Class.new(Widget)
+
+---@return Widget?
+function MatchSummaryFfaMatchSchedule:render()
+	if not self.props.match or DateExt.isDefaultTimestamp(self.props.match.date) then
+		return nil
+	end
+
+	return ContentItemContainer{
+		contentClass = 'panel-content__game-schedule',
+		items = {{
+			icon =  CountdownIcon{game = self.props.match},
+			title = 'Match:',
+			content = GameCountdown{game = self.props.match},
+		}}
+	}
+end
+
+return MatchSummaryFfaMatchSchedule


### PR DESCRIPTION
probably needs bot runs (from singleMatch to normal 2se bracket for ffa single matches
--> maybe make it so that `StarcraftSingleMatchDisplay.SingleMatchContainer` errors for ffa stuff

## Summary
Use the FFA MS Base Module in the sc(2) ffa display.
- make columns in the base ffa ms customizable via a parser
- adjust brkts/wikispecific on bot sc and sc2 to use horizontallist for ffa matches and "redirect" `Module:MatchSummary/Ffa` to the one on commons
- add a match schedule widget to be used if dates of all games of a match and the match are the same


## How did you test this change?
to be done