### PR TITLE
feat(standard): remove template fallback in flags

### DIFF
--- a/spec/flags_spec.lua
+++ b/spec/flags_spec.lua
@@ -26,7 +26,7 @@ describe('flags', function()
 			assert.are_equal(nlOutput, Flags.Icon{shouldLink = false, flag = 'nld'})
 			assert.are_equal(nlOutput, Flags.Icon{shouldLink = false, flag = 'holland'})
 
-			assert.are_equal('<span class=\"flag\">[[File:Space filler flag.png|36x24px|link=]]</span>',
+			assert.are_equal('<span class=\"flag\">[[File:Space filler flag.png|36x24px||link=]]</span>',
 				Flags.Icon{flag = 'tbd'})
 
 			assert.are_equal('Unknown flag: dummy',

--- a/spec/flags_spec.lua
+++ b/spec/flags_spec.lua
@@ -1,7 +1,6 @@
 --- Triple Comment to Enable our LLS Plugin
 describe('flags', function()
 	local Flags = require('Module:Flags')
-	local Template = require('Module:Template')
 
 	describe('icon', function()
 		it('check', function()
@@ -30,15 +29,8 @@ describe('flags', function()
 			assert.are_equal('<span class=\"flag\">[[File:Space filler flag.png|36x24px|link=]]</span>',
 				Flags.Icon{flag = 'tbd'})
 
-			local TemplateMock = stub(Template, "safeExpand")
-
-			Flags.Icon{shouldLink = true, flag = 'dummy'}
-			assert.stub(TemplateMock).was.called_with(mw.getCurrentFrame(), 'Flag/dummy')
-
-			Flags.Icon{shouldLink = false, flag = 'dummy'}
-			assert.stub(TemplateMock).was.called_with(mw.getCurrentFrame(), 'FlagNoLink/dummy')
-
-			TemplateMock:revert()
+			assert.are_equal('Unknown flag: dummy',
+				Flags.Icon{shouldLink = true, flag = 'dummy'})
 		end)
 	end)
 

--- a/standard/flags.lua
+++ b/standard/flags.lua
@@ -24,7 +24,7 @@ local Flags = {}
 ---@param args flagIconArgs?
 ---@param flagName string?
 ---@return string
----@overload fun(args: string): string
+---@overload fun(flagName: string): string
 function Flags.Icon(args, flagName)
 	local shouldLink
 	if type(args) == 'string' then
@@ -42,28 +42,19 @@ function Flags.Icon(args, flagName)
 	shouldLink = Logic.readBool(shouldLink)
 
 	local flagKey = Flags._convertToKey(flagName)
+	local flagData = MasterData.data[flagKey]
 
-	if flagKey then
-		local flagData = MasterData.data[flagKey]
-		if flagData.flag ~= 'File:Space filler flag.png' then
-			local link = ''
-			if flagData.name and shouldLink then
-				link = 'Category:' .. flagData.name
-			end
-			return '<span class="flag">[[' .. flagData.flag ..
-				'|36x24px|' .. flagData.name .. '|link=' .. link .. ']]</span>'
-		else
-			return '<span class="flag">[[' .. flagData.flag .. '|36x24px|link=]]</span>'
-		end
-	elseif shouldLink then
+	if not flagKey or not flagData then
 		mw.log('Unknown flag: ', flagName)
 		mw.ext.TeamLiquidIntegration.add_category('Pages with unknown flags')
-		return Template.safeExpand(mw.getCurrentFrame(), 'Flag/' .. mw.ustring.lower(flagName))
-	else
-		mw.log('Unknown flag: ', flagName)
-		mw.ext.TeamLiquidIntegration.add_category('Pages with unknown flags')
-		return Template.safeExpand(mw.getCurrentFrame(), 'FlagNoLink/' .. mw.ustring.lower(flagName))
+		return 'Unknown flag: ' .. flagName
 	end
+
+	local link = ''
+	if String.isNotEmpty(flagData.name) and shouldLink then
+		link = 'Category:' .. flagData.name
+	end
+	return '<span class="flag">[[' .. flagData.flag .. '|36x24px|' .. flagData.name .. '|link=' .. link .. ']]</span>'
 end
 
 -- Returns the localisation/country-adjective of a country or region


### PR DESCRIPTION
## Summary
As part of the Flag cleanup, remove the subtemplate fallback in flags handling. Instead display a simple warning.

Removed the special case for "File:Space filler flag.png", instead tweaked the code to have almost the same behaviour (but slightly better - will add a link if there's one).

## How did you test this change?
Auto tests