### PR TITLE
feat(participantTable): allow team opponents

### DIFF
--- a/lua/wikis/ageofempires/ParticipantTable/Custom.lua
+++ b/lua/wikis/ageofempires/ParticipantTable/Custom.lua
@@ -69,8 +69,7 @@ function AoEParticipantTable:readEntry(sectionArgs, key, index, config)
 		seed = valueFromArgs('seed'),
 	}
 
-	assert(Opponent.isType(opponentArgs.type) and opponentArgs.type ~= Opponent.team,
-		'Missing or unsupported opponent type for "' .. sectionArgs[key] .. '"')
+	assert(Opponent.isType(opponentArgs.type), 'Invalid opponent type for "' .. sectionArgs[key] .. '"')
 
 	local opponent = Opponent.readOpponentArgs(opponentArgs) or {}
 

--- a/lua/wikis/commons/ParticipantTable/Starcraft.lua
+++ b/lua/wikis/commons/ParticipantTable/Starcraft.lua
@@ -116,8 +116,7 @@ function StarcraftParticipantTable:readEntry(sectionArgs, key, index, config)
 		faction = valueFromArgs('race'),
 	}
 
-	assert(Opponent.isType(opponentArgs.type) and opponentArgs.type ~= Opponent.team,
-		'Missing or unsupported opponent type for "' .. sectionArgs[key] .. '"')
+	assert(Opponent.isType(opponentArgs.type), 'Invalid opponent type for "' .. sectionArgs[key] .. '"')
 
 	--unset wiki var for random events to not read players as random if prize pool already sets them as random
 	if config.isRandomEvent and opponentArgs.type == Opponent.solo then

--- a/lua/wikis/stormgate/ParticipantTable/Custom.lua
+++ b/lua/wikis/stormgate/ParticipantTable/Custom.lua
@@ -116,8 +116,7 @@ function StormgateParticipantTable:readEntry(sectionArgs, key, index, config)
 		faction = valueFromArgs('faction'),
 	}
 
-	assert(Opponent.isType(opponentArgs.type) and opponentArgs.type ~= Opponent.team,
-		'Missing or unsupported opponent type for "' .. sectionArgs[key] .. '"')
+	assert(Opponent.isType(opponentArgs.type), 'Invalid opponent type for "' .. sectionArgs[key] .. '"')
 
 	--unset wiki var for random events to not read players as random if prize pool already sets them as random
 	if config.isRandomEvent and opponentArgs.type == Opponent.solo then

--- a/lua/wikis/warcraft/ParticipantTable/Custom.lua
+++ b/lua/wikis/warcraft/ParticipantTable/Custom.lua
@@ -106,8 +106,7 @@ function CustomParticipantTable:readEntry(sectionArgs, key, index, config)
 		faction = valueFromArgs('race'),
 	}
 
-	assert(Opponent.isType(opponentArgs.type) and opponentArgs.type ~= Opponent.team,
-		'Missing or unsupported opponent type for "' .. sectionArgs[key] .. '"')
+	assert(Opponent.isType(opponentArgs.type), 'Invalid opponent type for "' .. sectionArgs[key] .. '"')
 
 	local opponent = Opponent.readOpponentArgs(opponentArgs) or {}
 


### PR DESCRIPTION
## Summary
rework of #4022
allows team opponents in participantTables but disables storage for them.

## How did you test this change?
to be done