### PR TITLE
feat(Infobox): Update Skill Infobox for Stormgate to properly display subfaction casters

### DIFF
--- a/components/infobox/commons/infobox_skill.lua
+++ b/components/infobox/commons/infobox_skill.lua
@@ -51,7 +51,12 @@ function Skill:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = args.informationType .. ' Information'},
-		Cell{name = 'Caster(s)', content = self:getAllArgsForBase(args, 'caster', {makeLink = true})},
+		Customizable{
+			id = 'caster',
+			children = {
+				Cell{name = 'Caster(s)', content = self:getAllArgsForBase(args, 'caster', {makeLink = true})},
+			}
+		},
 		Customizable{
 			id = 'cost',
 			children = {

--- a/components/infobox/wikis/stormgate/infobox_building_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_building_custom.lua
@@ -42,8 +42,8 @@ local HOTKEY_SEPERATOR = '&nbsp;&nbsp;/&nbsp;&nbsp;'
 local CREEP = 'Camp'
 local SORT_TABLE = {'1v1', 'coop', 'mayhem'}
 local GAME_MODE_ICON = {
-	coop = 'dungeon',
-	mayhem = 'fort',
+	coop = 'coop',
+	mayhem = 'mayhem',
 }
 
 ---@param frame Frame

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -41,8 +41,8 @@ local VALID_SKILLS = {
 }
 local SORT_TABLE = {'1v1', 'coop', 'mayhem'}
 local GAME_MODE_ICON = {
-	coop = 'dungeon',
-	mayhem = 'fort',
+	coop = 'coop',
+	mayhem = 'mayhem',
 }
 
 ---@param frame Frame

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -160,20 +160,22 @@ function CustomSkill:_castersDisplay()
 		end
 
 		if casterUnit.type == 'Hero' then
-			local sfData = Array.parseCommaSeparatedString(extraData.subfaction[1] or {}, ':')
-			return GAME_MODE_ICON[sfData[1]] and Page.makeInternalLink({},
-				Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(sfData[1])], size = '100%'}
+			local heroSubfactionData = Array.parseCommaSeparatedString(extraData.subfaction[1] or {}, ':')
+			return GAME_MODE_ICON[heroSubfactionData[1]] and Page.makeInternalLink({},
+				Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(heroSubfactionData[1])], size = '100%'}
 				.. ' ' .. casterUnit.name, caster)
 		end
 
-		local sfOutput = table.concat(Array.map(self:_parseSubfactionData(extraData.subfaction or {}), function(sfElement)
+		local casterSubfactions = table.concat(Array.map(self:_parseSubfactionData(extraData.subfaction or {}),
+			function(sfElement)
 				local gameModeIcon = GAME_MODE_ICON[sfElement[1]]
 					and Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(sfElement[1])], size = '100%'}
 				return gameModeIcon and sfElement[2]
 					and (gameModeIcon .. ' ' .. string.gsub(sfElement[2], ';', ', ')) or nil
-		end), ', ')
+			end),
+		', ')
 
-		return Page.makeInternalLink({}, casterUnit.name .. ' (' .. sfOutput .. ')', caster)
+		return Page.makeInternalLink({}, casterUnit.name .. ' (' .. casterSubfactions .. ')', caster)
 	end)
 end
 

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -39,6 +39,7 @@ local VALID_SKILLS = {
 	'Upgrade',
 	'Effect',
 }
