### PR TITLE
feat: Add tracking category for limited match pages

### DIFF
--- a/components/match_table/commons/match_table.lua
+++ b/components/match_table/commons/match_table.lua
@@ -312,6 +312,10 @@ function MatchTable:query()
 		table.insert(self.matches, self:matchFromRecord(match) or nil)
 	end, self.config.limit)
 
+	if self.config.limit and self.config.limit == #self.matches then
+		mw.ext.TeamLiquidIntegration.add_category('Limited match pages')
+	end
+
 	self.stats = self:statsFromMatches()
 
 	return self


### PR DESCRIPTION
## Summary
To be able to list pages where the number of matches meet the set limit, add a tracking category.
This allows to convert such pages into subpages with year ranges, without breaking them first

Noticed the need for this when trying to roll out on CS.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
