### PR TITLE
feat(infobox): add participants number to rematch infobox league

### DIFF
--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -39,18 +39,16 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'customcontent' then
-		if not String.isEmpty(args.team_number) then
-			table.insert(widgets, Title{children = 'Teams'})
-			table.insert(widgets, Cell{
-				name = 'Number of teams',
-				content = {args.team_number}
-			})
-		elseif not String.isEmpty(args.player_number) then
-			table.insert(widgets, Title{children = 'Players'})
-			table.insert(widgets, Cell{
-				name = 'Number of players',
-				content = {args.player_number}
-			})
+		if String.isNotEmpty(args.team_number) then
+			Array.appendWith(widgets,
+				Title{children = 'Teams'},
+				Cell{name = 'Number of teams', content = {args.team_number}
+			)
+		elseif String.isNotEmpty(args.player_number) then
+			Array.appendWith(widgets,
+				Title{children = 'Players'},
+				Cell{name = 'Number of players', content = {args.player_number}
+			)
 		end
 	end
 	return widgets

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -6,8 +6,10 @@
 --
 
 local Lua = require('Module:Lua')
+local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local String = Lua.import('Module:StringUtils')
+
 local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
 

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -17,7 +17,10 @@ local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 
+---@class RematchLeagueInfobox: InfoboxLeague
 local CustomLeague = Class.new(League)
+---@class RematchLeagueInfoboxWidgetInjector: WidgetInjector
+---@field caller RematchLeagueInfobox
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -1,0 +1,55 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local Class = Lua.import('Module:Class')
+local String = Lua.import('Module:StringUtils')
+local Injector = Lua.import('Module:Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+local Title = Widgets.Title
+local Center = Widgets.Center
+
+local CustomLeague = Class.new(League)
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return Html
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Widget[]
+---@return Widget[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'customcontent' then
+		if not String.isEmpty(args.team_number) then
+			table.insert(widgets, Title{children = 'Teams'})
+			table.insert(widgets, Cell{
+				name = 'Number of teams',
+				content = {args.team_number}
+			})
+		elseif not String.isEmpty(args.player_number) then
+			table.insert(widgets, Title{children = 'Players'})
+			table.insert(widgets, Cell{
+				name = 'Number of players',
+				content = {args.player_number}
+			})
+		end
+	end
+	return widgets
+end
+
+return CustomLeague

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -42,12 +42,12 @@ function CustomInjector:parse(id, widgets)
 		if String.isNotEmpty(args.team_number) then
 			Array.appendWith(widgets,
 				Title{children = 'Teams'},
-				Cell{name = 'Number of teams', content = {args.team_number}
+				Cell{name = 'Number of teams', content = {args.team_number}}
 			)
 		elseif String.isNotEmpty(args.player_number) then
 			Array.appendWith(widgets,
 				Title{children = 'Players'},
-				Cell{name = 'Number of players', content = {args.player_number}
+				Cell{name = 'Number of players', content = {args.player_number}}
 			)
 		end
 	end

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -14,7 +14,6 @@ local League = Lua.import('Module:Infobox/League')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
-local Center = Widgets.Center
 
 local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)


### PR DESCRIPTION
## Summary

This displays the number of participants (teams or players) in the infobox.

## How did you test this change?

Here: https://liquipedia.net/rematch/Rematch_Elite_Series/North_America

To test: `|dev=mej`