### PR TITLE
fix(match2): several issues from #5210

### DIFF
--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -1170,6 +1170,7 @@ end
 ---@field getGame? fun(match: table, map:table): string?
 ---@field ADD_SUB_GROUP? boolean
 ---@field BREAK_ON_EMPTY? boolean
+---@field RECALCULATE_FINISHED_WITH_OPPONENTS? boolean
 
 --- The standard way to process a map input.
 ---
@@ -1189,6 +1190,7 @@ end
 --- Additionally, the Parser may have the following properties:
 --- - ADD_SUB_GROUP boolean?
 --- - BREAK_ON_EMPTY boolean?
+--- - RECALCULATE_FINISHED_WITH_OPPONENTS boolean?
 ---@param match table
 ---@param opponents table[]
 ---@param Parser MapParserInterface
@@ -1248,6 +1250,12 @@ function MatchGroupInputUtil.standardProcessMaps(match, opponents, Parser)
 			end
 			return Table.merge(Parser.extendMapOpponent(map, opponentIndex), mapOpponent)
 		end)
+
+		if Parser.RECALCULATE_FINISHED_WITH_OPPONENTS and Parser.mapIsFinished then
+			map.finished = Parser.mapIsFinished(map, opponents, finishedInput, winnerInput)
+		elseif Parser.RECALCULATE_FINISHED_WITH_OPPONENTS then
+			map.finished = MatchGroupInputUtil.mapIsFinished(map, map.opponents)
+		end
 
 		-- needs map.opponents available!
 		if Parser.getMapMode then

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -850,9 +850,8 @@ function MatchGroupInputUtil.matchIsFinished(match, opponents)
 end
 
 ---@param map {winner: string|nil, finished: string?, bestof: integer?}
----@param opponents? {score: integer?}[]
 ---@return boolean
-function MatchGroupInputUtil.mapIsFinished(map, opponents)
+function MatchGroupInputUtil.mapIsFinished(map)
 	if MatchGroupInputUtil.isNotPlayed(map.winner, map.finished) then
 		return true
 	end
@@ -868,6 +867,19 @@ function MatchGroupInputUtil.mapIsFinished(map, opponents)
 
 	if Logic.isNotEmpty(map.finished) then
 		return true
+	end
+
+	return false
+end
+
+---@param map {winner: string|nil, finished: string?, bestof: integer?}
+---@param opponents? {score: integer?}[]
+---@param finishedInput string?
+---@return boolean
+function MatchGroupInputUtil.mapIsFinishedFromBestof(map, opponents, finishedInput)
+	local finished = Logic.readBoolOrNil(finishedInput)
+	if finished ~= nil then
+		return finished
 	end
 
 	local bestof = map.bestof
@@ -1170,7 +1182,6 @@ end
 ---@field getGame? fun(match: table, map:table): string?
 ---@field ADD_SUB_GROUP? boolean
 ---@field BREAK_ON_EMPTY? boolean
----@field RECALCULATE_FINISHED_WITH_OPPONENTS? boolean
 
 --- The standard way to process a map input.
 ---
@@ -1190,7 +1201,6 @@ end
 --- Additionally, the Parser may have the following properties:
 --- - ADD_SUB_GROUP boolean?
 --- - BREAK_ON_EMPTY boolean?
---- - RECALCULATE_FINISHED_WITH_OPPONENTS boolean?
 ---@param match table
 ---@param opponents table[]
 ---@param Parser MapParserInterface
@@ -1251,11 +1261,7 @@ function MatchGroupInputUtil.standardProcessMaps(match, opponents, Parser)
 			return Table.merge(Parser.extendMapOpponent(map, opponentIndex), mapOpponent)
 		end)
 
-		if Parser.RECALCULATE_FINISHED_WITH_OPPONENTS and Parser.mapIsFinished then
-			map.finished = Parser.mapIsFinished(map, opponents, finishedInput, winnerInput)
-		elseif Parser.RECALCULATE_FINISHED_WITH_OPPONENTS then
-			map.finished = MatchGroupInputUtil.mapIsFinished(map, map.opponents)
-		end
+		map.finished = map.finished or MatchGroupInputUtil.mapIsFinishedFromBestof(map, map.opponents, finishedInput)
 
 		-- needs map.opponents available!
 		if Parser.getMapMode then

