### PR TITLE
feat(infobox): add Chess Player/Team number display

### DIFF
--- a/components/infobox/wikis/chess/infobox_league_custom.lua
+++ b/components/infobox/wikis/chess/infobox_league_custom.lua
@@ -68,9 +68,11 @@ function CustomInjector:parse(id, widgets)
 	local caller = self.caller
 	local args = caller.args
 	if id == 'custom' then
-		table.insert(
+		Array.appendWith(
 			widgets,
-			Cell{name = 'Restrictions', content = caller:createRestrictionsCell(args.restrictions)}
+			Cell{name = 'Restrictions', content = caller:createRestrictionsCell(args.restrictions)},
+			Cell{name = 'Number of teams', content = {args.team_number}},
+			Cell{name = 'Number of players', content = {args.player_number}}
 		)
 	elseif id == 'gamesettings' then
 		local isVariant = caller.data.game ~= Game.toIdentifier()


### PR DESCRIPTION
## Summary
![image](https://github.com/user-attachments/assets/5f0c1012-846e-45c9-ae9a-13297f7ffece)
(not sure why it wasn't in the base infobox?)

## How did you test this change?
https://liquipedia.net/chess/index.php?title=Module:Infobox/League/Custom/dev/h2&action=edit

https://liquipedia.net/chess/User:Hesketh2/Test