### PR TITLE
feat(standings): improve party opponent support in ffa standings

### DIFF
--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
-local Page = require('Module:Page')
 local Table = require('Module:Table')
 
 local OpponentLibrary = require('Module:OpponentLibraries')

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -126,14 +126,7 @@ function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds, res
 	end
 
 	local opponent = Opponent.readOpponentArgs(opponentData)
-	opponent = Opponent.resolve(opponent, resolveDate, {syncPlayer = 1})
-	-- temp until we standardized name building to have underscores ...
-	if Opponent.typeIsParty(opponent.type) then
-		Array.forEach(opponent.players, function(player)
-			player.pageName = Page.pageifyLink(player.pageName or player.displayName)
-		end)
-	end
-	opponent.name = Opponent.toName(opponent)
+	opponent = Opponent.resolve(opponent, resolveDate, {syncPlayer = true})
 
 	return {
 		rounds = rounds,

--- a/components/standings/wikis/pubg/standings_table_legacy_ffa.lua
+++ b/components/standings/wikis/pubg/standings_table_legacy_ffa.lua
@@ -73,6 +73,7 @@ end
 
 ---Template:league standings end & Template:league standings end2
 ---@param frame Frame
+---@return table?
 function StandingTableLegacyFfa.templateEnd(frame)
 	local cnt = tonumber(Variables.varDefault('standings_legacy_count'))
 	if not cnt then

--- a/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
+++ b/components/standings/wikis/pubgmobile/standings_table_legacy_ffa.lua
@@ -94,6 +94,7 @@ end
 
 ---Template:league standings end & Template:league standings end2
 ---@param frame Frame
+---@return table?
 function StandingTableLegacyFfa.templateEnd(frame)
 	local cnt = tonumber(Variables.varDefault('standings_legacy_count'))
 	if not cnt then


### PR DESCRIPTION
## Summary
currently for party opponents they do not get displayed with flag nor link if they are not specified manually
this pr resolves the opponent (incl syncPlayer being activated) after reading its args so that those values are filled in automatically where possible

additionally added 2 missing return annos in the pubg(m) legacy stuff

## How did you test this change?
dev on https://liquipedia.net/geoguessr/User:Steve23/Testing_Page2