### PR TITLE
feat(notability checker): add missing notability checker config for overwatch and add newly created notability checker config for marvelrivals

### DIFF
--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -267,7 +267,6 @@ function Config.placementDropOffFunction(tier, tierType)
 
 				elseif (tier == 5 and placement == 1) then
 					return (score)
-			
 				elseif (tier == 5) then
 					return (score - 0.5)
 				end

--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -253,7 +253,6 @@ function Config.placementDropOffFunction(tier, tierType)
 
 				elseif (tier == 3 and placement <= 12) then
 					return (score - 5)
-			
 				elseif (tier == 3) then
 					return (score - 5.5)
 			

--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -261,7 +261,6 @@ function Config.placementDropOffFunction(tier, tierType)
 			
 				elseif (tier == 4 and placement <= 4) then
 					return (score - 2)
-			
 				elseif (tier == 4) then
 					return (score - 2.5)
 

--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -255,7 +255,6 @@ function Config.placementDropOffFunction(tier, tierType)
 					return (score - 5)
 				elseif (tier == 3) then
 					return (score - 5.5)
-			
 				elseif (tier == 4 and placement == 3) then
 					return (score)
 				elseif (tier == 4 and placement <= 4) then

--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -217,7 +217,6 @@ function Config.placementDropOffFunction(tier, tierType)
 				if ((tier == 1 or tier == 2 or tier == 3) and placement == 1) then
 					return score
 				end
-			
 			else
 				if (tier == 1 and placement <= 16) or placement == 1 then
 					return score

--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -1,0 +1,290 @@
+---
+-- @Liquipedia
+-- wiki=marvelrivals
+-- page=Module:NotabilityChecker/config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Table = require('Module:Table')
+
+local Config = {}
+
+Config.TIER_TYPE_GENERAL = 'general'
+Config.TIER_TYPE_QUALIFIER = 'qualifier'
+Config.TIER_TYPE_WEEKLY = 'weekly'
+Config.TIER_TYPE_MONTHLY = 'monthly'
+Config.TIER_TYPE_SHOW_MATCH = 'show match'
+Config.TIER_TYPE_MISC = 'misc'
+Config.MAX_NUMBER_OF_PARTICIPANTS = 12
+Config.MAX_NUMBER_OF_COACHES = 6
+
+-- How many placements should we retrieve from LPDB for a team/player?
+Config.PLACEMENT_LIMIT = 2000
+
+-- These are the notability thresholds needed by a team/player
+Config.NOTABILITY_THRESHOLD_MIN = 13
+Config.NOTABILITY_THRESHOLD_NOTABLE = 15
+
+-- Weights used for tournaments
+Config.weights = {
+	{
+		tier = 1,
+		options = {
+			dateLossIgnored = true,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 20,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 5,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOWMATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MISC,
+				points = 0,
+			},
+		},
+	},
+	{
+		tier = 2,
+		options = {
+			dateLossIgnored = true,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 12,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOWMATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MISC,
+				points = 0,
+			},
+		},
+	},
+	{
+		tier = 3,
+		options = {
+			dateLossIgnored = true,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 6,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOWMATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MISC,
+				points = 0,
+			},
+		},
+	},
+	{
+		tier = 4,
+		options = {
+			dateLossIgnored = true,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 3,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 0
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOWMATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MISC,
+				points = 0,
+			},
+		},
+	},
+	{
+		tier = 5,
+		options = {
+			dateLossIgnored = true,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 1,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOWMATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MISC,
+				points = 0,
+			},
+		},
+	},
+}
+
+-- This function adjusts the score for the placement, e.g.
+-- a first placement should score more than a 10th placement.
+function Config.placementDropOffFunction(tier, tierType)
+
+		return function(score, placement)
+			if (tierType == Config.TIER_TYPE_QUALIFIER) then
+				if ((tier == 1 or tier == 2 or tier == 3) and placement == 1) then
+					return score
+				end
+			
+			else
+				if (tier == 1 and placement <= 16) or placement == 1 then
+					return score
+
+				elseif (tier == 1) then
+					return (score - 5)
+
+				elseif (tier == 2 and placement == 1) then
+					return (score)
+
+				elseif (tier == 2 and placement <= 4) then
+					return (score - 2)
+
+				elseif (tier == 2 and placement <= 8) then
+					return (score - 5)
+
+				elseif (tier == 2 and placement <= 12) then
+					return (score - 8)
+
+				elseif (tier == 2 and placement <= 16) then
+					return (score - 10)
+
+				elseif (tier == 2) then
+					return (score - 11)
+
+				elseif (tier == 3 and placement == 1) then
+					return (score)
+
+				elseif (tier == 3 and placement <= 4) then
+					return (score - 3)
+
+				elseif (tier == 3 and placement <= 8) then
+					return (score - 4)
+
+				elseif (tier == 3 and placement <= 12) then
+					return (score - 5)
+			
+				elseif (tier == 3) then
+					return (score - 5.5)
+			
+				elseif (tier == 4 and placement == 3) then
+					return (score)
+			
+				elseif (tier == 4 and placement <= 4) then
+					return (score - 2)
+			
+				elseif (tier == 4) then
+					return (score - 2.5)
+
+				elseif (tier == 5 and placement == 1) then
+					return (score)
+			
+				elseif (tier == 5) then
+					return (score - 0.5)
+				end
+			end
+
+			return 0
+		end
+end
+
+-- Adjusts the score to compensate for the mode, you might
+-- want to decrease the points given for a certain mode
+function Config.adjustScoreForMode(score, mode)
+	return score
+end
+
+return Config

