### PR TITLE
fix(mainpage): apply new tournament list only on mainpage-v2

### DIFF
--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -56,7 +56,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 	border-bottom: 1px solid var( --clr-border, #bbbbbb );
 }
 
-body.skin-lakesideview .tournaments-list-heading {
+.mainpage-v2 .tournaments-list-heading {
 	background-color: ~"rgba( from var( --clr-wiki-theme-primary ) r g b / 0.12 )";
 	color: var( --clr-wiki-theme-primary );
 	padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## Summary

Total brain fart, got the new skin and the new mainpage mixed up in my head for #5723...

Changes the CSS qualifier to using mainpage v2 instead of the new skin.

## How did you test this change?

Dev tools
