### PR TITLE
feat(match2): do not apply bo1 display if there is a match walkover

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -610,12 +610,13 @@ end
 ---@return standardOpponent
 function MatchGroupUtil.opponentFromRecord(matchRecord, record, opponentIndex)
 	local extradata = MatchGroupUtil.parseOrCopyExtradata(record.extradata)
-
 	local score = record.score
 	local status = record.status
 	local bestof = tonumber(matchRecord.bestof)
 	local game1 = (matchRecord.match2games or {})[1]
-	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and game1 then
+	local hasWalkover = Array.any(matchRecord.match2opponents, function(opponent)
+			return opponent.status and opponent.status ~= 'S' end)
+	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and game1 and not hasWalkover then
 		local mapOpponent = (game1.opponents or {})[opponentIndex] or {}
 		score = mapOpponent.score
 		status = mapOpponent.status

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -616,7 +616,7 @@ function MatchGroupUtil.opponentFromRecord(matchRecord, record, opponentIndex)
 	local game1 = (matchRecord.match2games or {})[1]
 	local hasOnlyScores = Array.all(matchRecord.match2opponents, function(opponent)
 			return opponent.status == 'S' end)
-	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and game1 and not hasOnlyScores then
+	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and game1 and hasOnlyScores then
 		local mapOpponent = (game1.opponents or {})[opponentIndex] or {}
 		score = mapOpponent.score
 		status = mapOpponent.status

--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -614,9 +614,9 @@ function MatchGroupUtil.opponentFromRecord(matchRecord, record, opponentIndex)
 	local status = record.status
 	local bestof = tonumber(matchRecord.bestof)
 	local game1 = (matchRecord.match2games or {})[1]
-	local hasWalkover = Array.any(matchRecord.match2opponents, function(opponent)
-			return opponent.status and opponent.status ~= 'S' end)
-	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and game1 and not hasWalkover then
+	local hasOnlyScores = Array.all(matchRecord.match2opponents, function(opponent)
+			return opponent.status == 'S' end)
+	if bestof == 1 and Info.config.match2.gameScoresIfBo1 and game1 and not hasOnlyScores then
 		local mapOpponent = (game1.opponents or {})[opponentIndex] or {}
 		score = mapOpponent.score
 		status = mapOpponent.status


### PR DESCRIPTION
## Summary
- bo1 match
- one team gets DQed after the map is played
- in display it displays the map score of the played map instead of the match walkover
- desired behaviour: match walkover gets displayed

reported by @iMarbot 
https://discord.com/channels/93055209017729024/372075546231832576/1325273961428287518

## How did you test this change?
dev

before:
![image](https://github.com/user-attachments/assets/3fd9abd5-921d-4bb5-ab20-708e08a41a22)

after:
![image](https://github.com/user-attachments/assets/92b7eae9-e759-4425-8a06-6684ca8371c7)
