### PR TITLE
chore: fix OpponentLibraries type annotation

### DIFF
--- a/lua/wikis/commons/OpponentLibraries.lua
+++ b/lua/wikis/commons/OpponentLibraries.lua
@@ -14,6 +14,6 @@ local Opponent = Lua.import('Module:' .. (Info.opponentLibrary or 'Opponent'))
 local OpponentDisplay = Lua.import('Module:' .. (Info.opponentDisplayLibrary or 'OpponentDisplay'))
 
 return {
-	Opponent = Opponent, ---@module 'commons.Opponent'
-	OpponentDisplay = OpponentDisplay, ---@module 'commons.OpponentDisplay'
+	Opponent = Opponent, ---@module 'Opponent'
+	OpponentDisplay = OpponentDisplay, ---@module 'OpponentDisplay'
 }


### PR DESCRIPTION
## Summary

As a side effect of #5742, type annotations in OpponentLibraries do not correctly pick up `Module:Opponent` and `Module:OpponentDisplay`. This PR updates these annotations for them to work properly again.

## How did you test this change?

vscode