### PR TITLE
feat: Migrate AoE to standardized matchticker for players and tournaments

### DIFF
--- a/lua/wikis/ageofempires/Infobox/League/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/League/Custom.lua
@@ -123,11 +123,12 @@ function CustomLeague:createBottomContent()
 
 	if self.data.endDate and yesterday <= self.data.endDate then
 		---@diagnostic disable-next-line: missing-fields
-		return MatchTicker.tournament{args={
+		return MatchTicker.tournament{
 			tournament = self.pagename,
 			limit = tonumber(self.args.matchtickerlimit) or 7,
-			infoboxWrapperClass = false
-		}}
+			infoboxWrapperClass = 'false',
+			infoboxClass = true
+		}
 	end
 end
 

--- a/lua/wikis/ageofempires/Infobox/League/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/League/Custom.lua
@@ -122,13 +122,13 @@ function CustomLeague:createBottomContent()
 	local yesterday = os.date('%Y-%m-%d', os.time() - SECONDS_PER_DAY)
 
 	if self.data.endDate and yesterday <= self.data.endDate then
-		---@diagnostic disable-next-line: missing-fields
-		return MatchTicker.tournament{
+		local matchtickerArgs = {
 			tournament = self.pagename,
 			limit = tonumber(self.args.matchtickerlimit) or 7,
 			infoboxWrapperClass = 'false',
 			infoboxClass = true
 		}
+		return MatchTicker.tournament(matchtickerArgs)
 	end
 end
 

--- a/lua/wikis/ageofempires/Infobox/League/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/League/Custom.lua
@@ -15,7 +15,7 @@ local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local MapMode = require('Module:MapMode')
-local MatchTicker = require('Module:Matches Tournament')
+local MatchTicker = require('Module:MatchTicker/Custom')
 local Page = require('Module:Page')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
@@ -117,15 +117,16 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
----@return string?
+---@return Html?
 function CustomLeague:createBottomContent()
 	local yesterday = os.date('%Y-%m-%d', os.time() - SECONDS_PER_DAY)
 
 	if self.data.endDate and yesterday <= self.data.endDate then
-		return MatchTicker.get{args={
-			parent = self.pagename,
+		---@diagnostic disable-next-line: missing-fields
+		return MatchTicker.tournament{args={
+			tournament = self.pagename,
 			limit = tonumber(self.args.matchtickerlimit) or 7,
-			noInfoboxWrapper = true
+			infoboxWrapperClass = false
 		}}
 	end
 end

--- a/lua/wikis/ageofempires/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Person/Player/Custom.lua
@@ -12,7 +12,7 @@ local Game = require('Module:Game')
 local Info = require('Module:Info')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchTicker = require('Module:MatchesTicker/Custom')
+local MatchTicker = require('Module:MatchTicker/Custom')
 local Namespace = require('Module:Namespace')
 local Operator = require('Module:Operator')
 local Page = require('Module:Page')
@@ -217,7 +217,7 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
----@return string?
+---@return Html?
 function CustomPlayer:createBottomContent()
 	return MatchTicker.participant{player = self.pagename}
 end

--- a/lua/wikis/ageofempires/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Person/Player/Custom.lua
@@ -12,7 +12,7 @@ local Game = require('Module:Game')
 local Info = require('Module:Info')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local MatchTicker = require('Module:Matches Player')
+local MatchTicker = require('Module:MatchesTicker/Custom')
 local Namespace = require('Module:Namespace')
 local Operator = require('Module:Operator')
 local Page = require('Module:Page')
@@ -219,7 +219,7 @@ end
 
 ---@return string?
 function CustomPlayer:createBottomContent()
-	return MatchTicker.get{args = {self.pagename}}
+	return MatchTicker.participant{player = self.pagename}
 end
 
 ---@param id string

--- a/lua/wikis/commons/MatchTicker/Custom.lua
+++ b/lua/wikis/commons/MatchTicker/Custom.lua
@@ -18,7 +18,7 @@ local CURRENT_PAGE = mw.title.getCurrentTitle().text
 local CustomMatchTicker = {}
 
 ---Entry point for display on tournament pages
----@param frame Frame
+---@param frame Frame|table|nil
 ---@return Html
 function CustomMatchTicker.tournament(frame)
 	local args = Arguments.getArgs(frame)
@@ -38,7 +38,7 @@ function CustomMatchTicker.tournament(frame)
 end
 
 ---Entry point for display on the main page
----@param frame Frame?
+---@param frame Frame|table|nil
 ---@return Html
 function CustomMatchTicker.mainPage(frame)
 	local args = Arguments.getArgs(frame)
@@ -46,7 +46,7 @@ function CustomMatchTicker.mainPage(frame)
 end
 
 ---Entry point for display on the main page with the new style
----@param frame Frame?
+---@param frame Frame|table|nil
 ---@return Html?
 function CustomMatchTicker.newMainPage(frame)
 	local args = Arguments.getArgs(frame)
@@ -73,7 +73,7 @@ function CustomMatchTicker.newMainPage(frame)
 end
 
 ---Entry point for display on player pages
----@param frame Frame?
+---@param frame Frame|table|nil
 ---@return Html
 function CustomMatchTicker.player(frame)
 	local args = Arguments.getArgs(frame)
@@ -84,7 +84,7 @@ function CustomMatchTicker.player(frame)
 end
 
 ---Entry point for display on team pages
----@param frame Frame?
+---@param frame Frame|table|nil
 ---@return Html
 function CustomMatchTicker.team(frame)
 	local args = Arguments.getArgs(frame)


### PR DESCRIPTION
## Summary
Switches Infobox player and league to the standard matchticker on AoE
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
