### PR TITLE
ci: annotate test results for pull requests from forks

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           report_paths: 'report.xml'
           check_name: 'Lint Report'
+          annotate_only: (github.event.pull_request.head.repo.full_name != github.repository)
 
   lua-unit-test:
     runs-on: ubuntu-latest
@@ -63,3 +64,4 @@ jobs:
         with:
           report_paths: 'busted.xml'
           check_name: 'Test Report'
+          annotate_only: (github.event.pull_request.head.repo.full_name != github.repository)

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           report_paths: 'report.xml'
           check_name: 'Lint Report'
-          annotate_only: (github.event.pull_request.head.repo.full_name != github.repository)
+          annotate_only: ${{ (github.event.pull_request.head.repo.full_name != github.repository) }}
 
   lua-unit-test:
     runs-on: ubuntu-latest
@@ -64,4 +64,4 @@ jobs:
         with:
           report_paths: 'busted.xml'
           check_name: 'Test Report'
-          annotate_only: (github.event.pull_request.head.repo.full_name != github.repository)
+          annotate_only: ${{ (github.event.pull_request.head.repo.full_name != github.repository) }}


### PR DESCRIPTION
## Summary

For security reasons, GitHub does not allow writing checks from Actions workflow for PRs coming from forks. This PR adjusts workflow settings to let Actions annotate only instead of creating full checks when it is run from forks.

For documentation, see
- <https://github.com/mikepenz/action-junit-report?tab=readme-ov-file#inputs>
- <https://github.com/mikepenz/action-junit-report?tab=readme-ov-file#pr-run-permissions>

## How did you test this change?

https://github.com/Liquipedia/Lua-Modules/actions/runs/13699024313
