### PR TITLE
feat: throw proper error on unsupported TZ in the match table

### DIFF
--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -645,9 +645,13 @@ end
 ---@return string
 function MatchTable._calculateDateTimeString(timezone, timestamp)
 	local offset = Timezone.getOffset(timezone) or 0
-
-	return DateExt.formatTimestamp('M d, Y - H:i', timestamp + offset) ..
-		' ' .. Timezone.getTimezoneString(timezone)
+	local tzstring = Timezone.getTimezoneString(timezone)
+	if not tzstring then
+		error('Unsupported timezone: ' .. timezone)
+	end
+  
+ 	return DateExt.formatTimestamp('M d, Y - H:i', timestamp + offset) ..
+		' ' .. tzstring
 end
 
 ---@param match MatchTableMatch

--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -649,8 +649,8 @@ function MatchTable._calculateDateTimeString(timezone, timestamp)
 	if not tzstring then
 		error('Unsupported timezone: ' .. timezone)
 	end
-  
- 	return DateExt.formatTimestamp('M d, Y - H:i', timestamp + offset) ..
+
+	return DateExt.formatTimestamp('M d, Y - H:i', timestamp + offset) ..
 		' ' .. tzstring
 end
 


### PR DESCRIPTION
## Summary
Somewhat regularly an error with the match is reported (e.g. https://discord.com/channels/93055209017729024/372075546231832576/1330180220174729287)

This is related to an un-/partially supported timezone, so to make the error message more descriptive display the TZ in the error message.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
