### PR TITLE
feat(transfer): allow per-wiki settings for contract database TRef type

### DIFF
--- a/lua/wikis/commons/Transfer/References.lua
+++ b/lua/wikis/commons/Transfer/References.lua
@@ -313,8 +313,7 @@ function TransferRef._getTextAndLink(reference, options)
 	elseif refType == INSIDE_TYPE then
 			return 'Liquipedia has gained this information from a trusted inside source.'
 	elseif refType == CONTRACT_TYPE then
-		local transferConfig = Info.config.transfers or {}
-		local contractDatabaseRef = transferConfig.contractDatabaseRef
+		local contractDatabaseRef = (Info.config.transfers or {}).contractDatabaseRef
 		assert(contractDatabaseRef, 'Contract database type is not available')
 		link = contractDatabaseRef.link
 		local displayText = contractDatabaseRef.display

--- a/lua/wikis/commons/Transfer/References.lua
+++ b/lua/wikis/commons/Transfer/References.lua
@@ -319,7 +319,7 @@ function TransferRef._getTextAndLink(reference, options)
 		link = contractDatabaseRef.link
 		local displayText = contractDatabaseRef.display
 		return 'Transfer was not formally announced, but was revealed by changes in the ' ..
-			(linkInsideText and Page.makeExternalLink(displayText, link) .. '.' or displayText),
+			(linkInsideText and Page.makeExternalLink(displayText, link) or displayText) .. '.',
 			not linkInsideText and link or nil
 	end
 end

--- a/lua/wikis/commons/Transfer/References.lua
+++ b/lua/wikis/commons/Transfer/References.lua
@@ -11,8 +11,11 @@ local Array = require('Module:Array')
 local Icon = require('Module:Icon')
 local Json = require('Module:Json')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local Variables = require('Module:Variables')
+
+local Info = Lua.import('Module:Info', {loadData = true})
 
 local TransferRef = {}
 
@@ -310,10 +313,13 @@ function TransferRef._getTextAndLink(reference, options)
 	elseif refType == INSIDE_TYPE then
 			return 'Liquipedia has gained this information from a trusted inside source.'
 	elseif refType == CONTRACT_TYPE then
-		link = 'https://docs.google.com/spreadsheets/d/1Y7k5kQ2AegbuyiGwEPsa62e883FYVtHqr6UVut9RC4o/pubhtml#'
-		local appendedText = 'LoL Esports League-Recognized Contract Database'
+		local transferConfig = Info.config.transfers or {}
+		local contractDatabaseRef = transferConfig.contractDatabaseRef
+		assert(contractDatabaseRef, 'Contract database type is not available')
+		link = contractDatabaseRef.link
+		local displayText = contractDatabaseRef.display
 		return 'Transfer was not formally announced, but was revealed by changes in the ' ..
-			(linkInsideText and Page.makeExternalLink(appendedText, link) .. '.' or appendedText),
+			(linkInsideText and Page.makeExternalLink(displayText, link) .. '.' or displayText),
 			not linkInsideText and link or nil
 	end
 end

--- a/lua/wikis/commons/Transfer/References.lua
+++ b/lua/wikis/commons/Transfer/References.lua
@@ -313,7 +313,7 @@ function TransferRef._getTextAndLink(reference, options)
 		link = 'https://docs.google.com/spreadsheets/d/1Y7k5kQ2AegbuyiGwEPsa62e883FYVtHqr6UVut9RC4o/pubhtml#'
 		local appendedText = 'LoL Esports League-Recognized Contract Database'
 		return 'Transfer was not formally announced, but was revealed by changes in the ' ..
-			(linkInsideText and '[' .. link .. '|' .. appendedText .. ']].' or appendedText),
+			(linkInsideText and Page.makeExternalLink(appendedText, link) .. '.' or appendedText),
 			not linkInsideText and link or nil
 	end
 end

--- a/lua/wikis/commons/Transfer/References.lua
+++ b/lua/wikis/commons/Transfer/References.lua
@@ -313,10 +313,10 @@ function TransferRef._getTextAndLink(reference, options)
 	elseif refType == INSIDE_TYPE then
 			return 'Liquipedia has gained this information from a trusted inside source.'
 	elseif refType == CONTRACT_TYPE then
