### PR TITLE
fix(Lua): Remove arguments after calling getArgs

### DIFF
--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -138,7 +138,7 @@ function Class._frameToArgs(frame, options)
 		elseif key == 'module' or key == 'fn' or key == 'dev' then
 			-- Do not pass reserved arguments
 			-- Used by Lua.invoke
-			-- luacheck: ignore empty block (Loop can be executed at most once)
+			-- luacheck: ignore 542 (Empty if block)
 		else
 			namedArgs[key] = value
 		end

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -135,9 +135,10 @@ function Class._frameToArgs(frame, options)
 	for key, value in pairs(args) do
 		if type(key) == 'number' then
 			indexedArgs[key] = value
-		elseif key == 'module' or key == 'fn' then
+		elseif key == 'module' or key == 'fn' or key == 'dev' then
 			-- Do not pass reserved arguments
 			-- Used by Lua.invoke
+			-- luacheck: ignore empty block (Loop can be executed at most once)
 		else
 			namedArgs[key] = value
 		end

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -135,6 +135,9 @@ function Class._frameToArgs(frame, options)
 	for key, value in pairs(args) do
 		if type(key) == 'number' then
 			indexedArgs[key] = value
+		elseif key == 'module' or key == 'fn' then
+			-- Do not pass reserved arguments
+			-- Used by Lua.invoke
 		else
 			namedArgs[key] = value
 		end

--- a/lua/wikis/commons/Lua.lua
+++ b/lua/wikis/commons/Lua.lua
@@ -127,11 +127,6 @@ function Lua.invoke(frame)
 		'Lua.invoke: Module name should not begin with \'Module:\''
 	)
 
-	local newArgs = Table.copy(frame.args)
-	newArgs.module = nil
-	newArgs.fn = nil
-	frame.args = newArgs
-
 	local getDevFlag = function(startFrame)
 		local currentFrame = startFrame
 		while currentFrame do

--- a/lua/wikis/commons/Lua.lua
+++ b/lua/wikis/commons/Lua.lua
@@ -9,7 +9,6 @@
 local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local StringUtils = require('Module:StringUtils')
-local Table = require('Module:Table')
 
 local Lua = {}
 


### PR DESCRIPTION
## Summary
Copying the table breaks assumptions done by Arguments.getArgs that are used to distinguish between lua-passed args and arguments from wikicode.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
TBD
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
