### PR TITLE
fix(match2): missing WidgetUtil.collect

### DIFF
--- a/lua/wikis/rocketleague/MatchSummary.lua
+++ b/lua/wikis/rocketleague/MatchSummary.lua
@@ -233,11 +233,11 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		children = WidgetUtil.collect(
 			header,
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
-			MatchSummaryWidgets.GameCenter{children = {
+			MatchSummaryWidgets.GameCenter{children = WidgetUtil.collect(
 				DisplayHelper.Map(game),
 				Logic.readBool(extradata.ot) and ' - OT' or nil,
 				Logic.isNotEmpty(extradata.otlength) and ' (' .. extradata.otlength .. ')' or nil
-			}},
+			)},
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(2), flipped = true},
 			CustomMatchSummary._timeoutDisplay(extradata.timeout),
 			MatchSummaryWidgets.GameComment{children = comments}


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1362326829847019561
issue fixed by wrapping the code that adds the bad children with WidgetUtil.collect

## How did you test this change?
live