### PR TITLE
fix(match2): champion pick icons too big on mobile

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -972,10 +972,6 @@ div.brkts-popup-body-element-thumbs {
 
 .brkts-champion-icon img {
 	object-fit: cover;
-
-	@media ( max-width: 768px ) {
-		object-fit: cover;
-	}
 }
 
 @media ( hover: hover ) {


### PR DESCRIPTION
## Summary
Character Pick Icons are too big on mobile due to specificity issue. Move it around (and remove redundant styling). 

This caused game rows to overflow on mobile

## How did you test this change?
devtools