### PR TITLE
fix(match2): round scores are not displayed in valorant match pages on desktop environments

### DIFF
--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -103,22 +103,19 @@ local function getTeamHalvesDetails(game, teamIndex)
 	local teamHalf = game.extradata['t' .. teamIndex .. 'halfs']
 	if Table.isEmpty(teamHalf) then
 		return {}
-	end
-	if not startOvertime or not otherOvertime then
+	elseif not startOvertime or not otherOvertime then
 		return {
 			{side = startNormal, score = teamHalf[startNormal]},
 			{side = otherNormal, score = teamHalf[otherNormal]},
 		}
 	end
 
-	local startOvertimeScore = teamHalf['ot' .. startOvertime]
-	local otherOvertimeScore = teamHalf['ot' .. otherOvertime]
 	---@type {score: number, side: string}[]
 	return {
 		{side = startNormal, score = teamHalf[startNormal]},
 		{side = otherNormal, score = teamHalf[otherNormal]},
-		startOvertime and startOvertimeScore and {side = startOvertime, score = startOvertimeScore} or nil,
-		startOvertime and otherOvertimeScore and {side = otherOvertime, score = otherOvertimeScore} or nil,
+		{side = startOvertime, score = teamHalf['ot' .. startOvertime]},
+		{side = otherOvertime, score = teamHalf['ot' .. otherOvertime]},
 	}
 end
 

--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -92,7 +92,7 @@ local function getTeamHalvesDetails(game, teamIndex)
 	local startNormal, otherNormal = game.extradata.t1firstside, otherSide(game.extradata.t1firstside)
 	local startOvertime, otherOvertime = game.extradata.t1firstsideot, otherSide(game.extradata.t1firstsideot)
 
-	if not startNormal or not startOvertime then
+	if not startNormal or not otherNormal then
 		return {}
 	end
 
@@ -103,6 +103,12 @@ local function getTeamHalvesDetails(game, teamIndex)
 	local teamHalf = game.extradata['t' .. teamIndex .. 'halfs']
 	if Table.isEmpty(teamHalf) then
 		return {}
+	end
+	if not startOvertime or not otherOvertime then
+		return {
+			{side = startNormal, score = teamHalf[startNormal]},
+			{side = otherNormal, score = teamHalf[otherNormal]},
+		}
 	end
 
 	local startOvertimeScore = teamHalf['ot' .. startOvertime]


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/ea15d3fe5c9b0f6b7736322faff2dc8001b36d83/lua/wikis/valorant/MatchPage.lua#L95

`startOvertime` is always `nil` if no overtime rounds are played. This causes `not startOvertime` to evaluate to `true`, resulting as an empty table being returned, i.e., normal round scores are not returned. As a result of this, round scores are not displayed in game summaries in desktop environments.
This PR adjusts logic in this function so that normal round scores are properly returned.

## How did you test this change?

dev