### PR TITLE
feat: Drop dependency on MainPageTicker templates

### DIFF
--- a/lua/wikis/commons/MatchTicker/Custom.lua
+++ b/lua/wikis/commons/MatchTicker/Custom.lua
@@ -58,14 +58,15 @@ function CustomMatchTicker.newMainPage(frame)
 		args.featuredTournamentsOnly = true
 	end
 
-	args.tiertypes = args['filterbuttons-liquipediatiertypes']
-	args.regions = args['filterbuttons-regions']
-	args.games = args['filterbuttons-games']
+	args.tiertypes = args['filterbuttons-liquipediatiertype']
+	args.regions = args['filterbuttons-region']
+	args.games = args['filterbuttons-game']
 
 	if args.type == 'upcoming' then
 		-- Separate calls to be able to use separate limits
-		return MatchTicker(Table.merge(args, {ongoing = true})):query():create():addClass('new-match-style')
-		.. MatchTicker(Table.merge(args, {upcoming = true})):query():create():addClass('new-match-style')
+		return mw.html.create()
+			:node(MatchTicker(Table.merge(args, {ongoing = true})):query():create():addClass('new-match-style'))
+			:node(MatchTicker(Table.merge(args, {upcoming = true})):query():create():addClass('new-match-style'))
 	elseif args.type == 'recent' then
 		return MatchTicker(Table.merge(args, {recent = true})):query():create():addClass('new-match-style')
 	end

--- a/lua/wikis/commons/MatchTicker/Custom.lua
+++ b/lua/wikis/commons/MatchTicker/Custom.lua
@@ -51,6 +51,17 @@ end
 function CustomMatchTicker.newMainPage(frame)
 	local args = Arguments.getArgs(frame)
 	args.newStyle = true
+
+	args.tiers = args['filterbuttons-liquipediatier']
+	if args.tiers == 'curated' then
+		args.tiers = nil
+		args.featuredTournamentsOnly = true
+	end
+
+	args.tiertypes = args['filterbuttons-liquipediatiertypes']
+	args.regions = args['filterbuttons-regions']
+	args.games = args['filterbuttons-games']
+
 	return MatchTicker(args):query():create():addClass('new-match-style')
 end
 

--- a/lua/wikis/commons/MatchTicker/Custom.lua
+++ b/lua/wikis/commons/MatchTicker/Custom.lua
@@ -52,6 +52,13 @@ function CustomMatchTicker.newMainPage(frame)
 	local args = Arguments.getArgs(frame)
 	args.newStyle = true
 
+	if args.type == 'upcoming' then
+		args.upcoming = true
+		args.ongoing = true
+	elseif args.type == 'recent' then
+		args.recent = true
+	end
+
 	args.tiers = args['filterbuttons-liquipediatier']
 	if args.tiers == 'curated' then
 		args.tiers = nil

--- a/lua/wikis/commons/MatchTicker/Custom.lua
+++ b/lua/wikis/commons/MatchTicker/Custom.lua
@@ -47,17 +47,10 @@ end
 
 ---Entry point for display on the main page with the new style
 ---@param frame Frame?
----@return Html
+---@return Html?
 function CustomMatchTicker.newMainPage(frame)
 	local args = Arguments.getArgs(frame)
 	args.newStyle = true
-
-	if args.type == 'upcoming' then
-		args.upcoming = true
-		args.ongoing = true
-	elseif args.type == 'recent' then
-		args.recent = true
-	end
 
 	args.tiers = args['filterbuttons-liquipediatier']
 	if args.tiers == 'curated' then
@@ -69,7 +62,13 @@ function CustomMatchTicker.newMainPage(frame)
 	args.regions = args['filterbuttons-regions']
 	args.games = args['filterbuttons-games']
 
