### PR TITLE
feat: add national tiertype on dota2

### DIFF
--- a/standard/tier/wikis/dota2/tier_data.lua
+++ b/standard/tier/wikis/dota2/tier_data.lua
@@ -89,5 +89,12 @@ return {
 			link = 'Show Matches',
 			category = 'Showmatch Tournaments',
 		},
+		national = {
+			value = 'National',
+			sort = 'B2',
+			name = 'National',
+			short = 'Nation',
+			link = 'National Tournaments',
+			category = 'National Tournaments',
 	},
 }

--- a/standard/tier/wikis/dota2/tier_data.lua
+++ b/standard/tier/wikis/dota2/tier_data.lua
@@ -96,5 +96,6 @@ return {
 			short = 'Nation',
 			link = 'National Tournaments',
 			category = 'National Tournaments',
+		},
 	},
 }


### PR DESCRIPTION
## Summary

We have been using the custom "national" tier on the Dota 2 wiki Tier Data module for the past year, but it looks like this change was never pushed on GitHub. Liquipediabot has been undoing the changes recently to sync with the main repo. So I thought I'd have a go at fixing it myself. 

I don't use GitHub and this is my first PR so yell at me on #Gravy3776 if I've done something wrong )

## How did you test this change?

 The additional tier type was previously used on the Dota 2 wiki and works fine. 

edit: sorry I forgot a curly bracket