### PR TITLE
feat(match2): Include round scores in fighters generators

### DIFF
--- a/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
@@ -53,6 +53,7 @@ function WikiCopyPaste._getMap(mode)
 		'={{Map',
 		INDENT .. INDENT .. '|map=|winner=',
 		INDENT .. INDENT .. '|o1p1={{Chars|}}|o2p1={{Chars|}}',
+		INDENT .. INDENT .. '|score1=|score2=',
 		INDENT .. '}}'
 	)
 	return table.concat(lines, '\n')


### PR DESCRIPTION
## Summary

Fighters' match generators do not include map score parameters (that correspond to round scores of actual game) in the copy-paste output. This PR adds it.

## How did you test this change?

dev
