### PR TITLE
feat(infobox): additional storage in the infobox hero on MLBB

### DIFF
--- a/components/infobox/wikis/mobilelegends/infobox_unit_hero_custom.lua
+++ b/components/infobox/wikis/mobilelegends/infobox_unit_hero_custom.lua
@@ -187,6 +187,10 @@ function CustomHero:setLpdbData(args)
 		image = args.image,
 		date = args.releasedate,
 		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
+			lane = args.lane,
+			primaryrole = args.primaryrole,
+			secondaryrole = args.secondaryrole,
+			region = args.region,
 			releasedate = args.releasedate,
 		})
 	}


### PR DESCRIPTION
## Summary
Store `lane`, `primaryrole`, `secondaryrole`, and `region` to LPDB
## How did you test this change?
[Tested in this page](https://liquipedia.net/mobilelegends/Arlott)
![Screenshot (22)](https://github.com/user-attachments/assets/2ab9b094-6ab7-4d0f-9ef8-36bb1adf635e)

