### PR TITLE
feat: Team Roster NavBox

### DIFF
--- a/lua/wikis/ageofempires/Info.lua
+++ b/lua/wikis/ageofempires/Info.lua
@@ -109,5 +109,10 @@ return {
 			status = 2,
 			matchWidthMobile = 110,
 		},
+		teamRosterNavbox = {
+			links = {
+				playedMatches = 'Matches',
+			},
+		},
 	},
 }

--- a/lua/wikis/apexlegends/Info.lua
+++ b/lua/wikis/apexlegends/Info.lua
@@ -35,6 +35,11 @@ return {
 		match2 = {
 			status = 1,
 		},
+		teamRosterNavbox = {
+			hidePlayedMatches = true,
+			excludeStreamers = true,
+			staffLimitedPositions = {'manager', 'coach'},
+		},
 	},
 	defaultRoundPrecision = 0,
 }

--- a/lua/wikis/apexlegends/Info.lua
+++ b/lua/wikis/apexlegends/Info.lua
@@ -38,7 +38,6 @@ return {
 		teamRosterNavbox = {
 			hidePlayedMatches = true,
 			excludeStreamers = true,
-			staffLimitedPositions = {'manager', 'coach'},
 		},
 	},
 	defaultRoundPrecision = 0,

--- a/lua/wikis/brawlstars/Info.lua
+++ b/lua/wikis/brawlstars/Info.lua
@@ -36,6 +36,11 @@ return {
 			status = 2,
 			matchWidth = 150,
 		},
+		teamRosterNavbox = {
+			links = {
+				playedMatches = 'Matches',
+			},
+		},
 	},
 	defaultRoundPrecision = 0,
 }

--- a/lua/wikis/commons/Service/Team.lua
+++ b/lua/wikis/commons/Service/Team.lua
@@ -1,0 +1,98 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Service/Team
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Page = require('Module:Page')
+local Table = require('Module:Table')
+
+local TeamService = {}
+
+---@class StandardTeam
+---@field pageName string
+---@field fullName string?
+---@field bracketName string?
+---@field shortName string?
+---@field image string?
+---@field imageDark string?
+---@field members table[]?
+
+--- TODO: Add the rest and implement the lazy loading
+local LPDB_TEAM_FIELDS = {
+	'links',
+}
+
+---Fetches a standings table from a page. Tries to read from page variables before fetching from LPDB.
+---@param teamTemplate string
+---@return StandardTeam?
+function TeamService.getTeamByTemplate(teamTemplate)
+	if not teamTemplate or not mw.ext.TeamTemplate.teamexists(teamTemplate) then
+		return nil
+	end
+
+	local team = mw.ext.TeamTemplate.raw(teamTemplate)
+
+	if not team then
+		return nil
+	end
+	return TeamService.teamFromRecord(team)
+end
+
+---@param team StandardTeam
+---@return table[]
+function TeamService.getMembers(team)
+	local records = mw.ext.LiquipediaDB.lpdb('squadplayer', {
+		conditions = '[[pagename::' .. team.pageName .. ']]',
+		limit = 5000,
+	})
+	return Array.map(records, function(record)
+		return {
+			displayName = record.id,
+			pageName = record.link,
+			realName = record.name,
+			nationality = record.nationality,
+			position = record.position,
+			role = record.role,
+			type = record.type,
+			status = record.status,
+			faction = (record.extradata or {}).faction,
+			isMain = (record.extradata or {}).ismain ~= 'false', -- empty is considered true
+		}
+	end)
+end
+
+local TeamMT = {
+	-- Lazy loading of properties to avoid unnecessary database queries.
+	__index = function(team, property)
+		if property == 'members' then
+			team[property] = TeamService.getMembers(team)
+		elseif Table.includes(LPDB_TEAM_FIELDS, property) then
+			error('Not yet implmented')
+		end
+		return rawget(team, property)
+	end
+}
+
+---@param record teamTemplateData
+---@return StandardTeam
+function TeamService.teamFromRecord(record)
+	local team = {
+		pageName = Page.pageifyLink(record.page),
+		fullName = record.name,
+		bracketName = record.bracketname,
+		shortName = record.shortname,
+		image = record.image,
+		imageDark = record.imagedark,
+	}
+
+	-- Lazy loading of other properties
+	setmetatable(team, TeamMT)
+
+	return team
+end
+
+return TeamService

