### PR TITLE
fix: Aghcard's aghupgShadow hover values for light and dark themes

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -738,11 +738,11 @@ a.cf {
 		}
 
 		&:hover {
-			background-color: rgba( 9, 13, 17, 1 );
+			background-color: rgba( 142, 185, 229, 1 );
 			transition: 0.15s;
 
 			.theme--dark & {
-				background-color: rgba( 142, 185, 229, 1 );
+				background-color: rgba( 9, 13, 17, 1 );
 			}
 		}
 	}

--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -622,7 +622,7 @@ a.cf {
 		&:hover {
 			border: 0.0625rem solid var( --clr-elm-10 );
 
-			.theme--dark {
+			.theme--dark & {
 				border: 0.0625rem solid var( --clr-moon-90 );
 			}
 		}
@@ -632,7 +632,7 @@ a.cf {
 		background-color: #9fa1a3;
 		padding-top: 5px;
 
-		.theme--dark {
+		.theme--dark & {
 			background-color: #2c2f33;
 		}
 	}
@@ -647,7 +647,7 @@ a.cf {
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-30 );
 
 		&Title,
-		.theme--dark {
+		.theme--dark & {
 			color: #e2e2e6;
 			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base );
 		}
@@ -672,7 +672,7 @@ a.cf {
 		border: 0.0625rem solid #505050;
 		width: 100%;
 
-		.theme--dark {
+		.theme--dark & {
 			background: rgba( 18, 26, 33, 0.7 );
 		}
 	}
@@ -693,7 +693,7 @@ a.cf {
 		border: 0.0625rem solid #505050;
 		color: var( --clr-on-background );
 
-		.theme--dark {
+		.theme--dark & {
 			background: rgba( 35, 46, 52, 0.75 );
 		}
 	}
@@ -704,7 +704,7 @@ a.cf {
 		text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-gigas-80 );
 		flex-grow: 1;
 
-		.theme--dark {
+		.theme--dark & {
 			color: #a885ff;
 			text-shadow: 0.0625rem 0.0625rem 0.125rem var( --clr-moon-base ); // #000000
 		}
@@ -733,7 +733,7 @@ a.cf {
 		border: 0.0625rem solid #505050;
 		width: 100%;
 
-		.theme--dark {
+		.theme--dark & {
 			background: rgba( 18, 26, 33, 0.7 );
 		}
 
@@ -741,7 +741,7 @@ a.cf {
 			background-color: rgba( 9, 13, 17, 1 );
 			transition: 0.15s;
 
-			.theme--dark {
+			.theme--dark & {
 				background-color: rgba( 142, 185, 229, 1 );
 			}
 		}


### PR DESCRIPTION
## Summary

A fix for the aghupgShadow:hover values.

On light theme:
How it's pre-fix:
![before](https://github.com/user-attachments/assets/cad7efd5-c342-48fb-af48-de40508453e2)
How it should be:
![after](https://github.com/user-attachments/assets/7dee5663-ecc0-4a56-b122-7c3564e13109)

## How did you test this change?

Browser: Microsoft Edge 134.0.3124.85
Page: /dota2/Huskar
