### PR TITLE
refactor(mainpage): simplify transferPage param for transfer list widget

### DIFF
--- a/lua/wikis/apexlegends/MainPageLayout/data.lua
+++ b/lua/wikis/apexlegends/MainPageLayout/data.lua
@@ -43,9 +43,8 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			rumours = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/arenafps/MainPageLayout/data.lua
+++ b/lua/wikis/arenafps/MainPageLayout/data.lua
@@ -35,9 +35,8 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			transferQuery = false,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/brawlstars/MainPageLayout/data.lua
+++ b/lua/wikis/brawlstars/MainPageLayout/data.lua
@@ -35,9 +35,8 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			rumours = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/callofduty/MainPageLayout/data.lua
+++ b/lua/wikis/callofduty/MainPageLayout/data.lua
@@ -36,9 +36,8 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			limits = 10,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/commons/Widget/MainPage/TransfersList.lua
+++ b/lua/wikis/commons/Widget/MainPage/TransfersList.lua
@@ -25,7 +25,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field limit integer?
 ---@field rumours boolean?
 ---@field transferPortal string?
----@field transferPage fun():string
+---@field transferPage string?
 ---@field transferQuery boolean?
 ---@field onlyNotableTransfers boolean?
 
@@ -37,9 +37,7 @@ TransfersList.defaultProps = {
 	limit = 15,
 	rumours = false,
 	transferPortal = 'Portal:Transfers',
-	transferPage = function ()
-		return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-	end,
+	transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B'),
 	transferQuery = true
 }
 
@@ -63,7 +61,7 @@ function TransfersList:render()
 						'&#91;',
 							Link {
 							children = 'edit',
-							link = 'Special:EditPage/' .. self.props.transferPage()
+							link = 'Special:EditPage/' .. self.props.transferPage
 						},
 						'&#93;'
 					},

--- a/lua/wikis/deadlock/MainPageLayout/data.lua
+++ b/lua/wikis/deadlock/MainPageLayout/data.lua
@@ -47,9 +47,7 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			rumours = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y')
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y')
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/dota2/MainPageLayout/data.lua
+++ b/lua/wikis/dota2/MainPageLayout/data.lua
@@ -142,9 +142,8 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			transferPage = function ()
-				return 'Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/fortnite/MainPageLayout/data.lua
+++ b/lua/wikis/fortnite/MainPageLayout/data.lua
@@ -32,9 +32,7 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' .. os.date('%B')
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/freefire/MainPageLayout/data.lua
+++ b/lua/wikis/freefire/MainPageLayout/data.lua
@@ -34,9 +34,8 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/'
+				.. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/geoguessr/MainPageLayout/data.lua
+++ b/lua/wikis/geoguessr/MainPageLayout/data.lua
@@ -33,9 +33,7 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y')
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y')
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/halo/MainPageLayout/data.lua
+++ b/lua/wikis/halo/MainPageLayout/data.lua
@@ -35,9 +35,8 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			rumours = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/hearthstone/MainPageLayout/data.lua
+++ b/lua/wikis/hearthstone/MainPageLayout/data.lua
@@ -34,9 +34,8 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/heroes/MainPageLayout/data.lua
+++ b/lua/wikis/heroes/MainPageLayout/data.lua
@@ -36,9 +36,8 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			limits = 10,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/marvelrivals/MainPageLayout/data.lua
+++ b/lua/wikis/marvelrivals/MainPageLayout/data.lua
@@ -40,9 +40,8 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/mobilelegends/MainPageLayout/data.lua
+++ b/lua/wikis/mobilelegends/MainPageLayout/data.lua
@@ -42,9 +42,8 @@ local CONTENT = {
 		heading = 'Transfers',
 		body = TransfersList{
 			rumours = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y') .. '/' .. DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/osu/MainPageLayout/data.lua
+++ b/lua/wikis/osu/MainPageLayout/data.lua
@@ -35,9 +35,7 @@ local CONTENT = {
 		body = TransfersList{
 			transferQuery = false,
 			onlyNotableTransfers = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y')
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y')
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/starcraft2/MainPageLayout/data.lua
+++ b/lua/wikis/starcraft2/MainPageLayout/data.lua
@@ -37,9 +37,7 @@ local CONTENT = {
 		body = TransfersList{
 			transferQuery = false,
 			onlyNotableTransfers = true,
-			transferPage = function ()
-				return 'Player Transfers/' .. DateExt.quarterOf{ordinalSuffix = true} .. ' Quarter ' .. os.date('%Y')
-			end
+			transferPage = 'Player Transfers/' .. DateExt.quarterOf{ordinalSuffix = true} .. ' Quarter ' .. os.date('%Y')
 		},
 		boxid = 1509,
 	},

--- a/lua/wikis/worldoftanks/MainPageLayout/data.lua
+++ b/lua/wikis/worldoftanks/MainPageLayout/data.lua
@@ -35,9 +35,7 @@ local CONTENT = {
 		body = TransfersList{
 			rumours = true,
 			limits = 10,
-			transferPage = function ()
-				return 'Player Transfers/' .. os.date('%Y')
-			end
+			transferPage = 'Player Transfers/' .. os.date('%Y')
 		},
 		boxid = 1509,
 	},


### PR DESCRIPTION
## Summary

This PR simplifies `transferPage` prop of mainpage transfer list widget so that it takes `string` instead of `fun(): string`.

## How did you test this change?

dev in LoL / SC2