### PR TITLE
refactor(mainpage): rewrite this day components as widgets

### DIFF
--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -7,7 +7,6 @@
 --
 
 local Lua = require('Module:Lua')
-local Ordinal = require('Module:Ordinal')
 
 local ExternalMediaList = Lua.import('Module:ExternalMediaList')
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
@@ -18,7 +17,7 @@ local CenterDot = Lua.import('Module:Widget/MainPage/CenterDot')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Link = Lua.import('Module:Widget/Basic/Link')
-local Small = HtmlWidgets.Small
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
@@ -41,15 +40,8 @@ local CONTENT = {
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = WidgetUtil.collect(
-			'This day in League of Legends ',
-			Small{
-				attributes = { id = 'this-day-date' },
-				css = { ['margin-left'] = '5px' },
-				children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
-			}
-		),
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
 		padding = true,
 		boxid = 1510,
 	},

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -39,7 +39,7 @@ local CONTENT = {
 	},
 	thisDay = {
 		heading = ThisDayWidgets.Title(),
-		body = ThisDayWidgets.Content(),
+		body = ThisDayWidgets.Content{ birthdayListPage = 'Birthday list' },
 		padding = true,
 		boxid = 1510,
 	},

--- a/components/main_page/wikis/pubg/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubg/main_page_layout_data.lua
@@ -7,7 +7,6 @@
 --
 
 local Lua = require('Module:Lua')
-local Ordinal = require('Module:Ordinal')
 
 local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
@@ -16,7 +15,7 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local Link = Lua.import('Module:Widget/Basic/Link')
-local Small = HtmlWidgets.Small
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
@@ -39,15 +38,8 @@ local CONTENT = {
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = WidgetUtil.collect(
-			'This day in PUBG ',
-			Small{
-				attributes = { id = 'this-day-date' },
-				css = { ['margin-left'] = '5px' },
-				children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
-			}
-		),
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
 		padding = true,
 		boxid = 1510,
 	},

--- a/components/widget/main_page/widget_main_page_this_day.lua
+++ b/components/widget/main_page/widget_main_page_this_day.lua
@@ -1,0 +1,16 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/MainPage/ThisDay
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local ThisDayWidgets = {}
+
+ThisDayWidgets.Title = Lua.import('Module:Widget/MainPage/ThisDay/Title')
+ThisDayWidgets.Content = Lua.import('Module:Widget/MainPage/ThisDay/Content')
+
+return ThisDayWidgets

--- a/components/widget/main_page/widget_main_page_this_day_content.lua
+++ b/components/widget/main_page/widget_main_page_this_day_content.lua
@@ -51,6 +51,7 @@ function ThisDayContent:render()
 				}
 			}
 		} or nil,
