### PR TITLE
fix: Correct vertical offset of game icons in tournaments ticker

### DIFF
--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -105,7 +105,6 @@ div.main-page-banner .main-page-banner-bottom-row {
 .tournaments-list-name span.tournament-game-icon {
 	margin-left: -50px;
 	padding-right: 25px;
-	position: absolute;
 }
 
 .dropdown-menu .league-icon-small-image img,
@@ -117,7 +116,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 
 .dropdown-menu span.league-icon-small-image,
 .tournaments-list-name span.league-icon-small-image,
-.tournaments-list-name span.icon-small img {
+.tournaments-list-name span.icon-small {
 	vertical-align: -4px;
 	min-height: 21px;
 	min-width: 21px;

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -105,6 +105,7 @@ div.main-page-banner .main-page-banner-bottom-row {
 .tournaments-list-name span.tournament-game-icon {
 	margin-left: -50px;
 	padding-right: 25px;
+	position: absolute;
 }
 
 .dropdown-menu .league-icon-small-image img,


### PR DESCRIPTION
## Summary
The game icons had a vertical offset when compared to the tournament icons, as well as different spacing between components
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
inspect
Before:
![image](https://github.com/user-attachments/assets/fbd72f3a-6eae-490f-b4a5-5f313ff2e65f)
After:
![image](https://github.com/user-attachments/assets/fff463dd-da5f-4087-84f3-c8b375bc9828)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
