### PR TITLE
feat: add R6 points and award as TierType

### DIFF
--- a/lua/wikis/rainbowsix/Tier/Data.lua
+++ b/lua/wikis/rainbowsix/Tier/Data.lua
@@ -89,14 +89,6 @@ return {
 			link = 'Qualifier Tournaments',
 			category = 'Qualifier Tournaments',
 		},
-		misc = {
-			value = 'Misc',
-			sort = 'A9',
-			name = 'Misc',
-			short = 'Misc',
-			link = 'Miscellaneous Tournaments',
-			category = 'Miscellaneous Tournaments',
-		},
 		showmatch = {
 			value = 'Showmatch',
 			sort = 'B1',

--- a/lua/wikis/rainbowsix/Tier/Data.lua
+++ b/lua/wikis/rainbowsix/Tier/Data.lua
@@ -107,15 +107,15 @@ return {
 		},
 		points = {
 			value = 'Points',
-			sort = 'B1',
+			sort = 'B3',
 			name = 'Points',
-			short = 'Points',
+			short = 'Pts.',
 			link = 'Point Rankings',
 			category = 'Point Rankings',
 		},
 		award = {
 			value = 'Awards',
-			sort = 'B2',
+			sort = 'B4',
 			name = 'Awards',
 			short = 'Awards',
 			link = 'Award Shows',

--- a/lua/wikis/rainbowsix/Tier/Data.lua
+++ b/lua/wikis/rainbowsix/Tier/Data.lua
@@ -105,5 +105,13 @@ return {
 			link = 'Showmatches',
 			category = 'Showmatch Tournaments',
 		},
+		points = {
+			value = 'Points',
+			sort = 'B1',
+			name = 'Points',
+			short = 'Points',
+			link = 'Point Rankings',
+			category = 'Point Rankings',
+		},
 	},
 }

--- a/lua/wikis/rainbowsix/Tier/Data.lua
+++ b/lua/wikis/rainbowsix/Tier/Data.lua
@@ -113,5 +113,13 @@ return {
 			link = 'Point Rankings',
 			category = 'Point Rankings',
 		},
+		award = {
+			value = 'Awards',
+			sort = 'B2',
+			name = 'Awards',
+			short = 'Awards',
+			link = 'Award Shows',
+			category = 'Award Shows',
+		},
 	},
 }


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

1. Currently on the R6 wiki we use "Misc" for events with Point Rankings, it might be easier for viewers to understand when "Point Rankings" is used as text/tierType instead of "Misc". (See attached pictures for the current example)

![image](https://github.com/user-attachments/assets/98d86118-e36b-4170-861e-3a5de7449f6c)
![image](https://github.com/user-attachments/assets/ccf344dd-5ad5-41bd-ba34-3f48006fed50)

2. Same will happen for the Award Section, since we currently show quite a few Award Shows on the wiki it may be better to display that instead of Misc.

![image](https://github.com/user-attachments/assets/1d919d04-c5ef-4ef5-931a-0013664ebb30)

Current list of all events under "Misc.": https://liquipedia.net/rainbowsix/Miscellaneous_Tournaments

## How did you test this change?

No test, just added "points" and "award" to the /Data.
I know that once merged the "|tierType=" need to be updated on the pages where needed, this is no problem and can be done afterwards.

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
