### PR TITLE
refactor(match2): use standardProcessMaps in leagueoflegends

### DIFF
--- a/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
 local HeroNames = mw.loadData('Module:ChampionNames')
 local Lua = require('Module:Lua')
-local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 

--- a/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
@@ -77,9 +77,7 @@ end
 function MatchFunctions.extractMaps(match, opponents, MapParser)
 	---@type MapParserInterface
 	local mapParserWrapper = {
-		calculateMapScore = function(map)
-			return MapFunctions.calculateMapScore(map.winner, map.finished)
-		end,
+		calculateMapScore = MapFunctions.calculateMapScore,
 		getExtraData = FnUtil.curry(MapFunctions.getExtraData, MapParser),
 		getMap = MapParser.getMap,
 		getLength = MapParser.getLength,
@@ -178,14 +176,13 @@ function MapFunctions.getPlayersOfMapOpponent(MapParser, map, opponent, opponent
 	)
 end
 
----@param winnerInput string|integer|nil
----@param finished boolean
+---@param map table
 ---@return fun(opponentIndex: integer): integer?
-function MapFunctions.calculateMapScore(winnerInput, finished)
-	local winner = tonumber(winnerInput)
+function MapFunctions.calculateMapScore(map)
+	local winner = tonumber(map.winner)
 	return function(opponentIndex)
 		-- TODO Better to check if map has started, rather than finished, for a more correct handling
-		if not winner and not finished then
+		if not winner and not map.finished then
 			return
 		end
 		return winner == opponentIndex and 1 or 0


### PR DESCRIPTION
## Summary

This PR updates leagueoflegends match2 to use `MatchGroupInputUtil.standardProcessMaps`

## How did you test this change?

dev
