### PR TITLE
fix: Changing honorofkings wiki default game & name to Honor of Kings

### DIFF
--- a/standard/info/wikis/honorofkings/info.lua
+++ b/standard/info/wikis/honorofkings/info.lua
@@ -9,8 +9,8 @@
 return {
 	startYear = 2015,
 	wikiName = 'honorofkings',
-	name = 'Arena of Valor',
-	defaultGame = 'aov',
+	name = 'Honor of Kings',
+	defaultGame = 'hok',
 
 	games = {
 		aov = {


### PR DESCRIPTION
## Summary
Changing the game name to Honor of Kings and the default game to hok. Only noticed this because for some recent tournaments where `|game=` setting was forgotten, it defaulted to Arena of Valor (the original main game on the wiki) and was not noticed.

## How did you test this change?
dev, thus far only tested with tournament pages, not sure if any thing else is affected by those 2 parameters
