### PR TITLE
refactor(match2): use standardProcessMaps in dota2

### DIFF
--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -93,7 +93,7 @@ function MatchFunctions.extractMaps(match, opponents, MapParser)
 
 	---preprocess legacy stuff
 	for _, mapInput, mapIndex in Table.iter.pairsByPrefix(match, 'map', {requireIndex = true}) do
-		mapInput.publisherid = mapInput.matchid or String.nilIfEmpty(match['matchid' .. mapIndex])
+		mapInput.matchid = mapInput.matchid or String.nilIfEmpty(match['matchid' .. mapIndex])
 		mapInput.vod = mapInput.vod or String.nilIfEmpty(match['vodgame' .. mapIndex])
 	end
 
@@ -119,11 +119,11 @@ function MatchFunctions.getLinks(match, games)
 	links.datdota = {}
 
 	Array.forEach(
-		Array.filter(games, function(map) return map.publisherid ~= nil end),
+		Array.filter(games, function(map) return map.matchid ~= nil end),
 		function(map, mapIndex)
-			links.stratz[mapIndex] = 'https://stratz.com/match/' .. map.publisherid
-			links.dotabuff[mapIndex] = 'https://www.dotabuff.com/matches/' .. map.publisherid
-			links.datdota[mapIndex] = 'https://www.datdota.com/matches/' .. map.publisherid
+			links.stratz[mapIndex] = 'https://stratz.com/match/' .. map.matchid
+			links.dotabuff[mapIndex] = 'https://www.dotabuff.com/matches/' .. map.matchid
+			links.datdota[mapIndex] = 'https://www.datdota.com/matches/' .. map.matchid
 		end
 	)
 
@@ -172,7 +172,7 @@ end
 ---@return table
 function MapFunctions.getExtraData(MapParser, match, map, opponents)
 	local extraData = {
-		publisherid = tonumber(map.publisherid),
+		publisherid = map.matchid,
 	}
 	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, HeroNames)
 

--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -172,7 +172,7 @@ end
 ---@return table
 function MapFunctions.getExtraData(MapParser, match, map, opponents)
 	local extraData = {
-		publisherid = map.matchid,
+		publisherid = tonumber(map.matchid),
 	}
 	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, HeroNames)
 

--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -11,7 +11,6 @@ local FnUtil = require('Module:FnUtil')
 local HeroNames = mw.loadData('Module:HeroNames')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
@@ -93,7 +92,7 @@ function MatchFunctions.extractMaps(match, opponents, MapParser)
 	}
 
 	---preprocess legacy stuff
-	for key, mapInput, mapIndex in Table.iter.pairsByPrefix(match, 'map', {requireIndex = true}) do
+	for _, mapInput, mapIndex in Table.iter.pairsByPrefix(match, 'map', {requireIndex = true}) do
 		mapInput.publisherid = mapInput.matchid or String.nilIfEmpty(match['matchid' .. mapIndex])
 		mapInput.vod = mapInput.vod or String.nilIfEmpty(match['vodgame' .. mapIndex])
 	end

--- a/lua/wikis/dota2/MatchGroup/Input/Custom/MatchPage.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom/MatchPage.lua
@@ -14,8 +14,9 @@ local CustomMatchGroupInputMatchPage = {}
 
 ---@class dota2MatchDataExtended: dota2MatchData
 ---@field matchid integer
+---@field vod string?
 
----@param mapInput {matchid: string?, reversed: string?}
+---@param mapInput {matchid: string?, reversed: string?, vod: string?}
 ---@return dota2MatchDataExtended|table
 function CustomMatchGroupInputMatchPage.getMap(mapInput)
 	-- If no matchid is provided, assume this as a normal map
@@ -30,6 +31,7 @@ function CustomMatchGroupInputMatchPage.getMap(mapInput)
 	assert(map and type(map) == 'table', mapInput.matchid .. ' could not be retrieved.')
 	---@cast map dota2MatchDataExtended
 	map.matchid = matchId
+	map.vod = mapInput.vod
 
 	return map
 end


### PR DESCRIPTION
## Summary

This PR updates dota2 match2 to use `MatchGroupInputUtil.standardProcessMaps`

## How did you test this change?

dev
