### PR TITLE
feat: add support for multiple time controls on chess

### DIFF
--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -75,9 +75,8 @@ function CustomInjector:parse(id, widgets)
 		)
 	elseif id == 'gamesettings' then
 		local isVariant = caller.data.game ~= Game.toIdentifier()
-		local modes = mw.text.split(caller.data.mode, ',')
 		Array.appendWith(widgets,
-			Cell{name = 'Time Control' .. (#modes > 1 and 's' or ''), content = modes},
+			Cell{name = 'Time Control' .. (#args.modes > 1 and 's' or ''), content = args.modes},
 			isVariant and Cell{name = 'Variant', content = {Game.name{game = caller.data.game}}} or nil
 		)
 	end
@@ -97,20 +96,23 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	Array.forEach(CustomLeague.getRestrictions(args.restrictions),
 		function(res) lpdbData.extradata['restriction_' .. res.data] = 1 end)
 
+	lpdbData.extradata.modes = args.modes
+
 	return lpdbData
 end
 
 ---@param args table
 function CustomLeague:customParseArguments(args)
-	local modes = {}
+	-- Modes.
+	self.args.modes = {}
 	local modePairs = Table.iter.pairsByPrefix(self.args, 'mode', {requireIndex = false})
 	for _, mode, _ in modePairs do
-		table.insert(modes, MODES[string.lower(mode)])
+		table.insert(self.args.modes, MODES[string.lower(mode)])
 	end
-	if Table.isEmpty(modes) then
-		modes = {MODES.classical}
+	if Table.isEmpty(self.args.modes) then
+		self.args.modes = {MODES.classical}
 	end
-	self.data.mode = table.concat(modes, ',')
+	self.data.mode = self.args.modes[1]
 end
 
 ---@param restrictions string?

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -97,7 +97,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	Array.forEach(CustomLeague.getRestrictions(args.restrictions),
 		function(res) lpdbData.extradata['restriction_' .. res.data] = 1 end)
 
-	lpdbData.extradata.modes = data.modes
+	lpdbData.extradata.modes = self.data.modes
 
 	return lpdbData
 end

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -106,7 +106,7 @@ function CustomLeague:customParseArguments(args)
 	-- Modes.
 	self.args.modes = {}
 	local modePairs = Table.iter.pairsByPrefix(self.args, 'mode', {requireIndex = false})
-	for _, mode, _ in modePairs do
+	for _, mode in modePairs do
 		table.insert(self.args.modes, MODES[string.lower(mode)])
 	end
 	if Table.isEmpty(self.args.modes) then

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -12,7 +12,6 @@ local Game = require('Module:Game')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
-local Table = require('Module:Table')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')

--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Game = require('Module:Game')
-local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 local Table = require('Module:Table')
@@ -76,7 +75,7 @@ function CustomInjector:parse(id, widgets)
 		)
 	elseif id == 'gamesettings' then
 		local isVariant = caller.data.game ~= Game.toIdentifier()
-		local modes = Json.parse(caller.data.mode)
+		local modes = mw.text.split(caller.data.mode, ',')
 		Array.appendWith(widgets,
 			Cell{name = 'Time Control' .. (#modes > 1 and 's' or ''), content = modes},
 			isVariant and Cell{name = 'Variant', content = {Game.name{game = caller.data.game}}} or nil
@@ -111,7 +110,7 @@ function CustomLeague:customParseArguments(args)
 	if Table.isEmpty(modes) then
 		modes = {MODES.classical}
 	end
-	self.data.mode = Json.stringify(modes)
+	self.data.mode = table.concat(modes, ',')
 end
 
 ---@param restrictions string?


### PR DESCRIPTION
## Summary

Add support for multiple time controls in league infobox.
Stores first time control as `mode` in LPDB, and all of them in `extradata`.
Displays as separate lines in infobox.

## How did you test this change?

/dev