### PR TITLE
fix(opponent): all literals are assumed tbd in BracketOpponentEntry

### DIFF
--- a/lua/wikis/commons/Opponent.lua
+++ b/lua/wikis/commons/Opponent.lua
@@ -152,8 +152,10 @@ end
 
 ---Checks whether an opponent is TBD
 ---@param opponent standardOpponent
+---@param options {checkLiterals: boolean?}?
 ---@return boolean
-function Opponent.isTbd(opponent)
+function Opponent.isTbd(opponent, options)
+	options = options or {}
 	if opponent.type == Opponent.team then
 		return opponent.template == 'tbd'
 
@@ -162,7 +164,7 @@ function Opponent.isTbd(opponent)
 			or String.isEmpty(opponent.template)
 
 	elseif opponent.type == Opponent.literal then
-		return true
+		return options.checkLiterals ~= true or (opponent.name or ''):lower() == 'tbd'
 
 	else
 		return Array.any(opponent.players, Opponent.playerIsTbd)

--- a/lua/wikis/commons/Opponent.lua
+++ b/lua/wikis/commons/Opponent.lua
@@ -152,10 +152,8 @@ end
 
 ---Checks whether an opponent is TBD
 ---@param opponent standardOpponent
----@param options {checkLiterals: boolean?}?
 ---@return boolean
-function Opponent.isTbd(opponent, options)
-	options = options or {}
+function Opponent.isTbd(opponent)
 	if opponent.type == Opponent.team then
 		return opponent.template == 'tbd'
 
@@ -164,7 +162,7 @@ function Opponent.isTbd(opponent, options)
 			or String.isEmpty(opponent.template)
 
 	elseif opponent.type == Opponent.literal then
-		return options.checkLiterals ~= true or (opponent.name or ''):lower() == 'tbd'
+		return true
 
 	else
 		return Array.any(opponent.players, Opponent.playerIsTbd)

--- a/lua/wikis/commons/OpponentDisplay.lua
+++ b/lua/wikis/commons/OpponentDisplay.lua
@@ -41,7 +41,7 @@ OpponentDisplay.BracketOpponentEntry = Class.new(
 	function(self, opponent, options)
 		self.content = mw.html.create('div'):addClass('brkts-opponent-entry-left')
 
-		if options.showTbd == false and (Opponent.isEmpty(opponent) or Opponent.isTbd(opponent)) then
+		if options.showTbd == false and (Opponent.isEmpty(opponent) or Opponent.isTbd(opponent, {checkLiterals = true})) then
 			opponent = Opponent.blank()
 		end
 

--- a/lua/wikis/commons/OpponentDisplay.lua
+++ b/lua/wikis/commons/OpponentDisplay.lua
@@ -41,7 +41,10 @@ OpponentDisplay.BracketOpponentEntry = Class.new(
 	function(self, opponent, options)
 		self.content = mw.html.create('div'):addClass('brkts-opponent-entry-left')
 
-		if options.showTbd == false and (Opponent.isEmpty(opponent) or Opponent.isTbd(opponent, {checkLiterals = true})) then
+		if options.showTbd == false and (
+			Opponent.isEmpty(opponent) or
+			Opponent.isTbd(opponent) and opponent.type ~= Opponent.literal
+		) then
 			opponent = Opponent.blank()
 		end
 


### PR DESCRIPTION
## Summary
reported on discord that all literals are not displayed in brackets:
https://discord.com/channels/93055209017729024/372075546231832576/1396823389171355748

## How did you test this change?
dev