### PR TITLE
fix: accessing undefined variable in RL `Module:YearsActive`

### DIFF
--- a/lua/wikis/rocketleague/YearsActive.lua
+++ b/lua/wikis/rocketleague/YearsActive.lua
@@ -5,13 +5,15 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Class = require('Module:Class')
-local Lpdb = require('Module:Lpdb')
 local Lua = require('Module:Lua')
-local Set = require('Module:Set')
-local Table = require('Module:Table')
 
-local Condition = require('Module:Condition')
+local Class = Lua.import('Module:Class')
+local Info = Lua.import('Module:Info', {loadData = true})
+local Lpdb = Lua.import('Module:Lpdb')
+local Set = Lua.import('Module:Set')
+local Table = Lua.import('Module:Table')
+
+local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree
 local ConditionNode = Condition.Node
 local Comparator = Condition.Comparator
@@ -51,7 +53,7 @@ function CustomActiveYears._getBroadcastConditions(broadcaster, positions)
 
 	local tree = ConditionTree(BooleanOperator.all):add({
 		ConditionNode(ColumnName('page'), Comparator.eq, broadcaster),
-		ConditionNode(ColumnName('date_year'), Comparator.gt, CustomActiveYears.startYear - 1),
+		ConditionNode(ColumnName('date_year'), Comparator.gt, Info.startYear - 1),
 		positionTree,
 	})
 


### PR DESCRIPTION
## Summary
oversight in #6186
RL accessed the `ActiveYears.startYear` which was removed form the base.
This PR makes RL use `Info.startYear` (which was what got pushed into `ActiveYears.startYear` anyways)

additionally use Lua.import while at it

## How did you test this change?
live