### PR TITLE
feat(infobox): add support for armortype2 for Warcraft

### DIFF
--- a/lua/wikis/warcraft/Infobox/Building/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Building/Custom.lua
@@ -208,7 +208,7 @@ function CustomBuilding:_armorDisplay()
 	end
 	display = display .. ' ' .. (self.args.armor or 0)
 	if self.args.armor_upgrades then
-		display = display.. ' (' .. (tonumber(self.args.armor) + tonumber(self.args.armor_upgrades)) .. ')'
+		display = display.. ' (' .. (tonumber(self.args.armor or 0) + tonumber(self.args.armor_upgrades)) .. ')'
 	end
 	return display
 end

--- a/lua/wikis/warcraft/Infobox/Building/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Building/Custom.lua
@@ -191,7 +191,7 @@ function CustomBuilding:_defenseDisplay()
 
 	local display = ICON_HP .. ' ' .. (self.args.hp or 0)
 	if (tonumber(self.args.hitpoint_bonus) or 0) > 0 then
-		return display .. ' (' .. (tonumber(self.args.hp or 0) + tonumber(self.args.hitpoint_bonus)) .. ')'
+		return display .. ' (' .. (tonumber(self.args.hp) + tonumber(self.args.hitpoint_bonus)) .. ')'
 	end
 	return display
 end
@@ -208,7 +208,7 @@ function CustomBuilding:_armorDisplay()
 	end
 	display = display .. ' ' .. (self.args.armor or 0)
 	if self.args.armor_upgrades then
-		display = display.. ' (' .. (tonumber(self.args.armor or 0) + tonumber(self.args.armor_upgrades)) .. ')'
+		display = display.. ' (' .. (tonumber(self.args.armor) + tonumber(self.args.armor_upgrades)) .. ')'
 	end
 	return display
 end

--- a/lua/wikis/warcraft/Infobox/Building/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Building/Custom.lua
@@ -191,7 +191,7 @@ function CustomBuilding:_defenseDisplay()
 
 	local display = ICON_HP .. ' ' .. (self.args.hp or 0)
 	if (tonumber(self.args.hitpoint_bonus) or 0) > 0 then
-		return display .. ' (' .. self.args.hp + self.args.hitpoint_bonus .. ')'
+		return display .. ' (' .. (tonumber(self.args.hp or 0) + tonumber(self.args.hitpoint_bonus)) .. ')'
 	end
 	return display
 end
@@ -208,7 +208,7 @@ function CustomBuilding:_armorDisplay()
 	end
 	display = display .. ' ' .. (self.args.armor or 0)
 	if self.args.armor_upgrades then
-		display = display.. ' (' .. (self.args.armor + self.args.armor_upgrades) .. ')'
+		display = display.. ' (' .. (tonumber(self.args.armor or 0) + tonumber(self.args.armor_upgrades)) .. ')'
 	end
 	return display
 end

--- a/lua/wikis/warcraft/Infobox/Unit/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Unit/Custom.lua
@@ -159,7 +159,7 @@ function CustomUnit:_armorDisplay()
 	end
 	display = display .. ' ' .. (self.args.armor or 0)
 	if self.args.armor_upgrades then
-		display = display.. ' (' .. (tonumber(self.args.armor) + tonumber(self.args.armor_upgrades)) .. ')'
+		display = display.. ' (' .. (tonumber(self.args.armor or 0) + tonumber(self.args.armor_upgrades)) .. ')'
 	end
 	return display
 end

--- a/lua/wikis/warcraft/Infobox/Unit/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Unit/Custom.lua
@@ -159,7 +159,7 @@ function CustomUnit:_armorDisplay()
 	end
 	display = display .. ' ' .. (self.args.armor or 0)
 	if self.args.armor_upgrades then
-		display = display.. ' (' .. (tonumber(self.args.armor or 0) + tonumber(self.args.armor_upgrades)) .. ')'
+		display = display.. ' (' .. (tonumber(self.args.armor) + tonumber(self.args.armor_upgrades)) .. ')'
 	end
 	return display
 end

--- a/lua/wikis/warcraft/Infobox/Unit/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Unit/Custom.lua
@@ -134,7 +134,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 function CustomUnit._bounty(args)
-	if not args.bountybasethen then return end
+	if not args.bountybase then return end
 	local baseBounty = tonumber(args.bountybase) or 0
 	local bountyDice = tonumber(args.bountydice) or 1
 	local bountySides = tonumber(args.bountysides) or 1
@@ -145,17 +145,21 @@ end
 ---@return string
 function CustomUnit:_defenseDisplay()
 	local display = ICON_HP .. ' ' .. (self.args.hp or 0)
-	if tonumber(self.args.hitpoint_bonus) > 0 then
-		return display .. ' (' .. self.args.hp + self.args.hitpoint_bonus .. ')'
+	if tonumber(self.args.hitpoint_bonus or 0) > 0 then
+		return display .. ' (' .. (tonumber(self.args.hp) + tonumber(self.args.hitpoint_bonus)) .. ')'
 	end
 	return display
 end
 
 ---@return string
 function CustomUnit:_armorDisplay()
-	local display = ArmorIcon.run(self.args.armortype) .. ' ' .. (self.args.armor or 0)
+	local display = ArmorIcon.run(self.args.armortype)
+	if self.args.armortype2 then
+		display = display .. ' / ' .. ArmorIcon.run(self.args.armortype2)
+	end
+	display = display .. ' ' .. (self.args.armor or 0)
 	if self.args.armor_upgrades then
-		display = display.. ' (' .. (self.args.armor + self.args.armor_upgrades) .. ')'
+		display = display.. ' (' .. (tonumber(self.args.armor or 0) + tonumber(self.args.armor_upgrades)) .. ')'
 	end
 	return display
 end

--- a/lua/wikis/warcraft/Infobox/Unit/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Unit/Custom.lua
@@ -145,7 +145,7 @@ end
 ---@return string
 function CustomUnit:_defenseDisplay()
 	local display = ICON_HP .. ' ' .. (self.args.hp or 0)
-	if tonumber(self.args.hitpoint_bonus or 0) > 0 then
+	if (tonumber(self.args.hitpoint_bonus) or 0) > 0 then
 		return display .. ' (' .. (tonumber(self.args.hp) + tonumber(self.args.hitpoint_bonus)) .. ')'
 	end
 	return display


### PR DESCRIPTION
## Summary

Requested change in discord https://discord.com/channels/93055209017729024/268719633366777856/1362066381595476140

They want function which already exist in building module to have in unit as in the new patch they need it.

+ typo + nill catches

## How did you test this change?

dev
before/after:
![before warcraft](https://github.com/user-attachments/assets/2e003457-e512-4d86-b577-fd6e9478b6c6) ![after warcraft](https://github.com/user-attachments/assets/08056383-82f0-4f50-b2f6-43819a08d500)
