### PR TITLE
feat(icon): Chess King icons

### DIFF
--- a/standard/icon_data.lua
+++ b/standard/icon_data.lua
@@ -111,4 +111,8 @@ return {
 	-- Usage: Stormgate
 	dungeon = 'fas fa-dungeon',
 	fort = 'fab fa-fort-awesome',
+
+	-- Usage: Chess
+	chesskingwhite = 'far fa-chess-king',
+	chesskingblack = 'fas fa-chess-king',
 }


### PR DESCRIPTION
## Summary
As Chess Match2 requires an indicator to tell who is playing white and black in each game, the idea is to use a chess piece icon from fontawesome as indicator, as such two icons is required to be added

![image](https://github.com/user-attachments/assets/6182cb03-7026-4c82-befa-d849644d2af7)

## How did you test this change?
https://liquipedia.net/chess/FIDE_World_Chess_Championship/2024#Results

**Important as this blocks the match2, need this one to be added soon**