### PR TITLE
feat: update sadbox styling to match new mainpages

### DIFF
--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -2129,6 +2129,8 @@ Author(s): FO-nTTaX
 	font-size: 18px;
 	margin-bottom: 10px;
 	text-align: center;
+	border-radius: 0.5rem;
+	overflow: hidden;
 }
 
 .sadbox a {


### PR DESCRIPTION
## Summary

This makes it so the "in memory of" banner on mainpages has the right border radius to fit with the new main page panels

## How did you test this change?

https://liquipedia.net/leagueoflegends/Main_Page has this coded in already
