### PR TITLE
feat(match2): add bg color to thumbs

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -567,10 +567,11 @@
 .brkts-popup-body {
 	display: flex;
 	justify-content: space-evenly;
-	width: 100%;
 	flex-direction: column;
 	gap: 0.25rem;
 	overflow: auto;
+	margin: 0 -0.5rem;
+	padding: 0 0.5rem;
 }
 
 .brkts-popup-body-element {
@@ -597,7 +598,8 @@ div.brkts-popup-body-element-thumbs {
 }
 
 .brkts-popup-body-element.brkts-popup-body-game {
-	padding: 0.5rem 0;
+	padding: 0.5rem;
+	margin: 0 -0.5rem;
 
 	.brkts-champion-icon {
 		gap: 0.125rem;

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -973,7 +973,7 @@ div.brkts-popup-body-element-thumbs {
 
 @media ( hover: hover ) {
 	.brkts-champion-icon img:hover {
-		transform: scale( 2.5, 2.5 );
+		transform: scale( 2 ) translateY( 0.0625rem ); // added 1px to Y-center the image
 		object-fit: contain;
 	}
 }

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -613,11 +613,14 @@ div.brkts-popup-body-element-thumbs {
 				height: 1.25rem;
 			}
 
-			&:hover {
-				height: unset;
-				box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
-				outline: 0.0625rem solid #ffffff;
-				outline-offset: -0.0625rem;
+			@media ( hover: hover) {
+				&:hover {
+					height: unset;
+					box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
+					outline: 0.0625rem solid #ffffff;
+					outline-offset: -0.0625rem;
+					background-color: var( --clr-background );
+				}
 			}
 		}
 	}

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -613,7 +613,7 @@ div.brkts-popup-body-element-thumbs {
 				height: 1.25rem;
 			}
 
-			@media ( hover: hover) {
+			@media ( hover: hover ) {
 				&:hover {
 					height: unset;
 					box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );


### PR DESCRIPTION
## Summary

- Add a background-color to the thumbs in cases where the images are transparent (like valorant).
- Moved the hover into a css media feature

<img width="1182" height="874" alt="image" src="https://github.com/user-attachments/assets/4e9b8696-c5b7-420d-bb6a-f489dbeae9f3" />
<img width="1084" height="824" alt="image" src="https://github.com/user-attachments/assets/75c66b39-0df8-4216-b80b-fa2494e33d5a" />


## How did you test this change?

devtools
