### PR TITLE
fix(infobox): counterstrike patch infobox reading incorrect argument in chronology

### DIFF
--- a/lua/wikis/counterstrike/Infobox/Patch/Custom.lua
+++ b/lua/wikis/counterstrike/Infobox/Patch/Custom.lua
@@ -100,7 +100,7 @@ function CustomPatch:getChronologyData(args)
 		data.previous = (args['previous link'] or args.previous .. ' Patch') .. '|' .. args.previous
 	end
 	if args.next then
-		data.next = (args['next link'] or args.next .. ' Patch') .. '|' .. args.previous
+		data.next = (args['next link'] or args.next .. ' Patch') .. '|' .. args.next
 	end
 	return data
 end


### PR DESCRIPTION
## Summary

initial report: https://discord.com/channels/93055209017729024/372075546231832576/1365962895224995881

something that slipped through in #5766...

## How did you test this change?

hotfix in live