### PR TITLE
ci: use snapshot version of gh-actions-lua

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -12,20 +12,18 @@ jobs:
 
       - name: Setup lua
         # uses: leafo/gh-actions-lua@v11
-        # with:
-        #   luaVersion: '5.1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install lua5.1 liblua5.1-dev
+        uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
+        with:
+          luaVersion: '5.1'
 
       - name: Setup luarock
+        # See https://github.com/leafo/gh-actions-lua/issues/57
         # uses: leafo/gh-actions-luarocks@v5
         run: sudo apt-get install luarocks
 
       - name: Setup dependencies
         run: |
-          luarocks install --local --lua-version=5.1 luacheck
-          luarocks path --lr-bin >> $GITHUB_PATH
+          luarocks install --lua-version=5.1 luacheck
 
       - name: Run lint
         run: |
@@ -48,21 +46,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
+        # See https://github.com/leafo/gh-actions-lua/issues/57
         # uses: leafo/gh-actions-lua@v11
-        # with:
-        #   luaVersion: '5.1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install lua5.1 liblua5.1-dev
+        uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
+        with:
+          luaVersion: '5.1'
 
       - name: Setup luarocks
-        # uses: leafo/gh-actions-luarocks@v5
-        run: sudo apt-get install luarocks
+        uses: leafo/gh-actions-luarocks@v5
 
       - name: Setup dependencies
         run: |
-          luarocks install --local --lua-version=5.1 busted
-          luarocks path --lr-bin >> $GITHUB_PATH
+          luarocks install --lua-version=5.1 busted
 
       - name: Run test
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -11,9 +11,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
-        uses: leafo/gh-actions-lua@v11
-        with:
-          luaVersion: '5.1'
+        # uses: leafo/gh-actions-lua@v11
+        # with:
+        #   luaVersion: '5.1'
+        run: |
+          sudo apt-get update
+          apt-fast install lua5.1
 
       - name: Setup luarock
         uses: leafo/gh-actions-luarocks@v5
@@ -43,9 +46,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
-        uses: leafo/gh-actions-lua@v11
-        with:
-          luaVersion: '5.1'
+        # uses: leafo/gh-actions-lua@v11
+        # with:
+        #   luaVersion: '5.1'
+        run: |
+          sudo apt-get update
+          apt-fast install lua5.1
 
       - name: Setup luarocks
         uses: leafo/gh-actions-luarocks@v5

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 luacheck
-          
+          echo "$HOME/.luarocks" >> $GITHUB_PATH
+
       - name: Run lint
         run: |
-          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
           luacheck lua --config lua/.luacheckrc |
           luacheck lua --config lua/.luacheckrc --formatter=JUnit > report.xml
 
@@ -62,10 +62,10 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 busted
-          
+          echo "$HOME/.luarocks" >> $GITHUB_PATH
+
       - name: Run test
         run: |
-          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
           busted -C lua -v --run=ci --output=junit > busted.xml
 
       - name: Report test

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 luacheck
-          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
-
+          
       - name: Run lint
         run: |
+          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
           luacheck lua --config lua/.luacheckrc |
           luacheck lua --config lua/.luacheckrc --formatter=JUnit > report.xml
 
@@ -62,10 +62,10 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 busted
-          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
-
+          
       - name: Run test
         run: |
+          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
           busted -C lua -v --run=ci --output=junit > busted.xml
 
       - name: Report test

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup dependencies
         run: |
-          luarocks install --lua-version=5.1 luacheck
+          luarocks install --local --lua-version=5.1 luacheck
 
       - name: Run lint
         run: |
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup dependencies
         run: |
-          luarocks install --lua-version=5.1 busted
+          luarocks install --local --lua-version=5.1 busted
 
       - name: Run test
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 luacheck
-          luarocks path --lr-path >> $GITHUB_PATH
+          luarocks path --lr-bin >> $GITHUB_PATH
 
       - name: Run lint
         run: |
@@ -62,7 +62,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 busted
-          luarocks path --lr-path >> $GITHUB_PATH
+          luarocks path --lr-bin >> $GITHUB_PATH
 
       - name: Run test
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -11,15 +11,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
+        # See https://github.com/leafo/gh-actions-lua/issues/57
         # uses: leafo/gh-actions-lua@v11
         uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
         with:
           luaVersion: '5.1'
 
       - name: Setup luarock
