### PR TITLE
fix(Statistics): Don't limit to past events for ongoing years

### DIFF
--- a/lua/wikis/commons/PortalStatistics.lua
+++ b/lua/wikis/commons/PortalStatistics.lua
@@ -483,10 +483,6 @@ function StatisticsPortal.prizepoolBreakdown(args)
 			}
 		}
 
-		if yearValue == CURRENT_YEAR then
-			conditions:add{ConditionNode(ColumnName('sortdate'), Comparator.lt, DATE)}
-		end
-
 		local data = mw.ext.LiquipediaDB.lpdb('tournament', {
 				query = 'sum::prizepool',
 				limit = MAX_QUERY_LIMIT,


### PR DESCRIPTION
## Summary
Removes the condition that a tournament must have an enddate in the past for ongoing years for the "prizepool breakdown table"
![image](https://github.com/user-attachments/assets/b01b3123-edaf-48e1-8ef7-c7e6699a3461)

While i'm not sure whether it makes sense to have this condition or not, it should either apply to all entrypoints, or none.
This goes the easier route of removing it for the single endpoint (partially!) implementing it.

Reported on discord: https://discord.com/channels/93055209017729024/268719633366777856/1352595320759914576
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
