### PR TITLE
feat(mainpage): new Overwatch main page

### DIFF
--- a/components/filter_buttons/wikis/overwatch/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/overwatch/filter_buttons_config.lua
@@ -9,6 +9,7 @@
 local Tier = require('Module:Tier/Utils')
 local Config = {}
 
+---@type FilterButtonCategory[]
 Config.categories = {
 	{
 		name = 'liquipediatier',

--- a/components/filter_buttons/wikis/overwatch/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/overwatch/filter_buttons_config.lua
@@ -1,12 +1,18 @@
-local Config = {}
+---
+-- @Liquipedia
+-- wiki=overwatch
+-- page=Module:FilterButtons/Config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Tier = require('Module:Tier/Utils')
-local FnUtil = require('Module:FnUtil')
-local Game = require('Module:Game')
+local Config = {}
 
 Config.categories = {
 	{
 		name = 'liquipediatier',
-		query = 'liquipediatier',
+		property = 'liquipediaTier',
 		load = function(category)
 			category.items = {}
 			for _, tier in Tier.iterate('tiers') do
@@ -17,24 +23,6 @@ Config.categories = {
 		transform = function(tier)
 			return Tier.toName(tier)
 		end,
-		expandKey = "liquipediatiertype",
-		additionalClass = ''
-	},
-	{
-		name = 'liquipediatiertype',
-		query = 'liquipediatiertype',
-		expandable = true,
-		load = function(category)
-			category.items = {}
-			for _, tiertype in Tier.iterate('tierTypes') do
-				table.insert(category.items, tiertype.value)
-			end
-			--table.insert(category.items, "")
-		end,
-		transform = function(tiertype)
-			return tiertype
-		end,
-		additionalClass = ''
 	},
 }
 

--- a/components/filter_buttons/wikis/overwatch/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/overwatch/filter_buttons_config.lua
@@ -1,0 +1,41 @@
+local Config = {}
+local Tier = require('Module:Tier/Utils')
+local FnUtil = require('Module:FnUtil')
+local Game = require('Module:Game')
+
+Config.categories = {
+	{
+		name = 'liquipediatier',
+		query = 'liquipediatier',
+		load = function(category)
+			category.items = {}
+			for _, tier in Tier.iterate('tiers') do
+				table.insert(category.items, tier.value)
+			end
+		end,
+		defaultItems = {'1', '2', '3'},
+		transform = function(tier)
+			return Tier.toName(tier)
+		end,
+		expandKey = "liquipediatiertype",
+		additionalClass = ''
+	},
+	{
+		name = 'liquipediatiertype',
+		query = 'liquipediatiertype',
+		expandable = true,
+		load = function(category)
+			category.items = {}
+			for _, tiertype in Tier.iterate('tierTypes') do
+				table.insert(category.items, tiertype.value)
+			end
+			--table.insert(category.items, "")
+		end,
+		transform = function(tiertype)
+			return tiertype
+		end,
+		additionalClass = ''
+	},
+}
+
+return Config

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -7,6 +7,12 @@
 --
 
 local CONTENT = {
+	usefulArticles = {
+		heading = 'Useful Articles',
+		body = '{{Liquipedia:Useful Articles}}',
+		padding = true,
+		boxid = 1503,
+	},
 	wantToHelp = {
 		heading = 'Want To Help?',
 		body = '{{Liquipedia:Want_to_help}}',
@@ -18,7 +24,7 @@ local CONTENT = {
 		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
 			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
 			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|action=edit}} edit]&#93;</div>\n' ..
+			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>\n' ..
 			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
 			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
 			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
@@ -46,74 +52,150 @@ local CONTENT = {
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{MainPageMatches}}<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
+			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
+			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=TournamentsList|fn=run|upcomingDays=120|' ..
-			'completedDays=30|filterByTierTypes=true|useExternalFilters=true}}',
+		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
+			'|upcomingDays=120|completedDays=30}}',
 		boxid = 1508,
 	},
 }
 
 return {
-	main = {
-		{ -- Left
-			size = 6,
-			children = {
-				{
-					mobileOrder = 1,
-					content = CONTENT.specialEvents,
-				},
-								{
-					mobileOrder = 6,
-					content = CONTENT.thisDay,
-				},
-				{
-					mobileOrder = 4,
-					content = CONTENT.transfers,
-				},
-				{
-					mobileOrder = 8,
-					content = CONTENT.wantToHelp,
-				},
-			}
+	banner = {
+		lightmode = 'Overwatch-logo-lightmode.svg',
+		darkmode = 'Overwatch-logo-darkmode.svg',
+	},
+	metadesc = 'The Overwatch esports wiki covering everything from players, teams and transfers, ' ..
+		'to tournaments and results, maps, weapons, and operators.',
+	title = 'Overwatch',
+	navigation = {
+		{
+			file = 'Stalk3r OWCS Finals 2024.jpeg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
 		},
-		{ -- Right
-			size = 6,
-			children = {
-				{
-					mobileOrder = 2,
-					children = {
-						{
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.filterButtons,
+		{
+			file = 'Proper OWCS Finals.jpeg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'Proper OWCS Finals.jpeg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'Proper OWCS Finals.jpeg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'Proper OWCS Finals.jpeg',
+			title = 'Heroes',
+			link = 'Portal:Heroes',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::character]]',
+			},
+		},
+		{
+			file = 'Junkertown Overwatch map.jpg',
+			title = 'Maps',
+			link = 'Portal:Maps',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::map]]',
+			},
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 6,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 8,
+						content = CONTENT.wantToHelp,
+					},
+				}
+			},
+			{ -- Right
+				size = 6,
+				children = {
+					{
+						mobileOrder = 2,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
 								},
 							},
 						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.matches,
-								},
-							},
-						},
-						{
-							size = 6,
-							children = {
-								{
-									noPanel = true,
-									content = CONTENT.tournaments,
-								},
-							},
-						},
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.thisDay,
+					},
+				},
+			},
+			{
+				children = {
+					{
+						mobileOrder = 8,
+						content = CONTENT.usefulArticles,
 					},
 				},
 			},

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -37,12 +37,12 @@ local CONTENT = {
 			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
 		body = '{{Liquipedia:This day}}',
 		padding = true,
-		boxid = 1510,
+		boxid = 1509,
 	},
 	specialEvents = {
 		noPanel = true,
 		body = '{{Liquipedia:Special Event}}',
-		boxid = 1511,
+		boxid = 1510,
 	},
 	filterButtons = {
 		noPanel = true,

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -25,7 +25,7 @@ local CONTENT = {
 			'<div style="display:inline; float:left; font-style:italic;">[[#Top|Back to top]]</div>' ..
 			'<div style="display:inline; float:right;" class="plainlinks smalledit">' ..
 			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>' ..
-			'<div style="display:inline; white-space:nowrap; font-size:15px; font-style:italic; font-weight:bold;">' ..
+			'<div style="display:inline;white-space:nowrap; font-size:15px; font-style:italic; font-weight:bold;">' ..
 			'[[Portal:Transfers|See all Transfers]]<span style="font-style:normal; font-weight:normal; ' ..
 			'padding:0 5px;">&#8226;</span>[[Transfer query]]<br><span style="font-style:normal; padding:0 5px;">' ..
 			'&#8226;</span>[[Special:RunQuery/Transfer|Transfer Generator]]<span style="font-style:normal; padding:0 5px;">' ..

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -114,7 +114,7 @@ return {
 			},
 		},
 		{
-			file = 'Junkertown Overwatch map.jpg',
+			file = 'Kings row map.jpg',
 			title = 'Maps',
 			link = 'Portal:Maps',
 			count = {

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -186,7 +186,7 @@ return {
 			{
 				children = {
 					{
-						mobileOrder = 8,
+						mobileOrder = 7,
 						content = CONTENT.usefulArticles,
 					},
 				},

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -1,0 +1,122 @@
+---
+-- @Liquipedia
+-- wiki=overwatch
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local CONTENT = {
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = '{{Liquipedia:Want_to_help}}',
+		padding = true,
+		boxid = 1504,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
+			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
+			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
+			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|action=edit}} edit]&#93;</div>\n' ..
+			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
+			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
+			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
+			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
+			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
+			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = 'This day in Overwatch <small id="this-day-date" style = "margin-left: 5px">' ..
+			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
+		body = '{{Liquipedia:This day}}',
+		padding = true,
+		boxid = 1510,
+	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+		boxid = 1511,
+	},
+	filterButtons = {
+		noPanel = true,
+		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
+			'{{#invoke:Lua|invoke|module=FilterButtons|fn=getFromConfig}}</div>',
+	},
+	matches = {
+		heading = 'Matches',
+		body = '{{MainPageMatches}}<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
+			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		padding = true,
+		boxid = 1507,
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = '{{#invoke:Lua|invoke|module=TournamentsList|fn=run|upcomingDays=120|' ..
+			'completedDays=30|filterByTierTypes=true|useExternalFilters=true}}',
+		boxid = 1508,
+	},
+}
+
+return {
+	main = {
+		{ -- Left
+			size = 6,
+			children = {
+				{
+					mobileOrder = 1,
+					content = CONTENT.specialEvents,
+				},
+								{
+					mobileOrder = 6,
+					content = CONTENT.thisDay,
+				},
+				{
+					mobileOrder = 4,
+					content = CONTENT.transfers,
+				},
+				{
+					mobileOrder = 8,
+					content = CONTENT.wantToHelp,
+				},
+			}
+		},
+		{ -- Right
+			size = 6,
+			children = {
+				{
+					mobileOrder = 2,
+					children = {
+						{
+							children = {
+								{
+									noPanel = true,
+									content = CONTENT.filterButtons,
+								},
+							},
+						},
+						{
+							size = 6,
+							children = {
+								{
+									noPanel = true,
+									content = CONTENT.matches,
+								},
+							},
+						},
+						{
+							size = 6,
+							children = {
+								{
+									noPanel = true,
+									content = CONTENT.tournaments,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -54,7 +54,8 @@ local CONTENT = {
 		heading = 'Matches',
 		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
 			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
+			'font-size:15px; font-style:italic; text-align:center;">' ..
+			'[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
 	},

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -86,7 +86,7 @@ return {
 			},
 		},
 		{
-			file = 'Proper OWCS Finals.jpeg',
+			file = 'Team Falcons OWCS 2024 Major.jpg',
 			title = 'Teams',
 			link = 'Portal:Teams',
 			count = {
@@ -104,7 +104,7 @@ return {
 			},
 		},
 		{
-			file = 'Proper OWCS Finals.jpeg',
+			file = 'OWCS Stockholm 2024 Trophy.jpg',
 			title = 'Tournaments',
 			link = 'Portal:Tournaments',
 			count = {
@@ -113,7 +113,7 @@ return {
 			},
 		},
 		{
-			file = 'Proper OWCS Finals.jpeg',
+			file = 'Overwatch Heroes NavCard image.jpg',
 			title = 'Heroes',
 			link = 'Portal:Heroes',
 			count = {

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -21,16 +21,7 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = '{{LPDB storage|false}}{{Liquipedia:News/Transfers}}{{LPDB storage|true}}',
 		boxid = 1509,
 	},
 	thisDay = {

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -72,8 +72,8 @@ return {
 		lightmode = 'Overwatch-logo-lightmode.svg',
 		darkmode = 'Overwatch-logo-darkmode.svg',
 	},
-	metadesc = 'The Overwatch esports wiki covering everything from players, teams and transfers, ' ..
-		'to tournaments and results, maps, weapons, and operators.',
+	metadesc = 'Comprehensive Overwatch wiki with articles covering everything from heroes, to tournaments, ' ..
+		'to competitive players and teams.',
 	title = 'Overwatch',
 	navigation = {
 		{

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -21,7 +21,15 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{LPDB storage|false}}{{Liquipedia:News/Transfers}}{{LPDB storage|true}}',
+		body = '{{Transfer List|limit=15}}\n<div style="display:block; text-align:center; padding:0.5em;">' ..
+			'<div style="display:inline; float:left; font-style:italic;">[[#Top|Back to top]]</div>' ..
+			'<div style="display:inline; float:right;" class="plainlinks smalledit">' ..
+			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>' ..
+			'<div style="display:inline; white-space:nowrap; font-size:15px; font-style:italic; font-weight:bold;">' ..
+			'[[Portal:Transfers|See all Transfers]]<span style="font-style:normal; font-weight:normal; ' ..
+			'padding:0 5px;">&#8226;</span>[[Transfer query]]<br><span style="font-style:normal; padding:0 5px;">' ..
+			'&#8226;</span>[[Special:RunQuery/Transfer|Transfer Generator]]<span style="font-style:normal; padding:0 5px;">' ..
+			'&#8226;</span>[[Portal:Rumours|Rumours]]</div></div>',
 		boxid = 1509,
 	},
 	thisDay = {

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -76,7 +76,7 @@ return {
 	title = 'Overwatch',
 	navigation = {
 		{
-			file = 'Stalk3r OWCS Finals 2024.jpeg',
+			file = 'Team Falcons ChiYo at the 2024 Esports World Cup.jpg',
 			title = 'Players',
 			link = 'Portal:Players',
 			count = {
@@ -94,7 +94,7 @@ return {
 			},
 		},
 		{
-			file = 'Proper OWCS Finals.jpeg',
+			file = 'NTMR Infekted at OWCS 2024 Finals.jpg',
 			title = 'Transfers',
 			link = 'Portal:Transfers',
 			count = {

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -77,7 +77,7 @@ return {
 			},
 		},
 		{
-			file = 'Team Falcons OWCS 2024 Major.jpg',
+			file = 'Crazy Raccoon 2024 Esports World Cup Champions.jpg',
 			title = 'Teams',
 			link = 'Portal:Teams',
 			count = {

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -46,7 +46,7 @@ local CONTENT = {
 		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
 			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
 			'font-size:15px; font-style:italic; text-align:center;">' ..
-			'[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
+			'[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
 	},

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -25,7 +25,7 @@ local CONTENT = {
 			'<div style="display:inline; float:left; font-style:italic;">[[#Top|Back to top]]</div>' ..
 			'<div style="display:inline; float:right;" class="plainlinks smalledit">' ..
 			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>' ..
-			'<div style="display:inline;white-space:nowrap; font-size:15px; font-style:italic; font-weight:bold;">' ..
+			'<div style="white-space:nowrap; display:inline; font-size:15px; font-style:italic; font-weight:bold;">' ..
 			'[[Portal:Transfers|See all Transfers]]<span style="font-style:normal; font-weight:normal; ' ..
 			'padding:0 5px;">&#8226;</span>[[Transfer query]]<br><span style="font-style:normal; padding:0 5px;">' ..
 			'&#8226;</span>[[Special:RunQuery/Transfer|Transfer Generator]]<span style="font-style:normal; padding:0 5px;">' ..

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -56,7 +56,7 @@
 
 	.wiki-overwatch & {
 		@media ( min-width: 768px ) {
-			background: url( https://liquipedia.net/commons/images/6/62/Overwatch_Banner_bg.jpg ) no-repeat center / cover;
+			background: url( https://liquipedia.net/commons/images/0/0a/Overwatch-bg.png ) no-repeat center / cover;
 		}
 	}
 

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -54,6 +54,12 @@
 		}
 	}
 
+	.wiki-overwatch & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/6/62/Overwatch_Banner_bg.jpg ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-pubg & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/2/2d/PUBG_Banner_bg.jpg ) no-repeat center / cover;


### PR DESCRIPTION
## Summary

This PR standardizes main page layout of Overwatch wiki.

Credit for initial work done for this PR goes to @elisazanatta

## Checklist

- [x] Select images for navigation cards
- [x] Lint

## How did you test this change?

- Sandbox: <https://liquipedia.net/overwatch/User:ElectricalBoy/MainPage>