### PR TITLE
fix: untrimmed string.match result causing TT errors

### DIFF
--- a/lua/wikis/commons/Standings/Storage/StarcraftLegacy.lua
+++ b/lua/wikis/commons/Standings/Storage/StarcraftLegacy.lua
@@ -86,6 +86,7 @@ function Wrapper._processOpponent(args)
 		if not teamPage then
 			return
 		end
+		teamPage = mw.text.trim(teamPage)
 		return {type = Opponent.team, template = teamPage:lower()}
 	end
 


### PR DESCRIPTION
## Summary
found it while cleaning up pages with script errors

## How did you test this change?
live