### PR TITLE
feat(standings): swiss display style

### DIFF
--- a/components/opponent/commons/opponent.lua
+++ b/components/opponent/commons/opponent.lua
@@ -222,6 +222,14 @@ function Opponent.isOpponent(opponent)
 	error('Opponent.isOpponent: Not Implemented')
 end
 
+---Check if two opponents are the same opponent
+---It's still a work in progress, it's not fully implemented all cases
+---@param opponent1 standardOpponent
+---@param opponent2 standardOpponent
+function Opponent.same(opponent1, opponent2)
+	return Opponent.toName(opponent1) == Opponent.toName(opponent2)
+end
+
 ---Coerces an arbitary table into an opponent
 ---@param opponent table
 function Opponent.coerce(opponent)

--- a/components/standings/commons/standings.lua
+++ b/components/standings/commons/standings.lua
@@ -103,7 +103,7 @@ local StandingsMT = {
 local StandingsEntryMT = {
 	__index = function(entry, property)
 		if property == 'match' then
-			entry[property] = Standings.fetchMatch(entry.record)
+			entry[property] = Standings.fetchMatch(entry)
 		end
 		return rawget(entry, property)
 	end
@@ -173,9 +173,11 @@ end
 ---@return MatchGroupUtilMatch?
 function Standings.fetchMatch(entry)
 	---@diagnostic disable-next-line: invisible
-	local matchid = entry.record.matchid
+	local matchid = entry.record.extradata.matchid
+	if not matchid then
+		return
+	end
 	local bracketId = MatchGroupUtil.splitMatchId(matchid)
-
 	if not bracketId then
 		return
 	end

--- a/components/standings/commons/standings.lua
+++ b/components/standings/commons/standings.lua
@@ -49,11 +49,15 @@ local Standings = {}
 ---@field placement string
 ---@field position integer
 ---@field points number
+---@field matchWins integer
+---@field matchLosses integer
 ---@field positionStatus string?
 ---@field definitiveStatus string?
+---@field match MatchGroupUtilMatch?
 ---@field positionChangeFromPreviousRound integer
 ---@field pointsChangeFromPreviousRound number
 ---@field specialStatus 'dq'|'nc'|'' # nc = non-competing (not in the round)
+---@field private record standingstable
 
 ---Fetches a standings table from a page. Tries to read from page variables before fetching from LPDB.
 ---@param pagename string
@@ -96,6 +100,15 @@ local StandingsMT = {
 	end
 }
 
+local StandingsEntryMT = {
+	__index = function(entry, property)
+		if property == 'match' then
+			entry[property] = Standings.fetchMatch(entry.record)
+		end
+		return rawget(entry, property)
+	end
+}
+
 ---@param record standingstable
 ---@param entries standingsentry[]?
 ---@return StandingsModel
@@ -127,10 +140,16 @@ function Standings.entryFromRecord(record)
 		positionStatus = record.currentstatus,
 		definitiveStatus = record.definitestatus,
 		points = record.scoreboard.points,
+		matchWins = record.scoreboard.match.w,
+		matchLosses = record.scoreboard.match.l,
 		pointsChangeFromPreviousRound = record.extradata.pointschange,
 		specialStatus = record.extradata.specialstatus or '',
 		positionChangeFromPreviousRound = tonumber(record.placementchange),
+		record = record,
 	}
+
+	-- Some properties are derived from other properies and we can calculate them when accessed.
+	setmetatable(entry, StandingsEntryMT)
 
 	return entry
 end
@@ -148,6 +167,23 @@ function Standings.fetchMatches(standings)
 	return Array.filter(allMatchesFromBrackets, function(match)
 		return Table.includes(matchids, match.matchId)
 	end)
+end
+
+---@param entry StandingsEntryModel
+---@return MatchGroupUtilMatch?
+function Standings.fetchMatch(entry)
+	---@diagnostic disable-next-line: invisible
+	local matchid = entry.record.matchid
+	local bracketId = MatchGroupUtil.splitMatchId(matchid)
+
+	if not bracketId then
+		return
+	end
+
+	local allMatchesFromBrackets = MatchGroupUtil.fetchMatches(bracketId)
+	return Array.filter(allMatchesFromBrackets, function(match)
+		return match.matchId == matchid
+	end)[1]
 end
 
 ---@param standings StandingsModel

--- a/components/widget/standings/widget_standings.lua
+++ b/components/widget/standings/widget_standings.lua
@@ -11,6 +11,7 @@ local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
 local FfaStandings = Lua.import('Module:Widget/Standings/Ffa')
+local SwissStandings = Lua.import('Module:Widget/Standings/Swiss')
 
 local Standings = Lua.import('Module:Standings')
 
@@ -30,6 +31,10 @@ function StandingsWidget:render()
 
 	if standings.type == 'ffa' then
 		return FfaStandings{
+			standings = standings,
+		}
+	elseif standings.type == 'swiss' then
+		return SwissStandings{
 			standings = standings,
 		}
 	end

--- a/components/widget/standings/widget_standings_match_overview.lua
+++ b/components/widget/standings/widget_standings_match_overview.lua
@@ -1,0 +1,61 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Standings/MatchOverview
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
+---@class MatchOverviewWidget: Widget
+---@operator call(table): MatchOverviewWidget
+
+local MatchOverviewWidget = Class.new(Widget)
+
+---@return Widget?
+function MatchOverviewWidget:render()
+	---@type MatchGroupUtilMatch
+	local match = self.props.match
+	local showOpponent = tonumber(self.props.showOpponent)
+	if not match or not showOpponent or #match.opponents < 2 then
+		return
+	end
+
+	local opponent = match.opponents[showOpponent]
+	if not opponent then
+		return
+	end
+
+	return HtmlWidgets.Div{
+		css = {
+			['display'] = 'flex',
+			['justify-content'] = 'space-between',
+			['flex-direction'] = 'column',
+		},
+		children = {
+			HtmlWidgets.Span{
+				classes = {'match-overview-opponent'},
+				children = OpponentDisplay.BlockOpponent{
+					opponent = opponent,
+					showLink = true,
+					overflow = 'ellipsis',
+					teamStyle = 'icon',
+				}
+			},
+			HtmlWidgets.Span{
+				classes = {'match-overview-score'},
+				children = match.opponents[1].score .. ' - ' .. match.opponents[2].score,
+			},
+		},
+	}
+end
+
+return MatchOverviewWidget

--- a/components/widget/standings/widget_standings_match_overview.lua
+++ b/components/widget/standings/widget_standings_match_overview.lua
@@ -39,10 +39,10 @@ function MatchOverviewWidget:render()
 			['display'] = 'flex',
 			['justify-content'] = 'space-between',
 			['flex-direction'] = 'column',
+			['align-items'] = 'center',
 		},
 		children = {
 			HtmlWidgets.Span{
-				classes = {'match-overview-opponent'},
 				children = OpponentDisplay.BlockOpponent{
 					opponent = opponent,
 					showLink = true,
@@ -51,7 +51,9 @@ function MatchOverviewWidget:render()
 				}
 			},
 			HtmlWidgets.Span{
-				classes = {'match-overview-score'},
+				css = {
+					['font-size'] = '0.8em',
+				},
 				children = match.opponents[1].score .. ' - ' .. match.opponents[2].score,
 			},
 		},

