### PR TITLE
fix(mainpage): wrong COD Transfer pages

### DIFF
--- a/lua/wikis/callofduty/MainPageLayout/data.lua
+++ b/lua/wikis/callofduty/MainPageLayout/data.lua
@@ -6,6 +6,7 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
@@ -34,7 +35,13 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = TransfersList{rumours = true, limit = 10},
+		body = TransfersList{
+			rumours = true,
+			limits = 10,
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+			end
+		},
 		boxid = 1509,
 	},
 	thisDay = {


### PR DESCRIPTION
The old setup takes you to monthly transfer pages

but COD uses quarterly setup

changes based on APEX mainpage setup