### PR TITLE
fix(match2): missing nil catch in wow legacy matchlist wrapper

### DIFF
--- a/lua/wikis/worldofwarcraft/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/worldofwarcraft/MatchGroup/Legacy/MatchList.lua
@@ -62,7 +62,7 @@ function LegacyMatchList.processMatch(input)
 	local args = Json.parseStringified(input)
 	if Logic.isDeepEmpty(args) then return end
 
-	local details = Table.extract(args, 'details')
+	local details = Table.extract(args, 'details') or {}
 	-- remap matchX --> mapX
 	details = Table.map(details, function(key, value)
 		local mapIndex = key:match('^match(%d+)')


### PR DESCRIPTION
## Summary
reported on discord : https://discord.com/channels/93055209017729024/372075546231832576/1362001762646626325

## How did you test this change?
live