### PR TITLE
fix: match date not shown in schedules display if time zone adjustment is disabled

### DIFF
--- a/lua/wikis/commons/MatchesScheduleDisplay.lua
+++ b/lua/wikis/commons/MatchesScheduleDisplay.lua
@@ -186,6 +186,7 @@ function MatchesTable:dateDisplay(match)
 			countdownArgs.rawdatetime = true
 		end
 		countdownArgs.timestamp = match.timestamp
+		countdownArgs.date = DateExt.toCountdownArg(match.timestamp, match.timezoneId)
 		return dateCell:wikitext(Countdown._create(countdownArgs))
 	elseif self.config.onlyShowExactDates then
 		return dateCell


### PR DESCRIPTION
## Summary

Oversight from #6030
Because only the timestamp was passed in for countdown, the actual date was not shown if time zone adjustment was disabled in preferences. This PR adds `date` fallback to fix such behavior.

## How did you test this change?

dev