### PR TITLE
fix(mainpage): footer links of transfer list widget overflowing in mobile

### DIFF
--- a/lua/wikis/commons/Widget/MainPage/TransfersList.lua
+++ b/lua/wikis/commons/Widget/MainPage/TransfersList.lua
@@ -71,7 +71,9 @@ function TransfersList:render()
 				Div {
 					css = {
 						['white-space'] = 'nowrap',
-						display = 'inline',
+						display = 'inline flex',
+						['flex-wrap'] = 'wrap',
+						['justify-content'] = 'center',
 						margin = '0 10px',
 						['font-size'] = '15px',
 						['font-style'] = 'italic'


### PR DESCRIPTION
## Summary

Reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1362757042103914646

## How did you test this change?

dev
