### PR TITLE
fix(match2): match assumed finished wrongly

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -899,7 +899,7 @@ function MatchGroupInputUtil.majorityHasBeenWon(bestof, opponents)
 		return true
 	end
 	local scoreSum = Array.reduce(opponents, function(sum, opponent) return sum + (opponent.score or 0) end, 0)
-	if scoreSum >= bestof then
+	if bestof > 0 and scoreSum >= bestof then
 		return true
 	end
 	return false


### PR DESCRIPTION
## Summary
Currently if bestof is 0 and no maps are played the match is considered finished.
In particular if you have a match without maps this leads to the match being finished on wikis that count the number of maps to determine bestof.
example: https://liquipedia.net/geoguessr/Balkans_Qualifiers/2025/Stage_2

This PR adjusts the handling in `MatchGroupInputUtil.majorityHasBeenWon` to also check that bestof is >0 when assuming a match is finished if scoresum is >= bestof.
This resolves the above described issue without changing the processing in any other case.

## How did you test this change?
dev