### PR TITLE
fix(match2): header not displayed on mobile for big MS

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -476,7 +476,7 @@
 		top: 50% !important;
 		max-height: 50vh;
 		width: auto !important;
-		transform: translateY( -50% );
+		transform: translateY( -40% );
 	}
 }
 


### PR DESCRIPTION
## Summary
currently large MS do not display their header on mobile (it is pushed into the top bar which has higher z-lvl)
to fix that adjust the y-trnaslate from 50% to 40%

## How did you test this change?
dev tools

before:
<img width="419" height="695" alt="image" src="https://github.com/user-attachments/assets/c80a098b-1004-485e-93de-470bd465c36c" />

after:
<img width="400" height="681" alt="image" src="https://github.com/user-attachments/assets/602dd4dc-f932-4263-8c98-9799ebc0edf2" />
