### PR TITLE
feat(infobox): reduce minimap size for Afps

### DIFF
--- a/lua/wikis/arenafps/Infobox/Map/Custom.lua
+++ b/lua/wikis/arenafps/Infobox/Map/Custom.lua
@@ -53,7 +53,7 @@ function CustomInjector:parse(widgetId, widgets)
 				classes = {'infobox-image'},
 				children = {WidgetImage{
 					imageLight = args.minimap,
-					size = '600px',
+					size = '350px',
 					alignment = 'center',
 				}}
 			} or nil


### PR DESCRIPTION
## Summary

Reduce minimap size so the whole image can fit
Example: https://liquipedia.net/arenafps/Frontier

## How did you test this change?

dev and browser tools
