### PR TITLE
feat(Infobox): Support Game appearances for COD

### DIFF
--- a/components/infobox/wikis/callofduty/get_game_appearances.lua
+++ b/components/infobox/wikis/callofduty/get_game_appearances.lua
@@ -1,0 +1,56 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:GetGameAppearances
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Game = require('Module:Game')
+
+local MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT = 10
+
+local Appearances = {}
+
+function Appearances.player(args)
+	if not args or not args.player then return end
+
+	local conditions = Array.map(Array.range(1, MAX_NUMBER_OF_PLAYERS_IN_PLACEMENT), function(index)
+		return '[[opponentplayers_p' .. index .. '::' .. args.player .. ']]'
+	end)
+	table.insert(conditions, '[[opponentname::' .. args.player .. ']]')
+
+	local data = mw.ext.LiquipediaDB.lpdb('placement', {
+		conditions = table.concat(conditions, ' OR '),
+		query = 'game',
+		groupby = 'game asc',
+		limit = 1000,
+	})
+
+	local games = {}	
+	Array.forEach(data, function(item)
+		local game = Game.name{game = item.game}
+		if game then
+			mw.ext.TeamLiquidIntegration.add_category(game) 
+			table.insert(games, '[[' .. game .. ']]')
+		end
+	end)
+
+	return Appearances.removeDuplicates(games)
+end
+
+function Appearances.removeDuplicates(games)
+    hashSet = {}
+	Array.forEach(games, function(game)
+		hashSet[game] = true
+	end)
+
+	games = Array.extractKeys(hashSet)
+	table.sort(games)
+
+	return games
+end
+
+return Class.export(Appearances)


### PR DESCRIPTION
## Summary
I'm working on cleaning up COD wiki to be main wiki ready as requested by Rathoz, he suggested that since this is Infobox usage the file upload goes into Infobox folder

![image](https://github.com/user-attachments/assets/c3c96f73-742a-4f41-a4b7-439baff41d23)

One of these is to brought the Module:GetGameAppearances which is a local module to be a Git module with header, which is something I have never done before so I have no clue I just added the header and call it a day for now

What this module does is it allows an infobox player to list the game each player competes in based on the `game` fields in their stored prize data which links back to Info module

![image](https://github.com/user-attachments/assets/204c4671-1359-496d-949a-33308630fb31)

## How did you test this change?
LIVE

You can check with the Player Infobox file to see how this is being integrated in and if code change needed

## Side Note
- theres actually 2 local module, the other being Roles but that one I'll just merge all functionality into the player infobox
- Pokemon wiki also uses this module, so this will benefit when they going up to Main Wiki