### PR TITLE
feat(match2): show ffa display if > 2 opponents and matchlist on trackmania

### DIFF
--- a/components/match2/wikis/trackmania/brkts_wiki_specific.lua
+++ b/components/match2/wikis/trackmania/brkts_wiki_specific.lua
@@ -15,7 +15,7 @@ local BaseWikiSpecific = Lua.import('Module:Brkts/WikiSpecific/Base')
 local WikiSpecific = Table.copy(BaseWikiSpecific)
 
 function WikiSpecific.getMatchGroupContainer(matchGroupType, maxOpponentCount)
-	if maxOpponentCount > 4 then
+	if maxOpponentCount > 4 or (maxOpponentCount > 2 and matchGroupType == 'matchlist') then
 		local Horizontallist = Lua.import('Module:MatchGroup/Display/Horizontallist')
 		return Horizontallist.BracketContainer
 	elseif matchGroupType == 'matchlist' then


### PR DESCRIPTION
## Summary
matchlists can not display >2 opponents, hence if there are >2 opponents it doesn't make sense to display it as a matchlist at all
hence for `maxOpponentCount > 2 and matchGroupType == 'matchlist'` use ffa display

## How did you test this change?
not tested but change is super simple ...