### PR TITLE
feat(infobox): Support for mutiple Games on Map Infobox

### DIFF
--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
 
 local Game = Lua.import('Module:Game')
 local Injector = Lua.import('Module:Infobox/Widget/Injector')
@@ -26,8 +27,18 @@ local CustomInjector = Class.new(Injector)
 function CustomMap.run(frame)
 	local map = CustomMap(frame)
 	map:setWidgetInjector(CustomInjector(map))
-
 	return map:createInfobox()
+end
+
+---@param args table
+---@return string[]
+function CustomMap:_getGames(args)
+	if String.isNotEmpty(args.game) and String.isEmpty(args.game1) then
+		return {Game.name{game = args.game}}
+	else
+		local games = self:getAllArgsForBase(args, 'game')
+		return Array.map(games, function(game) return Game.name{game = game} end)
+	end
 end
 
 ---@param widgetId string
@@ -35,18 +46,16 @@ end
 ---@return Widget[]
 function CustomInjector:parse(widgetId, widgets)
 	local args = self.caller.args
-
 	if widgetId == 'custom' then
 		return Array.append(
 			widgets,
 			Cell{name = 'Type', content = {args.type}},
 			Cell{name = 'Size', content = {args.size}},
-			Cell{name = 'Game Version', content = {Game.name{game = args.game}}, options = {makeLink = true}},
+			Cell{name = 'Game Versions', content = self.caller:_getGames(args), options = {makeLink = true}},
 			Cell{name = 'Day/Night Variant', content = {args.daynight}},
 			Cell{name = 'Playlists', content = {args.playlist}}
 		)
 	end
-
 	return widgets
 end
 
@@ -54,9 +63,13 @@ end
 ---@param args table
 ---@return table
 function CustomMap:addToLpdb(lpdbData, args)
+	local games = self:_getGames(args)
 	lpdbData.extradata.type = args.type
 	lpdbData.extradata.size = args.size
-	lpdbData.extradata.game = Game.name{game = args.game}
+	-- Save all games
+	for i, game in ipairs(games) do
+		lpdbData.extradata["game" .. i] = game
+	end
 	lpdbData.extradata.daynight = args.daynight
 	lpdbData.extradata.playlist = args.playlist
 	return lpdbData

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -68,10 +68,9 @@ function CustomMap:addToLpdb(lpdbData, args)
 	local games = self:_getGames(args)
 	lpdbData.extradata.type = args.type
 	lpdbData.extradata.size = args.size
