### PR TITLE
feat(match2): don't add HDB warning on documentation pages

### DIFF
--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -771,12 +771,24 @@ end
 ---Whether this title is in any of the given namespaces.
 ---@param ... string|number
 ---@return boolean
-function mw.title:inNamespaces(...) end
+function mw.title:inNamespaces(...)
+	for _, ns in ipairs(arg) do
+		if ns == 0 then
+			return true
+		end
+	end
+	return false
+end
 
 ---Whether this title's subject namespace is in the given namespace.
 ---@param ns string|number
 ---@return boolean
-function mw.title:hasSubjectNamespace(ns) end
+function mw.title:hasSubjectNamespace(ns)
+	if ns == 0 or ns == 1 then
+		return true
+	end
+	return false
+end
 
 ---The same as mw.title.makeTitle( title.namespace, title.text .. '/' .. text ).
 ---@param text string

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -762,16 +762,15 @@ function mw.title:isSubpageOf(title2) end
 ---@param ns string|number
 ---@return boolean
 function mw.title:inNamespace(ns)
-	if ns == 0 then
-		return true
-	end
-	return false
+	-- Currently only supports mocking main namespace as all busted tests are written expecting it
+	return ns == 0
 end
 
 ---Whether this title is in any of the given namespaces.
 ---@param ... string|number
 ---@return boolean
 function mw.title:inNamespaces(...)
+	-- Currently only supports mocking main namespace as all busted tests are written expecting it
 	for _, ns in ipairs(arg) do
 		if ns == 0 then
 			return true
@@ -784,10 +783,8 @@ end
 ---@param ns string|number
 ---@return boolean
 function mw.title:hasSubjectNamespace(ns)
-	if ns == 0 or ns == 1 then
-		return true
-	end
-	return false
+	-- Currently only supports mocking main and talk namespace as all busted tests are written expecting it
+	return ns == 0 or ns == 1
 end
 
 ---The same as mw.title.makeTitle( title.namespace, title.text .. '/' .. text ).

--- a/lua/wikis/commons/MatchGroup/Base.lua
+++ b/lua/wikis/commons/MatchGroup/Base.lua
@@ -47,7 +47,7 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 		end
 	end
 
-	if not Variables.varDefault('tournament_parent') then
+	if store and not Variables.varDefault('tournament_parent') then
 		table.insert(warnings, 'Missing tournament context. Ensure the page has a InfoboxLeague or a HiddenDataBox.')
 		local userSpacePrefix = mw.title.getCurrentTitle().nsText == 'User' and 'User space ' or ''
 		mw.ext.TeamLiquidIntegration.add_category(userSpacePrefix .. 'Pages with missing tournament context')

--- a/lua/wikis/commons/MatchGroup/Base.lua
+++ b/lua/wikis/commons/MatchGroup/Base.lua
@@ -51,8 +51,8 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 
 	if not (Variables.varDefault('tournament_parent') or Namespace.isDocumentative(currentTitle)) then
 		table.insert(warnings, 'Missing tournament context. Ensure the page has a InfoboxLeague or a HiddenDataBox.')
-		local userSpacePrefix = Namespace.isUser(currentTitle) and 'User space ' or ''
-		mw.ext.TeamLiquidIntegration.add_category(userSpacePrefix .. 'Pages with missing tournament context')
+		local categoryPrefix = Namespace.isUser(currentTitle) and 'User space ' or ''
+		mw.ext.TeamLiquidIntegration.add_category(categoryPrefix .. 'Pages with missing tournament context')
 	end
 
 	if Logic.readBool(args.isLegacy) then

--- a/lua/wikis/commons/MatchGroup/Base.lua
+++ b/lua/wikis/commons/MatchGroup/Base.lua
@@ -9,9 +9,9 @@
 local Logic = require('Module:Logic')
 local Variables = require('Module:Variables')
 
-local NAMESPACE_USER = 'User'
-local NAMESPACE_TEMPLATE = 'Template'
-local NAMESPACE_MODULE = 'Module'
+local NS_USER = 'User'
+local NS_TEMPLATE = 'Template'
+local NS_MODULE = 'Module'
 
 local MatchGroupBase = {}
 
@@ -52,9 +52,9 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 		end
 	end
 
