### PR TITLE
Draft: New show hide buttons

### DIFF
--- a/javascript/commons/Collapse.js
+++ b/javascript/commons/Collapse.js
@@ -9,45 +9,61 @@ liquipedia.collapse = {
 				table.classList.add( 'collapsed' );
 			}
 		} );
-		liquipedia.collapse.setupCollapsibleMapsButtons();
 		liquipedia.collapse.setupCollapsibleButtons();
 		liquipedia.collapse.setupGeneralCollapsibleButtons();
 		liquipedia.collapse.setupToggleGroups();
 		liquipedia.collapse.setupDropdownBox();
 		liquipedia.collapse.setupCollapsibleNavFrameButtons();
 	},
+	textShow: '<i class="fas fa-eye"></i> Show',
+	textHide: '<i class="fas fa-eye-slash"></i> Hide',
+	makeShowButton: function( collapsible ) {
+		return liquipedia.collapse.makeButton(
+			liquipedia.collapse.textShow,
+			'collapseButtonShow',
+			collapsible
+		);
+	},
+	makeHideButton: function( collapsible ) {
+		return liquipedia.collapse.makeButton(
+			liquipedia.collapse.textHide,
+			'collapseButtonHide',
+			collapsible
+		);
+	},
+	makeButton: function( text, wrapperClass, collapsible ) {
+		const buttonWrapper = document.createElement( 'span' );
+		buttonWrapper.classList.add( 'collapseButton' );
+		buttonWrapper.classList.add( wrapperClass );
+		const button = document.createElement( 'button' );
+		button.classList.add( 'btn' );
+		button.classList.add( 'btn-secondary' );
+		button.classList.add( 'btn-xsmall' );
+		button.type = 'button';
+		button.innerHTML = text;
+		button.onclick = function( ev ) {
+			ev.preventDefault();
+			if ( wrapperClass === 'collapseButtonShow' ) {
+				collapsible.classList.remove( 'collapsed' );
+			} else {
+				collapsible.classList.add( 'collapsed' );
+			}
+		};
+		buttonWrapper.appendChild( button );
+		return buttonWrapper;
+	},
 	setupCollapsibleButtons: function() {
 		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( ( collapsible ) => {
 			const row = collapsible.querySelector( 'tr' );
 			if ( row !== null ) {
-				const collapseShowButton = document.createElement( 'span' );
-				collapseShowButton.classList.add( 'collapseButton' );
-				collapseShowButton.classList.add( 'collapseButtonShow' );
-				collapseShowButton.appendChild( document.createTextNode( '[' ) );
-				const collapseShowLink = document.createElement( 'a' );
-				collapseShowLink.href = '#';
-				collapseShowLink.innerHTML = 'show';
-				collapseShowLink.onclick = function( ev ) {
-					ev.preventDefault();
-					collapsible.classList.remove( 'collapsed' );
-				};
-				collapseShowButton.appendChild( collapseShowLink );
-				collapseShowButton.appendChild( document.createTextNode( ']' ) );
-				row.lastElementChild.insertBefore( collapseShowButton, row.lastElementChild.firstChild );
-				const collapseHideButton = document.createElement( 'span' );
-				collapseHideButton.classList.add( 'collapseButton' );
-				collapseHideButton.classList.add( 'collapseButtonHide' );
-				collapseHideButton.appendChild( document.createTextNode( '[' ) );
-				const collapseHideLink = document.createElement( 'a' );
-				collapseHideLink.href = '#';
-				collapseHideLink.innerHTML = 'hide';
-				collapseHideLink.onclick = function( ev ) {
-					ev.preventDefault();
-					collapsible.classList.add( 'collapsed' );
-				};
-				collapseHideButton.appendChild( collapseHideLink );
-				collapseHideButton.appendChild( document.createTextNode( ']' ) );
-				row.lastElementChild.insertBefore( collapseHideButton, row.lastElementChild.firstChild );
+				row.lastElementChild.insertBefore(
+					liquipedia.collapse.makeShowButton( collapsible ),
+					row.lastElementChild.firstChild
+				);
+				row.lastElementChild.insertBefore(
+					liquipedia.collapse.makeHideButton( collapsible ),
+					row.lastElementChild.firstChild
+				);
 			}
 		} );
 	},
@@ -94,73 +110,18 @@ liquipedia.collapse = {
 			}
 		} );
 	},
