### PR TITLE
fix(mainpage): Wildcard map categories

### DIFF
--- a/lua/wikis/wildcard/MainPageLayout/data.lua
+++ b/lua/wikis/wildcard/MainPageLayout/data.lua
@@ -101,7 +101,7 @@ return {
 			link = 'Portal:Arenas',
 			count = {
 				method = 'CATEGORY',
-				category = 'Arenas',
+				category = 'Maps',
 			},
 		},
 		{


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bc4e6d82-6dfc-4277-ab5e-8717842eab66)
The layout defines category count to Arenas which is wrong category so main page will throw out **0**, but I have no plans to make a custom map infobox, so it should be **Maps** here.


