### PR TITLE
feat(Infobox): Port remaining patch infoboxes

### DIFF
--- a/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
@@ -23,8 +23,6 @@ local VERSION_DEFINITE_EDITION = 'Definitive Edition'
 local GAME_AOE2 = 'aoe2'
 
 ---@class AoePatchInfobox: PatchInfobox
----@field gameIdentifier string?
----@field gameData GameData?
 local CustomPatch = Class.new(Patch)
 
 ---@class AoePatchInfoboxWidgetInjector: WidgetInjector

--- a/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
@@ -88,7 +88,7 @@ function CustomPatch:getChronologyData(args)
 		if Logic.isEmpty(input) then return end
 		return game .. '/' .. version
 			.. (args.expansion and ('/' .. args.expansion) or '')
-			.. prefix ' ' .. input .. '|' .. input
+			.. prefix .. ' ' .. input .. '|' .. input
 	end
 
 	return {

--- a/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
@@ -17,7 +17,6 @@ local Injector = Lua.import('Module:Widget/Injector')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local VERSION_DEFINITIVE_EDITION = 'Definitive Edition'
 
@@ -43,11 +42,11 @@ function CustomInjector:parse(id, widgets)
 	local caller = self.caller
 	local args  = caller.args
 	if id == 'version' then
-		return WidgetUtil.collect(
+		return {
 			Cell{name = 'Game', children = {Game.name{game = args.game, useDefault = false}}, options = {makeLink = true}},
 			Cell{name = 'Version', children = {args.version}, options = {makeLink = true}},
-			Cell{name = 'Expansion Set', children = {args.expansion}, options = {makeLink = true}}
-		)
+			Cell{name = 'Expansion Set', children = {args.expansion}, options = {makeLink = true}},
+		}
 	end
 
 	return widgets

--- a/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
@@ -19,8 +19,7 @@ local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local VERSION_DEFINITE_EDITION = 'Definitive Edition'
-local GAME_AOE2 = 'aoe2'
+local VERSION_DEFINITIVE_EDITION = 'Definitive Edition'
 
 ---@class AoePatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
@@ -79,20 +78,17 @@ end
 ---@param args table
 ---@return {previous: string?, next: string?}
 function CustomPatch:getChronologyData(args)
-	local game = Game.name{game = args.game, useDefault = false}
+	local game = Game.name{game = args.game, useDefault = false} or ''
 	local version = args.version or ''
+	local prefix = version == VERSION_DEFINITIVE_EDITION and '/Update ' or '/Patch '
 
 	---@param input string?
 	---@return string?
 	local buildChronolgyLink = function(input)
-		if Logic.isEmpty(input) then
-			return
-		elseif version ~= VERSION_DEFINITE_EDITION then
-			return (game or '') .. version .. '/Patch ' .. input .. '|' .. version
-		end
-		return (game or Game.name{game = GAME_AOE2}) .. '/' .. version
+		if Logic.isEmpty(input) then return end
+		return game .. '/' .. version
 			.. (args.expansion and ('/' .. args.expansion) or '')
-			.. '/Update ' .. input .. '|' .. input
+			.. prefix .. input .. '|' .. input
 	end
 
 	return {

--- a/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
@@ -46,7 +46,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'version' then
 		return WidgetUtil.collect(
 			Cell{name = 'Game', children = {Game.name{game = args.game, useDefault = false}}, options = {makeLink = true}},
-			Cell{name = 'Version', children = {args.version}},
+			Cell{name = 'Version', children = {args.version}, options = {makeLink = true}},
 			Cell{name = 'Expansion Set', children = {args.expansion}, options = {makeLink = true}}
 		)
 	end

--- a/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
@@ -80,7 +80,7 @@ end
 function CustomPatch:getChronologyData(args)
 	local game = Game.name{game = args.game, useDefault = false} or ''
 	local version = args.version or ''
-	local prefix = version == VERSION_DEFINITIVE_EDITION and '/Update ' or '/Patch '
+	local prefix = version == VERSION_DEFINITIVE_EDITION and '/Update' or '/Patch'
 
 	---@param input string?
 	---@return string?
@@ -88,7 +88,7 @@ function CustomPatch:getChronologyData(args)
 		if Logic.isEmpty(input) then return end
 		return game .. '/' .. version
 			.. (args.expansion and ('/' .. args.expansion) or '')
-			.. prefix .. input .. '|' .. input
+			.. prefix ' ' .. input .. '|' .. input
 	end
 
 	return {

--- a/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Patch/Custom.lua
@@ -1,0 +1,106 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Patch/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local Game = Lua.import('Module:Game')
+local Logic = Lua.import('Module:Logic')
+local Table = Lua.import('Module:Table')
+
+local Patch = Lua.import('Module:Infobox/Patch')
+local Injector = Lua.import('Module:Widget/Injector')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local VERSION_DEFINITE_EDITION = 'Definitive Edition'
+local GAME_AOE2 = 'aoe2'
+
+---@class AoePatchInfobox: PatchInfobox
+---@field gameIdentifier string?
+---@field gameData GameData?
+local CustomPatch = Class.new(Patch)
+
+---@class AoePatchInfoboxWidgetInjector: WidgetInjector
+---@field caller AoePatchInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomPatch.run(frame)
+	local patch = CustomPatch(frame)
+	patch:setWidgetInjector(CustomInjector(patch))
+	return patch:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args  = caller.args
+	if id == 'version' then
+		return WidgetUtil.collect(
+			Cell{name = 'Game', children = {Game.name{game = args.game, useDefault = false}}, options = {makeLink = true}},
+			Cell{name = 'Version', children = {args.version}},
+			Cell{name = 'Expansion Set', children = {args.expansion}, options = {makeLink = true}}
+		)
+	end
+
+	return widgets
+end
+
+---@param args table
+---@return string[]
+function CustomPatch:getWikiCategories(args)
+	local game = Game.name{game = args.game, useDefault = false}
+	return {
+		game and ('Updates (' .. game .. ')') or nil
+	}
+end
+
+---Adjust Lpdb data
+---@param lpdbData table
+---@param args table
+---@return table
+function CustomPatch:addToLpdb(lpdbData, args)
+	Table.mergeInto(lpdbData.extradata, {
+		game = Game.name{game = args.game, useDefault = false},
+		version = args.version, -- todo: check usage and eliminate in follow up
+		patchversion = args.patch_version, -- yes this is only stored but not displayed
+	})
+	return lpdbData
+end
+
+---@param args table
+---@return {previous: string?, next: string?}
+function CustomPatch:getChronologyData(args)
+	local game = Game.name{game = args.game, useDefault = false}
+	local version = args.version or ''
+
+	---@param input string?
+	---@return string?
+	local buildChronolgyLink = function(input)
+		if Logic.isEmpty(input) then
+			return
+		elseif version ~= VERSION_DEFINITE_EDITION then
+			return (game or '') .. version .. '/Patch ' .. input .. '|' .. version
+		end
+		return (game or Game.name{game = GAME_AOE2}) .. '/' .. version
+			.. (args.expansion and ('/' .. args.expansion) or '')
+			.. '/Update ' .. input .. '|' .. input
+	end
+
+	return {
+		previous = buildChronolgyLink(args.previous),
+		next = buildChronolgyLink(args.next),
+	}
+end
+
+return CustomPatch

--- a/lua/wikis/commons/Infobox/Patch.lua
+++ b/lua/wikis/commons/Infobox/Patch.lua
@@ -48,7 +48,10 @@ function Patch:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = (self:getInformationType(args)) .. ' Information'},
-		Cell{name = 'Version', content = {args.version}},
+		Customizable{id = 'version', children = {
+				Cell{name = 'Version', content = {args.version}},
+			}
+		},
 		Customizable{id = 'release', children = {
 				Cell{name = 'Release Date', content = {args.release}},
 			}

--- a/lua/wikis/heroes/Infobox/Patch/Custom.lua
+++ b/lua/wikis/heroes/Infobox/Patch/Custom.lua
@@ -1,0 +1,56 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Patch/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local Patch = Lua.import('Module:Infobox/Patch')
+local Injector = Lua.import('Module:Widget/Injector')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+
+---@class HeroesPatchInfobox: PatchInfobox
+local CustomPatch = Class.new(Patch)
+
+---@class HeroesPatchInfoboxWidgetInjector: WidgetInjector
+---@field caller HeroesPatchInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomPatch.run(frame)
+	local customPatch = CustomPatch(frame)
+	customPatch:setWidgetInjector(CustomInjector(customPatch))
+	return customPatch:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args  = caller.args
+	if id == 'release' then
+		table.insert(widgets, Cell{name = 'NA Release Date', children = {args.narelease}})
+	end
+
+	return widgets
+end
+
+---@param args table
+---@return {previous: string?, next: string?}
+function Patch:getChronologyData(args)
+	---@param input string?
+	---@return string?
+	local prefixIfExists = function(input)
+		return input and ('Patch ' .. input) or nil
+	end
+	return {previous = prefixIfExists(args.previous), next = prefixIfExists(args.next)}
+end
+
+return CustomPatch

--- a/lua/wikis/heroes/Infobox/Patch/Custom.lua
+++ b/lua/wikis/heroes/Infobox/Patch/Custom.lua
@@ -44,7 +44,7 @@ end
 
 ---@param args table
 ---@return {previous: string?, next: string?}
-function Patch:getChronologyData(args)
+function CustomPatch:getChronologyData(args)
 	---@param input string?
 	---@return string?
 	local prefixIfExists = function(input)

--- a/lua/wikis/rocketleague/Infobox/Patch/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Patch/Custom.lua
@@ -10,7 +10,7 @@ local Lua = require('Module:Lua')
 local Class = Lua.import('Module:Class')
 local Patch = Lua.import('Module:Infobox/Patch')
 
----@class SquadronsPatchInfobox: PatchInfobox
+---@class RockatleaguePatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
 
 ---@param frame Frame
@@ -23,14 +23,24 @@ end
 ---@param args table
 ---@return {previous: string?, next: string?}
 function CustomPatch:getChronologyData(args)
-	---@param prefix string
+	---@param input string?
 	---@return string?
-	local buildLink = function(prefix)
-		if not args[prefix] then return end
-		local link = args[prefix .. ' link'] or (args[prefix] .. ' Patch')
-		return link .. '|' .. args[prefix]
+	local makeLink = function(input)
+		return input and ('Version ' .. input .. '|V' .. input) or nil
 	end
-	return {previous = buildLink('previous'), next = buildLink('next')}
+	return {previous = makeLink(args.previous), next = makeLink(args.next)}
+end
+
+---@param args table
+---@return string[]
+function CustomPatch:getWikiCategories(args)
+	return {'Versions'}
+end
+
+---@param args table
+---@return string
+function Patch:getInformationType(args)
+	return 'Version'
 end
 
 return CustomPatch

--- a/lua/wikis/runeterra/Infobox/Patch/Custom.lua
+++ b/lua/wikis/runeterra/Infobox/Patch/Custom.lua
@@ -10,7 +10,7 @@ local Lua = require('Module:Lua')
 local Class = Lua.import('Module:Class')
 local Patch = Lua.import('Module:Infobox/Patch')
 
----@class WildriftPatchInfobox: PatchInfobox
+---@class RuneterraPatchInfobox: PatchInfobox
 local CustomPatch = Class.new(Patch)
 
 ---@param frame Frame
@@ -23,12 +23,14 @@ end
 ---@param args table
 ---@return {previous: string?, next: string?}
 function Patch:getChronologyData(args)
-	---@param input string?
+	---@param prefix string
 	---@return string?
-	local prefixIfExists = function(input)
-		return input and ('Patch ' .. input) or nil
+	local buildLink = function(prefix)
+		if not args[prefix] then return end
+		local link = args[prefix .. ' link'] or (args[prefix] .. ' Patch')
+		return link .. '|' .. args[prefix]
 	end
-	return {previous = prefixIfExists(args.previous), next = prefixIfExists(args.next)}
+	return {previous = buildLink('previous'), next = buildLink('next')}
 end
 
 return CustomPatch

--- a/lua/wikis/runeterra/Infobox/Patch/Custom.lua
+++ b/lua/wikis/runeterra/Infobox/Patch/Custom.lua
@@ -22,7 +22,7 @@ end
 
 ---@param args table
 ---@return {previous: string?, next: string?}
-function Patch:getChronologyData(args)
+function CustomPatch:getChronologyData(args)
 	---@param prefix string
 	---@return string?
 	local buildLink = function(prefix)

--- a/lua/wikis/squadrons/Infobox/Patch/Custom.lua
+++ b/lua/wikis/squadrons/Infobox/Patch/Custom.lua
@@ -1,0 +1,36 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Patch/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local Patch = Lua.import('Module:Infobox/Patch')
+
+---@class SquadronsPatchInfobox: PatchInfobox
+local CustomPatch = Class.new(Patch)
+
+---@param frame Frame
+---@return Html
+function CustomPatch.run(frame)
+	local customPatch = CustomPatch(frame)
+	return customPatch:createInfobox()
+end
+
+---@param args table
+---@return {previous: string?, next: string?}
+function Patch:getChronologyData(args)
+	---@param prefix string
+	---@return string?
+	local buildLink = function(prefix)
+		if not args[prefix] then return end
+		local link = args[prefix .. ' link'] or (args[prefix] .. ' Patch')
+		return link .. '|' .. args[prefix]
+	end
+	return {previous = buildLink('previous'), next = buildLink('next')}
+end
+
+return CustomPatch

--- a/lua/wikis/underlords/Infobox/Patch/Custom.lua
+++ b/lua/wikis/underlords/Infobox/Patch/Custom.lua
@@ -1,0 +1,36 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Patch/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local Patch = Lua.import('Module:Infobox/Patch')
+
+---@class UnderlordsPatchInfobox: PatchInfobox
+local CustomPatch = Class.new(Patch)
+
+---@param frame Frame
+---@return Html
+function CustomPatch.run(frame)
+	local customPatch = CustomPatch(frame)
+	return customPatch:createInfobox()
+end
+
+---@param args table
+---@return {previous: string?, next: string?}
+function Patch:getChronologyData(args)
+	---@param prefix string
+	---@return string?
+	local buildLink = function(prefix)
+		if not args[prefix] then return end
+		local link = args[prefix .. ' link'] or (args[prefix] .. ' Patch')
+		return link .. '|' .. args[prefix]
+	end
+	return {previous = buildLink('previous'), next = buildLink('next')}
+end
+
+return CustomPatch

--- a/lua/wikis/underlords/Infobox/Patch/Custom.lua
+++ b/lua/wikis/underlords/Infobox/Patch/Custom.lua
@@ -22,7 +22,7 @@ end
 
 ---@param args table
 ---@return {previous: string?, next: string?}
-function Patch:getChronologyData(args)
+function CustomPatch:getChronologyData(args)
 	---@param prefix string
 	---@return string?
 	local buildLink = function(prefix)

--- a/lua/wikis/wildrift/Infobox/Patch/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Patch/Custom.lua
@@ -22,7 +22,7 @@ end
 
 ---@param args table
 ---@return {previous: string?, next: string?}
-function Patch:getChronologyData(args)
+function CustomPatch:getChronologyData(args)
 	---@param input string?
 	---@return string?
 	local prefixIfExists = function(input)

--- a/lua/wikis/wildrift/Infobox/Patch/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Patch/Custom.lua
@@ -5,9 +5,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 
+local Class = Lua.import('Module:Class')
 local Patch = Lua.import('Module:Infobox/Patch')
 
 ---@class WildriftPatchInfobox: PatchInfobox

--- a/lua/wikis/wildrift/Infobox/Patch/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Patch/Custom.lua
@@ -1,0 +1,32 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Patch/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Patch = Lua.import('Module:Infobox/Patch')
+
+---@class WildriftPatchInfobox: PatchInfobox
+local CustomPatch = Class.new(Patch)
+
+---@param frame Frame
+---@return Html
+function CustomPatch.run(frame)
+	local customPatch = CustomPatch(frame)
+	return customPatch:createInfobox()
+end
+
+---@param args table
+---@return {previous: string?, next: string?}
+function Patch:getChronologyData(args)
+	local prefixIfExists = function(input)
+		return input and ('Patch ' .. input) or nil
+	end
+	return {previous = prefixIfExists(args.previous), next = prefixIfExists(args.next)}
+end
+
+return CustomPatch


### PR DESCRIPTION
## Summary
Port `Template:Infobox patch` on
- [x] wildrift
- [x] aoe
- [x] runeterra
- [x] squadrons
- [x] underlords
- [x] battlerite --> commons
- [x] heroes
- [x] rocketleague (infobox version)

this PR drops unused functionality from those infoboxes

## How did you test this change?
dev where reasonable

## bot jobs todo before rollout
- [x] wildrift: `\|\s*release date\s*=` --> `|release=`

## after merge
aoe: version = args.version, -- todo: check usage and eliminate in follow up
- merge (adds additional storage of version int `information` (blank until now)
- purge run
- adjust consumers
- follow up pr to kick the additional storage in extradata
