### PR TITLE
feat: Allow to modify tier-specific thresholds in TournamentsTicker

### DIFF
--- a/components/main_page/wikis/hearthstone/main_page_layout_data.lua
+++ b/components/main_page/wikis/hearthstone/main_page_layout_data.lua
@@ -60,7 +60,7 @@ local CONTENT = {
 	tournaments = {
 		heading = 'Tournaments',
 		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20}}',
+			'|upcomingDays=30|completedDays=20|modifierTypeQualifier=-2|modifierTier1=55|modifierTier2=55|modifierTier3=10}}',
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -60,7 +60,7 @@ local CONTENT = {
 	tournaments = {
 		heading = 'Tournaments',
 		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20}}',
+			'|upcomingDays=30|completedDays=20|modifierTypeQualifier=-2|modifierTier1=55|modifierTier2=55|modifierTier3=10}}',
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/widget/tournaments/widget_tournaments_ticker.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker.lua
@@ -33,19 +33,18 @@ function TournamentsTickerWidget:render()
 	local upcomingDays = self.props.upcomingDays
 	local completedDays = self.props.completedDays
 
-	--- These thresholds makes very little sense, but it's converted from legacy.
-	--- Let's revisit them with product, design and community at the later date
 	local tierThresholdModifiers = {
-		[1] = 55,
-		[2] = 55,
-		[3] = 22,
-		[4] = 0,
-		[5] = 0,
+		[1] = self.props.modifierTier1,
+		[2] = self.props.modifierTier2,
+		[3] = self.props.modifierTier3,
+		[4] = self.props.modifierTier4,
+		[5] = self.props.modifierTier5,
+		[-1] = self.props.modifierTierMisc,
 	}
 
 	--- The Tier Type thresholds only affect completed tournaments.
 	local tierTypeThresholdModifiers = {
-		['qualifier'] = -2,
+		['qualifier'] = self.props.modifierTypeQualifier,
 	}
 
 	local currentTimestamp = DateExt.getCurrentTimestamp()


### PR DESCRIPTION
## Summary
The legacy offsets previously added were only part of the commons version of the old ticker.
Most wikis (including most of the ones already converted to this) already had different local versions, with less weird offsets.
This allows to add the offsets, if necessary, via arguments.

IMO the default should be no offsets at all, and mainpage data can include them based on the specific old version the wiki used.

Check existing new main pages for old offsets:
- [x] apex - no modifiers
- [x] arenafps - used commons modifiers since november, 60/60 reduced to 40/40
- [x] deadlock - used commons modifiers, 120/60 reduced to 60/20
- [x] dota2 - previously 90 up, 30 completed, reduced to 30/20 now
- [x] fortnite - used commons modifiers since november
- [x] halo - used commons modifiers since november
- [x] hearthstone - 60/30 to 30/20, commons modifiers
- [x] lol - commons modifiers, 45/20 to 30/20
- [x] pubg - commons since june
- [x] pubgm - commons since august
- [x] r6 - commons since august
- [x] valorant - no modifiers
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
"dev" by checking the tables have correct content and timestamps are modified
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
