### PR TITLE
feat: add "SAP" alt text screen readers

### DIFF
--- a/lua/wikis/commons/Widget/Ratings/List.lua
+++ b/lua/wikis/commons/Widget/Ratings/List.lua
@@ -204,7 +204,7 @@ function RatingsList:render()
 					HtmlWidgets.Div {
 						children = {
 							HtmlWidgets.Span {children = 'Data provided by '},
-							HtmlWidgets.Div {children = '[[File:SAP_logo.svg|link=]]'}
+							HtmlWidgets.Div {children = '[[File:SAP_logo.svg|link=|SAP]]'}
 						},
 						classes = { 'ranking-table__top-row-logo-container' }
 					}

--- a/lua/wikis/dota2/MatchPage/Template.lua
+++ b/lua/wikis/dota2/MatchPage/Template.lua
@@ -11,7 +11,7 @@ return {
 	header =
 		[=[
 			<div class="match-bm-lol-match-header">
-				<div class="match-bm-match-header-powered-by">Data provided by [[File:SAP_logo.svg|link=]]</div>
+				<div class="match-bm-match-header-powered-by">Data provided by [[File:SAP_logo.svg|link=|SAP]]</div>
 				<div class="match-bm-lol-match-header-overview">
 					<div class="match-bm-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-match-header-team-group"><div class="match-bm-match-header-team-long">{{#page}}[[{{page}}|{{name}}]]{{/page}}</div><div class="match-bm-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div class="match-bm-lol-match-header-round-results">{{#seriesDots}}<div class="match-bm-lol-match-header-round-result result--{{.}}"></div>{{/seriesDots}}</div>{{/opponents.1}}</div></div>
 					<div class="match-bm-match-header-result">{{#isBestOfOne}}{{#games.1.apiInfo}}{{team1.scoreDisplay}}&ndash;{{team2.scoreDisplay}}{{/games.1.apiInfo}}{{/isBestOfOne}}{{^isBestOfOne}}{{opponents.1.score}}&ndash;{{opponents.2.score}}{{/isBestOfOne}}<div class="match-bm-match-header-result-text">{{statusText}}</div></div>

--- a/lua/wikis/leagueoflegends/MatchPage/Template.lua
+++ b/lua/wikis/leagueoflegends/MatchPage/Template.lua
@@ -11,7 +11,7 @@ return {
 	header =
 		[=[
 			<div class="match-bm-lol-match-header">
-				<div class="match-bm-match-header-powered-by">Data provided by [[File:SAP_logo.svg|link=]]</div>
+				<div class="match-bm-match-header-powered-by">Data provided by [[File:SAP_logo.svg|link=|SAP]]</div>
 				<div class="match-bm-lol-match-header-overview">
 					<div class="match-bm-lol-match-header-team">{{#opponents.1}}{{&iconDisplay}}<div class="match-bm-lol-match-header-team-long">{{#page}}[[{{page}}|{{name}}]]{{/page}}</div><div class="match-bm-lol-match-header-team-short">[[{{page}}|{{shortname}}]]</div><div>{{#seriesDots}} {{.}}{{/seriesDots}}</div>{{/opponents.1}}</div>
 					<div class="match-bm-lol-match-header-result">{{#isBestOfOne}}{{#games.1.apiInfo}}{{team1.scoreDisplay}}&ndash;{{team2.scoreDisplay}}{{/games.1.apiInfo}}{{/isBestOfOne}}{{^isBestOfOne}}{{opponents.1.score}}&ndash;{{opponents.2.score}}{{/isBestOfOne}}</div>


### PR DESCRIPTION
## Summary

Add alt text to "SAP" logo for screen readers.

## How did you test this change?

I tested `[[File:SAP_logo.svg|link=|SAP]]`  on wiki and it correctly adds alt text to the img element in HTML.