### PR TITLE
fix(match2): in FFA view, sorting ignores decimals

### DIFF
--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -599,8 +599,8 @@ liquipedia.battleRoyale = {
 		let valB = b.querySelector( `[data-sort-type='${ sortType }']` ).dataset.sortVal;
 
 		if ( sortType !== 'team' ) {
-			valA = parseInt( valA );
-			valB = parseInt( valB );
+			valA = parseFloat( valA );
+			valB = parseFloat( valB );
 		}
 
 		if ( dir === 'ascending' ) {


### PR DESCRIPTION
## Summary
On wikis that has decimal numbers as their scores, such as Hearthstone, the BR/FFA sorting doesn't account for decimals.
This was because it was running through parseInt instead of parseFloat.

Using parseFloat for all situations where it's currently parseInt is safe. The only thing that parseFloat doesn't support is non-base-10 systems.