### PR TITLE
feat(icon): add Chess King icon class

### DIFF
--- a/lua/wikis/commons/Icon/Data.lua
+++ b/lua/wikis/commons/Icon/Data.lua
@@ -126,4 +126,8 @@ return {
 
 	-- Usage: Charts
 	chart = 'far fa-chart-line',
+
+	-- Usage: Chess
+	chesskingoutline = 'far fa-chess-king',
+	chesskingfull = 'fas fa-chess-king',
 }


### PR DESCRIPTION
## Summary
Potential solutions for mass |dev usage in #5380  (Chess) Match2

The issue is to do with this class icon that used to refer the player that starts on white side in each game
![image](https://github.com/user-attachments/assets/e142b72d-eee5-439f-85c8-4d6ff30440d8)

Currently should you paste the same dev version to a non-dev setup, Every match will feature this error because the missing class icon 
![image](https://github.com/user-attachments/assets/d3b2724c-b59d-409b-8896-544acb4c2ae1)

What if the solution is, to keep #5380 in draft, but merge this one which effectively will allow the Match2 to work with no dev flags because the class now exists. I've manually tried having the icon module locally to test it out and it works. The missing Class IS the current blocker of this.

This way you can keep the setup in draft until approval or the new design is being decided

## Note
If suggested fix is "removing the white icon" its no different than if League should removed the way to indicate who plays red/blue




