### PR TITLE
fix(match2): Prevent premature return in match legacy on AoE

### DIFF
--- a/components/match2/wikis/ageofempires/match_legacy.lua
+++ b/components/match2/wikis/ageofempires/match_legacy.lua
@@ -44,12 +44,13 @@ function MatchLegacy.storeGames(match, match2)
 			Array.forEach(opponents, function(opponent, opponentIndex)
 				-- opponent.players can have gaps
 				for _, player in pairs(opponent.players) do
-					if Table.isEmpty(player) then return end
-					local prefix = 'o' .. opponentIndex .. 'p' .. player.index
-					game.extradata[prefix] = player.pageName
-					game.extradata[prefix .. 'faction'] = player.civ
-					game.extradata[prefix .. 'name'] = player.displayname
-					game.extradata[prefix .. 'flag'] = player.flag
+					if Table.isNotEmpty(player) then
+						local prefix = 'o' .. opponentIndex .. 'p' .. player.index
+						game.extradata[prefix] = player.pageName
+						game.extradata[prefix .. 'faction'] = player.civ
+						game.extradata[prefix .. 'name'] = player.displayname
+						game.extradata[prefix .. 'flag'] = player.flag
+					end
 				end
 			end)
 		elseif game.mode == '1v1' then


### PR DESCRIPTION
## Summary
Misread that the player handling code isn't in its own function, so upon empty player the entire team handling would be stopped.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
