### PR TITLE
feat: Add R6 Mobile to R6 wiki

### DIFF
--- a/lua/wikis/rainbowsix/Info.lua
+++ b/lua/wikis/rainbowsix/Info.lua
@@ -7,11 +7,24 @@
 --
 
 return {
-	startYear = 2006, --vegas from 2006; vegas2 from 2008; siege from 2015
+	startYear = 2006, --vegas from 2006; vegas2 from 2008; siege from 2015; mobile from 2022
 	wikiName = 'rainbowsix',
 	name = 'Rainbow Six',
 	defaultGame = 'siege',
 	games = {
+		mobile = {
+			abbreviation = 'R6M',
+			name = 'Tom Clancy\'s Rainbow Six Mobile',
+			link = 'Rainbow Six Siege',
+			logo = {
+				darkMode = 'Rainbow_Six_Mobile_darkmode.png',
+				lightMode = 'Rainbow_Six_Mobile_lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Rainbow_Six_Mobile_darkmode.png',
+				lightMode = 'Rainbow_Six_Mobile_lightmode.png',
+			},
+		},
 		siege = {
 			abbreviation = 'R6S',
 			name = 'Tom Clancy\'s Rainbow Six Siege',

--- a/lua/wikis/rainbowsix/Info.lua
+++ b/lua/wikis/rainbowsix/Info.lua
@@ -15,14 +15,14 @@ return {
 		mobile = {
 			abbreviation = 'R6M',
 			name = 'Tom Clancy\'s Rainbow Six Mobile',
-			link = 'Rainbow Six Siege',
+			link = 'Rainbow Six Mobile',
 			logo = {
-				darkMode = 'Rainbow_Six_Mobile_darkmode.png',
-				lightMode = 'Rainbow_Six_Mobile_lightmode.png',
+				darkMode = 'Rainbow Six Mobile darkmode.png',
+				lightMode = 'Rainbow Six Mobile lightmode.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Rainbow_Six_Mobile_darkmode.png',
-				lightMode = 'Rainbow_Six_Mobile_lightmode.png',
+				darkMode = 'Rainbow Six Mobile darkmode.png',
+				lightMode = 'Rainbow Six Mobile lightmode.png',
 			},
 		},
 		siege = {


### PR DESCRIPTION
## Summary
Given the game's development has been slowed down quite significantly (it's still on testing), but there has been some Community-ran events during the Beta test, might be worth having R6 Mobile events co-exist in the R6 wiki for the time being until they have expanded competitive enough that warrants its own standalone wiki. If not then at least we have a place to document it

## Side Note 
this can be merged right away since Siege X is two months away, R6M as a game is two years old at this point

## Side Note 2
The co-exist, then potential split later is also the approach internally being considered at for VALORANT Mobile as well (albeit w/o Info.lua changes)