### PR TITLE
feat(mainpage): Fornite change transfer data formatting

### DIFF
--- a/lua/wikis/fortnite/MainPageLayout/data.lua
+++ b/lua/wikis/fortnite/MainPageLayout/data.lua
@@ -34,7 +34,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
 			end
 		},
 		boxid = 1509,

--- a/lua/wikis/fortnite/MainPageLayout/data.lua
+++ b/lua/wikis/fortnite/MainPageLayout/data.lua
@@ -6,7 +6,6 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
 local Lua = require('Module:Lua')
 
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')


### PR DESCRIPTION
## Summary

Edit button is not working properly and linking to wrong page.
Fortnite editors switched their data formatting for trasnfers as they were hitting limits 

![image](https://github.com/user-attachments/assets/06984d19-cfd3-461e-a4db-220ec91c44bd)
Player_Transfers/2024/1st_Quarter -> Player_Transfers/2025/April

From quarter to month format


## How did you test this change?

dev
https://liquipedia.net/fortnite/User:Sl0thyMan/Sandbox/1

