### PR TITLE
chore(match2): cleanup unused param from readCasters

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
@@ -527,7 +527,7 @@ end
 ---@return table
 function FfaMatchFunctions.getExtraData(match, games, opponents, settings)
 	return {
-		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
+		casters = MatchGroupInputUtil.readCasters(match),
 		ffa = 'true',
 		placementinfo = settings.placementInfo,
 		settings = settings.settings,

--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -1411,7 +1411,7 @@ function MatchGroupInputUtil.standardProcessFfaMatch(match, Parser, mapProps)
 	match.links = MatchGroupInputUtil.getLinks(match)
 	match.extradata = Table.merge({
 		mvp = MatchGroupInputUtil.readMvp(match, opponents),
-		casters = MatchGroupInputUtil.readCasters(match, {noSort = true})
+		casters = MatchGroupInputUtil.readCasters(match)
 	}, Parser.getExtraData and Parser.getExtraData(match, games, opponents, settings) or {
 		placementinfo = settings.placementInfo,
 		settings = settings.settings,
@@ -1493,7 +1493,7 @@ function MatchGroupInputUtil.standardProcessFfaMaps(match, opponents, scoreSetti
 
 		map.extradata = Table.merge({
 			mvp = MatchGroupInputUtil.readMvp(map, opponents),
-			casters = MatchGroupInputUtil.readCasters(map, {noSort = true})
+			casters = MatchGroupInputUtil.readCasters(map)
 		}, Parser.getExtraData and Parser.getExtraData(match, map, opponents) or nil)
 
 		table.insert(maps, map)

--- a/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
@@ -500,7 +500,7 @@ end
 ---@return table
 function FfaMatchFunctions.getExtraData(match, games, opponents, settings)
 	return {
-		casters = MatchGroupInputUtil.readCasters(match, {noSort = true}),
+		casters = MatchGroupInputUtil.readCasters(match),
 		ffa = 'true',
 		placementinfo = settings.placementInfo,
 		settings = settings.settings,


### PR DESCRIPTION
## Summary

In #5863 `noSort` option was removed from `MatchGroupInputUtil.readCasters`
This PR cleans up existing references to it

## How did you test this change?

N/A
