### PR TITLE
fix: hr on panel-box-body not readable in darkmode

### DIFF
--- a/stylesheets/commons/Panels.less
+++ b/stylesheets/commons/Panels.less
@@ -102,6 +102,9 @@ html .panel-box-heading {
 
 		.theme--dark & {
 			background-color: #26292d;
+			> hr {
+				background-color: var(--clr-secondary-25);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
hr generally uses `var(--clr-secondary-16);` on darkmode
inside `panel-box-body` this is not readable (in darkmode)
to fix that adjust it to `var(--clr-secondary-25);` for this case

## How did you test this change?
browser dev tools