### PR TITLE
feat: standardize ffa standings parsing

### DIFF
--- a/components/standings/commons/standings.lua
+++ b/components/standings/commons/standings.lua
@@ -53,6 +53,7 @@ local Standings = {}
 ---@field definitiveStatus string?
 ---@field positionChangeFromPreviousRound integer
 ---@field pointsChangeFromPreviousRound number
+---@field specialstatus 'dq'|'nc'|''
 
 ---Fetches a standings table from a page. Tries to read from page variables before fetching from LPDB.
 ---@param pagename string
@@ -127,6 +128,7 @@ function Standings.entryFromRecord(record)
 		definitiveStatus = record.definitestatus,
 		points = record.scoreboard.points,
 		pointsChangeFromPreviousRound = record.extradata.pointschange,
+		specialStatus = record.extradata.specialstatus or '',
 		positionChangeFromPreviousRound = tonumber(record.placementchange),
 	}
 

--- a/components/standings/commons/standings.lua
+++ b/components/standings/commons/standings.lua
@@ -53,7 +53,7 @@ local Standings = {}
 ---@field definitiveStatus string?
 ---@field positionChangeFromPreviousRound integer
 ---@field pointsChangeFromPreviousRound number
----@field specialstatus 'dq'|'nc'|''
+---@field specialStatus 'dq'|'nc'|''
 
 ---Fetches a standings table from a page. Tries to read from page variables before fetching from LPDB.
 ---@param pagename string

--- a/components/standings/commons/standings.lua
+++ b/components/standings/commons/standings.lua
@@ -53,7 +53,7 @@ local Standings = {}
 ---@field definitiveStatus string?
 ---@field positionChangeFromPreviousRound integer
 ---@field pointsChangeFromPreviousRound number
----@field specialStatus 'dq'|'nc'|''
+---@field specialStatus 'dq'|'nc'|'' # nc = non-competing (not in the round)
 
 ---Fetches a standings table from a page. Tries to read from page variables before fetching from LPDB.
 ---@param pagename string

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -38,10 +38,10 @@ function StandingsParseWiki.parseWikiInput(args)
 		table.insert(rounds, StandingsParseWiki.parseWikiRound(roundData, roundIndex))
 	end
 
