### PR TITLE
fix: `Widget/Match/Summary/Break` missing while still used

### DIFF
--- a/lua/wikis/commons/Widget/Match/Summary/Break.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Break.lua
@@ -1,0 +1,27 @@
+---
+-- @Liquipedia
+-- page=Module:Widget/Match/Summary/Break
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+
+---@class MatchSummaryBreak: Widget
+---@operator call(table): MatchSummaryBreak
+local MatchSummaryBreak = Class.new(Widget)
+
+---@return Widget
+function MatchSummaryBreak:render()
+	return Div{
+		classes = {'brkts-popup-break'},
+	}
+end
+
+return MatchSummaryBreak


### PR DESCRIPTION
## Summary
regression of #6175
Still used in
- `Module:Widget/Match/Summary/GameComment` (used on 58 wikis)
- `Module:Widget/Match/Summary/MatchComment` (used in `Module:MatchSummary/Base` and hence on all wikis)

## How did you test this change?
live