### PR TITLE
fix(participantTable): highlight key unresolved

### DIFF
--- a/lua/wikis/ageofempires/ParticipantTable/Custom.lua
+++ b/lua/wikis/ageofempires/ParticipantTable/Custom.lua
@@ -90,7 +90,6 @@ function AoEParticipantTable:readEntry(sectionArgs, key, index, config)
 		dq = Logic.readBool(opponentArgs.dq),
 		note = opponentArgs.note,
 		opponent = opponent,
-		name = Opponent.toName(opponent),
 		inputIndex = index,
 		seed = tonumber(opponentArgs.seed)
 	}

--- a/lua/wikis/commons/ParticipantTable/Base.lua
+++ b/lua/wikis/commons/ParticipantTable/Base.lua
@@ -62,6 +62,8 @@ local prizePoolVars = PageVariableNamespace('PrizePool')
 ---@field note string?
 ---@field dq boolean
 ---@field inputIndex integer?
+---@field isResolved boolean?
+---@field sortName string
 
 ---@class ParticipantTable
 ---@operator call(Frame): ParticipantTable
@@ -170,12 +172,21 @@ function ParticipantTable:readSection(args)
 	local tbds = {}
 	Table.mapArgumentsByPrefix(args, {'p', 'player'}, function(key, index)
 		local entry = self:readEntry(args, key, index, config)
+		entry.sortName = Opponent.toName(entry.opponent)
 
 		if entry.opponent and Opponent.isTbd(entry.opponent) then
+			entry.name = Opponent.toName(entry.opponent)
 			table.insert(tbds, entry)
 			--needed so index is increased
 			return entry
 		end
+
+		entry.opponent = Opponent.resolve(entry.opponent, config.resolveDate, {
+			syncPlayer = config.syncPlayers,
+			overwritePageVars = true,
+		})
+		entry.isResolved = true
+		entry.name = Opponent.toName(entry.opponent)
 
 		if entriesByName[entry.name] then
 			error('Duplicate Input "|' .. key .. '=' .. args[key] .. '"')
@@ -188,16 +199,17 @@ function ParticipantTable:readSection(args)
 	end)
 
 	section.entries = Array.map(Import.importFromMatchGroupSpec(config, entriesByName), function(entry)
-		entry.opponent = Opponent.resolve(entry.opponent, config.resolveDate, {
+		entry.opponent = entry.isResolved and entry.opponent or Opponent.resolve(entry.opponent, config.resolveDate, {
 			syncPlayer = config.syncPlayers,
 			overwritePageVars = true,
 		})
+		entry.isResolved = true
 		self:setCustomPageVariables(entry, config)
 		return entry
 	end)
 
 	Array.sortInPlaceBy(section.entries, function(entry)
-		return config.sortOpponents and entry.name:lower() or entry.inputIndex or -1
+		return config.sortOpponents and entry.sortName:lower() or entry.inputIndex or -1
 	end)
 
 	Array.extendWith(section.entries, tbds)
@@ -249,7 +261,6 @@ function ParticipantTable:readEntry(sectionArgs, key, index, config)
 		dq = Logic.readBool(opponentArgs.dq),
 		note = opponentArgs.note,
 		opponent = opponent,
-		name = Opponent.toName(opponent),
 		inputIndex = index,
 	}
 end

--- a/lua/wikis/commons/ParticipantTable/Starcraft.lua
+++ b/lua/wikis/commons/ParticipantTable/Starcraft.lua
@@ -138,7 +138,6 @@ function StarcraftParticipantTable:readEntry(sectionArgs, key, index, config)
 		dq = Logic.readBool(opponentArgs.dq),
 		note = opponentArgs.note,
 		opponent = opponent,
-		name = Opponent.toName(opponent),
 		isQualified = Logic.nilOr(Logic.readBoolOrNil(sectionArgs[key .. 'qualified']), config.isQualified),
 		inputIndex = index,
 	}

--- a/lua/wikis/stormgate/ParticipantTable/Custom.lua
+++ b/lua/wikis/stormgate/ParticipantTable/Custom.lua
@@ -138,7 +138,6 @@ function StormgateParticipantTable:readEntry(sectionArgs, key, index, config)
 		dq = Logic.readBool(opponentArgs.dq),
 		note = opponentArgs.note,
 		opponent = opponent,
-		name = Opponent.toName(opponent),
 		isQualified = Logic.nilOr(Logic.readBoolOrNil(sectionArgs[key .. 'qualified']), config.isQualified),
 	}
 end

--- a/lua/wikis/warcraft/ParticipantTable/Custom.lua
+++ b/lua/wikis/warcraft/ParticipantTable/Custom.lua
@@ -123,7 +123,6 @@ function CustomParticipantTable:readEntry(sectionArgs, key, index, config)
 		dq = Logic.readBool(opponentArgs.dq),
 		note = opponentArgs.note,
 		opponent = opponent,
-		name = Opponent.toName(opponent),
 	}
 end
 


### PR DESCRIPTION
## Summary
The value used to set the opponent highlight hover in participants table is not resolved.

for context from discord DMs with Rath:
![image](https://github.com/user-attachments/assets/9139667e-11b1-495d-9ad5-32b481ee66cd)

This PR adjusts the ParticipantTable processing so that entry.name (whichg is used for that highlighting) its value uses the resolved oppoent name.

## How did you test this change?
dev