### PR TITLE
feat(infobox): standardize aoe units and hs/artifact/cr card infoboxes

### DIFF
--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -64,7 +64,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		local types = Array.map(caller:getAllArgsForBase(args, 'type'), function(unitType)
-			return Link{link = (args.type == MONK and '' or ' units') .. unitType, children = {unitType}}
+			return Link{link = unitType}
 		end)
 
 		local hasUpgradeSection = Logic.isNotEmpty(args['up food'])

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -11,7 +11,6 @@ local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local Game = Lua.import('Module:Game')
 local Logic = Lua.import('Module:Logic')
-local Table = Lua.import('Module:Table')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Unit = Lua.import('Module:Infobox/Unit')

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Game = Lua.import('Module:Game')
 local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
@@ -62,10 +63,8 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	if id == 'custom' then
-		local isMonk = args.type == MONK
-		local typeLinkPostFix = isMonk and '' or ' units'
 		local types = Array.map(caller:getAllArgsForBase(args, 'type'), function(unitType)
-			return Link{link = typeLinkPostFix .. unitType, children = {unitType}}
+			return Link{link = (args.type == MONK and '' or ' units') .. unitType, children = {unitType}}
 		end)
 
 		local hasUpgradeSection = Logic.isNotEmpty(args['up food'])
@@ -77,8 +76,8 @@ function CustomInjector:parse(id, widgets)
 		return WidgetUtil.collect(
 			Title{children = {mw.text.listToText(types, ', ', ' and ')}},
 			Cell{name = 'Range', children = {args.range}},
-			Cell{name = 'Restore time', children = {isMonk and args.rest or nil}},
-			Cell{name = 'Conversion time', children = {isMonk and args.convtime or nil}},
+			Cell{name = 'Restore time', children = {args.rest}},
+			Cell{name = 'Conversion time', children = {args.convtime}},
 			Cell{name = 'Minimum range', children = {args['min range']}},
 			Cell{
 				name = HtmlWidgets.Abbr{
@@ -139,7 +138,7 @@ function CustomInjector:parse(id, widgets)
 				HtmlWidgets.I{children = {Link{link = args.introduced}}},
 			}, options = {separator = ' '}},
 			Cell{name = 'Civilizations', children = {args.civilizations or args.civs}},
-			Cell{name = 'Starting age', children = {
+			Cell{name = 'Available in', children = {
 				AgeIcon{age = args.age},
 				Link{link = args.age},
 				args.age2,
@@ -184,9 +183,10 @@ function CustomInjector:parse(id, widgets)
 				args['pierce armor'] and (args['pierce armor'] .. ' pierce') or nil
 			)},
 			Cell{
-				name = '[[Armor class]]es:<br><small>(besides [[Pierce armor (armor class)|Pierce armor]], '
+				name = '[[Armor class|Armor classes]]:<br><small>(besides [[Pierce armor (armor class)|Pierce armor]], '
 					.. '[[Melee armor (armor class)|Melee armor]], [[Anti-Leitis (armor class)|Anti-Leitis]])</small>',
 				children = {args['armor classes']},
+				options = {suppressColon = true},
 			},
 		}
 	end
@@ -197,7 +197,7 @@ end
 ---@param args table
 ---@return string[]
 function CustomUnit:getWikiCategories(args)
-	return {'Units (Age of Empires II)'}
+	return {'Units (' .. Game.name{game = args.game} .. ')' }
 end
 
 return CustomUnit

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -117,7 +117,7 @@ function CustomInjector:parse(id, widgets)
 			)},
 			Cell{name = 'Research time', children = {args['up time']}},
 			Cell{name = 'Required', children = {args.required}, options = {makeLink = true}},
