### PR TITLE
feat: improve sorting the tournament ticker

### DIFF
--- a/lua/spec/operator_spec.lua
+++ b/lua/spec/operator_spec.lua
@@ -1,6 +1,7 @@
 --- Triple Comment to Enable our LLS Plugin
 describe('operator', function()
 	local Array = require('Module:Array')
+	local FnUtil = require('Module:FnUtil')
 	local Operator = require('Module:Operator')
 
 	describe('math', function()
@@ -103,6 +104,44 @@ describe('operator', function()
 				},
 			}
 			assert.are_same({4, 10, 7}, Array.map(foo, Operator.method('f', 1)))
+		end)
+	end)
+
+	describe('comparison', function()
+		it('lt', function()
+			local foo = {5, 3, 2, 1}
+			assert.are_same({5, 3, 2}, Array.filter(foo, FnUtil.curry(Operator.lt, 1)), 'lt')
+			assert.are_same({}, Array.filter(foo, FnUtil.curry(Operator.lt, 5)), 'lt')
+			assert.is_true(Operator.lt(1, 5))
+			assert.is_false(Operator.lt(1, 1))
+			assert.is_false(Operator.lt(5, 1))
+		end)
+
+		it('le', function()
+			local foo = {5, 3, 2, 1}
+			assert.are_same({5, 3, 2, 1}, Array.filter(foo, FnUtil.curry(Operator.le, 1)), 'le')
+			assert.are_same({5}, Array.filter(foo, FnUtil.curry(Operator.le, 5)), 'le')
+			assert.is_true(Operator.le(1, 5))
+			assert.is_true(Operator.le(1, 1))
+			assert.is_false(Operator.le(5, 1))
+		end)
+
+		it('gt', function()
+			local foo = {5, 3, 2, 1}
+			assert.are_same({}, Array.filter(foo, FnUtil.curry(Operator.gt, 1)), 'gt')
+			assert.are_same({3, 2, 1}, Array.filter(foo, FnUtil.curry(Operator.gt, 5)), 'gt')
+			assert.is_true(Operator.gt(5, 1))
+			assert.is_false(Operator.gt(1, 1))
+			assert.is_false(Operator.gt(1, 5))
+		end)
+
+		it('ge', function()
+			local foo = {5, 3, 2, 1}
+			assert.are_same({1}, Array.filter(foo, FnUtil.curry(Operator.ge, 1)), 'ge')
+			assert.are_same({5, 3, 2, 1}, Array.filter(foo, FnUtil.curry(Operator.ge, 5)), 'ge')
+			assert.is_true(Operator.ge(5, 1))
+			assert.is_true(Operator.ge(1, 1))
+			assert.is_false(Operator.ge(1, 5))
 		end)
 	end)
 end)

--- a/lua/wikis/commons/Operator.lua
+++ b/lua/wikis/commons/Operator.lua
@@ -66,6 +66,38 @@ function Operator.neq(a, b)
 	return a ~= b
 end
 
+--- Uses the __lt metamethod (a < b)
+---@param a any
+---@param b any
+---@return any
+function Operator.lt(a, b)
+	return a < b
+end
+
+--- Uses the __le metamethod (a <= b)
+---@param a any
+---@param b any
+---@return any
+function Operator.le(a, b)
+	return a <= b
+end
+
+--- Uses the __lt metamethod (b < a)
+---@param a any
+---@param b any
+---@return any
+function Operator.gt(a, b)
+	return a > b
+end
+
+--- Uses the __le metamethod (b <= a)
+---@param a any
+---@param b any
+---@return any
+function Operator.ge(a, b)
+	return a >= b
+end
+
 ---@param item string|number
 ---@return fun(tbl: table): any
 function Operator.property(item)

--- a/lua/wikis/commons/Widget/Tournaments/Ticker.lua
+++ b/lua/wikis/commons/Widget/Tournaments/Ticker.lua
@@ -13,6 +13,7 @@ local DateExt = require('Module:Date/Ext')
 local I18n = require('Module:I18n')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
@@ -87,30 +88,48 @@ function TournamentsTickerWidget:render()
 		end
 	end
 
-	local function sortByDate(a, b)
-		if not a.endDate then
+	---@param a StandardTournament
+	---@param b StandardTournament
+	---@param dateProperty 'endDate' | 'startDate'
+	---@param operator fun(a: StandardTournament, b: StandardTournament): boolean
+	local function sortByDateProperty(a, b, dateProperty, operator)
+		if not a[dateProperty] and not b[dateProperty] then
+			return nil
+		end
+		if not a[dateProperty] then
 			return true
 		end
-		if not b.endDate then
+		if not b[dateProperty] then
 			return false
 		end
-		if a.endDate.timestamp ~= b.endDate.timestamp then
-			return a.endDate.timestamp > b.endDate.timestamp
+		if a[dateProperty].timestamp ~= b[dateProperty].timestamp then
+			return operator(a[dateProperty].timestamp, b[dateProperty].timestamp)
 		end
-		return a.startDate.timestamp > b.startDate.timestamp
+		return nil
+	end
+
+	local function sortByDate(a, b)
+		local endDateSort = sortByDateProperty(a, b, 'endDate', Operator.gt)
+		if endDateSort ~= nil then
+			return endDateSort
+		end
+		local startDateSort = sortByDateProperty(a, b, 'startDate', Operator.gt)
+		if startDateSort ~= nil then
+			return startDateSort
+		end
+		return a.pageName < b.pageName
 	end
 
 	local function sortByDateUpcoming(a, b)
-		if a.startDate.timestamp ~= b.startDate.timestamp then
-			return a.startDate.timestamp > b.startDate.timestamp
+		local endDateSort = sortByDateProperty(a, b, 'startDate', Operator.gt)
+		if endDateSort ~= nil then
+			return endDateSort
 		end
-		if not a.endDate then
-			return true
+		local startDateSort = sortByDateProperty(a, b, 'endDate', Operator.gt)
+		if startDateSort ~= nil then
+			return startDateSort
 		end
-		if not b.endDate then
-			return false
-		end
-		return a.endDate.timestamp > b.endDate.timestamp
+		return a.pageName < b.pageName
 	end
 
 	local upcomingTournaments = Array.filter(allTournaments, filterByPhase('UPCOMING'))


### PR DESCRIPTION
## Summary
The new tournament ticker sometimes errors when there's bad dates (sort would not return the opposite between (`a, b` and `b, a`).
Sometimes display in non-optimal orders when one date is missing. 
This fixes it all

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
