### PR TITLE
feat: add Latin America flag

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1407,7 +1407,7 @@ local data = {
 		name = 'Iberia',
 	},
 	['latinamerica'] = {
-		flag = 'File:Space filler flag.png',
+		flag = 'File:MxUnasur hd.png',
 		localised = 'Latin American',
 		name = 'Latin America',
 	},


### PR DESCRIPTION
## Summary
Add [Latin American Flag](https://liquipedia.net/commons/Template:Flag/latin_america) to Module:Flag