### PR TITLE
fix(match2): Archon submatches in team matches not displaying properly

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -110,7 +110,7 @@ function MatchFunctions.getOpponentExtradata(opponent)
 		advantage = tonumber(opponent.advantage),
 		penalty = tonumber(opponent.penalty),
 		score2 = opponent.score2,
-		isarchon = opponent.isarchon,
+		isarchon = tostring(Logic.readBool(opponent.isarchon)),
 	}
 end
 
@@ -294,6 +294,7 @@ function MapFunctions.getTeamMapPlayers(mapInput, opponent, opponentIndex)
 				player = playerIdData.name or playerInputData.link or playerInputData.name:gsub(' ', '_'),
 				flag = Flags.CountryName(playerIdData.flag),
 				position = playerIndex,
+				isarchon = isArchon,
 			}
 		end
 	)

--- a/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_summary_starcraft.lua
@@ -222,7 +222,11 @@ function StarcraftMatchSummary.TeamSubMatchOpponnetRow(submatch)
 		end
 		return OpponentDisplay.BlockOpponent{
 			flip = opponentIndex == 1,
-			opponent = {players = players, type = Opponent.partyTypes[math.max(#players, 1)]},
+			opponent = {
+				players = players,
+				type = Opponent.partyTypes[math.max(#players, 1)],
+				isArchon = (opponents[opponentIndex] or {}).isArchon,
+			},
 			showLink = true,
 			overflow = 'ellipsis',
 		}


### PR DESCRIPTION
## Summary
- store the isarchon on mapOpponent level
- standardize the stored value on (match-) opponent level (i.e. use readBool)
- pass the isArchon bool to the opponent display

## How did you test this change?
live