### PR TITLE
fix(match2): scores of submatch headers compressed

### DIFF
--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -754,18 +754,20 @@ div.brkts-popup-body-element-thumbs {
 
 .brkts-popup-header-opponent-score-left {
 	border-right: 1px solid #aaaaaa;
-	width: 28px;
+	width: 1.75rem;
 	justify-content: center;
 	align-items: center;
 	display: flex;
+	padding: 0 0.25rem;
 }
 
 .brkts-popup-header-opponent-score-right {
 	border-left: 1px solid #aaaaaa;
-	width: 28px;
+	width: 1.75rem;
 	justify-content: center;
 	align-items: center;
 	display: flex;
+	padding: 0 0.25rem;
 }
 
 .brkts-popup-header-opponent.brkts-popup-header-opponent img {


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1402207585645498389

currently scores are compressed and running into player names/flags/factionIcons in the headers of submatches on craft wikis

this pr applies a temp solution of just applying a padding to those scores
the changed classes are not used ouside of this use case (according to a search in vscode)
hence it should only have impact on thse headers on craft wikis

proper solution would be to completely rework the headers of submatches on craft wikis but i currently do not have the time for that

## How did you test this change?
dev tools