### PR TITLE
fix(TransferList): Respect given sort order

### DIFF
--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -168,39 +168,29 @@ function TransferList:fetch()
 		conditions = self.conditions,
 		limit = self.config.limit,
 		order = self.config.sortOrder,
-		groupby = 'date desc, toteam desc, fromteam desc, role1 desc',--role2 desc
 	})
 
 	local groupedData = {}
+	local currentGroup
+	local cache = {}
 	Array.forEach(queryData, function(transfer)
-		local transfers = mw.ext.LiquipediaDB.lpdb('transfer', {
-			conditions = self:_buildConditions{
-				date = transfer.date,
-				fromTeam = transfer.fromteam or '',
-				toTeam = transfer.toteam or '',
-				roles1 = {transfer.role1},
-			},
-			limit = self.config.limit + 10,
-			order = self.config.sortOrder,
-		})
-		local currentGroup
-		local cache = {}
-		Array.forEach(transfers, function(transf)
-			if
-				cache.role2 ~= transf.role2 or
-				cache.team1_2 ~= transf.extradata.fromteamsec or
-				cache.team2_2 ~= transf.extradata.toteamsec
-			then
-				cache.role2 = transf.role2
-				cache.team1_2 = transfer.extradata.fromteamsec
-				cache.team2_2 = transfer.extradata.toteamsec
-				Array.appendWith(groupedData, currentGroup)
-				currentGroup = {}
-			end
-			table.insert(currentGroup, transf)
-		end)
-		Array.appendWith(groupedData, currentGroup)
+		if
+			cache.role1 ~= transfer.role1 or
+			cache.role2 ~= transfer.role2 or
+			cache.team1_2 ~= transfer.extradata.fromteamsec or
+			cache.team2_2 ~= transfer.extradata.toteamsec
+		then
+			cache.role1 = transfer.role1
+			cache.role2 = transfer.role2
+			cache.team1_2 = transfer.extradata.fromteamsec
+			cache.team2_2 = transfer.extradata.toteamsec
+
+			Array.appendWith(groupedData, currentGroup)
+			currentGroup = {}
+		end
+		table.insert(currentGroup, transfer)
 	end)
+	Array.appendWith(groupedData, currentGroup)
 
 	self.groupedTransfers = groupedData
 


### PR DESCRIPTION
## Summary
The combination of groupby (without role2) and refetch mangled the order, as reported on discord:
https://discord.com/channels/93055209017729024/372075546231832576/1400214955667493025
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev

Correct behavior TBC by mnmzzz
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
