### PR TITLE
fix: Always use status condition in matchtable

### DIFF
--- a/lua/wikis/commons/match_table/match_table.lua
+++ b/lua/wikis/commons/match_table/match_table.lua
@@ -381,12 +381,10 @@ function MatchTable:buildAdditionalConditions()
 	local args = self.args
 	local conditions = ConditionTree(BooleanOperator.all)
 		:add{ConditionNode(ColumnName('status'), Comparator.neq, 'notplayed')}
-	local hasAdditionalConditions = false
 
 	local getOrCondition = function(lpdbKey, input)
 		if Logic.isEmpty(input) then return end
 
-		hasAdditionalConditions = true
 		local orConditions = ConditionTree(BooleanOperator.any)
 		Array.forEach(mw.text.split(input, ','), function(value)
 			orConditions:add{ConditionNode(ColumnName(lpdbKey), Comparator.eq, String.trim(value))}
@@ -398,11 +396,8 @@ function MatchTable:buildAdditionalConditions()
 	getOrCondition('game', args.game)
 
 	if Logic.isNotEmpty(args.bestof) then
-		hasAdditionalConditions = true
 		conditions:add(ConditionNode(ColumnName('bestof'), Comparator.eq, args.bestof))
 	end
-
-	if not hasAdditionalConditions then return end
 
 	return conditions
 end


### PR DESCRIPTION
## Summary
Previously, the match table would create a condition on status != notplayed, but not use it unless also restricting to tier, game, or bestof.
Seems like an oversight of some form, so remove it.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