--- a/lua/wikis/commons/Service/Team.lua
+++ b/lua/wikis/commons/Service/Team.lua
@@ -61,7 +61,7 @@ function TeamService.getMembers(team)
 			type = record.type,
 			status = record.status,
 			faction = extradata.faction,
-			isMain = extradata.group or 'main',
+			group = extradata.group or 'main',
 		}
 	end)
 end

--- a/lua/wikis/commons/Service/Team.lua
+++ b/lua/wikis/commons/Service/Team.lua
@@ -1,6 +1,5 @@
 ---
 -- @Liquipedia
--- wiki=commons
 -- page=Module:Service/Team
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/lua/wikis/commons/Service/Team.lua
+++ b/lua/wikis/commons/Service/Team.lua
@@ -50,6 +50,7 @@ function TeamService.getMembers(team)
 		limit = 5000,
 	})
 	return Array.map(records, function(record)
+		local extradata = record.extradata or {}
 		return {
 			displayName = record.id,
 			pageName = record.link,
@@ -59,8 +60,8 @@ function TeamService.getMembers(team)
 			role = record.role,
 			type = record.type,
 			status = record.status,
-			faction = (record.extradata or {}).faction,
-			isMain = (record.extradata or {}).ismain ~= 'false', -- empty is considered true
+			faction = extradata.faction,
+			isMain = extradata.group or 'main',
 		}
 	end)
 end

--- a/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
+++ b/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
@@ -1,0 +1,117 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/NavBox/AutoTeam
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local Array = Lua.import('Module:Array')
+local Logic = Lua.import('Module:Logic')
+local Info = Lua.import('Module:Info', {loadData = true})
+local Table = Lua.import('Module:Table')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
+
+local TeamService = Lua.import('Module:Service/Team')
+
+local NavBox = Lua.import('Module:Widget/NavBox')
+
+local DEFAULT_LINK_CONFIG = {
+	results = 'Results',
+	playedMatches = 'Played Matches',
+}
+
+---@class AutoTeamNavbox: Widget
+---@operator call(table): AutoTeamNavbox
+local AutoTeamNavbox = Class.new(Widget)
+AutoTeamNavbox.defaultProps = {team = mw.title.getCurrentTitle().prefixedText}
+
+---@return Widget?
+function AutoTeamNavbox:render()
+	local team = TeamService.getTeamByTemplate(self.props.team)
+	if not team then
+		return
+	end
+
+	local members = team.members
+
+	if not members or #members == 0 then
+		return
+	end
+
+	local activeMembers = Array.filter(members, function(member)
+		return member.status == 'active' and Logic.isNotEmpty(member.displayName)
+	end)
+
+	local activePlayers = Array.filter(activeMembers, function(member)
+		return member.type == 'player' and member.isMain
+	end)
+	local secondaryRosterActivePlayers = Logic.nilIfEmpty(Array.filter(activeMembers, function(member)
+		return member.type == 'player' and not member.isMain
+	end))
+	local activeStaff = Array.filter(activeMembers, function(member)
+		return member.type == 'staff'
+	end)
+
+	local makeNote = function(position, role)
+		local content = {position, role}
+		return table.concat(Array.filter(content, Logic.isNotEmpty), ' - ')
+	end
+
+	local makePersonDisplay = function(member)
+		local note = Logic.nilIfEmpty(makeNote(member.position, member.role))
+		return HtmlWidgets.Fragment{children = {
+			Link{
+				link = member.pageName,
+				children = member.displayName,
+			},
+			note and '&nbsp;' or nil,
+			note and HtmlWidgets.Small{children = HtmlWidgets.I{children = '(' .. note .. ')'}} or nil,
+		}}
+	end
+
+	local orgChild = #activeStaff > 0 and Table.merge({
+		name = 'Organization',
+	}, Array.map(activeStaff, makePersonDisplay)) or nil
+
+	local linkConfig = Table.merge(DEFAULT_LINK_CONFIG, Info.config.teamSubPages)
+
+	---@param subPage string
+	---@param displayText string
+	---@return Widget?
+	local makeLink = function(subPage, displayText)
+		if not linkConfig[subPage] then return end
+		return Link{link = team.pageName .. '/' .. linkConfig[subPage], children = displayText}
+	end
+
+	---@type table
+	local linksChild = Array.append({Link{link = team.pageName, children = 'Overview'}},
+		makeLink('results', 'Results'),
+		makeLink('playedMatches', 'Played Matches'),
+		makeLink('playerResults', 'Player Results')
+	)
+	linksChild.name = 'Team'
+
+	return NavBox{
+		image = team.image,
+		imagedark = team.imageDark,
+		imagelink = team.pageName,
+		title = team.fullName or team.bracketName or team.shortName or team.pageName,
+		child1 = linksChild,
+		child2 = Table.merge({
+			name = secondaryRosterActivePlayers and 'Main Roster' or 'Roster',
+		}, Array.map(activePlayers, makePersonDisplay)),
+		child3 = secondaryRosterActivePlayers and Table.merge({
+			name = 'Additional Rosters',
+		}, Array.map(secondaryRosterActivePlayers, makePersonDisplay)) or orgChild,
+		child4 = secondaryRosterActivePlayers and orgChild,
+	}
+end
+
+return AutoTeamNavbox

