### PR TITLE
fix(match2): lol matchpage does not display game length for bo1 matches

### DIFF
--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -178,6 +178,47 @@ end
 
 ---@private
 ---@param game LoLMatchPageGame
+---@return Widget[]
+function MatchPage:_buildGameResultSummary(game)
+	return {
+		Div{
+			classes = {'match-bm-lol-game-summary-faction'},
+			children = game.teams[1].side and IconImage{
+				imageLight = 'Lol faction ' .. game.teams[1].side .. '.png',
+				link = '',
+				caption = game.teams[1].side .. ' side'
+			} or nil
+		},
+		Div{
+			classes = {'match-bm-lol-game-summary-score-holder'},
+			children = game.finished and {
+				Div{
+					classes = {'match-bm-lol-game-summary-score'},
+					children = {
+						game.teams[1].scoreDisplay,
+						'&ndash;',
+						game.teams[2].scoreDisplay
+					}
+				},
+				Div{
+					classes = {'match-bm-lol-game-summary-length'},
+					children = game.length
+				}
+			} or nil
+		},
+		Div{
+			classes = {'match-bm-lol-game-summary-faction'},
+			children = game.teams[2].side and IconImage{
+				imageLight = 'Lol faction ' .. game.teams[2].side .. '.png',
+				link = '',
+				caption = game.teams[2].side .. ' side'
+			} or nil
+		}
+	}
+end
+
+---@private
+---@param game LoLMatchPageGame
 ---@return Widget?
 function MatchPage:_renderGameOverview(game)
 	if self:isBestOfOne() then return end
@@ -193,41 +234,7 @@ function MatchPage:_renderGameOverview(game)
 					},
 					Div{
 						classes = {'match-bm-lol-game-summary-center'},
-						children = {
-							Div{
-								classes = {'match-bm-lol-game-summary-faction'},
-								children = game.teams[1].side and IconImage{
-									imageLight = 'Lol faction ' .. game.teams[1].side .. '.png',
-									link = '',
-									caption = game.teams[1].side .. ' side'
-								} or nil
-							},
-							Div{
-								classes = {'match-bm-lol-game-summary-score-holder'},
-								children = game.finished and {
-									Div{
-										classes = {'match-bm-lol-game-summary-score'},
-										children = {
-											game.teams[1].scoreDisplay,
-											'&ndash;',
-											game.teams[2].scoreDisplay
-										}
-									},
-									Div{
-										classes = {'match-bm-lol-game-summary-length'},
-										children = game.length
-									}
-								} or nil
-							},
-							Div{
-								classes = {'match-bm-lol-game-summary-faction'},
-								children = game.teams[2].side and IconImage{
-									imageLight = 'Lol faction ' .. game.teams[2].side .. '.png',
-									link = '',
-									caption = game.teams[2].side .. ' side'
-								} or nil
-							}
-						}
+						children = self:_buildGameResultSummary(game)
 					},
 					Div{
 						classes = {'match-bm-lol-game-summary-team'},
@@ -373,41 +380,7 @@ function MatchPage:_renderTeamStats(game)
 						},
 						Div{
 							classes = {'match-bm-team-stats-list-cell'},
-							children = self:isBestOfOne() and {
-								Div{
-									classes = {'match-bm-lol-game-summary-faction'},
-									children = game.teams[1].side and IconImage{
-										imageLight = 'Lol faction ' .. game.teams[1].side .. '.png',
-										link = '',
-										caption = game.teams[1].side .. ' side'
-									} or nil
-								},
-								Div{
-									classes = {'match-bm-lol-game-summary-score-holder'},
-									children = game.finished and {
-										Div{
-											classes = {'match-bm-lol-game-summary-score'},
-											children = {
-												game.teams[1].scoreDisplay,
-												'&ndash;',
-												game.teams[2].scoreDisplay
-											}
-										},
-										Div{
-											classes = {'match-bm-lol-game-summary-length'},
-											children = game.length
-										}
-									} or nil
-								},
-								Div{
-									classes = {'match-bm-lol-game-summary-faction'},
-									children = game.teams[2].side and IconImage{
-										imageLight = 'Lol faction ' .. game.teams[2].side .. '.png',
-										link = '',
-										caption = game.teams[2].side .. ' side'
-									} or nil
-								}
-							} or nil
+							children = self:isBestOfOne() and self:_buildGameResultSummary(game) or nil
 						},
 						Div{
 							classes = {'match-bm-lol-team-stats-header-team'},

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -371,7 +371,44 @@ function MatchPage:_renderTeamStats(game)
 							classes = {'match-bm-lol-team-stats-header-team'},
 							children = self.opponents[1].iconDisplay
 						},
-						Div{classes = {'match-bm-team-stats-list-cell'}},
+						Div{
+							classes = {'match-bm-team-stats-list-cell'},
+							children = self:isBestOfOne() and {
+								Div{
+									classes = {'match-bm-lol-game-summary-faction'},
+									children = game.teams[1].side and IconImage{
+										imageLight = 'Lol faction ' .. game.teams[1].side .. '.png',
+										link = '',
+										caption = game.teams[1].side .. ' side'
+									} or nil
+								},
+								Div{
+									classes = {'match-bm-lol-game-summary-score-holder'},
+									children = game.finished and {
+										Div{
+											classes = {'match-bm-lol-game-summary-score'},
+											children = {
+												game.teams[1].scoreDisplay,
+												'&ndash;',
+												game.teams[2].scoreDisplay
+											}
+										},
+										Div{
+											classes = {'match-bm-lol-game-summary-length'},
+											children = game.length
+										}
+									} or nil
+								},
+								Div{
+									classes = {'match-bm-lol-game-summary-faction'},
+									children = game.teams[2].side and IconImage{
+										imageLight = 'Lol faction ' .. game.teams[2].side .. '.png',
+										link = '',
+										caption = game.teams[2].side .. ' side'
+									} or nil
+								}
+							} or nil
+						},
 						Div{
 							classes = {'match-bm-lol-team-stats-header-team'},
 							children = self.opponents[2].iconDisplay

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1006,6 +1006,7 @@ Author(s): Rathoz
 }
 
 .match-bm-lol-game-summary-length {
+	font-weight: normal;
 	line-height: 100%;
 }
 
@@ -1226,7 +1227,7 @@ Author(s): Rathoz
 .match-bm-lol-team-stats-header {
 	display: flex;
 	flex-direction: row;
-	align-items: flex-start;
+	align-items: center;
 	background: #eaecf0;
 	border: 1px solid #bbbbbb;
 	align-self: stretch;


### PR DESCRIPTION
## Summary

regression from #5703

## How did you test this change?

dev

![before](https://github.com/user-attachments/assets/cd4c44e8-e196-46cb-8d1b-c4e4524c98b0)
before

![after](https://github.com/user-attachments/assets/ad6e475b-c134-47f1-b56b-8cf585d49478)
after