### PR TITLE
feat(Infobox): Add Infobox League for Rematch

### DIFF
--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -49,8 +49,8 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
 	local caller = self.caller
+	local args = caller.args
 
 	if id == 'custom' then
 		Array.appendWith(

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -57,13 +57,13 @@ function CustomInjector:parse(id, widgets)
 			widgets,
 			Cell{name = 'Platform', content = {caller.data.platform}}
 		)
-		elseif id == 'customcontent' then
-			if String.isNotEmpty(args.team_number) then
+	elseif id == 'customcontent' then
+		if String.isNotEmpty(args.team_number) then
 			Array.appendWith(widgets,
 				Title{children = 'Teams'},
 				Cell{name = 'Number of teams', content = {args.team_number}}
 			)
-			elseif String.isNotEmpty(args.player_number) then
+		elseif String.isNotEmpty(args.player_number) then
 			Array.appendWith(widgets,
 				Title{children = 'Players'},
 				Cell{name = 'Number of players', content = {args.player_number}}

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -23,7 +23,7 @@ local CustomInjector = Class.new(Injector)
 local PLATFORMS = {
 	playstation = 'PlayStation',
 	xbox = 'Xbox',
-	steam = 'Steam',
+	pc = 'PC',
 	cross = 'Cross-Platform',
 }
 
@@ -33,9 +33,12 @@ function CustomLeague.run(frame)
 	local league = CustomLeague(frame)
 	league:setWidgetInjector(CustomInjector(league))
 
-	league.args.platform = PLATFORMS[(league.args.platform or 'steam'):lower():gsub(' ', '')]
-
 	return league:createInfobox()
+end
+
+---@param args table
+function CustomLeague:customParseArguments(args)
+	self.data.platform = PLATFORMS[(self.args.platform or ''):lower():gsub(' ', '')] or PLATFORMS.pc
 end
 
 ---@param id string
@@ -43,11 +46,11 @@ end
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
 	local caller = self.caller
-	local args = caller.args
 
 	if id == 'custom' then
-		Array.appendWith(widgets,
-			Cell{name = 'Platform', content = {args.platform}}
+		Array.appendWith(
+			widgets,
+			Cell{name = 'Platform', content = {caller.data.platform}}
 		)
 	end
 

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -22,7 +22,7 @@ local CustomInjector = Class.new(Injector)
 -- Platform: Platform that the tournament is on
 local PLATFORMS = {
 	ps = 'PlayStation',
-	xbox = 'XBOX',
+	xbox = 'Xbox',
 	steam = 'Steam',
 	cross = 'Cross-Platform',
 }

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -1,0 +1,57 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Array = require('Module:Array')
+local Class = require('Module:Class')
+local Lua = require('Module:Lua')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = require('Module:Widget/All')
+local Cell = Widgets.Cell
+
+---@class RematchLeagueInfobox: InfoboxLeague
+local CustomLeague = Class.new(League)
+local CustomInjector = Class.new(Injector)
+
+-- Platform: Platform that the tournament is on
+local PLATFORMS = {
+	ps = 'PlayStation',
+	xbox = 'XBOX',
+	steam = 'Steam',
+	cross = 'Cross-Platform',
+}
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	league.args.platform = PLATFORMS[(league.args.platform or 'steam'):lower():gsub(' ', '')]
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local caller = self.caller
+	local args = caller.args
+
+	if id == 'custom' then
+		Array.appendWith(widgets,
+			Cell{name = 'Platform', content = {args.platform}}
+		)
+	end
+
+	return widgets
+end
+
+return CustomLeague

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -21,7 +21,7 @@ local CustomInjector = Class.new(Injector)
 
 -- Platform: Platform that the tournament is on
 local PLATFORMS = {
-	ps = 'PlayStation',
+	playstation = 'PlayStation',
 	xbox = 'Xbox',
 	steam = 'Steam',
 	cross = 'Cross-Platform',

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -5,18 +5,22 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Array = require('Module:Array')
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local String = Lua.import('Module:StringUtils')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
 
-local Widgets = require('Module:Widget/All')
+local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
+local Title = Widgets.Title
 
 ---@class RematchLeagueInfobox: InfoboxLeague
 local CustomLeague = Class.new(League)
+---@class RematchLeagueInfoboxWidgetInjector: WidgetInjector
+---@field caller RematchLeagueInfobox
 local CustomInjector = Class.new(Injector)
 
 -- Platform: Platform that the tournament is on
@@ -45,6 +49,7 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
 	local caller = self.caller
 
 	if id == 'custom' then
@@ -52,8 +57,19 @@ function CustomInjector:parse(id, widgets)
 			widgets,
 			Cell{name = 'Platform', content = {caller.data.platform}}
 		)
+		elseif id == 'customcontent' then
+			if String.isNotEmpty(args.team_number) then
+			Array.appendWith(widgets,
+				Title{children = 'Teams'},
+				Cell{name = 'Number of teams', content = {args.team_number}}
+			)
+			elseif String.isNotEmpty(args.player_number) then
+			Array.appendWith(widgets,
+				Title{children = 'Players'},
+				Cell{name = 'Number of players', content = {args.player_number}}
+			)
+		end
 	end
-
 	return widgets
 end
 


### PR DESCRIPTION
## Summary
Platform indication in Infobox League, due to the game doesnt have CrossPlay yet at launch

![image](https://github.com/user-attachments/assets/8d52e80d-65a4-441b-aebf-3d6353078c6a)

## How did you test this change?
![image](https://github.com/user-attachments/assets/08d0f198-9b59-4d89-a50b-732d5d669db9)

|dev=h2 - https://liquipedia.net/rematch/index.php?title=Module:Infobox/League/Custom/dev/h2&action=edit

## Note 
There's an earlier revision that I can't get it to display https://liquipedia.net/rematch/index.php?title=Module:Infobox/League/Custom/dev/h2&oldid=132 no idea why, so I went with what's in this PR instead