### PR TITLE
feat: automatically import ffa standings from matches

### DIFF
--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -39,8 +39,8 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	end)
 
 	local conditionsMatches = Condition.Tree(Condition.BooleanOperator.any)
-	Array.forEach(matchIds, function(match)
-		conditionsMatches:add(Condition.Node(Condition.ColumnName('match2id'), Condition.Comparator.eq, match))
+	Array.forEach(matchIds, function(matchid)
+		conditionsMatches:add(Condition.Node(Condition.ColumnName('match2id'), Condition.Comparator.eq, matchid))
 	end)
 
 	local opponents = {}

--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -34,13 +34,17 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	local matchIdToRound = {}
 	Array.forEach(rounds, function(round)
 		Array.forEach(round.matches, function(match)
-			matchIdToRound[match] = round.roundNumber
+			if matchIdToRound[match] then
+				table.insert(matchIdToRound[match], round.roundNumber)
+			else
+				matchIdToRound[match] = {round.roundNumber}
+			end
 		end)
 	end)
 
 	local conditionsMatches = Condition.Tree(Condition.BooleanOperator.any)
-	Array.forEach(matchIds, function(matchid)
-		conditionsMatches:add(Condition.Node(Condition.ColumnName('match2id'), Condition.Comparator.eq, matchid))
+	Array.forEach(matchIds, function(matchId)
+		conditionsMatches:add(Condition.Node(Condition.ColumnName('match2id'), Condition.Comparator.eq, matchId))
 	end)
 
 	local opponents = {}
@@ -51,8 +55,10 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 			query = 'match2opponents',
 		},
 		function(match2)
-			local roundNumber = matchIdToRound[match2.match2id]
-			StandingsParseLpdb.parseMatch(roundNumber, match2, opponents, scoreMapper, #rounds)
+			local roundNumbers = matchIdToRound[match2.match2id]
+			Array.forEach(roundNumbers, function(roundNumber)
+				StandingsParseLpdb.parseMatch(roundNumber, match2, opponents, scoreMapper, #rounds)
+			end)
 		end
 	)
 

--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -1,0 +1,110 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Standings/Parse/Lpdb
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Condition = require('Module:Condition')
+local Lpdb = require('Module:Lpdb')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+
+local StandingsParseLpdb = {}
+
+---@param rounds {roundNumber: integer, matches: string[]}[]
+---@param scoreMapper? fun(opponent: match2opponent): number?
+---@return {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
+	if not scoreMapper then
+		scoreMapper = function(opponent)
+			if opponent.status == 'S' then
+				return tonumber(opponent.score)
+			end
+			return nil
+		end
+	end
+	local matchIds = Array.flatMap(rounds, function(round)
+		return round.matches
+	end)
+
+	local matchIdToRound = {}
+	Array.forEach(rounds, function(round)
+		Array.forEach(round.matches, function(match)
+			matchIdToRound[match] = round.roundNumber
+		end)
+	end)
+
+	local conditionsMatches = Condition.Tree(Condition.BooleanOperator.any)
+	Array.forEach(matchIds, function(match)
+		conditionsMatches:add(Condition.Node(Condition.ColumnName('match2id'), Condition.Comparator.eq, match))
+	end)
+
+	local opponents = {}
+    Lpdb.executeMassQuery(
+		'match2',
+		{
+			conditions = conditionsMatches:toString(),
+			query = 'match2opponents',
+		},
+		function(match2)
+			local roundNumber = matchIdToRound[match2.match2id]
+			StandingsParseLpdb.parseMatch(roundNumber, match2, opponents, scoreMapper, #rounds)
+		end
+	)
+
+	return Array.map(opponents, function(opponentData)
+		return {
+			opponent = Opponent.fromMatch2Record(opponentData.opponent),
+			rounds = Array.map(opponentData.rounds, function(roundData)
+				return {
+					scoreboard = {
+						points = roundData.scoreboard.points,
+					},
+					specialstatus = roundData.specialstatus or 'nc',
+				}
+			end)
+		}
+	end)
+end
+
+---@param opponentData match2opponent
+---@param maxRounds integer
+---@return {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: match2opponent}
+function StandingsParseLpdb.newOpponent(opponentData, maxRounds)
+	return {
+		opponent = opponentData,
+		rounds = Array.map(Array.range(1, maxRounds), function()
+			return {
+				scoreboard = {},
+			}
+		end)
+	}
+end
+
+---@param roundNumber integer
+---@param match match2
+---@param opponents {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: match2opponent}[]
+---@param scoreMapper fun(opponent: match2opponent): number?
+---@param maxRounds integer
+function StandingsParseLpdb.parseMatch(roundNumber, match, opponents, scoreMapper, maxRounds)
+	Array.forEach(match.match2opponents, function(opponent)
+		---Find matching opponent
+		local standingsOpponentData = Array.find(opponents, function(opponentData)
+			return opponentData.opponent.name == opponent.name
+		end)
+		if not standingsOpponentData then
+			standingsOpponentData = StandingsParseLpdb.newOpponent(opponent, maxRounds)
+			table.insert(opponents, standingsOpponentData)
+		end
+		assert(standingsOpponentData.rounds[roundNumber], 'Round number out of bounds')
+		local opponentRoundData = standingsOpponentData.rounds[roundNumber]
+		opponentRoundData.scoreboard.points = scoreMapper(opponent)
+		opponentRoundData.specialstatus = ''
+	end)
+end
+
+return StandingsParseLpdb

--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -48,7 +48,7 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	end)
 
 	local opponents = {}
-    Lpdb.executeMassQuery(
+	Lpdb.executeMassQuery(
 		'match2',
 		{
 			conditions = conditionsMatches:toString(),

--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -102,7 +102,10 @@ function StandingsParseLpdb.parseMatch(roundNumber, match, opponents, scoreMappe
 		end
 		assert(standingsOpponentData.rounds[roundNumber], 'Round number out of bounds')
 		local opponentRoundData = standingsOpponentData.rounds[roundNumber]
-		opponentRoundData.scoreboard.points = scoreMapper(opponent)
+		local points = scoreMapper(opponent)
+		if points then
+			opponentRoundData.scoreboard.points = (opponentRoundData.scoreboard.points or 0) + points
+		end
 		opponentRoundData.specialstatus = ''
 	end)
 end

--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -17,7 +17,7 @@ local StandingsParseLpdb = {}
 
 ---@param rounds {roundNumber: integer, matches: string[]}[]
 ---@param scoreMapper? fun(opponent: match2opponent): number?
----@return {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+---@return StandingTableOpponentData[]
 function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	if not scoreMapper then
 		scoreMapper = function(opponent)
@@ -79,7 +79,7 @@ end
 
 ---@param opponentData match2opponent
 ---@param maxRounds integer
----@return {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: match2opponent}
+---@return StandingTableOpponentData
 function StandingsParseLpdb.newOpponent(opponentData, maxRounds)
 	return {
 		opponent = opponentData,
@@ -93,7 +93,7 @@ end
 
 ---@param roundNumber integer
 ---@param match match2
----@param opponents {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: match2opponent}[]
+---@param opponents StandingTableOpponentData[]
 ---@param scoreMapper fun(opponent: match2opponent): number?
 ---@param maxRounds integer
 function StandingsParseLpdb.parseMatch(roundNumber, match, opponents, scoreMapper, maxRounds)

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -24,7 +24,7 @@ local StandingsParseWiki = {}
 |round1={{Round|title=A vs B|started=true|finished=false}}
 <more rounds>
 <!-- Opponents -->
-|opponent1={{TeamOpponent|dreamfire|r1=17|r2=-|r3=-|r4=34|r5=32|r6=-}}
+|{{TeamOpponent|dreamfire|r1=17|r2=-|r3=-|r4=34|r5=32|r6=-}}
 <more opponents>
 }}
 ]]
@@ -42,10 +42,9 @@ function StandingsParseWiki.parseWikiInput(args)
 	end
 
 	---@type StandingTableOpponentData[]
-	local opponents = {}
-	for _, opponentData, _ in Table.iter.pairsByPrefix(args, 'opponent', {requireIndex = true}) do
-		table.insert(opponents, StandingsParseWiki.parseWikiOpponent(opponentData, #rounds))
-	end
+	local opponents = Array.map(args, function (opponentData)
+		return StandingsParseWiki.parseWikiOpponent(opponentData, #rounds)
+	end)
 
 	local wrapperMatches = Array.parseCommaSeparatedString(args.matches)
 	Array.extendWith(wrapperMatches, Array.flatMap(rounds, function(round)

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -106,4 +106,16 @@ function StandingsParseWiki.parseWikiBgs(input)
 	return statusParsed
 end
 
+---@param args table
+---@return (fun(opponent: match2opponent): number)|nil
+function StandingsParseWiki.makeScoringFunction(args)
+	if not args['p1'] then
+		return nil
+	end
+	return function(opponent)
+		local scoreFromPlacement = tonumber(args['p' .. opponent.placement])
+		return scoreFromPlacement or 0
+	end
+end
+
 return StandingsParseWiki

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -31,7 +31,7 @@ local StandingsParseWiki = {}
 
 ---@param args table
 ---@return {rounds: {roundNumber: integer, started: boolean, finished:boolean, title: string?, matches: string[]}[],
----opponents: {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[],
+---opponents: StandingTableOpponentData[],
 ---bgs: table<integer, string>,
 ---matches: string[]}
 function StandingsParseWiki.parseWikiInput(args)
@@ -41,7 +41,7 @@ function StandingsParseWiki.parseWikiInput(args)
 		table.insert(rounds, StandingsParseWiki.parseWikiRound(roundData, roundIndex))
 	end
 
-	---@type {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+	---@type StandingTableOpponentData[]
 	local opponents = {}
 	for _, opponentData, _ in Table.iter.pairsByPrefix(args, 'opponent', {requireIndex = true}) do
 		table.insert(opponents, StandingsParseWiki.parseWikiOpponent(opponentData, #rounds))
@@ -96,7 +96,7 @@ end
 
 ---@param opponentInput string
 ---@param numberOfRounds integer
----@return {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+---@return StandingTableOpponentData[]
 function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 	local opponentData = Json.parse(opponentInput)
 	local rounds = {}
@@ -110,7 +110,8 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 		else
 			specialStatus = input
 		end
-		table.insert(rounds, {scoreboard = {points = points}, specialstatus = specialStatus})
+		local tiebreakerPoints = numberOfRounds == i and tonumber(opponentData.tiebreaker) or nil
+		table.insert(rounds, {scoreboard = {points = points}, specialstatus = specialStatus, tiebreakerPoints = tiebreakerPoints})
 	end
 	return {rounds = rounds, opponent = Opponent.readOpponentArgs(opponentData)}
 end

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -30,7 +30,10 @@ local StandingsParseWiki = {}
 ]]
 
 ---@param args table
----@return table
+---@return {rounds: {roundNumber: integer, started: boolean, finished:boolean, title: string?, matches: string[]}[],
+---opponents: {rounds: {scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[],
+---bgs: table<integer, string>,
+---matches: string[]}
 function StandingsParseWiki.parseWikiInput(args)
 	---@type {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
 	local rounds = {}
@@ -54,7 +57,7 @@ end
 
 ---@param roundInput string
 ---@param roundIndex integer
----@return {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
+---@return {roundNumber: integer, started: boolean, finished:boolean, title: string?, matches: string[]}[]
 function StandingsParseWiki.parseWikiRound(roundInput, roundIndex)
 	local roundData = Json.parse(roundInput)
 	return {
@@ -62,6 +65,7 @@ function StandingsParseWiki.parseWikiRound(roundInput, roundIndex)
 		started = Logic.readBool(roundData.started),
 		finished = Logic.readBool(roundData.finished),
 		title = roundData.title,
+		matches = Array.parseCommaSeparatedString(roundData.matches),
 	}
 end
 

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -24,7 +24,7 @@ local StandingsParseWiki = {}
 |round1={{Round|title=A vs B|started=true|finished=false}}
 <more rounds>
 <!-- Opponents -->
-|opponent1={{TeamOpponent|dreamfire|placement=<optional>|r1=17|r2=-|r3=-|r4=34|r5=32|r6=-}}
+|opponent1={{TeamOpponent|dreamfire|r1=17|r2=-|r3=-|r4=34|r5=32|r6=-}}
 <more opponents>
 }}
 ]]
@@ -35,7 +35,7 @@ local StandingsParseWiki = {}
 ---bgs: table<integer, string>,
 ---matches: string[]}
 function StandingsParseWiki.parseWikiInput(args)
-	---@type {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
+	---@type {roundNumber: integer, started: boolean, finished:boolean, title: string?, matches: string[]}[]
 	local rounds = {}
 	for _, roundData, roundIndex in Table.iter.pairsByPrefix(args, 'round', {requireIndex = true}) do
 		table.insert(rounds, StandingsParseWiki.parseWikiRound(roundData, roundIndex))
@@ -47,11 +47,16 @@ function StandingsParseWiki.parseWikiInput(args)
 		table.insert(opponents, StandingsParseWiki.parseWikiOpponent(opponentData, #rounds))
 	end
 
+	local wrapperMatches = Array.parseCommaSeparatedString(args.matches)
+	Array.extendWith(wrapperMatches, Array.flatMap(rounds, function(round)
+		return round.matches
+	end))
+
 	return {
 		rounds = rounds,
 		opponents = opponents,
 		bgs = StandingsParseWiki.parseWikiBgs(args.bg),
-		matches = Array.parseCommaSeparatedString(args.matches),
+		matches = Array.unique(wrapperMatches),
 	}
 end
 

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -111,7 +111,11 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 			specialStatus = input
 		end
 		local tiebreakerPoints = numberOfRounds == i and tonumber(opponentData.tiebreaker) or nil
-		table.insert(rounds, {scoreboard = {points = points}, specialstatus = specialStatus, tiebreakerPoints = tiebreakerPoints})
+		table.insert(rounds, {
+			scoreboard = {points = points},
+			specialstatus = specialStatus,
+			tiebreakerPoints = tiebreakerPoints
+		})
 	end
 	return {rounds = rounds, opponent = Opponent.readOpponentArgs(opponentData)}
 end

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -98,13 +98,13 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 end
 
 ---@param opponentsInRound {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number,
----placement: integer?, slotindex: integer?, tiebreakerPoints: number}[]
+---placement: integer?, slotindex: integer?, extradata: table}[]
 function StandingsParser.determinePlacements(opponentsInRound)
 	table.sort(opponentsInRound, function(opponent1, opponent2)
 		if opponent1.points ~= opponent2.points then
 			return opponent1.points > opponent2.points
 		end
-		return opponent1.tiebreakerPoints > opponent2.tiebreakerPoints
+		return opponent1.extradata.tiebreakerpoints > opponent2.extradata.tiebreakerpoints
 	end)
 
 	local lastPts = math.huge

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -12,7 +12,7 @@ local Variables = require('Module:Variables')
 local StandingsParser = {}
 
 ---@param rounds {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
----@param opponents {rounds: {specialstatus: string, scoreboard: {points: number?}?}[]?, opponent: standardOpponent}[]
+---@param opponents StandingTableOpponentData[]
 ---@param bgs table<integer, string>
 ---@param title string?
 ---@param matches string[]
@@ -32,13 +32,14 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 		local opponentRounds = opponentData.rounds
 
 		return Array.map(rounds, function(round)
-			local pointsFromRound, statusInRound
+			local pointsFromRound, statusInRound, tiebreakerPoints
 			if opponentRounds and opponentRounds[round.roundNumber] then
 				local thisRoundsData = opponentRounds[round.roundNumber]
 				if thisRoundsData.scoreboard then
 					pointsFromRound = thisRoundsData.scoreboard.points
 				end
 				statusInRound = thisRoundsData.specialstatus
+				tiebreakerPoints = thisRoundsData.tiebreakerPoints
 			end
 			pointSum = pointSum + (pointsFromRound or 0)
 			---@type {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?}
@@ -50,6 +51,7 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 				extradata = {
 					pointschange = pointsFromRound,
 					specialstatus = statusInRound,
+					tiebreakerpoints = tiebreakerPoints or 0,
 				}
 			}
 		end)
@@ -61,11 +63,11 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 		end))
 	end)
 	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer,
-	---points: number?, placement: integer?, slotindex: integer}[]
+	---points: number, placement: integer?, slotindex: integer}[]
 
 	StandingsParser.setPlacementChange(entries)
 	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer,
-	---points: number?, placement: integer?, slotindex: integer, placementchange: integer?}[]
+	---points: number, placement: integer?, slotindex: integer, placementchange: integer?}[]
 
 	StandingsParser.addStatuses(entries, bgs, 'currentstatus')
 	if isFinished then
@@ -73,7 +75,7 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 			return opponentRound.roundindex == #rounds
 		end), bgs, 'definitestatus')
 	end
-	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
+	---@cast entries {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number,
 	---placement: integer?, slotindex: integer, placementchange: integer?,
 	---currentstatus: string?, definitestatus: string?}[]
 
@@ -95,11 +97,14 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 	}
 end
 
----@param opponentsInRound {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
----placement: integer?, slotindex: integer?}[]
+---@param opponentsInRound {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number,
+---placement: integer?, slotindex: integer?, tiebreakerPoints: number}[]
 function StandingsParser.determinePlacements(opponentsInRound)
 	table.sort(opponentsInRound, function(opponent1, opponent2)
-		return opponent1.points > opponent2.points
+		if opponent1.points ~= opponent2.points then
+			return opponent1.points > opponent2.points
+		end
+		return opponent1.tiebreakerPoints > opponent2.tiebreakerPoints
 	end)
 
 	local lastPts = math.huge
@@ -109,7 +114,7 @@ function StandingsParser.determinePlacements(opponentsInRound)
 	end)
 end
 
----@param opponentEnties {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
+---@param opponentEnties {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number,
 ---placement: integer?, slotindex: integer, placementchange: integer?}[]
 ---@param bgs table<integer, string>
 ---@param field 'currentstatus'|'definitestatus'
@@ -119,7 +124,7 @@ function StandingsParser.addStatuses(opponentEnties, bgs, field)
 	end)
 end
 
----@param opponents {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number?,
+---@param opponents {opponent: standardOpponent, standingindex: integer, roundindex: integer, points: number,
 ---placement: integer?, slotindex: integer, placementchange: integer?}[]
 function StandingsParser.setPlacementChange(opponents)
 	local opponentsByRounds = Array.groupBy(opponents, function (opponent)

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -45,7 +45,7 @@ function StandingsTable.fromTemplate(frame)
 		return StandingsTable.ffa(rounds, opponents, bgs, title, matches)
 	end
 
-	local importedOpponents = StandingsParseLpdb.importFromMatches(rounds)
+	local importedOpponents = StandingsParseLpdb.importFromMatches(rounds, StandingsParseWiki.makeScoringFunction(args))
 	opponents = StandingsTable.mergeOpponentsData(opponents, importedOpponents)
 	return StandingsTable.ffa(rounds, opponents, bgs, title, matches)
 end

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -7,9 +7,11 @@
 --
 
 local Arguments = require('Module:Arguments')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local StandingsParseWiki = Lua.import('Module:Standings/Parse/Wiki')
+local StandingsParseLpdb = Lua.import('Module:Standings/Parse/Lpdb')
 local StandingsParser = Lua.import('Module:Standings/Parser')
 local StandingsStorage = Lua.import('Module:Standings/Storage')
 
@@ -25,14 +27,20 @@ function StandingsTable.fromTemplate(frame)
 	if tableType ~= 'ffa' then
 		error('Unknown Standing Table Type')
 	end
+	local title = args.title
+
 	local parsedData = StandingsParseWiki.parseWikiInput(args)
-	return StandingsTable.ffa(
-		parsedData.rounds,
-		parsedData.opponents,
-		parsedData.bgs,
-		args.title,
-		parsedData.matches
-	)
+	local rounds = parsedData.rounds
+	local opponents = parsedData.opponents
+	local bgs = parsedData.bgs
+	local matches = parsedData.matches
+
+	if Logic.readBoolOrNil(args.import) == false then
+		return StandingsTable.ffa(rounds, opponents, bgs, title, matches)
+	end
+
+	opponents = StandingsParseLpdb.importFromMatches(rounds)
+	return StandingsTable.ffa(rounds, opponents, bgs, title, matches)
 end
 
 ---@param rounds any

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -25,6 +25,10 @@ local Opponent = OpponentLibrary.Opponent
 
 local StandingsTable = {}
 
+---@class StandingTableOpponentData
+---@field rounds {tiebreakerPoints: number?, specialstatus: string, scoreboard: {points: number?}?}[]?
+---@field opponent standardOpponent
+
 ---@param frame Frame
 ---@return Widget
 function StandingsTable.fromTemplate(frame)
@@ -50,6 +54,9 @@ function StandingsTable.fromTemplate(frame)
 	return StandingsTable.ffa(rounds, opponents, bgs, title, matches)
 end
 
+---@param manualOpponents StandingTableOpponentData[]
+---@param importedOpponents StandingTableOpponentData[]
+---@return StandingTableOpponentData[]
 function StandingsTable.mergeOpponentsData(manualOpponents, importedOpponents)
 	--- Add all manual opponents to the new opponents list
 	local newOpponents = Array.map(manualOpponents, FnUtil.identity)

--- a/standard/lpdb.lua
+++ b/standard/lpdb.lua
@@ -50,9 +50,10 @@ example:
 	return foundMatchIds
 ```
 ]==]
----@param tableName string
+---@generic T
+---@param tableName `T`
 ---@param queryParameters table
----@param itemChecker fun(item: table): boolean?
+---@param itemChecker fun(item: T): boolean?
 ---@param limit number?
 function Lpdb.executeMassQuery(tableName, queryParameters, itemChecker, limit)
 	queryParameters.offset = queryParameters.offset or 0


### PR DESCRIPTION
## Summary
This is the third step in that journey, in this step we build the first new feature, automatically fetching data from matches, so that contributors no longer need to enter information manually

### Additional Details
Matches should be moved into the rounds. Should be able to support one match, multiple matches or one or more matchgroups as input.
Having the old `|matches=` input in the outer layer still needs to be support for manual tables. 
```
{{FfaStandings|title=League Standings
|bg=1-10=stay, 11-20=down
<!-- Rounds -->
|round1={{Round|title=A vs B|started=true|finished=false|matches=glCe2PeAfD_0001}}
<more rounds>
<!-- Opponents -->
|{{TeamOpponent|dreamfire}}
<more opponents>
}}
```
### Acceptance criteria

- [x] Data needed for the standings is automatically retrieved from matches.
- [x] Supports multiple ways to determine matches that goes into a round
  - [x] One Match
  - [x] Multiple Matches
  - [x] MatchGroup
  - [x] MatchGroups 
- [x] Manual data overrides match data if conflicting
- [x] There needs to be an option to specify a non-direct relationship between scores and points.
  - For example, 25points for 1st place, 20 points for 2nd place etc in a match, instead of the score granted.
- [x] (optional) import opponents from matches too
## How did you test this change?
https://liquipedia.net/apexlegends/User:Rathoz