### PR TITLE
feat(match2): add empty player filter for valorant match page

### DIFF
--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -57,7 +57,7 @@ function MatchPage:populateGames()
 			local team = {}
 
 			team.scoreDisplay = game.winner == teamIdx and 'winner' or game.finished and 'loser' or '-'
-			team.players = game.opponents[teamIdx].players or {}
+			team.players = Array.filter(game.opponents[teamIdx].players or {}, Table.isNotEmpty)
 
 			return team
 		end)


### PR DESCRIPTION
## Summary

This PR adds a filter to suppress display of "not played" players' placeholders.

## How did you test this change?

dev