### PR TITLE
feat(standard): add TeamTemplate util functions

### DIFF
--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
-local Table = require('Module:Table')
 
 --[[
 A thin wrapper around mw.ext.TeamTemplate that memoizes extension calls
@@ -120,8 +119,7 @@ function TeamTemplate.queryHistoricalNames(name)
 	if resolvedName then
 		local index = TeamTemplate.queryHistorical(resolvedName) or {}
 		if Logic.isNotEmpty(index) then
-			local templates = Table.mapValues(index, FnUtil.identity)
-			return Array.unique(templates)
+			return Array.unique(Array.extractValues(index))
 		else
 			return { resolvedName }
 		end

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -1,3 +1,11 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:TeamTemplate
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local FnUtil = require('Module:FnUtil')
 local Logic = require('Module:Logic')
 

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -41,7 +41,7 @@ TeamTemplate.getPageName = FnUtil.memoize(function(resolvedTemplate)
 	local raw = mw.ext.TeamTemplate.raw(resolvedTemplate)
 	return raw and mw.ext.TeamLiquidIntegration.resolve_redirect(raw.page)
 end)
-	
+
 --[[
 Returns raw data of a team template for a team on a given date. Throws if the
 team template does not exist.

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -59,7 +59,7 @@ Returns the resolved page name of a team template that has been resolved to a
 date. Returns nil if the team does not exist, or if the page is not specified.
 ]]
 TeamTemplate.getPageName = FnUtil.memoize(function(resolvedTemplate)
-	local raw = mw.ext.TeamTemplate.raw(resolvedTemplate)
+	local raw = TeamTemplate.getRawOrNil(resolvedTemplate)
 	return raw and mw.ext.TeamLiquidIntegration.resolve_redirect(raw.page) or nil
 end)
 

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -28,8 +28,8 @@ timezone parts.
 ---@return string?
 function TeamTemplate.resolve(template, date)
 	template = template:gsub('_', ' ')
-	local raw = mw.ext.TeamTemplate.raw(template, date)
-	return raw and raw.templatename or nil
+	local raw = TeamTemplate.getRawOrNil(template, date) or {}
+	return raw.templatename
 end
 
 ---Returns true if the specified team template exists.

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -1,0 +1,69 @@
+local FnUtil = require('Module:FnUtil')
+local Logic = require('Module:Logic')
+
+--[[
+A thin wrapper around mw.ext.TeamTemplate that memoizes extension calls
+]]
+local TeamTemplate = {}
+
+--[[
+Resolves a team template to a specific date. Returns nil if the team does not
+exist.
+
+Note that team template changes only occur at midnights in the UTC timezone.
+So it is safe to pass Y-m-d date strings ('2021-11-08') without time or
+timezone parts.
+]]
+function TeamTemplate.resolve(template, date)
+	template = template:gsub('_', ' ')
+	local raw = mw.ext.TeamTemplate.raw(template, date)
+	return raw and raw.templatename
+end
+
+--- Retrieves the lightmode image and darkmode image for a given team template.
+---@param template string
+---@return string?
+---@return string?
+function TeamTemplate.getIcon(template)
+	local raw = mw.ext.TeamTemplate.raw(template)
+	if raw then
+		local icon = Logic.emptyOr(raw.image, raw.legacyimage)
+		local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
+		return icon, iconDark
+	end
+end
+
+--[[
+Returns the resolved page name of a team template that has been resolved to a
+date. Returns nil if the team does not exist, or if the page is not specified.
+]]
+TeamTemplate.getPageName = FnUtil.memoize(function(resolvedTemplate)
+	local raw = mw.ext.TeamTemplate.raw(resolvedTemplate)
+	return raw and mw.ext.TeamLiquidIntegration.resolve_redirect(raw.page)
+end)
+	
+--[[
+Returns raw data of a team template for a team on a given date. Throws if the
+team template does not exist.
+The team can be specified using a team page name, team template, or alias.
+]]
+function TeamTemplate.getRaw(team, date)
+	return TeamTemplate.getRawOrNil(team, date)
+		or error(TeamTemplate.noTeamMessage(team, date), 2)
+end
+
+--[[
+Same as TeamTemplate.getRaw, except that it returns nil if the team template
+does not exist.
+]]
+function TeamTemplate.getRawOrNil(team, date)
+	team = team:gsub('_', ' '):lower()
+	return mw.ext.TeamTemplate.raw(team, date)
+end
+
+function TeamTemplate.noTeamMessage(pageName, date)
+	return 'Missing template for team=' .. tostring(pageName)
+		.. (date and ' on date=' .. tostring(date) or '')
+end
+
+return TeamTemplate

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -22,6 +22,9 @@ Note that team template changes only occur at midnights in the UTC timezone.
 So it is safe to pass Y-m-d date strings ('2021-11-08') without time or
 timezone parts.
 ]]
