### PR TITLE
feat(prizepool): make ppt display behavour of win and lose similar to other placements

### DIFF
--- a/stylesheets/commons/Prizepooltable.less
+++ b/stylesheets/commons/Prizepooltable.less
@@ -226,6 +226,31 @@ body:not( .skin-bruinen ) div.background-color-fourth-place > *.prizepooltable-p
 	color: #ffffff;
 }
 
+body:not( .skin-bruinen ) div.prizepooltable > div.csstable-widget-row.bg-win {
+	/* need the `!important` due to bg-win (sadly) having an important in one of its definitions ... */
+	background-color: inherit !important;
+}
+
+body:not( .skin-bruinen ) div.csstable-widget-row.bg-win > .csstable-widget-cell {
+	border-bottom: 0.125rem solid var( --clr-forestgreen-background-color, transparent );
+}
+
+body:not( .skin-bruinen ) div.bg-win > *.prizepooltable-place {
+	background-color: var( --clr-forestgreen-background-color, inherit );
+}
+
+body:not( .skin-bruinen ) div.csstable-widget-row.bg-lose {
+	background-color: inherit;
+}
+
+body:not( .skin-bruinen ) div.csstable-widget-row.bg-lose > .csstable-widget-cell {
+	border-bottom: 0.125rem solid var( --clr-cinnabar-background-color, transparent );
+}
+
+body:not( .skin-bruinen ) div.bg-lose > *.prizepooltable-place {
+	background-color: var( --clr-cinnabar-background-color, inherit );
+}
+
 tr.background-color-disqualified,
 div.background-color-disqualified {
 	background-color: #dee3ef;


### PR DESCRIPTION
## Summary
currently:
- for win/lose the ppt in the new skin displays the entire row with complete bg
- for lose it only does so every 2nd row
![image](https://github.com/user-attachments/assets/a0ef0652-ea19-4edc-91df-4065056fcb62)

with this PR:
- the display mirrors the way normal place colors (gold, silver, bronze, copper) are applied in ppt
- for lose it is irrelevant if it is an even or odd row
![image](https://github.com/user-attachments/assets/63c4594f-bbf4-4e29-ab41-b43152bab67f)

## How did you test this change?
browser dev tools