### PR TITLE
feat(infobox): suppress fire rate display in valorant weapons infobox if undefined

### DIFF
--- a/components/infobox/wikis/valorant/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_weapon_custom.lua
@@ -127,7 +127,6 @@ function CustomWeapon:addToLpdb(lpdbData, args)
 		class = args.class,
 		price = args.price,
 		damage = self:getAllArgsForBase(args, 'damage'),
-		damage2 = args.damage2,
 		wallpenetration = args.wallpenetration,
 		ammo = args.ammo,
 		capacity = args.capacity,


### PR DESCRIPTION
## Summary

Some weapons in Valorant don't shoot (e.g., knives), and for such weapons it doesn't make much sense to display fire rate at all.
Thus, this PR adds extra logic to suppress fire rate display in such cases.

This PR also cleans up
- an unnecessary builder in the infobox (see https://github.com/Liquipedia/Lua-Modules/pull/5541#discussion_r1982814023)
- a duplicate data field in extradata (5f55300)

## How did you test this change?

preview with dev in live
