### PR TITLE
feat(match2): add storage support for simracing

### DIFF
--- a/lua/wikis/simracing/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/simracing/MatchGroup/Input/Custom.lua
@@ -1,0 +1,54 @@
+---
+-- @Liquipedia
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Lua = require('Module:Lua')
+local Operator = require('Module:Operator')
+
+local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
+
+local CustomMatchGroupInput = {}
+
+local FfaMatchFunctions = {
+	DEFAULT_MODE = 'team',
+}
+local FfaMapFunctions = {}
+
+---@param match table
+---@param options table?
+---@return table
+function CustomMatchGroupInput.processMatch(match, options)
+	return MatchGroupInputUtil.standardProcessMatch(match, nil, FfaMatchFunctions)
+end
+
+---@param match table
+---@param opponents table[]
+---@return table[]
+function FfaMatchFunctions.extractMaps(match, opponents, scoreSettings)
+	return MatchGroupInputUtil.standardProcessFfaMaps(match, opponents, scoreSettings, FfaMapFunctions)
+end
+
+--- For now we don't care, as we will not have a display anyway. It will only be used for storage.
+---@param match table
+---@param opponents table[]
+---@return boolean
+function FfaMatchFunctions.switchToFfa(match, opponents)
+	return true
+end
+
+---@param opponents table[]
+---@param maps table[]
+---@return fun(opponentIndex: integer): integer?
+function FfaMatchFunctions.calculateMatchScore(opponents, maps)
+	return function(opponentIndex)
+		return Array.reduce(Array.map(maps, function(map)
+			return map.opponents[opponentIndex].score or 0
+		end), Operator.add, 0)
+	end
+end
+
+return CustomMatchGroupInput


### PR DESCRIPTION
## Summary
Add some simple storage for simracing, we need it on the API for `<secret>`

## How did you test this change?
https://liquipedia.net/simracing/User:Rathoz