### PR TITLE
feat(match2): standardize template usage on worldofwarcraft

### DIFF
--- a/lua/wikis/worldofwarcraft/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/worldofwarcraft/GetMatchGroupCopyPaste/wiki.lua
@@ -22,7 +22,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil, bestof == 0)
 
 	local lines = Array.extend(
-		'{{Match2',
+		'{{Match',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)


### PR DESCRIPTION
## Checklists

- ~~Replace all `{{Match}}` usages with `{{Match/old}}`~~ (No existing use)
- [x] ~~Archive local version of `{{Match}}`~~ (deleted by @hjpalpha)
- [x] bot existing `{{Match2}}` to `{{Match}}`

## How did you test this change?

N/A