### PR TITLE
feat(NavBox): Allow uncollapsed overwrite outside of main and user space

### DIFF
--- a/lua/wikis/commons/Widget/NavBox.lua
+++ b/lua/wikis/commons/Widget/NavBox.lua
@@ -11,6 +11,7 @@ local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
+local Namespace = Lua.import('Module:Namespace')
 local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
@@ -106,7 +107,8 @@ function NavBox:_determineCollapsedState(collapsedInput)
 		return true
 	end
 
-	return NavBox._getNumberOfChildren(self.props) > 3
+	return (not Namespace.isMain() and not Namespace.isUser())
+		or NavBox._getNumberOfChildren(self.props) > 3
 end
 
 ---@private

--- a/lua/wikis/commons/Widget/NavBox.lua
+++ b/lua/wikis/commons/Widget/NavBox.lua
@@ -107,8 +107,8 @@ function NavBox:_determineCollapsedState(collapsedInput)
 		return true
 	end
 
-	return (not Namespace.isMain() and not Namespace.isUser())
-		or NavBox._getNumberOfChildren(self.props) > 3
+	return (Namespace.isMain() or Namespace.isUser())
+		and NavBox._getNumberOfChildren(self.props) > 3
 end
 
 ---@private


### PR DESCRIPTION
## Summary
If Navboxes are used outside of main and user space it is likely they are used on pages without infobox nor HDB, hence they would always show collapsed there (unless it having <=3 rows), even if used at the bottom of pages.
Due to that allow for non user/main namespaces to set uncollapse via `|collapsed=false`.

report on discord: https://discord.com/channels/93055209017729024/268719633366777856/1385295529017085953
suggestion for restricting it by namespace: https://discord.com/channels/93055209017729024/268719633366777856/1385337232738750615
(credits go to igeneral)

## How did you test this change?
dev