### PR TITLE
Remove custom SortDate for Warcraft

### DIFF
--- a/lua/wikis/warcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/League/Custom.lua
@@ -399,9 +399,6 @@ function CustomLeague:addToLpdb(lpdbData, args)
 		participantsNumber = tonumber(args.player_number) or 0
 	end
 	lpdbData.participantsnumber = participantsNumber
-	lpdbData.sortdate = self.data.startTime.startTime
-		and (self.data.startTime.startTime .. (self.data.startTime.timeZone or ''))
-		or self.data.firstMatch or self.data.startDate
 	lpdbData.mode = self:_getMode()
 	lpdbData.extradata.seriesnumber = self.data.number
 


### PR DESCRIPTION
## Summary
Removing the custom sorting date. 
Seems to have been used for the old mainpage, causing the new mainpage to not show ongoing tournaments.

Doesn't appear to be used anywhere else.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
https://liquipedia.net/warcraft/Module:Infobox/League/Custom/dev/kano
https://liquipedia.net/warcraft/Dolphin_Warcraft_Super_League/1
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
