### PR TITLE
fix(mainPage): linking to non existing monthly transfer pages on deadlock

### DIFF
--- a/components/main_page/wikis/deadlock/main_page_layout_data.lua
+++ b/components/main_page/wikis/deadlock/main_page_layout_data.lua
@@ -31,7 +31,7 @@ local CONTENT = {
 		'<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
 			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
 			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|action=edit}} edit]&#93;</div>\n' ..
+			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}|action=edit}} edit]&#93;</div>\n' ..
 			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
 			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
 			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..


### PR DESCRIPTION
removing CURRENTMONTH on "Module:MainPageLayout/data" because Deadlock only using Year for the Player Transfer

## Summary
Request by Krola
https://discord.com/channels/93055209017729024/765984788107624468/1335400935740014665