### PR TITLE
docs(match2): fix incorrect type annotation in MatchGroupUtil

### DIFF
--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -250,7 +250,7 @@ MatchGroupUtil.types.Game = TypeUtil.struct({
 ---@field tournament string?
 ---@field type string?
 ---@field vod string?
----@field winner string?
+---@field winner number?
 ---@field extradata table?
 ---@field timestamp number
 ---@field bestof number?


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/1f7c686c1c94d1aa82351d68f47ae79623cf3a90/lua/wikis/commons/MatchGroup/Util.lua#L275

## How did you test this change?

N/A