### PR TITLE
feat: allow countdown switch group to be containable so it does not change unrelated countdowns

### DIFF
--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -75,6 +75,7 @@ function MainPageLayout._makeCells(cells)
 						['box-id'] = item.content.boxid,
 						['padding'] = tostring(item.content.padding),
 						['heading'] = item.content.heading,
+						['panel-attributes'] = item.content.panelAttributes,
 					}))
 				end
 			end

--- a/components/main_page/wikis/apexlegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/apexlegends/main_page_layout_data.lua
@@ -56,6 +56,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/arenafps/main_page_layout_data.lua
+++ b/components/main_page/wikis/arenafps/main_page_layout_data.lua
@@ -56,6 +56,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/brawlstars/main_page_layout_data.lua
+++ b/components/main_page/wikis/brawlstars/main_page_layout_data.lua
@@ -56,6 +56,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/deadlock/main_page_layout_data.lua
+++ b/components/main_page/wikis/deadlock/main_page_layout_data.lua
@@ -66,6 +66,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/dota2/main_page_layout_data.lua
+++ b/components/main_page/wikis/dota2/main_page_layout_data.lua
@@ -111,6 +111,7 @@ local CONTENT = {
 			'font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/halo/main_page_layout_data.lua
+++ b/components/main_page/wikis/halo/main_page_layout_data.lua
@@ -56,6 +56,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/hearthstone/main_page_layout_data.lua
+++ b/components/main_page/wikis/hearthstone/main_page_layout_data.lua
@@ -56,6 +56,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -56,6 +56,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/marvelrivals/main_page_layout_data.lua
+++ b/components/main_page/wikis/marvelrivals/main_page_layout_data.lua
@@ -64,6 +64,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -57,6 +57,7 @@ local CONTENT = {
 			'[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -57,6 +57,7 @@ local CONTENT = {
 			'[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/pubgmobile/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubgmobile/main_page_layout_data.lua
@@ -57,6 +57,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/rainbowsix/main_page_layout_data.lua
+++ b/components/main_page/wikis/rainbowsix/main_page_layout_data.lua
@@ -56,6 +56,7 @@ local CONTENT = {
 			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -42,6 +42,7 @@ local CONTENT = {
 			'text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
+		panelAttributes = 'data-switch-group-container="countdown"',
 	},
 	tournaments = {
 		heading = 'Tournaments',

--- a/javascript/commons/Countdown.js
+++ b/javascript/commons/Countdown.js
@@ -78,9 +78,18 @@ liquipedia.countdown = {
 		} );
 	},
 	toggleCountdowns: function ( isCountdownToggled ) {
-		liquipedia.countdown.timerObjectNodes.forEach( ( timerObjectNode ) => {
-			timerObjectNode.querySelector( '.timer-object-date' ).classList.toggle( this.timerHiddenClass, isCountdownToggled );
-			timerObjectNode.querySelector( '.timer-object-countdown' ).classList.toggle( this.timerHiddenClass, !isCountdownToggled );
+		// Get all countdown toggle containers, if no container exists fall back to the body
+		let containers = document.querySelectorAll( '[data-switch-group-container="countdown"]' );
+		if ( containers.length === 0 ) {
+			containers = document.querySelectorAll( 'body' );
+		}
+		containers.forEach( ( container ) => {
+			// Find countdown nodes live so we don't run into issues with injected timer nodes
+			const timerObjectNodes = container.querySelectorAll( '.timer-object' );
+			timerObjectNodes.forEach( ( timerObjectNode ) => {
+				timerObjectNode.querySelector( '.timer-object-date' ).classList.toggle( this.timerHiddenClass, isCountdownToggled );
+				timerObjectNode.querySelector( '.timer-object-countdown' ).classList.toggle( this.timerHiddenClass, !isCountdownToggled );
+			} );
 		} );
 	},
 	parseTimerObjectNodeToDateObj: function ( timerObjectNode ) {


### PR DESCRIPTION
## Summary

Closes https://github.com/Liquipedia/Lua-Modules/issues/5326

## How did you test this change?

I have set up a minimal example on my dev here:
* With containment: http://fonttax.wiki.tldev.eu/rocketleague/Dfuvberwuivbr
* Without containment: http://fonttax.wiki.tldev.eu/rocketleague/Dfuvberwuivbr2
