### PR TITLE
refactor(mainpage): replace preprocessing with callParserFunction

### DIFF
--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -41,7 +41,7 @@ function MainPageLayout.make(frame)
 		children = {
 			NO_TABLE_OF_CONTENTS,
 			frame:preprocess(String.interpolate(METADESC, {metadesc = WikiData.metadesc})),
-			frame:preprocess('{{DISPLAYTITLE:' .. WikiData.title .. '}}'),
+			frame:callParserFunction('DISPLAYTITLE', WikiData.title),
 			HtmlWidgets.Div{
 				classes = {'header-banner'},
 				children = {
@@ -58,7 +58,7 @@ function MainPageLayout.make(frame)
 							}
 						},
 					},
-					frame:preprocess('{{#searchbox:}}'),
+					frame:callParserFunction('#searchbox', ''),
 				}
 			},
 			HtmlWidgets.Div{


### PR DESCRIPTION
## Summary

> Call a [parser function](https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Magic_words#Parser_functions), returning an appropriate string. This is preferable to `frame:preprocess`, but whenever possible, native Lua functions or Scribunto library functions should be preferred to this interface.
> 
> [MW Lua Reference Manual](https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#frame:callParserFunction)

## How did you test this change?

dev: <https://liquipedia.net/leagueoflegends/User:ElectricalBoy/MainPage>