### PR TITLE
fix(TransferList): Missing grouping on main teams

### DIFF
--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -174,11 +174,15 @@ function TransferList:fetch()
 	local cache = {}
 	Array.forEach(queryData, function(transfer)
 		if
+			cache.team1 ~= transfer.fromteam or
+			cache.team2 ~= transfer.toteam or
 			cache.role1 ~= transfer.role1 or
 			cache.role2 ~= transfer.role2 or
 			cache.team1_2 ~= transfer.extradata.fromteamsec or
 			cache.team2_2 ~= transfer.extradata.toteamsec
 		then
+			cache.team1 = transfer.fromteam
+			cache.team2 = transfer.toteam
 			cache.role1 = transfer.role1
 			cache.role2 = transfer.role2
 			cache.team1_2 = transfer.extradata.fromteamsec


### PR DESCRIPTION
## Summary
Regression from #6286:
When removing the initial query i forgot to add the primary teams to the cache/conditions for grouping.
Apparently the testpage only had transfer where roles were involved, so i didn't see this initially.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
