### PR TITLE
Additional light/darkmode styling for Facetcard and Aghcard templates

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -611,38 +611,67 @@ a.cf {
 }
 
 // Facetcard-related
-.facetBox {
-	background: rgba( 35, 46, 52, 0.25 );
-	padding: 0.3125rem;
-	border: 0.0625rem solid #505050;
-	color: #ffffff;
-	transition: 0.35s;
+.facet {
+	&Box {
+		background: rgba( 35, 46, 52, 0.25 );
+		padding: 0.3125rem;
+		border: 0.0625rem solid #505050;
+		color: var( --clr-on-background );
+		transition: 0.35s;
 
-	&:hover {
-		border: 0.0625rem solid var( --clr-elm-10 );
+		&:hover {
+			border: 0.0625rem solid var( --clr-elm-10 );
+
+			.theme--dark {
+				border: 0.0625rem solid var( --clr-moon-90 );
+			}
+		}
 	}
 
-	.theme--dark &:hover {
-		border: 0.0625rem solid var( --clr-moon-90 );
+	&Cell {
+		background-color: #9fa1a3;
+		padding-top:5px;
+
+		.theme--dark {
+			background-color: #2c2f33;
+		}
 	}
-}
 
-.facetTitle {
-	cursor: help;
-}
+	&Title {
+		cursor: help;
+	}
 
-.facetLink {
-	font-weight: bold;
-	color: #e2e2e6;
-	text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base ); // #000000
-}
+	&Link {
+		font-weight: bold;
+		color: var( --clr-moon-base ); // #000000
+		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-30 );
+		&Title,.theme--dark {
+			color: #e2e2e6;
+			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base )
+		}
+	}
 
-.facetDesc {
-	border-top: 0.125rem solid #505050;
-	padding-top: 0.3125rem;
+	&Desc {
+		border-top: 0.125rem solid #505050;
+		padding-top: 0.3125rem;
 
-	&:hover {
-		border-top: 0.125rem solid var( --clr-moon-80 );
+		&:hover {
+			border-top: 0.125rem solid var( --clr-moon-80 );
+		}
+	}
+
+	&Shadow {
+		display: inline-block;
+		background: rgba( 255, 255, 255, 0.7 );
+		text-align: left;
+		margin-top: 0;
+		margin-bottom: 0.3125rem;
+		padding: 0.3125rem;
+		border: 0.0625rem solid #505050;
+		width: 100%;
+		.theme--dark {
+			background: rgba( 18, 26, 33, 0.7 );
+		}
 	}
 }
 
@@ -653,20 +682,29 @@ a.cf {
 		max-width: 28.75rem; // 460px
 		width: 100%;
 		font-size: 90%; // convert to rem
-		background: rgba( 35, 46, 52, 0.75 );
+		background: rgba( 212, 216, 222, 0.75 );
 		text-align: left;
 		padding-left: 0.3125rem;
 		padding-right: 0.3125rem;
 		padding-top: 0.3125rem;
 		border: 0.0625rem solid #505050;
-		color: #d9e0e8;
+		color: var( --clr-on-background );
+
+		.theme--dark {
+			background: rgba( 35, 46, 52, 0.75 );
+		}
 	}
 
 	&Title {
 		font-weight: bold;
-		color: #a885ff;
-		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base ); // #000000
+		color: #5b37b7;
+		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-gigas-80 );
 		flex-grow: 1;
+
+		.theme--dark {
+			color: #a885ff;
+			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base ); // #000000
+		}
 	}
 
 	&New {
@@ -684,7 +722,7 @@ a.cf {
 
 	&Shadow {
 		display: inline-block;
-		background: rgba( 18, 26, 33, 0.7 );
+		background: rgba( 255, 255, 255, 0.7 );
 		text-align: left;
 		margin-top: 0;
 		margin-bottom: 0.3125rem;
@@ -692,9 +730,17 @@ a.cf {
 		border: 0.0625rem solid #505050;
 		width: 100%;
 
+		.theme--dark {
+			background: rgba( 18, 26, 33, 0.7 );
+		}
+
 		&:hover {
-			background-color: rgba( 9, 13, 17, 1 );
+			background-color: rgb( 9, 13, 17 );
 			transition: 0.15s;
+
+			.theme--dark {
+				background-color: rgb( 142, 185, 229 );
+			}
 		}
 	}
 

--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -646,7 +646,8 @@ a.cf {
 		color: var( --clr-moon-base ); // #000000
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-30 );
 		
-		&Title, .theme--dark {
+		&Title, 
+		.theme--dark {
 			color: #e2e2e6;
 			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base );
 		}

--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -645,8 +645,7 @@ a.cf {
 		font-weight: bold;
 		color: var( --clr-moon-base ); // #000000
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-30 );
-		
-		&Title, 
+		&Title,
 		.theme--dark {
 			color: #e2e2e6;
 			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base );
@@ -671,7 +670,6 @@ a.cf {
 		padding: 0.3125rem;
 		border: 0.0625rem solid #505050;
 		width: 100%;
-		
 		.theme--dark {
 			background: rgba( 18, 26, 33, 0.7 );
 		}

--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -630,7 +630,7 @@ a.cf {
 
 	&Cell {
 		background-color: #9fa1a3;
-		padding-top:5px;
+		padding-top: 5px;
 
 		.theme--dark {
 			background-color: #2c2f33;
@@ -645,9 +645,10 @@ a.cf {
 		font-weight: bold;
 		color: var( --clr-moon-base ); // #000000
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-30 );
-		&Title,.theme--dark {
+		
+		&Title, .theme--dark {
 			color: #e2e2e6;
-			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base )
+			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base );
 		}
 	}
 
@@ -669,6 +670,7 @@ a.cf {
 		padding: 0.3125rem;
 		border: 0.0625rem solid #505050;
 		width: 100%;
+		
 		.theme--dark {
 			background: rgba( 18, 26, 33, 0.7 );
 		}
@@ -735,11 +737,11 @@ a.cf {
 		}
 
 		&:hover {
-			background-color: rgb( 9, 13, 17 );
+			background-color: rgba( 9, 13, 17, 1 );
 			transition: 0.15s;
 
 			.theme--dark {
-				background-color: rgb( 142, 185, 229 );
+				background-color: rgba( 142, 185, 229, 1 );
 			}
 		}
 	}

--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -645,6 +645,7 @@ a.cf {
 		font-weight: bold;
 		color: var( --clr-moon-base ); // #000000
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-30 );
+
 		&Title,
 		.theme--dark {
 			color: #e2e2e6;
@@ -670,6 +671,7 @@ a.cf {
 		padding: 0.3125rem;
 		border: 0.0625rem solid #505050;
 		width: 100%;
+
 		.theme--dark {
 			background: rgba( 18, 26, 33, 0.7 );
 		}


### PR DESCRIPTION
This change appends Facetcard- and Aghscard-related styles to differentiate between lightmode and darkmode visuals.

## Summary

At the time, Facetcard and Aghcard operate only on darkmode styles (as a lot of our contributors use dark theme).
These settings should help with achieving better visuals on lightmode.

## How did you test this change?

Browser: Microsoft Edge v133.0.3065.92 64-bit

Pages used: "/dota2/Batrider" and "/dota2gameru/Batrider".

Aghcard example:
![Aghcard-example](https://github.com/user-attachments/assets/e2b60a6e-0a01-4832-bd27-d5a5183aeda8)

Facetcard example:
![Facetcard-example](https://github.com/user-attachments/assets/e9afb8b9-e2fe-430d-8bcf-0a7bb344db29)