### PR TITLE
feat(standings): Don't import TBDs in ffa standings

### DIFF
--- a/components/standings/commons/standings_parse_lpdb.lua
+++ b/components/standings/commons/standings_parse_lpdb.lua
@@ -68,8 +68,14 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	)
 
 	return Array.map(opponents, function(opponentData)
+		local opponent = Opponent.fromMatch2Record(opponentData.opponent)
+
+		if Opponent.isTbd(opponent) then
+			return
+		end
+
 		return {
-			opponent = Opponent.fromMatch2Record(opponentData.opponent),
+			opponent = opponent,
 			rounds = Array.map(opponentData.rounds, function(roundData)
 				return {
 					scoreboard = {


### PR DESCRIPTION
## Summary
Don't import TBDs in ffa standings.

This also resolves this ticket:
<img width="818" alt="image" src="https://github.com/user-attachments/assets/0b5dbe96-53f7-4477-bb29-8556c0ef1662" />


## How did you test this change?
dev: https://liquipedia.net/pubgmobile/User:Hjpalpha