### PR TITLE
feat(match2): use display name for teams in match page header

### DIFF
--- a/lua/wikis/commons/Widget/Match/Page/TeamDisplay.lua
+++ b/lua/wikis/commons/Widget/Match/Page/TeamDisplay.lua
@@ -56,7 +56,7 @@ function MatchPageTeamDisplay:render()
 				children = {
 					Div{
 						classes = { 'match-bm-match-header-team-long' },
-						children = { Link{ link = data.page } }
+						children = { Link{ link = data.page, children = data.name } }
 					},
 					Div{
 						classes = { 'match-bm-match-header-team-short' },


### PR DESCRIPTION
## Summary

see https://github.com/Liquipedia/Lua-Modules/pull/5858#issuecomment-2818959445

## How did you test this change?

dev
