### PR TITLE
fix(match2): underscores in winner field in fighters legacy storage

### DIFF
--- a/components/match2/wikis/fighters/match_legacy.lua
+++ b/components/match2/wikis/fighters/match_legacy.lua
@@ -130,7 +130,7 @@ function MatchLegacy._convertParameters(match2)
 			match.extradata[prefix .. 'displayname'] = player.displayname
 			match.extradata[prefix .. 'heads'] = table.concat(headList(index, 1), ',')
 			if match2.winner == index then
-				match.winner = player.name
+				match.winner = player.name:gsub('_', ' ')
 			end
 		elseif opponent.type == Opponent.duo then
 			local teamPrefix = 'team' .. index


### PR DESCRIPTION
## Summary

fixes #5426

underscore substitution for winner field of legacy storage was omitted in #5431

## How did you test this change?

N/A
