### PR TITLE
fix(MatchTicker): error on ffa matchlists without inherited header

### DIFF
--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -87,7 +87,10 @@ function Versus:create()
 	local scores, scores2 = self:scores()
 	local upperText, lowerText
 	if #self.match.opponents > 2 then
+		-- brackets always have an inherited header matchlists might lack them,
+		-- hence use matchIndex to generate a generic one for those cases
 		local headerRaw = self.match.match2bracketdata.inheritedheader
+			or ('Match' .. self.match.match2bracketdata.matchIndex)
 		upperText = DisplayHelper.expandHeader(headerRaw)[1]
 		if self.match.asGame then
 			upperText = upperText .. ' - ' .. self:gameTitle() .. self:mapTitle()

--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -90,7 +90,7 @@ function Versus:create()
 		-- brackets always have an inherited header matchlists might lack them,
 		-- hence use matchIndex to generate a generic one for those cases
 		local headerRaw = self.match.match2bracketdata.inheritedheader
-			or ('Match' .. self.match.match2bracketdata.matchIndex)
+			or ('Match ' .. self.match.match2bracketdata.matchIndex)
 		upperText = DisplayHelper.expandHeader(headerRaw)[1]
 		if self.match.asGame then
 			upperText = upperText .. ' - ' .. self:gameTitle() .. self:mapTitle()


### PR DESCRIPTION
resolves #5693 

## Summary
brackets always have an inherited header while ffa matchlists might lack them, hence use matchIndex to generate a generic one for those cases

## How did you test this change?
dev

before:
![image](https://github.com/user-attachments/assets/dc8913e0-e3db-493b-949d-fc65cb1f9007)
after:
![image](https://github.com/user-attachments/assets/f2fe972e-86d0-40c3-b480-95361fcca699)
