### PR TITLE
fix(infobox): fortnite infobox team using deprecated lpdb fields

### DIFF
--- a/lua/wikis/fortnite/Infobox/Team/Custom.lua
+++ b/lua/wikis/fortnite/Infobox/Team/Custom.lua
@@ -81,7 +81,7 @@ function CustomTeam:calculateEarnings()
 	local playerTeamConditions = ConditionTree(BooleanOperator.any)
 	for playerIndex = 1, MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS do
 		playerTeamConditions:add{
-			ConditionNode(ColumnName('players_p' .. playerIndex .. 'team'), Comparator.eq, team),
+			ConditionNode(ColumnName('opponentplayers_p' .. playerIndex .. 'team'), Comparator.eq, team),
 		}
 	end
 
@@ -89,7 +89,7 @@ function CustomTeam:calculateEarnings()
 		ConditionNode(ColumnName('date'), Comparator.neq, DateExt.defaultDateTime),
 		ConditionNode(ColumnName('prizemoney'), Comparator.gt, '0'),
 		ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('participantlink'), Comparator.eq, team),
+			ConditionNode(ColumnName('opponentname'), Comparator.eq, team),
 			ConditionTree(BooleanOperator.all):add{
 				ConditionNode(ColumnName('mode'), Comparator.neq, 'team'),
 				playerTeamConditions


### PR DESCRIPTION
## Summary
fortnite still uses deprecated fields to condition on for their custom earnings overwrite in infobox team
this also causes award prizes to not be accounted for

## How did you test this change?
dev