### PR TITLE
fix(match2): all players shown in each game on fifa team games

### DIFF
--- a/components/match2/wikis/easportsfc/match_summary.lua
+++ b/components/match2/wikis/easportsfc/match_summary.lua
@@ -94,6 +94,7 @@ end
 function CustomMatchSummary._extractPlayersFromGame(game, match)
 	return Array.map(game.opponents, function(opponent, opponentIndex)
 		return Array.map(opponent.players, function(player, playerIndex)
+			if not player.played then return end
 			local matchPlayer = match.opponents[opponentIndex].players[playerIndex]
 			return matchPlayer or {
 				displayName = player.displayname,


### PR DESCRIPTION
## Summary
currently `CustomMatchSummary._extractPlayersFromGame` just maps all game players, including the empty (aka not played) ones
this pr adds a check (1 line) that the according player actually played the map

## How did you test this change?
dev
