### PR TITLE
feat(infobox): add lol unoff. world champ infobox

### DIFF
--- a/components/infobox/wikis/leagueoflegends/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_unofficial_world_champion_custom.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- wiki=leagueoflegends
+-- page=Module:Infobox/UnofficialWorldChampion/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local Table = require('Module:Table')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local UnofficialWorldChampion = Lua.import('Module:Infobox/UnofficialWorldChampion')
+
+local Widgets = require('Module:Widget/All')
+local Breakdown = Widgets.Breakdown
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+
+---@class LoLUnofficialWorldChampionInfobox: UnofficialWorldChampionInfobox
+local CustomUnofficialWorldChampion = Class.new(UnofficialWorldChampion)
+
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomUnofficialWorldChampion.run(frame)
+	local unofficialWorldChampion = CustomUnofficialWorldChampion(frame)
+	unofficialWorldChampion:setWidgetInjector(CustomInjector(unofficialWorldChampion))
+
+	return unofficialWorldChampion:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		--Regional distribution
+		table.insert(widgets, String.isNotEmpty(args.region1) and Title{children = 'Regional distribution'} or nil)
+
+		for regionKey, region in Table.iter.pairsByPrefix(args, 'region') do
+			Array.appendWith(widgets,
+				Cell{name = (args[regionKey .. ' no'] or '') .. ' champions', content = {region}},
+				Breakdown{children = {args[regionKey .. ' champions']}}
+			)
+		end
+	end
+
+	return widgets
+end
+
+return CustomUnofficialWorldChampion


### PR DESCRIPTION
## Summary

This PR adds Unofficial World Champion infobox for LoL wiki.
Note: This uses the exact same code as the [Overwatch version](https://github.com/Liquipedia/Lua-Modules/blob/56e2e63845971e55dd13d5bcd09d4a2fe67d8a0a/components/infobox/wikis/overwatch/infobox_unofficial_world_champion_custom.lua), with some trivial name changes.

## How did you test this change?

live
