### PR TITLE
feat: make Smash infobox colors dark-mode compatible

### DIFF
--- a/stylesheets/commons/Infobox.less
+++ b/stylesheets/commons/Infobox.less
@@ -281,27 +281,27 @@ Author(s): FO-nTTaX
 
 /* Smash */
 .fo-nttax-infobox-wrapper.infobox-64 .infobox-header {
-	background-color: #d5e5b6;
+	background-color: var( --clr-atlantis-background-color );
 }
 
 .fo-nttax-infobox-wrapper.infobox-melee .infobox-header {
-	background-color: #b6e5c6;
+	background-color: var( --clr-forestgreen-background-color );
 }
 
 .fo-nttax-infobox-wrapper.infobox-brawl .infobox-header {
-	background-color: #b6d5e5;
+	background-color: var( --clr-elm-background-color );
 }
 
 .fo-nttax-infobox-wrapper.infobox-pm .infobox-header {
-	background-color: #c6b6e5;
+	background-color: var( --clr-vividviolet-background-color );
 }
 
 .fo-nttax-infobox-wrapper.infobox-wiiu .infobox-header {
-	background-color: #e5c6b6;
+	background-color: var( --clr-california-background-color );
 }
 
 .fo-nttax-infobox-wrapper.infobox-ultimate .infobox-header {
-	background-color: #e5b6d5;
+	background-color: var( --clr-redviolet-background-color );
 }
 
 /*******************************************************************************

--- a/stylesheets/commons/Infobox.less
+++ b/stylesheets/commons/Infobox.less
@@ -281,27 +281,27 @@ Author(s): FO-nTTaX
 
 /* Smash */
 .fo-nttax-infobox-wrapper.infobox-64 .infobox-header {
-	background-color: var( --clr-atlantis-background-color );
+	background-color: var( --clr-atlantis-background-color, #d5e5b6 );
 }
 
 .fo-nttax-infobox-wrapper.infobox-melee .infobox-header {
-	background-color: var( --clr-forestgreen-background-color );
+	background-color: var( --clr-forestgreen-background-color, #b6e5c6 );
 }
 
 .fo-nttax-infobox-wrapper.infobox-brawl .infobox-header {
-	background-color: var( --clr-elm-background-color );
+	background-color: var( --clr-elm-background-color, #b6d5e5 );
 }
 
 .fo-nttax-infobox-wrapper.infobox-pm .infobox-header {
-	background-color: var( --clr-vividviolet-background-color );
+	background-color: var( --clr-vividviolet-background-color, #c6b6e5 );
 }
 
 .fo-nttax-infobox-wrapper.infobox-wiiu .infobox-header {
-	background-color: var( --clr-california-background-color );
+	background-color: var( --clr-california-background-color, #e5c6b6 );
 }
 
 .fo-nttax-infobox-wrapper.infobox-ultimate .infobox-header {
-	background-color: var( --clr-redviolet-background-color );
+	background-color: var( --clr-redviolet-background-color, #e5b6d5 );
 }
 
 /*******************************************************************************


### PR DESCRIPTION
## Summary

Smash infoboxes are colored depending on which game is entered in the infobox. This PR makes them dark-mode compatible. 

Example of just one of the changes 
**Before**
![Screenshot 2025-01-10 113316](https://github.com/user-attachments/assets/ddd7dff2-00a0-4a09-8157-c1fdafdcf18a)
![Screenshot 2025-01-10 113339](https://github.com/user-attachments/assets/bb26fa7b-c0cf-4968-a3af-29a60cf975e0)

**After**
![Screenshot 2025-01-10 113433](https://github.com/user-attachments/assets/e34943aa-3fb0-43d0-8055-fe8fc979ddd1)
![Screenshot 2025-01-10 113454](https://github.com/user-attachments/assets/1895d522-22a5-4c19-ad39-3b7af3891c15)


## How did you test this change?

Inspect tool
