### PR TITLE
feat(match2): add tournament highlight to match pages

### DIFF
--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -21,7 +21,6 @@ local TeamTemplate = require('Module:TeamTemplate')
 local VodLink = require('Module:VodLink')
 
 local HighlightConditions = Lua.import('Module:HighlightConditions')
-local LeagueIcon = Lua.import('Module:LeagueIcon')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
@@ -221,13 +220,8 @@ function BaseMatchPage:render()
 				tournamentName = self.matchData.tournament,
 				poweredBy = self.getPoweredBy(),
 				highlighted = HighlightConditions.tournament(tournamentContext),
-				leagueIcon = LeagueIcon.display{
-					icon = tournamentContext.icon,
-					iconDark = tournamentContext.icondark,
-					link = self.matchData.parent,
-					name = self.matchData.tournament,
-					options = {noTemplate = true},
-				}
+				icon = tournamentContext.icon,
+				iconDark = tournamentContext.icondark,
 			},
 			self:renderMapVeto(),
 			self:renderGames(),

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -20,6 +20,8 @@ local Tabs = require('Module:Tabs')
 local TeamTemplate = require('Module:TeamTemplate')
 local VodLink = require('Module:VodLink')
 
+local HighlightConditions = Lua.import('Module:HighlightConditions')
+local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
@@ -204,6 +206,7 @@ end
 ---@return Widget
 function BaseMatchPage:render()
 	self:makeDisplayTitle()
+	local tournamentContext = self:_getMatchContext()
 	return Div{
 		children = WidgetUtil.collect(
 			Header {
@@ -216,6 +219,7 @@ function BaseMatchPage:render()
 				phase = MatchGroupUtil.computeMatchPhase(self.matchData),
 				tournamentName = self.matchData.tournament,
 				poweredBy = self.getPoweredBy(),
+				highlighted = HighlightConditions.tournament(tournamentContext),
 			},
 			self:renderMapVeto(),
 			self:renderGames(),
@@ -261,6 +265,11 @@ end
 ---@return string|Html|Widget
 function BaseMatchPage:renderGame(game)
 	error('BaseMatchPage:renderGame() cannot be called directly and must be overridden.')
+end
+
+---@return table
+function BaseMatchPage:_getMatchContext()
+	return MatchGroupInputUtil.getTournamentContext(self.matchData)
 end
 
 ---@protected

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -21,6 +21,7 @@ local TeamTemplate = require('Module:TeamTemplate')
 local VodLink = require('Module:VodLink')
 
 local HighlightConditions = Lua.import('Module:HighlightConditions')
+local LeagueIcon = Lua.import('Module:LeagueIcon')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
@@ -220,6 +221,13 @@ function BaseMatchPage:render()
 				tournamentName = self.matchData.tournament,
 				poweredBy = self.getPoweredBy(),
 				highlighted = HighlightConditions.tournament(tournamentContext),
+				leagueIcon = LeagueIcon.display{
+					icon = tournamentContext.icon,
+					iconDark = tournamentContext.icondark,
+					link = self.matchData.parent,
+					name = self.matchData.tournament,
+					options = {noTemplate = true},
+				}
 			},
 			self:renderMapVeto(),
 			self:renderGames(),

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -275,6 +275,7 @@ function BaseMatchPage:renderGame(game)
 	error('BaseMatchPage:renderGame() cannot be called directly and must be overridden.')
 end
 
+---@private
 ---@return table
 function BaseMatchPage:_getMatchContext()
 	return MatchGroupInputUtil.getTournamentContext(self.matchData)

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -220,8 +220,6 @@ function BaseMatchPage:render()
 				tournamentName = self.matchData.tournament,
 				poweredBy = self.getPoweredBy(),
 				highlighted = HighlightConditions.tournament(tournamentContext),
-				icon = tournamentContext.icon,
-				iconDark = tournamentContext.icondark,
 			},
 			self:renderMapVeto(),
 			self:renderGames(),

