### PR TITLE
fix: historic team templates for players not working as expected

### DIFF
--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -475,11 +475,13 @@ function Opponent.fromLpdbStruct(storageStruct)
 	if partySize then
 		local players = storageStruct.opponentplayers
 		local function playerFromLpdbStruct(playerIndex)
+			local prefix = 'p' .. playerIndex
+
 			return {
-				displayName = players['p' .. playerIndex .. 'dn'],
-				flag = Flags.CountryName(players['p' .. playerIndex .. 'flag']),
-				pageName = players['p' .. playerIndex],
-				team = players['p' .. playerIndex .. 'team'],
+				displayName = players[prefix .. 'dn'],
+				flag = Flags.CountryName(players[prefix .. 'flag']),
+				pageName = players[prefix],
+				team = players[prefix .. 'template'] or players[prefix .. 'team'],
 			}
 		end
 		local opponent = {


### PR DESCRIPTION
## Summary
`player.team` is stored into `...template`, but `player.team` load from `...team`. 

Keeping `...team` as a fallback



## How did you test this change?
Now:
<img width="339" alt="image" src="https://github.com/user-attachments/assets/43066eb6-a6b4-40e9-ba8b-39d563b25bb8" />

Before:
<img width="344" alt="image" src="https://github.com/user-attachments/assets/94fc5e3e-7818-4f56-95e6-f5796edd35e9" />
