### PR TITLE
feat(infobox): update abilities display in brawlstars unit infobox

### DIFF
--- a/lua/wikis/brawlstars/Infobox/Unit/Brawler/Custom.lua
+++ b/lua/wikis/brawlstars/Infobox/Unit/Brawler/Custom.lua
@@ -61,9 +61,10 @@ function CustomInjector:parse(id, widgets)
 			Title{children = 'Weapon & Super'},
 			Cell{name = 'Primary Weapon', content = {args.attack}},
 			Cell{name = 'Super Ability', content = {args.super}},
-			Title{children = 'Gadgets & Star Powers'},
+			Title{children = 'Abilities'},
 			Cell{name = 'Gadgets', content = {args.gadget}},
-			Cell{name = 'Star Powers', content = {args.star}}
+			Cell{name = 'Star Powers', content = {args.star}},
+			Cell{name = 'Hypercharge', content = {args.hypercharge}}
 		)
 	end
 


### PR DESCRIPTION
## Summary
Added support for the "Hypercharge" ability by introducing a new cell in the Brawler infobox and renaming the section title to "Abilities" for clarity.

The game has long featured the "Hypercharge" ability, but the infobox template did not support displaying this information. This change resolves that limitation by adding a dedicated field for Hypercharge, ensuring that all key brawler abilities are properly represented.

## How did you test this change?
Pages with new version of Infobox: 
1. https://liquipedia.net/brawlstars/Shelly
2. https://liquipedia.net/brawlstars/8-Bit

**Before:**
![browser_YI2KWb7etn](https://github.com/user-attachments/assets/18edee98-17d3-434e-bf3c-235270a3a5d9)

**After:**
![browser_eHYJC1gJ0h](https://github.com/user-attachments/assets/862100b9-9ade-46a4-b0fb-05b110dbc7d6)

Now infobox supports Hypercharge and title renamed right.