### PR TITLE
feat(mainpage): improve tournament list headers on Lakeside

### DIFF
--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -57,7 +57,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 }
 
 body.skin-lakesideview .tournaments-list-heading {
-	background-color: var( --clr-wiki-primary-container );
+	background-color: rgb( from var( --clr-wiki-theme-primary ) r g b / 0.12 );
 	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;
 	border-radius: 0.5rem;
@@ -65,6 +65,11 @@ body.skin-lakesideview .tournaments-list-heading {
 	line-height: 1.25rem;
 	margin-bottom: 0.5rem;
 	border: 0;
+}
+
+.theme--dark body.skin-lakesideview .tournaments-list-heading {
+	background-color: rgb( from #ffffff r g b / 0.12 );
+	color: #ffffff;
 }
 
 .tournaments-list-type-list {

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -65,11 +65,11 @@ body.skin-lakesideview .tournaments-list-heading {
 	line-height: 1.25rem;
 	margin-bottom: 0.5rem;
 	border: 0;
-}
 
-.theme--dark body.skin-lakesideview .tournaments-list-heading {
-	background-color: rgba( from #ffffff r g b / 0.12 );
-	color: #ffffff;
+	.theme--dark & {
+		background-color: rgba( from #ffffff r g b / 0.12 );
+		color: #ffffff;
+	}
 }
 
 .tournaments-list-type-list {

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -68,7 +68,7 @@ body.skin-lakesideview .tournaments-list-heading {
 }
 
 .theme--dark body.skin-lakesideview .tournaments-list-heading {
-	background-color: rgb( from #ffffff r g b / 0.12 );
+	background-color: rgba( from #ffffff r g b / 0.12 );
 	color: #ffffff;
 }
 

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -56,6 +56,17 @@ div.main-page-banner .main-page-banner-bottom-row {
 	border-bottom: 1px solid var( --clr-border, #bbbbbb );
 }
 
+body.skin-lakesideview .tournaments-list-heading {
+	background-color: var(--clr-wiki-primary-container);
+	color: var(--clr-wiki-theme-primary);
+	padding: 0.5rem 0.75rem;
+	border-radius: 0.5rem;
+	font-size: 0.875rem;
+	line-height: 1.25rem;
+	margin-bottom: 1rem;
+	border: none;
+}
+
 .tournaments-list-type-list {
 	margin-bottom: 15px !important;
 	margin-left: 0 !important;

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -57,8 +57,8 @@ div.main-page-banner .main-page-banner-bottom-row {
 }
 
 body.skin-lakesideview .tournaments-list-heading {
-	background-color: var(--clr-wiki-primary-container);
-	color: var(--clr-wiki-theme-primary);
+	background-color: var( --clr-wiki-primary-container );
+	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;
 	border-radius: 0.5rem;
 	font-size: 0.875rem;

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -63,7 +63,7 @@ body.skin-lakesideview .tournaments-list-heading {
 	border-radius: 0.5rem;
 	font-size: 0.875rem;
 	line-height: 1.25rem;
-	margin-bottom: 1rem;
+	margin-bottom: 0.5rem;
 	border: none;
 }
 

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -57,7 +57,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 }
 
 body.skin-lakesideview .tournaments-list-heading {
-	background-color: rgb( from var( --clr-wiki-theme-primary ) r g b / 0.12 );
+	background-color: rgba( from var( --clr-wiki-theme-primary ) r g b / 0.12 );
 	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;
 	border-radius: 0.5rem;

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -64,7 +64,7 @@ body.skin-lakesideview .tournaments-list-heading {
 	font-size: 0.875rem;
 	line-height: 1.25rem;
 	margin-bottom: 0.5rem;
-	border: none;
+	border: 0;
 }
 
 .tournaments-list-type-list {


### PR DESCRIPTION
## Summary

The current headers are not following wiki colors at all and stand out way too much like they don't belong. This is a quick fix to stealing some CSS from the filter buttons and upcoming/completed toggles to match the style of the headers for the tournaments list to something that actually looks like it belongs there.

(Will apply to all Lakeside wikis, not just dota2 but obviously will use Lakeside colors for each wiki)

| Current | Proposed |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0b3b1d79-4eaa-4e1b-9cfd-67b2837231b9) | ![image](https://github.com/user-attachments/assets/11c86430-ade0-43b1-a506-939f13fa9526) |

## How did you test this change?

Browser dev tools.