+		HtmlWidgets.Br(),
 		Small{
 			attributes = { id = 'this-day-trivialink' },
 			children = {

--- a/components/widget/main_page/widget_main_page_this_day_content.lua
+++ b/components/widget/main_page/widget_main_page_this_day_content.lua
@@ -42,7 +42,7 @@ function ThisDayContent:render()
 		},
 		showBirthdayList and HtmlWidgets.Fragment{
 			children = {
-				HtmlWidgets.Hr,
+				HtmlWidgets.Hr(),
 				Small{
 					css = { ['font-style'] = 'italic' },
 					children = {

--- a/components/widget/main_page/widget_main_page_this_day_content.lua
+++ b/components/widget/main_page/widget_main_page_this_day_content.lua
@@ -1,0 +1,45 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/MainPage/ThisDay/Content
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local Small = HtmlWidgets.Small
+
+---@class ThisDayContent: Widget
+---@operator call(table): ThisDayContent
+local ThisDayContent = Class.new(Widget)
+
+function ThisDayContent:render()
+	local today = os.date('*t')
+	local frame = mw.getCurrentFrame()
+	return {
+		Div{
+			attributes = { id = 'this-day-facts' },
+			children = {
+				frame:expandTemplate{ title = 'Liquipedia:This day/' .. today.month .. '/' .. today.day }
+			}
+		},
+		Small{
+			attributes = { id = 'this-day-trivialink' },
+			children = {
+				'Add trivia about this day ',
+				Link{
+					children = 'here',
+					link = 'Liquipedia:This_day/' .. today.month .. '/' .. today.day
+				}
+			}
+		}
+	}
+end
+
+return ThisDayContent

--- a/components/widget/main_page/widget_main_page_this_day_content.lua
+++ b/components/widget/main_page/widget_main_page_this_day_content.lua
@@ -8,15 +8,18 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local String = require('Module:StringUtils')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class ThisDayContent: Widget
----@field props { month: integer?, day: integer? }
+---@field props { month: integer?, day: integer?, birthdayListPage: string? }
 ---@operator call(table): ThisDayContent
 local ThisDayContent = Class.new(Widget)
 ThisDayContent.defaultProps = {
@@ -28,13 +31,26 @@ function ThisDayContent:render()
 	local month = self.props.month
 	local day = self.props.day
 	local frame = mw.getCurrentFrame()
-	return {
+	local birthdayListPage = self.props.birthdayListPage
+	local showBirthdayList = String.isNotEmpty(birthdayListPage) and Page.exists(birthdayListPage)
+	return WidgetUtil.collect(
 		Div{
 			attributes = { id = 'this-day-facts' },
 			children = {
 				frame:expandTemplate{ title = 'Liquipedia:This day/' .. month .. '/' .. day }
 			}
 		},
+		showBirthdayList and HtmlWidgets.Fragment{
+			children = {
+				HtmlWidgets.Hr,
+				Small{
+					css = { ['font-style'] = 'italic' },
+					children = {
+						Link{ children = 'Click to see all birthdays', link = birthdayListPage }
+					}
+				}
+			}
+		} or nil,
 		Small{
 			attributes = { id = 'this-day-trivialink' },
 			children = {
@@ -45,7 +61,7 @@ function ThisDayContent:render()
 				}
 			}
 		}
-	}
+	)
 end
 
 return ThisDayContent

--- a/components/widget/main_page/widget_main_page_this_day_content.lua
+++ b/components/widget/main_page/widget_main_page_this_day_content.lua
@@ -10,6 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
+local Template = require('Module:Template')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
@@ -37,7 +38,7 @@ function ThisDayContent:render()
 		Div{
 			attributes = { id = 'this-day-facts' },
 			children = {
-				frame:expandTemplate{ title = 'Liquipedia:This day/' .. month .. '/' .. day }
+				Template.safeExpand(frame, 'Liquipedia:This day/' .. month .. '/' .. day)
 			}
 		},
 		showBirthdayList and HtmlWidgets.Fragment{

--- a/components/widget/main_page/widget_main_page_this_day_content.lua
+++ b/components/widget/main_page/widget_main_page_this_day_content.lua
@@ -16,17 +16,23 @@ local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
 
 ---@class ThisDayContent: Widget
+---@field props { month: integer?, day: integer? }
 ---@operator call(table): ThisDayContent
 local ThisDayContent = Class.new(Widget)
+ThisDayContent.defaultProps = {
+	month = tonumber(os.date('%m')),
+	day = tonumber(os.date('%d'))
+}
 
 function ThisDayContent:render()
-	local today = os.date('*t')
+	local month = self.props.month
+	local day = self.props.day
 	local frame = mw.getCurrentFrame()
 	return {
 		Div{
 			attributes = { id = 'this-day-facts' },
 			children = {
-				frame:expandTemplate{ title = 'Liquipedia:This day/' .. today.month .. '/' .. today.day }
+				frame:expandTemplate{ title = 'Liquipedia:This day/' .. month .. '/' .. day }
 			}
 		},
 		Small{
@@ -35,7 +41,7 @@ function ThisDayContent:render()
 				'Add trivia about this day ',
 				Link{
 					children = 'here',
-					link = 'Liquipedia:This_day/' .. today.month .. '/' .. today.day
+					link = 'Liquipedia:This_day/' .. month .. '/' .. day
 				}
 			}
 		}

--- a/components/widget/main_page/widget_main_page_this_day_title.lua
+++ b/components/widget/main_page/widget_main_page_this_day_title.lua
@@ -1,0 +1,42 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/MainPage/ThisDay/Title
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local Ordinal = require('Module:Ordinal')
+local String = require('Module:StringUtils')
+
+local Info = Lua.import('Module:Info', { loadData = true })
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Small = HtmlWidgets.Small
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+---@class ThisDayTitle: Widget
+---@field props { name: string? }
+---@operator call(table): ThisDayTitle
+local ThisDayTitle = Class.new(Widget)
+ThisDayTitle.defaultProps = {
+	name = Info.name
+}
+
+function ThisDayTitle:render()
+	local name = self.props.name
+	assert(String.isNotEmpty(name), 'Invalid name: ' .. tostring(name))
+	return WidgetUtil.collect(
+		'This day in ' .. name .. ' ',
+		Small{
+			attributes = { id = 'this-day-date' },
+			css = { ['margin-left'] = '5px' },
+			children = { '(' .. os.date('%B') .. ' ' .. Ordinal.toOrdinal(tonumber(os.date('%d'))) .. ')' }
+		}
+	)
+end
+
+return ThisDayTitle


### PR DESCRIPTION
## Summary

This PR introduces `Module:Widget/MainPage/ThisDay/Title` and `Module:Widget/MainPage/ThisDay/Content` to (fully/partially) replace Html widgets and `{{Liquipedia:This day}}`, respectively.

Note that rewriting [Module:ThisDay](https://liquipedia.net/commons/Module:ThisDay) is not considered to be within scope of this PR and would likely require a separate PR on its own.

## How did you test this change?

dev in LoL/PUBG
