### PR TITLE
Create infobox_company_custom.lua

### DIFF
--- a/components/infobox/wikis/chess/infobox_company_custom.lua
+++ b/components/infobox/wikis/chess/infobox_company_custom.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- wiki=chess
+-- page=Module:Infobox/Company/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Company = Lua.import('Module:Infobox/Company')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+
+---@class Formula1CompanyInfobox: CompanyInfobox
+local CustomCompany = Class.new(Company)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomCompany.run(frame)
+	local company = CustomCompany(frame)
+	company:setWidgetInjector(CustomInjector(company))
+	return company:createInfobox(frame)
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		local staffInfoCells = {
+			{key = 'president', name = 'President'},
+			{key = 'deputypresident', name = 'Deputy President'},
+		}
+		if not Array.any(staffInfoCells, function(cellData) return args[cellData.key] end) then
+			return widgets
+		end
+
+		return Array.extendWith(widgets,
+			{Title{children = 'Staff Information'}},
+			Array.map(staffInfoCells, function(cellData)
+				return Cell{name = cellData.name, content = {args[cellData.key]}}
+			end)
+		)
+	end
+
+	return widgets
+end
+
+return CustomCompany


### PR DESCRIPTION
## Summary
This change introduces infobox_company_custom.lua for the Chess Wiki, enabling the addition of a Staff Information section in the company infobox
Goal to enhance the presentation of staff info (President, Deputy President) for the International Chess Federation in the Chess Wiki (same feature as on the Formula1 Wiki http://github.com/Liquipedia/Lua-Modules/blob/main/components/infobox/wikis/formula1/infobox_company_custom.lua)