### PR TITLE
feat: Dota 2 Rankings table for the main rankings page

### DIFF
--- a/components/ratings/ratings_storage_extension.lua
+++ b/components/ratings/ratings_storage_extension.lua
@@ -1,0 +1,131 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Ratings/Storage/Extension
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Date = require('Module:Date/Ext')
+local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
+
+local RatingsStorageExtension = {}
+
+local PROGRESSION_STEP_DAYS = 7 -- How many days each progression step is
+
+---@param date string
+---@param teamLimit integer?
+---@param progressionLimit integer?
+---@return RatingsEntry[]
+function RatingsStorageExtension.getRankings(date, teamLimit, progressionLimit)
+	if not date then
+		error('No date provided')
+	end
+	if date > Date.getContextualDateOrNow() then
+		error('Cannot get rankings for future date')
+	end
+	-- Calculate Progression Points
+	local progressionDates = {}
+	progressionLimit = progressionLimit or 1
+	local nextProgression = Date.parseIsoDate(date)
+	table.insert(progressionDates, os.date('%F', os.time(nextProgression)) --[[@as string]])
+	for _ = 1, progressionLimit do
+		nextProgression.day = nextProgression.day - PROGRESSION_STEP_DAYS
+		table.insert(progressionDates, os.date('%F', os.time(nextProgression)) --[[@as string]])
+	end
+
+	-- Get the ratings and progression
+	local teams = mw.ext.Dota2Ranking.get(progressionDates[#progressionDates], date)
+	-- Endpoint doesn't support team limit (yet?), so we'll have to cut it short here
+	teams = Array.sub(teams, 1, math.min(teamLimit or #teams))
+
+	-- Add additional data to the teams
+	return Array.map(teams, function(team)
+		local teamInfo = RatingsStorageExtension._getTeamInfo(team.name)
+
+		-- Parse progression data
+		local teamProgressionParsed = Array.map(team.progression, function(progression)
+			return RatingsStorageExtension._progressionRecord(progression.date, progression.rating, progression.rank)
+		end)
+		-- We need to add the current day to the progression too
+		local progressionToday = RatingsStorageExtension._progressionRecord(progressionDates[1], team.rating, team.rank)
+		table.insert(teamProgressionParsed, 1, progressionToday)
+
+		-- Map to correct order and prepare for missing data
+		local progression = Array.map(progressionDates, function(progressionDate)
+			return Array.find(teamProgressionParsed, function(progression)
+				return progression.date == progressionDate
+			end) or {
+				date = progressionDate,
+			}
+		end)
+
+		local isNew = not progression[2].rank
+		---@type RatingsEntry
+		local newTeam = {
+			name = team.name,
+			rank = team.rank,
+			rating = RatingsStorageExtension._normalizeRating(team.rating),
+			region = teamInfo.region,
+			opponent = Opponent.resolve(Opponent.readOpponentArgs({type = Opponent.team, team.name}), date),
+			change = not isNew and progression[2].rank - progression[1].rank or nil,
+			streak = team.streak,
+			progression = progression,
+		}
+		return newTeam
+	end)
+end
+
+--- Create a progression entry
+---@param date string
+---@param rating number
+---@param rank integer
+---@return {date: string, rating: number, rank: integer}
+function RatingsStorageExtension._progressionRecord(date, rating, rank)
+	return {
+		date = date,
+		rating = RatingsStorageExtension._normalizeRating(rating),
+		rank = rank,
+	}
+end
+
+--- Normalize a rating
+---@param rating number
+---@return number
+function RatingsStorageExtension._normalizeRating(rating)
+	return math.floor((rating * 1000) + 0.5)
+end
+
+--- Get team information from Team Template and Team Page
+---@param teamName string
+---@return {region: string?}
+function RatingsStorageExtension._getTeamInfo(teamName)
+	local teamInfo = RatingsStorageExtension._fetchTeamInfo(teamName)
+
+	return {
+		region = teamInfo.region,
+	}
+end
+
+--- Fetch team information from Team Page
+---@param name string
+---@return {region: string?}
+function RatingsStorageExtension._fetchTeamInfo(name)
+	local res = mw.ext.LiquipediaDB.lpdb(
+		'team',
+		{
+			query = 'region, template',
+			limit = 1,
+			conditions = '[[pagename::' .. string.gsub(name, ' ', '_') .. ']]'
+		}
+	)
+	if not res[1] then
+		mw.log('Warning: Cannot find teampage for ' .. name)
+	end
+
+	return res[1] or {}
+end
+
+return RatingsStorageExtension

--- a/components/ratings/ratings_storage_factory.lua
+++ b/components/ratings/ratings_storage_factory.lua
@@ -1,0 +1,42 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Ratings/Storage/Factory
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local FnUtil = require('Module:FnUtil')
+
+---@class RatingsEntry
+---@field opponent standardOpponent
+---@field rating number
+---@field region string
+---@field streak integer
+---@field change integer? # nil = new, otherwise indicate change in rank
+---@field progression {date: string, rating: number?, rank: integer?}[]
+
+---@alias RatingsDisplayGetRankings fun(teamLimit: integer, progressionLimit?: integer):RatingsEntry[]
+
+local RatingsStorageFactory = {}
+
+---@param props {storageType: 'lpdb'|'extension', id: string?, date: string?}
+---@return RatingsDisplayGetRankings
+function RatingsStorageFactory.createGetRankings(props)
+	local storageType = props.storageType
+
+	if storageType == 'lpdb' then
+		error('LPDB Not Yet Supported by the revamp')
+		local RatingsStorageLpdb = require('Module:Ratings/Storage/Lpdb')
+		assert(props.id, 'ID is required for LPDB storage')
+		return FnUtil.curry(RatingsStorageLpdb.getRankings, props.id)
+	elseif storageType == 'extension' then
+		local RatingsStorageExtension = require('Module:Ratings/Storage/Extension')
+		local date = props.date
+		return FnUtil.curry(RatingsStorageExtension.getRankings, date)
+	end
+
+	error('Unknown storage type: ' .. (storageType or ''))
+end
+
+return RatingsStorageFactory

--- a/components/ratings/ratings_storage_factory.lua
+++ b/components/ratings/ratings_storage_factory.lua
@@ -20,17 +20,11 @@ local FnUtil = require('Module:FnUtil')
 
 local RatingsStorageFactory = {}
 
----@param props {storageType: 'lpdb'|'extension', id: string?, date: string?}
+---@param props {storageType: 'extension', id: string?, date: string?}
 ---@return RatingsDisplayGetRankings
 function RatingsStorageFactory.createGetRankings(props)
 	local storageType = props.storageType
-
-	if storageType == 'lpdb' then
-		error('LPDB Not Yet Supported by the revamp')
-		local RatingsStorageLpdb = require('Module:Ratings/Storage/Lpdb')
-		assert(props.id, 'ID is required for LPDB storage')
-		return FnUtil.curry(RatingsStorageLpdb.getRankings, props.id)
-	elseif storageType == 'extension' then
+	if storageType == 'extension' then
 		local RatingsStorageExtension = require('Module:Ratings/Storage/Extension')
 		local date = props.date
 		return FnUtil.curry(RatingsStorageExtension.getRankings, date)

--- a/components/ratings/rocketleague/ratings_display.lua
+++ b/components/ratings/rocketleague/ratings_display.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=commons
+-- wiki=rocketleague
 -- page=Module:Ratings/Display
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -12,7 +12,7 @@ local RatingsStorageLpdb = require('Module:Ratings/Storage/Lpdb')
 
 local RatingsDisplay = {}
 
----@class RatingsEntry
+---@class RatingsEntryOld
 ---@field matches integer
 ---@field name string
 ---@field rating number
@@ -22,7 +22,7 @@ local RatingsDisplay = {}
 ---@field progression table[]
 
 ---@class RatingsDisplayInterface
----@field build fun(teamRankings: RatingsEntry[]):string
+---@field build fun(teamRankings: RatingsEntryOld[]):string
 
 local LIMIT_HISTORIC_ENTRIES = 24 -- How many historic entries are fetched
 
@@ -55,7 +55,7 @@ end
 
 ---@param id string
 ---@param progressionLimit integer
----@return RatingsEntry[]
+---@return RatingsEntryOld[]
 function RatingsDisplay._getTeamRankings(id, progressionLimit)
 	local teams = RatingsStorageLpdb.getRankings(id, progressionLimit)
 

--- a/components/ratings/rocketleague/ratings_display_graph.lua
+++ b/components/ratings/rocketleague/ratings_display_graph.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=commons
+-- wiki=rocketleague
 -- page=Module:Ratings/Display/Graph
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -16,7 +16,7 @@ local RatingsDisplayGraph = {}
 local LIMIT_TEAMS = 10 -- How many teams to show in the combined graph
 local LIMIT_TEAMS_SELECTED = 5 -- How many teams are preselected in the graph
 
----@param teamRankings RatingsEntry[]
+---@param teamRankings RatingsEntryOld[]
 ---@return string
 function RatingsDisplayGraph.build(teamRankings)
 	local teams = Array.sub(teamRankings, 1, LIMIT_TEAMS)

--- a/components/ratings/rocketleague/ratings_display_list.lua
+++ b/components/ratings/rocketleague/ratings_display_list.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=commons
+-- wiki=rocketleague
 -- page=Module:Ratings/Display/List
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -15,7 +15,7 @@ local RatingsDisplayList = {}
 
 local LIMIT_TEAMS = 100 -- How many teams to show in the list/table
 
----@param teamRankings RatingsEntry[]
+---@param teamRankings RatingsEntryOld[]
 ---@return string
 function RatingsDisplayList.build(teamRankings)
 	local teams = Array.sub(teamRankings, 1, LIMIT_TEAMS)

--- a/components/ratings/rocketleague/ratings_storage_lpdb.lua
+++ b/components/ratings/rocketleague/ratings_storage_lpdb.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- wiki=commons
+-- wiki=rocketleague
 -- page=Module:Ratings/Storage/Lpdb
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/components/widget/ratings/widget_ratings.lua
+++ b/components/widget/ratings/widget_ratings.lua
@@ -1,0 +1,74 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Ratings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Date = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local Info = Lua.import('Module:Info')
+local Widget = Lua.import('Module:Widget')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local RatingsList = Lua.import('Module:Widget/Ratings/List')
+
+---@class Ratings: Widget
+---@operator call(table): Ratings
+local Ratings = Class.new(Widget)
+Ratings.defaultProps = {
+	teamLimit = 20,
+	progressionLimit = 10,
+	dropdownLimit = 12,
+	storageType = 'lpdb',
+	date = os.date('%F') --[[@as string]],
+}
+
+---@param date string #iso formated date string (YYYY-MM-DD)
+---@param interval 'weekly' | 'monthly'
+---@return unknown
+local function earlierValidDate(date, interval)
+	local simplifiedParsedDate = Date.parseIsoDate(date)
+	if not simplifiedParsedDate then
+		error('Invalid date provided')
+	end
+	local parsedDate = os.date('*t', os.time(simplifiedParsedDate))
+	if interval == 'weekly' then
+		-- 1 is Sunday, 2 is Monday, ..., 7 is Saturday
+		-- american week counting
+		if parsedDate.wday == 1 then
+			parsedDate.day = parsedDate.day - 6
+		else
+			parsedDate.day = parsedDate.day - parsedDate.wday + 2
+		end
+		return parsedDate
+	elseif interval == 'monthly' then
+		parsedDate.day = 1
+		return parsedDate
+	end
+	error('Invalid interval specific for ratings')
+end
+
+---@return Widget
+function Ratings:render()
+	local actualDate = earlierValidDate(self.props.date, Info.config.ratings.interval)
+
+	return HtmlWidgets.Div {
+		attributes = {
+			class = 'ranking-table__wrapper',
+		},
+		children = WidgetUtil.collect(
+			RatingsList {
+				teamLimit = self.props.teamLimit,
+				progressionLimit = self.props.progressionLimit,
+				storageType = self.props.storageType,
+				date = actualDate,
+			}
+		),
+	}
+end
+
+return Ratings

--- a/components/widget/ratings/widget_ratings_list.lua
+++ b/components/widget/ratings/widget_ratings_list.lua
@@ -1,0 +1,129 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Ratings/List
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Flags = require('Module:Flags')
+local Lua = require('Module:Lua')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
+local Widget = Lua.import('Module:Widget')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local PlacementChange = Lua.import('Module:Widget/Standings/PlacementChange')
+local RatingsStorageFactory = Lua.import('Module:Ratings/Storage/Factory')
+
+---@class RatingsList: Widget
+---@field _base Widget
+---@operator call(table): RatingsList
+local RatingsList = Class.new(Widget)
+
+---@return Widget
+function RatingsList:render()
+	-- Simple check to verify that the input is a osdate
+	assert(self.props.date and self.props.date.wday, 'Invalid date provided')
+	---@type osdate
+	local date = self.props.date
+	local dateAsString = os.date('%F', os.time(date)) --[[@as string]]
+
+	local teamLimit = tonumber(self.props.teamLimit) or self.defaultProps.teamLimit
+	local progressionLimit = tonumber(self.props.progressionLimit) or self.defaultProps.progressionLimit
+
+	local getRankings = RatingsStorageFactory.createGetRankings {
+		storageType = self.props.storageType,
+		date = dateAsString,
+		id = self.props.id,
+	}
+	local teams = getRankings(teamLimit, progressionLimit)
+
+	local teamRows = Array.map(teams, function(team, rank)
+		local streakText = team.streak > 1 and team.streak .. 'W' or (team.streak < -1 and (-team.streak) .. 'L') or '-'
+		local streakClass = (team.streak > 1 and 'group-table-rank-change-up')
+			or (team.streak < -1 and 'group-table-rank-change-down')
+			or nil
+
+		local changeText = (not team.change and 'NEW') or PlacementChange { change = team.change }
+
+		local teamRow = WidgetUtil.collect(
+			HtmlWidgets.Td { attributes = { ['data-ranking-table-cell'] = 'rank' }, children = rank },
+			HtmlWidgets.Td { attributes = { ['data-ranking-table-cell'] = 'change' }, children = changeText },
+			HtmlWidgets.Td {
+				attributes = { ['data-ranking-table-cell'] = 'team' },
+				children = OpponentDisplay.BlockOpponent { opponent = team.opponent, teamStyle = 'hybrid' }
+			},
+			HtmlWidgets.Td { attributes = { ['data-ranking-table-cell'] = 'rating' }, children = team.rating },
+			HtmlWidgets.Td {
+				attributes = { ['data-ranking-table-cell'] = 'region' },
+				children = Flags.Icon(team.region) .. Flags.CountryName(team.region)
+			},
+			HtmlWidgets.Td {
+				attributes = { ['data-ranking-table-cell'] = 'streak' },
+				children = streakText,
+				classes = { streakClass }
+			}
+		)
+
+		local isEven = rank % 2 == 0
+		local rowClasses = { 'ranking-table__row' }
+		if isEven then
+			table.insert(rowClasses, 'ranking-table__row--even')
+		end
+		return {
+			HtmlWidgets.Tr { children = teamRow, classes = rowClasses },
+		}
+	end)
+
+	local formattedDate = os.date('%b %d, %Y', os.time(date)) --[[@as string]]
+	local tableHeader = HtmlWidgets.Tr {
+		children = HtmlWidgets.Th {
+			attributes = { colspan = '7' },
+			children = HtmlWidgets.Div {
+				children = { 'Last updated: ' .. formattedDate, '[[File:DataProvidedSAP.svg|link=]]' }
+			},
+			classes = { 'ranking-table__top-row' },
+		}
+	}
+
+	return HtmlWidgets.Div {
+		attributes = {
+			['data-ranking-table'] = 'content',
+		},
+		children = WidgetUtil.collect(
+			HtmlWidgets.Table {
+				attributes = { ['data-ranking-table'] = 'table' },
+				classes = { 'ranking-table' },
+				children = WidgetUtil.collect(
+					tableHeader,
+					HtmlWidgets.Tr {
+						children = WidgetUtil.collect(
+							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'rank' }, children = 'Rank' },
+							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'change' }, children = '+/-' },
+							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'team' }, children = 'Team' },
+							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'rating' }, children = 'Points' },
+							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'region' }, children = 'Region' },
+							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'streak' }, children = 'Streak' }
+						),
+						classes = { 'ranking-table__header-row' },
+					},
+					Array.flatten(teamRows)
+				)
+			}
+		)
+	}
+end
+
+---@param error Error
+---@return string
+function RatingsList:getDerivedStateFromError(error)
+	error.message = 'Could not load the selected week.'
+	return self._base:getDerivedStateFromError(error)
+end
+
+return RatingsList