-	if not (Variables.varDefault('tournament_parent') or currentTitle:inNamespaces(NAMESPACE_TEMPLATE, NAMESPACE_MODULE)) then
+	if not (Variables.varDefault('tournament_parent') or currentTitle:inNamespaces(NS_TEMPLATE, NS_MODULE)) then
 		table.insert(warnings, 'Missing tournament context. Ensure the page has a InfoboxLeague or a HiddenDataBox.')
-		local userSpacePrefix = currentTitle:hasSubjectNamespace(NAMESPACE_USER) and 'User space ' or ''
+		local userSpacePrefix = currentTitle:hasSubjectNamespace(NS_USER) and 'User space ' or ''
 		mw.ext.TeamLiquidIntegration.add_category(userSpacePrefix .. 'Pages with missing tournament context')
 	end
 
@@ -100,7 +100,7 @@ end
 ---@return string
 function MatchGroupBase.getBracketIdPrefix()
 	local currentTitle = mw.title.getCurrentTitle()
-	if currentTitle:hasSubjectNamespace(NAMESPACE_USER) then
+	if currentTitle:hasSubjectNamespace(NS_USER) then
 		return currentTitle.nsText .. '_' .. currentTitle.rootText .. '_'
 	elseif not currentTitle:inNamespace(0) then
 		return currentTitle.nsText .. '_'

--- a/lua/wikis/commons/MatchGroup/Base.lua
+++ b/lua/wikis/commons/MatchGroup/Base.lua
@@ -7,11 +7,8 @@
 --
 
 local Logic = require('Module:Logic')
+local Namespace = require('Module:Namespace')
 local Variables = require('Module:Variables')
-
-local NS_USER = 'User'
-local NS_TEMPLATE = 'Template'
-local NS_MODULE = 'Module'
 
 local MatchGroupBase = {}
 
@@ -52,9 +49,9 @@ function MatchGroupBase.readOptions(args, matchGroupType)
 		end
 	end
 
-	if not (Variables.varDefault('tournament_parent') or currentTitle:inNamespaces(NS_TEMPLATE, NS_MODULE)) then
+	if not (Variables.varDefault('tournament_parent') or Namespace.isDocumentative(currentTitle)) then
 		table.insert(warnings, 'Missing tournament context. Ensure the page has a InfoboxLeague or a HiddenDataBox.')
-		local userSpacePrefix = currentTitle:hasSubjectNamespace(NS_USER) and 'User space ' or ''
+		local userSpacePrefix = Namespace.isUser(currentTitle) and 'User space ' or ''
 		mw.ext.TeamLiquidIntegration.add_category(userSpacePrefix .. 'Pages with missing tournament context')
 	end
 
@@ -100,9 +97,9 @@ end
 ---@return string
 function MatchGroupBase.getBracketIdPrefix()
 	local currentTitle = mw.title.getCurrentTitle()
-	if currentTitle:hasSubjectNamespace(NS_USER) then
+	if Namespace.isUser(currentTitle) then
 		return currentTitle.nsText .. '_' .. currentTitle.rootText .. '_'
-	elseif not currentTitle:inNamespace(0) then
+	elseif not Namespace.isMain(currentTitle) then
 		return currentTitle.nsText .. '_'
 	else
 		return ''

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -22,14 +22,15 @@ local NS_MODULE_TALK = 829
 
 local Namespace = {}
 
----Determins whether a given title object is in a given namespace, and optionally it's talk namespace.
+---Determins whether a given title object is in the given namespaces, and optionally their talk namespaces.
 ---@param title Title
----@param namespace string|number
+---@param namespaces (string|integer)[]
 ---@param includeTalk boolean?
 ---@return boolean
-local function isInNamespace(title, namespace, includeTalk)
-	local fn = includeTalk and title.hasSubjectNamespace or title.inNamespace
-	return fn(title, namespace)
+local function isInNamespace(title, namespaces, includeTalk)
+	return includeTalk and Array.any(namespaces, function (namespace)
+		return title:hasSubjectNamespace(namespace)
+	end) or title:inNamespaces(unpack(namespaces))
 end
 
 ---Determines if a title object is in the Main namespace.
@@ -39,7 +40,7 @@ end
 ---@return boolean
 function Namespace.isMain(title)
 	title = title or mw.title.getCurrentTitle()
