### PR TITLE
feat(mainpage): update content order in brawlstars mainpage

### DIFF
--- a/lua/wikis/brawlstars/MainPageLayout/data.lua
+++ b/lua/wikis/brawlstars/MainPageLayout/data.lua
@@ -165,10 +165,6 @@ return {
 						mobileOrder = 3,
 						content = CONTENT.transfers,
 					},
-					{
-						mobileOrder = 6,
-						content = CONTENT.wantToHelp,
-					},
 				}
 			},
 			{ -- Right
@@ -206,11 +202,15 @@ return {
 						},
 					},
 					{
+						mobileOrder = 4,
+						content = CONTENT.wantToHelp,
+					},
+					{
 						mobileOrder = 5,
 						content = CONTENT.thisDay,
 					},
 					{
-						mobileOrder = 4,
+						mobileOrder = 6,
 						content = CONTENT.usefulArticles,
 					},
 				},


### PR DESCRIPTION
Shuffling widget positions

## Summary

**Want To Help?** widget moved to the right.
And some **mobileOrder** changes

## How did you test this change?

https://liquipedia.net/brawlstars/Main_Page/Sandbox

### Before:
![2025-05-26_21-34-19](https://github.com/user-attachments/assets/decd0111-dc3a-433e-b886-32052e2eb04a)

### After:
![2025-05-26_21-34-50](https://github.com/user-attachments/assets/cdec9ddb-eea9-44db-b264-0c7c82e7006a)
