### PR TITLE
fix(mainpage): Restore MLBB's tournament upcoming defaults

### DIFF
--- a/lua/wikis/mobilelegends/MainPageLayout/data.lua
+++ b/lua/wikis/mobilelegends/MainPageLayout/data.lua
@@ -88,7 +88,7 @@ local CONTENT = {
 	tournaments = {
 		heading = 'Tournaments',
 		body = TournamentsTicker{
-			upcomingDays = 60,
+			upcomingDays = 75,
 			completedDays = 45
 		},
 		padding = true,


### PR DESCRIPTION
## Summary

[Originally listed to show all tournaments upcoming in 75 days](https://liquipedia.net/mobilelegends/index.php?title=Main_Page&action=edit&oldid=69218), but the new page changed it to 60.