### PR TITLE
fix: Set batch limit when querying in match table

### DIFF
--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -291,6 +291,7 @@ function MatchTable:query()
 		order = 'date desc',
 		query = 'match2opponents, match2games, date, dateexact, icon, icondark, liquipediatier, game, type, '
 			.. 'liquipediatiertype, tournament, pagename, tickername, vod, winner, extradata',
+		limit = 50,
 	}, function(match)
 		table.insert(self.matches, self:matchFromRecord(match) or nil)
 	end, self.config.limit)


### PR DESCRIPTION
## Summary
When compared with the match1 matchtable, this version used drastically more Lua memory.
To be able to still render most pages, limit the batch size in Lpdb::executeMassQuery.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
