### PR TITLE
feat(match2): Add dark theme support for BR table navigation

### DIFF
--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -74,6 +74,8 @@ Author(s): Elysienna
 
 		.theme--dark & {
 			border: 0.0625rem solid rgba( 255, 255, 255, 0.08 );
+			background-color: rgba( 24, 24, 24, 0.9 );
+			color: #ffffff;
 		}
 
 		&.navigate--left {


### PR DESCRIPTION
## Summary

Add dark theme bg color to arrow navigation in table.

![image](https://github.com/user-attachments/assets/ee9c678e-b344-4da2-83c7-55b41e868c13)

## How did you test this change?

Live, for example https://liquipedia.net/apexlegends/BLGS/2024/Regional_Finals/APAC_South