### PR TITLE
fix(mainpage): PUBG see more matches url fix

### DIFF
--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -54,7 +54,7 @@ local CONTENT = {
 		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}'..
 			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
 			'font-size:15px; font-style:italic; text-align:center;">' ..
-			'[[Liquipedia:Upcoming and ongoing matches|See more matches]]</div>',
+			'[[Liquipedia:Matches|See more matches]]</div>',
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {


### PR DESCRIPTION
## Summary
It should now go to the more matches link using the new ticker 
https://liquipedia.net/pubg/Liquipedia:Matches

the old link goes to the old ticker

## How did you test this change?
Live