### PR TITLE
feat(Infobox): Update unit and building infobox on stormgate regarding subfaction data (part 2)

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -39,8 +39,11 @@ local ICON_ENERGY = '[[File:EnergyIcon.gif|link=]]'
 local ICON_DEPRECATED = '[[File:Cancelled Tournament.png|link=]]'
 local HOTKEY_SEPERATOR = '&nbsp;&nbsp;/&nbsp;&nbsp;'
 local CREEP = 'Camp'
-local GAME_MODE_NAME = {coop = 'Co-op', mayhem = 'Team Mayhem'}
-local SORT_TABLE = {'1v1', 'mayhem', 'coop'}
+local SORT_TABLE = {'1v1', 'coop', 'mayhem'}
+local GAME_MODE_ICON = {
+	coop = '<i class="fas fa-dungeon" title="Co-op"></i>',
+	mayhem = '<i class="fab fa-fort-awesome" title="Team Mayhem"></i>',
+}
 
 ---@param frame Frame
 ---@return Html
@@ -75,8 +78,9 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(
 			widgets,
 			Cell{name = 'Size', content = {args.size}},
-			Cell{name = 'Sight', content = {args.sight}},
 			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
+			Cell{name = 'Speed', content = {args.speed}},
+			Cell{name = 'Sight', content = {args.sight}},
 			Cell{name = 'Upgrades To', content = caller:_csvToPageList(args.upgrades_to)},
 			Cell{name = 'Introduced', content = {args.introducedDisplay}}
 		)
@@ -161,9 +165,9 @@ function CustomBuilding:subHeaderDisplay(args)
 	end
 
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
-		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
-		return GAME_MODE_NAME[string.lower(subfactionElement[1])] ..
-			': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
+		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_ICON[string.lower(subfactionElement[1])] then return end
+		return GAME_MODE_ICON[string.lower(subfactionElement[1])] .. ' '
+			.. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
 	end)
 
 	return tostring(mw.html.create('span')

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -13,6 +13,7 @@ local Class = require('Module:Class')
 local CostDisplay = require('Module:Infobox/Extension/CostDisplay')
 local Faction = require('Module:Faction')
 local Hotkeys = require('Module:Hotkey')
+local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -41,8 +42,8 @@ local HOTKEY_SEPERATOR = '&nbsp;&nbsp;/&nbsp;&nbsp;'
 local CREEP = 'Camp'
 local SORT_TABLE = {'1v1', 'coop', 'mayhem'}
 local GAME_MODE_ICON = {
-	coop = '<i class="fas fa-dungeon" title="Co-op"></i>',
-	mayhem = '<i class="fab fa-fort-awesome" title="Team Mayhem"></i>',
+	coop = 'dungeon',
+	mayhem = 'fort',
 }
 
 ---@param frame Frame
@@ -166,7 +167,7 @@ function CustomBuilding:subHeaderDisplay(args)
 
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
 		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_ICON[string.lower(subfactionElement[1])] then return end
-		return GAME_MODE_ICON[string.lower(subfactionElement[1])] .. ' '
+		return Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(subfactionElement[1])], size = '100%'} .. ' '
 			.. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
 	end)
 

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -35,8 +35,15 @@ local ICON_ARMOR = '[[File:Icon_Armor.png|link=Armor]]'
 local ICON_ENERGY = '[[File:EnergyIcon.gif|link=]]'
 local ICON_DEPRECATED = '[[File:Cancelled Tournament.png|link=]]'
 local HOTKEY_SEPERATOR = '&nbsp;&nbsp;/&nbsp;&nbsp;'
-local GAME_MODE_NAME = {coop = 'Co-op', mayhem = 'Team Mayhem'}
-local SORT_TABLE = {'1v1', 'mayhem', 'coop'}
+local SORT_TABLE = {'1v1', 'coop', 'mayhem'}
+local GAME_MODE_NAME =	{
+	coop = 'Co-op',
+	mayhem = 'Team Mayhem',
+}
+local GAME_MODE_ICON = {
+	coop = '<i class="fas fa-dungeon" title="Co-op"></i>',
+	mayhem = '<i class="fab fa-fort-awesome" title="Team Mayhem"></i>',
+}
 
 ---@param frame Frame
 ---@return Html
