### PR TITLE
feat(NavBox): Add option to treat NavBox as child

### DIFF
--- a/lua/wikis/commons/Widget/NavBox.lua
+++ b/lua/wikis/commons/Widget/NavBox.lua
@@ -44,7 +44,7 @@ function NavBox:render()
 
 	-- as a first step collapse at the top and uncollapse at the bottom
 	-- as heuristic assume we are at the bottom if an infobox or HDB is above
-	local shouldCollapse = Logic.readBool(Table.extract(props, 'collapsed')) not (
+	local shouldCollapse = Logic.readBool(Table.extract(props, 'collapsed')) or not (
 		Variables.varDefault('has_infobox') -- any page with an infobox
 		or Variables.varDefault('tournament_parent') -- any Page with a HDB
 	)


### PR DESCRIPTION
## Summary
Sometimes NavBoxes are used inside other NavBoxes while on other pages the same NavBox is shown directly on the page.
To account for that add an option to the NavBox widget to be able to be treated as a NavBoxChild (i.e. return the stringified Json) via a bool param input.

Additionally allow to enforce a navbox being collapsed even at the bottom of a page.

## How did you test this change?
dev