### PR TITLE
fix: args.tournament not parsed correctly

### DIFF
--- a/lua/wikis/commons/TournamentStructure.lua
+++ b/lua/wikis/commons/TournamentStructure.lua
@@ -1,5 +1,6 @@
 ---
 -- @Liquipedia
+-- wiki=commons
 -- page=Module:TournamentStructure
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
@@ -54,8 +55,7 @@ function TournamentStructure.readMatchGroupsSpec(args)
 	end
 
 	local listsOfPageNames = {}
-	table.insert(listsOfPageNames, args.tournament)
-	for _, pageNamesInput in Table.iter.pairsByPrefix(args, 'tournament') do
+	for _, pageNamesInput in Table.iter.pairsByPrefix(args, 'tournament', {requireIndex = false}) do
 		table.insert(listsOfPageNames, Json.parseIfTable(pageNamesInput) or {pageNamesInput})
 	end
 

--- a/lua/wikis/commons/TournamentStructure.lua
+++ b/lua/wikis/commons/TournamentStructure.lua
@@ -1,6 +1,5 @@
 ---
 -- @Liquipedia
--- wiki=commons
 -- page=Module:TournamentStructure
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute


### PR DESCRIPTION
## Summary
`args.tournament` was inserted before the loop in which the handling was adjusted.
As a solution just made the `pairsByPrefix` not require index for this loop and kick the extra line above

## How did you test this change?
dev