### PR TITLE
feat(Infobox): Infobox League for War Thunder

### DIFF
--- a/components/infobox/wikis/warthunder/infobox_league_custom.lua
+++ b/components/infobox/wikis/warthunder/infobox_league_custom.lua
@@ -1,0 +1,75 @@
+---
+-- @Liquipedia
+-- wiki=warthunder
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
+
+---@class WarThunderLeagueInfobox: InfoboxLeague
+local CustomLeague = Class.new(League)
+local CustomInjector = Class.new(Injector)
+
+-- Battle Mode: Different Battle Mode each providing different pacing.
+local BATTLEMODE = {
+	ab = 'Arcade',
+	rb = 'Realistic',
+	sb = 'Simulator',
+	rbm = 'Realistic with Markers',
+}
+
+-- Vehicle: Type of units played in the event.
+local VEHICLE = {
+	aviation = 'Aviation',
+	ground = 'Ground',
+	naval = 'Naval',
+	multiple = 'Multiple',
+}
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args = caller.args
+
+	if id == 'custom' then
+		-- Process battle mode - convert to lowercase for matching
+		local battlemodeInput = string.lower(args.battlemode or '')
+		local battlemodeValue = BATTLEMODE[battlemodeInput] or 'Unknown'
+
+		-- Process vehicle type - convert to lowercase for matching
+		local vehicleInput = string.lower(args.vehicle or '')
+		local vehicleValue = VEHICLE[vehicleInput] or 'Unknown'
+
+		Array.appendWith(
+			widgets,
+			Cell{name = 'Battle Mode', content = {battlemodeValue}},
+			Cell{name = 'Vehicle', content = {vehicleValue}}
+		)
+	end
+
+	return widgets
+end
+
+return CustomLeague

--- a/components/infobox/wikis/warthunder/infobox_league_custom.lua
+++ b/components/infobox/wikis/warthunder/infobox_league_custom.lua
@@ -20,8 +20,8 @@ local Cell = Widgets.Cell
 local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
 
--- Battle Mode: Different Battle Mode each providing different pacing.
-local BATTLEMODES = {
+-- Game Mode: Different Battle Mode each providing different pacing.
+local MODES = {
 	ab = 'Arcade',
 	rb = 'Realistic',
 	sb = 'Simulator',
@@ -52,11 +52,11 @@ function CustomInjector:parse(id, widgets)
 	local args = caller.args
 
 	if id == 'custom' then
-		local battleMode = BATTLEMODES[string.lower(args.battlemode or '')] or 'Unknown'
+		local mode = MODES[string.lower(args.mode or '')] or 'Unknown'
 		local vehicle = VEHICLES[string.lower(args.vehicle or '')] or 'Unknown'
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Battle Mode', content = {battleMode}},
+			Cell{name = 'Mode', content = {mode}},
 			Cell{name = 'Vehicle', content = {vehicle}}
 		)
 	end

--- a/components/infobox/wikis/warthunder/infobox_league_custom.lua
+++ b/components/infobox/wikis/warthunder/infobox_league_custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
@@ -21,15 +22,14 @@ local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
 
 -- Battle Mode: Different Battle Mode each providing different pacing.
-local BATTLEMODE = {
+local BATTLEMODES = {
 	ab = 'Arcade',
 	rb = 'Realistic',
 	sb = 'Simulator',
 	rbm = 'Realistic with Markers',
 }
-
 -- Vehicle: Type of units played in the event.
-local VEHICLE = {
+local VEHICLES = {
 	aviation = 'Aviation',
 	ground = 'Ground',
 	naval = 'Naval',
@@ -53,18 +53,12 @@ function CustomInjector:parse(id, widgets)
 	local args = caller.args
 
 	if id == 'custom' then
-		-- Process battle mode - convert to lowercase for matching
-		local battlemodeInput = string.lower(args.battlemode or '')
-		local battlemodeValue = BATTLEMODE[battlemodeInput] or 'Unknown'
-
-		-- Process vehicle type - convert to lowercase for matching
-		local vehicleInput = string.lower(args.vehicle or '')
-		local vehicleValue = VEHICLE[vehicleInput] or 'Unknown'
-
+		local battleMode = BATTLEMODES[string.lower(args.battlemode or '')] or 'Unknown'
+		local vehicle = VEHICLES[string.lower(args.vehicle or '')] or 'Unknown'
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Battle Mode', content = {battlemodeValue}},
-			Cell{name = 'Vehicle', content = {vehicleValue}}
+			Cell{name = 'Battle Mode', content = {battleMode}},
+			Cell{name = 'Vehicle', content = {vehicle}}
 		)
 	end
 

--- a/components/infobox/wikis/warthunder/infobox_league_custom.lua
+++ b/components/infobox/wikis/warthunder/infobox_league_custom.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local Operator = require('Module:Operator')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')


### PR DESCRIPTION
## Summary
Customizations are **Battle Type** and **Vehicles**

this is to indicate
- one of the 3 Battle type in the game (Arcade, Realistic, Simulator) which defines the match speed
- one of the Vehicle unit types in the game (Aviation, Naval, Ground, or Multiple for tournaments which runs various) 


## Notes 
Contributors dont want to type the full mode names hence the input is just AB/RB/SB, matching their official ingame naming
