### PR TITLE
feat: team rankings progression graph on rankings table

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
 	],
 	"globals": {
 		"liquipedia": "readonly",
+		"echarts": "readonly",
 		"_paq": "readonly",
 		"gtag": "readonly",
 		"Share": "readonly"

--- a/components/widget/ratings/widget_ratings.lua
+++ b/components/widget/ratings/widget_ratings.lua
@@ -25,6 +25,7 @@ Ratings.defaultProps = {
 	dropdownLimit = 12,
 	storageType = 'lpdb',
 	date = os.date('%F') --[[@as string]],
+	showGraph = true,
 }
 
 --- Finds the latest valid start date for the ratings
@@ -67,6 +68,7 @@ function Ratings:render()
 				progressionLimit = self.props.progressionLimit,
 				storageType = self.props.storageType,
 				date = startDate,
+				showGraph = self.props.showGraph,
 			}
 		),
 	}

--- a/components/widget/ratings/widget_ratings_list.lua
+++ b/components/widget/ratings/widget_ratings_list.lua
@@ -31,10 +31,10 @@ local RatingsStorageFactory = Lua.import('Module:Ratings/Storage/Factory')
 local RatingsList = Class.new(Widget)
 
 ---@param teamData RatingsEntry
----@param standardYMax integer
+---@param defaultMaxY integer
 ---@return string
-local function makeTeamChart(teamData, standardYMax)
-	local progression = Array.reverse(teamData.progression) -- TODO: Sort instead
+local function makeTeamChart(teamData, defaultMaxY)
+	local progression = Array.sortBy(teamData.progression, Operator.property('date'))
 	local worstRankOfTeam = Array.max(Array.map(progression, Operator.property('rank')))
 
 	local dates = Array.map(Array.map(progression, Operator.property('date')), function(isoDate)
@@ -55,7 +55,7 @@ local function makeTeamChart(teamData, standardYMax)
 			type = 'value',
 			inverse = true,
 			min = 1,
-			max = math.max(worstRankOfTeam, standardYMax),
+			max = math.max(worstRankOfTeam, defaultMaxY),
 		},
 		tooltip = {
 			trigger = 'axis',

--- a/components/widget/ratings/widget_ratings_list.lua
+++ b/components/widget/ratings/widget_ratings_list.lua
@@ -8,8 +8,12 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Date = require('Module:Date/Ext')
 local Flags = require('Module:Flags')
+local Icon = require('Module:Icon')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
 
 local OpponentLibraries = require('Module:OpponentLibraries')
 local OpponentDisplay = OpponentLibraries.OpponentDisplay
@@ -25,6 +29,59 @@ local RatingsStorageFactory = Lua.import('Module:Ratings/Storage/Factory')
 ---@operator call(table): RatingsList
 local RatingsList = Class.new(Widget)
 
+---@param teamData RatingsEntry
+---@param standardYMax integer
+---@return string
+local function makeTeamChart(teamData, standardYMax)
+	local progression = Array.reverse(teamData.progression) -- TODO: Sort instead
+	local worstRankOfTeam = Array.max(Array.map(progression, Operator.property('rank')))
+
+	local dates = Array.map(Array.map(progression, Operator.property('date')), function(isoDate)
+		return os.date('%b %d', os.time(Date.parseIsoDate(isoDate)))
+	end)
+
+	return mw.ext.Charts.chart {
+		xAxis = {
+			name = 'Date',
+			nameLocation = 'middle',
+			type = 'category',
+			data = dates,
+		},
+		yAxis = {
+			name = 'Rank',
+			nameLocation = 'middle',
+			nameRotate = 90,
+			type = 'value',
+			inverse = true,
+			min = 1,
+			max = math.max(worstRankOfTeam, standardYMax),
+		},
+		tooltip = {
+			trigger = 'axis',
+		},
+		grid = {
+			show = true,
+		},
+		size = {
+			height = 250,
+			pwidth = 100,
+		},
+		series = {
+			{
+				data = Array.map(progression, function(progress)
+					return progress.rank and tostring(progress.rank) or ''
+				end),
+				type = 'line',
+				name = 'Rank',
+				symbolSize = 8,
+				itemStyle = {
+					color = '#EE6666',
+				},
+			}
+		}
+	}
+end
+
 ---@return Widget
 function RatingsList:render()
 	-- Simple check to verify that the input is a osdate
@@ -35,6 +92,7 @@ function RatingsList:render()
 
 	local teamLimit = tonumber(self.props.teamLimit) or self.defaultProps.teamLimit
 	local progressionLimit = tonumber(self.props.progressionLimit) or self.defaultProps.progressionLimit
+	local showGraph = Logic.readBool(self.props.showGraph)
 
 	local getRankings = RatingsStorageFactory.createGetRankings {
 		storageType = self.props.storageType,
@@ -44,6 +102,7 @@ function RatingsList:render()
 	local teams = getRankings(teamLimit, progressionLimit)
 
 	local teamRows = Array.map(teams, function(team, rank)
+		local uniqueId = dateAsString .. '-' .. rank
 		local streakText = team.streak > 1 and team.streak .. 'W' or (team.streak < -1 and (-team.streak) .. 'L') or '-'
 		local streakClass = (team.streak > 1 and 'group-table-rank-change-up')
 			or (team.streak < -1 and 'group-table-rank-change-down')
@@ -67,8 +126,42 @@ function RatingsList:render()
 				attributes = { ['data-ranking-table-cell'] = 'streak' },
 				children = streakText,
 				classes = { streakClass }
-			}
+			},
+			showGraph and (HtmlWidgets.Td {
+				attributes = {
+					class = 'ranking-table__toggle-graph-cell',
+					['data-ranking-table-cell'] = 'graph'
+				},
+				children = HtmlWidgets.Span {
+					attributes = {
+						class = 'ranking-table__toggle-graph',
+						['data-ranking-table'] = 'toggle',
+						['data-ranking-table-id'] = uniqueId,
+						['aria-controls'] = uniqueId,
+						tabindex = '1'
+					},
+					children = Icon.makeIcon { iconName = 'expand' }
+			} }) or nil
 		)
