### PR TITLE
feat: Add "Rainbow Six Siege X" to Module:Info

### DIFF
--- a/lua/wikis/rainbowsix/Info.lua
+++ b/lua/wikis/rainbowsix/Info.lua
@@ -7,11 +7,24 @@
 --
 
 return {
-	startYear = 2006, --vegas from 2006; vegas2 from 2008; siege from 2015; mobile from 2022
+	startYear = 2006, --vegas from 2006; vegas2 from 2008; siege from 2015; mobile from 2022; siegex from 2025
 	wikiName = 'rainbowsix',
 	name = 'Rainbow Six',
 	defaultGame = 'siege',
 	games = {
+		siegex = {
+			abbreviation = 'R6X',
+			name = 'Tom Clancy\'s Rainbow Six Siege X',
+			link = 'Rainbow Six Siege X',
+			logo = {
+				darkMode = 'Rainbow Six Siege X default allmode.png',
+				lightMode = 'Rainbow Six Siege X default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Rainbow Six Siege X default allmode.png',
+				lightMode = 'Rainbow Six Siege X default allmode.png',
+			},
+		},
 		mobile = {
 			abbreviation = 'R6M',
 			name = 'Tom Clancy\'s Rainbow Six Mobile',


### PR DESCRIPTION
## Summary

Adding the name "Tom Clancy's Rainbow Six Siege X" into the League infobox with |game=siegex.
Also adds the new defeault icon (for game and TeamCard)

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

Dev

![image](https://github.com/user-attachments/assets/6c63d59f-4d79-4735-abe8-f7edc8afc621)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