-			Chronology{title = 'Connected Units'}
+			Chronology{args = args, title = 'Connected Units'}
 		)
 	elseif id == 'builtfrom' then
 		return {

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -7,13 +7,25 @@
 
 local Lua = require('Module:Lua')
 
+local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
+local Table = Lua.import('Module:Table')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Unit = Lua.import('Module:Infobox/Unit')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
+local Chronology = Widgets.Chronology
+local Title = Widgets.Title
+local AgeIcon = Lua.import('Module:Widget/Infobox/AgeIcon')
+local ExpansionIcon = Lua.import('Module:Widget/Infobox/ExpansionIcon')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local MONK = 'Monk'
 
 ---@class AgeOfEmpiresUnitInfobox: UnitInfobox
 local CustomUnit = Class.new(Unit)
@@ -34,15 +46,158 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
+	local caller = self.caller
+	local args = caller.args
+
+	---@param input string?
+	---@param label string
+	---@return Widget?
+	local costDisplay = function(input, label)
+		if not input then return end
+		return HtmlWidgets.Fragment{children = {
+			input,
+			' ',
+			Link{link = label},
+		}}
+	end
 
 	if id == 'custom' then
+		local isMonk = args.type == MONK
+		local typeLinkPostFix = isMonk and '' or ' units'
+		local types = Array.map(caller:getAllArgsForBase(args, 'type'), function(unitType)
+			return Link{link = typeLinkPostFix .. unitType, children = {unitType}}
+		end)
+
+		local hasUpgradeSection = Logic.isNotEmpty(args['up food'])
+			or Logic.isNotEmpty(args['up wood'])
+			or Logic.isNotEmpty(args['up gold'])
+			or Logic.isNotEmpty(args['up stone'])
+			or Logic.isNotEmpty(args['up time'])
+
+		return WidgetUtil.collect(
+			Title{children = {mw.text.listToText(types, ', ', ' and ')}},
+			Cell{name = 'Range', children = {args.range}},
+			Cell{name = 'Restore time', children = {isMonk and args.rest or nil}},
+			Cell{name = 'Conversion time', children = {isMonk and args.convtime or nil}},
+			Cell{name = 'Minimum range', children = {args['min range']}},
+			Cell{
+				name = HtmlWidgets.Abbr{
+					title = 'Number of frames between clicking to attack until the attack is followed through',
+					children = {'Frame delay'},
+				},
+				children = {args['frame delay']},
+			},
+			Cell{name = 'Projectile Speed', children = {args['projectile speed']}},
+			Cell{name = 'Accuracy', children = {args.accuracy and (args.accuracy .. '%') or nil}},
+			Cell{name = 'Training time', children = {args.time}},
+			Cell{name = 'Hit points', children = {args['hit points']}},
+
+			Cell{name = 'Speed', children = {args['movement speed']}},
+			Cell{name = 'Line of sight', children = WidgetUtil.collect(
+				args['line of sight'],
+				args.darkLos and {
+					AgeIcon{age = 'Dark'},
+					' ',
+					args.darkLos,
+				} or nil,
+				args.feudalLos and {
+					AgeIcon{age = 'Feudal'},
+					' ',
+					args.feudalLos,
+				} or nil,
+				args.castleLos and {
+					AgeIcon{age = 'Castle'},
+					' ',
+					args.castleLos,
+				} or nil,
+				args.imperialLos and {
+					AgeIcon{age = 'Imperial'},
+					' ',
+					args.imperialLos,
+				} or nil
+			)},
+			hasUpgradeSection and Title{children = {'Upgrade Information'}} or nil,
+			Cell{name = 'Upgrade cost', children = WidgetUtil.collect(
+				costDisplay(args['up food'], 'Food'),
+				costDisplay(args['up wood'], 'Wood'),
+				costDisplay(args['up gold'], 'Gold'),
+				costDisplay(args['up stone'], 'Stone')
+			)},
+			Cell{name = 'Research time', children = {args['up time']}},
+			Cell{name = 'Required', children = {args.required}, options = {makeLink = true}},
+			Chronology{
+				title = 'Connected Units',
+				links = Table.filterByKey(args, function(key)
+					return type(key) == 'string' and (key:match('^previous%d?$') ~= nil or key:match('^next%d?$') ~= nil)
+				end)
+			}
+		)
+	elseif id == 'builtfrom' then
 		return {
-			Cell{name = 'label', children = {}},
+			Cell{name = 'First introduced', children = {
+				ExpansionIcon{expansion = args.introduced},
+				HtmlWidgets.I{children = {Link{link = args.introduced}}},
+			}, options = {separator = ' '}},
+			Cell{name = 'Civilizations', children = {args.civilizations or args.civs}},
+			Cell{name = 'Starting age', children = {
+				AgeIcon{age = args.age},
+				Link{link = args.age},
+				args.age2,
+			}, options = {separator = ' '}},
+			Cell{
+				name = 'Trained at',
+				children = caller:getAllArgsForBase(args, 'builtfrom'),
+				options = {makeLink = true, separator = ' '}
+			},
+		}
+	elseif id == 'cost' then
+		return {Cell{name = 'Cost', children = WidgetUtil.collect(
+			costDisplay(args.food, 'Food'),
+			costDisplay(args.wood, 'Wood'),
+			costDisplay(args.gold, 'Gold'),
+			costDisplay(args.stone, 'Stone')
+		)}}
+	elseif id == 'type' then return {}
+	elseif id == 'attack' then
+		return {
+			Cell{name = 'Attack damage', children = {args.attack}},
+			Cell{name = 'Attack type', children = {args['attack type']}},
+			Cell{
+				name = 'Hidden Attack bonuses:<br>(vs armor classes)',
+				children = {args['attack bonus']},
+				options = {suppressColon = true}
+			},
+			Cell{
+				name = HtmlWidgets.Abbr{
+					title = 'Reload time (in seconds)',
+					children = {'Rate of Fire'},
+				},
+				children = {args['rate of fire']},
+			},
+			Cell{name = 'Blast Radius', children = {args['blast radius']}},
+		}
+	elseif id == 'defense' then
+		return {
+			Cell{name = 'Garrison', children = {args.garrison}},
+			Cell{name = 'Armor', children = WidgetUtil.collect(
+				args['melee armor'] and (args['melee armor'] .. ' melee') or nil,
+				args['pierce armor'] and (args['pierce armor'] .. ' pierce') or nil
+			)},
+			Cell{
+				name = '[[Armor class]]es:<br><small>(besides [[Pierce armor (armor class)|Pierce armor]], '
+					.. '[[Melee armor (armor class)|Melee armor]], [[Anti-Leitis (armor class)|Anti-Leitis]])</small>',
+				children = {args['armor classes']},
+			},
 		}
 	end
 
 	return widgets
+end
+
+---@param args table
+---@return string[]
+function CustomUnit:getWikiCategories(args)
+	return {'Units (Age of Empires II)'}
 end
 
 return CustomUnit

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -26,8 +26,6 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Link = Lua.import('Module:Widget/Basic/Link')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local MONK = 'Monk'
-
 ---@class AgeOfEmpiresUnitInfobox: UnitInfobox
 local CustomUnit = Class.new(Unit)
 ---@class AgeOfEmpiresUnitInfoboxWidgetInjector: WidgetInjector

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -116,7 +116,7 @@ function CustomInjector:parse(id, widgets)
 			)},
 			Cell{name = 'Research time', children = {args['up time']}},
 			Cell{name = 'Required', children = {args.required}, options = {makeLink = true}},
