### PR TITLE
Update Custom.lua

### DIFF
--- a/lua/wikis/crossfire/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/crossfire/MatchGroup/Input/Custom.lua
@@ -79,6 +79,7 @@ function MatchFunctions.getExtraData(match, games, opponents)
 	return {
 		mvp = MatchGroupInputUtil.readMvp(match, opponents),
 		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
+		mapveto = MatchGroupInputUtil.getMapVeto(match),
 	}
 end
 


### PR DESCRIPTION
Add the map veto into the module

## Summary

For many years, CrossFire, similar to other FPS games' esports scene, has implemented a map veto to determine a matchup's maps being used. Here's an example in Vietnam's top Crossfire league:
![image](https://github.com/user-attachments/assets/8098a2fa-adbc-4bb3-9d6d-89a40f7a4ffb)

Unfortunately, our wiki has never tracked these down the same way as the Valorant wiki applies it.

## How did you test this change?

