### PR TITLE
feat(match2): standardize template usage on teamfortress

### DIFF
--- a/lua/wikis/teamfortress/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/teamfortress/GetMatchGroupCopyPaste/wiki.lua
@@ -31,7 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local streams = Logic.readBool(args.streams)
 
 	local lines = Array.extend({},
-		'{{Match2',
+		'{{Match',
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),


### PR DESCRIPTION
## Checklists

- [x] Replace all `{{Match}}` usages with `{{Match/old}}` (handled by @hjpalpha's bot)
- [x] Archive local version of `{{Match}}`
- [x] bot existing `{{Match2}}` to `{{Match}}`

## How did you test this change?

N/A