### PR TITLE
feat(Infobox): add tracking categorie for marginalized gender tournaments on overwatch

### DIFF
--- a/lua/wikis/overwatch/Infobox/League/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/League/Custom.lua
@@ -46,7 +46,6 @@ end
 ---@param args table
 function CustomLeague:customParseArguments(args)
 	self.data.publishertier = self:_validPublisherTier(args.publishertier) and args.publishertier:lower()
-	self.data.marginalizedgender = Logic.readBool(args.marginalized_gender)
 end
 
 ---@param id string
@@ -128,7 +127,7 @@ function CustomLeague:getWikiCategories(args)
 		table.insert(categories, Game.name{game = args.game} .. ' Competitions')
 	end
 
-	if self.data.marginalizedgender then
+	if self.data.marginalizedgender = Logic.readBool(args.marginalized_gender) then
 		table.insert(categories, 'Marginalized Gender Tournaments')
 	end
 

--- a/lua/wikis/overwatch/Infobox/League/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/League/Custom.lua
@@ -127,7 +127,7 @@ function CustomLeague:getWikiCategories(args)
 		table.insert(categories, Game.name{game = args.game} .. ' Competitions')
 	end
 
-	if self.data.marginalizedgender = Logic.readBool(args.marginalized_gender) then
+	if Logic.readBool(args.marginalized_gender) then
 		table.insert(categories, 'Marginalized Gender Tournaments')
 	end
 

--- a/lua/wikis/overwatch/Infobox/League/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/League/Custom.lua
@@ -46,6 +46,7 @@ end
 ---@param args table
 function CustomLeague:customParseArguments(args)
 	self.data.publishertier = self:_validPublisherTier(args.publishertier) and args.publishertier:lower()
+	self.data.marginalizedgender = Logic.readBool(args.marginalized_gender)
 end
 
 ---@param id string
@@ -125,6 +126,10 @@ function CustomLeague:getWikiCategories(args)
 		table.insert(categories, 'Tournaments without game version')
 	else
 		table.insert(categories, Game.name{game = args.game} .. ' Competitions')
+	end
+
+	if self.data.marginalizedgender then
+		table.insert(categories, 'Marginalized Gender Tournaments')
 	end
 
 	return categories


### PR DESCRIPTION
## Summary

Add a "marginalized gender" input to the infobox league custom. Use the new input for a tracking category "Marginalized Gender Tournaments".

Im not sure if this should also be stored into LPDB?

## How did you test this change?

dev
