### PR TITLE
feat(match2): standardize template usage on paladins

### DIFF
--- a/lua/wikis/paladins/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/paladins/GetMatchGroupCopyPaste/wiki.lua
@@ -28,7 +28,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local showScore = Logic.nilOr(Logic.readBoolOrNil(args.score), bestof == 0)
 
 	local lines = Array.extend(
-		'{{Match2',
+		'{{Match',
 		Logic.readBool(args.showScore) and INDENT .. '|finished=' or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)


### PR DESCRIPTION
## Summary

- ~~Replace all `{{Match}}` usages with `{{Match/old}}`~~ (No existing use)
- ~~Archive local version of `{{Match}}`~~ (does not exist)
- [x] bot existing `{{Match2}}` to `{{Match}}`

## How did you test this change?

N/A