### PR TITLE
feat: Allow to inherit map dates

### DIFF
--- a/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
@@ -31,7 +31,7 @@ local MatchFunctions = {
 }
 local MapFunctions = {
 	BREAK_ON_EMPTY = true,
-	INHERIT_MAPDATES = true,
+	INHERIT_MAP_DATES = true,
 }
 
 local FffMatchFunctions = {

--- a/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
@@ -31,6 +31,7 @@ local MatchFunctions = {
 }
 local MapFunctions = {
 	BREAK_ON_EMPTY = true,
+	INHERIT_MAPDATES = true,
 }
 
 local FffMatchFunctions = {

--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -1197,7 +1197,7 @@ end
 ---@field getGame? fun(match: table, map:table): string?
 ---@field ADD_SUB_GROUP? boolean
 ---@field BREAK_ON_EMPTY? boolean
----@field INHERIT_MAPDATES? boolean
+---@field INHERIT_MAP_DATES? boolean
 
 --- The standard way to process a map input.
 ---
@@ -1237,7 +1237,7 @@ function MatchGroupInputUtil.standardProcessMaps(match, opponents, Parser)
 		local winnerInput = map.winner --[[@as string?]]
 
 		local dateToUse = map.date or match.date
-		if Parser.INHERIT_MAPDATES then
+		if Parser.INHERIT_MAP_DATES then
 			dateToUse = map.date or lastDate
 			lastDate = dateToUse
 		end

--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -1197,6 +1197,7 @@ end
 ---@field getGame? fun(match: table, map:table): string?
 ---@field ADD_SUB_GROUP? boolean
 ---@field BREAK_ON_EMPTY? boolean
+---@field INHERIT_MAPDATES? boolean
 
 --- The standard way to process a map input.
 ---
@@ -1225,6 +1226,8 @@ end
 function MatchGroupInputUtil.standardProcessMaps(match, opponents, Parser)
 	local maps = {}
 	local subGroup = 0
+	local lastDate = match.date
+
 	for key, mapInput, mapIndex in Table.iter.pairsByPrefix(match, 'map', {requireIndex = true}) do
 		local map = Parser.getMap and Parser.getMap(mapInput) or mapInput
 		if Parser.BREAK_ON_EMPTY and Logic.isDeepEmpty(map) then
@@ -1234,6 +1237,11 @@ function MatchGroupInputUtil.standardProcessMaps(match, opponents, Parser)
 		local winnerInput = map.winner --[[@as string?]]
 
 		local dateToUse = map.date or match.date
+		if Parser.INHERIT_MAPDATES then
+			dateToUse = map.date or lastDate
+			lastDate = dateToUse
+		end
+
 		Table.mergeInto(map, MatchGroupInputUtil.readDate(dateToUse))
 
 		if Parser.ADD_SUB_GROUP then


### PR DESCRIPTION
## Summary
Allows to "inherit" map dates onto subsequent maps when enabled via Parser flag.
Sometimes groups of maps are played at the same date; this allows to enter the date only for the first map, and inherits it to following maps until a different date is put in.

Also enable it on AoE.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
