### PR TITLE
feat: support for the curated option for the new main pages

### DIFF
--- a/components/filter_buttons/filter_buttons.lua
+++ b/components/filter_buttons/filter_buttons.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local FnUtil = require('Module:FnUtil')
+local I18n = require('Module:I18n')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -31,6 +32,8 @@ local DROPDOWN_ARROW = '&#8203;▼&#8203;'
 ---@field expandable boolean?
 ---@field order? fun(a: string, b: string): boolean
 ---@field load? fun(cat: FilterButtonCategory)
+---@field hasFeatured boolean?
+---@field featuredByDefault boolean?
 
 ---Builds filterbuttons based on config stored in Module:FilterButtons/Config
 ---Can be used from wikicode
@@ -81,16 +84,15 @@ function FilterButtons.getButtonRow(category)
 		:attr('data-filter', 'data-filter')
 		:attr('data-filter-effect','fade')
 		:attr('data-filter-group', 'filterbuttons-' .. category.name)
+		:attr('data-filter-default-curated', category.featuredByDefault and 'true' or nil)
 		:tag('span')
 			:addClass('filter-button')
 			:addClass('filter-button-all')
 			:attr('data-filter-on', 'all')
-			:wikitext('All')
+			:wikitext(I18n.translate('filterbuttons-all'))
 			:done()
 
-	local transform = category.transform or FnUtil.identity
-	for _, value in ipairs(category.items or {}) do
-		local text = transform(value)
+	local makeButton = function(value, text)
 		local button = mw.html.create('span')
 			:addClass('filter-button')
 			:attr('data-filter-on', value)
@@ -99,6 +101,16 @@ function FilterButtons.getButtonRow(category)
 			button:addClass('filter-button--active')
 		end
 		buttons:node(button)
+	end
+
+	if category.hasFeatured then
+		makeButton('curated', I18n.translate('filterbuttons-featured'))
+	end
+
+	local transformValueToText = category.transform or FnUtil.identity
+	for _, value in ipairs(category.items or {}) do
+		local text = transformValueToText(value)
+		makeButton(value, text)
 	end
 
 	if String.isNotEmpty(category.expandKey) then

--- a/components/match_ticker/commons/match_ticker.lua
+++ b/components/match_ticker/commons/match_ticker.lua
@@ -361,14 +361,18 @@ function MatchTicker:keepMatch(match)
 		if not match.tournamentData then
 			return false
 		end
-		return Table.includes(self.config.regions, match.tournamentData.region)
+		if not Table.includes(self.config.regions, match.tournamentData.region) then
+			return false
+		end
 	end
 
 	if self.config.featuredTournamentsOnly then
 		if not match.tournamentData then
 			return false
 		end
-		return match.tournamentData.featured
+		if not match.tournamentData.featured then
+			return false
+		end
 	end
 
 	--remove matches with empty/BYE opponents
@@ -376,21 +380,23 @@ function MatchTicker:keepMatch(match)
 		return false
 	end
 
-	if self.config.showAllTbdMatches then
-		return true
+	if not self.config.showAllTbdMatches then
+		local isTbdMatch = Array.all(match.opponents, function(opponent)
+			return Opponent.isEmpty(opponent) or Opponent.isTbd(opponent)
+		end)
+		local toss = isTbdMatch and previousMatchWasTbd
+		if isTbdMatch then
+			previousMatchWasTbd = true
+		else
+			previousMatchWasTbd = false
+		end
+
+		if toss == true then
+			return false
+		end
 	end
 
-	local isTbdMatch = Array.all(match.opponents, function(opponent)
-		return Opponent.isEmpty(opponent) or Opponent.isTbd(opponent)
-	end)
-	local toss = isTbdMatch and previousMatchWasTbd
-	if isTbdMatch then
-		previousMatchWasTbd = true
-	else
-		previousMatchWasTbd = false
-	end
-
-	return not toss
+	return true
 end
 
 ---Overwritable per wiki decision

--- a/components/tournament/tournament.lua
+++ b/components/tournament/tournament.lua
@@ -62,6 +62,19 @@ function Tournaments.getAllTournaments(conditions, filterTournament)
 	return tournaments
 end
 
