### PR TITLE
fix(match2): always show matchdetails button when logged in

### DIFF
--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -86,12 +86,13 @@ function MatchButtonBar:render()
 	local matchPageButton = MatchPageButton{
 		matchId = matchId,
 		hasMatchPage = Logic.isNotEmpty(match.bracketData.matchPage),
+		displayMatchPage = displayMatchPage,
 	}
 
 	return HtmlWidgets.Div{
 		classes = {'match-info-links'},
 		children = WidgetUtil.collect(
-			displayMatchPage and matchPageButton or nil,
+			Info.config.match2.matchPage and matchPageButton or nil,
 			displayStreams and StreamsContainer{
 				streams = StreamLinks.filterStreams(match.stream),
 				callToActionLimit = displayMatchPage and 0 or 2,

--- a/lua/wikis/commons/Widget/Match/PageButton.lua
+++ b/lua/wikis/commons/Widget/Match/PageButton.lua
@@ -36,6 +36,7 @@ function MatchPageButton:render()
 	if self.props.hasMatchPage then
 		return Button{
 			title = 'View match details',
+			classes = { (not self.props.displayMatchPage) and 'show-when-logged-in' or nil },
 			variant = self.props.buttonType,
 			size = 'sm',
 			link = link,


### PR DESCRIPTION
## Summary
As per complaints on discord creating match pages has become harder for contributors.
Also accessing them to edit them (e.g. for date changes) is harder too.

This PR makes it so that the `+ Add details` or Match details button will always show for contributors.

Please be aware that this also affects the match ticker for logged in users.
Additionally the callToActionLimit stays the same for contributors. Not sure if this could have unintended side effects. But couldn't find an example where it looked ugly so far.

## How did you test this change?
dev