### PR TITLE
fix: standard lib doesn't handle namespaces with underscore correctly

### DIFF
--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -519,16 +519,16 @@ function mw.message:isBlank() end
 ---@return boolean
 function mw.message:isDisabled() end
 
----@alias namespaceInfo {id: number, name: string, canonicalName: string, displayName: string, hasSubpages: boolean, hasGenderDistinction: boolean, isCapitalized: boolean, isContent: boolean, isIncludable: boolean, isMovable:boolean, isSubject: boolean, isTalk: boolean, defaultContentModel: string, aliases: string[], subject: namespaceInfo, talk: namespaceInfo, associated: namespaceInfo}
+---@alias namespaceInfo {id: integer, name: string, canonicalName: string, displayName: string, hasSubpages: boolean, hasGenderDistinction: boolean, isCapitalized: boolean, isContent: boolean, isIncludable: boolean, isMovable:boolean, isSubject: boolean, isTalk: boolean, defaultContentModel: string, aliases: string[], subject: namespaceInfo, talk: namespaceInfo, associated: namespaceInfo}
 ---@class Site
 ---@field currentVersion string
 ---@field scriptPath string
 ---@field server string
 ---@field siteName string
----@field namespaces table<number|string, namespaceInfo>
----@field contentNamespaces table<number|string, namespaceInfo>
----@field subjectNamespaces table<number|string, namespaceInfo>
----@field talkNamespaces table<number|string, namespaceInfo>
+---@field namespaces table<integer, namespaceInfo>
+---@field contentNamespaces table<integer, namespaceInfo>
+---@field subjectNamespaces table<integer, namespaceInfo>
+---@field talkNamespaces table<integer, namespaceInfo>
 ---@field stats {pages: number, articles: number, files: number, edits: number, users: number, activeUsers: number, admins: number, pagesInCategory: fun(category: string, which: 'all'|'subcats'|'files'|'pages'|'*'):integer}
 mw.site = {server = 'https://liquipedia.net/wiki/'}
 

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -77,6 +77,7 @@ end)
 ---@param name string?
 ---@return integer?
 function Namespace.idFromName(name)
+	name = (name or ''):gsub('_', ' ')
 	return Namespace.getIdsByName()[name]
 end
 

--- a/lua/wikis/commons/TournamentStructure.lua
+++ b/lua/wikis/commons/TournamentStructure.lua
@@ -178,7 +178,7 @@ end
 function TournamentStructure.getMatchGroupFilter(matchGroupId)
 	local namespaceName = matchGroupId:match('^(%w+)_')
 	local clauses = Array.extend(
-		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName) .. ']]') or nil,
+		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName:gsub('_', ' ')) .. ']]') or nil,
 		'[[match2bracketid::' .. matchGroupId .. ']]'
 	)
 	return table.concat(clauses, ' AND ')
@@ -191,7 +191,7 @@ end
 function TournamentStructure.getPageNameFilter(matchGroupType, pageName)
 	local namespaceName, basePageName, stageName = TournamentStructure._splitPageName(pageName)
 	local clauses = Array.extend(
-		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName) .. ']]') or nil,
+		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName:gsub('_', ' ')) .. ']]') or nil,
 		('[[pagename::' .. basePageName:gsub('%s', '_') .. ']]'),
 		stageName and (matchGroupType == 'bracket') and ('[[match2bracketdata_sectionheader::' .. stageName .. ']]') or nil,
 		stageName and (matchGroupType == 'standingstable') and ('[[extradata_stagename::' .. stageName .. ']]') or nil

--- a/lua/wikis/commons/TournamentStructure.lua
+++ b/lua/wikis/commons/TournamentStructure.lua
@@ -178,7 +178,7 @@ end
 function TournamentStructure.getMatchGroupFilter(matchGroupId)
 	local namespaceName = matchGroupId:match('^(%w+)_')
 	local clauses = Array.extend(
-		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName:gsub('_', ' ')) .. ']]') or nil,
+		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName) .. ']]') or nil,
 		'[[match2bracketid::' .. matchGroupId .. ']]'
 	)
 	return table.concat(clauses, ' AND ')
@@ -191,7 +191,7 @@ end
 function TournamentStructure.getPageNameFilter(matchGroupType, pageName)
 	local namespaceName, basePageName, stageName = TournamentStructure._splitPageName(pageName)
 	local clauses = Array.extend(
-		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName:gsub('_', ' ')) .. ']]') or nil,
+		namespaceName and ('[[namespace::' .. Namespace.idFromName(namespaceName) .. ']]') or nil,
 		('[[pagename::' .. basePageName:gsub('%s', '_') .. ']]'),
 		stageName and (matchGroupType == 'bracket') and ('[[match2bracketdata_sectionheader::' .. stageName .. ']]') or nil,
 		stageName and (matchGroupType == 'standingstable') and ('[[extradata_stagename::' .. stageName .. ']]') or nil


### PR DESCRIPTION
## Summary
currently if a namespace with undersocre (e.g. `User_talk:`) is used we get a nil return which can cause nil concats in some places
This PR fixes that issue by switching underscores to spaces in `Namespace.idFromName`
Also: fixed some annos for mw.site so an anno warning in `Module:Namespace` vanished

## How did you test this change?
dev