### PR TITLE
feat(infobox): set wiki vars in all namespaces

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -238,7 +238,6 @@ function Person:createInfobox()
 			)))
 
 	if self:shouldStoreData(args) then
-		self:_definePageVariables(args)
 		self:_setLpdbData(
 			args,
 			links,
@@ -246,6 +245,8 @@ function Person:createInfobox()
 			personType.store
 		)
 	end
+
+	self:_definePageVariables(args)
 
 	return self:build(widgets)
 end

--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -196,11 +196,13 @@ function Team:createInfobox()
 		self:categories(unpack(self:getWikiCategories(args)))
 	end
 
-	-- Store LPDB data and Wiki-variables
+	-- Store LPDB data
 	if self:shouldStore(args) then
 		self:_setLpdbData(args, links)
-		self:_definePageVariables(args)
 	end
+
+	-- Store Wiki-variables
+	self:_definePageVariables(args)
 
 	return self:build(widgets)
 end


### PR DESCRIPTION
## Summary

Define page variables even when outside of mainspace, since they would not have an effect outside of the page itself, unlike LPDB.

## How did you test this change?

TODO