### PR TITLE
feat(ExternalMediaList): Add option to display team icons besides EMLs

### DIFF
--- a/components/external_media_links/external_media_list.lua
+++ b/components/external_media_links/external_media_list.lua
@@ -336,11 +336,10 @@ end
 ---@param date string
 ---@return string?
 function MediaList._displayTeam(subject, date)
-	local team = PlayerExt.syncTeam(subject, nil, {date=date})
+	local team = PlayerExt.syncTeam(subject, nil, {date = date})
 	if not team then
 		return
 	end
-	---@cast team -nil
 	return Team.icon(nil, team)
 end
 

--- a/components/external_media_links/external_media_list.lua
+++ b/components/external_media_links/external_media_list.lua
@@ -15,9 +15,7 @@ local PlayerExt = require('Module:Player/Ext')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
-
-local OpponentLibraries = require('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Team = require('Module:Team')
 
 local MediaList = {}
 
@@ -339,12 +337,11 @@ end
 ---@return string?
 function MediaList._displayTeam(subject, date)
 	local team = PlayerExt.syncTeam(subject, nil, {date=date})
-
 	if not team then
 		return
 	end
 	---@cast team -nil
-	return OpponentDisplay.InlineTeamContainer{template=team, style='icon'}
+	return Team.icon(nil, team)
 end
 
 ---Displays the link to the Form with which External Media Links are to be created.

--- a/components/external_media_links/external_media_list.lua
+++ b/components/external_media_links/external_media_list.lua
@@ -11,9 +11,13 @@ local Class = require('Module:Class')
 local Flag = require('Module:Flags')
 local Logic = require('Module:Logic')
 local Page = require('Module:Page')
+local PlayerExt = require('Module:Player/Ext')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local MediaList = {}
 
@@ -60,13 +64,15 @@ function MediaList._parseArgs(args)
 	args.subject1 = args.subject1 or args.subject
 	args.player1 = args.player1 or args.player
 
+	local subjects = Array.mapIndexes(function(subjectIndex)
+		local subject = args['subject' .. subjectIndex] or args['player' .. subjectIndex]
+		return subject and mw.ext.TeamLiquidIntegration.resolve_redirect(subject) or nil
+	end)
+
 	return {
 		types = args.type and Array.map(Array.map(mw.text.split(args.type, ','), String.trim), string.lower) or nil,
 		author = args.author and mw.ext.TeamLiquidIntegration.resolve_redirect(args.author) or nil,
-		subjects = Array.mapIndexes(function(subjectIndex)
-			local subject = args['subject' .. subjectIndex] or args['player' .. subjectIndex]
-			return subject and mw.ext.TeamLiquidIntegration.resolve_redirect(subject) or nil
-		end),
+		subjects = subjects,
 		org = args.organization and mw.ext.TeamLiquidIntegration.resolve_redirect(args.organization) or nil,
 		showUsUk = Logic.readBool(args.show_usuk),
 		year = tonumber(args.year),
@@ -79,7 +85,8 @@ function MediaList._parseArgs(args)
 		event = Logic.readBool(args.event)
 			and mw.title.getCurrentTitle().prefixedText
 			or (args.event and mw.ext.TeamLiquidIntegration.resolve_redirect(args.event))
-			or nil
+			or nil,
+		showSubjectTeam = Logic.readBool(args.showSubjectTeam) and #subjects == 1
 	}
 end
 
@@ -227,6 +234,7 @@ end
 function MediaList._row(item, args)
 	local row = mw.html.create('li')
 		:node(MediaList._editButton(item.pagename))
+		:wikitext(args.showSubjectTeam and MediaList._displayTeam(args.subjects[1], item.date) or '')
 		:wikitext(item.date .. NON_BREAKING_SPACE .. '|' .. NON_BREAKING_SPACE)
 
 	if String.isNotEmpty(item.language) and item.language ~= 'en' and (item.language ~= 'usuk' or args.showUsUk) then
@@ -323,6 +331,20 @@ function MediaList._displayTranslation(item)
 	end
 
 	return translation .. NON_BREAKING_SPACE .. 'by' .. NON_BREAKING_SPACE .. item.extradata.translator .. ')'
+end
+
+---Displays the subject's team for a given External Media Link
+---@param subject string
+---@param date string
+---@return string?
+function MediaList._displayTeam(subject, date)
+	local team = PlayerExt.syncTeam(subject, nil, {date=date})
+
+	if not team then
+		return
+	end
+	---@cast team -nil
+	return OpponentDisplay.InlineTeamContainer{template=team, style='icon'}
 end
 
 ---Displays the link to the Form with which External Media Links are to be created.


### PR DESCRIPTION
## Summary
As requested by some TG-heavy wikis, e.g. valorant:
Automatically display the team icon of the subject at the time of the EML.
Only enabled when there is a single subject to query for, and the flag `showSubjectTeam` is set.
Requires TeamHistory datapoints to be saved on the player's page.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
