### PR TITLE
feat(mainpage): Add news and stats navcards to LoL mainpage

### DIFF
--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -156,6 +156,11 @@ return {
 				table = 'externalmedialink',
 			},
 		},
+		{
+			file = 'Gen.G Mata Worlds 2024.jpg',
+			title = 'Statistics',
+			link = 'Portal:Statistics',
+		},
 	},
 	layouts = {
 		main = {

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -147,6 +147,15 @@ return {
 				conditions = '[[type::patch]]',
 			},
 		},
+		{
+			file = 'Worlds 2024 Finalists.jpg',
+			title = 'News',
+			link = 'Portal:News',
+			count = {
+				method = 'LPDB',
+				table = 'externalmedialink',
+			},
+		},
 	},
 	layouts = {
 		main = {


### PR DESCRIPTION
## Summary

LoL mainpage had a news navcard and a statistics navcard, both of which were unintentionally omitted in #5302. This PR restores the two.

## How did you test this change?

dev