### PR TITLE
feat: Allow empty ConditionTrees to be added as node to a ConditionTree

### DIFF
--- a/lua/spec/condition_spec.lua
+++ b/lua/spec/condition_spec.lua
@@ -60,7 +60,7 @@ describe('LPDB Condition Builder', function()
 				cond1:toString()
 			)
 			assert.are_equal(
-				'([[game::commons1]] OR [[game::commons2]])',
+				'[[game::commons1]] OR [[game::commons2]]',
 				cond2:toString()
 			)
 			assert.are_equal(

--- a/lua/spec/condition_spec.lua
+++ b/lua/spec/condition_spec.lua
@@ -86,6 +86,10 @@ describe('LPDB Condition Builder', function()
 				cond2,
 				cond3,
 			}
+			local cond5 = ConditionTree(BooleanOperator.all):add{
+				ConditionTree(BooleanOperator.all):add{ConditionTree(BooleanOperator.all):add{}},
+				ConditionNode(ColumnName('game'), Comparator.eq, game1),
+			}
 
 			assert.are_equal(
 				'[[game::commons1]]',
@@ -103,6 +107,10 @@ describe('LPDB Condition Builder', function()
 				'([[game::commons1]]) AND ([[game::commons1]] OR [[game::commons2]]) AND '..
 					'(([[game::commons1]] OR [[game::commons2]]))',
 				cond4:toString()
+			)
+			assert.are_equal(
+				'[[game::commons1]]',
+				cond5:toString()
 			)
 		end)
 	end)

