### PR TITLE
feat: Support games filter in match ticker

### DIFF
--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -96,6 +96,7 @@ end
 ---@field tiers string[]?
 ---@field tierTypes string[]?
 ---@field regions string[]?
+---@field games string[]?
 ---@field newStyle boolean?
 ---@field featuredTournamentsOnly boolean?
 
@@ -142,6 +143,9 @@ function MatchTicker:init(args)
 					Array.parseCommaSeparatedString(args.tiertypes), FnUtil.curry(Tier.isValid, 1)
 				), function(tiertype)
 					return select(2, Tier.toValue(1, tiertype))
+				end) or nil,
+		games = args.games and Array.map(Array.parseCommaSeparatedString(args.games), function (game)
+					return Game.toIdentifier{game=game}
 				end) or nil,
 		newStyle = Logic.readBool(args.newStyle),
 		featuredTournamentsOnly = Logic.readBool(args.featuredTournamentsOnly),
@@ -292,6 +296,16 @@ function MatchTicker:buildQueryConditions()
 
 
 		conditions:add(tierTypeConditions)
+	end
+
+	if Table.isNotEmpty(config.games) then
+		local tierConditions = ConditionTree(BooleanOperator.any)
+
+		Array.forEach(config.games, function(game)
+			tierConditions:add { ConditionNode(ColumnName('game'), Comparator.eq, game) }
+		end)
+
+		conditions:add(tierConditions)
 	end
 
 	conditions:add(self:dateConditions())


### PR DESCRIPTION
## Summary
Allow to filter the matchticker by list of games (e.g. using filterbuttons)
PR/branch stacked on #5637 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev: https://liquipedia.net/ageofempires/User:SyntacticSalt/Main_Page
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
