### PR TITLE
feat(match2): add darkmode support to link icons on matchPages

### DIFF
--- a/components/match2/wikis/dota2/match_page_template.lua
+++ b/components/match2/wikis/dota2/match_page_template.lua
@@ -33,7 +33,7 @@ return {
 					</div>{{/vods.1}}{{#parsedLinks.1}}
 					<div class="match-bm-match-additional-section">
 						<div class="match-bm-match-additional-section-header">Socials</div>
-						<div class="match-bm-match-additional-section-body">{{#parsedLinks}}[[{{icon}}|link={{link}}|15px|{{text}}]]{{/parsedLinks}}</div>
+						<div class="match-bm-match-additional-section-body vodlink">{{#parsedLinks}}[[{{icon}}|link={{link}}|15px|{{text}}]]{{/parsedLinks}}</div>
 					</div>{{/parsedLinks.1}}{{#patch}}
 					<div class="match-bm-match-additional-section">
 						<div class="match-bm-match-additional-section-header">Patch</div>

--- a/components/match2/wikis/leagueoflegends/match_page_template.lua
+++ b/components/match2/wikis/leagueoflegends/match_page_template.lua
@@ -34,7 +34,7 @@ return {
 				{{#vods}}
 					<div class="match-bm-lol-match-additional-list">{{#icons}}{{&.}}{{/icons}}</div>
 				{{/vods}}
-				<div class="match-bm-lol-match-additional-list">{{#parsedLinks}}[[{{icon}}|link={{link}}|15px|{{text}}]]{{/parsedLinks}}</div>
+				<div class="match-bm-lol-match-additional-list vodlink">{{#parsedLinks}}[[{{icon}}|link={{link}}|15px|{{text}}]]{{/parsedLinks}}</div>
 				{{#patch}}
 					<div class="match-bm-lol-match-additional-list">[[Patch {{patch}}]]</div>
 				{{/patch}}


### PR DESCRIPTION
resolves #5346

## Summary
add the vodlink class to the div wrapper that is around the icons so they get inverted in darkmode

alternative solution would be to append both used classes at
https://github.com/Liquipedia/Lua-Modules/blob/710b7b9f133a431bb0c83d9e8d32b86697945ac5/stylesheets/commons/Miscellaneous.less#L2211-L2212

## How did you test this change?
browser dev tools