### PR TITLE
fix(matchTicker): faction icons

### DIFF
--- a/components/match2/commons/match_group_util.lua
+++ b/components/match2/commons/match_group_util.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Date = require('Module:Date/Ext')
+local Faction = require('Module:Faction')
 local FnUtil = require('Module:FnUtil')
 local Info = require('Module:Info')
 local Json = require('Module:Json')
@@ -634,6 +635,7 @@ function MatchGroupUtil.opponentFromRecord(matchRecord, record, opponentIndex)
 		status = status,
 		template = nilIfEmpty(record.template),
 		type = nilIfEmpty(record.type) or 'literal',
+		isArchon = Logic.readBool(extradata.isarchon),
 	}
 end
 
@@ -663,6 +665,7 @@ function MatchGroupUtil.playerFromRecord(record)
 		flag = nilIfEmpty(record.flag),
 		pageName = record.name,
 		team = Table.extract(extradata, 'playerteam'),
+		faction = Faction.read(extradata.faction) or Faction.defaultFaction
 	}
 end
 

--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -423,7 +423,7 @@ function MatchTicker:sortMatches(matches)
 		if a.match2id ~= b.match2id then
 			return a.match2id < b.match2id
 		end
-		return a.asGameIdx < b.asGameIdx
+		return (a.asGameIdx or 0) < (b.asGameIdx or 0)
 	end)
 end
 

--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -438,10 +438,10 @@ function MatchTicker:adjustMatch(match)
 	local opponentNames = Array.extend({self.config.player}, self.config.teamPages)
 	if
 		--check for the name value
-		Table.includes(opponentNames, (match.opponents[2].name:gsub(' ', '_')))
+		Table.includes(opponentNames, ((match.opponents[2].name or ''):gsub(' ', '_')))
 		--check inside match2players too for the player value
 		or self.config.player and Table.any(match.opponents[2].players, function(_, playerData)
-			return (playerData.name or ''):gsub(' ', '_') == self.config.player end)
+			return (playerData.pageName or ''):gsub(' ', '_') == self.config.player end)
 	then
 		return MatchTicker.switchOpponents(match)
 	end


### PR DESCRIPTION
## Summary
- factiosn not being processed
- missing nil catch
- wrong key name being used
- sort misbehaving sometimes and trying to compare a match with itself (not even a copy, but itself ...)
```
["a"] = table#2 {....},
["b"] = table#2,
```

remark: if #5308 gets merged first this PR only fixes the faction issue

## How did you test this change?
dev
