### PR TITLE
fix(TransferList): Restore behavior for display limit

### DIFF
--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -165,14 +165,14 @@ function TransferList:fetch()
 	self.conditions = self:_buildConditions()
 	local queryData = mw.ext.LiquipediaDB.lpdb('transfer', {
 		conditions = self.conditions,
-		limit = self.config.limit,
+		limit = self.config.limit * 5,
 		order = self.config.sortOrder,
 	})
 
 	local groupedData = {}
 	local currentGroup
 	local cache = {}
-	Array.forEach(queryData, function(transfer)
+	for _, transfer in ipairs(queryData) do
 		if
 			cache.team1 ~= transfer.fromteam or
 			cache.team2 ~= transfer.toteam or
@@ -189,10 +189,13 @@ function TransferList:fetch()
 			cache.team2_2 = transfer.extradata.toteamsec
 
 			Array.appendWith(groupedData, currentGroup)
+			if #groupedData == self.config.limit then
+				break
+			end
 			currentGroup = {}
 		end
 		table.insert(currentGroup, transfer)
-	end)
+	end
 	Array.appendWith(groupedData, currentGroup)
 
 	self.groupedTransfers = groupedData


### PR DESCRIPTION
## Summary
When switching from multi-query to single query, i also missed that this influences the application of the limit parameter:
Old version would limit the amount of transfer rows (roughly), new version limits to the exact amount of persons.

- [ ] This is an option to restore a similar behavior to the old verison; not sure whether we want that or instead say to adjust the limits.

- [ ] Instead of initially fetching a multiple of the limit, we could also refetch with offset. Not sure whether that's preferable.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
