### PR TITLE
feat(infobox): Free Fire Infobox league cleanup

### DIFF
--- a/lua/wikis/freefire/Infobox/Team/Custom.lua
+++ b/lua/wikis/freefire/Infobox/Team/Custom.lua
@@ -5,18 +5,21 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
 local Lua = require('Module:Lua')
-local PlacementStats = require('Module:InfoboxPlacementStats')
-local Template = require('Module:Template')
+
+local Class = Lua.import('Module:Class')
+
+local OpponentLibraries = Lua.import('Module:OpponentLibraries')
+local OpponentDisplay = OpponentLibraries.OpponentDisplay
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')
 
-local Widgets = require('Module:Widget/All')
+local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
+local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
----@class FreefireInfoboxTeam: InfoboxTeam
+---@class FreeFireInfoboxTeam: InfoboxTeam
 local CustomTeam = Class.new(Team)
 local CustomInjector = Class.new(Injector)
 
@@ -29,29 +32,11 @@ function CustomTeam.run(frame)
 	return team:createInfobox()
 end
 
----@param id string
----@param widgets Widget[]
----@return Widget[]
-function CustomInjector:parse(id, widgets)
-	local args = self.caller.args
-	if id == 'staff' then
-		table.insert(widgets, 1, Cell{name = 'Founders', content = {args.founders}})
-		table.insert(widgets, 2, Cell{name = 'CEO', content = {args.ceo}})
-		table.insert(widgets, Cell{name = 'Analysts', content = {args.analysts}})
-	end
-	return widgets
-end
-
----@return string
+---@return string?
 function CustomTeam:createBottomContent()
-	return tostring(PlacementStats.run{
-		tiers = {'1', '2', '3', '4'},
-		participant = self.name,
-	}) .. Template.expandTemplate(
-		mw.getCurrentFrame(),
-		'Upcoming and ongoing tournaments of',
-		{team = self.name}
-	)
+	if not self.args.disbanded then
+		return UpcomingTournaments{name = self.pagename}
+	end
 end
 
 return CustomTeam


### PR DESCRIPTION
Part of Main Wiki Cleanup

## Summary
I make some changes to the Infobox Team setup if this is going to be required for a main wiki preparation, here's what I did

- I ported the setup from VALORANT, mainly to get use of the "Upcoming Tournaments" widget, in which Free Fire's setup is still an expanded template

- Infobox now looks a bit more slimmer vs old versiion

## How did you test this change?
Left is New Version - `|dev=h2`
https://liquipedia.net/freefire/RRQ_Kazu

<img width="730" height="854" alt="image" src="https://github.com/user-attachments/assets/32d1bc48-76ce-409f-9716-9d70a86ba00d" />

