### PR TITLE
fix(match2): display title for match page not being applied in certain conditions

### DIFF
--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -206,7 +206,7 @@ end
 function BaseMatchPage:render()
 	local displayTitle = self:makeDisplayTitle()
 	if String.isNotEmpty(displayTitle) then
-		mw.getCurrentFrame():preprocess('{{DISPLAYTITLE:' .. displayTitle .. '|noreplace}}')
+		mw.getCurrentFrame():callParserFunction('DISPLAYTITLE', displayTitle, 'noreplace')
 	end
 
 	local tournamentContext = self:_getMatchContext()


### PR DESCRIPTION
## Summary

Currently, in certain scenarios (e.g., tournament does not have `tickername`) the match page does not apply display title after it is generated.
This PR adjusts display title generation logic to cover such cases.

## How did you test this change?

dev