### PR TITLE
fix(match2): tft bestof processing inconsistent with map removal

### DIFF
--- a/lua/wikis/tft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/tft/MatchGroup/Input/Custom.lua
@@ -7,7 +7,6 @@
 --
 
 local Array = require('Module:Array')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 local Variables = require('Module:Variables')

--- a/lua/wikis/tft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/tft/MatchGroup/Input/Custom.lua
@@ -21,7 +21,9 @@ local MatchFunctions = {
 local FfaMatchFunctions = {
 	DEFAULT_MODE = 'solos',
 }
-local MapFunctions = {}
+local MapFunctions = {
+	BREAK_ON_EMPTY = true
+}
 local FfaMapFunctions = {}
 
 local DEFAULT_BESTOF = 3
@@ -66,12 +68,6 @@ function MatchFunctions.getBestOf(bestofInput)
 	local bestof = tonumber(bestofInput) or tonumber(Variables.varDefault('match_bestof')) or DEFAULT_BESTOF
 	Variables.varDefine('match_bestof', bestof)
 	return bestof
-end
-
----@param games table[]
----@return table[]
-function MatchFunctions.removeUnsetMaps(games)
-	return Array.filter(games, Logic.isNotEmpty)
 end
 
 ---@param map table


### PR DESCRIPTION
## Summary
Currently empty maps show on tft wiki
this is mostly due to the match date making the map table not empty when doing the removal check
Due to tft not relying on the number of inputted maps for bestof calculations the solution proposed in this PR is to just kick the removal function and instead enable the break on empty option as done on other wikis that have a similar bestif handling


## How did you test this change?
dev