### PR TITLE
feat: Opponent-hover darkmode support

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -127,6 +127,11 @@
 .brkts-match.brkts-hover {
 	box-shadow: 0 0 2px rgba( 0, 0, 0, 0.5 );
 	border: 1px solid rgba( 0, 0, 0, 0.5 );
+
+	.theme--dark & {
+		box-shadow: 0 0 2px rgba( 255, 255, 255, 0.5 );
+		border: 1px solid rgba( 255, 255, 255, 0.5 );
+	}
 }
 
 .brkts-br-wrapper.brkts-br-wrapper {
@@ -411,6 +416,10 @@
 
 .brkts-hover > .brkts-matchlist-cell {
 	box-shadow: inset 0 6px 8px -5px rgba( 0, 0, 0, 0.4 ), inset 0 -6px 8px -5px rgba( 0, 0, 0, 0.4 );
+
+	.theme--dark & {
+		box-shadow: inset 0 6px 8px -5px rgba( 255, 255, 255, 0.4 ), inset 0 -6px 8px -5px rgba( 255, 255, 255, 0.4 );
+	}
 }
 
 .brkts-matchlist-cell.brkts-opponent-hover-active {
@@ -420,11 +429,19 @@
 .brkts-matchlist-cell.brkts-opponent-hover-active:nth-child( 1 )::after,
 .brkts-matchlist-cell.brkts-opponent-hover-active:nth-child( 4 )::after {
 	box-shadow: -1px 0 2px rgba( 0, 0, 0, 0.7 ), 0 1px 2px rgba( 0, 0, 0, 0.7 ), 0 -1px 2px rgba( 0, 0, 0, 0.7 );
+
+	.theme--dark & {
+		box-shadow: -1px 0 2px rgba( 255, 255, 255, 0.7 ), 0 1px 2px rgba( 255, 255, 255, 0.7 ), 0 -1px 2px rgba( 255, 255, 255, 0.7 );
+	}
 }
 
 .brkts-matchlist-cell.brkts-opponent-hover-active:nth-child( 2 )::after,
 .brkts-matchlist-cell.brkts-opponent-hover-active:nth-child( 5 )::after {
 	box-shadow: 1px 0 2px rgba( 0, 0, 0, 0.7 ), 0 1px 2px rgba( 0, 0, 0, 0.7 ), 0 -1px 2px rgba( 0, 0, 0, 0.7 );
+
+	.theme--dark & {
+		box-shadow: 1px 0 2px rgba( 255, 255, 255, 0.7 ), 0 1px 2px rgba( 255, 255, 255, 0.7 ), 0 -1px 2px rgba( 255, 255, 255, 0.7 );
+	}
 }
 
 .brkts-matchlist-match > .brkts-match-info-icon {
@@ -1070,6 +1087,10 @@ div.brkts-opponent-hover::after {
 
 div.brkts-opponent-hover-active::after {
 	box-shadow: -1px 0 2px rgba( 0, 0, 0, 0.7 ), 1px 0 2px rgba( 0, 0, 0, 0.7 ), 0 -1px 2px rgba( 0, 0, 0, 0.7 ), 0 1px 2px rgba( 0, 0, 0, 0.7 );
+
+	.theme--dark & {
+		box-shadow: -1px 0 2px rgba( 255, 255, 255, 0.7 ), 1px 0 2px rgba( 255, 255, 255, 0.7 ), 0 -1px 2px rgba( 255, 255, 255, 0.7 ), 0 1px 2px rgba( 255, 255, 255, 0.7 );
+	}
 }
 
 /**

--- a/stylesheets/commons/OpponentList.less
+++ b/stylesheets/commons/OpponentList.less
@@ -90,6 +90,10 @@ Author: hjpalpha
 
 .participantTable-entry.brkts-opponent-hover-active {
 	box-shadow: -1px 0 2px rgba( 0, 0, 0, 0.7 ) inset, 1px 0 2px rgba( 0, 0, 0, 0.7 ) inset, 0 -1px 2px rgba( 0, 0, 0, 0.7 ) inset, 0 1px 2px rgba( 0, 0, 0, 0.7 ) inset;
+
+	.theme--dark & {
+		box-shadow: -1px 0 2px rgba( 255, 255, 255, 0.7 ) inset, 1px 0 2px rgba( 255, 255, 255, 0.7 ) inset, 0 -1px 2px rgba( 255, 255, 255, 0.7 ) inset, 0 1px 2px rgba( 255, 255, 255, 0.7 ) inset;
+	}
 }
 
 .participantTable-entry.brkts-opponent-hover::after {
@@ -134,6 +138,10 @@ Author: hjpalpha
 
 .brkts-opponent-hover-active > .participantTable-entry::after {
 	box-shadow: -1px 0 2px rgba( 0, 0, 0, 0.7 ) inset, 1px 0 2px rgba( 0, 0, 0, 0.7 ) inset, 0 -1px 2px rgba( 0, 0, 0, 0.7 ) inset, 0 1px 2px rgba( 0, 0, 0, 0.7 ) inset;
+
+	.theme--dark & {
+		box-shadow: -1px 0 2px rgba( 255, 255, 255, 0.7 ) inset, 1px 0 2px rgba( 255, 255, 255, 0.7 ) inset, 0 -1px 2px rgba( 255, 255, 255, 0.7 ) inset, 0 1px 2px rgba( 255, 255, 255, 0.7 ) inset;
+	}
 }
 
 /* specific overwrites for faction participant tables */


### PR DESCRIPTION
## Summary
Currently in darkmode the opponent hovers are very hard to see.
This PR changes the color used for opponent hover in darkmode from black to white. Opacity etc stays the same

## How did you test this change?
browser dev tools & after that pushed to live

before:
![IMG_5144](https://github.com/user-attachments/assets/c8dff7a4-75ad-4b4c-8703-c97acd60bf09)
after:
![image](https://github.com/user-attachments/assets/36c57a6f-7739-4d79-8c78-29c7791ca313)


