### PR TITLE
feat: Remove PointsDistribution from GameSummary

### DIFF
--- a/lua/wikis/commons/GameSummary.lua
+++ b/lua/wikis/commons/GameSummary.lua
@@ -35,7 +35,6 @@ function CustomGameSummary.getGameByMatchId(props)
 		idx = props.gameIdx,
 		children = {
 			MatchSummaryWidgets.GameDetails{game = game},
-			MatchSummaryWidgets.PointsDistribution{scores = scoringData},
 			MatchSummaryWidgets.Mvp(game.extradata.mvp),
 			SummaryHelper.standardGame(game)
 		}

--- a/lua/wikis/pubg/MatchSummary/Ffa.lua
+++ b/lua/wikis/pubg/MatchSummary/Ffa.lua
@@ -32,7 +32,7 @@ function CustomMatchSummary.getByMatchId(props)
 			idx = 0,
 			children = WidgetUtil.collect(
 				MatchSummaryWidgets.GamesSchedule{match = match},
-				MatchSummaryWidgets.PointsDistribution{scores = scoringData},
+				-- MatchSummaryWidgets.PointsDistribution{scores = scoringData},
 				MatchSummaryWidgets.Mvp(match.extradata.mvp),
 				MatchSummaryWidgets.MatchComment{match = match},
 				SummaryHelper.standardMatch(match)

--- a/lua/wikis/pubg/MatchSummary/Ffa.lua
+++ b/lua/wikis/pubg/MatchSummary/Ffa.lua
@@ -32,7 +32,7 @@ function CustomMatchSummary.getByMatchId(props)
 			idx = 0,
 			children = WidgetUtil.collect(
 				MatchSummaryWidgets.GamesSchedule{match = match},
-				-- MatchSummaryWidgets.PointsDistribution{scores = scoringData},
+				MatchSummaryWidgets.PointsDistribution{scores = scoringData},
 				MatchSummaryWidgets.Mvp(match.extradata.mvp),
 				MatchSummaryWidgets.MatchComment{match = match},
 				SummaryHelper.standardMatch(match)


### PR DESCRIPTION
## Summary

For the Battle Royale Match2 tables we currently show the Point Distribution Tab both on the overall standings and on a game level.

From feedback that came in, the game level point distribution seems redundant; it's already shown on the first view, takes quite some space, and the points are already laid out in the "results" of the game itself