### PR TITLE
fix(stylesheets): increase the size of the row so that the buttons fit into the box

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -1179,7 +1179,7 @@ div.brkts-opponent-hover-active::after {
 .brkts-designer-match-row {
 	place-content: stretch space-between;
 	display: flex;
-	height: 22px;
+	height: 26px;
 }
 
 .brkts-designer-small-button.brkts-designer-small-button.brkts-designer-small-button {


### PR DESCRIPTION
## Summary

Before:
<img width="205" height="113" alt="image" src="https://github.com/user-attachments/assets/3b1bfcec-8efc-4e88-9a98-8bfb729dd9d3" />

After:
<img width="218" height="119" alt="image" src="https://github.com/user-attachments/assets/143402d8-dbef-4fcd-93a6-4bf8e45fa57c" />


## How did you test this change?

dev tools