### PR TITLE
feat(NavBox): "always" show current month/quarter/year

### DIFF
--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -183,17 +183,17 @@ function DateExt.quarterOf(props)
 end
 
 ---@param date string|integer|osdateparam?
----@return integer?
+---@return integer
 function DateExt.getYearOf(date)
 	local timestamp = DateExt.readTimestamp(date) or DateExt.getCurrentTimestamp()
-	return tonumber(DateExt.formatTimestamp('Y', timestamp))
+	return tonumber(DateExt.formatTimestamp('Y', timestamp)) --[[@as integer]]
 end
 
 ---@param date string|integer|osdateparam?
----@return integer?
+---@return integer
 function DateExt.getMonthOf(date)
 	local timestamp = DateExt.readTimestamp(date) or DateExt.getCurrentTimestamp()
-	return tonumber(DateExt.formatTimestamp('n', timestamp))
+	return tonumber(DateExt.formatTimestamp('n', timestamp)) --[[@as integer]]
 end
 
 return DateExt

--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -182,4 +182,18 @@ function DateExt.quarterOf(props)
 	return quarter .. Ordinal.suffix(quarter)
 end
 
+---@param date string|integer|osdateparam?
+---@return integer?
+function DateExt.getYearOf(date)
+	local timestamp = DateExt.readTimestamp(date) or DateExt.getCurrentTimestamp()
+	return tonumber(DateExt.formatTimestamp('Y', timestamp))
+end
+
+---@param date string|integer|osdateparam?
+---@return integer?
+function DateExt.getMonthOf(date)
+	local timestamp = DateExt.readTimestamp(date) or DateExt.getCurrentTimestamp()
+	return tonumber(DateExt.formatTimestamp('n', timestamp))
+end
+
 return DateExt

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -109,7 +109,7 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 	local currentQuarter = DateExt.quarterOf{}
 	local currentMonth = DateExt.getMonthOf()
 	local quarter = tonumber((firstEntry.abbreviation:match('Q(%d)')))
-	local origMonthAbbreviation = firstEntry.abbreviation:match('^(.*?) ?#?%d?$')
+	local origMonthAbbreviation = firstEntry.abbreviation:gsub('#.*', '')
 	local monthTimeStamp = (not quarter) and DateExt.readTimestamp(origMonthAbbreviation .. ' 1970') or nil
 	local month = monthTimeStamp and DateExt.formatTimestamp('n', monthTimeStamp) or nil
 
@@ -131,7 +131,7 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 		local monthAbbreviation = TransferNavBox._getMonthAbbreviation(month)
 		if not monthAbbreviation then return children end
 
-		pageName = pageName:gsub('/[^/]*', '/' .. monthAbbreviation)
+		pageName = pageName:gsub('/[^/]*/?%d?$', '/' .. monthAbbreviation)
 		table.insert(children.child0, 1, Link{
 			link = pageName,
 			children = {monthAbbreviation},
@@ -217,10 +217,14 @@ function TransferNavBox._readQuarterOrMonth(pageName)
 		return 'Q' .. quarter
 	end
 	-- try to extract month
-	local month, appendix = pageName:match('.*[tT]ransfers/%d%d%d%d/(.*?)/?(%d?)$')
+	local month = pageName:match('.*[tT]ransfers/%d%d%d%d/(.*)$')
+	if not month then return end
+	local appendix = month:match('/(%d)$')
+	month = month:gsub('/%d$', '')
 
 	local abbreviation = TransferNavBox._getMonthAbbreviation(month)
-	return abbreviation and (abbreviation .. '#' .. (appendix or '')) or nil
+	if not abbreviation then return end
+	return table.concat({abbreviation, appendix}, '#')
 end
 
 ---@private

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -124,16 +124,18 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 				link = pageName,
 				children = {'Q' .. currentQuarter},
 			})
+			return children
 		end
 
