### PR TITLE
fix: Make enddate inclusive on matchtable

### DIFF
--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -46,6 +46,7 @@ local INVALID_TIER_SORT = 'ZZ'
 local SCORE_STATUS = 'S'
 local SCORE_CONCAT = '&nbsp;&#58;&nbsp;'
 local BO1_SCORE_CONCAT = '&nbsp;-&nbsp;'
+local SECONDS_ONE_DAY = 3600 * 24
 
 ---@alias MatchTableMode `Opponent.solo` | `Opponent.team`
 
@@ -348,7 +349,7 @@ function MatchTable:buildDateConditions()
 
 	if timeRange.endDate ~= DateExt.maxTimestamp then
 		conditions:add{ConditionNode(ColumnName('date'), Comparator.lt,
-			DateExt.formatTimestamp('c', timeRange.endDate + 3600 * 24))}
+			DateExt.formatTimestamp('c', timeRange.endDate + SECONDS_ONE_DAY))}
 	end
 
 	return conditions

--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -347,7 +347,8 @@ function MatchTable:buildDateConditions()
 	end
 
 	if timeRange.endDate ~= DateExt.maxTimestamp then
-		conditions:add{ConditionNode(ColumnName('date'), Comparator.lt, DateExt.formatTimestamp('c', timeRange.endDate))}
+		conditions:add{ConditionNode(ColumnName('date'), Comparator.lt,
+			DateExt.formatTimestamp('c', timeRange.endDate + 3600 * 24))}
 	end
 
 	return conditions


### PR DESCRIPTION
## Summary
To align with other components (e.g. TournamentsListing), the enddate should be inclusive.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
