### PR TITLE
fix: match ticker "show countdown" is only visible with default filters

### DIFF
--- a/lua/wikis/commons/Widget/Match/Ticker/Container.lua
+++ b/lua/wikis/commons/Widget/Match/Ticker/Container.lua
@@ -119,8 +119,6 @@ function MatchTickerContainer:render()
 				attributes = {
 					['data-switch-group-container'] = 'countdown',
 					['data-toggle-area-content'] = '1',
-					['data-filter-expansion-template'] = buildTemplateExpansionString('upcoming'),
-					['data-filter-groups'] = filterText,
 				},
 				children = {
 					HtmlWidgets.Div{
@@ -140,7 +138,13 @@ function MatchTickerContainer:render()
 							HtmlWidgets.Div{children = 'Show Countdown'},
 						},
 					},
-					callTemplate('upcoming'),
+					HtmlWidgets.Div{
+						attributes = {
+							['data-filter-expansion-template'] = buildTemplateExpansionString('upcoming'),
+							['data-filter-groups'] = filterText,
+						},
+						children = callTemplate('upcoming'),
+					}
 				}
 			},
 			HtmlWidgets.Div{


### PR DESCRIPTION
## Summary
The "Show Countdown" is only visible when on default tier filters, any API call would override the entire ticker, of which the countdown was now a part of. Moving the part which gets overriden by the API call into a div one step lower (splitting up the html attributes really)

## How did you test this change?
dev