### PR TITLE
feat(mainpage): Add Wild Rift

### DIFF
--- a/lua/wikis/wildrift/MainPageLayout/data.lua
+++ b/lua/wikis/wildrift/MainPageLayout/data.lua
@@ -88,7 +88,7 @@ return {
 		lightmode = 'League_of_Legends_Wild_Rift_default_allmode.svg',
 		darkmode = 'League_of_Legends_Wild_Rift_default_allmode.svg',
 	},
-	metadesc = 'Comprehensive Wild Rift wiki with articles covering everything from weapons, to strategies, '..
+	metadesc = 'Comprehensive Wild Rift wiki with articles covering everything from champions, to strategies, '..
 		'to tournaments, to competitive players and teams.',
 	title = 'Wild Rift',
 	navigation = {

--- a/lua/wikis/wildrift/MainPageLayout/data.lua
+++ b/lua/wikis/wildrift/MainPageLayout/data.lua
@@ -1,0 +1,205 @@
+---
+-- @Liquipedia
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local DateExt = require('Module:Date/Ext')
+local Lua = require('Module:Lua')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local LiquipediaApp = Lua.import('Module:Widget/MainPage/LiquipediaApp')
+local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WantToHelp = Lua.import('Module:Widget/MainPage/WantToHelp')
+
+local CONTENT = {
+	usefulArticles = {
+		heading = 'The Game',
+		body = '{{Liquipedia:Useful Articles}}',
+		padding = true,
+		boxid = 1503,
+	},
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = WantToHelp{},
+		padding = true,
+		boxid = 1504,
+	},
+	liquipediaApp = {
+		heading = 'Download the Liquipedia App',
+		padding = true,
+		body = LiquipediaApp{},
+		boxid = 1505,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = TransfersList{
+			rumours = true,
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+		},
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content(),
+		padding = true,
+		boxid = 1510,
+	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+		boxid = 1516,
+	},
+	filterButtons = {
+		noPanel = true,
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		},
+	},
+	matches = {
+		heading = 'Matches',
+		body = MatchTicker{},
+		padding = true,
+		boxid = 1507,
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = TournamentsTicker{
+			upcomingDays = 60,
+			completedDays = 60
+		},
+		padding = true,
+		boxid = 1508,
+	},
+}
+
+return {
+	banner = {
+		lightmode = 'League_of_Legends_Wild_Rift_default_allmode.svg',
+		darkmode = 'League_of_Legends_Wild_Rift_default_allmode.svg',
+	},
+	metadesc = 'Comprehensive Wild Rift wiki with articles covering everything from weapons, to strategies, '..
+		'to tournaments, to competitive players and teams.',
+	title = 'Wild Rift',
+	navigation = {
+		{
+			file = 'Keyd_Stars_WC_2022.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'BRU Whatthejes ICONS 2022.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'Icons_Trophy.jpg',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'NOVA Long ICONS22.jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'ITzSTU4RT at the TFT Esports World Cup 2024.jpg',
+			title = 'Statistics',
+			link = 'Portal:Statistics',
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 6,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 3,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.wantToHelp,
+					},
+					{
+						mobileOrder = 8,
+						content = CONTENT.liquipediaApp,
+					},
+				}
+			},
+			{ -- Right
+				size = 6,
+				children = {
+					{
+						mobileOrder = 2,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
+								},
+							},
+						},
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.thisDay,
+					},
+					{
+						mobileOrder = 7,
+						content = CONTENT.usefulArticles,
+					},
+				},
+			},
+		},
+	},
+}

--- a/lua/wikis/wildrift/MainPageLayout/data.lua
+++ b/lua/wikis/wildrift/MainPageLayout/data.lua
@@ -5,9 +5,10 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local DateExt = require('Module:Date/Ext')
+
 local Lua = require('Module:Lua')
 
+local DateExt = Lua.import('Module:Date/Ext')
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 

--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -210,6 +210,12 @@
 		}
 	}
 
+	.wiki-wildrift & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/f/f3/Wild_Rift_wiki_banner.webp ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-worldoftanks & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/f/f3/Worldoftanks_banner.png ) no-repeat center / cover;


### PR DESCRIPTION
## Summary
New Main Page for Wild Rift 

## Notes
1.Due to the very low amount of tournaments, this is why days are set to 60 
(at the time of this writing, setting both to 60 shows up only 12 tournaments so it will be fine) 

2.Most of pills images are .jpg due to it's existing photos from 2022

## How did you test this change?
https://liquipedia.net/wildrift/User:Hesketh2/test

## Extra Notes
More of new main page will come flooding in the coming days and week to keep up with the recent design changes. Most of Mobile games page setup will be on me