### PR TITLE
refactor(mainpage): load Lua directly from mainpage layout data

### DIFF
--- a/components/main_page/wikis/apexlegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/apexlegends/main_page_layout_data.lua
@@ -6,6 +6,22 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local ExternalMediaList = Lua.import('Module:ExternalMediaList')
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local CenterDot = Lua.import('Module:Widget/MainPage/CenterDot')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'The Game',
@@ -21,22 +37,17 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{Current term}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Apex Legends <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
 		padding = true,
 		boxid = 1510,
 	},
@@ -46,14 +57,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		},
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -62,18 +86,37 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=30}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 30
+		},
 		padding = true,
 		boxid = 1508,
 	},
 	headlines = {
 		heading = 'Headlines',
-		body = '{{ExternalMediaList|subject=!|limit=4}}' ..
-			'<div style{{=}}"display:block; text-align:center; padding:0.5em;">' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px; font-size:15px; font-style:italic;">' ..
-			'[[Portal:News|See all Headlines]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Special:FormEdit/ExternalMediaLinks|Add a Headline]]</div></div>',
+		body = WidgetUtil.collect(
+			ExternalMediaList.get{ subject = '!', limit = 4 },
+			Div{
+				css = { display = 'block', ['text-align'] = 'center', padding = '0.5em', },
+				children = {
+					Div{
+						css = {
+							['white-space'] = 'nowrap',
+							display = 'inline',
+							margin = '0 10px',
+							['font-size'] = '15px',
+							['font-style'] = 'italic',
+						},
+						children = {
+							Link{ children = 'See all Headlines', link = 'Portal:News' },
+							CenterDot(),
+							Link{ children = 'Add a Headline', link = 'Special:FormEdit/ExternalMediaLinks' }
+						}
+					}
+				}
+			}
+		),
 		padding = true,
 		boxid = 1511,
 	},

--- a/components/main_page/wikis/apexlegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/apexlegends/main_page_layout_data.lua
@@ -40,7 +40,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/apexlegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/apexlegends/main_page_layout_data.lua
@@ -40,7 +40,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/arenafps/main_page_layout_data.lua
+++ b/components/main_page/wikis/arenafps/main_page_layout_data.lua
@@ -6,6 +6,20 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,22 +35,18 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{Current term}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{
+			transferQuery = false,
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Arena FPS <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
 		padding = true,
 		boxid = 1510,
 	},
