### PR TITLE
feat: add tostring support to condition nodes

### DIFF
--- a/lua/spec/condition_spec.lua
+++ b/lua/spec/condition_spec.lua
@@ -15,7 +15,8 @@ describe('LPDB Condition Builder', function()
 			)
 			assert.are_equal(
 				'[[date::<2020-03-02T00:00:00.000]]',
-				conditionNode1:toString()
+				conditionNode1:toString(),
+				tostring(conditionNode1)
 			)
 		end)
 
@@ -25,7 +26,8 @@ describe('LPDB Condition Builder', function()
 			)
 			assert.are_equal(
 				'([[date::>2020-03-02T00:00:00.000]] OR [[date::2020-03-02T00:00:00.000]])',
-				conditionNode2:toString()
+				conditionNode2:toString(),
+				tostring(conditionNode2)
 			)
 		end)
 
@@ -35,7 +37,8 @@ describe('LPDB Condition Builder', function()
 			)
 			assert.are_equal(
 				'([[date::<2020-03-02T00:00:00.000]] OR [[date::2020-03-02T00:00:00.000]])',
-				conditionNode3:toString()
+				conditionNode3:toString(),
+				tostring(conditionNode3)
 			)
 		end)
 	end)
@@ -60,7 +63,8 @@ describe('LPDB Condition Builder', function()
 			assert.are_equal(
 				'[[date::<2020-03-02T00:00:00.000]] AND ([[opponent::Team Liquid]] OR [[opponent::Team Secret]]) ' ..
 				'AND [[extradata_region::Europe]]',
-				tree:toString()
+				tree:toString(),
+				tostring(tree)
 			)
 		end)
 		it('with empty trees', function()
@@ -93,24 +97,29 @@ describe('LPDB Condition Builder', function()
 
 			assert.are_equal(
 				'[[game::commons1]]',
-				cond1:toString()
+				cond1:toString(),
+				tostring(cond1)
 			)
 			assert.are_equal(
 				'[[game::commons1]] OR [[game::commons2]]',
-				cond2:toString()
+				cond2:toString(),
+				tostring(cond2)
 			)
 			assert.are_equal(
 				'([[game::commons1]] OR [[game::commons2]])',
-				cond3:toString()
+				cond3:toString(),
+				tostring(cond3)
 			)
 			assert.are_equal(
 				'([[game::commons1]]) AND ([[game::commons1]] OR [[game::commons2]]) AND '..
 					'(([[game::commons1]] OR [[game::commons2]]))',
-				cond4:toString()
+				cond4:toString(),
+				tostring(cond4)
 			)
 			assert.are_equal(
 				'[[game::commons1]]',
-				cond5:toString()
+				cond5:toString(),
+				tostring(cond5)
 			)
 		end)
 	end)

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -18,6 +18,18 @@ local Condition = {}
 ---@class AbstractConditionNode:BaseClass
 local _ConditionNode = Class.new()
 
+---Returns the string representation of this condition node.
+function _ConditionNode:__tostring()
+	return self:toString()
+end
+
+---Returns the string representation of this condition node.
+---@protected
+---@return string
+function _ConditionNode:toString()
+	error('_ConditionNode:toString() cannot be called directly and must be overridden.')
+end
+
 ---A tree of conditions, specifying the conditions for an LPDB request.
 ---Can be used recursively, as in, a tree of trees.
 ---@class ConditionTree:AbstractConditionNode


### PR DESCRIPTION
## Summary

This PR adds `__tostring` metamethod to condition nodes, allowing the builtin `tostring` function to be used with it.

## How did you test this change?

189c7f2