### PR TITLE
feat(Infobox): add Infobox League for Chess

### DIFF
--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -49,7 +49,7 @@ local RESTRICTIONS = {
 	senior = {
 		name = 'Senior Players Only',
 		link = 'Senior Tournaments',
-		data = 'Senior',
+		data = 'senior',
 	},
 }
 
@@ -99,7 +99,6 @@ end
 function CustomLeague:customParseArguments(args)
 	self.data.mode = self:_getGameMode()
 end
-
 
 ---@return string?
 function CustomLeague:_getGameMode()

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -73,7 +73,7 @@ end
 ---@param args table
 ---@return table
 function CustomLeague:addToLpdb(lpdbData, args)
-	
+
 	lpdbData.extradata.female = args.female or 'false'
 	lpdbData.extradata.junior = args.junior or 'false'
 	lpdbData.extradata.senior = args.senior or 'false'

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -31,7 +31,6 @@ local MODES = {
 	dice = 'Dice Chess',
 	various = 'Multiple',
 }
-
 local RESTRICTIONS = {
 	female = {
 		name = 'Female Players Only',
@@ -111,12 +110,7 @@ end
 ---@param restrictions string?
 ---@return {name: string, data: string, link: string}[]
 function CustomLeague.getRestrictions(restrictions)
-	if String.isEmpty(restrictions) then
-		return {}
-	end
-	---@cast restrictions -nil
-
-	return Array.map(Array.parseCommaSeparatedString(inputString, sep),
+	return Array.map(Array.parseCommaSeparatedString(inputString),
 		function(restriction) return RESTRICTIONS[restriction] end)
 end
 

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -1,0 +1,67 @@
+---
+-- @Liquipedia
+-- wiki=chess
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+
+---@class ChessLeagueInfobox: InfoboxLeague
+local CustomLeague = Class.new(League)
+local CustomInjector = Class.new(Injector)
+
+local MODES = {
+	classical = 'Classical',
+	blitz = 'Blitz',
+	rapid = 'Rapid',
+	chess960 = 'Chess960',
+	puzzle = 'Puzzle Rush',
+	dice = 'Dice Chess',
+	various = 'Multiple',
+}
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'gamesettings' then
+		return {Cell{name = 'Variant', content = {self.caller:_getGameMode()}},}
+	end
+	
+	return widgets
+end
+
+---@param args table
+function CustomLeague:customParseArguments(args)
+	self.data.mode = self:_getGameMode()
+end
+
+
+---@return string?
+function CustomLeague:_getGameMode()
+	return MODES[string.lower(self.args.mode or '')] or MODES['classical']
+end
+
+return CustomLeague

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
 
 local Injector = Lua.import('Module:Widget/Injector')

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -8,14 +8,12 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
-local Title = Widgets.Title
 
 ---@class ChessLeagueInfobox: InfoboxLeague
 local CustomLeague = Class.new(League)
@@ -44,12 +42,11 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
 
 	if id == 'gamesettings' then
 		return {Cell{name = 'Variant', content = {self.caller:_getGameMode()}},}
 	end
-	
+
 	return widgets
 end
 

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -110,7 +110,7 @@ end
 ---@param restrictions string?
 ---@return {name: string, data: string, link: string}[]
 function CustomLeague.getRestrictions(restrictions)
-	return Array.map(Array.parseCommaSeparatedString(inputString),
+	return Array.map(Array.parseCommaSeparatedString(restrictions),
 		function(restriction) return RESTRICTIONS[restriction] end)
 end
 

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -31,7 +31,6 @@ local MODES = {
 	various = 'Multiple',
 }
 
-
 local RESTRICTIONS = {
 	female = {
 		name = 'Female Players Only',
@@ -68,38 +67,29 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
-
+	local caller = self.caller
+	local args = caller.args
 	if id == 'custom' then
 		table.insert(
 			widgets,
-			Cell{name = 'Restrictions', content = self.caller:createRestrictionsCell(args.restrictions)}
+			Cell{name = 'Restrictions', content = caller:createRestrictionsCell(args.restrictions)}
 		)
 	elseif id == 'gamesettings' then
-		return {Cell{name = 'Variant', content = {self.caller:_getGameMode()}}}
+		return {Cell{name = 'Variant', content = {caller.data.mode}}}
 	end
-
 	return widgets
 end
 
 ---@param args table
 ---@return string[]
 function CustomLeague:getWikiCategories(args)
-	local categories = {}
-
-	if String.isNotEmpty(args.restrictions) then
-		Array.extendWith(categories, Array.map(CustomLeague.getRestrictions(args.restrictions),
-				function(res) return res.link end))
-	end
-
-	return categories
+	return Array.map(CustomLeague.getRestrictions(args.restrictions), Operator.property('link'))
 end
 
 ---@param lpdbData table
 ---@param args table
 ---@return table
 function CustomLeague:addToLpdb(lpdbData, args)
-
 	Array.forEach(CustomLeague.getRestrictions(args.restrictions),
 		function(res) lpdbData.extradata['restriction_' .. res.data] = 1 end)
 
@@ -125,8 +115,8 @@ function CustomLeague.getRestrictions(restrictions)
 	end
 	---@cast restrictions -nil
 
-	return Array.map(mw.text.split(restrictions, ','),
-		function(restriction) return RESTRICTIONS[mw.text.trim(restriction)] end)
+	return Array.map(Array.parseCommaSeparatedString(inputString, sep),
+		function(restriction) return RESTRICTIONS[restriction] end)
 end
 
 ---@param restrictions string?

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -8,10 +8,8 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
-
 
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Injector = Lua.import('Module:Widget/Injector')
@@ -48,6 +49,37 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	return widgets
+end
+
+---@param args table
+---@return string[]
+function CustomLeague:getWikiCategories(args)
+	local categories = {}
+
+	if Logic.readBool(args.female) then
+		table.insert(categories, 'Female Tournaments')
+	elseif Logic.readBool(args.junior) then
+		table.insert(categories, 'Junior Tournaments')
+	elseif Logic.readBool(args.senior) then
+		table.insert(categories, 'Senior Tournaments')
+	elseif Logic.readBool(args.amateur) then
+		table.insert(categories, 'Amateur Tournaments')
+	end
+
+	return categories
+end
+
+---@param lpdbData table
+---@param args table
+---@return table
+function CustomLeague:addToLpdb(lpdbData, args)
+	
+	lpdbData.extradata.female = args.female or 'false'
+	lpdbData.extradata.junior = args.junior or 'false'
+	lpdbData.extradata.senior = args.senior or 'false'
+	lpdbData.extradata.amateur = args.amateur or 'false'
+
+	return lpdbData
 end
 
 ---@param args table

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
-local String = require('Module:StringUtils')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -70,11 +70,13 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
-	if id == 'gamesettings' then
-		Array.appendWith(widgets,
-		Cell{name = 'Variant', content = {self.caller:_getGameMode()}},
-		Cell{name = 'Restrictions', content = self.caller:createRestrictionsCell(args.restrictions)}
+	if id == 'custom' then
+		table.insert(
+			widgets,
+			Cell{name = 'Restrictions', content = self.caller:createRestrictionsCell(args.restrictions)}
 		)
+	elseif id == 'gamesettings' then
+		return {Cell{name = 'Variant', content = {self.caller:_getGameMode()}}}
 	end
 
 	return widgets


### PR DESCRIPTION
## Summary
Stacking Chess PRs before wiki install

The chess wiki will have some customization 

## Customizations needed
- a **Type/Variant** of the chess modes, using `|mode=`
**`Classical` is majority but other exist (e.g. `blitz/rapid`) if unset, it will be default to `Classical`.** 

- a **Category Range** this is basically how VALORANT handles Female tourney, except theres four of it: Junior, Female, Senior and Amateur. Editors want to use `qualifier` tiertypes on these events
**UPDATE: Now replaced with the way CS wiki implements this.**

## How did you test this change?
![image](https://github.com/user-attachments/assets/8eb01c0d-6195-4896-8cc9-58c6800b23a9)

https://liquipedia.net/callofduty/User:Hesketh2/Chess/FIDE_World_Chess_Championship/2024

## Regarding Chess Wiki 
Wiki is expected to be installed next week, I wouldnt want to stall it any longer

## Notes
Time Control is being considered but it's so dynamic that it likely won't be in the scope of this PR
