### PR TITLE
feat(Infobox): Add Infobox player for chess

### DIFF
--- a/lua/wikis/chess/Info.lua
+++ b/lua/wikis/chess/Info.lua
@@ -1,6 +1,5 @@
 ---
 -- @Liquipedia
--- wiki=chess
 -- page=Module:Info
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -48,6 +47,12 @@ return {
 		match2 = {
 			status = 2,
 			matchWidth = 180,
+		},
+		infoboxPlayer = {
+			autoTeam = true,
+			automatedHistory = {
+				mode = 'automatic',
+			},
 		},
 	},
 	defaultRoundPrecision = 0,

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -8,10 +8,8 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
-local Json = require('Module:Json')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 local Variables = require('Module:Variables')
 

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -1,0 +1,98 @@
+---
+-- @Liquipedia
+-- wiki=chess
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Json = require('Module:Json')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+local Table = require('Module:Table')
+local TeamHistoryAuto = require('Module:TeamHistoryAuto')
+local Variables = require('Module:Variables')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Player = Lua.import('Module:Infobox/Person')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+
+---@class ChessInfoboxPlayer: Person
+local CustomPlayer = Class.new(Player)
+local CustomInjector = Class.new(Injector)
+
+local TITLES = {
+	{code = "gm", name = "Grandmaster"},
+	{code = "im", name = "International Master"},
+	{code = "wgm", name = "Woman Grandmaster"},
+	{code = "fm", name = "FIDE Master"},
+	{code = "wim", name = "Woman International Master"},
+	{code = "cm", name = "Candidate Master"},
+	{code = "wfm", name = "Woman FIDE Master"},
+	{code = "wcm", name = "Woman Candidate Master"},
+}
+
+---@param frame Frame
+---@return Html
+function CustomPlayer.run(frame)
+	local player = CustomPlayer(frame)
+	player:setWidgetInjector(CustomInjector(player))
+
+	player.args.id = player.args.id or player.args.romanized_name or player.args.name
+
+	player.args.autoTeam = true
+	player.args.history = TeamHistoryAuto.results{
+		convertrole = true,
+		addlpdbdata = true
+	}
+
+	-- Title.
+	player.args.title = Array.find(
+		TITLES,
+		function (title, _)
+			return Logic.isNotEmpty(player.args['title_' .. title.code])
+		end
+	)
+
+	return player:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		-- Titles.
+		local hasTitle = Logic.isNotEmpty(args.title)
+		if hasTitle then
+			Array.extendWith(widgets,
+				{Title{children = 'Titles'}},
+				Array.map(
+					TITLES,
+					function (title)
+						return Cell{name = title.name, content = {args['title_' .. title.code]}}
+					end
+				)
+			)
+		end
+
+	elseif id == 'region' then
+		return {}
+	end
+
+	return widgets
+end
+
+---@param args table
+function CustomPlayer:defineCustomPageVariables(args)
+	Variables.varDefine('player_title', args.title and args.title.name or 'Player')
+end
+
+return CustomPlayer

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -1,6 +1,5 @@
 ---
 -- @Liquipedia
--- wiki=chess
 -- page=Module:Infobox/Person/Player/Custom
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -47,14 +47,6 @@ function CustomPlayer.run(frame)
 		addlpdbdata = true
 	}
 
-	-- Title.
-	player.args.title = Array.find(
-		TITLES,
-		function (title)
-			return Logic.isNotEmpty(player.args['title_' .. title.code])
-		end
-	)
-
 	return player:createInfobox()
 end
 
@@ -65,13 +57,16 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'custom' then
-		-- Titles.
-		local hasTitle = Logic.isNotEmpty(args.title)
-		if hasTitle then
+		local titles = Array.filter(TITLES,
+			function (title)
+				return Logic.isNotEmpty(args['title_' .. title.code])
+			end
+		)
+		if #titles > 0 then
 			Array.extendWith(widgets,
 				{Title{children = 'Titles'}},
 				Array.map(
-					TITLES,
+					titles,
 					function (title)
 						return Cell{name = title.name, content = {args['title_' .. title.code]}}
 					end

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -11,7 +11,6 @@ local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
-local Variables = require('Module:Variables')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
@@ -25,14 +24,14 @@ local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 
 local TITLES = {
-	{code = "gm", name = "Grandmaster"},
-	{code = "im", name = "International Master"},
-	{code = "wgm", name = "Woman Grandmaster"},
-	{code = "fm", name = "FIDE Master"},
-	{code = "wim", name = "Woman International Master"},
-	{code = "cm", name = "Candidate Master"},
-	{code = "wfm", name = "Woman FIDE Master"},
-	{code = "wcm", name = "Woman Candidate Master"},
+	{code = 'gm', name = 'Grandmaster'},
+	{code = 'im', name = 'International Master'},
+	{code = 'wgm', name = 'Woman Grandmaster'},
+	{code = 'fm', name = 'FIDE Master'},
+	{code = 'wim', name = 'Woman International Master'},
+	{code = 'cm', name = 'Candidate Master'},
+	{code = 'wfm', name = 'Woman FIDE Master'},
+	{code = 'wcm', name = 'Woman Candidate Master'},
 }
 
 ---@param frame Frame
@@ -52,7 +51,7 @@ function CustomPlayer.run(frame)
 	-- Title.
 	player.args.title = Array.find(
 		TITLES,
-		function (title, _)
+		function (title)
 			return Logic.isNotEmpty(player.args['title_' .. title.code])
 		end
 	)
@@ -86,11 +85,6 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	return widgets
-end
-
----@param args table
-function CustomPlayer:defineCustomPageVariables(args)
-	Variables.varDefine('player_title', args.title and args.title.name or 'Player')
 end
 
 return CustomPlayer

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -9,7 +9,6 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local TeamHistoryAuto = require('Module:TeamHistoryAuto')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
@@ -40,12 +39,6 @@ function CustomPlayer.run(frame)
 	player:setWidgetInjector(CustomInjector(player))
 
 	player.args.id = player.args.id or player.args.romanized_name or player.args.name
-
-	player.args.autoTeam = true
-	player.args.history = TeamHistoryAuto.results{
-		convertrole = true,
-		addlpdbdata = true
-	}
 
 	return player:createInfobox()
 end


### PR DESCRIPTION
## Summary
This is a re-created PR  of the closing one, due to Ratings implementation is on indefinite freezer.

**Infobox code was made in February, please account this into any potential spots that may be replaced by newer standardizations**

The only customization in here is the new **Title** section, detailing the exact year a player has recieved a chess title. 
![image](https://github.com/user-attachments/assets/cd530228-bb15-4de9-821e-3f017ff634b2)

Three are included: Grandmaster, International Master and FIDE Master. 
Additionally for Female players they can have another 3 more being Female only variation of those (maximum of 6, but in all players pages, Four listings are the furthest so far)

![image](https://github.com/user-attachments/assets/2e937cf2-670c-4adb-858f-6ae32dfa0b5e)

In previous PR, hjp suggested titles to be under achievements section, but I'm not sure how to do it as they arent populate by auto through tournaments (and if it displays properly, where achievements would display a tournament icon for major wins)

## How did you test this change?
LIVE