### PR TITLE
feat(Infobox): Add Mobile Platform to R6 wiki

### DIFF
--- a/lua/wikis/rainbowsix/Infobox/League/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/League/Custom.lua
@@ -38,6 +38,7 @@ local PLATFORM_ALIAS = {
 	playstation = 'Playstation',
 	ps = 'Playstation',
 	ps4 = 'Playstation',
+	mobile = 'Mobile',
 }
 
 local UBISOFT_TIERS = {


### PR DESCRIPTION
## Summary
Actually, this should be together with #5861  (Module:Info)  for the same reason

I wasn't aware R6 InfoLeague had platform inputs too

![image](https://github.com/user-attachments/assets/242891e9-de0a-42a7-8213-8b41563c304d)

## How did you test this change?
DEV