### PR TITLE
refactor(matchTable): make use of `MatchGroupUtil.matchFromRecord`

### DIFF
--- a/lua/wikis/commons/MatchGroup/Display/Helper.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Helper.lua
@@ -110,9 +110,9 @@ end
 function DisplayHelper.MatchCountdownBlock(match)
 	local dateString
 	if match.dateIsExact == true then
-		local timestamp = Date.readTimestamp(match.date) + (Timezone.getOffset{timezone = match.extradata.timezoneid} or 0)
+		local timestamp = Date.readTimestamp(match.date) + (Timezone.getOffset{timezone = match.timezoneId} or 0)
 		dateString = Date.formatTimestamp('F j, Y - H:i', timestamp) .. ' '
-				.. (Timezone.getTimezoneString{timezone = match.extradata.timezoneid} or UTC)
+				.. (Timezone.getTimezoneString{timezone = match.timezoneId} or UTC)
 	else
 		dateString = mw.getContentLanguage():formatDate('F j, Y', match.date)
 	end

--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -263,6 +263,7 @@ MatchGroupUtil.types.Game = TypeUtil.struct({
 ---@field winner number?
 ---@field extradata table?
 ---@field timestamp number
+---@field timezoneId string?
 ---@field bestof number?
 MatchGroupUtil.types.Match = TypeUtil.struct({
 	bracketData = MatchGroupUtil.types.BracketData,
@@ -565,6 +566,7 @@ function MatchGroupUtil.matchFromRecord(record)
 		stream = Json.parseIfString(record.stream) or {},
 		tickername = record.tickername,
 		timestamp = tonumber(Table.extract(extradata, 'timestamp')),
+		timezoneId = Table.extract(extradata, 'timezoneid'),
 		tournament = record.tournament,
 		type = nilIfEmpty(record.type) or 'literal',
 		vod = nilIfEmpty(record.vod),

--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -78,7 +78,6 @@ local SECONDS_ONE_DAY = 3600 * 24
 ---@field linkSubPage boolean
 
 ---@class MatchTableMatch: MatchGroupUtilMatch
----@field timezone string
 ---@field displayName string
 ---@field pageName string
 ---@field vods {index: number, link: string}[]
@@ -414,7 +413,6 @@ function MatchTable:matchFromRecord(record)
 
 	---@type MatchTableMatch
 	local match = Table.merge({
-		timezone = record.extradata.timezoneid or UTC,
 		displayName = String.nilIfEmpty(record.tournament) or record.pagename:gsub('_', ' '),
 		pageName = record.pagename,
 		vods = self:vodsFromRecord(record),
@@ -672,7 +670,7 @@ function MatchTable:_displayDate(match)
 	return cell:node(Countdown._create{
 		timestamp = match.timestamp,
 		finished = true,
-		date = MatchTable._calculateDateTimeString(match.timezone, match.timestamp),
+		date = MatchTable._calculateDateTimeString(match.timezoneId or UTC, match.timestamp),
 		rawdatetime = true,
 	} or nil)
 end

--- a/lua/wikis/commons/Widget/Match/Countdown.lua
+++ b/lua/wikis/commons/Widget/Match/Countdown.lua
@@ -37,7 +37,7 @@ function MatchCountdown:render()
 		classes = {'match-info-countdown'},
 		children = Countdown._create{
 			rawdatetime = match.finished,
-			date = DateExt.toCountdownArg(match.timestamp, match.extradata.timezoneid, match.dateIsExact),
+			date = DateExt.toCountdownArg(match.timestamp, match.timezoneId, match.dateIsExact),
 			finished = match.finished,
 		},
 	}


### PR DESCRIPTION
## Summary
as a follow up for #6199 refactor matchTable to use `MatchGroupUtil.matchFromRecord`

## How did you test this change?
dev