### PR TITLE
refactor(infobox): rewrite LoL champion infobox

### DIFF
--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -47,6 +47,10 @@ function Character:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = (args.informationType or 'Character') .. ' Information'},
+		Customizable{
+			id = 'overview',
+			children = {}
+		},
 		Cell{name = 'Real Name', content = {args.realname}},
 		Customizable{
 			id = 'country',

--- a/components/infobox/commons/infobox_character.lua
+++ b/components/infobox/commons/infobox_character.lua
@@ -47,10 +47,6 @@ function Character:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = (args.informationType or 'Character') .. ' Information'},
-		Customizable{
-			id = 'overview',
-			children = {}
-		},
 		Cell{name = 'Real Name', content = {args.realname}},
 		Customizable{
 			id = 'country',

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -168,9 +168,9 @@ end
 ---@return string[]
 function CustomCharacter:getWikiCategories(args)
 	if not Namespace.isMain() then return {} end
-	return Array.appendWith({'Champions'},
-		String.isNotEmpty(args.attacktype) and (args.attacktype .. ' Champions') or nil,
-		String.isNotEmpty(args.primaryrole) and (args.primaryrole .. ' Champions') or nil
+	return WidgetUtil.collect(
+		String.isNotEmpty(args.attacktype) and (args.attacktype .. ' Champion') or nil,
+		String.isNotEmpty(args.primaryrole) and (args.primaryrole .. ' Champion') or nil
 	)
 end
 

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -44,12 +44,6 @@ function CustomCharacter.run(frame)
 	local character = CustomCharacter(frame)
 	character:setWidgetInjector(CustomInjector(character))
 	character.args.informationType = 'Champion'
-
-	-- legacy args that need to be botted
-	local args = character.args
-	args.name = args.championname
-	args.caption = args.quote
-
 	return character:createInfobox()
 end
 

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -47,8 +47,8 @@ function CustomCharacter.run(frame)
 	character.args.informationType = 'Champion'
 
 	local args = character.args
+	args.name = args.championname
 	args.caption = args.quote
-
 
 	return character:createInfobox()
 end
@@ -57,7 +57,6 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
 	if id == 'overview' then
 		local breakDownContents = WidgetUtil.collect(
 			self:_toBreakDownCell('region', 'Region', 'RegionIcon'),

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -111,10 +111,10 @@ function CustomCharacter:_getPriceCell()
 	local args = self.args
 	local costContent = WidgetUtil.collect(
 		String.isNotEmpty(args.costbe) and HtmlWidgets.Fragment{
-			children = { args.costbe, ' ', BLUE_ESSENCE_ICON }
+			children = { BLUE_ESSENCE_ICON, ' ', args.costbe }
 		} or nil,
 		String.isNotEmpty(args.costrp) and HtmlWidgets.Fragment{
-			children = { args.costrp, ' ', RIOT_POINTS_ICON }
+			children = { RIOT_POINTS_ICON, ' ', args.costrp }
 		} or nil
 	)
 	return Cell{ name = 'Price', content = costContent }

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -159,7 +159,7 @@ function CustomCharacter:_getCustomCells()
 		Cell{name = 'Movement Speed', content = {args.movespeed}}
 	)
 
-	local wins, loses = CharacterWinLoss.run()
+	local wins, loses = CharacterWinLoss.run(args.name)
 	if wins + loses == 0 then return widgets end
 
 	local winPercentage = Math.round(wins * 100 / (wins + loses), 2)

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -20,7 +20,6 @@ local Injector = Lua.import('Module:Widget/Injector')
 
 local Widgets = Lua.import('Module:Widget/All')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
-local Breakdown = Widgets.Breakdown
 local Cell = Widgets.Cell
 local IconImageWidget = Lua.import('Module:Widget/Image/Icon/Image')
 local Title = Widgets.Title

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -122,7 +122,6 @@ function CustomCharacter:_getCustomCells()
 		Cell{name = 'Resource Bar', content = {args.secondarybar}},
 		Cell{name = 'Secondary Bar', content = {args.secondarybar1}},
 		Cell{name = 'Secondary Attributes', content = {args.secondaryattributes1}},
-		Cell{name = 'Release Date', content = {args.releasedate}}
 	}
 
 	if Array.any({'hp', 'hplvl', 'hpreg', 'hpreglvl'}, function(key) return String.isNotEmpty(args[key]) end) then

--- a/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
+++ b/components/infobox/wikis/leagueoflegends/infobox_character_custom.lua
@@ -93,6 +93,7 @@ function CustomInjector:_toBreakDownCell(key, title, dataModule)
 			HtmlWidgets.Br{},
 			IconImageWidget{
 				imageLight = iconData.icon,
+				size = '50px',
 				link = iconData.link
 			}
 		}
@@ -114,20 +115,18 @@ function CustomCharacter:_getPriceCell()
 end
 
 ---@return Widget[]
-function CustomCharacter:getCustomCells()
+function CustomCharacter:_getCustomCells()
 	local args = self.args
-	local widgets = {}
-	Array.appendWith(
-		widgets,
+	local widgets = {
 		Cell{name = 'Attack Type', content = {args.attacktype}},
 		Cell{name = 'Resource Bar', content = {args.secondarybar}},
 		Cell{name = 'Secondary Bar', content = {args.secondarybar1}},
 		Cell{name = 'Secondary Attributes', content = {args.secondaryattributes1}},
 		Cell{name = 'Release Date', content = {args.releasedate}}
-	)
+	}
 
 	if Array.any({'hp', 'hplvl', 'hpreg', 'hpreglvl'}, function(key) return String.isNotEmpty(args[key]) end) then
-		table.insert(widgets, Title{children = 'Base Statistics'})
+		Array.appendWith(widgets, Title{children = 'Base Statistics'})
 	end
 
 	local function bonusPerLevel(start, bonuslvl)

--- a/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
+++ b/components/main_page/wikis/leagueoflegends/main_page_layout_data.lua
@@ -178,7 +178,7 @@ return {
 			count = {
 				method = 'LPDB',
 				table = 'datapoint',
-				conditions = '[[type::hero]]',
+				conditions = '[[type::character]]',
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Currently, champion infobox in LoL extends unit infobox. This doesn't make much sense as champions are playable characters in LoL.
Thus, this PR adjusts champion infobox to extend character infobox, and rewrites the infobox code accordingly.

## How did you test this change?

first in dev, then in live