### PR TITLE
fix(opponent): smash char standardization errors due to game suffix

### DIFF
--- a/components/opponent/wikis/smash/opponent_custom.lua
+++ b/components/opponent/wikis/smash/opponent_custom.lua
@@ -34,7 +34,7 @@ function CustomOpponent.readOpponentArgs(args)
 	local game = args.game or Variables.varDefault('tournament_game') or Info.defaultGame
 	opponent.players[1].game = game
 
-	local CharacterStandardizationData = mw.loadData('Module:CharacterStandardization/' .. game)
+	local CharacterStandardizationData = mw.loadData('Module:CharacterStandardization')
 
 	Array.forEach(opponent.players, function (player, playerIndex)
 		local stringInput = args['chars' .. playerIndex] or (playerIndex == 1 and args.chars) or nil

--- a/components/opponent/wikis/smash/opponent_custom.lua
+++ b/components/opponent/wikis/smash/opponent_custom.lua
@@ -13,6 +13,7 @@ local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
+local CharacterStandardizationData = Lua.import('module:CharacterStandardization', {loadData = true})
 local Opponent = Lua.import('Module:Opponent')
 
 local CustomOpponent = Table.deepCopy(Opponent)
@@ -33,8 +34,6 @@ function CustomOpponent.readOpponentArgs(args)
 
 	local game = args.game or Variables.varDefault('tournament_game') or Info.defaultGame
 	opponent.players[1].game = game
-
-	local CharacterStandardizationData = mw.loadData('Module:CharacterStandardization')
 
 	Array.forEach(opponent.players, function (player, playerIndex)
 		local stringInput = args['chars' .. playerIndex] or (playerIndex == 1 and args.chars) or nil


### PR DESCRIPTION
## Summary

Smash uses a single module for character naming standardization. It is not broken out by game due to the shared rosters. Referring to game specific submodules for this breaks thousands of pages.

## How did you test this change?

live
