### PR TITLE
feat: add R6:Vegas (1) 

### DIFF
--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -37,6 +37,18 @@ return {
 				darkMode = 'Rainbow Six Vegas default darkmode.png',
 				lightMode = 'Rainbow Six Vegas default lightmode.png',
 			},
+		vegas = {
+			abbreviation = 'R6V',
+			name = 'Tom Clancy\'s Rainbow Six Vegas',
+			link = 'Rainbow Six Vegas',
+			logo = {
+				darkMode = 'R6 Vegas 2 icon.png',
+				lightMode = 'R6 Vegas 2 icon.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Rainbow Six Vegas default darkmode.png',
+				lightMode = 'Rainbow Six Vegas default lightmode.png',
+			},
 		},
 	},
 	config = {

--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -21,8 +21,8 @@ return {
 				lightMode = 'Rainbow Six Siege gameicon lightmode.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Rainbow Six Siege Logo darkmode.png',
-				lightMode = 'Rainbow Six Siege Logo lightmode.png',
+				darkMode = 'Rainbow Six Siege default darkmode.png',
+				lightMode = 'Rainbow Six Siege default lightmode.png',
 			},
 		},
 		vegas2 = {
@@ -34,8 +34,8 @@ return {
 				lightMode = 'R6 Vegas 2 icon.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Rainbow Six Vegas Logo darkmode.png',
-				lightMode = 'Rainbow Six Vegas Logo lightmode.png',
+				darkMode = 'Rainbow Six Vegas default darkmode.png',
+				lightMode = 'Rainbow Six Vegas default lightmode.png',
 			},
 		},
 	},

--- a/standard/info/wikis/rainbowsix/info.lua
+++ b/standard/info/wikis/rainbowsix/info.lua
@@ -30,20 +30,21 @@ return {
 			name = 'Tom Clancy\'s Rainbow Six Vegas 2',
 			link = 'Rainbow Six Vegas 2',
 			logo = {
-				darkMode = 'R6 Vegas 2 icon.png',
-				lightMode = 'R6 Vegas 2 icon.png',
+				darkMode = 'Rainbow Six Vegas 2 icon allmode.png',
+				lightMode = 'Rainbow Six Vegas 2 icon allmode.png',
 			},
 			defaultTeamLogo = {
 				darkMode = 'Rainbow Six Vegas default darkmode.png',
 				lightMode = 'Rainbow Six Vegas default lightmode.png',
 			},
+		},
 		vegas = {
 			abbreviation = 'R6V',
 			name = 'Tom Clancy\'s Rainbow Six Vegas',
 			link = 'Rainbow Six Vegas',
 			logo = {
-				darkMode = 'R6 Vegas 2 icon.png',
-				lightMode = 'R6 Vegas 2 icon.png',
+				darkMode = 'Rainbow Six Vegas 2 icon allmode.png',
+				lightMode = 'Rainbow Six Vegas 2 icon allmode.png',
 			},
 			defaultTeamLogo = {
 				darkMode = 'Rainbow Six Vegas default darkmode.png',


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->
### Minor change

Recently a page was made for Rainbow Six Vegas (1) which resulted in not showing the game icon on in the Template:TournamentsLists or the game name in the Infobox on said page (see below).
This edit should add the game icon and name onto the wiki, the Icon for Vegas 1 is the same as for Vegas 2, which already was present in this file.

I have also updated the file links to the Default TeamCard images to their correct new filename.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->

Did not test, should not break anything but will display the Vegas game name icon on this page: 
- https://liquipedia.net/rainbowsix/A-Tier_Tournaments#2007 (in the Game spot)
- https://liquipedia.net/rainbowsix/Major_League_Gaming/2007/Charlotte (When |game=vegas is being used in the infobox it should show: "Game: Tom Clancy's Rainbow Six Vegas")
