### PR TITLE
feat(infobox): Change default CHZZK link

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -83,7 +83,7 @@ local PREFIXES = {
 		match = 'https://www.chessgames.com/perl/chessgame?gid=',
 	},
 	chessresults = {'https://chess-results.com/'},
-	chzzk = {'https://chzzk.naver.com/live/'},
+	chzzk = {'https://chzzk.naver.com/'},
 	civdraft = {match = 'https://aoe2cm.net/draft/'},
 	cntft = {'https://lol.qq.com/tft/#/masterDetail/'},
 	corestrike = {'https://corestrike.gg/lookup/'},


### PR DESCRIPTION
## Summary

The CHZZK social link should lead to the main page of the user and not the dedicated streaming section of their profile. This shows just a 90% black screen if they are not currently streaming.

Removing the /live fixes the link use from an infobox. Nothing else needs to be adjusted.

## How did you test this change?

Removed the /live manually from a few links and all profiles still work

With /live
<img width="223" height="130" alt="grafik" src="https://github.com/user-attachments/assets/9666aa8b-63ca-41b9-905f-d916b73ba77a" />

Without /live
<img width="217" height="113" alt="grafik" src="https://github.com/user-attachments/assets/c80fa0dd-f1a9-4090-91a3-1cf9ed8a2339" />