-	-- Save all games
-	for i, game in ipairs(games) do
-		lpdbData.extradata["game" .. i] = game
-	end
+	Table.mergeInto(lpdbData.extradata, Table.map(self:_getGames(args), function(gameIndex, game)
+		return 'game' .. gameIndex, game
+	end))
 	lpdbData.extradata.daynight = args.daynight
 	lpdbData.extradata.playlist = args.playlist
 	return lpdbData

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -9,7 +9,6 @@
 local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
 local Game = Lua.import('Module:Game')

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -54,6 +54,11 @@ function CustomInjector:parse(widgetId, widgets)
 
 	if widgetId == 'custom' then
 		return Array.append(
+function CustomInjector:parse(widgetId, widgets)
+	local args = self.caller.args
+
+	if widgetId == 'custom' then
+		return Array.append(
 			widgets,
 			Cell{name = 'Type', content = {args.type}},
 			Cell{name = 'Size', content = {args.size}},

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -56,7 +56,7 @@ function CustomInjector:parse(widgetId, widgets)
 			widgets,
 			Cell{name = 'Type', content = {args.type}},
 			Cell{name = 'Size', content = {args.size}},
-			Cell{name = 'Game Versions', content = self.caller:_getGames(args), options = {makeLink = true}},
+			Cell{name = #games > 1 and 'Game Versions' or 'Game Version', content = games, options = {makeLink = true}},
 			Cell{name = 'Day/Night Variant', content = {args.daynight}},
 			Cell{name = 'Playlists', content = {args.playlist}}
 		)

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -27,6 +27,7 @@ local CustomInjector = Class.new(Injector)
 function CustomMap.run(frame)
 	local map = CustomMap(frame)
 	map:setWidgetInjector(CustomInjector(map))
+
 	return map:createInfobox()
 end
 

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -47,6 +47,7 @@ end
 ---@return Widget[]
 function CustomInjector:parse(widgetId, widgets)
 	local args = self.caller.args
+
 	if widgetId == 'custom' then
 		return Array.append(
 			widgets,

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -34,12 +34,15 @@ end
 ---@param args table
 ---@return string[]
 function CustomMap:_getGames(args)
-	if String.isNotEmpty(args.game) and String.isEmpty(args.game1) then
-		return {Game.name{game = args.game}}
-	else
-		local games = self:getAllArgsForBase(args, 'game')
-		return Array.map(games, function(game) return Game.name{game = game} end)
+	local games = Array.mapIndexes(
+		function(i)
+			return i == 1 and (args.game1 or args.game) or args['game' .. i]
+		end,
+		function(i, value) return String.isNotEmpty(value) end
+	)
+	return Array.map(games, function(game) return Game.name{game = game} 
 	end
+	)
 end
 
 ---@param widgetId string

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -69,7 +69,6 @@ end
 ---@param args table
 ---@return table
 function CustomMap:addToLpdb(lpdbData, args)
-	local games = self:_getGames(args)
 	lpdbData.extradata.type = args.type
 	lpdbData.extradata.size = args.size
 	Table.mergeInto(lpdbData.extradata, Table.map(self:_getGames(args), function(gameIndex, game)

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local Game = Lua.import('Module:Game')
 local Injector = Lua.import('Module:Infobox/Widget/Injector')

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -35,15 +35,7 @@ end
 ---@param args table
 ---@return string[]
 function CustomMap:_getGames(args)
-	local games = Array.mapIndexes(
-		function(i)
-			return i == 1 and (args.game1 or args.game) or args['game' .. i]
-		end,
-		function(i, value) return String.isNotEmpty(value) end
-	)
-	return Array.map(games, function(game) return Game.name{game = game}
-	end
-	)
+	return Array.map(self:getAllArgsForBase(args, 'game'), function(game) return Game.name{game = game} end)
 end
 
 ---@param widgetId string

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -41,7 +41,7 @@ function CustomMap:_getGames(args)
 		end,
 		function(i, value) return String.isNotEmpty(value) end
 	)
-	return Array.map(games, function(game) return Game.name{game = game} 
+	return Array.map(games, function(game) return Game.name{game = game}
 	end
 	)
 end

--- a/lua/wikis/callofduty/Infobox/Map/Custom.lua
+++ b/lua/wikis/callofduty/Infobox/Map/Custom.lua
@@ -53,11 +53,7 @@ function CustomInjector:parse(widgetId, widgets)
 	local args = self.caller.args
 
 	if widgetId == 'custom' then
-		return Array.append(
-function CustomInjector:parse(widgetId, widgets)
-	local args = self.caller.args
-
-	if widgetId == 'custom' then
+		local games = self.caller:_getGames(args)
 		return Array.append(
 			widgets,
 			Cell{name = 'Type', content = {args.type}},


### PR DESCRIPTION
## Summary

Requested by Hesketh to support multiple games in the infobox as usually same map is in multiple versions of the game.

Not sure if we should handle extradata differentely

## How did you test this change?

dev=slothy

|game=name of the game still works same as before 
```
{{Infobox map|dev=slothy
|name     = Azhir Cave
|image    = COD MW map Azhir Cave.png
|creator  = Activision
|location = Tobraka, [[Urzikstan]]
|released = 2019-10-25
|size     = Medium
|type     = 6v6
|game1=mw2019
|game2=mw3
|day/night variant = Both
|playlist = Competitive<br>Multiplayer
}}
```

![image](https://github.com/user-attachments/assets/91e9b87d-963a-4162-89d8-ecbc177fc364)
![image](https://github.com/user-attachments/assets/1ca6c7c9-0c30-4e66-bed3-37eef57d13f2)


