### PR TITLE
perf: improve memory performance of match ticker

### DIFF
--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -214,7 +214,7 @@ function MatchTicker:query(matches)
 					return false
 				end
 			end,
-			DEFAULT_LIMIT * 10
+			DEFAULT_LIMIT * 20
 		)
 	end
 


### PR DESCRIPTION
## Summary
Improves memory performance of the match ticker, and also ensures that it will always find results (well, limiting it to 20 queries)

## How did you test this change?
Functionally works.
Is more efficient when it comes to post filters (can actually retrieve all matches up to limit). And does that without breaking the memory bank.
As example, just as efficient on all wikis. With a region filter with which exists 45 matches in the future of on LoL, new version could find them all, while existing version only fetched 35. 