### PR TITLE
feat: change var for bg-first

### DIFF
--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -587,7 +587,7 @@ ul.nav-tabs li.game-64,
 .background-color-first-place,
 .bg-first,
 .bg-p1 {
-	background-color: var( --achievement-placement-1, #ffe982 );
+	background-color: var( --prize-pool-gold, #ffe982 );
 }
 
 /* TULIP TREE */

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -587,7 +587,7 @@ ul.nav-tabs li.game-64,
 .background-color-first-place,
 .bg-first,
 .bg-p1 {
-	background-color: var( --achievement-placement-1, #ffd739 );
+	background-color: var( --achievement-placement-1, #ffe982 );
 }
 
 /* TULIP TREE */

--- a/stylesheets/commons/Colours.less
+++ b/stylesheets/commons/Colours.less
@@ -587,7 +587,7 @@ ul.nav-tabs li.game-64,
 .background-color-first-place,
 .bg-first,
 .bg-p1 {
-	background-color: var( --clr-semantic-gold-80, #ffe982 );
+	background-color: var( --achievement-placement-1, #ffd739 );
 }
 
 /* TULIP TREE */


### PR DESCRIPTION
## Summary

The current var for `bg-first` is unreadable in darkmode so this switches to a more readable version. I'm not sure if this is the intended use case for `achievement-placement-1` but it looks good IMO. The attached images display the PR's changes via the "First" text. You can see what the current version is here: https://liquipedia.net/commons/Template:Bgcolortext

![Screenshot 2024-12-23 085058](https://github.com/user-attachments/assets/8a1f2f63-8e91-44a8-bff8-b4324a4de4e4)
![Screenshot 2024-12-23 085117](https://github.com/user-attachments/assets/ae38e1e8-2b32-4e8c-9b95-3b1c825ebd51)

## How did you test this change?

inspect tools
