### PR TITLE
fix(links): update to new toornament subdomain

### DIFF
--- a/standard/links/commons/links.lua
+++ b/standard/links/commons/links.lua
@@ -294,7 +294,7 @@ local PREFIXES = {
 	tlprofile = {'https://tl.net/forum/profile.php?user='},
 	tlstream = {'https://tl.net/video/streams/'},
 	tonamel = {'https://tonamel.com/competition/'},
-	toornament = {'https://www.toornament.com/tournaments/'},
+	toornament = {'https://play.toornament.com/tournaments/'},
 	['trackmania-io'] = {
 		'https://trackmania.io/#/competitions/comp/',
 		player = 'https://trackmania.io/#/player/',


### PR DESCRIPTION
## Summary

They moved all the tournament platform stuff to play subdomain. Just fixing the URLs so they are correct.

## How did you test this change?

Just data fix