@@ -46,14 +56,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -62,8 +85,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=40|completedDays=40}}',
+		body = TournamentsTicker{
+			upcomingDays = 40,
+			completedDays = 40
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/arenafps/main_page_layout_data.lua
+++ b/components/main_page/wikis/arenafps/main_page_layout_data.lua
@@ -37,7 +37,6 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferQuery = false,
-			rumours = true,
 			transferPage = function ()
 				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end

--- a/components/main_page/wikis/arenafps/main_page_layout_data.lua
+++ b/components/main_page/wikis/arenafps/main_page_layout_data.lua
@@ -39,7 +39,7 @@ local CONTENT = {
 			transferQuery = false,
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/arenafps/main_page_layout_data.lua
+++ b/components/main_page/wikis/arenafps/main_page_layout_data.lua
@@ -39,7 +39,7 @@ local CONTENT = {
 			transferQuery = false,
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/brawlstars/main_page_layout_data.lua
+++ b/components/main_page/wikis/brawlstars/main_page_layout_data.lua
@@ -38,7 +38,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/brawlstars/main_page_layout_data.lua
+++ b/components/main_page/wikis/brawlstars/main_page_layout_data.lua
@@ -6,6 +6,20 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,22 +35,19 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{Current term}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Brawl Stars <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
 		padding = true,
 		boxid = 1510,
 	},
@@ -46,14 +57,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -62,8 +86,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 20
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/brawlstars/main_page_layout_data.lua
+++ b/components/main_page/wikis/brawlstars/main_page_layout_data.lua
@@ -38,7 +38,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/deadlock/main_page_layout_data.lua
+++ b/components/main_page/wikis/deadlock/main_page_layout_data.lua
@@ -6,6 +6,19 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	updates = {
 		heading = 'Updates',
@@ -27,23 +40,19 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n' ..
-		'<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y')
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Deadlock <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
 		padding = true,
 		boxid = 1510,
 	},
@@ -56,14 +65,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -72,8 +94,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=60|completedDays=20}}',
+		body = TournamentsTicker{
+			upcomingDays = 60,
+			completedDays = 20
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/dota2/main_page_layout_data.lua
+++ b/components/main_page/wikis/dota2/main_page_layout_data.lua
@@ -91,7 +91,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+				return 'Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/dota2/main_page_layout_data.lua
+++ b/components/main_page/wikis/dota2/main_page_layout_data.lua
@@ -91,7 +91,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/dota2/main_page_layout_data.lua
+++ b/components/main_page/wikis/dota2/main_page_layout_data.lua
@@ -91,7 +91,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/dota2/main_page_layout_data.lua
+++ b/components/main_page/wikis/dota2/main_page_layout_data.lua
@@ -357,7 +357,7 @@ return {
 			},
 		},
 		{
-			file = 'Rune of Arcane prev.png',
+			file = 'Dota 2 Rune Arcane preview.png',
 			title = 'Mechanics',
 			link = 'Mechanics',
 			count = {

--- a/components/main_page/wikis/dota2/main_page_layout_data.lua
+++ b/components/main_page/wikis/dota2/main_page_layout_data.lua
@@ -6,6 +6,20 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	aboutMain = {
 		heading = 'About Liquipedia’s Dota 2 Wiki',
@@ -75,23 +89,16 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n' ..
-			'<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'\t<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'\t<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Transfers/{{Current term}}|action=edit}} edit]&#93;</div>\n' ..
-			'\t<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px; font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>[[Transfer query]]' ..
-			'<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]</div>\n' ..
-			'</div>',
+		body = TransfersList{
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Dota <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{ birthdayListPage = 'Birthday list' },
 		padding = true,
 		boxid = 1510,
 	},
@@ -101,14 +108,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-		'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; font-size:15px; ' ..
-			'font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -117,8 +137,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 20
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/fortnite/main_page_layout_data.lua
+++ b/components/main_page/wikis/fortnite/main_page_layout_data.lua
@@ -34,7 +34,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/fortnite/main_page_layout_data.lua
+++ b/components/main_page/wikis/fortnite/main_page_layout_data.lua
@@ -6,6 +6,17 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,22 +32,18 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{Current term}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Fortnite <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
 		padding = true,
 		boxid = 1510,
 	},
@@ -46,13 +53,17 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=14|completedDays=7}}',
+		body = TournamentsTicker{
+			upcomingDays = 14,
+			completedDays = 7
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/fortnite/main_page_layout_data.lua
+++ b/components/main_page/wikis/fortnite/main_page_layout_data.lua
@@ -34,7 +34,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/halo/main_page_layout_data.lua
+++ b/components/main_page/wikis/halo/main_page_layout_data.lua
@@ -6,6 +6,20 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,22 +35,19 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{Current term}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Halo <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
 		padding = true,
 		boxid = 1510,
 	},
@@ -46,14 +57,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -62,8 +86,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 20
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/halo/main_page_layout_data.lua
+++ b/components/main_page/wikis/halo/main_page_layout_data.lua
@@ -38,7 +38,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/halo/main_page_layout_data.lua
+++ b/components/main_page/wikis/halo/main_page_layout_data.lua
@@ -38,7 +38,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/hearthstone/main_page_layout_data.lua
+++ b/components/main_page/wikis/hearthstone/main_page_layout_data.lua
@@ -36,7 +36,6 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			rumours = true,
 			transferPage = function ()
 				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end

