### PR TITLE
feat(mainpage): standardize handling of navigation cards

### DIFF
--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -38,7 +38,7 @@ function MainPageLayout.make(frame)
 		classes = {'mainpage-v2'},
 		children = {
 			NO_TABLE_OF_CONTENTS,
-			String.interpolate(METADESC, {metadesc = WikiData.metadesc}),
+			frame:preprocess(String.interpolate(METADESC, {metadesc = WikiData.metadesc})),
 			frame:preprocess('{{DISPLAYTITLE:' .. WikiData.title .. '}}'),
 			Template.expandTemplate(frame, 'Header banner', {
 				['logo-lighttheme'] = WikiData.banner.lightmode,
@@ -85,7 +85,7 @@ function MainPageLayout._makeCells(cells)
 	return output
 end
 
----@param navigationData {file: string?, link: string?, count: table?, text: string?}
+---@param navigationData {file: string?, link: string?, count: table?, title: string?}
 ---@return WidgetHtml
 function MainPageLayout._makeNavigationCard(navigationData)
 	local count
@@ -104,11 +104,11 @@ function MainPageLayout._makeNavigationCard(navigationData)
 		children = {
 			HtmlWidgets.Div{
 				classes = {'navigation-card__image'},
-				children = Image.display(navigationData.file, nil, {size = 240}),
+				children = Image.display(navigationData.file, nil, {size = 240, link = ''}),
 			},
 			HtmlWidgets.Span{
 				classes = {'navigation-card__title'},
-				children = LinkWidget{link = navigationData.link, children = navigationData.text}
+				children = LinkWidget{link = navigationData.link, children = navigationData.title}
 			},
 			count and HtmlWidgets.Span{
 				classes = {'navigation-card__subtitle'},

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -97,7 +97,7 @@ function MainPageLayout._makeNavigationCard(navigationData)
 		if navigationData.count.method == 'LPDB' then
 			count = LpdbCounter.count{table = navigationData.count.table, conditions = navigationData.count.conditions}
 		elseif navigationData.count.method == 'CATEGORY' then
-			count = mw.getCurrentFrame():preprocess('{{PAGESINCATEGORY:'.. navigationData.count.category .. '}}')
+			count = mw.getCurrentFrame():preprocess('{{PAGESINCATEGORY:'.. navigationData.count.category .. '|pages}}')
 		else
 			count = navigationData.count.value
 		end

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -97,7 +97,7 @@ function MainPageLayout._makeNavigationCard(navigationData)
 		if navigationData.count.method == 'LPDB' then
 			count = LpdbCounter.count{table = navigationData.count.table, conditions = navigationData.count.conditions}
 		elseif navigationData.count.method == 'CATEGORY' then
-			count = mw.getCurrentFrame():preprocess('{{PAGESINCATEGORY:'.. navigationData.count.category .. '|pages}}')
+			count = mw.site.stats.pagesInCategory(navigationData.count.category, 'pages')
 		else
 			count = navigationData.count.value
 		end

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -12,6 +12,7 @@ local Grid = require('Module:Grid')
 local Image = require('Module:Image')
 local LpdbCounter = require('Module:LPDB entity count')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 local Template = require('Module:Template')
 
 local WikiData = Lua.import('Module:MainPageLayout/data')
@@ -20,7 +21,16 @@ local LinkWidget = Lua.import('Module:Widget/Basic/Link')
 
 local MainPageLayout = {}
 
+local NO_TABLE_OF_CONTENTS = '__NOTOC__'
+local METADESC = '<metadesc>${metadesc}</metadesc>'
+
 function MainPageLayout.make(frame)
+	assert(WikiData.banner, 'MainPageLayout: Banner data not found')
+	assert(WikiData.layouts, 'MainPageLayout: Layout data not found')
+	assert(WikiData.navigation, 'MainPageLayout: Navigation data not found')
+	assert(WikiData.metadesc, 'MainPageLayout: Metadesc data not found')
+	assert(WikiData.title, 'MainPageLayout: Title data not found')
+
 	local args = Arguments.getArgs(frame)
 
 	local layout = WikiData.layouts[args.layout] or WikiData.layouts.main
@@ -29,6 +39,9 @@ function MainPageLayout.make(frame)
 	return HtmlWidgets.Div{
 		classes = {'mainpage-v2'},
 		children = {
+			NO_TABLE_OF_CONTENTS,
+			String.interpolate(METADESC, {metadesc = WikiData.metadesc}),
+			frame:preprocess('{{DISPLAYTITLE:' .. WikiData.title .. '}}'),
 			Template.expandTemplate(frame, 'Header banner', {
 				['logo-lighttheme'] = WikiData.banner.lightmode,
 				['logo-darktheme'] = WikiData.banner.darkmode,

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -32,9 +32,7 @@ function MainPageLayout.make(frame)
 	assert(WikiData.title, 'MainPageLayout: Title data not found')
 
 	local args = Arguments.getArgs(frame)
-
 	local layout = WikiData.layouts[args.layout] or WikiData.layouts.main
-	local content = table.concat(MainPageLayout._makeCells(layout))
 
 	return HtmlWidgets.Div{
 		classes = {'mainpage-v2'},
@@ -50,7 +48,7 @@ function MainPageLayout.make(frame)
 				classes = {'navigation-cards'},
 				children = Array.map(WikiData.navigation, MainPageLayout._makeNavigationCard)
 			},
-			content,
+			table.concat(MainPageLayout._makeCells(layout)),
 		},
 	}
 end
@@ -112,7 +110,7 @@ function MainPageLayout._makeNavigationCard(navigationData)
 				classes = {'navigation-card__title'},
 				children = LinkWidget{link = navigationData.link, children = navigationData.text}
 			},
-			navigationData.count and HtmlWidgets.Span{
+			count and HtmlWidgets.Span{
 				classes = {'navigation-card__subtitle'},
 				children = count,
 			} or nil,

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -9,18 +9,37 @@
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
 local Grid = require('Module:Grid')
+local Image = require('Module:Image')
+local LpdbCounter = require('Module:LPDB entity count')
 local Lua = require('Module:Lua')
 local Template = require('Module:Template')
 
-local Layouts = Lua.import('Module:MainPageLayout/data')
+local WikiData = Lua.import('Module:MainPageLayout/data')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local LinkWidget = Lua.import('Module:Widget/Basic/Link')
 
 local MainPageLayout = {}
 
 function MainPageLayout.make(frame)
 	local args = Arguments.getArgs(frame)
 
-	local layout = Layouts[args.layout or 'main']
-	return table.concat(MainPageLayout._makeCells(layout))
+	local layout = WikiData.layouts[args.layout] or WikiData.layouts.main
+	local content = table.concat(MainPageLayout._makeCells(layout))
+
+	return HtmlWidgets.Div{
+		classes = {'mainpage-v2'},
+		children = {
+			Template.expandTemplate(frame, 'Header banner', {
+				['logo-lighttheme'] = WikiData.banner.lightmode,
+				['logo-darktheme'] = WikiData.banner.darkmode,
+			}),
+			HtmlWidgets.Div{
+				classes = {'navigation-cards'},
+				children = Array.map(WikiData.navigation, MainPageLayout._makeNavigationCard)
+			},
+			content,
+		},
+	}
 end
 
 function MainPageLayout._makeCells(cells)
@@ -53,6 +72,39 @@ function MainPageLayout._makeCells(cells)
 	end
 	table.insert(output, Grid._end_grid{})
 	return output
+end
+
+---@param navigationData {file: string?, link: string?, count: table?, text: string?}
+---@return WidgetHtml
+function MainPageLayout._makeNavigationCard(navigationData)
+	local count
+	if navigationData.count then
+		if navigationData.count.method == 'LPDB' then
+			count = LpdbCounter.count{table = navigationData.count.table, conditions = navigationData.count.conditions}
+		elseif navigationData.count.method == 'CATEGORY' then
+			count = mw.getCurrentFrame():preprocess('{{PAGESINCATEGORY:'.. navigationData.count.category .. '}}')
+		else
+			count = navigationData.count.value
+		end
+	end
+
+	return HtmlWidgets.Div{
+		classes = {'navigation-card'},
+		children = {
+			HtmlWidgets.Div{
+				classes = {'navigation-card__image'},
+				children = Image.display(navigationData.file, nil, {size = 240}),
+			},
+			HtmlWidgets.Span{
+				classes = {'navigation-card__title'},
+				children = LinkWidget{link = navigationData.link, children = navigationData.text}
+			},
+			navigationData.count and HtmlWidgets.Span{
+				classes = {'navigation-card__subtitle'},
+				children = count,
+			} or nil,
+		}
+	}
 end
 
 return MainPageLayout

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -24,6 +24,8 @@ local MainPageLayout = {}
 local NO_TABLE_OF_CONTENTS = '__NOTOC__'
 local METADESC = '<metadesc>${metadesc}</metadesc>'
 
+---@param frame Frame
+---@return WidgetHtml
 function MainPageLayout.make(frame)
 	assert(WikiData.banner, 'MainPageLayout: Banner data not found')
 	assert(WikiData.layouts, 'MainPageLayout: Layout data not found')
@@ -53,6 +55,8 @@ function MainPageLayout.make(frame)
 	}
 end
 
+---@param cells table[]
+---@return string[]
 function MainPageLayout._makeCells(cells)
 	local frame = mw.getCurrentFrame()
 	local output = {}

--- a/components/main_page/wikis/dota2/main_page_layout_data.lua
+++ b/components/main_page/wikis/dota2/main_page_layout_data.lua
@@ -120,183 +120,285 @@ local CONTENT = {
 	},
 }
 
+local LAYOUT_MAIN = {
+	{ -- Left
+		size = 6,
+		children = {
+			{
+				mobileOrder = 1,
+				content = CONTENT.aboutMain,
+			},
+			{
+				mobileOrder = 4,
+				content = CONTENT.heroes,
+			},
+			{
+				mobileOrder = 5,
+				content = CONTENT.updates,
+			},
+			{
+				mobileOrder = 9,
+				content = CONTENT.usefulArticles,
+			},
+			{
+				mobileOrder = 7,
+				content = CONTENT.wantToHelp,
+			},
+		},
+	},
+	{ -- Right
+		size = 6,
+		children = {
+			{
+				mobileOrder = 2,
+				content = CONTENT.specialEvents
+			},
+			{
+				mobileOrder = 3,
+				children = {
+					{
+						children = {
+							{
+								noPanel = true,
+								content = CONTENT.filterButtons,
+							},
+						},
+					},
+					{
+						size = 6,
+						children = {
+							{
+								noPanel = true,
+								content = CONTENT.matches,
+							},
+						},
+					},
+					{
+						size = 6,
+						children = {
+							{
+								noPanel = true,
+								content = CONTENT.tournaments,
+							},
+						},
+					},
+				},
+			},
+			{
+				mobileOrder = 6,
+				content = CONTENT.transfers,
+			},
+			{
+				mobileOrder = 9,
+				content = CONTENT.thisDay,
+			},
+		},
+	},
+}
+
+local LAYOUT_ESPORTS = {
+	{ -- Left
+		size = 6,
+		children = {
+			{
+				mobileOrder = 1,
+				content = CONTENT.aboutEsport,
+			},
+			{
+				mobileOrder = 2,
+				content = CONTENT.specialEvents,
+			},
+			{
+				mobileOrder = 4,
+				content = CONTENT.transfers,
+			},
+			{
+				mobileOrder = 6,
+				content = CONTENT.thisDay,
+			},
+			{
+				mobileOrder = 7,
+				content = CONTENT.wantToHelp,
+			},
+		}
+	},
+	{ -- Right
+		size = 6,
+		children = {
+			{
+				mobileOrder = 3,
+				children = {
+					{
+						children = {
+							{
+								noPanel = true,
+								content = CONTENT.filterButtons,
+							},
+						},
+					},
+					{
+						size = 6,
+						children = {
+							{
+								noPanel = true,
+								content = CONTENT.matches,
+							},
+						},
+					},
+					{
+						size = 6,
+						children = {
+							{
+								noPanel = true,
+								content = CONTENT.tournaments,
+							},
+						},
+					},
+				},
+			},
+			{
+				mobileOrder = 5,
+				content = CONTENT.updates,
+			},
+		},
+	},
+}
+
+local LAYOUT_GAME = {
+	{ -- Left
+		size = 6,
+		children = {
+			{
+				mobileOrder = 1,
+				content = CONTENT.aboutGame,
+			},
+			{
+				mobileOrder = 2,
+				content = CONTENT.heroes,
+			},
+			{
+				mobileOrder = 6,
+				content = CONTENT.wantToHelp,
+			},
+		},
+	},
+	{ -- Right
+		size = 6,
+		children = {
+			{
+				mobileOrder = 3,
+				content = CONTENT.updates
+			},
+			{
+				mobileOrder = 4,
+				content = CONTENT.thisDay,
+			},
+			{
+				mobileOrder = 5,
+				content = CONTENT.usefulArticles,
+			},
+		},
+	},
+}
+
 return {
-	main = {
-		{ -- Left
-			size = 6,
-			children = {
-				{
-					mobileOrder = 1,
-					content = CONTENT.aboutMain,
-				},
-				{
-					mobileOrder = 4,
-					content = CONTENT.heroes,
-				},
-				{
-					mobileOrder = 5,
-					content = CONTENT.updates,
-				},
-				{
-					mobileOrder = 9,
-					content = CONTENT.usefulArticles,
-				},
-				{
-					mobileOrder = 7,
-					content = CONTENT.wantToHelp,
-				},
+	banner = {
+		lightmode = 'Dota2logo-light-theme.svg',
+		darkmode = 'Dota2logo-dark-theme.svg',
+	},
+	metadesc = 'Comprehensive Dota 2 wiki with articles covering everything from heroes and items, to strategies, ' ..
+		'to tournaments, to competitive players, and teams.',
+	title = 'The Dota 2 Wiki',
+	navigation = {
+		{
+			file = 'Morphling_Large.png',
+			title = 'Heroes',
+			link = 'Heroes',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::hero]] and [[extradata_game::]]',
 			},
 		},
-		{ -- Right
-			size = 6,
-			children = {
-				{
-					mobileOrder = 2,
-					content = CONTENT.specialEvents
-				},
-				{
-					mobileOrder = 3,
-					children = {
-						{
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.filterButtons,
-								},
-							},
-						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.matches,
-								},
-							},
-						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.tournaments,
-								},
-							},
-						},
-					},
-				},
-				{
-					mobileOrder = 6,
-					content = CONTENT.transfers,
-				},
-				{
-					mobileOrder = 9,
-					content = CONTENT.thisDay,
-				},
+		{
+			file = 'Blink_Dagger Large.png',
+			title = 'Items',
+			link = 'Items',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::item]]',
+			},
+		},
+		{
+			file = 'Rune of Arcane prev.png',
+			title = 'Mechanics',
+			link = 'Mechanics',
+			count = {
+				method = 'CATEGORY',
+				category = 'Mechanics',
+			},
+		},
+		{
+			file = 'Main Page Dota 2 Cosmetics.jpg',
+			title = 'Cosmetics',
+			link = 'Cosmetics',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::cosmetic_item]]',
+			},
+		},
+		{
+			file = 'Neutral map.jpg',
+			title = 'Updates',
+			link = 'Updates',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::version]]',
+			},
+		},
+		{
+			file = 'The International 2016.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'Team_Spirit_win_The_International_2023.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = '7ckngMad_EPICENTER_Major_2019.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'Team_Liquid_The_International_2023.jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
 			},
 		},
 	},
