### PR TITLE
fix(opponent): missing nil check in `isArchon` check

### DIFF
--- a/lua/wikis/commons/Opponent/Starcraft.lua
+++ b/lua/wikis/commons/Opponent/Starcraft.lua
@@ -101,7 +101,7 @@ function StarcraftOpponent.fromLpdbStruct(storageStruct)
 		return nil
 	end
 
-	opponent.isArchon = storageStruct.opponentplayers.isArchon
+	opponent.isArchon = (storageStruct.opponentplayers or {}).isArchon
 
 	return opponent
 end


### PR DESCRIPTION
## Summary
causing issues on some sc(2) pages, hence noticed the missing nil check

## How did you test this change?
live