### PR TITLE
feat(mainpage): enable rumour portal in rocketleague main page

### DIFF
--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -36,7 +36,8 @@ local CONTENT = {
 		body = TransfersList{
 			transferPortal = 'Transfers',
 			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
-				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter',
+			rumours = true
 		},
 		boxid = 1509,
 	},


### PR DESCRIPTION
## Summary

small oversight from #5660

## How did you test this change?

dev