### PR TITLE
feat(match2): Adjust match-info-popup position and length

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -462,7 +462,7 @@
  * MatchSummary
  */
 
-.brkts-match-info-popup {
+.brkts-popup.brkts-match-info-popup {
 	border-radius: 0.5rem;
 	box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
 	position: absolute;
@@ -473,10 +473,10 @@
 		bottom: unset;
 		left: 1rem !important;
 		right: 1rem;
-		top: 50% !important;
-		max-height: 50vh;
+		top: calc(~"50% + 3.125rem") !important;
+		max-height: calc(~"100vh - 14.625rem"); // 14.625rem = 234px (50px nav + 32px padding + 50px footer)
 		width: auto !important;
-		transform: translateY( -40% );
+		transform: translateY(-50%);
 	}
 }
 
@@ -505,7 +505,6 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-start;
-	max-height: 80vh;
 	width: 330px;
 	flex-wrap: unset;
 	font-size: 0.6875rem;
@@ -522,9 +521,8 @@
 		border-color: rgba( 255, 255, 255, 0.08 );
 	}
 
-	@media ( max-width: 768px ) {
+	@media ( min-width: 768px ) {
 		max-height: 65vh;
-		overflow: auto;
 	}
 
 	.timer-object-date {
@@ -585,6 +583,7 @@
 	width: 100%;
 	flex-direction: column;
 	gap: 0.5rem;
+	overflow: auto;
 }
 
 .brkts-popup-body-element {

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -473,8 +473,8 @@
 		bottom: unset;
 		left: 1rem !important;
 		right: 1rem;
-		top: calc(~"50% + 3.125rem") !important;
-		max-height: calc(~"100vh - 14.625rem"); // 14.625rem = 234px (115px nav + 32px padding + 50px footer)
+		top: calc(~"50% + ((9.5rem - 3.125rem) / 2)") !important; // Add half of the difference between the top and bottom height to make it 'centered' (152px - 50px)
+		max-height: calc(~"100vh - (9.5rem + 2rem + 3.125rem)"); // 14.625rem = 234px (152px ad and nav + 32px spacing + 50px footer)
 		width: auto !important;
 		transform: translateY(-50%);
 	}

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -474,7 +474,7 @@
 		left: 1rem !important;
 		right: 1rem;
 		top: calc(~"50% + 3.125rem") !important;
-		max-height: calc(~"100vh - 14.625rem"); // 14.625rem = 234px (50px nav + 32px padding + 50px footer)
+		max-height: calc(~"100vh - 14.625rem"); // 14.625rem = 234px (115px nav + 32px padding + 50px footer)
 		width: auto !important;
 		transform: translateY(-50%);
 	}


### PR DESCRIPTION
## Summary

I think I made the correct calculations now
<img width="888" height="1790" alt="image" src="https://github.com/user-attachments/assets/52f5c430-2774-4e22-8935-bfc3e7110d34" />
<img width="892" height="1770" alt="image" src="https://github.com/user-attachments/assets/64b7eb0e-165e-4460-ae00-faad2e0bbaa6" />

- So with the new calculations it sets the popup in the center of the viewport
- Moves the scrollbar from the `brkts-popup` to `brkts-popup-body` in so the header and bottom (button) is always visible.
- I've also added a max-height to screens larger than 769px

## How did you test this change?

http://laura.wiki.tldev.eu/rocketleague/The_International/2024/Main_Event
