### PR TITLE
feat(match2): comment display for match page

### DIFF
--- a/lua/wikis/commons/MatchGroup/Display/Helper.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Helper.lua
@@ -10,13 +10,18 @@ local Array = require('Module:Array')
 local Date = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
 local I18n = require('Module:I18n')
-local Info = require('Module:Info')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local Page = require('Module:Page')
+local PlayerDisplay = require('Module:Player/Display')
+local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Timezone = require('Module:Timezone')
 
-local Opponent = Lua.import('Module:Opponent')
+local Info = Lua.import('Module:Info', {loadData = true})
+
+local OpponentLibraries = Lua.import('Module:OpponentLibraries')
+local Opponent = OpponentLibraries.Opponent
 
 local DisplayHelper = {}
 local NONBREAKING_SPACE = '&nbsp;'
@@ -116,6 +121,56 @@ function DisplayHelper.MatchCountdownBlock(match)
 		-- Workaround for .brkts-popup-body-element > * selector
 		:css('display', 'block')
 		:node(require('Module:Countdown')._create(stream))
+end
+
+---Creates comments that describe substitute player(s) of the match.
+---@param match table
+---@return string[]
+function DisplayHelper.createSubstitutesComment(match)
+	local comment = {}
+	Array.forEach(match.opponents, function(opponent)
+		local substitutions = (opponent.extradata or {}).substitutions
+		if Logic.isEmpty(substitutions) then
+			return
+		end
+
+		Array.forEach(substitutions, function(substitution)
+			if Logic.isEmpty(substitution.substitute) then
+				return
+			end
+
+			local subString = {}
+			table.insert(subString, string.format('%s stands in',
+				tostring(PlayerDisplay.InlinePlayer{player = substitution.substitute})
+			))
+
+			if Logic.isNotEmpty(substitution.player) then
+				table.insert(subString, string.format('for %s',
+					tostring(PlayerDisplay.InlinePlayer{player = substitution.player})
+				))
+			end
+
+			if opponent.type == Opponent.team then
+				local team = require('Module:Team').queryRaw(opponent.template)
+				if team then
+					table.insert(subString, string.format('on <b>%s</b>', Page.makeInternalLink(team.shortname, team.page)))
+				end
+			end
+
+			if Table.isNotEmpty(substitution.games) then
+				local gamesNoun = Logic.emptyOr(Info.config.match2.gameNoun, 'game') .. (#substitution.games > 1 and 's' or '')
+				table.insert(subString, string.format('on %s %s', gamesNoun, mw.text.listToText(substitution.games)))
+			end
+
+			if String.isNotEmpty(substitution.reason) then
+				table.insert(subString, string.format('due to %s', substitution.reason))
+			end
+
+			table.insert(comment, table.concat(subString, ' ') .. '.')
+		end)
+	end)
+
+	return comment
 end
 
 ---Displays the map name and link, and the status of the match if it had an unusual status.

--- a/lua/wikis/commons/MatchGroup/Display/Helper.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Helper.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Date = require('Module:Date/Ext')
+local Flags = require('Module:Flags')
 local FnUtil = require('Module:FnUtil')
 local I18n = require('Module:I18n')
 local Logic = require('Module:Logic')
@@ -26,6 +27,9 @@ local Opponent = OpponentLibraries.Opponent
 local DisplayHelper = {}
 local NONBREAKING_SPACE = '&nbsp;'
 local UTC = Timezone.getTimezoneString('UTC')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
 
 -- Whether to allow highlighting an opponent via mouseover
 ---@param opponent standardOpponent
@@ -171,6 +175,28 @@ function DisplayHelper.createSubstitutesComment(match)
 	end)
 
 	return comment
