### PR TITLE
fix(mainpage): osu! name fix

### DIFF
--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -89,9 +89,9 @@ return {
 		lightmode = 'Osu! full colour allmode.png',
 		darkmode = 'Osu! full colour allmode.png',
 	},
-	metadesc = 'Comprehensive OSU! wiki with articles covering everything from tournaments, ' ..
+	metadesc = 'Comprehensive osu! wiki with articles covering everything from tournaments, ' ..
 		'to competitive players and teams.',
-	title = 'OSU!',
+	title = 'osu!',
 	navigation = {
 		{
 			file = 'FlyingTunaCOE2023.jpg',


### PR DESCRIPTION
## Summary

osu naming issue. 
an oversight on my part.

![image](https://github.com/user-attachments/assets/85bba2de-d4ce-4ebc-81ec-84f52779c9bb)
https://osu.ppy.sh/wiki/en/Brand_identity_guidelines

## How did you test this change?

none
