### PR TITLE
chore(match2): remove finished param from Valorant match2 copy-paste generator

### DIFF
--- a/lua/wikis/valorant/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/valorant/GetMatchGroupCopyPaste/wiki.lua
@@ -48,7 +48,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		index == 1 and Logic.readBool(args.matchsection) and (INDENT .. '|matchsection=') or nil,
-		INDENT .. '|date=|finished=',
+		INDENT .. '|date=',
 		streams and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		Logic.readBool(args.casters) and (INDENT .. '|caster1= |caster2=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)


### PR DESCRIPTION
## Summary

`|finished=` param in Valorant match2 is mostly redundant as the system automatically handles it if not specified. Let's remove it.

## How did you test this change?

trivial string change