### PR TITLE
feat(Class): Add option to only export a specified set of functions

### DIFF
--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -64,14 +64,25 @@ end
 ---@param options ?table
 ---@return T
 function Class.export(class, options)
-	for name, f in pairs(class) do
+	options = options or {}
+
+	local checkFunction = function(functionName)
+		local f = class[functionName]
 		-- We only want to export functions, and only functions which are public (no underscore)
-		if (
-			type(f) == 'function' and
-				(not string.find(name, Class.PRIVATE_FUNCTION_SPECIFIER))
-		) then
-			class[name] = Class._wrapFunction(class[name], options)
+		if type(f) ~= 'function' or string.find(functionName, Class.PRIVATE_FUNCTION_SPECIFIER) then
+			return
 		end
+		class[functionName] = Class._wrapFunction(f, options)
+	end
+
+	if type(options.onlyExport) == 'table' and #options.onlyExport > 0 then
+		for _, functionName in ipairs(options.onlyExport) do
+			checkFunction(functionName)
+		end
+		return class
+	end
+	for name in pairs(class) do
+		checkFunction(name)
 	end
 	return class
 end


### PR DESCRIPTION
## Summary
Add option to only export a specified set of functions with `Class.export`.
This allows a gradual cleanup of modules to specify functions to export for modules that contain entry points that should only be accesed by lua and not via invoke.
After that cleanup we can kick the usage of spread operator in the return of `Class._wrapFunction`.

Alternative would be to refactor a ton of modules where this option will allow us to solve those via a simple small change. (Especially helpful for non-git modules.)

## How did you test this change?
to be done

## Todo
check all git modules that could make use of this and add the (small) resp. change to this PR