### PR TITLE
feat: Cache Stream Links

### DIFF
--- a/lua/wikis/commons/Links/Stream.lua
+++ b/lua/wikis/commons/Links/Stream.lua
@@ -15,9 +15,12 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Page = require('Module:Page')
+local PageVariableNamespace = require('Module:PageVariableNamespace')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
+
+local streamVars = PageVariableNamespace('StreamCache')
 
 local TLNET_STREAM = 'stream'
 
@@ -71,9 +74,17 @@ end
 ---@return string
 function StreamLinks.resolve(platformName, streamValue)
 	platformName = StreamLinks.resolvePlatform(platformName)
-	local streamLink = mw.ext.StreamPage.resolve_stream(platformName, streamValue)
 
-	return (string.gsub(streamLink, 'Special:Stream/' .. platformName, ''))
+	local cachedLink = streamVars:get(platformName .. '_' .. streamValue)
+	if cachedLink then
+		return cachedLink
+	end
+
+	local streamLink = mw.ext.StreamPage.resolve_stream(platformName, streamValue)
+	local cleanedStreamLink = string.gsub(streamLink, 'Special:Stream/' .. platformName, '')
+	streamVars:set(platformName .. '_' .. streamValue, cleanedStreamLink)
+
+	return cleanedStreamLink
 end
 
 ---@param platform string


### PR DESCRIPTION
## Summary
Cache stream links as wiki vars for performance improvements

## How did you test this change?
dev

Perf diff:
https://liquipedia.net/honorofkings/King_Growth_League/2025/Spring/Group_Stage/Week_8-9
![Screenshot 2025-04-10 124442](https://github.com/user-attachments/assets/890435e6-ca11-41f1-be75-18be3297fefc)

https://liquipedia.net/honorofkings/King_Growth_League/2024/Summer/Group_Stage/Second_Leg
![Screenshot 2025-04-10 124824](https://github.com/user-attachments/assets/c87a70d7-0948-4a35-9251-579bc80df6ab)

Mind using dev makes things a tad slower as it adds the `Pages using dev modules` category for each called component. So in live the Perf diff will be bigger than in tests. (For the second screenshot it is ~180ms for the category adding alone)