### PR TITLE
feat(match2): make team name alignment consistent in match page header

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -40,6 +40,7 @@ Author(s): Rathoz
 		.match-bm-match-header-team-group {
 			@media ( min-width: 768px ) {
 				align-items: flex-end;
+				text-align: end;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Right now, if the display name of opponent 1 is too long, the split parts of the name gets aligned on the left.
This PR changes the text to be aligned on the right.

## How did you test this change?

browser dev tools

before:
![before](https://github.com/user-attachments/assets/c331b38a-9e04-4fbf-9e50-256f89b06cf5)

after:
![after](https://github.com/user-attachments/assets/722a60f4-6d5b-4300-b74c-e3e9a1a7e95c)

