### PR TITLE
feat: Let matchticker group expanded games that share the same date

### DIFF
--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -457,6 +457,7 @@ function MatchTicker:expandGamesOfMatch(match)
 	return Array.map(Array.groupAdjacentBy(expandedGames, Operator.property('date')), function (gameGroup)
 		if #gameGroup > 1 then
 			table.insert(gameGroup[1].asGameIdx, gameGroup[#gameGroup].asGameIdx)
+			gameGroup[1].asGameIdx = Array.flatten(gameGroup[1].asGameIdx)
 		end
 
 		return gameGroup[1]

--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -443,7 +443,7 @@ function MatchTicker:expandGamesOfMatch(match)
 		local gameMatch = Table.copy(match)
 		gameMatch.match2games = nil
 		gameMatch.asGame = true
-		gameMatch.asGameIdx = {gameIndex}
+		gameMatch.asGameIndexes = {gameIndex}
 
 		gameMatch.winner = game.winner
 		gameMatch.date = game.date
@@ -457,8 +457,8 @@ function MatchTicker:expandGamesOfMatch(match)
 
 	return Array.map(Array.groupAdjacentBy(expandedGames, Operator.property('date')), function (gameGroup)
 		if #gameGroup > 1 then
-			table.insert(gameGroup[1].asGameIdx, gameGroup[#gameGroup].asGameIdx)
-			gameGroup[1].asGameIdx = Array.flatten(gameGroup[1].asGameIdx)
+			local lastIndexes = gameGroup[#gameGroup].asGameIndexes
+			table.insert(gameGroup[1].asGameIndexes, lastIndexes[#lastIndexes])
 		end
 
 		return gameGroup[1]
@@ -480,7 +480,7 @@ function MatchTicker:sortMatches(matches)
 		if a.match2id ~= b.match2id then
 			return a.match2id < b.match2id
 		end
-		return ((a.asGameIdx or {})[1] or 0) < ((b.asGameIdx or {})[1] or 0)
+		return ((a.asGameIndexes or {})[1] or 0) < ((b.asGameIndexes or {})[1] or 0)
 	end)
 end
 

--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -132,7 +132,7 @@ function Versus:gameTitle()
 	if not self.match.asGameIdx then
 		return ''
 	end
-	return 'Game #' .. (self.match.asGameIdx)
+	return 'Game #' .. (table.concat(self.match.asGameIdx, '-'))
 end
 
 ---@return string

--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -130,10 +130,10 @@ end
 
 ---@return string
 function Versus:gameTitle()
-	if not self.match.asGameIdx then
+	if not self.match.asGameIndexes then
 		return ''
 	end
-	return 'Game #' .. (table.concat(self.match.asGameIdx, '-'))
+	return 'Game #' .. (table.concat(self.match.asGameIndexes, '-'))
 end
 
 ---@return string


### PR DESCRIPTION
## Summary
closes #5987 
On AoE it is somewhat common that longer series get stretched over multiple days; they thus have different dates set on specific games.
Since the matchticker expands these games into separate entries, they pollute the mainpage massively.

This "merges" games that share the same date together.
Currently, scores shown will be of the first game of that group - not sure if we want more elaborate display there, or even no score at all.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
before
![image](https://github.com/user-attachments/assets/4b3e32bd-7bd3-4a6e-8d7c-802cfb3da971)

after
![image](https://github.com/user-attachments/assets/f7038582-91df-4bb1-9a32-6901d8e9f905)

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
