### PR TITLE
fix(infobox): lpdb field/data inconsistent with valorant weapons infobox params

### DIFF
--- a/components/infobox/wikis/valorant/infobox_weapon_custom.lua
+++ b/components/infobox/wikis/valorant/infobox_weapon_custom.lua
@@ -128,15 +128,15 @@ function CustomWeapon:addToLpdb(lpdbData, args)
 		price = args.price,
 		damage = self:getAllArgsForBase(args, 'damage'),
 		wallpenetration = args.wallpenetration,
-		ammo = args.ammo,
-		capacity = args.capacity,
+		magsize = args.magsize,
+		ammocap = args.ammocap,
 		reload = args.reloadspeed,
 		movementspeed = args.movementspeed,
-		firingmode = args.firemode,
-		firerate = args.rateoffire,
-		fireratemin = args.minrateoffire,
-		fireratemax = args.maxrateoffire,
-		fireratealternate = args.altrateoffire,
+		firemode = args.firemode,
+		rateoffire = args.rateoffire,
+		minrateoffire = args.minrateoffire,
+		maxrateoffire = args.maxrateoffire,
+		altrateoffire = args.altrateoffire,
 	}
 	return lpdbData
 end


### PR DESCRIPTION
## Summary

In Valorant's weapons infobox, some fields are named using legacy param names, some are trying to read from legacy param name, etc...
This PR fixes them all

## How did you test this change?

N/A
