### PR TITLE
feat(match2): use display name for players instead of pagename in LoL match page

### DIFF
--- a/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
@@ -172,7 +172,6 @@ function MapFunctions.getPlayersOfMapOpponent(MapParser, map, opponent, opponent
 			local participant = participantList[playerIndex]
 			participant.player = playerIdData.name or playerInputData.link or playerInputData.name
 			participant.displayName = playerIdData.displayname or playerInputData.name
-			local participant = participantList[playerIndex]
 			participant.character = getCharacterName(participant.character)
 			return participant
 		end

--- a/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/leagueoflegends/MatchGroup/Input/Custom.lua
@@ -168,7 +168,10 @@ function MapFunctions.getPlayersOfMapOpponent(MapParser, map, opponent, opponent
 			local participant = participantList[playerIndex]
 			return participant and {name = participant.player} or nil
 		end,
-		function(playerIndex)
+		function(playerIndex, playerIdData, playerInputData)
+			local participant = participantList[playerIndex]
+			participant.player = playerIdData.name or playerInputData.link or playerInputData.name
+			participant.displayName = playerIdData.displayname or playerInputData.name
 			local participant = participantList[playerIndex]
 			participant.character = getCharacterName(participant.character)
 			return participant

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -486,7 +486,8 @@ function MatchPage:_renderPlayerPerformance(game, teamIndex, player)
 							caption = mw.getContentLanguage():ucfirst(player.role),
 							link = ''
 						},
-						playerName = player.player
+						playerLink = player.player,
+						playerName = player.displayName or player.player
 					},
 					Div{
 						classes = {'match-bm-lol-players-player-loadout'},


### PR DESCRIPTION
## Summary

Right now player names in LoL matchpages use the full player pagename for display instead of the "display name" (e.g., [Viper (Korean player)](https://liquipedia.net/leagueoflegends/Viper_(Korean_player)) instead of just Viper).
This PR changes this behavior to use display names instead.

## How did you test this change?

dev