### PR TITLE
feat(mainpage): format numbers in nav cards

### DIFF
--- a/lua/wikis/commons/Widget/MainPage/NavigationCard.lua
+++ b/lua/wikis/commons/Widget/MainPage/NavigationCard.lua
@@ -42,7 +42,7 @@ function NavigationCard:render()
 			},
 			count and HtmlWidgets.Span{
 				classes = {'navigation-card__subtitle'},
-				children = count,
+				children = mw.getContentLanguage():formatNum(count),
 			} or nil
 		)
 	}

--- a/lua/wikis/commons/Widget/MainPage/NavigationCard.lua
+++ b/lua/wikis/commons/Widget/MainPage/NavigationCard.lua
@@ -42,7 +42,7 @@ function NavigationCard:render()
 			},
 			count and HtmlWidgets.Span{
 				classes = {'navigation-card__subtitle'},
-				children = mw.getContentLanguage():formatNum(count),
+				children = mw.getContentLanguage():formatNum(tonumber(count) --[[@as integer]]),
 			} or nil
 		)
 	}


### PR DESCRIPTION
## Summary
format count number in nav cards on main pages with formatNum

requested on discord: https://discord.com/channels/93055209017729024/213614988647071744/1356017559216066726

## How did you test this change?
dev

before:
![IMG_5189](https://github.com/user-attachments/assets/a6a9e24a-d319-4907-9b45-48ae70d21d3f)

after:
![IMG_5188](https://github.com/user-attachments/assets/d6c3a024-275d-452a-a25f-9b20f094fff0)
