### PR TITLE
feat: Display game icons in tournament ticker

### DIFF
--- a/components/tournament/tournament.lua
+++ b/components/tournament/tournament.lua
@@ -108,6 +108,7 @@ function Tournament.tournamentFromRecord(record)
 		iconDark = record.icondark,
 		abbreviation = record.abbreviation,
 		series = record.series,
+		game = record.game
 	}
 
 	-- Some properties are derived from other properies and we can calculate them when accessed.

--- a/components/widget/tournaments/widget_tournament_label.lua
+++ b/components/widget/tournaments/widget_tournament_label.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Game = require('Module:Game')
 local LeagueIcon = require('Module:LeagueIcon')
 local Lua = require('Module:Lua')
 
@@ -44,6 +45,9 @@ function TournamentsTickerWidget:render()
 					['padding-left'] = '25px',
 				},
 				children = {
+					self.props.displayGameIcon and Game.icon{
+						game = tournament.game,
+					} or nil,
 					LeagueIcon.display {
 						icon = tournament.icon,
 						iconDark = tournament.iconDark,

--- a/components/widget/tournaments/widget_tournament_label.lua
+++ b/components/widget/tournaments/widget_tournament_label.lua
@@ -42,11 +42,22 @@ function TournamentsTickerWidget:render()
 				classes = {'tournaments-list-name'},
 				css = {
 					['flex-grow'] = '1',
-					['padding-left'] = '25px',
+					['padding-left'] = self.props.displayGameIcon and '50px' or '25px',
 				},
 				children = {
-					self.props.displayGameIcon and Game.icon{
-						game = tournament.game,
+					self.props.displayGameIcon and HtmlWidgets.Span{
+						css = {
+							['margin-left'] = '-50px'
+						},
+						classes = {'league-icon-small-image'},
+						children  = {
+							Game.icon{
+								game = tournament.game,
+								noSpan = true,
+								size = '50',
+								noLink = true
+							}
+						}
 					} or '',
 					LeagueIcon.display {
 						icon = tournament.icon,

--- a/components/widget/tournaments/widget_tournament_label.lua
+++ b/components/widget/tournaments/widget_tournament_label.lua
@@ -47,7 +47,7 @@ function TournamentsTickerWidget:render()
 				children = {
 					self.props.displayGameIcon and Game.icon{
 						game = tournament.game,
-					} or nil,
+					} or '',
 					LeagueIcon.display {
 						icon = tournament.icon,
 						iconDark = tournament.iconDark,

--- a/components/widget/tournaments/widget_tournaments_ticker.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker.lua
@@ -11,6 +11,7 @@ local Condition = require('Module:Condition')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local I18n = require('Module:I18n')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
@@ -135,6 +136,9 @@ function TournamentsTickerWidget:render()
 		}
 	}
 
+
+	local displayGameIcon = Logic.readBool(self.props.displayGameIcon)
+
 	return HtmlWidgets.Div{
 		children = {
 			HtmlWidgets.Ul{
@@ -144,9 +148,9 @@ function TournamentsTickerWidget:render()
 					['data-filter-effect'] = 'fade',
 				},
 				children = {
-					Sublist{title = 'Upcoming', tournaments = upcomingTournaments} ,
-					Sublist{title = 'Ongoing', tournaments = ongoingTournaments},
-					Sublist{title = 'Completed', tournaments = completedTournaments},
+					Sublist{title = 'Upcoming', tournaments = upcomingTournaments, displayGameIcon = displayGameIcon} ,
+					Sublist{title = 'Ongoing', tournaments = ongoingTournaments, displayGameIcon = displayGameIcon},
+					Sublist{title = 'Completed', tournaments = completedTournaments, displayGameIcon = displayGameIcon},
 					fallbackElement
 				}
 			}

--- a/components/widget/tournaments/widget_tournaments_ticker.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker.lua
@@ -137,7 +137,7 @@ function TournamentsTickerWidget:render()
 	}
 
 
-	local displayGameIcon = Logic.readBool(self.props.displayGameIcon)
+	local displayGameIcons = Logic.readBool(self.props.displayGameIcons)
 
 	return HtmlWidgets.Div{
 		children = {
@@ -148,9 +148,9 @@ function TournamentsTickerWidget:render()
 					['data-filter-effect'] = 'fade',
 				},
 				children = {
-					Sublist{title = 'Upcoming', tournaments = upcomingTournaments, displayGameIcon = displayGameIcon} ,
-					Sublist{title = 'Ongoing', tournaments = ongoingTournaments, displayGameIcon = displayGameIcon},
-					Sublist{title = 'Completed', tournaments = completedTournaments, displayGameIcon = displayGameIcon},
+					Sublist{title = 'Upcoming', tournaments = upcomingTournaments, displayGameIcons = displayGameIcons} ,
+					Sublist{title = 'Ongoing', tournaments = ongoingTournaments, displayGameIcons = displayGameIcons},
+					Sublist{title = 'Completed', tournaments = completedTournaments, displayGameIcons = displayGameIcons},
 					fallbackElement
 				}
 			}

--- a/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
@@ -46,7 +46,10 @@ function TournamentsTickerWidget:render()
 	local list = HtmlWidgets.Ul{
 		classes = {'tournaments-list-type-list'},
 		children = Array.map(self.props.tournaments, function(tournament)
-			return HtmlWidgets.Li{children = createFilterWrapper(tournament, TournamentLabel{tournament = tournament})}
+			return HtmlWidgets.Li{children = createFilterWrapper(tournament, TournamentLabel{
+				tournament = tournament,
+				displayGame = self.props.displayGameIcon
+			})}
 		end),
 	}
 

--- a/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
+++ b/components/widget/tournaments/widget_tournaments_ticker_sublist.lua
@@ -48,7 +48,7 @@ function TournamentsTickerWidget:render()
 		children = Array.map(self.props.tournaments, function(tournament)
 			return HtmlWidgets.Li{children = createFilterWrapper(tournament, TournamentLabel{
 				tournament = tournament,
-				displayGame = self.props.displayGameIcon
+				displayGameIcon = self.props.displayGameIcons
 			})}
 		end),
 	}


### PR DESCRIPTION
## Summary
Allow to display game icons in tournament ticker when enabled via flag `displayGameIcons`.
Required to enable new mainpage on e.g. AoE
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
![image](https://github.com/user-attachments/assets/8a5be096-c608-429f-becb-1bae9b9bfc52)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
