### PR TITLE
refactor(opponent): remove git usage of `Module:OpponentLibraries`

### DIFF
--- a/lua/wikis/ageofempires/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/ageofempires/GetMatchGroupCopyPaste/wiki.lua
@@ -10,8 +10,7 @@ local Class = require('Module:Class')
 local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 

--- a/lua/wikis/ageofempires/Infobox/Team/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Team/Custom.lua
@@ -9,8 +9,7 @@ local Array = require('Module:Array')
 local Class = require('Module:Class')
 local GameLookup = require('Module:GameLookup')
 local Lua = require('Module:Lua')
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 local TeamTemplates = require('Module:Team')
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')

--- a/lua/wikis/ageofempires/Match/Legacy.lua
+++ b/lua/wikis/ageofempires/Match/Legacy.lua
@@ -16,8 +16,7 @@ local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchLegacyUtil = Lua.import('Module:MatchGroup/Legacy/Util')
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 
 function MatchLegacy.storeMatch(match2)

--- a/lua/wikis/ageofempires/MatchMaps/Legacy.lua
+++ b/lua/wikis/ageofempires/MatchMaps/Legacy.lua
@@ -20,8 +20,7 @@ local MatchGroupBase = Lua.import('Module:MatchGroup/Base')
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MAX_NUMBER_OF_OPPONENTS = 2
 local GSL_WINNERS = 'winners'

--- a/lua/wikis/ageofempires/MatchSummary.lua
+++ b/lua/wikis/ageofempires/MatchSummary.lua
@@ -19,8 +19,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 local PlayerDisplay = require('Module:Player/Display')
 
 local CustomMatchSummary = {}

--- a/lua/wikis/ageofempires/ParticipantTable/Custom.lua
+++ b/lua/wikis/ageofempires/ParticipantTable/Custom.lua
@@ -24,8 +24,7 @@ local Operator = require('Module:Operator')
 
 local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local AoEParticipantTable = {}
 

--- a/lua/wikis/ageofempires/PrizePool/Custom.lua
+++ b/lua/wikis/ageofempires/PrizePool/Custom.lua
@@ -13,8 +13,7 @@ local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Variables = require('Module:Variables')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local PrizePool = Lua.import('Module:PrizePool')
 

--- a/lua/wikis/arenafps/MatchMaps/Legacy.lua
+++ b/lua/wikis/arenafps/MatchMaps/Legacy.lua
@@ -18,8 +18,7 @@ local MatchGroupBase = Lua.import('Module:MatchGroup/Base')
 
 local globalVars = PageVariableNamespace()
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MAX_NUMBER_OF_OPPONENTS = 2
 local MAX_NUM_MAPS = 9

--- a/lua/wikis/battalion/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/battalion/MatchGroup/Legacy/MatchList.lua
@@ -14,8 +14,7 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/battalion/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/battalion/MatchGroup/Legacy/MatchList.lua
@@ -5,16 +5,17 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local Json = require('Module:Json')
-local Logic = require('Module:Logic')
-local Match = require('Module:Match')
-local MatchGroup = require('Module:MatchGroup')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
-local Table = require('Module:Table')
-local Template = require('Module:Template')
+local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
+local Match = Lua.import('Module:Match')
+local MatchGroup = Lua.import('Module:MatchGroup')
 local Opponent = Lua.import('Module:Opponent/Custom')
+local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local Table = Lua.import('Module:Table')
+local Template = Lua.import('Module:Template')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/brawlhalla/Match/Legacy.lua
+++ b/lua/wikis/brawlhalla/Match/Legacy.lua
@@ -17,8 +17,7 @@ local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchLegacyUtil = Lua.import('Module:MatchGroup/Legacy/Util')
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 function MatchLegacy.storeMatch(match2)
 	local match = MatchLegacy._convertParameters(match2)

--- a/lua/wikis/brawlhalla/MatchSummary.lua
+++ b/lua/wikis/brawlhalla/MatchSummary.lua
@@ -14,8 +14,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchSummary = {}
 

--- a/lua/wikis/brawlhalla/PrizePool/Custom.lua
+++ b/lua/wikis/brawlhalla/PrizePool/Custom.lua
@@ -10,8 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local PrizePool = Lua.import('Module:PrizePool')
 

--- a/lua/wikis/brawlstars/PrizePool/Custom.lua
+++ b/lua/wikis/brawlstars/PrizePool/Custom.lua
@@ -13,8 +13,7 @@ local Namespace = require('Module:Namespace')
 local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local PrizePool = Lua.import('Module:PrizePool')
 

--- a/lua/wikis/callofduty/MatchMaps/Legacy.lua
+++ b/lua/wikis/callofduty/MatchMaps/Legacy.lua
@@ -17,8 +17,7 @@ local Template = require('Module:Template')
 local Match = Lua.import('Module:Match')
 local MatchGroup = Lua.import('Module:MatchGroup')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/clashroyale/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/clashroyale/GetMatchGroupCopyPaste/wiki.lua
@@ -13,8 +13,7 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---@class ClashroyaleMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)

--- a/lua/wikis/clashroyale/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/clashroyale/MatchGroup/Input/Custom.lua
@@ -16,8 +16,7 @@ local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 
 local CustomMatchGroupInput = {}

--- a/lua/wikis/clashroyale/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/clashroyale/MatchGroup/Legacy/MatchList.lua
@@ -5,17 +5,18 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local Array = require('Module:Array')
-local Json = require('Module:Json')
-local Logic = require('Module:Logic')
-local Match = require('Module:Match')
-local MatchGroup = require('Module:MatchGroup')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
-local Table = require('Module:Table')
-local Template = require('Module:Template')
+local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
+local Array = Lua.import('Module:Array')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
+local Match = Lua.import('Module:Match')
+local MatchGroup = Lua.import('Module:MatchGroup')
 local Opponent = Lua.import('Module:Opponent/Custom')
+local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local Table = Lua.import('Module:Table')
+local Template = Lua.import('Module:Template')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/clashroyale/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/clashroyale/MatchGroup/Legacy/MatchList.lua
@@ -15,8 +15,7 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/clashroyale/MatchSummary.lua
+++ b/lua/wikis/clashroyale/MatchSummary.lua
@@ -19,7 +19,7 @@ local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local NUM_CARDS_PER_PLAYER = 8
 local CARD_COLOR_1 = 'blue'

--- a/lua/wikis/clashroyale/MatchSummary.lua
+++ b/lua/wikis/clashroyale/MatchSummary.lua
@@ -18,9 +18,8 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local NUM_CARDS_PER_PLAYER = 8
 local CARD_COLOR_1 = 'blue'

--- a/lua/wikis/commons/Earnings/Base.lua
+++ b/lua/wikis/commons/Earnings/Base.lua
@@ -17,8 +17,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Team = Lua.import('Module:Team')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Earnings = {}
 

--- a/lua/wikis/commons/ExternalMediaList.lua
+++ b/lua/wikis/commons/ExternalMediaList.lua
@@ -17,8 +17,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Tabs = Lua.import('Module:Tabs')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MediaList = {}
 

--- a/lua/wikis/commons/ExternalMediaList.lua
+++ b/lua/wikis/commons/ExternalMediaList.lua
@@ -17,7 +17,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Tabs = Lua.import('Module:Tabs')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MediaList = {}
 

--- a/lua/wikis/commons/GetMatchGroupCopyPaste/Starcraft.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste/Starcraft.lua
@@ -13,8 +13,7 @@ local Logic = Lua.import('Module:Logic')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 --WikiSpecific Code for MatchList and Bracket Code Generators
 

--- a/lua/wikis/commons/GetMatchGroupCopyPaste/wiki/Base.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste/wiki/Base.lua
@@ -11,8 +11,7 @@ local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local Logic = Lua.import('Module:Logic')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---Base-WikiSpecific Code for MatchList and Bracket Code Generators
 ---@class Match2CopyPasteBase

--- a/lua/wikis/commons/HiddenDataBox.lua
+++ b/lua/wikis/commons/HiddenDataBox.lua
@@ -28,8 +28,7 @@ local DEFAULT_TIER_TYPE = 'general'
 
 local Language = mw.getContentLanguage()
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---Entry point
 ---@param args table?

