### PR TITLE
fix(prizepool): missing 'no circuit defined' catch

### DIFF
--- a/lua/wikis/fighters/PrizePool/Custom.lua
+++ b/lua/wikis/fighters/PrizePool/Custom.lua
@@ -85,6 +85,10 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	lpdbData.extradata.matchid = opponent.additionalData.LASTVSMATCHID
 
+	if not Variables.varExists('circuit') then
+		return lpdbData
+	end
+
 	lpdbData.extradata.circuit = Variables.varDefault('circuit')
 	lpdbData.extradata.circuit_tier = Variables.varDefault('circuit_tier')
 	lpdbData.extradata.circuit2 = Variables.varDefault('circuit2')


### PR DESCRIPTION
## Summary

regression from #5659

The setup from #5659 assumed that any ppt with points would have a circuit associated with it. This assumption is not true in one specific edge case: EWC.
This PR handles the forementioned edge case

## How did you test this change?

preview with dev