### PR TITLE
chore: remove unused `fetchMatch2Player` option

### DIFF
--- a/lua/wikis/commons/Player/Ext/Starcraft.lua
+++ b/lua/wikis/commons/Player/Ext/Starcraft.lua
@@ -142,7 +142,6 @@ function StarcraftPlayerExt.syncPlayer(player, options)
 	player.faction = player.faction
 		or globalVars:get(player.displayName .. '_faction')
 		or options.fetchPlayer ~= false and StarcraftPlayerExt.fetchPlayerFaction(player.pageName, options.date)
-		or match2Player() and match2Player().faction
 		or Faction.defaultFaction
 
 	if options.savePageVar ~= false then


### PR DESCRIPTION
## Summary
as per search with https://tools.liquipedia.0xff0000.dev/?view=search there is no usage of this, hence we can remove it

## How did you test this change?
N/A