### PR TITLE
feat: Allow custom limit on match ticker container

### DIFF
--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -47,8 +47,8 @@ function MatchTickerContainer:render()
 		return String.interpolate(
 			'#invoke:Lua|invoke|module=${module}|fn=${fn}${args}',
 			{
-				module = self.props.module,
-				fn = self.props.fn,
+				module = self.defaultProps.module,
+				fn = self.defaultProps.fn,
 				args = table.concat(Array.extractValues(Table.map(
 					{limit=self.props.limit, type=type, dev=devFlag},
 					function (key, value)
@@ -61,8 +61,8 @@ function MatchTickerContainer:render()
 
 	---@param type 'upcoming' |'recent'
 	local function callTemplate(type)
-		local ticker = Lua.import('Module:' .. self.props.module)
-		return ticker[self.props.fn](
+		local ticker = Lua.import('Module:' .. self.defaultProps.module)
+		return ticker[self.defaultProps.fn](
 			Table.merge(
 				{limit=self.props.limit, type=type},
 				defaultFilterParams

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -52,7 +52,7 @@ function MatchTickerContainer:render()
 				args = table.concat(Array.extractValues(Table.map(
 					{limit=self.props.limit, type=type, dev=devFlag},
 					function (key, value)
-						return String.interpolate('|${key}=${value}', {key=key, value=value})
+						return key, String.interpolate('|${key}=${value}', {key=key, value=value})
 					end
 				)), '')
 			}

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -22,13 +22,9 @@ local FilterConfig = Lua.import('Module:FilterButtons/Config')
 ---@operator call(table): MatchTickerContainer
 local MatchTickerContainer = Class.new(Widget)
 MatchTickerContainer.defaultProps = {
-	matchTicker = {
-		module = 'MatchTicker/Custom',
-		fn = 'newMainPage',
-		args = {
-			limit = 10,
-		}
-	},
+	limit = 10,
+	module = 'MatchTicker/Custom',
+	fn = 'newMainPage',
 }
 
 ---@return Widget
@@ -48,31 +44,28 @@ function MatchTickerContainer:render()
 
 	---@param type 'upcoming' | 'recent'
 	local function buildTemplateExpansionString(type)
-		local config = self.defaultProps.matchTicker
-
 		return String.interpolate(
 			'#invoke:Lua|invoke|module=${module}|fn=${fn}${args}',
 			{
-				module = config.module,
-				fn = config.fn,
-				args = table.concat(Array.map(
-					Table.entries(Table.merge(config.args, {type=type, dev=devFlag})),
-					function (entry)
-						return String.interpolate('|${key}=${value}', {key = entry[1], value = entry[2]})
+				module = self.defaultProps.module,
+				fn = self.defaultProps.fn,
+				args = table.concat(Array.extractValues(Table.map(
+					{limit=self.defaultProps.limit, type=type, dev=devFlag},
+					function (key, value)
+						return String.interpolate('|${key}=${value}', {key=key, value=value})
 					end
-				), '')
+				)), '')
 			}
 		)
 	end
 
-	---@param type 'upcoming' | 'recent'
+	---@param type 'upcoming' |'recent'
 	local function callTemplate(type)
 		local config = self.defaultProps.matchTicker
 		local ticker = Lua.import('Module:' .. config.module)
 		return ticker[config.fn](
 			Table.merge(
-				config.args,
-				{type = type},
+				{limit=self.defaultProps.limit, type=type},
 				defaultFilterParams
 			)
 		)

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -47,10 +47,10 @@ function MatchTickerContainer:render()
 		return String.interpolate(
 			'#invoke:Lua|invoke|module=${module}|fn=${fn}${args}',
 			{
-				module = self.defaultProps.module,
-				fn = self.defaultProps.fn,
+				module = self.props.module,
+				fn = self.props.fn,
 				args = table.concat(Array.extractValues(Table.map(
-					{limit=self.defaultProps.limit, type=type, dev=devFlag},
+					{limit=self.props.limit, type=type, dev=devFlag},
 					function (key, value)
 						return String.interpolate('|${key}=${value}', {key=key, value=value})
 					end
@@ -61,10 +61,10 @@ function MatchTickerContainer:render()
 
 	---@param type 'upcoming' |'recent'
 	local function callTemplate(type)
-		local ticker = Lua.import('Module:' .. self.defaultProps.module)
-		return ticker[self.defaultProps.fn](
+		local ticker = Lua.import('Module:' .. self.props.module)
+		return ticker[self.props.fn](
 			Table.merge(
-				{limit=self.defaultProps.limit, type=type},
+				{limit=self.props.limit, type=type},
 				defaultFilterParams
 			)
 		)
@@ -140,7 +140,7 @@ function MatchTickerContainer:render()
 					['data-filter-expansion-template'] = buildTemplateExpansionString('recent'),
 					['data-filter-groups'] = filterText,
 				},
-				children = callTemplate('upcoming'),
+				children = callTemplate('recent'),
 			},
 		},
 	}

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -61,9 +61,8 @@ function MatchTickerContainer:render()
 
 	---@param type 'upcoming' |'recent'
 	local function callTemplate(type)
-		local config = self.defaultProps.matchTicker
-		local ticker = Lua.import('Module:' .. config.module)
-		return ticker[config.fn](
+		local ticker = Lua.import('Module:' .. self.defaultProps.module)
+		return ticker[self.defaultProps.fn](
 			Table.merge(
 				{limit=self.defaultProps.limit, type=type},
 				defaultFilterParams


### PR DESCRIPTION
## Summary
Flattens the props structure to allow overriding the limit from invoke args.
This needs to be handled with care, as it can easily lead to rate limits.
It might be a good idea to allow for a higher, but set ratelimit (e.g. 25 matches) instead of exposing the parameter.

Also fix a bug where the wrong type was set for default display of recent matches
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
(bugfix already live)
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
