### PR TITLE
feat(standard): implement name order logic

### DIFF
--- a/components/infobox/commons/infobox_person.lua
+++ b/components/infobox/commons/infobox_person.lua
@@ -12,6 +12,7 @@ local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Namespace = require('Module:Namespace')
+local NameOrder = require('Module:NameOrder')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -39,16 +40,6 @@ local Person = Class.new(BasicInfobox)
 
 local Language = mw.getContentLanguage()
 local LINK_VARIANT = 'player'
-local COUNTRIES_EASTERN_NAME_ORDER = {
-	'China',
-	'Taiwan',
-	'Hong Kong',
-	'Vietnam',
-	'South Korea',
-	'Cambodia',
-	'Macau',
-	'Singapore',
-}
 
 ---@enum PlayerStatus
 local Status = {
@@ -560,9 +551,9 @@ end
 ---@param args table
 ---@return table
 function Person:_flipNameOrder(args)
-	if not Logic.readBool(args.nonameflip) and Table.includes(COUNTRIES_EASTERN_NAME_ORDER, args.country) then
-		args.givenname, args.familyname = args.familyname, args.givenname
-	end
+	args.givenname, args.familyname = NameOrder.reorderNames(
+		args.givenname, args.familyname, {country = args.country, forceWesternOrder = args.nonameflip}
+	)
 	return args
 end
 

--- a/spec/name_order_spec.lua
+++ b/spec/name_order_spec.lua
@@ -32,25 +32,33 @@ describe('NameOrder', function()
 		it('verify', function ()
 			--Faker
 			local inputFirstName1, inputLastName1 = 'Sang-hyeok', 'Lee'
-			local outputLastName1, outputFirstName1 = NameOrder.reorderNames(inputFirstName1, inputLastName1, {country = 'South Korea'})
+			local outputLastName1, outputFirstName1 = NameOrder.reorderNames(
+				inputFirstName1, inputLastName1, {country = 'South Korea'}
+			)
 			assert.are_equal(inputFirstName1, outputFirstName1)
 			assert.are_equal(inputLastName1, outputLastName1)
 
 			--generic western name
 			local inputFirstName2, inputLastName2 = 'John', 'Doe'
-			local outputFirstName2, outputLastName2 = NameOrder.reorderNames(inputFirstName2, inputLastName2, {country = 'United Kingdom'})
+			local outputFirstName2, outputLastName2 = NameOrder.reorderNames(
+				inputFirstName2, inputLastName2, {country = 'United Kingdom'}
+			)
 			assert.are_equal(inputFirstName2, outputFirstName2)
 			assert.are_equal(inputLastName2, outputLastName2)
 
 			--Deft, with reordering suppressed
 			local inputFirstName3, inputLastName3 = 'Hyuk-kyu', 'Kim'
-			local outputFirstName3, outputLastName3 = NameOrder.reorderNames(inputFirstName3, inputLastName3, {country = 'South Korea', forceWesternOrder = true})
+			local outputFirstName3, outputLastName3 = NameOrder.reorderNames(
+				inputFirstName3, inputLastName3, {country = 'South Korea', forceWesternOrder = true}
+			)
 			assert.are_equal(inputFirstName3, outputFirstName3)
 			assert.are_equal(inputLastName3, outputLastName3)
 
 			--generic western name, with force reordering
 			local inputFirstName4, inputLastName4 = 'Jane', 'Doe'
-			local outputLastName4, outputFirstName4 = NameOrder.reorderNames(inputFirstName4, inputLastName4, {country = 'United States', forceEasternOrder = true})
+			local outputLastName4, outputFirstName4 = NameOrder.reorderNames(
+				inputFirstName4, inputLastName4, {country = 'United States', forceEasternOrder = true}
+			)
 			assert.are_equal(inputFirstName4, outputFirstName4)
 			assert.are_equal(inputLastName4, outputLastName4)
 		end)

--- a/spec/name_order_spec.lua
+++ b/spec/name_order_spec.lua
@@ -1,0 +1,58 @@
+--- Triple Comment to Enable our LLS Plugin
+describe('NameOrder', function()
+	local NameOrder = require('Module:NameOrder')
+
+	describe('uses eastern order', function ()
+		it('verify', function ()
+			assert.is_true(NameOrder.usesEasternNameOrder('China'))
+			assert.is_true(NameOrder.usesEasternNameOrder('Taiwan'))
+			assert.is_true(NameOrder.usesEasternNameOrder('Hong Kong'))
+			assert.is_true(NameOrder.usesEasternNameOrder('Vietnam'))
+			assert.is_true(NameOrder.usesEasternNameOrder('South Korea'))
+			assert.is_true(NameOrder.usesEasternNameOrder('Cambodia'))
+			assert.is_true(NameOrder.usesEasternNameOrder('Macau'))
+			assert.is_true(NameOrder.usesEasternNameOrder('Singapore'))
+		end)
+	end)
+
+	describe('does not use eastern order', function ()
+		it('verify', function ()
+			assert.is_not_true(NameOrder.usesEasternNameOrder('United States'))
+			assert.is_not_true(NameOrder.usesEasternNameOrder('Germany'))
+			assert.is_not_true(NameOrder.usesEasternNameOrder('Japan'))
+			assert.is_not_true(NameOrder.usesEasternNameOrder('France'))
+			assert.is_not_true(NameOrder.usesEasternNameOrder('Canada'))
+			assert.is_not_true(NameOrder.usesEasternNameOrder('Brazil'))
+			assert.is_not_true(NameOrder.usesEasternNameOrder('Russia'))
+			assert.is_not_true(NameOrder.usesEasternNameOrder('Spain'))
+		end)
+	end)
+
+	describe('name reordering', function ()
+		it('verify', function ()
+			--Faker
+			local inputFirstName1, inputLastName1 = 'Sang-hyeok', 'Lee'
+			local outputLastName1, outputFirstName1 = NameOrder.reorderNames(inputFirstName1, inputLastName1, {country = 'South Korea'})
+			assert.are_equal(inputFirstName1, outputFirstName1)
+			assert.are_equal(inputLastName1, outputLastName1)
+
+			--generic western name
+			local inputFirstName2, inputLastName2 = 'John', 'Doe'
+			local outputFirstName2, outputLastName2 = NameOrder.reorderNames(inputFirstName2, inputLastName2, {country = 'United Kingdom'})
+			assert.are_equal(inputFirstName2, outputFirstName2)
+			assert.are_equal(inputLastName2, outputLastName2)
+
+			--Deft, with reordering suppressed
+			local inputFirstName3, inputLastName3 = 'Hyuk-kyu', 'Kim'
+			local outputFirstName3, outputLastName3 = NameOrder.reorderNames(inputFirstName3, inputLastName3, {country = 'South Korea', forceWesternOrder = true})
+			assert.are_equal(inputFirstName3, outputFirstName3)
+			assert.are_equal(inputLastName3, outputLastName3)
+
+			--generic western name, with force reordering
+			local inputFirstName4, inputLastName4 = 'Jane', 'Doe'
+			local outputLastName4, outputFirstName4 = NameOrder.reorderNames(inputFirstName4, inputLastName4, {country = 'United States', forceEasternOrder = true})
+			assert.are_equal(inputFirstName4, outputFirstName4)
+			assert.are_equal(inputLastName4, outputLastName4)
+		end)
+	end)
+end)

--- a/standard/name_order.lua
+++ b/standard/name_order.lua
@@ -43,14 +43,14 @@ User may specify overrides to force/suppress reordering.
 ---@param options {country: string?, forceEasternOrder: boolean?, forceWesternOrder: boolean?}
 ---@return string, string
 function NameOrder.reorderNames(givenName, familyName, options)
-	if Array.any({
-		options.forceEasternOrder,
-		not options.forceWesternOrder,
-		NameOrder.usesEasternNameOrder(options.country)
-	}, Logic.readBool) then
+	if options.forceEasternOrder then
+		return familyName, givenName
+	elseif options.forceWesternOrder then
+		return givenName, familyName
+	elseif NameOrder.usesEasternNameOrder(options.country) then
 		return familyName, givenName
 	else
-		return givenName, familyName
+		return familyName, givenName
 	end
 end
 

--- a/standard/name_order.lua
+++ b/standard/name_order.lua
@@ -6,9 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Logic = require('Module:Logic')
 local Table = require('Module:Table')
 
 local NameOrder = {}

--- a/standard/name_order.lua
+++ b/standard/name_order.lua
@@ -31,7 +31,7 @@ end
 
 --[[
 Reorders name as required by the Name Standards.
-For countries using the eastern order, (familyName, givenName) is returned whereas
+(familyName, givenName) is returned for countries using the eastern order whereas
 (givenName, familyName) is returned for countries using the western order.
 
 User may specify overrides to force/suppress reordering.

--- a/standard/name_order.lua
+++ b/standard/name_order.lua
@@ -1,0 +1,57 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:NameOrder
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Table = require('Module:Table')
+
+local NameOrder = {}
+
+local COUNTRIES_EASTERN_NAME_ORDER = {
+	'China',
+	'Taiwan',
+	'Hong Kong',
+	'Vietnam',
+	'South Korea',
+	'Cambodia',
+	'Macau',
+	'Singapore',
+}
+
+---Checks whether the specified country uses Eastern name order
+---@param country string?
+---@return boolean
+function NameOrder.usesEasternNameOrder(country)
+	return Table.includes(COUNTRIES_EASTERN_NAME_ORDER, country)
+end
+
+--[[
+Reorders name as required by the Name Standards.
+For countries using the eastern order, (familyName, givenName) is returned whereas
+(givenName, familyName) is returned for countries using the western order.
+
+User may specify overrides to force/suppress reordering.
+]]
+---@param givenName string
+---@param familyName string
+---@param options {country: string?, forceEasternOrder: boolean?, forceWesternOrder: boolean?}
+---@return string, string
+function NameOrder.reorderNames(givenName, familyName, options)
+	if Array.any({
+		options.forceEasternOrder,
+		not options.forceWesternOrder,
+		NameOrder.usesEasternNameOrder(options.country)
+	}, Logic.readBool) then
+		return familyName, givenName
+	else
+		return givenName, familyName
+	end
+end
+
+return Class.export(NameOrder)

--- a/standard/name_order.lua
+++ b/standard/name_order.lua
@@ -48,7 +48,7 @@ function NameOrder.reorderNames(givenName, familyName, options)
 	elseif NameOrder.usesEasternNameOrder(options.country) then
 		return familyName, givenName
 	else
-		return familyName, givenName
+		return givenName, familyName
 	end
 end
 


### PR DESCRIPTION
## Summary

This PR implements [lpcommons:Liquipedia:Name Standards#Name Order](https://liquipedia.net/commons/Liquipedia:Name_Standards#Name_Order)

## How did you test this change?

included test suite (26c2e46)
