### PR TITLE
feat(match): Legacy wrappers for runeterra

### DIFF
--- a/lua/wikis/runeterra/MatchGroup/Legacy/Default.lua
+++ b/lua/wikis/runeterra/MatchGroup/Legacy/Default.lua
@@ -1,0 +1,23 @@
+---
+-- @Liquipedia
+-- wiki=runeterra
+-- page=Module:MatchGroup/Legacy/Default
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local MatchGroupLegacy = Lua.import('Module:MatchGroup/Legacy')
+
+---@class RuneterraMatchGroupLegacyDefault: MatchGroupLegacy
+local MatchGroupLegacyDefault = Class.new(MatchGroupLegacy)
+
+---@param frame Frame
+---@return string
+function MatchGroupLegacyDefault.run(frame)
+	return MatchGroupLegacyDefault(frame):build()
+end
+
+return MatchGroupLegacyDefault


### PR DESCRIPTION
## Summary
Legacy wrapper for runeterra brackets

## How did you test this change?
live, bot run under way

## to be done manually
- https://liquipedia.net/runeterra/Special:WhatLinksHere/Template:32DEBracket (1 usage, mapping makes no sense)
- https://liquipedia.net/runeterra/Special:WhatLinksHere/Template:4DE4SBracket (2 usages, complete garbage)
- https://liquipedia.net/runeterra/Special:WhatLinksHere/Template:32SEBracket (7 usages, complete garbage)
- matchlist conversion (1 page): https://liquipedia.net/runeterra/index.php?title=LoR_Masters_Europe:_Chronicles_of_Targon&action=edit&section=9