### PR TITLE
feat(notability): Adjust notability gain from qualifiers for marvelrivals

### DIFF
--- a/lua/wikis/marvelrivals/NotabilityChecker/config.lua
+++ b/lua/wikis/marvelrivals/NotabilityChecker/config.lua
@@ -45,7 +45,7 @@ Config.weights = {
 			},
 			{
 				name = Config.TIER_TYPE_QUALIFIER,
-				points = 5,
+				points = 3,
 			},
 			{
 				name = Config.TIER_TYPE_SHOW_MATCH,
@@ -81,7 +81,7 @@ Config.weights = {
 			},
 			{
 				name = Config.TIER_TYPE_QUALIFIER,
-				points = 0,
+				points = 2,
 			},
 			{
 				name = Config.TIER_TYPE_SHOW_MATCH,
@@ -117,7 +117,7 @@ Config.weights = {
 			},
 			{
 				name = Config.TIER_TYPE_QUALIFIER,
-				points = 0,
+				points = 1,
 			},
 			{
 				name = Config.TIER_TYPE_SHOW_MATCH,


### PR DESCRIPTION
## Summary

With the updated Notability Guidelines of 2025-06-02 was a change in how notability points for qualifiers were distributed, see [Marvel Rivals Notability Guidelines](https://liquipedia.net/marvelrivals/Liquipedia:Notability_Guidelines). See also request in [Discord ](https://discord.com/channels/93055209017729024/268719633366777856/1384644881212899428) about this topic

## How did you test this change?

Simple number change and im not smart enough to invoke a config/dev in the Special:RunQuery/Notability_Checker
