### PR TITLE
feat(infobox): add weapon custom infoboxes

### DIFF
--- a/lua/wikis/commons/Infobox/Weapon.lua
+++ b/lua/wikis/commons/Infobox/Weapon.lua
@@ -49,6 +49,7 @@ function Weapon:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = (args.informationType or 'Weapon') .. ' Information'},
+		Cell{name = 'Other', content = {args['other names']}},
 		Cell{
 			name = 'Class',
 			content = self:getAllArgsForBase(args, 'class', {makeLink = not Logic.readBool(args.disableClassLink)}),
@@ -71,10 +72,14 @@ function Weapon:createInfobox()
 		},
 		Customizable{
 			id = 'damage',
-			children = { Cell{name = 'Base Damage', content = {args.damage}} }
+			children = {
+				Cell{name = 'Base Damage', content = {args.damage}},
+				Cell{name = 'Armor penetration', content = {args['armor penetration']}},
+			}
 		},
 		Cell{name = 'Magazine Size', content = {args.magsize}},
 		Cell{name = 'Ammo Capacity', content = {args.ammocap}},
+		Cell{name = 'Ammunition/Capacity', content = {args.ammo}},
 		Cell{name = 'Reload Speed', content = {
 			Logic.isNotEmpty(args.reloadspeed) and (
 				args.reloadspeed .. (args.reloadspeedunit and (' ' .. args.reloadspeedunit) or '')
@@ -87,6 +92,7 @@ function Weapon:createInfobox()
 			}
 		},
 		Cell{name = 'Firing Mode', content = {args.firemode}},
+		Cell{name = 'Movement Speed', content = {args['movement speed']}},
 		Customizable{
 			id = 'side',
 			children = {

--- a/lua/wikis/commons/Infobox/Weapon.lua
+++ b/lua/wikis/commons/Infobox/Weapon.lua
@@ -49,38 +49,44 @@ function Weapon:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = (args.informationType or 'Weapon') .. ' Information'},
-		Cell{name = 'Other', content = {args['other names']}},
+		Cell{name = 'Other', children = {args['other names']}},
 		Cell{
 			name = 'Class',
-			content = self:getAllArgsForBase(args, 'class', {makeLink = not Logic.readBool(args.disableClassLink)}),
+			children = self:getAllArgsForBase(args, 'class', {makeLink = not Logic.readBool(args.disableClassLink)}),
 		},
 		Cell{
 			name = 'Origin',
-			content = {self:_createLocation(args.origin)},
+			children = {self:_createLocation(args.origin)},
 		},
 		Customizable{
 			id = 'price',
 			children = {
-				Cell{name = 'Price', content = {args.price}}
-			}
+				Cell{name = 'Price', children = {args.price}},
+			},
 		},
 		Customizable{
 			id = 'killaward',
 			children = {
-				Cell{name = 'Kill Award', content = {args.killaward}}
-			}
+				Cell{name = 'Kill Award', children = {args.killaward}},
+			},
 		},
 		Customizable{
 			id = 'damage',
 			children = {
-				Cell{name = 'Base Damage', content = {args.damage}},
-				Cell{name = 'Armor penetration', content = {args['armor penetration']}},
-			}
+				Cell{name = 'Base Damage', children = {args.damage}},
+				Cell{name = 'Armor penetration', children = {args['armor penetration']}},
+			},
 		},
