### PR TITLE
fix: add missing link to full ratings on RL Mainpage

### DIFF
--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -61,7 +61,10 @@ local CONTENT = {
 		body = HtmlWidgets.Fragment{
 			children = {
 				RatingsDisplay.graph{id = 'rating'},
-				'<div style="text-align: center;"><i>[[Portal:Rating#The Rating|See the full ranking]]</i></div>'
+				Div{
+					css = { ['text-align'] = 'center' },
+					children = HtmlWidgets.I{children = '[[Portal:Rating#The Rating|See the full ranking]]' }
+				}
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
The link to the full rankings was missing from the old mainpage
added a link back
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
https://liquipedia.net/rocketleague/Module:MainPageLayout/data/dev/jj
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
