### PR TITLE
fix: Use OpponentDisplay.InlineScore on match pages

### DIFF
--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -12,6 +12,8 @@ local Image = require('Module:Image')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
+local OpponentDisplay = Lua.import('Module:OpponentLibraries').OpponentDisplay
+
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
@@ -47,7 +49,7 @@ function MatchPageHeader:_makeResultDisplay()
 		classes = { 'match-bm-match-header-result' },
 		children = WidgetUtil.collect(
 			(self.props.isBestOfOne or phase == 'upcoming') and '' or (
-				opponent1.score .. '&ndash;' .. opponent2.score),
+				OpponentDisplay.InlineScore(opponent1) .. '&ndash;' .. OpponentDisplay.InlineScore(opponent2)),
 			Div{
 				classes = { 'match-bm-match-header-result-text' },
 				children = { phase == 'ongoing' and 'live' or phase }


### PR DESCRIPTION
## Summary
Prevents the matchpage from showing -1 scores on non-score results.
Also makes it future-proof for eventual float scores.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
