### PR TITLE
fix(NavBox): edit link  not opening page to edit

### DIFF
--- a/lua/wikis/commons/Widget/NavBox/EditButton.lua
+++ b/lua/wikis/commons/Widget/NavBox/EditButton.lua
@@ -20,20 +20,18 @@ local NavBoxEditButton = Class.new(Widget)
 ---@return Widget?
 function NavBoxEditButton:render()
 	if not self.props.templateLink then return end
-	local editLink = HtmlWidgets.Fragment{children = {
-		mw.text.nowiki('['),
-		Link{
-			linktype = 'external',
-			link = tostring(mw.uri.fullUrl( 'Template:' .. self.props.templateLink, 'action=edit' )),
-			children = {'e'},
-		},
-		mw.text.nowiki(']'),
-	}}
 
 	return HtmlWidgets.Span{
 		classes = {'navigation-not-searchable'},
 		css = {float = 'left', ['font-size'] = 'xx-small', padding = 0},
-		children = {editLink}
+		children = {
+			mw.text.nowiki('['),
+			Link{
+				link = 'Special:EditPage/Template:' .. self.props.templateLink,
+				children = {'e'},
+			},
+			mw.text.nowiki(']'),
+		}
 	}
 end
 

--- a/lua/wikis/commons/Widget/NavBox/EditButton.lua
+++ b/lua/wikis/commons/Widget/NavBox/EditButton.lua
@@ -24,8 +24,7 @@ function NavBoxEditButton:render()
 		mw.text.nowiki('['),
 		Link{
 			linktype = 'external',
-			link = mw.site.server ..
-				tostring(mw.uri.localUrl( 'Template:' .. self.props.templateLink, 'action=edit' )),
+			link = tostring(mw.uri.fullUrl( 'Template:' .. self.props.templateLink, 'action=edit' )),
 			children = {'e'},
 		},
 		mw.text.nowiki(']'),

--- a/lua/wikis/commons/Widget/NavBox/EditButton.lua
+++ b/lua/wikis/commons/Widget/NavBox/EditButton.lua
@@ -22,7 +22,12 @@ function NavBoxEditButton:render()
 	if not self.props.templateLink then return end
 	local editLink = HtmlWidgets.Fragment{children = {
 		mw.text.nowiki('['),
-		Link{link = 'Template:' .. self.props.templateLink, children = {'e'}},
+		Link{
+			linktype = 'external',
+			link = mw.site.server ..
+				tostring(mw.uri.localUrl( 'Template:' .. self.props.templateLink, 'action=edit' )),
+			children = {'e'},
+		},
 		mw.text.nowiki(']'),
 	}}
 


### PR DESCRIPTION
## Summary
Currently edit link in navboxes just links to the page instead of actually opening it in a way so you can start editing directly.
This PR adjust the behaviour accordingly.

## How did you test this change?
dev