### PR TITLE
feat(mainpage): Wildcard new pill images

### DIFF
--- a/lua/wikis/wildcard/MainPageLayout/data.lua
+++ b/lua/wikis/wildcard/MainPageLayout/data.lua
@@ -71,12 +71,12 @@ return {
 	title = 'The Wildcard Wiki',
 	navigation = {
 		{
-			file = 'Wildcard header Wildcards.png',
+			file = 'Wildcard header Wildcards.webp',
 			title = 'Wildcards',
 			link = 'Portal:Wildcards',
 		},
 		{
-			file = 'Wildcard header Champions.png',
+			file = 'Wildcard header Champions.webp',
 			title = 'Champions',
 			link = 'Portal:Champions',
 			count = {
@@ -86,7 +86,7 @@ return {
 			},
 		},
 		{
-			file = 'Wildcard header Summons.png',
+			file = 'Wildcard header Summons.webp',
 			title = 'Summons',
 			link = 'Portal:Summons',
 			count = {
@@ -96,7 +96,7 @@ return {
 			},
 		},
 		{
-			file = 'Wildcard header Arenas.png',
+			file = 'Wildcard header Arenas.webp',
 			title = 'Arenas',
 			link = 'Portal:Arenas',
 			count = {
@@ -105,12 +105,12 @@ return {
 			},
 		},
 		{
-			file = 'Wildcard header Mechanics.png',
+			file = 'Wildcard header Mechanics.webp',
 			title = 'Mechanics',
 			link = 'Portal:Mechanics',
 		},
 		{
-			file = 'Wildcard header Decks.png',
+			file = 'Wildcard header Decks.webp',
 			title = 'Decks',
 			link = 'Portal:Decks',
 		},

--- a/lua/wikis/wildcard/MainPageLayout/data.lua
+++ b/lua/wikis/wildcard/MainPageLayout/data.lua
@@ -71,12 +71,12 @@ return {
 	title = 'The Wildcard Wiki',
 	navigation = {
 		{
-			file = 'Wildcard gameasset wildcards pill.png',
+			file = 'Wildcard header Wildcards.png',
 			title = 'Wildcards',
 			link = 'Portal:Wildcards',
 		},
 		{
-			file = 'Wildcard Champions Lineup.webp',
+			file = 'Wildcard header Champions.png',
 			title = 'Champions',
 			link = 'Portal:Champions',
 			count = {
@@ -86,7 +86,7 @@ return {
 			},
 		},
 		{
-			file = 'Wildcard Characters 1.jpg',
+			file = 'Wildcard header Summons.png',
 			title = 'Summons',
 			link = 'Portal:Summons',
 			count = {
@@ -96,7 +96,7 @@ return {
 			},
 		},
 		{
-			file = 'Wildcard Lushland Arena.jpg',
+			file = 'Wildcard header Arenas.png',
 			title = 'Arenas',
 			link = 'Portal:Arenas',
 			count = {
@@ -105,12 +105,12 @@ return {
 			},
 		},
 		{
-			file = 'Wildcard Frostburn Arena.jpg',
+			file = 'Wildcard header Mechanics.png',
 			title = 'Mechanics',
 			link = 'Portal:Mechanics',
 		},
 		{
-			file = 'Wildcard gameasset Wildcard Bulwark Boost.png',
+			file = 'Wildcard header Decks.png',
 			title = 'Decks',
 			link = 'Portal:Decks',
 		},


### PR DESCRIPTION
Devs have provided a series of new artworks for both the header and the pills. 

Pills had some different file extension vs the old one so I uploaded these separately hence the filename changes all of them now in PNG (and I couldnt recall why I was randomly putting JPG/WEBP in among the PNG pills at first lol)


Header doesnt it's just the same webp so I uploaded the banner as new version over the same file hence no changes on the css

![image](https://github.com/user-attachments/assets/20bd55bd-add4-4859-af42-0c2763369b9f)
