### PR TITLE
feat(match2): add caster row support to LoL

### DIFF
--- a/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
+++ b/components/match2/wikis/leagueoflegends/match_group_input_custom.lua
@@ -129,6 +129,7 @@ end
 function MatchFunctions.getExtraData(match, games, opponents)
 	return {
 		mvp = MatchGroupInputUtil.readMvp(match, opponents),
+		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
 	}
 end
 

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -11,6 +11,7 @@ local CustomMatchSummary = {}
 local Array = require('Module:Array')
 local DateExt = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 

--- a/components/match2/wikis/leagueoflegends/match_summary.lua
+++ b/components/match2/wikis/leagueoflegends/match_summary.lua
@@ -46,7 +46,8 @@ function CustomMatchSummary.createBody(match)
 		showMatchPage and MatchSummaryWidgets.MatchPageLink{matchId = matchId} or nil,
 		Array.map(match.games, FnUtil.curry(CustomMatchSummary._createGame, match.date)),
 		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date}
+		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date},
+		MatchSummaryWidgets.Casters{casters = Json.parseIfString(match.extradata.casters)}
 	)}
 end
 


### PR DESCRIPTION
## Summary

LoL wiki records casters for international events (namely MSIs and Worlds) and they currently rely on using comments.
This PR adds support for caster rows (refs: #4313, #4943) to LoL match2.

## How did you test this change?

dev: [leagueoflegends:User:ElectricalBoy/Sandbox2](https://liquipedia.net/leagueoflegends/User:ElectricalBoy/Sandbox2)
