### PR TITLE
feat(match2): change gamenoun used in substitute comment

### DIFF
--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -19,6 +19,8 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local VodLink = require('Module:VodLink')
 
+local Info = Lua.import('Module:Info', {loadData = true})
+
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local Links = Lua.import('Module:Links')
@@ -432,7 +434,7 @@ function MatchSummary.createSubstitutesComment(match)
 			end
 
 			if Table.isNotEmpty(substitution.games) then
-				local gamesNoun = 'game' .. (#substitution.games > 1 and 's' or '')
+				local gamesNoun = Logic.emptyOr(Info.config.match2.gameNoun, 'game') .. (#substitution.games > 1 and 's' or '')
 				table.insert(subString, string.format('on %s %s', gamesNoun, mw.text.listToText(substitution.games)))
 			end
 

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -432,7 +432,7 @@ function MatchSummary.createSubstitutesComment(match)
 			end
 
 			if Table.isNotEmpty(substitution.games) then
-				local gamesNoun = 'map' .. (#substitution.games > 1 and 's' or '')
+				local gamesNoun = 'game' .. (#substitution.games > 1 and 's' or '')
 				table.insert(subString, string.format('on %s %s', gamesNoun, mw.text.listToText(substitution.games)))
 			end
 

--- a/lua/wikis/counterstrike/Info.lua
+++ b/lua/wikis/counterstrike/Info.lua
@@ -124,6 +124,7 @@ local infoData = {
 			scoreWidth = 26,
 			matchWidth = 200,
 			gameScoresIfBo1 = true,
+			gameNoun = 'map',
 		},
 	},
 }


### PR DESCRIPTION
## Summary

Per-map substitute comment uses 'map' univerally, without any option to override. This is wrong in some wikis, e.g., leagueoflegends, because they should be called 'games' not 'maps'.
This PR adds an option to optionally override this.

## How did you test this change?

preview with dev