+---@param template string
+---@param date string|number?
+---@return string?
 function TeamTemplate.resolve(template, date)
 	template = template:gsub('_', ' ')
 	local raw = mw.ext.TeamTemplate.raw(template, date)
@@ -55,6 +58,9 @@ Returns raw data of a team template for a team on a given date. Throws if the
 team template does not exist.
 The team can be specified using a team page name, team template, or alias.
 ]]
+---@param team string
+---@param date string|number?
+---@return teamTemplateData
 function TeamTemplate.getRaw(team, date)
 	return TeamTemplate.getRawOrNil(team, date)
 		or error(TeamTemplate.noTeamMessage(team, date), 2)
@@ -64,11 +70,18 @@ end
 Same as TeamTemplate.getRaw, except that it returns nil if the team template
 does not exist.
 ]]
+---@param team string
+---@param date string|number?
+---@return teamTemplateData?
 function TeamTemplate.getRawOrNil(team, date)
 	team = team:gsub('_', ' '):lower()
 	return mw.ext.TeamTemplate.raw(team, date)
 end
 
+---Creates error message for missing team templates.
+---@param pageName string
+---@param date string|number?
+---@return string
 function TeamTemplate.noTeamMessage(pageName, date)
 	return 'Missing template for team=' .. tostring(pageName)
 		.. (date and ' on date=' .. tostring(date) or '')

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -101,7 +101,7 @@ end
 
 --[[
 Returns raw data of a historical team template.
-Keys of the returned table is of form YYYY-MM-DD and
+Keys of the returned table are of form YYYY-MM-DD and
 their corresponding values are team template names.
 ]]
 ---@param name string

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -30,7 +30,7 @@ timezone parts.
 function TeamTemplate.resolve(template, date)
 	template = template:gsub('_', ' ')
 	local raw = mw.ext.TeamTemplate.raw(template, date)
-	return raw and raw.templatename
+	return raw and raw.templatename or nil
 end
 
 ---Returns true if the specified team template exists.
@@ -60,7 +60,7 @@ date. Returns nil if the team does not exist, or if the page is not specified.
 ]]
 TeamTemplate.getPageName = FnUtil.memoize(function(resolvedTemplate)
 	local raw = mw.ext.TeamTemplate.raw(resolvedTemplate)
-	return raw and mw.ext.TeamLiquidIntegration.resolve_redirect(raw.page)
+	return raw and mw.ext.TeamLiquidIntegration.resolve_redirect(raw.page) or nil
 end)
 
 --[[

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -119,9 +119,9 @@ An empty array is returned if the specified team template does not exist.
 function TeamTemplate.queryHistoricalNames(name)
     local resolvedName = TeamTemplate.resolve(name)
 	if resolvedName then
-		local index = TeamTemplate.queryHistorical(resolvedName) or {}
-		if Logic.isNotEmpty(index) then
-			return Array.unique(Array.extractValues(index))
+		local historical = TeamTemplate.queryHistorical(resolvedName) or {}
+		if Logic.isNotEmpty(historical) then
+			return Array.unique(Array.extractValues(historical))
 		else
 			return { resolvedName }
 		end

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -45,7 +45,7 @@ end
 ---@return string?
 ---@return string?
 function TeamTemplate.getIcon(template)
-	local raw = mw.ext.TeamTemplate.raw(template)
+	local raw = TeamTemplate.getRawOrNil(template)
 	if not raw then
 		return
 	end

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -58,6 +58,8 @@ end
 Returns the resolved page name of a team template that has been resolved to a
 date. Returns nil if the team does not exist, or if the page is not specified.
 ]]
+---@param resolvedTemplate string
+---@return string|nil
 TeamTemplate.getPageName = FnUtil.memoize(function(resolvedTemplate)
 	local raw = TeamTemplate.getRawOrNil(resolvedTemplate)
 	return raw and mw.ext.TeamLiquidIntegration.resolve_redirect(raw.page) or nil

--- a/standard/team_template.lua
+++ b/standard/team_template.lua
@@ -47,11 +47,12 @@ end
 ---@return string?
 function TeamTemplate.getIcon(template)
 	local raw = mw.ext.TeamTemplate.raw(template)
-	if raw then
-		local icon = Logic.emptyOr(raw.image, raw.legacyimage)
-		local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
-		return icon, iconDark
+	if not raw then
+		return
 	end
+	local icon = Logic.emptyOr(raw.image, raw.legacyimage)
+	local iconDark = Logic.emptyOr(raw.imagedark, raw.legacyimagedark)
+	return icon, iconDark
 end
 
 --[[


### PR DESCRIPTION
## Summary

This PR moves [Module:TeamTemplate](https://liquipedia.net/commons/Module:TeamTemplate) to the repository. Utility functions for historic team templates are also added.

## How did you test this change?

c53f78d is identical to the [Commons version](https://liquipedia.net/commons/Special:PermanentLink/738389)
c53f78d...33ca97d add documentation (no code change)
6e2f941 remains untested
