### PR TITLE
fix: class naming for Facetcard and Aghcard-related styles

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -622,7 +622,7 @@ a.cf {
 		&:hover {
 			border: 0.0625rem solid var( --clr-elm-10 );
 
-			.theme--dark {
+			.theme--dark & {
 				border: 0.0625rem solid var( --clr-moon-90 );
 			}
 		}
@@ -632,7 +632,7 @@ a.cf {
 		background-color: #9fa1a3;
 		padding-top: 5px;
 
-		.theme--dark {
+		.theme--dark & {
 			background-color: #2c2f33;
 		}
 	}
@@ -647,7 +647,7 @@ a.cf {
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-30 );
 
 		&Title,
-		.theme--dark {
+		.theme--dark & {
 			color: #e2e2e6;
 			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base );
 		}
@@ -672,7 +672,7 @@ a.cf {
 		border: 0.0625rem solid #505050;
 		width: 100%;
 
-		.theme--dark {
+		.theme--dark & {
 			background: rgba( 18, 26, 33, 0.7 );
 		}
 	}
@@ -693,7 +693,7 @@ a.cf {
 		border: 0.0625rem solid #505050;
 		color: var( --clr-on-background );
 
-		.theme--dark {
+		.theme--dark & {
 			background: rgba( 35, 46, 52, 0.75 );
 		}
 	}
@@ -704,7 +704,7 @@ a.cf {
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-gigas-80 );
 		flex-grow: 1;
 
-		.theme--dark {
+		.theme--dark & {
 			color: #a885ff;
 			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base ); // #000000
 		}
@@ -733,7 +733,7 @@ a.cf {
 		border: 0.0625rem solid #505050;
 		width: 100%;
 
-		.theme--dark {
+		.theme--dark & {
 			background: rgba( 18, 26, 33, 0.7 );
 		}
 
@@ -741,7 +741,7 @@ a.cf {
 			background-color: rgba( 9, 13, 17, 1 );
 			transition: 0.15s;
 
-			.theme--dark {
+			.theme--dark & {
 				background-color: rgba( 142, 185, 229, 1 );
 			}
 		}


### PR DESCRIPTION
Added & operator so the style names would parsed as ".theme--dark X" rather than "X .theme--dark"

## Summary

Fix on class naming being screwed up because of a forgotten & operator

## How did you test this change?

Browser: Microsoft Edge 133.0.3065.92

Page: "/dota2/Batrider"
