### PR TITLE
feat: add match page buttons to VAL matchticker

### DIFF
--- a/lua/wikis/valorant/Info.lua
+++ b/lua/wikis/valorant/Info.lua
@@ -36,6 +36,7 @@ return {
 			status = 2,
 			matchWidth = 180,
 			gameScoresIfBo1 = true,
+			matchPage = true,
 		},
 		transfers = {
 			contractDatabase = {

--- a/lua/wikis/valorant/MatchSummary.lua
+++ b/lua/wikis/valorant/MatchSummary.lua
@@ -7,10 +7,13 @@
 --
 
 local Array = require('Module:Array')
+local DateExt = require('Module:Date/Ext')
+local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
 local Operator = require('Module:Operator')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
+local MatchPage = Lua.import('Module:MatchPage')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
@@ -22,6 +25,28 @@ local CustomMatchSummary = {}
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '500px', teamStyle = 'bracket'})
 end
+
+---@param match MatchGroupUtilMatch
+---@return MatchSummaryBody
+function CustomMatchSummary.createBody(match)
+	-- Original Match Id must be used to match page links if it exists.
+	-- It can be different from the matchId when shortened brackets are used.
+	local matchId = match.extradata.originalmatchid or match.matchId
+
+	local showCountdown = match.timestamp ~= DateExt.defaultTimestamp
+	local showMatchPage = MatchPage.isEnabledFor(match)
+
+	return MatchSummaryWidgets.Body{children = WidgetUtil.collect(
+		showCountdown and MatchSummaryWidgets.Row{children = DisplayHelper.MatchCountdownBlock(match)} or nil,
+		showMatchPage and MatchSummaryWidgets.MatchPageLink{matchId = matchId} or nil,
+		Array.map(match.games, FnUtil.curry(CustomMatchSummary.createGame, match.date)),
+		MatchSummaryWidgets.Mvp(match.extradata.mvp),
+		MatchSummaryWidgets.Casters{casters = match.extradata.casters},
+		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = match.game}))
+	)}
+end
+
+
 
 ---@param date string
 ---@param game MatchGroupUtilGame


### PR DESCRIPTION
## Summary
As a user, I want to be able to dive deeper into checking (or adding!) match details, while browsing the main page or the matches portal.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
