### PR TITLE
fix(match2): team icon in matchpage header not aligned properly in darkmode

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -76,8 +76,7 @@ Author(s): Rathoz
 	[ data-darkreader-scheme="dark" ] &,
 	.theme--dark & {
 		span.team-template-image-icon.darkmode,
-		span.team-template-image-icon.team-template-darkmode,
-		span.team-template-image-legacy.team-template-darkmode {
+		span.team-template-image-icon.team-template-darkmode {
 			display: flex !important;
 		}
 	}

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -73,6 +73,15 @@ Author(s): Rathoz
 		justify-content: center;
 	}
 
+	[ data-darkreader-scheme="dark" ] &,
+	.theme--dark & {
+		span.team-template-image-icon.darkmode,
+		span.team-template-image-icon.team-template-darkmode,
+		span.team-template-image-legacy.team-template-darkmode {
+			display: flex !important;
+		}
+	}
+
 	.team-template-image-icon {
 		display: flex;
 		align-items: center;

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -75,8 +75,8 @@ Author(s): Rathoz
 
 	[ data-darkreader-scheme="dark" ] &,
 	.theme--dark & {
-		span.team-template-image-icon.darkmode,
-		span.team-template-image-icon.team-template-darkmode {
+		.team-template-image-icon.darkmode,
+		.team-template-image-icon.team-template-darkmode {
 			display: flex !important;
 		}
 	}


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/7a720717-b566-485c-8f7d-099d1778fde0)

Right now team logo in the updated matchpage layout (#5703) does not get aligned properly because the `display=flex` property set here

https://github.com/Liquipedia/Lua-Modules/blob/d898c7aec0fed7e358fe312cd9fa3d5b9c45b043/stylesheets/commons/BigMatch.less#L70-L74

 gets overridden by this:

https://github.com/Liquipedia/Lua-Modules/blob/d898c7aec0fed7e358fe312cd9fa3d5b9c45b043/stylesheets/commons/TeamTemplates.less#L138-L142

This PR fixes this issue by creating a rule with higher specificity.

## How did you test this change?

browser dev tools