### PR TITLE
feat(mainpage): remove marvel rivals heroes table

### DIFF
--- a/lua/wikis/marvelrivals/MainPageLayout/data.lua
+++ b/lua/wikis/marvelrivals/MainPageLayout/data.lua
@@ -58,12 +58,6 @@ local CONTENT = {
 		body = '{{Liquipedia:Special Event}}',
 		boxid = 1516,
 	},
-	heroes = {
-		heading = 'Heroes',
-		body = '{{Liquipedia:HeroTable}}',
-		padding = true,
-		boxid = 1501,
-	},
 	filterButtons = {
 		noPanel = true,
 		body = Div{
@@ -190,10 +184,6 @@ return {
 						mobileOrder = 1,
 						noPanel = true,
 						content = CONTENT.specialEvents,
-					},
-					{
-						mobileOrder = 2,
-						content = CONTENT.heroes,
 					},
 					{
 						mobileOrder = 4,


### PR DESCRIPTION
## Summary
Removes the HeroTable on Main page as requested on discord: https://discord.com/channels/93055209017729024/1316071697555914804/1390401952793497742

## How did you test this change?

[dev](https://liquipedia.net/marvelrivals/Module:MainPageLayout/data/dev/Rocketdog)
