### PR TITLE
chore: use standard lpdb fields in NotabilityCecker conditioning

### DIFF
--- a/lua/wikis/commons/NotabilityChecker.lua
+++ b/lua/wikis/commons/NotabilityChecker.lua
@@ -97,7 +97,7 @@ end
 function NotabilityChecker._calculateTeamNotability(team)
 	local data = mw.ext.LiquipediaDB.lpdb('placement', {
 		limit = Config.PLACEMENT_LIMIT,
-		conditions = '[[participant::' .. team .. ']]',
+		conditions = '[[opponentname::' .. team .. ']]',
 		query = 'pagename, tournament, date, placement, liquipediatier, liquipediatiertype, extradata, mode',
 	})
 
@@ -111,7 +111,7 @@ function NotabilityChecker._calculatePersonNotability(person)
 	-- We check for names with spaces, then names with underscores.
 	local conditions = {}
 	for _, name in pairs({person, (person:gsub(' ', '_'))}) do
-		table.insert(conditions, '[[participant::' .. name .. ']]')
+		table.insert(conditions, '[[opponentname::' .. name .. ']]')
 		for i = 1, Config.MAX_NUMBER_OF_PARTICIPANTS do
 			table.insert(conditions, '[[opponentplayers_p' .. tostring(i) .. '::' .. name .. ']]')
 		end


### PR DESCRIPTION
## Summary
Use standardized `opponentname` instead of `participant` in NotabilityChecker module

## How did you test this change?
not tested but since the participant field is just a copy of the opponentname one ....