### PR TITLE
fix: wrong css class used for team templates with both legacy and new images

### DIFF
--- a/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
+++ b/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
@@ -93,7 +93,7 @@ function TeamInlineWidget:render()
 			imageLight = Logic.emptyOr(self.teamTemplate.image, self.teamTemplate.legacyimage),
 			imageDark = Logic.emptyOr(self.teamTemplate.imagedark, self.teamTemplate.legacyimagedark),
 			page = self.teamTemplate.page,
-			legacy = Logic.isNotEmpty(self.teamTemplate.legacyimage)
+			legacy = Logic.isEmpty(self.teamTemplate.image) and Logic.isNotEmpty(self.teamTemplate.legacyimage)
 		},
 		self:_getNameComponent()
 	), ' ')


### PR DESCRIPTION
## Summary

#5900 assumed that each team template had only one of new image or legacy image; not both.
However, as reported [here](https://discord.com/channels/93055209017729024/372075546231832576/1382097367238709340), there are some team templates with both new and legacy images, and in such cases, the widget ends up using css class for legacy with new images.
This PR adds extra check so that the widget does not switch to using legacy css class in such scenarios.

## How did you test this change?

dev