### PR TITLE
feat(mainpage): new rocketleague main page

### DIFF
--- a/lua/wikis/rocketleague/FilterButtons/Config.lua
+++ b/lua/wikis/rocketleague/FilterButtons/Config.lua
@@ -1,0 +1,77 @@
+---
+-- @Liquipedia
+-- page=Module:FilterButtons/Config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Table = Lua.import('Module:Table')
+local Tier = Lua.import('Module:Tier/Utils')
+
+local Config = {}
+
+local REGION_TO_SUPERREGION = {
+	['Europe'] = 'EU',
+	['North America'] = 'NA',
+	['Oceania'] = 'OCE',
+	['Latin America North'] = 'SAM',
+	['Latin America South'] = 'SAM',
+	['Brazil'] = 'SAM',
+	['South America'] = 'SAM',
+	['Other'] = 'Other',
+}
+
+local REGIONS_IN_SUPERREGION = Table.mapValues(Table.groupBy(REGION_TO_SUPERREGION, function(region, superRegion)
+	return superRegion
+end), function(superRegion)
+	return Array.extractKeys(superRegion)
+end)
+
+---@type FilterButtonCategory[]
+Config.categories = {
+	{
+		name = 'liquipediatier',
+		property = 'liquipediaTier',
+		load = function(category)
+			category.items = {}
+			for _, tier in Tier.iterate('tiers') do
+				table.insert(category.items, tier.value)
+			end
+		end,
+		defaultItems = {'1', '2', '3'},
+		transform = function(tier)
+			return Tier.toName(tier)
+		end,
+		expandKey = 'region',
+	},
+	{
+		name = 'region',
+		property = 'region',
+		expandable = true,
+		items = {'EU', 'NA', 'OCE', 'SAM', 'Other'},
+		defaultItem = 'Other',
+		itemToPropertyValues = function(region)
+			-- Input is a region
+			if REGION_TO_SUPERREGION[region] then
+				return table.concat(REGIONS_IN_SUPERREGION[REGION_TO_SUPERREGION[region]], ',')
+			end
+			-- Input is a superRegion
+			if REGIONS_IN_SUPERREGION[region] then
+				return table.concat(REGIONS_IN_SUPERREGION[region], ',')
+			end
+			-- Unknown input
+			return ''
+		end,
+		itemIsValid = function(region)
+			return REGION_TO_SUPERREGION[region] ~= nil
+		end,
+		transform = function(region)
+			return REGION_TO_SUPERREGION[region] or region
+		end,
+	},
+}
+
+return Config

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -94,7 +94,7 @@ return {
 	title = 'Rocket League',
 	navigation = {
 		{
-			file = '',
+			file = 'RLCS Worlds 2024 LAN Michal Konkol zen.jpg',
 			title = 'Players',
 			link = 'Portal:Players',
 			count = {
@@ -103,7 +103,7 @@ return {
 			},
 		},
 		{
-			file = '',
+			file = 'RLCS Worlds 2024 Media Day Rachel Mathews Team BDS.jpg',
 			title = 'Teams',
 			link = 'Portal:Teams',
 			count = {
@@ -121,12 +121,12 @@ return {
 			},
 		},
 		{
-			file = '',
+			file = 'RLCS Worlds 2024 LAN Michal Konkol Bachi.jpg',
 			title = 'Statistics',
 			link = 'Portal:Statistics',
 		},
 		{
-			file = '',
+			file = 'RLCS Copenhagen Major 2024 LAN Adela Sznajder itachi.jpg',
 			title = 'Transfers',
 			link = 'Portal:Transfers',
 			count = {

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -10,16 +10,14 @@ local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
-local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
 local RatingsDisplay = Lua.import('Module:Ratings/Display')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
-local Link = Lua.import('Module:Widget/Basic/Link')
+local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
 local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local CONTENT = {
 	theGame = {
@@ -71,20 +69,7 @@ local CONTENT = {
 	},
 	matches = {
 		heading = 'Matches',
-		body = WidgetUtil.collect(
-			MatchTickerContainer{},
-			Div{
-				css = {
-					['white-space'] = 'nowrap',
-					display = 'block',
-					margin = '0 10px',
-					['font-size'] = '15px',
-					['font-style'] = 'italic',
-					['text-align'] = 'center',
-				},
-				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
-			}
-		),
+		body = MatchTicker{},
 		padding = true,
 		boxid = 1507,
 		panelAttributes = {

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -1,0 +1,235 @@
+---
+-- @Liquipedia
+-- wiki=rocketleague
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local MatchTickerContainer = Lua.import('Module:Widget/Match/Ticker/Container')
+local RatingsDisplay = Lua.import('Module:Ratings/Display')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local CONTENT = {
+	theGame = {
+		heading = 'The Game',
+		body = '{{Liquipedia:The Game}}',
+		padding = true,
+		boxid = 1503,
+	},
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = '{{Liquipedia:Want_to_help}}',
+		padding = true,
+		boxid = 1504,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = TransfersList{
+			transferPortal = 'Transfers',
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+			end
+		},
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
+		padding = true,
+		boxid = 1510,
+	},
+	rlcsEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:RLCS Events}}',
+	},
+	specialEvent = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+	},
+	rating = {
+		heading = 'Liquipedia Rating',
+		body = RatingsDisplay.graph{id = 'rating'},
+	},
+	filterButtons = {
+		noPanel = true,
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
+	},
+	matches = {
+		heading = 'Matches',
+		body = WidgetUtil.collect(
+			MatchTickerContainer{},
+			Div{
+				css = {
+					['white-space'] = 'nowrap',
+					display = 'block',
+					margin = '0 10px',
+					['font-size'] = '15px',
+					['font-style'] = 'italic',
+					['text-align'] = 'center',
+				},
+				children = { Link{ children = 'See more matches', link = 'Liquipedia:Matches'} }
+			}
+		),
+		padding = true,
+		boxid = 1507,
+		panelAttributes = {
+			['data-switch-group-container'] = 'countdown',
+		},
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = TournamentsTicker{},
+		padding = true,
+		boxid = 1508,
+	},
+}
+
+return {
+	banner = {
+		lightmode = 'Rocket League default lightmode.png',
+		darkmode = 'Rocket League default darkmode.png',
+	},
+	metadesc = 'Comprehensive Rocket League wiki with articles covering everything from cars and maps, ' ..
+		'to tournaments, to competitive players and teams.',
+	title = 'Rocket League',
+	navigation = {
+		{
+			file = '',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = '',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = '',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = '',
+			title = 'Statistics',
+			link = 'Portal:Statistics',
+		},
+		{
+			file = '',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = '',
+			title = 'Help',
+			link = 'Help:Contents',
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 6,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.rlcsEvents,
+					},
+					{
+						mobileOrder = 2,
+						content = CONTENT.specialEvent,
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 7,
+						content = CONTENT.wantToHelp,
+					},
+				}
+			},
+			{ -- Right
+				size = 6,
+				children = {
+					{
+						mobileOrder = 3,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
+								},
+							},
+						},
+					},
+					{
+						mobileOrder = 5,
+						content = CONTENT.rating,
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.thisDay,
+					},
+				},
+			},
+			{
+				children = {
+					{
+						mobileOrder = 8,
+						content = CONTENT.theGame,
+					}
+				},
+			},
+		},
+	},
+}

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -5,9 +5,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 
+local DateExt = Lua.import('Module:Date/Ext')
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local RatingsDisplay = Lua.import('Module:Ratings/Display')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -110,7 +110,7 @@ return {
 			},
 		},
 		{
-			file = '',
+			file = 'RLCS Season 8 Trophy.jpg',
 			title = 'Tournaments',
 			link = 'Portal:Tournaments',
 			count = {

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -36,9 +36,8 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferPortal = 'Transfers',
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -1,6 +1,5 @@
 ---
 -- @Liquipedia
--- wiki=rocketleague
 -- page=Module:MainPageLayout/data
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -133,7 +133,7 @@ return {
 			},
 		},
 		{
-			file = '',
+			file = 'Flakes casual photo.jpg',
 			title = 'Help',
 			link = 'Help:Contents',
 		},

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -108,6 +108,12 @@
 		}
 	}
 
+	.wiki-rocketleague & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/5/56/Header-rl.png ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-smite & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/1/12/Smite-banner.png ) no-repeat center / cover;


### PR DESCRIPTION
## Summary

This PR adds new mainpage config for Rocket League.

### Checklists

- [x] ~~Fix broken tournament ticker (probably caused by bad `sdate`/`edate`s)~~ #5408
- [x] Add region filter for filter buttons
- [x] Find photos for navigation cards
- [x] Add banner image

## How did you test this change?

https://liquipedia.net/rocketleague/User:ElectricalBoy/MainPage