--- a/components/match2/commons/match_group_input_util.lua
+++ b/components/match2/commons/match_group_input_util.lua
@@ -850,8 +850,9 @@ function MatchGroupInputUtil.matchIsFinished(match, opponents)
 end
 
 ---@param map {winner: string|nil, finished: string?, bestof: integer?}
+---@param opponents? {score: integer?}[]
 ---@return boolean
-function MatchGroupInputUtil.mapIsFinished(map)
+function MatchGroupInputUtil.mapIsFinished(map, opponents)
 	if MatchGroupInputUtil.isNotPlayed(map.winner, map.finished) then
 		return true
 	end
@@ -867,19 +868,6 @@ function MatchGroupInputUtil.mapIsFinished(map)
 
 	if Logic.isNotEmpty(map.finished) then
 		return true
-	end
-
-	return false
-end
-
----@param map {winner: string|nil, finished: string?, bestof: integer?}
----@param opponents? {score: integer?}[]
----@param finishedInput string?
----@return boolean
-function MatchGroupInputUtil.mapIsFinishedFromBestof(map, opponents, finishedInput)
-	local finished = Logic.readBoolOrNil(finishedInput)
-	if finished ~= nil then
-		return finished
 	end
 
 	local bestof = map.bestof
@@ -1228,12 +1216,6 @@ function MatchGroupInputUtil.standardProcessMaps(match, opponents, Parser)
 			map.bestof = Parser.getMapBestOf(map)
 		end
 
-		if Parser.mapIsFinished then
-			map.finished = Parser.mapIsFinished(map, opponents, finishedInput, winnerInput)
-		else
-			map.finished = MatchGroupInputUtil.mapIsFinished(map)
-		end
-
 		if Parser.getPatch then
 			map.patch = Parser.getPatch(map)
 		end
@@ -1261,7 +1243,11 @@ function MatchGroupInputUtil.standardProcessMaps(match, opponents, Parser)
 			return Table.merge(Parser.extendMapOpponent(map, opponentIndex), mapOpponent)
 		end)
 
-		map.finished = map.finished or MatchGroupInputUtil.mapIsFinishedFromBestof(map, map.opponents, finishedInput)
+		if Parser.mapIsFinished then
+			map.finished = Parser.mapIsFinished(map, opponents, finishedInput, winnerInput)
+		else
+			map.finished = MatchGroupInputUtil.mapIsFinished(map, map.opponents)
+		end
 
 		-- needs map.opponents available!
 		if Parser.getMapMode then

--- a/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_input_starcraft.lua
@@ -239,10 +239,9 @@ end
 ---@return fun(opponentIndex: integer): integer?
 function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
-	local finished = map.finished
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/ageofempires/match_group_input_custom.lua
+++ b/components/match2/wikis/ageofempires/match_group_input_custom.lua
@@ -300,7 +300,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/artifact/match_group_input_custom.lua
+++ b/components/match2/wikis/artifact/match_group_input_custom.lua
@@ -94,7 +94,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/brawlhalla/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlhalla/match_group_input_custom.lua
@@ -86,7 +86,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -31,7 +31,6 @@ local DEFAULT_BESTOF_MAP = 3
 local MatchFunctions = {}
 local MapFunctions = {
 	BREAK_ON_EMPTY = true,
-	RECALCULATE_FINISHED_WITH_OPPONENTS = true,
 }
 
 MatchFunctions.DEFAULT_MODE = 'team'

--- a/components/match2/wikis/brawlstars/match_group_input_custom.lua
+++ b/components/match2/wikis/brawlstars/match_group_input_custom.lua
@@ -31,6 +31,7 @@ local DEFAULT_BESTOF_MAP = 3
 local MatchFunctions = {}
 local MapFunctions = {
 	BREAK_ON_EMPTY = true,
+	RECALCULATE_FINISHED_WITH_OPPONENTS = true,
 }
 
 MatchFunctions.DEFAULT_MODE = 'team'