-		local timestamp = DateExt.readTimestamp(currentMonth .. ' 1970') --[[@as integer]]
-		local monthAbbreviation = DateExt.formatTimestamp('M', timestamp)
+		local monthAbbreviation = TransferNavBox._getMonthAbbreviation(month)
+		if not monthAbbreviation then return children end
+
 		pageName = pageName:gsub('/[^/]*', '/' .. monthAbbreviation)
 		table.insert(children.child0, 1, Link{
 			link = pageName,
 			children = {monthAbbreviation},
 		})
-
+		return children
 	end
 
 	if currentYear == firstEntry.year then
@@ -215,6 +217,14 @@ function TransferNavBox._readQuarterOrMonth(pageName)
 	end
 	-- try to extract month
 	local month = pageName:match('.*[tT]ransfers/%d%d%d%d/(.*)')
+
+	return TransferNavBox._getMonthAbbreviation(month)
+end
+
+---@private
+---@param month string?
+---@return string?
+function TransferNavBox._getMonthAbbreviation(month)
 	if Logic.isEmpty(month) then return end
 
 	-- we have to account for transfer pages not fitting the format we will ignore those and throw them away

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -31,13 +31,21 @@ function TransferNavBox:render()
 	local miscPages = Table.extract(pagesByYear, 'misc')
 	---@cast pagesByYear table<integer, string[]>
 
+	local remainingPagesByYear = {}
+
 	local firstEntry
 
 	for year, pages in Table.iter.spairs(pagesByYear, TransferNavBox._sortByYear) do
 		---@type table
 		local childData = Array.map(pages, function(pageName)
 			local abbreviation = TransferNavBox._readQuarterOrMonth(pageName)
-			if not abbreviation then return end
+			if not abbreviation then
+				if not remainingPagesByYear[year] then
+					remainingPagesByYear[year] = {}
+				end
+				table.insert(remainingPagesByYear[year], pageName)
+				return
+			end
 			if not firstEntry then
 				firstEntry = {pageName = pageName, year = year, abbreviation = abbreviation}
 			end
@@ -59,7 +67,7 @@ function TransferNavBox:render()
 		collapsedChildren = TransferNavBox._checkForCurrentQuarterOrMonth(collapsedChildren, firstEntry)
 	end
 
-	local unsorted, unsourced, yearly, additionalMisc = TransferNavBox._getUnsortedUnsourcedYearly(pagesByYear)
+	local unsorted, unsourced, yearly, additionalMisc = TransferNavBox._getUnsortedUnsourcedYearly(remainingPagesByYear)
 	if Logic.isNotEmpty(unsorted) then
 		collapsedChildren['child' .. childIndex] = Table.merge(unsorted, {name = 'Unsorted'})
 		childIndex = childIndex + 1

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -105,7 +105,7 @@ end
 ---@param firstEntry {pageName: string, year: integer, abbreviation: string}
 ---@return table<string, table<string|integer, string|Widget|integer>>
 function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
-	local currentYear = DateExt.getYearOf() --[[@as integer]]
+	local currentYear = DateExt.getYearOf()
 	local currentQuarter = DateExt.quarterOf{}
 	local currentMonth = DateExt.getMonthOf()
 	local quarter = tonumber((firstEntry.abbreviation:match('Q(%d)')))
@@ -196,7 +196,7 @@ function TransferNavBox._getUnsortedUnsourcedYearly(pagesByYear)
 		end)
 	end
 
-	local currentYear = DateExt.getYearOf() --[[@as integer]]
+	local currentYear = DateExt.getYearOf()
 	if latestYear and currentYear == (latestYear.year + 1) then
 		local pageName = latestYear.pageName:gsub(latestYear.year, currentYear)
 		table.insert(yearly, 1, toDisplay(pageName, currentYear))

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -109,8 +109,8 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 	local currentQuarter = DateExt.quarterOf{}
 	local currentMonth = DateExt.getMonthOf()
 	local quarter = tonumber((firstEntry.abbreviation:match('Q(%d)')))