@@ -116,8 +123,8 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'custom' then
 		Array.appendWith(widgets,
 			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
-			Cell{name = 'Sight', content = {args.sight}},
 			Cell{name = 'Speed', content = {args.speed}},
+			Cell{name = 'Sight', content = {args.sight}},
 			Cell{name = 'Upgrades To', content = {caller:_displayCsvAsPageCsv(args.upgrades_to)}},
 			Cell{name = 'Introduced', content = {args.introducedDisplay}}
 		)
@@ -169,10 +176,14 @@ function CustomUnit:subHeaderDisplay(args)
 	end
 
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
-		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_NAME[string.lower(subfactionElement[1])] then return end
-		if args.informationType == 'Hero' then return GAME_MODE_NAME[string.lower(subfactionElement[1])] end
-		return GAME_MODE_NAME[string.lower(subfactionElement[1])] ..
-			': ' .. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
+		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_ICON[string.lower(subfactionElement[1])] then return end
+		if args.informationType == 'Hero' then 
+			return GAME_MODE_ICON[string.lower(subfactionElement[1])] .. ' '
+				.. GAME_MODE_NAME[string.lower(subfactionElement[1])]
+		end
+
+		return GAME_MODE_ICON[string.lower(subfactionElement[1])] .. ' '
+			.. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
 	end)
 
 	return tostring(mw.html.create('span')

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -13,6 +13,7 @@ local Class = require('Module:Class')
 local CostDisplay = require('Module:Infobox/Extension/CostDisplay')
 local Faction = require('Module:Faction')
 local Hotkeys = require('Module:Hotkey')
+local Icon = require('Module:Icon')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -41,8 +42,8 @@ local GAME_MODE_NAME =	{
 	mayhem = 'Team Mayhem',
 }
 local GAME_MODE_ICON = {
-	coop = '<i class="fas fa-dungeon" title="Co-op"></i>',
-	mayhem = '<i class="fab fa-fort-awesome" title="Team Mayhem"></i>',
+	coop = 'dungeon',
+	mayhem = 'fort',
 }
 
 ---@param frame Frame
@@ -178,11 +179,11 @@ function CustomUnit:subHeaderDisplay(args)
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
 		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_ICON[string.lower(subfactionElement[1])] then return end
 		if args.informationType == 'Hero' then
-			return GAME_MODE_ICON[string.lower(subfactionElement[1])] .. ' '
+			return Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(subfactionElement[1])], size = '100%'} .. ' '
 				.. GAME_MODE_NAME[string.lower(subfactionElement[1])]
 		end
 
-		return GAME_MODE_ICON[string.lower(subfactionElement[1])] .. ' '
+		return Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(subfactionElement[1])], size = '100%'} .. ' '
 			.. self:_displayCsvAsPageCsv(subfactionElement[2], ';')
 	end)
 

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -177,7 +177,7 @@ function CustomUnit:subHeaderDisplay(args)
 
 	local parts = Array.map(self:_parseSubfactionData(subfactionData), function(subfactionElement)
 		if Logic.isEmpty(subfactionElement[2]) or not GAME_MODE_ICON[string.lower(subfactionElement[1])] then return end
-		if args.informationType == 'Hero' then 
+		if args.informationType == 'Hero' then
 			return GAME_MODE_ICON[string.lower(subfactionElement[1])] .. ' '
 				.. GAME_MODE_NAME[string.lower(subfactionElement[1])]
 		end

--- a/standard/icon_data.lua
+++ b/standard/icon_data.lua
@@ -105,6 +105,10 @@ return {
 	standings_staydown = 'fas fa-chevron-down',
 	standings_down = 'fas fa-skull',
 
-	-- Usage sorting
+	-- Usage: sorting
 	sort = 'far fa-arrows-alt-v',
+
+	-- Usage: Stormgate
+	dungeon = 'fas fa-dungeon',
+	fort = 'fab fa-fort-awesome',
 }


### PR DESCRIPTION
## Summary

Small follow-up pr to https://github.com/Liquipedia/Lua-Modules/pull/5263 regarding
* adding font awesome icons to represent Co-op and Team Mayhem on Unit Infobox
* adding font awesome icons to represent Co-op and Team Mayhem on Building Infobox

Small changes to appearance of Unit and Building Infobox, especially:
* adding speed to Buildings Infobox (no storage)

![image](https://github.com/user-attachments/assets/d00505a5-ac48-486e-81b5-a562446fe596)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev-tools

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
