### PR TITLE
fix: Remove default tiers in AoE filterbuttons

### DIFF
--- a/lua/wikis/ageofempires/FilterButtons/Config.lua
+++ b/lua/wikis/ageofempires/FilterButtons/Config.lua
@@ -22,7 +22,6 @@ Config.categories = {
 				table.insert(category.items, tier.value)
 			end
 		end,
-		defaultItems = {'1', '2', '3'},
 		transform = function(tier)
 			return Tier.toName(tonumber(tier))
 		end,


### PR DESCRIPTION
## Summary
Another leftover that isn't supposed to be rolled out; AoE community is quite diverse so we want to give a neutral starting point.
Didn't notice since i had dirty localstorage on the test page.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