-			Chronology{args = args, title = 'Connected Units'}
+			Chronology{args = args, title = 'Connected Units', showTitle = true}
 		)
 	elseif id == 'builtfrom' then
 		return {

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -61,10 +61,6 @@ function CustomInjector:parse(id, widgets)
 	end
 
 	if id == 'custom' then
-		local types = Array.map(caller:getAllArgsForBase(args, 'type'), function(unitType)
-			return Link{link = unitType}
-		end)
-
 		local hasUpgradeSection = Logic.isNotEmpty(args['up food'])
 			or Logic.isNotEmpty(args['up wood'])
 			or Logic.isNotEmpty(args['up gold'])
@@ -72,7 +68,6 @@ function CustomInjector:parse(id, widgets)
 			or Logic.isNotEmpty(args['up time'])
 
 		return WidgetUtil.collect(
-			Title{children = {mw.text.listToText(types, ', ', ' and ')}},
 			Cell{name = 'Range', children = {args.range}},
 			Cell{name = 'Restore time', children = {args.rest}},
 			Cell{name = 'Conversion time', children = {args.convtime}},
@@ -138,7 +133,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Civilizations', children = {args.civilizations or args.civs}},
 			Cell{name = 'Available in', children = {
 				AgeIcon{age = args.age},
-				Link{link = args.age},
+				Link{link = args.age and (args.age .. ' Age') or nil},
 				args.age2,
 			}, options = {separator = ' '}},
 			Cell{
@@ -156,7 +151,12 @@ function CustomInjector:parse(id, widgets)
 		)}}
 	elseif id == 'type' then return {}
 	elseif id == 'attack' then
+		local types = Array.map(caller:getAllArgsForBase(args, 'type'), function(unitType)
+			return tostring(Link{link = unitType})
+		end)
+
 		return {
+			Title{children = {mw.text.listToText(types, ', ', ' and ') .. ' unit'}},
 			Cell{name = 'Attack damage', children = {args.attack}},
 			Cell{name = 'Attack type', children = {args['attack type']}},
 			Cell{

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -117,12 +117,7 @@ function CustomInjector:parse(id, widgets)
 			)},
 			Cell{name = 'Research time', children = {args['up time']}},
 			Cell{name = 'Required', children = {args.required}, options = {makeLink = true}},