--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -6,8 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Table = require('Module:Table')
-
 local Config = {}
 
 Config.TIER_TYPE_GENERAL = 'general'

--- a/components/notability/wikis/marvelrivals/notablity_checker_config.lua
+++ b/components/notability/wikis/marvelrivals/notablity_checker_config.lua
@@ -258,7 +258,6 @@ function Config.placementDropOffFunction(tier, tierType)
 			
 				elseif (tier == 4 and placement == 3) then
 					return (score)
-			
 				elseif (tier == 4 and placement <= 4) then
 					return (score - 2)
 				elseif (tier == 4) then

--- a/components/notability/wikis/overwatch/notability_checker_config.lua
+++ b/components/notability/wikis/overwatch/notability_checker_config.lua
@@ -1,0 +1,235 @@
+---
+-- @Liquipedia
+-- wiki=overwatch
+-- page=Module:NotabilityChecker/config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Table = require('Module:Table')
+
+local Config = {}
+
+-- These are constants, you don't need to touch them
+-- unless values for liquipediatiertype change
+Config.TIER_TYPE_GENERAL = 'general'
+Config.TIER_TYPE_QUALIFIER = 'qualifier'
+Config.TIER_TYPE_WEEKLY = 'weekly'
+Config.TIER_TYPE_MONTHLY = 'monthly'
+Config.TIER_TYPE_SHOW_MATCH = 'show match'
+
+-- How many placements should we retrieve from LPDB for a team/player?
+Config.NOTABILITY_THRESHOLD_MIN = 2000
+Config.PLACEMENT_LIMIT = 2000
+
+Config.MAX_NUMBER_OF_PARTICIPANTS = 12
+Config.MAX_NUMBER_OF_COACHES = 6
+
+-- Which LPDB placement parameters do we care about?
+Config.PLACEMENT_QUERY =
+	'pagename, tournament, date, placement, liquipediatier, ' ..
+	'liquipediatiertype, players, extradata, mode'
+
+-- These are the notability thresholds needed by a team/player
+Config.NOTABILITY_THRESHOLD_NOTABLE = 2000
+
+-- These are all the liquipediatiertypes which should be extra "penalised"
+-- for a lower placement, see also the placementDropOffFunction below.
+-- Generally these types will award the same points for first, but then
+-- quickly decrease the point rewards as the placement gets lower
+Config.EXTRA_DROP_OFF_TYPES = {
+	Config.TIER_TYPE_QUALIFIER,
+}
+
+-- Weights used for tournaments
+Config.weights = {
+	{
+		tier = 1,
+		options = {
+			dateLossIgnored = true,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 20000,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 50,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 25,
+			},
+		},
+	},
+	{
+		tier = 2,
+		options = {
+			dateLossIgnored = false,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 10000,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 50,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 25,
+			},
+		},
+	},
+	{
+		tier = 3,
+		options = {
+			dateLossIgnored = false,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 600,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 50,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 25,
+			},
+		},
+	},
+	{
+		tier = 4,
+		options = {
+			dateLossIgnored = false,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 300,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 50,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 25,
+			},
+		},
+	},
+	{
+		tier = 5,
+		options = {
+			dateLossIgnored = false,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 100,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 50,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 25,
+			},
+		},
+	},
+	{
+		tier = -1,
+		options = {
+			dateLossIgnored = false,
+		},
+		tiertype = {
+			{
+				name = Config.TIER_TYPE_GENERAL,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_QUALIFIER,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_SHOW_MATCH,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_MONTHLY,
+				points = 0,
+			},
+			{
+				name = Config.TIER_TYPE_WEEKLY,
+				points = 0,
+			},
+		},
+	},
+}
+
+-- This function adjusts the score for the placement, e.g.
+-- a first placement should score more than a 10th placement.
+-- See also the EXTRA_DROP_OFF_TYPES.
+function Config.placementDropOffFunction(tier, tierType)
+	-- R6 is currently setting 0 points for the EXTRA_DROP_OFF types
+	-- but have plans to add points for them once modnotability is added on the wiki
+	if tierType ~= nil and Table.includes(Config.EXTRA_DROP_OFF_TYPES, tierType:lower()) then
+		return function(score, placement) return score / (placement * placement) end
+	end
+
+	return function(score, placement) return score / placement end
+end
+
+-- Adjusts the score to compensate for the mode, you might
+-- want to decrease the points given for a certain mode
+function Config.adjustScoreForMode(score, mode)
+	return score
+end
+
+return Config


### PR DESCRIPTION
## Summary

Add the existing notability checker config from overwatch to the repo, module already exists for ages
Add newly created notability checker config from marvelrivals that was created a few days ago

## How did you test this change?

Already works with local module versions, just pushing it to github
