### PR TITLE
fix(match2): missing nil catch sc(2)

### DIFF
--- a/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
+++ b/components/match2/commons/starcraft_starcraft2/match_group_util_starcraft.lua
@@ -148,7 +148,7 @@ function StarcraftMatchGroupUtil.computeGameOpponents(game, matchOpponents)
 			})
 		end) --[[@as table[] ]]
 
-		local isSpecialArchon = mode:match('^%dS$')
+		local isSpecialArchon = (mode or ''):match('^%dS$')
 		if isSpecialArchon then
 			-- Team melee: Sort players by the order they were inputted
 			table.sort(players, function(a, b) return a.position < b.position end)


### PR DESCRIPTION
## Summary
Add a missing nil catch in sc(2) MatchGroupUtil.
It is only relevant for ffa stuff.

## How did you test this change?
live as bug fix