--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -124,7 +124,7 @@ function MatchPageHeader:render()
 				Div{
 					classes = Array.extend(
 						'match-bm-match-header-tournament',
-						self.props.highlighted and 'valvepremier-highlighted' or nil
+						self.props.highlighted and 'tournament-highlighted-bg' or nil
 					),
 					children = WidgetUtil.collect(
 						self:_makeLeagueIcon(),

--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -32,8 +32,6 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field tournamentName string?
 ---@field poweredBy string?
 ---@field highlighted boolean?
----@field icon string?
----@field iconDark string?
 
 ---@class MatchPageHeader: Widget
 ---@operator call(MatchPageHeaderParameters): MatchPageHeader
@@ -77,26 +75,6 @@ function MatchPageHeader:_showMvps()
 	}
 end
 
----@private
----@return string[]?
-function MatchPageHeader:_makeLeagueIcon()
-	local icon = self.props.icon
-	local iconDark = self.props.iconDark
-
-	if Logic.isEmpty(icon) then return end
-
-	return {
-		LeagueIcon.display{
-			icon = icon,
-			iconDark = iconDark,
-			link = self.props.parent,
-			name = self.props.tournamentName,
-			options = {noTemplate = true},
-		},
-		'&nbsp;'
-	}
-end
-
 ---@return Widget[]
 function MatchPageHeader:render()
 	local opponent1 = self.props.opponent1
@@ -126,10 +104,9 @@ function MatchPageHeader:render()
 						'match-bm-match-header-tournament',
 						self.props.highlighted and 'tournament-highlighted-bg' or nil
 					),
-					children = WidgetUtil.collect(
-						self:_makeLeagueIcon(),
+					children = {
 						Link{ link = self.props.parent, children = self.props.tournamentName }
-					)
+					}
 				},
 				Div{
 					classes = { 'match-bm-match-header-date' },

--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -30,6 +30,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field tournamentName string?
 ---@field poweredBy string?
 ---@field highlighted boolean?
+---@field leagueIcon string?
 
 ---@class MatchPageHeader: Widget
 ---@operator call(MatchPageHeaderParameters): MatchPageHeader
@@ -102,9 +103,11 @@ function MatchPageHeader:render()
 						'match-bm-match-header-tournament',
 						self.props.highlighted and 'valvepremier-highlighted' or nil
 					),
-					children = {
+					children = WidgetUtil.collect(
+						self.props.leagueIcon,
+						self.props.leagueIcon and '&nbsp;' or nil,
 						Link{ link = self.props.parent, children = self.props.tournamentName }
-					}
+					)
 				},
 				Div{
 					classes = { 'match-bm-match-header-date' },

--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -29,6 +29,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field phase 'finished'|'ongoing'|'upcoming'
 ---@field tournamentName string?
 ---@field poweredBy string?
+---@field highlighted boolean?
 
 ---@class MatchPageHeader: Widget
 ---@operator call(MatchPageHeaderParameters): MatchPageHeader
@@ -97,7 +98,10 @@ function MatchPageHeader:render()
 					}
 				},
 				Div{
-					classes = { 'match-bm-match-header-tournament' },
+					classes = Array.extend(
+						'match-bm-match-header-tournament',
+						self.props.highlighted and 'valvepremier-highlighted' or nil
+					),
 					children = {
 						Link{ link = self.props.parent, children = self.props.tournamentName }
 					}

--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -12,8 +12,6 @@ local Image = require('Module:Image')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
-local LeagueIcon = Lua.import('Module:LeagueIcon')
-
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div

--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -12,6 +12,8 @@ local Image = require('Module:Image')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
+local LeagueIcon = Lua.import('Module:LeagueIcon')
+
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
@@ -30,7 +32,8 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field tournamentName string?
 ---@field poweredBy string?
 ---@field highlighted boolean?
----@field leagueIcon string?
+---@field icon string?
+---@field iconDark string?
 
 ---@class MatchPageHeader: Widget
 ---@operator call(MatchPageHeaderParameters): MatchPageHeader
@@ -74,6 +77,26 @@ function MatchPageHeader:_showMvps()
 	}
 end
 
+---@private
+---@return string[]?
+function MatchPageHeader:_makeLeagueIcon()
+	local icon = self.props.icon
+	local iconDark = self.props.iconDark
+
+	if Logic.isEmpty(icon) then return end
+
+	return {
+		LeagueIcon.display{
+			icon = icon,
+			iconDark = iconDark,
+			link = self.props.parent,
+			name = self.props.tournamentName,
+			options = {noTemplate = true},
+		},
+		'&nbsp;'
+	}
+end
+
 ---@return Widget[]
 function MatchPageHeader:render()
 	local opponent1 = self.props.opponent1
@@ -104,8 +127,7 @@ function MatchPageHeader:render()
 						self.props.highlighted and 'valvepremier-highlighted' or nil
 					),
 					children = WidgetUtil.collect(
-						self.props.leagueIcon,
-						self.props.leagueIcon and '&nbsp;' or nil,
+						self:_makeLeagueIcon(),
 						Link{ link = self.props.parent, children = self.props.tournamentName }
 					)
 				},


### PR DESCRIPTION
## Summary

This PR adds highlight (as specified by `Module:HighlightConditions`) to the match page header.

## How did you test this change?

dev: <https://liquipedia.net/leagueoflegends/Match:ID_User_ElectricalBoy_zqx7pe0nDj_R01-M001>