### PR TITLE
feat: handle uppercase mode names in osu notability checker

### DIFF
--- a/components/notability/wikis/osu/notability_checker_config.lua
+++ b/components/notability/wikis/osu/notability_checker_config.lua
@@ -298,15 +298,15 @@ end
 -- Adjusts the score to compensate for the mode, you might
 -- want to decrease the points given for a certain mode
 function Config.adjustScoreForMode(score, mode)
-	if string.lower(mode) == "taiko" then
+	if string.lower(mode or '') == "taiko" then
         return score * 1.2
     end
 
-	if string.lower(mode) == "catch" then
+	if string.lower(mode or '') == "catch" then
         return score * 1.2
     end
 
-	if string.lower(mode) == "mania 7k" then
+	if string.lower(mode or '') == "mania 7k" then
         return score * 1.2
     end
 

--- a/components/notability/wikis/osu/notability_checker_config.lua
+++ b/components/notability/wikis/osu/notability_checker_config.lua
@@ -298,15 +298,15 @@ end
 -- Adjusts the score to compensate for the mode, you might
 -- want to decrease the points given for a certain mode
 function Config.adjustScoreForMode(score, mode)
-	if string.lower(mode or '') == "taiko" then
+	if string.lower(mode or '') == 'taiko' then
         return score * 1.2
     end
 
-	if string.lower(mode or '') == "catch" then
+	if string.lower(mode or '') == 'catch' then
         return score * 1.2
     end
 
-	if string.lower(mode or '') == "mania 7k" then
+	if string.lower(mode or '') == 'mania 7k' then
         return score * 1.2
     end
 

--- a/components/notability/wikis/osu/notability_checker_config.lua
+++ b/components/notability/wikis/osu/notability_checker_config.lua
@@ -298,15 +298,15 @@ end
 -- Adjusts the score to compensate for the mode, you might
 -- want to decrease the points given for a certain mode
 function Config.adjustScoreForMode(score, mode)
-	if mode == "taiko" then
+	if string.lower(mode) == "taiko" then
         return score * 1.2
     end
 
-	if mode == "catch" then
+	if string.lower(mode) == "catch" then
         return score * 1.2
     end
 
-	if mode == "mania 7k" then
+	if string.lower(mode) == "mania 7k" then
         return score * 1.2
     end
 


### PR DESCRIPTION
## Summary

Handling for cases where game mode isn't provided as all lowercase in the infobox

## How did you test this change?

https://liquipedia.net/osu/index.php?title=Module:NotabilityChecker/config&diff=41182&oldid=41179
tried it on the wiki with this event:
https://liquipedia.net/osu/Newbie_Taiko_Journey/2

This tournament should award 2*1.2=2.4 points for the winner.
Without change if mode is "Taiko" in infobox:
![image](https://github.com/user-attachments/assets/52d0d02e-7c97-457c-b585-8e2e1f53e809)

With change if mode is "Taiko" in infobox:
![image](https://github.com/user-attachments/assets/a2032629-45c4-4365-9dd3-d39d40cfe215)

Without change if mode is "taiko" in infobox:
![image](https://github.com/user-attachments/assets/cc1fb444-09c6-42d2-9e29-0c546ca8eea1)


With change if mode is "taiko" in infobox:
![image](https://github.com/user-attachments/assets/de5e2549-237d-45da-bdf4-cdcf92f1c77b)
