### PR TITLE
Update .collapseButton CSS class to pull away from inline text.

### DIFF
--- a/stylesheets/commons/NavFrame.less
+++ b/stylesheets/commons/NavFrame.less
@@ -111,6 +111,7 @@ html.client-js .collapsible.collapsed > tr:nth-child( n+2 ) {
 	text-align: right;
 	width: auto;
 	min-width: 40px;
+	offset-left: 0.15rem;
 }
 
 .broadcast-talent-partner-list-frame .collapseButton {


### PR DESCRIPTION
## Summary

Buttons used to show/hide content do not have any space between text within the same line. All these buttons have the .collapseButton CSS class.

Adding an "offset-left: 0.yyy[rem];" to the class can fix this without adding much width. I am unaware of any issues this could cause because of the "float: right;" within the same class.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

Dev Tools.

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
___New.___

<img width="822" height="802" alt="image" src="https://github.com/user-attachments/assets/69085d2e-026d-43ba-811c-8cf80db26ef4" />

___Old.___
<img width="821" height="812" alt="image" src="https://github.com/user-attachments/assets/1cb31b88-ecad-430f-84fd-304957324896" />
