### PR TITLE
feat(lpdb): add `datapoint` Model to Lpdb module

### DIFF
--- a/lua/wikis/commons/Lpdb.lua
+++ b/lua/wikis/commons/Lpdb.lua
@@ -285,4 +285,16 @@ Lpdb.SquadPlayer = Model('squadplayer', {
 	{name = 'extradata', fieldType = 'struct', default = {}},
 })
 
+---@class DataPoint:Model
+Lpdb.DataPoint = Model('datapoint', {
+	{name = 'objectname', fieldType = 'string'},
+	{name = 'type', fieldType = 'string', default = ''},
+	{name = 'name', fieldType = 'string', default = ''},
+	{name = 'information', fieldType = 'string', default = ''},
+	{name = 'image', fieldType = 'string', default = ''},
+	{name = 'imagedark', fieldType = 'string', default = ''},
+	{name = 'date', fieldType = 'string', default = 0},
+	{name = 'extradata', fieldType = 'struct', default = {}},
+})
+
 return Lpdb


### PR DESCRIPTION
## Summary

Added `datapoint` as a model to the LPDB module so that it can be used to store arbitrary datapoint items.

## How did you test this change?

Tested on `/dev` and it seems to work as intended (at least for storage).

| Code | LPDB |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/97ad2b4a-89f4-40a7-90f2-63fe4c1b1276) | ![image](https://github.com/user-attachments/assets/1006a79e-1bf6-4d20-b661-3f75330aecd8) | 
