### PR TITLE
fix(ParticipantTable): button display on AoE

### DIFF
--- a/lua/wikis/ageofempires/ParticipantTable/Custom.lua
+++ b/lua/wikis/ageofempires/ParticipantTable/Custom.lua
@@ -155,8 +155,6 @@ function AoEParticipantTable:_createTitle(tabletitle, buttontitle, togglearea, b
 			:tag('span')
 				:addClass('toggle-area-button btn btn-small btn-primary')
 				:attr('data-toggle-area-btn', buttonarea)
-				:css('padding-top', '2px')
-				:css('padding-bottom', '2px')
 				:css('position', 'absolute')
 				:wikitext(buttontitle)
 


### PR DESCRIPTION
## Summary
Reported on discord https://discord.com/channels/93055209017729024/1392450006224474112/1399020362049523783

The width change is to not have the button cover the title.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Before: 
<img width="362" height="503" alt="image" src="https://github.com/user-attachments/assets/6a3a1918-99b3-43b0-a32b-8f3689e7a94d" />
After:
<img width="314" height="404" alt="image" src="https://github.com/user-attachments/assets/5bf3ede8-66b0-4e6d-b745-daafa1fd9d46" />

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
