### PR TITLE
feat(match2): improve map veto header on SC2

### DIFF
--- a/lua/wikis/commons/MatchSummary/Starcraft.lua
+++ b/lua/wikis/commons/MatchSummary/Starcraft.lua
@@ -62,8 +62,8 @@ function StarcraftMatchSummary.createBody(match)
 		subMatches and Array.map(subMatches, StarcraftMatchSummary.TeamSubmatch)
 			or Array.map(match.games, FnUtil.curry(StarcraftMatchSummary.Game, {})),
 		Logic.isNotEmpty(match.vetoes) and MatchSummaryWidgets.Row{
-			classes = {'brkts-popup-sc-game-header brkts-popup-sc-veto-center'},
-			children = {'Vetoes'},
+			classes = {'brkts-popup-sc-veto-center'},
+			children = {HtmlWidgets.B{children = {'Vetoes'}}},
 		} or nil,
 		Array.map(match.vetoes or {}, StarcraftMatchSummary.Veto) or nil
 	)}

--- a/lua/wikis/stormgate/MatchSummary.lua
+++ b/lua/wikis/stormgate/MatchSummary.lua
@@ -63,8 +63,8 @@ function CustomMatchSummary.createBody(match)
 		subMatches and Array.map(subMatches, CustomMatchSummary.TeamSubmatch)
 			or Array.map(match.games, FnUtil.curry(CustomMatchSummary.Game, {hasHeroes = hasHeroes})),
 		Logic.isNotEmpty(match.vetoes) and MatchSummaryWidgets.Row{
-			classes = {'brkts-popup-sc-game-header brkts-popup-sc-veto-center'},
-			children = {'Vetoes'},
+			classes = {'brkts-popup-sc-veto-center'},
+			children = {HtmlWidgets.B{children = {'Vetoes'}}},
 		} or nil,
 		Array.map(match.vetoes or {}, CustomMatchSummary.Veto) or nil
 	)}

--- a/lua/wikis/warcraft/MatchSummary.lua
+++ b/lua/wikis/warcraft/MatchSummary.lua
@@ -64,8 +64,8 @@ function CustomMatchSummary.createBody(match)
 		subMatches and Array.map(subMatches, CustomMatchSummary.TeamSubmatch)
 			or Array.map(match.games, FnUtil.curry(CustomMatchSummary.Game, {hasHeroes = hasHeroes})),
 		Logic.isNotEmpty(match.vetoes) and MatchSummaryWidgets.Row{
-			classes = {'brkts-popup-sc-game-header brkts-popup-sc-veto-center'},
-			children = {'Vetoes'},
+			classes = {'brkts-popup-sc-veto-center'},
+			children = {HtmlWidgets.B{children = {'Vetoes'}}},
 		} or nil,
 		Array.map(match.vetoes or {}, CustomMatchSummary.Veto) or nil
 	)}

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -1318,31 +1318,6 @@ div.brkts-opponent-hover-active::after {
 	overflow: auto;
 }
 
-.brkts-popup-sc-game {
-	line-height: 1.4;
-	padding: 4px 10px;
-}
-
-@media ( max-width: 768px ) {
-	.brkts-popup-sc-game {
-		padding: 4px 4px;
-	}
-}
-
-.brkts-popup-sc-game-header {
-	border-top: 1px solid var( --table-border-color, #dddddd );
-	display: block;
-	margin-top: -4px;
-	padding-top: 4px;
-	text-align: center;
-}
-
-// can probably be kicked with MatchSummary refactor on WC/SG
-.brkts-popup-sc-game-body {
-	align-items: center;
-	display: flex;
-}
-
 .brkts-popup-sc-game-center {
 	flex: 1 1;
 	min-width: 0;
@@ -1366,21 +1341,6 @@ div.brkts-opponent-hover-active::after {
 
 .brkts-popup-sc-veto {
 	padding: 0;
-}
-
-// can probably be kicked with MatchSummary refactor on WC/SG
-.brkts-popup-sc-veto-body {
-	align-items: center;
-	display: flex;
-	line-height: 1.4;
-	padding: 4px 10px;
-}
-
-// can probably be kicked with MatchSummary refactor on WC/SG
-@media ( max-width: 768px ) {
-	.brkts-popup-sc-veto-body {
-		padding: 4px 4px;
-	}
 }
 
 .brkts-popup-sc-veto-center {


### PR DESCRIPTION
## Summary
due to recent changes the veto header now has a not so nice margin/padding issue
to solve that remove the usage of `.brkts-popup-sc-game-header`
also bold the veto header to amke clear it is a header...

additionally kick some unused classes

## How did you test this change?
dev tools

before:
<img width="890" height="234" alt="image" src="https://github.com/user-attachments/assets/efce62f5-6929-4c9c-8047-60b10fab0ba1" />

after:
<img width="890" height="250" alt="image" src="https://github.com/user-attachments/assets/9139d29c-377f-4a2c-b6e0-59c5a3c48a60" />