### PR TITLE
feat(match2): remove player names being links in RL Brackets

### DIFF
--- a/lua/wikis/rocketleague/OpponentDisplay/Custom.lua
+++ b/lua/wikis/rocketleague/OpponentDisplay/Custom.lua
@@ -63,16 +63,6 @@ function CustomOpponentDisplay.BracketOpponentEntry:addScores(opponent)
 	end
 end
 
----@param opponent RocketLeagueStandardOpponent
-function CustomOpponentDisplay.BracketOpponentEntry:createPlayers(opponent)
-	local playerNode = OpponentDisplay.BlockPlayers({
-		opponent = opponent,
-		overflow = 'ellipsis',
-		showLink = true,
-	})
-	self.content:node(playerNode)
-end
-
 ---Displays a score or status of the opponent, as a string.
 ---@param props {opponent: RocketLeagueStandardOpponent, status: string?, score: number?}
 ---@return number|string


### PR DESCRIPTION
## Summary
remove some RL customization, after checking with the community that it's okay