### PR TITLE
docs(match2): fix incorrect return type annotation in valorant match page map parser

### DIFF
--- a/lua/wikis/valorant/MatchGroup/Input/Custom/MatchPage.lua
+++ b/lua/wikis/valorant/MatchGroup/Input/Custom/MatchPage.lua
@@ -44,7 +44,7 @@ local function makeShortSideName(longName)
 end
 
 ---@param mapInput {matchid: string?, reversed: string?, vod: string?, region: string?}
----@return dota2MatchDataExtended|table
+---@return valorantMatchDataExtended|table
 function CustomMatchGroupInputMatchPage.getMap(mapInput)
 	-- If no matchid is provided, assume this as a normal map
 	if not mapInput or not mapInput.matchid then


### PR DESCRIPTION
## How did you test this change?

N/A