### PR TITLE
feat: Inline team display widgets

### DIFF
--- a/lua/wikis/commons/ExternalMediaList.lua
+++ b/lua/wikis/commons/ExternalMediaList.lua
@@ -10,12 +10,14 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Flag = require('Module:Flags')
 local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local Page = require('Module:Page')
 local PlayerExt = require('Module:Player/Ext/Custom')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
-local Team = require('Module:Team')
+
+local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 
 local MediaList = {}
 
@@ -232,7 +234,7 @@ end
 function MediaList._row(item, args)
 	local row = mw.html.create('li')
 		:node(MediaList._editButton(item.pagename))
-		:wikitext(args.showSubjectTeam and MediaList._displayTeam(args.subjects[1], item.date) or '')
+		:node(args.showSubjectTeam and MediaList._displayTeam(args.subjects[1], item.date) or '')
 		:wikitext(item.date .. NON_BREAKING_SPACE .. '|' .. NON_BREAKING_SPACE)
 
 	if String.isNotEmpty(item.language) and item.language ~= 'en' and (item.language ~= 'usuk' or args.showUsUk) then
@@ -334,13 +336,13 @@ end
 ---Displays the subject's team for a given External Media Link
 ---@param subject string
 ---@param date string
----@return string?
+---@return Widget?
 function MediaList._displayTeam(subject, date)
 	local _, team = PlayerExt.syncTeam(subject, nil, {date = date})
 	if not team then
 		return
 	end
-	return Team.icon(nil, team, date)
+	return TeamInline{name = team, date = date, displayType = 'icon'}
 end
 
 ---Displays the link to the Form with which External Media Links are to be created.

--- a/lua/wikis/commons/ExternalMediaList.lua
+++ b/lua/wikis/commons/ExternalMediaList.lua
@@ -17,7 +17,8 @@ local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 local Tabs = require('Module:Tabs')
 
