### PR TITLE
feat: enable headtohead storage and wiki variable on dota2

### DIFF
--- a/components/hidden_data_box/wikis/dota2/hidden_data_box_custom.lua
+++ b/components/hidden_data_box/wikis/dota2/hidden_data_box_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
@@ -37,6 +38,12 @@ function CustomHiddenDataBox.addCustomVariables(args, queryResult)
 	Variables.varDefine('tournament_ticker_name', Variables.varDefault('tournament_tickername'))
 	Variables.varDefine('tournament_icon_dark', Variables.varDefault('tournament_icondark'))
 	Variables.varDefine('tournament_parent_page', Variables.varDefault('tournament_parent'))
+
+	Variables.varDefine('headtohead', tostring(Logic.readBool(Logic.emptyOr(
+		args.headtohead,
+		Variables.varDefault('headtohead'),
+		(queryResult.extradata or {}).headtohead
+	))))
 
 	BasicHiddenDataBox.checkAndAssign('tournament_patch', args.patch, queryResult.patch)
 end

--- a/components/infobox/wikis/dota2/infobox_league_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_league_custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Game = require('Module:Game')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Variables = require('Module:Variables')
@@ -86,6 +87,7 @@ end
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.extradata.individual = String.isNotEmpty(args.player_number) and 'true' or ''
 	lpdbData.extradata.dpcpoints = String.isNotEmpty(args.points) or ''
+	lpdbData.extradata.headtohead = self.data.headtohead
 
 	return lpdbData
 end
@@ -93,11 +95,13 @@ end
 ---@param args table
 function CustomLeague:customParseArguments(args)
 	self.data.publishertier = (self.publisherTier or {}).name
+	self.data.headtohead = tostring(Logic.readBool(args.headtohead))
 end
 
 ---@param args table
 function CustomLeague:defineCustomPageVariables(args)
 	-- Custom Vars
+	Variables.varDefine('headtohead', self.data.headtohead)
 	Variables.varDefine('tournament_pro_circuit_points', args.points or '')
 	local isIndividual = String.isNotEmpty(args.individual) or String.isNotEmpty(args.player_number)
 	Variables.varDefine('tournament_individual', isIndividual and 'true' or '')


### PR DESCRIPTION
## Summary
currently dota2 sets the wiki variable manually but still has the input in the infobox (currently doing nothing)
![image](https://github.com/user-attachments/assets/5e041144-333b-47e7-9be4-d7f6cf8b02e2)

this also leads to it not working on subpages and match pages
this pr adds the storage in lpdb and wiki variable of headtohead in infobox league and support in hiddenDataBox

basically the initial report: https://discord.com/channels/93055209017729024/372075546231832576/1317925849491570800

## How did you test this change?
dev