### PR TITLE
feat(infobox): Add Update FIFAe Word Cup history to RL Infobox player

### DIFF
--- a/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_person_player_custom.lua
@@ -123,6 +123,7 @@ function CustomInjector:parse(id, widgets)
 		end
 
 		Array.extendWith(widgets,
+			getHistoryCells('history_fwc', '[[FIFAe World Cup|FIFAe World Cup]] History'),
 			getHistoryCells('history_iwo', '[[Intel World Open|Intel World Open]] History'),
 			getHistoryCells('history_gfinity', '[[Gfinity/Elite_Series|Gfinity Elite Series]] History'),
 			getHistoryCells('history_odl', '[[Oceania Draft League|Oceania Draft League]] History'),


### PR DESCRIPTION
## Summary
Adding FIFAe Word Cup history to player pages

## How did you test this change?
dev: https://liquipedia.net/rocketleague/User:Reidthesloth/Player_Card_Test