--- a/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
+++ b/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
@@ -13,9 +13,11 @@ local Array = Lua.import('Module:Array')
 local Info = Lua.import('Module:Info', {loadData = true})
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
+local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
 local Widget = Lua.import('Module:Widget')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Link = Lua.import('Module:Widget/Basic/Link')
 
@@ -61,15 +63,14 @@ function AutoTeamNavbox:render()
 	local config = Info.config.teamRosterNavbox or {}
 	local showOrg = not config.hideOrg
 
-	local childrenArray = Array.extend(
+	local childrenArray = WidgetUtil.collect(
 		{AutoTeamNavbox._makeLinksChild(team.pageName)},
 		Array.map(activePlayersByGroup, function(playerGroup)
-			local name = #activePlayersByGroup == 1 and 'Roster' or (string.upper(playerGroup[1].group) .. ' Roster')
+			local name = #activePlayersByGroup == 1 and 'Roster' or (String.upperCaseFirst(playerGroup[1].group) .. ' Roster')
 			return AutoTeamNavbox._makeRosterRow(playerGroup, name)
-		end)
+		end),
+		showOrg and (AutoTeamNavbox._makeRosterRow(activeStaff, 'Organization')) or nil
 	)
-	-- can not be added with the `Array.extend`, because it would try to append the items of the org row as children
-	table.insert(childrenArray, showOrg and (AutoTeamNavbox._makeRosterRow(activeStaff, 'Organization')) or nil)
 
 	local children = Table.map(childrenArray, function(index, child) return 'child' .. index, child end)
 

--- a/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
+++ b/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
@@ -97,7 +97,7 @@ function AutoTeamNavbox._makeLinksChild(pageName)
 	---@type table
 	local linksChild = Array.append({Link{link = pageName, children = 'Overview'}},
 		makeLink('results', 'Results'),
-		makeLink('playedMatches', 'Played Matches'),
+		not config.hidePlayedMatches and makeLink('playedMatches', 'Played Matches') or nil,
 		makeLink('playerResults', 'Player Results')
 	)
 	linksChild.name = 'Team'

--- a/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
+++ b/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
@@ -58,8 +58,14 @@ function AutoTeamNavbox:render()
 	local activeStaff = Array.filter(activeMembers, function(member)
 		return member.type == 'staff'
 	end)
+	local config = Info.config.teamRosterNavbox or {}
+	if config.staffLimitedPositions then
+		activeStaff = Array.filter(activeStaff, function(member)
+			return Table.includes(config.staffLimitedPositions, member.position)
+		end)
+	end
 