--- a/components/widget/standings/widget_standings_placement_change.lua
+++ b/components/widget/standings/widget_standings_placement_change.lua
@@ -24,7 +24,7 @@ PlacementChangeWidget.defaultProps = {
 function PlacementChangeWidget:render()
 	local change = self.props.change
 	if change == 0 then
-		return
+		return HtmlWidgets.Span{children = '-'}
 	end
 	local positive = change > 0
 	return HtmlWidgets.Span{

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -953,6 +953,14 @@ function mw.uri.fullUrl(s, s2) return 'https://liquipedia.net/' end
 mw.ext = {}
 mw.ext.LiquipediaDB = require('definitions.liquipedia_db')
 
+mw.ext.Dota2Ranking = {}
+
+---@param startDate string #YYYY-MM-DD
+---@param endDate string #YYYY-MM-DD
+---@return {name: string, rank: integer, rating: number, streak: integer,
+---progression: {date: string, rating: number, rank: integer}[]}[]
+function mw.ext.Dota2Ranking.get(startDate, endDate) end
+
 mw.ext.VariablesLua = {}
 ---@alias wikiVariableKey string|number
 ---@alias wikiVariableValue string|number|nil

--- a/definitions/mw.lua
+++ b/definitions/mw.lua
@@ -955,10 +955,11 @@ mw.ext.LiquipediaDB = require('definitions.liquipedia_db')
 
 mw.ext.Dota2Ranking = {}
 
+---@alias Dota2RankingRecord {name: string, rank: integer, rating: number, streak: integer,
+---progression: {date: string, rating: number, rank: integer}[]}
 ---@param startDate string #YYYY-MM-DD
 ---@param endDate string #YYYY-MM-DD
----@return {name: string, rank: integer, rating: number, streak: integer,
----progression: {date: string, rating: number, rank: integer}[]}[]
+---@return Dota2RankingRecord[]
 function mw.ext.Dota2Ranking.get(startDate, endDate) end
 
 mw.ext.VariablesLua = {}

--- a/standard/info/wikis/dota2/info.lua
+++ b/standard/info/wikis/dota2/info.lua
@@ -50,6 +50,9 @@ return {
 			status = 2,
 			matchWidth = 180,
 		},
+		ratings = {
+			interval = 'weekly',
+		}
 	},
 	defaultRoundPrecision = 0,
 }