-		local contractDatabaseRef = (Info.config.transfers or {}).contractDatabaseRef
-		assert(contractDatabaseRef, 'Contract database type is not available on this wiki')
-		link = contractDatabaseRef.link
-		local displayText = contractDatabaseRef.display
+		local contractDatabase = (Info.config.transfers or {}).contractDatabase
+		assert(contractDatabase, 'Contract database type is not available on this wiki')
+		link = contractDatabase.link
+		local displayText = contractDatabase.display
 		return 'Transfer was not formally announced, but was revealed by changes in the ' ..
 			(linkInsideText and Page.makeExternalLink(displayText, link) or displayText) .. '.',
 			not linkInsideText and link or nil

--- a/lua/wikis/commons/Transfer/References.lua
+++ b/lua/wikis/commons/Transfer/References.lua
@@ -314,7 +314,7 @@ function TransferRef._getTextAndLink(reference, options)
 			return 'Liquipedia has gained this information from a trusted inside source.'
 	elseif refType == CONTRACT_TYPE then
 		local contractDatabaseRef = (Info.config.transfers or {}).contractDatabaseRef
-		assert(contractDatabaseRef, 'Contract database type is not available')
+		assert(contractDatabaseRef, 'Contract database type is not available on this wiki')
 		link = contractDatabaseRef.link
 		local displayText = contractDatabaseRef.display
 		return 'Transfer was not formally announced, but was revealed by changes in the ' ..

--- a/lua/wikis/leagueoflegends/Info.lua
+++ b/lua/wikis/leagueoflegends/Info.lua
@@ -39,7 +39,7 @@ return {
 		},
 		transfers = {
 			showTeamName = true,
-			contractDatabaseRef = {
+			contractDatabase = {
 				link = 'https://docs.google.com/spreadsheets/d/1Y7k5kQ2AegbuyiGwEPsa62e883FYVtHqr6UVut9RC4o/pubhtml',
 				display = 'LoL Esports League-Recognized Contract Database'
 			},

--- a/lua/wikis/leagueoflegends/Info.lua
+++ b/lua/wikis/leagueoflegends/Info.lua
@@ -39,6 +39,10 @@ return {
 		},
 		transfers = {
 			showTeamName = true,
+			contractDatabaseRef = {
+				link = 'https://docs.google.com/spreadsheets/d/1Y7k5kQ2AegbuyiGwEPsa62e883FYVtHqr6UVut9RC4o/pubhtml',
+				display = 'LoL Esports League-Recognized Contract Database'
+			},
 		},
 	},
 	defaultRoundPrecision = 0,

--- a/lua/wikis/valorant/Info.lua
+++ b/lua/wikis/valorant/Info.lua
@@ -38,7 +38,7 @@ return {
 			gameScoresIfBo1 = true,
 		},
 		transfers = {
-			contractDatabaseRef = {
+			contractDatabase = {
 				-- luacheck: push ignore
 				link = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRmmWiBmMMD43m5VtZq54nKlmj0ZtythsA1qCpegwx-iRptx2HEsG0T3cQlG1r2AIiKxBWnaurJZQ9Q/pubhtml',
 				-- luacheck: pop

--- a/lua/wikis/valorant/Info.lua
+++ b/lua/wikis/valorant/Info.lua
@@ -39,7 +39,9 @@ return {
 		},
 		transfers = {
 			contractDatabaseRef = {
+				-- luacheck: push ignore
 				link = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRmmWiBmMMD43m5VtZq54nKlmj0ZtythsA1qCpegwx-iRptx2HEsG0T3cQlG1r2AIiKxBWnaurJZQ9Q/pubhtml',
+				-- luacheck: pop
 				display = 'VALORANT Champions Tour Global Contract Database'
 			},
 		},

--- a/lua/wikis/valorant/Info.lua
+++ b/lua/wikis/valorant/Info.lua
@@ -37,5 +37,11 @@ return {
 			matchWidth = 180,
 			gameScoresIfBo1 = true,
 		},
+		transfers = {
+			contractDatabaseRef = {
+				link = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRmmWiBmMMD43m5VtZq54nKlmj0ZtythsA1qCpegwx-iRptx2HEsG0T3cQlG1r2AIiKxBWnaurJZQ9Q/pubhtml',
+				display = 'VALORANT Champions Tour Global Contract Database'
+			},
+		},
 	},
 }


### PR DESCRIPTION
## Summary

Currently `CONTRACT_TYPE` has hardcoded values in Commons that are specific to League of Legends.
This PR extracts the hardcoded values to `Module:Info`, and makes TRef to read from the stored config instead.

This PR also adds contract database config for Valorant.

## How did you test this change?

dev