### PR TITLE
feat(Infobox): on stormgate, allow attacks to have multiple bonus damage instances

### DIFF
--- a/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
+++ b/components/infobox/extensions/wikis/stormgate/infobox_extension_attack.lua
@@ -64,10 +64,16 @@ function Attack._displayDamage(data)
 		return (data.damagePercentage .. '%')
 	elseif not data.damage then
 		return
-	elseif Logic.isEmpty(data.bonus) or not data.bonusDamage then
+	elseif Logic.isEmpty(data.bonusData) then
 		return data.damage
 	end
-	return data.damage .. ' (+' .. data.bonusDamage .. ' vs ' .. Attack._displayArray(data.bonus) .. ')'
+
+	local parts = Array.extend({data.damage}, Array.map(data.bonusData, function(bonusElement)
+		if Logic.isEmpty(bonusElement.bonusDamage) then return end
+		return ' +' .. bonusElement.bonusDamage .. ' vs ' .. Page.makeInternalLink(bonusElement.bonus)
+	end))
+
+	return table.concat(parts, '<br>')
 end
 
 ---@param data table
@@ -75,15 +81,32 @@ end
 function Attack._displayDPS(data)
 	if not data.dps then
 		return
-	elseif Logic.isEmpty(data.bonus) or not data.bonusDps then
+	elseif Logic.isEmpty(data.bonusData) then
 		return data.dps
 	end
-	return data.dps .. ' (+' .. data.bonusDps .. ' vs ' .. Attack._displayArray(data.bonus) .. ')'
+
+	local parts = Array.extend({data.dps}, Array.map(data.bonusData, function(bonusElement)
+		if Logic.isEmpty(bonusElement.bonusDps) then return end
+		return ' +' .. bonusElement.bonusDps .. ' vs ' .. Page.makeInternalLink(bonusElement.bonus)
+	end))
+
+	return table.concat(parts, '<br>')
 end
 
 ---@param args table
 ---@return StormgateAttackData
 function Attack._parse(args)
+	local bonusInput = Array.parseCommaSeparatedString(args.bonus)
+	local bonusDamageInput = Array.parseCommaSeparatedString(args.bonus_damage)
+	local bonusDpsInput = Array.parseCommaSeparatedString(args.bonus_dps)
+	local bonusData = Array.map(bonusInput, function(bonusElement, bonusIndex)
+		return {
+			bonus = bonusElement,
+			bonusDamage = tonumber(bonusDamageInput[bonusIndex]),
+			bonusDps = tonumber(bonusDpsInput[bonusIndex]),
+		}
+	end)
+
 	return {
 		targets = Array.map(Array.map(Array.parseCommaSeparatedString(args.target), string.lower), String.upperCaseFirst),
 		damage = tonumber(args.damage),
@@ -91,9 +114,7 @@ function Attack._parse(args)
 		effect = Array.parseCommaSeparatedString(args.effect),
 		speed = tonumber(args.speed),
 		dps = tonumber(args.dps),
-		bonus = Array.parseCommaSeparatedString(args.bonus),
-		bonusDamage = tonumber(args.bonus_damage),
-		bonusDps = tonumber(args.bonus_dps),
+		bonusData = bonusData,
 		range = tonumber(args.range),
 	}
 end


### PR DESCRIPTION
## Summary

Allow attacks to have multiple bonus damage instances with different bonus damage values. 

Examples for units with multiple bonus damage instances (dev-mode):
- https://liquipedia.net/stormgate/Lancer
![image](https://github.com/user-attachments/assets/38cfd1cf-f1ba-4efe-97f8-f45b4dabfe9e)
- https://liquipedia.net/stormgate/SCOUT
![image](https://github.com/user-attachments/assets/1c8ab7e7-a466-4776-84f1-92e4d89b3279)

Example for unit with just one bonus damage instance (dev-mode):
- https://liquipedia.net/stormgate/Saber 
![image](https://github.com/user-attachments/assets/31772eae-5228-4865-b4a8-8b35d6e5a487)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev tools

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
