### PR TITLE
feat: Add option to link to a subpage in match table

### DIFF
--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -547,7 +547,7 @@ function MatchTable:build()
 		end
 		display:node(self:matchRow(match))
 	end)
-	
+
 	if self.config.linkSubPage then
 		local pagename = self.title.text .. '/Matches'
 		display:tag('tr')

--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -151,7 +151,8 @@ function MatchTable:_readDefaultConfig()
 		showType = Logic.readBool(args.showType),
 		showYearHeaders = Logic.readBool(args.showYearHeaders),
 		useTickerName = Logic.readBool(args.useTickerName),
-		teamStyle = String.nilIfEmpty(args.teamStyle) or 'short'
+		teamStyle = String.nilIfEmpty(args.teamStyle) or 'short',
+		linkSubPage = Logic.readBool(args.linkSubPage)
 	}
 end
 
@@ -546,6 +547,15 @@ function MatchTable:build()
 		end
 		display:node(self:matchRow(match))
 	end)
+	
+	if self.config.linkSubPage then
+		local pagename = self.title.text .. '/Matches'
+		display:tag('tr')
+			:tag('th')
+				:attr('colspan', 42)
+				:css('font-style', 'italic')
+				:wikitext('[[' .. pagename .. '|Extended list of matches]]')
+	end
 
 	local wrappedTableNode = mw.html.create('div')
 		:addClass('match-table-wrapper')


### PR DESCRIPTION
## Summary
Some wikis (i.e. AoE) display some recent matches on a player's main page, and then a full list of matches on a subpage.
This adds the option to link to such a subpage, similar to the ResultsTable (when showing achievements).

The name of the subpage itself is hardcoded, as that is also already done in case of the year-range subpages.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
