### PR TITLE
fix: Handle removed match2games in matchticker

### DIFF
--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -336,7 +336,7 @@ function Details:countdown(matchPageIcon)
 			}
 		end
 
-		local gameVods = Array.map(Array.map(match.match2games, Operator.property('vod')), makeVod)
+		local gameVods = Array.map(Array.map(match.match2games or {}, Operator.property('vod')), makeVod)
 
 		countdownDisplay:node(makeVod(match.vod))
 		Array.forEach(gameVods, function(vod)


### PR DESCRIPTION
## Summary
When https://github.com/Liquipedia/Lua-Modules/blob/95994e526aebe6967358828b13f76fcfee5ce435/lua/wikis/commons/MatchTicker.lua#L443 is applied, the DisplayComponent would fail due to the field being nil.

While in the specific case I'm not sure whether this game unpacking is actually intended to happen, that's another thing to investigate.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev to live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
