### PR TITLE
feat(mainpage): COD new mainpage

### DIFF
--- a/lua/wikis/callofduty/FilterButtons/Config.lua
+++ b/lua/wikis/callofduty/FilterButtons/Config.lua
@@ -1,0 +1,34 @@
+local Config = {}
+local Tier = require('Module:Tier/Utils')
+local Game = require('Module:Game')
+
+Config.categories = {
+	{
+		name = 'liquipediatier',
+		property = 'liquipediaTier',
+		load = function(category)
+			category.items = {}
+			for _, tier in Tier.iterate('tiers') do
+				table.insert(category.items, tier.value)
+			end
+		end,
+		defaultItems = {'1', '2', '3'},
+		transform = function(tier)
+			return Tier.toName(tier)
+		end,
+		expandKey = "game",
+	},
+	{
+		name = 'game',
+		property = 'game',
+		expandable = true,
+		load = function(category)
+			category.items = Game.listGames({ordered = true})
+		end,
+		transform = function(game)
+			return Game.icon({game = game, noSpan = true, noLink = true, size = '20x20px'})
+		end
+	}
+}
+
+return Config

--- a/lua/wikis/callofduty/FilterButtons/Config.lua
+++ b/lua/wikis/callofduty/FilterButtons/Config.lua
@@ -31,9 +31,7 @@ Config.categories = {
 		name = 'game',
 		property = 'game',
 		expandable = true,
-		load = function(category)
-			category.items = Game.listGames({ordered = true})
-		end,
+		items = {'bo6', 'wz', 'codm'},
 		transform = function(game)
 			return Game.icon({game = game, noSpan = true, noLink = true, size = '20x20px'})
 		end

--- a/lua/wikis/callofduty/FilterButtons/Config.lua
+++ b/lua/wikis/callofduty/FilterButtons/Config.lua
@@ -1,5 +1,14 @@
-local Config = {}
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:FilterButtons/Config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
 local Tier = require('Module:Tier/Utils')
+local Config = {}
+
 local Game = require('Module:Game')
 
 Config.categories = {

--- a/lua/wikis/callofduty/MainPageLayout/data.lua
+++ b/lua/wikis/callofduty/MainPageLayout/data.lua
@@ -1,0 +1,233 @@
+---
+-- @Liquipedia
+-- wiki=callofduty
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local CONTENT = {
+	usefulArticles = {
+		heading = 'Useful Articles',
+		body = '{{Liquipedia:Useful Articles}}',
+		padding = true,
+		boxid = 1503,
+	},
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = '{{Liquipedia:Want_to_help}}',
+		padding = true,
+		boxid = 1504,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = TransfersList{rumours = true, limit = 10},
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
+		padding = true,
+		boxid = 1510,
+	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+	},
+	liquipediaApp = {
+		heading = 'Download the Liquipedia App',
+		padding = true,
+		body = '{{Liquipedia:App}}',
+		boxid = 1507,
+	},
+	filterButtons = {
+		noPanel = true,
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
+	},
+	matches = {
+		heading = 'Matches',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
+		padding = true,
+		boxid = 1507,
+		panelAttributes = {
+			['data-switch-group-container'] = 'countdown',
+		},
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = TournamentsTicker{
+			upcomingDays = 30,
+			completedDays = 20,
+			displayGameIcons = true
+		},
+		padding = true,
+		boxid = 1508,
+	},
+}
+
+return {
+	banner = {
+		lightmode = 'COD logo lightmode.svg',
+		darkmode = 'COD logo darkmode.svg',
+	},
+	metadesc = 'The Call of Duty (COD) esports wiki covering everything from players, teams and transfers, ' ..
+		'to tournaments and results, maps and games.',
+	title = 'Call of Duty',
+	navigation = {
+		{
+			file = 'Elevate at CODM World Championship 2024.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'Seattle Surge at EWC 2024.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'Warzone Trophy at EWC 2024.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'Insight at EWC 2024.jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'COD Infinite Warfare Wallpaper.jpg',
+			title = 'Games',
+			link = 'Portal:Games',
+			count = {
+				method = 'CATEGORY',
+				category = 'Games',
+			},
+		},
+		{
+			file = 'COD Black Ops 6 Map Skyline.jpg',
+			title = 'Maps',
+			link = 'Portal:Maps',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::map]]',
+			},
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 5,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 3,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.wantToHelp,
+					},
+					{
+						mobileOrder = 7,
+						content = CONTENT.liquipediaApp,
+					},
+				}
+			},
+			{ -- Right
+				size = 7,
+				children = {
+					{
+						mobileOrder = 2,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
+								},
+							},
+						},
+					},
+					{
+						mobileOrder = 5,
+						content = CONTENT.thisDay,
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.usefulArticles,
+					},
+				},
+			},
+		},
+	},
+}

--- a/lua/wikis/callofduty/MainPageLayout/data.lua
+++ b/lua/wikis/callofduty/MainPageLayout/data.lua
@@ -53,7 +53,7 @@ local CONTENT = {
 		heading = 'Download the Liquipedia App',
 		padding = true,
 		body = '{{Liquipedia:App}}',
-		boxid = 1507,
+		boxid = 1505,
 	},
 	filterButtons = {
 		noPanel = true,

--- a/lua/wikis/callofduty/MainPageLayout/data.lua
+++ b/lua/wikis/callofduty/MainPageLayout/data.lua
@@ -49,12 +49,6 @@ local CONTENT = {
 		noPanel = true,
 		body = '{{Liquipedia:Special Event}}',
 	},
-	liquipediaApp = {
-		heading = 'Download the Liquipedia App',
-		padding = true,
-		body = '{{Liquipedia:App}}',
-		boxid = 1505,
-	},
 	filterButtons = {
 		noPanel = true,
 		body = Div{
@@ -146,8 +140,9 @@ return {
 			title = 'Games',
 			link = 'Portal:Games',
 			count = {
-				method = 'CATEGORY',
-				category = 'Games',
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::game]]',
 			},
 		},
 		{
@@ -177,10 +172,6 @@ return {
 					{
 						mobileOrder = 6,
 						content = CONTENT.wantToHelp,
-					},
-					{
-						mobileOrder = 7,
-						content = CONTENT.liquipediaApp,
 					},
 				}
 			},

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -18,6 +18,12 @@
 		}
 	}
 
+	.wiki-callofduty & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/b/bc/COD_Wiki_Banner.png ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-deadlock & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/8/8f/Deadlock_mainpage_banner.png ) no-repeat center / cover;


### PR DESCRIPTION
## Summary
Setup based on R6 but making tournaments a bit wider because it has the game icons

This requires a filter buttons that can filter events by games which is recently merged

## How did you test this change?
https://liquipedia.net/callofduty/User:Hesketh2/maintest

## Some help needed
COD changes game they compete every year, how can I adjust the Filter module to limits to just some games? 
![image](https://github.com/user-attachments/assets/fdf1fb62-7670-47dc-a947-7647f9f9aae5)

for reference currently I need these three entries based on info module
`bo6` << these are the ones that changes every year 
`wz`  << doesnt change every year
`codm` << doesnt change every year

The rest are old game versions  that doesnt compete events anymore

![image](https://github.com/user-attachments/assets/ed2f87ad-f306-40db-9269-4efc6e596e2a)

