### PR TITLE
feat(dota): blasttv series page links

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -56,6 +56,9 @@ local PREFIXES = {
 		'https://blast.tv/',
 		match = 'https://blast.tv/',
 	},
+	blasttvdota = {
+		'https://blast.tv/dota/',
+	},
 	bluesky = {'https://bsky.app/profile/'},
 	booyah = {'https://booyah.live/'},
 	bracket = {''},
@@ -368,6 +371,7 @@ local ICON_KEYS_TO_RENAME = {
 	['bilibili-stream'] = 'bilibili',
 	daumcafe = 'cafe-daum',
 	blasttv = 'blast',
+	blasttvdota = 'blast',
 	['esea-d'] = 'esea-league',
 	['faceit-c'] = 'faceit',
 	['faceit-c2'] = 'faceit',

--- a/lua/wikis/commons/Links/PriorityGroups.lua
+++ b/lua/wikis/commons/Links/PriorityGroups.lua
@@ -20,6 +20,7 @@ return {
 		'battlefy',
 		'b5csgo',
 		'blasttv',
+		'blasttvdota',
 		'cfs',
 		'challengermode',
 		'challonge',

--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -110,10 +110,16 @@ function MatchFunctions.getLinks(match, games)
 	links.stratz = {}
 	links.dotabuff = {}
 	links.datdota = {}
+	links.blasttvdota = {}
 
 	Array.forEach(
 		Array.filter(games, function(map) return map.matchid ~= nil end),
 		function(map, mapIndex)
+			-- only 1 matchId is needed for blasttv
+			-- blast.tv/dota/match/{matchid} redirects to series page with all matches
+			if mapIndex == 1 then
+				links.blasttvdota[mapIndex] = 'https://www.blast.tv/dota/match/' .. map.matchid
+			end
 			links.stratz[mapIndex] = 'https://stratz.com/match/' .. map.matchid
 			links.dotabuff[mapIndex] = 'https://www.dotabuff.com/matches/' .. map.matchid
 			links.datdota[mapIndex] = 'https://www.datdota.com/matches/' .. map.matchid


### PR DESCRIPTION
## Summary

Add BLAST.tv dota series page on DOTA MatchGroupInput. Will only show 1 link for the series that includes all matches rather than a link per match.

https://blast.tv/dota/tournaments/pgl-wallachia-season-5/match/c0151417/gg-avulus

## How did you test this change?

TBD