-	return MatchTicker(args):query():create():addClass('new-match-style')
+	if args.type == 'upcoming' then
+		-- Separate calls to be able to use separate limits
+		return MatchTicker(Table.merge(args, {ongoing = true})):query():create():addClass('new-match-style')
+		.. MatchTicker(Table.merge(args, {upcoming = true})):query():create():addClass('new-match-style')
+	elseif args.type == 'recent' then
+		return MatchTicker(Table.merge(args, {recent = true})):query():create():addClass('new-match-style')
+	end
 end
 
 ---Entry point for display on player pages

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -70,7 +70,7 @@ function MatchTickerContainer:render()
 	---@param type 'upcoming' | 'recent'
 	local function callTemplate(type)
 		local config = self.defaultProps.matchTicker
-		local ticker = require(config.module)
+		local ticker = require('Module:' .. config.module)
 		return ticker[config.fn](
 			Table.merge(
 				config.args,

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -40,11 +40,9 @@ function MatchTickerContainer:render()
 	local filters = Array.map(FilterConfig.categories, Operator.property('name')) or {}
 	local filterText = table.concat(Array.map(filters, filterName), ',')
 
-	local defaultFilterParams = Array.reduce(FilterConfig.categories, function (aggregate, category)
-		return Table.merge(aggregate, {
-			[filterName(category.name)] = table.concat(category.defaultItems, ',')
-		})
-	end, {})
+	local defaultFilterParams = Table.map(FilterConfig.categories, function (_, category)
+		return filterName(category.name), table.concat(category.defaultItems, ',')
+	end)
 
 	local devFlag = FeatureFlag.get('dev')
 

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -62,7 +62,7 @@ function MatchTickerContainer:render()
 				args = table.concat(Array.map(
 					Table.entries(Table.merge(config.args, {type=type, dev=devFlag})),
 					function (entry)
-						return String.interpolate('|${1}=${2}', entry)
+						return String.interpolate('|${key}=${value}', {key = entry[1], value = entry[2]})
 					end
 				), '')
 			}

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -8,11 +8,11 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local FeatureFlag = require('Module:FeatureFlag')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local Template = require('Module:Template')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
@@ -48,6 +48,8 @@ function MatchTickerContainer:render()
 		})
 	end, {})
 
+	local devFlag = FeatureFlag.get('dev')
+
 	---@param type 'upcoming' | 'recent'
 	local function buildTemplateExpansionString(type)
 		local config = self.defaultProps.matchTicker
@@ -58,7 +60,7 @@ function MatchTickerContainer:render()
 				module = config.module,
 				fn = config.fn,
 				args = table.concat(Array.map(
-					Table.entries(Table.merge(config.args, {type=type})),
+					Table.entries(Table.merge(config.args, {type=type, dev=devFlag})),
 					function (entry)
 						return String.interpolate('|${1}=${2}', entry)
 					end
@@ -70,7 +72,7 @@ function MatchTickerContainer:render()
 	---@param type 'upcoming' | 'recent'
 	local function callTemplate(type)
 		local config = self.defaultProps.matchTicker
-		local ticker = require('Module:' .. config.module)
+		local ticker = Lua.import('Module:' .. config.module)
 		return ticker[config.fn](
 			Table.merge(
 				config.args,

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -26,9 +26,7 @@ MatchTickerContainer.defaultProps = {
 		module = 'MatchTicker/Custom',
 		fn = 'newMainPage',
 		args = {
-			upcomingLimit = 10,
-			ongoingLimit = 10,
-			recentLimit = 10,
+			limit = 10,
 		}
 	},
 }


### PR DESCRIPTION
## Summary
Aims to improve the main page match ticker flow by
- moving the filterbuttons argument mapping into the matchticker entrypoint `newMainPage`
- moving limit arguments into the container module
- using Lua.import/Lua.invoke when expanding the matchticker, both using JS and for the default display
- passing the button category defaults when calling the default ticker
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev on https://liquipedia.net/ageofempires/User:SyntacticSalt/Main_Page
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
