### PR TITLE
feat(opponent): Advanced filter and return for team history in Player/Ext

### DIFF
--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -32,6 +32,13 @@ local PlayerExt = {globalVars = globalVars}
 ---@field fetchMatch2Player boolean?
 ---@field date string|number|osdate?
 
+---@class PlayerExtSyncTeamOptions
+---@field date string|number|osdate?
+---@field useTimeless boolean?
+---@field fetchPlayer boolean?
+---@field savePageVar boolean?
+---@field returnRaw boolean?
+
 --[===[
 Splits a wiki link of a player into a pageName and displayName.
 
@@ -266,7 +273,7 @@ options.returnRaw: Whether to return the template without resolving. Disabled by
 ]]
 ---@param pageName string
 ---@param template string?
----@param options {date: string|number|osdate?, useTimeless: boolean, fetchPlayer: boolean, savePageVar: boolean, returnRaw: boolean}
+---@param options PlayerExtSyncTeamOptions
 ---@return string?
 function PlayerExt.syncTeam(pageName, template, options)
 	options = options or {}
@@ -315,7 +322,7 @@ function PlayerExt.syncTeam(pageName, template, options)
 
 	if options.returnRaw then
 		return entry and entry.raw or nil
-	end		
+	end
 	return entry and entry.template or nil
 end
 

--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -272,8 +272,8 @@ PlayerExt.syncTeam. Enabled by default.
 ---@param pageName string
 ---@param template string?
 ---@param options PlayerExtSyncTeamOptions
----@return string? template
 ---@return string? resolvedTemplate
+---@return string? rawTemplate
 function PlayerExt.syncTeam(pageName, template, options)
 	options = options or {}
 	local dateInput = Logic.emptyOr(options.date, DateExt.getContextualDateOrNow())

--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -268,12 +268,12 @@ options.savePageVar: Whether to save results to page variables. Enabled by
 default.
 options.useTimeless: Whether to use the template passed to a previous call of
 PlayerExt.syncTeam. Enabled by default.
-options.returnRaw: Whether to return the template without resolving. Disabled by default.
 ]]
 ---@param pageName string
 ---@param template string?
 ---@param options PlayerExtSyncTeamOptions
----@return string?
+---@return string? template
+---@return string? resolvedTemplate
 function PlayerExt.syncTeam(pageName, template, options)
 	options = options or {}
 	local dateInput = Logic.emptyOr(options.date, DateExt.getContextualDateOrNow())

--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -37,7 +37,6 @@ local PlayerExt = {globalVars = globalVars}
 ---@field useTimeless boolean?
 ---@field fetchPlayer boolean?
 ---@field savePageVar boolean?
----@field returnRaw boolean?
 
 --[===[
 Splits a wiki link of a player into a pageName and displayName.
@@ -320,10 +319,10 @@ function PlayerExt.syncTeam(pageName, template, options)
 		playerVars:set(pageName .. '.teamHistory', Json.stringify(history))
 	end
 
-	if options.returnRaw then
-		return entry and entry.raw or nil
+	if not entry then
+		return nil
 	end
-	return entry and entry.template or nil
+	return entry.template, entry.raw
 end
 
 ---Same as PlayerExt.syncTeam, except it does not save the player's team to page variables.

--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -262,10 +262,11 @@ options.savePageVar: Whether to save results to page variables. Enabled by
 default.
 options.useTimeless: Whether to use the template passed to a previous call of
 PlayerExt.syncTeam. Enabled by default.
+options.returnRaw: Whether to return the template without resolving. Disabled by default.
 ]]
 ---@param pageName string
 ---@param template string?
----@param options {date: string|number|osdate?, useTimeless: boolean, fetchPlayer: boolean, savePageVar: boolean}
+---@param options {date: string|number|osdate?, useTimeless: boolean, fetchPlayer: boolean, savePageVar: boolean, returnRaw: boolean}
 ---@return string?
 function PlayerExt.syncTeam(pageName, template, options)
 	options = options or {}
@@ -296,6 +297,7 @@ function PlayerExt.syncTeam(pageName, template, options)
 		or options.fetchPlayer ~= false and PlayerExt.fetchTeamHistoryEntry(pageName, options.date)
 
 	if entry and not entry.isResolved then
+		entry.raw = entry.template
 		entry.template = entry.template and TeamTemplate.resolve(entry.template, options.date)
 		entry.isResolved = true
 	end
@@ -311,6 +313,9 @@ function PlayerExt.syncTeam(pageName, template, options)
 		playerVars:set(pageName .. '.teamHistory', Json.stringify(history))
 	end
 
+	if options.returnRaw then
+		return entry and entry.raw or nil
+	end		
 	return entry and entry.template or nil
 end
 

--- a/components/opponent/commons/player_ext.lua
+++ b/components/opponent/commons/player_ext.lua
@@ -276,7 +276,7 @@ function PlayerExt.syncTeam(pageName, template, options)
 	local historyVar = playerVars:get(pageName .. '.teamHistory')
 	local history = historyVar and Json.parse(historyVar) or {}
 	local pageVarEntry = options.useTimeless ~= false and history.timeless
-		or Array.find(history, function(entry) return date < entry.leaveDate end)
+		or Array.find(history, function(entry) return entry.joinDate <= date and date < entry.leaveDate end)
 
 	local timelessEntry = template and {
 		isResolved = pageVarEntry and template == pageVarEntry.template,

--- a/components/opponent/wikis/rocketleague/player_ext_custom.lua
+++ b/components/opponent/wikis/rocketleague/player_ext_custom.lua
@@ -60,17 +60,20 @@ end
 
 ---@param pageName string
 ---@param template string?
----@param options {date: string|number|osdate?, useTimeless: boolean, fetchPlayer: boolean, savePageVar: boolean}
----@return string?
+---@param options PlayerExtSyncTeamOptions
+---@return string? resolvedTemplate
+---@return string? rawTemplate
 function PlayerExtCustom.syncTeam(pageName, template, options)
 	options = options or {}
 
-	template = PlayerExt.syncTeam(pageName, template, options)
-	if Logic.isNotEmpty(template) or options.fetchPlayer == false then return template end
+	local rawTemplate
+	template, rawTemplate = PlayerExt.syncTeam(pageName, template, options)
+	if Logic.isNotEmpty(template) or options.fetchPlayer == false then return template, rawTemplate end
 
 	local entry = PlayerExtCustom._fetchTeamFromPlacement(pageName, options.date) --[[@as table]]
 
 	if entry and not entry.isResolved then
+		entry.raw = entry.template
 		entry.template = entry.template and TeamTemplate.resolve(entry.template, options.date)
 		entry.isResolved = true
 	end
@@ -87,7 +90,10 @@ function PlayerExtCustom.syncTeam(pageName, template, options)
 		playerVars:set(pageName .. '.teamHistory', Json.stringify(history))
 	end
 
-	return entry and entry.template or nil
+	if not entry then
+		return nil
+	end
+	return entry.template, entry.raw
 end
 
 return PlayerExtCustom


### PR DESCRIPTION
## Summary
Noticed when testing #5419:
The team sync would only check the pagevars for leavedate, so when querying multiple dates in descending fashion, only the latest team would be returned.
This allows to query dates in either direction.

In addition, add option to return unresolved template. This is necessary to be able to display correct subtemplates when two different dates during the player's time on the time are queried, and there was a HTT change inbetween.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