-	local showOrg = not (Info.config.teamRosterNavbox or {}).hideOrg
+	local showOrg = not config.hideOrg
 
 	local childrenArray = Array.append({},
 		AutoTeamNavbox._makeLinksChild(team.pageName),

--- a/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
+++ b/lua/wikis/commons/Widget/NavBox/AutoTeam.lua
@@ -1,6 +1,5 @@
 ---
 -- @Liquipedia
--- wiki=commons
 -- page=Module:Widget/NavBox/AutoTeam
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/lua/wikis/commons/Widget/NavBox/AutoTeam/Player.lua
+++ b/lua/wikis/commons/Widget/NavBox/AutoTeam/Player.lua
@@ -1,6 +1,5 @@
 ---
 -- @Liquipedia
--- wiki=commons
 -- page=Module:Widget/NavBox/AutoTeam/Player
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute

--- a/lua/wikis/commons/Widget/NavBox/AutoTeam/Player.lua
+++ b/lua/wikis/commons/Widget/NavBox/AutoTeam/Player.lua
@@ -1,0 +1,36 @@
+---
+-- @Liquipedia
+-- wiki=commons
+-- page=Module:Widget/NavBox/AutoTeam/Player
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
+local Page = Lua.import('Module:Page')
+local Widget = Lua.import('Module:Widget')
+local AutoTeamNavbox = Lua.import('Module:Widget/NavBox/AutoTeam')
+
+---@class PlayerAutoTeamNavbox: Widget
+---@operator call(table): PlayerAutoTeamNavbox
+local PlayerAutoTeamNavbox = Class.new(Widget)
+PlayerAutoTeamNavbox.defaultProps = {player = mw.title.getCurrentTitle().prefixedText}
+
+---@return Widget?
+function PlayerAutoTeamNavbox:render()
+	local player = Page.pageifyLink(self.props.player)
+	local queryResult = mw.ext.LiquipediaDB.lpdb('player', {
+		query = 'team',
+		conditions = '[[pagename::' .. player .. ']]',
+		limit = 1,
+	})[1] or {}
+	local team = queryResult.team
+	if Logic.isEmpty(team) then return end
+
+	return AutoTeamNavbox{team = team}
+end
+
+return PlayerAutoTeamNavbox

--- a/lua/wikis/counterstrike/Info.lua
+++ b/lua/wikis/counterstrike/Info.lua
@@ -126,6 +126,11 @@ local infoData = {
 			gameScoresIfBo1 = true,
 			gameNoun = 'map',
 		},
+		teamRosterNavbox = {
+			links = {
+				playedMatches = 'Matches',
+			},
+		},
 	},
 }
 

--- a/lua/wikis/fighters/Info.lua
+++ b/lua/wikis/fighters/Info.lua
@@ -1712,6 +1712,10 @@ return {
 		match2 = {
 			status = 1,
 		},
+		teamRosterNavbox = {
+			hideOrg = true,
+			hideOverview = true,
+		},
 	},
 	opponentLibrary = 'Opponent/Custom',
 }

--- a/lua/wikis/formula1/Info.lua
+++ b/lua/wikis/formula1/Info.lua
@@ -38,5 +38,8 @@ return {
 		transfers = {
 			showTeamName = true,
 		},
+		teamRosterNavbox = {
+			hideOverview = true,
+		},
 	},
 }

--- a/lua/wikis/fortnite/Info.lua
+++ b/lua/wikis/fortnite/Info.lua
@@ -35,5 +35,8 @@ return {
 		match2 = {
 			status = 1,
 		},
+		teamRosterNavbox = {
+			hidePlayedMatches = true,
+		},
 	},
 }

--- a/lua/wikis/smash/Info.lua
+++ b/lua/wikis/smash/Info.lua
@@ -100,6 +100,10 @@ return {
 		match2 = {
 			status = 1,
 		},
+		teamRosterNavbox = {
+			hideOrg = true,
+			hideOverview = true,
+		},
 	},
 	opponentLibrary = 'Opponent/Custom',
 }

--- a/lua/wikis/starcraft2/Info.lua
+++ b/lua/wikis/starcraft2/Info.lua
@@ -63,9 +63,12 @@ return {
 			matchWidthMobile = 110,
 			matchWidth = 150,
 		},
