### PR TITLE
fix(match2): wrong capitalisation in extradata key

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
@@ -158,7 +158,7 @@ function MatchFunctions.getExtraData(match, games, opponents)
 	end
 
 	Array.forEach(games, function(_, subGroupIndex)
-		extradata['subGroup' .. subGroupIndex .. 'header'] = Logic.nilIfEmpty(match['submatch' .. subGroupIndex .. 'header'])
+		extradata['subgroup' .. subGroupIndex .. 'header'] = Logic.nilIfEmpty(match['submatch' .. subGroupIndex .. 'header'])
 	end)
 
 	return extradata


### PR DESCRIPTION
## Summary
when retrieving it is expected to be lowercased, resulting in currently the subgroup headers not showing

## How did you test this change?
N/A