### PR TITLE
feat(mainpage): Clash Royale tweaks

### DIFF
--- a/lua/wikis/clashroyale/MainPageLayout/data.lua
+++ b/lua/wikis/clashroyale/MainPageLayout/data.lua
@@ -64,8 +64,8 @@ local CONTENT = {
 	tournaments = {
 		heading = 'Tournaments',
 		body = TournamentsTicker{
-			upcomingDays = 30,
-			completedDays = 30,
+			upcomingDays = 60,
+			completedDays = 60,
 		},
 		padding = true,
 		boxid = 1508,

--- a/lua/wikis/clashroyale/MainPageLayout/data.lua
+++ b/lua/wikis/clashroyale/MainPageLayout/data.lua
@@ -128,7 +128,7 @@ return {
 			},
 		},
 		{
-			file = 'TL Crl West Spring-2019.png',
+			file = 'Nova_Crl_2018_World_Finals.jpg',
 			title = 'Statistics',
 			link = 'Portal:Statistics',
 		},


### PR DESCRIPTION
Image change on the statistics pill as I was pointed having 2 pills from TL players might be a bit too unbalance, so a suggestion were to use another team on it instead

<img width="1032" height="124" alt="image" src="https://github.com/user-attachments/assets/37a5fb43-c7d9-4927-8e40-a00b5fdece0c" />

**Edit**: We were also suggested to ramp up the Upcoming days significantly, because the low number of tournaments. So we are bumping both to 60

## New image
<img width="269" height="191" alt="image" src="https://github.com/user-attachments/assets/5e398800-e951-4e9c-9333-d93160053ffc" />
