### PR TITLE
fix(mvpTable): Player Cell not left aligned

### DIFF
--- a/components/mvp_table/commons/mvp_table.lua
+++ b/components/mvp_table/commons/mvp_table.lua
@@ -185,7 +185,7 @@ end
 ---@return Html
 function MvpTable._row(item, args)
 	local row = mw.html.create('tr')
-		:tag('td'):node(OpponentDisplay.BlockOpponent{
+		:tag('td'):css('text-align', 'left'):node(OpponentDisplay.BlockOpponent{
 			opponent = {type = Opponent.solo, players = {{
 				displayName = item.displayName,
 				flag = item.flag,


### PR DESCRIPTION
## Summary
in #5372 the display was changed to use OpponentDisplay. But while doing so the left-alignment was removed, this PR re-adds the left-alignment.

reported on discord: https://discord.com/channels/93055209017729024/268719633366777856/1338646233283039272

## How did you test this change?
dev to live