--- a/components/match2/wikis/clashroyale/match_group_input_custom.lua
+++ b/components/match2/wikis/clashroyale/match_group_input_custom.lua
@@ -93,7 +93,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 

--- a/components/match2/wikis/clashroyale/match_group_input_custom.lua
+++ b/components/match2/wikis/clashroyale/match_group_input_custom.lua
@@ -179,16 +179,17 @@ end
 ---@return table
 function MapFunctions.getCardsExtradata(mapOpponents)
 	local extradata = {}
-	for opponentIndex, opponent in ipairs(mapOpponents) do
-		for playerIndex, player in pairs(opponent.players or {}) do
+	Array.forEach(mapOpponents, function(opponent, opponentIndex)
+		Array.forEach(Array.map(opponent.players or {}, Logic.nilIfEmpty), function(player, playerIndex)
 			local prefix = 't' .. opponentIndex .. 'p' .. playerIndex
 			extradata[prefix .. 'tower'] = player.cards.tower
 			-- participant.cards is an array plus the tower value ....
-			for cardIndex, card in ipairs(player.cards) do
+			Array.forEach(player.cards, function(card, cardIndex)
 				extradata[prefix .. 'c' .. cardIndex] = card
-			end
-		end
-	end
+			end)
+		end)
+	end)
+
 	return extradata
 end
 

