### PR TITLE
feat(infobox): Expose THA special roles flag to infobox args on valorant

### DIFF
--- a/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
@@ -67,7 +67,11 @@ function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.history = TeamHistoryAuto.results{convertrole = true, addlpdbdata = true, specialRoles = true}
+	player.args.history = TeamHistoryAuto.results{
+		convertrole = true,
+		addlpdbdata = true,
+		specialRoles = Logic.readBool(player.args.historySpecialRoles)
+	}
 	player.args.autoTeam = true
 	player.args.agents = SignaturePlayerAgents.get{player = player.pagename, top = 3}
 	player.role = player:_getRoleData(player.args.role)

--- a/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
@@ -70,7 +70,7 @@ function CustomPlayer.run(frame)
 	player.args.history = TeamHistoryAuto.results{
 		convertrole = true,
 		addlpdbdata = true,
-		specialRoles = Logic.readBool(player.args.historySpecialRoles)
+		specialRoles = player.args.historySpecialRoles
 	}
 	player.args.autoTeam = true
 	player.args.agents = SignaturePlayerAgents.get{player = player.pagename, top = 3}


### PR DESCRIPTION
## Summary
Misunderstanding what actually was requested in #5646 
They want to enable it case by case:
> We have many players who were retired and then unretired, for them specialroles looks better, but for those who didnt return, basic retired param looks better

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
