### PR TITLE
feat(mainpage): Standardize PUBG main page

### DIFF
--- a/components/filter_buttons/wikis/pubg/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/pubg/filter_buttons_config.lua
@@ -1,0 +1,44 @@
+---
+-- @Liquipedia
+-- wiki=pubg
+-- page=Module:FilterButtons/Config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Tier = require('Module:Tier/Utils')
+local Config = {}
+
+Config.categories = {
+	{
+		name = 'liquipediatier',
+		property = 'liquipediaTier',
+		load = function(category)
+			category.items = {}
+			for _, tier in Tier.iterate('tiers') do
+				table.insert(category.items, tier.value)
+			end
+		end,
+		defaultItems = {'1', '2', '3'},
+		transform = function(tier)
+			return Tier.toName(tier)
+		end,
+		expandKey = "liquipediatiertype",
+	},
+	{
+		name = 'liquipediatiertype',
+		property = 'liquipediaTierType',
+		expandable = true,
+		load = function(category)
+			category.items = {}
+			for _, tiertype in Tier.iterate('tierTypes') do
+				table.insert(category.items, Tier.toIdentifier(tiertype.value))
+			end
+		end,
+		transform = function(tiertype)
+			return select(2, Tier.toName(1, tiertype))
+		end,
+	},
+}
+
+return Config

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -1,0 +1,196 @@
+---
+-- @Liquipedia
+-- wiki=pubg
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local CONTENT = {
+	usefulArticles = {
+		heading = 'Useful Articles',
+		body = '{{Liquipedia:Useful Articles}}',
+		padding = true,
+		boxid = 1503,
+	},
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = '{{Liquipedia:Want_to_help}}',
+		padding = true,
+		boxid = 1504,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = '{{Transfer List|limit=15|title=}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
+			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
+			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
+			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>\n' ..
+			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
+			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
+			'[[Special:RunQuery/Transfer history|Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
+			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
+			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
+			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = 'This day in PUBG <small id="this-day-date" style = "margin-left: 5px">' ..
+			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
+		body = '{{Liquipedia:This day}}',
+		padding = true,
+		boxid = 1510,
+	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+	},
+	filterButtons = {
+		noPanel = true,
+		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
+			'{{#invoke:Lua|invoke|module=FilterButtons|fn=getFromConfig}}</div>',
+	},
+	matches = {
+		heading = 'Matches',
+		body = '{{MainPageMatches}}<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
+			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
+		padding = true,
+		boxid = 1507,
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = '{{#invoke:Lua|invoke|module=TournamentsList|fn=run|defaultTiers=1,2,3|upcomingDays=90|' ..
+			'completedDays=60|filterByTierTypes=true|useExternalFilters=true}}',
+		padding = true,
+		boxid = 1508,
+	},
+}
+
+return {
+	banner = {
+		lightmode = 'PUBG 2021 default allmode.png',
+		darkmode = 'PUBG 2021 default allmode.png',
+	},
+	metadesc = 'The PUBG esports wiki covering everything from players, teams and transfers, to ' ..
+		'tournaments and results, maps, and weapons.',
+	title = 'PUBG',
+	navigation = {
+		{
+			file = '',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = '',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = '',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = '',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'ErangelNew.jpg',
+			title = 'Maps',
+			link = 'Portal:Maps',
+			count = {
+				method = 'CATEGORY',
+				category = 'Maps',
+			},
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 6,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.aboutEsport,
+					},
+					{
+						mobileOrder = 2,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 7,
+						content = CONTENT.wantToHelp,
+					},
+				}
+			},
+			{ -- Right
+				size = 6,
+				children = {
+					{
+						mobileOrder = 3,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
+								},
+							},
+						},
+					},
+					{
+						mobileOrder = 5,
+						content = CONTENT.thisDay,
+					},
+				},
+			},
+			{
+				children = {
+					{
+						mobileOrder = 6,
+						content = CONTENT.usefulArticles,
+					},
+				},
+			},
+		},
+	},
+}

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -77,7 +77,7 @@ return {
 	title = 'PUBG',
 	navigation = {
 		{
-			file = '',
+			file = 'KSV at IEM XII Katowice.jpg',
 			title = 'Players',
 			link = 'Portal:Players',
 			count = {
@@ -86,7 +86,7 @@ return {
 			},
 		},
 		{
-			file = '',
+			file = 'T1 PUBG at EWC 2024.jpg',
 			title = 'Teams',
 			link = 'Portal:Teams',
 			count = {
@@ -95,7 +95,7 @@ return {
 			},
 		},
 		{
-			file = '',
+			file = 'Danawa e-sports at EWC 2024.jpg',
 			title = 'Transfers',
 			link = 'Portal:Transfers',
 			count = {
@@ -104,7 +104,7 @@ return {
 			},
 		},
 		{
-			file = '',
+			file = 'EWC 2024 PUBG Trophy closeup.jpg',
 			title = 'Tournaments',
 			link = 'Portal:Tournaments',
 			count = {

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -30,8 +30,7 @@ local CONTENT = {
 			'[[Special:RunQuery/Transfer history|Transfer query]]' ..
 			'<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
 			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+			'</center></div>\n</div>',
 		boxid = 1509,
 	},
 	thisDay = {

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -58,8 +58,8 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=TournamentsList|fn=run|defaultTiers=1,2,3|upcomingDays=90|' ..
-			'completedDays=60|filterByTierTypes=true|useExternalFilters=true}}',
+		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
+			'|upcomingDays=90|completedDays=60}}',
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -27,7 +27,8 @@ local CONTENT = {
 			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>\n' ..
 			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
 			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Special:RunQuery/Transfer history|Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
+			'[[Special:RunQuery/Transfer history|Transfer query]]' ..
+			'<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
 			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
 			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
 			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
@@ -52,7 +53,8 @@ local CONTENT = {
 	matches = {
 		heading = 'Matches',
 		body = '{{MainPageMatches}}<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
+			'font-size:15px; font-style:italic; text-align:center;">' ..
+			'[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
 	},

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -52,7 +52,8 @@ local CONTENT = {
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{MainPageMatches}}<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
+		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}'..
+			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
 			'font-size:15px; font-style:italic; text-align:center;">' ..
 			'[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
 		padding = true,

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -24,6 +24,12 @@
 		}
 	}
 
+	.wiki-pubg & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/2/2d/PUBG_Banner_bg.jpg ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-pubgmobile & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/1/1a/PUBG_Mobile_banner_bg.jpg ) no-repeat center / cover;


### PR DESCRIPTION
## Summary

_Depends on #5295, #5296_

This PR standardizes main page layout of PUBG wiki.

## Checklist

- [x] Select images for navigation cards (c0cf915)
- [x] Check compatibility with #5295, #5296 once it is merged
- [x] Lint

## How did you test this change?

- Sandbox: <https://liquipedia.net/pubg/User:ElectricalBoy/MainPage>