### PR TITLE
refactor(match2): standardize ffa opponent code generation

### DIFF
--- a/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
+++ b/components/match2/commons/get_match_group_copy_paste_wiki_base.lua
@@ -104,6 +104,26 @@ function WikiCopyPaste.getOpponent(mode, showScore)
 	return ''
 end
 
+---subfunction used to generate the code for the Opponent template in Ffa matches, depending on the type of opponent
+---@param mode string
+---@param mapCount integer
+---@return string
+function WikiCopyPaste.getFfaOpponent(mode, mapCount)
+	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
+		return '|m' .. idx .. '={{MS||}}'
+	end))
+
+	if mode == Opponent.solo then
+		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
+	elseif mode == Opponent.team then
+		return '{{TeamOpponent|' .. mapScores .. '}}'
+	elseif mode == Opponent.literal then
+		return '{{Literal|}}'
+	end
+
+	return ''
+end
+
 ---function that sets the text that starts the invoke of the MatchGroup Moduiles,
 ---contains madatory stuff like bracketid, templateid and MatchGroup type (matchlist or bracket)
 ---@param template string

--- a/components/match2/wikis/apexlegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/apexlegends/get_match_group_copy_paste_wiki.lua
@@ -38,32 +38,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
---subfunction used to generate the code for the Opponent template, depending on the type of opponent
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/apexlegends/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/apexlegends/get_match_group_copy_paste_wiki.lua
@@ -10,9 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators

--- a/components/match2/wikis/arenafps/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/arenafps/get_match_group_copy_paste_wiki.lua
@@ -77,31 +77,12 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getFfaOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getFfaOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/arenafps/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/arenafps/get_match_group_copy_paste_wiki.lua
@@ -13,9 +13,6 @@ local Logic = require('Module:Logic')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 ---@class ArenaFPSMatchCopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 

--- a/components/match2/wikis/autochess/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/autochess/get_match_group_copy_paste_wiki.lua
@@ -37,32 +37,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
---subfunction used to generate the code for the Opponent template, depending on the type of opponent
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|' .. mapScores .. '}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/autochess/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/autochess/get_match_group_copy_paste_wiki.lua
@@ -10,9 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators

--- a/components/match2/wikis/callofduty/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/callofduty/get_match_group_copy_paste_wiki.lua
@@ -13,9 +13,6 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 ---@class CallofDutyMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 

--- a/components/match2/wikis/callofduty/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/callofduty/get_match_group_copy_paste_wiki.lua
@@ -83,31 +83,12 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getFfaOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getFfaOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/fortnite/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/fortnite/get_match_group_copy_paste_wiki.lua
@@ -86,7 +86,7 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getFfaOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
@@ -97,7 +97,7 @@ end
 ---@param mode string
 ---@param mapCount integer
 ---@return string
-function WikiCopyPaste._getFfaOpponent(mode, mapCount)
+function WikiCopyPaste.getFfaOpponent(mode, mapCount)
 	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
 		return '|m' .. idx .. '={{MS||}}'
 	end))

--- a/components/match2/wikis/freefire/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/freefire/get_match_group_copy_paste_wiki.lua
@@ -77,31 +77,12 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getFfaOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getFfaOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|' .. mapScores .. '}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/freefire/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/freefire/get_match_group_copy_paste_wiki.lua
@@ -12,9 +12,6 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 ---@class FreefireMatchCopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 

--- a/components/match2/wikis/halo/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/halo/get_match_group_copy_paste_wiki.lua
@@ -13,9 +13,6 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 ---@class HaloMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 

--- a/components/match2/wikis/halo/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/halo/get_match_group_copy_paste_wiki.lua
@@ -77,31 +77,12 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getFfaOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getFfaOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/naraka/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/naraka/get_match_group_copy_paste_wiki.lua
@@ -38,32 +38,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
---subfunction used to generate the code for the Opponent template, depending on the type of opponent
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|' .. mapScores .. '}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/naraka/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/naraka/get_match_group_copy_paste_wiki.lua
@@ -10,9 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators

--- a/components/match2/wikis/pubg/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/pubg/get_match_group_copy_paste_wiki.lua
@@ -37,32 +37,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
---subfunction used to generate the code for the Opponent template, depending on the type of opponent
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|' .. mapScores .. '}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/pubg/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/pubg/get_match_group_copy_paste_wiki.lua
@@ -10,9 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators

--- a/components/match2/wikis/pubgmobile/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/pubgmobile/get_match_group_copy_paste_wiki.lua
@@ -37,32 +37,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
---subfunction used to generate the code for the Opponent template, depending on the type of opponent
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|' .. mapScores .. '}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/pubgmobile/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/pubgmobile/get_match_group_copy_paste_wiki.lua
@@ -10,9 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators

--- a/components/match2/wikis/tft/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/tft/get_match_group_copy_paste_wiki.lua
@@ -80,31 +80,12 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getFfaOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getFfaOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/tft/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/tft/get_match_group_copy_paste_wiki.lua
@@ -13,9 +13,6 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 ---@class TftMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 

--- a/components/match2/wikis/underlords/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/underlords/get_match_group_copy_paste_wiki.lua
@@ -37,32 +37,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|vod=}}'
 		end),
 		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, bestof)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
 	)
 
 	return table.concat(lines, '\n')
-end
-
---subfunction used to generate the code for the Opponent template, depending on the type of opponent
----@param mode string
----@param mapCount integer
----@return string
-function WikiCopyPaste._getOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
-		return '|m' .. idx .. '={{MS||}}'
-	end))
-
-	if mode == Opponent.solo then
-		return '{{SoloOpponent||flag=' .. mapScores .. '}}'
-	elseif mode == Opponent.team then
-		return '{{TeamOpponent|' .. mapScores .. '}}'
-	elseif mode == Opponent.literal then
-		return '{{Literal|' .. mapScores .. '}}'
-	end
-
-	return ''
 end
 
 return WikiCopyPaste

--- a/components/match2/wikis/underlords/get_match_group_copy_paste_wiki.lua
+++ b/components/match2/wikis/underlords/get_match_group_copy_paste_wiki.lua
@@ -10,9 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators


### PR DESCRIPTION
## Summary

This PR adds `WikiCopyPaste.getFfaOpponent()` and removes all custom variants of Ffa opponent generator functions.
One noteworthy exception is Fortnite that overrides the base version with support for 2Opponent/3Opponent (no other FFA wiki had it).

## How did you test this change?

dev in PUBG