### PR TITLE
docs: add query string functions to mw.uri def

### DIFF
--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -1004,6 +1004,19 @@ function mw.uri.encode(str, enctype) end
 ---@return string
 function mw.uri.decode(str, enctype) end
 
+---Encodes a table as a URI query string.
+---@param query table<string, string|number|any[]|false>
+---@return string
+function mw.uri.buildQueryString(query) end
+
+---Decodes the query string `s` to a table. Optional arguments `i` and `j` may be used to specify
+---the substring of `s` to be parsed.
+---@param s string
+---@param i integer? the position of first character of the substring to be parsed; defaults to 1
+---@param j integer? the position of last character of the substring to be parsed; defaults to the length of `s`
+---@return table
+function mw.uri.parseQueryString(s, i, j) end
+
 ---Validates the specified table (or URI object).
 ---@param arg table|URI
 ---@return boolean result whether the argument was valid


### PR DESCRIPTION
## Summary

This PR adds [`mw.uri.buildQueryString`](https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.uri.buildQueryString) (used by [halo match2 parser](https://github.com/Liquipedia/Lua-Modules/blob/76db272a7965268f32ee90aaf6886b30d0ef83f8/lua/wikis/halo/MatchGroup/Input/Custom.lua#L100)) and [`mw.uri.parseQueryString`](https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.uri.parseQueryString) (inverse of former) definitions.

## How did you test this change?

N/A