+end
+
+---Creates display components for caster(s).
+---@param casters {name: string?, displayName: string?, flag: string?}[]
+---@return (string|Widget|nil)[]
+function DisplayHelper.createCastersDisplay(casters)
+	return Array.map(casters, function(caster)
+		if not caster.name then
+			return nil
+		end
+
+		local casterLink = Link{children = caster.displayName, link = caster.name}
+		if not caster.flag then
+			return casterLink
+		end
+
+		return HtmlWidgets.Fragment{children = {
+			Flags.Icon(caster.flag),
+			NONBREAKING_SPACE,
+			casterLink,
+		}}
+	end)
 end
 
 ---Displays the map name and link, and the status of the match if it had an unusual status.

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -286,8 +286,12 @@ end
 ---@private
 ---@return MatchPageComment[]
 function BaseMatchPage:_getComments()
+	local substituteComments = DisplayHelper.createSubstitutesComment(self.matchData)
 	return WidgetUtil.collect(
 		self.matchData.comment and Comment{children = self.matchData.comment} or nil,
+		Logic.isNotEmpty(substituteComments) and Comment{
+			children = Array.interleave(substituteComments, HtmlWidgets.Br{})
+		} or nil,
 		self:addComments()
 	)
 end

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -24,6 +24,7 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local AdditionalSection = Lua.import('Module:Widget/Match/Page/AdditionalSection')
+local Comment = Lua.import('Module:Widget/Match/Page/Comment')
 local Div = HtmlWidgets.Div
 local Footer = Lua.import('Module:Widget/Match/Page/Footer')
 local Header = Lua.import('Module:Widget/Match/Page/Header')
@@ -257,6 +258,7 @@ end
 function BaseMatchPage:footer()
 	local vods = self:getVods()
 	return Footer{
+		comments = self:_getComments(),
 		children = WidgetUtil.collect(
 			#vods > 0 and AdditionalSection{
 				header = 'VODs',
@@ -279,6 +281,21 @@ function BaseMatchPage:footer()
 			}
 		)
 	}
+end
+
+---@private
+---@return MatchPageComment[]
+function BaseMatchPage:_getComments()
+	return WidgetUtil.collect(
+		self.matchData.comment and Comment{children = self.matchData.comment} or nil,
+		self:addComments()
+	)
+end
+
+---@protected
+---@return MatchPageComment[]
+function BaseMatchPage:addComments()
+	return {}
 end
 
 ---@protected

--- a/lua/wikis/commons/Widget/Match/Page/Comment.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Comment.lua
@@ -1,0 +1,35 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Match/Page/Comment
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Widget = Lua.import('Module:Widget')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+
+---@class MatchPageCommentParameters
+---@field children (string|Html|Widget|nil)|(string|Html|Widget|nil)[]
+
+---@class MatchPageComment: Widget
+---@operator call(MatchPageCommentParameters): MatchPageComment
+---@field props MatchPageCommentParameters
+local MatchPageComment = Class.new(Widget)
+
+---@return Widget[]
+function MatchPageComment:render()
+	return {
+		Div{
+			classes = { 'match-bm-lol-match-additional-list' },
+			children = WidgetUtil.collect(self.props.children)
+		}
+	}
+end
+
+return MatchPageComment

--- a/lua/wikis/commons/Widget/Match/Page/Comment.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Comment.lua
@@ -26,7 +26,7 @@ local MatchPageComment = Class.new(Widget)
 function MatchPageComment:render()
 	return {
 		Div{
-			classes = { 'match-bm-lol-match-additional-list' },
+			classes = { 'match-bm-match-additional-comment' },
 			children = WidgetUtil.collect(self.props.children)
 		}
 	}

--- a/lua/wikis/commons/Widget/Match/Page/Footer.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Footer.lua
@@ -24,21 +24,24 @@ local Div = HtmlWidgets.Div
 ---@field props MatchPageFooterParameters
 local MatchPageFooter = Class.new(Widget)
 
----@return Widget[]
+---@return Widget[]?
 function MatchPageFooter:render()