-		teamSubPages = {
-			playedMatches = 'Matches',
-			playerResults = 'Player Results',
+		teamRosterNavbox = {
+			links = {
+				playedMatches = 'Matches',
+				playerResults = 'Player Results',
+			},
+			hideOrg = true, -- still in discussion if we want to enable it in the future
 		},
 	},
 	opponentLibrary = 'Opponent/Starcraft',

--- a/lua/wikis/starcraft2/Info.lua
+++ b/lua/wikis/starcraft2/Info.lua
@@ -63,6 +63,10 @@ return {
 			matchWidthMobile = 110,
 			matchWidth = 150,
 		},
+		teamSubPages = {
+			playedMatches = 'Matches',
+			playerResults = 'Player Results',
+		},
 	},
 	opponentLibrary = 'Opponent/Starcraft',
 	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',

--- a/lua/wikis/starcraft2/Info.lua
+++ b/lua/wikis/starcraft2/Info.lua
@@ -68,7 +68,7 @@ return {
 				playedMatches = 'Matches',
 				playerResults = 'Player Results',
 			},
-			hideOrg = true, -- still in discussion if we want to enable it in the future
+			hideOrg = true,
 		},
 	},
 	opponentLibrary = 'Opponent/Starcraft',

--- a/lua/wikis/starcraft2/Squad/Custom.lua
+++ b/lua/wikis/starcraft2/Squad/Custom.lua
@@ -58,7 +58,10 @@ function CustomSquad._playerRow(person, squadStatus, squadType)
 
 	if squadStatus == SquadUtils.SquadStatus.ACTIVE then
 		local isMain = Logic.readBool(squadArgs.main) or Logic.isEmpty(squadArgs.squad)
-		squadPerson.extradata = Table.merge({ismain = tostring(isMain)}, squadPerson.extradata)
+		squadPerson.extradata = Table.merge({
+			ismain = tostring(isMain), --legacy for during conversion only!
+			group = (not isMain) and 'Additional' or nil,
+		}, squadPerson.extradata)
 	end
 	squadPerson.newteamspecial = Logic.emptyOr(squadPerson.newteamspecial,
 		Logic.readBool(person.retired) and 'retired' or nil,

--- a/lua/wikis/starcraft2/Squad/Custom.lua
+++ b/lua/wikis/starcraft2/Squad/Custom.lua
@@ -60,7 +60,7 @@ function CustomSquad._playerRow(person, squadStatus, squadType)
 		local isMain = Logic.readBool(squadArgs.main) or Logic.isEmpty(squadArgs.squad)
 		squadPerson.extradata = Table.merge({
 			ismain = tostring(isMain), --legacy for during conversion only!
-			group = (not isMain) and 'Additional' or nil,
+			group = isMain and 'main' or 'additional',
 		}, squadPerson.extradata)
 	end
 	squadPerson.newteamspecial = Logic.emptyOr(squadPerson.newteamspecial,

--- a/lua/wikis/tft/Info.lua
+++ b/lua/wikis/tft/Info.lua
@@ -49,6 +49,9 @@ return {
 			status = 1,
 			sortCasters = true,
 		},
+		teamRosterNavbox = {
+			hidePlayedMatches = true,
+		},
 	},
 	defaultRoundPrecision = 0,
 }

--- a/lua/wikis/valorant/Info.lua
+++ b/lua/wikis/valorant/Info.lua
@@ -46,5 +46,10 @@ return {
 				display = 'VALORANT Champions Tour Global Contract Database'
 			},
 		},
+		teamRosterNavbox = {
+			links = {
+				playedMatches = 'Matches',
+			},
+		},
 	},
 }


### PR DESCRIPTION
## Summary
Based on something Rath send me via DMs.
I just added some stuff to it :P

## How did you test this change?
live (new modules) /dev (existing modules)
https://liquipedia.net/starcraft2/User:Hjpalpha/wip13

## after merge:
- [ ] purge job on sc2 to update squad data
- [ ] adjust commons versions of `Template:Team roster` and `Template:Player team roster`
- [ ] nuke all local versions of `Template:Team roster` and `Template:Player team roster`
- [ ] follow up PR to remove the legacy `ismain` storage for sc2 squads
- [ ] nuke all versions of `Module:NavboxGenerator`