### PR TITLE
feat(match2): show mapRow for set players but missing winner/map on aoe

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -216,6 +216,7 @@ MatchGroupUtil.types.Walkover = TypeUtil.literalUnion('l', 'ff', 'dq')
 ---@field vod string?
 ---@field walkover WalkoverType?
 ---@field winner integer?
+---@field status string?
 ---@field extradata table?
 MatchGroupUtil.types.Game = TypeUtil.struct({
 	comment = 'string?',

--- a/components/match2/wikis/ageofempires/match_summary.lua
+++ b/components/match2/wikis/ageofempires/match_summary.lua
@@ -10,10 +10,10 @@ local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local Faction = require('Module:Faction')
 local Game = require('Module:Game')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapMode = require('Module:MapMode')
 local Operator = require('Module:Operator')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
@@ -83,7 +83,9 @@ end
 ---@param props {game: string?, soloMode: boolean}
 ---@return Widget?
 function CustomMatchSummary._createGame(game, props)
-	if not game.map and not game.winner and String.isEmpty(game.resultType) then return end
+	if (not game.map) and (not game.winner) and Logic.isEmpty(game.status) and Logic.isDeepEmpty(game.opponents) then
+		return
+	end
 
 	local normGame = Game.abbreviation{game = props.game}:lower()
 	game.mapDisplayName = game.mapDisplayName or game.map


### PR DESCRIPTION
waiting for purge run to finish (to make sure gameOpponent.status is populated)

## Summary
Adjust the condition on which the map is not shown to check for non empty opponents data.
That way for set players but unset winner and unset map it would still display the row.

While at it also converted resulttype check to status check (the default win is auto checked via opponents data not being empty/winner being set)

Requested/reported in the aoe discord channel: https://discord.com/channels/93055209017729024/717412628330446929/1319422214306529352

## How did you test this change?
dev on https://liquipedia.net/ageofempires/User:SyntacticSalt/Sandbox/2