### PR TITLE
feat(infobox): Add default player infobox custom

### DIFF
--- a/lua/wikis/commons/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/commons/Infobox/Person/Player/Custom.lua
@@ -20,4 +20,3 @@ function CustomPlayer.run(frame)
 end
 
 return CustomPlayer
-  

--- a/lua/wikis/commons/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/commons/Infobox/Person/Player/Custom.lua
@@ -1,0 +1,23 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Person/Player/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Class = require('Module:Class')
+
+local Player = Lua.import('Module:Infobox/Person')
+
+---@class CustomInfoboxPlayer: Person
+local CustomPlayer = Class.new(Player
+
+---@param frame Frame
+---@return Html
+function CustomPlayer.run(frame)
+	return CustomPlayer(frame):createInfobox()
+end
+
+return CustomPlayer
+  

--- a/lua/wikis/commons/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/commons/Infobox/Person/Player/Custom.lua
@@ -11,7 +11,7 @@ local Class = require('Module:Class')
 local Player = Lua.import('Module:Infobox/Person')
 
 ---@class CustomInfoboxPlayer: Person
-local CustomPlayer = Class.new(Player
+local CustomPlayer = Class.new(Player)
 
 ---@param frame Frame
 ---@return Html


### PR DESCRIPTION
## Summary
Add a default custom for infobox player so that new wikis can use it out of the box.
With #5808 the choice for THA/autoTeam will get moved to Module:Info, hence the need for custom just to decide on that should be eliminated.

## How did you test this change?
untested but trivial