### PR TITLE
feat(infobox): LPDB data point for RL unofficial world champion infobox

### DIFF
--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -43,6 +43,10 @@ end
 function UnofficialWorldChampion:createInfobox()
 	local args = self.args
 
+	args.currentChampOpponent = Opponent.readOpponentArgs(
+		Json.parseIfString(args['current champion'])
+	)
+
 	local widgets = {
 		Header{
 			name = 'Unofficial World Champion',
@@ -55,7 +59,7 @@ function UnofficialWorldChampion:createInfobox()
 		Center{
 			children = {
 				OpponentDisplay.InlineOpponent{
-					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['current champion']))
+					opponent = args.currentChampOpponent
 				}
 			},
 			classes = { 'infobox-size-20', 'infobox-bold' }
@@ -140,6 +144,7 @@ function UnofficialWorldChampion:createInfobox()
 		Center{children = {args.footnotes}},
 	}
 
+	self:setLpdbData(args)
 	return self:build(widgets)
 end
 
@@ -158,6 +163,10 @@ function UnofficialWorldChampion:_parseRegionalDistribution()
 		)
 	end
 	return widgets
+end
+
+---@param args table
+function UnofficialWorldChampion:setLpdbData(args)
 end
 
 return UnofficialWorldChampion

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -12,6 +12,9 @@ local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
+local OpponentLibraries = require('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
 local BasicInfobox = Lua.import('Module:Infobox/Basic')
 
 local Widgets = require('Module:Widget/All')
@@ -47,21 +50,28 @@ function UnofficialWorldChampion:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = 'Current Champion'},
-		Center{children = { args['current champion'] }, classes = { 'infobox-size-20', 'infobox-bold' }},
+		Center{
+			children = {
+				OpponentDisplay.InlineTeamContainer{
+					template = args['current champion']
+				}
+			},
+			classes = { 'infobox-size-20', 'infobox-bold' }
+		},
 		Builder{
 			builder = function()
 				if not String.isEmpty(args['gained date']) then
-					local contentCell
-					if not (String.isEmpty(args['gained against result']) or String.isEmpty(args['gained against'])) then
-						contentCell = args['gained against result'] .. ' vs ' .. args['gained against']
-					elseif not String.isEmpty(args['gained against result']) then
-						contentCell = args['gained against result'] .. ' vs Unknown'
-					elseif not String.isEmpty(args['gained against']) then
-						contentCell = ' vs ' .. args['gained against']
-					end
 					return {
 						Title{children = 'Title Gained'},
-						Cell{name = args['gained date'], content = { contentCell }},
+						Cell{
+							name = args['gained date'],
+							options = { separator = ' ' },
+							content = WidgetUtil.collect(
+								String.nilIfEmpty(args['gained against result']),
+								'vs',
+								OpponentDisplay.InlineTeamContainer{ template = args['gained against'] }
+							)
+						},
 					}
 				end
 			end
@@ -69,7 +79,7 @@ function UnofficialWorldChampion:createInfobox()
 		Title{children = 'Most Defences'},
 		Cell{
 			name = (args['most defences no'] or '?') .. ' Matches',
-			content = { args['most defences'] },
+			content = { OpponentDisplay.InlineTeamContainer{ template = args['most defences'] } },
 		},
 		Customizable{id = 'defences', children = {
 				Builder{
@@ -85,17 +95,17 @@ function UnofficialWorldChampion:createInfobox()
 		Title{children = 'Longest Consecutive Time as Champion'},
 		Cell{
 			name = (args['longest consecutive no'] or '?') .. ' days',
-			content = { args['longest consecutive'] },
+			content = { OpponentDisplay.InlineTeamContainer{ template = args['longest consecutive'] } },
 		},
 		Title{children = 'Longest Total Time as Champion'},
 		Cell{
 			name = (args['longest total no'] or '?') .. ' days',
-			content = { args['longest total'] },
+			content = { OpponentDisplay.InlineTeamContainer{ template = args['longest total'] } },
 		},
 		Title{children = 'Most Times Held'},
 		Cell{
 			name = (args['most times held no'] or '?') .. ' times',
-			content = { args['most times held'] },
+			content = { OpponentDisplay.InlineTeamContainer{ template = args['most times held'] } },
 		},
 		Customizable{
 			id = 'regionaldistribution',

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -8,11 +8,13 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local OpponentLibraries = require('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
 local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic')
@@ -52,8 +54,8 @@ function UnofficialWorldChampion:createInfobox()
 		Title{children = 'Current Champion'},
 		Center{
 			children = {
-				OpponentDisplay.InlineTeamContainer{
-					template = args['current champion']
+				OpponentDisplay.InlineOpponent{
+					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['current champion']))
 				}
 			},
 			classes = { 'infobox-size-20', 'infobox-bold' }
@@ -69,7 +71,10 @@ function UnofficialWorldChampion:createInfobox()
 							content = WidgetUtil.collect(
 								String.nilIfEmpty(args['gained against result']),
 								'vs',
-								OpponentDisplay.InlineTeamContainer{ template = args['gained against'] }
+								OpponentDisplay.InlineOpponent{
+									opponent = Opponent.readOpponentArgs(Json.parseIfString(args['gained against'])),
+									teamStyle = 'short'
+								}
 							)
 						},
 					}
@@ -79,7 +84,11 @@ function UnofficialWorldChampion:createInfobox()
 		Title{children = 'Most Defences'},
 		Cell{
 			name = (args['most defences no'] or '?') .. ' Matches',
-			content = { OpponentDisplay.InlineTeamContainer{ template = args['most defences'] } },
+			content = {
+				OpponentDisplay.InlineOpponent{
+					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['most defences']))
+				}
+			},
 		},
 		Customizable{id = 'defences', children = {
 				Builder{
@@ -95,17 +104,29 @@ function UnofficialWorldChampion:createInfobox()
 		Title{children = 'Longest Consecutive Time as Champion'},
 		Cell{
 			name = (args['longest consecutive no'] or '?') .. ' days',
-			content = { OpponentDisplay.InlineTeamContainer{ template = args['longest consecutive'] } },
+			content = {
+				OpponentDisplay.InlineOpponent{
+					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['longest consecutive']))
+				}
+			},
 		},
 		Title{children = 'Longest Total Time as Champion'},
 		Cell{
 			name = (args['longest total no'] or '?') .. ' days',
-			content = { OpponentDisplay.InlineTeamContainer{ template = args['longest total'] } },
+			content = {
+				OpponentDisplay.InlineOpponent{
+					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['longest total']))
+				}
+			},
 		},
 		Title{children = 'Most Times Held'},
 		Cell{
 			name = (args['most times held no'] or '?') .. ' times',
-			content = { OpponentDisplay.InlineTeamContainer{ template = args['most times held'] } },
+			content = {
+				OpponentDisplay.InlineOpponent{
+					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['most times held']))
+				}
+			},
 		},
 		Customizable{
 			id = 'regionaldistribution',

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -36,10 +36,6 @@ local UnofficialWorldChampion = Class.new(BasicInfobox)
 ---@return Html
 function UnofficialWorldChampion.run(frame)
 	local unofficialWorldChampion = UnofficialWorldChampion(frame)
-	local args = unofficialWorldChampion.args
-	args.currentChampOpponent = Opponent.readOpponentArgs(
-		Json.parseIfString(args['current champion'])
-	)
 	return unofficialWorldChampion:createInfobox()
 end
 
@@ -49,7 +45,7 @@ function UnofficialWorldChampion:createInfobox()
 
 	local widgets = {
 		Header{
-			name = 'Unofficial Wrld Champion',
+			name = 'Unofficial World Champion',
 			image = args.image,
 			imageDark = args.imagedark or args.imagedarkmode,
 			size = args.imagesize,
@@ -59,7 +55,7 @@ function UnofficialWorldChampion:createInfobox()
 		Center{
 			children = {
 				OpponentDisplay.InlineOpponent{
-					opponent = args.currentChampOpponent
+					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['current champion']))
 				}
 			},
 			classes = { 'infobox-size-20', 'infobox-bold' }
@@ -129,7 +125,8 @@ function UnofficialWorldChampion:createInfobox()
 			content = {
 				OpponentDisplay.InlineOpponent{
 					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['most times held']))
-				}
+				},
+				String.nilIfEmpty(args['most times held desc'])
 			},
 		},
 		Customizable{

--- a/components/infobox/commons/infobox_unofficial_world_champion.lua
+++ b/components/infobox/commons/infobox_unofficial_world_champion.lua
@@ -36,6 +36,10 @@ local UnofficialWorldChampion = Class.new(BasicInfobox)
 ---@return Html
 function UnofficialWorldChampion.run(frame)
 	local unofficialWorldChampion = UnofficialWorldChampion(frame)
+	local args = unofficialWorldChampion.args
+	args.currentChampOpponent = Opponent.readOpponentArgs(
+		Json.parseIfString(args['current champion'])
+	)
 	return unofficialWorldChampion:createInfobox()
 end
 
@@ -45,7 +49,7 @@ function UnofficialWorldChampion:createInfobox()
 
 	local widgets = {
 		Header{
-			name = 'Unofficial World Champion',
+			name = 'Unofficial Wrld Champion',
 			image = args.image,
 			imageDark = args.imagedark or args.imagedarkmode,
 			size = args.imagesize,
@@ -55,7 +59,7 @@ function UnofficialWorldChampion:createInfobox()
 		Center{
 			children = {
 				OpponentDisplay.InlineOpponent{
-					opponent = Opponent.readOpponentArgs(Json.parseIfString(args['current champion']))
+					opponent = args.currentChampOpponent
 				}
 			},
 			classes = { 'infobox-size-20', 'infobox-bold' }

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -25,13 +25,14 @@ function CustomUnofficialWorldChampion.run(frame)
 	return unofficialWorldChampion:createInfobox()
 end
 
-function CustomUnofficialWorldChampion:_setLpdbData()
-	if Namespace.isMain() and Logic.readBool(self.args.storeLPDB) then
+---@param args table
+function CustomUnofficialWorldChampion:setLpdbData(args)
+	if Namespace.isMain() and Logic.readBool(args.storeLPDB) then
 		mw.ext.LiquipediaDB.lpdb_datapoint(
 			'Unofficial World Champion',
 			Json.stringifySubTables({
 				type = 'Unofficial World Champion',
-				name = self.args.currentChampOpponent.template
+				name = args.currentChampOpponent.template
 			})
 		)
 	end

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -33,10 +33,10 @@ function CustomUnofficialWorldChampion:setLpdbData(args)
 
 	mw.ext.LiquipediaDB.lpdb_datapoint(
 		'unofficial_world_champion',
-		Json.stringifySubTables({
+		{
 			type = 'Unofficial World Champion',
 			name = args.currentChampOpponent.template
-		})
+		}
 	)
 end
 

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -32,7 +32,7 @@ function CustomUnofficialWorldChampion:setLpdbData(args)
 	end
 
 	mw.ext.LiquipediaDB.lpdb_datapoint(
-		'Unofficial World Champion',
+		'unofficial_world_champion',
 		Json.stringifySubTables({
 			type = 'Unofficial World Champion',
 			name = args.currentChampOpponent.template

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Class = require('Module:Class')
-local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -1,0 +1,39 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague
+-- page=Module:Infobox/UnofficialWorldChampion/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Json = require('Module:Json')
+local Lua = require('Module:Lua')
+local Namespace = require('Module:Namespace')
+
+local UnofficialWorldChampion = Lua.import('Module:Infobox/UnofficialWorldChampion')
+
+---@class RocketLeagueUnofficialWorldChampionInfobox: UnofficialWorldChampionInfobox
+local CustomUnofficialWorldChampion = Class.new(UnofficialWorldChampion)
+
+---@param frame Frame
+---@return Html
+function CustomUnofficialWorldChampion.run(frame)
+	local unofficialWorldChampion = CustomUnofficialWorldChampion(frame)
+	unofficialWorldChampion:_setLpdbData()
+	return unofficialWorldChampion:createInfobox()
+end
+
+function CustomUnofficialWorldChampion:_setLpdbData()
+	if Namespace.isMain() then
+		mw.ext.LiquipediaDB.lpdb_datapoint(
+			'Unofficial World Champion',
+			Json.stringifySubTables({
+				type = 'Unofficial World Champion',
+				name = self.args['current champion']
+			})
+		)
+	end
+end
+
+return CustomUnofficialWorldChampion

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -27,15 +27,17 @@ end
 
 ---@param args table
 function CustomUnofficialWorldChampion:setLpdbData(args)
-	if Namespace.isMain() and Logic.readBool(args.storeLPDB) then
-		mw.ext.LiquipediaDB.lpdb_datapoint(
-			'Unofficial World Champion',
-			Json.stringifySubTables({
-				type = 'Unofficial World Champion',
-				name = args.currentChampOpponent.template
-			})
-		)
+	if not Namespace.isMain() or not Logic.readBool(args.storeLPDB) then
+		return
 	end
+
+	mw.ext.LiquipediaDB.lpdb_datapoint(
+		'Unofficial World Champion',
+		Json.stringifySubTables({
+			type = 'Unofficial World Champion',
+			name = args.currentChampOpponent.template
+		})
+	)
 end
 
 return CustomUnofficialWorldChampion

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -30,7 +30,7 @@ function CustomUnofficialWorldChampion:_setLpdbData()
 			'Unofficial World Champion',
 			Json.stringifySubTables({
 				type = 'Unofficial World Champion',
-				name = self.args['current champion']
+				name = self.args.currentChampOpponent.template
 			})
 		)
 	end

--- a/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
+++ b/components/infobox/wikis/rocketleague/infobox_unofficial_world_champion_custom.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local Json = require('Module:Json')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Namespace = require('Module:Namespace')
 
@@ -25,7 +26,7 @@ function CustomUnofficialWorldChampion.run(frame)
 end
 
 function CustomUnofficialWorldChampion:_setLpdbData()
-	if Namespace.isMain() then
+	if Namespace.isMain() and Logic.readBool(self.args.storeLPDB) then
 		mw.ext.LiquipediaDB.lpdb_datapoint(
 			'Unofficial World Champion',
 			Json.stringifySubTables({


### PR DESCRIPTION
## Summary

This PR:
- refactors Unofficial World Champion infobox to accept match2 opponents  
  Right now all the data are passed in using `{{Team}}` (or `{{TeamShort}}`). With fe900f7 and 599604c, infobox now expects `{{Opponent}}` templates to be passed in and rendering for opponents is put on the infobox side.
- Adds optional LPDB data point for RL's unofficial world champion infobox  
  This is wanted for their mainpage `¯\_(ツ)_/¯`

## How did you test this change?

- <https://liquipedia.net/leagueoflegends/User:ElectricalBoy/Sandbox4>
- <https://liquipedia.net/rocketleague/User:ElectricalBoy>
