### PR TITLE
fix(matchpage): Fetch player name by ingame ID on dota2

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -475,6 +475,9 @@ function MatchGroupInputUtil.readPlayersOfTeam(teamName, manualPlayersInput, opt
 				displayName = globalVars:get(varPrefix .. 'dn'),
 				flag = globalVars:get(varPrefix .. 'flag'),
 				faction = globalVars:get(varPrefix .. 'faction'),
+				-- To be discussed - prefixed with "custom" to make sure it's not confused with e.g. opponentXpY
+				-- Used on dota2 for ingame IDs
+				customId = globalVars:get(varPrefix .. 'id'),
 			}
 		end
 		playerIndex = playerIndex + 1

--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -42,7 +42,7 @@ MatchFunctions.getBestOf = MatchGroupInputUtil.getBestOf
 ---@field getObjectives fun(map: table, opponentIndex: integer): string?
 ---@field getHeroPicks fun(map: table, opponentIndex: integer): string[]?
 ---@field getHeroBans fun(map: table, opponentIndex: integer): string[]?
----@field getParticipants fun(map: table, opponentIndex: integer): table[]?
+---@field getParticipants fun(map: table, opponentIndex: integer, opponent: table): table[]?
 ---@field getVetoPhase fun(map: table): table?
 
 ---@param match table
@@ -237,7 +237,7 @@ end
 function MapFunctions.getPlayersOfMapOpponent(MapParser, map, opponent, opponentIndex)
 	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, HeroNames)
 
-	local participantList = MapParser.getParticipants(map, opponentIndex) or {}
+	local participantList = MapParser.getParticipants(map, opponentIndex, opponent) or {}
 	return MatchGroupInputUtil.parseMapPlayers(
 		opponent.match2players,
 		participantList,

--- a/lua/wikis/dota2/MatchGroup/Input/Custom/MatchPage.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom/MatchPage.lua
@@ -9,6 +9,7 @@
 local Array = require('Module:Array')
 local Logic = require('Module:Logic')
 local Operator = require('Module:Operator')
+local Table = require('Module:Table')
 
 local CustomMatchGroupInputMatchPage = {}
 
@@ -57,8 +58,9 @@ end
 
 ---@param map dota2MatchDataExtended
 ---@param opponentIndex integer
+---@param opponent table
 ---@return table[]?
-function CustomMatchGroupInputMatchPage.getParticipants(map, opponentIndex)
+function CustomMatchGroupInputMatchPage.getParticipants(map, opponentIndex, opponent)
 	local team = map['team' .. opponentIndex] ---@type dota2MatchTeam?
 	if not team then return end
 	if not team.players then return end
@@ -69,6 +71,14 @@ function CustomMatchGroupInputMatchPage.getParticipants(map, opponentIndex)
 			image = item.image,
 		}
 	end
+
+	local ingameIDmapping = Array.reduce(opponent.players, function (aggregate, player)
+		if player.customId then
+			aggregate[player.customId] = player
+		end
+		return aggregate
+	end, {})
+
 	local function fetchLpdbPlayer(playerId)
 		if not playerId then return end
 		return mw.ext.LiquipediaDB.lpdb('player', {
@@ -77,7 +87,7 @@ function CustomMatchGroupInputMatchPage.getParticipants(map, opponentIndex)
 		})[1]
 	end
 	local players = Array.map(team.players, function(player)
-		local playerData = fetchLpdbPlayer(player.id) or {}
+		local playerData = fetchLpdbPlayer(player.id) or ingameIDmapping[player.id] or {}
 		return {
 			player = playerData.pagename or player.name,
 			name = playerData.id,


### PR DESCRIPTION
## Summary
Reported on [discord](https://discord.com/channels/93055209017729024/372075546231832576/1353011527011274802):
The dota2 API sometimes returns an empty name field, but does return a numeric ingame ID.
The processing then tries to fetch LPDB::player data for that ID to get a (page)name.

However, this fails for players without pages. For these cases, dota2 uses `pXid` as TeamCard input, which could be used to get the player data from.

I'm unsure on how to properly pass on that variable into the custom processing - there are several steps in MGU where it would need to be added, and i don't want to entirely override these functions in a custom just for that.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
TBD
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
