### PR TITLE
feat(match2): Add non-BR support for Fortnite

### DIFF
--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
-local Variables = require('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 

--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -20,13 +20,12 @@ local MatchFunctions = {
 		applyUnderScores = true,
 		maxNumPlayers = 3,
 	},
-	DEFAULT_MODE = 'team'
+	DEFAULT_MODE = 'team',
+	getBestOf = MatchGroupInputUtil.getBestOf,
 }
 local FfaMatchFunctions = {}
 local MapFunctions = {}
 local FfaMapFunctions = {}
-
-local DEFAULT_BESTOF = 3
 
 ---@param match table
 ---@param options table?
@@ -61,22 +60,6 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
-end
-
----@param bestofInput string|integer?
----@return integer
-function MatchFunctions.getBestOf(bestofInput)
-	local bestof = tonumber(bestofInput) or tonumber(Variables.varDefault('match_bestof')) or DEFAULT_BESTOF
-	Variables.varDefine('match_bestof', bestof)
-	return bestof
-end
-
----@param games table[]
----@return table[]
-function MatchFunctions.removeUnsetMaps(games)
-	return Array.filter(games, function(map)
-		return map.map ~= nil
-	end)
 end
 
 ---@param match table
@@ -145,6 +128,5 @@ function FfaMapFunctions.getExtraData(match, map, opponents)
 		comment = map.comment,
 	}
 end
-
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 
@@ -59,6 +60,12 @@ function MatchFunctions.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
+end
+
+---@param games table[]
+---@return table[]
+function MatchFunctions.removeUnsetMaps(games)
+	return Array.filter(games, Logic.isNotDeepEmpty)
 end
 
 ---@param match table

--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -43,17 +43,6 @@ function MatchFunctions.extractMaps(match, opponents)
 	return MatchGroupInputUtil.standardProcessMaps(match, opponents, MapFunctions)
 end
 
----@param match table
----@param games table[]
----@param opponents table[]
----@return table
-function MatchFunctions.getExtraData(match, games, opponents)
-	return {
-		mvp = MatchGroupInputUtil.readMvp(match, opponents),
-		casters = MatchGroupInputUtil.readCasters(match),
-	}
-end
-
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer?
 function MatchFunctions.calculateMatchScore(maps)

--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -18,12 +18,17 @@ local MatchFunctions = {
 	OPPONENT_CONFIG = {
 		resolveRedirect = true,
 		applyUnderScores = true,
-		maxNumPlayers = 3,
+		maxNumPlayers = 4,
 	},
 	DEFAULT_MODE = 'team',
 	getBestOf = MatchGroupInputUtil.getBestOf,
 }
 local FfaMatchFunctions = {
+	OPPONENT_CONFIG = {
+		resolveRedirect = true,
+		applyUnderScores = true,
+		maxNumPlayers = 3,
+	},
 	DEFAULT_MODE = 'solos',
 }
 local MapFunctions = {}

--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -23,7 +23,9 @@ local MatchFunctions = {
 	DEFAULT_MODE = 'team',
 	getBestOf = MatchGroupInputUtil.getBestOf,
 }
-local FfaMatchFunctions = {}
+local FfaMatchFunctions = {
+	DEFAULT_MODE = 'solos',
+}
 local MapFunctions = {}
 local FfaMapFunctions = {}
 

--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -9,10 +9,11 @@
 local Array = require('Module:Array')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
