### PR TITLE
feat(match2): use vod inside maps over vodgameX in LoL generator

### DIFF
--- a/lua/wikis/leagueoflegends/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/leagueoflegends/GetMatchGroupCopyPaste/wiki.lua
@@ -50,9 +50,6 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			end), ' ')
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return INDENT .. '|vodgame'.. mapIndex ..'='
-		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, args)
 		end),
 		'}}'
@@ -71,6 +68,7 @@ function WikiCopyPaste._getMapCode(mapIndex, args)
 	local bans = Logic.readBool(args.bans)
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map',
+		INDENT .. INDENT .. '|vod=',
 		INDENT .. INDENT .. '|team1side=',
 		INDENT .. INDENT .. '|t1c1= |t1c2= |t1c3= |t1c4= |t1c5=',
 		bans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,


### PR DESCRIPTION
## Summary

context: https://discord.com/channels/93055209017729024/268719633366777856/1338326984039727207

This PR kicks legacy `vodgameX` params used by LoL generator and adds `vod` params inside maps.

## How did you test this change?

dev
