### PR TITLE
feat(mainpage): add special events panel to marvelrivals mainpage

### DIFF
--- a/lua/wikis/marvelrivals/MainPageLayout/data.lua
+++ b/lua/wikis/marvelrivals/MainPageLayout/data.lua
@@ -55,12 +55,15 @@ local CONTENT = {
 		padding = true,
 		boxid = 1510,
 	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+	},
 	heroes = {
 		heading = 'Heroes',
 		body = '{{Liquipedia:HeroTable}}',
 		padding = true,
 		boxid = 1501,
-
 	},
 	filterButtons = {
 		noPanel = true,
@@ -217,6 +220,14 @@ return {
 					{
 						mobileOrder = 2,
 						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.specialEvents,
+									},
+								},
+							},
 							{
 								children = {
 									{

--- a/lua/wikis/marvelrivals/MainPageLayout/data.lua
+++ b/lua/wikis/marvelrivals/MainPageLayout/data.lua
@@ -202,6 +202,11 @@ return {
 				children = {
 					{
 						mobileOrder = 1,
+						noPanel = true,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 2,
 						content = CONTENT.heroes,
 					},
 					{
@@ -218,16 +223,8 @@ return {
 				size = 6,
 				children = {
 					{
-						mobileOrder = 2,
+						mobileOrder = 3,
 						children = {
-							{
-								children = {
-									{
-										noPanel = true,
-										content = CONTENT.specialEvents,
-									},
-								},
-							},
 							{
 								children = {
 									{


### PR DESCRIPTION
Adds "Liquipedia:Special Event" to the Main Page.

## Summary

Provides the ability for contributors to add featured events to the Main Page of the Marvel Rivals wiki. This is seen on many other wikis and allows easy access to pages of major current tournaments/leagues. It's placed on the right side above the matches and tournaments panels, similar to the Dota 2 Main Page layout in order to keep Heroes available at the top on the left.

## How did you test this change?

Test "Main Page" - https://liquipedia.net/marvelrivals/User:Schon/MainPage
Test "Liquipedia:MainPageLayout/data" - https://liquipedia.net/marvelrivals/Module:MainPageLayout/data/dev/Schon
