### PR TITLE
fix(Infobox): Stormgate Skill Infobox didn't show standard factions as caster of top-bar abilites

### DIFF
--- a/components/infobox/wikis/stormgate/infobox_skill_custom.lua
+++ b/components/infobox/wikis/stormgate/infobox_skill_custom.lua
@@ -145,6 +145,12 @@ function CustomSkill:_castersDisplay()
 	local casters = self:getAllArgsForBase(self.args, 'caster')
 
 	return Array.map(casters, function(caster)
+		local factionPageNames = Array.map(Faction.coreFactions, function (faction)
+			return Faction.getProps(faction)['pageName']
+		end)
+
+		if Table.includes(factionPageNames, caster) then return Page.makeInternalLink({}, caster, caster) end
+
 		local casterUnit = mw.ext.LiquipediaDB.lpdb('datapoint', {
 			conditions = '([[type::Unit]] OR [[type::Hero]] or [[type::building]]) AND [[pagename::'
 				.. string.gsub(caster, ' ', '_') .. ']]',


### PR DESCRIPTION
## Summary

Small bugfix for skill infobox display to show standard factions as casters for top-bar abilities similar as how it is done in SkillCards (this part was somehow missing in the last pr).

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

dev tools, i.e. 
- https://liquipedia.net/stormgate/Promote
- https://liquipedia.net/stormgate/Power_Surge
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
