### PR TITLE
feat(opponent): add note support to inline opponent display

### DIFF
--- a/components/opponent/commons/opponent_display.lua
+++ b/components/opponent/commons/opponent_display.lua
@@ -119,27 +119,33 @@ end
 ---@field showFlag boolean?
 ---@field showLink boolean?
 ---@field dq boolean?
+---@field note string|number|nil
 ---@field teamStyle teamStyle?
 
 ---Displays an opponent as an inline element. Useful for describing opponents in prose.
 ---@param props InlineOpponentProps
----@return Html|string|nil
+---@return Html|nil
 function OpponentDisplay.InlineOpponent(props)
 	local opponent = props.opponent
 
+	local opponentNode
 	if opponent.type == Opponent.team then
-		return OpponentDisplay.InlineTeamContainer({
+		opponentNode = OpponentDisplay.InlineTeamContainer({
 			flip = props.flip,
 			style = props.teamStyle,
 			template = opponent.template or 'tbd',
 		})
 	elseif opponent.type == Opponent.literal then
-		return opponent.name or ''
+		opponentNode = opponent.name or ''
 	elseif Opponent.typeIsParty(opponent.type) then
-		return OpponentDisplay.InlinePlayers(props)
+		opponentNode = OpponentDisplay.InlinePlayers(props)
 	else
 		error('Unrecognized opponent.type ' .. opponent.type)
 	end
+
+	return mw.html.create()
+		:node(opponentNode)
+		:node(props.note and mw.html.create('sup'):addClass('note'):wikitext(props.note) or '')
 end
 
 ---@param props InlineOpponentProps

--- a/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
+++ b/components/opponent/commons/starcraft_starcraft2/opponent_display_starcraft.lua
@@ -97,19 +97,13 @@ StarcraftOpponentDisplay.BracketOpponentEntry = BracketOpponentEntry
 function StarcraftOpponentDisplay.InlineOpponent(props)
 	local opponent = props.opponent
 
-	if opponent.type == Opponent.team then
-		return OpponentDisplay.InlineTeamContainer({
-			flip = props.flip,
-			showLink = props.showLink,
-			style = props.teamStyle,
-			team = opponent.team,
-			template = opponent.template or 'tbd',
-		})
-	elseif opponent.type == 'literal' then
-		return OpponentDisplay.InlineOpponent(props)
-	else -- opponent.type == Opponent.solo Opponent.duo Opponent.trio Opponent.quad
-		return StarcraftOpponentDisplay.PlayerInlineOpponent(props)
+	if Opponent.typeIsParty((opponent or {}).type) then
+		return mw.html.create()
+			:node(StarcraftOpponentDisplay.InlinePlayers(props))
+			:node(props.note and mw.html.create('sup'):addClass('note'):wikitext(props.note) or '')
 	end
+
+	return OpponentDisplay.InlineOpponent(props)
 end
 
 ---Displays an opponent as a block element. The width of the component is

--- a/components/opponent/wikis/stormgate/opponent_display_custom.lua
+++ b/components/opponent/wikis/stormgate/opponent_display_custom.lua
@@ -62,12 +62,14 @@ CustomOpponentDisplay.BracketOpponentEntry.addScores = OpponentDisplay.BracketOp
 ---@field hideFaction boolean?
 
 ---@param props StormgateInlineOpponentProps
----@return Html|string|nil
+---@return Html|nil
 function CustomOpponentDisplay.InlineOpponent(props)
 	local opponent = props.opponent
 
 	if Opponent.typeIsParty((opponent or {}).type) then
-		return CustomOpponentDisplay.InlinePlayers(props)
+		return mw.html.create()
+			:node(CustomOpponentDisplay.InlinePlayers(props))
+			:node(props.note and mw.html.create('sup'):addClass('note'):wikitext(props.note) or '')
 	end
 
 	return OpponentDisplay.InlineOpponent(props)

--- a/components/opponent/wikis/warcraft/opponent_display_custom.lua
+++ b/components/opponent/wikis/warcraft/opponent_display_custom.lua
@@ -62,12 +62,15 @@ CustomOpponentDisplay.BracketOpponentEntry.addScores = OpponentDisplay.BracketOp
 ---@field showFaction boolean?
 
 ---@param props WarcraftInlineOpponentProps
----@return Html|string|nil
+---@return Html|nil
 function CustomOpponentDisplay.InlineOpponent(props)
 	local opponent = props.opponent
 
 	if Opponent.typeIsParty((opponent or {}).type) then
-		return CustomOpponentDisplay.InlinePlayers(props)
+		return mw.html.create()
+			:node(CustomOpponentDisplay.InlinePlayers(props))
+			:node(props.note and mw.html.create('sup'):addClass('note'):wikitext(props.note) or '')
+
 	end
 
 	return OpponentDisplay.InlineOpponent(props)


### PR DESCRIPTION
## Summary
Add note support to inline opponent display.
reported on discord that in match2 gtl (non git) notes do not work, this PR fixes that.

## How did you test this change?
dev (sc2 still to be tested)