### PR TITLE
feat: adjust panel-box colors on certain wiki themes

### DIFF
--- a/stylesheets/commons/Panels.less
+++ b/stylesheets/commons/Panels.less
@@ -2,17 +2,28 @@
 Template(s): Panels
 Author(s): FO-nTTaX
 *******************************************************************************/
-.panel-box {
+// Add html prefix to get higher specificity
+html .panel-box {
 	margin-bottom: 10px;
 	border: 0.0625rem solid var( --panel-box-border-color, var( --wiki-bordercolor-light ) );
+
+	&.wiki-bordercolor-light {
+		border-color: var( --panel-box-border-color, var( --wiki-bordercolor-light ) );
+	}
 }
 
-.panel-box-heading {
+// Add html prefix to get higher specificity
+html .panel-box-heading {
 	font-size: 18px;
 	font-weight: bold;
 	padding: 5px 10px;
 	background-color: var( --panel-header-background-color, var( --wiki-color-light ) );
-	border-bottom: 0.0625rem solid var( --panel-header-background-color, var( --wiki-bordercolor-light ) );
+	border-bottom: 0.0625rem solid var( --panel-box-border-color, var( --wiki-bordercolor-light ) );
+	color: var( --panel-box-color );
+
+	&.wiki-bordercolor-light {
+		border-color: var( --panel-box-border-color, var( --wiki-bordercolor-light ) );
+	}
 }
 
 .panel-box-heading:not( :first-child ) {


### PR DESCRIPTION
## Summary

This is part of the ticket https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/issues/156 to set other colors for themes sun, tuliptree, redviolet, gigas and forestgreen.

This needs to be deployed together with https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/merge_requests/129

- add specificity
- add new variable for panel border color
- add color

## How did you test this change?

wikidev
