### PR TITLE
fix(mainpage): fix classes count g:hearthstone

### DIFF
--- a/lua/wikis/hearthstone/MainPageLayout/data.lua
+++ b/lua/wikis/hearthstone/MainPageLayout/data.lua
@@ -134,7 +134,7 @@ return {
 			link = 'Classes',
 			count = {
 				method = 'CATEGORY',
-				category = 'Classes',
+				category = 'Class',
 			}
 		},
 	},


### PR DESCRIPTION
## Summary
Classes count on main page use wrong category (Classes instead of Class), so it shows 0 instead of 11
<img width="255" height="180" alt="Снимок экрана 2025-07-25 120427" src="https://github.com/user-attachments/assets/dc2c3a9b-625f-405a-8299-85418721527b" />

## How did you test this change?
https://liquipedia.net/hearthstone/User:Nikita_r28/test


