### PR TITLE
refactor(match2): clean up mapveto start widget

### DIFF
--- a/lua/wikis/commons/I18n/Data.lua
+++ b/lua/wikis/commons/I18n/Data.lua
@@ -52,5 +52,8 @@ return {
 
 		['brkts-header-q'] = 'Qualified,Qual.,Q',
 		['brkts-header-tp'] = 'Third Place Match,3rd Place,3rd',
+
+		-- MatchSummary Map Veto
+		['matchsummary-mapveto-start'] = 'Start Map Veto',
 	}
 }

--- a/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
@@ -8,6 +8,7 @@
 
 local Array = require('Module:Array')
 local Class = require('Module:Class')
+local I18n = require('Module:I18n')
 local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
@@ -16,7 +17,7 @@ local IconFa = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 
 local ARROW_LEFT = IconFa{iconName = 'startleft', size = '110%'}
 local ARROW_RIGHT = IconFa{iconName = 'startright', size = '110%'}
-local START_MAP_VETO = HtmlWidgets.B{children = 'Start Map Veto'}
+local START_MAP_VETO = HtmlWidgets.B{children = I18n.translate('matchsummary-mapveto-start')}
 
 ---@class MatchSummaryMapVetoStart: Widget
 ---@operator call(table): MatchSummaryMapVetoStart

--- a/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
@@ -12,9 +12,10 @@ local Lua = require('Module:Lua')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local IconFa = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 
-local ARROW_LEFT = '[[File:Arrow sans left.svg|15x15px|link=|Left team starts]]'
-local ARROW_RIGHT = '[[File:Arrow sans right.svg|15x15px|link=|Right team starts]]'
+local ARROW_LEFT = IconFa{iconName = 'startleft', size = '110%'}
+local ARROW_RIGHT = IconFa{iconName = 'startright', size = '110%'}
 
 ---@class MatchSummaryMapVetoStart: Widget
 ---@operator call(table): MatchSummaryMapVetoStart

--- a/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
@@ -16,6 +16,7 @@ local IconFa = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 
 local ARROW_LEFT = IconFa{iconName = 'startleft', size = '110%'}
 local ARROW_RIGHT = IconFa{iconName = 'startright', size = '110%'}
+local START_MAP_VETO = HtmlWidgets.B{children = 'Start Map Veto'}
 
 ---@class MatchSummaryMapVetoStart: Widget
 ---@operator call(table): MatchSummaryMapVetoStart
@@ -31,7 +32,7 @@ function MatchSummaryMapVetoStart:render()
 	local children = {}
 	if self.props.firstVeto == 1 then
 		children = {
-			'<b>Start Map Veto</b>',
+			START_MAP_VETO,
 			ARROW_LEFT,
 			format,
 		}
@@ -39,7 +40,7 @@ function MatchSummaryMapVetoStart:render()
 		children = {
 			format,
 			ARROW_RIGHT,
-			'<b>Start Map Veto</b>',
+			START_MAP_VETO,
 		}
 	end
 


### PR DESCRIPTION
## Summary

This PR:
- replaces arrow images being used for start indicators with fontawesome icons
  The original images were gray in color, making them hard to see under darkmode
- refactors hardcoded html string to separate widget

## How did you test this change?

dev