### PR TITLE
fix(Lua): actually remove `args.module` and `args.fn`

### DIFF
--- a/lua/wikis/commons/Lua.lua
+++ b/lua/wikis/commons/Lua.lua
@@ -9,6 +9,7 @@
 local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local StringUtils = require('Module:StringUtils')
+local Table = require('Module:Table')
 
 local Lua = {}
 
@@ -126,8 +127,10 @@ function Lua.invoke(frame)
 		'Lua.invoke: Module name should not begin with \'Module:\''
 	)
 
-	frame.args.module = nil
-	frame.args.fn = nil
+	local newArgs = Table.deepCopy(frame.args)
+	newArgs.module = nil
+	newArgs.fn = nil
+	frame.args = newArgs
 
 	local getDevFlag = function(startFrame)
 		local currentFrame = startFrame


### PR DESCRIPTION
## Summary
Currently we try to remove `args.module` and `args.fn` during `Lua.invoke` (wrapper-) calls.
This doesn't work due to the metatable in `frame.args`.
To actually remove it we would either have to manipulate the metatable (if it isn't protected ...) or replace `frame.args` with a copy of itself that doesn't copy the metatable.

This PR implements the 2nd option for now.

## How did you test this change?
https://liquipedia.net/starcraft2/User:Hjpalpha/wip34