### PR TITLE
feat: change the highlight to only be the tournament  bar

### DIFF
--- a/lua/wikis/commons/Widget/Match/Card.lua
+++ b/lua/wikis/commons/Widget/Match/Card.lua
@@ -105,12 +105,12 @@ function MatchCard:render()
 	}
 
 	return HtmlWidgets.Div{
-		classes = {'match-info', highlight and HIGHLIGHT_CLASS or nil},
+		classes = {'match-info'},
 		children = WidgetUtil.collect(
 			MatchCountdown{match = match},
 			MatchHeader{match = match},
 			not self.props.hideTournament and HtmlWidgets.Div{
-				classes = {'match-info-tournament'},
+				classes = {'match-info-tournament', highlight and HIGHLIGHT_CLASS or nil},
 				children = {tournamentLink},
 			} or nil,
 			HtmlWidgets.Div{


### PR DESCRIPTION
## Summary

before and after
<img width="366" height="296" alt="image" src="https://github.com/user-attachments/assets/41fd2bf8-39b3-4914-b4f7-cb2ee635c1e4" />

## How did you test this change?

dev tools