### PR TITLE
feat: increase limit of imported entries per standingsTable

### DIFF
--- a/standard/tournament_structure.lua
+++ b/standard/tournament_structure.lua
@@ -266,7 +266,7 @@ function TournamentStructure.fetchGroupTableEntries(group)
 	local records = mw.ext.LiquipediaDB.lpdb('standingsentry', {
 		conditions = '[[standingsindex::' .. group.standingsindex .. ']] AND '
 			.. '[[pagename::' .. group.pagename .. ']] AND [[roundindex::' .. roundIndex .. ']]',
-		limit = '100',
+		limit = 1000,
 		query = 'scoreboard, currentstatus, extradata, opponenttype, '
 			.. 'opponentname, opponenttemplate, opponentplayers, placement'
 	})


### PR DESCRIPTION
## Summary
increase the limit of standingsentries that get imported per standingstable during e.g. PPT import from 100 to 1000

required by chess wiki as reported on discord:
https://discord.com/channels/93055209017729024/268719633366777856/1339215360381026436

## How did you test this change?
N/A