-	return WidgetUtil.collect(
+	local comments = self.props.comments
+	local children = self.props.children
+	if Logic.isEmpty(comments) and Logic.isEmpty(children) then return end
+	return {
 		HtmlWidgets.H3{ children = 'Additional Information' },
 		Div{
 			classes = { 'match-bm-match-additional' },
 			children = WidgetUtil.collect(
-				Logic.isNotEmpty(self.props.comments) and Div{
+				Logic.isNotEmpty(comments) and Div{
 					classes = {'match-bm-match-additional-comments'},
-					children = self.props.comments
+					children = comments
 				} or nil,
-				self.props.children
+				children
 			)
 		}
-	)
+	}
 end
 
 return MatchPageFooter

--- a/lua/wikis/commons/Widget/Match/Page/Footer.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Footer.lua
@@ -28,13 +28,15 @@ local MatchPageFooter = Class.new(Widget)
 function MatchPageFooter:render()
 	return WidgetUtil.collect(
 		HtmlWidgets.H3{ children = 'Additional Information' },
-		Logic.isNotEmpty(self.props.comments) and Div{
-			classes = { 'match-bm-lol-match-additional' },
-			children = self.props.comments
-		} or nil,
 		Div{
 			classes = { 'match-bm-match-additional' },
-			children = WidgetUtil.collect(self.props.children)
+			children = WidgetUtil.collect(
+				Logic.isNotEmpty(self.props.comments) and Div{
+					classes = {'match-bm-match-additional-comments'},
+					children = self.props.comments
+				} or nil,
+				self.props.children
+			)
 		}
 	)
 end

--- a/lua/wikis/commons/Widget/Match/Page/Footer.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Footer.lua
@@ -7,6 +7,7 @@
 --
 
 local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
@@ -15,6 +16,7 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
 ---@class MatchPageFooterParameters
+---@field comments MatchPageComment[]?
 ---@field children (string|Html|Widget|nil)|(string|Html|Widget|nil)[]
 
 ---@class MatchPageFooter: Widget
@@ -24,13 +26,17 @@ local MatchPageFooter = Class.new(Widget)
 
 ---@return Widget[]
 function MatchPageFooter:render()
-	return {
+	return WidgetUtil.collect(
 		HtmlWidgets.H3{ children = 'Additional Information' },
+		Logic.isNotEmpty(self.props.comments) and Div{
+			classes = { 'match-bm-lol-match-additional' },
+			children = self.props.comments
+		} or nil,
 		Div{
 			classes = { 'match-bm-match-additional' },
 			children = WidgetUtil.collect(self.props.children)
 		}
-	}
+	)
 end
 
 return MatchPageFooter

--- a/lua/wikis/commons/Widget/Match/Summary/Casters.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Casters.lua
@@ -8,12 +8,12 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Flags = require('Module:Flags')
 local Lua = require('Module:Lua')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
-local Link = Lua.import('Module:Widget/Basic/Link')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class MatchSummaryCasters: Widget
@@ -26,22 +26,7 @@ function MatchSummaryCasters:render()
 		return nil
 	end
 
-	local casters = Array.map(self.props.casters, function(caster)
-		if not caster.name then
-			return nil
-		end
-
-		local casterLink = Link{children = caster.displayName, link = caster.name}
-		if not caster.flag then
-			return casterLink
-		end
-
-		return HtmlWidgets.Fragment{children = {
-			Flags.Icon(caster.flag),
-			'&nbsp;',
-			casterLink,
-		}}
-	end)
+	local casters = DisplayHelper.createCastersDisplay(self.props.casters)
 
 	if #casters == 0 then
 		return nil

--- a/lua/wikis/commons/Widget/Match/Summary/Ffa/GameDetails.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Ffa/GameDetails.lua
@@ -13,8 +13,9 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+
 local Widget = Lua.import('Module:Widget')
-local Link = Lua.import('Module:Widget/Basic/Link')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local ContentItemContainer = Lua.import('Module:Widget/Match/Summary/Ffa/ContentItemContainer')
 local IconWidget = Lua.import('Module:Widget/Image/Icon/Fontawesome')
@@ -31,22 +32,7 @@ function MatchSummaryFfaGameDetails:render()
 	local game = self.props.game
 	assert(game, 'No game provided')
 
-	local casters = Array.map(game.extradata.casters or {}, function(caster)
-		if not caster.name then
-			return nil
-		end
-
-		local casterLink = Link{children = caster.displayName, link = caster.name}
-		if not caster.flag then
-			return casterLink
-		end
-
-		return HtmlWidgets.Fragment{children = {
-			Flags.Icon(caster.flag),
-			'&nbsp;',
-			casterLink,
-		}}
-	end)
+	local casters = DisplayHelper.createCastersDisplay(game.extradata.casters)
 
 	return ContentItemContainer{contentClass = 'panel-content__game-schedule', items = WidgetUtil.collect(
 		{

--- a/lua/wikis/commons/Widget/Match/Summary/Ffa/GameDetails.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Ffa/GameDetails.lua
@@ -8,7 +8,6 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Flags = require('Module:Flags')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')

--- a/lua/wikis/commons/Widget/Match/Summary/Ffa/MatchInformation.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Ffa/MatchInformation.lua
@@ -8,9 +8,10 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Flags = require('Module:Flags')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 local ContentItemContainer = Lua.import('Module:Widget/Match/Summary/Ffa/ContentItemContainer')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
@@ -82,22 +83,7 @@ function MatchSummaryFfaMatchInformation:_getCasterItem()
 	local rawCasters = self.props.extradata.casters
 	if Logic.isEmpty(rawCasters) then return end
 
-	local casters = Array.map(rawCasters, function(caster)
-		if not caster.name then
-			return nil
-		end
-
-		local casterLink = Link{children = caster.displayName, link = caster.name}
-		if not caster.flag then
-			return casterLink
-		end
-
-		return HtmlWidgets.Fragment{children = {
-			Flags.Icon(caster.flag),
-			'&nbsp;',
-			casterLink,
-		}}
-	end)
+	local casters = DisplayHelper.createCastersDisplay(rawCasters)
 
 	if #casters == 0 then return end
 	return {

--- a/lua/wikis/dota2/MatchPage.lua
+++ b/lua/wikis/dota2/MatchPage.lua
@@ -11,6 +11,7 @@ local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
@@ -21,6 +22,8 @@ local BaseMatchPage = Lua.import('Module:MatchPage/Base')
 local Display = Lua.import('Module:MatchPage/Template')
 
 local Link = Lua.import('Module:Widget/Basic/Link')
+local Comment = Lua.import('Module:Widget/Match/Page/Comment')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class Dota2MatchPage: BaseMatchPage
 local MatchPage = Class.new(BaseMatchPage)
@@ -129,6 +132,20 @@ end
 function MatchPage:getPatchLink()
 	if Logic.isEmpty(self.matchData.patch) then return end
 	return Link{ link = 'Version ' .. self.matchData.patch }
+end
+
+---@return MatchPageComment[]
+function MatchPage:addComments()
+	local casters = Json.parseIfString(self.matchData.extradata.casters)
+	if Logic.isEmpty(casters) then return {} end
+	return {
+		Comment{
+			children = WidgetUtil.collect(
+				#casters > 1 and 'Casters: ' or 'Caster: ',
+				Array.interleave(casters, ', ')
+			)
+		}
+	}
 end
 
 return MatchPage

--- a/lua/wikis/dota2/MatchPage.lua
+++ b/lua/wikis/dota2/MatchPage.lua
@@ -20,6 +20,7 @@ local TemplateEngine = require('Module:TemplateEngine')
 
 local BaseMatchPage = Lua.import('Module:MatchPage/Base')
 local Display = Lua.import('Module:MatchPage/Template')
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Comment = Lua.import('Module:Widget/Match/Page/Comment')
@@ -142,7 +143,7 @@ function MatchPage:addComments()
 		Comment{
 			children = WidgetUtil.collect(
 				#casters > 1 and 'Casters: ' or 'Caster: ',
-				Array.interleave(casters, ', ')
+				Array.interleave(DisplayHelper.createCastersDisplay(casters), ', ')
 			)
 		}
 	}

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -21,6 +21,7 @@ local TemplateEngine = require('Module:TemplateEngine')
 
 local BaseMatchPage = Lua.import('Module:MatchPage/Base')
 local Display = Lua.import('Module:MatchPage/Template')
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 local Comment = Lua.import('Module:Widget/Match/Page/Comment')
 local WidgetUtil = Lua.import('Module:Widget/Util')
@@ -174,7 +175,7 @@ function MatchPage:addComments()
 		Comment{
 			children = WidgetUtil.collect(
 				#casters > 1 and 'Casters: ' or 'Caster: ',
-				Array.interleave(casters, ', ')
+				Array.interleave(DisplayHelper.createCastersDisplay(casters), ', ')
 			)
 		}
 	}

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -11,6 +11,7 @@ local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local DateExt = require('Module:Date/Ext')
 local FnUtil = require('Module:FnUtil')
+local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
@@ -20,6 +21,9 @@ local TemplateEngine = require('Module:TemplateEngine')
 
 local BaseMatchPage = Lua.import('Module:MatchPage/Base')
 local Display = Lua.import('Module:MatchPage/Template')
+
+local Comment = Lua.import('Module:Widget/Match/Page/Comment')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class LoLMatchPageGame: MatchPageGame
 ---@field vetoByTeam table[]
@@ -160,6 +164,20 @@ function MatchPage:renderGame(game)
 	local inputTable = Table.merge(self.matchData, game)
 	inputTable.heroIcon = FnUtil.curry(self.getCharacterIcon, self)
 	return TemplateEngine():render(Display.game, inputTable)
+end
+
+---@return MatchPageComment[]
+function MatchPage:addComments()
+	local casters = Json.parseIfString(self.matchData.extradata.casters)
+	if Logic.isEmpty(casters) then return {} end
+	return {
+		Comment{
+			children = WidgetUtil.collect(
+				#casters > 1 and 'Casters: ' or 'Caster: ',
+				Array.interleave(casters, ', ')
+			)
+		}
+	}
 end
 
 return MatchPage

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1259,22 +1259,6 @@ ul.match-bm-lol-game-veto-overview-pick {
 	}
 }
 
-.match-bm-lol-match-additional-list {
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
-	align-items: center;
-	padding: 4px;
-	gap: 4px;
-	border: 1px solid #bbbbbb;
-	background: #f5f5f5;
-
-	.theme--dark & {
-		background-color: var( --clr-secondary-16 );
-		border-color: var( --clr-secondary-25 );
-	}
-}
-
 .match-bm-team-stats {
 	border: 0.0625rem solid #bbbbbb;
 	margin-bottom: 1rem;

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1196,9 +1196,34 @@ ul.match-bm-lol-game-veto-overview-pick {
 .match-bm-match-additional {
 	display: flex;
 	gap: 1rem;
+	flex-wrap: wrap;
 
 	@media ( max-width: 767px ) {
 		flex-direction: column;
+	}
+
+	&-comments {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex: 3 0 100%;
+		flex-direction: column;
+		padding: 4px;
+		gap: 4px;
+		border: 1px solid #bbbbbb;
+		background: #f5f5f5;
+
+		.theme--dark & {
+			background-color: var( --clr-secondary-16 );
+			border-color: var( --clr-secondary-25 );
+		}
+
+		> div {
+			display: block;
+			text-align: center;
+			vertical-align: middle;
+			white-space: normal;
+		}
 	}
 
 	&-section {


### PR DESCRIPTION
## Summary

resolves #5711

This PR also includes refactoring of substitute / caster comments as they were both needed for the match page.

## How did you test this change?

dev + browser dev tools

![image](https://github.com/user-attachments/assets/09e3598f-feb3-41ed-886b-d385a9b3a9d7)
