### PR TITLE
chore: remove unneeded string replace

### DIFF
--- a/lua/wikis/commons/TeamTemplate.lua
+++ b/lua/wikis/commons/TeamTemplate.lua
@@ -28,7 +28,6 @@ timezone parts.
 ---@param date string|number?
 ---@return string?
 function TeamTemplate.resolve(template, date)
-	template = template:gsub('_', ' ')
 	local raw = TeamTemplate.getRawOrNil(template, date) or {}
 	return raw.templatename
 end


### PR DESCRIPTION
## Summary
the removed line is not needed as the function that gets called in the line after it already does the according replacement of its own

## How did you test this change?
N/A