### PR TITLE
feat(NavBox): add lpdb auto generated transfer navbox

### DIFF
--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -18,7 +18,7 @@ local Widget = Lua.import('Module:Widget')
 local NavBox = Lua.import('Module:Widget/NavBox')
 local Link = Lua.import('Module:Widget/Basic/Link')
 
----@class SeriesChildFromLpdb: Widget
+---@class TransferNavBox: Widget
 local TransferNavBox = Class.new(Widget)
 
 ---@return Widget

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -20,7 +20,7 @@ local Link = Lua.import('Module:Widget/Basic/Link')
 
 ---@class SeriesChildFromLpdb: Widget
 local TransferNavBox = Class.new(Widget)
-TransferNavBox.defaultProps = {portalLink = Portal:Transfers}
+TransferNavBox.defaultProps = {portalLink = 'Portal:Transfers'}
 
 ---@return Widget
 function TransferNavBox:render()

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -58,7 +58,7 @@ function TransferNavBox._buildPageDisplay(pageName)
 	_, _, month = string.find(pageName, '.*[tT]ransfers/%d%d%d%d/(.*)')
 	if Logic.isEmpty(month) then return end
 
-	-- we have to account fo transfer pages not fitting the format we will ignore those and throw them away
+	-- we have to account for transfer pages not fitting the format we will ignore those and throw them away
 	-- but since the date functions would error on them rather pcall the date functions
 	local formatMonth = function()
 		local timestamp = DateExt.readTimestamp(month .. ' 1970')

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -19,6 +19,7 @@ local NavBox = Lua.import('Module:Widget/NavBox')
 local Link = Lua.import('Module:Widget/Basic/Link')
 
 ---@class SeriesChildFromLpdb: Widget
+---@field props {portalLink: string}
 local TransferNavBox = Class.new(Widget)
 TransferNavBox.defaultProps = {portalLink = 'Portal:Transfers'}
 
@@ -44,6 +45,9 @@ function TransferNavBox:render()
 	return NavBox(Table.merge(children, {title = 'Transfers', titleLink = self.props.portalLink}))
 end
 
+---@private
+---@param pageName string
+---@return Widget?
 function TransferNavBox._buildPageDisplay(pageName)
 	-- try to extract quarter
 	local quarter, _
@@ -74,6 +78,7 @@ function TransferNavBox._buildPageDisplay(pageName)
 	}
 end
 