+
+		local graphRow = showGraph and {
+			HtmlWidgets.Td {
+				attributes = {
+					colspan = '7',
+					['data-ranking-table-cell'] = 'graph'
+				},
+				children = HtmlWidgets.Div {
+					children = {
+						OpponentDisplay.InlineOpponent { opponent = team.opponent },
+						Logic.tryOrElseLog(
+							function() return makeTeamChart(team, teamLimit) end,
+							function() return 'Failed to make graph for team' end
+						)
+					},
+					classes = { 'ranking-table__graph-row-container' }
+				}
+			}
+		} or nil
 
 		local isEven = rank % 2 == 0
 		local rowClasses = { 'ranking-table__row' }
@@ -77,6 +170,15 @@ function RatingsList:render()
 		end
 		return {
 			HtmlWidgets.Tr { children = teamRow, classes = rowClasses },
+			showGraph and HtmlWidgets.Tr {
+				children = graphRow,
+				classes = { 'ranking-table__graph-row d-none' },
+				attributes = {
+					['data-ranking-table'] = 'graph-row',
+					['aria-expanded'] = 'false',
+					['data-ranking-table-id'] = uniqueId
+				},
+			} or nil
 		}
 	end)
 
@@ -108,7 +210,11 @@ function RatingsList:render()
 							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'team' }, children = 'Team' },
 							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'rating' }, children = 'Points' },
 							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'region' }, children = 'Region' },
-							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'streak' }, children = 'Streak' }
+							HtmlWidgets.Th { attributes = { ['data-ranking-table-cell'] = 'streak' }, children = 'Streak' },
+							showGraph and HtmlWidgets.Th {
+								attributes = { ['data-ranking-table-cell'] = 'graph' },
+								children = Icon.makeIcon { iconName = 'chart' }
+							} or nil
 						),
 						classes = { 'ranking-table__header-row' },
 					},

--- a/javascript/commons/RankingTable.js
+++ b/javascript/commons/RankingTable.js
@@ -1,0 +1,75 @@
+liquipedia.rankingTable = {
+	identifierAttribute: 'data-ranking-table-id',
+	ContentSelector: '[data-ranking-table="content"]',
+	toggleButtonSelector: '[data-ranking-table="toggle"]',
+	graphRowSelector: '[data-ranking-table="graph-row"]',
+	patchLabelElement: null,
+	activeSelectOption: null,
+	rankingContent: null,
+	toggleButtonListeners: [],
+
+	init: function () {
+		this.rankingContent = document.querySelector( this.ContentSelector );
+		if ( !this.rankingContent ) {
+			return;
+		}
+
+		this.toggleGraphVisibility();
+	},
+
+	removeToggleButtonListeners: function () {
+		this.toggleButtonListeners.forEach( ( { button, listener } ) => {
+			button.removeEventListener( 'click', listener );
+		} );
+		this.toggleButtonListeners = [];
+	},
+
+	updatePatchLabel: function ( patch ) {
+		if ( !this.patchLabelElement ) {
+			this.patchLabelElement = document.querySelector( this.patchLabelSelector );
+		}
+		this.patchLabelElement.innerText = patch;
+	},
+
+	toggleGraphVisibility: function () {
+		const toggleButtons = document.querySelectorAll( this.toggleButtonSelector );
+		toggleButtons.forEach( ( button ) => {
+			const listener = () => this.onToggleButtonClick( button );
+			button.addEventListener( 'click', listener );
+			this.toggleButtonListeners.push( { button, listener } );
+		} );
+	},
+
+	onToggleButtonClick: function ( button ) {
+		const graphRowId = button.getAttribute( this.identifierAttribute );
+		const graphRow = document.querySelector(
+			`${ this.graphRowSelector }[${ this.identifierAttribute }="${ graphRowId }"]`
+		);
+
+		if ( graphRow ) {
+			graphRow.classList.toggle( 'd-none' );
+			const isExpanded = button.getAttribute( 'aria-expanded' ) === 'true';
+			button.setAttribute( 'aria-expanded', String( !isExpanded ) );
+
+			if ( !graphRow.classList.contains( 'd-none' ) ) {
+				// Initialize or resize charts when the div is visible
+				this.resizeCharts( graphRow );
+			}
+		}
+	},
+
+	resizeCharts: function ( graphRow ) {
+		const instances = graphRow.querySelectorAll( '[_echarts_instance_]' );
+		instances.forEach( ( chart ) => {
+			let chartInstance = echarts.getInstanceByDom( chart );
+			if ( chartInstance ) {
+				chartInstance.resize();
+			} else {
+				// Initialize the chart if it is not already initialized
+				chartInstance = echarts.init( chart );
+			}
+		} );
+	}
+};
+
+liquipedia.core.modules.push( 'rankingTable' );

--- a/standard/icon_data.lua
+++ b/standard/icon_data.lua
@@ -112,4 +112,7 @@ return {
 	-- Usage: Stormgate
 	coop = 'fas fa-dungeon',
 	mayhem = 'fab fa-fort-awesome',
+
+	-- Usage: Charts
+	chart = 'far fa-chart-line',
 }


### PR DESCRIPTION
## Summary
An expandable/collapsable section for each team in the rankings, that shows their placement progress over time

## How did you test this change?
Laura's dev wiki