### PR TITLE
feat(Infobox): Update unit and building infobox regarding subfaction data

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -152,7 +152,7 @@ function CustomBuilding:subHeaderDisplay(args)
 		coop = 'Co-op',
 		mayhem = 'Team Mayhem'
 	}
-    local subfactionData = Array.parseCommaSeparatedString(args.subfaction)
+	local subfactionData = Array.parseCommaSeparatedString(args.subfaction)
 
 	if Table.includes(subfactionData, '1v1') then return tostring(mw.html.create('span')
 		:css('font-size', '90%')

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -39,6 +39,8 @@ local ICON_ENERGY = '[[File:EnergyIcon.gif|link=]]'
 local ICON_DEPRECATED = '[[File:Cancelled Tournament.png|link=]]'
 local HOTKEY_SEPERATOR = '&nbsp;&nbsp;/&nbsp;&nbsp;'
 local CREEP = 'Camp'
+local GAME_MODE_NAME = {coop = 'Co-op', mayhem = 'Team Mayhem'}
+local SORT_TABLE = {'1v1', 'mayhem', 'coop'}
 
 ---@param frame Frame
 ---@return Html
@@ -148,40 +150,37 @@ end
 ---@param args table
 ---@return string?
 function CustomBuilding:subHeaderDisplay(args)
-    local GAME_MODE_NAME = {
-		coop = 'Co-op',
-		mayhem = 'Team Mayhem'
-	}
 	local subfactionData = Array.parseCommaSeparatedString(args.subfaction)
 
-	if Table.includes(subfactionData, '1v1') then return tostring(mw.html.create('span')
-		:css('font-size', '90%')
-		:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. '
-			.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
-	) end
+	if Table.includes(subfactionData, '1v1') then
+		return tostring(mw.html.create('span')
+			:css('font-size', '90%')
+			:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. '
+				.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
+		)
+	end
 
-    local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
-        if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
-        return GAME_MODE_NAME[string.lower(subfactionElement[1])] ..
+	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
+		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
+		return GAME_MODE_NAME[string.lower(subfactionElement[1])] ..
 			': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
-    end)
+	end)
 
-    return tostring(mw.html.create('span')
+	return tostring(mw.html.create('span')
 		:css('font-size', '90%')
 		:wikitext(table.concat(parts, '<br>'))
-    )
+	)
 end
 
 ---@param data table
 ---@return table?
 function CustomBuilding:_parseSubfactionData(data)
