### PR TITLE
feat(infobox): Add HS Infobox hero and hero power

### DIFF
--- a/lua/wikis/commons/Infobox/Effect.lua
+++ b/lua/wikis/commons/Infobox/Effect.lua
@@ -1,0 +1,58 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Effect
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local Table = Lua.import('Module:Table')
+
+local BasicInfobox = Lua.import('Module:Infobox/Basic')
+local Links = Lua.import('Module:Links')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Header = Widgets.Header
+local Title = Widgets.Title
+local Center = Widgets.Center
+local Builder = Widgets.Builder
+local Customizable = Widgets.Customizable
+
+---@class EffectInfobox: BasicInfobox
+local Effect = Class.new(BasicInfobox)
+
+---@return string
+function Effect:createInfobox()
+	local args = self.args
+
+	local widgets = {
+		Header{
+			name = args.name,
+			image = args.image,
+			imageDark = args.imagedark or args.imagedarkmode,
+			size = args.imagesize,
+		},
+		Center{children = {args.caption}},
+		Title{children = 'Effect Information'},
+		Center{children = {args.effect}},
+		Customizable{id = 'custom', children = {}},
+		Builder{
+			builder = function()
+				local links = Links.transform(args)
+				if not Table.isEmpty(links) then
+					return {
+						Title{children = 'Links'},
+						Widgets.Links{links = links}
+					}
+				end
+			end
+		},
+		Center{children = {args.footnotes}},
+	}
+
+	return self:build(widgets)
+end
+
+return Effect

--- a/lua/wikis/commons/Infobox/Effect/Custom.lua
+++ b/lua/wikis/commons/Infobox/Effect/Custom.lua
@@ -1,0 +1,23 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Effect/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Effect = Lua.import('Module:Infobox/Effect')
+
+---@class CustomEffectInfobox: EffectInfobox
+local CustomEffect = Class.new(Effect)
+
+---@param frame Frame
+---@return Html
+function CustomEffect.run(frame)
+	return CustomEffect(frame):createInfobox()
+end
+
+return CustomEffect

--- a/lua/wikis/hearthstone/Infobox/Character/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Character/Custom.lua
@@ -68,6 +68,7 @@ end
 
 ---@param lpdbData table
 ---@param args table
+---@return table
 function CustomCharacter:addToLpdb(lpdbData, args)
 	lpdbData.extradata.hero = args.hero or ''
 	lpdbData.extradata.power = args.power or ''

--- a/lua/wikis/hearthstone/Infobox/Character/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Character/Custom.lua
@@ -5,11 +5,12 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local Class = require('Module:Class')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local Page = require('Module:Page')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
+local Page = Lua.import('Module:Page')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Character = Lua.import('Module:Infobox/Character')
@@ -29,7 +30,6 @@ local CustomInjector = Class.new(Injector)
 ---@return Html
 function CustomCharacter.run(frame)
 	local character = CustomCharacter(frame)
-	character.args.informationType = 'Class'
 	character:setWidgetInjector(CustomInjector(character))
 	return character:createInfobox()
 end
@@ -50,7 +50,8 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Alternative Heroes', content = alternativeHeroes},
 			Cell{name = 'Hero Power', content = {Page.makeInternalLink(args.power)}},
 			Cell{name = 'Abilities', content = abilities},
-			Cell{name = 'Deck types', content = deckType}
+			Cell{name = 'Deck types', content = deckType},
+			Cell{name = 'Playable', content = {args.playable}}
 		)
 	end
 

--- a/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
@@ -11,7 +11,7 @@ local Lua = require('Module:Lua')
 local Effect = Lua.import('Module:Infobox/Effect')
 local Injector = Lua.import('Module:Widget/Injector')
 
-local Widgets = require('Module:Widget/All')
+local Widgets = Lua.import('Module:Widget/All')
 local Title = Widgets.Title
 local Cell = Widgets.Cell
 

--- a/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
@@ -5,8 +5,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
 
 local Effect = Lua.import('Module:Infobox/Effect')
 local Injector = Lua.import('Module:Widget/Injector')

--- a/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
@@ -1,0 +1,53 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Effect/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Effect = Lua.import('Module:Infobox/Effect')
+local Injector = Lua.import('Module:Widget/Injector')
+
+local Widgets = require('Module:Widget/All')
+local Title = Widgets.Title
+local Cell = Widgets.Cell
+local Center = Widgets.Center
+local Builder = Widgets.Builder
+local Customizable = Widgets.Customizable
+
+---@class HearthstoneEffectInfobox: EffectInfobox
+local CustomEffect = Class.new(Effect)
+---@class HearthstoneEffectInfoboxInjector: WidgetInjector
+---@field caller HearthstoneEffectInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomEffect.run(frame)
+	local effect = CustomEffect(frame)
+	effect:setWidgetInjector(CustomInjector(effect))
+
+	return effect:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+	if id == 'custom' then
+		return {
+			Title{children = 'Hero Power Information'},
+			Cell{name = 'Class', content = {args.class}, options = {makeLink = true}},
+			Cell{name = 'Hero', content = {args.hero}, options = {makeLink = true}},
+			Cell{name = 'Playable', content = {args.playable}},
+		}
+	end
+
+	return widgets
+end
+
+return CustomEffect

--- a/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Effect/Custom.lua
@@ -14,9 +14,6 @@ local Injector = Lua.import('Module:Widget/Injector')
 local Widgets = require('Module:Widget/All')
 local Title = Widgets.Title
 local Cell = Widgets.Cell
-local Center = Widgets.Center
-local Builder = Widgets.Builder
-local Customizable = Widgets.Customizable
 
 ---@class HearthstoneEffectInfobox: EffectInfobox
 local CustomEffect = Class.new(Effect)


### PR DESCRIPTION
## Summary
- add a base + custom `Infobox/Effect` for `Template:Infobox hero power`
- adjust the existing `Module:Infobox/Character/Custom` to be able to handle `Template:Infobox class` (as it currently already does) and additonally `Template:Infobox hero`

## How did you test this change?
dev