-	esports = {
-		{ -- Left
-			size = 6,
-			children = {
-				{
-					mobileOrder = 1,
-					content = CONTENT.aboutEsport,
-				},
-				{
-					mobileOrder = 2,
-					content = CONTENT.specialEvents,
-				},
-				{
-					mobileOrder = 4,
-					content = CONTENT.transfers,
-				},
-				{
-					mobileOrder = 6,
-					content = CONTENT.thisDay,
-				},
-				{
-					mobileOrder = 7,
-					content = CONTENT.wantToHelp,
-				},
-			}
-		},
-		{ -- Right
-			size = 6,
-			children = {
-				{
-					mobileOrder = 3,
-					children = {
-						{
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.filterButtons,
-								},
-							},
-						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.matches,
-								},
-							},
-						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.tournaments,
-								},
-							},
-						},
-					},
-				},
-				{
-					mobileOrder = 5,
-					content = CONTENT.updates,
-				},
-			},
-		},
-	},
-	game = {
-		{ -- Left
-			size = 6,
-			children = {
-				{
-					mobileOrder = 1,
-					content = CONTENT.aboutGame,
-				},
-				{
-					mobileOrder = 2,
-					content = CONTENT.heroes,
-				},
-				{
-					mobileOrder = 6,
-					content = CONTENT.wantToHelp,
-				},
-			},
-		},
-		{ -- Right
-			size = 6,
-			children = {
-				{
-					mobileOrder = 3,
-					content = CONTENT.updates
-				},
-				{
-					mobileOrder = 4,
-					content = CONTENT.thisDay,
-				},
-				{
-					mobileOrder = 5,
-					content = CONTENT.usefulArticles,
-				},
-			},
-		},
+	layouts = {
+		main = LAYOUT_MAIN,
+		esports = LAYOUT_ESPORTS,
+		game = LAYOUT_GAME,
 	},
 }

