### PR TITLE
feat(infobox): move AutoPI into infobox

### DIFF
--- a/lua/wikis/honorofkings/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/honorofkings/Infobox/Person/Player/Custom.lua
@@ -9,7 +9,9 @@ local Array = require('Module:Array')
 local CharacterIcon = require('Module:CharacterIcon')
 local Class = require('Module:Class')
 local HeroNames = mw.loadData('Module:HeroNames')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
+local PlayerIntroduction = require('Module:PlayerIntroduction/Custom')
 local Table = require('Module:Table')
 
 local Injector = Lua.import('Module:Widget/Injector')
@@ -27,11 +29,44 @@ local CustomInjector = Class.new(Injector)
 ---@return Html
 function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
+	local args = player.args
 	player:setWidgetInjector(CustomInjector(player))
 
-	player.args.autoTeam = true
+	args.autoTeam = true
 
-	return player:createInfobox()
+	local builtInfobox = player:createInfobox()
+
+	local autoPlayerIntro = ''
+	if Logic.readBool((args.autoPI or ''):lower()) then
+		autoPlayerIntro = PlayerIntroduction.run{
+			player = player.pagename,
+			team = args.team,
+			name = args.romanized_name or args.name,
+			first_name = args.first_name,
+			last_name = args.last_name,
+			status = args.status,
+			type = player:getPersonType(args).store,
+			role = (player.roles[1] or {}).display,
+			role2 = (player.roles[2] or {}).display,
+			id = args.id,
+			idIPA = args.idIPA,
+			idAudio = args.idAudio,
+			birthdate = player.age.birthDateIso,
+			deathdate = player.age.deathDateIso,
+			nationality = args.country,
+			nationality2 = args.country2,
+			nationality3 = args.country3,
+			subtext = args.subtext,
+			freetext = args.freetext,
+			convert_role = true,
+			show_role = true,
+		}
+	end
+
+	return mw.html.create()
+		:node(builtInfobox)
+		:node(autoPlayerIntro)
+
 end
 
 ---@param id string

--- a/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
@@ -9,8 +9,10 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local ChampionNames = mw.loadData('Module:ChampionNames')
 local CharacterIcon = require('Module:CharacterIcon')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Page = require('Module:Page')
+local PlayerIntroduction = require('Module:PlayerIntroduction/Custom')
 local String = require('Module:StringUtils')
 local Team = require('Module:Team')
 local TeamHistoryAuto = require('Module:TeamHistoryAuto')
@@ -31,14 +33,46 @@ local CustomInjector = Class.new(Injector)
 ---@return Html
 function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
+	local args = player.args
 	player:setWidgetInjector(CustomInjector(player))
 
-	if String.isEmpty(player.args.history) then
-		player.args.history = TeamHistoryAuto.results{addlpdbdata = true}
+	if String.isEmpty(args.history) then
+		args.history = TeamHistoryAuto.results{addlpdbdata = true}
 	end
-	player.args.autoTeam = true
+	args.autoTeam = true
 
-	return player:createInfobox()
+	local builtInfobox = player:createInfobox()
+
+	local autoPlayerIntro = ''
+	if Logic.readBool((args.autoPI or ''):lower()) then
+		autoPlayerIntro = PlayerIntroduction.run{
+			player = player.pagename,
+			team = args.team,
+			name = args.romanized_name or args.name,
+			first_name = args.first_name,
+			last_name = args.last_name,
+			status = args.status,
+			type = player:getPersonType(args).store,
+			role = (player.roles[1] or {}).display,
+			role2 = (player.roles[2] or {}).display,
+			id = args.id,
+			idIPA = args.idIPA,
+			idAudio = args.idAudio,
+			birthdate = player.age.birthDateIso,
+			deathdate = player.age.deathDateIso,
+			nationality = args.country,
+			nationality2 = args.country2,
+			nationality3 = args.country3,
+			subtext = args.subtext,
+			freetext = args.freetext,
+			convert_role = true,
+			show_role = true,
+		}
+	end
+
+	return mw.html.create()
+		:node(builtInfobox)
+		:node(autoPlayerIntro)
 end
 
 ---@param id string


### PR DESCRIPTION
## Summary
Moving remaining wikis that have AutoPI calls in their Infobox Template into the Lua Infobox instead

First part of #6009

At deploy the following templates needs to be updated:
https://liquipedia.net/wildrift/index.php?title=Template:Infobox_player&action=edit
https://liquipedia.net/honorofkings/index.php?title=Template:Infobox_player&action=edit
https://liquipedia.net/leagueoflegends/index.php?title=Template:Infobox_player&action=edit
https://liquipedia.net/valorant/index.php?title=Template:Infobox_player&action=edit
https://liquipedia.net/valorant/index.php?title=Template:Infobox_commentator&action=edit

## How did you test this change?
Tested on HoK