### PR TITLE
feat(info): Add Tarkov Arena+War Thunder Info

### DIFF
--- a/standard/info/wikis/tarkovarena/info.lua
+++ b/standard/info/wikis/tarkovarena/info.lua
@@ -1,0 +1,41 @@
+---
+-- @Liquipedia
+-- wiki=tarkovarena
+-- page=Module:Info
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	startYear = 2023,
+	wikiName = 'tarkovarena',
+	name = 'Escape from Tarkov: Arena',
+	defaultGame = 'Escape from Tarkov: Arena',
+	games = {
+		tarkovarena = {
+			abbreviation = 'EFT Arena',
+			name = 'Escape from Tarkov: Arena',
+			link = 'Escape from Tarkov: Arena',
+			logo = {
+				darkMode = 'Tarkov Arena default allmode.png',
+				lightMode = 'Tarkov Arena default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Tarkov Arena default allmode.png',
+				lightMode = 'Tarkov Arena default allmode.png',
+			},
+		},
+	},
+	config = {
+		squads = {
+			hasPosition = false,
+			hasSpecialTeam = false,
+			allowManual = false,
+		},
+		match2 = {
+			status = 2,
+			matchWidth = 180,
+		},
+	},
+	defaultRoundPrecision = 0,
+}


### PR DESCRIPTION
For two newly installed wikis

Note: `tarkovarena` is the url of the wiki, while the full game name is `Escape From Tarkov: Arena` we use a shortened name for the url because too long