### PR TITLE
feat(mainpage): show top 10 players in Warcraft ELO ranking

### DIFF
--- a/lua/wikis/warcraft/MainPageLayout/data.lua
+++ b/lua/wikis/warcraft/MainPageLayout/data.lua
@@ -12,6 +12,7 @@ local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
 
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
+local Link = Lua.import('Module:Widget/Basic/Link')
 local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
 local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
@@ -46,7 +47,17 @@ local CONTENT = {
 	},
 	eloRanking = {
 		heading = 'Warcraft3.info Elo Ranking',
-		body = W3EloRanking{},
+		body = HtmlWidgets.Fragment{children = {
+			W3EloRanking{},
+			Div{
+				css = {['text-align'] = 'center'},
+				children = Link{
+					link = 'https://warcraft3.info/stats/elo_ranking',
+					linktype = 'external',
+					children = 'Full ranking',
+				}
+			}
+		}},
 		boxid = 1525,
 	},
 	specialEvents = {

--- a/lua/wikis/warcraft/MainPageLayout/data.lua
+++ b/lua/wikis/warcraft/MainPageLayout/data.lua
@@ -16,6 +16,7 @@ local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
 local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
 local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
 local WantToHelp = Lua.import('Module:Widget/MainPage/WantToHelp')
+local W3EloRanking = Lua.import('Module:Widget/W3EloRanking')
 
 local CONTENT = {
 	usefulArticles = {
@@ -45,7 +46,7 @@ local CONTENT = {
 	},
 	eloRanking = {
 		heading = 'Warcraft3.info Elo Ranking',
-		body = '{{W3EloMainpage}}',
+		body = W3EloRanking{},
 		boxid = 1525,
 	},
 	specialEvents = {

--- a/lua/wikis/warcraft/Widget/W3EloRanking.lua
+++ b/lua/wikis/warcraft/Widget/W3EloRanking.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- page=Module:Widget/W3EloStandings
+-- page=Module:Widget/W3EloRanking
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
@@ -18,16 +18,16 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Link = Lua.import('Module:Widget/Basic/Link')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
----@class W3EloStandings: Widget
----@operator call({count: integer?}): W3EloStandings
+---@class W3EloRanking: Widget
+---@operator call({count: integer?}): W3EloRanking
 ---@field props {count: integer?}
-local W3EloStandings = Class.new(Widget)
-W3EloStandings.defaultProps = {
+local W3EloRanking = Class.new(Widget)
+W3EloRanking.defaultProps = {
 	count = 10,
 }
 
 ---@return Widget?
-function W3EloStandings:render()
+function W3EloRanking:render()
 	local rawData = mw.ext.TeamLiquidIntegration.w3elo(self.props.count)
 
 	if type(rawData) ~= 'table' then
@@ -40,8 +40,8 @@ function W3EloStandings:render()
 			classes = {'wikitable', 'wikitable-striped', 'rankingtable'},
 			css = {width = '100%'},
 			children = WidgetUtil.collect(
-				W3EloStandings._buildHeader(),
-				Array.map(rawData, W3EloStandings._buildStandingRow)
+				W3EloRanking._buildHeader(),
+				Array.map(rawData, W3EloRanking._buildStandingRow)
 			)
 		}
 	}
@@ -49,7 +49,7 @@ end
 
 ---@private
 ---@return Widget
-function W3EloStandings._buildHeader()
+function W3EloRanking._buildHeader()
 	return HtmlWidgets.Tr{
 		children = Array.map({'Rank', 'Player', 'Rating'}, function (header)
 			return HtmlWidgets.Th{
@@ -64,7 +64,7 @@ end
 ---@param data table
 ---@param placement integer
 ---@return Widget
-function W3EloStandings._buildStandingRow(data, placement)
+function W3EloRanking._buildStandingRow(data, placement)
 	local country = data.country
 	local race = string.lower(data.main_race or '')
 
@@ -88,4 +88,4 @@ function W3EloStandings._buildStandingRow(data, placement)
 	}
 end
 
-return W3EloStandings
+return W3EloRanking

--- a/lua/wikis/warcraft/Widget/W3EloRanking.lua
+++ b/lua/wikis/warcraft/Widget/W3EloRanking.lua
@@ -9,13 +9,11 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
-local Flags = Lua.import('Module:Flags')
 local Logic = Lua.import('Module:Logic')
-local Template = Lua.import('Module:Template')
+local PlayerDisplay = Lua.import('Module:Player/Display/Custom')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
-local Link = Lua.import('Module:Widget/Basic/Link')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class W3EloRanking: Widget
@@ -65,23 +63,18 @@ end
 ---@param placement integer
 ---@return Widget
 function W3EloRanking._buildStandingRow(data, placement)
-	local country = data.country
 	local race = string.lower(data.main_race or '')
-
-	local raceshort = string.sub(race, 0, 1)
 
 	return HtmlWidgets.Tr{
 		children = {
 			HtmlWidgets.Td{children = placement},
 			HtmlWidgets.Td{
-				children = Array.interleave({
-					Flags.Icon{flag = country or ''},
-					Template.safeExpand(mw.getCurrentFrame(), 'RaceIconSmall', {raceshort}),
-					Link{
-						link = data.name,
-						children = Logic.emptyOr(data.liquipedia, data.name)
-					}
-				}, ' ')
+				children = PlayerDisplay.InlinePlayer{player = {
+					flag = data.country,
+					displayName = data.name,
+					pageName = Logic.emptyOr(data.liquipedia, data.name),
+					faction = string.sub(race, 0, 1)
+				}}
 			},
 			HtmlWidgets.Td{children = data.elo}
 		}

--- a/lua/wikis/warcraft/Widget/W3EloStandings.lua
+++ b/lua/wikis/warcraft/Widget/W3EloStandings.lua
@@ -66,13 +66,7 @@ end
 ---@return Widget
 function W3EloStandings._buildStandingRow(data, placement)
 	local country = data.country
-		if country == "zz" then
-			country = "xx"
-		end
-
-	local race = string.lower( data.main_race or '' )
-
-	if race == '' then mw.logObject(data) end
+	local race = string.lower(data.main_race or '')
 
 	local raceshort = string.sub(race, 0, 1)
 

--- a/lua/wikis/warcraft/Widget/W3EloStandings.lua
+++ b/lua/wikis/warcraft/Widget/W3EloStandings.lua
@@ -1,0 +1,97 @@
+---
+-- @Liquipedia
+-- page=Module:Widget/W3EloStandings
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local Flags = Lua.import('Module:Flags')
+local Logic = Lua.import('Module:Logic')
+local Template = Lua.import('Module:Template')
+
+local Widget = Lua.import('Module:Widget')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+---@class W3EloStandings: Widget
+---@operator call({count: integer?}): W3EloStandings
+---@field props {count: integer?}
+local W3EloStandings = Class.new(Widget)
+W3EloStandings.defaultProps = {
+	count = 10,
+}
+
+---@return Widget?
+function W3EloStandings:render()
+	local rawData = mw.ext.TeamLiquidIntegration.w3elo(self.props.count)
+
+	if type(rawData) ~= 'table' then
+		return rawData
+	end
+
+	return HtmlWidgets.Div{
+		classes = {'table-responsive'},
+		children = HtmlWidgets.Table{
+			classes = {'wikitable', 'wikitable-striped', 'rankingtable'},
+			css = {width = '100%'},
+			children = WidgetUtil.collect(
+				W3EloStandings._buildHeader(),
+				Array.map(rawData, W3EloStandings._buildStandingRow)
+			)
+		}
+	}
+end
+
+---@private
+---@return Widget
+function W3EloStandings._buildHeader()
+	return HtmlWidgets.Tr{
+		children = Array.map({'Rank', 'Player', 'Rating'}, function (header)
+			return HtmlWidgets.Th{
+				css = {['text-align'] = 'left'},
+				children = header
+			}
+		end)
+	}
+end
+
+---@private
+---@param data table
+---@param placement integer
+---@return Widget
+function W3EloStandings._buildStandingRow(data, placement)
+	local country = data.country
+		if country == "zz" then
+			country = "xx"
+		end
+
+	local race = string.lower( data.main_race or '' )
+
+	if race == '' then mw.logObject(data) end
+
+	local raceshort = string.sub(race, 0, 1)
+
+	return HtmlWidgets.Tr{
+		children = {
+			HtmlWidgets.Td{children = placement},
+			HtmlWidgets.Td{
+				children = Array.interleave({
+					Flags.Icon{flag = country or ''},
+					Template.safeExpand(mw.getCurrentFrame(), 'RaceIconSmall', {raceshort}),
+					Link{
+						link = data.name,
+						children = Logic.emptyOr(data.liquipedia, data.name)
+					}
+				}, ' ')
+			},
+			HtmlWidgets.Td{children = data.elo}
+		}
+	}
+end
+
+return W3EloStandings

--- a/stylesheets/commons/Mainpage.less
+++ b/stylesheets/commons/Mainpage.less
@@ -508,11 +508,6 @@ table.infobox_matches_content.publisher-match.winner-draw {
 	padding: 0 1em;
 }
 
-/* ranking table */
-body.page-Main_Page .rankingtable tr:nth-of-type( n + 7 ) {
-	display: none;
-}
-
 /* filter for smash */
 .tournaments-list .filter-64 {
 	background-color: #d5e5b6;


### PR DESCRIPTION
## Summary

[Context](https://discord.com/channels/93055209017729024/161454541009715200/1400501452174004314)

This PR:
- Rewrites [Module:W3InfoElo](https://liquipedia.net/warcraft/Module:W3InfoElo) and adds it to this repository
- Updates Warcraft main page to use the above widget
- Throws away css classes that hide some of the rankings

## How did you test this change?

dev + browser dev tools