### PR TITLE
feat: remove of unused games for worldoftanks

### DIFF
--- a/standard/info/wikis/worldoftanks/info.lua
+++ b/standard/info/wikis/worldoftanks/info.lua
@@ -25,19 +25,6 @@ return {
 				lightMode = 'World of Tanks default lightmode.png',
 			},
 		},
-		['wot blitz'] = {
-			abbreviation = 'WoT Blitz',
-			name = 'World of Tanks Blitz',
-			link = 'World of Tanks Blitz',
-			logo = {
-				darkMode = 'World of Tanks Blitz default darkmode.png',
-				lightMode = 'World of Tanks Blitz default lightmode.png',
-			},
-			defaultTeamLogo = {
-				darkMode = 'World of Tanks default darkmode.png',
-				lightMode = 'World of Tanks default lightmode.png',
-			},
-		},
 		['mir tankov'] = {
 			abbreviation = 'Tanki',
 			name = 'Mir Tankov',
@@ -45,19 +32,6 @@ return {
 			logo = {
 				darkMode = 'Mir Tankov default darkmode.png',
 				lightMode = 'Mir Tankov default lightmode.png',
-			},
-			defaultTeamLogo = {
-				darkMode = 'World of Tanks default darkmode.png',
-				lightMode = 'World of Tanks default lightmode.png',
-			},
-		},
-		['tanks blitz'] = {
-			abbreviation = 'Tanks Blitz',
-			name = 'Tanks Blitz',
-			link = 'Tanks Blitz',
-			logo = {
-				darkMode = 'Tanks Blitz default darkmode.png',
-				lightMode = 'Tanks Blitz default lightmode.png',
 			},
 			defaultTeamLogo = {
 				darkMode = 'World of Tanks default darkmode.png',


### PR DESCRIPTION
## Summary

We plan to focus exclusively on World of Tanks and Mir Tankov in the worldoftanks section. This PR aims to remove unused games (World of Tanks Blitz and Blitz) that were mistakenly added.

## How did you test this change?
I've noticed those unused games appearing when using the `PortalStatistics` functions, such as `coverageStatistics` and `pieChartBreakdown`. These functions aren't working properly either, but that's a separate issue.