--- a/components/match2/wikis/clashroyale/match_group_input_custom.lua
+++ b/components/match2/wikis/clashroyale/match_group_input_custom.lua
@@ -180,7 +180,7 @@ end
 function MapFunctions.getCardsExtradata(mapOpponents)
 	local extradata = {}
 	Array.forEach(mapOpponents, function(opponent, opponentIndex)
-		Array.forEach(Array.map(opponent.players or {}, Logic.nilIfEmpty), function(player, playerIndex)
+		Array.forEach(Array.filter(opponent.players or {}, Logic.isNotEmpty), function(player, playerIndex)
 			local prefix = 't' .. opponentIndex .. 'p' .. playerIndex
 			extradata[prefix .. 'tower'] = player.cards.tower
 			-- participant.cards is an array plus the tower value ....

--- a/components/match2/wikis/deadlock/match_group_input_custom.lua
+++ b/components/match2/wikis/deadlock/match_group_input_custom.lua
@@ -109,7 +109,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -89,7 +89,7 @@ function MapFunctions._processPlayerMapData(map, opponent, opponentIndex)
 			if Opponent.typeIsParty(opponent.type) then
 				return {name = (opponent.match2players[playerIndex] or {}).name}
 			end
-			return {name = map['o' .. opponentIndex .. 'p' .. playerIndex]}
+			return {name = map['t' .. opponentIndex .. 'p' .. playerIndex]}
 		end,
 		function(playerIndex, playerIdData, playerInputData)
 			local charInputs = Json.parseIfTable(map['o' .. opponentIndex .. 'p' .. playerIndex]) or {} ---@type string[]

--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -86,7 +86,10 @@ function MapFunctions._processPlayerMapData(map, opponent, opponentIndex)
 		opponent.match2players,
 		players,
 		function(playerIndex)
-			return {name = map['t' .. opponentIndex .. 'p' .. playerIndex]}
+			if Opponent.typeIsParty(opponent.type) then
+				return {name = (opponent.match2players[playerIndex] or {}).name}
+			end
+			return {name = map['o' .. opponentIndex .. 'p' .. playerIndex]}
 		end,
 		function(playerIndex, playerIdData, playerInputData)
 			local charInputs = Json.parseIfTable(map['o' .. opponentIndex .. 'p' .. playerIndex]) or {} ---@type string[]

--- a/components/match2/wikis/fighters/match_group_input_custom.lua
+++ b/components/match2/wikis/fighters/match_group_input_custom.lua
@@ -115,7 +115,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/hearthstone/match_group_input_custom.lua
+++ b/components/match2/wikis/hearthstone/match_group_input_custom.lua
@@ -79,7 +79,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/heroes/match_group_input_custom.lua
+++ b/components/match2/wikis/heroes/match_group_input_custom.lua
@@ -109,7 +109,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/honorofkings/get_match_group_copy_paste_wiki.lua
@@ -27,7 +27,7 @@ local INDENT = WikiCopyPaste.Indent
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
-	local numberOfBans = tonumber(args.bans)
+	local numberOfBans = tonumber(args.bans) or 0
 
 	local lines = Array.extend(
 		'{{Match',

--- a/components/match2/wikis/honorofkings/match_group_input_custom.lua
+++ b/components/match2/wikis/honorofkings/match_group_input_custom.lua
@@ -123,7 +123,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/magic/match_group_input_custom.lua
+++ b/components/match2/wikis/magic/match_group_input_custom.lua
@@ -85,7 +85,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/omegastrikers/match_group_input_custom.lua
+++ b/components/match2/wikis/omegastrikers/match_group_input_custom.lua
@@ -20,6 +20,7 @@ local CustomMatchGroupInput = {}
 local MatchFunctions = {}
 local MapFunctions = {
 	BREAK_ON_EMPTY = true,
+	RECALCULATE_FINISHED_WITH_OPPONENTS = true,
 }
 
 local DEFAULT_BESTOF_MATCH = 5

--- a/components/match2/wikis/omegastrikers/match_group_input_custom.lua
+++ b/components/match2/wikis/omegastrikers/match_group_input_custom.lua
@@ -20,7 +20,6 @@ local CustomMatchGroupInput = {}
 local MatchFunctions = {}
 local MapFunctions = {
 	BREAK_ON_EMPTY = true,
-	RECALCULATE_FINISHED_WITH_OPPONENTS = true,
 }
 
 local DEFAULT_BESTOF_MATCH = 5

--- a/components/match2/wikis/paladins/match_group_input_custom.lua
+++ b/components/match2/wikis/paladins/match_group_input_custom.lua
@@ -97,7 +97,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/pokemon/match_group_input_custom.lua
+++ b/components/match2/wikis/pokemon/match_group_input_custom.lua
@@ -110,7 +110,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/smash/match_group_input_custom.lua
+++ b/components/match2/wikis/smash/match_group_input_custom.lua
@@ -144,7 +144,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/smite/match_group_input_custom.lua
+++ b/components/match2/wikis/smite/match_group_input_custom.lua
@@ -86,7 +86,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/splatoon/match_group_input_custom.lua
+++ b/components/match2/wikis/splatoon/match_group_input_custom.lua
@@ -110,7 +110,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/stormgate/match_group_input_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_input_custom.lua
@@ -175,10 +175,9 @@ end
 ---@return fun(opponentIndex: integer): integer?
 function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
-	local finished = map.finished
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/tetris/match_group_input_custom.lua
+++ b/components/match2/wikis/tetris/match_group_input_custom.lua
@@ -84,7 +84,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/tft/match_group_input_custom.lua
+++ b/components/match2/wikis/tft/match_group_input_custom.lua
@@ -92,7 +92,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -204,10 +204,9 @@ end
 ---@return fun(opponentIndex: integer): integer?
 function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
-	local finished = map.finished
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/wildrift/match_group_input_custom.lua
+++ b/components/match2/wikis/wildrift/match_group_input_custom.lua
@@ -110,7 +110,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0

--- a/components/match2/wikis/worldofwarcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/worldofwarcraft/match_group_input_custom.lua
@@ -91,7 +91,7 @@ function MapFunctions.calculateMapScore(map)
 	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not map.finished then
+		if not winner then
 			return
 		end
 		return winner == opponentIndex and 1 or 0


### PR DESCRIPTION
## Summary
- suppress an anno warning that annoyed me while checking on these issues
- account for party types while processing map player data on fighters (basically copied from smash)
- fix finished handling on brawlstars and omegastrikers which needs to come after the opponent processing and needs the opponents passed
  - mind other wikis rely on finished processing being done before the opponent processing, hence introduced the option to recalculate finished after the opponent processing
- fix nil error on clashroyale

## How did you test this change?
dev