--- a/lua/spec/condition_spec.lua
+++ b/lua/spec/condition_spec.lua
@@ -8,26 +8,70 @@ describe('LPDB Condition Builder', function()
 	local BooleanOperator = Condition.BooleanOperator
 	local ColumnName = Condition.ColumnName
 
-	it('build condition', function()
-		local tree = ConditionTree(BooleanOperator.all):add({
-			ConditionNode(
-				ColumnName('date'), Comparator.lessThan, '2020-03-02T00:00:00.000'
-			),
-			ConditionTree(BooleanOperator.any):add({
-				ConditionNode(ColumnName('opponent'), Comparator.equals, 'Team Liquid'),
-				ConditionNode(ColumnName('opponent'), Comparator.equals, 'Team Secret'),
-			}),
-			ConditionNode(
-				ColumnName('region', 'extradata'), Comparator.equals, 'Europe'
-			),
-		})
+	describe('build condition', function()
+		it('without empty trees', function()
+			local tree = ConditionTree(BooleanOperator.all):add({
+				ConditionNode(
+					ColumnName('date'), Comparator.lessThan, '2020-03-02T00:00:00.000'
+				),
+				ConditionTree(BooleanOperator.any):add({
+					ConditionNode(ColumnName('opponent'), Comparator.equals, 'Team Liquid'),
+					ConditionNode(ColumnName('opponent'), Comparator.equals, 'Team Secret'),
+				}),
+				ConditionNode(
+					ColumnName('region', 'extradata'), Comparator.equals, 'Europe'
+				),
+			})
 
-		tree:add()
+			tree:add()
 
-		assert.are_equal(
-			'[[date::<2020-03-02T00:00:00.000]] AND ([[opponent::Team Liquid]] OR [[opponent::Team Secret]]) ' ..
-			'AND [[extradata_region::Europe]]',
-			tree:toString()
-		)
+			assert.are_equal(
+				'[[date::<2020-03-02T00:00:00.000]] AND ([[opponent::Team Liquid]] OR [[opponent::Team Secret]]) ' ..
+				'AND [[extradata_region::Europe]]',
+				tree:toString()
+			)
+		end)
+		it('with empty trees', function()
+			local game1 = 'commons1'
+			local game2 = 'commons2'
+
+			local cond1 = ConditionTree(BooleanOperator.all):add{
+				ConditionTree(BooleanOperator.all):add{},
+				ConditionNode(ColumnName('game'), Comparator.eq, game1),
+				ConditionTree(BooleanOperator.all)
+			}
+			local cond2 = ConditionTree(BooleanOperator.any):add{
+				ConditionNode(ColumnName('game'), Comparator.eq, game1),
+				ConditionNode(ColumnName('game'), Comparator.eq, game2),
+			}
+			local cond3 = ConditionTree(BooleanOperator.all):add{
+				ConditionTree(BooleanOperator.all):add{},
+				cond2,
+				ConditionTree(BooleanOperator.all),
+			}
+			local cond4 = ConditionTree(BooleanOperator.all):add{
+				cond1,
+				cond2,
+				cond3,
+			}
+
+			assert.are_equal(
+				'[[game::commons1]]',
+				cond1:toString()
+			)
+			assert.are_equal(
+				'([[game::commons1]] OR [[game::commons2]])',
+				cond2:toString()
+			)
+			assert.are_equal(
+				'([[game::commons1]] OR [[game::commons2]])',
+				cond3:toString()
+			)
+			assert.are_equal(
+				'([[game::commons1]]) AND ([[game::commons1]] OR [[game::commons2]]) AND '..
+					'(([[game::commons1]] OR [[game::commons2]]))',
+				cond4:toString()
+			)
+		end)
 	end)
 end)

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -6,9 +6,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
-local String = require('Module:StringUtils')
 local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local String = require('Module:StringUtils')
 
 local Condition = {}
 
@@ -32,15 +33,15 @@ local ConditionTree = Class.new(_ConditionNode,
 ---@param node AbstractConditionNode|AbstractConditionNode[]|nil
 ---@return self
 function ConditionTree:add(node)
-	if not node then
+	if Logic.isEmpty(node) then
 		return self
 	elseif Class.instanceOf(node, _ConditionNode) then
 		table.insert(self._nodes, node)
 	else
 		-- List of nodes
-		for _, value in pairs(node) do
-			table.insert(self._nodes, value)
-		end
+		Array.forEach(node, function(subNode)
+			self:add(subNode)
+		end)
 	end
 	return self
 end
@@ -51,7 +52,11 @@ function ConditionTree:toString()
 	return table.concat(Array.map(self._nodes,
 		function(node)
 			if Class.instanceOf(node, ConditionTree) then
-				return String.interpolate('(${node})', {node = node:toString()})
+				local nodeString = node:toString()
+				if Logic.isEmpty(nodeString) then return end
+				return String.interpolate('(${node})', {node = nodeString})
+			elseif Logic.isEmpty(node) then
+				return
 			end
 
 			return node:toString()

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -34,7 +34,7 @@ local ConditionTree = Class.new(_ConditionNode,
 ---@param node AbstractConditionNode|AbstractConditionNode[]|nil
 ---@return self
 function ConditionTree:add(node)
-	if Logic.isEmpty(node) then
+	if not node then
 		return self
 	elseif Class.instanceOf(node, _ConditionNode) then
 		table.insert(self._nodes, node)


### PR DESCRIPTION
## Summary
Currently if adding a ConditionTree which has no nodes (i.e. is empty) as a node to a ConditionTree the resulting condition strings can't be interpreted by LPDB due to the containing stuff like e.g. ` AND ()`.

This PR adjusts handling of empty ConditionTrees as Nodes so that the resulting coindition strings can be read by LPDB.

## How did you test this change?
dev + busted

From the examples added so spec:
| | Old string | New string |
| ----- | ----- | ----- |
| 1 | `() AND [[game::commons1]] AND ()` | `[[game::commons1]]` |
| 2 | `() AND ([[game::commons1]] OR [[game::commons2]]) AND ()` | `[[game::commons1]] OR [[game::commons2]]` |
| 3  | `() AND ([[game::commons1]] OR [[game::commons2]]) AND ()` | `([[game::commons1]] OR [[game::commons2]])` |
| 4 | `(() AND [[game::commons1]] AND ()) AND ([[game::commons1]] OR [[game::commons2]]) AND (() AND ([[game::commons1]] OR [[game::commons2]]) AND ())` | `([[game::commons1]]) AND ([[game::commons1]] OR [[game::commons2]]) AND (([[game::commons1]] OR [[game::commons2]]))` |