+---@private
 ---@return table<integer, string[]>
 function TransferNavBox._getGroupedData()
 	local queryData = mw.ext.LiquipediaDB.lpdb('transfer', {

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -20,6 +20,7 @@ local Link = Lua.import('Module:Widget/Basic/Link')
 
 ---@class SeriesChildFromLpdb: Widget
 local TransferNavBox = Class.new(Widget)
+TransferNavBox.defaultProps = {portalLink = Portal:Transfers}
 
 ---@return Widget
 function TransferNavBox:render()
@@ -40,7 +41,7 @@ function TransferNavBox:render()
 			childIndex = childIndex + 1
 		end
 	end
-	return NavBox(Table.merge(children, {title = 'Transfers', titleLink = 'Portal:Transfers'}))
+	return NavBox(Table.merge(children, {title = 'Transfers', titleLink = self.props.portalLink}))
 end
 
 function TransferNavBox._buildPageDisplay(pageName)

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -19,9 +19,7 @@ local NavBox = Lua.import('Module:Widget/NavBox')
 local Link = Lua.import('Module:Widget/Basic/Link')
 
 ---@class SeriesChildFromLpdb: Widget
----@field props {portalLink: string}
 local TransferNavBox = Class.new(Widget)
-TransferNavBox.defaultProps = {portalLink = 'Portal:Transfers'}
 
 ---@return Widget
 function TransferNavBox:render()
@@ -66,7 +64,7 @@ function TransferNavBox:render()
 
 	return NavBox{
 		title = 'Transfers',
-		titleLink = self.props.portalLink,
+		titleLink = 'Portal:Transfers',
 		child1 = firstChild,
 		collapsed = false, -- is used on pages without navbox / HDB, hence would always collapse else
 		child2 = Logic.isNotEmpty(collapsedChildren)

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -1,0 +1,96 @@
+---
+-- @Liquipedia
+-- page=Module:Widget/NavBox/Transfer
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local DateExt = Lua.import('Module:Date/Ext')
+local Logic = Lua.import('Module:Logic')
+local Operator = Lua.import('Module:Operator')
+local Table = Lua.import('Module:Table')
+
+local Widget = Lua.import('Module:Widget')
+local NavBox = Lua.import('Module:Widget/NavBox')
+local Link = Lua.import('Module:Widget/Basic/Link')
+
+---@class SeriesChildFromLpdb: Widget
+local TransferNavBox = Class.new(Widget)
+
+---@return Widget
+function TransferNavBox:render()
+	local pagesByYear = TransferNavBox._getGroupedData()
+	local children = {}
+	local childIndex = 1
+
+	local sort = function(tbl, year1, year2)
+		return year2 < year1
+	end
+
+	for year, pages in Table.iter.spairs(pagesByYear, sort) do
+		---@type table
+		local childData = Array.map(pages, TransferNavBox._buildPageDisplay)
+		if Logic.isNotEmpty(childData) then
+			childData.name = year
+			children['child' .. childIndex] = childData
+			childIndex = childIndex + 1
+		end
+	end
+	return NavBox(Table.merge(children, {title = 'Transfers', titleLink = 'Portal:Transfers'}))
+end
+
+function TransferNavBox._buildPageDisplay(pageName)
+	-- try to extract quarter
+	local quarter, _
+	_, _, quarter = string.find(pageName, '.*(%d)%a%a_[qQ]uarter.*')
+	if Logic.isNotEmpty(quarter) then
+		return Link{
+			link = pageName,
+			children = {'Q' .. quarter}
+		}
+	end
+	-- try to extract month
+	local month
+	_, _, month = string.find(pageName, '.*[tT]ransfers/%d%d%d%d/(.*)')
+	if Logic.isEmpty(month) then return end
+
+	-- we have to account fo transfer pages not fitting the format we will ignore those and throw them away
+	-- but since the date functions would error on them rather pcall the date functions
+	local formatMonth = function()
+		local timestamp = DateExt.readTimestamp(month .. ' 1970')
+		assert(timestamp)
+		return DateExt.formatTimestamp('M', timestamp)
+	end
+	local success, monthAbbrviation = pcall(formatMonth)
+	if not success then return end
+	return Link{
+		link = pageName,
+		children = {monthAbbrviation}
+	}
+end
+
+---@return table<integer, string[]>
+function TransferNavBox._getGroupedData()
+	local queryData = mw.ext.LiquipediaDB.lpdb('transfer', {
+		query = 'pagename',
+		order = 'date desc',
+		groupby = 'pagename asc',
+		limit = 5000,
+	})
+	local pages = Array.map(queryData, Operator.property('pagename'))
+	-- throw away all pages that do not contain a year
+	pages = Array.filter(pages, function(pageName)
+		return pageName:find('%d%d%d%d') ~= nil
+	end)
+	local _, pagesByYear = Array.groupBy(pages, function(pageName)
+		local year = tonumber((pageName:gsub('.*(%d%d%d%d).*', '%1')))
+		return year
+	end)
+	return pagesByYear
+end
+
+return TransferNavBox

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -69,7 +69,9 @@ function TransferNavBox:render()
 		titleLink = self.props.portalLink,
 		child1 = firstChild,
 		collapsed = false, -- is used on pages without navbox / HDB, hence would always collapse else
-		child2 = Table.merge({collapsed = true, title = 'Further Transfers'}, collapsedChildren),
+		child2 = Logic.isNotEmpty(collapsedChildren)
+			and Table.merge({collapsed = true, title = 'Further Transfers'}, collapsedChildren)
+			or nil,
 	}
 end
 


### PR DESCRIPTION
## Summary
generates an automated navbox for transfer pages

## How did you test this change?
"live" (new module)

example on sc2:
![image](https://github.com/user-attachments/assets/bdf4b96c-8d53-4079-9b4b-d8b3238f23c7)
![image](https://github.com/user-attachments/assets/f8c22663-1b4d-4ba8-8326-5cf27674ac7f)


example on val (the bad month order is due to wrong transfer dates on the pages that are shifted, e.g. the may 2025 one has a transfer from 2024 ...):
![image](https://github.com/user-attachments/assets/cb6f49fe-a007-49f3-8de7-5bd59fdc3b72)
![image](https://github.com/user-attachments/assets/3a0e7cf3-c996-4667-ac3c-27518218a260)
