### PR TITLE
Standardize main page layout for Deadlock

### DIFF
--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -18,6 +18,12 @@
 		}
 	}
 
+	.wiki-deadlock & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/8/8f/Deadlock_mainpage_banner.png ) no-repeat center / cover;
+		}
+	}
+
 	@media ( min-width: 768px ) {
 		box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
 		height: 8.875rem;


### PR DESCRIPTION
## Summary

 With help of Kano we made a new main page for Deadlock. Now we wanna push changes to background image. Its gonna be easier to test images when image gonna be show directly on the new layout.

## How did you test this change?

The new main page is available in Kano's user space, and I have tested images in my user space.
https://liquipedia.net/deadlock/User:Kanoodles/TestTest
https://liquipedia.net/deadlock/User:Sl0thyMan/Sandbox/10

## Before BG
![New Main Space - BG before](https://github.com/user-attachments/assets/b57b4d7f-674b-41cc-bf75-3dca95e7587b)

## After BG (photoshopped)
![New Main Space - BG after](https://github.com/user-attachments/assets/1b0ba67b-10c3-4b00-ae4e-04cac6d32f28)
