### PR TITLE
fix: Make BR date section not span over infobox

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -135,6 +135,7 @@
 }
 
 .brkts-br-wrapper.brkts-br-wrapper {
+	display: flow-root;
 	width: calc( ~"var(--match-width) + var(--score-width)" );
 }
 


### PR DESCRIPTION
## Summary

This resolves the styling issue reported here by using `display: flow-root;`
Fixes #5307