### PR TITLE
feat(Info): Add rematch info.lua

### DIFF
--- a/lua/wikis/rematch/info.lua
+++ b/lua/wikis/rematch/info.lua
@@ -1,0 +1,40 @@
+---
+-- @Liquipedia
+-- page=Module:Info
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	startYear = 2025,
+	wikiName = 'rematch',
+	name = 'Rematch',
+	defaultGame = 'rematch',
+	games = {
+		rematch = {
+			abbreviation = 'Rematch',
+			name = 'Rematch',
+			link = 'Rematch',
+			logo = {
+				darkMode = 'Rematch darkmode.png',
+				lightMode = 'Rematch lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Rematch darkmode.png',
+				lightMode = 'Rematch  lightmode.png',
+			},
+		},
+	},
+	config = {
+		squads = {
+			hasPosition = false,
+			hasSpecialTeam = false,
+			allowManual = false,
+		},
+		match2 = {
+			status = 2,
+			matchWidth = 180,
+		},
+	},
+	defaultRoundPrecision = 0,
+}


### PR DESCRIPTION
## Summary
Info.lua for new wiki **Rematch**

## Note 
Match2 PR will also be up in another one, should the file here has **0** in match2 status until its merged, or I can keep it 2 from the get go?