### PR TITLE
fix: dota2 h2h icon alignment

### DIFF
--- a/stylesheets/commons/Bracket.less
+++ b/stylesheets/commons/Bracket.less
@@ -272,7 +272,7 @@ td.bracket-game .icon {
 }
 
 .match-row-icon {
-	left: -11px;
+	left: -19px;
 	top: 6px;
 }
 


### PR DESCRIPTION
## Summary

The match pop up icon in match result lists on the Head to Head query pages should be centered on the border between the two result cells, at the moment it is not. it looks like roughly a 7px difference between what it is and what it should be, this might also be due to the size of the cells differing which means maybe this should be an equation to figure out the spacing, but I am not sure where else this class is used.

## How did you test this change?

dev tools