### PR TITLE
feat: Increase Tap Area for Section Header Accordions on new Main Page

### DIFF
--- a/lua/wikis/commons/Widget/Panel.lua
+++ b/lua/wikis/commons/Widget/Panel.lua
@@ -38,18 +38,23 @@ local Panel = Class.new(Widget)
 ---@return Widget
 function Panel:render()
 	local boxId = self.props.boxId
+	local attributes = self.props.headingAttributes or {}
+	local hasToggle = boxId ~= nil
+
+	if hasToggle then
+		attributes = Table.merge(attributes, {
+			tabindex = "0",
+			['data-component'] =  "panel-box-collapsible-button"
+		})
+	end
 
 	local heading = Div{
 		classes = { 'panel-box-heading', 'wiki-color-dark', 'wiki-backgroundcolor-light', 'wiki-bordercolor-light' },
-		attributes = self.props.headingAttributes,
+		attributes = attributes,
 		children = WidgetUtil.collect(
-			boxId and {
+			hasToggle and {
 				Div{
 					classes = { 'panel-box-heading-icon' },
-					attributes = {
-						tabindex = "0",
-						['data-component'] =  "panel-box-collapsible-button"
-					},
 					children = { IconFa{iconName = 'collapse'}, }
 				}
 			} or nil,
@@ -61,12 +66,12 @@ function Panel:render()
 
 	local body = Div{
 		classes = WidgetUtil.collect(
-			boxId and 'panel-box-collapsible-content' or nil,
+			hasToggle and 'panel-box-collapsible-content' or nil,
 			Logic.readBool(self.props.padding) and 'panel-box-body' or nil,
 			self.props.bodyClass
 		),
 		css = self.props.bodyStyle,
-		attributes = boxId and {
+		attributes = hasToggle and {
 			['data-component'] = 'panel-box-content'
 		} or {},
 		children = self.props.children
@@ -75,7 +80,7 @@ function Panel:render()
 	return Div{
 		classes = WidgetUtil.collect('panel-box', 'wiki-bordercolor-light', self.props.classes),
 		attributes = Table.merge(
-			boxId and {
+			hasToggle and {
 				['data-component'] = 'panel-box',
 				['data-panel-box-id'] = boxId
 			} or {},

--- a/stylesheets/commons/Panels.less
+++ b/stylesheets/commons/Panels.less
@@ -85,7 +85,7 @@ html .panel-box-heading {
 			transition: transform 0.2s linear;
 		}
 
-		@media ( hover: hover )  {
+		@media ( hover: hover ) {
 			&:hover .panel-box-heading-icon {
 				opacity: 1;
 			}

--- a/stylesheets/commons/Panels.less
+++ b/stylesheets/commons/Panels.less
@@ -83,11 +83,11 @@ html .panel-box-heading {
 			margin-right: 0.75rem;
 			transform-origin: center;
 			transition: transform 0.2s linear;
+		}
 
-			@media ( hover: hover ) {
-				&:hover {
-					opacity: 1;
-				}
+		@media ( hover: hover )  {
+			&:hover .panel-box-heading-icon {
+				opacity: 1;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

To improve user experience by making the accordion headers more intuitive and easier to interact with. Expanding the clickable area will reduce frustration and enhance accessibility for both mobile and web. Modify the section header accordions so that the entire header can be tapped to open or close the accordion, rather than just the ^ chevron icon.


## How did you test this change?
dev and devtools