### PR TITLE
chore(match2): Remove the remaining usage of deprecated match2/match2game fields

### DIFF
--- a/components/infobox/wikis/starcraft/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft/infobox_person_player_custom.lua
@@ -228,9 +228,13 @@ function CustomPlayer:_getMatchupData()
 	local foundData = false
 	local processMatch = function(match)
 		foundData = true
-		vs = CustomPlayer._addScoresToVS(vs, match.match2opponents, player, playerWithoutUnderscore)
 		local year = string.sub(match.date, 1, 4)
 		years[tonumber(year)] = year
+
+		if Array.any(match.match2opponents, function(opponent) return opponent.status and opponent.status ~= 'S' end) then
+			return
+		end
+		vs = CustomPlayer._addScoresToVS(vs, match.match2opponents, player, playerWithoutUnderscore)
 	end
 
 	Lpdb.executeMassQuery('match2', queryParameters, processMatch)

--- a/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_person_player_custom.lua
@@ -199,6 +199,10 @@ function CustomPlayer:_getMatchupData(player)
 			table.insert(self.recentMatches, match)
 		end
 
+		if Array.any(match.match2opponents, function(opponent) return opponent.status and opponent.status ~= 'S' end) then
+			return
+		end
+
 		self:_addToStats(match, player, playerWithoutUnderscore)
 	end
 
@@ -206,7 +210,6 @@ function CustomPlayer:_getMatchupData(player)
 		conditions = table.concat({
 			'[[finished::1]]', -- only finished matches
 			'[[winner::!]]', -- expect a winner
-			'[[walkover::]]', -- exclude default wins/losses
 			'[[status::!notplayed]]', -- i.e. ignore not played matches
 			'[[date::!' .. DateExt.defaultDate .. ']]', --i.e. wrongly set up
 			'([[opponent::' .. player .. ']] OR [[opponent::' .. playerWithoutUnderscore .. ']])'

--- a/components/match2/wikis/clashroyale/match_summary.lua
+++ b/components/match2/wikis/clashroyale/match_summary.lua
@@ -136,7 +136,7 @@ function CustomMatchSummary._calculateSubMatchWinner(subMatch)
 
 	local subMatchIsFinished = Array.all(subMatch.games, function(game)
 		return Logic.isNotEmpty(game.winner)
-			or game.resulttype == 'np'
+			or game.status == 'notplayed'
 
 	end)
 	if not subMatchIsFinished then return end


### PR DESCRIPTION
## Summary
Remove the remaining usage of deprecated match2/match2game fields.
- CR (missed in #5229)
- sc/sc2 query condition in infobox player

## How did you test this change?
dev