### PR TITLE
feat: legacy support for ffa standings on pubgm

### DIFF
--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -118,10 +118,13 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 			scoreboard = {points = points},
 			specialstatus = specialStatus,
 			tiebreakerPoints = tiebreakerPoints,
-			startingPoints = opponentData.startingpoints,
 		})
 	end
-	return {rounds = rounds, opponent = Opponent.readOpponentArgs(opponentData)}
+	return {
+		rounds = rounds,
+		opponent = Opponent.readOpponentArgs(opponentData),
+		startingPoints = opponentData.startingpoints,
+	}
 end
 
 ---@param input string

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -117,7 +117,8 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds)
 		table.insert(rounds, {
 			scoreboard = {points = points},
 			specialstatus = specialStatus,
-			tiebreakerPoints = tiebreakerPoints
+			tiebreakerPoints = tiebreakerPoints,
+			startingPoints = opponentData.startingpoints,
 		})
 	end
 	return {rounds = rounds, opponent = Opponent.readOpponentArgs(opponentData)}

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -28,7 +28,7 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 
 	local entries = Array.flatMap(opponents, function(opponentData)
 		local opponent = opponentData.opponent
-		local pointSum = 0
+		local pointSum = opponentData.startingPoints or 0
 		local opponentRounds = opponentData.rounds
 
 		return Array.map(rounds, function(round)

--- a/components/standings/commons/standings_table.lua
+++ b/components/standings/commons/standings_table.lua
@@ -25,9 +25,13 @@ local Opponent = OpponentLibrary.Opponent
 
 local StandingsTable = {}
 
+---@class Scoreboard
+---@field points number?
+
 ---@class StandingTableOpponentData
----@field rounds {tiebreakerPoints: number?, specialstatus: string, scoreboard: {points: number?}?}[]?
+---@field rounds {tiebreakerPoints: number?, specialstatus: string, scoreboard: Scoreboard?}[]?
 ---@field opponent standardOpponent
+---@field startingPoints number?
 
 ---@param frame Frame
 ---@return Widget

--- a/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
+++ b/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
@@ -99,10 +99,13 @@ function StandingTableLegacyFfa.templateEnd(frame)
 	if not cnt then
 		return
 	end
-	local startArgs = Json.parse(Variables.varDefault('standings_legacy_start'))
+	local startArgs = Json.parseIfString(Variables.varDefault('standings_legacy_start'))
+	if not startArgs then
+		return
+	end
 	Variables.varDefine('standings_legacy_start', nil)
-	local slots = Array.mapIndexes(function(index)
-		local data = (Json.parse(Variables.varDefault('standings_legacy_slot_' .. index)))
+	local slots = Array.map(Array.range(1, cnt), function(index)
+		local data = (Json.parseIfString(Variables.varDefault('standings_legacy_slot_' .. index)))
 		Variables.varDefine('standings_legacy_slot_' .. index, nil)
 		return data
 	end)
@@ -112,8 +115,8 @@ function StandingTableLegacyFfa.templateEnd(frame)
 	end)
 
 	---@type StandingTableOpponentData[]
-	local opponents = Array.mapIndexes(function(teamIndex)
-		return StandingTableLegacyFfa.parseTeamInputManualSlots(slots[teamIndex])
+	local opponents = Array.map(slots, function(slot)
+		return StandingTableLegacyFfa.parseTeamInputManualSlots(slot)
 	end)
 
 	-- TODO BGS are gonna be impossible to do cleanly? Ignoring them for now
@@ -141,7 +144,7 @@ end
 
 ---@param args table
 ---@param teamIndex integer
----@return {type: OpponentType, [1]: string, tiebreaker: string?, r1: string?}?
+---@return {type: OpponentType, [1]: string, tiebreaker: string?, startingpoints: string?, r1: string?}?
 function StandingTableLegacyFfa.parseTeamInput(args, teamIndex)
 	local team = args['team' .. teamIndex] or args['p' .. teamIndex .. 'team']
 	if not team then
@@ -163,7 +166,7 @@ function StandingTableLegacyFfa.parseTeamInput(args, teamIndex)
 end
 
 ---@param args table
----@return {type: OpponentType, [1]: string, tiebreaker: string?, r1: string?}?
+---@return {type: OpponentType, [1]: string, startingpoints: string?, r1: string?}?
 function StandingTableLegacyFfa.parseTeamInputManualSlots(args)
 	if not args then
 		return nil

--- a/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
+++ b/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
@@ -1,0 +1,195 @@
+---
+-- @Liquipedia
+-- wiki=pubgmobile
+-- page=Module:Standings/Table/Legacy/Ffa
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Arguments = require('Module:Arguments')
+local Array = require('Module:Array')
+local Json = require('Module:Json')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local Variables = require('Module:Variables')
+
+local StandingTable = Lua.import('Module:Standings/Table')
+
+local OpponentLibrary = require('Module:OpponentLibraries')
+local Opponent = OpponentLibrary.Opponent
+
+local StandingTableLegacyFfa = {}
+
+---@param args table
+---@return table
+function StandingTableLegacyFfa.getStandardParameter(args)
+	return {
+		tabletype = 'ffa',
+		import = false,
+		started = true,
+		finished = true,
+		title = args.title,
+		matches = args.matches,
+	}
+end
+
+---Template:League standings without lobby
+---@param frame Frame
+---@return table
+function StandingTableLegacyFfa.withoutLobby(frame)
+	local args = Arguments.getArgs(frame)
+	local rounds = Table.map(Array.range(1, tonumber(args.rounds) or 1), function(roundIndex)
+		return 'round' .. roundIndex, StandingTableLegacyFfa.parseRoundInput(args, roundIndex)
+	end)
+
+	---@type StandingTableOpponentData[]
+	local opponents = Array.mapIndexes(function(teamIndex)
+		return StandingTableLegacyFfa.parseTeamInput(args, teamIndex)
+	end)
+
+	local bgs = StandingTableLegacyFfa.parseWikiBgs(args, 'bg')
+
+	return StandingTable.fromTemplate(Table.merge(
+		StandingTableLegacyFfa.getStandardParameter(args), bgs, rounds, opponents
+	))
+end
+
+---Template:League_standings_with_past_results
+---@param frame Frame
+---@return table
+function StandingTableLegacyFfa.pastResults(frame)
+	local args = Arguments.getArgs(frame)
+	local rounds = Table.map(Array.range(1, tonumber(args.rounds) or 1), function(roundIndex)
+		return 'round' .. roundIndex, StandingTableLegacyFfa.parseRoundInput(args, roundIndex)
+	end)
+
+	---@type StandingTableOpponentData[]
+	local opponents = Array.mapIndexes(function(teamIndex)
+		return StandingTableLegacyFfa.parseTeamInput(args, teamIndex)
+	end)
+
+	local bgs = StandingTableLegacyFfa.parseWikiBgs(args, 'pbg')
+
+	return StandingTable.fromTemplate(Table.merge(
+		StandingTableLegacyFfa.getStandardParameter(args), bgs, rounds, opponents
+	))
+end
+
+---Template:league standings start
+---@param frame Frame
+function StandingTableLegacyFfa.slotStart(frame)
+	local args = Arguments.getArgs(frame)
+	Variables.varDefine('standings_legacy_start', Json.stringify(args))
+	Variables.varDefine('standings_legacy_count', 0)
+end
+
+---Template:league standings slot & Template:league standings slot2
+---@param frame Frame
+function StandingTableLegacyFfa.slot(frame)
+	local args = Arguments.getArgs(frame)
+	local cnt = (tonumber(Variables.varDefault('standings_legacy_count')) or 0) + 1
+	Variables.varDefine('standings_legacy_slot_' .. cnt, Json.stringify(args))
+	Variables.varDefine('standings_legacy_count', cnt)
+end
+
+---Template:league standings end & Template:league standings end2
+---@param frame Frame
+function StandingTableLegacyFfa.templateEnd(frame)
+	local cnt = tonumber(Variables.varDefault('standings_legacy_count'))
+	if not cnt then
+		return
+	end
+	local startArgs = Json.parse(Variables.varDefault('standings_legacy_start'))
+	Variables.varDefine('standings_legacy_start', nil)
+	local slots = Array.mapIndexes(function(index)
+		local data = (Json.parse(Variables.varDefault('standings_legacy_slot_' .. index)))
+		Variables.varDefine('standings_legacy_slot_' .. index, nil)
+		return data
+	end)
+
+	local rounds = Table.map(Array.range(1, tonumber(startArgs.rounds) or 1), function(roundIndex)
+		return 'round' .. roundIndex, StandingTableLegacyFfa.parseRoundInput(startArgs, roundIndex)
+	end)
+
+	---@type StandingTableOpponentData[]
+	local opponents = Array.mapIndexes(function(teamIndex)
+		return StandingTableLegacyFfa.parseTeamInputManualSlots(slots[teamIndex])
+	end)
+
+	-- TODO BGS are gonna be impossible to do cleanly? Ignoring them for now
+
+	return StandingTable.fromTemplate(Table.merge(
+		StandingTableLegacyFfa.getStandardParameter(startArgs), rounds, opponents
+	))
+end
+
+---@param args table
+---@param roundIndex integer
+---@return {title: string, started: boolean, finished: boolean}
+function StandingTableLegacyFfa.parseRoundInput(args, roundIndex)
+	local title = args['r' .. roundIndex]
+	if not title then
+		title = (args.rname or args.roundname or 'Round') .. ' ' .. roundIndex
+	end
+	return {
+		title = title,
+		-- Legacy, so let's assume finished
+		started = true,
+		finished = true,
+	}
+end
+
+---@param args table
+---@param teamIndex integer
+---@return {type: OpponentType, [1]: string, tiebreaker: string?, r1: string?}?
+function StandingTableLegacyFfa.parseTeamInput(args, teamIndex)
+	local team = args['team' .. teamIndex] or args['p' .. teamIndex .. 'team']
+	if not team then
+		return nil
+	end
+	local pointsInput = args['standings' .. teamIndex] or args['p' .. teamIndex .. 'results']
+	local roundData = Array.parseCommaSeparatedString(pointsInput)
+	local rounds = Table.map(roundData, function (roundIndex, value)
+		return 'r' .. roundIndex, value
+	end)
+
+	return Table.merge(
+		{type = Opponent.team, team, tiebreaker = args['tiebreaker' .. teamIndex]},
+		rounds
+	)
+end
+
+---@param args table
+---@return {type: OpponentType, [1]: string, tiebreaker: string?, r1: string?}?
+function StandingTableLegacyFfa.parseTeamInputManualSlots(args)
+	if not args then
+		return nil
+	end
+	local roundDatas = Array.parseCommaSeparatedString(args.results)
+	local rounds = Table.map(roundDatas, function (roundIndex, roundData)
+		local data = Array.parseCommaSeparatedString(roundData, '-')
+		return 'r' .. roundIndex, data[2]
+	end)
+
+	local startingPoints = -(tonumber(args.penalty) or 0)
+
+	return Table.merge(
+		{type = Opponent.team, args.team, startingpoints = startingPoints},
+		rounds
+	)
+end
+
+--- Ususually can just do an or between the prefix, but one uses both bg and pbg.
+--- And one uses only bg, but for the thing that the other one uses pbg.
+---@param args table
+---@param prefix 'bg'|'pbg'
+---@return string
+function StandingTableLegacyFfa.parseWikiBgs(args, prefix)
+	local bgs = {}
+	for _, value, index in Table.iter.pairsByPrefix(args, prefix, {requireIndex = true}) do
+		table.insert(bgs, index .. '=' .. value)
+	end
+	return table.concat(bgs, ',')
+end
+
+return StandingTableLegacyFfa

--- a/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
+++ b/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
@@ -50,7 +50,7 @@ function StandingTableLegacyFfa.withoutLobby(frame)
 	local bgs = StandingTableLegacyFfa.parseWikiBgs(args, 'bg')
 
 	return StandingTable.fromTemplate(Table.merge(
-		StandingTableLegacyFfa.getStandardParameter(args), bgs, rounds, opponents
+		StandingTableLegacyFfa.getStandardParameter(args), {bg = bgs}, rounds, opponents
 	))
 end
 
@@ -71,7 +71,7 @@ function StandingTableLegacyFfa.pastResults(frame)
 	local bgs = StandingTableLegacyFfa.parseWikiBgs(args, 'pbg')
 
 	return StandingTable.fromTemplate(Table.merge(
-		StandingTableLegacyFfa.getStandardParameter(args), bgs, rounds, opponents
+		StandingTableLegacyFfa.getStandardParameter(args), {bg = bgs}, rounds, opponents
 	))
 end
 
@@ -153,8 +153,11 @@ function StandingTableLegacyFfa.parseTeamInput(args, teamIndex)
 		return 'r' .. roundIndex, value
 	end)
 
+	local tiebreaker = args['tiebreaker' .. teamIndex] or args['p' .. teamIndex .. 'temp_tie']
+	local startingPoints = args['changes' .. teamIndex] or args['p' .. teamIndex .. 'changes']
+
 	return Table.merge(
-		{type = Opponent.team, team, tiebreaker = args['tiebreaker' .. teamIndex]},
+		{type = Opponent.team, team, tiebreaker = tiebreaker, startingpoints = startingPoints},
 		rounds
 	)
 end


### PR DESCRIPTION
## Summary
Adds support for startingpoints as it's needed for this feature.

Wiki-specific PUBGM legacy wrapper so that we don't need to update all existing instances to new wikicode. 

PUBGM have multiple variants of previous Ffa Standings. 4 have been identified so far, but there may be more showing up.

* Template:League standings without lobby
* Template:League_standings_with_past_results
* Template:league standings slot
* Template:league standings slot2

## How did you test this change?
All 3 setups tested (withoutLobby, pastResults, and slot-family)