### PR TITLE
feat(mainpage): re-attempt improve tournament list headers on Lakeside

### DIFF
--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -57,7 +57,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 }
 
 body.skin-lakesideview .tournaments-list-heading {
-	background-color: var( --clr-wiki-primary-container );
+	background-color: rgb( from var( --clr-wiki-theme-primary ) r g b / 0.12 );
 	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;
 	border-radius: 0.5rem;
@@ -65,6 +65,11 @@ body.skin-lakesideview .tournaments-list-heading {
 	line-height: 1.25rem;
 	margin-bottom: 0.5rem;
 	border: 0;
+}
+
+.theme--dark body.skin-lakesideview .tournaments-list-heading {
+	background-color: rgb( from #ffffff r g b / 0.12 );
+	color: #ffffff;
 }
 
 .tournaments-list-type-list {

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -65,11 +65,11 @@ body.skin-lakesideview .tournaments-list-heading {
 	line-height: 1.25rem;
 	margin-bottom: 0.5rem;
 	border: 0;
-}
 
-.theme--dark body.skin-lakesideview .tournaments-list-heading {
-	background-color: rgba( from #ffffff r g b / 0.12 );
-	color: #ffffff;
+	.theme--dark & {
+		background-color: rgba( from #ffffff r g b / 0.12 );
+		color: #ffffff;
+	}
 }
 
 .tournaments-list-type-list {

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -68,7 +68,7 @@ body.skin-lakesideview .tournaments-list-heading {
 }
 
 .theme--dark body.skin-lakesideview .tournaments-list-heading {
-	background-color: rgb( from #ffffff r g b / 0.12 );
+	background-color: rgba( from #ffffff r g b / 0.12 );
 	color: #ffffff;
 }
 

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -56,6 +56,17 @@ div.main-page-banner .main-page-banner-bottom-row {
 	border-bottom: 1px solid var( --clr-border, #bbbbbb );
 }
 
+body.skin-lakesideview .tournaments-list-heading {
+	background-color: var(--clr-wiki-primary-container);
+	color: var(--clr-wiki-theme-primary);
+	padding: 0.5rem 0.75rem;
+	border-radius: 0.5rem;
+	font-size: 0.875rem;
+	line-height: 1.25rem;
+	margin-bottom: 1rem;
+	border: none;
+}
+
 .tournaments-list-type-list {
 	margin-bottom: 15px !important;
 	margin-left: 0 !important;

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -57,7 +57,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 }
 
 body.skin-lakesideview .tournaments-list-heading {
-	background-color: rgba( from var( --clr-wiki-theme-primary ) r g b / 0.12 );
+	background-color: ~"rgba( from var( --clr-wiki-theme-primary ) r g b / 0.12 )";
 	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;
 	border-radius: 0.5rem;
@@ -67,7 +67,7 @@ body.skin-lakesideview .tournaments-list-heading {
 	border: 0;
 
 	.theme--dark & {
-		background-color: rgba( from #ffffff r g b / 0.12 );
+		background-color: ~"rgba( from #ffffff r g b / 0.12 )";
 		color: #ffffff;
 	}
 }

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -57,8 +57,8 @@ div.main-page-banner .main-page-banner-bottom-row {
 }
 
 body.skin-lakesideview .tournaments-list-heading {
-	background-color: var(--clr-wiki-primary-container);
-	color: var(--clr-wiki-theme-primary);
+	background-color: var( --clr-wiki-primary-container );
+	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;
 	border-radius: 0.5rem;
 	font-size: 0.875rem;

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -63,7 +63,7 @@ body.skin-lakesideview .tournaments-list-heading {
 	border-radius: 0.5rem;
 	font-size: 0.875rem;
 	line-height: 1.25rem;
-	margin-bottom: 1rem;
+	margin-bottom: 0.5rem;
 	border: none;
 }
 

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -57,7 +57,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 }
 
 body.skin-lakesideview .tournaments-list-heading {
-	background-color: rgb( from var( --clr-wiki-theme-primary ) r g b / 0.12 );
+	background-color: rgba( from var( --clr-wiki-theme-primary ) r g b / 0.12 );
 	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;
 	border-radius: 0.5rem;

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -64,7 +64,7 @@ body.skin-lakesideview .tournaments-list-heading {
 	font-size: 0.875rem;
 	line-height: 1.25rem;
 	margin-bottom: 0.5rem;
-	border: none;
+	border: 0;
 }
 
 .tournaments-list-type-list {


### PR DESCRIPTION
## Summary

After #5584 was reverted by #5718 due to LESS compile issues. This is a re-attempt at getting the working CSS with LESS compiler into the repo.

## How did you test this change?

LESS online compiler, dev tools, and Alex also tested on dev wiki.

https://discord.com/channels/93055209017729024/1209065403955806270/1354549202792878191
