### PR TITLE
feat(mainpage): update image for players navigation in valorant mainpage

### DIFF
--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -99,7 +99,7 @@ return {
 			},
 		},
 		{
-			file = 'Stalk3r OWCS Finals 2024.jpeg',
+			file = 'EDward Gaming VALORANT Masters Shanghai 2024.jpg',
 			title = 'Players',
 			link = 'Portal:Players',
 			count = {


### PR DESCRIPTION
## Summary

The current mainpage uses an Overwatch(???) photo for players navbox. This PR updates this to a Valorant photo.

Blame GodOfPog for choice of photo 😆

## How did you test this change?

dev