### PR TITLE
refactor(resultsTable): use `DateExt` instead of `mw.lang`

### DIFF
--- a/lua/wikis/commons/ResultsTable.lua
+++ b/lua/wikis/commons/ResultsTable.lua
@@ -9,6 +9,7 @@
 local Abbreviation = require('Module:Abbreviation')
 local Class = require('Module:Class')
 local Currency = require('Module:Currency')
+local DateExt = require('Module:Date/Ext')
 local Game = require('Module:Game')
 local LeagueIcon = require('Module:LeagueIcon')
 local Lua = require('Module:Lua')
@@ -66,7 +67,7 @@ function ResultsTable:buildRow(placement)
 
 	local row = mw.html.create('tr')
 		:addClass(self:rowHighlight(placement))
-		:tag('td'):wikitext(mw.getContentLanguage():formatDate('Y-m-d', placement.date)):done()
+		:tag('td'):wikitext(DateExt.toYmdInUtc(placement.date)):done()
 		:node(placementCell)
 
 	local tierDisplay, tierSortValue = self:tierDisplay(placement)

--- a/lua/wikis/commons/ResultsTable/Award.lua
+++ b/lua/wikis/commons/ResultsTable/Award.lua
@@ -8,6 +8,7 @@
 
 local Class = require('Module:Class')
 local Currency = require('Module:Currency')
+local DateExt = require('Module:Date/Ext')
 local LeagueIcon = require('Module:LeagueIcon')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
@@ -51,7 +52,7 @@ end
 function AwardsTable:buildRow(placement)
 	local row = mw.html.create('tr')
 		:addClass(self:rowHighlight(placement))
-		:tag('td'):wikitext(mw.getContentLanguage():formatDate('Y-m-d', placement.date)):done()
+		:tag('td'):wikitext(DateExt.toYmdInUtc(placement.date)):done()
 
 	local tierDisplay, tierSortValue = self:tierDisplay(placement)
 


### PR DESCRIPTION
## Summary

Both tables use `mw.getContentLanguage():formatDate('Y-m-d', placement.date)` instead of the pre-defined `DateExt.toYmdInUtc(placement.date)`. Just changing them to match the standard approach.

## How did you test this change?

Currently untested.
