### PR TITLE
fix: reverse active logic on vod dropdown btn & darkmode

### DIFF
--- a/lua/wikis/commons/Widget/Match/VodsDropdown.lua
+++ b/lua/wikis/commons/Widget/Match/VodsDropdown.lua
@@ -23,9 +23,6 @@ local Span = HtmlWidgets.Span
 ---@class VodsDropdown: Widget
 ---@operator call(table): VodsDropdown
 local VodsDropdown = Class.new(Widget)
-VodsDropdown.defaultProps = {
-	matchIsLive = true,
-}
 
 ---@return Widget?
 function VodsDropdown:render()
@@ -88,7 +85,7 @@ function VodsDropdown:render()
 	---@return Widget
 	local vodToggleButton = function(vodCount)
 		local showButton = Button{
-			classes = {'general-collapsible-expand-button', 'btn--active'},
+			classes = {'general-collapsible-expand-button'},
 			children = Span{
 				children = {
 					ImageIcon{imageLight = VodLink.getIcon()},
@@ -102,8 +99,8 @@ function VodsDropdown:render()
 			variant = 'tertiary',
 		}
 		local hideButton = Button{
-			classes = {'general-collapsible-collapse-button'},
-			children = HtmlWidgets.Fragment{
+			classes = {'general-collapsible-collapse-button', 'btn--active'},
+			children = Span{
 				children = {
 					ImageIcon{imageLight = VodLink.getIcon()},
 					' ',

--- a/stylesheets/commons/Miscellaneous.less
+++ b/stylesheets/commons/Miscellaneous.less
@@ -2227,8 +2227,8 @@ Author(s): iMarbot
 		}
 	}
 
-	&[ src*="Vod.svg" ],
-	&[ src*="Vod-" ] {
+	& img[ src*="Vod.svg" ],
+	& img[ src*="Vod-" ] {
 		/* Changes the color of the VOD icon to Secondary 80 (B3B3B3) */
 		filter: invert( 79% ) sepia( 1% ) saturate( 0% ) hue-rotate( 121deg ) brightness( 93% ) contrast( 85% );
 	}


### PR DESCRIPTION
## Summary
Fixes:
Vod Dropdown Active state was reversed
Missing number of vods when active
the VOD icon selector was wrong
## How did you test this change?
live/devtools