### PR TITLE
feat: Separate DACH and germanspeaking flags

### DIFF
--- a/standard/flags_master_data.lua
+++ b/standard/flags_master_data.lua
@@ -1391,6 +1391,11 @@ local data = {
 		localised = 'CIS',
 		name = 'CIS',
 	},
+	['dach'] = {
+		flag = 'File:Dach_hd.png',
+		localised = '',
+		name = 'DACH',
+	},
 	['eastasia'] = {
 		flag = 'File:East asia flag hd.png',
 		localised = 'East Asian',
@@ -2175,7 +2180,6 @@ local aliases = {
 	['usgb'] = 'englishspeaking',
 	['usuk'] = 'englishspeaking',
 	['deat'] = 'germanspeaking',
-	['dach'] = 'germanspeaking',
 	['esmx'] = 'spanishspeaking',
 	['ptbr'] = 'portuguesespeaking',
 	['ruby'] = 'russianspeaking',


### PR DESCRIPTION
## Summary
They got merged when template-based flags were removed, but this doesn't make sense, as the image used for `germanspeaking` does not include switzerland (the `CH` in DACH).
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
