### PR TITLE
fix: error handling and typo on ffa standings

### DIFF
--- a/components/standings/commons/standings.lua
+++ b/components/standings/commons/standings.lua
@@ -181,7 +181,7 @@ function Standings.makeRounds(standings)
 
 	local roundCount = Array.maxBy(Array.map(standingsEntries, Operator.property('roundindex')), FnUtil.identity)
 
-	return Array.map(Array.range(1, roundCount), function(roundIndex)
+	return Array.map(Array.range(1, roundCount or 1), function(roundIndex)
 		local roundEntries = Array.filter(standingsEntries, function(entry)
 			return tonumber(entry.roundindex) == roundIndex
 		end)

--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -31,6 +31,11 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 		return round.matches
 	end)
 
+	-- No Matches in the round, cannot import
+	if #matchIds == 0 then
+		return {}
+	end
+
 	local matchIdToRound = {}
 	Array.forEach(rounds, function(round)
 		Array.forEach(round.matches, function(match)

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -47,7 +47,7 @@ function StandingsTable.fromTemplate(frame)
 	local bgs = parsedData.bgs
 	local matches = parsedData.matches
 
-	if importScoreFromMatches then
+	if not importScoreFromMatches then
 		return StandingsTable.ffa(rounds, opponents, bgs, title, matches)
 	end
 


### PR DESCRIPTION
## Summary
Import param being reversed in logic
Add some error handling for when there are 
* No opponents 
* Import is enabled, but no matches are entered for a round

## How did you test this change?
Partially live