### PR TITLE
feat(navBox): allow empty child overwrite

### DIFF
--- a/lua/wikis/commons/Widget/NavBox/Child.lua
+++ b/lua/wikis/commons/Widget/NavBox/Child.lua
@@ -45,7 +45,7 @@ NavBoxChild.defaultProps = {
 function NavBoxChild:render()
 	local props = self.props
 
-	assert(props[1] or props.child1, EMPTY_CHILD_ERROR)
+	assert(Logic.readBool(props.allowEmpty) or props[1] or props.child1, EMPTY_CHILD_ERROR)
 
 	local listElements = Array.mapIndexes(function(index)
 		return self.props[index]


### PR DESCRIPTION
## Summary
in some edge cases an empty child is intended, hence soften the check for empty children to have an overwrite option that allows an empty child

## How did you test this change?
dev