### PR TITLE
feat(infobox): create custom item infobox for stormgate

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_item_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_item_custom.lua
@@ -136,10 +136,8 @@ end
 
 ---@param args table
 ---@return string[]
-function CustomItem:getCategories(args)
-	local categories = {args.informationType}
-
-	return categories
+function CustomItem:getWikiCategories(args)
+	return {'Gear'}
 end
 
 ---@param args table

--- a/components/infobox/wikis/stormgate/infobox_item_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_item_custom.lua
@@ -43,16 +43,16 @@ function CustomItem.run(frame)
 
 	item:setWidgetInjector(CustomInjector(item))
 
-	self.data = {
-		introduced = self:_processPatchFromId(args.introduced),
-		deprecated = self:_processPatchFromId(args.deprecated),
+	item.data = {
+		introduced = item:_processPatchFromId(args.introduced),
+		deprecated = item:_processPatchFromId(args.deprecated),
 	}
 
 	local builtInfobox = item:createInfobox()
 
 	return mw.html.create()
 		:node(builtInfobox)
-		:node(CustomItem._deprecatedWarning(self.data.deprecated.display))
+		:node(CustomItem._deprecatedWarning(item.data.deprecated.display))
 end
 
 ---@param id string

--- a/components/infobox/wikis/stormgate/infobox_item_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_item_custom.lua
@@ -44,8 +44,8 @@ function CustomItem.run(frame)
 	item:setWidgetInjector(CustomInjector(item))
 
 	item.data = {
-		introduced = item:_processPatchFromId(args.introduced),
-		deprecated = item:_processPatchFromId(args.deprecated),
+		introduced = item:_processPatchFromId(item.args.introduced),
+		deprecated = item:_processPatchFromId(item.args.deprecated),
 	}
 
 	local builtInfobox = item:createInfobox()
@@ -66,7 +66,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Title{children = args.informationType .. ' Information'},
 			Cell{name = 'Slot', content = {tonumber(args.slot)}},
-			Cell{name = 'Introduced', content = {self.data.introduced.display}}
+			Cell{name = 'Introduced', content = {CustomItem:_processPatchFromId(args.introduced).display}}
 		}
 	elseif id == 'availability' then
 		return {
@@ -136,7 +136,7 @@ end
 
 ---@param args table
 ---@return string[]
-function CustomItem:getWikiCategories(args)
+function CustomItem:getWikiCategories()
 	return {'Gear'}
 end
 
@@ -162,7 +162,7 @@ end
 
 ---@param input string?
 ---@return {store: string?, display: string?}
-function CustomItem:_processPatchFromId(key)
+function CustomItem:_processPatchFromId(input)
 	if String.isEmpty(input) then return {} end
 
 	local patches = mw.ext.LiquipediaDB.lpdb('datapoint', {

--- a/components/infobox/wikis/stormgate/infobox_item_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_item_custom.lua
@@ -66,7 +66,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Title{children = args.informationType .. ' Information'},
 			Cell{name = 'Slot', content = {tonumber(args.slot)}},
-			Cell{name = 'Introduced', content = {CustomItem:_processPatchFromId(args.introduced).display}}
+			Cell{name = 'Introduced', content = {caller.data.introduced.display}}
 		}
 	elseif id == 'availability' then
 		return {

--- a/components/infobox/wikis/stormgate/infobox_item_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_item_custom.lua
@@ -1,0 +1,193 @@
+---
+-- @Liquipedia
+-- wiki=stormgate
+-- page=Module:Infobox/Item/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Faction = require('Module:Faction')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+local MessageBox = require('Module:Message box')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Item = Lua.import('Module:Infobox/Item')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
+local Center = Widgets.Center
+local Title = Widgets.Title
+
+---@class StormgateItemInfobox: ItemInfobox
+local CustomItem = Class.new(Item)
+local CustomInjector = Class.new(Injector)
+
+local ICON_DEPRECATED = '[[File:Cancelled Tournament.png|link=]]'
+local VALID_ITEMS = {
+	'Gear',
+}
+
+---@param frame Frame
+---@return Html
+function CustomItem.run(frame)
+	local item = CustomItem(frame)
+
+	assert(Table.includes(VALID_ITEMS, item.args.informationType), 'Missing or invalid "informationType"')
+
+	item:setWidgetInjector(CustomInjector(item))
+
+	item:_processPatchFromId('introduced')
+	item:_processPatchFromId('deprecated')
+
+	local builtInfobox = item:createInfobox()
+
+	return mw.html.create()
+		:node(builtInfobox)
+		:node(CustomItem._deprecatedWarning(item.args.deprecatedDisplay))
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args = caller.args
+
+	if id == 'info' then
+		return {
+			Title{children = args.informationType .. ' Information'},
+			Cell{name = 'Slot', content = {tonumber(args.slot)}},
+			Cell{name = 'Introduced', content = {args.introducedDisplay}}
+		}
+	elseif id == 'availability' then
+		return {
+			Title{children = 'Availability'},
+			Cell{name = 'Faction', content = {CustomItem._getFactionsDisplay(args.faction)}},
+			Cell{name = 'Unlocked', content = {CustomItem._getUnlockedDisplay(args.unlocked)}},
+		}
+	elseif id == 'recipe' then
+		return {
+			Title{children = 'Tags'},
+			Center{children = {CustomItem._getTagsDisplay(args.tags)}}
+		}
+	elseif Table.includes({'attributes', 'ability', 'maps', 'recipe'}, id) then
+		return {}
+	end
+
+	return widgets
+end
+
+---@param factionArgs table
+---@return string?
+function CustomItem._getFactionsDisplay(factionArgs)
+	local parsedFactionArgs = Array.map(Array.parseCommaSeparatedString(factionArgs), Faction.read)
+
+	if Array.all(Faction.coreFactions, function(faction)
+		return Table.includes(parsedFactionArgs, faction)
+	end) then return 'any' end
+
+	local factions = Array.map(Faction.coreFactions, function(faction)
+		return Table.includes(parsedFactionArgs, faction) and faction
+	end)
+
+	return table.concat(Array.map(factions, function(faction)
+		return Faction.Icon{faction=faction}
+	end), ' ')
+end
+
+---@param unlockedArgs table
+---@return string?
+function CustomItem._getUnlockedDisplay(unlockedArgs)
+	local parsedUnlockedArgs = Array.parseCommaSeparatedString(unlockedArgs, ':')
+
+	local hero =  mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = '[[type::Hero]] AND [[pagename::' .. parsedUnlockedArgs[1] .. '/Coop]]',
+		order = 'name asc',
+		query = 'information, type, name, pagename, extradata',
+		limit = 1,
+	})[1] or {}
+
+	if type(hero) ~= 'table' or Logic.isEmpty(hero) then return nil end
+
+	return Page.makeInternalLink({}, hero.name, hero.pagename) .. ' level ' .. parsedUnlockedArgs[2]
+end
+
+
+---@param tagArgs table
+---@return string?
+function CustomItem._getTagsDisplay(tagArgs)
+	local tags = Array.sortBy(Array.parseCommaSeparatedString(tagArgs), function(item)
+		return tostring(item)
+	end)
+
+	return table.concat(Array.map(tags, function(tag)
+		return Page.makeInternalLink({onlyIfExists=true}, tag, tag) or tag
+	end), ', ')
+end
+
+---@param args table
+---@return string[]
+function CustomItem:getCategories(args)
+	local categories = {args.informationType}
+
+	return categories
+end
+
+---@param args table
+function CustomItem:setLpdbData(args)
+	mw.ext.LiquipediaDB.lpdb_datapoint('item_' .. self.pagename, {
+		name = args.name,
+		type = args.informationType,
+		--information = --currently unused
+		image = args.image,
+		imagedark = args.imagedark,
+		extradata = mw.ext.LiquipediaDB.lpdb_create_json{
+			deprecated = args.deprecated or '',
+			introduced = args.introduced or '',
+			faction = Array.parseCommaSeparatedString(args.faction),
+			subfaction = Array.parseCommaSeparatedString(args.subfaction),
+			slot = tonumber(args.slot),
+			unlocked = args.unlocked,
+			tags = Array.parseCommaSeparatedString(args.tags),
+		},
+	})
+end
+
+---@param key string
+function CustomItem:_processPatchFromId(key)
+	local args = self.args
+	local input = Table.extract(args, key)
+	if String.isEmpty(input) then return end
+
+	local patches = mw.ext.LiquipediaDB.lpdb('datapoint', {
+		conditions = '[[type::patch]]',
+		limit = 5000,
+	})
+
+	args[key] = (Array.filter(patches, function(patch)
+		return String.endsWith(patch.pagename, '/' .. input)
+	end)[1] or {}).pagename
+	assert(args[key], 'Invalid patch "' .. input .. '"')
+
+	args[key .. 'Display'] = Page.makeInternalLink(input, args[key])
+end
+
+---@param patch string?
+---@return Html?
+function CustomItem._deprecatedWarning(patch)
+	if not patch then return end
+
+	return MessageBox.main('ambox', {
+		image= ICON_DEPRECATED,
+		class='ambox-red',
+		text= 'This has been removed with Patch ' .. patch,
+	})
+end
+
+return CustomItem


### PR DESCRIPTION
## Summary

This would be the first version of a custom item infobox for stormgate which would feature hero gear for coop so far. When more item types are brought into the game it can be extended. 

Examples of two random infoboxes created this way:
![image](https://github.com/user-attachments/assets/dba223ab-2b2c-4d70-a9db-fa260cf76c03)
![image](https://github.com/user-attachments/assets/8f36ab27-7519-4c36-84a4-f3eb0095b61f)




<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev tools (https://liquipedia.net/stormgate/Module:Infobox/Item/Custom/dev/senti)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
