### PR TITLE
fix: Mismatch in "key" and "value" Tier/Data R6

### DIFF
--- a/lua/wikis/rainbowsix/Tier/Data.lua
+++ b/lua/wikis/rainbowsix/Tier/Data.lua
@@ -105,7 +105,7 @@ return {
 			link = 'Point Rankings',
 			category = 'Point Rankings',
 		},
-		award = {
+		awards = {
 			value = 'Awards',
 			sort = 'B4',
 			name = 'Awards',


### PR DESCRIPTION
Fixed the mismatch in key/value so the TierType will be shown instead of Undefined

## Summary

Fixed the typo so both the key and the value match exactly which should result in Undefined to show the correct tiertype.

(I am aware that I need to manually update the `|...tiertype` in the infobox on the pages where currently `|...tiertype=Award` is used)

<hr/>

![image](https://github.com/user-attachments/assets/e10ae7ec-04bc-4daa-88de-792fc42d3655)
> https://liquipedia.net/rainbowsix/Spoit


## How did you test this change?

No test, found the answer in the discord: 
> https://discord.com/channels/93055209017729024/268719633366777856/1128675422264107129

<hr/>

![image](https://github.com/user-attachments/assets/9a06de17-e809-472a-b74f-47f7fa405481)
