### PR TITLE
fix: Adjust markup for sortbottom headers in ResultsTable

### DIFF
--- a/lua/wikis/commons/ResultsTable/Base.lua
+++ b/lua/wikis/commons/ResultsTable/Base.lua
@@ -376,6 +376,9 @@ function BaseResultsTable:build()
 			:tag('td'):attr('colspan', 42):wikitext('No recorded results found.'))
 	end
 
+	-- Hidden tr that contains a td to prevent the first yearHeader from being inside thead
+	displayTable:node(mw.html.create('tr'):css('display', 'none'):tag('td'):allDone())
+
 	for _, dataSet in ipairs(self.data) do
 		for _, row in ipairs(self:_buildRows(dataSet)) do
 			displayTable:node(row)


### PR DESCRIPTION
## Summary
Resolves #5904 

I don't really like this hack, but afaik there is no other way to force the row into the body instead of head of the table, as the corresponding tags are inserted by the MW parser.
Changing the yearHeader cells into `td` to prevent them from being picked up as header is also not really an option, as then the striped formatting applies resulting in worse display.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
