### PR TITLE
fix(match2): handle game links with interruptions

### DIFF
--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -176,7 +176,7 @@ function Footer:addLinks(links)
 		if not currentLinkData then
 			mw.log('Unknown link: ' .. linkType)
 		elseif type(link) == 'table' then
-			Array.forEach(link, function(gameLink, gameIdx)
+			Table.iter.forEachPair(link, function(gameIdx, gameLink)
 				local newText = currentLinkData.text .. ' on Game ' .. gameIdx
 				self:addLink(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText)
 			end)

--- a/components/match2/commons/match_summary_base.lua
+++ b/components/match2/commons/match_summary_base.lua
@@ -176,10 +176,10 @@ function Footer:addLinks(links)
 		if not currentLinkData then
 			mw.log('Unknown link: ' .. linkType)
 		elseif type(link) == 'table' then
-			Table.iter.forEachPair(link, function(gameIdx, gameLink)
+			for gameIdx, gameLink in Table.iter.spairs(link) do
 				local newText = currentLinkData.text .. ' on Game ' .. gameIdx
 				self:addLink(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText)
-			end)
+			end
 		else
 			self:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text)
 		end


### PR DESCRIPTION
## Summary
When not all maps have a specific link added, the link table is not a real array so needs to be iterated with pairs, not ipairs
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
