### PR TITLE
ci(deploy): change deploy to use a bot password

### DIFF
--- a/.github/workflows/deploy test.yml
+++ b/.github/workflows/deploy test.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Personal Lua Deploy
         if: steps.changed-files.outputs.any_changed == 'true'
         env:
-          WIKI_USER: ${{ secrets.LP_USER }}
-          WIKI_PASSWORD: ${{ secrets.LP_PASSWORD }}
+          WIKI_USER: ${{ secrets.LP_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.LP_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.LP_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
           LUA_DEV_ENV_NAME: "/dev/${{ github.event.inputs.luadevenv }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Resource Deploy
         if: steps.res-changed-files.outputs.any_changed == 'true'
         env:
-          WIKI_USER: ${{ secrets.LP_USER }}
-          WIKI_PASSWORD: ${{ secrets.LP_PASSWORD }}
+          WIKI_USER: ${{ secrets.LP_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.LP_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.LP_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
         run: bash scripts/deploy_res.sh "${{ steps.res-changed-files.outputs.all_changed_files }}"
@@ -44,8 +44,8 @@ jobs:
       - name: Lua Deploy
         if: steps.lua-changed-files.outputs.any_changed == 'true'
         env:
-          WIKI_USER: ${{ secrets.LP_USER }}
-          WIKI_PASSWORD: ${{ secrets.LP_PASSWORD }}
+          WIKI_USER: ${{ secrets.LP_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.LP_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.LP_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
         run: bash scripts/deploy.sh "${{ steps.lua-changed-files.outputs.all_changed_files }}"
@@ -69,8 +69,8 @@ jobs:
       - name: Deploy Old Dev
         if: steps.changed-files.outputs.any_changed == 'true'
         env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_USER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_PASSWORD }}
+          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL }}
           DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}
@@ -79,8 +79,8 @@ jobs:
       - name: Deploy New Dev
         if: steps.changed-files.outputs.any_changed == 'true'
         env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_USER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_PASSWORD }}
+          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL2 }}
           DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -17,16 +17,16 @@ jobs:
 
       - name: Resource Deploy
         env:
-          WIKI_USER: ${{ secrets.LP_USER }}
-          WIKI_PASSWORD: ${{ secrets.LP_PASSWORD }}
+          WIKI_USER: ${{ secrets.LP_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.LP_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.LP_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
         run: bash scripts/deploy_res.sh
 
       - name: Lua Deploy
         env:
-          WIKI_USER: ${{ secrets.LP_USER }}
-          WIKI_PASSWORD: ${{ secrets.LP_PASSWORD }}
+          WIKI_USER: ${{ secrets.LP_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.LP_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.LP_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
         run: bash scripts/deploy.sh
@@ -42,8 +42,8 @@ jobs:
 
       - name: Deploy Old Dev
         env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_USER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_PASSWORD }}
+          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL }}
           DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}
@@ -51,8 +51,8 @@ jobs:
 
       - name: Deploy New Dev
         env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_USER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_PASSWORD }}
+          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
+          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
           WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL2 }}
           DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -68,14 +68,13 @@ for luaFile in $luaFiles; do
         -s \
         -b "$ckf" \
         -c "$ckf" \
-        --data-urlencode "username=${WIKI_USER}" \
-        --data-urlencode "password=${WIKI_PASSWORD}" \
-        --data-urlencode "logintoken=${loginToken}" \
-        --data-urlencode "loginreturnurl=${WIKI_BASE_URL}" \
+        --data-urlencode "lgname=${WIKI_USER}" \
+        --data-urlencode "lgpassword=${WIKI_PASSWORD}" \
+        --data-urlencode "lgtoken=${loginToken}" \
         -H "User-Agent: ${userAgent}" \
         -H 'Accept-Encoding: gzip' \
         -H "Authorization: Basic ${DEV_WIKI_BASIC_AUTH}" \
-        -X POST "${wikiApiUrl}?format=json&action=clientlogin" \
+        -X POST "${wikiApiUrl}?format=json&action=login" \
         | gunzip \
         > /dev/null
       loggedin[$wiki]=1

--- a/scripts/deploy_res.sh
+++ b/scripts/deploy_res.sh
@@ -32,13 +32,12 @@ curl \
   -s \
   -b "$ckf" \
   -c "$ckf" \
-  --data-urlencode "username=${WIKI_USER}" \
-  --data-urlencode "password=${WIKI_PASSWORD}" \
-  --data-urlencode "logintoken=${loginToken}" \
-  --data-urlencode "loginreturnurl=${WIKI_BASE_URL}" \
+  --data-urlencode "lgname=${WIKI_USER}" \
+  --data-urlencode "lgpassword=${WIKI_PASSWORD}" \
+  --data-urlencode "lgtoken=${loginToken}" \
   -H "User-Agent: ${userAgent}" \
   -H 'Accept-Encoding: gzip' \
-  -X POST "${wikiApiUrl}?format=json&action=clientlogin" \
+  -X POST "${wikiApiUrl}?format=json&action=login" \
   | gunzip \
   > /dev/null
 


### PR DESCRIPTION
## Summary
This changes the deploy scripts to use a bot password.

Closes https://github.com/Liquipedia/Lua-Modules/issues/5169

## How did you test this change?
I tested locally if I can log in with a bot password in this way.

:warning: **CAUTION**: The variables for the dev deploys have not been set up yet, Nadox and Darkrai should set these up. Values for live deploy exist already.
