### PR TITLE
feat(stylesheets): add vod alt icon to invert list

### DIFF
--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -2220,7 +2220,8 @@ Author(s): iMarbot
 		&[ src*="Interview32" ],
 		&[ src*="Highlights_Icon32" ],
 		&[ src*="Captain_Icon" ],
-		&[ src*="Recap_Icon" ] {
+		&[ src*="Recap_Icon" ],
+		&[ src*="Vod_Alt_Icon" ] {
 			filter: invert( 1 );
 		}
 	}


### PR DESCRIPTION
## Summary

add Vod alt icon to `filter: invert` list for the F1 wiki
https://liquipedia.net/formula1/Liquipedia:Previous_Race_Weekend

## How did you test this change?

inspect tools
