### PR TITLE
fix(match2): missing nil catch in submatch check

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -190,7 +190,7 @@ end
 function StarcraftMatchGroupUtil.constructSubmatch(games, match)
 	local firstGame = games[1]
 	local opponents = Table.deepCopy(firstGame.opponents)
-	local isSubmatch = String.startsWith(firstGame.map, 'Submatch')
+	local isSubmatch = String.startsWith(firstGame.map or '', 'Submatch')
 	if isSubmatch then
 		games = {firstGame}
 	end

--- a/components/match2/wikis/stormgate/match_group_util_custom.lua
+++ b/components/match2/wikis/stormgate/match_group_util_custom.lua
@@ -184,7 +184,7 @@ end
 function CustomMatchGroupUtil.constructSubmatch(games, match)
 	local firstGame = games[1]
 	local opponents = Table.deepCopy(firstGame.opponents)
-	local isSubmatch = String.startsWith(firstGame.map, 'Submatch')
+	local isSubmatch = String.startsWith(firstGame.map or '', 'Submatch')
 	if isSubmatch then
 		games = {firstGame}
 	end

--- a/components/match2/wikis/warcraft/match_group_util_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_util_custom.lua
@@ -176,7 +176,7 @@ end
 function CustomMatchGroupUtil.constructSubmatch(games, match)
 	local firstGame = games[1]
 	local opponents = Table.deepCopy(firstGame.opponents)
-	local isSubmatch = String.startsWith(firstGame.map, 'Submatch')
+	local isSubmatch = String.startsWith(firstGame.map or '', 'Submatch')
 	if isSubmatch then
 		games = {firstGame}
 	end


### PR DESCRIPTION
## Summary
On SC(2), WC and SG team matches error on empty map input due to a missing nil catch in the check if the map begins with `'Submatch'`.
This PR adds the missing nil catch on the 3 wikis

## How did you test this change?
