### PR TITLE
feat(match2): add matchpage support to copy-paste generator

### DIFF
--- a/lua/wikis/commons/GetMatchGroupCopyPaste.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste.lua
@@ -236,6 +236,8 @@ function CopyPaste.matchPage(frame, args)
 		args = Arguments.getArgs(frame)
 	end
 
+	args.generateMatchPage = true
+
 	local bestof = tonumber(args.bestof) or 3
 	local opponents = tonumber(args.opponents) or 2
 	local mode = WikiSpecific.getMode(args.mode)

--- a/lua/wikis/commons/GetMatchGroupCopyPaste.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste.lua
@@ -245,7 +245,7 @@ function CopyPaste.matchPage(frame, args)
 	local display = WikiSpecific.getMatchCode(bestof, mode, 1, opponents, args)
 
 	-- Manually change 'Match' to 'MatchPage'
-	display = display:gsub('()',{[8]='Page'})
+	display = display:gsub('Match2?', 'MatchPage')
 
 	return CopyPaste._generateCopyPaste(display)
 end

--- a/lua/wikis/commons/GetMatchGroupCopyPaste.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste.lua
@@ -228,6 +228,26 @@ function CopyPaste.singleMatch(frame, args)
 	return CopyPaste._generateCopyPaste(display)
 end
 
+---@param frame Frame
+---@param args table
+---@return Html
+function CopyPaste.matchPage(frame, args)
+	if not args then
+		args = Arguments.getArgs(frame)
+	end
+
+	local bestof = tonumber(args.bestof) or 3
+	local opponents = tonumber(args.opponents) or 2
+	local mode = WikiSpecific.getMode(args.mode)
+
+	local display = WikiSpecific.getMatchCode(bestof, mode, 1, opponents, args)
+
+	-- Manually change 'Match' to 'MatchPage'
+	display = display:gsub('()',{[8]='Page'})
+
+	return CopyPaste._generateCopyPaste(display)
+end
+
 ---@param display string
 ---@return Html
 function CopyPaste._generateCopyPaste(display)

--- a/lua/wikis/commons/GetMatchGroupCopyPaste.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste.lua
@@ -245,7 +245,7 @@ function CopyPaste.matchPage(frame, args)
 	local display = WikiSpecific.getMatchCode(bestof, mode, 1, opponents, args)
 
 	-- Manually change 'Match' to 'MatchPage'
-	display = display:gsub('Match2?', 'MatchPage')
+	display = display:gsub('Match2?', 'MatchPage', 1)
 
 	return CopyPaste._generateCopyPaste(display)
 end

--- a/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
@@ -42,7 +42,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|matchid'.. mapIndex ..'='
 		end),
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, bans)
+			return WikiCopyPaste._getMapCode(mapIndex, args)
 		end),
 		'}}'
 	)
@@ -51,9 +51,13 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 ---@param mapIndex integer
----@param bans boolean
+---@param args table
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, bans)
+function WikiCopyPaste._getMapCode(mapIndex, args)
+	if Logic.readBool(args.generateMatchPage) then
+		return INDENT .. '|map' .. mapIndex .. '={{ApiMap|matchid=|reversed=}}'
+	end
+	local bans = Logic.readBool(args.bans)
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map',
 		INDENT .. INDENT .. '|team1side=',

--- a/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
@@ -21,7 +21,6 @@ local INDENT = ''
 --returns the Code for a Match, depending on the input
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil, bestof == 0)
-	local bans = Logic.readBool(args.bans)
 
 	local lines = Array.extend(
 		'{{Match',

--- a/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
@@ -21,6 +21,7 @@ local INDENT = ''
 --returns the Code for a Match, depending on the input
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil, bestof == 0)
+	local generateMatchPage = Logic.readBool(args.generateMatchPage)
 
 	local lines = Array.extend(
 		'{{Match',
@@ -37,11 +38,11 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Array.map(Array.range(1, bestof), function(mapIndex)
 			return INDENT .. '|vodgame'.. mapIndex ..'='
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		generateMatchPage and {} or Array.map(Array.range(1, bestof), function(mapIndex)
 			return INDENT .. '|matchid'.. mapIndex ..'='
 		end),
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, args)
+			return WikiCopyPaste._getMapCode(mapIndex, Logic.readBool(args.bans), generateMatchPage)
 		end),
 		'}}'
 	)
@@ -50,13 +51,13 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 ---@param mapIndex integer
----@param args table
+---@param bans boolean
+---@param generateMatchPage boolean
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, args)
-	if Logic.readBool(args.generateMatchPage) then
+function WikiCopyPaste._getMapCode(mapIndex, bans, generateMatchPage)
+	if Logic.readBool(generateMatchPage) then
 		return INDENT .. '|map' .. mapIndex .. '={{ApiMap|matchid=|reversed=}}'
 	end
-	local bans = Logic.readBool(args.bans)
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map',
 		INDENT .. INDENT .. '|team1side=',

--- a/lua/wikis/leagueoflegends/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/leagueoflegends/GetMatchGroupCopyPaste/wiki.lua
@@ -31,7 +31,6 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	end
 
 	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
-	local bans = Logic.readBool(args.bans)
 	local casters = tonumber(args.casters) or 0
 
 	local lines = Array.extend(
@@ -55,7 +54,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			return INDENT .. '|vodgame'.. mapIndex ..'='
 		end),
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return WikiCopyPaste._getMapCode(mapIndex, bans)
+			return WikiCopyPaste._getMapCode(mapIndex, args)
 		end),
 		'}}'
 	)
@@ -64,9 +63,13 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 end
 
 ---@param mapIndex integer
----@param bans boolean
+---@param args table
 ---@return string
-function WikiCopyPaste._getMapCode(mapIndex, bans)
+function WikiCopyPaste._getMapCode(mapIndex, args)
+	if Logic.readBool(args.generateMatchPage) then
+		return INDENT .. '|map' .. mapIndex .. '={{ApiMap|matchid=|reversed=}}'
+	end
+	local bans = Logic.readBool(args.bans)
 	return table.concat(Array.extend(
 		INDENT .. '|map' .. mapIndex .. '={{Map',
 		INDENT .. INDENT .. '|team1side=',


### PR DESCRIPTION
## Summary

resolves #5605

~~Note: wouldn't work properly on dota2 until #5749 gets merged~~ mitigation: 25aad18...7121397

## How did you test this change?

- [dota2:Special:RunQuery/MatchPageCopyPaste/dev](<https://liquipedia.net/dota2/Special:RunQuery/MatchPageCopyPaste/dev>)
- [leagueoflegends:Special:RunQuery/MatchPageCopyPaste/dev](<https://liquipedia.net/leagueoflegends/Special:RunQuery/MatchPageCopyPaste/dev>)