### PR TITLE
feat: change standings to look on started rather than finished to determine rounds to show

### DIFF
--- a/components/standings/commons/standings.lua
+++ b/components/standings/commons/standings.lua
@@ -36,6 +36,7 @@ local Standings = {}
 
 ---@class StandingsRound
 ---@field round integer
+---@field started boolean
 ---@field finished boolean
 ---@field title string
 ---@field opponents StandingsEntryModel[]
@@ -163,8 +164,9 @@ function Standings.makeRounds(standings)
 		return {
 			round = roundIndex,
 			opponents = opponents,
-			finished = (lpdbdata.extradata.rounds[roundIndex] or {}).finished,
-			title = (lpdbdata.extradata.rounds[roundIndex] or {}).title,
+			finished = (lpdbdata.extradata.rounds[roundIndex] or {}).finished or false,
+			started = (lpdbdata.extradata.rounds[roundIndex] or {}).started or false,
+			title = (lpdbdata.extradata.rounds[roundIndex] or {}).title or ('Round ' .. roundIndex),
 		}
 	end)
 end


### PR DESCRIPTION
## Summary
Use "started", which currently means that the last previous round has ended, to determine when to update "Current". This matches the old behavior. Will be tweaked in the future as we go further in the project, when a "sdate" is introduced in addition to the "edate" (or maybe replacing entirely). 

## How did you test this change?
dev -> live