### PR TITLE
Center PlayerNumber in tournamentCard

### DIFF
--- a/stylesheets/commons/DivTable.less
+++ b/stylesheets/commons/DivTable.less
@@ -197,7 +197,8 @@ Author(s): iMarbot
 .gridTable.tournamentCard .gridCell.Game,
 .gridTable.tournamentCard .gridCell.Series,
 .gridTable.tournamentCard .gridCell.Prize,
-.gridTable.tournamentCard .gridCell.GameSeries {
+.gridTable.tournamentCard .gridCell.GameSeries,
+.gridTable.tournamentCard .gridCell.PlayerNumber {
 	justify-content: center;
 }
 


### PR DESCRIPTION
## Summary

Centres the player number cell in the tournament card

## How did you test this change?

Inspected css