--- a/lua/wikis/commons/Infobox/Extension/Achievements.lua
+++ b/lua/wikis/commons/Infobox/Extension/Achievements.lua
@@ -18,8 +18,7 @@ local Team = Lua.import('Module:Team')
 
 local CustomDefaultOptions = Lua.requireIfExists('Module:Infobox/Extension/Achievements/Custom') or {}
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local NON_BREAKING_SPACE = '&nbsp;'
 local DEFAULT_PLAYER_LIMIT = 10

--- a/lua/wikis/commons/Infobox/UnofficialWorldChampion.lua
+++ b/lua/wikis/commons/Infobox/UnofficialWorldChampion.lua
@@ -14,7 +14,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic')
 

--- a/lua/wikis/commons/Infobox/UnofficialWorldChampion.lua
+++ b/lua/wikis/commons/Infobox/UnofficialWorldChampion.lua
@@ -13,9 +13,8 @@ local Json = Lua.import('Module:Json')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic')
 

--- a/lua/wikis/commons/InfoboxPlacementStats.lua
+++ b/lua/wikis/commons/InfoboxPlacementStats.lua
@@ -14,8 +14,7 @@ local Medals = Lua.import('Module:Medals')
 local Team = Lua.import('Module:Team')
 local Tier = Lua.import('Module:Tier/Custom')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local DEFAULT_TIERS = {'1', '2', '3'}
 local DEFAULT_EXCLUDED_TIER_TYPES = {'Qualifier'}

--- a/lua/wikis/commons/MatchGroup/Display/Bracket.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Bracket.lua
@@ -19,9 +19,8 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local NON_BREAKING_SPACE = '&nbsp;'
 local OPPONENT_HEIGHT_PADDING = 4

--- a/lua/wikis/commons/MatchGroup/Display/Bracket.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Bracket.lua
@@ -20,7 +20,7 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local NON_BREAKING_SPACE = '&nbsp;'
 local OPPONENT_HEIGHT_PADDING = 4

--- a/lua/wikis/commons/MatchGroup/Display/Helper.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Helper.lua
@@ -21,8 +21,7 @@ local Timezone = Lua.import('Module:Timezone')
 
 local Info = Lua.import('Module:Info', {loadData = true})
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local DisplayHelper = {}
 local NONBREAKING_SPACE = '&nbsp;'

--- a/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
@@ -18,7 +18,7 @@ local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchlistDisplay = {propTypes = {}, types = {}}
 

--- a/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
@@ -18,8 +18,7 @@ local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibrary.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchlistDisplay = {propTypes = {}, types = {}}
 

--- a/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
@@ -19,8 +19,7 @@ local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local ASSUME_FINISHED_AFTER = MatchGroupInputUtil.ASSUME_FINISHED_AFTER
 local NOW = os.time()

--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -27,8 +27,7 @@ local Links = Lua.import('Module:Links')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local PlayerExt = Lua.import('Module:Player/Ext/Custom')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace{cached = true}
 

--- a/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
@@ -17,8 +17,7 @@ local Table = Lua.import('Module:Table')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SCORE_STATUS = MatchGroupInputUtil.STATUS.SCORE
 

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -25,7 +25,7 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local AdditionalSection = Lua.import('Module:Widget/Match/Page/AdditionalSection')

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -25,8 +25,7 @@ local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local AdditionalSection = Lua.import('Module:Widget/Match/Page/AdditionalSection')

--- a/lua/wikis/commons/MatchSummary/Base/Ffa.lua
+++ b/lua/wikis/commons/MatchSummary/Base/Ffa.lua
@@ -13,8 +13,7 @@ local Game = Lua.import('Module:Game')
 local Operator = Lua.import('Module:Operator')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchUtil = Lua.import('Module:Match/Util')
 

--- a/lua/wikis/commons/MatchSummary/Base/Ffa.lua
+++ b/lua/wikis/commons/MatchSummary/Base/Ffa.lua
@@ -13,7 +13,7 @@ local Game = Lua.import('Module:Game')
 local Operator = Lua.import('Module:Operator')
 local Table = Lua.import('Module:Table')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchUtil = Lua.import('Module:Match/Util')
 

