### PR TITLE
feat(infobox): remove lpdb storage of deprecated infobox team fields

### DIFF
--- a/components/infobox/commons/infobox_team.lua
+++ b/components/infobox/commons/infobox_team.lua
@@ -355,8 +355,6 @@ function Team:_setLpdbData(args, links)
 		earningsbyyear = self.yearlyEarnings or {},
 		createdate = args.created,
 		disbanddate = ReferenceCleaner.clean(args.disbanded),
-		coach = args.coaches or args.coach,
-		manager = args.manager,
 		template = self.teamTemplate.historicaltemplate or self.teamTemplate.templatename,
 		status = args.disbanded and Status.DISBANDED or Status.ACTIVE,
 		links = mw.ext.LiquipediaDB.lpdb_create_json(

--- a/components/infobox/extensions/commons/role_of.lua
+++ b/components/infobox/extensions/commons/role_of.lua
@@ -11,7 +11,6 @@ local Class = require('Module:Class')
 local OpponentLibraries = require('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
 local OpponentDisplay = OpponentLibraries.OpponentDisplay
-local Variables = require('Module:Variables')
 
 local RoleOf = {}
 
@@ -43,7 +42,6 @@ function RoleOf.get(args)
 			return
 		end
 
-		Variables.varDefine(args.role .. 'id', staff.link)
 		local opponent = Opponent.readOpponentArgs{
 			type = Opponent.solo,
 			name = staff.id,

--- a/components/infobox/wikis/dota2/infobox_team_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_team_custom.lua
@@ -9,7 +9,6 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local RoleOf = require('Module:RoleOf')
-local Variables = require('Module:Variables')
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Team = Lua.import('Module:Infobox/Team')

--- a/components/infobox/wikis/dota2/infobox_team_custom.lua
+++ b/components/infobox/wikis/dota2/infobox_team_custom.lua
@@ -73,8 +73,6 @@ end
 ---@return table
 function CustomTeam:addToLpdb(lpdbData, args)
 	lpdbData.extradata.teamid = args.teamid
-	lpdbData.coach = Variables.varDefault('coachid') or args.coach or args.coaches
-	lpdbData.manager = Variables.varDefault('managerid') or args.manager
 
 	return lpdbData
 end

--- a/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
@@ -13,7 +13,6 @@ local RoleOf = require('Module:RoleOf')
 local String = require('Module:StringUtils')
 local TeamTemplate = require('Module:Team')
 local Template = require('Module:Template')
-local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Region = Lua.import('Module:Region')

--- a/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_team_custom.lua
@@ -92,9 +92,6 @@ function CustomTeam:addToLpdb(lpdbData, args)
 		lpdbData.extradata.competesin = string.upper(args.league)
 	end
 
-	lpdbData.coach = Variables.varDefault('coachid') or args.coach or args.coaches
-	lpdbData.manager = Variables.varDefault('managerid') or args.manager
-
 	return lpdbData
 end
 


### PR DESCRIPTION
## Summary

Follow-up for #5555
This PR reapplies LPDB storage portion of #5480. It doesn't touch the display portion, nor is it intended to.

## How did you test this change?

preview with dev in LoL and Valorant