-	setupCollapsibleMapsButtons: function() {
-		document.querySelectorAll( '#mw-content-text .collapsible' ).forEach( ( collapsible ) => {
-			const row = collapsible.querySelector( 'tr' );
-			if ( row !== null && collapsible.querySelector( '.maprow' ) !== null ) {
-				const collapseShowButton = document.createElement( 'span' );
-				collapseShowButton.classList.add( 'collapseButton' );
-				collapseShowButton.classList.add( 'collapseButtonMapsShow' );
-				collapseShowButton.appendChild( document.createTextNode( '[' ) );
-				const collapseShowLink = document.createElement( 'a' );
-				collapseShowLink.href = '#';
-				collapseShowLink.innerHTML = '+maps';
-				collapseShowLink.onclick = function( ev ) {
-					ev.preventDefault();
-					collapsible.classList.add( 'uncollapsed-maps' );
-				};
-				collapseShowButton.appendChild( collapseShowLink );
-				collapseShowButton.appendChild( document.createTextNode( ']' ) );
-				row.lastElementChild.insertBefore( collapseShowButton, row.lastElementChild.firstChild );
-				const collapseHideButton = document.createElement( 'span' );
-				collapseHideButton.classList.add( 'collapseButton' );
-				collapseHideButton.classList.add( 'collapseButtonMapsHide' );
-				collapseHideButton.appendChild( document.createTextNode( '[' ) );
-				const collapseHideLink = document.createElement( 'a' );
-				collapseHideLink.href = '#';
-				collapseHideLink.innerHTML = '-maps';
-				collapseHideLink.onclick = function( ev ) {
-					ev.preventDefault();
-					collapsible.classList.remove( 'uncollapsed-maps' );
-				};
-				collapseHideButton.appendChild( collapseHideLink );
-				collapseHideButton.appendChild( document.createTextNode( ']' ) );
-				row.lastElementChild.insertBefore( collapseHideButton, row.lastElementChild.firstChild );
-			}
-		} );
-	},
 	setupCollapsibleNavFrameButtons: function() {
 		document.querySelectorAll( '#mw-content-text .NavFrame' ).forEach( ( navFrame ) => {
 			const head = navFrame.querySelector( '.NavHead' );
 			if ( head !== null ) {
-				const collapseShowButton = document.createElement( 'span' );
-				collapseShowButton.classList.add( 'collapseButton' );
-				collapseShowButton.classList.add( 'collapseButtonShow' );
-				collapseShowButton.appendChild( document.createTextNode( '[' ) );
-				const collapseShowLink = document.createElement( 'a' );
-				collapseShowLink.href = '#';
-				collapseShowLink.innerHTML = 'show';
-				collapseShowLink.onclick = function( ev ) {
-					ev.preventDefault();
-					navFrame.classList.remove( 'collapsed' );
-				};
-				collapseShowButton.appendChild( collapseShowLink );
-				collapseShowButton.appendChild( document.createTextNode( ']' ) );
-				head.insertBefore( collapseShowButton, head.firstChild );
-				const collapseHideButton = document.createElement( 'span' );
-				collapseHideButton.classList.add( 'collapseButton' );
-				collapseHideButton.classList.add( 'collapseButtonHide' );
-				collapseHideButton.appendChild( document.createTextNode( '[' ) );
-				const collapseHideLink = document.createElement( 'a' );
-				collapseHideLink.href = '#';
-				collapseHideLink.innerHTML = 'hide';
-				collapseHideLink.onclick = function( ev ) {
-					ev.preventDefault();
-					navFrame.classList.add( 'collapsed' );
-				};
-				collapseHideButton.appendChild( collapseHideLink );
-				collapseHideButton.appendChild( document.createTextNode( ']' ) );
-				head.insertBefore( collapseHideButton, head.firstChild );
+				head.insertBefore(
+					liquipedia.collapse.makeShowButton( navFrame ),
+					head.firstChild
+				);
+				head.insertBefore(
+					liquipedia.collapse.makeHideButton( navFrame ),
+					head.firstChild
+				);
 			}
 		} );
 	},

--- a/javascript/commons/Prizepooltable.js
+++ b/javascript/commons/Prizepooltable.js
@@ -27,7 +27,11 @@ liquipedia.prizepooltable = {
 				const row = prizepooltable.querySelector( 'tr:nth-child(' + ( cutAfter + 2 ) + ')' );
 				if ( row !== null ) {
 					const rowNode = document.createElement( 'tr' );
-					rowNode.innerHTML = '<td colspan="' + Math.max( prizepooltable.querySelectorAll( 'tr:nth-child(1) th, tr:nth-child(1) td' ).length, prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length ) + '" class="prizepooltabletoggle"><small class="prizepooltableshow">' + openText + '</small><small class="prizepooltablehide">' + closeText + '</small></td>';
+					rowNode.innerHTML = '<td colspan="' + Math.max(
+						prizepooltable.querySelectorAll( 'tr:nth-child(1) th, tr:nth-child(1) td' ).length,
+						prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length
+					) + '" class="prizepooltabletoggle"><small class="prizepooltableshow">'
+						+ openText + '</small><small class="prizepooltablehide">' + closeText + '</small></td>';
 					row.parentNode.insertBefore( rowNode, row );
 				}
 			}

--- a/javascript/commons/Prizepooltable.js
+++ b/javascript/commons/Prizepooltable.js
@@ -30,8 +30,8 @@ liquipedia.prizepooltable = {
 					rowNode.innerHTML = '<td colspan="' + Math.max(
 						prizepooltable.querySelectorAll( 'tr:nth-child(1) th, tr:nth-child(1) td' ).length,
 						prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length
-					) + '" class="prizepooltabletoggle"><small class="prizepooltableshow">'
-						+ openText + '</small><small class="prizepooltablehide">' + closeText + '</small></td>';
+					) + '" class="prizepooltabletoggle"><small class="prizepooltableshow">' +
+						openText + '</small><small class="prizepooltablehide">' + closeText + '</small></td>';
 					row.parentNode.insertBefore( rowNode, row );
 				}
 			}


### PR DESCRIPTION
## Summary

We want the show and hide buttons of collapsibles to look like actual buttons

<img width="85" height="29" alt="image" src="https://github.com/user-attachments/assets/482b0dce-848e-4828-abda-4772e40f6d17" />

<img width="87" height="31" alt="image" src="https://github.com/user-attachments/assets/a10c3cc5-311b-44d8-9b09-d85f8020cb39" />

This is currently blocked by an internal MR for updated button classes and might require a fix for these depending on what the final class names will be.

See https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/merge_requests/143

## How did you test this change?

Dev tools
