### PR TITLE
feat: Re-enable rating fetch from AoEDB extension

### DIFF
--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -59,7 +59,7 @@ local RATINGCONFIG = {
 		{text = 'QM', id = 'aoe4net_id', game = 'aoe4'},
 	},
 	aom = {
-		{text = '[[Age of Mythology Retold|Retold]]', id = 'aomr_id', game = 'aoemr'},
+		{text = '[[Age of Mythology Retold|Retold]]', id = 'aomr_id', game = 'aomr'},
 		{text = 'Elo [[Voobly]]', id = 'aom_voobly_elo'},
 		{text = 'Elo [[Age of Mythology/Extended Edition|AoM EE]]', id = 'aom_ee_elo'},
 	}

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -59,7 +59,7 @@ local RATINGCONFIG = {
 		{text = 'QM', id = 'aoe4net_id', game = 'aoe4'},
 	},
 	aom = {
-		{text = '[[Age of Mythology Retold|Retold]]', id = 'aomr_id', game = 'aomr'},
+		{text = '[[Age of Mythology/Retold|Retold]]', id = 'aomr_id', game = 'aomr'},
 		{text = 'Elo [[Voobly]]', id = 'aom_voobly_elo'},
 		{text = 'Elo [[Age of Mythology/Extended Edition|AoM EE]]', id = 'aom_ee_elo'},
 	}

--- a/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
+++ b/components/infobox/wikis/ageofempires/infobox_person_player_custom.lua
@@ -43,6 +43,7 @@ local CustomInjector = Class.new(Injector)
 
 local RATINGCONFIG = {
 	aoe2 = {
+		{text = 'RM [[Age of Empires II/Definitive Edition|DE]]', id = 'aoe2net_id', game = 'aoe2de'},
 		{
 			text = Page.makeExternalLink('Tournament', 'https://aoe-elo.com/players'),
 			id = 'aoe-elo.com_id',
@@ -51,9 +52,14 @@ local RATINGCONFIG = {
 		{text = 'RM [[Voobly]]', id = 'voobly_elo'},
 	},
 	aoe3 = {
+		{text = 'Supremacy [[Age of Empires III/Definitive Edition|DE]]', id = 'aoe3net_id', game = 'aoe3de'},
 		{text = 'Supremacy', id = 'aoe3_elo'},
 	},
+	aoe4 = {
+		{text = 'QM', id = 'aoe4net_id', game = 'aoe4'},
+	},
 	aom = {
+		{text = '[[Age of Mythology Retold|Retold]]', id = 'aomr_id', game = 'aoemr'},
 		{text = 'Elo [[Voobly]]', id = 'aom_voobly_elo'},
 		{text = 'Elo [[Age of Mythology/Extended Edition|AoM EE]]', id = 'aom_ee_elo'},
 	}


### PR DESCRIPTION
## Summary
AoEDB extension has been fixed thanks to Darkrai:
Re-enable ratings for AoE 2, 3, 4
Add new option to fetch rating for AoMR
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
