### PR TITLE
feat: update order of nav cards on Marvel Rival's mainpage

### DIFF
--- a/components/main_page/wikis/marvelrivals/main_page_layout_data.lua
+++ b/components/main_page/wikis/marvelrivals/main_page_layout_data.lua
@@ -87,13 +87,39 @@ return {
 	title = 'The Marvel Rivals Wiki',
 	navigation = {
 		{
-			file = 'Marvel Rivals gameasset Patches allmode.jpg',
-			title = 'Patches',
-			link = 'Portal:Patches',
+			file = 'SparkR OWCS Major 2024.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
 			count = {
 				method = 'LPDB',
-				table = 'datapoint',
-				conditions = '[[type::patch]]',
+				table = 'player',
+			},
+		},
+		{
+			file = 'Crazy Raccoon 2024 Esports World Cup Champions.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'NTMR Infekted at OWCS 2024 Finals.jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'OWCS Stockholm 2024 Trophy.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
 			},
 		},
 		{
@@ -107,6 +133,15 @@ return {
 			},
 		},
 		{
+			file = 'Marvel_Rivals_icon_Planet_x_Pals.png',
+			title = 'Mechanics',
+			link = 'Mechanics',
+			count = {
+				method = 'CATEGORY',
+				category = 'Mechanics',
+			},
+		},
+		{
 			file = 'Marvel_Rivals_map_Royal_Palace.jpg',
 			title = 'Maps',
 			link = 'Portal:Maps',
@@ -117,48 +152,13 @@ return {
 			},
 		},
 		{
-			file = 'Marvel_Rivals_icon_Planet_x_Pals.png',
-			title = 'Mechanics',
-			link = 'Mechanics',
-			count = {
-				method = 'CATEGORY',
-				category = 'Mechanics',
-			},
-		},
-		{
-			file = 'OWCS Stockholm 2024 Trophy.jpg',
-			title = 'Tournaments',
-			link = 'Portal:Tournaments',
+			file = 'Marvel Rivals gameasset Patches allmode.jpg',
+			title = 'Patches',
+			link = 'Portal:Patches',
 			count = {
 				method = 'LPDB',
-				table = 'tournament',
-			},
-		},
-		{
-			file = 'Crazy Raccoon 2024 Esports World Cup Champions.jpg',
-			title = 'Teams',
-			link = 'Portal:Teams',
-			count = {
-				method = 'LPDB',
-				table = 'team',
-			},
-		},
-		{
-			file = 'SparkR OWCS Major 2024.jpg',
-			title = 'Players',
-			link = 'Portal:Players',
-			count = {
-				method = 'LPDB',
-				table = 'player',
-			},
-		},
-		{
-			file = 'NTMR Infekted at OWCS 2024 Finals.jpg',
-			title = 'Transfers',
-			link = 'Portal:Transfers',
-			count = {
-				method = 'LPDB',
-				table = 'transfer',
+				table = 'datapoint',
+				conditions = '[[type::patch]]',
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Changed order of nav card according to discord poll on discord
https://discord.com/channels/93055209017729024/1316071697555914804/1346576596554744021

## How did you test it?
Test it in my sandbox
https://liquipedia.net/marvelrivals/Module:MainPageLayout/data/dev/slothy
https://liquipedia.net/marvelrivals/User:Sl0thyMan/Sandbox/1

![image](https://github.com/user-attachments/assets/26a4cc21-16b6-4c6f-a7af-5dc07331bd44)
