### PR TITLE
fix(mainpage): ow wiki missing padding on TournamentsTicker panel

### DIFF
--- a/lua/wikis/overwatch/MainPageLayout/data.lua
+++ b/lua/wikis/overwatch/MainPageLayout/data.lua
@@ -68,6 +68,7 @@ local CONTENT = {
 			upcomingDays = 120,
 			completedDays = 30
 		},
+		padding = true,
 		boxid = 1508,
 	},
 }


### PR DESCRIPTION
## Summary

For some reason the OW wiki mainpage was missing the padding param for the TournamentsTicker panel. With the changes to the new layout, it looks quite bad.

| OW | R6 |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7088e4b2-b720-4852-9e54-88460ebeab58) | ![image](https://github.com/user-attachments/assets/6304eb27-1e8d-4848-835b-153dd2ce6511) | 

## How did you test this change?

Untested, but just copied the same param from all the other mainpage data modules to this one.
