### PR TITLE
feat: allow editors to merge regions into super-regions in the new mainpage filters

### DIFF
--- a/components/components/filter_buttons/wikis/deadlock/filter_buttons_config.lua
+++ b/components/components/filter_buttons/wikis/deadlock/filter_buttons_config.lua
@@ -9,6 +9,7 @@
 local Tier = require('Module:Tier/Utils')
 local Config = {}
 
+---@type FilterButtonCategory[]
 Config.categories = {
 	{
 		name = 'liquipediatier',

--- a/components/filter_buttons/filter_buttons.lua
+++ b/components/filter_buttons/filter_buttons.lua
@@ -109,9 +109,11 @@ function FilterButtons.getButtonRow(category)
 	end
 
 	local transformValueToText = category.transform or FnUtil.identity
+	local itemToPropertyValues = category.itemToPropertyValues or FnUtil.identity
 	for _, value in ipairs(category.items or {}) do
 		local text = transformValueToText(value)
-		makeButton(value, text)
+		local filterValue = itemToPropertyValues(value) or value
+		makeButton(filterValue, text)
 	end
 
 	if String.isNotEmpty(category.expandKey) then

--- a/components/filter_buttons/filter_buttons.lua
+++ b/components/filter_buttons/filter_buttons.lua
@@ -26,6 +26,7 @@ local DROPDOWN_ARROW = '&#8203;▼&#8203;'
 ---@field items string[]?
 ---@field defaultItems string[]?
 ---@field defaultItem string?
+---@field itemToPropertyValues? fun(item: string): string?
 ---@field itemIsValid? fun(item: string): boolean
 ---@field transform? fun(item: string): string?
 ---@field expandKey string?

--- a/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
@@ -14,6 +14,7 @@ local Config = {}
 
 local REGION_TO_SUPERREGION = {
 	['Europe'] = 'EMEA',
+	['Turkey'] = 'EMEA',
 	['Korea'] = 'Korea',
 	['China'] = 'China',
 	['North America'] = 'Americas',
@@ -23,6 +24,7 @@ local REGION_TO_SUPERREGION = {
 	['Taiwan'] = 'Pacific',
 	['Oceania'] = 'Pacific',
 	['Japan'] = 'Pacific',
+	['Vietnam'] = 'Pacific',
 	['Other'] = 'Other',
 }
 

--- a/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
@@ -6,22 +6,31 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
+local Table = require('Module:Table')
 local Tier = require('Module:Tier/Utils')
+
 local Config = {}
 
-local REGION_NAME_TO_SHORTNAME = {
-	['Europe'] = 'eu',
-	['North America'] = 'na',
-	['Korea'] = 'kr',
-	['China'] = 'ch',
-	['Japan'] = 'jp',
-	['Latin America North'] = 'latam n',
-	['Latin America South'] = 'latam s',
-	['Taiwan'] = 'tw',
-	['Oceania'] = 'oce',
-	['Brazil'] = 'br',
-	['Other'] = 'other',
+local REGION_TO_SUPERREGION = {
+	['Europe'] = 'EMEA',
+	['Korea'] = 'Korea',
+	['China'] = 'China',
+	['North America'] = 'Americas',
+	['Latin America North'] = 'Americas',
+	['Latin America South'] = 'Americas',
+	['Brazil'] = 'Americas',
+	['Taiwan'] = 'Pacific',
+	['Oceania'] = 'Pacific',
+	['Japan'] = 'Pacific',
+	['Other'] = 'Other',
 }
+
+local REGIONS_IN_SUPERREGION = Table.mapValues(Table.groupBy(REGION_TO_SUPERREGION, function(region, superRegion)
+	return superRegion
+end), function(superRegion)
+	return Array.extractKeys(superRegion)
+end)
 
 ---@type FilterButtonCategory[]
 Config.categories = {
@@ -44,17 +53,17 @@ Config.categories = {
 		name = 'region',
 		property = 'region',
 		expandable = true,
-		items = {
-			'Europe', 'North America', 'Korea', 'China', 'Japan', 'Latin America North',
-			'Latin America South', 'Taiwan', 'Oceania', 'Brazil', 'Other',
-		},
-		defaultItems = { 'Europe', 'North America', 'Korea', 'China', 'Brazil', 'Other' },
+		items = { 'EMEA', 'Korea', 'China', 'Americas', 'Pacific', 'Other', },
+		defaultItems = { 'EMEA', 'Korea', 'China', 'Americas', 'Pacific', 'Other' },
 		defaultItem = 'Other',
+		itemToPropertyValues = function(region)
+			return table.concat(REGIONS_IN_SUPERREGION[REGION_TO_SUPERREGION[region]], ',')
+		end,
 		itemIsValid = function(region)
-			return REGION_NAME_TO_SHORTNAME[region] ~= nil
+			return REGION_TO_SUPERREGION[region] ~= nil
 		end,
 		transform = function(region)
-			return REGION_NAME_TO_SHORTNAME[region]
+			return REGION_TO_SUPERREGION[region]
 		end,
 	},
 }

--- a/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
@@ -53,17 +53,26 @@ Config.categories = {
 		name = 'region',
 		property = 'region',
 		expandable = true,
+		-- This is a bit stupid that we need to use one region from each superRegion
 		items = { 'EMEA', 'Korea', 'China', 'Americas', 'Pacific', 'Other', },
-		defaultItems = { 'EMEA', 'Korea', 'China', 'Americas', 'Pacific', 'Other' },
 		defaultItem = 'Other',
 		itemToPropertyValues = function(region)
-			return table.concat(REGIONS_IN_SUPERREGION[REGION_TO_SUPERREGION[region]], ',')
+			-- Input is a region
+			if REGION_TO_SUPERREGION[region] then
+				return table.concat(REGIONS_IN_SUPERREGION[REGION_TO_SUPERREGION[region]], ',')
+			end
+			-- Input is a superRegion
+			if REGIONS_IN_SUPERREGION[region] then
+				return table.concat(REGIONS_IN_SUPERREGION[region], ',')
+			end
+			-- Unknown input
+			return ''
 		end,
 		itemIsValid = function(region)
 			return REGION_TO_SUPERREGION[region] ~= nil
 		end,
 		transform = function(region)
-			return REGION_TO_SUPERREGION[region]
+			return REGION_TO_SUPERREGION[region] or region
 		end,
 	},
 }

--- a/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
@@ -53,7 +53,6 @@ Config.categories = {
 		name = 'region',
 		property = 'region',
 		expandable = true,
-		-- This is a bit stupid that we need to use one region from each superRegion
 		items = { 'EMEA', 'Korea', 'China', 'Americas', 'Pacific', 'Other', },
 		defaultItem = 'Other',
 		itemToPropertyValues = function(region)

--- a/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
+++ b/components/filter_buttons/wikis/leagueoflegends/filter_buttons_config.lua
@@ -15,16 +15,17 @@ local Config = {}
 local REGION_TO_SUPERREGION = {
 	['Europe'] = 'EMEA',
 	['Turkey'] = 'EMEA',
+	['Arab States'] = 'EMEA',
 	['Korea'] = 'Korea',
 	['China'] = 'China',
 	['North America'] = 'Americas',
 	['Latin America North'] = 'Americas',
 	['Latin America South'] = 'Americas',
 	['Brazil'] = 'Americas',
-	['Taiwan'] = 'Pacific',
-	['Oceania'] = 'Pacific',
-	['Japan'] = 'Pacific',
-	['Vietnam'] = 'Pacific',
+	['Taiwan'] = 'APAC',
+	['Oceania'] = 'APAC',
+	['Japan'] = 'APAC',
+	['Vietnam'] = 'APAC',
 	['Other'] = 'Other',
 }
 
@@ -55,7 +56,7 @@ Config.categories = {
 		name = 'region',
 		property = 'region',
 		expandable = true,
-		items = { 'EMEA', 'Korea', 'China', 'Americas', 'Pacific', 'Other', },
+		items = { 'Korea', 'China', 'EMEA', 'Americas', 'APAC', 'Other', },
 		defaultItem = 'Other',
 		itemToPropertyValues = function(region)
 			-- Input is a region

--- a/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
@@ -29,7 +29,7 @@ function TournamentsTickerWidget:render()
 	local createFilterWrapper = function(tournament, child)
 		return Array.reduce(FilterConfig.categories, function(prev, filterCategory)
 			local itemIsValid = filterCategory.itemIsValid or function(item) return true end
-			local itemToPropertyValues = filterCategory.itemToPropertyValues or function(item) return true end
+			local itemToPropertyValues = filterCategory.itemToPropertyValues or function(item) return item end
 			local value = tournament[filterCategory.property]
 			local filterValue = itemIsValid(value) and value or filterCategory.defaultItem
 			return HtmlWidgets.Div{

--- a/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
@@ -29,12 +29,13 @@ function TournamentsTickerWidget:render()
 	local createFilterWrapper = function(tournament, child)
 		return Array.reduce(FilterConfig.categories, function(prev, filterCategory)
 			local itemIsValid = filterCategory.itemIsValid or function(item) return true end
+			local itemToPropertyValues = filterCategory.itemToPropertyValues or function(item) return true end
 			local value = tournament[filterCategory.property]
 			local filterValue = itemIsValid(value) and value or filterCategory.defaultItem
 			return HtmlWidgets.Div{
 				attributes = {
 					['data-filter-group'] = 'filterbuttons-' .. filterCategory.name,
-					['data-filter-category'] = filterValue,
+					['data-filter-category'] = itemToPropertyValues(filterValue),
 					['data-curated'] = tournament.featured and '' or nil,
 				},
 				children = prev,


### PR DESCRIPTION
## Summary
Resolves #5329 and https://gitlab.com/teamliquid-dev/liquipedia/issue-bucket/-/issues/224

Code is terrible, because sometimes mappings from SR to R is needed, and sometimes the other way around... Depending on component and usage...

A way for certain wikis to filter Matches and Tournaments based on super-region

### Acceptance criteria

- [x] Should be installable on any wiki that needs it
- [x] Should allow for customization of filters by the editors (based on the scene)
- [x] Should filter the matches and the tournament list
- [x] Should interact with the Tier filter (selecting Tier 1, Tier 2, + LatAm should show all Tier1/2 matches and tournaments from the LatAm region)

### League of Legends
For League of Legends, they request the following super-regions:

* Americas (Including everything in North/Central/South america)
* EMEA (Europe, Africa, Middle East)
* Pacific (Basically all of Asia + Oceania excluding CN and KR)
* China
* Korea

## How did you test this change?
dev
https://liquipedia.net/leagueoflegends/User:ElectricalBoy/MainPage