### PR TITLE
feat(match2): Use Highlight Conditions in `isFeatured` for CS wiki

### DIFF
--- a/lua/wikis/counterstrike/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/counterstrike/MatchGroup/Input/Custom.lua
@@ -14,6 +14,7 @@ local Operator = require('Module:Operator')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
+local HighlightConditions = Lua.import('Module:HighlightConditions')
 local OpponentLibraries = Lua.import('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
@@ -146,7 +147,7 @@ function MatchFunctions.isFeatured(match, opponents)
 	if Table.includes(FEATURED_TIERS, tonumber(match.liquipediatier)) then
 		return true
 	end
-	if Logic.isNotEmpty(match.publishertier) then
+	if HighlightConditions.tournament(match) then
 		return true
 	end
 


### PR DESCRIPTION
## Summary

When we started adding Valve tiers for the new VRS stuff to the publishertier, too much started becoming featured. For example 
![image](https://github.com/user-attachments/assets/91c30711-0632-4b4a-aa8a-80a206d153dd)

Use the same logic as other places for highlighting results/tournaments/matches so that only the intended Valve tiers (majors, etc.) actually mean the match is featured.

## How did you test this change?

Tested via dev deploy.
