### PR TITLE
feat(match2): add additional objectives to league of legends match pages

### DIFF
--- a/lua/wikis/leagueoflegends/MatchGroup/Input/Custom/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchGroup/Input/Custom/MatchPage.lua
@@ -113,7 +113,9 @@ function CustomMatchGroupInputMatchPage.getObjectives(map, opponentIndex)
 		inhibitors = team.inhibitorKills,
 		barons = team.baronKills,
 		dragons = team.dragonKills,
-		heralds = team.heraldKills,
+		heralds = team.riftHeraldKills,
+		grubs = team.grubKills,
+		atakhans = team.atakhanKills,
 	}
 end
 

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -409,6 +409,24 @@ function MatchPage:_renderTeamStats(game)
 							team2Value = game.teams[2].objectives.inhibitors
 						},
 						{
+							icon = IconImage{imageLight = 'Lol stat icon grub.png', link = ''},
+							name = 'Void Grubs',
+							team1Value = game.teams[1].objectives.grubs,
+							team2Value = game.teams[2].objectives.grubs
+						},
+						{
+							icon = IconImage{imageLight = 'Lol stat icon herald.png', link = ''},
+							name = 'Rift Heralds',
+							team1Value = game.teams[1].objectives.heralds,
+							team2Value = game.teams[2].objectives.heralds
+						},
+						{
+							icon = IconImage{imageLight = 'Lol stat icon atakhan.png', link = ''},
+							name = 'Atakhan',
+							team1Value = game.teams[1].objectives.atakhans,
+							team2Value = game.teams[2].objectives.atakhans
+						},
+						{
 							icon = IconImage{imageLight = 'Lol stat icon dragon.png', link = ''},
 							name = 'Dragons',
 							team1Value = game.teams[1].objectives.dragons,


### PR DESCRIPTION
## Summary
Add Rift Heralds, Atakhan and Void Grubs to the objectives panel
