### PR TITLE
modified "data provided by sap" logo on match pages

### DIFF
--- a/lua/wikis/dota2/match2/match_page_template.lua
+++ b/lua/wikis/dota2/match2/match_page_template.lua
@@ -11,7 +11,7 @@ return {
 	header =
 		[=[
 			<div class="match-bm-lol-match-header">
-				<div class="match-bm-match-header-powered-by">[[File:DataProvidedSAP.svg|link=]]</div>
+				<div class="match-bm-match-header-powered-by">Data provided by [[File:SAP_logo.svg|link=]]</div>
 				<div class="match-bm-lol-match-header-overview">
 					<div class="match-bm-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-match-header-team-group"><div class="match-bm-match-header-team-long">{{#page}}[[{{page}}|{{name}}]]{{/page}}</div><div class="match-bm-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div class="match-bm-lol-match-header-round-results">{{#seriesDots}}<div class="match-bm-lol-match-header-round-result result--{{.}}"></div>{{/seriesDots}}</div>{{/opponents.1}}</div></div>
 					<div class="match-bm-match-header-result">{{#isBestOfOne}}{{#games.1.apiInfo}}{{team1.scoreDisplay}}&ndash;{{team2.scoreDisplay}}{{/games.1.apiInfo}}{{/isBestOfOne}}{{^isBestOfOne}}{{opponents.1.score}}&ndash;{{opponents.2.score}}{{/isBestOfOne}}<div class="match-bm-match-header-result-text">{{statusText}}</div></div>

--- a/lua/wikis/leagueoflegends/match2/match_page_template.lua
+++ b/lua/wikis/leagueoflegends/match2/match_page_template.lua
@@ -11,7 +11,7 @@ return {
 	header =
 		[=[
 			<div class="match-bm-lol-match-header">
-				<div class="match-bm-match-header-powered-by">[[File:DataProvidedSAP.svg|link=]]</div>
+				<div class="match-bm-match-header-powered-by">Data provided by [[File:SAP_logo.svg|link=]]</div>
 				<div class="match-bm-lol-match-header-overview">
 					<div class="match-bm-lol-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-lol-match-header-team-long">{{#page}}[[{{page}}|{{name}}]]{{/page}}</div><div class="match-bm-lol-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div>{{#seriesDots}} {{.}}{{/seriesDots}}</div>{{/opponents.1}}</div>
 					<div class="match-bm-lol-match-header-result">{{#isBestOfOne}}{{#games.1.apiInfo}}{{team1.scoreDisplay}}&ndash;{{team2.scoreDisplay}}{{/games.1.apiInfo}}{{/isBestOfOne}}{{^isBestOfOne}}{{opponents.1.score}}&ndash;{{opponents.2.score}}{{/isBestOfOne}}</div>

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -210,8 +210,7 @@ Author(s): Rathoz
 	padding: 1rem;
 	background: #f5f5f5;
 	border-bottom: 1px solid #bbbbbb;
-	font-size: 1rem;
-	font-weight: bold;
+	font-weight: normal;
 
 	@media ( min-width: 768px ) {
 		justify-content: flex-end;


### PR DESCRIPTION
…ch page header

## Summary

Match page header logos were outdated. This PR adds an updated SAP logo in the header and adds a "Data provided by " text before that.

## How did you test this change?

Checked how the changes look on page with chrome dev tools.