### PR TITLE
feat(infobox): add valve tier info icon for league on cs wiki

### DIFF
--- a/lua/wikis/commons/Icon.lua
+++ b/lua/wikis/commons/Icon.lua
@@ -18,6 +18,8 @@ local Icon = {}
 ---@field screenReaderHidden boolean?
 ---@field hover string?
 ---@field size integer|string|nil
+---@field pageLink string?
+---@field externalLink string?
 ---@field additionalClasses string[]?
 ---@field attributes table<string, string>?
 
@@ -33,7 +35,7 @@ function Icon.makeIcon(props)
 	if Logic.isNumeric(size) then
 		size = size .. 'px'
 	end
-	return tostring(mw.html.create('i')
+	local iconString = tostring(mw.html.create('i')
 			:addClass(icon)
 			:addClass(props.color)
 			:addClass(Logic.isNotEmpty(props.additionalClasses) and table.concat(props.additionalClasses, ' ') or nil)
@@ -42,6 +44,14 @@ function Icon.makeIcon(props)
 			:attr('aria-hidden', props.screenReaderHidden and 'true' or nil)
 			:attr(props.attributes and props.attributes or {})
 	)
+
+	if Logic.isNotEmpty(props.pageLink) then
+		return '[[' .. props.pageLink .. '|' .. iconString .. ']]'
+	elseif Logic.isNotEmpty(props.externalLink) then
+		return '[' .. props.pageLink .. ' ' .. iconString .. ']'
+	else
+		return iconString
+	end
 end
 
 return Class.export(Icon)

--- a/lua/wikis/commons/Icon/Data.lua
+++ b/lua/wikis/commons/Icon/Data.lua
@@ -126,4 +126,7 @@ return {
 
 	-- Usage: Charts
 	chart = 'far fa-chart-line',
+
+	--Usage: Generic info icon
+	info = 'fas fa-info-circle',
 }

--- a/lua/wikis/counterstrike/Infobox/League/Custom.lua
+++ b/lua/wikis/counterstrike/Infobox/League/Custom.lua
@@ -20,6 +20,7 @@ local Variables = require('Module:Variables')
 local Currency = Lua.import('Module:Currency')
 local Game = Lua.import('Module:Game')
 local HighlightConditions = Lua.import('Module:HighlightConditions')
+local Icon = Lua.import('Module:Icon')
 local InfoboxPrizePool = Lua.import('Module:Infobox/Extensions/PrizePool')
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
@@ -85,10 +86,14 @@ local VALVE_TIERS = {
 	['rmr event'] = {meta = 'Regional Major Rankings event', name = 'RMR Event', link = 'Regional Major Rankings'},
 	['tier 1'] = {meta = 'Valve Tier 1 event', name = 'Tier 1', link = 'Valve Tier 1 Events'},
 	['tier 1 qualifier'] = {meta = 'Valve Tier 1 qualifier', name = 'Tier 1 Qualifier', link = 'Valve Tier 1 Events'},
+	['tier 1 wildcard'] = {meta = 'Valve Tier 1 Wildcard event', name = 'Tier 1 Wildcard', link = 'Valve Wildcard Events'},
 	['tier 2'] = {meta = 'Valve Tier 2 event', name = 'Tier 2', link = 'Valve Tier 2 Events'},
 	['tier 2 qualifier'] = {meta = 'Valve Tier 2 qualifier', name = 'Tier 2 Qualifier', link = 'Valve Tier 2 Events'},
+	['tier 2 wildcard'] = {meta = 'Valve Tier 2 Wildcard event', name = 'Tier 2 Wildcard', link = 'Valve Wildcard Events'},
 	['wildcard'] = {meta = 'Valve Wildcard event', name = 'Wildcard', link = 'Valve Wildcard Events'},
 }
+
+local VALVE_TOR_START_DATE = '2025-01-01'
 
 local RESTRICTIONS = {
 	female = {
@@ -380,7 +385,14 @@ end
 ---@return string?
 function CustomLeague:_createValveTierCell()
 	if self.valveTier then
-		return '[[' .. self.valveTier.link .. '|' .. self.valveTier.name .. ']]'
+		local tierLink = '[[' .. self.valveTier.link .. '|' .. self.valveTier.name .. ']]'
+		local torInfo = (self.data.endDate >= VALVE_TOR_START_DATE) and Icon.makeIcon({
+				iconName = 'matchpopup',
+				hover = 'Click for further details',
+				pageLink = '#Valve Operational Requirements',
+				attributes = {style = 'color: var(--clr-on-background);'}
+			}) or ''
+		return tierLink .. (Logic.isNotEmpty(torInfo) and ('&ensp;' .. torInfo) or '')
 	end
 end
 

--- a/lua/wikis/counterstrike/Infobox/League/Custom.lua
+++ b/lua/wikis/counterstrike/Infobox/League/Custom.lua
@@ -387,7 +387,7 @@ function CustomLeague:_createValveTierCell()
 	if self.valveTier then
 		local tierLink = '[[' .. self.valveTier.link .. '|' .. self.valveTier.name .. ']]'
 		local torInfo = (self.data.endDate >= VALVE_TOR_START_DATE) and Icon.makeIcon({
-				iconName = 'matchpopup',
+				iconName = 'info',
 				hover = 'Click for further details',
 				pageLink = '#Valve Operational Requirements',
 				attributes = {style = 'color: var(--clr-on-background);'}


### PR DESCRIPTION
## Summary

Adds a icon to CS valve tier section for any tournaments ending in 2025 or later. This will link to a new section on tournament pages with more info about the valve tier.

![image](https://github.com/user-attachments/assets/9e379b19-ab92-4fc9-9b6b-4ef557a647eb)


## How did you test this change?

Tested on /dev.
