### PR TITLE
feat(opponent): support faction darkmode icons on SG and WC

### DIFF
--- a/components/opponent/wikis/stormgate/player_display_custom.lua
+++ b/components/opponent/wikis/stormgate/player_display_custom.lua
@@ -116,7 +116,7 @@ function CustomPlayerDisplay.InlinePlayer(props)
 end
 
 function CustomPlayerDisplay.Faction(faction)
-	return Faction.Icon{size = 'small', showLink = false, showTitle = false, faction = faction}
+	return Faction.Icon{size = 'small', showLink = false, faction = faction}
 end
 
 return CustomPlayerDisplay

--- a/components/opponent/wikis/warcraft/player_display_custom.lua
+++ b/components/opponent/wikis/warcraft/player_display_custom.lua
@@ -102,7 +102,7 @@ function CustomPlayerDisplay.InlinePlayer(props)
 end
 
 function CustomPlayerDisplay.Faction(faction)
-	return Faction.Icon{size = 'small', showLink = false, showTitle = false, faction = faction}
+	return Faction.Icon{size = 'small', showLink = false, faction = faction}
 end
 
 return CustomPlayerDisplay


### PR DESCRIPTION
## Summary
set the title in the faction image so that css grabs them and makes them white for darkmode

## How did you test this change?
dev tools