### PR TITLE
feat(match2): standardize template usage on dota2

### DIFF
--- a/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
@@ -24,7 +24,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local bans = Logic.readBool(args.bans)
 
 	local lines = Array.extend(
-		'{{Match2', -- Template:Match is used by match1 for now. Using Template:Match2 until it has been worked away.
+		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)


### PR DESCRIPTION
## Checklists

- [x] Replace all `{{Match}}` usages with `{{Match/old}}` (former is redirect of latter)
- [x] Archive local version of `{{Match}}`
- [x] bot existing `{{Match2}}` to `{{Match}}`  

## How did you test this change?

N/A