### PR TITLE
refactor(match2): add separate widget for slash in match pages

### DIFF
--- a/lua/wikis/commons/Widget/Match/Page/Slash.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Slash.lua
@@ -1,0 +1,28 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/Match/Page/Slash
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+
+---@class MatchPageSlash: Widget
+---@operator call(table): MatchPageSlash
+local MatchPageSlash = Class.new(Widget)
+
+---@return Widget
+function MatchPageSlash:render()
+	return HtmlWidgets.Span{
+		classes = {'slash'},
+		children = '/'
+	}
+end
+
+return MatchPageSlash

--- a/lua/wikis/dota2/MatchPage.lua
+++ b/lua/wikis/dota2/MatchPage.lua
@@ -22,6 +22,7 @@ local IconFa = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local IconImage = Lua.import('Module:Widget/Image/Icon/Image')
 local PlayerDisplay = Lua.import('Module:Widget/Match/Page/PlayerDisplay')
 local PlayerStat = Lua.import('Module:Widget/Match/Page/PlayerStat')
+local Slash = Lua.import('Module:Widget/Match/Page/Slash')
 local StatsList = Lua.import('Module:Widget/Match/Page/StatsList')
 local TeamVeto = Lua.import('Module:Widget/Match/Page/TeamVeto')
 local VetoItem = Lua.import('Module:Widget/Match/Page/VetoItem')
@@ -34,7 +35,6 @@ local MatchPage = Class.new(BaseMatchPage)
 local GOLD_ICON = IconFa{iconName = 'gold', hover = 'Gold'}
 local ITEM_IMAGE_SIZE = '64px'
 local KDA_ICON = IconFa{iconName = 'kda', hover = 'KDA'}
-local SPAN_SLASH = HtmlWidgets.Span{classes = {'slash'}, children = '/'}
 
 ---@param props {match: MatchGroupUtilMatch}
 ---@return Widget
@@ -189,12 +189,12 @@ function MatchPage:_renderTeamStats(game)
 										game.teams[1].kills,
 										game.teams[1].deaths,
 										game.teams[1].assists
-									}, SPAN_SLASH),
+									}, Slash{}),
 									team2Value = Array.interleave({
 										game.teams[2].kills,
 										game.teams[2].deaths,
 										game.teams[2].assists
-									}, SPAN_SLASH)
+									}, Slash{})
 								},
 								{
 									icon = GOLD_ICON,
@@ -368,7 +368,7 @@ function MatchPage:_renderPlayerPerformance(game, teamIndex, player)
 						title = {KDA_ICON, 'KDA'},
 						data = Array.interleave({
 							player.kills, player.deaths, player.assists
-						}, SPAN_SLASH)
+						}, Slash{})
 					},
 					PlayerStat{
 						title = {IconFa{iconName = 'damage'}, 'DMG'},
@@ -376,7 +376,7 @@ function MatchPage:_renderPlayerPerformance(game, teamIndex, player)
 					},
 					PlayerStat{
 						title = {IconFa{iconName = 'dota2_lhdn'}, 'LH/DN'},
-						data = Array.interleave({player.lasthits, player.denies}, SPAN_SLASH)
+						data = Array.interleave({player.lasthits, player.denies}, Slash{})
 					},
 					PlayerStat{
 						title = {GOLD_ICON, 'NET'},

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -23,6 +23,7 @@ local IconFa = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local IconImage = Lua.import('Module:Widget/Image/Icon/Image')
 local PlayerStat = Lua.import('Module:Widget/Match/Page/PlayerStat')
 local PlayerDisplay = Lua.import('Module:Widget/Match/Page/PlayerDisplay')
+local Slash = Lua.import('Module:Widget/Match/Page/Slash')
 local StatsList = Lua.import('Module:Widget/Match/Page/StatsList')
 local VetoItem = Lua.import('Module:Widget/Match/Page/VetoItem')
 local VetoRow = Lua.import('Module:Widget/Match/Page/VetoRow')
@@ -72,7 +73,6 @@ local ITEMS_TO_SHOW = 6
 
 local KDA_ICON = IconFa{iconName = 'leagueoflegends_kda', hover = 'KDA'}
 local GOLD_ICON = IconFa{iconName = 'gold', hover = 'Gold'}
-local SPAN_SLASH = HtmlWidgets.Span{classes = {'slash'}, children = '/'}
 
 ---@param props {match: MatchGroupUtilMatch}
 ---@return Widget
@@ -384,12 +384,12 @@ function MatchPage:_renderTeamStats(game)
 								game.teams[1].kills,
 								game.teams[1].deaths,
 								game.teams[1].assists
-							}, SPAN_SLASH),
+							}, Slash{}),
 							team2Value = Array.interleave({
 								game.teams[2].kills,
 								game.teams[2].deaths,
 								game.teams[2].assists
-							}, SPAN_SLASH)
+							}, Slash{})
 						},
 						{
 							icon = GOLD_ICON,
@@ -497,7 +497,7 @@ function MatchPage:_renderPlayerPerformance(game, teamIndex, player)
 						title = {KDA_ICON, 'KDA'},
 						data = Array.interleave({
 							player.kills, player.deaths, player.assists
-						}, SPAN_SLASH)
+						}, Slash{})
 					},
 					PlayerStat{
 						title = {

--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -20,14 +20,13 @@ local IconFa = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local PlayerDisplay = Lua.import('Module:Widget/Match/Page/PlayerDisplay')
 local PlayerStat = Lua.import('Module:Widget/Match/Page/PlayerStat')
 local RoundsOverview = Lua.import('Module:Widget/Match/Page/RoundsOverview')
+local Slash = Lua.import('Module:Widget/Match/Page/Slash')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 ---@class ValorantMatchPage: BaseMatchPage
 ---@operator call(MatchPageMatch): ValorantMatchPage
 local MatchPage = Class.new(BaseMatchPage)
-
-local SPAN_SLASH = HtmlWidgets.Span{classes = {'slash'}, children = '/'}
 
 local WIN_TYPE_TO_ICON = {
 	['elimination'] = 'elimination',
@@ -138,7 +137,7 @@ function MatchPage:_renderGameOverview(game)
 					},
 					children = half.score
 				}
-			end), SPAN_SLASH)
+			end), Slash{})
 		}
 	end
 
@@ -270,7 +269,7 @@ function MatchPage:_renderPlayerPerformance(game, teamIndex, player)
 						title = {IconFa{iconName = 'kda'}, 'KDA'},
 						data = Array.interleave({
 							player.kills, player.deaths, player.assists
-						}, SPAN_SLASH)
+						}, Slash{})
 					},
 					PlayerStat{
 						title = {IconFa{iconName = 'kast'}, 'KAST'},


### PR DESCRIPTION
## Summary

All match page implementations use slash. Let's refactor it as a separate widget.

## How did you test this change?

dev