### PR TITLE
docs(date): Always return string type for `DateExt.formatTimestamp`

### DIFF
--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -337,7 +337,7 @@ end
 ---@param format string
 ---@param timestamp string|osdateparam?
 ---@param localTime boolean?
----@return number|string
+---@return string
 function mw.language:formatDate(format, timestamp, localTime)
 	local function localTimezoneOffset(ts)
 		local utcDt = os.date("!*t", ts)

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -361,10 +361,10 @@ function mw.language:formatDate(format, timestamp, localTime)
 
 	if format == 'U' then
 		if not timestamp then
-			return os.time(os.date("!*t") --[[@as osdateparam]])
+			return tostring(os.time(os.date("!*t") --[[@as osdateparam]]))
 		end
 		if type(timestamp) ~= 'string' then
-			return os.time(timestamp)
+			return tostring(os.time(timestamp))
 		end
 		local tzHour, tzMinutes = timestamp:match('([%-%+]%d?%d):(%d%d)$')
 		local offset = 0
@@ -379,7 +379,7 @@ function mw.language:formatDate(format, timestamp, localTime)
 
 		local ts = os.time(makeOsdateParam(year, month, day, hour, minute, second)) - offset
 
-		return ts + localTimezoneOffset(ts)
+		return tostring(ts + localTimezoneOffset(ts))
 	elseif format == 'c' then
 		local outFormat = '%Y-%m-%dT%H:%M:%S'
 		if not timestamp then

--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -82,7 +82,7 @@ end)
 --- The format string is the same used by mw.language.formatDate and {{#time}}.
 ---@param format string
 ---@param timestamp string|integer
----@return string|number
+---@return string
 function DateExt.formatTimestamp(format, timestamp)
 	return mw.getContentLanguage():formatDate(format, '@' .. timestamp)
 end

--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -100,8 +100,7 @@ end
 ---@param dateOrTimestamp string|integer|osdate|osdateparam
 ---@return string
 function DateExt.toYmdInUtc(dateOrTimestamp)
-	-- Return value is cast as string because format 'Y-m-d' should not be interpreted as a number
-	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp) or '') --[[@as string]]
+	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp) or '')
 end
 
 ---@param dateString string|integer|osdate|osdateparam

--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -98,9 +98,10 @@ end
 --- Truncates the time of day in a date string or timestamp, and returns the date formatted as yyyy-mm-dd.
 --- The time of day is truncated in the UTC timezone. The time of day and timezone are discarded.
 ---@param dateOrTimestamp string|integer|osdate|osdateparam
----@return string|number
+---@return string
 function DateExt.toYmdInUtc(dateOrTimestamp)
-	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp) or '')
+	-- Return value is cast as string because format 'Y-m-d' should not be interpreted as a number
+	return DateExt.formatTimestamp('Y-m-d', DateExt.readTimestamp(dateOrTimestamp) or '') --[[@as string]]
 end
 
 ---@param dateString string|integer|osdate|osdateparam

--- a/lua/wikis/smash/Infobox/League/Custom.lua
+++ b/lua/wikis/smash/Infobox/League/Custom.lua
@@ -431,7 +431,7 @@ function CustomLeague:_formatDate(date)
 
 		-- Month and year are known
 	elseif dateParts[3] == UNKNOWN_DATE_PART then
-		return tostring(mw.getContentLanguage():formatDate('F Y', dateParts[1] .. '-' .. dateParts[2] .. '-01'))
+		return mw.getContentLanguage():formatDate('F Y', dateParts[1] .. '-' .. dateParts[2] .. '-01')
 
 		-- All parts known
 	else

--- a/lua/wikis/smash/Infobox/League/Custom.lua
+++ b/lua/wikis/smash/Infobox/League/Custom.lua
@@ -435,7 +435,7 @@ function CustomLeague:_formatDate(date)
 
 		-- All parts known
 	else
-		return tostring(mw.getContentLanguage():formatDate('F j, Y', date))
+		return mw.getContentLanguage():formatDate('F j, Y', date)
 	end
 end
 


### PR DESCRIPTION
## Summary

The format string used in `DateExt.toYmdInUtc()` is going to always return a string value and should not be interpreted as a number. Cast the return value this way and changed annotation.

https://discord.com/channels/93055209017729024/874304000718172200/1355919729532862825

## How did you test this change?

Tested in VS Code.
