### PR TITLE
ci: update dependencies to versions running node20

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -11,12 +11,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
-        uses: leafo/gh-actions-lua@v10
+        uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: '5.1'
 
       - name: Setup luarock
-        uses: leafo/gh-actions-luarocks@v4
+        uses: leafo/gh-actions-luarocks@v5
 
       - name: Setup dependencies
         run: |
@@ -42,12 +42,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
-        uses: leafo/gh-actions-lua@v10
+        uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: '5.1'
 
       - name: Setup luarocks
-        uses: leafo/gh-actions-luarocks@v4
+        uses: leafo/gh-actions-luarocks@v5
 
       - name: Setup dependencies
         run: |


### PR DESCRIPTION
## Summary

Upstream CI dependency finally released their node20 version. Let's update these to node20 so we can get rid of the deprecation warning and the potential of failing pipelines when node16 is dropped from GH.
