### PR TITLE
feat(match2): add caster row support for geoguessr

### DIFF
--- a/lua/wikis/geoguessr/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/geoguessr/MatchGroup/Input/Custom.lua
@@ -33,6 +33,16 @@ function MatchFunctions.extractMaps(match, opponents)
 	return MatchGroupInputUtil.standardProcessMaps(match, opponents, MapFunctions)
 end
 
+---@param match table
+---@param games table[]
+---@param opponents table[]
+---@return table
+function MatchFunctions.getExtraData(match, games, opponents)
+	return {
+		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
+	}
+end
+
 ---@param games table[]
 ---@return table[]
 function MatchFunctions.removeUnsetMaps(games)


### PR DESCRIPTION
## Summary
The main point of this pull request is to add caster parameter to GeoGuessr, since for now, GeoGuessr still doesn't have caster parameter for Match

## How did you test this change?
dev(steve23) and in this page
https://liquipedia.net/geoguessr/User:Steve23/Bot_Testing_Page