### PR TITLE
fix(matchticker): vodlink icon stays lightmode under dark theme

### DIFF
--- a/lua/wikis/commons/Widget/Match/Card.lua
+++ b/lua/wikis/commons/Widget/Match/Card.lua
@@ -85,6 +85,7 @@ function MatchCard:render()
 			link = vod,
 			size = 'sm',
 			grow = callToAction,
+			classes = {'vodlink'},
 			children = {
 				ImageIcon{imageLight = VodLink.getIcon(index)},
 				callToAction and ' ' or nil,


### PR DESCRIPTION
## Summary

Current version of match ticker leaves vod icon as lightmode even under darkmode (see screenshot below). This PR fixes this behavior.

<img width="340" height="166" alt="Image" src="https://github.com/user-attachments/assets/d5346ac8-44ab-407b-b044-2fe21b11e85e" />

## How did you test this change?

preview with dev