### PR TITLE
feat: unify mobile break points to one value

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -197,7 +197,7 @@ Author(s): Rathoz
 	}
 }
 
-@media ( max-width: 413px ) {
+@media ( max-width: 435px ) {
 	.match-bm-lol-match-header-result {
 		font-size: 24px;
 	}
@@ -535,7 +535,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 		font-size: 15px;
 	}
 
-	@media ( max-width: 413px ) {
+	@media ( max-width: 435px ) {
 		font-size: 12px;
 	}
 
@@ -563,7 +563,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 }
 
-@media ( max-width: 413px ) {
+@media ( max-width: 435px ) {
 	.match-bm-lol-players-wrapper {
 		font-size: 12px;
 	}
@@ -950,7 +950,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	position: relative;
 }
 
-@media ( max-width: 413px ) {
+@media ( max-width: 435px ) {
 	.match-bm-lol-players-player-avatar,
 	.match-bm-lol-players-player-icon > a > img {
 		width: 32px;
@@ -1014,7 +1014,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	font-weight: bold;
 }
 
-@media ( max-width: 413px ) {
+@media ( max-width: 435px ) {
 	.match-bm-lol-players-player-loadout img {
 		width: 16px;
 		height: 16px;
@@ -1178,7 +1178,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 }
 
-@media ( max-width: 413px ) {
+@media ( max-width: 435px ) {
 	.match-bm-lol-game-summary-faction {
 		width: 16px;
 		height: 16px;
@@ -1214,7 +1214,7 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 }
 
-@media ( max-width: 413px ) {
+@media ( max-width: 435px ) {
 	.match-bm-lol-game-summary-score {
 		font-size: 15px;
 	}

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -333,7 +333,7 @@
 	}
 }
 
-@media ( max-width: 415px ) {
+@media ( max-width: 435px ) {
 	.brkts-matchlist {
 		width: 100% !important;
 	}

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -11,7 +11,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 	margin-bottom: 15px;
 }
 
-@media ( max-width: 424px ) {
+@media ( max-width: 435px ) {
 	div.main-page-banner .main-page-banner-top-row {
 		font-size: 9vw;
 	}

--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -1961,7 +1961,7 @@ div.battleground-banner {
 Template(s): Hiding Legend box for mobiles
 Author(s): Ricci
 *******************************************************************************/
-@media ( max-width: 415px ) {
+@media ( max-width: 435px ) {
 	.legend-box-mobile {
 		display: none !important;
 	}

--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -1204,7 +1204,7 @@ Author(s): iMarbot
 	}
 }
 
-@media ( max-width: 430px ) {
+@media ( max-width: 435px ) {
 	.showmatch-team-full {
 		display: none;
 	}
@@ -1271,7 +1271,7 @@ Author(s): iMarbot
 	}
 }
 
-@media ( max-width: 430px ) {
+@media ( max-width: 435px ) {
 	.wikitable.showmatch {
 		width: 100% !important;
 	}

--- a/stylesheets/commons/Teamcard.less
+++ b/stylesheets/commons/Teamcard.less
@@ -314,7 +314,7 @@ Author: warnull
 	border: 1px solid var( --clr-border, #bbbbbb );
 }
 
-@media ( max-width: 415px ) {
+@media ( max-width: 435px ) {
 	.rts-team-list-card {
 		width: 100% !important;
 	}


### PR DESCRIPTION
resolves #5238

## Summary
Currently break point for 100% width is 415px in some components while it is 435px in others.
This PR adjusts the components with 415px breakpoint to swwitch to also using 435px breakpoint and hence unifying the break points to one value.
Especially notable is that GTL has 435px while matchlists have 415px, so for devices with a width between 416-435 the display looks bad (see #5238)

## How did you test this change?
N/A