### PR TITLE
feat(infobox): additional storage in items/charactes infobox

### DIFF
--- a/components/infobox/wikis/deadlock/infobox_character_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_character_custom.lua
@@ -91,7 +91,7 @@ function CustomHero:addToLpdb(lpdbData, args)
 		damagebullet = args.damagebullet,
 		damagemeleelight = args.damagemeleelight,
 		damagemeleeheavy = args.damagemeleeheavy,
-		playable = tostring(Logic.readBool(args.playable or 'true')),
+		playable = tostring(Logic.readBool(args.playable or true)),
 		removed = tostring(Logic.readBool(args.removed))
 	}
 

--- a/components/infobox/wikis/deadlock/infobox_character_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_character_custom.lua
@@ -91,7 +91,7 @@ function CustomHero:addToLpdb(lpdbData, args)
 		damagebullet = args.damagebullet,
 		damagemeleelight = args.damagemeleelight,
 		damagemeleeheavy = args.damagemeleeheavy,
-		playable = tostring(Logic.readBool(args.playable or true)),
+		playable = tostring(Logic.nilOr(Logic.readBoolOrNil(args.playable), true)),
 		removed = tostring(Logic.readBool(args.removed))
 	}
 

--- a/components/infobox/wikis/deadlock/infobox_character_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_character_custom.lua
@@ -92,7 +92,7 @@ function CustomHero:addToLpdb(lpdbData, args)
 		damagemeleelight = args.damagemeleelight,
 		damagemeleeheavy = args.damagemeleeheavy,
 		playable = tostring(Logic.readBool(args.playable or 'true')),
-		removed = tostring(Logic.readBool(args.removed or 'false')),
+		removed = tostring(Logic.readBool(args.removed))
 	}
 
 	return lpdbData

--- a/components/infobox/wikis/deadlock/infobox_item_custom.lua
+++ b/components/infobox/wikis/deadlock/infobox_item_custom.lua
@@ -186,7 +186,7 @@ function CustomItem:setLpdbData(args)
 			cost = args.itemcost,
 			category = args.category,
 			removed = tostring(Logic.readBool(args.removed)),
-			tier = args.tier,
+			tier = tonumber(args.tier),
 		})
 	}
 	mw.ext.LiquipediaDB.lpdb_datapoint('item_' .. (args.name or self.pagename), lpdbData)


### PR DESCRIPTION
## infobox_items_custom.lua
## Summary

Saving args.tier to DB for invoking count on [Portal:Items](https://liquipedia.net/deadlock/Portal:Items)

This gonna be automatically invoked based on "|tier=|type=" in [Template:ItemCostHeader](https://liquipedia.net/deadlock/Template:ItemCostHeader).
Already prepared setup for it inside of the template.

## How did you test this change?
Dev version in [Basic Magazine](https://liquipedia.net/deadlock/Basic_Magazine)
Part of the Invoke in my [Sandbox](https://liquipedia.net/deadlock/User:Sl0thyMan/Sandbox/24)
![image](https://github.com/user-attachments/assets/17030ce8-2128-419d-8dd4-6e3e300d13b6)

## infobox_character_custom.lua
## Summary

Saving args.playable and args.removed to DB for invoking count on [Portal:Heroes](https://liquipedia.net/deadlock/Portal:Heroes).
args.removed is more of the preparation as right now there is no heroes which is completely deleted. If we not gonna scratched heroes from the game before Title Deadlock was announced.

## How did you test this change?

Dev version in [Abrams](https://liquipedia.net/deadlock/Abrams)
Tried showing DB without any args. Which default to 
playable = true
removed = false

and even tried setting up args.removed/playable manually to specific state.
With args.
![image](https://github.com/user-attachments/assets/7ac74bb9-983c-4500-8102-244d80ac2639)
Without args.
![image](https://github.com/user-attachments/assets/3d21d4d7-0a27-4e73-9b7b-e0909247e81a)