-local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
+local OpponentLibraries = Lua.import('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local MediaList = {}
 
@@ -342,7 +343,7 @@ function MediaList._displayTeam(subject, date)
 	if not team then
 		return
 	end
-	return TeamInline{name = team, date = date, displayType = 'icon'}
+	return OpponentDisplay.InlineTeamContainer{template = team, date = date, displayType = 'icon'}
 end
 
 ---Displays the link to the Form with which External Media Links are to be created.

--- a/lua/wikis/commons/ExternalMediaList.lua
+++ b/lua/wikis/commons/ExternalMediaList.lua
@@ -343,7 +343,7 @@ function MediaList._displayTeam(subject, date)
 	if not team then
 		return
 	end
-	return OpponentDisplay.InlineTeamContainer{template = team, date = date, displayType = 'icon'}
+	return OpponentDisplay.InlineTeamContainer{template = team, date = date, style = 'icon'}
 end
 
 ---Displays the link to the Form with which External Media Links are to be created.

--- a/lua/wikis/commons/OpponentDisplay.lua
+++ b/lua/wikis/commons/OpponentDisplay.lua
@@ -252,17 +252,10 @@ end
 ---@param props {flip: boolean?, template: string, style: teamStyle?}
 ---@return Widget?
 function OpponentDisplay.InlineTeamContainer(props)
-	if props.style == 'standard' or not props.style then
-		return TeamInline{ name = props.template, flip = props.flip, displayType = 'standard' }
-	elseif props.style == 'short' then
-		return TeamInline{ name = props.template, flip = props.flip, displayType = 'short' }
-	elseif props.style == 'bracket' then
-		if not props.flip then
-			return TeamInline{ name = props.template, displayType = 'bracket' }
-		else
-			error('Flipped style=bracket is not supported')
-		end
-	end
+	local style = props.style or 'standard'
+	TypeUtil.assertValue(style, OpponentDisplay.types.TeamStyle)
+	assert(style ~= 'bracket' or not props.flip, 'Flipped style=bracket is not supported')
+	return TeamInline{name = props.template, flip = props.flip, displayType = style}
 end
 
 --[[

--- a/lua/wikis/commons/OpponentDisplay.lua
+++ b/lua/wikis/commons/OpponentDisplay.lua
@@ -249,13 +249,13 @@ function OpponentDisplay.BlockPlayers(props)
 end
 
 ---Displays a team as an inline element. The team is specified by a template.
----@param props {flip: boolean?, template: string, style: teamStyle?}
+---@param props {flip: boolean?, template: string, date: number|string?, style: teamStyle?}
 ---@return Widget?
 function OpponentDisplay.InlineTeamContainer(props)
 	local style = props.style or 'standard'
 	TypeUtil.assertValue(style, OpponentDisplay.types.TeamStyle)
 	assert(style ~= 'bracket' or not props.flip, 'Flipped style=bracket is not supported')
-	return TeamInline{name = props.template, flip = props.flip, displayType = style}
+	return TeamInline{name = props.template, date = props.date, flip = props.flip, displayType = style}
 end
 
 --[[

--- a/lua/wikis/commons/OpponentDisplay.lua
+++ b/lua/wikis/commons/OpponentDisplay.lua
@@ -13,11 +13,12 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Math = require('Module:MathUtil')
 local Table = require('Module:Table')
-local Template = require('Module:Template')
 local TypeUtil = require('Module:TypeUtil')
 
 local Opponent = Lua.import('Module:Opponent')
 local PlayerDisplay = Lua.import('Module:Player/Display/Custom')
+
+local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 
 local zeroWidthSpace = '&#8203;'
 
@@ -249,54 +250,19 @@ end
 
 ---Displays a team as an inline element. The team is specified by a template.
 ---@param props {flip: boolean?, template: string, style: teamStyle?}
----@return string?
+---@return Widget?
 function OpponentDisplay.InlineTeamContainer(props)
-	local teamExists = mw.ext.TeamTemplate.teamexists(props.template)
 	if props.style == 'standard' or not props.style then
-		if not props.flip then
-			return teamExists
-				and mw.ext.TeamTemplate.team(props.template)
-				or Template.safeExpand(mw.getCurrentFrame(), 'Team', {props.template})
-		else
-			return teamExists
-				and mw.ext.TeamTemplate.team2(props.template)
-				or Template.safeExpand(mw.getCurrentFrame(), 'Team2', {props.template})
-		end
+		return TeamInline{ name = props.template, flip = props.flip, displayType = 'standard' }
 	elseif props.style == 'short' then
-		if not props.flip then
-			return teamExists
-				and mw.ext.TeamTemplate.teamshort(props.template)
-				or Template.safeExpand(mw.getCurrentFrame(), 'TeamShort', {props.template})
-		else
-			return teamExists
-				and mw.ext.TeamTemplate.team2short(props.template)
-				or Template.safeExpand(mw.getCurrentFrame(), 'Team2Short', {props.template})
-		end
+		return TeamInline{ name = props.template, flip = props.flip, displayType = 'short' }
 	elseif props.style == 'bracket' then
 		if not props.flip then
-			return teamExists
-				and mw.ext.TeamTemplate.teambracket(props.template)
-				or Template.safeExpand(mw.getCurrentFrame(), 'TeamBracket', {props.template})
+			return TeamInline{ name = props.template, displayType = 'bracket' }
 		else
 			error('Flipped style=bracket is not supported')
 		end
 	end
-end
-
---[[
-Displays a team as an inline element. The team is specified by a team struct.
-Only the default icon is supported.
-]]
----@param props {flip: boolean?, style: teamStyle?, team: standardTeamProps}
----@return string
-function OpponentDisplay.InlineTeam(props)
-	return (OpponentDisplay.InlineTeamContainer(Table.merge(props, {
-		template = 'default',
-	}))
-		:gsub('DefaultPage', props.team.pageName)
-		:gsub('DefaultName', Logic.emptyOr(props.team.displayName, zeroWidthSpace) --[[@as string]])
-		:gsub('DefaultShort', props.team.shortName)
-		:gsub('DefaultBracket', props.team.bracketName))
 end
 
 --[[

--- a/lua/wikis/commons/PortalPlayers.lua
+++ b/lua/wikis/commons/PortalPlayers.lua
@@ -14,7 +14,6 @@ local Logic = require('Module:Logic')
 local Links = require('Module:Links')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local Team = require('Module:Team')
 
 local OpponentLibraries = require('Module:OpponentLibraries')
 local Opponent = OpponentLibraries.Opponent
@@ -265,7 +264,9 @@ function PortalPlayers:row(player, isPlayer)
 		:wikitext(self.showLocalizedName and (' (' .. player.localizedname .. ')') or nil)
 
 	local role = not isPlayer and mw.language.getContentLanguage():ucfirst((player.extradata or {}).role or '') or ''
-	local teamText = mw.ext.TeamTemplate.teamexists(player.team) and Team.team(nil, player.team) or ''
+	local teamText = mw.ext.TeamTemplate.teamexists(player.team) and tostring(OpponentDisplay.InlineTeamContainer{
+		template = player.team, displayType = 'standard'
+	}) or ''
 	if String.isNotEmpty(role) and String.isEmpty(teamText) then
 		teamText = role
 	elseif String.isNotEmpty(role) then

--- a/lua/wikis/commons/Widget/Image/Icon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon.lua
@@ -15,7 +15,7 @@ local Widget = Lua.import('Module:Widget')
 ---@operator call(table): IconWidget
 local Icon = Class.new(Widget)
 
----@return (string|Widget)?
+---@return (string|Widget)|(string|Widget)[]?
 function Icon:render()
 	error('Widget/Image/Icon is an interface and should not be instantiated directly')
 end

--- a/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
@@ -22,7 +22,7 @@ local ICON_SIZE = '100x50px'
 ---@field imageDark string?
 ---@field page string?
 ---@field size string?
----@field nolink boolean?
+---@field noLink boolean?
 ---@field legacy boolean?
 
 ---@class TeamIconWidget: IconWidget
@@ -44,7 +44,7 @@ end
 
 ---@return string?
 function TeamIcon:_getPageLink()
-	return self.props.nolink and '' or self.props.page
+	return self.props.noLink and '' or self.props.page
 end
 
 ---@return Widget|Widget[]

--- a/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
@@ -51,13 +51,14 @@ end
 function TeamIcon:render()
 	local imageLight = self.props.imageLight
 	local imageDark = self.props.imageDark or self.props.imageLight
+	local size = self.props.size
 	local allmode = imageLight == imageDark
 	if allmode then
 		return HtmlWidgets.Span{
 			classes = TeamIcon._getSpanClasses{theme = 'allmode', legacy = self.props.legacy},
 			children = {
 				Image.display(imageLight, nil, {
-					size = ICON_SIZE,
+					size = size,
 					alignment = 'middle',
 					link = self:_getPageLink()
 				})
@@ -69,7 +70,7 @@ function TeamIcon:render()
 			classes = TeamIcon._getSpanClasses{theme = 'lightmode'},
 			children = {
 				Image.display(imageLight, nil, {
-					size = ICON_SIZE,
+					size = size,
 					alignment = 'middle',
 					link = self:_getPageLink()
 				})
@@ -79,7 +80,7 @@ function TeamIcon:render()
 			classes = TeamIcon._getSpanClasses{theme = 'darkmode'},
 			children = {
 				Image.display(imageDark, nil, {
-					size = ICON_SIZE,
+					size = size,
 					alignment = 'middle',
 					link = self:_getPageLink()
 				})

--- a/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
@@ -36,7 +36,7 @@ TeamIcon.defaultProps = {
 ---@param props { theme: 'lightmode'|'darkmode'|'allmode', legacy: boolean? }
 ---@return string[]
 function TeamIcon._getSpanClasses(props)
-	return Array.append({},
+	return Array.extend(
 		'team-template-image-' .. props.legacy and 'legacy' or 'icon',
 		props.theme ~= 'allmode' and ('team-template-' .. props.theme) or nil
 	)

--- a/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
@@ -53,11 +53,12 @@ function TeamIcon:render()
 	local imageDark = self.props.imageDark or self.props.imageLight
 	local size = self.props.size
 	local allmode = imageLight == imageDark
-	if allmode then
-		return HtmlWidgets.Span{
-			classes = TeamIcon._getSpanClasses{theme = 'allmode', legacy = self.props.legacy},
+
+	local buildSpan = function(image, theme)
+		return Span{
+			classes = TeamIcon._getSpanClasses{theme = theme, legacy = self.props.legacy},
 			children = {
-				Image.display(imageLight, nil, {
+				Image.display(image, nil, {
 					size = size,
 					alignment = 'middle',
 					link = self:_getPageLink()
@@ -65,27 +66,13 @@ function TeamIcon:render()
 			}
 		}
 	end
+
+	if allmode then
+		return buildSpan(imageLight, 'allmode')
+	end
 	return {
-		Span{
-			classes = TeamIcon._getSpanClasses{theme = 'lightmode'},
-			children = {
-				Image.display(imageLight, nil, {
-					size = size,
-					alignment = 'middle',
-					link = self:_getPageLink()
-				})
-			}
-		},
-		Span{
-			classes = TeamIcon._getSpanClasses{theme = 'darkmode'},
-			children = {
-				Image.display(imageDark, nil, {
-					size = size,
-					alignment = 'middle',
-					link = self:_getPageLink()
-				})
-			}
-		}
+		buildSpan(imageLight, 'lightmode'),
+		buildSpan(imageDark, 'darkmode')
 	}
 end
 

--- a/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
@@ -41,7 +41,7 @@ function TeamIcon:_buildSpan(image, theme)
 	local size = self.props.size
 	return Span{
 		classes = Array.extend(
-			'team-template-image-' .. self.props.legacy and 'legacy' or 'icon',
+			'team-template-image-' .. (self.props.legacy and 'legacy' or 'icon'),
 			theme ~= 'allmode' and ('team-template-' .. theme) or nil
 		),
 		children = {

--- a/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
@@ -1,0 +1,91 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Image/Icon/TeamIcon
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Image = require('Module:Image')
+local Lua = require('Module:Lua')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Span = HtmlWidgets.Span
+local WidgetIcon = Lua.import('Module:Widget/Image/Icon')
+
+local ICON_SIZE = '100x50px'
+
+---@class TeamIconWidgetParameters
+---@field imageLight string
+---@field imageDark string?
+---@field page string?
+---@field size string?
+---@field nolink boolean?
+---@field legacy boolean?
+
+---@class TeamIconWidget: IconWidget
+---@operator call(TeamIconWidgetParameters): TeamIconWidget
+---@field props TeamIconWidgetParameters
+local TeamIcon = Class.new(WidgetIcon)
+TeamIcon.defaultProps = {
+	size = ICON_SIZE
+}
+
+---@param props { theme: 'lightmode'|'darkmode'|'allmode', legacy: boolean? }
+---@return string[]
+function TeamIcon._getSpanClasses(props)
+	return Array.append({},
+		'team-template-image-' .. props.legacy and 'legacy' or 'icon',
+		props.theme ~= 'allmode' and ('team-template-' .. props.theme) or nil
+	)
+end
+
+---@return string?
+function TeamIcon:_getPageLink()
+	return self.props.nolink and '' or self.props.page
+end
+
+---@return Widget|Widget[]
+function TeamIcon:render()
+	local imageLight = self.props.imageLight
+	local imageDark = self.props.imageDark or self.props.imageLight
+	local allmode = imageLight == imageDark
+	if allmode then
+		return HtmlWidgets.Span{
+			classes = TeamIcon._getSpanClasses{theme = 'allmode', legacy = self.props.legacy},
+			children = {
+				Image.display(imageLight, nil, {
+					size = ICON_SIZE,
+					alignment = 'middle',
+					link = self:_getPageLink()
+				})
+			}
+		}
+	end
+	return {
+		Span{
+			classes = TeamIcon._getSpanClasses{theme = 'lightmode'},
+			children = {
+				Image.display(imageLight, nil, {
+					size = ICON_SIZE,
+					alignment = 'middle',
+					link = self:_getPageLink()
+				})
+			}
+		},
+		Span{
+			classes = TeamIcon._getSpanClasses{theme = 'darkmode'},
+			children = {
+				Image.display(imageDark, nil, {
+					size = ICON_SIZE,
+					alignment = 'middle',
+					link = self:_getPageLink()
+				})
+			}
+		}
+	}
+end
+
+return TeamIcon

--- a/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
+++ b/lua/wikis/commons/Widget/Image/Icon/TeamIcon.lua
@@ -33,15 +33,28 @@ TeamIcon.defaultProps = {
 	size = ICON_SIZE
 }
 
----@param props { theme: 'lightmode'|'darkmode'|'allmode', legacy: boolean? }
----@return string[]
-function TeamIcon._getSpanClasses(props)
-	return Array.extend(
-		'team-template-image-' .. props.legacy and 'legacy' or 'icon',
-		props.theme ~= 'allmode' and ('team-template-' .. props.theme) or nil
-	)
+---@private
+---@param image string
+---@param theme 'lightmode'|'darkmode'|'allmode'
+---@return Widget
+function TeamIcon:_buildSpan(image, theme)
+	local size = self.props.size
+	return Span{
+		classes = Array.extend(
+			'team-template-image-' .. self.props.legacy and 'legacy' or 'icon',
+			theme ~= 'allmode' and ('team-template-' .. theme) or nil
+		),
+		children = {
+			Image.display(image, nil, {
+				size = size,
+				alignment = 'middle',
+				link = self:_getPageLink()
+			})
+		}
+	}
 end
 
+---@private
 ---@return string?
 function TeamIcon:_getPageLink()
 	return self.props.noLink and '' or self.props.page
@@ -51,28 +64,14 @@ end
 function TeamIcon:render()
 	local imageLight = self.props.imageLight
 	local imageDark = self.props.imageDark or self.props.imageLight
-	local size = self.props.size
 	local allmode = imageLight == imageDark
 
-	local buildSpan = function(image, theme)
-		return Span{
-			classes = TeamIcon._getSpanClasses{theme = theme, legacy = self.props.legacy},
-			children = {
-				Image.display(image, nil, {
-					size = size,
-					alignment = 'middle',
-					link = self:_getPageLink()
-				})
-			}
-		}
-	end
-
 	if allmode then
-		return buildSpan(imageLight, 'allmode')
+		return self:_buildSpan(imageLight, 'allmode')
 	end
 	return {
-		buildSpan(imageLight, 'lightmode'),
-		buildSpan(imageDark, 'darkmode')
+		self:_buildSpan(imageLight, 'lightmode'),
+		self:_buildSpan(imageDark, 'darkmode')
 	}
 end
 

--- a/lua/wikis/commons/Widget/TeamDisplay/Component/Name.lua
+++ b/lua/wikis/commons/Widget/TeamDisplay/Component/Name.lua
@@ -1,0 +1,46 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/TeamDisplay/Component/Name
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local Span = HtmlWidgets.Span
+
+---@class TeamNameDisplayParameters
+---@field additionalClasses string[]?
+---@field displayName string?
+---@field noLink boolean?
+---@field page string?
+
+---@class TeamNameDisplay: Widget
+---@operator call(TeamNameDisplayParameters): TeamNameDisplay
+---@field props TeamNameDisplayParameters
+local TeamNameDisplay = Class.new(Widget)
+
+---@return Widget?
+function TeamNameDisplay:render()
+	local displayName = self.props.displayName
+	if String.isEmpty(displayName) then return end
+	local page = self.props.page
+	return Span{
+		classes = Array.extend({ 'team-template-text' }, self.props.additionalClasses),
+		children = {
+			self.props.noLink and displayName or self.props.noLink and displayName or Link{
+				children = displayName,
+				link = page
+			}
+		}
+	}
+end
+
+return TeamNameDisplay

--- a/lua/wikis/commons/Widget/TeamDisplay/Component/Name.lua
+++ b/lua/wikis/commons/Widget/TeamDisplay/Component/Name.lua
@@ -35,7 +35,7 @@ function TeamNameDisplay:render()
 	return Span{
 		classes = Array.extend({ 'team-template-text' }, self.props.additionalClasses),
 		children = {
-			self.props.noLink and displayName or self.props.noLink and displayName or Link{
+			self.props.noLink and displayName or Link{
 				children = displayName,
 				link = page
 			}

--- a/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
+++ b/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
@@ -1,0 +1,120 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/TeamDisplay/Inline
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local TeamTemplate = require('Module:TeamTemplate')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Span = HtmlWidgets.Span
+local TeamIcon = Lua.import('Module:Widget/Image/Icon/TeamIcon')
+local TeamName = Lua.import('Module:Widget/TeamDisplay/Component/Name')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+---@class InlineType
+---@field displayType string
+---@field displayNames table<string, string[]>
+
+---@type table<teamStyle, InlineType>
+local TEAM_INLINE_TYPES = {
+	['bracket'] = {
+		displayType = 'bracket',
+		displayNames = {['bracketname'] = {}}
+	},
+	['icon'] = {
+		displayType = 'icon',
+		displayNames = {}
+	},
+	['short'] = {
+		displayType = 'short',
+		displayNames = {['shortname'] = {}}
+	},
+	['standard'] = {
+		displayType = 'standard',
+		displayNames = {['name'] = {}}
+	},
+	['hybrid'] = {
+		displayType = 'standard',
+		displayNames = {
+			['bracketname'] = {'mobile-hide'},
+			['shortname'] = {'mobile-only'}
+		}
+	}
+}
+
+---@class TeamInlineParameters
+---@field name string?
+---@field date number|string?
+---@field teamTemplate teamTemplateData?
+---@field flip boolean?
+---@field displayType teamStyle
+
+---@class TeamInlineWidget: Widget
+---@operator call(TeamInlineParameters): TeamInlineWidget
+---@field name string?
+---@field props TeamInlineParameters
+---@field teamTemplate teamTemplateData
+---@field flip boolean
+---@field displayType InlineType
+local TeamInlineWidget = Class.new(Widget,
+	---@param self self
+	---@param input TeamInlineParameters
+	function (self, input)
+		assert(TEAM_INLINE_TYPES[input.displayType], 'Invalid display type')
+		self.teamTemplate = input.teamTemplate or TeamTemplate.getRawOrNil(input.name, input.date)
+		self.name = (self.teamTemplate or {}).name or input.name
+		self.flip = Logic.readBool(input.flip)
+		self.displayType = TEAM_INLINE_TYPES[input.displayType]
+	end
+)
+
+---@return Widget
+function TeamInlineWidget:render()
+	local teamTemplate = self.teamTemplate
+	if not teamTemplate then
+		mw.ext.TeamLiquidIntegration.add_category('Pages with missing team templates')
+		return HtmlWidgets.Small{
+			classes = { 'error' },
+			children = { TeamTemplate.noTeamMessage(self.name) }
+		}
+	end
+	local flip = self.flip
+	local children = Array.interleave(WidgetUtil.collect(
+		TeamIcon{
+			imageLight = Logic.emptyOr(self.teamTemplate.image, self.teamTemplate.legacyimage),
+			imageDark = Logic.emptyOr(self.teamTemplate.imagedark, self.teamTemplate.legacyimagedark),
+			page = self.teamTemplate.page,
+			legacy = Logic.isNotEmpty(self.teamTemplate.legacyimage)
+		},
+		self:getNameComponent()
+	), ' ')
+	return Span{
+		attributes = { ['data-highlighting-class'] = self.teamTemplate.name },
+		classes = { 'team-template-team' .. (flip and '2' or '') .. '-' .. self.displayType.displayType },
+		children = flip and Array.reverse(children) or children
+	}
+end
+
+---@return Widget
+function TeamInlineWidget:getNameComponent()
+	return HtmlWidgets.Fragment{
+		children = Array.map(Table.entries(self.displayType.displayNames), function (element)
+			return TeamName{
+				additionalClasses = element[2],
+				displayName = self.teamTemplate[element[1]],
+				page = self.teamTemplate.page
+			}
+		end)
+	}
+end
+
+return TeamInlineWidget

--- a/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
+++ b/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
@@ -95,7 +95,7 @@ function TeamInlineWidget:render()
 			page = self.teamTemplate.page,
 			legacy = Logic.isNotEmpty(self.teamTemplate.legacyimage)
 		},
-		self:getNameComponent()
+		self:_getNameComponent()
 	), ' ')
 	return Span{
 		attributes = { ['data-highlighting-class'] = self.teamTemplate.name },
@@ -104,8 +104,9 @@ function TeamInlineWidget:render()
 	}
 end
 
+---@private
 ---@return Widget
-function TeamInlineWidget:getNameComponent()
+function TeamInlineWidget:_getNameComponent()
 	return HtmlWidgets.Fragment{
 		children = Array.map(Table.entries(self.displayType.displayNames), function (element)
 			return TeamName{

--- a/lua/wikis/easportsfc/PortalPlayers/Custom.lua
+++ b/lua/wikis/easportsfc/PortalPlayers/Custom.lua
@@ -14,7 +14,6 @@ local Links = require('Module:Links')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local Team = require('Module:Team')
 
 local AgeCalculation = Lua.import('Module:AgeCalculation')
 local PortalPlayers = Lua.import('Module:PortalPlayers')
@@ -88,7 +87,9 @@ function CustomPortalPlayers:row(player, isPlayer)
 	row:tag('td'):node(CustomPortalPlayers._getAge(player))
 
 	local role = not isPlayer and mw.language.getContentLanguage():ucfirst((player.extradata or {}).role or '') or ''
-	local teamText = mw.ext.TeamTemplate.teamexists(player.team) and Team.team(nil, player.team) or ''
+	local teamText = mw.ext.TeamTemplate.teamexists(player.team) and tostring(OpponentDisplay.InlineTeamContainer{
+		template = player.team, displayType = 'standard'
+	}) or ''
 	if String.isNotEmpty(role) and String.isEmpty(teamText) then
 		teamText = role
 	elseif String.isNotEmpty(role) then

--- a/lua/wikis/formula1/Infobox/Team/Custom.lua
+++ b/lua/wikis/formula1/Infobox/Team/Custom.lua
@@ -10,7 +10,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
-local TeamTemplates = require('Module:Team')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')
@@ -19,6 +18,7 @@ local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 local Center = Widgets.Center
+local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 
 ---@class Formula1InfoboxTeam: InfoboxTeam
 local CustomTeam = Class.new(Team)
@@ -58,7 +58,7 @@ function CustomInjector:parse(id, widgets)
 
 		if args.academy then
 			local academyTeams = Array.map(self.caller:getAllArgsForBase(args, 'academy'), function(team)
-				return TeamTemplates.team(nil, team)
+				return TeamInline{name = team, displayType = 'standard' }
 			end)
 			Array.extendWith(widgets,
 				{Title{children = 'Academy Team' .. (Table.size(academyTeams) > 1 and 's' or '')}},

--- a/lua/wikis/formula1/Infobox/Team/Custom.lua
+++ b/lua/wikis/formula1/Infobox/Team/Custom.lua
@@ -11,6 +11,9 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
+local OpponentLibraries = Lua.import('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')
 
@@ -18,7 +21,6 @@ local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 local Center = Widgets.Center
-local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 
 ---@class Formula1InfoboxTeam: InfoboxTeam
 local CustomTeam = Class.new(Team)
@@ -58,7 +60,7 @@ function CustomInjector:parse(id, widgets)
 
 		if args.academy then
 			local academyTeams = Array.map(self.caller:getAllArgsForBase(args, 'academy'), function(team)
-				return TeamInline{name = team, displayType = 'standard' }
+				return OpponentDisplay.InlineTeamContainer{template = team, displayType = 'standard' }
 			end)
 			Array.extendWith(widgets,
 				{Title{children = 'Academy Team' .. (Table.size(academyTeams) > 1 and 's' or '')}},

--- a/lua/wikis/formula1/PortalPlayers/Custom.lua
+++ b/lua/wikis/formula1/PortalPlayers/Custom.lua
@@ -14,7 +14,6 @@ local Links = require('Module:Links')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
-local Team = require('Module:Team')
 
 local AgeCalculation = Lua.import('Module:AgeCalculation')
 local PortalPlayers = Lua.import('Module:PortalPlayers')
@@ -88,7 +87,9 @@ function CustomPortalPlayers:row(player, isPlayer)
 	row:tag('td'):node(CustomPortalPlayers._getAge(player))
 
 	local role = not isPlayer and mw.language.getContentLanguage():ucfirst((player.extradata or {}).role or '') or ''
-	local teamText = mw.ext.TeamTemplate.teamexists(player.team) and Team.team(nil, player.team) or ''
+	local teamText = mw.ext.TeamTemplate.teamexists(player.team) and tostring(OpponentDisplay.InlineTeamContainer{
+		template = player.team, displayType = 'standard'
+	}) or ''
 	if String.isNotEmpty(role) and String.isEmpty(teamText) then
 		teamText = role
 	elseif String.isNotEmpty(role) then

--- a/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
@@ -12,6 +12,9 @@ local Lua = require('Module:Lua')
 local RoleOf = require('Module:RoleOf')
 local String = require('Module:StringUtils')
 
+local OpponentLibraries = Lua.import('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Injector = Lua.import('Module:Widget/Injector')
 local Region = Lua.import('Module:Region')
@@ -19,7 +22,6 @@ local Team = Lua.import('Module:Infobox/Team')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
-local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 local REGION_REMAPPINGS = {
@@ -81,7 +83,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{name = 'Abbreviation', content = {args.abbreviation}},
 			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {
-				args.affiliate and TeamInline{name = args.affiliate, displayType = 'standard'} or nil}}
+				args.affiliate and OpponentDisplay.InlineTeamContainer{template = args.affiliate, displayType = 'standard'} or nil}}
 		}
 	end
 

--- a/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
@@ -11,7 +11,6 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local RoleOf = require('Module:RoleOf')
 local String = require('Module:StringUtils')
-local TeamTemplate = require('Module:Team')
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Injector = Lua.import('Module:Widget/Injector')
@@ -20,6 +19,7 @@ local Team = Lua.import('Module:Infobox/Team')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
+local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 local REGION_REMAPPINGS = {
@@ -81,7 +81,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{name = 'Abbreviation', content = {args.abbreviation}},
 			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {
-				args.affiliate and TeamTemplate.team(nil, args.affiliate) or nil}}
+				args.affiliate and TeamInline{name = args.affiliate, displayType = 'standard'} or nil}}
 		}
 	end
 

--- a/lua/wikis/valorant/Infobox/Team/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Team/Custom.lua
@@ -9,12 +9,14 @@
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
+local OpponentLibraries = Lua.import('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
+
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
-local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 ---@class ValorantInfoboxTeam: InfoboxTeam
@@ -43,7 +45,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'custom' then
 		return {
 			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {
-				args.affiliate and TeamInline{name = args.affiliate, displayType = 'standard'} or nil}}
+				args.affiliate and OpponentDisplay.InlineTeamContainer{template = args.affiliate, displayType = 'standard'} or nil}}
 		}
 	end
 	return widgets

--- a/lua/wikis/valorant/Infobox/Team/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Team/Custom.lua
@@ -8,13 +8,13 @@
 
 local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local TeamTemplate = require('Module:Team')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
+local TeamInline = Lua.import('Module:Widget/TeamDisplay/Inline')
 local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 ---@class ValorantInfoboxTeam: InfoboxTeam
@@ -43,7 +43,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'custom' then
 		return {
 			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {
-				args.affiliate and TeamTemplate.team(nil, args.affiliate) or nil}}
+				args.affiliate and TeamInline{name = args.affiliate, displayType = 'standard'} or nil}}
 		}
 	end
 	return widgets


### PR DESCRIPTION
## Summary

_Cherry-picked from #5649_

This PR introduces inline display widgets for team templates, removing uses of `Team.team`, `Team.icon`, etc.

## How did you test this change?

dev