### PR TITLE
feat(Faction): Add option to show name besides Icon

### DIFF
--- a/lua/wikis/commons/Faction.lua
+++ b/lua/wikis/commons/Faction.lua
@@ -168,6 +168,7 @@ end
 ---@field size string|number|nil
 ---@field title string?
 ---@field game string?
+---@field showName boolean?
 Faction.propTypes.Icon = TypeUtil.struct{
 	faction = 'string',
 	showLink = 'boolean?',
@@ -175,6 +176,7 @@ Faction.propTypes.Icon = TypeUtil.struct{
 	size = TypeUtil.union('string', 'number', 'nil'),
 	title = 'string?',
 	game = 'string?',
+	showName = 'boolean?',
 }
 
 local namedSizes = {
@@ -211,6 +213,7 @@ function Faction.Icon(props)
 		.. '|' .. size
 		.. (props.showTitle ~= false and '|' .. (props.title or factionProps.name) or '')
 		.. ']]'
+		.. (props.showName and ('&nbsp;' .. (props.title or factionProps.name)) or '')
 end
 
 


### PR DESCRIPTION
## Summary
Adds an option to show the name of the faction when using the Icon entrypoint.
This allows to display a faction icon and name from direct invoke of the faction module.
The existing toName function is not compatible with direct invokes due to the argument structure.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev:
![grafik](https://github.com/user-attachments/assets/51c7055a-3b57-428c-90a0-c4fc24ed1796)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
