### PR TITLE
feat(mainpage): new Osu! main page

### DIFF
--- a/lua/wikis/osu/FilterButtons/Config.lua
+++ b/lua/wikis/osu/FilterButtons/Config.lua
@@ -1,0 +1,45 @@
+---
+-- @Liquipedia
+-- wiki=osu
+-- page=Module:FilterButtons/Config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Tier = require('Module:Tier/Utils')
+local Config = {}
+
+---@type FilterButtonCategory[]
+Config.categories = {
+	{
+		name = 'liquipediatier',
+		property = 'liquipediaTier',
+		load = function(category)
+			category.items = {}
+			for _, tier in Tier.iterate('tiers') do
+				table.insert(category.items, tier.value)
+			end
+		end,
+		defaultItems = {'1', '2', '3'},
+		transform = function(tier)
+			return Tier.toName(tier)
+		end,
+		expandKey = "liquipediatiertype",
+	},
+	{
+		name = 'liquipediatiertype',
+		property = 'liquipediaTierType',
+		expandable = true,
+		load = function(category)
+			category.items = {}
+			for _, tiertype in Tier.iterate('tierTypes') do
+				table.insert(category.items, Tier.toIdentifier(tiertype.value))
+			end
+		end,
+		transform = function(tiertype)
+			return select(2, Tier.toName(1, tiertype))
+		end,
+	},
+}
+
+return Config

--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -111,7 +111,7 @@ return {
 			},
 		},
 		{
-			file = 'Rainbow Six BLAST Montreal 2024 phase2 (4).jpg',
+			file = 'SadShibaCOE2023_3.jpg',
 			title = 'Transfers',
 			link = 'Portal:Transfers',
 			count = {

--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -7,8 +7,6 @@
 
 local Lua = require('Module:Lua')
 
-local DateExt = Lua.import('Module:Date/Ext')
-
 local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 

--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -54,8 +54,7 @@ local CONTENT = {
 	},
 	specialEvents = {
 		noPanel = true,
-		body = '{{Liquipedia:New Special Event}}',
-		boxid = 1511,
+		body = '{{Liquipedia:Special Event}}',
 	},
 	filterButtons = {
 		noPanel = true,

--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -85,8 +85,8 @@ local CONTENT = {
 
 return {
 	banner = {
-		lightmode = 'Osu simple allmode.png',
-		darkmode = 'Osu simple allmode.png',
+		lightmode = 'Osu! full colour allmode.png',
+		darkmode = 'Osu! full colour allmode.png',
 	},
 	metadesc = 'Comprehensive OSU! wiki with articles covering everything from tournaments, ' ..
 		'to competitive players and teams.',

--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -43,7 +43,7 @@ local CONTENT = {
 			transferQuery = false,
 			onlyNotableTransfers = true,
 			transferPage = function ()
-				return 'Player Transfers/' .. DateExt.quarterOf{ordinalSuffix = true} .. ' Quarter ' .. os.date('%Y')
+				return 'Player Transfers/' .. os.date('%Y')
 			end
 		},
 		boxid = 1509,

--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -1,0 +1,214 @@
+-- @Liquipedia
+-- wiki=osu
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local DateExt = Lua.import('Module:Date/Ext')
+
+local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+
+local CONTENT = {
+	usefulArticles = {
+		heading = 'Useful Articles',
+		body = '{{Liquipedia:Useful Articles}}',
+		padding = true,
+		boxid = 1503,
+	},
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = '{{Liquipedia:Want_to_help}}',
+		padding = true,
+		boxid = 1504,
+	},
+	liquipediaApp = {
+		heading = 'Download the Liquipedia App',
+		padding = true,
+		body = '{{Liquipedia:App}}',
+		boxid = 1505,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = TransfersList{
+			transferQuery = false,
+			onlyNotableTransfers = true,
+			transferPage = function ()
+				return 'Player Transfers/' .. DateExt.quarterOf{ordinalSuffix = true} .. ' Quarter ' .. os.date('%Y')
+			end
+		},
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
+		padding = true,
+		boxid = 1510,
+	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:New Special Event}}',
+		boxid = 1511,
+	},
+	filterButtons = {
+		noPanel = true,
+		body = Div{
+			css = {width = '100%', ['margin-bottom'] = '8px'},
+			children = { FilterButtonsWidget() }
+		},
+	},
+	matches = {
+		heading = 'Matches',
+		body = MatchTicker{},
+		padding = true,
+		boxid = 1507,
+		panelAttributes = {
+			['data-switch-group-container'] = 'countdown',
+		},
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = TournamentsTicker{
+			upcomingDays = 60,
+			completedDays = 30
+		},
+		padding = true,
+		boxid = 1508,
+	},
+}
+
+return {
+	banner = {
+		lightmode = 'Osu simple allmode.png',
+		darkmode = 'Osu simple allmode.png',
+	},
+	metadesc = 'Comprehensive OSU! wiki with articles covering everything from tournaments, ' ..
+		'to competitive players and teams.',
+	title = 'OSU!',
+	navigation = {
+		{
+			file = 'FlyingTunaCOE2023.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'Team_Spirit_win_The_International_2023.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'Rainbow Six BLAST Montreal 2024 phase2 (4).jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'Hammer Trophy of the Six Invitational 2020.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'Deadlock gameasset Patches allmode.png',
+			title = 'Glossary',
+			link = 'Glossary',
+		},
+		{
+			file = 'SadShibaCOE2023 2.jpg',
+			title = 'Statistics',
+			link = 'Portal:Statistics',
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 6,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 8,
+						content = CONTENT.wantToHelp,
+					},
+					{
+						mobileOrder = 9,
+						content = CONTENT.liquipediaApp,
+					},
+				}
+			},
+			{ -- Right
+				size = 6,
+				children = {
+					{
+						mobileOrder = 2,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
+								},
+							},
+						},
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.thisDay,
+					},
+					{
+						mobileOrder = 7,
+						content = CONTENT.usefulArticles,
+					},
+				},
+			},
+		},
+	},
+}

--- a/lua/wikis/osu/Tier/Data.lua
+++ b/lua/wikis/osu/Tier/Data.lua
@@ -63,7 +63,6 @@ return {
 			short = '?',
 		},
 	},
-
 	tierTypes = {
 		qualifier = {
 			value = 'Qualifier',

--- a/lua/wikis/osu/Tier/Data.lua
+++ b/lua/wikis/osu/Tier/Data.lua
@@ -1,0 +1,93 @@
+---
+-- @Liquipedia
+-- wiki=osu
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[-1] = {
+			value = '-1',
+			sort = 'C1',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Misc Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+	},
+}

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -84,6 +84,12 @@
 		}
 	}
 
+	.wiki-osu & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/2/2b/Osu_mainpage_banner.jpg ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-overwatch & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/0/0a/Overwatch-bg.png ) no-repeat center / cover;


### PR DESCRIPTION
## Summary

Setting up the new Main page on Osu!
## How did you test this change?

Also adding Tier.Data. They don't wanna filter it by month and week.
They don't use it. No tournamnet of this usage.

Tested on https://liquipedia.net/osu/User:Sl0thyMan/Sandbox/2

Banner tested via inspect:
![image](https://github.com/user-attachments/assets/f5309fa4-b3d5-4d52-8081-c45b407282a4)

Opening as draft as I am still not sure if there are better pictures to use. 
Osu doesn't really have any usable photos for Teams/Transfers and Tournaments.
At least I didn't found any osu related