### PR TITLE
feat: update bg-color for map veto "protect"

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -817,7 +817,7 @@ div.brkts-popup-body-element-thumbs {
 }
 
 .brkts-popup-mapveto .brkts-popup-mapveto-protect {
-	background-color: var( --clr-vividviolet-90, #f1d2fa ) !important;
+	background-color: var( --clr-vividviolet-background-color, #f1d2fa ) !important;
 }
 
 .brkts-popup-mvp {


### PR DESCRIPTION
## Summary

Updating color scheme for protect as it doesn't look good in darkmode. 
Text no readable 

Before:
![image](https://github.com/user-attachments/assets/485e1b05-171b-4a0e-8535-a044fdef2d47)
![image](https://github.com/user-attachments/assets/b3dfad41-a441-44fc-b18d-f02be3db4eed)


After:
![image](https://github.com/user-attachments/assets/2973e7d7-ddf0-47ef-97b5-038e4be1a9a1)
![image](https://github.com/user-attachments/assets/a3a5e135-5a2b-41c4-9df6-6b92404d294c)


## How did you test this change?

inspect mode

