### PR TITLE
feat: increase match card widths for SMITE

### DIFF
--- a/standard/info/wikis/smite/info.lua
+++ b/standard/info/wikis/smite/info.lua
@@ -47,6 +47,7 @@ return {
 		},
 		match2 = {
 			status = 2,
+			matchWidth = 180,
 		},
 		transfers = {
 			showTeamName = true,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a52b2780-bb03-4883-881a-b26b1bb1e4e0)
(set to 180)

for whatever reason SMITE team name is pretty longer than usual and default width often eclipsed through the names which isnt good looking, 180 will help with the majority of the wiki 
