### PR TITLE
fix(match2): map image zoom not triggered when hovering over mapveto title

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1266,10 +1266,8 @@ span.slash {
 		}
 
 		@media ( hover: hover ) {
-			&:hover &-image {
-				img {
-					transform: scale( 1.1 );
-				}
+			&:hover &-image img {
+				transform: scale( 1.1 );
 			}
 		}
 

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1263,12 +1263,12 @@ span.slash {
 				height: 100%;
 				transition: transform 0.2s linear;
 			}
+		}
 
-			@media ( hover: hover ) {
-				&:hover {
-					img {
-						transform: scale( 1.1 );
-					}
+		@media ( hover: hover ) {
+			&:hover &-image {
+				img {
+					transform: scale( 1.1 );
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Map image inside mapveto card should zoom in when hovering anywhere over it. However, it is triggered only when the cursor is directly over the image. This PR adjusts the hover trigger so that the original behavior is restored.

## How did you test this change?

Browser dev tools