--- a/components/main_page/wikis/hearthstone/main_page_layout_data.lua
+++ b/components/main_page/wikis/hearthstone/main_page_layout_data.lua
@@ -38,7 +38,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/hearthstone/main_page_layout_data.lua
+++ b/components/main_page/wikis/hearthstone/main_page_layout_data.lua
@@ -6,6 +6,20 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,22 +35,17 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}/1st_Quarter|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{
+			rumours = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf() .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Hearthstone <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
 		padding = true,
 		boxid = 1510,
 	},
@@ -46,14 +55,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -62,8 +84,14 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20|modifierTypeQualifier=-2|modifierTier1=55|modifierTier2=55|modifierTier3=10}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 20,
+			modifierTypeQualifier = -2,
+			modifierTier1 = 55,
+			modifierTier2 = 55,
+			modifierTier3 = 10
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/hearthstone/main_page_layout_data.lua
+++ b/components/main_page/wikis/hearthstone/main_page_layout_data.lua
@@ -38,7 +38,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{} .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 			end
 		},
 		boxid = 1509,

--- a/components/main_page/wikis/marvelrivals/main_page_layout_data.lua
+++ b/components/main_page/wikis/marvelrivals/main_page_layout_data.lua
@@ -6,6 +6,19 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	updates = {
 		heading = 'Updates',
@@ -27,21 +40,18 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n' ..
-		'<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]</center></div>\n</div>',
+		body = TransfersList{
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y')
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Marvel Rivals <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
 		padding = true,
 		boxid = 1510,
 	},
@@ -54,14 +64,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -70,8 +93,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=60|completedDays=20}}',
+		body = TournamentsTicker{
+			upcomingDays = 60,
+			completedDays = 20
+		},
 		padding = true,
 		boxid = 1508,
 	},

--- a/components/main_page/wikis/overwatch/main_page_layout_data.lua
+++ b/components/main_page/wikis/overwatch/main_page_layout_data.lua
@@ -6,6 +6,19 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,23 +34,14 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style="display:block; text-align:center; padding:0.5em;">' ..
-			'<div style="display:inline; float:left; font-style:italic;">[[#Top|Back to top]]</div>' ..
-			'<div style="display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[[Special:EditPage/Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|edit]]&#93;</div>' ..
-			'<div style="white-space:nowrap; display:inline; font-size:15px; font-style:italic; font-weight:bold;">' ..
-			'[[Portal:Transfers|See all Transfers]]<span style="font-style:normal; font-weight:normal; ' ..
-			'padding:0 5px;">&#8226;</span>[[Transfer query]]<br><span style="font-style:normal; padding:0 5px;">' ..
-			'&#8226;</span>[[Special:RunQuery/Transfer|Transfer Generator]]<span style="font-style:normal; padding:0 5px;">' ..
-			'&#8226;</span>[[Portal:Rumours|Rumours]]</div></div>',
+		body = TransfersList{rumours = true},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Overwatch <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
 		padding = true,
-		boxid = 1509,
+		boxid = 1510,
 	},
 	specialEvents = {
 		noPanel = true,
@@ -46,15 +50,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">' ..
-			'[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -63,8 +79,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=120|completedDays=30}}',
+		body = TournamentsTicker{
+			upcomingDays = 120,
+			completedDays = 30
+		},
 		boxid = 1508,
 	},
 }

--- a/components/main_page/wikis/pubgmobile/main_page_layout_data.lua
+++ b/components/main_page/wikis/pubgmobile/main_page_layout_data.lua
@@ -6,6 +6,21 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+
+local ExternalMediaList = Lua.import('Module:ExternalMediaList')
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local CenterDot = Lua.import('Module:Widget/MainPage/CenterDot')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,23 +36,14 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Special:RunQuery/Transfer_history|Transfer query]]' ..
-			'<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{rumours = true},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in PUBG Mobile <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
 		padding = true,
 		boxid = 1510,
 	},
