### PR TITLE
fix(match2): misaligned text when row breaking

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -687,6 +687,7 @@ div.brkts-popup-body-element-thumbs {
 	align-items: center;
 	justify-content: center;
 	gap: 4px;
+	text-align: center;
 }
 
 .brkts-popup-winloss-icon {


### PR DESCRIPTION
## Summary

Issue spotted with map names on AoE. If there's a line break the text got center aligned? This seems to fix it

## How did you test this change?
dev tools