--- a/lua/wikis/commons/MatchSummary/Starcraft.lua
+++ b/lua/wikis/commons/MatchSummary/Starcraft.lua
@@ -22,7 +22,7 @@ local MatchGroupUtilStarcraft = Lua.import('Module:MatchGroup/Util/Custom')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local ICONS = {
 	veto = Icon.makeIcon{iconName = 'veto', color = 'cinnabar-text', size = '110%'},

--- a/lua/wikis/commons/MatchSummary/Starcraft.lua
+++ b/lua/wikis/commons/MatchSummary/Starcraft.lua
@@ -21,9 +21,8 @@ local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local MatchGroupUtilStarcraft = Lua.import('Module:MatchGroup/Util/Custom')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local ICONS = {
 	veto = Icon.makeIcon{iconName = 'veto', color = 'cinnabar-text', size = '110%'},

--- a/lua/wikis/commons/MatchSummary/Starcraft/Ffa.lua
+++ b/lua/wikis/commons/MatchSummary/Starcraft/Ffa.lua
@@ -12,8 +12,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local BaseMatchSummary = Lua.import('Module:MatchSummary/Base/Ffa')

--- a/lua/wikis/commons/MatchSummary/Starcraft/Ffa.lua
+++ b/lua/wikis/commons/MatchSummary/Starcraft/Ffa.lua
@@ -12,7 +12,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Table = Lua.import('Module:Table')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local BaseMatchSummary = Lua.import('Module:MatchSummary/Base/Ffa')

--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -30,7 +30,7 @@ local VodLink = Lua.import('Module:VodLink')
 local PlayerExt = Lua.import('Module:Player/Ext/Custom')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchPageButton = Lua.import('Module:Widget/Match/PageButton')
 

--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -29,9 +29,8 @@ local VodLink = Lua.import('Module:VodLink')
 
 local PlayerExt = Lua.import('Module:Player/Ext/Custom')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchPageButton = Lua.import('Module:Widget/Match/PageButton')
 

--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -18,8 +18,7 @@ local Table = Lua.import('Module:Table')
 local Team = Lua.import('Module:Team')
 local Tier = Lua.import('Module:Tier/Utils')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 local MatchUtil = Lua.import('Module:Match/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local Tournament = Lua.import('Module:Tournament')

--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -28,9 +28,8 @@ local VodLink = Lua.import('Module:VodLink')
 local HighlightConditions = Lua.import('Module:HighlightConditions')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local VS = 'vs'
 local SCORE_STATUS = 'S'

--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -29,7 +29,7 @@ local HighlightConditions = Lua.import('Module:HighlightConditions')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local VS = 'vs'
 local SCORE_STATUS = 'S'

--- a/lua/wikis/commons/MatchesScheduleDisplay.lua
+++ b/lua/wikis/commons/MatchesScheduleDisplay.lua
@@ -20,7 +20,7 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree

--- a/lua/wikis/commons/MatchesScheduleDisplay.lua
+++ b/lua/wikis/commons/MatchesScheduleDisplay.lua
@@ -19,9 +19,8 @@ local Table = Lua.import('Module:Table')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree

--- a/lua/wikis/commons/MvpTable.lua
+++ b/lua/wikis/commons/MvpTable.lua
@@ -21,9 +21,8 @@ local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MvpTable = {}
 

--- a/lua/wikis/commons/MvpTable.lua
+++ b/lua/wikis/commons/MvpTable.lua
@@ -22,7 +22,7 @@ local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MvpTable = {}
 

--- a/lua/wikis/commons/Opponent/Custom.lua
+++ b/lua/wikis/commons/Opponent/Custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Opponent = Lua.import('Module:Opponent')
+
+return Opponent

--- a/lua/wikis/commons/OpponentDisplay/Custom.lua
+++ b/lua/wikis/commons/OpponentDisplay/Custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local OpponentDisplay = Lua.import('Module:OpponentDisplay')
+
+return OpponentDisplay

--- a/lua/wikis/commons/OpponentLibraries.lua
+++ b/lua/wikis/commons/OpponentLibraries.lua
@@ -5,6 +5,9 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+--to be removed after cleanup of non git modules
+---@deprecated
+
 local Lua = require('Module:Lua')
 
 local Info = Lua.import('Module:Info')

--- a/lua/wikis/commons/ParticipantTable/Base.lua
+++ b/lua/wikis/commons/ParticipantTable/Base.lua
@@ -22,7 +22,7 @@ local Template = Lua.import('Module:Template')
 local Variables = Lua.import('Module:Variables')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Import = Lua.import('Module:ParticipantTable/Import')
 local PlayerExt = Lua.import('Module:Player/Ext/Custom')

--- a/lua/wikis/commons/ParticipantTable/Base.lua
+++ b/lua/wikis/commons/ParticipantTable/Base.lua
@@ -21,9 +21,8 @@ local Table = Lua.import('Module:Table')
 local Template = Lua.import('Module:Template')
 local Variables = Lua.import('Module:Variables')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Import = Lua.import('Module:ParticipantTable/Import')
 local PlayerExt = Lua.import('Module:Player/Ext/Custom')

--- a/lua/wikis/commons/ParticipantTable/Import.lua
+++ b/lua/wikis/commons/ParticipantTable/Import.lua
@@ -11,8 +11,7 @@ local Array = Lua.import('Module:Array')
 local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TournamentStructure = Lua.import('Module:TournamentStructure')
 

--- a/lua/wikis/commons/ParticipantTable/Starcraft.lua
+++ b/lua/wikis/commons/ParticipantTable/Starcraft.lua
@@ -40,8 +40,7 @@ local Variables = Lua.import('Module:Variables')
 
 local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local StarcraftParticipantTable = {}
 

--- a/lua/wikis/commons/PortalPlayers.lua
+++ b/lua/wikis/commons/PortalPlayers.lua
@@ -17,7 +17,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local DEFAULT_PLAYER_TYPE = 'Players'
 local NONBREAKING_SPACE = '&nbsp;'

--- a/lua/wikis/commons/PortalPlayers.lua
+++ b/lua/wikis/commons/PortalPlayers.lua
@@ -16,9 +16,8 @@ local Links = Lua.import('Module:Links')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local DEFAULT_PLAYER_TYPE = 'Players'
 local NONBREAKING_SPACE = '&nbsp;'

--- a/lua/wikis/commons/PortalStatistics.lua
+++ b/lua/wikis/commons/PortalStatistics.lua
@@ -25,7 +25,7 @@ local Table = Lua.import('Module:Table')
 local Tier = Lua.import('Module:Tier/Custom')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree

--- a/lua/wikis/commons/PortalStatistics.lua
+++ b/lua/wikis/commons/PortalStatistics.lua
@@ -24,9 +24,8 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Tier = Lua.import('Module:Tier/Custom')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree

--- a/lua/wikis/commons/PrizePool.lua
+++ b/lua/wikis/commons/PrizePool.lua
@@ -16,8 +16,7 @@ local Import = Lua.import('Module:PrizePool/Import')
 local BasePrizePool = Lua.import('Module:PrizePool/Base')
 local Placement = Lua.import('Module:PrizePool/Placement')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Widgets = Lua.import('Module:Widget/All')
 local TableRow = Widgets.TableRow

--- a/lua/wikis/commons/PrizePool/Award.lua
+++ b/lua/wikis/commons/PrizePool/Award.lua
@@ -15,8 +15,7 @@ local String = Lua.import('Module:StringUtils')
 local BasePrizePool = Lua.import('Module:PrizePool/Base')
 local Placement = Lua.import('Module:PrizePool/Award/Placement')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Widgets = Lua.import('Module:Widget/All')
 local TableRow = Widgets.TableRow

--- a/lua/wikis/commons/PrizePool/Award/Placement.lua
+++ b/lua/wikis/commons/PrizePool/Award/Placement.lua
@@ -12,8 +12,7 @@ local Table = Lua.import('Module:Table')
 
 local BasePlacement = Lua.import('Module:PrizePool/Placement/Base')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local _tbd_index = 0
 

--- a/lua/wikis/commons/PrizePool/Award/Starcraft.lua
+++ b/lua/wikis/commons/PrizePool/Award/Starcraft.lua
@@ -18,8 +18,7 @@ local AwardPrizePool = Lua.import('Module:PrizePool/Award')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomLpdbInjector = Class.new(LpdbInjector)
 

--- a/lua/wikis/commons/PrizePool/Base.lua
+++ b/lua/wikis/commons/PrizePool/Base.lua
@@ -21,9 +21,8 @@ local Variables = Lua.import('Module:Variables')
 local Currency = Lua.import('Module:Currency')
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Widgets = Lua.import('Module:Widget/All')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/PrizePool/Base.lua
+++ b/lua/wikis/commons/PrizePool/Base.lua
@@ -22,7 +22,7 @@ local Currency = Lua.import('Module:Currency')
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Widgets = Lua.import('Module:Widget/All')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/PrizePool/Import.lua
+++ b/lua/wikis/commons/PrizePool/Import.lua
@@ -20,8 +20,7 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local Placement = Lua.import('Module:PrizePool/Placement')
 local TournamentStructure = Lua.import('Module:TournamentStructure')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local AUTOMATION_START_DATE = '2023-01-01'
 local GROUPSCORE_DELIMITER = '/'

--- a/lua/wikis/commons/PrizePool/Legacy.lua
+++ b/lua/wikis/commons/PrizePool/Legacy.lua
@@ -18,8 +18,7 @@ local Template = Lua.import('Module:Template')
 local CustomPrizePool = Lua.import('Module:PrizePool/Custom')
 local CustomAwardPrizePool = Lua.import('Module:PrizePool/Award/Custom')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local LegacyPrizePool = {}
 

--- a/lua/wikis/commons/PrizePool/Legacy/Starcraft.lua
+++ b/lua/wikis/commons/PrizePool/Legacy/Starcraft.lua
@@ -20,8 +20,7 @@ local CustomPrizePool = Lua.import('Module:PrizePool/Custom')
 local CustomAwardPrizePool = Lua.import('Module:PrizePool/Award/Custom')
 local LegacyPrizePool = Lua.import('Module:PrizePool/Legacy')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local StarcraftLegacyPrizePool = {}
 

--- a/lua/wikis/commons/PrizePool/Placement.lua
+++ b/lua/wikis/commons/PrizePool/Placement.lua
@@ -21,8 +21,7 @@ local Table = Lua.import('Module:Table')
 ---@field opponents BasePlacementOpponent[]
 local BasePlacement = Lua.import('Module:PrizePool/Placement/Base')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local DASH = '&#045;'
 

--- a/lua/wikis/commons/PrizePool/Placement/Base.lua
+++ b/lua/wikis/commons/PrizePool/Placement/Base.lua
@@ -14,8 +14,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local BASE_CURRENCY = 'USD'
 local LOCAL_CURRENCY_VARIABLE_POST_FIX = 'local'

--- a/lua/wikis/commons/PrizePool/Starcraft.lua
+++ b/lua/wikis/commons/PrizePool/Starcraft.lua
@@ -20,8 +20,7 @@ local PrizePool = Lua.import('Module:PrizePool')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomLpdbInjector = Class.new(LpdbInjector)
 

--- a/lua/wikis/commons/Ratings/Storage/Extension.lua
+++ b/lua/wikis/commons/Ratings/Storage/Extension.lua
@@ -10,8 +10,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Date = Lua.import('Module:Date/Ext')
 local FnUtil = Lua.import('Module:FnUtil')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local RatingsStorageExtension = {}
 

--- a/lua/wikis/commons/ResultsTable.lua
+++ b/lua/wikis/commons/ResultsTable.lua
@@ -19,8 +19,7 @@ local Table = Lua.import('Module:Table')
 
 local BaseResultsTable = Lua.import('Module:ResultsTable/Base')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 --- @class ResultsTable: BaseResultsTable
 local ResultsTable = Class.new(BaseResultsTable)

--- a/lua/wikis/commons/ResultsTable/Award.lua
+++ b/lua/wikis/commons/ResultsTable/Award.lua
@@ -13,8 +13,7 @@ local DateExt = Lua.import('Module:Date/Ext')
 local LeagueIcon = Lua.import('Module:LeagueIcon')
 local Page = Lua.import('Module:Page')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local BaseResultsTable = Lua.import('Module:ResultsTable/Base')
 

--- a/lua/wikis/commons/ResultsTable/Base.lua
+++ b/lua/wikis/commons/ResultsTable/Base.lua
@@ -20,7 +20,7 @@ local Team = Lua.import('Module:Team')
 local Tier = Lua.import('Module:Tier/Custom')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree

--- a/lua/wikis/commons/ResultsTable/Base.lua
+++ b/lua/wikis/commons/ResultsTable/Base.lua
@@ -19,9 +19,8 @@ local Table = Lua.import('Module:Table')
 local Team = Lua.import('Module:Team')
 local Tier = Lua.import('Module:Tier/Custom')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree

--- a/lua/wikis/commons/RoleOf.lua
+++ b/lua/wikis/commons/RoleOf.lua
@@ -9,9 +9,8 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local RoleOf = {}
 

--- a/lua/wikis/commons/RoleOf.lua
+++ b/lua/wikis/commons/RoleOf.lua
@@ -10,7 +10,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local RoleOf = {}
 

--- a/lua/wikis/commons/SeriesMedalStats/Faction.lua
+++ b/lua/wikis/commons/SeriesMedalStats/Faction.lua
@@ -13,8 +13,7 @@ local Class = Lua.import('Module:Class')
 local Faction = Lua.import('Module:Faction')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MedalStatsBase = Lua.import('Module:SeriesMedalStats')
 

--- a/lua/wikis/commons/SeriesMedalStats/Flags.lua
+++ b/lua/wikis/commons/SeriesMedalStats/Flags.lua
@@ -13,8 +13,7 @@ local Class = Lua.import('Module:Class')
 local Flags = Lua.import('Module:Flags')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MedalStatsBase = Lua.import('Module:SeriesMedalStats')
 

--- a/lua/wikis/commons/SeriesMedalStats/Participant.lua
+++ b/lua/wikis/commons/SeriesMedalStats/Participant.lua
@@ -13,9 +13,8 @@ local Class = Lua.import('Module:Class')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MedalStatsBase = Lua.import('Module:SeriesMedalStats')
 

--- a/lua/wikis/commons/SeriesMedalStats/Participant.lua
+++ b/lua/wikis/commons/SeriesMedalStats/Participant.lua
@@ -14,7 +14,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MedalStatsBase = Lua.import('Module:SeriesMedalStats')
 

--- a/lua/wikis/commons/SeriesMedalStats/ParticipantTeam.lua
+++ b/lua/wikis/commons/SeriesMedalStats/ParticipantTeam.lua
@@ -13,8 +13,7 @@ local Class = Lua.import('Module:Class')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MedalStatsBase = Lua.import('Module:SeriesMedalStats')
 

--- a/lua/wikis/commons/Squad/Row.lua
+++ b/lua/wikis/commons/Squad/Row.lua
@@ -9,9 +9,8 @@ local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
 local Icon = Lua.import('Module:Icon')
-local OpponentLib = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLib.Opponent
-local OpponentDisplay = OpponentLib.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 local String = Lua.import('Module:StringUtils')
 local Template = Lua.import('Module:Template')
 

--- a/lua/wikis/commons/Standings.lua
+++ b/lua/wikis/commons/Standings.lua
@@ -19,8 +19,7 @@ local Variables = Lua.import('Module:Variables')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local Tournament = Lua.import('Module:Tournament')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Standings = {}
 

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -13,8 +13,7 @@ local Lpdb = Lua.import('Module:Lpdb')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local StandingsParseLpdb = {}
 

--- a/lua/wikis/commons/Standings/Parse/Wiki.lua
+++ b/lua/wikis/commons/Standings/Parse/Wiki.lua
@@ -13,8 +13,7 @@ local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TiebreakerFactory = Lua.import('Module:Standings/Tiebreaker/Factory')
 

--- a/lua/wikis/commons/Standings/Storage.lua
+++ b/lua/wikis/commons/Standings/Storage.lua
@@ -16,8 +16,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local StandingsStorage = {}
 local ALLOWED_SCORE_BOARD_KEYS = {'w', 'd', 'l'}

--- a/lua/wikis/commons/Standings/Table.lua
+++ b/lua/wikis/commons/Standings/Table.lua
@@ -20,8 +20,7 @@ local StandingsStorage = Lua.import('Module:Standings/Storage')
 
 local Display = Lua.import('Module:Widget/Standings')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local StandingsTable = {}
 

--- a/lua/wikis/commons/Standings/Table/Legacy/Ffa.lua
+++ b/lua/wikis/commons/Standings/Table/Legacy/Ffa.lua
@@ -15,8 +15,7 @@ local Variables = Lua.import('Module:Variables')
 
 local StandingTable = Lua.import('Module:Standings/Table')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local StandingTableLegacyFfa = {}
 

--- a/lua/wikis/commons/Standings/Tiebreaker/Buchholz.lua
+++ b/lua/wikis/commons/Standings/Tiebreaker/Buchholz.lua
@@ -10,8 +10,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TiebreakerInterface = Lua.import('Module:Standings/Tiebreaker/Interface')
 

--- a/lua/wikis/commons/TeamCard/Storage.lua
+++ b/lua/wikis/commons/TeamCard/Storage.lua
@@ -14,8 +14,7 @@ local Variables = Lua.import('Module:Variables')
 
 local Custom = Lua.import('Module:TeamCard/Custom')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TeamCardStorage = {}
 

--- a/lua/wikis/commons/TournamentStructure.lua
+++ b/lua/wikis/commons/TournamentStructure.lua
@@ -323,7 +323,7 @@ end
 function TournamentStructure._mergeGroupEntriesIntoGroup(entries, group)
 	local transformedGroup = {}
 	for _, entry in ipairs(entries) do
-		local opponent = Lua.import('Module:OpponentLibraries').Opponent.fromLpdbStruct(entry)
+		local opponent = Lua.import('Module:Opponent/Custom').Opponent.fromLpdbStruct(entry)
 		local finished = group.extradata.finished or group.extradata.groupfinished
 		local extradata = {
 			placeRange = entry.extradata.placerange,

--- a/lua/wikis/commons/TournamentsListing/CardList.lua
+++ b/lua/wikis/commons/TournamentsListing/CardList.lua
@@ -24,7 +24,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Conditions = Lua.import('Module:TournamentsListing/Conditions')
 local HighlightConditions = Lua.import('Module:HighlightConditions')

--- a/lua/wikis/commons/TournamentsListing/CardList.lua
+++ b/lua/wikis/commons/TournamentsListing/CardList.lua
@@ -23,9 +23,8 @@ local Region = Lua.import('Module:Region')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Conditions = Lua.import('Module:TournamentsListing/Conditions')
 local HighlightConditions = Lua.import('Module:HighlightConditions')

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -17,8 +17,7 @@ local Operator = Lua.import('Module:Operator')
 local Table = Lua.import('Module:Table')
 local Team = Lua.import('Module:Team')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TransferRowDisplay = Lua.import('Module:TransferRow/Display')
 

--- a/lua/wikis/commons/Widget/Infobox/UpcomingTournaments.lua
+++ b/lua/wikis/commons/Widget/Infobox/UpcomingTournaments.lua
@@ -19,8 +19,7 @@ local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/Widget/Match/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Header.lua
@@ -19,8 +19,7 @@ local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local Span = HtmlWidgets.Span
 local Div = HtmlWidgets.Div
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class MatchHeaderProps
 ---@field match MatchGroupUtilMatch

--- a/lua/wikis/commons/Widget/Match/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Header.lua
@@ -19,7 +19,7 @@ local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local Span = HtmlWidgets.Span
 local Div = HtmlWidgets.Div
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class MatchHeaderProps
 ---@field match MatchGroupUtilMatch

--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -12,7 +12,7 @@ local Class = Lua.import('Module:Class')
 local Image = Lua.import('Module:Image')
 local Logic = Lua.import('Module:Logic')
 
-local OpponentDisplay = Lua.import('Module:OpponentLibraries').OpponentDisplay
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/Widget/Match/Page/MapVeto.lua
+++ b/lua/wikis/commons/Widget/Match/Page/MapVeto.lua
@@ -13,8 +13,7 @@ local Image = Lua.import('Module:Image')
 
 local Map = Lua.import('Module:Map')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/Widget/Match/Page/MapVeto.lua
+++ b/lua/wikis/commons/Widget/Match/Page/MapVeto.lua
@@ -13,7 +13,7 @@ local Image = Lua.import('Module:Image')
 
 local Map = Lua.import('Module:Map')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/Widget/Match/Page/RoundsOverview.lua
+++ b/lua/wikis/commons/Widget/Match/Page/RoundsOverview.lua
@@ -15,8 +15,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class MatchPageRoundsOverviewProps
 ---@field rounds ValorantRoundData[]

--- a/lua/wikis/commons/Widget/Match/Page/RoundsOverview.lua
+++ b/lua/wikis/commons/Widget/Match/Page/RoundsOverview.lua
@@ -15,7 +15,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class MatchPageRoundsOverviewProps
 ---@field rounds ValorantRoundData[]

--- a/lua/wikis/commons/Widget/Match/Page/TeamDisplay.lua
+++ b/lua/wikis/commons/Widget/Match/Page/TeamDisplay.lua
@@ -11,8 +11,7 @@ local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local TeamTemplate = Lua.import('Module:TeamTemplate')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/Widget/Ratings/List.lua
+++ b/lua/wikis/commons/Widget/Ratings/List.lua
@@ -15,8 +15,7 @@ local Icon = Lua.import('Module:Icon')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local WidgetUtil = Lua.import('Module:Widget/Util')

--- a/lua/wikis/commons/Widget/Ratings/List.lua
+++ b/lua/wikis/commons/Widget/Ratings/List.lua
@@ -15,7 +15,7 @@ local Icon = Lua.import('Module:Icon')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local WidgetUtil = Lua.import('Module:Widget/Util')

--- a/lua/wikis/commons/Widget/Standings/Ffa.lua
+++ b/lua/wikis/commons/Widget/Standings/Ffa.lua
@@ -18,7 +18,7 @@ local DataTable = Lua.import('Module:Widget/Basic/DataTable')
 local RoundSelector = Lua.import('Module:Widget/Standings/RoundSelector')
 local PlacementChange = Lua.import('Module:Widget/Standings/PlacementChange')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local STATUS_TO_DISPLAY = {
 	dq = 'DQ',

--- a/lua/wikis/commons/Widget/Standings/Ffa.lua
+++ b/lua/wikis/commons/Widget/Standings/Ffa.lua
@@ -18,8 +18,7 @@ local DataTable = Lua.import('Module:Widget/Basic/DataTable')
 local RoundSelector = Lua.import('Module:Widget/Standings/RoundSelector')
 local PlacementChange = Lua.import('Module:Widget/Standings/PlacementChange')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local STATUS_TO_DISPLAY = {
 	dq = 'DQ',

--- a/lua/wikis/commons/Widget/Standings/MatchOverview.lua
+++ b/lua/wikis/commons/Widget/Standings/MatchOverview.lua
@@ -12,7 +12,7 @@ local Class = Lua.import('Module:Class')
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class MatchOverviewWidget: Widget
 ---@operator call(table): MatchOverviewWidget

--- a/lua/wikis/commons/Widget/Standings/MatchOverview.lua
+++ b/lua/wikis/commons/Widget/Standings/MatchOverview.lua
@@ -12,8 +12,7 @@ local Class = Lua.import('Module:Class')
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class MatchOverviewWidget: Widget
 ---@operator call(table): MatchOverviewWidget

--- a/lua/wikis/commons/Widget/Standings/Swiss.lua
+++ b/lua/wikis/commons/Widget/Standings/Swiss.lua
@@ -17,7 +17,7 @@ local DataTable = Lua.import('Module:Widget/Basic/DataTable')
 local MatchOverview = Lua.import('Module:Widget/Standings/MatchOverview')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class StandingsSwissWidget: Widget
 ---@operator call(table): StandingsSwissWidget

--- a/lua/wikis/commons/Widget/Standings/Swiss.lua
+++ b/lua/wikis/commons/Widget/Standings/Swiss.lua
@@ -16,9 +16,8 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local DataTable = Lua.import('Module:Widget/Basic/DataTable')
 local MatchOverview = Lua.import('Module:Widget/Standings/MatchOverview')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 ---@class StandingsSwissWidget: Widget
 ---@operator call(table): StandingsSwissWidget

--- a/lua/wikis/counterstrike/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/counterstrike/MatchGroup/Input/Custom.lua
@@ -16,8 +16,7 @@ local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
 local HighlightConditions = Lua.import('Module:HighlightConditions')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
 local FEATURED_TIERS = {1, 2}

--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -18,8 +18,7 @@ local Variables = Lua.import('Module:Variables')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchGroupInput = {}
 local MatchFunctions = {}

--- a/lua/wikis/easportsfc/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/easportsfc/MatchGroup/Input/Custom.lua
@@ -12,8 +12,7 @@ local Ordinal = require('Module:Ordinal')
 local Operator = require('Module:Operator')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchGroupInput = {}
 CustomMatchGroupInput.DEFAULT_MODE = 'solo'

--- a/lua/wikis/easportsfc/MatchSummary.lua
+++ b/lua/wikis/easportsfc/MatchSummary.lua
@@ -15,7 +15,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 

--- a/lua/wikis/easportsfc/MatchSummary.lua
+++ b/lua/wikis/easportsfc/MatchSummary.lua
@@ -15,8 +15,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibrary.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local NO_CHECK = '[[File:NoCheck.png|link=]]'
 

--- a/lua/wikis/easportsfc/PortalPlayers/Custom.lua
+++ b/lua/wikis/easportsfc/PortalPlayers/Custom.lua
@@ -17,7 +17,7 @@ local Table = require('Module:Table')
 local AgeCalculation = Lua.import('Module:AgeCalculation')
 local PortalPlayers = Lua.import('Module:PortalPlayers')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local NON_PLAYER_HEADER = Abbreviation.make{text = 'Staff', title = 'Coaches, Managers, Analysts and more'}
 	.. ' & ' .. Abbreviation.make{text = 'Talents', title = 'Commentators, Observers, Hosts and more'}

--- a/lua/wikis/easportsfc/PortalPlayers/Custom.lua
+++ b/lua/wikis/easportsfc/PortalPlayers/Custom.lua
@@ -17,8 +17,7 @@ local Table = require('Module:Table')
 local AgeCalculation = Lua.import('Module:AgeCalculation')
 local PortalPlayers = Lua.import('Module:PortalPlayers')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibrary.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local NON_PLAYER_HEADER = Abbreviation.make{text = 'Staff', title = 'Coaches, Managers, Analysts and more'}
 	.. ' & ' .. Abbreviation.make{text = 'Talents', title = 'Commentators, Observers, Hosts and more'}

--- a/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
@@ -12,8 +12,7 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators
 ---@class FightersMatchCopyPaste: Match2CopyPasteBase

--- a/lua/wikis/fighters/Info.lua
+++ b/lua/wikis/fighters/Info.lua
@@ -1716,5 +1716,4 @@ return {
 			hideOverview = true,
 		},
 	},
-	opponentLibrary = 'Opponent/Custom',
 }

--- a/lua/wikis/fighters/Match/Legacy.lua
+++ b/lua/wikis/fighters/Match/Legacy.lua
@@ -19,8 +19,7 @@ local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchLegacyUtil = Lua.import('Module:MatchGroup/Legacy/Util')
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 
 function MatchLegacy.storeMatch(match2)

--- a/lua/wikis/fighters/MatchSummary.lua
+++ b/lua/wikis/fighters/MatchSummary.lua
@@ -17,8 +17,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 local PlayerDisplay = Lua.import('Module:Player/Display')
 
 local CustomMatchSummary = {}

--- a/lua/wikis/fighters/ParticipantTable/Custom.lua
+++ b/lua/wikis/fighters/ParticipantTable/Custom.lua
@@ -10,7 +10,7 @@ local Table = require('Module:Table')
 
 local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local CustomParticipantTable = {}
 

--- a/lua/wikis/fighters/ParticipantTable/Custom.lua
+++ b/lua/wikis/fighters/ParticipantTable/Custom.lua
@@ -10,8 +10,7 @@ local Table = require('Module:Table')
 
 local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibrary.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local CustomParticipantTable = {}
 

--- a/lua/wikis/fighters/PrizePool/Custom.lua
+++ b/lua/wikis/fighters/PrizePool/Custom.lua
@@ -14,8 +14,7 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local PrizePool = Lua.import('Module:PrizePool')
 

--- a/lua/wikis/formula1/Infobox/Team/Custom.lua
+++ b/lua/wikis/formula1/Infobox/Team/Custom.lua
@@ -10,7 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')

--- a/lua/wikis/formula1/Infobox/Team/Custom.lua
+++ b/lua/wikis/formula1/Infobox/Team/Custom.lua
@@ -10,8 +10,7 @@ local Class = require('Module:Class')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')

--- a/lua/wikis/formula1/PortalPlayers/Custom.lua
+++ b/lua/wikis/formula1/PortalPlayers/Custom.lua
@@ -17,8 +17,7 @@ local Table = require('Module:Table')
 local AgeCalculation = Lua.import('Module:AgeCalculation')
 local PortalPlayers = Lua.import('Module:PortalPlayers')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local NON_PLAYER_HEADER = Abbreviation.make{text = 'Staff',
 	title = 'Team Principals, Race Engineers, Strategists and more'}

--- a/lua/wikis/formula1/PortalPlayers/Custom.lua
+++ b/lua/wikis/formula1/PortalPlayers/Custom.lua
@@ -17,7 +17,7 @@ local Table = require('Module:Table')
 local AgeCalculation = Lua.import('Module:AgeCalculation')
 local PortalPlayers = Lua.import('Module:PortalPlayers')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local NON_PLAYER_HEADER = Abbreviation.make{text = 'Staff',
 	title = 'Team Principals, Race Engineers, Strategists and more'}

--- a/lua/wikis/fortnite/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fortnite/GetMatchGroupCopyPaste/wiki.lua
@@ -11,8 +11,7 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---@class FortniteMatchCopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)

--- a/lua/wikis/fortnite/Infobox/Team/Custom.lua
+++ b/lua/wikis/fortnite/Infobox/Team/Custom.lua
@@ -16,8 +16,7 @@ local Table = require('Module:Table')
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell

--- a/lua/wikis/fortnite/PrizePool/Legacy/Custom.lua
+++ b/lua/wikis/fortnite/PrizePool/Legacy/Custom.lua
@@ -12,8 +12,7 @@ local Variables = require('Module:Variables')
 
 local LegacyPrizePool = Lua.import('Module:PrizePool/Legacy')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp', w = 'w', d = 'd', l = 'l', q = 'q'}
 

--- a/lua/wikis/fortnite/ResultsTable/Custom.lua
+++ b/lua/wikis/fortnite/ResultsTable/Custom.lua
@@ -14,8 +14,7 @@ local Table = require('Module:Table')
 local ResultsTable = Lua.import('Module:ResultsTable')
 local AwardsTable = Lua.import('Module:ResultsTable/Award')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomResultsTable = {}
 

--- a/lua/wikis/halo/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/halo/MatchGroup/Input/Custom.lua
@@ -12,8 +12,7 @@ local Table = require('Module:Table')
 local Variables = require('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchGroupInput = {}
 local MatchFunctions = {

--- a/lua/wikis/hearthstone/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/hearthstone/GetMatchGroupCopyPaste/wiki.lua
@@ -11,8 +11,7 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---WikiSpecific Code for MatchList and Bracket Code Generators
 ---@class HearthstoneMatchCopyPaste: Match2CopyPasteBase

--- a/lua/wikis/hearthstone/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/hearthstone/MatchGroup/Input/Custom.lua
@@ -15,8 +15,7 @@ local Operator = Lua.import('Module:Operator')
 local Table = Lua.import('Module:Table')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchGroupInput = {}
 local OPPONENT_CONFIG = {

--- a/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
@@ -14,8 +14,7 @@ local Table = require('Module:Table')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SCORE_STATUS = 'S'
 

--- a/lua/wikis/hearthstone/MatchMaps/Legacy.lua
+++ b/lua/wikis/hearthstone/MatchMaps/Legacy.lua
@@ -14,8 +14,7 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/hearthstone/MatchMaps/Legacy.lua
+++ b/lua/wikis/hearthstone/MatchMaps/Legacy.lua
@@ -5,16 +5,17 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local Array = require('Module:Array')
-local Logic = require('Module:Logic')
-local Json = require('Module:Json')
-local MatchGroup = require('Module:MatchGroup')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
-local Table = require('Module:Table')
-local Template = require('Module:Template')
+local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
+local Array = Lua.import('Module:Array')
+local Logic = Lua.import('Module:Logic')
+local Json = Lua.import('Module:Json')
+local MatchGroup = Lua.import('Module:MatchGroup')
 local Opponent = Lua.import('Module:Opponent/Custom')
+local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local Table = Lua.import('Module:Table')
+local Template = Lua.import('Module:Template')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/hearthstone/MatchSummary.lua
+++ b/lua/wikis/hearthstone/MatchSummary.lua
@@ -15,8 +15,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchSummary = {}
 

--- a/lua/wikis/heroes/MatchMaps/Legacy.lua
+++ b/lua/wikis/heroes/MatchMaps/Legacy.lua
@@ -16,8 +16,7 @@ local Table = require('Module:Table')
 local Match = Lua.import('Module:Match')
 local MatchGroup = Lua.import('Module:MatchGroup')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 

--- a/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
@@ -12,8 +12,7 @@ local Logic = Lua.import('Module:Logic')
 local RoleOf = Lua.import('Module:RoleOf')
 local String = Lua.import('Module:StringUtils')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Injector = Lua.import('Module:Widget/Injector')

--- a/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/leagueoflegends/Infobox/Team/Custom.lua
@@ -12,7 +12,7 @@ local Logic = Lua.import('Module:Logic')
 local RoleOf = Lua.import('Module:RoleOf')
 local String = Lua.import('Module:StringUtils')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Injector = Lua.import('Module:Widget/Injector')

--- a/lua/wikis/magic/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/magic/MatchGroup/Input/Custom.lua
@@ -12,8 +12,7 @@ local Variables = require('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchGroupInput = {}
 local MapFunctions = {}

--- a/lua/wikis/overwatch/PrizePool/Custom.lua
+++ b/lua/wikis/overwatch/PrizePool/Custom.lua
@@ -13,8 +13,7 @@ local Logic = Lua.import('Module:Logic')
 local Variables = Lua.import('Module:Variables')
 
 local PrizePool = Lua.import('Module:PrizePool')
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 local CustomLpdbInjector = Class.new(LpdbInjector)

--- a/lua/wikis/pokemon/PrizePool/Custom.lua
+++ b/lua/wikis/pokemon/PrizePool/Custom.lua
@@ -11,8 +11,7 @@ local Lua = require('Module:Lua')
 local Logic = require('Module:Logic')
 local Variables = require('Module:Variables')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local PrizePool = Lua.import('Module:PrizePool')
 

--- a/lua/wikis/rocketleague/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/rocketleague/GetMatchGroupCopyPaste/wiki.lua
@@ -11,8 +11,7 @@ local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---@class RocketleagueMatch2CopyPaste: Match2CopyPasteBase
 local WikiCopyPaste = Class.new(BaseCopyPaste)

--- a/lua/wikis/smash/Info.lua
+++ b/lua/wikis/smash/Info.lua
@@ -104,5 +104,4 @@ return {
 			hideOverview = true,
 		},
 	},
-	opponentLibrary = 'Opponent/Custom',
 }

--- a/lua/wikis/smash/Match/Legacy.lua
+++ b/lua/wikis/smash/Match/Legacy.lua
@@ -19,8 +19,7 @@ local Table = require('Module:Table')
 
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchLegacyUtil = Lua.import('Module:MatchGroup/Legacy/Util')
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 
 function MatchLegacy.storeMatch(match2)

--- a/lua/wikis/smash/MatchGroup/Display/Bracket/Custom.lua
+++ b/lua/wikis/smash/MatchGroup/Display/Bracket/Custom.lua
@@ -10,9 +10,8 @@ local Characters = require('Module:Characters')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')

--- a/lua/wikis/smash/MatchGroup/Display/Bracket/Custom.lua
+++ b/lua/wikis/smash/MatchGroup/Display/Bracket/Custom.lua
@@ -11,7 +11,7 @@ local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local BracketDisplay = Lua.import('Module:MatchGroup/Display/Bracket')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')

--- a/lua/wikis/smash/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/smash/MatchGroup/Util/Custom.lua
@@ -11,8 +11,7 @@ local Table = require('Module:Table')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SmashMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 

--- a/lua/wikis/smash/MatchSummary.lua
+++ b/lua/wikis/smash/MatchSummary.lua
@@ -16,8 +16,7 @@ local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 local PlayerDisplay = Lua.import('Module:Player/Display')
 
 local CustomMatchSummary = {}

--- a/lua/wikis/smash/PortalPlayers/Custom.lua
+++ b/lua/wikis/smash/PortalPlayers/Custom.lua
@@ -15,8 +15,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Team = Lua.import('Module:Team')
 
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibrary.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Characters = Lua.import('Module:Characters')
 

--- a/lua/wikis/smash/PortalPlayers/Custom.lua
+++ b/lua/wikis/smash/PortalPlayers/Custom.lua
@@ -15,7 +15,7 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Team = Lua.import('Module:Team')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Characters = Lua.import('Module:Characters')
 

--- a/lua/wikis/smash/PrizePool/Custom.lua
+++ b/lua/wikis/smash/PrizePool/Custom.lua
@@ -11,8 +11,7 @@ local Json = require('Module:Json')
 local Lua = require('Module:Lua')
 local Variables = require('Module:Variables')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local PrizePool = Lua.import('Module:PrizePool')
 

--- a/lua/wikis/squadrons/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/squadrons/MatchGroup/Legacy/MatchList.lua
@@ -14,8 +14,7 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/squadrons/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/squadrons/MatchGroup/Legacy/MatchList.lua
@@ -5,16 +5,17 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local Json = require('Module:Json')
-local Logic = require('Module:Logic')
-local Match = require('Module:Match')
-local MatchGroup = require('Module:MatchGroup')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
-local Table = require('Module:Table')
-local Template = require('Module:Template')
+local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
+local Match = Lua.import('Module:Match')
+local MatchGroup = Lua.import('Module:MatchGroup')
 local Opponent = Lua.import('Module:Opponent/Custom')
+local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local Table = Lua.import('Module:Table')
+local Template = Lua.import('Module:Template')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/starcraft/Info.lua
+++ b/lua/wikis/starcraft/Info.lua
@@ -38,6 +38,6 @@ return {
 		},
 	},
 	maximumNumberOfPlayersInPlacements = 35,
-	opponentLibrary = 'Opponent/Starcraft',
-	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
+	opponentLibrary = 'Opponent/Starcraft', --to be removed after cleanup of non git modules
+	opponentDisplayLibrary = 'OpponentDisplay/Starcraft', --to be removed after cleanup of non git modules
 }

--- a/lua/wikis/starcraft/Infobox/Team/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Team/Custom.lua
@@ -25,8 +25,7 @@ local Injector = Lua.import('Module:Widget/Injector')
 local RaceBreakdown = Lua.import('Module:Infobox/Extension/RaceBreakdown')
 local Team = Lua.import('Module:Infobox/Team')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Breakdown = Widgets.Breakdown

--- a/lua/wikis/starcraft/Opponent/Custom.lua
+++ b/lua/wikis/starcraft/Opponent/Custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local StarcraftOpponent = Lua.import('Module:Opponent/Starcraft')
+
+return StarcraftOpponent

--- a/lua/wikis/starcraft/OpponentDisplay/Custom.lua
+++ b/lua/wikis/starcraft/OpponentDisplay/Custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- page=Module:OpponentDisplay/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft')
+
+return StarcraftOpponentDisplay

--- a/lua/wikis/starcraft2/Info.lua
+++ b/lua/wikis/starcraft2/Info.lua
@@ -70,6 +70,6 @@ return {
 			hideOrg = true,
 		},
 	},
-	opponentLibrary = 'Opponent/Starcraft',
-	opponentDisplayLibrary = 'OpponentDisplay/Starcraft',
+	opponentLibrary = 'Opponent/Starcraft', --to be removed after cleanup of non git modules
+	opponentDisplayLibrary = 'OpponentDisplay/Starcraft', --to be removed after cleanup of non git modules
 }

--- a/lua/wikis/starcraft2/Infobox/Team/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Team/Custom.lua
@@ -24,8 +24,7 @@ local Injector = Lua.import('Module:Widget/Injector')
 local RaceBreakdown = Lua.import('Module:Infobox/Extension/RaceBreakdown')
 local Team = Lua.import('Module:Infobox/Team')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Breakdown = Widgets.Breakdown

--- a/lua/wikis/starcraft2/Opponent/Custom.lua
+++ b/lua/wikis/starcraft2/Opponent/Custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- page=Module:Opponent/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local StarcraftOpponent = Lua.import('Module:Opponent/Starcraft')
+
+return StarcraftOpponent

--- a/lua/wikis/starcraft2/OpponentDisplay/Custom.lua
+++ b/lua/wikis/starcraft2/OpponentDisplay/Custom.lua
@@ -1,0 +1,12 @@
+---
+-- @Liquipedia
+-- page=Module:OpponentDisplay/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local StarcraftOpponentDisplay = Lua.import('Module:OpponentDisplay/Starcraft')
+
+return StarcraftOpponentDisplay

--- a/lua/wikis/starcraft2/ResultsTable/Custom.lua
+++ b/lua/wikis/starcraft2/ResultsTable/Custom.lua
@@ -20,9 +20,8 @@ local Variables = Lua.import('Module:Variables')
 local ResultsTable = Lua.import('Module:ResultsTable')
 local AwardsTable = Lua.import('Module:ResultsTable/Award')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]'
 local DEFAULT_EVENT_ICON = ''

