### PR TITLE
fix(MatchTicker): Use correct timestamp when expanding games

### DIFF
--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -453,7 +453,7 @@ function MatchTicker:expandGamesOfMatch(match)
 		gameMatch.opponents = Array.map(match.opponents, function(opponent, opponentIndex)
 			return MatchUtil.enrichGameOpponentFromMatchOpponent(opponent, game.opponents[opponentIndex])
 		end)
-		Table.mergeInto(gameMatch.extradata, game.extradata)
+		game.extradata = Table.merge(gameMatch.extradata, game.extradata)
 		return gameMatch
 	end)
 


### PR DESCRIPTION
## Summary
New matchcard uses timestamp and not date, so correctly copy that from the game.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
