### PR TITLE
fix: incorrect param name in this day patch query

### DIFF
--- a/lua/wikis/commons/ThisDay/Query.lua
+++ b/lua/wikis/commons/ThisDay/Query.lua
@@ -63,7 +63,7 @@ function ThisDayQuery.patch(month, day)
 
 	return Patch.queryPatches{
 		limit = 5000,
-		conditions = conditions,
+		additionalConditions = conditions,
 		query = 'pagename, name, date',
 		order = 'date asc, name asc'
 	}


### PR DESCRIPTION
## Summary

Original report: https://discord.com/channels/93055209017729024/372075546231832576/1402250590880272457

## How did you test this change?

dev