### PR TITLE
refactor(mainpage): grid into widget

### DIFF
--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -8,7 +8,6 @@
 
 local Arguments = require('Module:Arguments')
 local Array = require('Module:Array')
-local Grid = require('Module:Grid')
 local Image = require('Module:Image')
 local LpdbCounter = require('Module:LPDB entity count')
 local Lua = require('Module:Lua')

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -82,10 +82,10 @@ function MainPageLayout._makeCells(cells)
 		for _, item in ipairs(column.children) do
 			local content = {}
 			if item.content then
+				local contentBody = item.content.body
 				if item.content.noPanel then
-					table.insert(content, frame:preprocess(item.content.body))
+					table.insert(content, type(contentBody) == 'string' and frame:preprocess(contentBody) or tostring(contentBody))
 				else
-					local contentBody = item.content.body
 					table.insert(content, tostring(PanelWidget{
 						body = type(contentBody) == 'string' and frame:preprocess(contentBody) or contentBody,
 						boxId = item.content.boxid,

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -104,7 +104,7 @@ function MainPageLayout._makeCells(cells)
 		table.insert(output, GridCell{cellContent = cellContent, lg = column.size, xs = 'ignore', sm = 'ignore'})
 	end
 
-	return GridContainer{ cellContent = output }
+	return GridContainer{ gridCells = output }
 end
 
 ---@param navigationData {file: string?, link: string?, count: table?, title: string?}

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -97,7 +97,7 @@ function MainPageLayout._makeCells(cells)
 				end
 			end
 			if item.children then
-				Array.extendWith(content, MainPageLayout._makeCells(item.children))
+				Array.extendWith(content, { MainPageLayout._makeCells(item.children) })
 			end
 			table.insert(cellContent, GridCell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -14,8 +14,7 @@ local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 
 local WikiData = Lua.import('Module:MainPageLayout/data')
-local GridContainer = Lua.import('Module:Widget/Grid/Container')
-local GridCell = Lua.import('Module:Widget/Grid/Cell')
+local GridWidgets = Lua.import('Module:Widget/Grid')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local LinkWidget = Lua.import('Module:Widget/Basic/Link')
 local PanelWidget = Lua.import('Module:Widget/Panel')
@@ -104,12 +103,12 @@ function MainPageLayout._makeCells(cells)
 			if item.children then
 				Array.extendWith(content, { MainPageLayout._makeCells(item.children) })
 			end
-			table.insert(cellContent, GridCell{cellContent = content, ['order-xs'] = item.mobileOrder})
+			table.insert(cellContent, GridWidgets.Cell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end
-		table.insert(output, GridCell{cellContent = cellContent, lg = column.size, xs = 'ignore', sm = 'ignore'})
+		table.insert(output, GridWidgets.Cell{cellContent = cellContent, lg = column.size, xs = 'ignore', sm = 'ignore'})
 	end
 
-	return GridContainer{ gridCells = output }
+	return GridWidgets.Container{ gridCells = output }
 end
 
 ---@param navigationData {file: string?, link: string?, count: table?, title: string?}

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -70,8 +70,8 @@ function MainPageLayout.make(frame)
 	}
 end
 
----@param body string|Widget|Html|nil
----@return string|Widget|Html|nil
+---@param body (string|Widget|Html|nil)|(string|Widget|Html|nil)[]
+---@return (string|Widget|Html|nil)|(string|Widget|Html|nil)[]
 function MainPageLayout._processCellBody(body)
 	local frame = mw.getCurrentFrame()
 	return type(body) == 'string' and frame:preprocess(body) or body

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -101,7 +101,7 @@ function MainPageLayout._makeCells(cells)
 				end
 			end
 			if item.children then
-				Array.extendWith(content, { MainPageLayout._makeCells(item.children) })
+				Array.extendWith(content, MainPageLayout._makeCells(item.children))
 			end
 			table.insert(cellContent, GridWidgets.Cell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -71,10 +71,16 @@ function MainPageLayout.make(frame)
 	}
 end
 
+---@param body string|Widget
+---@return string|Widget
+function MainPageLayout._processCellBody(body)
+	local frame = mw.getCurrentFrame()
+	return type(body) == 'string' and frame:preprocess(body) or body
+end
+
 ---@param cells table[]
 ---@return Widget
 function MainPageLayout._makeCells(cells)
-	local frame = mw.getCurrentFrame()
 	local output = {}
 
 	for _, column in ipairs(cells) do
@@ -84,10 +90,10 @@ function MainPageLayout._makeCells(cells)
 			if item.content then
 				local contentBody = item.content.body
 				if item.content.noPanel then
-					table.insert(content, type(contentBody) == 'string' and frame:preprocess(contentBody) or tostring(contentBody))
+					table.insert(content, MainPageLayout._processCellBody(contentBody))
 				else
 					table.insert(content, PanelWidget{
-						body = type(contentBody) == 'string' and frame:preprocess(contentBody) or contentBody,
+						body = MainPageLayout._processCellBody(contentBody),
 						boxId = item.content.boxid,
 						padding = item.content.padding,
 						heading = item.content.heading,

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -101,7 +101,7 @@ function MainPageLayout._makeCells(cells)
 				end
 			end
 			if item.children then
-				Array.extendWith(content, MainPageLayout._makeCells(item.children))
+				Array.appendWith(content, MainPageLayout._makeCells(item.children))
 			end
 			table.insert(cellContent, GridWidgets.Cell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -70,8 +70,8 @@ function MainPageLayout.make(frame)
 	}
 end
 
----@param body string|Widget
----@return string|Widget
+---@param body string|Widget|Html|nil
+---@return string|Widget|Html|nil
 function MainPageLayout._processCellBody(body)
 	local frame = mw.getCurrentFrame()
 	return type(body) == 'string' and frame:preprocess(body) or body

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -85,8 +85,9 @@ function MainPageLayout._makeCells(cells)
 				if item.content.noPanel then
 					table.insert(content, frame:preprocess(item.content.body))
 				else
+					local contentBody = item.content.body
 					table.insert(content, tostring(PanelWidget{
-						body = frame:preprocess(item.content.body),
+						body = type(contentBody) == 'string' and frame:preprocess(contentBody) or contentBody,
 						boxId = item.content.boxid,
 						padding = item.content.padding,
 						heading = item.content.heading,

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -92,7 +92,7 @@ function MainPageLayout._makeCells(cells)
 					table.insert(content, MainPageLayout._processCellBody(contentBody))
 				else
 					table.insert(content, PanelWidget{
-						body = MainPageLayout._processCellBody(contentBody),
+						children = MainPageLayout._processCellBody(contentBody),
 						boxId = item.content.boxid,
 						padding = item.content.padding,
 						heading = item.content.heading,

--- a/components/main_page/commons/main_page_layout.lua
+++ b/components/main_page/commons/main_page_layout.lua
@@ -15,6 +15,8 @@ local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 
 local WikiData = Lua.import('Module:MainPageLayout/data')
+local GridContainer = Lua.import('Module:Widget/Grid/Container')
+local GridCell = Lua.import('Module:Widget/Grid/Cell')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local LinkWidget = Lua.import('Module:Widget/Basic/Link')
 local PanelWidget = Lua.import('Module:Widget/Panel')
@@ -65,18 +67,17 @@ function MainPageLayout.make(frame)
 				classes = {'navigation-cards'},
 				children = Array.map(WikiData.navigation, MainPageLayout._makeNavigationCard)
 			},
-			table.concat(MainPageLayout._makeCells(layout)),
+			MainPageLayout._makeCells(layout),
 		},
 	}
 end
 
 ---@param cells table[]
----@return string[]
+---@return Widget
 function MainPageLayout._makeCells(cells)
 	local frame = mw.getCurrentFrame()
 	local output = {}
 
-	table.insert(output, Grid._start_grid{})
 	for _, column in ipairs(cells) do
 		local cellContent = {}
 		for _, item in ipairs(column.children) do
@@ -86,24 +87,24 @@ function MainPageLayout._makeCells(cells)
 				if item.content.noPanel then
 					table.insert(content, type(contentBody) == 'string' and frame:preprocess(contentBody) or tostring(contentBody))
 				else
-					table.insert(content, tostring(PanelWidget{
+					table.insert(content, PanelWidget{
 						body = type(contentBody) == 'string' and frame:preprocess(contentBody) or contentBody,
 						boxId = item.content.boxid,
 						padding = item.content.padding,
 						heading = item.content.heading,
 						panelAttributes = item.content.panelAttributes,
-					}))
+					})
 				end
 			end
 			if item.children then
 				Array.extendWith(content, MainPageLayout._makeCells(item.children))
 			end
-			table.insert(cellContent, tostring(Grid._cell{table.concat(content), ['order-xs'] = item.mobileOrder}))
+			table.insert(cellContent, GridCell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end
-		table.insert(output, tostring(Grid._cell{table.concat(cellContent), lg = column.size, xs = 'ignore', sm = 'ignore'}))
+		table.insert(output, GridCell{cellContent = cellContent, lg = column.size, xs = 'ignore', sm = 'ignore'})
 	end
-	table.insert(output, Grid._end_grid{})
-	return output
+
+	return GridContainer{ cellContent = output }
 end
 
 ---@param navigationData {file: string?, link: string?, count: table?, title: string?}

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -16,11 +16,11 @@ local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
-local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
 local Span = HtmlWidgets.Span
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CENTER_DOT = Span{
 	css = {
@@ -54,16 +54,14 @@ local CONTENT = {
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = Fragment{
-			children = {
-				'This day in League of Legends ',
-				Small{
-					attributes = { id = 'this-day-date' },
-					css = { ['margin-left'] = '5px' },
-					children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
-				}
+		heading = WidgetUtil.collect(
+			'This day in League of Legends ',
+			Small{
+				attributes = { id = 'this-day-date' },
+				css = { ['margin-left'] = '5px' },
+				children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
 			}
-		},
+		),
 		body = '{{Liquipedia:This day}}',
 		padding = true,
 		boxid = 1510,
@@ -81,22 +79,20 @@ local CONTENT = {
 	},
 	matches = {
 		heading = 'Matches',
-		body = Fragment{
-			children = {
-				MatchTickerContainer{},
-				Div{
-					css = {
-						['white-space'] = 'nowrap',
-						display = 'block',
-						margin = '0 10px',
-						['font-size'] = '15px',
-						['font-style'] = 'italic',
-						['text-align'] = 'center',
-					},
-					children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
-				}
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
 			}
-		},
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -118,30 +114,28 @@ local CONTENT = {
 	},
 	headlines = {
 		heading = 'Headlines',
-		body = Fragment{
-			children = {
-				ExternalMediaList.get({ subject = '!', limit = 4 }),
-				Div{
-					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em', },
-					children = {
-						Div{
-							css = {
-								['white-space'] = 'nowrap',
-								display = 'inline',
-								margin = '0 10px',
-								['font-size'] = '15px',
-								['font-style'] = 'italic',
-							},
-							children = {
-								Link{ children = 'See all Headlines', link = 'Portal:News' },
-								CENTER_DOT,
-								Link{ children = 'Add a Headline', link = 'Special:FormEdit/ExternalMediaLinks' }
-							}
+		body = WidgetUtil.collect(
+			ExternalMediaList.get({ subject = '!', limit = 4 }),
+			Div{
+				css = { display = 'block', ['text-align'] = 'center', padding = '0.5em', },
+				children = {
+					Div{
+						css = {
+							['white-space'] = 'nowrap',
+							display = 'inline',
+							margin = '0 10px',
+							['font-size'] = '15px',
+							['font-style'] = 'italic',
+						},
+						children = {
+							Link{ children = 'See all Headlines', link = 'Portal:News' },
+							CENTER_DOT,
+							Link{ children = 'Add a Headline', link = 'Special:FormEdit/ExternalMediaLinks' }
 						}
 					}
 				}
 			}
-		},
+		),
 		padding = true,
 		boxid = 1511,
 	},

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -19,6 +19,7 @@ local TransferList = Lua.import('Module:TransferList')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Fragment = HtmlWidgets.Fragment
+local Small = HtmlWidgets.Small
 local Span = HtmlWidgets.Span
 
 local CENTER_DOT = Span{
@@ -89,8 +90,16 @@ local CONTENT = {
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in League of Legends <small id="this-day-date" style = "margin-left: 5px">(' ..
-			os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')</small>',
+		heading = Fragment{
+			children = {
+				'This day in League of Legends ',
+				Small{
+					attributes = { id = 'this-day-date' },
+					css = { ['margin-left'] = '5px' },
+					children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
+				}
+			}
+		},
 		body = '{{Liquipedia:This day}}',
 		padding = true,
 		boxid = 1510,

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -6,8 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
+local Template = require('Module:Template')
 
 local ExternalMediaList = Lua.import('Module:ExternalMediaList')
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
@@ -17,6 +19,19 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Fragment = HtmlWidgets.Fragment
 local Span = HtmlWidgets.Span
+
+local CENTER_DOT = Span{
+	css = {
+		['font-style'] = 'normal',
+		['padding'] = '0 5px',
+	},
+	children = { '&#8226;' }
+}
+
+---@return string
+local function getTransferSubPage()
+	return os.date('%Y') .. '/' .. os.date('%B')
+end
 
 local CONTENT = {
 	usefulArticles = {
@@ -33,16 +48,43 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15|title=}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = Fragment{
+			children = {
+				Template.safeExpand(mw.getCurrentFrame(), 'Transfer List', { limit = 15, title = '' }),
+				Div{
+					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
+					children = {
+						Div{
+							css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
+							children = { Page.makeInternalLink('Back to top', '#Top') }
+						},
+						Div{
+							classes = { 'plainlinks', 'smalledit' },
+							css = { display = 'inline', float = 'right' },
+							children = { '&#91;' .. Page.makeInternalLink('edit', 'Special:EditPage/Player Transfers/' .. getTransferSubPage() ) .. '&#93;' },
+						},
+						Div{
+							css = {
+								['white-space'] = 'nowrap',
+								display = 'inline',
+								margin = '0 10px',
+								['font-size'] = '15px',
+								['font-style'] = 'italic'
+							},
+							children = {
+								Page.makeInternalLink('See more transfers', 'Portal:Transfers'),
+								CENTER_DOT,
+								Page.makeInternalLink('Transfer query', 'Special:RunQuery/Transfer_history'),
+								CENTER_DOT,
+								Page.makeInternalLink('Input Form', 'lpcommons:Special:RunQuery/Transfer'),
+								CENTER_DOT,
+								Page.makeInternalLink('Rumours', 'Portal:Rumours'),
+							}
+						},
+					}
+				}
+			}
+		},
 		boxid = 1509,
 	},
 	thisDay = {
@@ -116,13 +158,7 @@ local CONTENT = {
 							},
 							children = {
 								Page.makeInternalLink('See all Headlines', 'Portal:News'),
-								Span{
-									css = {
-										['font-style'] = 'normal',
-										['padding'] = '0 5px',
-									},
-									children = { '&#8226;' }
-								},
+								CENTER_DOT,
 								Page.makeInternalLink('Add a Headline', 'Special:FormEdit/ExternalMediaLinks')
 							}
 						}

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -7,6 +7,7 @@
 --
 
 local Lua = require('Module:Lua')
+local Ordinal = require('Module:Ordinal')
 local Page = require('Module:Page')
 
 local ExternalMediaList = Lua.import('Module:ExternalMediaList')
@@ -88,8 +89,8 @@ local CONTENT = {
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in League of Legends <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
+		heading = 'This day in League of Legends <small id="this-day-date" style = "margin-left: 5px">(' ..
+			os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')</small>',
 		body = '{{Liquipedia:This day}}',
 		padding = true,
 		boxid = 1510,

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -13,7 +13,6 @@ local ExternalMediaList = Lua.import('Module:ExternalMediaList')
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
-local TransferList = Lua.import('Module:TransferList')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
@@ -21,6 +20,7 @@ local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
 local Span = HtmlWidgets.Span
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 
 local CENTER_DOT = Span{
 	css = {
@@ -29,11 +29,6 @@ local CENTER_DOT = Span{
 	},
 	children = { '&#8226;' }
 }
-
----@return string
-local function getTransferPage()
-	return 'Special:EditPage/Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-end
 
 local CONTENT = {
 	usefulArticles = {
@@ -50,42 +45,11 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = Fragment{
-			children = {
-				TransferList{ limit = 15 }:fetch():create(),
-				Div{
-					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
-					children = {
-						Div{
-							css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
-							children = { Link{ children = 'Back to top', link = '#Top'} }
-						},
-						Div{
-							classes = { 'plainlinks', 'smalledit' },
-							css = { display = 'inline', float = 'right' },
-							children = { '&#91;', Link{ children = 'edit', link = getTransferPage() }, '&#93;' },
-						},
-						Div{
-							css = {
-								['white-space'] = 'nowrap',
-								display = 'inline',
-								margin = '0 10px',
-								['font-size'] = '15px',
-								['font-style'] = 'italic'
-							},
-							children = {
-								Link{ children = 'See more transfers', link = 'Portal:Transfers' },
-								CENTER_DOT,
-								Link{ children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
-								CENTER_DOT,
-								Link{ children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
-								CENTER_DOT,
-								Link{ children = 'Rumours', link = 'Portal:Rumours' },
-							}
-						},
-					}
-				}
-			}
+		body = TransfersList {
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
+			end
 		},
 		boxid = 1509,
 	},

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -10,6 +10,7 @@ local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 
 local ExternalMediaList = Lua.import('Module:ExternalMediaList')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
@@ -62,9 +63,22 @@ local CONTENT = {
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = Fragment{
+			children = {
+				MatchTickerContainer{},
+				Div{
+					css = {
+						['white-space'] = 'nowrap',
+						display = 'block',
+						margin = '0 10px',
+						['font-size'] = '15px',
+						['font-style'] = 'italic',
+						['text-align'] = 'center',
+					},
+					children = { Page.makeInternalLink('See more matches', 'Liquipedia:Matches') }
+				}
+			}
+		},
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -25,7 +25,7 @@ local Span = HtmlWidgets.Span
 local CENTER_DOT = Span{
 	css = {
 		['font-style'] = 'normal',
-		['padding'] = '0 5px',
+		padding = '0 5px',
 	},
 	children = { '&#8226;' }
 }

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -6,6 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -62,8 +66,14 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20|modifierTypeQualifier=-2|modifierTier1=55|modifierTier2=55|modifierTier3=10}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 20,
+			modifierTypeQualifier = -2,
+			modifierTier1 = 55,
+			modifierTier2 = 55,
+			modifierTier3 = 10
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -8,12 +8,12 @@
 
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
-local Template = require('Module:Template')
 
 local ExternalMediaList = Lua.import('Module:ExternalMediaList')
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+local TransferList = Lua.import('Module:TransferList')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
@@ -50,7 +50,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = Fragment{
 			children = {
-				Template.safeExpand(mw.getCurrentFrame(), 'Transfer List', { limit = 15, title = '' }),
+				TransferList{ limit = 15 }:fetch():create(),
 				Div{
 					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
 					children = {

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local Template = require('Module:Template')

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -8,7 +8,6 @@
 
 local Lua = require('Module:Lua')
 local Ordinal = require('Module:Ordinal')
-local Page = require('Module:Page')
 
 local ExternalMediaList = Lua.import('Module:ExternalMediaList')
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
@@ -19,6 +18,7 @@ local TransferList = Lua.import('Module:TransferList')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Fragment = HtmlWidgets.Fragment
+local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
 local Span = HtmlWidgets.Span
 
@@ -58,12 +58,12 @@ local CONTENT = {
 					children = {
 						Div{
 							css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
-							children = { Page.makeInternalLink('Back to top', '#Top') }
+							children = { Link{ children = 'Back to top', link = '#Top'} }
 						},
 						Div{
 							classes = { 'plainlinks', 'smalledit' },
 							css = { display = 'inline', float = 'right' },
-							children = { '&#91;' .. Page.makeInternalLink('edit', getTransferPage() ) .. '&#93;' },
+							children = { '&#91;', Link{ children = 'edit', link = getTransferPage() }, '&#93;' },
 						},
 						Div{
 							css = {
@@ -74,13 +74,13 @@ local CONTENT = {
 								['font-style'] = 'italic'
 							},
 							children = {
-								Page.makeInternalLink('See more transfers', 'Portal:Transfers'),
+								Link{ children = 'See more transfers', link = 'Portal:Transfers' },
 								CENTER_DOT,
-								Page.makeInternalLink('Transfer query', 'Special:RunQuery/Transfer_history'),
+								Link{ children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
 								CENTER_DOT,
-								Page.makeInternalLink('Input Form', 'lpcommons:Special:RunQuery/Transfer'),
+								Link{ children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
 								CENTER_DOT,
-								Page.makeInternalLink('Rumours', 'Portal:Rumours'),
+								Link{ children = 'Rumours', link = 'Portal:Rumours' },
 							}
 						},
 					}
@@ -129,7 +129,7 @@ local CONTENT = {
 						['font-style'] = 'italic',
 						['text-align'] = 'center',
 					},
-					children = { Page.makeInternalLink('See more matches', 'Liquipedia:Matches') }
+					children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
 				}
 			}
 		},
@@ -169,9 +169,9 @@ local CONTENT = {
 								['font-style'] = 'italic',
 							},
 							children = {
-								Page.makeInternalLink('See all Headlines', 'Portal:News'),
+								Link{ children = 'See all Headlines', link = 'Portal:News' },
 								CENTER_DOT,
-								Page.makeInternalLink('Add a Headline', 'Special:FormEdit/ExternalMediaLinks')
+								Link{ children = 'Add a Headline', link = 'Special:FormEdit/ExternalMediaLinks' }
 							}
 						}
 					}

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -29,8 +29,8 @@ local CENTER_DOT = Span{
 }
 
 ---@return string
-local function getTransferSubPage()
-	return os.date('%Y') .. '/' .. os.date('%B')
+local function getTransferPage()
+	return 'Special:EditPage/Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
 end
 
 local CONTENT = {
@@ -61,7 +61,7 @@ local CONTENT = {
 						Div{
 							classes = { 'plainlinks', 'smalledit' },
 							css = { display = 'inline', float = 'right' },
-							children = { '&#91;' .. Page.makeInternalLink('edit', 'Special:EditPage/Player Transfers/' .. getTransferSubPage() ) .. '&#93;' },
+							children = { '&#91;' .. Page.makeInternalLink('edit', getTransferPage() ) .. '&#93;' },
 						},
 						Div{
 							css = {

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -45,12 +45,7 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = TransfersList {
-			rumours = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-			end
-		},
+		body = TransfersList{rumours = true},
 		boxid = 1509,
 	},
 	thisDay = {

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -11,6 +11,7 @@ local Page = require('Module:Page')
 local Template = require('Module:Template')
 
 local ExternalMediaList = Lua.import('Module:ExternalMediaList')
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 
@@ -99,8 +100,10 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -14,21 +14,13 @@ local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 
+local CenterDot = Lua.import('Module:Widget/MainPage/CenterDot')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
-local Span = HtmlWidgets.Span
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 local WidgetUtil = Lua.import('Module:Widget/Util')
-
-local CENTER_DOT = Span{
-	css = {
-		['font-style'] = 'normal',
-		padding = '0 5px',
-	},
-	children = { '&#8226;' }
-}
 
 local CONTENT = {
 	usefulArticles = {
@@ -124,7 +116,7 @@ local CONTENT = {
 						},
 						children = {
 							Link{ children = 'See all Headlines', link = 'Portal:News' },
-							CENTER_DOT,
+							CenterDot(),
 							Link{ children = 'Add a Headline', link = 'Special:FormEdit/ExternalMediaLinks' }
 						}
 					}

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -115,7 +115,7 @@ local CONTENT = {
 	headlines = {
 		heading = 'Headlines',
 		body = WidgetUtil.collect(
-			ExternalMediaList.get({ subject = '!', limit = 4 }),
+			ExternalMediaList.get{ subject = '!', limit = 4 },
 			Div{
 				css = { display = 'block', ['text-align'] = 'center', padding = '0.5em', },
 				children = {

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -7,8 +7,15 @@
 --
 
 local Lua = require('Module:Lua')
+local Page = require('Module:Page')
 
+local ExternalMediaList = Lua.import('Module:ExternalMediaList')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Fragment = HtmlWidgets.Fragment
+local Span = HtmlWidgets.Span
 
 local CONTENT = {
 	usefulArticles = {
@@ -79,11 +86,36 @@ local CONTENT = {
 	},
 	headlines = {
 		heading = 'Headlines',
-		body = '{{ExternalMediaList|subject=!|limit=4}}' ..
-			'<div style{{=}}"display:block; text-align:center; padding:0.5em;">' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px; font-size:15px; font-style:italic;">' ..
-			'[[Portal:News|See all Headlines]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Special:FormEdit/ExternalMediaLinks|Add a Headline]]</div></div>',
+		body = Fragment{
+			children = {
+				ExternalMediaList.get({ subject = '!', limit = 4 }),
+				Div{
+					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em', },
+					children = {
+						Div{
+							css = {
+								['white-space'] = 'nowrap',
+								display = 'inline',
+								margin = '0 10px',
+								['font-size'] = '15px',
+								['font-style'] = 'italic',
+							},
+							children = {
+								Page.makeInternalLink('See all Headlines', 'Portal:News'),
+								Span{
+									css = {
+										['font-style'] = 'normal',
+										['padding'] = '0 5px',
+									},
+									children = { '&#8226;' }
+								},
+								Page.makeInternalLink('Add a Headline', 'Special:FormEdit/ExternalMediaLinks')
+							}
+						}
+					}
+				}
+			}
+		},
 		padding = true,
 		boxid = 1511,
 	},

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -19,20 +19,7 @@ local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
-local Span = HtmlWidgets.Span
-
-local CENTER_DOT = Span{
-	css = {
-		['font-style'] = 'normal',
-		padding = '0 5px',
-	},
-	children = { '&#8226;' }
-}
-
----@return string
-local function getTransferPage()
-	return 'Special:EditPage/Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-end
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 
 local CONTENT = {
 	usefulArticles = {
@@ -49,40 +36,11 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = Fragment{
-			children = {
-				TransferList{ limit = 15 }:fetch():create(),
-				Div{
-					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
-					children = {
-						Div{
-							css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
-							children = { Link{ children = 'Back to top', link = '#Top'} }
-						},
-						Div{
-							classes = { 'plainlinks', 'smalledit' },
-							css = { display = 'inline', float = 'right' },
-							children = { '&#91;', Link{ children = 'edit', link = getTransferPage() }, '&#93;' },
-						},
-						Div{
-							css = {
-								['white-space'] = 'nowrap',
-								display = 'inline',
-								margin = '0 10px',
-								['font-size'] = '15px',
-								['font-style'] = 'italic'
-							},
-							children = {
-								Link{ children = 'See more transfers', link = 'Portal:Transfers' },
-								CENTER_DOT,
-								Link{ children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
-								CENTER_DOT,
-								Link{ children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' }
-							}
-						},
-					}
-				}
-			}
+		body = TransfersList {
+			rumours = false,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
+			end
 		},
 		boxid = 1509,
 	},

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -35,12 +35,7 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = TransfersList {
-			rumours = false,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-			end
-		},
+		body = TransfersList{},
 		boxid = 1509,
 	},
 	thisDay = {

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -6,6 +6,34 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+local Ordinal = require('Module:Ordinal')
+
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+local TransferList = Lua.import('Module:TransferList')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local Fragment = HtmlWidgets.Fragment
+local Link = Lua.import('Module:Widget/Basic/Link')
+local Small = HtmlWidgets.Small
+local Span = HtmlWidgets.Span
+
+local CENTER_DOT = Span{
+	css = {
+		['font-style'] = 'normal',
+		['padding'] = '0 5px',
+	},
+	children = { '&#8226;' }
+}
+
+---@return string
+local function getTransferPage()
+	return 'Special:EditPage/Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
+end
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,21 +49,54 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15|title=}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Special:RunQuery/Transfer history|Transfer query]]' ..
-			'<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'</center></div>\n</div>',
+		body = Fragment{
+			children = {
+				TransferList{ limit = 15 }:fetch():create(),
+				Div{
+					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
+					children = {
+						Div{
+							css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
+							children = { Link{ children = 'Back to top', link = '#Top'} }
+						},
+						Div{
+							classes = { 'plainlinks', 'smalledit' },
+							css = { display = 'inline', float = 'right' },
+							children = { '&#91;', Link{ children = 'edit', link = getTransferPage() }, '&#93;' },
+						},
+						Div{
+							css = {
+								['white-space'] = 'nowrap',
+								display = 'inline',
+								margin = '0 10px',
+								['font-size'] = '15px',
+								['font-style'] = 'italic'
+							},
+							children = {
+								Link{ children = 'See more transfers', link = 'Portal:Transfers' },
+								CENTER_DOT,
+								Link{ children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
+								CENTER_DOT,
+								Link{ children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' }
+							}
+						},
+					}
+				}
+			}
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in PUBG <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
+		heading = Fragment{
+			children = {
+				'This day in PUBG ',
+				Small{
+					attributes = { id = 'this-day-date' },
+					css = { ['margin-left'] = '5px' },
+					children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
+				}
+			}
+		},
 		body = '{{Liquipedia:This day}}',
 		padding = true,
 		boxid = 1510,
@@ -46,15 +107,29 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}'..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">' ..
-			'[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
+		body = Fragment{
+			children = {
+				MatchTickerContainer{},
+				Div{
+					css = {
+						['white-space'] = 'nowrap',
+						display = 'block',
+						margin = '0 10px',
+						['font-size'] = '15px',
+						['font-style'] = 'italic',
+						['text-align'] = 'center',
+					},
+					children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+				}
+			}
+		},
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -63,8 +138,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=90|completedDays=60}}',
+		body = TournamentsTicker{
+			upcomingDays = 90,
+			completedDays = 60
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -15,10 +15,10 @@ local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
-local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CONTENT = {
 	usefulArticles = {
@@ -44,16 +44,14 @@ local CONTENT = {
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = Fragment{
-			children = {
-				'This day in PUBG ',
-				Small{
-					attributes = { id = 'this-day-date' },
-					css = { ['margin-left'] = '5px' },
-					children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
-				}
+		heading = WidgetUtil.collect(
+			'This day in PUBG ',
+			Small{
+				attributes = { id = 'this-day-date' },
+				css = { ['margin-left'] = '5px' },
+				children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
 			}
-		},
+		),
 		body = '{{Liquipedia:This day}}',
 		padding = true,
 		boxid = 1510,
@@ -71,22 +69,20 @@ local CONTENT = {
 	},
 	matches = {
 		heading = 'Matches',
-		body = Fragment{
-			children = {
-				MatchTickerContainer{},
-				Div{
-					css = {
-						['white-space'] = 'nowrap',
-						display = 'block',
-						margin = '0 10px',
-						['font-size'] = '15px',
-						['font-style'] = 'italic',
-						['text-align'] = 'center',
-					},
-					children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
-				}
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
 			}
-		},
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -24,7 +24,7 @@ local Span = HtmlWidgets.Span
 local CENTER_DOT = Span{
 	css = {
 		['font-style'] = 'normal',
-		['padding'] = '0 5px',
+		padding = '0 5px',
 	},
 	children = { '&#8226;' }
 }

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -11,7 +11,6 @@ local Ordinal = require('Module:Ordinal')
 
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
-local TransferList = Lua.import('Module:TransferList')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div

--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -27,7 +27,7 @@ end
 local CENTER_DOT = Span{
 	css = {
 		['font-style'] = 'normal',
-		['padding'] = '0 5px',
+		padding = '0 5px',
 	},
 	children = { '&#8226;' }
 }

--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -10,7 +10,6 @@ local Lua = require('Module:Lua')
 
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
-local TransferList = Lua.import('Module:TransferList')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div

--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -13,10 +13,10 @@ local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
-local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CONTENT = {
 	theGame = {
@@ -48,22 +48,20 @@ local CONTENT = {
 	},
 	matches = {
 		heading = 'Matches',
-		body = Fragment{
-			children = {
-				MatchTickerContainer{},
-				Div{
-					css = {
-						['white-space'] = 'nowrap',
-						display = 'block',
-						margin = '0 10px',
-						['font-size'] = '15px',
-						['font-style'] = 'italic',
-						['text-align'] = 'center',
-					},
-					children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
-				}
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
 			}
-		},
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {

--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -6,6 +6,32 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+local TransferList = Lua.import('Module:TransferList')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Fragment = HtmlWidgets.Fragment
+local Link = Lua.import('Module:Widget/Basic/Link')
+local Span = HtmlWidgets.Span
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+
+---@return string
+local function getTransferPage()
+	return 'Special:EditPage/Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
+end
+
+local CENTER_DOT = Span{
+	css = {
+		['font-style'] = 'normal',
+		['padding'] = '0 5px',
+	},
+	children = { '&#8226;' }
+}
+
 local CONTENT = {
 	theGame = {
 		heading = 'The Game',
@@ -15,15 +41,43 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}<div style="display:block; text-align:center; padding:0.5em;">' ..
-			'<div style="display:inline; float:left; font-style:italic;">[[#Top|Back to top]]</div>' ..
-			'<div style="display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>' ..
-			'<div style="white-space:nowrap; display:inline; margin:0 10px; font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]</div><div style="white-space:nowrap; display:inline; margin:0 10px; font-size:15px; ' ..
-			'font-style:italic;">[[Special:RunQuery/Transfer|Input Form]]<span style="font-style:normal; ' ..
-			'padding:0 5px;">&#8226;</span>[[Portal:Rumours|Rumours]]</div></div>',
+		body = Fragment{
+			children = {
+				TransferList{ limit = 15 }:fetch():create(),
+				Div{
+					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
+					children = {
+						Div{
+							css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
+							children = { Link{ children = 'Back to top', link = '#Top'} }
+						},
+						Div{
+							classes = { 'plainlinks', 'smalledit' },
+							css = { display = 'inline', float = 'right' },
+							children = { '&#91;', Link{ children = 'edit', link = getTransferPage() }, '&#93;' },
+						},
+						Div{
+							css = {
+								['white-space'] = 'nowrap',
+								display = 'inline',
+								margin = '0 10px',
+								['font-size'] = '15px',
+								['font-style'] = 'italic'
+							},
+							children = {
+								Link{ children = 'See more transfers', link = 'Portal:Transfers' },
+								CENTER_DOT,
+								Link{ children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
+								CENTER_DOT,
+								Link{ children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
+								CENTER_DOT,
+								Link{ children = 'Rumours', link = 'Portal:Rumours' },
+							}
+						},
+					}
+				}
+			}
+		},
 		boxid = 1509,
 	},
 	specialEvents = {
@@ -32,14 +86,29 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; font-size:15px; font-style:italic; ' ..
-			'text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = Fragment{
+			children = {
+				MatchTickerContainer{},
+				Div{
+					css = {
+						['white-space'] = 'nowrap',
+						display = 'block',
+						margin = '0 10px',
+						['font-size'] = '15px',
+						['font-style'] = 'italic',
+						['text-align'] = 'center',
+					},
+					children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+				}
+			}
+		},
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -48,8 +117,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=21|completedDays=14}}',
+		body = TournamentsTicker{
+			upcomingDays = 21,
+			completedDays = 14,
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -27,12 +27,7 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = TransfersList {
-			rumours = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-			end
-		},
+		body = TransfersList{rumours = true},
 		boxid = 1509,
 	},
 	specialEvents = {

--- a/components/main_page/wikis/valorant/main_page_layout_data.lua
+++ b/components/main_page/wikis/valorant/main_page_layout_data.lua
@@ -16,21 +16,8 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
-local Span = HtmlWidgets.Span
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
-
----@return string
-local function getTransferPage()
-	return 'Special:EditPage/Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-end
-
-local CENTER_DOT = Span{
-	css = {
-		['font-style'] = 'normal',
-		padding = '0 5px',
-	},
-	children = { '&#8226;' }
-}
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 
 local CONTENT = {
 	theGame = {
@@ -41,42 +28,11 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = Fragment{
-			children = {
-				TransferList{ limit = 15 }:fetch():create(),
-				Div{
-					css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
-					children = {
-						Div{
-							css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
-							children = { Link{ children = 'Back to top', link = '#Top'} }
-						},
-						Div{
-							classes = { 'plainlinks', 'smalledit' },
-							css = { display = 'inline', float = 'right' },
-							children = { '&#91;', Link{ children = 'edit', link = getTransferPage() }, '&#93;' },
-						},
-						Div{
-							css = {
-								['white-space'] = 'nowrap',
-								display = 'inline',
-								margin = '0 10px',
-								['font-size'] = '15px',
-								['font-style'] = 'italic'
-							},
-							children = {
-								Link{ children = 'See more transfers', link = 'Portal:Transfers' },
-								CENTER_DOT,
-								Link{ children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
-								CENTER_DOT,
-								Link{ children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
-								CENTER_DOT,
-								Link{ children = 'Rumours', link = 'Portal:Rumours' },
-							}
-						},
-					}
-				}
-			}
+		body = TransfersList {
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
+			end
 		},
 		boxid = 1509,
 	},

--- a/components/transfer/commons/transfer_list.lua
+++ b/components/transfer/commons/transfer_list.lua
@@ -67,12 +67,10 @@ local DEFAULT_VALUES = {
 ---@field baseConditions ConditionTree
 ---@field conditions string
 local TransferList = Class.new(
-	---@param frame Frame
+	---@param args table
 	---@return self
-	function(self, frame)
-		local args = Arguments.getArgs(frame)
+	function(self, args)
 		self.config = self:parseArgs(args)
-
 		return self
 	end
 )
@@ -80,7 +78,8 @@ local TransferList = Class.new(
 ---@param frame Frame
 ---@return Html
 function TransferList.run(frame)
-	return TransferList(frame):fetch():create()
+	local args = Arguments.getArgs(frame)
+	return TransferList(args):fetch():create()
 end
 
 ---@param args table

--- a/components/widget/grid/widget_grid.lua
+++ b/components/widget/grid/widget_grid.lua
@@ -1,0 +1,16 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Grid
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local GridWidgets = {}
+
+GridWidgets.Container = Lua.import('Module:Widget/Grid/Container')
+GridWidgets.Cell = Lua.import('Module:Widget/Grid/Cell')
+
+return GridWidgets

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -1,0 +1,87 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Grid/Cell
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+
+local GRID_WIDTHS = {
+	'xs',
+	'sm',
+	'md',
+	'lg',
+	'xl',
+	'xxl'
+}
+
+local GRID_DIRECTIONS = {
+	'',
+	'x',
+	'y',
+	'l',
+	'r',
+	't',
+	'b'
+}
+
+---@class GridCell: Widget
+---@operator call(table): Panel
+---@field props table<string, any>
+local GridCell = Class.new(Widget)
+
+---@return Widget
+function GridCell:render()
+	local addedSpecificClass = false
+
+	local cellClasses = { 'lp-col' }
+	for _, width in ipairs( GRID_WIDTHS ) do
+		if self.props.width then
+			addedSpecificClass = true
+			local widthPrefix = ''
+			if width == 'xs' then
+				addedSpecificClass = true
+			elseif self.props.width == 'default' then
+				widthPrefix = width
+			else
+				widthPrefix = width .. '-'
+			end
+			if self.props.width == 'ignore' then
+				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. 'contents')
+			elseif self.props.width == 'default' then
+				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix)
+			else
+				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props.width)
+			end
+		end
+		if self.props[ 'order-' .. width ] then
+			local width_prefix = width ~= 'xs' and width .. '-' or ''
+			Array.extendWith(cellClasses, 'lp-order-' .. width_prefix .. self.props[ 'order-' .. width ])
+		end
+		for _, direction in ipairs( GRID_DIRECTIONS ) do
+			if self.props[ 'm' .. direction .. '-' .. width ] then
+				local width_prefix = width ~= 'xs' and width .. '-' or ''
+				Array.extendWith(cellClasses, 'm' .. direction .. '-' .. width_prefix .. self.props[ 'm' .. direction .. '-' .. width ])
+			end
+		end
+	end
+
+	if not addedSpecificClass and self.props.noDefault then
+		Array.extendWith(cellClasses, 'lp-col-12')
+	end
+
+	return Div{
+		classes = cellClasses,
+		children = self.props.cellContent
+	}
+end
+
+return GridCell

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -38,26 +38,32 @@ local GRID_DIRECTIONS = {
 ---@field props table<string, any>
 local GridCell = Class.new(Widget)
 
+---@param width string
+---@return string[]
+function GridCell:_getCellClasses(width)
+	local widthPrefix = ''
+	if width ~= 'xs' then
+		if self.props[width] == 'default' then
+			widthPrefix = width
+		else
+			widthPrefix = width .. '-'
+		end
+	end
+	if self.props[width] == 'ignore' then
+		return {'lp-d-' .. widthPrefix .. 'contents'}
+	elseif self.props[width] == 'default' then
+		return {'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix}
+	else
+		return {'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[width]}
+	end
+end
+
 ---@return Widget
 function GridCell:render()
 	local cellClasses = { 'lp-col' }
 	Array.forEach(GRID_WIDTHS, function (width)
 		if self.props[width] then
-			local widthPrefix = ''
-			if width ~= 'xs' then
-				if self.props[width] == 'default' then
-					widthPrefix = width
-				else
-					widthPrefix = width .. '-'
-				end
-			end
-			if self.props[width] == 'ignore' then
-				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'contents'})
-			elseif self.props[width] == 'default' then
-				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix})
-			else
-				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[width]})
-			end
+			Array.extendWith(cellClasses, self:_getCellClasses(width))
 		end
 		if self.props['order-' .. width] then
 			local width_prefix = width ~= 'xs' and width .. '-' or ''

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
@@ -81,7 +82,7 @@ function GridCell:render()
 
 	if Array.all(GRID_WIDTHS, function (width)
 		return self.props[width] == nil
-	end) and not self.props.noDefault then
+	end) and not Logic.readBool(self.props.noDefault) then
 		Array.extendWith(cellClasses, 'lp-col-12')
 	end
 

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -40,8 +40,6 @@ local GridCell = Class.new(Widget)
 
 ---@return Widget
 function GridCell:render()
-	local addedSpecificClass = false
-
 	local cellClasses = { 'lp-col' }
 	Array.forEach(GRID_WIDTHS, function (width)
 		if self.props[ width ] then

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -49,32 +49,32 @@ function GridCell:render()
 			local widthPrefix = ''
 			if width == 'xs' then
 				addedSpecificClass = true
-			elseif self.props.width == 'default' then
+			elseif self.props[ width ] == 'default' then
 				widthPrefix = width
 			else
 				widthPrefix = width .. '-'
 			end
-			if self.props.width == 'ignore' then
-				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. 'contents')
+			if self.props[ width ] == 'ignore' then
+				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'contents'})
 			elseif self.props.width == 'default' then
-				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix)
+				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix})
 			else
-				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[ width ])
+				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[ width ]})
 			end
 		end
 		if self.props[ 'order-' .. width ] then
 			local width_prefix = width ~= 'xs' and width .. '-' or ''
-			Array.extendWith(cellClasses, 'lp-order-' .. width_prefix .. self.props[ 'order-' .. width ])
+			Array.extendWith(cellClasses, {'lp-order-' .. width_prefix .. self.props[ 'order-' .. width ]})
 		end
 		for _, direction in ipairs( GRID_DIRECTIONS ) do
 			if self.props[ 'm' .. direction .. '-' .. width ] then
 				local width_prefix = width ~= 'xs' and width .. '-' or ''
-				Array.extendWith(cellClasses, 'm' .. direction .. '-' .. width_prefix .. self.props[ 'm' .. direction .. '-' .. width ])
+				Array.extendWith(cellClasses, {'m' .. direction .. '-' .. width_prefix .. self.props[ 'm' .. direction .. '-' .. width ]})
 			end
 		end
 	end
 
-	if not addedSpecificClass and self.props.noDefault then
+	if not addedSpecificClass and not self.props.noDefault then
 		Array.extendWith(cellClasses, 'lp-col-12')
 	end
 

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -73,8 +73,8 @@ function GridCell:render()
 		end
 	end)
 
-	if not Array.any(GRID_WIDTHS, function (width)
-		return self.props[width] ~= nil
+	if Array.all(GRID_WIDTHS, function (width)
+		return self.props[width] == nil
 	end) and not self.props.noDefault then
 		Array.extendWith(cellClasses, 'lp-col-12')
 	end

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -44,7 +44,7 @@ function GridCell:render()
 
 	local cellClasses = { 'lp-col' }
 	for _, width in ipairs( GRID_WIDTHS ) do
-		if self.props.width then
+		if self.props[ width ] then
 			addedSpecificClass = true
 			local widthPrefix = ''
 			if width == 'xs' then
@@ -59,7 +59,7 @@ function GridCell:render()
 			elseif self.props.width == 'default' then
 				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix)
 			else
-				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props.width)
+				Array.extendWith(cellClasses, 'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[ width ])
 			end
 		end
 		if self.props[ 'order-' .. width ] then

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -76,7 +76,7 @@ function GridCell:render()
 		end
 	end)
 
-	if Array.any(GRID_WIDTHS, function (width)
+	if not Array.any(GRID_WIDTHS, function (width)
 		return self.props[width] ~= nil
 	end) and not self.props.noDefault then
 		Array.extendWith(cellClasses, 'lp-col-12')

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
@@ -43,9 +44,8 @@ function GridCell:render()
 	local addedSpecificClass = false
 
 	local cellClasses = { 'lp-col' }
-	for _, width in ipairs( GRID_WIDTHS ) do
+	Array.forEach(GRID_WIDTHS, function (width)
 		if self.props[ width ] then
-			addedSpecificClass = true
 			local widthPrefix = ''
 			if width ~= 'xs' then
 				if self.props[ width ] == 'default' then
@@ -74,9 +74,11 @@ function GridCell:render()
 				})
 			end
 		end
-	end
+	end)
 
-	if not addedSpecificClass and not self.props.noDefault then
+	if Array.any(GRID_WIDTHS, function (width)
+		return self.props[width] ~= nil
+	end) and not self.props.noDefault then
 		Array.extendWith(cellClasses, 'lp-col-12')
 	end
 

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -69,7 +69,7 @@ function GridCell:render()
 		for _, direction in ipairs( GRID_DIRECTIONS ) do
 			if self.props[ 'm' .. direction .. '-' .. width ] then
 				local width_prefix = width ~= 'xs' and width .. '-' or ''
-				Array.extendWith(cellClasses, {'m' .. direction .. '-' .. width_prefix .. self.props[ 'm' .. direction .. '-' .. width ]})
+				Array.extendWith(cellClasses, {'m' .. direction .. '-' .. width_prefix .. self.props['m' .. direction .. '-' .. width]})
 			end
 		end
 	end

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -68,14 +68,17 @@ function GridCell:render()
 		end
 		if self.props['order-' .. width] then
 			local width_prefix = width ~= 'xs' and width .. '-' or ''
-			Array.extendWith(cellClasses, {'lp-order-' .. width_prefix .. self.props['order-' .. width]})
+			Array.appendWith(
+				cellClasses, 'lp-order-' .. width_prefix .. self.props['order-' .. width]
+			)
 		end
 		Array.forEach(GRID_DIRECTIONS, function (direction)
 			if self.props['m' .. direction .. '-' .. width] then
 				local width_prefix = width ~= 'xs' and width .. '-' or ''
-				Array.extendWith(cellClasses, {
+				Array.appendWith(
+					cellClasses,
 					'm' .. direction .. '-' .. width_prefix .. self.props['m' .. direction .. '-' .. width]
-				})
+				)
 			end
 		end)
 	end)
@@ -83,7 +86,7 @@ function GridCell:render()
 	if Array.all(GRID_WIDTHS, function (width)
 		return self.props[width] == nil
 	end) and not Logic.readBool(self.props.noDefault) then
-		Array.extendWith(cellClasses, 'lp-col-12')
+		Array.appendWith(cellClasses, 'lp-col-12')
 	end
 
 	return Div{

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -69,7 +69,9 @@ function GridCell:render()
 		for _, direction in ipairs( GRID_DIRECTIONS ) do
 			if self.props[ 'm' .. direction .. '-' .. width ] then
 				local width_prefix = width ~= 'xs' and width .. '-' or ''
-				Array.extendWith(cellClasses, {'m' .. direction .. '-' .. width_prefix .. self.props['m' .. direction .. '-' .. width]})
+				Array.extendWith(cellClasses, {
+					'm' .. direction .. '-' .. width_prefix .. self.props[ 'm' .. direction .. '-' .. width ]
+				})
 			end
 		end
 	end

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -63,14 +63,14 @@ function GridCell:render()
 			local width_prefix = width ~= 'xs' and width .. '-' or ''
 			Array.extendWith(cellClasses, {'lp-order-' .. width_prefix .. self.props[ 'order-' .. width ]})
 		end
-		for _, direction in ipairs( GRID_DIRECTIONS ) do
+		Array.forEach(GRID_DIRECTIONS, function (direction)
 			if self.props[ 'm' .. direction .. '-' .. width ] then
 				local width_prefix = width ~= 'xs' and width .. '-' or ''
 				Array.extendWith(cellClasses, {
 					'm' .. direction .. '-' .. width_prefix .. self.props[ 'm' .. direction .. '-' .. width ]
 				})
 			end
-		end
+		end)
 	end)
 
 	if Array.all(GRID_WIDTHS, function (width)

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -53,7 +53,7 @@ function GridCell:render()
 			end
 			if self.props[width] == 'ignore' then
 				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'contents'})
-			elseif self.props.width == 'default' then
+			elseif self.props[width] == 'default' then
 				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix})
 			else
 				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[width]})

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -42,32 +42,32 @@ local GridCell = Class.new(Widget)
 function GridCell:render()
 	local cellClasses = { 'lp-col' }
 	Array.forEach(GRID_WIDTHS, function (width)
-		if self.props[ width ] then
+		if self.props[width] then
 			local widthPrefix = ''
 			if width ~= 'xs' then
-				if self.props[ width ] == 'default' then
+				if self.props[width] == 'default' then
 					widthPrefix = width
 				else
 					widthPrefix = width .. '-'
 				end
 			end
-			if self.props[ width ] == 'ignore' then
+			if self.props[width] == 'ignore' then
 				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'contents'})
 			elseif self.props.width == 'default' then
 				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. '-block', 'lp-col-' .. widthPrefix})
 			else
-				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[ width ]})
+				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'block', 'lp-col-' .. widthPrefix .. self.props[width]})
 			end
 		end
-		if self.props[ 'order-' .. width ] then
+		if self.props['order-' .. width] then
 			local width_prefix = width ~= 'xs' and width .. '-' or ''
-			Array.extendWith(cellClasses, {'lp-order-' .. width_prefix .. self.props[ 'order-' .. width ]})
+			Array.extendWith(cellClasses, {'lp-order-' .. width_prefix .. self.props['order-' .. width]})
 		end
 		Array.forEach(GRID_DIRECTIONS, function (direction)
-			if self.props[ 'm' .. direction .. '-' .. width ] then
+			if self.props['m' .. direction .. '-' .. width] then
 				local width_prefix = width ~= 'xs' and width .. '-' or ''
 				Array.extendWith(cellClasses, {
-					'm' .. direction .. '-' .. width_prefix .. self.props[ 'm' .. direction .. '-' .. width ]
+					'm' .. direction .. '-' .. width_prefix .. self.props['m' .. direction .. '-' .. width]
 				})
 			end
 		end)

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -47,12 +47,12 @@ function GridCell:render()
 		if self.props[ width ] then
 			addedSpecificClass = true
 			local widthPrefix = ''
-			if width == 'xs' then
-				addedSpecificClass = true
-			elseif self.props[ width ] == 'default' then
-				widthPrefix = width
-			else
-				widthPrefix = width .. '-'
+			if width ~= 'xs' then
+				if self.props[ width ] == 'default' then
+					widthPrefix = width
+				else
+					widthPrefix = width .. '-'
+				end
 			end
 			if self.props[ width ] == 'ignore' then
 				Array.extendWith(cellClasses, {'lp-d-' .. widthPrefix .. 'contents'})

--- a/components/widget/grid/widget_grid_cell.lua
+++ b/components/widget/grid/widget_grid_cell.lua
@@ -34,7 +34,7 @@ local GRID_DIRECTIONS = {
 }
 
 ---@class GridCell: Widget
----@operator call(table): Panel
+---@operator call(table): GridCell
 ---@field props table<string, any>
 local GridCell = Class.new(Widget)
 

--- a/components/widget/grid/widget_grid_container.lua
+++ b/components/widget/grid/widget_grid_container.lua
@@ -18,6 +18,11 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 ---@field props {center: boolean?, rowGap: string?, gridCells:(Widget|string|Html|nil)|(Widget|string|Html|nil)[]}
 local GridContainer = Class.new(Widget)
 
+GridContainer.defaultProps = {
+	center = false,
+	rowGap = '0px'
+}
+
 ---@return Widget
 function GridContainer:render()
 	return HtmlWidgets.Div{
@@ -25,7 +30,7 @@ function GridContainer:render()
 		children = {
 			HtmlWidgets.Div{
 				classes = { Logic.readBool(self.props.center) and 'lp-row-center' or 'lp-row' },
-				css = { ['row-gap'] = self.props.rowGap or '0px' },
+				css = { ['row-gap'] = self.props.rowGap },
 				children = self.props.gridCells
 			}
 		}

--- a/components/widget/grid/widget_grid_container.lua
+++ b/components/widget/grid/widget_grid_container.lua
@@ -14,7 +14,7 @@ local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
 ---@class GridContainer: Widget
----@operator call(table): Panel
+---@operator call(table): GridContainer
 ---@field props table<string, any>
 local GridContainer = Class.new(Widget)
 

--- a/components/widget/grid/widget_grid_container.lua
+++ b/components/widget/grid/widget_grid_container.lua
@@ -1,0 +1,35 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Grid/Container
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+
+---@class GridContainer: Widget
+---@operator call(table): Panel
+---@field props table<string, any>
+local GridContainer = Class.new(Widget)
+
+---@return Widget
+function GridContainer:render()
+	return HtmlWidgets.Div{
+		classes = { 'lp-container-fluid' },
+		children = {
+			HtmlWidgets.Div{
+				classes = { Logic.readBool(self.props.center) and 'lp-row-center' or 'lp-row' },
+				css = { ['row-gap'] = self.props.rowGap or '0px' },
+				children = self.props.gridCells
+			}
+		}
+	}
+end
+
+return GridContainer

--- a/components/widget/grid/widget_grid_container.lua
+++ b/components/widget/grid/widget_grid_container.lua
@@ -15,7 +15,7 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
 ---@class GridContainer: Widget
 ---@operator call(table): GridContainer
----@field props table<string, any>
+---@field props {center: boolean?, rowGap: string?, gridCells:(Widget|string|Html|nil)|(Widget|string|Html|nil)[]}
 local GridContainer = Class.new(Widget)
 
 ---@return Widget

--- a/components/widget/main_page/widget_main_page_center_dot.lua
+++ b/components/widget/main_page/widget_main_page_center_dot.lua
@@ -1,0 +1,29 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/MainPage/CenterDot
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+
+---@class CenterDot: Widget
+---@operator call(table): CenterDot
+local CenterDot = Class.new(Widget)
+
+function CenterDot:render()
+	return HtmlWidgets.Span{
+		css = {
+			['font-style'] = 'normal',
+			padding = '0 5px',
+		},
+		children = {'&#8226;'},
+	}
+end
+
+return CenterDot

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -28,16 +28,25 @@ local CENTER_DOT = Span{
 	children = { '&#8226;' }
 }
 
+---@class TransfersListParameters
+---@field limit integer?
+---@field rumours boolean?
+---@field transferPortal string?
+---@field transferPage fun():string
+---@field transferQuery boolean?
+
 ---@class TransfersList: Widget
 ---@operator call(table): TransfersList
----@field props {limit: integer?, rumours: boolean?, transferPage: fun():string}
+---@field props TransfersListParameters
 local TransfersList = Class.new(Widget)
 TransfersList.defaultProps = {
 	limit = 15,
 	rumours = false,
+	transferPortal = 'Portal:Transfers',
 	transferPage = function ()
 		return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-	end
+	end,
+	transferQuery = true
 }
 
 function TransfersList:render()
@@ -71,8 +80,11 @@ function TransfersList:render()
 						['font-style'] = 'italic'
 					},
 					children = Array.interleave({
-						Link { children = 'See more transfers', link = 'Portal:Transfers' },
-						Link { children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
+						Link { children = 'See more transfers', link = self.props.transferPortal },
+						Logic.readBool(self.props.transferQuery) and Link {
+							children = 'Transfer query',
+							link = 'Special:RunQuery/Transfer history'
+						} or nil,
 						Link { children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
 						Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil,
 					}, CENTER_DOT)

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -31,6 +31,12 @@ local CENTER_DOT = Span{
 ---@operator call(table): TransfersList
 ---@field props table<string, any>
 local TransfersList = Class.new(Widget)
+TransfersList.defaultProps = {
+	rumours = false,
+	transferPage = function ()
+		return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
+	end
+}
 
 function TransfersList:render()
 	return WidgetUtil.collect(

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -1,0 +1,76 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/MainPage/TransfersList
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local TransferList = Lua.import('Module:TransferList')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Fragment = HtmlWidgets.Fragment
+local Link = Lua.import('Module:Widget/Basic/Link')
+local Span = HtmlWidgets.Span
+
+local CENTER_DOT = Span{
+	css = {
+		['font-style'] = 'normal',
+		padding = '0 5px',
+	},
+	children = { '&#8226;' }
+}
+
+---@class TransfersList: Widget
+---@operator call(table): Panel
+---@field props table<string, any>
+local TransfersList = Class.new(Widget)
+
+---@return WidgetHtml
+function TransfersList:render()
+	return Fragment {
+		children = {
+			TransferList { limit = self.props.limit or 15 }:fetch():create(),
+			Div {
+				css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
+				children = {
+					Div {
+						css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
+						children = { Link { children = 'Back to top', link = '#Top' } }
+					},
+					Div {
+						classes = { 'plainlinks', 'smalledit' },
+						css = { display = 'inline', float = 'right' },
+						children = { '&#91;', Link { children = 'edit', link = 'Special:EditPage/' .. self.props.transferPage() }, '&#93;' },
+					},
+					Div {
+						css = {
+							['white-space'] = 'nowrap',
+							display = 'inline',
+							margin = '0 10px',
+							['font-size'] = '15px',
+							['font-style'] = 'italic'
+						},
+						children = {
+							Link { children = 'See more transfers', link = 'Portal:Transfers' },
+							CENTER_DOT,
+							Link { children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
+							CENTER_DOT,
+							Link { children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
+							Logic.readBool(self.props.rumours) and CENTER_DOT or nil,
+							Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil,
+						}
+					},
+				}
+			}
+		}
+	}
+end
+
+return TransfersList

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -32,6 +32,7 @@ local CENTER_DOT = Span{
 ---@field props table<string, any>
 local TransfersList = Class.new(Widget)
 TransfersList.defaultProps = {
+	limit = 15,
 	rumours = false,
 	transferPage = function ()
 		return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
@@ -40,7 +41,7 @@ TransfersList.defaultProps = {
 
 function TransfersList:render()
 	return WidgetUtil.collect(
-		TransferList { limit = self.props.limit or 15 }:fetch():create(),
+		TransferList { limit = self.props.limit }:fetch():create(),
 		Div {
 			css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
 			children = {

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -47,7 +47,14 @@ function TransfersList:render()
 					Div {
 						classes = { 'plainlinks', 'smalledit' },
 						css = { display = 'inline', float = 'right' },
-						children = { '&#91;', Link { children = 'edit', link = 'Special:EditPage/' .. self.props.transferPage() }, '&#93;' },
+						children = {
+							'&#91;',
+								Link {
+								children = 'edit',
+								link = 'Special:EditPage/' .. self.props.transferPage()
+							},
+							'&#93;'
+						},
 					},
 					Div {
 						css = {

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -29,7 +29,7 @@ local CENTER_DOT = Span{
 }
 
 ---@class TransfersList: Widget
----@operator call(table): Panel
+---@operator call(table): TransfersList
 ---@field props table<string, any>
 local TransfersList = Class.new(Widget)
 

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -15,7 +15,6 @@ local TransferList = Lua.import('Module:TransferList')
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
-local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Span = HtmlWidgets.Span
 local WidgetUtil = Lua.import('Module:Widget/Util')

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -79,15 +79,15 @@ function TransfersList:render()
 						['font-size'] = '15px',
 						['font-style'] = 'italic'
 					},
-					children = Array.interleave({
+					children = Array.interleave(WidgetUtil.collect(
 						Link { children = 'See more transfers', link = self.props.transferPortal },
 						Logic.readBool(self.props.transferQuery) and Link {
 							children = 'Transfer query',
 							link = 'Special:RunQuery/Transfer history'
 						} or nil,
 						Link { children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
-						Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil,
-					}, CENTER_DOT)
+						Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil
+					), CENTER_DOT)
 				},
 			}
 		}

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -29,7 +29,7 @@ local CENTER_DOT = Span{
 
 ---@class TransfersList: Widget
 ---@operator call(table): TransfersList
----@field props table<string, any>
+---@field props {limit: integer?, rumours: boolean?, transferPage: fun():string}
 local TransfersList = Class.new(Widget)
 TransfersList.defaultProps = {
 	limit = 15,

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
@@ -69,15 +70,12 @@ function TransfersList:render()
 						['font-size'] = '15px',
 						['font-style'] = 'italic'
 					},
-					children = {
+					children = Array.interleave({
 						Link { children = 'See more transfers', link = 'Portal:Transfers' },
-						CENTER_DOT,
 						Link { children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
-						CENTER_DOT,
 						Link { children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
-						Logic.readBool(self.props.rumours) and CENTER_DOT or nil,
 						Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil,
-					}
+					}, CENTER_DOT)
 				},
 			}
 		}

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -18,6 +18,7 @@ local Div = HtmlWidgets.Div
 local Fragment = HtmlWidgets.Fragment
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Span = HtmlWidgets.Span
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CENTER_DOT = Span{
 	css = {
@@ -32,52 +33,49 @@ local CENTER_DOT = Span{
 ---@field props table<string, any>
 local TransfersList = Class.new(Widget)
 
----@return WidgetHtml
 function TransfersList:render()
-	return Fragment {
-		children = {
-			TransferList { limit = self.props.limit or 15 }:fetch():create(),
-			Div {
-				css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
-				children = {
-					Div {
-						css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
-						children = { Link { children = 'Back to top', link = '#Top' } }
-					},
-					Div {
-						classes = { 'plainlinks', 'smalledit' },
-						css = { display = 'inline', float = 'right' },
-						children = {
-							'&#91;',
-								Link {
-								children = 'edit',
-								link = 'Special:EditPage/' .. self.props.transferPage()
-							},
-							'&#93;'
+	return WidgetUtil.collect(
+		TransferList { limit = self.props.limit or 15 }:fetch():create(),
+		Div {
+			css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
+			children = {
+				Div {
+					css = { display = 'inline', float = 'left', ['font-style'] = 'italic' },
+					children = { Link { children = 'Back to top', link = '#Top' } }
+				},
+				Div {
+					classes = { 'plainlinks', 'smalledit' },
+					css = { display = 'inline', float = 'right' },
+					children = {
+						'&#91;',
+							Link {
+							children = 'edit',
+							link = 'Special:EditPage/' .. self.props.transferPage()
 						},
+						'&#93;'
 					},
-					Div {
-						css = {
-							['white-space'] = 'nowrap',
-							display = 'inline',
-							margin = '0 10px',
-							['font-size'] = '15px',
-							['font-style'] = 'italic'
-						},
-						children = {
-							Link { children = 'See more transfers', link = 'Portal:Transfers' },
-							CENTER_DOT,
-							Link { children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
-							CENTER_DOT,
-							Link { children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
-							Logic.readBool(self.props.rumours) and CENTER_DOT or nil,
-							Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil,
-						}
+				},
+				Div {
+					css = {
+						['white-space'] = 'nowrap',
+						display = 'inline',
+						margin = '0 10px',
+						['font-size'] = '15px',
+						['font-style'] = 'italic'
 					},
-				}
+					children = {
+						Link { children = 'See more transfers', link = 'Portal:Transfers' },
+						CENTER_DOT,
+						Link { children = 'Transfer query', link = 'Special:RunQuery/Transfer_history' },
+						CENTER_DOT,
+						Link { children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
+						Logic.readBool(self.props.rumours) and CENTER_DOT or nil,
+						Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil,
+					}
+				},
 			}
 		}
-	}
+	)
 end
 
 return TransfersList

--- a/components/widget/main_page/widget_main_page_transfers_list.lua
+++ b/components/widget/main_page/widget_main_page_transfers_list.lua
@@ -13,20 +13,12 @@ local Lua = require('Module:Lua')
 
 local TransferList = Lua.import('Module:TransferList')
 
+local CenterDot = Lua.import('Module:Widget/MainPage/CenterDot')
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Link = Lua.import('Module:Widget/Basic/Link')
-local Span = HtmlWidgets.Span
 local WidgetUtil = Lua.import('Module:Widget/Util')
-
-local CENTER_DOT = Span{
-	css = {
-		['font-style'] = 'normal',
-		padding = '0 5px',
-	},
-	children = { '&#8226;' }
-}
 
 ---@class TransfersListParameters
 ---@field limit integer?
@@ -34,6 +26,7 @@ local CENTER_DOT = Span{
 ---@field transferPortal string?
 ---@field transferPage fun():string
 ---@field transferQuery boolean?
+---@field onlyNotableTransfers boolean?
 
 ---@class TransfersList: Widget
 ---@operator call(table): TransfersList
@@ -51,7 +44,10 @@ TransfersList.defaultProps = {
 
 function TransfersList:render()
 	return WidgetUtil.collect(
-		TransferList { limit = self.props.limit }:fetch():create(),
+		TransferList{
+			limit = self.props.limit,
+			onlyNotableTransfers = self.props.onlyNotableTransfers,
+		}:fetch():create(),
 		Div {
 			css = { display = 'block', ['text-align'] = 'center', padding = '0.5em' },
 			children = {
@@ -87,7 +83,7 @@ function TransfersList:render()
 						} or nil,
 						Link { children = 'Input Form', link = 'lpcommons:Special:RunQuery/Transfer' },
 						Logic.readBool(self.props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil
-					), CENTER_DOT)
+					), CenterDot())
 				},
 			}
 		}

--- a/components/widget/misc/widget_panel.lua
+++ b/components/widget/misc/widget_panel.lua
@@ -56,7 +56,7 @@ function Panel:render()
 		attributes = boxId and {
 			['data-component'] = 'panel-box-content'
 		} or {},
-		children = self.props.body
+		children = self.props.children
 	}
 
 	return Div{


### PR DESCRIPTION
## Summary

This PR introduces `Module:Widget/Grid/Container` and `Module:Widget/Grid/Cell`, with the purpose of replacing [Module:Grid](https://liquipedia.net/commons/Module:Grid). This also updates layout data for LoL / Valorant so that widgets are directly passed into the grid widgets (see #5528 for initial work).

## How did you test this change?

- dev in LoL / Valorant / PUBG
- preview in OW with dev: for testing backwards compatibility
