### PR TITLE
feat(infobox): hero infobox for honorofkings

### DIFF
--- a/lua/wikis/honorofkings/Infobox/Character/Custom.lua
+++ b/lua/wikis/honorofkings/Infobox/Character/Custom.lua
@@ -64,9 +64,7 @@ function CustomInjector:parse(id, widgets)
 			},
 		}
 	elseif id == 'custom' then
-		return WidgetUtil.collect(
-			self.caller:_getCustomCells()
-		)
+		return self.caller:_getCustomCells()
     end
 	return widgets
 end


### PR DESCRIPTION
Custom.lua for Infobox/Character

## Summary
Since HoK still didnt have a hero page, then i try to create it with some code from mlbb hero page. Some editor has been discuss this and agree with just some info since wiki still including 2 games for now.

## How did you test this change?
<img width="540" height="680" alt="Screenshot_20250720-205302_Thorium_1" src="https://github.com/user-attachments/assets/f5f1019c-4079-49d4-9574-01c67791f958" />
This the test page https://liquipedia.net/honorofkings/User:Riieee/TestHero

A thread has been created in discord/hok, but look like it private and cant get any link there
