### PR TITLE
feat(match2): sort players by descending order of ACS in valorant matchpage

### DIFF
--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -10,7 +10,6 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local MathUtil = Lua.import('Module:MathUtil')
-local Operator = Lua.import('Module:Operator')
 local Table = Lua.import('Module:Table')
 
 local BaseMatchPage = Lua.import('Module:MatchPage/Base')


### PR DESCRIPTION
## Summary

This PR sorts players in Valorant matchpage in the descending order of their ACS.

## How did you test this change?

dev