-    local sortTable = {'1v1', 'mayhem', 'coop'}
 	local parsedElements = Array.map(data, function(dataElement)
 		return Array.parseCommaSeparatedString(dataElement, ':')
 	end)
 
 	return Array.sortBy(parsedElements, function(element)
-		return Array.indexOf(sortTable, function(sortElement)
+		return Array.indexOf(SORT_TABLE, function(sortElement)
 			return sortElement == string.lower(element[1])
 		end)
 	end)

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -177,7 +177,7 @@ end
 function CustomBuilding:_parseSubfactionData(data)
     local sortTable = {'1v1', 'mayhem', 'coop'}
 	local parsedElements = Array.map(data, function(dataElement)
-        return Array.parseCommaSeparatedString(dataElement, ':')
+		return Array.parseCommaSeparatedString(dataElement, ':')
 	end)
 
 	return Array.sortBy(parsedElements, function(element)

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -164,7 +164,8 @@ function CustomUnit:subHeaderDisplay(args)
 		return tostring(mw.html.create('span')
 			:css('font-size', '90%')
 			:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. '
-				.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.')))
+				.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
+		)
 	end
 
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -164,13 +164,15 @@ function CustomUnit:subHeaderDisplay(args)
 
 	if Table.includes(subfactionData, '1v1') then return tostring(mw.html.create('span')
 		:css('font-size', '90%')
-		:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
+		:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. '
+			.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
 	) end
 
     local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
         if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
 		if args.informationType == 'Hero' then return GAME_MODE_NAME[string.lower(subfactionElement[1])] end
-        return GAME_MODE_NAME[string.lower(subfactionElement[1])] .. ': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
+        return GAME_MODE_NAME[string.lower(subfactionElement[1])] ..
+			': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
     end)
 
     return tostring(mw.html.create('span')

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -168,12 +168,12 @@ function CustomUnit:subHeaderDisplay(args)
 			.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
 	) end
 
-    local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
-        if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
+	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
+		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
 		if args.informationType == 'Hero' then return GAME_MODE_NAME[string.lower(subfactionElement[1])] end
-        return GAME_MODE_NAME[string.lower(subfactionElement[1])] ..
+		return GAME_MODE_NAME[string.lower(subfactionElement[1])] ..
 			': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
-    end)
+	end)
 
     return tostring(mw.html.create('span')
 		:css('font-size', '90%')

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -35,6 +35,8 @@ local ICON_ARMOR = '[[File:Icon_Armor.png|link=Armor]]'
 local ICON_ENERGY = '[[File:EnergyIcon.gif|link=]]'
 local ICON_DEPRECATED = '[[File:Cancelled Tournament.png|link=]]'
 local HOTKEY_SEPERATOR = '&nbsp;&nbsp;/&nbsp;&nbsp;'
+local GAME_MODE_NAME = {coop = 'Co-op', mayhem = 'Team Mayhem'}
+local SORT_TABLE = {'1v1', 'mayhem', 'coop'}
 
 ---@param frame Frame
 ---@return Html
@@ -156,17 +158,14 @@ end
 ---@param args table
 ---@return string?
 function CustomUnit:subHeaderDisplay(args)
-    local GAME_MODE_NAME = {
-		coop = 'Co-op',
-		mayhem = 'Team Mayhem'
-	}
-    local subfactionData = Array.parseCommaSeparatedString(args.subfaction)
+	local subfactionData = Array.parseCommaSeparatedString(args.subfaction)
 
-	if Table.includes(subfactionData, '1v1') then return tostring(mw.html.create('span')
-		:css('font-size', '90%')
-		:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. '
-			.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
-	) end
+	if Table.includes(subfactionData, '1v1') then
+		return tostring(mw.html.create('span')
+			:css('font-size', '90%')
+			:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. '
+				.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
+	end
 
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
 		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
@@ -175,22 +174,21 @@ function CustomUnit:subHeaderDisplay(args)
 			': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
 	end)
 
-    return tostring(mw.html.create('span')
+	return tostring(mw.html.create('span')
 		:css('font-size', '90%')
 		:wikitext(table.concat(parts, '<br>'))
-    )
+	)
 end
 
 ---@param data table
 ---@return table?
 function CustomUnit:_parseSubfactionData(data)
-    local sortTable = {'1v1', 'mayhem', 'coop'}
 	local parsedElements = Array.map(data, function(dataElement)
-        return Array.parseCommaSeparatedString(dataElement, ':')
+		return Array.parseCommaSeparatedString(dataElement, ':')
 	end)
 
 	return Array.sortBy(parsedElements, function(element)
-		return Array.indexOf(sortTable, function(sortElement)
+		return Array.indexOf(SORT_TABLE, function(sortElement)
 			return sortElement == string.lower(element[1])
 		end)
 	end)

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -164,7 +164,7 @@ function CustomUnit:subHeaderDisplay(args)
 		return tostring(mw.html.create('span')
 			:css('font-size', '90%')
 			:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. '
-				.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
+				.. 'It might also be part of certain Hero rosters in Team Mayhem or Co-op.')))
 	end
 
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -156,14 +156,44 @@ end
 ---@param args table
 ---@return string?
 function CustomUnit:subHeaderDisplay(args)
