### PR TITLE
feat(match2): Adjust background color for placement and kills

### DIFF
--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -221,7 +221,7 @@ Author(s): Elysienna
 				justify-content: center;
 				align-items: center;
 				padding: 0.5rem 0;
-				background-color: var( --table-background-color, #fafafa );
+				background-color: var( --table-variant-background-color, #fafafa );
 
 				.theme--dark & {
 					border-right: 0.0625rem solid rgba( 255, 255, 255, 0.08 );
@@ -234,10 +234,6 @@ Author(s): Elysienna
 				justify-content: center;
 				align-items: center;
 				padding: 0.5rem 0;
-
-				.panel-table__row:not( .row--header ) & {
-					background-color: var( --table-background-color, #ffffff );
-				}
 			}
 
 			&-total-points {

--- a/stylesheets/commons/BattleRoyale/PanelTable.less
+++ b/stylesheets/commons/BattleRoyale/PanelTable.less
@@ -221,7 +221,7 @@ Author(s): Elysienna
 				justify-content: center;
 				align-items: center;
 				padding: 0.5rem 0;
-				background-color: var( --table-variant-background-color, #fafafa );
+				background-color: var( --table-striped-background-color, #fafafa );
 
 				.theme--dark & {
 					border-right: 0.0625rem solid rgba( 255, 255, 255, 0.08 );


### PR DESCRIPTION
## Summary

In this MR:
- remove the background-color for kills column (removing it didn't change anything afaik) 
- change the variable for the placement column

Dark theme
![image](https://github.com/user-attachments/assets/610d066c-89be-411c-90b2-329fdd231124)

Light theme
![image](https://github.com/user-attachments/assets/5bdf05a3-954d-43e2-a75a-868b1eeba93d)

Bruinen
![image](https://github.com/user-attachments/assets/e1e43983-7060-4dfc-9d27-76bcf0d0196f)

## How did you test this change?

Devtools
