### PR TITLE
feat(match2): Allow player order input on any non-solo opponent (AoE)

### DIFF
--- a/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
@@ -240,8 +240,14 @@ function MapFunctions.getPlayersOfMapOpponent(map, opponent, opponentIndex)
 	local players
 	if opponent.type == Opponent.team then
 		players = Array.parseCommaSeparatedString(map['players' .. opponentIndex])
-	else
+	elseif opponent.type == Opponent.solo then
 		players = Array.map(opponent.match2players, Operator.property('name'))
+	else
+		-- Party of 2 or more players
+		players = Logic.emptyOr(
+			Array.parseCommaSeparatedString(map['players' .. opponentIndex]),
+			Array.map(opponent.match2players, Operator.property('name'))
+		) or {}
 	end
 	local civs = Array.parseCommaSeparatedString(map['civs' .. opponentIndex])
 


### PR DESCRIPTION
## Summary
As the order of displayed players in a match has a meaning on AoE, allow to read the players from manual input for each map, for all non-solo opponent types.
Falls back to the players set on the opponent directly if no input is present.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
