### PR TITLE
fix(prizepool): fighters ppt saving incorrect display names for leaderboard

### DIFF
--- a/lua/wikis/fighters/PrizePool/Custom.lua
+++ b/lua/wikis/fighters/PrizePool/Custom.lua
@@ -11,6 +11,7 @@ local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Json = require('Module:Json')
 local Lpdb = require('Module:Lpdb')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
@@ -121,11 +122,14 @@ end
 ---@param prize string|number|boolean?
 function CustomPrizePool.addPointsDatapoint(data, prize)
 	local opponentData = Opponent.fromLpdbStruct(data)
+	if opponentData.type ~= Opponent.solo then return
+	elseif Logic.isEmpty(prize) then return end
+	local player = opponentData.players[1]
 	local pointsDataPoint = Lpdb.DataPoint:new{
-		objectname = 'Points_' .. opponentData.name,
+		objectname = 'Points_' .. player.pageName,
 		type = 'points',
 		name = mw.ext.TeamLiquidIntegration.resolve_redirect(data.extradata.circuit),
-		information = opponentData.name,
+		information = player.pageName,
 		date = data.date,
 		extradata = {
 			points = prize,
@@ -133,11 +137,11 @@ function CustomPrizePool.addPointsDatapoint(data, prize)
 			tournament = Variables.varDefault('tournament_link'),
 			parent = Variables.varDefault('tournament_parent'),
 			shortname = Variables.varDefault('tournament_name'),
-			participant = opponentData.players[1].pageName,
+			participant = player.pageName,
 			game = Variables.varDefault('tournament_game'),
 			type = Variables.varDefault('tournament_type'),
-			participantname = opponentData.players[1].displayName,
-			participantflag = opponentData.players[1].flag,
+			participantname = player.displayName,
+			participantflag = player.flag,
 			publishertier = data.extradata.circuit_tier or Variables.varDefault('circuittier'),
 			region = Variables.varDefault('circuitregion'),
 		}

--- a/lua/wikis/fighters/PrizePool/Custom.lua
+++ b/lua/wikis/fighters/PrizePool/Custom.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Json = require('Module:Json')
+local Lpdb = require('Module:Lpdb')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
@@ -119,26 +120,29 @@ end
 ---@param data placement
 ---@param prize string|number|boolean?
 function CustomPrizePool.addPointsDatapoint(data, prize)
-	mw.ext.LiquipediaDB.lpdb_datapoint('Points_' .. data.participant, {
+	local opponentData = Opponent.fromLpdbStruct(data)
+	local pointsDataPoint = Lpdb.DataPoint:new{
+		objectname = 'Points_' .. opponentData.name,
 		type = 'points',
 		name = mw.ext.TeamLiquidIntegration.resolve_redirect(data.extradata.circuit),
-		information = data.participant,
+		information = opponentData.name,
 		date = data.date,
-		extradata = mw.ext.LiquipediaDB.lpdb_create_json({
+		extradata = {
 			points = prize,
 			placement = data.placement,
 			tournament = Variables.varDefault('tournament_link'),
 			parent = Variables.varDefault('tournament_parent'),
 			shortname = Variables.varDefault('tournament_name'),
-			participant = data.participant,
+			participant = opponentData.players[1].pageName,
 			game = Variables.varDefault('tournament_game'),
 			type = Variables.varDefault('tournament_type'),
-			participantname = data.participant,
-			participantflag = data.participantflag,
+			participantname = opponentData.players[1].displayName,
+			participantflag = opponentData.players[1].flag,
 			publishertier = data.extradata.circuit_tier or Variables.varDefault('circuittier'),
 			region = Variables.varDefault('circuitregion'),
-		})
-	})
+		}
+	}
+	pointsDataPoint:save()
 end
 
 return CustomPrizePool


### PR DESCRIPTION
## Summary

initial report: https://discord.com/channels/93055209017729024/202549269134180352/1368388143836954644

> It looks like match2 made it so disambiguated tags appear in the learderboards as full links. e.g. Yagami (Australian Player) instead of just Yagami

## How did you test this change?

dev into live