### PR TITLE
feat(match2): add toggle for date, vod, stream, and maps in fighters generator

### DIFF
--- a/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
@@ -34,8 +34,8 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match|bestof=' .. bestof,
-		args.date == 'true' and INDENT .. '|date=' or nil,
-		args.vod == 'true' and INDENT .. '|twitch=|vod=' or nil,
+		Logic.readBool(args.date) and INDENT .. '|date=' or nil,
+		Logic.readBool(args.vod) and INDENT .. '|twitch=|vod=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end), 

--- a/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
@@ -38,9 +38,8 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.vod) and INDENT .. '|twitch=|vod=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
-		end), 
-		Logic.readBool(args.details) and 
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		end),
+		Logic.readBool(args.details) and Array.map(Array.range(1, bestof), function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(mode)
 		end) or nil,
 		'}}'

--- a/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
@@ -39,7 +39,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end), 
-		args.details == 'true' and 
+		Logic.readBool(args.details) and 
 		Array.map(Array.range(1, bestof), function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(mode)
 		end) or nil,

--- a/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
@@ -34,14 +34,15 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match|bestof=' .. bestof,
-		INDENT .. '|date=',
-		INDENT .. '|twitch=|vod=',
+		args.date == 'true' and INDENT .. '|date=' or nil,
+		args.vod == 'true' and INDENT .. '|twitch=|vod=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
-		end),
+		end), 
+		args.details == 'true' and 
 		Array.map(Array.range(1, bestof), function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(mode)
-		end),
+		end) or nil,
 		'}}'
 	)
 


### PR DESCRIPTION
Date, vod and stream are pretty much never used in fighters so being able to just not generating them makes sense. 

A toggle which prevent maps from being generated even if bestof is >0 was added as well. The option to set bestof to an accurate number in a large bracket and not have 100 of lines of maps added also is a pretty convenient on a wiki that uses large bracket very often. 