### PR TITLE
fix(match2): wrong table used to call function from on wc3

### DIFF
--- a/components/match2/wikis/warcraft/match_group_input_custom.lua
+++ b/components/match2/wikis/warcraft/match_group_input_custom.lua
@@ -484,7 +484,7 @@ function FfaMatchFunctions.matchIsFinished(match, opponents)
 		return true
 	end
 
-	return MatchFunctions.placementHasBeenSet(opponents)
+	return FfaMatchFunctions.placementHasBeenSet(opponents)
 end
 
 ---@param opponents table[]


### PR DESCRIPTION
## Summary
Tried to call `MatchFunctions.placementHasBeenSet` which does not exist as it is a function for the ffa match and hence needs to call `FfaMatchFunctions.placementHasBeenSet` instead

## How did you test this change?
live