### PR TITLE
feat: store enddate in ffa standings

### DIFF
--- a/components/prize_pool/commons/prize_pool_import.lua
+++ b/components/prize_pool/commons/prize_pool_import.lua
@@ -30,6 +30,7 @@ local DEFAULT_ELIMINATION_STATUS = 'down'
 local THIRD_PLACE_MATCH_ID = 'RxMTP'
 local GSL_GROUP_OPPONENT_NUMBER = 4
 local SWISS_GROUP_TYPE = 'swiss'
+local FFA_GROUP_TYPE = 'ffa'
 local GSL_STYLE_SCORES = {
 	{w = 2, d = 0, l = 0},
 	{w = 2, d = 0, l = 1},
@@ -234,7 +235,11 @@ function Import:_computeGroupTablePlacementEntries(standingRecords, options)
 	local placementEntries = {}
 	local placementIndexes = {}
 
-	for _, record in ipairs(standingRecords) do
+	Array.forEach(standingRecords, function (record)
+		--- We do not yet support importing FFA groups
+		if record.type == FFA_GROUP_TYPE then
+			return
+		end
 		if options.importWinners or Table.includes(options.groupElimStatuses, record.currentstatus) then
 			local entry = {
 				date = record.extradata.enddate,
@@ -265,7 +270,7 @@ function Import:_computeGroupTablePlacementEntries(standingRecords, options)
 				table.insert(placementEntries[placementIndexes[record.placement]], entry)
 			end
 		end
-	end
+	end)
 
 	return placementEntries
 end

--- a/components/standings/commons/standings_parse_wiki.lua
+++ b/components/standings/commons/standings_parse_wiki.lua
@@ -31,10 +31,7 @@ local StandingsParseWiki = {}
 ]]
 
 ---@param args table
----@return {rounds: {roundNumber: integer, started: boolean, finished:boolean, title: string?, matches: string[]}[],
----opponents: StandingTableOpponentData[],
----bgs: table<integer, string>,
----matches: string[]}
+---@return StandingsTableProps
 function StandingsParseWiki.parseWikiInput(args)
 	---@type {roundNumber: integer, started: boolean, finished:boolean, title: string?, matches: string[]}[]
 	local rounds = {}
@@ -46,7 +43,7 @@ function StandingsParseWiki.parseWikiInput(args)
 		rounds = {StandingsParseWiki.parseWikiRound(args, 1)}
 	end
 
-	local date = DateExt.readTimestamp(args.date) or DateExt.getContextualDateOrNow()
+	local date = DateExt.toYmdInUtc(args.date) or DateExt.getContextualDateOrNow()
 
 	---@type StandingTableOpponentData[]
 	local opponents = Array.map(args, function (opponentData)
@@ -58,10 +55,13 @@ function StandingsParseWiki.parseWikiInput(args)
 		return round.matches
 	end))
 
+	---@type StandingsTableProps
 	return {
 		rounds = rounds,
 		opponents = opponents,
 		bgs = StandingsParseWiki.parseWikiBgs(args.bg),
+		title = args.title,
+		endDate = date,
 		matches = Array.unique(wrapperMatches),
 	}
 end
@@ -102,6 +102,7 @@ end
 
 ---@param opponentInput string|table
 ---@param numberOfRounds integer
+---@param resolveDate string
 ---@return StandingTableOpponentData[]
 function StandingsParseWiki.parseWikiOpponent(opponentInput, numberOfRounds, resolveDate)
 	local opponentData = Json.parseIfString(opponentInput)

--- a/components/standings/commons/standings_parser.lua
+++ b/components/standings/commons/standings_parser.lua
@@ -11,18 +11,16 @@ local Variables = require('Module:Variables')
 
 local StandingsParser = {}
 
----@param rounds {roundNumber: integer, started: boolean, finished:boolean, title: string?}[]
----@param opponents StandingTableOpponentData[]
----@param bgs table<integer, string>
----@param title string?
----@param matches string[]
+---@param props StandingsTableProps
 ---@return StandingsTableStorage
-function StandingsParser.parse(rounds, opponents, bgs, title, matches)
+function StandingsParser.parse(props)
 	-- TODO: When all legacy (of all standing type) have been converted, the wiki variable should be updated
 	-- to follow the namespace format. Eg new name could be `standings_standingsindex`
 	local lastStandingsIndex = tonumber(Variables.varDefault('standingsindex')) or -1
 	local standingsindex = lastStandingsIndex + 1
 	Variables.varDefine('standingsindex', standingsindex)
+
+	local rounds, opponents, bgs = props.rounds, props.opponents, props.bgs
 
 	local isFinished = Array.all(rounds, function(round) return round.finished end)
 
@@ -82,15 +80,16 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches)
 	---@type StandingsTableStorage
 	return {
 		standingsindex = standingsindex,
-		title = title,
+		title = props.title,
 		type = 'ffa', -- We only deal with ffa atm
 		entries = entries,
-		matches = matches,
+		matches = props.matches,
 		roundcount = #rounds,
 		hasdraw = false,
 		hasovertime = false,
 		haspoints = true,
 		finished = isFinished,
+		enddate = props.endDate,
 		extradata = {
 			rounds = rounds,
 		},

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -334,10 +334,11 @@ function mw.language:formatNum(num, options)
 end
 
 ---Formats a date according to the given format string. If timestamp is omitted, the default is the current time. The value for local must be a boolean or nil; if true, the time is formatted in the wiki's local time rather than in UTC.
----@param format string
+---@param format 'U'
 ---@param timestamp string|osdateparam?
 ---@param localTime boolean?
----@return number|string
+---@return number
+---@overload fun(format: string, timestamp: string|osdateparam, localTime:boolean?):string
 function mw.language:formatDate(format, timestamp, localTime)
 	local function localTimezoneOffset(ts)
 		local utcDt = os.date("!*t", ts)

--- a/spec/page_spec.lua
+++ b/spec/page_spec.lua
@@ -2,9 +2,8 @@
 describe('Page', function()
 	local Page = require('Module:Page')
 
-	local orig = mw.title.new
 	before_each(function()
-		mw.title.new = spy.new(function(page)
+		stub(mw.title, 'new', function (page)
 			if page == 'https://google.com' then
 				return nil
 			end
@@ -12,7 +11,8 @@ describe('Page', function()
 		end)
 	end)
 	after_each(function()
-		mw.title.new = orig
+		---@diagnostic disable-next-line: undefined-field
+		mw.title.new:revert()
 	end)
 
 	describe('exists', function()

--- a/standard/date_ext.lua
+++ b/standard/date_ext.lua
@@ -79,9 +79,10 @@ end)
 
 --- Formats a timestamp according to the specified format.
 --- The format string is the same used by mw.language.formatDate and {{#time}}.
----@param format string
+---@param format 'U'
 ---@param timestamp string|integer
----@return string|number
+---@return number
+---@overload fun(format: string, timestamp: string|integer):string
 function DateExt.formatTimestamp(format, timestamp)
 	return mw.getContentLanguage():formatDate(format, '@' .. timestamp)
 end
@@ -97,7 +98,7 @@ end
 --- Truncates the time of day in a date string or timestamp, and returns the date formatted as yyyy-mm-dd.
 --- The time of day is truncated in the UTC timezone. The time of day and timezone are discarded.
 ---@param dateOrTimestamp string|integer|osdate|osdateparam
----@return string|number
+---@return string
 function DateExt.toYmdInUtc(dateOrTimestamp)
 	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp) or '')
 end


### PR DESCRIPTION
## Summary
Store enddate (so that it can be used by import later)

But also disable import, as it doesn't support FFA yet

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
