### PR TITLE
feat(infobox): update FACEIT League links to match new format

### DIFF
--- a/standard/links/wikis/counterstrike/links_custom_data.lua
+++ b/standard/links/wikis/counterstrike/links_custom_data.lua
@@ -19,7 +19,7 @@ return {
 			player = 'https://www.faceit.com/en/players/',
 		},
 		['faceit-l'] = {
-			'https://www.faceit.com/en//league//a14b8616-45b9-4581-8637-4dfd0b5f6af8/',
+			'https://www.faceit.com/en/-/league/-/a14b8616-45b9-4581-8637-4dfd0b5f6af8/',
 		},
 		esl = {
 			'',

--- a/standard/links/wikis/overwatch/links_custom_data.lua
+++ b/standard/links/wikis/overwatch/links_custom_data.lua
@@ -9,7 +9,7 @@
 return {
 	prefixes = {
 		['faceit-l'] = {
-			'https://www.faceit.com/en//league//88c7f7ec-4cb8-44d3-a5db-6e808639c232/',
+			'https://www.faceit.com/en/-/league/-/88c7f7ec-4cb8-44d3-a5db-6e808639c232/',
 		},
 		faceit = {
 			'',


### PR DESCRIPTION
## Summary

Due to them changing their web app navigator, the empty URL bits were breaking links. Hyphens work as before now.

## How did you test this change?

Pushed live for CS wiki as just data.
