### PR TITLE
feat(infobox): Unit rework for Wildcard

### DIFF
--- a/lua/wikis/wildcard/Infobox/Unit/Custom.lua
+++ b/lua/wikis/wildcard/Infobox/Unit/Custom.lua
@@ -16,6 +16,7 @@ local Unit = Lua.import('Module:Infobox/Unit')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
+local Title = Widgets.Title
 
 ---@class WildcardUnitInfobox: UnitInfobox
 local CustomUnit = Class.new(Unit)
@@ -40,11 +41,18 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Pronouns', content = {args.pronouns}},
 			Cell{name = 'House', content = {args.house}},
 			Cell{name = 'Rarity', content = {args.rarity}},
-			Cell{name = 'Mana Cost', content = {args.cost}},
 			Cell{name = 'Quantity', content = {args.quantity}},
+			Cell{name = 'Mana Cost', content = {args.cost}},
 			Cell{name = 'Health', content = {args.health}},
 			Cell{name = 'Movement Speed', content = {args.movement}},
-			Cell{name = 'Key Words', content = {args.keywords}}
+			Cell{name = 'Sight Range', content = {args.sightrange}},
+			Cell{name = 'Key Words', content = {args.keywords}},
+			Title{children = 'Basic Stats'},
+			Cell{name = 'Healing', content = {args.healing}},
+			Cell{name = 'Mobility', content = {args.mobility}},
+			Cell{name = 'Offense', content = {args.offense}},
+			Cell{name = 'Defense', content = {args.defense}},
+			Cell{name = 'Utility', content = {args.utility}}
 		)
 	end
 	return widgets


### PR DESCRIPTION
## Summary
Game is having a major rework soon, this includes the Unit module requiring some changes in display, most notably is the base stat values which is just the same as Character Infobox. 

Previously these stats is put under a SpellCard but now  each summon would have their own ability, we decide on moving these back to the infobox just like Characters it's more consistent that way. Outside of that is a new stat called Sight Range.

![image](https://github.com/user-attachments/assets/15b42926-1647-4434-a65e-28b052289f23)


## How did you test this change?
LIVE https://liquipedia.net/wildcard/Beakit