### PR TITLE
fix(matchticker): CTA text is showing when there's 4+ streams

### DIFF
--- a/stylesheets/commons/Match.less
+++ b/stylesheets/commons/Match.less
@@ -159,7 +159,7 @@
 		gap: 0.5rem;
 		align-self: stretch;
 
-		&:has( > :last-child:nth-child( 3 ) ) .match-button-cta-text {
+		&:has( > :nth-last-child(3) ) .match-button-cta-text {
 			display: none;
 		}
 

--- a/stylesheets/commons/Match.less
+++ b/stylesheets/commons/Match.less
@@ -159,7 +159,7 @@
 		gap: 0.5rem;
 		align-self: stretch;
 
-		&:has( > :nth-last-child(3) ) .match-button-cta-text {
+		&:has( > :nth-last-child( 3 ) ) .match-button-cta-text {
 			display: none;
 		}
 


### PR DESCRIPTION
## Summary
the CTA text hider only targeted exactly 3 streams, instead of 3+. This fixes it

<img width="380" height="566" alt="image" src="https://github.com/user-attachments/assets/bea490cb-ff30-47e1-a725-92515084d0b4" />


## How did you test this change?
devtools