### PR TITLE
ci: Bump mikepenz/action-junit-report from 4 to 5

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -28,7 +28,7 @@ jobs:
           luacheck ./ --formatter=JUnit > report.xml
 
       - name: Report lint
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v5
         if: always()
         with:
           report_paths: 'report.xml'
@@ -58,7 +58,7 @@ jobs:
           busted -v --run=ci --output=junit > busted.xml
 
       - name: Report test
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v5
         if: always()
         with:
           report_paths: 'busted.xml'


### PR DESCRIPTION
## Summary

Bumps [mikepenz/action-junit-report](https://github.com/mikepenz/action-junit-report) from 4 to 5.

## How did you test this change?

<https://github.com/Liquipedia/Lua-Modules/actions/runs/13104214227>
