### PR TITLE
infobox(feat): Add more Chess time controls

### DIFF
--- a/lua/wikis/chess/Infobox/League/Custom.lua
+++ b/lua/wikis/chess/Infobox/League/Custom.lua
@@ -27,6 +27,8 @@ local MODES = {
 	classical = 'Classical',
 	blitz = 'Blitz',
 	rapid = 'Rapid',
+	bullet = 'Bullet',
+	hyperbullet = 'Hyperbullet',
 }
 
 local RESTRICTIONS = {


### PR DESCRIPTION
## Summary
![image](https://github.com/user-attachments/assets/aeede6bf-b8e7-43fc-a52d-338be5861429)

Originally not existed because early wiki launch coverage omits them, at today's state these are now starting to being added to the wiki, these are [bullet](https://www.chess.com/terms/bullet-chess) (1 Minute)  and hyperbullet (30 Seconds) time controls

## How did you test this change?
https://liquipedia.net/chess/Bullet_Chess_Championship/2025
![image](https://github.com/user-attachments/assets/2283a92b-89f4-4a8f-bc1b-648db936cb4e)
