### PR TITLE
feat(infobox): remove staff section on sc2 infobox team

### DIFF
--- a/components/infobox/wikis/starcraft2/infobox_team_custom.lua
+++ b/components/infobox/wikis/starcraft2/infobox_team_custom.lua
@@ -108,6 +108,8 @@ function CustomInjector:parse(id, widgets)
 			})
 			index = index + 1
 		end
+	elseif id == 'staff' then
+		return {}
 	end
 	return widgets
 end


### PR DESCRIPTION
## Summary
Nuke the useless and outdated staff sections on sc2 team infoboxes.
Sadly we do not get to nuke this bullshit from more wikis but at least for wikis that do not want it we should nuke it via the customs.

## How did you test this change?
N/A