### PR TITLE
feat(matchticker): Add option to display game icons in new matchticker display

### DIFF
--- a/lua/wikis/ageofempires/MainPageLayout/data.lua
+++ b/lua/wikis/ageofempires/MainPageLayout/data.lua
@@ -58,6 +58,7 @@ local CONTENT = {
 	matches = {
 		heading = 'Matches',
 		body = MatchTicker{
+			displayGameIcons = true,
 			matchesPortal = 'Liquipedia:Upcoming_and_ongoing_matches'
 		},
 		padding = true,

--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -97,6 +97,7 @@ end
 ---@field games string[]?
 ---@field newStyle boolean?
 ---@field featuredTournamentsOnly boolean?
+---@field displayGameIcons boolean?
 
 ---@class MatchTicker
 ---@operator call(table): MatchTicker

--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -146,6 +146,7 @@ function MatchTicker:init(args)
 				end) or nil,
 		newStyle = Logic.readBool(args.newStyle),
 		featuredTournamentsOnly = Logic.readBool(args.featuredTournamentsOnly),
+		displayGameIcons = Logic.readBool(args.displayGameIcons)
 	}
 
 	--min 1 of them has to be set; recent can not be set while any of the others is set
@@ -168,6 +169,10 @@ function MatchTicker:init(args)
 		Table.isEmpty(config.tournaments)))
 
 	config.hideTournament = Logic.readBool(args.hideTournament or Table.isNotEmpty(config.tournaments))
+
+	if config.displayGameIcons then
+		table.insert(config.queryColumns, 'game')
+	end
 
 	local wrapperClasses = type(args.wrapperClasses) == 'table' and args.wrapperClasses
 		or args.wrapperClasses == NONE and {}

--- a/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
@@ -145,7 +145,7 @@ function Details:create()
 			:wikitext('+ Add details')
 		), link))
 	elseif self.displayGameIcons then
-		matchBottomBar:node(Game.icon{game=self.match.game, noLink=true, size='50'})
+		matchBottomBar:node(Game.icon{game=self.match.game, noLink=true, size='50px', spanClass='icon-small'})
 	end
 
 	return self.root

--- a/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
@@ -105,7 +105,7 @@ end
 ---@field root Html
 ---@field hideTournament boolean
 ---@field onlyHighlightOnValue string?
----@field displayGameIcon boolean
+---@field displayGameIcons boolean
 ---@field match table
 local Details = Class.new(
 	function(self, args)
@@ -113,7 +113,7 @@ local Details = Class.new(
 		self.root = mw.html.create('div'):addClass('match-details')
 		self.hideTournament = args.hideTournament
 		self.onlyHighlightOnValue = args.onlyHighlightOnValue
-		self.displayGameIcon = args.displayGameIcons
+		self.displayGameIcons = args.displayGameIcons
 		self.match = args.match
 	end
 )
@@ -144,7 +144,7 @@ function Details:create()
 			:attr('title', 'Add Match Page')
 			:wikitext('+ Add details')
 		), link))
-	elseif self.displayGameIcon then
+	elseif self.displayGameIcons then
 		matchBottomBar:node(Game.icon{game=self.match.game})
 	end
 
@@ -280,7 +280,8 @@ function Match:detailsRow()
 	return Details{
 		match = self.match,
 		hideTournament = self.config.hideTournament,
-		onlyHighlightOnValue = self.config.onlyHighlightOnValue
+		onlyHighlightOnValue = self.config.onlyHighlightOnValue,
+		displayGameIcons = self.config.displayGameIcons
 	}:create()
 end
 

--- a/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
@@ -13,6 +13,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
 local DateExt = require('Module:Date/Ext')
+local Game = require('Module:Game')
 local Info = require('Module:Info')
 local LeagueIcon = require('Module:LeagueIcon')
 local Logic = require('Module:Logic')
@@ -104,6 +105,7 @@ end
 ---@field root Html
 ---@field hideTournament boolean
 ---@field onlyHighlightOnValue string?
+---@field displayGameIcon boolean
 ---@field match table
 local Details = Class.new(
 	function(self, args)
@@ -111,6 +113,7 @@ local Details = Class.new(
 		self.root = mw.html.create('div'):addClass('match-details')
 		self.hideTournament = args.hideTournament
 		self.onlyHighlightOnValue = args.onlyHighlightOnValue
+		self.displayGameIcon = args.displayGameIcons
 		self.match = args.match
 	end
 )
@@ -141,6 +144,8 @@ function Details:create()
 			:attr('title', 'Add Match Page')
 			:wikitext('+ Add details')
 		), link))
