### PR TITLE
fix(MatchesScheduleDisplay): not accounting for possibility of non-string args keys

### DIFF
--- a/lua/wikis/commons/MatchesScheduleDisplay.lua
+++ b/lua/wikis/commons/MatchesScheduleDisplay.lua
@@ -74,7 +74,7 @@ function MatchesTable:init(args)
 		onlyShowExactDates = Logic.readBool(args.dateexact),
 		shortenRoundNames = Logic.readBool(args.shortedroundnames),
 		pages = Array.map(Array.extractValues(
-				Table.filterByKey(args, function(key) return key:find('^tournament%d-$') end)
+				Table.filterByKey(args, function(key) return string.find(key, '^tournament%d-$') ~= nil end)
 			), function(page) return (page:gsub(' ', '_')) end),
 	}
 


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1364333175467409428

additionally fixed a wrong anno in the same line

## How did you test this change?
live as bug fix