### PR TITLE
chore: clean up `Class._wrapFunction`

### DIFF
--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -76,20 +76,13 @@ function Class.export(class, options)
 	return class
 end
 
--- Duplicate Table.isNotEmpty() here to avoid circular dependencies with Table
-local function TableIsNotEmpty(tbl)
-	-- luacheck: push ignore (Loop can be executed at most once)
-	for _ in pairs(tbl) do
-		return true
-	end
-	-- luacheck: pop
-	return false
-end
-
 ---
 -- Wrap the given function with an argument parses so that both wikicode and lua
 -- arguments are accepted
 --
+---@param f function
+---@param options table?
+---@return function
 function Class._wrapFunction(f, options)
 	options = options or {}
 	local alwaysRewriteArgs = options.trim
@@ -110,38 +103,12 @@ function Class._wrapFunction(f, options)
 			)
 
 		if shouldRewriteArgs then
-			local namedArgs, indexedArgs = Class._frameToArgs(frame, options)
-			if namedArgs then
-				return f(namedArgs, unpack(indexedArgs))
-			else
-				return f(unpack(indexedArgs))
-			end
+			local args = Arguments.getArgs(frame, options)
+			return f(args)
 		else
 			return f(...)
 		end
 	end
-end
-
---[[
-Translates a frame object into arguments expected by a lua function.
-]]
-function Class._frameToArgs(frame, options)
-	local args = Arguments.getArgs(frame, options)
-
-	-- getArgs adds a metatable to the table. This breaks unpack. So we remove it.
-	-- We also add all named params to a special table, since unpack removes them.
-	local indexedArgs = {}
-	local namedArgs = {}
-	for key, value in pairs(args) do
-		if type(key) == 'number' then
-			indexedArgs[key] = value
-		-- remove args that are needed for the Lua.invoke wrapper
-		elseif key ~= 'module' and key ~= 'fn' and key ~= 'dev' and key ~= 'frameOnly' then
-			namedArgs[key] = value
-		end
-	end
-
-	return (TableIsNotEmpty(namedArgs) and namedArgs or nil), indexedArgs
 end
 
 ---@param instance any

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -80,9 +80,10 @@ end
 -- Wrap the given function with an argument parses so that both wikicode and lua
 -- arguments are accepted
 --
----@param f function
+---@generic F:function
+---@param f F
 ---@param options table?
----@return function
+---@return F
 function Class._wrapFunction(f, options)
 	options = options or {}
 	local alwaysRewriteArgs = options.trim

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -80,7 +80,7 @@ end
 -- Wrap the given function with an argument parses so that both wikicode and lua
 -- arguments are accepted
 --
----@generic F:function
+---@generic F:fun(props: table)
 ---@param f F
 ---@param options table?
 ---@return F


### PR DESCRIPTION
## Summary
Part of Option2 in #5818

if we go for this PR we need to do theis change to `Module:Arguments`:
https://liquipedia.net/commons/index.php?title=Module%3AArguments%2Fdev%2Fhjp2&type=revision&diff=860449&oldid=860445

Cleans up `Class.export`/`Class._wrapFunction` so it doesn't split up the args into named and unnamed anymore.
Additionally moves out the removal of the `dev`, `module` and `fn` arguments (which get added due to using the lua invoke wrapper) into `Module:Arguments` so they also get removed if Module:Class is not used. (see above suggested change to MOdule:Arguments)

https://liquipedia.net/commons/index.php?title=Module%3AArguments%2Fdev%2Fhjp2&type=revision&diff=860449&oldid=860445

## How did you test this change?
dev

initial perf test show no diff for normal modules and a tiny improvement for modules using Class.export (as args is a metatable again for them with this change)