### PR TITLE
fix: remove force team linking on commons

### DIFF
--- a/lua/wikis/commons/MatchSummary/Base/Ffa.lua
+++ b/lua/wikis/commons/MatchSummary/Base/Ffa.lua
@@ -113,7 +113,6 @@ local MATCH_OVERVIEW_COLUMNS = {
 			value = function (opponent, idx)
 				return OpponentDisplay.BlockOpponent{
 					opponent = opponent,
-					showLink = true,
 					overflow = 'ellipsis',
 					teamStyle = 'hybrid',
 					showPlayerTeam = true,
@@ -290,7 +289,6 @@ local GAME_STANDINGS_COLUMNS = {
 				return OpponentDisplay.BlockOpponent{
 					opponent = opponent,
 					game = opponent.game,
-					showLink = true,
 					overflow = 'ellipsis',
 					teamStyle = 'hybrid',
 					showPlayerTeam = true,

--- a/lua/wikis/commons/MvpTable.lua
+++ b/lua/wikis/commons/MvpTable.lua
@@ -195,7 +195,6 @@ function MvpTable._row(item, args)
 				pageName = item.name,
 				team = item.team and TeamTemplate.resolve(item.team, DateExt.getContextualDateOrNow()) or nil,
 			}}},
-			showLink = true,
 			overflow = 'ellipsis',
 			showPlayerTeam = true,
 		}):done()

--- a/lua/wikis/commons/Widget/Standings/Ffa.lua
+++ b/lua/wikis/commons/Widget/Standings/Ffa.lua
@@ -105,7 +105,6 @@ function StandingsFfaWidget:render()
 								classes = {teamBackground},
 								children = OpponentDisplay.BlockOpponent{
 									opponent = slot.opponent,
-									showLink = true,
 									overflow = 'ellipsis',
 									teamStyle = 'hybrid',
 									showPlayerTeam = true,

--- a/lua/wikis/commons/Widget/Standings/MatchOverview.lua
+++ b/lua/wikis/commons/Widget/Standings/MatchOverview.lua
@@ -45,7 +45,6 @@ function MatchOverviewWidget:render()
 			HtmlWidgets.Span{
 				children = OpponentDisplay.BlockOpponent{
 					opponent = opponent,
-					showLink = true,
 					overflow = 'ellipsis',
 					teamStyle = 'icon',
 				}

--- a/lua/wikis/commons/Widget/Standings/Swiss.lua
+++ b/lua/wikis/commons/Widget/Standings/Swiss.lua
@@ -82,7 +82,6 @@ function StandingsSwissWidget:render()
 							classes = {teamBackground},
 							children = OpponentDisplay.BlockOpponent{
 								opponent = slot.opponent,
-								showLink = true,
 								overflow = 'ellipsis',
 								teamStyle = 'hybrid',
 								showPlayerTeam = true,


### PR DESCRIPTION
## Summary
None-tbd's will still have links, as that is the default behavior
## How did you test this change?
Match2 FFA change is Live