+---@param pagename string
+---@return StandardTournament?
+function Tournaments.getTournament(pagename)
+	local record = mw.ext.LiquipediaDB.lpdb('tournament', {
+		conditions = '[[pagename::' .. pagename .. ']]',
+		limit = 1,
+	})[1]
+	if not record then
+		return nil
+	end
+	return Tournaments.tournamentFromRecord(record, Tournaments.makeFeaturedFunction())
+end
+
 local TouranmentMT = {
 	__index = function(tournament, property)
 		if property == 'featured' then

--- a/components/tournament/tournament.lua
+++ b/components/tournament/tournament.lua
@@ -14,7 +14,7 @@ local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local Tier = require('Module:Tier/Utils')
 
-local Tournaments = {}
+local Tournament = {}
 
 ---@enum TournamentPhase
 local TOURNAMENT_PHASE = {
@@ -43,7 +43,7 @@ local TOURNAMENT_PHASE = {
 ---@param conditions ConditionTree?
 ---@param filterTournament fun(tournament: StandardTournament): boolean
 ---@return StandardTournament[]
-function Tournaments.getAllTournaments(conditions, filterTournament)
+function Tournament.getAllTournaments(conditions, filterTournament)
 	local tournaments = {}
 	Lpdb.executeMassQuery(
 		'tournament',
@@ -53,7 +53,7 @@ function Tournaments.getAllTournaments(conditions, filterTournament)
 			limit = 1000,
 		},
 		function(record)
-			local tournament = Tournaments.tournamentFromRecord(record)
+			local tournament = Tournament.tournamentFromRecord(record)
 			if not filterTournament or filterTournament(tournament) then
 				table.insert(tournaments, tournament)
 			end
@@ -64,7 +64,7 @@ end
 
 ---@param pagename string
 ---@return StandardTournament?
-function Tournaments.getTournament(pagename)
+function Tournament.getTournament(pagename)
 	local record = mw.ext.LiquipediaDB.lpdb('tournament', {
 		conditions = '[[pagename::' .. pagename .. ']]',
 		limit = 1,
@@ -72,16 +72,16 @@ function Tournaments.getTournament(pagename)
 	if not record then
 		return nil
 	end
-	return Tournaments.tournamentFromRecord(record, Tournaments.makeFeaturedFunction())
+	return Tournament.tournamentFromRecord(record, Tournament.makeFeaturedFunction())
 end
 
 local TouranmentMT = {
 	__index = function(tournament, property)
 		if property == 'featured' then
-			tournament[property] = Tournaments.isFeatured(tournament)
+			tournament[property] = Tournament.isFeatured(tournament)
 		end
 		if property == 'phase' then
-			tournament[property] = Tournaments.calculatePhase(tournament)
+			tournament[property] = Tournament.calculatePhase(tournament)
 		end
 		return rawget(tournament, property)
 	end
@@ -89,10 +89,10 @@ local TouranmentMT = {
 
 ---@param record tournament
 ---@return StandardTournament
-function Tournaments.tournamentFromRecord(record)
+function Tournament.tournamentFromRecord(record)
 
-	local startDate = Tournaments.parseDateRecord(Logic.nilOr(record.extradata.startdatetext, record.startdate))
-	local endDate = Tournaments.parseDateRecord(Logic.nilOr(record.extradata.enddatetext, record.sortdate, record.enddate))
+	local startDate = Tournament.parseDateRecord(Logic.nilOr(record.extradata.startdatetext, record.startdate))
+	local endDate = Tournament.parseDateRecord(Logic.nilOr(record.extradata.enddatetext, record.sortdate, record.enddate))
 
 	local tournament = {
 		displayName = Logic.emptyOr(record.tickername, record.name) or record.pagename:gsub('_', ' '),
@@ -118,7 +118,7 @@ end
 
 ---@param tournament StandardTournament
 ---@return TournamentPhase
-function Tournaments.calculatePhase(tournament)
+function Tournament.calculatePhase(tournament)
 	if tournament.status == 'finished' then
 		return TOURNAMENT_PHASE.FINISHED
 	end
@@ -140,7 +140,7 @@ end
 --- This function parses fuzzy dates into a structured format.
 ---@param dateRecord string? # date in the format of `YYYY-MM-DD`, with `-MM-DD` optional.
 ---@return {year: integer, month: integer?, day: integer?, timestamp: integer?}?
-function Tournaments.parseDateRecord(dateRecord)
+function Tournament.parseDateRecord(dateRecord)
 	if not dateRecord then
 		return nil
 	end
@@ -163,7 +163,7 @@ end
 --- Determines if a tournament is featured.
 ---@param record StandardTournament
 ---@return boolean
-function Tournaments.isFeatured(record)
+function Tournament.isFeatured(record)
 	local curatedData = Lua.requireIfExists('Module:TournamentsList/CuratedData', {loadData = true})
 	if not curatedData then
 		return false
@@ -194,10 +194,7 @@ function Tournaments.isFeatured(record)
 			return nil
 		end
 
-		return mw.ext.LiquipediaDB.lpdb('tournament', {
-			conditions = '[[pagename::' .. parentPage .. ']]',
-			limit = 1,
-		})[1] or parentData(parentPage, maxDepth - 1)
+		return Tournament.getTournament(parentPage) or parentData(parentPage, maxDepth - 1)
 	end
 	local parentTournament = parentData(pagename, 2)
 
@@ -205,7 +202,7 @@ function Tournaments.isFeatured(record)
 		return false
 	end
 
-	return Tournaments.tournamentFromRecord(parentTournament).featured
+	return parentTournament.featured
 end
 
-return Tournaments
+return Tournament

--- a/components/tournament/tournament.lua
+++ b/components/tournament/tournament.lua
@@ -72,7 +72,7 @@ function Tournament.getTournament(pagename)
 	if not record then
 		return nil
 	end
-	return Tournament.tournamentFromRecord(record, Tournament.makeFeaturedFunction())
+	return Tournament.tournamentFromRecord(record)
 end
 
 local TouranmentMT = {

--- a/components/widget/tournaments/widget_tournaments_ticker.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker.lua
@@ -41,21 +41,24 @@ function TournamentsTickerWidget:render()
 		[3] = 22,
 		[4] = 0,
 		[5] = 0,
+	}
+
+	--- The Tier Type thresholds only affect completed tournaments.
+	local tierTypeThresholdModifiers = {
 		['qualifier'] = -2,
 	}
 
 	local currentTimestamp = DateExt.getCurrentTimestamp()
 	local function isWithinDateRange(tournament)
-		local modifiedThreshold = tierThresholdModifiers[tournament.liquipediaTierType]
-			or tierThresholdModifiers[tournament.liquipediaTier]
-			or 0
+		local modifiedThreshold = tierThresholdModifiers[tournament.liquipediaTier] or 0
+		local modifiedCompletedThreshold = tierTypeThresholdModifiers[tournament.liquipediaTierType] or modifiedThreshold
 
 		if not tournament.startDate then
 			return false
 		end
 
 		local startDateThreshold = currentTimestamp + (upcomingDays + modifiedThreshold) * 24 * 60 * 60
-		local endDateThreshold = currentTimestamp - (completedDays + modifiedThreshold) * 24 * 60 * 60
+		local endDateThreshold = currentTimestamp - (completedDays + modifiedCompletedThreshold) * 24 * 60 * 60
 
 		if tournament.phase == 'ONGOING' then
 			return true

--- a/standard/i18n_data.lua
+++ b/standard/i18n_data.lua
@@ -11,6 +11,10 @@ return {
 		-- Tournament Filter
 		['tournament-ticker-no-tournaments'] = 'No tournaments found for your selected filters!',
 
+		-- Filter Buttons
+		['filter-buttons-all'] = 'All',
+		['filter-buttons-featured'] = 'Curated',
+
 		-- Dates
 		['date-unknown'] = 'TBA',
 		['date-range-different-months'] = '${startMonth} ${startDate} - ${endMonth} ${endDate}',

--- a/standard/i18n_data.lua
+++ b/standard/i18n_data.lua
@@ -12,8 +12,8 @@ return {
 		['tournament-ticker-no-tournaments'] = 'No tournaments found for your selected filters!',
 
 		-- Filter Buttons
-		['filter-buttons-all'] = 'All',
-		['filter-buttons-featured'] = 'Curated',
+		['filterbuttons-all'] = 'All',
+		['filterbuttons-featured'] = 'Curated',
 
 		-- Dates
 		['date-unknown'] = 'TBA',


### PR DESCRIPTION
## Summary

Adds the curated option for FilterButtons, and for MatchTicker to only show matches from curated tournaments. 

Needed for Counterstrike's new main Page.

While it doesn't have a strict dependecy on any other PR, #5320, #5321 and #5322 should preferably be merged first for performance reasons.

The following templates needs to be updated at merge from their dev/rath version.
https://liquipedia.net/commons/Template:MainPageMatches/Upcoming
https://liquipedia.net/commons/Template:MainPageMatches/Completed

## How did you test this change?
TournamentTicker on [CS](https://liquipedia.net/counterstrike/User:Rathoz)
MatchTicker on [CS](https://liquipedia.net/counterstrike/User:Rathoz), [SC2](https://liquipedia.net/starcraft2/User:Rathoz)
MatchTicker player On [SC2](https://liquipedia.net/starcraft2/HerO_(Kim_Joon_Ho)) (in preview)