### PR TITLE
feat: enable squad positions for WR & War Thunder

### DIFF
--- a/lua/wikis/warthunder/Info.lua
+++ b/lua/wikis/warthunder/Info.lua
@@ -28,7 +28,7 @@ return {
 	},
 	config = {
 		squads = {
-			hasPosition = false,
+			hasPosition = true,
 			hasSpecialTeam = false,
 			allowManual = false,
 		},

--- a/lua/wikis/wildrift/Info.lua
+++ b/lua/wikis/wildrift/Info.lua
@@ -28,7 +28,7 @@ return {
 	},
 	config = {
 		squads = {
-			hasPosition = false,
+			hasPosition = true,
 			hasSpecialTeam = false,
 			allowManual = true,
 		},


### PR DESCRIPTION
## Summary
No idea why WR had it at false (and not true like League PC) so I enable it
![image](https://github.com/user-attachments/assets/3fe8e127-907e-4618-a74f-d5cb6e291b67)


as for War Thunder the contributors have mentioned there are positions usage they want to have it shown on squad (to indicate the type of vehicle a player is designated at. I was told the designated vehicles behave similar to MOBA as they are not changing on the fly all the time)
![image](https://github.com/user-attachments/assets/7c841bed-930b-43fd-9582-5c389212bc71)

