### PR TITLE
fix: typo in tournament ticker

### DIFF
--- a/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
@@ -27,7 +27,7 @@ function TournamentsTickerWidget:render()
 		return
 	end
 
-	local filters = Array.map(FilterConfig.categories, Operator.propety('propety')) or {}
+	local filters = Array.map(FilterConfig.categories, Operator.property('property')) or {}
 
 	local createFilterWrapper = function(tournament, child)
 		return Array.reduce(filters, function(prev, filter)


### PR DESCRIPTION
## Summary

Had fixed it on the wiki during testing, but seems like I missed to push it
## How did you test this change?

Live