### PR TITLE
feat: change font size in blockquotes

### DIFF
--- a/stylesheets/commons/Quote.less
+++ b/stylesheets/commons/Quote.less
@@ -1,6 +1,6 @@
 /*******************************************************************************
 Template(s): Quotes
-Author(s): ???
+Author(s): salle
 *******************************************************************************/
 blockquote.quote {
 	font-style: italic;
@@ -8,7 +8,7 @@ blockquote.quote {
 	padding: 5px 60px;
 	position: relative;
 	max-width: 990px;
-	font-size: 16px;
+	font-size: 1rem;
 }
 
 blockquote.quote::before {


### PR DESCRIPTION
## Summary

Fixed pixel size fonts are bad, found one in the wild, so fixing it to rem.

## How did you test this change?

Chrome dev tools.