--- a/stylesheets/commons/RankingTable.less
+++ b/stylesheets/commons/RankingTable.less
@@ -1,0 +1,165 @@
+.ranking-table {
+	&__wrapper {
+		--_border-color: rgba( 0, 0, 0, 0.16 );
+		--_background-color: rgba( 0, 0, 0, 0.08 );
+		--_background-color-even: rgba( 0, 0, 0, 0.04 );
+		--_border: 0.0625rem solid var( --_border-color );
+		--_patch-label-color: var( --clr-secondary-16 );
+
+		.theme--dark & {
+			--_border-color: rgba( 255, 255, 255, 0.16 );
+			--_background-color: rgba( 255, 255, 255, 0.08 );
+			--_background-color-even: rgba( 255, 255, 255, 0.04 );
+			--_patch-label-color: #ffffff;
+		}
+	}
+	border: var( --_border );
+
+	@media ( max-width: 768px ) {
+		font-size: 0.875rem;
+	}
+
+	&__top-row {
+		background-color: var( --_background-color );
+		padding: 1rem 0.75rem;
+		border-bottom: var( --_border );
+		font-weight: normal;
+
+		> div {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+
+			@media ( max-width: 768px ) {
+				flex-direction: column;
+				align-items: flex-start;
+			}
+		}
+	}
+
+	&__footer-row {
+		padding: 1rem 0.75rem;
+		font-weight: bold;
+
+		div {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 0.5rem;
+		}
+	}
+
+	&__header-row {
+		background-color: var( --_background-color );
+		border-bottom: var( --_border );
+
+		th {
+			padding: 0.5rem 1rem;
+
+			&:not( :first-child ) {
+				border-left: var( --_border );
+			}
+		}
+	}
+
+	&__row {
+		&:not( :first-child ) {
+			border-top: var( --_border );
+		}
+
+		&:not( :last-child ) {
+			border-bottom: var( --_border );
+		}
+
+		&--even {
+			background-color: var( --_background-color-even );
+		}
+
+		&--overfive {
+			@media ( max-width: 768px ) {
+				display: none;
+			}
+		}
+
+		> td {
+			padding: 0.5rem 1rem;
+
+			@media ( max-width: 768px ) {
+				padding: 0.5rem 0.75rem;
+			}
+
+			&:not( :first-child ) {
+				border-left: var( --_border );
+			}
+
+			.flag {
+				margin-right: 0.5rem;
+			}
+		}
+	}
+
+	&__toggle-graph {
+		cursor: pointer;
+		display: flex;
+		height: 100%;
+		position: absolute;
+		inset: 0;
+		align-items: center;
+		justify-content: center;
+
+		&[ aria-expanded="true" ] > i {
+			transform: rotate( 180deg );
+		}
+
+		& > i {
+			transition: transform 0.2s linear;
+		}
+
+		td&-cell {
+			padding: 0;
+			position: relative;
+		}
+	}
+
+	&__graph-row-container {
+		padding: 1.5rem;
+
+		.team-template-team-standard {
+			display: flex;
+			justify-content: center;
+			font-weight: bold;
+		}
+	}
+
+	// Hide table cells region and streak on mobile due to limited horizontal space
+	@media ( max-width: 768px ) {
+		[ data-ranking-table-cell="region" ],
+		[ data-ranking-table-cell="streak" ] {
+			display: none;
+		}
+	}
+
+	&--small {
+		[ data-ranking-table-cell="region" ],
+		[ data-ranking-table-cell="streak" ] {
+			display: none;
+		}
+	}
+
+	&__select-container {
+		margin-bottom: 1rem;
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+
+		& > select.ranking-table__select {
+			border-color: var( --_border-color );
+			background-color: var( --_background-color );
+		}
+	}
+
+	&__patch-label {
+		color: var( --_patch-label-color );
+		opacity: 0.7;
+	}
+}


### PR DESCRIPTION
## Summary
A data table, showing the top 20 Dota 2 teams, updated weekly.

Existing RL ratings system is moved to RL specific, to be merged into this flow at a later time.
## How did you test this change?

Laura's dev wiki