--- a/components/widget/standings/widget_standings_swiss.lua
+++ b/components/widget/standings/widget_standings_swiss.lua
@@ -34,7 +34,6 @@ function StandingsSwissWidget:render()
 	---@type StandingsModel
 	local standings = self.props.standings
 	local lastRound = standings.rounds[#standings.rounds]
-	local hasFutureRounds = not standings.rounds[#standings.rounds].started
 
 	return DataTable{
 		wrapperClasses = {'standings-ffa'},
@@ -69,7 +68,7 @@ function StandingsSwissWidget:render()
 			Array.map(lastRound.opponents, function(slot)
 				local positionBackground = slot.positionStatus and ('bg-' .. slot.positionStatus) or nil
 				local teamBackground
-				if not hasFutureRounds and slot.definitiveStatus then
+				if slot.definitiveStatus then
 					teamBackground = 'bg-' .. slot.definitiveStatus
 				end
 				return HtmlWidgets.Tr{

--- a/components/widget/standings/widget_standings_swiss.lua
+++ b/components/widget/standings/widget_standings_swiss.lua
@@ -1,0 +1,140 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Standings/Swiss
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+
+local WidgetUtil = Lua.import('Module:Widget/Util')
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local DataTable = Lua.import('Module:Widget/Basic/DataTable')
+local MatchOverview = Lua.import('Module:Widget/Standings/MatchOverview')
+
+local OpponentLibraries = require('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
+---@class StandingsSwissWidget: Widget
+---@operator call(table): StandingsSwissWidget
+
+local StandingsSwissWidget = Class.new(Widget)
+
+---@return Widget?
+function StandingsSwissWidget:render()
+	if not self.props.standings then
+		return
+	end
+
+	---@type StandingsModel
+	local standings = self.props.standings
+	local activeRounds = (Array.maxBy(
+		Array.filter(standings.rounds, function(round) return round.started end),
+		function (round) return round.round end
+	) or {round = 0}).round
+	local hasFutureRounds = not standings.rounds[#standings.rounds].started
+
+	return DataTable{
+		wrapperClasses = {'standings-ffa', 'toggle-area', 'toggle-area-' .. activeRounds},
+		classes = {'wikitable-bordered', 'wikitable-striped'},
+		attributes = {['data-toggle-area'] = activeRounds},
+		children = WidgetUtil.collect(
+			-- Outer header
+			HtmlWidgets.Tr{children = HtmlWidgets.Th{
+				attributes = {
+					colspan = 100,
+				},
+				children = {
+					HtmlWidgets.Div{
+						css = {['position'] = 'relative'},
+						children = {
+							HtmlWidgets.Span{
+								children = standings.title
+							},
+						},
+					},
+				},
+			}},
+			-- Column Header
+			HtmlWidgets.Tr{children = WidgetUtil.collect(
+				HtmlWidgets.Th{children = '#'},
+				HtmlWidgets.Th{children = 'Participant'},
+				HtmlWidgets.Th{children = 'Matches'},
+				Array.map(standings.rounds, function(round)
+					return HtmlWidgets.Th{children = round.title}
+				end)
+			)},
+			-- Rows
+			Array.flatMap(standings.rounds, function(round)
+				return Array.map(round.opponents, function(slot)
+					local positionBackground = slot.positionStatus and ('bg-' .. slot.positionStatus) or nil
+					local teamBackground
+					if not hasFutureRounds and slot.definitiveStatus then
+						teamBackground = 'bg-' .. slot.definitiveStatus
+					end
+					return HtmlWidgets.Tr{
+						children = WidgetUtil.collect(
+							HtmlWidgets.Td{
+								children = {slot.placement, '.'},
+								css = {['font-weight'] = 'bold'},
+								classes = {positionBackground},
+							},
+							HtmlWidgets.Td{
+								classes = {teamBackground},
+								children = OpponentDisplay.BlockOpponent{
+									opponent = slot.opponent,
+									showLink = true,
+									overflow = 'ellipsis',
+									teamStyle = 'hybrid',
+									showPlayerTeam = true,
+								}
+							},
+							HtmlWidgets.Td{
+								classes = {teamBackground},
+								children = table.concat({slot.matchWins, slot.matchLosses}, '-'),
+								css = {['font-weight'] = 'bold', ['text-align'] = 'center'}
+							},
+							Array.map(standings.rounds, function(columnRound)
+								local entry = Array.find(columnRound.opponents, function(columnSlot)
+									return Table.deepEquals(columnSlot.opponent, slot.opponent)
+								end)
+								if not entry then
+									return HtmlWidgets.Td{}
+								end
+
+								local match = entry.match
+								if not match then
+									return HtmlWidgets.Td{}
+								end
+
+								local opposingOpponentIndex = Array.indexOf(match.opponents, function(opponent)
+									return not Table.deepEquals(opponent, slot.opponent)
+								end)
+								if not entry.match[opposingOpponentIndex] then
+									return HtmlWidgets.Td{}
+								end
+
+								return HtmlWidgets.Td{
+									children = MatchOverview{
+										match = match,
+										showOpponent = opposingOpponentIndex,
+									},
+								}
+							end)
+						),
+						attributes = {
+							['data-toggle-area-content'] = round.round,
+						}
+					}
+				end)
+			end)
+		)
+	}
+end
+
+return StandingsSwissWidget

--- a/components/widget/standings/widget_standings_swiss.lua
+++ b/components/widget/standings/widget_standings_swiss.lua
@@ -113,7 +113,16 @@ function StandingsSwissWidget:render()
 								return HtmlWidgets.Td{}
 							end
 
+							local bgClassSuffix
+							if match.finished then
+								local winner = match.winner
+								bgClassSuffix = winner == opposingOpponentIndex and 'down' or winner == 0 or 'draw' or 'up'
+							end
+
 							return HtmlWidgets.Td{
+								classes = {
+									bgClassSuffix and ('bg-' .. bgClassSuffix) or nil,
+								},
 								children = MatchOverview{
 									match = match,
 									showOpponent = opposingOpponentIndex,

--- a/components/widget/standings/widget_standings_swiss.lua
+++ b/components/widget/standings/widget_standings_swiss.lua
@@ -107,7 +107,7 @@ function StandingsSwissWidget:render()
 							end
 
 							local opposingOpponentIndex = Array.indexOf(match.opponents, function(opponent)
-								return Opponent.same(entry.opponent, slot.opponent)
+								return not Opponent.same(entry.opponent, opponent)
 							end)
 							if not entry.match.opponents[opposingOpponentIndex] then
 								return HtmlWidgets.Td{}


### PR DESCRIPTION
## Feature description

There exists **at least 20 versions** out there that are automated (automatically populates with match data), in at least 2 major branches. In addition, there **exists 11 versions** of non-automated table. All version have terrible, unmaintainable code and the data storage shoehorned in, in the only way that was possible, terribly. Tiebreakers can break when large numbers are involved. Doing any maintenance and especially new features is next to impossible.

This is the first step in that journey, in this step we build a sustainable standardized display system for Swiss. 

## Additional Details

Use the existing data we store on R6, to build a sustainable display system. It shall only use data in LPDB, for many reasons (such as decreased spaghetti, cleaner code, removal of transclusions, ensures we store all data LPDB consumers needs). Additional data may need to be added to LPDB, in which case shall we added to extradata for now.

## How did you test this change?
https://liquipedia.net/rainbowsix/User:Rathoz/Leagues/blabla
![image](https://github.com/user-attachments/assets/62256f36-b5b0-48c0-9a49-401d144ad62f)
