### PR TITLE
feat(tier): align halo's FFA shortname to tiertype

### DIFF
--- a/standard/tier/wikis/halo/tier_data.lua
+++ b/standard/tier/wikis/halo/tier_data.lua
@@ -93,7 +93,7 @@ return {
 			value = 'FFA',
 			sort = 'B2',
 			name = 'FFA',
-			short = 'Showm.',
+			short = 'FFA',
 			link = 'Free For All Tournaments',
 			category = 'FFA Tournaments',
 		},


### PR DESCRIPTION
## Summary

The FFA tiertype shortname was set to `Showm.` instead of just `FFA`
https://discord.com/channels/93055209017729024/268719633366777856/1333469058976186378

## How did you test this change?

pushed live
