### PR TITLE
feat(prizePool): store prizepoints2

### DIFF
--- a/lua/spec/prize_pool_spec.lua
+++ b/lua/spec/prize_pool_spec.lua
@@ -102,7 +102,7 @@ describe('prize pool', function()
 			PrizePool(prizePoolArgs):create():build()
 			assert.stub(LpdbPlacementStub).was.called_with('ranking_abc1_Rathoz', {
 				date = '2022-10-15',
-				extradata = '{"prizepoints":""}',
+				extradata = '{"prizepoints":"","prizepoints2":""}',
 				game = 'commons',
 				icon = 'test.png',
 				icondark = 'test dark.png',

--- a/lua/wikis/ageofempires/PrizePool/Award/Custom.lua
+++ b/lua/wikis/ageofempires/PrizePool/Award/Custom.lua
@@ -18,7 +18,6 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 local CustomAwardPrizePool = {}
 
 local IS_AWARD = true
-local PRIZE_TYPE_POINTS = 'POINTS'
 
 -- Template entry point
 ---@param frame Frame

--- a/lua/wikis/ageofempires/PrizePool/Award/Custom.lua
+++ b/lua/wikis/ageofempires/PrizePool/Award/Custom.lua
@@ -46,10 +46,6 @@ end
 function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.extradata.patch = Variables.varDefault('tournament_patch')
 
-	-- legacy points, to be standardized
-	lpdbData.extradata.points = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
-	lpdbData.extradata.points2 = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 2)
-
 	return lpdbData
 end
 

--- a/lua/wikis/ageofempires/PrizePool/Custom.lua
+++ b/lua/wikis/ageofempires/PrizePool/Custom.lua
@@ -24,7 +24,6 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 local CustomPrizePool = {}
 
 local PRIZE_TYPE_QUALIFIES = 'QUALIFIES'
-local PRIZE_TYPE_POINTS = 'POINTS'
 local QUALIFIER = 'Qualifier'
 local TIER_VALUE = {10, 6, 4, 2}
 

--- a/lua/wikis/ageofempires/PrizePool/Custom.lua
+++ b/lua/wikis/ageofempires/PrizePool/Custom.lua
@@ -69,17 +69,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	lpdbData.extradata.patch = Variables.varDefault('tournament_patch')
 
-	-- legacy points, to be standardized
-	local points = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
-	---for points it can never be boolean
-	---@cast points -boolean
-	lpdbData.extradata.points = points
-	Variables.varDefine(lpdbData.objectName .. '_pointprize', lpdbData.extradata.points)
-	local points2 = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 2)
-	---for points it can never be boolean
-	---@cast points2 -boolean
-	lpdbData.extradata.points2 = points2
-	Variables.varDefine(lpdbData.objectName .. '_pointprize2', lpdbData.extradata.points2)
+	Variables.varDefine(lpdbData.objectName .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine(lpdbData.objectName .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 	local prizeIsQualifier = function(prize)
 		return prize.type == PRIZE_TYPE_QUALIFIES

--- a/lua/wikis/apexlegends/PrizePool/Custom.lua
+++ b/lua/wikis/apexlegends/PrizePool/Custom.lua
@@ -48,6 +48,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(participantLower .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 	lpdbData.extradata.location = Variables.varDefault('tournament_location_region', '')
 	return lpdbData
 end

--- a/lua/wikis/brawlstars/PrizePool/Custom.lua
+++ b/lua/wikis/brawlstars/PrizePool/Custom.lua
@@ -64,6 +64,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, 'QUALIFIES1') and 1 or 0
 
 	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 
 	if not Opponent.isTbd(opponent.opponentData) then
 		Variables.varDefine('qualified_' .. lpdbData.opponentname, lpdbData.qualified)

--- a/lua/wikis/commons/PrizePool/Award/Placement.lua
+++ b/lua/wikis/commons/PrizePool/Award/Placement.lua
@@ -77,6 +77,7 @@ function AwardPlacement:_getLpdbData(...)
 
 		local prizeMoney = tonumber(self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_BASE_CURRENCY .. 1)) or 0
 		local pointsReward = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
+		local pointsReward2 = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 2)
 		local lpdbData = {
 			date = opponent.date,
 			prizemoney = prizeMoney,
@@ -86,6 +87,7 @@ function AwardPlacement:_getLpdbData(...)
 			extradata = {
 				award = self.award,
 				prizepoints = tostring(pointsReward or ''),
+				prizepoints2 = tostring(pointsReward2 or ''),
 				-- legacy
 				participantteam = (opponentType == Opponent.solo and players.p1team)
 									and Opponent.toName{template = players.p1team, type = 'team'}

--- a/lua/wikis/commons/PrizePool/Award/Starcraft.lua
+++ b/lua/wikis/commons/PrizePool/Award/Starcraft.lua
@@ -73,10 +73,6 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Table.mergeInto(lpdbData.extradata, {
 		seriesnumber = CustomPrizePool._seriesNumber(),
-
-		-- to be removed once poinst storage is standardized
-		points = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1),
-		points2 = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 2),
 	})
 
 	lpdbData.tournament = _tournament_name

--- a/lua/wikis/commons/PrizePool/Award/Starcraft.lua
+++ b/lua/wikis/commons/PrizePool/Award/Starcraft.lua
@@ -25,7 +25,6 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 
 local CustomPrizePool = {}
 
-local PRIZE_TYPE_POINTS = 'POINTS'
 local IS_AWARD = true
 
 local _series

--- a/lua/wikis/commons/PrizePool/Custom.lua
+++ b/lua/wikis/commons/PrizePool/Custom.lua
@@ -49,6 +49,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/commons/PrizePool/Custom.lua
+++ b/lua/wikis/commons/PrizePool/Custom.lua
@@ -49,7 +49,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
+		lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/commons/PrizePool/Placement.lua
+++ b/lua/wikis/commons/PrizePool/Placement.lua
@@ -243,6 +243,7 @@ function Placement:_getLpdbData(...)
 
 		local prizeMoney = tonumber(self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_BASE_CURRENCY .. 1)) or 0
 		local pointsReward = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1)