-	local monthAbbreviation = firstEntry.abbreviation:match('^(.*?) ?#?%d?$')
-	local monthTimeStamp = (not quarter) and DateExt.readTimestamp(monthAbbreviation .. ' 1970') or nil
+	local origMonthAbbreviation = firstEntry.abbreviation:match('^(.*?) ?#?%d?$')
+	local monthTimeStamp = (not quarter) and DateExt.readTimestamp(origMonthAbbreviation .. ' 1970') or nil
 	local month = monthTimeStamp and DateExt.formatTimestamp('n', monthTimeStamp) or nil
 
 	local addCurrent = function()

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -110,7 +110,7 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 	local currentMonth = DateExt.getMonthOf()
 	local quarter = tonumber((firstEntry.abbreviation:match('Q(%d)')))
 	local monthAbbreviation = firstEntry.abbreviation:match('^(.*?) ?#?%d?$')
-	local monthTimeStamp = (not quarter) and DateExt.readTimestamp(firstEntry.abbreviation .. ' 1970') or nil
+	local monthTimeStamp = (not quarter) and DateExt.readTimestamp(monthAbbreviation .. ' 1970') or nil
 	local month = monthTimeStamp and DateExt.formatTimestamp('n', monthTimeStamp) or nil
 
 	local addCurrent = function()

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -97,12 +97,14 @@ end
 ---@return Widget[] unsourced
 ---@return Widget[] yearly
 ---@return Widget[] misc
+---@return integer? latestYear
 function TransferNavBox._getUnsortedUnsourcedYearly(pagesByYear)
 	local toDisplay = function(pageName, year)
 		return Link{link = pageName, children = {year}}
 	end
 
 	local unsorted, unsourced, yearly, misc = {}, {}, {}, {}
+	local latestYear
 	for year, pages in Table.iter.spairs(pagesByYear, TransferNavBox._sortByYear) do
 		Array.forEach(pages, function(pageName)
 			local name, name2, _
@@ -115,10 +117,19 @@ function TransferNavBox._getUnsortedUnsourcedYearly(pagesByYear)
 				table.insert(unsourced, toDisplay(pageName, year))
 			elseif pageName:match('[tT]ransfers/' .. year .. '$') then
 				table.insert(yearly, toDisplay(pageName, year))
+				if not latestYear then
+					latestYear = {year = year, pageName = pageName}
+				end
 			else
 				table.insert(misc, pageName)
 			end
 		end)
+	end
+
+	local currentYear = DateExt. -- get current year
+	if latestYear and currentYear == (latestYear.year + 1) then
+		local pageName = latestYear.pageName:gsub(latestYear.year, currentYear)
+		table.insert(yearly, 1, toDisplay(pageName, currentYear))
 	end
 
 	return unsorted, unsourced, yearly, misc

--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -109,6 +109,7 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 	local currentQuarter = DateExt.quarterOf{}
 	local currentMonth = DateExt.getMonthOf()
 	local quarter = tonumber((firstEntry.abbreviation:match('Q(%d)')))
+	local monthAbbreviation = firstEntry.abbreviation:match('^(.*?) ?#?%d?$')
 	local monthTimeStamp = (not quarter) and DateExt.readTimestamp(firstEntry.abbreviation .. ' 1970') or nil
 	local month = monthTimeStamp and DateExt.formatTimestamp('n', monthTimeStamp) or nil
 
@@ -216,9 +217,10 @@ function TransferNavBox._readQuarterOrMonth(pageName)
 		return 'Q' .. quarter
 	end
 	-- try to extract month
-	local month = pageName:match('.*[tT]ransfers/%d%d%d%d/(.*)')
+	local month, appendix = pageName:match('.*[tT]ransfers/%d%d%d%d/(.*?)/?(%d?)$')
 
-	return TransferNavBox._getMonthAbbreviation(month)
+	local abbreviation = TransferNavBox._getMonthAbbreviation(month)
+	return abbreviation and (abbreviation .. '#' .. (appendix or '')) or nil
 end
 
 ---@private


### PR DESCRIPTION
## Summary
as per request on discord:
For transfer navbox add the current month/quarter/year (depending which is applicable) if in the same year of the latest query result (or january of the year after to account for year switches).
Also fixes a few issues that were reported on discord

## How did you test this change?
dev