--- a/lua/wikis/starcraft2/ResultsTable/Custom.lua
+++ b/lua/wikis/starcraft2/ResultsTable/Custom.lua
@@ -21,7 +21,7 @@ local ResultsTable = Lua.import('Module:ResultsTable')
 local AwardsTable = Lua.import('Module:ResultsTable/Award')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]'
 local DEFAULT_EVENT_ICON = ''

--- a/lua/wikis/stormgate/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/stormgate/GetMatchGroupCopyPaste/wiki.lua
@@ -11,8 +11,7 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 local MODE_CONVERSION = {
 	['1v1'] = {Opponent.solo},
 	['2v2'] = {Opponent.duo},

--- a/lua/wikis/stormgate/Info.lua
+++ b/lua/wikis/stormgate/Info.lua
@@ -38,6 +38,4 @@ return {
 		},
 	},
 	defaultRoundPrecision = 0,
-	opponentLibrary = 'Opponent/Custom',
-	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }

--- a/lua/wikis/stormgate/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/stormgate/MatchGroup/Input/Custom.lua
@@ -18,8 +18,7 @@ local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TBD = 'TBD'
 local DEFAULT_HERO_FACTION = CharacterAliases.default.faction

--- a/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
@@ -16,8 +16,7 @@ local TypeUtil = require('Module:TypeUtil')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SCORE_STATUS = 'S'
 

