### PR TITLE
feat(match2): increase the winloss icon size

### DIFF
--- a/lua/wikis/commons/Widget/Match/Summary/GameWinLossIndicator.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/GameWinLossIndicator.lua
@@ -16,10 +16,10 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
 local ICONS = {
-	win = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text', size = '110%'},
-	draw = Icon.makeIcon{iconName = 'draw', color = 'bright-sun-text', size = '110%'},
-	loss = Icon.makeIcon{iconName = 'loss', color = 'cinnabar-text', size = '110%'},
-	empty = '[[File:NoCheck.png|link=|16px]]',
+	win = Icon.makeIcon{iconName = 'winner', color = 'forest-green-text'},
+	draw = Icon.makeIcon{iconName = 'draw', color = 'bright-sun-text'},
+	loss = Icon.makeIcon{iconName = 'loss', color = 'cinnabar-text'},
+	empty = '[[File:NoCheck.png|link=|14px]]',
 }
 
 ---@class MatchSummaryGameWinLossIndicator: Widget

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -636,6 +636,10 @@ div.brkts-popup-body-element-thumbs {
 
 	.brkts-popup-winloss-icon {
 		margin: unset;
+
+		& > i {
+			font-size: 0.875rem;
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
We want the size to be 14px (0.875rem), not the 110% of 11px.

## How did you test this change?

devtools