### PR TITLE
feat: support FFA/BR events in Match Ticker

### DIFF
--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -50,6 +50,12 @@ local ScoreBoard = Class.new(
 function ScoreBoard:create()
 	local match = self.match
 	local winner = tonumber(match.winner)
+	local opponents = #match.match2opponents
+
+	if opponents > 2 then
+		--- "FFA/BR" view
+		return self.root:node(self:title())
+	end
 
 	return self.root
 		:node(self:opponent(match.match2opponents[1], winner == 1, true):addClass('team-left'))
@@ -92,8 +98,15 @@ end
 ---@return Html
 function ScoreBoard:versus()
 	return mw.html.create('div')
-	:addClass('versus')
-	:node(DefaultMatchTickerDisplayComponents.Versus(self.match):create())
+		:addClass('versus')
+		:node(DefaultMatchTickerDisplayComponents.Versus(self.match):create())
+end
+
+---@return Html
+function ScoreBoard:title()
+	return mw.html.create('div')
+		:addClass('versus')
+		:node(self.match.header)
 end
 
 ---Display class for the details of a match displayed at the bottom of a match ticker

--- a/components/match_ticker/commons/match_ticker_display_components_new.lua
+++ b/components/match_ticker/commons/match_ticker_display_components_new.lua
@@ -25,6 +25,7 @@ local VodLink = require('Module:VodLink')
 
 local DefaultMatchTickerDisplayComponents = Lua.import('Module:MatchTicker/DisplayComponents')
 local HighlightConditions = Lua.import('Module:HighlightConditions')
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 local OpponentLibraries = require('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
@@ -104,9 +105,10 @@ end
 
 ---@return Html
 function ScoreBoard:title()
+	local header = self.match.match2bracketdata.inheritedheader
 	return mw.html.create('div')
 		:addClass('versus')
-		:node(self.match.header)
+		:node(DisplayHelper.expandHeader(header)[1])
 end
 
 ---Display class for the details of a match displayed at the bottom of a match ticker


### PR DESCRIPTION
## Feature description
Some games are not PARTICIPANT vs PARTICIPANT, but rather 3 or more. This is most common in Battle Royale and other FFA game styles, but also in the common format with 4-participant Trackmania matches. 

The Match Ticker currently only have a PARTICIPANT vs PARTICIPANT display. A new display variant for 3+ Participants matches needs to be added.

## Summary
This adds basic DISPLAY support for FFA/BR matches in the new style match ticker
![image](https://github.com/user-attachments/assets/ba0310c4-fe67-4b3f-97eb-422ecd7bb8a7)

For full (BR) support, game based displays are needed as well, which will be another ticket

## How did you test this change?
https://liquipedia.net/apexlegends/User:Rathoz