### PR TITLE
feat(match2): add more options on LoL copy-paste generator

### DIFF
--- a/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
@@ -28,7 +28,7 @@ local INDENT = WikiCopyPaste.Indent
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	if Logic.realBool(args.bigMatch) then
 		return '{{Match}}'
-	end 
+	end
 
 	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
 	local bans = Logic.readBool(args.bans)

--- a/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
@@ -26,11 +26,15 @@ local INDENT = WikiCopyPaste.Indent
 ---@param args table
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	if Logic.realBool(args.bigMatch) then
+		return '{{Match}}'
+	end 
+
 	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
 	local bans = Logic.readBool(args.bans)
 
 	local lines = Array.extend(
-		'{{Match',
+		'{{Match|patch=|bestof=' .. bestof,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
@@ -38,7 +42,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.hasDate) and {
 			INDENT .. '|date=',
 			INDENT .. '|twitch= |youtube=',
-			INDENT .. '|reddit= |gol=',
+			(Logic.readBool(args.reddit) and INDENT .. '|reddit= |gol=' or nil),
 			INDENT .. '|mvp='
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)

--- a/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/leagueoflegends/get_match_group_copy_paste_wiki.lua
@@ -34,7 +34,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local bans = Logic.readBool(args.bans)
 
 	local lines = Array.extend(
-		'{{Match|patch=|bestof=' .. bestof,
+		'{{Match|patch=',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)


### PR DESCRIPTION
## Summary
- Fixed bug where `reddit` (extra parameters) input in form no longer makes a difference as to whether the reddit parameters are generated
- Added such that `|patch` and `|bestof` are included by default in each `{{Match}}`
- Added functionality to allow for matchcode to not be fully generated if BigMatch should be used for this particular matchlist.

## How did you test this change?
/dev
