### PR TITLE
Make main page reflect old order of portals

### DIFF
--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -92,6 +92,42 @@ return {
 	title = 'League of Legends',
 	navigation = {
 		{
+			file = 'DRX Deft Worlds 2022 Champion.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'T1 Worlds 2024.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'G2 Worlds 2024.jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'Worlds Trophy 2024.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
 			file = 'T1 Worlds23 Skins Splash Art.jpg',
 			title = 'Champions',
 			link = 'Champions',
@@ -109,42 +145,6 @@ return {
 				method = 'LPDB',
 				table = 'datapoint',
 				conditions = '[[type::patch]]',
-			},
-		},
-		{
-			file = 'Worlds Trophy 2024.jpg',
-			title = 'Tournaments',
-			link = 'Portal:Tournaments',
-			count = {
-				method = 'LPDB',
-				table = 'tournament',
-			},
-		},
-		{
-			file = 'T1 Worlds 2024.jpg',
-			title = 'Teams',
-			link = 'Portal:Teams',
-			count = {
-				method = 'LPDB',
-				table = 'team',
-			},
-		},
-		{
-			file = 'DRX Deft Worlds 2022 Champion.jpg',
-			title = 'Players',
-			link = 'Portal:Players',
-			count = {
-				method = 'LPDB',
-				table = 'player',
-			},
-		},
-		{
-			file = 'G2 Worlds 2024.jpg',
-			title = 'Transfers',
-			link = 'Portal:Transfers',
-			count = {
-				method = 'LPDB',
-				table = 'transfer',
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

Following an update to the homepage layout, the order of portals changed. The priority of champions/patches makes it feel like a game wiki instead of an esports wiki, while messing with years of muscle memory. Changes will 'return' the original order..

## How did you test this change?

Tested in userspace to check reflected changes: https://liquipedia.net/leagueoflegends/User:RonanHoogmoed/MainpageUpdate
Issues are not occuring on either desktop or mobile layouts. Order of items is as intended (Players -> Teams -> Transfers -> Tournaments -> Champions -> Patches)