### PR TITLE
fix: some components show score with 2 decimal places

### DIFF
--- a/lua/wikis/commons/OpponentDisplay/Starcraft.lua
+++ b/lua/wikis/commons/OpponentDisplay/Starcraft.lua
@@ -6,14 +6,16 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local Class = require('Module:Class')
-local Icon = require('Module:Icon')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Table = require('Module:Table')
 
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
 local Faction = Lua.import('Module:Faction')
+local Icon = Lua.import('Module:Icon')
+local Logic = Lua.import('Module:Logic')
+local Math = Lua.import('Module:MathUtil')
+local Table = Lua.import('Module:Table')
+
 local Opponent = Lua.import('Module:Opponent')
 local OpponentDisplay = Lua.import('Module:OpponentDisplay')
 local StarcraftPlayerDisplay = Lua.import('Module:Player/Display/Starcraft')
@@ -273,12 +275,12 @@ function StarcraftOpponentDisplay.InlineScore(opponent)
 		local advantage = tonumber(opponent.extradata.advantage) or 0
 		if advantage > 0 then
 			local title = 'Advantage of ' .. advantage .. ' game' .. (advantage > 1 and 's' or '')
-			return '<abbr title="' .. title .. '">' .. opponent.score .. '</abbr>'
+			return '<abbr title="' .. title .. '">' .. tostring(Math.round(opponent.score, 2)) .. '</abbr>'
 		end
 		local penalty = tonumber(opponent.extradata.penalty) or 0
 		if penalty > 0 then
 			local title = 'Penalty of ' .. penalty .. ' game' .. (penalty > 1 and 's' or '')
-			return '<abbr title="' .. title .. '">' .. opponent.score .. '</abbr>'
+			return '<abbr title="' .. title .. '">' .. tostring(Math.round(opponent.score, 2)) .. '</abbr>'
 		end
 	end
 

--- a/lua/wikis/commons/OpponentDisplay/Starcraft.lua
+++ b/lua/wikis/commons/OpponentDisplay/Starcraft.lua
@@ -13,7 +13,6 @@ local Class = Lua.import('Module:Class')
 local Faction = Lua.import('Module:Faction')
 local Icon = Lua.import('Module:Icon')
 local Logic = Lua.import('Module:Logic')
-local Math = Lua.import('Module:MathUtil')
 local Table = Lua.import('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent')

--- a/lua/wikis/commons/OpponentDisplay/Starcraft.lua
+++ b/lua/wikis/commons/OpponentDisplay/Starcraft.lua
@@ -271,18 +271,7 @@ StarcraftOpponentDisplay.CheckMark =
 ---@param opponent StarcraftStandardOpponent
 ---@return string
 function StarcraftOpponentDisplay.InlineScore(opponent)
-	if opponent.status == 'S' then
-		local advantage = tonumber(opponent.extradata.advantage) or 0
-		if advantage > 0 then
-			local title = 'Advantage of ' .. advantage .. ' game' .. (advantage > 1 and 's' or '')
-			return '<abbr title="' .. title .. '">' .. tostring(Math.round(opponent.score, 2)) .. '</abbr>'
-		end
-		local penalty = tonumber(opponent.extradata.penalty) or 0
-		if penalty > 0 then
-			local title = 'Penalty of ' .. penalty .. ' game' .. (penalty > 1 and 's' or '')
-			return '<abbr title="' .. title .. '">' .. tostring(Math.round(opponent.score, 2)) .. '</abbr>'
-		end
-	end
+	local scoreDisplay = OpponentDisplay.InlineScore(opponent)
 
 	if Logic.readBool(opponent.extradata.noscore) then
 		return (opponent.placement == 1 or opponent.advances)
@@ -290,7 +279,19 @@ function StarcraftOpponentDisplay.InlineScore(opponent)
 			or ''
 	end
 
-	return OpponentDisplay.InlineScore(opponent)
+	---@param value number
+	---@param TitleStart string
+	---@return string?
+	local makeAbbrScoreInfo = function(value, TitleStart)
+		if opponent.status ~= 'S' or value <= 0 then
+			return
+		end
+		local title = TitleStart .. ' of ' .. value .. ' game' .. (value > 1 and 's' or '')
+		return '<abbr title="' .. title .. '">' .. scoreDisplay .. '</abbr>'
+	end
+	local advantage = tonumber(opponent.extradata.advantage) or 0
+	local penalty = tonumber(opponent.extradata.penalty) or 0
+	return makeAbbrScoreInfo(advantage, 'Advantage') or makeAbbrScoreInfo(penalty, 'Penalty') or scoreDisplay
 end
 
 return StarcraftOpponentDisplay


### PR DESCRIPTION
## Summary
![image](https://github.com/user-attachments/assets/a81cc373-aad6-4237-9953-985009a9e0ef)
the score display with 2 decimal places only happens if advantage/penalty is set

this PR accounts for these edge cases

## How did you test this change?
dev