### PR TITLE
feat: Hide countdown from matchticker completed

### DIFF
--- a/javascript/commons/SwitchButtons.js
+++ b/javascript/commons/SwitchButtons.js
@@ -43,7 +43,7 @@
  * The switch button can be easily accessed and manipulated by other components using the getSwitchGroup method.
  *
  * Usage Methods:
- * - setCountdownVisibility(isVisible): Controls the visibility of the countdown toggle (true to show, false to hide).
+ * setCountdownVisibility(isVisible): Controls the visibility of the countdown toggle (true to show, false to hide).
  *
  * SwitchGroup object contains the following properties:
  * - type: The type of the switch group (toggle or pill).
@@ -84,7 +84,7 @@ liquipedia.switchButtons = {
 		const switchGroup = this.switchGroups['countdown'];
 
 		if (switchGroup && switchGroup.nodes.length > 0) {
-			const container = switchGroup.nodes[0].closest('.switch-toggle-container');
+			const container = switchGroup.nodes[0].closest('[data-component="switch-toggle-container"]');
 			if (container) {
 				container.classList[isVisible ? 'remove' : 'add']('d-none');
 			}

--- a/javascript/commons/SwitchButtons.js
+++ b/javascript/commons/SwitchButtons.js
@@ -42,6 +42,9 @@
  * Properties:
  * The switch button can be easily accessed and manipulated by other components using the getSwitchGroup method.
  *
+ * Usage Methods:
+ * - setCountdownVisibility(isVisible): Controls the visibility of the countdown toggle (true to show, false to hide).
+ *
  * SwitchGroup object contains the following properties:
  * - type: The type of the switch group (toggle or pill).
  * - name: The name of the switch group.
@@ -75,6 +78,17 @@ liquipedia.switchButtons = {
 				this.attachEventListener( switchGroup, activeClassName );
 			}
 		} );
+	},
+
+	setCountdownVisibility: function(isVisible) {
+		const switchGroup = this.switchGroups['countdown'];
+
+		if (switchGroup && switchGroup.nodes.length > 0) {
+			const container = switchGroup.nodes[0].closest('.switch-toggle-container');
+			if (container) {
+				container.classList[isVisible ? 'remove' : 'add']('d-none');
+			}
+		}
 	},
 
 	getOrCreateSwitchGroup: function ( type, groupName, element, activeClassName ) {
@@ -144,6 +158,10 @@ liquipedia.switchButtons = {
 
 	attachEventListener: function ( switchGroup, activeClassName ) {
 		switchGroup.nodes.forEach( ( node ) => {
+			if ( switchGroup.name === 'matchFiler' && switchGroup.value === 'completed' ) {
+				this.setCountdownVisibility(false);
+			}
+
 			node.addEventListener( 'click', () => {
 				const newValue = this.getNewValue( node, switchGroup.type, activeClassName );
 
@@ -155,6 +173,11 @@ liquipedia.switchButtons = {
 					}
 					this.updateDOM( switchGroup, newValue );
 					this.triggerCustomEvent( node, switchGroup );
+
+					// Handle countdown toggle visibility when matchFiler group changes
+					if (switchGroup.name === 'matchFiler') {
+						this.setCountdownVisibility(newValue !== 'completed');
+					}
 				}
 			} );
 		} );

--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -117,6 +117,9 @@ function MatchTickerContainer:render()
 			},
 			HtmlWidgets.Div{
 				classes = {'switch-toggle-container'},
+				attributes = {
+					['data-component'] = 'switch-toggle-container'
+				},
 				css = {margin = '1rem 0'},
 				children = {
 					HtmlWidgets.Div{


### PR DESCRIPTION
## Summary

Hide countdown toggle on completed matches tab

<img width="770" height="632" alt="image" src="https://github.com/user-attachments/assets/86732fdd-46fa-4219-b528-9bd83a76e0fa" />


## How did you test this change?

http://laura.wiki.tldev.eu/rocketleague/Main_Page

## Closes
https://gitlab.com/teamliquid-dev/liquipedia/issue-bucket/-/issues/555
