### PR TITLE
ci(deploy): remove deploy to dev-wikis

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,39 +49,3 @@ jobs:
           WIKI_UA_EMAIL: ${{ secrets.LP_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
         run: bash scripts/deploy.sh "${{ steps.lua-changed-files.outputs.all_changed_files }}"
-
-  dev-deploy:
-    name: Dev Wikis
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - id: changed-files
-        uses: tj-actions/changed-files@v42
-        with:
-          files: |
-            components/**/*.lua
-            standard/**/*.lua
-
-      - name: Deploy Old Dev
-        if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
-          WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
-          WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL }}
-          DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}
-        run: bash scripts/deploy.sh "${{ steps.changed-files.outputs.all_changed_files }}"
-
-      - name: Deploy New Dev
-        if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
-          WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
-          WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL2 }}
-          DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}
-        run: bash scripts/deploy.sh "${{ steps.changed-files.outputs.all_changed_files }}"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -30,30 +30,3 @@ jobs:
           WIKI_UA_EMAIL: ${{ secrets.LP_UA_EMAIL }}
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
         run: bash scripts/deploy.sh
-
-  dev-deploy:
-    name: Dev Wikis
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Deploy Old Dev
-        env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
-          WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
-          WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL }}
-          DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}
-        run: bash scripts/deploy.sh
-
-      - name: Deploy New Dev
-        env:
-          WIKI_USER: ${{ secrets.DEV_WIKI_BOTUSER }}
-          WIKI_PASSWORD: ${{ secrets.DEV_WIKI_BOTPASSWORD }}
-          WIKI_UA_EMAIL: ${{ secrets.DEV_WIKI_UA_EMAIL }}
-          WIKI_BASE_URL: ${{ secrets.DEV_WIKI_BASE_URL2 }}
-          DEV_WIKI_BASIC_AUTH: ${{ secrets.DEV_WIKI_BASIC_AUTH }}
-        run: bash scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 userAgent="GitHub Autodeploy Bot/1.1.0 (${WIKI_UA_EMAIL})"
-devWikis=('rocketleague' 'commons')
 pat='\-\-\-\
 \-\- @Liquipedia\
 \-\- wiki=([^
@@ -36,11 +35,6 @@ for luaFile in $luaFiles; do
     wiki="${BASH_REMATCH[1]}"
     page="${BASH_REMATCH[2]}${LUA_DEV_ENV_NAME}"
 
-    if [[ ! ( ("${DEV_WIKI_BASIC_AUTH}" == "") || ("${devWikis[*]}" =~ ${wiki}) ) ]]; then
-        echo '...skipping - dev wiki not applicable...'
-        continue
-    fi
-
     echo '...magic comment found - updating wiki...'
 
     echo "...wiki = $wiki"
@@ -59,7 +53,6 @@ for luaFile in $luaFiles; do
           -d "format=json&action=query&meta=tokens&type=login" \
           -H "User-Agent: ${userAgent}" \
           -H 'Accept-Encoding: gzip' \
-          -H "Authorization: Basic ${DEV_WIKI_BASIC_AUTH}" \
           -X POST "$wikiApiUrl" \
           | gunzip \
           | jq ".query.tokens.logintoken" -r
@@ -73,7 +66,6 @@ for luaFile in $luaFiles; do
         --data-urlencode "lgtoken=${loginToken}" \
         -H "User-Agent: ${userAgent}" \
         -H 'Accept-Encoding: gzip' \
-        -H "Authorization: Basic ${DEV_WIKI_BASIC_AUTH}" \
         -X POST "${wikiApiUrl}?format=json&action=login" \
         | gunzip \
         > /dev/null
@@ -91,7 +83,6 @@ for luaFile in $luaFiles; do
         -d "format=json&action=query&meta=tokens" \
         -H "User-Agent: ${userAgent}" \
         -H 'Accept-Encoding: gzip' \
-        -H "Authorization: Basic ${DEV_WIKI_BASIC_AUTH}" \
         -X POST "$wikiApiUrl" \
         | gunzip \
         | jq ".query.tokens.csrftoken" -r
@@ -109,7 +100,6 @@ for luaFile in $luaFiles; do
         --data-urlencode "token=${editToken}" \
         -H "User-Agent: ${userAgent}" \
         -H 'Accept-Encoding: gzip' \
-        -H "Authorization: Basic ${DEV_WIKI_BASIC_AUTH}" \
         -X POST "${wikiApiUrl}?format=json&action=edit" \
         | gunzip
     )


### PR DESCRIPTION
## Summary
The dev deploy hasn't been working for >6 months now. Since no steps have been taken to fix it, as there seems to been no need for it. Removing it as it's erroring our deploy pipelines.