+local SORT_TABLE = {'1v1', 'coop', 'mayhem'}
 local GAME_MODE_ICON = {
 	coop = 'dungeon',
 	mayhem = 'fort',
@@ -142,7 +143,7 @@ end
 
 function CustomSkill:_castersDisplay()
 	local casters = self:getAllArgsForBase(self.args, 'caster')
-	
+
 	return Array.map(casters, function(caster)
 		local casterUnit = mw.ext.LiquipediaDB.lpdb('datapoint', {
 			conditions = '([[type::Unit]] OR [[type::Hero]] or [[type::building]]) AND [[pagename::'
@@ -154,7 +155,9 @@ function CustomSkill:_castersDisplay()
 
 		local extraData = casterUnit.extradata or {}
 
-		if Table.includes(extraData.subfaction or {}, '1v1') then return Page.makeInternalLink({}, casterUnit.name, caster) end
+		if Table.includes(extraData.subfaction or {}, '1v1') then
+			return Page.makeInternalLink({}, casterUnit.name, caster)
+		end
 
 		if casterUnit.type == 'Hero' then
 			local sfData = Array.parseCommaSeparatedString(extraData.subfaction[1] or {}, ':')

--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -11,6 +11,8 @@ local Class = require('Module:Class')
 local CostDisplay = require('Module:Infobox/Extension/CostDisplay')
 local Faction = require('Module:Faction')
 local Hotkeys = require('Module:Hotkey')
+local Icon = require('Module:Icon')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
@@ -36,6 +38,10 @@ local VALID_SKILLS = {
 	'Trait',
 	'Upgrade',
 	'Effect',
+}
+local GAME_MODE_ICON = {
+	coop = 'dungeon',
+	mayhem = 'fort',
 }
 
 ---@param frame Frame
@@ -78,7 +84,11 @@ function CustomInjector:parse(id, widgets)
 	local caller = self.caller
 	local args = caller.args
 
-	if id == 'cost' then
+	if id == 'caster' then
+		return {
+			Cell{name = 'Caster(s)', content = caller:_castersDisplay()},
+		}
+	elseif id == 'cost' then
 		return {
 			Cell{name = 'Cost', content = {caller:_costDisplay()}},
 			Cell{name = 'Recharge Time', content = {args.charge_time and (args.charge_time .. 's') or nil}},
@@ -128,6 +138,54 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	return widgets
+end
+
+function CustomSkill:_castersDisplay()
+	local casters = self:getAllArgsForBase(self.args, 'caster')
+	
+	return Array.map(casters, function(caster)
+		local casterUnit = mw.ext.LiquipediaDB.lpdb('datapoint', {
+			conditions = '([[type::Unit]] OR [[type::Hero]] or [[type::building]]) AND [[pagename::'
+				.. string.gsub(caster, ' ', '_') .. ']]',
+			limit = 1,
+		})[1] or {}
+
+		if type(casterUnit) ~= 'table' or Logic.isEmpty(casterUnit) then return end
+
+		local extraData = casterUnit.extradata or {}
+
+		if Table.includes(extraData.subfaction or {}, '1v1') then return Page.makeInternalLink({}, casterUnit.name, caster) end
+
+		if casterUnit.type == 'Hero' then
+			local sfData = Array.parseCommaSeparatedString(extraData.subfaction[1] or {}, ':')
+			return GAME_MODE_ICON[sfData[1]] and Page.makeInternalLink({},
+				Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(sfData[1])], size = '100%'}
+				.. ' ' .. casterUnit.name, caster)
+		end
+
+		local sfOutput = table.concat(Array.map(self:_parseSubfactionData(extraData.subfaction or {}), function(sfElement)
+				local gameModeIcon = GAME_MODE_ICON[sfElement[1]]
+					and Icon.makeIcon{iconName = GAME_MODE_ICON[string.lower(sfElement[1])], size = '100%'}
+				return gameModeIcon and sfElement[2]
+					and (gameModeIcon .. ' ' .. string.gsub(sfElement[2], ';', ', ')) or nil
+		end), ', ')
+
+		return Page.makeInternalLink({}, casterUnit.name .. ' (' .. sfOutput .. ')', caster)
+	end)
+end
+
+---@param data table
+---@return table?
+function CustomSkill:_parseSubfactionData(data)
+	local parsedElements = Array.map(data, function(dataElement)
+		return Array.parseCommaSeparatedString(dataElement, ':')
+	end)
+
+	return Array.sortBy(parsedElements, function(element)
+		return Array.indexOf(SORT_TABLE, function(sortElement)
+			return sortElement == string.lower(element[1])
+		end)
+	end)
 end
 
 ---@param prefix string

--- a/components/infobox/wikis/stormgate/infobox_unit_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_unit_custom.lua
@@ -42,8 +42,8 @@ local GAME_MODE_NAME =	{
 	mayhem = 'Team Mayhem',
 }
 local GAME_MODE_ICON = {
-	coop = 'dungeon',
-	mayhem = 'fort',
+	coop = 'coop',
+	mayhem = 'mayhem',
 }
 
 ---@param frame Frame

--- a/standard/icon_data.lua
+++ b/standard/icon_data.lua
@@ -109,6 +109,6 @@ return {
 	sort = 'far fa-arrows-alt-v',
 
 	-- Usage: Stormgate
-	dungeon = 'fas fa-dungeon',
-	fort = 'fab fa-fort-awesome',
+	coop = 'fas fa-dungeon',
+	mayhem = 'fab fa-fort-awesome',
 }


### PR DESCRIPTION
## Summary

1. Make 'caster' on `Infobox/Skill` customizable
2. Update caster display in `Infobox/Skill/Custom` to properly show subfaction casters (follow up on https://github.com/Liquipedia/Lua-Modules/pull/5263 and https://github.com/Liquipedia/Lua-Modules/pull/5340)
![grafik](https://github.com/user-attachments/assets/a3b5452a-c7a8-46d7-a9f3-98030b530a73)
3. Update Icon Data for stormgate. Use game mode name ('coop', 'mayhem') instead of icon name ('dungeon', 'fort') so when we change the icon later we only have to change the relevant icon in `Module:Icon/Data` and not all Modules that use it

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev tools

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
