### PR TITLE
fix: Correctly display import errors when in dev mode

### DIFF
--- a/lua/wikis/commons/ResultOrError.lua
+++ b/lua/wikis/commons/ResultOrError.lua
@@ -116,7 +116,7 @@ end
 ---Errors with a JSON string for use by `liquipedia.customLuaErrors` JS module.
 ---@return any
 function ResultOrError.Error:get()
-	error(self.error)
+	error(tostring(self.error))
 end
 
 --[[


### PR DESCRIPTION
## Summary
Closes #5870 

There is a tiny difference between dev/no-dev mode, where the dev error message also includes the line in ResultOrError.lua, as that is where the error is rethrown

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev (on a long chain of manually imported dev modules, as the modules isn't Lua.imported)
Before:
![image](https://github.com/user-attachments/assets/c32ab7e6-fff9-466c-979f-914baa13a0f8)
Before, no dev:
![image](https://github.com/user-attachments/assets/cdcb4359-9c60-440b-a2d8-fa41f87b7e26)
After:
![image](https://github.com/user-attachments/assets/f00a4a8a-791e-4ccf-b45d-bc8335f82a70)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
