### PR TITLE
fix(MatchTicker): Use correct FilterButtonCategory field

### DIFF
--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -31,7 +31,7 @@ function MatchTickerContainer:render()
 
 	local filters = Array.map(FilterConfig.categories, Operator.property('name')) or {}
 	local filterText = table.concat(Array.map(filters, function(filter)
-		return 'filterbuttons-' .. string.lower(filter)
+		return 'filterbuttons-' .. filter
 	end), ',')
 
 	return HtmlWidgets.Div{

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -29,7 +29,7 @@ function MatchTickerContainer:render()
 	local upcomingTemplate = self.props.upcomingTemplate
 	local completedTemplate = self.props.completedTemplate
 
-	local filters = Array.map(FilterConfig.categories, Operator.property('property')) or {}
+	local filters = Array.map(FilterConfig.categories, Operator.property('name')) or {}
 	local filterText = table.concat(Array.map(filters, function(filter)
 		return 'filterbuttons-' .. string.lower(filter)
 	end), ',')


### PR DESCRIPTION
## Summary
Filterbuttons (and thus also TournamentsTicker) use the `name` field to build the group name.
MatchTicker used `property` field, which originally was meant to indicate LPDB columns to get the value from.

This means that whenever the two fields don't align, the JS breaks (separate problem)

Closes #5626 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
Does not require change to any template, as all existing configs need to have it matching anyways
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
