### PR TITLE
fix: Disambiguate some faction links on AoE

### DIFF
--- a/lua/wikis/ageofempires/Faction/Data.lua
+++ b/lua/wikis/ageofempires/Faction/Data.lua
@@ -201,7 +201,8 @@ local factionPropsAoE2 = {
 	},
 	ethiopians = {
 		index = 17,
-		name = 'Ethiopians' .. AOE2_SUFFIX,
+		name = 'Ethiopians',
+		pageName = 'Ethiopians' .. AOE2_SUFFIX,
 		faction = 'ethiopians',
 	},
 	franks = {
@@ -247,7 +248,8 @@ local factionPropsAoE2 = {
 	},
 	italians = {
 		index = 26,
-		name = 'Italians' .. AOE2_SUFFIX,
+		name = 'Italians',
+		pageNname = 'Italians' .. AOE2_SUFFIX,
 		faction = 'italians',
 	},
 	japanese = {
@@ -436,7 +438,8 @@ local factionPropsAoE3 = {
 	},
 	french = {
 		index = 6,
-		name = 'French' .. AOE3_SUFFIX,
+		name = 'French',
+		pageName = 'French' .. AOE3_SUFFIX,
 		faction = 'french',
 	},
 	germans = {

--- a/lua/wikis/ageofempires/Faction/Data.lua
+++ b/lua/wikis/ageofempires/Faction/Data.lua
@@ -174,6 +174,7 @@ local factionPropsAoE2 = {
 	byzantines = {
 		index = 12,
 		name = 'Byzantines',
+		pageName = 'Byzantines'  .. AOE2_SUFFIX,
 		faction = 'byzantines',
 	},
 	celts = {
@@ -200,7 +201,7 @@ local factionPropsAoE2 = {
 	},
 	ethiopians = {
 		index = 17,
-		name = 'Ethiopians',
+		name = 'Ethiopians' .. AOE2_SUFFIX,
 		faction = 'ethiopians',
 	},
 	franks = {
@@ -246,7 +247,7 @@ local factionPropsAoE2 = {
 	},
 	italians = {
 		index = 26,
-		name = 'Italians',
+		name = 'Italians' .. AOE2_SUFFIX,
 		faction = 'italians',
 	},
 	japanese = {
@@ -435,7 +436,7 @@ local factionPropsAoE3 = {
 	},
 	french = {
 		index = 6,
-		name = 'French',
+		name = 'French' .. AOE3_SUFFIX,
 		faction = 'french',
 	},
 	germans = {

--- a/lua/wikis/ageofempires/Faction/Data.lua
+++ b/lua/wikis/ageofempires/Faction/Data.lua
@@ -249,7 +249,7 @@ local factionPropsAoE2 = {
 	italians = {
 		index = 26,
 		name = 'Italians',
-		pageNname = 'Italians' .. AOE2_SUFFIX,
+		pageName = 'Italians' .. AOE2_SUFFIX,
 		faction = 'italians',
 	},
 	japanese = {


### PR DESCRIPTION
## Summary
Adds suffixes used to disambiguate civilization pages where missing.
When civs exist in multiple games, the plain `Civname` page is used as a disambiguation page, and all links should directly go to `Civname/Gamename` pages if possible.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
N/A
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
