### PR TITLE
feat(match2): Add team mode to fighters generator

### DIFF
--- a/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
@@ -54,9 +54,9 @@ end
 function WikiCopyPaste._getMap(mode)
 	local lines = Array.extend(
 		'={{Map',
-		INDENT .. INDENT .. '|map=',
-		INDENT .. INDENT .. (mode == Opponent.team and '|t1p1=' or '') .. '|o1p1={{Chars|}}|score1=',
-		INDENT .. INDENT .. (mode == Opponent.team and '|t2p1=' or '') .. '|o2p1={{Chars|}}|score2=',
+		mode == Opponent.team and INDENT .. INDENT .. '|t1p1=|t2p1=' or nil,
+		INDENT .. INDENT .. '|o1p1={{Chars|}}|o2p1={{Chars|}}',
+		INDENT .. INDENT .. '|score1=|score2=',
 		INDENT .. INDENT .. '|winner=',
 		INDENT .. '}}'
 	)

--- a/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
@@ -56,8 +56,7 @@ function WikiCopyPaste._getMap(mode)
 		'={{Map',
 		mode == Opponent.team and INDENT .. INDENT .. '|t1p1=|t2p1=' or nil,
 		INDENT .. INDENT .. '|o1p1={{Chars|}}|o2p1={{Chars|}}',
-		INDENT .. INDENT .. '|score1=|score2=',
-		INDENT .. INDENT .. '|winner=',
+		INDENT .. INDENT .. '|score1=|score2=|winner=',
 		INDENT .. '}}'
 	)
 	return table.concat(lines, '\n')

--- a/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/fighters/get_match_group_copy_paste_wiki.lua
@@ -13,6 +13,9 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+
 ---WikiSpecific Code for MatchList and Bracket Code Generators
 ---@class FightersMatchCopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
@@ -51,9 +54,10 @@ end
 function WikiCopyPaste._getMap(mode)
 	local lines = Array.extend(
 		'={{Map',
-		INDENT .. INDENT .. '|map=|winner=',
-		INDENT .. INDENT .. '|o1p1={{Chars|}}|o2p1={{Chars|}}',
-		INDENT .. INDENT .. '|score1=|score2=',
+		INDENT .. INDENT .. '|map=',
+		INDENT .. INDENT .. (mode == Opponent.team and '|t1p1=' or '') .. '|o1p1={{Chars|}}|score1=',
+		INDENT .. INDENT .. (mode == Opponent.team and '|t2p1=' or '') .. '|o2p1={{Chars|}}|score2=',
+		INDENT .. INDENT .. '|winner=',
 		INDENT .. '}}'
 	)
 	return table.concat(lines, '\n')


### PR DESCRIPTION
## Summary

Fighters match2 uses `tXpY` param for specifying which member of the team played the game. This PR adds these `tXpY` params (specifically, `t1p1` and `t2p1`) to the generator output when used under team mode.

## How did you test this change?

[dev](https://liquipedia.net/fighters/Special:RunQuery/BracketCopyPaste/dev)
