### PR TITLE
chore(mainpage): fix deploy header in chess data

### DIFF
--- a/lua/wikis/chess/MainPageLayout/data.lua
+++ b/lua/wikis/chess/MainPageLayout/data.lua
@@ -1,3 +1,4 @@
+---
 -- @Liquipedia
 -- page=Module:MainPageLayout/data
 --


### PR DESCRIPTION
## Summary

Applying changes from #6256 to chess wiki
Was looking into why #6244 hadn't deployed after merging, likely this is the reason?

## How did you test this change?

Not tested - only deploy header changed