### PR TITLE
chore(match2): remove redundant caster processing in sc(2) & wc customs

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
@@ -527,7 +527,6 @@ end
 ---@return table
 function FfaMatchFunctions.getExtraData(match, games, opponents, settings)
 	return {
-		casters = MatchGroupInputUtil.readCasters(match),
 		ffa = 'true',
 		placementinfo = settings.placementInfo,
 		settings = settings.settings,

--- a/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
@@ -500,7 +500,6 @@ end
 ---@return table
 function FfaMatchFunctions.getExtraData(match, games, opponents, settings)
 	return {
-		casters = MatchGroupInputUtil.readCasters(match),
 		ffa = 'true',
 		placementinfo = settings.placementInfo,
 		settings = settings.settings,


### PR DESCRIPTION
## Summary
The casters already already get processed by `MatchGroupInputUtil.standardProcessFfaMatch`.
So atm on those 2 wikis the casters are processed on commons and afterwards processed in the wiki customs again with the same result.

## How did you test this change?
dev