### PR TITLE
feat(infobox): use plural for one cell description

### DIFF
--- a/components/infobox/wikis/counterstrike/infobox_company_custom.lua
+++ b/components/infobox/wikis/counterstrike/infobox_company_custom.lua
@@ -37,7 +37,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		table.insert(widgets, Cell{name = 'Series', content = {args.series}})
 	elseif id == 'parent' then
-		table.insert(widgets, Cell{name = 'Sister Company', content = {args.sister}})
+		table.insert(widgets, Cell{name = 'Sister Companies', content = {args.sister}})
 		table.insert(widgets, Cell{name = 'Subsidiaries', content = {args.subsidiaries}})
 		table.insert(widgets, Cell{name = 'Focus', content = {args.focus or args.industry}})
 	elseif id == 'dates' then


### PR DESCRIPTION
## Summary
use plural for one cell description in cs infobox company
requested by Mnmzzz on discord:
https://discord.com/channels/93055209017729024/874304000718172200/1342381340221505637

## How did you test this change?
N/A