### PR TITLE
feat(infobox): adjust heroes infobox team

### DIFF
--- a/lua/wikis/heroes/Infobox/Team/Custom.lua
+++ b/lua/wikis/heroes/Infobox/Team/Custom.lua
@@ -5,14 +5,24 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local RoleOf = require('Module:RoleOf')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local RoleOf = Lua.import('Module:RoleOf')
+local Template = Lua.import('Module:Template')
 
 local Team = Lua.import('Module:Infobox/Team')
+local Injector = Lua.import('Module:Widget/Injector')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
 
 ---@class HeroesInfoboxTeam: InfoboxTeam
 local CustomTeam = Class.new(Team)
+---@class HeroesInfoboxTeamInjector: WidgetInjector
+---@field caller HeroesInfoboxTeam
+local CustomInjector = Class.new(Injector)
 
 function CustomTeam.run(frame)
 	local team = CustomTeam(frame)
@@ -22,7 +32,26 @@ function CustomTeam.run(frame)
 	team.args.manager = RoleOf.get{role = 'Manager'}
 	team.args.captain = RoleOf.get{role = 'Captain'}
 
+	team:setWidgetInjector(CustomInjector(team))
+
 	return team:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args = caller.args
+	if id == 'custom' then
+		return {
+			Cell{name = 'Tag', children = {args.tag}},
+			Cell{name = 'Tag', children = Array.map(caller:getAllArgsForBase(args, 'color'), function(color)
+				return Template.safeExpand(mw.getCurrentFrame(), 'Color box', {color})
+			end)},
+		}
+	end
+	return widgets
 end
 
 return CustomTeam

--- a/lua/wikis/heroes/Infobox/Team/Custom.lua
+++ b/lua/wikis/heroes/Infobox/Team/Custom.lua
@@ -48,7 +48,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Tag', children = {args.tag}},
 			Cell{name = 'Tag', children = Array.map(caller:getAllArgsForBase(args, 'color'), function(color)
 				return Template.safeExpand(mw.getCurrentFrame(), 'Color box', {color})
-			end)},
+			end), options = {separator = ' '}},
 		}
 	end
 	return widgets

--- a/lua/wikis/heroes/Infobox/Team/Custom.lua
+++ b/lua/wikis/heroes/Infobox/Team/Custom.lua
@@ -46,7 +46,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return {
 			Cell{name = 'Tag', children = {args.tag}},
-			Cell{name = 'Tag', children = Array.map(caller:getAllArgsForBase(args, 'color'), function(color)
+			Cell{name = 'Color(s)', children = Array.map(caller:getAllArgsForBase(args, 'color'), function(color)
 				return Template.safeExpand(mw.getCurrentFrame(), 'Color box', {color})
 			end), options = {separator = ' '}},
 		}


### PR DESCRIPTION
## Summary
adjusts heroes infobox team to be able to use it for `Template:Infobox tespateam` too (and hence be able to nuke that template)

## How did you test this change?
dev