### PR TITLE
feat(match2): allow empty map(name) input in maps on tft

### DIFF
--- a/lua/wikis/tft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/tft/MatchGroup/Input/Custom.lua
@@ -7,6 +7,7 @@
 --
 
 local Array = require('Module:Array')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 local Variables = require('Module:Variables')

--- a/lua/wikis/tft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/tft/MatchGroup/Input/Custom.lua
@@ -70,9 +70,7 @@ end
 ---@param games table[]
 ---@return table[]
 function MatchFunctions.removeUnsetMaps(games)
-	return Array.filter(games, function(map)
-		return map.map ~= nil
-	end)
+	return Array.filter(games, Logic.isNotEmpty)
 end
 
 ---@param map table

--- a/lua/wikis/tft/MatchSummary.lua
+++ b/lua/wikis/tft/MatchSummary.lua
@@ -26,10 +26,6 @@ end
 ---@param gameIndex integer
 ---@return Widget?
 function CustomMatchSummary.createGame(date, game, gameIndex)
-	if not game.map then
-		return
-	end
-
 	local function makeTeamSection(opponentIndex)
 		return {
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = opponentIndex},

--- a/lua/wikis/tft/MatchSummary.lua
+++ b/lua/wikis/tft/MatchSummary.lua
@@ -37,7 +37,7 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		classes = {'brkts-popup-body-game'},
 		children = WidgetUtil.collect(
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
-			MatchSummaryWidgets.GameCenter{children = 
+			MatchSummaryWidgets.GameCenter{children =
 				game.map and DisplayHelper.Map(game)
 				or {'Game ', gameIndex}
 			},

--- a/lua/wikis/tft/MatchSummary.lua
+++ b/lua/wikis/tft/MatchSummary.lua
@@ -37,7 +37,7 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		classes = {'brkts-popup-body-game'},
 		children = WidgetUtil.collect(
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
-			MatchSummaryWidgets.GameCenter{children = DisplayHelper.Map(game)},
+			MatchSummaryWidgets.GameCenter{children = {'Round ', gameIndex}},
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(2), flipped = true},
 			MatchSummaryWidgets.GameComment{children = game.comment}
 		)

--- a/lua/wikis/tft/MatchSummary.lua
+++ b/lua/wikis/tft/MatchSummary.lua
@@ -37,7 +37,10 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		classes = {'brkts-popup-body-game'},
 		children = WidgetUtil.collect(
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
-			MatchSummaryWidgets.GameCenter{children = {'Round ', gameIndex}},
+			MatchSummaryWidgets.GameCenter{children = 
+				game.map and DisplayHelper.Map(game)
+				or {'Game ', gameIndex}
+			},
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(2), flipped = true},
 			MatchSummaryWidgets.GameComment{children = game.comment}
 		)


### PR DESCRIPTION
## Summary
as per request on discord allow empty/missing map name input on maps in standard matches on tft
as stated on discord they seem to not have map names quite often

## How did you test this change?
dev