+		local pointsReward2 = self:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 2)
 		local lpdbData = {
 			image = image,
 			imagedark = imageDark,
@@ -268,6 +269,7 @@ function Placement:_getLpdbData(...)
 			),
 			extradata = {
 				prizepoints = tostring(pointsReward or ''),
+				prizepoints2 = tostring(pointsReward2 or ''),
 				participantteam = (opponentType == Opponent.solo and players.p1team)
 									and Opponent.toName{template = players.p1team, type = 'team'}
 									or nil,

--- a/lua/wikis/commons/PrizePool/Starcraft.lua
+++ b/lua/wikis/commons/PrizePool/Starcraft.lua
@@ -27,7 +27,6 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 
 local CustomPrizePool = {}
 
-local PRIZE_TYPE_POINTS = 'POINTS'
 local SC2 = 'starcraft2'
 
 local _series

--- a/lua/wikis/commons/PrizePool/Starcraft.lua
+++ b/lua/wikis/commons/PrizePool/Starcraft.lua
@@ -104,10 +104,6 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	lpdbData.extradata = Table.mergeInto(lpdbData.extradata, {
 		seriesnumber = CustomPrizePool._seriesNumber(),
-
-		-- to be removed once poinst storage is standardized
-		points = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1),
-		points2 = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 2),
 	})
 
 	lpdbData.tournament = _tournament_name

--- a/lua/wikis/counterstrike/PrizePool/Custom.lua
+++ b/lua/wikis/counterstrike/PrizePool/Custom.lua
@@ -78,6 +78,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end
 
 	Variables.varDefine('prizepoints_' .. lpdbData.participant, lpdbData.extradata.prizepoints)
+	Variables.varDefine('prizepoints2_' .. lpdbData.participant, lpdbData.extradata.prizepoints2)
 	Variables.varDefine('enddate_' .. lpdbData.participant, lpdbData.date)
 	Variables.varDefine('placement_' .. lpdbData.participant, lpdbData.placement)
 

--- a/lua/wikis/dota2/PrizePool/Custom.lua
+++ b/lua/wikis/dota2/PrizePool/Custom.lua
@@ -52,6 +52,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine(redirectedTeam .. '_' .. lpdbPrefix .. 'date', lpdbData.date)
 	Variables.varDefine(lpdbPrefix .. (redirectedTeam:lower()) .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(lpdbPrefix .. (redirectedTeam:lower()) .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 
 
 	return lpdbData

--- a/lua/wikis/formula1/PrizePool/Custom.lua
+++ b/lua/wikis/formula1/PrizePool/Custom.lua
@@ -90,6 +90,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/formula1/PrizePool/Custom.lua
+++ b/lua/wikis/formula1/PrizePool/Custom.lua
@@ -90,7 +90,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
+		lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/fortnite/PrizePool/Custom.lua
+++ b/lua/wikis/fortnite/PrizePool/Custom.lua
@@ -52,7 +52,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
+		lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/fortnite/PrizePool/Custom.lua
+++ b/lua/wikis/fortnite/PrizePool/Custom.lua
@@ -52,6 +52,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/halo/PrizePool/Custom.lua
+++ b/lua/wikis/halo/PrizePool/Custom.lua
@@ -49,6 +49,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/halo/PrizePool/Custom.lua
+++ b/lua/wikis/halo/PrizePool/Custom.lua
@@ -49,7 +49,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
+		lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/leagueoflegends/PrizePool/Custom.lua
+++ b/lua/wikis/leagueoflegends/PrizePool/Custom.lua
@@ -49,6 +49,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 
 	return lpdbData

--- a/lua/wikis/leagueoflegends/PrizePool/Custom.lua
+++ b/lua/wikis/leagueoflegends/PrizePool/Custom.lua
@@ -49,7 +49,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
+		lpdbData.extradata.prizepoints2)
 
 
 	return lpdbData

--- a/lua/wikis/mobilelegends/PrizePool/Custom.lua
+++ b/lua/wikis/mobilelegends/PrizePool/Custom.lua
@@ -48,6 +48,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 
 	return lpdbData

--- a/lua/wikis/mobilelegends/PrizePool/Custom.lua
+++ b/lua/wikis/mobilelegends/PrizePool/Custom.lua
@@ -48,7 +48,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
+		lpdbData.extradata.prizepoints2)
 
 
 	return lpdbData

