### PR TITLE
fix(mainpage): standardize first h3 padding

### DIFF
--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -294,7 +294,8 @@ body.page-Main_Page .mainpage-transfer .divRow:nth-of-type( n + 17 ) {
 	overflow: hidden;
 }
 
-#this-day-facts > h3:first-child {
+#this-day-facts > h3:first-child,
+.useful-articles-layout > div > h3:first-child {
 	margin-top: 0;
 	padding-top: 0;
 }

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -298,7 +298,7 @@ body.page-Main_Page .mainpage-transfer .divRow:nth-of-type( n + 17 ) {
 	h3:first-child,
 	h4:first-child {
 		margin-top: 0;
-		padding-top: 0
+		padding-top: 0;
 	}
 }
 

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -294,10 +294,12 @@ body.page-Main_Page .mainpage-transfer .divRow:nth-of-type( n + 17 ) {
 	overflow: hidden;
 }
 
-#this-day-facts > h3:first-child,
-.useful-articles-layout > div > h3:first-child {
-	margin-top: 0;
-	padding-top: 0;
+.panel-box-body {
+	h3:first-child,
+	h4:first-child {
+		margin-top: 0;
+		padding-top: 0
+	}
 }
 
 /* Matches box */


### PR DESCRIPTION
## Summary

The spacing between the top of the new main page cards and the first h3 element is not standard.

| `#this-day-facts > h3:first-child` | `.useful-articles-layout > div > h3:first-child` |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cc2026a3-2199-4838-9a96-19b1294af892) | ![image](https://github.com/user-attachments/assets/8331aa6c-265f-4abf-912c-bbb336f9fd5c) |

Essentially just making them both the same (zero) spacing so that it looks better and takes up less space.

## How did you test this change?

Browser dev tools.
![image](https://github.com/user-attachments/assets/977fa530-79f8-44f7-b94b-1c4f7ba2d598)

