### PR TITLE
feat(infobox): use highlight conditions to determine sponsored category on CS

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -229,7 +229,6 @@ function CustomLeague:getWikiCategories(args)
 	end
 
 	if HighlightConditions.tournament(self.data) then
-		mw.logObject(self.data, "data")
 		table.insert(categories, 'Valve Sponsored Tournaments')
 	end
 

--- a/components/infobox/wikis/counterstrike/infobox_league_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_league_custom.lua
@@ -19,6 +19,7 @@ local Variables = require('Module:Variables')
 
 local Currency = Lua.import('Module:Currency')
 local Game = Lua.import('Module:Game')
+local HighlightConditions = Lua.import('Module:HighlightConditions')
 local InfoboxPrizePool = Lua.import('Module:Infobox/Extensions/PrizePool')
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
@@ -227,7 +228,8 @@ function CustomLeague:getWikiCategories(args)
 		table.insert(categories, 'ESL Pro Tour Tournaments')
 	end
 
-	if self.valveTier then
+	if HighlightConditions.tournament(self.data) then
+		mw.logObject(self.data, "data")
 		table.insert(categories, 'Valve Sponsored Tournaments')
 	end
 


### PR DESCRIPTION
## Summary

Only the highlighted tournaments are valve sponsored, so using that to determine category too.

## How did you test this change?

Tested on `/dev`.