### PR TITLE
docs: fix incorrect function name spelling in mw.language def

### DIFF
--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -429,7 +429,7 @@ function mw.language:convertGrammar(word, case) end
 ---@param case string
 ---@param word string
 ---@return string
-function mw.language:gammer(case, word) end
+function mw.language:grammar(case, word) end
 
 ---Returns a Unicode arrow character corresponding to direction:
 ---@param direction 'forwards'|'backwards'|'left'|'right'|'up'|'down'


### PR DESCRIPTION
## Summary

ref: <https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.language:convertGrammar>

## How did you test this change?

N/A
