### PR TITLE
feat(mainpage): new crossfire main page

### DIFF
--- a/lua/wikis/crossfire/data.lua
+++ b/lua/wikis/crossfire/data.lua
@@ -1,0 +1,207 @@
+---
+-- @Liquipedia
+-- wiki=crossfire
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+
+local CONTENT = {
+	usefulArticles = {
+		heading = 'Useful Articles',
+		body = '{{Liquipedia:Useful Articles}}',
+		padding = true,
+		boxid = 1503,
+	},
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = '{{Liquipedia:Want_to_help}}',
+		padding = true,
+		boxid = 1504,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = TransfersList{
+			transferPage = function ()
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+			end
+		},
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
+		padding = true,
+		boxid = 1510,
+	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+	},
+	filterButtons = {
+		noPanel = true,
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
+	},
+	matches = {
+		heading = 'Matches',
+		body = MatchTicker{},
+		padding = true,
+		boxid = 1507,
+		panelAttributes = {
+			['data-switch-group-container'] = 'countdown',
+		},
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = TournamentsTicker{
+			upcomingDays = 60,
+			completedDays = 30
+		},
+		padding = true,
+		boxid = 1508,
+	},
+}
+
+return {
+	banner = {
+		lightmode = 'Crossfire default lightmode.png',
+		darkmode = 'Crossfire default darkmode.png',
+	},
+	metadesc = 'The Crossfire esports wiki covering everything from players, teams and transfers, ' ..
+		'to tournaments and results and maps.',
+	title = 'Crossfire',
+	navigation = {
+		{
+			file = 'Harlen @ CFS 2017.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'All Gamers @ CFPL-M.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'Treak @ CFS 2016.jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'SV @ CFPL S10.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'Black Widow A Long.webp',
+			title = 'Maps',
+			link = 'Portal:Maps',
+		},
+		{
+			file = 'Ayom, Xyc & KK @ CFS 2015 CN.jpg',
+			title = 'Statistics',
+			link = 'Portal:Statistics',
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 6,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 3,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 5,
+						content = CONTENT.thisDay,
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.wantToHelp,
+					},
+				}
+			},
+			{ -- Right
+				size = 6,
+				children = {
+					{
+						mobileOrder = 2,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{ -- Bottom
+				children = {
+					{
+						mobileOrder = 4,
+						content = CONTENT.usefulArticles,
+					},
+				},
+			},
+		},
+	},
+}

--- a/lua/wikis/crossfire/filter_buttons_config.lua
+++ b/lua/wikis/crossfire/filter_buttons_config.lua
@@ -1,0 +1,45 @@
+---
+-- @Liquipedia
+-- wiki=crossfire
+-- page=Module:FilterButtons/Config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Tier = require('Module:Tier/Utils')
+local Config = {}
+
+---@type FilterButtonCategory[]
+Config.categories = {
+	{
+		name = 'liquipediatier',
+		property = 'liquipediaTier',
+		load = function(category)
+			category.items = {}
+			for _, tier in Tier.iterate('tiers') do
+				table.insert(category.items, tier.value)
+			end
+		end,
+		defaultItems = {'1', '2', '3'},
+		transform = function(tier)
+			return Tier.toName(tier)
+		end,
+		expandKey = "liquipediatiertype",
+	},
+	{
+		name = 'liquipediatiertype',
+		property = 'liquipediaTierType',
+		expandable = true,
+		load = function(category)
+			category.items = {}
+			for _, tiertype in Tier.iterate('tierTypes') do
+				table.insert(category.items, Tier.toIdentifier(tiertype.value))
+			end
+		end,
+		transform = function(tiertype)
+			return select(2, Tier.toName(1, tiertype))
+		end,
+	},
+}
+
+return Config

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -30,6 +30,12 @@
 		}
 	}
 
+	.wiki-crossfire & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/6/6c/Crossfire_mainpage_banner.png ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-deadlock & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/8/8f/Deadlock_mainpage_banner.png ) no-repeat center / cover;


### PR DESCRIPTION
## Summary
This PR adds new mainpage for Crossfire

bg for downloaded directly from official website (https://we.esports.z8games.com/) and cropped, but not sure if we can hide it under fairuselogo despite its simple bg. Definitely there are better options so I would say this is more like placeholder imo.
![image](https://github.com/user-attachments/assets/77e28656-d2e3-4d14-a5c2-525bca437df3)

This logo would be cool if not having that text on it. -> https://z8games.akamaized.net/cfna/esports/live/assets/images/roadmap-header-we.jpg
### Checklist:
- [ ] Found better mainpage wide banner? (contacted TO)
- [ ] Any better image for "Transfers"? (contacted TO)
- [ ] Would be good to have image with trophy only (didn't found any uploaded - contacted TO)

## How did you test this change?
https://liquipedia.net/crossfire/User:Sl0thyMan/sandbox/1

with banner:
![image](https://github.com/user-attachments/assets/e86838b8-52f3-4d7b-9471-d59e159b9ee6)