-		Cell{name = 'Magazine Size', content = {args.magsize}},
-		Cell{name = 'Ammo Capacity', content = {args.ammocap}},
-		Cell{name = 'Ammunition/Capacity', content = {args.ammo}},
-		Cell{name = 'Reload Speed', content = {
+		Customizable{
+			id = 'magsize',
+			children = {
+				Cell{name = 'Magazine Size', children = {args.magsize}},
+			},
+		},
+
+		Cell{name = 'Ammo Capacity', children = {args.ammocap}},
+		Cell{name = 'Ammunition/Capacity', children = {args.ammo}},
+		Cell{name = 'Reload Speed', children = {
 			Logic.isNotEmpty(args.reloadspeed) and (
 				args.reloadspeed .. (args.reloadspeedunit and (' ' .. args.reloadspeedunit) or '')
 			) or nil
@@ -88,18 +94,18 @@ function Weapon:createInfobox()
 		Customizable{
 			id = 'rateoffire',
 			children = {
-				Cell{name = 'Rate of Fire', content = {args.rateoffire}}
+				Cell{name = 'Rate of Fire', children = {args.rateoffire}}
 			}
 		},
-		Cell{name = 'Accuracy', content = {args.accuracy}},
-		Cell{name = 'Range', content = {args.range}},
-		Cell{name = 'Unique Characteristics', content = {args.charact}},
-		Cell{name = 'Firing Mode', content = {args.firemode}},
-		Cell{name = 'Movement Speed', content = {args['movement speed']}},
+		Cell{name = 'Accuracy', children = {args.accuracy}},
+		Cell{name = 'Range', children = {args.range}},
+		Cell{name = 'Unique Characteristics', children = {args.charact}},
+		Cell{name = 'Firing Mode', children = self:getAllArgsForBase(args, 'firemode')},
+		Cell{name = 'Movement Speed', children = {args['movement speed']}},
 		Customizable{
 			id = 'side',
 			children = {
-				Cell{name = 'Side', content = {args.side}},
+				Cell{name = 'Side', children = {args.side}},
 			}
 		},
 		Customizable{
@@ -111,7 +117,7 @@ function Weapon:createInfobox()
 						return {
 							Cell{
 								name = #users > 1 and 'Users' or 'User',
-								content = users,
+								children = users,
 							}
 						}
 					end
@@ -127,7 +133,7 @@ function Weapon:createInfobox()
 						return {
 							Cell{
 								name = #games > 1 and 'Game Appearances' or 'Game Appearance',
-								content = games,
+								children = games,
 							}
 						}
 					end

--- a/lua/wikis/commons/Infobox/Weapon.lua
+++ b/lua/wikis/commons/Infobox/Weapon.lua
@@ -91,6 +91,9 @@ function Weapon:createInfobox()
 				Cell{name = 'Rate of Fire', content = {args.rateoffire}}
 			}
 		},
+		Cell{name = 'Accuracy', content = {args.accuracy}},
+		Cell{name = 'Range', content = {args.range}},
+		Cell{name = 'Unique Characteristics', content = {args.charact}},
 		Cell{name = 'Firing Mode', content = {args.firemode}},
 		Cell{name = 'Movement Speed', content = {args['movement speed']}},
 		Customizable{

--- a/lua/wikis/commons/Infobox/Weapon.lua
+++ b/lua/wikis/commons/Infobox/Weapon.lua
@@ -49,7 +49,7 @@ function Weapon:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = (args.informationType or 'Weapon') .. ' Information'},
-		Cell{name = 'Other', children = {args['other names']}},
+		Cell{name = 'Other', children = {args.othernames}},
 		Cell{
 			name = 'Class',
 			children = self:getAllArgsForBase(args, 'class', {makeLink = not Logic.readBool(args.disableClassLink)}),
@@ -74,7 +74,7 @@ function Weapon:createInfobox()
 			id = 'damage',
 			children = {
 				Cell{name = 'Base Damage', children = {args.damage}},
-				Cell{name = 'Armor penetration', children = {args['armor penetration']}},
+				Cell{name = 'Armor penetration', children = {args.armorpenetration}},
 			},
 		},
 		Customizable{
@@ -101,7 +101,7 @@ function Weapon:createInfobox()
 		Cell{name = 'Range', children = {args.range}},
 		Cell{name = 'Unique Characteristics', children = {args.charact}},
 		Cell{name = 'Firing Mode', children = self:getAllArgsForBase(args, 'firemode')},
-		Cell{name = 'Movement Speed', children = {args['movement speed']}},
+		Cell{name = 'Movement Speed', children = {args.movementspeed}},
 		Customizable{
 			id = 'side',
 			children = {

--- a/lua/wikis/counterstrike/Infobox/Weapon/Custom.lua
+++ b/lua/wikis/counterstrike/Infobox/Weapon/Custom.lua
@@ -46,14 +46,10 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		WidgetUtil.collect(
 			widgets,
-			Cell{name = 'Other', content = {args['other names']}},
 			Cell{name = 'Recoil control', content = {args['recoil control']}},
 			Cell{name = 'Accurate range', content = {args['accurate range'] and (args['accurate range'] .. 'm') or nil}},
-			Cell{name = 'Armor penetration', content = {args['armor penetration']}},
 			Cell{name = 'Penetration power', content = {args['penetration power']}},
-			Cell{name = 'Ammunition/Capacity', content = {args.ammo}},
 			Cell{name = 'Reload time', content = {args['reload time'] and (args['reload time'] .. 's') or nil}},
-			Cell{name = 'Movement Speed', content = {args['movement speed']}},
 			Cell{name = 'Units per second', content = {args['units per second']}},
 			Cell{name = 'Hotkey', content = {args.hotkey}},
 			caller:_achievementsDisplay()

--- a/lua/wikis/counterstrike/Infobox/Weapon/Custom.lua
+++ b/lua/wikis/counterstrike/Infobox/Weapon/Custom.lua
@@ -1,0 +1,88 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Weapon/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+local Center = Widgets.Center
+local WidgetImage = Lua.import('Module:Widget/Image/Icon/Image')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Weapon = Lua.import('Module:Infobox/Weapon')
+
+---@class CounterstrikeWeaponInfobox: WeaponInfobox
+local CustomWeapon = Class.new(Weapon)
+---@class CounterstrikeWeaponInfoboxInjector
+---@field caller CounterstrikeWeaponInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomWeapon.run(frame)
+	local weapon = CustomWeapon(frame)
+	weapon:setWidgetInjector(CustomInjector(weapon))
+
+	return weapon:createInfobox(frame)
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args = caller.args
+
+	if id == 'custom' then
+		WidgetUtil.collect(
+			widgets,
+			Cell{name = 'Other', content = {args['other names']}},
+			Cell{name = 'Recoil control', content = {args['recoil control']}},
+			Cell{name = 'Accurate range', content = {args['accurate range'] and (args['accurate range'] .. 'm') or nil}},
+			Cell{name = 'Armor penetration', content = {args['armor penetration']}},
+			Cell{name = 'Penetration power', content = {args['penetration power']}},
+			Cell{name = 'Ammunition/Capacity', content = {args.ammo}},
+			Cell{name = 'Reload time', content = {args['reload time'] and (args['reload time'] .. 's') or nil}},
+			Cell{name = 'Movement Speed', content = {args['movement speed']}},
+			Cell{name = 'Units per second', content = {args['units per second']}},
+			Cell{name = 'Hotkey', content = {args.hotkey}},
+			caller:_achievementsDisplay()
+		)
+	end
+
+	return widgets
+end
+
+---@return Widget[]?
+function CustomWeapon:_achievementsDisplay()
+	local args = self.args
+	local achievements = Array.mapIndexes(function(index)
+		local prefix = 'achievement'  .. index
+		if (not args[prefix]) or (not args[prefix .. 'image']) then
+			return WidgetImage{
+				imageLight = args[prefix .. 'image'],
+				link = args[prefix .. 'link'] or '',
+				size = '35px',
+			}
+		end
+	end)
+
+	if Logic.isEmpty(achievements) then return end
+
+	return {
+		Title{children = {'Achievements'}},
+		Center{classes = {'infobox-icons'}, children = achievements},
+	}
+end
+
+return CustomWeapon

--- a/lua/wikis/counterstrike/Infobox/Weapon/Custom.lua
+++ b/lua/wikis/counterstrike/Infobox/Weapon/Custom.lua
@@ -44,7 +44,7 @@ function CustomInjector:parse(id, widgets)
 	local args = caller.args
 
 	if id == 'custom' then
-		WidgetUtil.collect(
+		return WidgetUtil.collect(
 			widgets,
 			Cell{name = 'Recoil control', content = {args['recoil control']}},
 			Cell{name = 'Accurate range', content = {args['accurate range'] and (args['accurate range'] .. 'm') or nil}},
@@ -64,13 +64,12 @@ function CustomWeapon:_achievementsDisplay()
 	local args = self.args
 	local achievements = Array.mapIndexes(function(index)
 		local prefix = 'achievement'  .. index
-		if (not args[prefix]) or (not args[prefix .. 'image']) then
-			return WidgetImage{
-				imageLight = args[prefix .. 'image'],
-				link = args[prefix .. 'link'] or '',
-				size = '35px',
-			}
-		end
+		if (not args[prefix]) or (not args[prefix .. 'image']) then return end
+		return WidgetImage{
+			imageLight = args[prefix .. 'image'],
+			link = args[prefix .. 'link'] or '',
+			size = '35px',
+		}
 	end)
 
 	if Logic.isEmpty(achievements) then return end

--- a/lua/wikis/pubgmobile/Infobox/Weapon/Custom.lua
+++ b/lua/wikis/pubgmobile/Infobox/Weapon/Custom.lua
@@ -5,22 +5,22 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local PageLink = require('Module:Page')
-local String = require('Module:StringUtils')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Weapon = Lua.import('Module:Infobox/Weapon')
 
-local Widgets = require('Module:Widget/All')
+local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
-local Center = Widgets.Center
-local Title = Widgets.Title
+local Link = Lua.import('Module:Widget/Basic/Link')
 
 ---@class PubgmobileWeaponInfobox: WeaponInfobox
 local CustomWeapon = Class.new(Weapon)
+---@class PubgmobileWeaponInfoboxInjector
+---@field caller PubgmobileWeaponInfobox
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
@@ -36,37 +36,52 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
+	local caller = self.caller
+	local args = caller.args
 	if id == 'custom' then
-		Array.appendWith(
-			widgets,
-			Cell{name = 'Ammo Type', content = {args.ammotype}},
-			Cell{name = 'Throw Speed', content = {args.throwspeed}},
-			Cell{name = 'Throw Cooldown', content = {args.throwcooldown}}
-		)
-
-		if String.isEmpty(args.map1) then
-			return widgets
-		end
-
-		local maps = Array.map(self.caller:getAllArgsForBase(args, 'map'), function(map)
-			return tostring(CustomWeapon:_createNoWrappingSpan(PageLink.makeInternalLink({}, map)))
-		end)
-
-		table.insert(widgets, Title{children = 'Maps'})
-		table.insert(widgets, Center{children = {table.concat(maps, '&nbsp;• ')}})
+		return {
+			Cell{name = 'Type', children = {
+				args.type and Link{
+					link = ':Category:' .. args.type .. 's',
+					children = {args.type .. 's'},
+				} or nil
+			}},
+			Cell{name = 'Ammo Type', children = {args.ammotype}, options = {makeLink = true}},
+			Cell{name = 'Reload time', children = {args['reload time']}},
+			Cell{name = 'Throw time', children = {args['throw time'] and (args['throw time'] .. 's') or nil}},
+			Cell{name = 'Throw cooldown', children = {args['throw time'] and (args['throw cooldown'] .. 's') or nil}},
+			Cell{name = 'Released', children = {args.release}},
+			Cell{name = 'Removed', children = {args.removed}},
+			Cell{name = 'Maps', children = caller:getAllArgsForBase(args, 'map', {makeLink = true})}
+		}
+	elseif id == 'damage' then
+		return {
+			Cell{name = 'Damage', children = {args.damage}},
+			Cell{name = 'Base Damage', children = {args['base damage']}},
+			Cell{name = 'Area Damage', children = {args['area damage']}},
+		}
+	elseif id == 'magsize' then
+		return {
+			Cell{name = 'Magazine Size', options = {separator = ' '}, children = {
+				args.damage,
+				args['ext-magazine'] and ('(Extended: ' .. args['ext-magazine'] .. ')') or nil,
+			}},
+		}
 	end
 
 	return widgets
 end
 
----@param content string|number|Html|nil
----@return Html
-function CustomWeapon:_createNoWrappingSpan(content)
-	local span = mw.html.create('span')
-		:css('white-space', 'nowrap')
-		:node(content)
-	return span
+---@param args table
+---@return string[]
+function CustomWeapon:getWikiCategories(args)
+	local maps = self:getAllArgsForBase(args, 'map')
+	local categories = Array.map(maps, function(map)
+		return map .. ' Weapons'
+	end)
+	return Array.append(categories,
+		args.ammotype and (args.ammotype .. ' Gun') or nil
+	)
 end
 
 return CustomWeapon


### PR DESCRIPTION
## Summary
- [x] counterstrike
- [x] freefire --> use commons (after this PR)
- [x] pubgmobile
  - old one had no usage, so move `Template:Weapon info` into its place and adjust the module accordingly

## Remark
not converting fortnite in this PR.
for fortnite it might be good to do weapon infobox together with item infobox as they share lots of stuff

## How did you test this change?
dev

## required bot jobs before roll put
- [x] counterstrike `kill award` --> `killaward`
- [x] counterstrike `firing mode` --> `firemode`
- [x] freefire `fire rate` --> `rateoffire`
- [x] pubgmobile `magazine` --> `magsize`
- [x] pubgmobile `fire rate` --> `rateoffire`
- [x] pubgmobile `mode(\d?)` --> `firemode\1`
- [x] pubgmobile `capacity` --> `ammocap`
- [x] pubgmobile `ammo` --> `ammotype`
- [x] counterstrike extra run due to review
- [x] freefire extra run due to review