--- a/components/main_page/wikis/rainbowsix/main_page_layout_data.lua
+++ b/components/main_page/wikis/rainbowsix/main_page_layout_data.lua
@@ -66,69 +66,131 @@ local CONTENT = {
 }
 
 return {
-	main = {
-		{ -- Left
-			size = 6,
-			children = {
-				{
-					mobileOrder = 1,
-					content = CONTENT.aboutEsport,
-				},
-				{
-					mobileOrder = 2,
-					content = CONTENT.specialEvents,
-				},
-				{
-					mobileOrder = 4,
-					content = CONTENT.transfers,
-				},
-				{
-					mobileOrder = 6,
-					content = CONTENT.thisDay,
-				},
-				{
-					mobileOrder = 7,
-					content = CONTENT.wantToHelp,
-				},
-			}
+	banner = {
+		lightmode = 'Rainbow Six Siege logo lightmode.svg',
+		darkmode = 'Rainbow Six Siege logo darkmode.svg',
+	},
+	metadesc = 'The Rainbow Six (R6) esports wiki covering everything from players, teams and transfers, ' ..
+		'to tournaments and results, maps, weapons, and operators.',
+	title = 'Rainbow Six',
+	navigation = {
+		{
+			file = 'W7m Champions of BLAST Major Montreal 2024.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
 		},
-		{ -- Right
-			size = 6,
-			children = {
-				{
-					mobileOrder = 3,
-					children = {
-						{
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.filterButtons,
+		{
+			file = 'Shaiiko BLAST R6 Montreal Major 2024.jpeg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'Hammer Trophy of the Six Invitational 2020.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'Rainbow Six BLAST Montreal 2024 phase2 (4).jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'Deimos Trophy of the Manchester major 2024.jpg',
+			title = 'Operators',
+			link = 'Portal:Operators',
+			count = {
+				method = 'CATEGORY',
+				category = 'Operators',
+			},
+		},
+		{
+			file = 'R6s map lair.png',
+			title = 'Maps',
+			link = 'Portal:Maps',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::map]]',
+			},
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 6,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 3,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.wantToHelp,
+					},
+				}
+			},
+			{ -- Right
+				size = 6,
+				children = {
+					{
+						mobileOrder = 2,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
 								},
 							},
-						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.matches,
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
 								},
 							},
-						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.tournaments,
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
 								},
 							},
 						},
 					},