+	elseif self.displayGameIcon then
+		matchBottomBar:node(Game.icon{game=self.match.game})
 	end
 
 	return self.root

--- a/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents/New.lua
@@ -145,7 +145,7 @@ function Details:create()
 			:wikitext('+ Add details')
 		), link))
 	elseif self.displayGameIcons then
-		matchBottomBar:node(Game.icon{game=self.match.game})
+		matchBottomBar:node(Game.icon{game=self.match.game, noLink=true, size='50'})
 	end
 
 	return self.root

--- a/lua/wikis/commons/Widget/MainPage/MatchTicker.lua
+++ b/lua/wikis/commons/Widget/MainPage/MatchTicker.lua
@@ -27,7 +27,7 @@ MatchTicker.defaultProps = {
 ---@return Widget[]
 function MatchTicker:render()
 	return WidgetUtil.collect(
-		MatchTickerContainer{self.props.displayGameIcons},
+		MatchTickerContainer{displayGameIcons = self.props.displayGameIcons},
 		HtmlWidgets.Div{
 			css = {
 				['white-space'] = 'nowrap',

--- a/lua/wikis/commons/Widget/MainPage/MatchTicker.lua
+++ b/lua/wikis/commons/Widget/MainPage/MatchTicker.lua
@@ -17,7 +17,7 @@ local Link = Lua.import('Module:Widget/Basic/Link')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class MatchTicker: Widget
----@field props { matchesPortal: string? }
+---@field props { matchesPortal: string?, displayGameIcons: boolean? }
 ---@operator call(table): MatchTicker
 local MatchTicker = Class.new(Widget)
 MatchTicker.defaultProps = {
@@ -27,7 +27,7 @@ MatchTicker.defaultProps = {
 ---@return Widget[]
 function MatchTicker:render()
 	return WidgetUtil.collect(
-		MatchTickerContainer{},
+		MatchTickerContainer{self.props.displayGameIcons},
 		HtmlWidgets.Div{
 			css = {
 				['white-space'] = 'nowrap',

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -57,7 +57,7 @@ function MatchTickerContainer:render()
 				args = table.concat(Array.extractValues(Table.map(
 					Table.merge(matchTickerArgs, {type=type, dev=devFlag}),
 					function (key, value)
-						return key, String.interpolate('|${key}=${value}', {key=key, value=value})
+						return key, String.interpolate('|${key}=${value}', {key=key, value=tostring(value)})
 					end
 				)), '')
 			}

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -40,6 +40,11 @@ function MatchTickerContainer:render()
 		return filterName(category.name), table.concat(category.defaultItems or {}, ',')
 	end)
 
+	local matchTickerArgs = {
+		limit = self.props.limit,
+		displayGameIcons = self.props.displayGameIcons
+	}
+
 	local devFlag = FeatureFlag.get('dev')
 
 	---@param type 'upcoming' | 'recent'
@@ -50,7 +55,7 @@ function MatchTickerContainer:render()
 				module = self.defaultProps.module,
 				fn = self.defaultProps.fn,
 				args = table.concat(Array.extractValues(Table.map(
-					{limit=self.props.limit, type=type, dev=devFlag},
+					Table.merge(matchTickerArgs, {type=type, dev=devFlag}),
 					function (key, value)
 						return key, String.interpolate('|${key}=${value}', {key=key, value=value})
 					end
@@ -64,7 +69,8 @@ function MatchTickerContainer:render()
 		local ticker = Lua.import('Module:' .. self.defaultProps.module)
 		return ticker[self.defaultProps.fn](
 			Table.merge(
-				{limit=self.props.limit, type=type},
+				{type=type},
+				matchTickerArgs,
 				defaultFilterParams
 			)
 		)

--- a/lua/wikis/commons/Widget/Tournament/Label.lua
+++ b/lua/wikis/commons/Widget/Tournament/Label.lua
@@ -53,9 +53,9 @@ function TournamentsTickerLabelWidget:render()
 						children  = {
 							Game.icon{
 								game = tournament.game,
-								noSpan = true,
-								size = '50',
-								noLink = true
+								noLink=true,
+								size='50px',
+								spanClass='icon-small'
 							}
 						}
 					} or '',


### PR DESCRIPTION
## Summary
Adds the option to display game icons in the new matchticker, at the location where some wikis have their matchpage links.
Also enables the option on the wiki AoE; further fixes the incorrect size string for game icons in the tournament ticker (alt and title were also set to 50)
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
before:
![grafik](https://github.com/user-attachments/assets/fb12188b-1c55-420f-8cf9-dde15abb5a06)
after (with option enabled):
![grafik](https://github.com/user-attachments/assets/f0e512e4-cd26-4186-988f-2f51b9900821)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
