### PR TITLE
feat(mainpage): change chess transfer links to yearly

### DIFF
--- a/lua/wikis/chess/MainPageLayout/data.lua
+++ b/lua/wikis/chess/MainPageLayout/data.lua
@@ -31,7 +31,7 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-    		limit = 10,
+			limit = 10,
 			transferPage = 'Player Transfers/' .. os.date('%Y'),
 		},
 		boxid = 1509,

--- a/lua/wikis/chess/MainPageLayout/data.lua
+++ b/lua/wikis/chess/MainPageLayout/data.lua
@@ -30,7 +30,10 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = TransfersList{limit = 10},
+		body = TransfersList{
+    		limit = 10,
+			transferPage = 'Player Transfers/' .. os.date('%Y'),
+		},
 		boxid = 1509,
 	},
 	thisDay = {


### PR DESCRIPTION
## Summary
Chess Transfer pages are year-based

the current setup actually missed out this config causing the [edit] button to be month-based by accident


## How did you test this change?
/dev/h2
![image](https://github.com/user-attachments/assets/c3341113-3e83-404e-900e-6681312fe66d)