### PR TITLE
chore(Roles): Add generic staff role

### DIFF
--- a/lua/wikis/commons/Roles/StaffRoles.lua
+++ b/lua/wikis/commons/Roles/StaffRoles.lua
@@ -36,6 +36,7 @@ local staffRoles = {
 	['streamer'] = {category = 'Streamers', display = 'Streamer'},
 	['talent'] = {category = 'Talents', display = 'Talent'},
 	['organizer'] = {category = 'Tournament Organizer', display = 'Tournament Organizer'},
+	['staff'] = {category = 'Staff', display = 'Staff'},
 }
 
 staffRoles['commentator'] = staffRoles['caster']


### PR DESCRIPTION
## Summary
Add a generic staff role to staff roles.
Idea is that it can be used for not yet covered stuff which likely do not warrant a role of their own, like e.g. mapMakers (sc2), illustrators (artifact), ...

## How did you test this change?
N/A, just data