-        # See https://github.com/leafo/gh-actions-lua/issues/57
-        # uses: leafo/gh-actions-luarocks@v5
-        run: sudo apt-get install luarocks
+        uses: leafo/gh-actions-luarocks@v5
 
       - name: Setup dependencies
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -16,10 +16,11 @@ jobs:
         #   luaVersion: '5.1'
         run: |
           sudo apt-get update
-          sudo apt-get install lua5.1
+          sudo apt-get install lua5.1 liblua5.1-dev
 
       - name: Setup luarock
-        uses: leafo/gh-actions-luarocks@v5
+        # uses: leafo/gh-actions-luarocks@v5
+        run: sudo apt-get install luarocks
 
       - name: Setup dependencies
         run: |
@@ -51,10 +52,11 @@ jobs:
         #   luaVersion: '5.1'
         run: |
           sudo apt-get update
-          sudo apt-get install lua5.1
+          sudo apt-get install lua5.1 liblua5.1-dev
 
       - name: Setup luarocks
-        uses: leafo/gh-actions-luarocks@v5
+        # uses: leafo/gh-actions-luarocks@v5
+        run: sudo apt-get install luarocks
 
       - name: Setup dependencies
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 luacheck
-          eval $(luarocks path --lr-bin) >> $GITHUB_PATH
+          luarocks path --lr-path >> $GITHUB_PATH
 
       - name: Run lint
         run: |
@@ -62,7 +62,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 busted
-          eval $(luarocks path --lr-bin) >> $GITHUB_PATH
+          luarocks path --lr-path >> $GITHUB_PATH
 
       - name: Run test
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -16,7 +16,7 @@ jobs:
         #   luaVersion: '5.1'
         run: |
           sudo apt-get update
-          apt-fast install lua5.1
+          sudo apt-get install lua5.1
 
       - name: Setup luarock
         uses: leafo/gh-actions-luarocks@v5
@@ -51,7 +51,7 @@ jobs:
         #   luaVersion: '5.1'
         run: |
           sudo apt-get update
-          apt-fast install lua5.1
+          sudo apt-get install lua5.1
 
       - name: Setup luarocks
         uses: leafo/gh-actions-luarocks@v5

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 luacheck
+          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
 
       - name: Run lint
         run: |
@@ -61,6 +62,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 busted
+          echo "$HOME/.luarocks" >> "$GITHUB_PATH"
 
       - name: Run test
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 luacheck
-          eval $(luarocks path) >> $GITHUB_PATH
+          eval $(luarocks path --lr-bin) >> $GITHUB_PATH
 
       - name: Run lint
         run: |
@@ -62,7 +62,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 busted
-          eval $(luarocks path) >> $GITHUB_PATH
+          eval $(luarocks path --lr-bin) >> $GITHUB_PATH
 
       - name: Run test
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 luacheck
-          echo "$HOME/.luarocks" >> $GITHUB_PATH
+          eval $(luarocks path) >> $GITHUB_PATH
 
       - name: Run lint
         run: |
@@ -62,7 +62,7 @@ jobs:
       - name: Setup dependencies
         run: |
           luarocks install --local --lua-version=5.1 busted
-          echo "$HOME/.luarocks" >> $GITHUB_PATH
+          eval $(luarocks path) >> $GITHUB_PATH
 
       - name: Run test
         run: |

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
-        # See https://github.com/leafo/gh-actions-lua/issues/57
+        # Workaround until https://github.com/leafo/gh-actions-lua/issues/57 is resolved
         # uses: leafo/gh-actions-lua@v11
         uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
         with:
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup lua
-        # See https://github.com/leafo/gh-actions-lua/issues/57
+        # Workaround until https://github.com/leafo/gh-actions-lua/issues/57 is resolved
         # uses: leafo/gh-actions-lua@v11
         uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
         with:


### PR DESCRIPTION
## Summary

This PR mitigates #5979.
Full fix would be bumping `leafo/gh-actions-lua` to latest once it gets updated.

## How did you test this change?

https://github.com/Liquipedia/Lua-Modules/actions/runs/15553601405
