### PR TITLE
feat(Notability): Change B-Tier points to 700 in overwatch

### DIFF
--- a/lua/wikis/overwatch/NotabilityChecker/config.lua
+++ b/lua/wikis/overwatch/NotabilityChecker/config.lua
@@ -107,7 +107,7 @@ Config.weights = {
 		tiertype = {
 			{
 				name = Config.TIER_TYPE_GENERAL,
-				points = 600,
+				points = 700,
 			},
 			{
 				name = Config.TIER_TYPE_QUALIFIER,


### PR DESCRIPTION
## Summary

Change B-Tier points from 600 to 700 as per poll in the Wiki 2025 Feedback thread on discord

https://discord.com/channels/93055209017729024/1323697205080490185/1348702592657522728


## How did you test this change?

none, simple value change