@@ -47,14 +53,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -63,18 +82,37 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=30}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 30
+		},
 		padding = true,
 		boxid = 1508,
 	},
 	headlines = {
 		heading = 'Headlines',
-		body = '{{ExternalMediaList|subject=!|organization=!|limit=5}}' ..
-			'<div style="display:block; text-align:center; padding:0.5em;">' ..
-			'<div style="white-space:nowrap; display:inline; margin:0 10px; font-size:15px; font-style:italic;">' ..
-			'[[Portal:News|See all Headlines]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Special:FormEdit/ExternalMediaLinks|Add a Headline]]</div>',
+		body = WidgetUtil.collect(
+			ExternalMediaList.get{ subject = '!', limit = 5 },
+			Div{
+				css = { display = 'block', ['text-align'] = 'center', padding = '0.5em', },
+				children = {
+					Div{
+						css = {
+							['white-space'] = 'nowrap',
+							display = 'inline',
+							margin = '0 10px',
+							['font-size'] = '15px',
+							['font-style'] = 'italic',
+						},
+						children = {
+							Link{ children = 'See all Headlines', link = 'Portal:News' },
+							CenterDot(),
+							Link{ children = 'Add a Headline', link = 'Special:FormEdit/ExternalMediaLinks' }
+						}
+					}
+				}
+			}
+		),
 		padding = true,
 		boxid = 1511,
 	},

--- a/components/main_page/wikis/rainbowsix/main_page_layout_data.lua
+++ b/components/main_page/wikis/rainbowsix/main_page_layout_data.lua
@@ -6,6 +6,19 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local CONTENT = {
 	usefulArticles = {
 		heading = 'Useful Articles',
@@ -21,22 +34,14 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = '{{Transfer List|limit=15}}\n<div style{{=}}"display:block; text-align:center; padding:0.5em;">\n' ..
-			'<div style{{=}}"display:inline; float:left; font-style:italic;">\'\'[[#Top|Back to top]]\'\'</div>\n' ..
-			'<div style{{=}}"display:inline; float:right;" class="plainlinks smalledit">' ..
-			'&#91;[{{FULLURL:Player Transfers/{{CURRENTYEAR}}/{{CURRENTMONTHNAME}}|action=edit}} edit]&#93;</div>\n' ..
-			'<div style{{=}}"white-space:nowrap; display:inline; margin:0 10px font-size:15px; font-style:italic;">' ..
-			'[[Portal:Transfers|See more transfers]]<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Transfer query]]<span style{{=}}"font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[lpcommons:Special:RunQuery/Transfer|Input Form]]' ..
-			'<span style="font-style:normal; padding:0 5px;">&#8226;</span>' ..
-			'[[Portal:Rumours|Rumours]]</center></div>\n</div>',
+		body = TransfersList{rumours = true},
 		boxid = 1509,
 	},
 	thisDay = {
-		heading = 'This day in Rainbow Six <small id="this-day-date" style = "margin-left: 5px">' ..
-			'({{#time:F}} {{Ordinal|{{#time:j}}}})</small>',
-		body = '{{Liquipedia:This day}}',
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
 		padding = true,
 		boxid = 1510,
 	},
@@ -46,14 +51,27 @@ local CONTENT = {
 	},
 	filterButtons = {
 		noPanel = true,
-		body = '<div style{{=}}"width:100%;margin-bottom:8px;">' ..
-			'{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=FilterButtons}}</div>',
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
 	},
 	matches = {
 		heading = 'Matches',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Match/Ticker/Container}}' ..
-			'<div style{{=}}"white-space:nowrap; display: block; margin:0 10px; ' ..
-			'font-size:15px; font-style:italic; text-align:center;">[[Liquipedia:Matches|See more matches]]</div>',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {
@@ -62,8 +80,10 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = '{{#invoke:Lua|invoke|module=Widget/Factory|fn=fromTemplate|widget=Tournaments/Ticker' ..
-			'|upcomingDays=30|completedDays=20}}',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 20
+		},
 		padding = true,
 		boxid = 1508,
 	},


### PR DESCRIPTION
## Summary

~~_Depends on #5451 (`DateExt.quarterOf` part of it)_~~

Follow-up for #5530
This PR replaces most wikicode strings into direct Lua calls.

## How did you test this change?

dev