-	return isInNamespace(title, NS_MAIN) or isInNamespace(title, NS_MODULE_TALK)
+	return isInNamespace(title, {NS_MAIN}) or isInNamespace(title, {NS_MODULE_TALK})
 end
 
 ---Determines if a title object is in the User namespace, also considers
@@ -50,7 +51,7 @@ end
 ---@return boolean
 function Namespace.isUser(title, excludeTalk)
 	title = title or mw.title.getCurrentTitle()
-	return isInNamespace(title, NS_USER, not excludeTalk)
+	return isInNamespace(title, {NS_USER}, not excludeTalk)
 end
 
 ---Determines if a title object is in a namespace used for documentation purposes (`NS_PROJECT`,
@@ -62,10 +63,7 @@ end
 ---@return boolean
 function Namespace.isDocumentative(title, excludeTalk)
 	title = title or mw.title.getCurrentTitle()
-	return excludeTalk and title:inNamespaces(NS_PROJECT, NS_TEMPLATE, NS_HELP, NS_MODULE)
-		or Array.any({NS_PROJECT, NS_TEMPLATE, NS_HELP, NS_MODULE}, function (namespace)
-			return title:hasSubjectNamespace(namespace)
-		end)
+	return isInNamespace(title, {NS_PROJECT, NS_TEMPLATE, NS_HELP, NS_MODULE}, not excludeTalk)
 end
 
 Namespace.getIdsByName = FnUtil.memoize(function()

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -22,6 +22,16 @@ local NS_MODULE_TALK = 829
 
 local Namespace = {}
 
+---Determins whether a given title object is in a given namespace, and optionally it's talk namespace.
+---@param title Title
+---@param namespace string|number
+---@param includeTalk boolean?
+---@return boolean
+local function isInNamespace(title, namespace, includeTalk)
+	local fn = includeTalk and title.hasSubjectNamespace or title.inNamespace
+	return fn(namespace)
+end
+
 ---Determines if a title object is in the Main namespace.
 ---`NS_MODULE_TALK` is treated as Main namespace for ScribuntoUnit to work properly.
 ---Will use the title object of the page this module is invoked on if no title is provided.
@@ -29,7 +39,7 @@ local Namespace = {}
 ---@return boolean
 function Namespace.isMain(title)
 	title = title or mw.title.getCurrentTitle()
-	return title:inNamespace(NS_MAIN) or title:inNamespace(NS_MODULE_TALK)
+	return isInNamespace(title, NS_MAIN) or isInNamespace(title, NS_MODULE_TALK)
 end
 
 ---Determines if a title object is in the User namespace, also considers
@@ -40,7 +50,7 @@ end
 ---@return boolean
 function Namespace.isUser(title, excludeTalk)
 	title = title or mw.title.getCurrentTitle()
-	return excludeTalk and title:inNamespace(NS_USER) or title:hasSubjectNamespace(NS_USER)
+	return isInNamespace(title, NS_USER, not excludeTalk)
 end
 
 ---Determines if a title object is in a namespace used for documentation purposes (`NS_PROJECT`,

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -29,7 +29,7 @@ local Namespace = {}
 ---@return boolean
 local function isInNamespace(title, namespace, includeTalk)
 	local fn = includeTalk and title.hasSubjectNamespace or title.inNamespace
-	return fn(namespace)
+	return fn(title, namespace)
 end
 
 ---Determines if a title object is in the Main namespace.

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -33,7 +33,7 @@ function Namespace.isMain(title)
 end
 
 ---Determines if a title object is in the User namespace, also considers
----the User Talk namespace (unless exluded using the `excludeTalk` paramater).
+---the User Talk namespace (unless excluded using the `excludeTalk` paramater).
 ---Will use the title object of the page this module is invoked on if no title is provided.
 ---@param title Title?
 ---@param excludeTalk boolean?
@@ -44,7 +44,7 @@ function Namespace.isUser(title, excludeTalk)
 end
 
 ---Determines if a title object is in a namespace used for documentation purposes (`NS_PROJECT`,
----`NS_TEMPLATE`, `NS_HELP`, and `NS_MODULE`), also considers their talk pages (unless exluded
+---`NS_TEMPLATE`, `NS_HELP`, and `NS_MODULE`), also considers their talk pages (unless excluded
 ---using the `excludeTalk` paramater). Will use the title object of the page this module is
 ---invoked on if no title is provided.
 ---@param title Title?

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -6,18 +6,56 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local FnUtil = require('Module:FnUtil')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
+local NS_MAIN = 0
+local NS_USER = 2
+local NS_PROJECT = 4
+local NS_TEMPLATE = 10
+local NS_HELP = 12
+local NS_MODULE = 828
+local NS_MODULE_TALK = 829
+
 local Namespace = {}
 
----Determines if the page this module is invoked on is in main space
----829 (ModuleTalk) is treated as main space for ScribuntoUnit to work properly
+---Determines if a title object is in the Main namespace.
+---`NS_MODULE_TALK` is treated as Main namespace for ScribuntoUnit to work properly.
+---Will use the title object of the page this module is invoked on if no title is provided.
+---@param title Title?
 ---@return boolean
-function Namespace.isMain()
-	return mw.title.getCurrentTitle():inNamespace(0) or mw.title.getCurrentTitle():inNamespace(829)
+function Namespace.isMain(title)
+	title = title or mw.title.getCurrentTitle()
+	return title:inNamespace(NS_MAIN) or title:inNamespace(NS_MODULE_TALK)
+end
+
+---Determines if a title object is in the User namespace, also considers
+---the User Talk namespace (unless exluded using the `excludeTalk` paramater).
+---Will use the title object of the page this module is invoked on if no title is provided.
+---@param title Title?
+---@param excludeTalk boolean?
+---@return boolean
+function Namespace.isUser(title, excludeTalk)
+	title = title or mw.title.getCurrentTitle()
+	return excludeTalk and title:inNamespace(NS_USER) or title:hasSubjectNamespace(NS_USER)
+end
+
+---Determines if a title object is in a namespace used for documentation purposes (`NS_PROJECT`,
+---`NS_TEMPLATE`, `NS_HELP`, and `NS_MODULE`), also considers their talk pages (unless exluded
+---using the `excludeTalk` paramater). Will use the title object of the page this module is
+---invoked on if no title is provided.
+---@param title Title?
+---@param excludeTalk boolean?
+---@return boolean
+function Namespace.isDocumentative(title, excludeTalk)
+	title = title or mw.title.getCurrentTitle()
+	return excludeTalk and title:inNamespaces(NS_PROJECT, NS_TEMPLATE, NS_HELP, NS_MODULE)
+		or Array.any({NS_PROJECT, NS_TEMPLATE, NS_HELP, NS_MODULE}, function (namespace)
+			return title:hasSubjectNamespace(namespace)
+		end)
 end
 
 Namespace.getIdsByName = FnUtil.memoize(function()

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -28,9 +28,12 @@ local Namespace = {}
 ---@param includeTalk boolean?
 ---@return boolean
 local function isInNamespace(title, namespaces, includeTalk)
-	return includeTalk and Array.any(namespaces, function (namespace)
-		return title:hasSubjectNamespace(namespace)
-	end) or title:inNamespaces(unpack(namespaces))
+	if includeTalk then
+		return Array.any(namespaces, function (namespace)
+			return title:hasSubjectNamespace(namespace)
+		end)
+	end
+	return title:inNamespaces(unpack(namespaces))
 end
 
 ---Determines if a title object is in the Main namespace.
@@ -40,7 +43,7 @@ end
 ---@return boolean
 function Namespace.isMain(title)
 	title = title or mw.title.getCurrentTitle()
-	return isInNamespace(title, {NS_MAIN}) or isInNamespace(title, {NS_MODULE_TALK})
+	return isInNamespace(title, {NS_MAIN, NS_MODULE_TALK})
 end
 
 ---Determines if a title object is in the User namespace, also considers

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -14,7 +14,7 @@ local Table = require('Module:Table')
 
 local NS_MAIN = 0
 local NS_USER = 2
-local NS_PROJECT = 4
+local NS_PROJECT = 4 -- "Liquipedia" namespace
 local NS_TEMPLATE = 10
 local NS_HELP = 12
 local NS_MODULE = 828


### PR DESCRIPTION
## Summary

When storage is disabled, having a parent or not seems irrelevant. For example https://liquipedia.net/counterstrike/Liquipedia:Match2 is showing a pointless warning.

## How did you test this change?

Untested as of yet, gathering feedback/opinions.
