### PR TITLE
feat(match2): don't show countdowns for empty dates on FFA/BR

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -690,6 +690,7 @@ function MatchGroupUtil.gameFromRecord(record, opponentCount)
 	return {
 		comment = nilIfEmpty(Table.extract(extradata, 'comment')),
 		date = record.date,
+		dateIsExact = nilIfEmpty(Table.extract(extradata, 'dateexact')),
 		extradata = extradata,
 		game = record.game,
 		header = nilIfEmpty(Table.extract(extradata, 'header')),

--- a/components/widget/match/summary/ffa/widget_match_summary_ffa_game_countdown.lua
+++ b/components/widget/match/summary/ffa/widget_match_summary_ffa_game_countdown.lua
@@ -28,11 +28,18 @@ function MatchSummaryFfaGameCountdown:render()
 	end
 
 	local timestamp = Date.readTimestamp(game.date)
-	if not timestamp then
+	if not timestamp or timestamp == Date.defaultTimestamp then
 		return
 	end
-	-- TODO Use local TZ
-	local dateString = Date.formatTimestamp('F j, Y - H:i', timestamp) .. ' ' .. Timezone.getTimezoneString('UTC')
+
+	local dateString
+	if game.dateIsExact == true then
+		-- TODO: Use game-TZ
+		dateString = Date.formatTimestamp('F j, Y - H:i', timestamp) .. ' '
+				.. Timezone.getTimezoneString('UTC')
+	else
+		dateString = mw.getContentLanguage():formatDate('F j, Y', game.date)
+	end
 
 	local streamParameters = Table.merge(game.stream, {
 		date = dateString,

--- a/components/widget/match/summary/ffa/widget_match_summary_ffa_game_countdown.lua
+++ b/components/widget/match/summary/ffa/widget_match_summary_ffa_game_countdown.lua
@@ -33,7 +33,7 @@ function MatchSummaryFfaGameCountdown:render()
 	end
 
 	local dateString
-	if game.dateIsExact == true then
+	if game.dateIsExact then
 		-- TODO: Use game-TZ
 		dateString = Date.formatTimestamp('F j, Y - H:i', timestamp) .. ' '
 				.. Timezone.getTimezoneString('UTC')


### PR DESCRIPTION
## Summary
Currently in BR/FFA display, we display the datetime regardless of its accuracy. Add support so that it won't display a date that epoch-default. 
Additionally, also make it not show the hour/min for estimated dates.

## How did you test this change?
dev
![image](https://github.com/user-attachments/assets/f7982a29-09ee-43a5-85fa-65d486176890)
![image](https://github.com/user-attachments/assets/04ce2dcf-dac4-4394-9ff1-fac4a24e3454)
