### PR TITLE
fix(match table): Do not add tracking category when linking to subpage

### DIFF
--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -313,7 +313,7 @@ function MatchTable:query()
 		table.insert(self.matches, self:matchFromRecord(match) or nil)
 	end, self.config.limit)
 
-	if self.config.limit and self.config.limit == #self.matches then
+	if self.config.limit and self.config.limit == #self.matches and not self.config.linkSubPage then
 		mw.ext.TeamLiquidIntegration.add_category('Limited match pages')
 	end
 


### PR DESCRIPTION
## Summary
The tracking category is meant for pages that are meant to display a complete list, but run into the set limit and thus omit matches.
Some wikis use short versions on an opponent's page, similar to Achievements vs. Results tables, and link to a subpage with the entire list. These tables shouldn't be added to the tracking category.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
