### PR TITLE
fix(infobox): country category singular

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/Location.lua
+++ b/lua/wikis/commons/Widget/Infobox/Location.lua
@@ -26,7 +26,7 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Location = Class.new(Widget)
 Location.defaultProps = {
 	args = {},
-	infoboxType = 'Tournament',
+	infoboxType = 'Tournaments',
 	shouldSetCategory = true,
 	showTbdOnEmpty = true,
 }


### PR DESCRIPTION
## Summary
country category should be plural instead of singular
this pr adjusts the postfix to be plural

planned follow up (likely tomorrow):
- rename props params a bit
- remove option to not set category
- set category on series infobox via it too and hence be able to kick a function
  - needs decision if we want to change the category postfix for it

## How did you test this change?
live