### PR TITLE
ci: change failure to import from a print to error

### DIFF
--- a/lua/spec/helpers/test_helper.lua
+++ b/lua/spec/helpers/test_helper.lua
@@ -206,7 +206,7 @@ return function(busted, helper, options)
 			local mocked_import = {}
 			setmetatable(mocked_import, {
 				__index = function(t, k)
-					print('Warning!', 'called', module, '.', k, 'but', module, 'was unable to be imported')
+					error(('Called ' .. module .. '.' .. k .. ' but ' .. module .. ' was unable to be imported'))
 				end
 			})
 

--- a/lua/spec/helpers/test_helper.lua
+++ b/lua/spec/helpers/test_helper.lua
@@ -206,7 +206,7 @@ return function(busted, helper, options)
 			local mocked_import = {}
 			setmetatable(mocked_import, {
 				__index = function(t, k)
-					error(('Called ' .. module .. '.' .. k .. ' but ' .. module .. ' was unable to be imported'))
+					error('Called ' .. module .. '.' .. k .. ' but ' .. module .. ' was unable to be imported')
 				end
 			})
 


### PR DESCRIPTION
## Summary
This makes inability to import behave better in the CI pipeline.

Currently a print would cause the output to not be able to be read, which just made it fail without an error.

This makes the error clear

