### PR TITLE
Create earnings.lua

### DIFF
--- a/components/earnings/wikis/brawlstars/earnings.lua
+++ b/components/earnings/wikis/brawlstars/earnings.lua
@@ -1,0 +1,16 @@
+---
+-- @Liquipedia
+-- wiki=brawlstars
+-- page=Module:Earnings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local CustomEarnings = Lua.import('Module:Earnings/Base', {requireDevIfEnabled = true})
+
+CustomEarnings.defaultNumberOfPlayersInTeam = 3
+
+return Class.export(CustomEarnings)


### PR DESCRIPTION
defaultnumberofplayers to 3.
Data are not calculated correctly so all earnings were divided by 5 by default.  unavailable data?