### PR TITLE
fix(Statistics): game identifiers not found

### DIFF
--- a/components/statistics/count.lua
+++ b/components/statistics/count.lua
@@ -242,12 +242,8 @@ function Count._baseConditions(args, isTournament)
 	local conditions = ConditionTree(BooleanOperator.all)
 
 	if args.game then
-		local gameIdentifier = Game.toIdentifier{game = args.game, useDefault = false}
-		local gameConditions = ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('game'), Comparator.eq, args.game),
-			gameIdentifier and ConditionNode(ColumnName('game'), Comparator.eq, gameIdentifier) or nil,
-		}
-		conditions:add(gameConditions)
+		local gameIdentifier = Game.toIdentifier{game = args.game, useDefault = false} or args.game
+		conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, gameIdentifier)}
 	end
 
 	if args.type then

--- a/components/statistics/count.lua
+++ b/components/statistics/count.lua
@@ -8,9 +8,9 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Game = require('Module:Game')
 local Logic = require('Module:Logic')
 local Lpdb = require('Module:Lpdb')
-
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Team = require('Module:Team')
@@ -242,7 +242,12 @@ function Count._baseConditions(args, isTournament)
 	local conditions = ConditionTree(BooleanOperator.all)
 
 	if args.game then
-		conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, args.game)}
+		local gameIdentifier = Game.toIdentifier{game = args.game, useDefault = false}
+		local gameConditions = ConditionTree(BooleanOperator.any):add{
+			ConditionNode(ColumnName('game'), Comparator.eq, args.game),
+			gameIdentifier and ConditionNode(ColumnName('game'), Comparator.eq, gameIdentifier) or nil,
+		}
+		conditions:add(gameConditions)
 	end
 
 	if args.type then

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -580,6 +580,9 @@ function StatisticsPortal.pieChartBreakdown(args)
 	)
 
 	if args.multiGame then
+		local games = Array.map(StatisticsPortal._isTableOrSplitOrDefault(args.customGames, GAMES), function(game)
+			return Game.toIdentifier{game = args.game, useDefault = false} or args.game
+		end)
 		wrapper:node(mw.html.create('div')
 			:addClass('template-box')
 			:css('padding-right', '5em')
@@ -587,7 +590,7 @@ function StatisticsPortal.pieChartBreakdown(args)
 			:css('text-align', 'center')
 			:wikitext('Game Breakdown')
 			:node(StatisticsPortal._getPieChartData(
-				args, 'game', 'Other', StatisticsPortal._isTableOrSplitOrDefault(args.customGames, GAMES)
+				args, 'game', 'Other', games
 			))
 		)
 	end

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -72,7 +72,7 @@ function StatisticsPortal.gameEarningsChart(args)
 	args = args or {}
 
 	local games = Array.map(StatisticsPortal._isTableOrSplitOrDefault(args.customGames, GAMES), function(game)
-		return Game.toIdentifier{game = args.game, useDefault = false} or args.game
+		return Game.toIdentifier{game = game, useDefault = false} or game
 	end)
 
 	local params = {
@@ -585,7 +585,7 @@ function StatisticsPortal.pieChartBreakdown(args)
 
 	if args.multiGame then
 		local games = Array.map(StatisticsPortal._isTableOrSplitOrDefault(args.customGames, GAMES), function(game)
-			return Game.toIdentifier{game = args.game, useDefault = false} or args.game
+			return Game.toIdentifier{game = game, useDefault = false} or game
 		end)
 		wrapper:node(mw.html.create('div')
 			:addClass('template-box')

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -71,11 +71,15 @@ Section: Chart Entry Functions
 function StatisticsPortal.gameEarningsChart(args)
 	args = args or {}
 
+	local games = Array.map(StatisticsPortal._isTableOrSplitOrDefault(args.customGames, GAMES), function(game)
+		return Game.toIdentifier{game = args.game, useDefault = false} or args.game
+	end)
+
 	local params = {
 		variable = 'game',
 		processFunction = StatisticsPortal._defaultProcessFunction,
 		catLabel = 'Year',
-		defaultInputs = GAMES,
+		defaultInputs = games,
 		axisRotate = tonumber(args.axisRotate),
 	}
 

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -935,7 +935,12 @@ function StatisticsPortal._getPieChartData(args, groupBy, defaultValue, groupVal
 
 	if groupBy == 'game' and Logic.readBool(args.abbreviateGame) then
 		chartData = Array.map(chartData, function(entry)
-			entry.name = Game.abbreviation{game = entry.name} or entry.name
+			entry.name = Game.abbreviation{game = entry.name, useDefault = false} or entry.name
+			return entry
+		end)
+	elseif groupBy == 'game' then
+		chartData = Array.map(chartData, function(entry)
+			entry.name = Game.name{game = entry.name, useDefault = false} or entry.name
 			return entry
 		end)
 	end

--- a/components/statistics/portal_statistics.lua
+++ b/components/statistics/portal_statistics.lua
@@ -468,7 +468,8 @@ function StatisticsPortal.prizepoolBreakdown(args)
 		local conditions = StatisticsPortal._returnBaseConditions()
 
 		if args.game then
-			conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, args.game)}
+			local gameIdentifier = Game.toIdentifier{game = args.game, useDefault = false} or args.game
+			conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, gameIdentifier)}
 		end
 
 		conditions:add{ConditionTree(BooleanOperator.all):add{
@@ -517,7 +518,8 @@ function StatisticsPortal.prizepoolBreakdown(args)
 	local conditions = StatisticsPortal._returnBaseConditions()
 
 	if args.game then
-		conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, args.game)}
+		local gameIdentifier = Game.toIdentifier{game = args.game, useDefault = false} or args.game
+		conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, gameIdentifier)}
 	end
 
 	conditions:add{ConditionTree(BooleanOperator.all):add{
@@ -630,7 +632,8 @@ function StatisticsPortal.pieChartBreakdown(args)
 	end
 
 	if args.game then
-		conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, args.game)}
+		local gameIdentifier = Game.toIdentifier{game = args.game, useDefault = false} or args.game
+		conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, gameIdentifier)}
 	end
 
 	local data = mw.ext.LiquipediaDB.lpdb('tournament', {
@@ -896,7 +899,8 @@ function StatisticsPortal._getPieChartData(args, groupBy, defaultValue, groupVal
 	end
 
 	if args.game then
-		LPDBConditions:add{ConditionNode(ColumnName('game'), Comparator.eq, args.game)}
+		local gameIdentifier = Game.toIdentifier{game = args.game, useDefault = false} or args.game
+		LPDBConditions:add{ConditionNode(ColumnName('game'), Comparator.eq, gameIdentifier)}
 	end
 
 	local function parseTournament(data)
@@ -1469,6 +1473,5 @@ function StatisticsPortal._addArrays(arrays)
 		return Array.reduce(Array.map(arrays, Operator.property(index)), Operator.add)
 	end)
 end
-
 
 return Class.export(StatisticsPortal)


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/268719633366777856/1336632125872410685
games (usually) get stored as identifiers not as full names
hence enable the query to look for the identifiers too
due to possible custom input or wikis possibly storing game as name (instead of identifier) i leave the fallback of the plain input there too

## How did you test this change?
dev