### PR TITLE
feat(mainpage): update image for statistics navbox in valorant mainpage

### DIFF
--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -108,7 +108,7 @@ return {
 			},
 		},
 		{
-			file = 'Valorant-champions-seoul-2024.jpg',
+			file = 'MIBR GC Coaches VCT GC Championship 2024.jpg',
 			title = 'Statistics',
 			link = 'Portal:Statistics',
 		},


### PR DESCRIPTION
## Summary

Transfers and statistics navcards used the same image and this was not caught in #5330, so this PR updates image for statistics navcard.

## How did you test this change?

dev
