### PR TITLE
feat(Infobox): Add new restriction inputs

### DIFF
--- a/lua/wikis/chess/Infobox/League/Custom.lua
+++ b/lua/wikis/chess/Infobox/League/Custom.lua
@@ -50,10 +50,10 @@ local RESTRICTIONS = {
 		link = 'Senior Tournaments',
 		data = 'senior',
 	},
-	computer = {
-		name = 'Computers Only',
-		link = 'Computer Tournaments',
-		data = 'computer',
+	engine = {
+		name = 'Chess Engines Only',
+		link = 'Computer Chess Tournaments',
+		data = 'engine',
 	},
 }
 

--- a/lua/wikis/chess/Infobox/League/Custom.lua
+++ b/lua/wikis/chess/Infobox/League/Custom.lua
@@ -50,10 +50,10 @@ local RESTRICTIONS = {
 		link = 'Senior Tournaments',
 		data = 'senior',
 	},
-	engine = {
-		name = 'Chess Engines',
-		link = 'Chess Engine Tournaments',
-		data = 'engine',
+	computer = {
+		name = 'Computers Only',
+		link = 'Computer Tournaments',
+		data = 'computer',
 	},
 }
 

--- a/lua/wikis/chess/Infobox/League/Custom.lua
+++ b/lua/wikis/chess/Infobox/League/Custom.lua
@@ -50,6 +50,11 @@ local RESTRICTIONS = {
 		link = 'Senior Tournaments',
 		data = 'senior',
 	},
+	engine = {
+		name = 'Chess Engines',
+		link = 'Chess Engine Tournaments',
+		data = 'engine',
+	},
 }
 
 ---@param frame Frame


### PR DESCRIPTION
## Summary
Chess contains a series of tournaments for the **computer chess** or **chess platform/engines** - https://en.wikipedia.org/wiki/Top_Chess_Engine_Championship 

I believe it would be ideal to give these events its own restrictions indicator, allowing tournaments portal to contain a filtered section just for these, the updated name will be **computer** for clarity


## How did you test this change?
LIVE https://liquipedia.net/chess/Top_Chess_Engine_Championship/Cup_15