### PR TITLE
fix: Load scripts from current skin for WC3 creep spots

### DIFF
--- a/javascript/commons/Miscellaneous.js
+++ b/javascript/commons/Miscellaneous.js
@@ -357,7 +357,7 @@ liquipedia.core.modules.push( 'talenttemplate' );
 liquipedia.creepspot = {
 	init: function() {
 		if ( document.querySelector( '.creep-spot' ) !== null ) {
-			mw.loader.using( 'skins.bruinen.scripts' ).then( () => {
+			mw.loader.using( 'skins.' + mw.config.get( 'skin' ) + '.scripts' ).then( () => {
 				document.querySelectorAll( '.creep-spot' ).forEach( ( cs ) => {
 					const $this = $( cs );
 					const options = {


### PR DESCRIPTION
## Summary

This makes sure the WC3 wiki does not load in bruinen scripts when the lakesideview beta is enabled

## How did you test this change?

dev tools