### PR TITLE
fix(mainpage): syntax error in 'want to help' widget

### DIFF
--- a/lua/wikis/commons/Widget/MainPage/WantToHelp.lua
+++ b/lua/wikis/commons/Widget/MainPage/WantToHelp.lua
@@ -164,7 +164,7 @@ function WantToHelp:render()
 				}
 			end
 			return text
-		end}
+		end},
 		' listed needing help.'
 	}
 end


### PR DESCRIPTION
## Summary

original report: https://discord.com/channels/93055209017729024/372075546231832576/1370362259607388322

## How did you test this change?

dev