### PR TITLE
fix(match2): popup on matches without details on sc2

### DIFF
--- a/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
+++ b/components/match2/wikis/starcraft2/brkts_wiki_specific.lua
@@ -16,7 +16,7 @@ local BaseWikiSpecific = Lua.import('Module:Brkts/WikiSpecific/Base')
 local WikiSpecific = Table.copy(BaseWikiSpecific)
 
 WikiSpecific.matchFromRecord = FnUtil.lazilyDefineFunction(function()
-	local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Starcraft')
+	local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 	return StarcraftMatchGroupUtil.matchFromRecord
 end)
 
@@ -60,5 +60,10 @@ function WikiSpecific.getMatchContainer(displayMode)
 		return WikiSpecific.adjustMatchGroupContainerConfig(SingleMatch.SingleMatchContainer)
 	end
 end
+
+WikiSpecific.matchHasDetails = FnUtil.lazilyDefineFunction(function()
+	local StarcraftMatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
+	return StarcraftMatchGroupUtil.matchHasDetails
+end)
 
 return WikiSpecific


### PR DESCRIPTION
## Summary
introduced with #5311
- removed a function i should not have removed
- did not replace all `Module:MatchGroup/Util/Starcraft` with `Module:MatchGroup/Util/Custom` in that one file

rechecked all files changed in that PR and this is the only upsi
re-added the function to the file and chancged the util/starcraft to util/custom

## How did you test this change?
dev to live