### PR TITLE
feat(mainpage): use Overwatch2 logo in mainpage

### DIFF
--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -68,8 +68,8 @@ local CONTENT = {
 
 return {
 	banner = {
-		lightmode = 'Overwatch-logo-lightmode.svg',
-		darkmode = 'Overwatch-logo-darkmode.svg',
+		lightmode = 'Overwatch 2 full lightmode.png',
+		darkmode = 'Overwatch 2 full darkmode.png',
 	},
 	metadesc = 'Comprehensive Overwatch wiki with articles covering everything from heroes, to tournaments, ' ..
 		'to competitive players and teams.',


### PR DESCRIPTION
## Summary

Current mainpage uses Overwatch logo, and OW editors wanted it to be updated

## How did you test this change?

dev
