### PR TITLE
refactor(match2): clean up head-to-head link generator in dota2

### DIFF
--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -978,13 +978,17 @@ mw.uri = {}
 ---@param page string
 ---@param query string|table?
 ---@return URI
-function mw.uri.localUrl(page, query) end
+function mw.uri.localUrl(page, query)
+	return ''
+end
 
 ---Returns a URI object for the full URL for a page, with optional query string/table
 ---@param page string
 ---@param query string|table?
 ---@return URI
-function mw.uri.fullUrl(page, query) end
+function mw.uri.fullUrl(page, query)
+	return 'https://liquipedia.net/'
+end
 
 ---@alias UriEncodeType 'QUERY'|'PATH'|'WIKI'
 

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -974,6 +974,7 @@ function mw.ustring.upper(s) return string.upper(s) end
 ---@field fragment string?
 mw.uri = {}
 
+---Returns a URI object for the local URL for a page, with optional query string/table
 ---@param page string
 ---@param query string|table?
 ---@return URI

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -963,9 +963,27 @@ function mw.ustring.toNFKD(s) return tostring(s) end
 ---@return string
 function mw.ustring.upper(s) return string.upper(s) end
 
+---@class URI
+---@field protocol string?
+---@field user string?
+---@field password string?
+---@field host string?
+---@field port integer?
+---@field path string?
+---@field query table?
+---@field fragment string?
 mw.uri = {}
-function mw.uri.localUrl(s, s2) return '' end
-function mw.uri.fullUrl(s, s2) return 'https://liquipedia.net/' end
+
+---@param page string
+---@param query string|table?
+---@return URI
+function mw.uri.localUrl(page, query) end
+
+---Returns a URI object for the full URL for a page, with optional query string/table
+---@param page string
+---@param query string|table?
+---@return URI
+function mw.uri.fullUrl(page, query) end
 
 ---@alias UriEncodeType 'QUERY'|'PATH'|'WIKI'
 
@@ -980,6 +998,24 @@ function mw.uri.encode(str, enctype) end
 ---@param enctype UriEncodeType?
 ---@return string
 function mw.uri.decode(str, enctype) end
+
+---Validates the specified table (or URI object).
+---@param arg table|URI
+---@return boolean result whether the argument was valid
+---@return string? desc explanation of the found problems (if any)
+function mw.uri.validate(arg) end
+
+---Parses a string into this URI object.
+---@param str string
+function mw.uri:parse(str) end
+
+---Creates a copy of this URI object.
+---@return URI
+function mw.uri:clone() end
+
+---Merges the parameters table into the query table of this URI object.
+---@param parameters table
+function mw.uri:extend(parameters) end
 
 mw.ext = {}
 mw.ext.LiquipediaDB = require('definitions.liquipedia_db')

--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -138,10 +138,15 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 		return opponent.type == Opponent.team
 	end)
 	if Logic.readBool(Logic.emptyOr(match.headtohead, Variables.varDefault('headtohead'))) and isTeamGame then
-		local team1, team2 = string.gsub(opponents[1].name, ' ', '_'), string.gsub(opponents[2].name, ' ', '_')
-		return tostring(mw.uri.fullUrl('Special:RunQuery/Match_history')) ..
-			'?pfRunQueryFormName=Match+history&Head_to_head_query%5Bplayer%5D=' .. team1 ..
-			'&Head_to_head_query%5Bopponent%5D=' .. team2 .. '&wpRunQuery=Run+query'
+		return tostring(mw.uri.fullUrl(
+			'Special:RunQuery/Match history',
+			{
+				pfRunQueryFormName = 'Match history',
+				['Head to head query[player]'] = string.gsub(opponents[1].name, ' ', '_'),
+				['Head to head query[opponent]'] = string.gsub(opponents[2].name, ' ', '_'),
+				wpRunQuery = 'Run query'
+			}
+		))
 	end
 end
 


### PR DESCRIPTION
## Summary

This PR:
- adds `mw.uri` library specification (adapted from MediaWiki Lua reference manual)
- cleans up head-to-head link generator using `mw.uri`

## How did you test this change?

dev