-	---@type {input: table, opponent: standardOpponent}[]
+	---@type {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
 	local opponents = {}
 	for _, opponentData, _ in Table.iter.pairsByPrefix(args, 'opponent', {requireIndex = true}) do
-		table.insert(opponents, StandingsParseWiki.parseWikiOpponent(opponentData))
+		table.insert(opponents, StandingsParseWiki.parseWikiOpponent(opponentData, #rounds))
 	end
 
 	return {
@@ -54,7 +54,7 @@ end
 
 ---@param roundInput string
 ---@param roundIndex integer
----@return table
+---@return {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
 function StandingsParseWiki.parseWikiRound(roundInput, roundIndex)
 	local roundData = Json.parse(roundInput)
 	return {
@@ -66,10 +66,16 @@ function StandingsParseWiki.parseWikiRound(roundInput, roundIndex)
 end
 
 ---@param opponentInput string
----@return table
-function StandingsParseWiki.parseWikiOpponent(opponentInput)
+---@param numberOfRounds integer
+---@return {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 	local opponentData = Json.parse(opponentInput)
-	return {input = opponentData, opponent = Opponent.readOpponentArgs(opponentData)}
+	local rounds = {}
+	for i = 1, numberOfRounds do
+		local points = tonumber(opponentData['r' .. i])
+		table.insert(rounds, {scoreboard = {points = points}})
+	end
+	return {rounds = rounds, opponent = Opponent.readOpponentArgs(opponentData)}
 end
 
 ---@param input string

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -72,8 +72,14 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 	local opponentData = Json.parse(opponentInput)
 	local rounds = {}
 	for i = 1, numberOfRounds do
-		local points = tonumber(opponentData['r' .. i])
-		table.insert(rounds, {scoreboard = {points = points}})
+		local input = opponentData['r' .. i]
+		local points, specialStatus
+		if Logic.isNumeric(input) then
+			points = tonumber(input)
+		else
+			specialStatus = input
+		end
+		table.insert(rounds, {scoreboard = {points = points}, specialstatus = specialStatus})
 	end
 	return {rounds = rounds, opponent = Opponent.readOpponentArgs(opponentData)}
 end

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -67,13 +67,13 @@ end
 
 ---@param opponentInput string
 ---@param numberOfRounds integer
----@return {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+---@return {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
 function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 	local opponentData = Json.parse(opponentInput)
 	local rounds = {}
 	for i = 1, numberOfRounds do
 		local input = opponentData['r' .. i]
-		local points, specialStatus
+		local points, specialStatus = nil, ''
 		if Logic.isNumeric(input) then
 			points = tonumber(input)
 		else

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -1,0 +1,91 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Standings/Parse/Wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Table = require('Module:Table')
+
+local OpponentLibrary = require('Module:OpponentLibraries')
+local Opponent = OpponentLibrary.Opponent
+
+local StandingsParseWiki = {}
+
+--[[
+{{FfaStandings|title=League Standings
+|bg=1-10=stay, 11-20=down
+|matches=...,...,...
+<!-- Rounds -->
+|round1={{Round|title=A vs B|started=true|finished=false}}
+<more rounds>
+<!-- Opponents -->
+|opponent1={{TeamOpponent|dreamfire|placement=<optional>|r1=17|r2=-|r3=-|r4=34|r5=32|r6=-}}
+<more opponents>
+}}
+]]
+
+---@param args table
+---@return table
+function StandingsParseWiki.parseWikiInput(args)
+	---@type {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
+	local rounds = {}
+	for _, roundData, roundIndex in Table.iter.pairsByPrefix(args, 'round', {requireIndex = true}) do
+		table.insert(rounds, StandingsParseWiki.parseWikiRound(roundData, roundIndex))
+	end
+
+	---@type {input: table, opponent: standardOpponent}[]
+	local opponents = {}
+	for _, opponentData, _ in Table.iter.pairsByPrefix(args, 'opponent', {requireIndex = true}) do
+		table.insert(opponents, StandingsParseWiki.parseWikiOpponent(opponentData))
+	end
+
+	return {
+		rounds = rounds,
+		opponents = opponents,
+		bgs = StandingsParseWiki.parseWikiBgs(args.bg),
+		matches = Array.parseCommaSeparatedString(args.matches),
+	}
+end
+
+---@param roundInput string
+---@param roundIndex integer
+---@return table
+function StandingsParseWiki.parseWikiRound(roundInput, roundIndex)
+	local roundData = Json.parse(roundInput)
+	return {
+		roundNumber = roundIndex,
+		started = Logic.readBool(roundData.started),
+		finished = Logic.readBool(roundData.finished),
+		title = roundData.title,
+	}
+end
+
+---@param opponentInput string
+---@return table
+function StandingsParseWiki.parseWikiOpponent(opponentInput)
+	local opponentData = Json.parse(opponentInput)
+	return {input = opponentData, opponent = Opponent.readOpponentArgs(opponentData)}
+end
+
+---@param input string
+---@return table<integer, string>
+function StandingsParseWiki.parseWikiBgs(input)
+	local statusParsed = {}
+	Array.forEach(Array.parseCommaSeparatedString(input, ','), function (status)
+		local placements, color = unpack(Array.parseCommaSeparatedString(status, '='))
+		local pStart, pEnd = unpack(Array.parseCommaSeparatedString(placements, '-'))
+		local pStartNumber = tonumber(pStart) --[[@as integer]]
+		local pEndNumber = tonumber(pEnd) or pStartNumber
+		Array.forEach(Array.range(pStartNumber, pEndNumber), function(placement)
+			statusParsed[placement] = color
+		end)
+	end)
+	return statusParsed
+end
+
+return StandingsParseWiki

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -79,7 +79,7 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 		elseif input == '-' then
 			specialStatus = 'nc'
 		else
-			specialStatus =  input
+			specialStatus = input
 		end
 		table.insert(rounds, {scoreboard = {points = points}, specialstatus = specialStatus})
 	end

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -76,8 +76,10 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 		local points, specialStatus = nil, ''
 		if Logic.isNumeric(input) then
 			points = tonumber(input)
+		elseif input == '-' then
+			specialStatus = 'nc'
 		else
-			specialStatus = input
+			specialStatus =  input
 		end
 		table.insert(rounds, {scoreboard = {points = points}, specialstatus = specialStatus})
 	end

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -117,8 +117,8 @@ function StandingsParser.setPlacementChange(opponents)
 		Array.sortInPlaceBy(opponentByRounds, function (opponentInRound)
 			return opponentInRound.roundindex
 		end)
+		local lastPlacement
 		Array.forEach(opponentByRounds, function(opponent)
-			local lastPlacement
 			if lastPlacement and opponent.placement then
 				opponent.placementchange = lastPlacement - opponent.placement
 			end

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -58,10 +58,12 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 			return opponentRound.roundindex == round.roundNumber
 		end))
 	end)
-	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer}[]
+	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer,
+	---points: number?, placement: integer?, slotindex: integer}[]
 
 	StandingsParser.setPlacementChange(entries)
-	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
+	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer,
+	---points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
 
 	StandingsParser.addStatuses(entries, bgs, 'currentstatus')
 	if isFinished then
@@ -69,7 +71,9 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 			return opponentRound.roundindex == #rounds
 		end), bgs, 'definitestatus')
 	end
-	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?, currentstatus: string?, definitestatus: string?}[]
+	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
+	---placement: integer?, slotindex: integer, placementchange: integer?,
+	---currentstatus: string?, definitestatus: string?}[]
 
 
 	---@type StandingsTableStorage
@@ -90,7 +94,8 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 	}
 end
 
----@param opponentsInRound {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer?}[]
+---@param opponentsInRound {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
+---placement: integer?, slotindex: integer?}[]
 function StandingsParser.determinePlacements(opponentsInRound)
 	table.sort(opponentsInRound, function(opponent1, opponent2)
 		return opponent1.points > opponent2.points
@@ -103,7 +108,8 @@ function StandingsParser.determinePlacements(opponentsInRound)
 	end)
 end
 
----@param opponentEnties {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
+---@param opponentEnties {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
+---placement: integer?, slotindex: integer, placementchange: integer?}[]
 ---@param bgs table<integer, string>
 ---@param field 'currentstatus'|'definitestatus'
 function StandingsParser.addStatuses(opponentEnties, bgs, field)
@@ -112,7 +118,8 @@ function StandingsParser.addStatuses(opponentEnties, bgs, field)
 	end)
 end
 
----@param opponents {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
+---@param opponents {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
+---placement: integer?, slotindex: integer, placementchange: integer?}[]
 function StandingsParser.setPlacementChange(opponents)
 	local opponentsByRounds = Array.groupBy(opponents, function (opponent)
 		return opponent.opponent

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -32,12 +32,13 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 		local opponentRounds = opponentData.rounds
 
 		return Array.map(rounds, function(round)
-			local pointsFromRound
+			local pointsFromRound, statusInRound
 			if opponentRounds then
 				local thisRoundsData = opponentRounds[round.roundNumber]
 				if thisRoundsData and thisRoundsData.scoreboard then
 					pointsFromRound = thisRoundsData.scoreboard.points
 				end
+				statusInRound = statusInRound.specialstatus
 			end
 			pointSum = pointSum + (pointsFromRound or 0)
 			---@type {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?}
@@ -48,6 +49,7 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 				points = pointSum,
 				extradata = {
 					pointschange = pointsFromRound,
+					specialstatus = statusInRound,
 				}
 			}
 		end)
@@ -74,7 +76,6 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
 	---placement: integer?, slotindex: integer, placementchange: integer?,
 	---currentstatus: string?, definitestatus: string?}[]
-
 
 	---@type StandingsTableStorage
 	return {

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -12,7 +12,7 @@ local Variables = require('Module:Variables')
 local StandingsParser = {}
 
 ---@param rounds {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
----@param opponents {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+---@param opponents {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
 ---@param bgs table<integer, string>
 ---@param title string?
 ---@param matches string[]
@@ -33,12 +33,12 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 
 		return Array.map(rounds, function(round)
 			local pointsFromRound, statusInRound
-			if opponentRounds then
+			if opponentRounds and opponentRounds[round.roundNumber] then
 				local thisRoundsData = opponentRounds[round.roundNumber]
-				if thisRoundsData and thisRoundsData.scoreboard then
+				if thisRoundsData.scoreboard then
 					pointsFromRound = thisRoundsData.scoreboard.points
 				end
-				statusInRound = statusInRound.specialstatus
+				statusInRound = thisRoundsData.specialstatus
 			end
 			pointSum = pointSum + (pointsFromRound or 0)
 			---@type {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?}

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -32,15 +32,14 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 		local opponentRounds = opponentData.rounds
 
 		return Array.map(rounds, function(round)
-			if not opponentRounds or not round.started then
-				return {}
+			local pointsFromRound
+			if opponentRounds then
+				local thisRoundsData = opponentRounds[round.roundNumber]
+				if thisRoundsData and thisRoundsData.scoreboard then
+					pointsFromRound = thisRoundsData.scoreboard.points
+				end
 			end
-			local thisRoundsData = opponentRounds[round.roundNumber]
-			if not thisRoundsData or not thisRoundsData.scoreboard then
-				return {}
-			end
-			local points = thisRoundsData.scoreboard.points or 0
-			pointSum = pointSum + points
+			pointSum = pointSum + (pointsFromRound or 0)
 			---@type {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?}
 			return {
 				opponent = opponent,
@@ -48,7 +47,7 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 				roundindex = round.roundNumber,
 				points = pointSum,
 				extradata = {
-					pointschange = thisRoundsData.scoreboard.points,
+					pointschange = pointsFromRound,
 				}
 			}
 		end)

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -1,0 +1,130 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Standings/Parser
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Variables = require('Module:Variables')
+
+local StandingsParser = {}
+
+---@param rounds table[]
+---@param opponents table[]
+---@param bgs table<integer, string>
+---@param title string?
+---@param matches string[]
+---@return StandingsTableStorage
+function StandingsParser.parse(rounds, opponents, bgs, title, matches)
+	-- TODO: When all legacy (of all standing type) have been converted, the wiki variable should be updated
+	-- to follow the namespace format. Eg new name could be `standings_standingsindex`
+	local lastStandingsIndex = tonumber(Variables.varDefault('standingsindex')) or -1
+	local standingsindex = lastStandingsIndex + 1
+	Variables.varDefine('standingsindex', standingsindex)
+
+	local isFinished = Array.all(rounds, function(round) return round.finished end)
+
+	local entries = Array.flatMap(opponents, function(opponentData)
+		local opponent = opponentData.opponent
+		local opponentInput = opponentData.input
+		local pointSum = 0
+
+		return Array.map(rounds, function(round)
+			if not round.started then
+				return {}
+			end
+			-- TODO Move to wikicode parsing
+			local points = tonumber(opponentInput['r' .. round.roundNumber]) or 0
+			pointSum = pointSum + points
+			---@type {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?}
+			return {
+				opponent = opponent,
+				standingsindex = standingsindex,
+				roundindex = round.roundNumber,
+				points = pointSum,
+			}
+		end)
+	end)
+
+	Array.forEach(rounds, function(round)
+		StandingsParser.determinePlacements(Array.filter(entries, function(opponentRound)
+			return opponentRound.roundindex == round.roundNumber
+		end))
+	end)
+	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer}[]
+
+	StandingsParser.setPlacementChange(entries)
+	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
+
+	StandingsParser.addStatuses(entries, bgs, 'currentstatus')
+	if isFinished then
+		StandingsParser.addStatuses(Array.filter(entries, function(opponentRound)
+			return opponentRound.roundindex == #rounds
+		end), bgs, 'definitestatus')
+	end
+	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?, currentstatus: string?, definitestatus: string?}[]
+
+
+	---@type StandingsTableStorage
+	return {
+		standingsindex = standingsindex,
+		title = title,
+		type = 'ffa', -- We only deal with ffa atm
+		entries = entries,
+		matches = matches,
+		roundcount = #rounds,
+		hasdraw = false,
+		hasovertime = false,
+		haspoints = true,
+		finished = isFinished,
+		extradata = {
+			rounds = rounds,
+		},
+	}
+end
+
+---@param opponentsInRound {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer?}[]
+function StandingsParser.determinePlacements(opponentsInRound)
+	table.sort(opponentsInRound, function(opponent1, opponent2)
+		return opponent1.points < opponent2.points
+	end)
+
+	local lastPts = math.huge
+	Array.forEach(opponentsInRound, function(opponent, slotindex)
+		opponent.slotindex = slotindex
+		opponent.placement = lastPts == opponent.points and opponentsInRound[slotindex - 1].placement or slotindex
+	end)
+end
+
+---@param opponentEnties {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
+---@param bgs table<integer, string>
+---@param field 'currentstatus'|'definitestatus'
+function StandingsParser.addStatuses(opponentEnties, bgs, field)
+	Array.forEach(opponentEnties, function(opponent)
+		opponent[field] = bgs[opponent.slotindex]
+	end)
+end
+
+---@param opponents {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
+function StandingsParser.setPlacementChange(opponents)
+	local opponentsByRounds = Array.groupBy(opponents, function (opponent)
+		return opponent.opponent
+	end)
+
+	Array.forEach(opponentsByRounds, function (opponentByRounds)
+		Array.sortInPlaceBy(opponentByRounds, function (opponentInRound)
+			return opponentInRound.roundindex
+		end)
+		Array.forEach(opponentByRounds, function(opponent)
+			local lastPlacement
+			if lastPlacement and opponent.placement then
+				opponent.placementchange = lastPlacement - opponent.placement
+			end
+			lastPlacement = opponent.placement
+		end)
+	end)
+end
+
+return StandingsParser

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -11,8 +11,8 @@ local Variables = require('Module:Variables')
 
 local StandingsParser = {}
 
----@param rounds table[]
----@param opponents table[]
+---@param rounds {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
+---@param opponents {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
 ---@param bgs table<integer, string>
 ---@param title string?
 ---@param matches string[]
@@ -28,15 +28,18 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 
 	local entries = Array.flatMap(opponents, function(opponentData)
 		local opponent = opponentData.opponent
-		local opponentInput = opponentData.input
 		local pointSum = 0
+		local opponentRounds = opponentData.rounds
 
 		return Array.map(rounds, function(round)
-			if not round.started then
+			if not opponentRounds or not round.started then
 				return {}
 			end
-			-- TODO Move to wikicode parsing
-			local points = tonumber(opponentInput['r' .. round.roundNumber]) or 0
+			local thisRoundsData = opponentRounds[round.roundNumber]
+			if not thisRoundsData or not thisRoundsData.scoreboard then
+				return {}
+			end
+			local points = thisRoundsData.scoreboard.points or 0
 			pointSum = pointSum + points
 			---@type {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?}
 			return {

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -47,6 +47,9 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 				standingsindex = standingsindex,
 				roundindex = round.roundNumber,
 				points = pointSum,
+				extradata = {
+					pointschange = thisRoundsData.scoreboard.points,
+				}
 			}
 		end)
 	end)
@@ -91,7 +94,7 @@ end
 ---@param opponentsInRound {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?, placement: integer?, slotindex: integer?}[]
 function StandingsParser.determinePlacements(opponentsInRound)
 	table.sort(opponentsInRound, function(opponent1, opponent2)
-		return opponent1.points < opponent2.points
+		return opponent1.points > opponent2.points
 	end)
 
 	local lastPts = math.huge

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -34,7 +34,7 @@ local DISQUALIFIED = 'dq'
 ---@field hasovertime boolean
 ---@field haspoints boolean
 ---@field finished boolean
----@field enddate string? #formated as 'Y-m-d' DEPRECATED
+---@field enddate string?
 ---@field extradata table
 
 ---@class StandingEntriesStorage

--- a/components/standings/commons/standings_storage.lua
+++ b/components/standings/commons/standings_storage.lua
@@ -23,6 +23,37 @@ local ALLOWED_SCORE_BOARD_KEYS = {'w', 'd', 'l'}
 local SCOREBOARD_FALLBACK = {w = 0, d = 0, l = 0}
 local DISQUALIFIED = 'dq'
 
+---@class StandingsTableStorage
+---@field standingsindex integer
+---@field title string?
+---@field type 'ffa'|'swiss'|'league'
+---@field entries StandingEntriesStorage[]
+---@field matches string[]
+---@field roundcount integer
+---@field hasdraw boolean
+---@field hasovertime boolean
+---@field haspoints boolean
+---@field finished boolean
+---@field enddate string? #formated as 'Y-m-d' DEPRECATED
+---@field extradata table
+
+---@class StandingEntriesStorage
+---@field standingsindex integer
+---@field roundindex integer
+---@field slotindex integer
+---@field opponent standardOpponent
+---@field participant string?
+---@field placement string?
+---@field points number
+---@field definitestatus string?
+---@field currentstatus string?
+---@field placementchange integer?
+---@field diff integer?
+---@field match table?
+---@field game table?
+---@field overtime table?
+---@field extradata table
+
 ---@param data table
 function StandingsStorage.run(data)
 	if Table.isEmpty(data) then

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -13,7 +13,7 @@ local StandingsParseWiki = Lua.import('Module:Standings/Parse/Wiki')
 local StandingsParser = Lua.import('Module:Standings/Parser')
 local StandingsStorage = Lua.import('Module:Standings/Storage')
 
-local Display = Lua.import('le:Widget/Standings/Ffa')
+local Display = Lua.import('Module:Widget/Standings/Ffa')
 
 local StandingsTable = {}
 
@@ -25,7 +25,7 @@ function StandingsTable.fromTemplate(frame)
 	if tableType ~= 'ffa' then
 		error('Unknown Standing Table Type')
 	end
-	return StandingsTable.ffa(StandingsParseWiki.parseWikiInput(args))
+	return StandingsTable.ffa(unpack(StandingsParseWiki.parseWikiInput(args)))
 end
 
 ---@param rounds any

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -13,7 +13,7 @@ local StandingsParseWiki = Lua.import('Module:Standings/Parse/Wiki')
 local StandingsParser = Lua.import('Module:Standings/Parser')
 local StandingsStorage = Lua.import('Module:Standings/Storage')
 
-local Display = Lua.import('Module:Widget/Standings/Ffa')
+local Display = Lua.import('Module:Widget/Standings')
 
 local StandingsTable = {}
 
@@ -25,7 +25,14 @@ function StandingsTable.fromTemplate(frame)
 	if tableType ~= 'ffa' then
 		error('Unknown Standing Table Type')
 	end
-	return StandingsTable.ffa(unpack(StandingsParseWiki.parseWikiInput(args)))
+	local parsedData = StandingsParseWiki.parseWikiInput(args)
+	return StandingsTable.ffa(
+		parsedData.rounds,
+		parsedData.opponents,
+		parsedData.bgs,
+		args.title,
+		parsedData.matches
+	)
 end
 
 ---@param rounds any
@@ -37,7 +44,7 @@ end
 function StandingsTable.ffa(rounds, opponents, bgs, title, matches)
 	local standingsTable = StandingsParser.parse(rounds, opponents, bgs, title, matches)
 	StandingsStorage.run(standingsTable)
-	return Display{standings = standingsTable}
+	return Display{pageName = mw.title.getCurrentTitle().text, standingsIndex = standingsTable.standingsindex}
 end
 
 return StandingsTable

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -1,0 +1,43 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Standings/Table
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Lua = require('Module:Lua')
+
+local StandingsParseWiki = Lua.import('Module:Standings/Parse/Wiki')
+local StandingsParser = Lua.import('Module:Standings/Parser')
+local StandingsStorage = Lua.import('Module:Standings/Storage')
+
+local Display = Lua.import('le:Widget/Standings/Ffa')
+
+local StandingsTable = {}
+
+---@param frame Frame
+---@return Widget
+function StandingsTable.fromTemplate(frame)
+	local args = Arguments.getArgs(frame)
+	local tableType = args.tabletype
+	if tableType ~= 'ffa' then
+		error('Unknown Standing Table Type')
+	end
+	return StandingsTable.ffa(StandingsParseWiki.parseWikiInput(args))
+end
+
+---@param rounds any
+---@param opponents any
+---@param bgs any
+---@param title any
+---@param matches any
+---@return Widget
+function StandingsTable.ffa(rounds, opponents, bgs, title, matches)
+	local standingsTable = StandingsParser.parse(rounds, opponents, bgs, title, matches)
+	StandingsStorage.run(standingsTable)
+	return Display{standings = standingsTable}
+end
+
+return StandingsTable

--- a/components/widget/standings/widget_standings_ffa.lua
+++ b/components/widget/standings/widget_standings_ffa.lua
@@ -20,6 +20,11 @@ local PlacementChange = Lua.import('Module:Widget/Standings/PlacementChange')
 local OpponentLibraries = require('Module:OpponentLibraries')
 local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
+local STATUS_TO_DISPLAY = {
+	dq = 'DQ',
+	nc = '-',
+}
+
 ---@class StandingsFfaWidget: Widget
 ---@operator call(table): StandingsFfaWidget
 
@@ -115,15 +120,16 @@ function StandingsFfaWidget:render()
 								css = {['font-weight'] = 'bold', ['text-align'] = 'center'}
 							},
 							Array.map(standings.rounds, function(columnRound)
-								local text = ''
+								local text
 								if columnRound.round <= round.round then
-									local newPoints = (Array.find(columnRound.opponents, function(columnSlot)
+									local opponent = Array.find(columnRound.opponents, function(columnSlot)
 										return columnSlot.opponent.name == slot.opponent.name
-									end).pointsChangeFromPreviousRound)
-									if newPoints then
-										text = tostring(newPoints)
+									end)
+									local roundStatus = opponent.specialstatus
+									if roundStatus == '' then
+										text = opponent.pointsChangeFromPreviousRound
 									else
-										text = '-'
+										text = STATUS_TO_DISPLAY[roundStatus]
 									end
 								end
 								return HtmlWidgets.Td{children = text, css = {['text-align'] = 'center'}}

--- a/components/widget/standings/widget_standings_ffa.lua
+++ b/components/widget/standings/widget_standings_ffa.lua
@@ -125,7 +125,7 @@ function StandingsFfaWidget:render()
 									local opponent = Array.find(columnRound.opponents, function(columnSlot)
 										return columnSlot.opponent.name == slot.opponent.name
 									end)
-									local roundStatus = opponent.specialstatus
+									local roundStatus = opponent.specialStatus
 									if roundStatus == '' then
 										text = opponent.pointsChangeFromPreviousRound
 									else


### PR DESCRIPTION
## Summary
Next step in the FFA standings standardization process. With this, it can replace the existing FFA tables on Apex for future tournaments.

The next step after this are automation and legacy input parser.

## How did you test this change?
https://liquipedia.net/apexlegends/User:Kanoodles/RathTest by Kano