+local Variables = require('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
-local MapFunctions = {}
+local CustomMatchGroupInput = {}
 local MatchFunctions = {
 	OPPONENT_CONFIG = {
 		resolveRedirect = true,
@@ -21,31 +22,102 @@ local MatchFunctions = {
 	},
 	DEFAULT_MODE = 'team'
 }
+local FfaMatchFunctions = {
+	DEFAULT_MODE = 'solos',
+}
+local MapFunctions = {}
+local FfaMapFunctions = {}
 
-local CustomMatchGroupInput = {}
+local DEFAULT_BESTOF = 3
 
 ---@param match table
 ---@param options table?
 ---@return table
 function CustomMatchGroupInput.processMatch(match, options)
-	return MatchGroupInputUtil.standardProcessFfaMatch(match, MatchFunctions)
+	return MatchGroupInputUtil.standardProcessMatch(match, MatchFunctions, FfaMatchFunctions)
 end
 
---
--- match related functions
---
+--- Normal 2-opponent Match
+
+---@param match table
+---@param opponents table[]
+---@return table[]
+function MatchFunctions.extractMaps(match, opponents)
+	return MatchGroupInputUtil.standardProcessMaps(match, opponents, MapFunctions)
+end
+
+---@param match table
+---@param games table[]
+---@param opponents table[]
+---@return table
+function MatchFunctions.getExtraData(match, games, opponents)
+	return {
+		mvp = MatchGroupInputUtil.readMvp(match, opponents),
+		casters = MatchGroupInputUtil.readCasters(match),
+	}
+end
+
+---@param maps table[]
+---@return fun(opponentIndex: integer): integer?
+function MatchFunctions.calculateMatchScore(maps)
+	return function(opponentIndex)
+		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
+	end
+end
+
+---@param bestofInput string|integer?
+---@return integer
+function MatchFunctions.getBestOf(bestofInput)
+	local bestof = tonumber(bestofInput) or tonumber(Variables.varDefault('match_bestof')) or DEFAULT_BESTOF
+	Variables.varDefine('match_bestof', bestof)
+	return bestof
+end
+
+---@param games table[]
+---@return table[]
+function MatchFunctions.removeUnsetMaps(games)
+	return Array.filter(games, function(map)
+		return map.map ~= nil
+	end)
+end
+
+---@param match table
+---@param map table
+---@param opponents table[]
+---@return table
+function MapFunctions.getExtraData(match, map, opponents)
+	return {
+		comment = map.comment,
+	}
+end
+
+---@param map table
+---@return fun(opponentIndex: integer): integer?
+function MapFunctions.calculateMapScore(map)
+	local winner = tonumber(map.winner)
+	return function(opponentIndex)
+		-- TODO Better to check if map has started, rather than finished, for a more correct handling
+		if not winner and not map.finished then
+			return
+		end
+		return winner == opponentIndex and 1 or 0
+	end
+end
+
+--- FFA Match
+
 ---@param match table
 ---@param opponents table[]
 ---@param scoreSettings table
 ---@return table[]
-function MatchFunctions.extractMaps(match, opponents, scoreSettings)
-	return MatchGroupInputUtil.standardProcessFfaMaps(match, opponents, scoreSettings, MapFunctions)
+function FfaMatchFunctions.extractMaps(match, opponents, scoreSettings)
+	return MatchGroupInputUtil.standardProcessFfaMaps(match, opponents, scoreSettings, FfaMapFunctions)
 end
 
 ---@param opponents table[]
 ---@param maps table[]
 ---@return fun(opponentIndex: integer): integer?
-function MatchFunctions.calculateMatchScore(opponents, maps)
+function FfaMatchFunctions.calculateMatchScore(opponents, maps)
 	return function(opponentIndex)
 		return Array.reduce(Array.map(maps, function(map)
 			return map.opponents[opponentIndex].score or 0
@@ -58,26 +130,23 @@ end
 ---@param opponents table[]
 ---@param settings table
 ---@return table
-function MatchFunctions.getExtraData(match, games, opponents, settings)
+function FfaMatchFunctions.getExtraData(match, games, opponents, settings)
 	return {
 		placementinfo = settings.placementInfo,
 		settings = settings.settings,
 	}
 end
 
---
--- map related functions
---
-
 ---@param match table
 ---@param map table
 ---@param opponents table[]
 ---@return table
-function MapFunctions.getExtraData(match, map, opponents)
+function FfaMapFunctions.getExtraData(match, map, opponents)
 	return {
 		dateexact = map.dateexact,
 		comment = map.comment,
 	}
 end
+
 
 return CustomMatchGroupInput

--- a/components/match2/wikis/fortnite/match_group_input_custom.lua
+++ b/components/match2/wikis/fortnite/match_group_input_custom.lua
@@ -22,9 +22,7 @@ local MatchFunctions = {
 	},
 	DEFAULT_MODE = 'team'
 }
-local FfaMatchFunctions = {
-	DEFAULT_MODE = 'solos',
-}
+local FfaMatchFunctions = {}
 local MapFunctions = {}
 local FfaMapFunctions = {}
 

--- a/components/match2/wikis/fortnite/match_summary.lua
+++ b/components/match2/wikis/fortnite/match_summary.lua
@@ -1,0 +1,51 @@
+---
+-- @Liquipedia
+-- wiki=fortnite
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
+local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local CustomMatchSummary = {}
+
+---@param args table
+---@return Html
+function CustomMatchSummary.getByMatchId(args)
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
+end
+
+---@param date string
+---@param game MatchGroupUtilGame
+---@param gameIndex integer
+---@return Widget?
+function CustomMatchSummary.createGame(date, game, gameIndex)
+	if not game.map then
+		return
+	end
+
+	local function makeTeamSection(opponentIndex)
+		return {
+			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = opponentIndex},
+			DisplayHelper.MapScore(game.opponents[opponentIndex], game.status)
+		}
+	end
+
+	return MatchSummaryWidgets.Row{
+		classes = {'brkts-popup-body-game'},
+		children = WidgetUtil.collect(
+			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
+			MatchSummaryWidgets.GameCenter{children = DisplayHelper.Map(game)},
+			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(2), flipped = true},
+			MatchSummaryWidgets.GameComment{children = game.comment}
+		)
+	}
+end
+
+return CustomMatchSummary


### PR DESCRIPTION
## Summary
I want it like how TFT is able to display both Brackets and Battle Royale together. So like #5196 in reverse

I'm starting with using TFT's setup as basis, because I never edit BR-related match2 yet

## Side Note 
things like `OPPONENT_CONFIG` on matchFunctions is carried from FN's current setup

FN doesnt really have a strict default mode **(FOR BR),** they changed pretty regularly `(e.g. Duos in 2024, but Trios in 2025)` after talking to hjp I've come to a decision to left it unset for BR

## How did you test this change?
DEV https://liquipedia.net/fortnite/User:Hesketh2/Test

**Test includes putting both BR and Bracket on same page with same dev on both**