### PR TITLE
feat: split ggxrd and ggxrds on Fighters 

### DIFF
--- a/lua/wikis/fighters/Info.lua
+++ b/lua/wikis/fighters/Info.lua
@@ -521,6 +521,19 @@ return {
 		},
 		ggxrd = {
 			abbreviation = 'GG XRD',
+			name = 'Guilty Gear Xrd',
+			link = 'Guilty Gear Xrd',
+			logo = {
+				darkMode = 'GGXrdSign Logo.png',
+				lightMode = 'GGXrdSign Logo.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'GGXrdSign Logo.png',
+				lightMode = 'GGXrdSign Logo.png',
+			},
+		},
+		ggxrds = {
+			abbreviation = 'GG XRD S',
 			name = 'Guilty Gear Xrd -SIGN-',
 			link = 'Guilty Gear Xrd -SIGN-',
 			logo = {


### PR DESCRIPTION
This change is a fix to a game title in fighters. 

Guilty Gear Xrd (ggxrd) is currently named and linked to Guilty Gear Xrd -SIGN- in this module, which is a mistake since SIGN is a version and not part of the game's title (Sign is one of the 3 versions of the game, the other 2 are already included in this module). 

Here's the link to the game page:
https://liquipedia.net/fighters/Guilty_Gear_Xrd

In addition to fixing the name/link for ggxrd, this change also adds SIGN as a separate parameter (ggxrds) because versions are also included in this module despite us not using them at the moment, since fighters combine different versions results into the parent game (which is a lot more user friendly). The logo remains the same for both ggxrd and ggxrds because there is no separate logo for "base" Xrd, Sign was its launch version.

References about this issue in the discord:
https://discord.com/channels/93055209017729024/202549269134180352/1362536558238109776
https://discord.com/channels/93055209017729024/202549269134180352/1303334889168310303

## Summary

The point of the change is to fix the game's display in infoboxes. Here's an example of why it's an issue:

https://liquipedia.net/fighters/ARCREVO/2019/GGXrdR2

"Guilty Gear Xrd -SIGN- REV 2" doesn't make sense as its listing 2 completely different versions of the game. -SIGN- should just be removed here.

## How did you test this change?

Not sure how I'd test it but it's a very simple change so there shouldn't be any issues.

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