-				},
-				{
-					mobileOrder = 5,
-					content = CONTENT.usefulArticles,
+					{
+						mobileOrder = 5,
+						content = CONTENT.thisDay,
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.usefulArticles,
+					},
 				},
 			},
 		},

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -529,7 +529,7 @@ function mw.message:isDisabled() end
 ---@field contentNamespaces table<number|string, namespaceInfo>
 ---@field subjectNamespaces table<number|string, namespaceInfo>
 ---@field talkNamespaces table<number|string, namespaceInfo>
----@field stats {pages: number, articles: number, files: number, edits: number, users: number, activeUsers: number, admins: number}
+---@field stats {pages: number, articles: number, files: number, edits: number, users: number, activeUsers: number, admins: number, pagesInCategory: fun(category: string, which: 'all'|'subcats'|'files'|'pages'|'*'):integer}
 mw.site = {server = 'https://liquipedia.net/wiki/'}
 
 ---Returns a table holding data about available interwiki prefixes. If filter is the string "local", then only data for local interwiki prefixes is returned. If filter is the string "!local", then only data for non-local prefixes is returned. If no filter is specified, data for all prefixes is returned. A "local" prefix in this context is one that is for the same project.


### PR DESCRIPTION
## Summary
Move the full mainpage into the module, instead of just the content

This adds the follow func, in addition to the full stucture.

* Display Title
* Metadesc
* Header Banner (still calls external template)
* Navigation Cards (changed from template & varies queries for counting into Lua)

## How did you test this change?
/dev on R6