### PR TITLE
feat(Match2): Rematch implementation

### DIFF
--- a/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
@@ -1,0 +1,47 @@
+---
+-- @Liquipedia
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class GoalsMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+--returns the Code for a Match, depending on the input
+---@param bestof integer
+---@param mode string
+---@param index integer
+---@param opponents integer
+---@param args table
+---@return string
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.readBool(args.score)
+	local streams = Logic.readBool(args.streams)
+
+	local lines = Array.extend({},
+		'{{Match',
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
+		end),
+		INDENT .. '|date= |finished=',
+		streams and (INDENT .. '|twitch=|vod=') or nil,
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|score2=|finished=}}'
+		end),
+		'}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+return WikiCopyPaste

--- a/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
----@class GoalsMatch2CopyPaste: Match2CopyPasteBase
+---@class RematchMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)
 
 local INDENT = WikiCopyPaste.Indent

--- a/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
@@ -36,7 +36,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT .. '|date= |finished=',
 		streams and (INDENT .. '|twitch=|vod=') or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)
-			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|score2=|finished=}}'
+			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|score2= |otlength= |finished=}}'
 		end),
 		'}}'
 	)

--- a/lua/wikis/rematch/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/rematch/MatchGroup/Input/Custom.lua
@@ -6,6 +6,7 @@
 --
 
 local Lua = require('Module:Lua')
+local Logic = require('Module:Logic')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
@@ -38,6 +39,17 @@ function CustomMatchGroupInput.calculateMatchScore(maps)
 	return function(opponentIndex)
 		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
 	end
+end
+
+---@param match table
+---@param map table
+---@param opponents table[]
+---@return table
+function MapFunctions.getExtraData(match, map, opponents)
+	return {
+		otlength = map.otlength,
+		hasot = Logic.isNotEmpty(map.otlength) or Logic.readBool(map.overtime),
+	}
 end
 
 return CustomMatchGroupInput

--- a/lua/wikis/rematch/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/rematch/MatchGroup/Input/Custom.lua
@@ -1,0 +1,43 @@
+---
+-- @Liquipedia
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
+
+local CustomMatchGroupInput = {}
+CustomMatchGroupInput.DEFAULT_MODE = 'team'
+CustomMatchGroupInput.getBestOf = MatchGroupInputUtil.getBestOf
+
+local MapFunctions = {
+	BREAK_ON_EMPTY = true,
+}
+
+-- called from Module:MatchGroup
+---@param match table
+---@param options table?
+---@return table
+function CustomMatchGroupInput.processMatch(match, options)
+	return MatchGroupInputUtil.standardProcessMatch(match, CustomMatchGroupInput)
+end
+
+---@param match table
+---@param opponents table[]
+---@return table[]
+function CustomMatchGroupInput.extractMaps(match, opponents)
+	return MatchGroupInputUtil.standardProcessMaps(match, opponents, MapFunctions)
+end
+
+---@param maps table[]
+---@return fun(opponentIndex: integer): integer
+function CustomMatchGroupInput.calculateMatchScore(maps)
+	return function(opponentIndex)
+		return MatchGroupInputUtil.computeMatchScoreFromMapWinners(maps, opponentIndex)
+	end
+end
+
+return CustomMatchGroupInput

--- a/lua/wikis/rematch/MatchSummary.lua
+++ b/lua/wikis/rematch/MatchSummary.lua
@@ -31,7 +31,11 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		children = WidgetUtil.collect(
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
 			DisplayHelper.MapScore(game.opponents[1], game.status),
-			MatchSummaryWidgets.GameCenter{children = ('Game ' .. gameIndex)},
+			MatchSummaryWidgets.GameCenter{children = WidgetUtil.collect(
+				'Game ' .. gameIndex,
+				game.extradata.hasot and ' - OT' or nil,
+				game.extradata.otlength and (' (' .. game.extradata.otlength .. ')') or nil
+			)},
 			DisplayHelper.MapScore(game.opponents[2], game.status),
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
 			MatchSummaryWidgets.GameComment{children = game.comment}

--- a/lua/wikis/rematch/MatchSummary.lua
+++ b/lua/wikis/rematch/MatchSummary.lua
@@ -9,7 +9,7 @@ local CustomMatchSummary = {}
 
 local Lua = require('Module:Lua')
 
-local DisplayHelper = require('Module:MatchGroup/Display/Helper')
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')

--- a/lua/wikis/rematch/MatchSummary.lua
+++ b/lua/wikis/rematch/MatchSummary.lua
@@ -1,0 +1,42 @@
+---
+-- @Liquipedia
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local CustomMatchSummary = {}
+
+local Lua = require('Module:Lua')
+
+local DisplayHelper = require('Module:MatchGroup/Display/Helper')
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
+local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+---@param args table
+---@return Html
+function CustomMatchSummary.getByMatchId(args)
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
+end
+
+---@param date string
+---@param game MatchGroupUtilGame
+---@param gameIndex integer
+---@return MatchSummaryRow
+function CustomMatchSummary.createGame(date, game, gameIndex)
+	return MatchSummaryWidgets.Row{
+		classes = {'brkts-popup-body-game'},
+		css = {['font-size'] = '80%', padding = '4px'},
+		children = WidgetUtil.collect(
+			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
+			DisplayHelper.MapScore(game.opponents[1], game.status),
+			MatchSummaryWidgets.GameCenter{children = ('Game ' .. gameIndex)},
+			DisplayHelper.MapScore(game.opponents[2], game.status),
+			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
+			MatchSummaryWidgets.GameComment{children = game.comment}
+		)
+	}
+end
+
+return CustomMatchSummary


### PR DESCRIPTION
## Summary
Match2 setup for new wiki **Rematch**

The starting reivsion will be a paste of **GOALS** wiki with no changes  as that's where contributor have been pre-documenting Rematch events there, so a simple setup we need just only Game X and map scores on each side.

## How did you test this change?
LIVE

https://liquipedia.net/rematch/Early_Access_Tournament/Europe

![image](https://github.com/user-attachments/assets/e6e4a37b-9bdb-451a-ac16-6b8c6932a188)

#Notes
Includes all three file: Input, Summary and CopyPaste