-	if Logic.isEmpty(args.subfaction) or
-		string.find(args.subfaction, '1v1') or
-		string.find(args.subfaction, self.pagename) then return end
-	return tostring(mw.html.create('span')
+    local GAME_MODE_NAME = {
+		coop = 'Co-op',
+		mayhem = 'Team Mayhem'
+	}
+    local subfactionData = Array.parseCommaSeparatedString(args.subfaction)
+
+	if Table.includes(subfactionData, '1v1') then return tostring(mw.html.create('span')
 		:css('font-size', '90%')
-		:wikitext('Hero: ' .. self:_displayCsvAsPageCsv(args.subfaction))
-	)
+		:wikitext(Abbreviation.make('Standard', 'This is part of Head to Head 1v1. It might also be part of certain Hero rosters in Team Mayhem or Co-op.'))
+	) end
+
+    local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
+        if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
+		if args.informationType == 'Hero' then return GAME_MODE_NAME[string.lower(subfactionElement[1])] end
+        return GAME_MODE_NAME[string.lower(subfactionElement[1])] .. ': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
+    end)
+
+    return tostring(mw.html.create('span')
+		:css('font-size', '90%')
+		:wikitext(table.concat(parts, '<br>'))
+    )
 end
+
+---@param data table
+---@return table?
+function CustomUnit:_parseSubfactionData(data)
+    local sortTable = {'1v1', 'mayhem', 'coop'}
+	local parsedElements = Array.map(data, function(dataElement)
+        return Array.parseCommaSeparatedString(dataElement, ':')
+	end)
+
+	return Array.sortBy(parsedElements, function(element)
+		return Array.indexOf(sortTable, function(sortElement)
+			return sortElement == string.lower(element[1])
+		end)
+	end)
+end
+
 
 ---@return string?
 function CustomUnit:_getHotkeys()
@@ -274,17 +304,19 @@ function CustomUnit._hotkeys(hotkey1, hotkey2)
 end
 
 ---@param inputString string?
+---@param sep string?
 ---@return string[]
-function CustomUnit:_csvToPageList(inputString)
-	return Array.map(Array.parseCommaSeparatedString(inputString), function(value)
+function CustomUnit:_csvToPageList(inputString, sep)
+	return Array.map(Array.parseCommaSeparatedString(inputString, sep), function(value)
 		return Page.makeInternalLink(value)
 	end)
 end
 
 ---@param input string?
+---@param sep string?
 ---@return string
-function CustomUnit:_displayCsvAsPageCsv(input)
-	return table.concat(self:_csvToPageList(input), ', ')
+function CustomUnit:_displayCsvAsPageCsv(input, sep)
+	return table.concat(self:_csvToPageList(input, sep), ', ')
 end
 
 ---@param key string
@@ -314,7 +346,7 @@ function CustomUnit._deprecatedWarning(patch)
 	return MessageBox.main('ambox', {
 		image= ICON_DEPRECATED,
 		class='ambox-red',
-		text= 'This has been removed from 1v1 with Patch ' .. patch,
+		text= 'This has been removed with Patch ' .. patch,
 	})
 end
 


### PR DESCRIPTION
## Summary

From what we know about the Team Mayhem mode (3v3) and what they said in blog posts, AMAs and interviews it’s pretty safe to assume, that heroes in Co-op and Team Mayhem and possibly their units can significantly different from each other. Currently the unit and building infobox doesn't support this properly. 

This pr updates the input for `|subfaction=` that it supports inputs like `|subfaction=1v1, coop:Blockade;Amara;Ryker, mayhem:Blockade` (example)

The output in the infobox (subheader) will look like this:

![grafik](https://github.com/user-attachments/assets/589b8e2f-710b-4a82-bd7e-5f010a70f2f7)
![grafik](https://github.com/user-attachments/assets/d89198d8-623e-47d4-8105-f49e974b6069)
![grafik](https://github.com/user-attachments/assets/04da96cf-599e-45b5-93f6-984eb123c533)


<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev tools

**Note:** this will need some follow-up changes for hero pages and subfaction units and will even break a few pages there that I need to fix/update once the pr is merged.

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
