### PR TITLE
feat: support LinkedIn team links

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -151,7 +151,7 @@ local PREFIXES = {
 		player = 'https://gg.letsplay.live/profile/view-stats/',
 		match = 'https://old.letsplay.live/match/',
 	},
-	linkedin = {'https://www.linkedin.com/in/'},
+	linkedin = {'https://www.linkedin.com/'},
 	loco = {'https://loco.gg/streamers/'},
 	lolchess = {'https://lolchess.gg/profile/'},
 	lrthread = {'', match = ''},

--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -151,7 +151,10 @@ local PREFIXES = {
 		player = 'https://gg.letsplay.live/profile/view-stats/',
 		match = 'https://old.letsplay.live/match/',
 	},
-	linkedin = {'https://www.linkedin.com/'},
+	linkedin = {
+		team = 'https://www.linkedin.com/company/',
+		player = 'https://www.linkedin.com/in/',
+	},
 	loco = {'https://loco.gg/streamers/'},
 	lolchess = {'https://lolchess.gg/profile/'},
 	lrthread = {'', match = ''},


### PR DESCRIPTION
## Summary

The previous base url was made for personnal accounts but for companies it is `.com/company/name` and not `.com/in/name`.