--- a/lua/wikis/overwatch/PrizePool/Custom.lua
+++ b/lua/wikis/overwatch/PrizePool/Custom.lua
@@ -52,6 +52,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(participantLower .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 	lpdbData.qualified = placement:getPrizeRewardForOpponent(opponent, 'QUALIFIES1') and 1 or 0
 
 	if Opponent.isTbd(opponent.opponentData) then

--- a/lua/wikis/pokemon/PrizePool/Custom.lua
+++ b/lua/wikis/pokemon/PrizePool/Custom.lua
@@ -58,6 +58,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
 
 
 	return lpdbData

--- a/lua/wikis/pokemon/PrizePool/Custom.lua
+++ b/lua/wikis/pokemon/PrizePool/Custom.lua
@@ -58,7 +58,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine('enddate_' .. lpdbPrefix .. team, lpdbData.date)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
-	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
+		lpdbData.extradata.prizepoints2)
 
 
 	return lpdbData

--- a/lua/wikis/pubg/PrizePool/Custom.lua
+++ b/lua/wikis/pubg/PrizePool/Custom.lua
@@ -46,6 +46,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	)
 
 	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/pubgmobile/PrizePool/Custom.lua
+++ b/lua/wikis/pubgmobile/PrizePool/Custom.lua
@@ -46,6 +46,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	)
 
 	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(mw.ustring.lower(lpdbData.participant) .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/rainbowsix/PrizePool/Custom.lua
+++ b/lua/wikis/rainbowsix/PrizePool/Custom.lua
@@ -61,6 +61,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	end
 
 	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/rocketleague/PrizePool/Custom.lua
+++ b/lua/wikis/rocketleague/PrizePool/Custom.lua
@@ -54,6 +54,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(participantLower .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 	Variables.varDefine('enddate_'.. participantLower, lpdbData.date)
 
 	if Opponent.isTbd(opponent.opponentData) then

--- a/lua/wikis/tetris/PrizePool/Custom.lua
+++ b/lua/wikis/tetris/PrizePool/Custom.lua
@@ -50,6 +50,9 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participants:lower()) ..
 		'_pointprize', lpdbData.extradata.prizepoints
 	)
+	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (participants:lower()) ..
+		'_pointprize2', lpdbData.extradata.prizepoints2
+	)
 
 	return lpdbData
 end

--- a/lua/wikis/trackmania/PrizePool/Custom.lua
+++ b/lua/wikis/trackmania/PrizePool/Custom.lua
@@ -66,6 +66,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints', lpdbData.extradata.prizepoints)
 	Variables.varDefine(lpdbData.participant:lower() .. '_prizepointsTitle', lpdbData.extradata.prizepointsTitle)
+	Variables.varDefine(lpdbData.participant:lower() .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 
 	return lpdbData
 end

--- a/lua/wikis/valorant/PrizePool/Custom.lua
+++ b/lua/wikis/valorant/PrizePool/Custom.lua
@@ -49,6 +49,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	local participantLower = mw.ustring.lower(lpdbData.participant)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
+	Variables.varDefine(participantLower .. '_prizepoints2', lpdbData.extradata.prizepoints2)
 	Variables.varDefine('enddate_'.. lpdbData.participant .. '_date', lpdbData.date)
 	Variables.varDefine('status'.. lpdbData.participant .. '_date', lpdbData.date)
 

--- a/lua/wikis/warcraft/PrizePool/Custom.lua
+++ b/lua/wikis/warcraft/PrizePool/Custom.lua
@@ -60,9 +60,6 @@ end
 ---@return placement
 function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	lpdbData.extradata = Table.mergeInto(lpdbData.extradata, {
-		-- to be removed once poinst storage is standardized
-		points = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 1),
-		points2 = placement:getPrizeRewardForOpponent(opponent, PRIZE_TYPE_POINTS .. 2),
 		seriesnumber = CustomPrizePool._seriesNumber()
 	})
 

--- a/lua/wikis/warcraft/PrizePool/Custom.lua
+++ b/lua/wikis/warcraft/PrizePool/Custom.lua
@@ -23,7 +23,6 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 
 local CustomPrizePool = {}
 
-local PRIZE_TYPE_POINTS = 'POINTS'
 local AUTOMATION_START_DATE = '2023-10-16'
 
 -- Template entry point


### PR DESCRIPTION
prereq:
- [x] adjust all onwiki consumers
- [x] give a warning in api announcements channel on discord that we rename `points(2)` on sc2, sc, sg and wc (plus potentially aoe) to `prizepoints(2)` in lpdb_placement_extradata

## Summary
some wikis currently store `points2`
some wikis have the desire to have such storage too
goal is to avoid more customs and instead store `points2` via commons renaming it to `prizepoints2` to be in line with the already via commons stored `prizepoints`

storing `prizepoints2` also allows removing the custom storages of `points` and `points2` (due to already preping all consumer modules)

## How did you test this change?
dev