### PR TITLE
fix(mainpage): Wildcard header naming

### DIFF
--- a/lua/wikis/wildcard/MainPageLayout/data.lua
+++ b/lua/wikis/wildcard/MainPageLayout/data.lua
@@ -42,8 +42,8 @@ local CONTENT = {
 		boxid = 1501,
 	},
 	wildcards = {
-		heading = 'Wildcards',
-		body = '{{Liquipedia:Wildcards}}',
+		heading = 'Wild Cards',
+		body = '{{Liquipedia:Wild Cards}}',
 		padding = true,
 		boxid = 1513,
 	},
@@ -72,8 +72,8 @@ return {
 	navigation = {
 		{
 			file = 'Wildcard header Wildcards.webp',
-			title = 'Wildcards',
-			link = 'Portal:Wildcards',
+			title = 'Wild Cards',
+			link = 'Portal:Wild Cards',
 		},
 		{
 			file = 'Wildcard header Champions.webp',


### PR DESCRIPTION
It turns out that the **Wildcard** game mechanics header, we actually misspelled it. Devs corrected this to us as **Wild Cards** (not to be confused, this is one of the game's mechanic, not referring to the game's name)

![image](https://github.com/user-attachments/assets/d40ab3e6-7b18-42b6-b58f-198350a1f1a4)
