### PR TITLE
chore: remove `play.eslgaming`

### DIFF
--- a/lua/test_assets/lpdb_player.lua
+++ b/lua/test_assets/lpdb_player.lua
@@ -35,7 +35,6 @@ return {
 		['image'] = 'Soniqs Supr.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/a/ab/Soniqs_Supr.jpg/320px-Soniqs_Supr.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/10033345',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/suprmane',
 			['home'] = 'http&#58;//supr.gg/',
 			['siege-gg'] = 'https&#58;//siege.gg/players/134',
@@ -74,7 +73,6 @@ return {
 		['image'] = 'Yuuk at Six Invitational 2018.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/5/54/Yuuk_at_Six_Invitational_2018.jpg/400px-Yuuk_at_Six_Invitational_2018.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/9877455',
 			['facebook'] = 'https&#58;//facebook.com/LucasYuukRodrigues',
 			['instagram'] = 'https&#58;//www.instagram.com/LucasYuuk',
 			['twitch'] = 'https&#58;//www.twitch.tv/tigeryuuk',
@@ -118,7 +116,6 @@ return {
 		['image'] = 'Bullet1 SI20.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/0/01/Bullet1_SI20.jpg/400px-Bullet1_SI20.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/9884488',
 			['facebook'] = 'https&#58;//facebook.com/bullet1r6',
 			['instagram'] = 'https&#58;//www.instagram.com/bullet1r6',
 			['siege-gg'] = 'https&#58;//siege.gg/players/98',
@@ -165,7 +162,6 @@ return {
 		['image'] = 'S3xycake DHMTL19.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/6/6d/S3xycake_DHMTL19.jpg/400px-S3xycake_DHMTL19.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/10196794',
 			['facebook'] = 'https&#58;//facebook.com/xsexycake',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/xS3xyCake',
 			['instagram'] = 'https&#58;//www.instagram.com/xsexycake',
@@ -212,7 +208,6 @@ return {
 		['image'] = 'BiBoo Wolves 2022.png',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/c/c0/BiBoo_Wolves_2022.png/222px-BiBoo_Wolves_2022.png',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/7171663',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/BiBooAF',
 			['siege-gg'] = 'https&#58;//siege.gg/players/19',
 			['twitch'] = 'https&#58;//www.twitch.tv/bibooaf',
@@ -258,7 +253,6 @@ return {
 		['image'] = 'Bosco Six Invitational 2019.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/f/f2/Bosco_Six_Invitational_2019.jpg/400px-Bosco_Six_Invitational_2019.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/10083685',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/Bosco-',
 			['siege-gg'] = 'https&#58;//siege.gg/players/67',
 			['twitch'] = 'https&#58;//www.twitch.tv/Bosco',
@@ -305,7 +299,6 @@ return {
 		['image'] = 'Psycho BR6 2021 S1.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/a/ac/Psycho_BR6_2021_S1.jpg/400px-Psycho_BR6_2021_S1.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/9579997',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/PsychoR6',
 			['instagram'] = 'https&#58;//www.instagram.com/psychor6',
 			['siege-gg'] = 'https&#58;//siege.gg/players/92',
@@ -348,7 +341,6 @@ return {
 		['image'] = 'Pzd Malvinas Gaming 2022.png',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/b/bd/Pzd_Malvinas_Gaming_2022.png/188px-Pzd_Malvinas_Gaming_2022.png',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/8055975',
 			['facebook'] = 'https&#58;//facebook.com/pzddr6',
 			['siege-gg'] = 'https&#58;//siege.gg/players/95',
 			['twitch'] = 'https&#58;//www.twitch.tv/pzddr6',
@@ -391,7 +383,6 @@ return {
 		['image'] = 'wag DH Valencia 2018.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/c/cf/Wag_DH_Valencia_2018.jpg/400px-Wag_DH_Valencia_2018.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/8039261',
 			['facebook'] = 'https&#58;//facebook.com/wagaofps',
 			['twitter'] = 'https&#58;//twitter.com/wagaofps',
 			['youtube'] = 'https&#58;//www.youtube.com/wagaofps',
@@ -428,9 +419,7 @@ return {
 		['id'] = 'Thyy',
 		['image'] = '',
 		['imageurl'] = '',
-		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/9819674',
-		},
+		['links'] = {},
 		['localizedname'] = '',
 		['name'] = 'Thiago Nicézio',
 		['namespace'] = '0',
@@ -465,7 +454,6 @@ return {
 		['image'] = 'SpawNsss at Six Invitational 2018.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/6/60/SpawNsss_at_Six_Invitational_2018.jpg/400px-SpawNsss_at_Six_Invitational_2018.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/8377849',
 			['facebook'] = 'https&#58;//facebook.com/1SpawNsss',
 			['instagram'] = 'https&#58;//www.instagram.com/spwnsss',
 			['twitter'] = 'https&#58;//twitter.com/davidbcouto',
@@ -512,7 +500,6 @@ return {
 		['image'] = 'RaFaLe.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/4/4b/RaFaLe.jpg/314px-RaFaLe.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/7127557',
 			['siege-gg'] = 'https&#58;//siege.gg/players/18',
 			['twitter'] = 'https&#58;//twitter.com/RaFaLe_R6',
 			['youtube'] = 'https&#58;//www.youtube.com/SEBADRI92',
@@ -552,7 +539,6 @@ return {
 		['image'] = 'zephir dhv19.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/2/21/Zephir_dhv19.jpg/400px-Zephir_dhv19.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/7318557',
 			['instagram'] = 'https&#58;//www.instagram.com/zephir6s',
 			['twitch'] = 'https&#58;//www.twitch.tv/ZephiR6S',
 			['twitter'] = 'https&#58;//twitter.com/ZephiR6S',
@@ -591,7 +577,6 @@ return {
 		['image'] = 'Spark 2.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/0/05/Spark_2.jpg/321px-Spark_2.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/6871996',
 			['instagram'] = 'https&#58;//www.instagram.com/sparkr6s',
 			['twitch'] = 'https&#58;//www.twitch.tv/sparkr6s',
 			['twitter'] = 'https&#58;//twitter.com/SparkR6S',
@@ -634,7 +619,6 @@ return {
 		['image'] = 'Voy at Six Invitational 2018.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/3/3d/Voy_at_Six_Invitational_2018.jpg/400px-Voy_at_Six_Invitational_2018.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/7237814',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/Voy_',
 			['twitch'] = 'https&#58;//www.twitch.tv/VoyR6S',
 			['twitter'] = 'https&#58;//twitter.com/ValentinCh_',
@@ -671,7 +655,6 @@ return {
 		['image'] = 'gCR at Six Invitational 2018.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/2/2d/GCR_at_Six_Invitational_2018.jpg/400px-GCR_at_Six_Invitational_2018.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/10536788',
 			['facebook'] = 'https&#58;//facebook.com/gcrfps',
 			['twitch'] = 'https&#58;//www.twitch.tv/gcr_r6',
 			['twitter'] = 'https&#58;//twitter.com/gcrr6',
@@ -752,7 +735,6 @@ return {
 		['image'] = 'Geoo DH Montreal 2018.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/1/11/Geoo_DH_Montreal_2018.jpg/400px-Geoo_DH_Montreal_2018.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/9919890',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/geoolicious',
 			['instagram'] = 'https&#58;//www.instagram.com/tsm_geometrics',
 			['siege-gg'] = 'https&#58;//siege.gg/players/54',
@@ -795,7 +777,6 @@ return {
 		['image'] = 'Shuttle Astralis.png',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/2/2d/Shuttle_Astralis.png/353px-Shuttle_Astralis.png',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/11332895',
 			['faceit'] = 'https&#58;//www.faceit.com/en/players/shuttle-',
 			['siege-gg'] = 'https&#58;//siege.gg/players/55',
 			['twitch'] = 'https&#58;//www.twitch.tv/shuttle',
@@ -836,7 +817,6 @@ return {
 		['image'] = 'Whiteskark sixcup2017.jpg',
 		['imageurl'] = 'https&#58;//liquipedia.net/commons/images/thumb/6/64/Whiteskark_sixcup2017.jpg/311px-Whiteskark_sixcup2017.jpg',
 		['links'] = {
-			['esl'] = 'https&#58;//play.eslgaming.com/player/10797046',
 			['facebook'] = 'https&#58;//facebook.com/Whiteshark67',
 			['twitch'] = 'https&#58;//www.twitch.tv/whiteshark67',
 			['twitter'] = 'https&#58;//twitter.com/Wshark67',

--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -113,12 +113,6 @@ local PREFIXES = {
 		match = 'https://play.esea.net/match/',
 	},
 	['esea-d'] = {'https://play.esea.net/league/standings?divisionId='},
-	esl = {
-		'',
-		team = 'https://play.eslgaming.com/team/',
-		player = 'https://play.eslgaming.com/player/',
-		match = 'https://play.eslgaming.com/match/',
-	},
 	esplay = {'https://esplay.com/tournament/'},
 	esportal = {'https://esportal.com/tournament/'},
 	etf2l = {
@@ -352,7 +346,6 @@ SUFFIXES = Table.merge(SUFFIXES, CustomData.suffixes or {})
 local ALIASES = {
 	['ask-fm'] = {'afk.fm', 'askfm'},
 	douyu = {'douyutv'},
-	esl = {'eslgaming'},
 	['facebook-gaming'] = {'fbgg'},
 	home = {'website', 'web', 'site', 'url'},
 	huyatv = {'huya'},
@@ -442,11 +435,6 @@ local MATCH_ICONS = {
 	ebattle = {
 		icon = 'File:Ebattle Series allmode.png',
 		text = 'Match page on ebattle'
-	},
-	esl = {
-		icon = 'File:ESL_2019_icon_lightmode.png',
-		iconDark = 'File:ESL_2019_icon_darkmode.png',
-		text = 'Match page on ESL'
 	},
 	esea = {
 		icon = 'File:ESEA icon allmode.png',
@@ -698,7 +686,7 @@ function Links.makeFullLinksForTableItems(links, variant, fallbackToBase)
 end
 
 --remove appended number
---needed because the link icons Lua.import e.g. 'esl' instead of 'esl2'
+--needed because the link icons require e.g. 'twitch' instead of 'twitch2'
 ---@param key string
 ---@return string
 function Links.removeAppendedNumber(key)

--- a/lua/wikis/commons/Links/PriorityGroups.lua
+++ b/lua/wikis/commons/Links/PriorityGroups.lua
@@ -31,7 +31,6 @@ return {
 		'dotabuff',
 		'esea',
 		'esea-d',
-		'esl',
 		'esplay',
 		'esportal',
 		'etf2l',

--- a/lua/wikis/counterstrike/Links/CustomData.lua
+++ b/lua/wikis/counterstrike/Links/CustomData.lua
@@ -20,10 +20,5 @@ return {
 		['faceit-l'] = {
 			'https://www.faceit.com/en/-/league/-/a14b8616-45b9-4581-8637-4dfd0b5f6af8/',
 		},
-		esl = {
-			'',
-			team = 'https://play.eslgaming.com/counterstrike/csgo/team/',
-			player = 'https://play.eslgaming.com/counterstrike/csgo/player/',
-		}
 	},
 }

--- a/lua/wikis/counterstrike/MatchExternalLinks.lua
+++ b/lua/wikis/counterstrike/MatchExternalLinks.lua
@@ -29,14 +29,6 @@ return {
 		max = 2,
 	},
 	{
-		name = 'esl',
-		icon = 'ESL 2019 icon lightmode.png',
-		iconDark = 'ESL 2019 icon darkmode.png',
-		prefixLink = 'https://play.eslgaming.com/match/',
-		label = 'Matchpage and Stats on ESL Play',
-		isMapStats = true
-	},
-	{
 		name = 'esea',
 		icon = 'ESEA icon.png',
 		prefixLink = 'https://play.esea.net/match/',

--- a/lua/wikis/warcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Person/Player/Custom.lua
@@ -37,7 +37,6 @@ function CustomPlayer.run(frame)
 	args.achievements = Achievements.player{noTemplate = true}
 
 	-- Profiles to links
-	args.esl = args.esl or args.eslprofile
 	args.nwc3l = args.nwc3l or args.nwc3lprofile
 
 	-- Uppercase first letter in status

--- a/lua/wikis/warcraft/Infobox/Team/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Team/Custom.lua
@@ -40,11 +40,6 @@ local PROFILES = {
 		link = 'https://nwc3l.com/team/',
 		text = 'NWC3L ${name}\'s profile'
 	},
-	eslprofile = {
-		icon = 'ESL_2019_icon.png',
-		link = 'https://play.eslgaming.com/team/',
-		text = 'ESL ${name}\'s profile'
-	},
 }
 
 ---@param frame Frame

--- a/lua/wikis/warcraft/Links/CustomData.lua
+++ b/lua/wikis/warcraft/Links/CustomData.lua
@@ -11,10 +11,5 @@ return {
 			'https://challonge.com/',
 			player = 'https://challonge.com/users/',
 		},
-		esl = {
-			'https://play.eslgaming.com/warcraft/',
-			team = 'https://play.eslgaming.com/team/',
-			player = 'https://play.eslgaming.com/player/',
-		},
 	},
 }

--- a/stylesheets/commons/Icons.less
+++ b/stylesheets/commons/Icons.less
@@ -85,7 +85,6 @@ Note: When adding a new icon, please add to
 	.icon-make-image( escharts, "//liquipedia.net/commons/images/9/99/InfoboxIcon_EsportsCharts.png" );
 	.icon-make-image( esea, "//liquipedia.net/commons/images/9/99/InfoboxIcon_ESEA.png" );
 	.icon-make-image( esea-league, "//liquipedia.net/commons/images/8/8e/InfoboxIcon_ESEA_League.png" );
-	.icon-make-image( esl, "//liquipedia.net/commons/images/4/44/InfoboxIcon_ESL.png" );
 	.icon-make-image( esplay, "//liquipedia.net/commons/images/e/ec/InfoboxIcon_Esplay.png" );
 	.icon-make-image( esportal, "//liquipedia.net/commons/images/c/c2/InfoboxIcon_Esportal.png" );
 	.icon-make-image( etf2l, "//liquipedia.net/commons/images/6/61/InfoboxIcon_ETF2L.png" );


### PR DESCRIPTION
## Summary
remove `play.eslgaming` as the site is dead (everything redirects to just `https://esl.com/play/`) and to my knowledge there is no replacement for it to which the old ids can be mapped

## How did you test this change?
N/A