### PR TITLE
chore(match2): kick bestof param from dota2 copy-paste generator

### DIFF
--- a/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
@@ -25,7 +25,6 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match',
-		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)


### PR DESCRIPTION
## Summary

This PR kicks `bestof` param from Dota2 copy-paste generator.

## How did you test this change?

dev