-			Chronology{
-				title = 'Connected Units',
-				links = Table.filterByKey(args, function(key)
-					return type(key) == 'string' and (key:match('^previous%d?$') ~= nil or key:match('^next%d?$') ~= nil)
-				end)
-			}
+			Chronology{title = 'Connected Units'}
 		)
 	elseif id == 'builtfrom' then
 		return {

--- a/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Unit/Custom.lua
@@ -1,0 +1,48 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Unit/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Unit = Lua.import('Module:Infobox/Unit')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+
+---@class AgeOfEmpiresUnitInfobox: UnitInfobox
+local CustomUnit = Class.new(Unit)
+---@class AgeOfEmpiresUnitInfoboxWidgetInjector: WidgetInjector
+---@field caller AgeOfEmpiresUnitInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomUnit.run(frame)
+	local unit = CustomUnit(frame)
+	unit:setWidgetInjector(CustomInjector(unit))
+
+	return unit:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		return {
+			Cell{name = 'label', children = {}},
+		}
+	end
+
+	return widgets
+end
+
+return CustomUnit

--- a/lua/wikis/artifact/Infobox/Unit/Custom.lua
+++ b/lua/wikis/artifact/Infobox/Unit/Custom.lua
@@ -1,0 +1,48 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Unit/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Unit = Lua.import('Module:Infobox/Unit')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+
+---@class ArtifactUnitInfobox: UnitInfobox
+local CustomUnit = Class.new(Unit)
+---@class ArtifactUnitInfoboxWidgetInjector: WidgetInjector
+---@field caller ArtifactUnitInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomUnit.run(frame)
+	local unit = CustomUnit(frame)
+	unit:setWidgetInjector(CustomInjector(unit))
+
+	return unit:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		return {
+			Cell{name = 'label', children = {}},
+		}
+	end
+
+	return widgets
+end
+
+return CustomUnit

--- a/lua/wikis/artifact/Infobox/Unit/Custom.lua
+++ b/lua/wikis/artifact/Infobox/Unit/Custom.lua
@@ -46,10 +46,10 @@ function CustomUnit.run(frame)
 	unit.args.informationType = 'Card'
 	unit:setWidgetInjector(CustomInjector(unit))
 
-	return HtmlWidgets.Fragment{
+	return HtmlWidgets.Fragment{children = {
 		unit:createInfobox(),
-		CustomUnit._buildDescription(unit.args),
-	}
+		unit:_buildDescription(unit.args),
+	}}
 end
 
 ---@param id string

--- a/lua/wikis/artifact/Infobox/Unit/Custom.lua
+++ b/lua/wikis/artifact/Infobox/Unit/Custom.lua
@@ -7,13 +7,31 @@
 
 local Lua = require('Module:Lua')
 
+local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Unit = Lua.import('Module:Infobox/Unit')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
+local Center = Widgets.Center
+local Title = Widgets.Title
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local TYPE_TO_COST_TYPE = {
+	consumable = 'gold',
+	weapon = 'gold',
+	armor = 'gold',
+	accessory = 'gold',
+	deed = 'gold',
+	item = 'gold',
+	default = 'mana',
+}
 
 ---@class ArtifactUnitInfobox: UnitInfobox
 local CustomUnit = Class.new(Unit)
@@ -22,27 +40,149 @@ local CustomUnit = Class.new(Unit)
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
----@return Html
+---@return Widget
 function CustomUnit.run(frame)
 	local unit = CustomUnit(frame)
+	unit.args.informationType = 'Card'
 	unit:setWidgetInjector(CustomInjector(unit))
 
-	return unit:createInfobox()
+	return HtmlWidgets.Fragment{
+		unit:createInfobox(),
+		CustomUnit._buildDescription(unit.args),
+	}
 end
 
 ---@param id string
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
+	local caller = self.caller
+	local args = caller.args
 
 	if id == 'custom' then
+		local makePatch = function(input)
+			if not input then return end
+			return Link{
+				link = 'Patch ' .. input,
+				children = {input},
+			}
+		end
+		return WidgetUtil.collect(
+			Cell{name = 'Color', children = {args.color}, options = {makeLink = true}},
+			Cell{name = 'Rarity', children = {args.rarity}, options = {makeLink = true}},
+			Cell{name = 'Hero Card', children = {args.hero}, options = {makeLink = true}},
+			Cell{name = 'Signature Card', children = {args.signature}, options = {makeLink = true}},
+			Cell{name = 'Set', children = {args.set}, options = {makeLink = true}},
+			Cell{name = 'Introduced', children = {makePatch(args.startversion)}},
+			Cell{name = 'Removed since', children = {makePatch(args.endversion)}},
+			Cell{name = 'Illustrator', children = {args.illustrator}, options = {makeLink = true}},
+			args.effect and Title{children = 'Effect'} or nil,
+			args.effect and Center{children = {args.effect}} or nil
+		)
+	elseif id == 'cost' then
 		return {
-			Cell{name = 'label', children = {}},
+			Cell{name = 'Cost', children = {caller:getCostDisplay()}},
+		}
+	elseif id == 'type' then
+		return {
+			Cell{name = 'Type', children = {args.type}, options = {makeLink = true}},
+		}
+	elseif id == 'attack' then
+		return {
+			Cell{name = Link{link = 'Damage'}, children = {args.damage}},
+		}
+	elseif id == 'defense' then
+		return {
+			Cell{name = Link{link = 'Armor'}, children = {args.armor}},
+			Cell{name = Link{link = 'Health'}, children = {args.health}},
 		}
 	end
 
 	return widgets
+end
+
+---@param args table
+---@return string[]
+function CustomUnit:getWikiCategories(args)
+	local postfix = ' Cards'
+	local costType = self:getCostType()
+	return Array.append({},
+		'Cards',
+		'Cards costing ' .. self:getCostDisplay(),
+		(costType == TYPE_TO_COST_TYPE.default and 'Item' or '') .. postfix,
+		args.type and (args.type .. postfix) or nil,
+		args.color and (args.color .. postfix) or nil,
+		args.color and args.type and (args.color .. ' ' .. args.type .. postfix) or nil,
+		args.rarity and (args.rarity .. postfix) or nil,
+		args.hero and ('Signature' .. postfix) or nil,
+		args.set and (args.set .. postfix) or nil,
+		args.illustrator and ('Cards illustrated by ' .. args.illustrator) or nil
+	)
+end
+
+---@return string
+function CustomUnit:getCostType()
+	return TYPE_TO_COST_TYPE[(self.args.type or ''):lower()] or TYPE_TO_COST_TYPE.default
+end
+
+---@return string
+function CustomUnit:getCostDisplay()
+	local costType = self:getCostType()
+	return self.args[costType] .. ' ' .. costType .. (costType ~= TYPE_TO_COST_TYPE.default and ' coins' or '')
+end
+
+---@param args table
+function CustomUnit:setLpdbData(args)
+	local lpdbData = {
+		name = self.name,
+		type = 'card',
+		image = args.image,
+		extradata = {
+			color = args.color,
+			cost = args.mana or args.gold,
+			rarity = args.rarity,
+			type = args.type,
+			damage = args.damage,
+			armor = args.armor,
+			health = args.health,
+			effect = args.effect,
+			start = args.startversion,
+			['end'] = args.endversion,
+			illustrator = args.illustrator,
+			set = args.set,
+			signature = args.signature,
+		},
+	}
+	mw.ext.LiquipediaDB.lpdb_datapoint('card_' .. self.name, Json.stringifySubTables(lpdbData))
+end
+
+---@return Widget?
+function CustomUnit:_buildDescription()
+	local args = self.args
+	if not Logic.readBool(args['generate description']) then return end
+
+	local lowerCaseIfExist = function(input)
+		return input and (' ' .. input:lower()) or nil
+	end
+
+	local attackDefenseInfo = mw.text.listToText(Array.append({},
+		args.damage and (args.damage .. ' attack') or nil,
+		args.armor and (args.armor .. ' point' .. (tonumber(args.armor) == 1 and '' or 's') .. ' of armor') or nil,
+		args.health and (args.health .. ' point' .. (tonumber(args.health) == 1 and '' or 's') .. ' of health') or nil
+	), ', ', ' and ')
+
+	return HtmlWidgets.Fragment{
+		children = WidgetUtil.collect(
+			HtmlWidgets.B{children = self.name},
+			' is a',
+			args.mana and (' ' .. args.mana .. '-mana cost') or nil,
+			args.gold and (' ' .. args.gold .. '-gold cost') or nil,
+			lowerCaseIfExist(args.color),
+			lowerCaseIfExist(args.type),
+			attackDefenseInfo and (' with ' .. attackDefenseInfo) or nil,
+			'.'
+		)
+	}
 end
 
 return CustomUnit

--- a/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
+++ b/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
@@ -7,13 +7,31 @@
 
 local Lua = require('Module:Lua')
 
+local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Unit = Lua.import('Module:Infobox/Unit')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
+local Center = Widgets.Center
+local Title = Widgets.Title
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local TYPE_TO_COST_TYPE = {
+	consumable = 'gold',
+	weapon = 'gold',
+	armor = 'gold',
+	accessory = 'gold',
+	deed = 'gold',
+	item = 'gold',
+	default = 'mana',
+}
 
 ---@class ClashroyaleUnitInfobox: UnitInfobox
 local CustomUnit = Class.new(Unit)
@@ -22,27 +40,121 @@ local CustomUnit = Class.new(Unit)
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
----@return Html
+---@return Widget
 function CustomUnit.run(frame)
 	local unit = CustomUnit(frame)
+	unit.args.informationType = 'Card'
 	unit:setWidgetInjector(CustomInjector(unit))
 
-	return unit:createInfobox()
+	return HtmlWidgets.Fragment{
+		unit:createInfobox(),
+		CustomUnit._buildDescription(unit.args),
+	}
 end
 
 ---@param id string
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
+	local caller = self.caller
+	local args = caller.args
 
 	if id == 'custom' then
+		local makePatch = function(input)
+			if not input then return end
+			return Link{
+				link = 'Patch ' .. input,
+				children = {input},
+			}
+		end
 		return {
-			Cell{name = 'label', children = {}},
+			Cell{name = 'Ability', children = {args.ability}},
+			Cell{name = 'Ability Elixir Cost', children = {args['ability elixir cost']}},
+			Cell{name = 'Game Mode', children = {args['game mode']}},
+			Cell{name = 'Rarity', children = {args.rarity}},
+			Cell{name = 'Cycles', children = {args.cycles}},
+			Cell{name = 'Arena', children = {args.arena}, options = {makeLink = true}},
+			Cell{name = 'Release Date', children = {args['release date']}},
+			Cell{name = 'Deletion Date', children = {args['deletion date']}},
+			Cell{name = 'Set', children = {args.set}, options = {makeLink = true}},
+			Cell{name = 'Summoned by', children = {args.summonedby}, options = {makeLink = true}},
+			Cell{name = 'Introduced', children = {makePatch(args.startversion)}},
+			Cell{name = 'Removed since', children = {makePatch(args.endversion)}},
+		}
+	elseif id == 'cost' then
+		return {
+			Cell{name = 'Elixir Cost', children = {args.elixir}},
 		}
 	end
 
 	return widgets
+end
+
+---@param args table
+---@return string[]
+function CustomUnit:getWikiCategories(args)
+	local postfix = ' Cards'
+	return Array.append({},
+		'Cards',
+		args.set and (args.set .. postfix) or nil,
+		args.arena and (args.arena .. postfix) or nil,
+		args.cycles and (args.cycles .. postfix) or nil,
+		args.rarity and (args.rarity .. postfix) or nil,
+		args.type and (args.type .. postfix) or nil,
+		args.ability and (args.ability .. '-Cards') or nil,
+		args.elixir and (args.elixir .. '-Elixir' .. postfix) or nil,
+		args['game mode'] and (args['game mode'] .. postfix) or nil
+	)
+end
+
+---@param args table
+function CustomUnit:setLpdbData(args)
+	local lpdbData = {
+		name = self.name,
+		type = 'card',
+		image = args.image,
+		date = args['release date'],
+		extradata = {
+			color = args.color,
+			cost = args.elixir,
+			rarity = args.rarity,
+			type = args.type,
+			arena = args.arena,
+			description = args.caption,
+			startversion = args.startversion,
+			endversion = args.endversion,
+			set = args.set,
+			summonedby = args.summonedby,
+			chosenfrom = args.chosenfrom,
+			artist = args.artist,
+			craftable = args.craftable and string.lower(args.craftable) or nil,
+		},
+	}
+	mw.ext.LiquipediaDB.lpdb_datapoint('card_' .. self.name, Json.stringifySubTables(lpdbData))
+end
+
+---@return Widget?
+function CustomUnit:_buildDescription()
+	local args = self.args
+	if not Logic.readBool(args['generate description']) then return end
+
+	local lowerCaseIfExist = function(input)
+		return input and (' ' .. input:lower()) or nil
+	end
+
+	return HtmlWidgets.Fragment{
+		children = WidgetUtil.collect(
+			HtmlWidgets.B{children = self.name},
+			' is a',
+			lowerCaseIfExist(args.elixir),
+			'-Elixir',
+			lowerCaseIfExist(args.rarity),
+			lowerCaseIfExist(args.type),
+			' card that is unlocked from the',
+			args.arena and (' ' .. args.arena) or nil,
+			' arena.'
+		)
+	}
 end
 
 return CustomUnit

--- a/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
+++ b/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
@@ -17,21 +17,9 @@ local Unit = Lua.import('Module:Infobox/Unit')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
-local Center = Widgets.Center
-local Title = Widgets.Title
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Link = Lua.import('Module:Widget/Basic/Link')
 local WidgetUtil = Lua.import('Module:Widget/Util')
-
-local TYPE_TO_COST_TYPE = {
-	consumable = 'gold',
-	weapon = 'gold',
-	armor = 'gold',
-	accessory = 'gold',
-	deed = 'gold',
-	item = 'gold',
-	default = 'mana',
-}
 
 ---@class ClashroyaleUnitInfobox: UnitInfobox
 local CustomUnit = Class.new(Unit)

--- a/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
+++ b/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
@@ -69,13 +69,13 @@ function CustomInjector:parse(id, widgets)
 		end
 		return {
 			Cell{name = 'Ability', children = {args.ability}},
-			Cell{name = 'Ability Elixir Cost', children = {args['ability elixir cost']}},
-			Cell{name = 'Game Mode', children = {args['game mode']}},
+			Cell{name = 'Ability Elixir Cost', children = {args.abilityelixircost}},
+			Cell{name = 'Game Mode', children = {args.gamemode}},
 			Cell{name = 'Rarity', children = {args.rarity}},
 			Cell{name = 'Cycles', children = {args.cycles}},
 			Cell{name = 'Arena', children = {args.arena}, options = {makeLink = true}},
-			Cell{name = 'Release Date', children = {args['release date']}},
-			Cell{name = 'Deletion Date', children = {args['deletion date']}},
+			Cell{name = 'Release Date', children = {args.releasedate}},
+			Cell{name = 'Deletion Date', children = {args.deletiondate}},
 			Cell{name = 'Set', children = {args.set}, options = {makeLink = true}},
 			Cell{name = 'Summoned by', children = {args.summonedby}, options = {makeLink = true}},
 			Cell{name = 'Introduced', children = {makePatch(args.startversion)}},
@@ -103,7 +103,7 @@ function CustomUnit:getWikiCategories(args)
 		args.type and (args.type .. postfix) or nil,
 		args.ability and (args.ability .. '-Cards') or nil,
 		args.elixir and (args.elixir .. '-Elixir' .. postfix) or nil,
-		args['game mode'] and (args['game mode'] .. postfix) or nil
+		args.gamemode and (args.gamemode .. postfix) or nil
 	)
 end
 
@@ -113,7 +113,7 @@ function CustomUnit:setLpdbData(args)
 		name = self.name,
 		type = 'card',
 		image = args.image,
-		date = args['release date'],
+		date = args.releasedate,
 		extradata = {
 			color = args.color,
 			cost = args.elixir,

--- a/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
+++ b/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
@@ -1,0 +1,48 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Unit/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Unit = Lua.import('Module:Infobox/Unit')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+
+---@class ClashroyaleUnitInfobox: UnitInfobox
+local CustomUnit = Class.new(Unit)
+---@class ClashroyaleUnitInfoboxWidgetInjector: WidgetInjector
+---@field caller ClashroyaleUnitInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomUnit.run(frame)
+	local unit = CustomUnit(frame)
+	unit:setWidgetInjector(CustomInjector(unit))
+
+	return unit:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		return {
+			Cell{name = 'label', children = {}},
+		}
+	end
+
+	return widgets
+end
+
+return CustomUnit

--- a/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
+++ b/lua/wikis/clashroyale/Infobox/Unit/Custom.lua
@@ -34,10 +34,10 @@ function CustomUnit.run(frame)
 	unit.args.informationType = 'Card'
 	unit:setWidgetInjector(CustomInjector(unit))
 
-	return HtmlWidgets.Fragment{
+	return HtmlWidgets.Fragment{children = {
 		unit:createInfobox(),
-		CustomUnit._buildDescription(unit.args),
-	}
+		unit:_buildDescription(unit.args),
+	}}
 end
 
 ---@param id string

--- a/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
@@ -7,13 +7,30 @@
 
 local Lua = require('Module:Lua')
 
+local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Unit = Lua.import('Module:Infobox/Unit')
 
 local Widgets = Lua.import('Module:Widget/All')
+local Breakdown = Widgets.Breakdown
 local Cell = Widgets.Cell
+local Center = Widgets.Center
+local Title = Widgets.Title
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+local Image = require('Module:Widget/Image/Icon/Image')
+
+local CRAFT_DATA = {
+	common = {cost = '40 (Gold: 400)', value = '5 (Gold: 50)'},
+	rare = {cost = '100 (Gold: 800)', value = '20 (Gold: 100)'},
+	epic = {cost = '400 (Gold: 1600)', value = '100 (Gold: 400)'},
+	legendary = {cost = '1600 (Gold: 3200)', value = '400 (Gold: 1600)'},
+}
 
 ---@class HearthstoneUnitInfobox: UnitInfobox
 local CustomUnit = Class.new(Unit)
@@ -22,9 +39,10 @@ local CustomUnit = Class.new(Unit)
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
----@return Html
+---@return Widget
 function CustomUnit.run(frame)
 	local unit = CustomUnit(frame)
+	unit.args.informationType = 'Card'
 	unit:setWidgetInjector(CustomInjector(unit))
 
 	return unit:createInfobox()
@@ -34,15 +52,127 @@ end
 ---@param widgets Widget[]
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
+	local caller = self.caller
+	local args = caller.args
 
 	if id == 'custom' then
+		local hasAttributes = Logic.isNotEmpty(args.cost) or Logic.isNotEmpty(args.attack) or Logic.isNotEmpty(args.hp)
+
+		---@param input string?
+		---@return Widget?
+		local makePatch = function(input)
+			if not input then return end
+			return Link{
+				link = 'Patch ' .. input,
+				children = {input},
+			}
+		end
+
+		---@param image string
+		---@param link string
+		---@param value string?
+		---@return Widget
+		local makeAttribute = function(image, link, value)
+			return HtmlWidgets.Fragment{children = {
+				Image{size = 'x32px', alignment = 'text-top', link = link, imageLight = image},
+				HtmlWidgets.Br{},
+				value,
+			}}
+		end
+
+		---@return Widget?
+		local makeCraftable = function()
+			if Logic.readBoolOrNil(args.craftable) == false or string.lower(args.set or '') ~= 'expert' then
+				return
+			end
+			local craftData = CRAFT_DATA[args.rarity]
+			if not craftData then return end
+			return {
+				Cell{name = 'Crafting Cost', children = {craftData.cost}},
+				Cell{name = 'Disenchant Value', children = {craftData.value}},
+			}
+		end
+
+		return WidgetUtil.collect(
+			Cell{name = 'Rarity', children = {args.rarity}, options = {makeLink = true}},
+			Cell{name = 'Set', children = {args.set}, options = {makeLink = true}},
+			Cell{name = 'Summoned by', children = {args.summonedby}, options = {makeLink = true}},
+			Cell{name = 'Chosen from', children = {args.chosenfrom}, options = {makeLink = true}},
+			makeCraftable(),
+			Cell{name = 'Introduced', children = {makePatch(args.startversion)}},
+			Cell{name = 'Removed since', children = {makePatch(args.endversion)}},
+			Cell{
+				name = 'Artist',
+				children = {args.artist and Link{link = ':Category:Art by ' .. args.artist, children = {args.artist}} or nil}
+			},
+			hasAttributes and Title{children = {'Attributes'},} or nil,
+			hasAttributes and Breakdown{
+				children = WidgetUtil.collect(
+					makeAttribute('Mana_Cost_hs.png', 'Mana', args.cost),
+					makeAttribute(string.lower(args.type or '') == 'weapon' and 'Weapon.png' or 'AttackIcon.png',
+						'Attack', args.atk),
+					args.hp and makeAttribute('HitPointIcon.png', 'Hit Points', args.hp)
+						or makeAttribute('Shield.png', 'Durability', args.durability)
+				),
+				classes = {'infobox-center'}
+			} or nil,
+			args.effect and Title{children = {'Effect'}},
+			args.effect and Center{children = {args.effect}},
+			args.description and Title{children = {'Description'}},
+			args.description and Center{children = {args.description}}
+		)
+	elseif id == 'cost' or id == 'attack' then return {}
+	elseif id == 'type' then
 		return {
-			Cell{name = 'label', children = {}},
+			Cell{name = 'Class', children = {args.class}, options = {makeLink = true}},
+			Cell{name = 'Type', children = {args.type}, options = {makeLink = true}},
+			Cell{name = 'Subtype', children = {args.subtype}, options = {makeLink = true}},
 		}
 	end
 
 	return widgets
+end
+
+---@param args table
+---@return string[]
+function CustomUnit:getWikiCategories(args)
+	local postfix = ' Cards'
+	return Array.append({},
+		'Cards',
+		args.class and (args.class .. postfix) or nil,
+		args.type and (args.type .. postfix) or nil,
+		args.subtype and (args.subtype .. postfix) or nil,
+		args.rarity and (args.rarity .. postfix) or nil,
+		args.set and (args.set .. postfix) or nil,
+		args.artist and ('Art by ' .. args.artist) or nil
+	)
+end
+
+---@param args table
+function CustomUnit:setLpdbData(args)
+	local lpdbData = {
+		name = self.name,
+		type = 'card',
+		image = args.image,
+		extradata = {
+			summonedby = args.summonedby,
+			chosenfrom = args.chosenfrom,
+			class = args.class,
+			cost = args.cost,
+			rarity = args.rarity,
+			subtype = args.subtype,
+			atk = args.attack,
+			durability = args.durability,
+			hitpoints = args.hp or args.durability,
+			description = args.description,
+			effect = args.effect,
+			startversion = args.startversion,
+			endversion = args.endversion,
+			set = args.set,
+			artist = args.artist,
+		},
+	}
+	mw.ext.LiquipediaDB.lpdb_datapoint('card_' .. self.name, Json.stringifySubTables(lpdbData))
 end
 
 return CustomUnit

--- a/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
@@ -1,0 +1,48 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Unit/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local Unit = Lua.import('Module:Infobox/Unit')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+
+---@class HearthstoneUnitInfobox: UnitInfobox
+local CustomUnit = Class.new(Unit)
+---@class HearthstoneUnitInfoboxWidgetInjector: WidgetInjector
+---@field caller HearthstoneUnitInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomUnit.run(frame)
+	local unit = CustomUnit(frame)
+	unit:setWidgetInjector(CustomInjector(unit))
+
+	return unit:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		return {
+			Cell{name = 'label', children = {}},
+		}
+	end
+
+	return widgets
+end
+
+return CustomUnit

--- a/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
@@ -73,6 +73,7 @@ function CustomInjector:parse(id, widgets)
 		---@param value string?
 		---@return Widget
 		local makeAttribute = function(image, link, value)
+			-- returning Fragment is needed to have placeholders where necessary
 			if not value then return HtmlWidgets.Fragment{} end
 			return HtmlWidgets.Fragment{children = {
 				Image{size = 'x32px', alignment = 'text-top', link = link, imageLight = image},

--- a/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
@@ -73,6 +73,7 @@ function CustomInjector:parse(id, widgets)
 		---@param value string?
 		---@return Widget
 		local makeAttribute = function(image, link, value)
+			if not value then return HtmlWidgets.Fragment{} end
 			return HtmlWidgets.Fragment{children = {
 				Image{size = 'x32px', alignment = 'text-top', link = link, imageLight = image},
 				HtmlWidgets.Br{},
@@ -117,9 +118,7 @@ function CustomInjector:parse(id, widgets)
 				classes = {'infobox-center'}
 			} or nil,
 			args.effect and Title{children = {'Effect'}},
-			args.effect and Center{children = {args.effect}},
-			args.description and Title{children = {'Description'}},
-			args.description and Center{children = {args.description}}
+			args.effect and Center{children = {args.effect}}
 		)
 	elseif id == 'cost' or id == 'attack' then return {}
 	elseif id == 'type' then

--- a/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Unit/Custom.lua
@@ -110,7 +110,7 @@ function CustomInjector:parse(id, widgets)
 				children = WidgetUtil.collect(
 					makeAttribute('Mana_Cost_hs.png', 'Mana', args.cost),
 					makeAttribute(string.lower(args.type or '') == 'weapon' and 'Weapon.png' or 'AttackIcon.png',
-						'Attack', args.atk),
+						'Attack', args.attack),
 					args.hp and makeAttribute('HitPointIcon.png', 'Hit Points', args.hp)
 						or makeAttribute('Shield.png', 'Durability', args.durability)
 				),


### PR DESCRIPTION
depends on #6108 (for the aoe icon widgets) and #6109 (chronology)

## Summary
standardization of
- [x] https://liquipedia.net/ageofempires/Template:Infobox_units
- [x] https://liquipedia.net/hearthstone/Template:Infobox_card
- [x] https://liquipedia.net/artifact/Template:Infobox_card
- [x] https://liquipedia.net/clashroyale/Template:Infobox_card
- [x] https://liquipedia.net/hearthstone/Template:Infobox_card_automated
  - uses `#getcarddata` extension ...
  - extension seems to not work but on one page
  - oos, suggest to archive/nurke this one entirely

## How did you test this change?
dev

## bot jobs needed before rollout
- [x] aoe: `"\|\s*building(\d*)\s*=" "|builtfrom="`
- [x] cr: `"\|\s*ability elixir cost\s*=" "|abilityelixircost="`
- [x] cr: `"\|\s*game mode\s*=" "|gamemode="`
- [x] cr: `"\|\s*release date\s*=" "|releasedate="`
- [x] cr: `"\|\s*deletion date\s*=" "|deletiondate="`
- [x] hs: `"\|\s*atk\s*=" "|attack="`