### PR TITLE
fix(infobox): faction category has initial letter instead of full name in StarCraft's player infobox

### DIFF
--- a/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
@@ -519,7 +519,7 @@ function CustomPlayer:getWikiCategories(categories)
 	end
 
 	for _, faction in pairs(Faction.readMultiFaction(args.race, {alias = false})) do
-		table.insert(categories, faction .. ' Players')
+		table.insert(categories, Faction.toName(faction) .. ' Players')
 	end
 
 	local botCategoryKeys = {


### PR DESCRIPTION
## Summary

In the Broodwar wiki, the player infobox applies a race category, but the category applied are "P Players", "T Players", "Z Players" instead of "Protoss Players", "Terran Players" and "Zerg Players" respectively.

Examples:
* https://liquipedia.net/starcraft/Soma
* https://liquipedia.net/starcraft/Free

## How did you test this change?

`dev=enuaj`
