### PR TITLE
fix: Lua.invoke args adjust causing issues

### DIFF
--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -136,7 +136,7 @@ function Class._frameToArgs(frame, options)
 		if type(key) == 'number' then
 			indexedArgs[key] = value
 		-- remove args.module and args.fn as they get added to use the Lua.invoke wrapper
-		elseif key ~= 'module' and key ~= 'fn' then
+		elseif key ~= 'module' and key ~= 'fn' and key ~= 'dev' then
 			namedArgs[key] = value
 		end
 	end

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -135,8 +135,8 @@ function Class._frameToArgs(frame, options)
 	for key, value in pairs(args) do
 		if type(key) == 'number' then
 			indexedArgs[key] = value
-		-- remove args.module and args.fn as they get added to use the Lua.invoke wrapper
-		elseif key ~= 'module' and key ~= 'fn' and key ~= 'dev' then
+		-- remove args that are needed for the Lua.invoke wrapper
+		elseif key ~= 'module' and key ~= 'fn' and key ~= 'dev' and key ~= 'frameOnly' then
 			namedArgs[key] = value
 		end
 	end

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -135,7 +135,8 @@ function Class._frameToArgs(frame, options)
 	for key, value in pairs(args) do
 		if type(key) == 'number' then
 			indexedArgs[key] = value
-		else
+		-- remove args.module and args.fn as they get added to use the Lua.invoke wrapper
+		elseif key ~= 'module' and key ~= 'fn' then
 			namedArgs[key] = value
 		end
 	end

--- a/lua/wikis/commons/Lua.lua
+++ b/lua/wikis/commons/Lua.lua
@@ -128,7 +128,7 @@ function Lua.invoke(frame)
 
 	-- idealy would remove frame.args.module and frame.args.fn
 	-- but due to how frame.args behaves this is not possible without having negative impact on the performance
-	-- todo: solve this issue once Class.export has been removed everywhere
+	-- or causing other issues
 
 	local getDevFlag = function(startFrame)
 		local currentFrame = startFrame

--- a/lua/wikis/commons/Lua.lua
+++ b/lua/wikis/commons/Lua.lua
@@ -9,7 +9,6 @@
 local FeatureFlag = require('Module:FeatureFlag')
 local Logic = require('Module:Logic')
 local StringUtils = require('Module:StringUtils')
-local Table = require('Module:Table')
 
 local Lua = {}
 
@@ -127,10 +126,9 @@ function Lua.invoke(frame)
 		'Lua.invoke: Module name should not begin with \'Module:\''
 	)
 
-	local newArgs = Table.copy(frame.args)
-	newArgs.module = nil
-	newArgs.fn = nil
-	frame.args = newArgs
+	-- idealy would remove frame.args.module and frame.args.fn
+	-- but due to how frame.args behaves this is not possible without having negative impact on the performance
+	-- todo: solve this issue once Class.export has been removed everywhere
 
 	local getDevFlag = function(startFrame)
 		local currentFrame = startFrame


### PR DESCRIPTION
## Summary
- reverts #5690 as per a report on discord it caused issues in rare cases
- does not add back the (not working) `frame.args.module = nil; frame.args.fn = nil`
- adjusts `Class.export` handling (in `Class._frameToArgs`) instead so it removes the module and fn args there
  - needed because of the stupid way Class.export handles args ...

## Plans for after this PR
- bot over all invokes to use `Lua.invoke` wrapper
  - plus fixing possible issues that arise during that
- prepare all modules that use `Class.export` to handle normal args table instead of the stuff with seperated unnamed args
- prepare templates regarding frameOnly
- let `Lua.invoke` use `Arguments.getArgs` so we can just use args in all modules instead of frame (if frame is needed outside of parsing args can just use `mw.getCurrentFrame()`)
  - plus adding frameOnly handling ... --> needs asjusting templates too!
  - plus adjusting `Module:Arguments` to auto remove `args.module` and `args.fn`
- remove usage of `Class,export` on git (104 modules as of opening this PR)
  - will allow several simplifications too
- remove usage of `Class.export` outside of git (~350 modules)
- remove `Class.export` from `module:Class`

## How did you test this change?
to be done