### PR TITLE
feat(match2): make Winner/Loser pills in dota2 match page prettier

### DIFF
--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1136,7 +1136,7 @@ span.slash {
 			border-radius: 0.875rem;
 			min-height: 1.5rem;
 			color: #ffffff;
-			padding: 0.1rem 0.5rem;
+			padding: 0.125rem 0.5rem;
 			text-transform: uppercase;
 			font-weight: bold;
 			width: 88px;

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1139,8 +1139,8 @@ span.slash {
 			padding: 0.1rem 0.5rem;
 			text-transform: uppercase;
 			font-weight: bold;
-			width:88px;
-			text-align:center;
+			width: 88px;
+			text-align: center;
 
 			&.state--winner {
 				background-color: var( --clr-semantic-positive-40 );

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1133,12 +1133,14 @@ span.slash {
 
 		&-state {
 			background-color: var( --clr-on-background );
-			border-radius: 0.75rem;
+			border-radius: 0.85rem;
 			min-height: 1.5rem;
 			color: #ffffff;
-			padding: 0 0.5rem;
+			padding: 0.1rem 0.5rem;
 			text-transform: uppercase;
 			font-weight: bold;
+			width:88px;
+			text-align:center;
 
 			&.state--winner {
 				background-color: var( --clr-semantic-positive-40 );

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1133,7 +1133,7 @@ span.slash {
 
 		&-state {
 			background-color: var( --clr-on-background );
-			border-radius: 0.85rem;
+			border-radius: 0.875rem;
 			min-height: 1.5rem;
 			color: #ffffff;
 			padding: 0.1rem 0.5rem;

--- a/stylesheets/commons/BigMatch.less
+++ b/stylesheets/commons/BigMatch.less
@@ -1139,7 +1139,7 @@ span.slash {
 			padding: 0.125rem 0.5rem;
 			text-transform: uppercase;
 			font-weight: bold;
-			width: 88px;
+			width: 5.5rem;
 			text-align: center;
 
 			&.state--winner {


### PR DESCRIPTION
Thought the current pills were a bit shrink-wrapped and could use with a tiny bit more padding in the pill around the text, static width also means the pills have equal size for both loser and winner pills.

## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
