### PR TITLE
fix: Correctly display tournament tags with Tier Misc and tiertype

### DIFF
--- a/lua/wikis/ageofempires/Tier/Data.lua
+++ b/lua/wikis/ageofempires/Tier/Data.lua
@@ -44,7 +44,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/brawlhalla/Tier/Data.lua
+++ b/lua/wikis/brawlhalla/Tier/Data.lua
@@ -44,7 +44,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/brawlstars/Tier/Data.lua
+++ b/lua/wikis/brawlstars/Tier/Data.lua
@@ -44,7 +44,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/counterstrike/Tier/Data.lua
+++ b/lua/wikis/counterstrike/Tier/Data.lua
@@ -44,7 +44,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/criticalops/Tier/Data.lua
+++ b/lua/wikis/criticalops/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/easportsfc/Tier/Data.lua
+++ b/lua/wikis/easportsfc/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/formula1/Tier/Data.lua
+++ b/lua/wikis/formula1/Tier/Data.lua
@@ -68,7 +68,7 @@ return {
 			value = '-1',
 			sort = 'A8',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Events',
 			category = 'Miscellaneous Events',
 		},

--- a/lua/wikis/honorofkings/Tier/Data.lua
+++ b/lua/wikis/honorofkings/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/mobilelegends/Tier/Data.lua
+++ b/lua/wikis/mobilelegends/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/osu/Tier/Data.lua
+++ b/lua/wikis/osu/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/overwatch/Tier/Data.lua
+++ b/lua/wikis/overwatch/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/pubg/Tier/Data.lua
+++ b/lua/wikis/pubg/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/rainbowsix/Tier/Data.lua
+++ b/lua/wikis/rainbowsix/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/rocketleague/Tier/Data.lua
+++ b/lua/wikis/rocketleague/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/sideswipe/Tier/Data.lua
+++ b/lua/wikis/sideswipe/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/splatoon/Tier/Data.lua
+++ b/lua/wikis/splatoon/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/splitgate/Tier/Data.lua
+++ b/lua/wikis/splitgate/Tier/Data.lua
@@ -44,7 +44,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/starcraft/Tier/Data.lua
+++ b/lua/wikis/starcraft/Tier/Data.lua
@@ -36,7 +36,7 @@ return {
 			value = '-1',
 			sort = 'A5',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 		},
 		[''] = {
 			value = nil,

--- a/lua/wikis/starcraft2/Tier/Data.lua
+++ b/lua/wikis/starcraft2/Tier/Data.lua
@@ -44,7 +44,7 @@ return {
 			value = '-1',
 			sort = 'A5',
 			name = 'Misc',
-			short = 'M',
+			short = 'M.',
 		},
 		[''] = {
 			value = nil,

--- a/lua/wikis/stormgate/Tier/Data.lua
+++ b/lua/wikis/stormgate/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'A6',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Misc Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/tetris/Tier/Data.lua
+++ b/lua/wikis/tetris/Tier/Data.lua
@@ -44,7 +44,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/wildrift/Tier/Data.lua
+++ b/lua/wikis/wildrift/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/worldoftanks/Tier/Data.lua
+++ b/lua/wikis/worldoftanks/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/lua/wikis/zula/Tier/Data.lua
+++ b/lua/wikis/zula/Tier/Data.lua
@@ -52,7 +52,7 @@ return {
 			value = '-1',
 			sort = 'C1',
 			name = 'Misc',
-			short = 'Misc',
+			short = 'M.',
 			link = 'Miscellaneous Tournaments',
 			category = 'Misc Tournaments',
 		},

--- a/stylesheets/commons/TournamentTags.less
+++ b/stylesheets/commons/TournamentTags.less
@@ -134,6 +134,10 @@ Author(s): Elysienna
 		&.chip--tier5 {
 			background-color: @tier5-chip-background-color;
 		}
+
+		&.chip--misc {
+			background-color: @misc-chip-background-color;
+		}
 	}
 
 	&__text {


### PR DESCRIPTION
## Summary
Fixes the bad display of misc-tournaments that also have a tiertype set on the mainpage.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev and inspect

Before:
![grafik](https://github.com/user-attachments/assets/ebd363cf-ca2f-425c-a405-97442446915e)

After:
![grafik](https://github.com/user-attachments/assets/f8e95c0a-6a46-4d1f-9334-c48a41701146)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
