### PR TITLE
fix: Add trailing slash for bluesky link prefix

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -52,7 +52,7 @@ local PREFIXES = {
 		stream = 'https://live.bilibili.com/',
 	},
 	['bilibili-stream'] = {'https://live.bilibili.com/'},
-	bluesky = {'https://bsky.app/profile'},
+	bluesky = {'https://bsky.app/profile/'},
 	booyah = {'https://booyah.live/'},
 	bracket = {''},
 	breakingpoint = {match = 'https://www.breakingpoint.gg/match/'},


### PR DESCRIPTION
## Summary
Now `|bluesky=username` leads you to bsky.app/profileusername
Should be bsky.app/profile/username