### PR TITLE
docs(Tier): un-deprecate `Tier.toNumber`

### DIFF
--- a/lua/wikis/commons/Tier/Utils.lua
+++ b/lua/wikis/commons/Tier/Utils.lua
@@ -204,10 +204,9 @@ Tier.legacyShortNumbers = FnUtil.memoize(function()
 	end)
 end)
 
---- Legacy: Converts legacy tier input to its numeric value. DEPRECATED!!!
+--- Converts legacy tier input to its numeric value.
 ---@param tier string|integer|nil
 ---@return integer?
----@deprecated
 function Tier.toNumber(tier)
 	return tonumber(tier)
 		or Tier.legacyNumbers()[string.lower(tier or ''):gsub(' ', '')]

--- a/lua/wikis/commons/Tier/Utils.lua
+++ b/lua/wikis/commons/Tier/Utils.lua
@@ -193,14 +193,14 @@ end
 ---@return {[string]: integer?}
 Tier.legacyNumbers = FnUtil.memoize(function()
 	return Table.map(TierData.tiers, function(key, data)
-		return data.name:lower():gsub(' ', ''), tonumber(key)
+		return data.name:lower(), tonumber(key)
 	end)
 end)
 
 ---@return {[string]: integer?}
 Tier.legacyShortNumbers = FnUtil.memoize(function()
 	return Table.map(TierData.tiers, function(key, data)
-		return data.short:lower():gsub(' ', ''), tonumber(key)
+		return data.short:lower(), tonumber(key)
 	end)
 end)
 
@@ -209,8 +209,8 @@ end)
 ---@return integer?
 function Tier.toNumber(tier)
 	return tonumber(tier)
-		or Tier.legacyNumbers()[string.lower(tier or ''):gsub(' ', '')]
-		or Tier.legacyShortNumbers()[string.lower(tier or ''):gsub(' ', '')]
+		or Tier.legacyNumbers()[string.lower(tier or '')]
+		or Tier.legacyShortNumbers()[string.lower(tier or '')]
 end
 
 return Tier


### PR DESCRIPTION
## Summary
as it is still used by several wikis of whom several want to keep it, i think we should un-deprecate `Tier.toNumber`
(also gets rid of some anno warnings)

wikis that currently use it:
- aoe
- brawlhalla
- cs
- fighters
- smash
- val

## How did you test this change?
VSCode