--- a/lua/wikis/stormgate/MatchSummary.lua
+++ b/lua/wikis/stormgate/MatchSummary.lua
@@ -21,9 +21,8 @@ local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local ICONS = {
 	veto = Icon.makeIcon{iconName = 'veto', color = 'cinnabar-text', size = '110%'},

--- a/lua/wikis/stormgate/MatchSummary.lua
+++ b/lua/wikis/stormgate/MatchSummary.lua
@@ -22,7 +22,7 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local ICONS = {
 	veto = Icon.makeIcon{iconName = 'veto', color = 'cinnabar-text', size = '110%'},

--- a/lua/wikis/stormgate/ParticipantTable/Custom.lua
+++ b/lua/wikis/stormgate/ParticipantTable/Custom.lua
@@ -39,8 +39,7 @@ local Variables = require('Module:Variables')
 
 local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local StormgateParticipantTable = {}
 

--- a/lua/wikis/tetris/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/tetris/MatchGroup/Input/Custom.lua
@@ -11,8 +11,7 @@ local Variables = require('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomMatchGroupInput = {}
 local MapFunctions = {

--- a/lua/wikis/trackmania/Info.lua
+++ b/lua/wikis/trackmania/Info.lua
@@ -153,6 +153,4 @@ return {
 			sortCasters = true,
 		},
 	},
-	opponentLibrary = 'Opponent',
-	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }

--- a/lua/wikis/trackmania/Match/Legacy.lua
+++ b/lua/wikis/trackmania/Match/Legacy.lua
@@ -14,8 +14,7 @@ local Operator = require('Module:Operator')
 local String = require('Module:StringUtils')
 local Table = require('Module:Table')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MatchLegacyUtil = Lua.import('Module:MatchGroup/Legacy/Util')
 

--- a/lua/wikis/trackmania/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/trackmania/MatchGroup/Legacy/MatchList.lua
@@ -5,17 +5,18 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local Array = require('Module:Array')
-local Json = require('Module:Json')
-local Logic = require('Module:Logic')
-local Match = require('Module:Match')
-local MatchGroup = require('Module:MatchGroup')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
-local Table = require('Module:Table')
-local Template = require('Module:Template')
+local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
+local Array = Lua.import('Module:Array')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
+local Match = Lua.import('Module:Match')
+local MatchGroup = Lua.import('Module:MatchGroup')
 local Opponent = Lua.import('Module:Opponent/Custom')
+local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local Table = Lua.import('Module:Table')
+local Template = Lua.import('Module:Template')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/trackmania/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/trackmania/MatchGroup/Legacy/MatchList.lua
@@ -15,8 +15,7 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/valorant/GameTable/Character/Custom.lua
+++ b/lua/wikis/valorant/GameTable/Character/Custom.lua
@@ -14,8 +14,7 @@ local Class = Lua.import('Module:Class')
 local MathUtil = Lua.import('Module:MathUtil')
 local Page = Lua.import('Module:Page')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CharacterGameTable = Lua.import('Module:GameTable/Character')
 

--- a/lua/wikis/valorant/Infobox/Team/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Team/Custom.lua
@@ -9,8 +9,7 @@ local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
 
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')

--- a/lua/wikis/valorant/Infobox/Team/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Team/Custom.lua
@@ -9,7 +9,7 @@ local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')

--- a/lua/wikis/warcraft/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/warcraft/GetMatchGroupCopyPaste/wiki.lua
@@ -11,8 +11,7 @@ local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 
 local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
-local OpponentLibrary = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MODE_CONVERSION = {
 	['1v1'] = {Opponent.solo},

--- a/lua/wikis/warcraft/Info.lua
+++ b/lua/wikis/warcraft/Info.lua
@@ -63,6 +63,4 @@ return {
 			matchWidth = 150,
 		},
 	},
-	opponentLibrary = 'Opponent/Custom',
-	opponentDisplayLibrary = 'OpponentDisplay/Custom',
 }

--- a/lua/wikis/warcraft/LegacyMatchMaps.lua
+++ b/lua/wikis/warcraft/LegacyMatchMaps.lua
@@ -17,8 +17,7 @@ local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 local Template = require('Module:Template')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/warcraft/LegacyMatchMaps.lua
+++ b/lua/wikis/warcraft/LegacyMatchMaps.lua
@@ -7,17 +7,18 @@
 
 --converts the old matchlists to be readable by the match2 system
 
-local Arguments = require('Module:Arguments')
-local Array = require('Module:Array')
-local Json = require('Module:Json')
-local Logic = require('Module:Logic')
-local Match = require('Module:Match')
-local MatchGroup = require('Module:MatchGroup')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
-local Table = require('Module:Table')
-local Template = require('Module:Template')
+local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
+local Array = Lua.import('Module:Array')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
+local Match = Lua.import('Module:Match')
+local MatchGroup = Lua.import('Module:MatchGroup')
 local Opponent = Lua.import('Module:Opponent/Custom')
+local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local Table = Lua.import('Module:Table')
+local Template = Lua.import('Module:Template')
 
 local globalVars = PageVariableNamespace()
 local matchlistVars = PageVariableNamespace('LegacyMatchlist')

--- a/lua/wikis/warcraft/Match/Legacy.lua
+++ b/lua/wikis/warcraft/Match/Legacy.lua
@@ -20,8 +20,7 @@ local Variables = require('Module:Variables')
 local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchLegacyUtil = Lua.import('Module:MatchGroup/Legacy/Util')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local UNKNOWNREASON_DEFAULT_LOSS = 'L'
 local TBD = 'TBD'

--- a/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
@@ -22,8 +22,7 @@ local Table = Lua.import('Module:Table')
 local Variables = Lua.import('Module:Variables')
 
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
-local OpponentLibraries = Lua.import('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TBD = 'TBD'
 local NEUTRAL_HERO_FACTION = 'neutral'

--- a/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
@@ -16,8 +16,7 @@ local Table = require('Module:Table')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
 local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local TEAM_DISPLAY_MODE = 'team'
 local UNIFORM_DISPLAY_MODE = 'uniform'

--- a/lua/wikis/warcraft/MatchSummary.lua
+++ b/lua/wikis/warcraft/MatchSummary.lua
@@ -21,9 +21,8 @@ local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local ICONS = {
 	veto = Icon.makeIcon{iconName = 'veto', color = 'cinnabar-text', size = '110%'},

--- a/lua/wikis/warcraft/MatchSummary.lua
+++ b/lua/wikis/warcraft/MatchSummary.lua
@@ -22,7 +22,7 @@ local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local ICONS = {
 	veto = Icon.makeIcon{iconName = 'veto', color = 'cinnabar-text', size = '110%'},

--- a/lua/wikis/warcraft/MatchSummary/Ffa.lua
+++ b/lua/wikis/warcraft/MatchSummary/Ffa.lua
@@ -11,8 +11,7 @@ local Array = require('Module:Array')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local OpponentDisplay = OpponentLibraries.OpponentDisplay
+local Opponent = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local BaseMatchSummary = Lua.import('Module:MatchSummary/Base/Ffa')

--- a/lua/wikis/warcraft/MatchSummary/Ffa.lua
+++ b/lua/wikis/warcraft/MatchSummary/Ffa.lua
@@ -11,7 +11,7 @@ local Array = require('Module:Array')
 local Lua = require('Module:Lua')
 local Table = require('Module:Table')
 
-local Opponent = Lua.import('Module:OpponentDisplay/Custom')
+local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local BaseMatchSummary = Lua.import('Module:MatchSummary/Base/Ffa')

--- a/lua/wikis/warcraft/ParticipantTable/Custom.lua
+++ b/lua/wikis/warcraft/ParticipantTable/Custom.lua
@@ -35,8 +35,7 @@ local Variables = require('Module:Variables')
 
 local ParticipantTable = Lua.import('Module:ParticipantTable/Base')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local CustomParticipantTable = {}
 

--- a/lua/wikis/warcraft/PrizePool/Legacy/Custom.lua
+++ b/lua/wikis/warcraft/PrizePool/Legacy/Custom.lua
@@ -11,8 +11,7 @@ local Table = require('Module:Table')
 
 local LegacyPrizePool = Lua.import('Module:PrizePool/Legacy')
 
-local OpponentLibrary = require('Module:OpponentLibraries')
-local Opponent = OpponentLibrary.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SPECIAL_PLACES = {dq = 'dq', dnf = 'dnf', dnp = 'dnp', w = 'w', d = 'd', l = 'l', q = 'q'}
 

--- a/lua/wikis/worldofwarcraft/MatchGroup/Legacy/Default.lua
+++ b/lua/wikis/worldofwarcraft/MatchGroup/Legacy/Default.lua
@@ -12,8 +12,7 @@ local Lua = require('Module:Lua')
 
 local MatchGroupLegacy = Lua.import('Module:MatchGroup/Legacy')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local MAX_NUMBER_OF_OPPONENTS = 2
 

--- a/lua/wikis/worldofwarcraft/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/worldofwarcraft/MatchGroup/Legacy/MatchList.lua
@@ -5,16 +5,17 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local Array = require('Module:Array')
-local Json = require('Module:Json')
-local Logic = require('Module:Logic')
-local Match = require('Module:Match')
-local MatchGroup = require('Module:MatchGroup')
-local PageVariableNamespace = require('Module:PageVariableNamespace')
-local Table = require('Module:Table')
+local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
+local Array = Lua.import('Module:Array')
+local Json = Lua.import('Module:Json')
+local Logic = Lua.import('Module:Logic')
+local Match = Lua.import('Module:Match')
+local MatchGroup = Lua.import('Module:MatchGroup')
 local Opponent = Lua.import('Module:Opponent/Custom')
+local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local Table = Lua.import('Module:Table')
 
 local globalVars = PageVariableNamespace()
 

--- a/lua/wikis/worldofwarcraft/MatchGroup/Legacy/MatchList.lua
+++ b/lua/wikis/worldofwarcraft/MatchGroup/Legacy/MatchList.lua
@@ -14,8 +14,7 @@ local MatchGroup = require('Module:MatchGroup')
 local PageVariableNamespace = require('Module:PageVariableNamespace')
 local Table = require('Module:Table')
 
-local OpponentLibraries = require('Module:OpponentLibraries')
-local Opponent = OpponentLibraries.Opponent
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local globalVars = PageVariableNamespace()
 


### PR DESCRIPTION
## Summary
remove git usage of `Module:OpponentLibraries`

## follow up:
- remove non git usage (way easier after this PR got merged!, should be ~70 modules i guess)
- nuke `Module:OpponentLibraries` + adjust sc & sc2 `Module:Info` accordingly

## How did you test this change?
untested
(just search & replace)