### PR TITLE
fix(GameSummary): Removed flex-basis to fit icon and content on the same row on mobile

### DIFF
--- a/stylesheets/commons/BattleRoyale/Panel.less
+++ b/stylesheets/commons/BattleRoyale/Panel.less
@@ -189,10 +189,6 @@ Author(s): Elysienna
 		&__container {
 			display: flex;
 			align-items: center;
-
-			@media ( max-width: 767px ) {
-				flex-basis: 100%;
-			}
 		}
 
 		&__icon {


### PR DESCRIPTION
## Summary

The icons are split into separate lines in the GameSummary on mobile. They should fit on the same row, saving some space and looking better.

Before:
![image](https://github.com/user-attachments/assets/e99d4d78-6ea6-437d-8362-5c1c481fbd2e)

After:
![image](https://github.com/user-attachments/assets/31918e45-bfe8-4fec-a974-a143925ef4ea)
