### PR TITLE
[WiP] feat(match2): add support for new ban format on r6

### DIFF
--- a/lua/wikis/rainbowsix/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/rainbowsix/MatchGroup/Input/Custom.lua
@@ -10,6 +10,7 @@ local Array = require('Module:Array')
 local CharacterNames = require('Module:CharacterNames')
 local FnUtil = require('Module:FnUtil')
 local Lua = require('Module:Lua')
+local Table = require('Module:Table')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
@@ -17,7 +18,8 @@ local CustomMatchGroupInput = {}
 local MatchFunctions = {}
 local MapFunctions = {}
 
-local MAX_NUM_BANS = 2
+local MAX_NUM_BANS = 6
+local VALID_BAN_TYPES = {'atk', 'def'}
 MatchFunctions.DEFAULT_MODE = 'team'
 MatchFunctions.getBestOf = MatchGroupInputUtil.getBestOf
 
@@ -84,10 +86,18 @@ function MapFunctions.getExtraData(match, map, opponents)
 
 	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, CharacterNames)
 	Array.forEach(opponents, function(_, opponentIndex)
-		extradata['t' .. opponentIndex .. 'bans'] = Array.map(Array.range(1, MAX_NUM_BANS), function(banIndex)
-			local ban = map['t' .. opponentIndex .. 'ban' .. banIndex]
+		local prefix = 't' .. opponentIndex
+		extradata[prefix .. 'bans'] = Array.map(Array.range(1, MAX_NUM_BANS), function(banIndex)
+			local ban = map[prefix .. 'ban' .. banIndex]
 			return getCharacterName(ban) or ''
 		end)
+		-- to be enabled after bot jobs:
+		-- assert(map[prefix .. 'bantypes'])
+
+		extradata[prefix .. 'bantypes'] = Array.parseCommaSeparatedString(map[prefix .. 'bantypes'])
+		assert(Array.all(extradata[prefix .. 'bantypes'], function(banType)
+			return Table.includes(VALID_BAN_TYPES, banType)
+		end))
 	end)
 
 	return extradata


### PR DESCRIPTION
## Summary
As per request on discord R6 gets a new game which requires support fo a new ban format.
This PR implements the support for this.
Due to the new ban format it is also necessary to store the ban types for all bans.
This is so in the stats module it can be determined which ban is for atk and which for def.

After this PR there will be need of a bot job to add the ban type input for all old usages.
After that a small follow up PR will be done to enforce the ban type input if there are inputted bans.

## How did you test this change?
to be done