### PR TITLE
refactor(mainpage): remove unneeded <nowiki> on deadlock

### DIFF
--- a/lua/wikis/deadlock/MainPageLayout/data.lua
+++ b/lua/wikis/deadlock/MainPageLayout/data.lua
@@ -20,7 +20,7 @@ local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 local CONTENT = {
 	updates = {
 		heading = 'Updates',
-		body = '<nowiki>\n</nowiki>{{Main Page Updates}}',
+		body = '{{Main Page Updates}}',
 		padding = true,
 		boxid = 1502,
 	},


### PR DESCRIPTION
## Summary

Kick "nowiki" in updates. It does nothing.
Not sure why it was there in the first place.

![image](https://github.com/user-attachments/assets/82ba19cb-cd93-4e30-83d4-69cf19cd8672)


## How did you test this change?
inspect + modified wildcard [module](https://liquipedia.net/wildcard/Module:MainPageLayout/data) as it still in the PR https://github.com/Liquipedia/Lua-Modules/pull/5543
