### PR TITLE
chore(infobox): `content` --> `children` [P-Z]

### DIFF
--- a/lua/wikis/pokemon/Infobox/Company/Custom.lua
+++ b/lua/wikis/pokemon/Infobox/Company/Custom.lua
@@ -39,17 +39,17 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return Array.appendWith(widgets,
 			Title{children = 'Staff Members'},
-			Cell{name = 'Directors', content = Array.parseCommaSeparatedString(args.directors)},
-			Cell{name = 'Event Organizer', content = Array.parseCommaSeparatedString(args.organizers)},
-			Cell{name = 'Editors', content = Array.parseCommaSeparatedString(args.editors)},
-			Cell{name = 'Commentators', content = Array.parseCommaSeparatedString(args.commentators)},
+			Cell{name = 'Directors', children = Array.parseCommaSeparatedString(args.directors)},
+			Cell{name = 'Event Organizer', children = Array.parseCommaSeparatedString(args.organizers)},
+			Cell{name = 'Editors', children = Array.parseCommaSeparatedString(args.editors)},
+			Cell{name = 'Commentators', children = Array.parseCommaSeparatedString(args.commentators)},
 			unpack(Array.mapIndexes(function(roleIndex)
 				local prefix = 'role' .. roleIndex
 				if not args[prefix] then return end
-				return Cell{name = args[prefix], content = Array.parseCommaSeparatedString(args[prefix .. '_list'])}
+				return Cell{name = args[prefix], children = Array.parseCommaSeparatedString(args[prefix .. '_list'])}
 			end)),
-			Cell{name = 'Members', content = Array.parseCommaSeparatedString(args.members)},
-			Cell{name = 'Former Staff', content = Array.parseCommaSeparatedString(args.former_staff)}
+			Cell{name = 'Members', children = Array.parseCommaSeparatedString(args.members)},
+			Cell{name = 'Former Staff', children = Array.parseCommaSeparatedString(args.former_staff)}
 		)
 	end
 	return widgets

--- a/lua/wikis/pokemon/Infobox/League/Custom.lua
+++ b/lua/wikis/pokemon/Infobox/League/Custom.lua
@@ -45,16 +45,16 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'gamesettings' then
 		return {
-			Cell{name = 'Game version', content = {Game.name{game = args.game}}},
-			Cell{name = 'Game mode', content = {self.caller:_getGameMode()}},
+			Cell{name = 'Game version', children = {Game.name{game = args.game}}},
+			Cell{name = 'Game mode', children = {self.caller:_getGameMode()}},
 		}
 	elseif id == 'customcontent' then
 		if args.player_number then
 			table.insert(widgets, Title{children = 'Players'})
-			table.insert(widgets, Cell{name = 'Number of players', content = {args.player_number}})
+			table.insert(widgets, Cell{name = 'Number of players', children = {args.player_number}})
 		elseif args.team_number then
 			table.insert(widgets, Title{children = 'Teams'})
-			table.insert(widgets, Cell{name = 'Number of teams', content = {args.team_number}})
+			table.insert(widgets, Cell{name = 'Number of teams', children = {args.team_number}})
 		end
 	end
 

--- a/lua/wikis/pokemon/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/pokemon/Infobox/Person/Player/Custom.lua
@@ -42,7 +42,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Game Appearances', content = GameAppearances.player({player = caller.pagename})},
+			Cell{name = 'Game Appearances', children = GameAppearances.player({player = caller.pagename})},
 		}
 	elseif id == 'history' then
 		local manualHistory = args.history

--- a/lua/wikis/pubg/Infobox/Company/Custom.lua
+++ b/lua/wikis/pubg/Infobox/Company/Custom.lua
@@ -36,7 +36,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		table.insert(widgets, Cell{
 			name = CustomCompany._createSisterCompaniesDescription(args),
-			content = self.caller:getAllArgsForBase(args, 'sister', {})
+			children = self.caller:getAllArgsForBase(args, 'sister', {})
 		})
 	end
 	return widgets

--- a/lua/wikis/pubg/Infobox/League/Custom.lua
+++ b/lua/wikis/pubg/Infobox/League/Custom.lua
@@ -81,21 +81,21 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'gamesettings' then
 		return {
-			Cell{name = 'Game version', content = {Game.name{game = args.game}}},
-			Cell{name = 'Game mode', content = {self.caller:_getGameMode(args)}},
-			Cell{name = 'Patch', content = {CustomLeague._getPatchVersion(args)}},
-			Cell{name = 'Platform', content = {self.caller:_getPlatform(args)}},
+			Cell{name = 'Game version', children = {Game.name{game = args.game}}},
+			Cell{name = 'Game mode', children = {self.caller:_getGameMode(args)}},
+			Cell{name = 'Patch', children = {CustomLeague._getPatchVersion(args)}},
+			Cell{name = 'Platform', children = {self.caller:_getPlatform(args)}},
 		}
 	elseif id == 'customcontent' then
 		if args.player_number then
 			table.insert(widgets, Title{children = 'Players'})
-			table.insert(widgets, Cell{name = 'Number of players', content = {args.player_number}})
+			table.insert(widgets, Cell{name = 'Number of players', children = {args.player_number}})
 		end
 
 		--teams section
 		if args.team_number then
 			table.insert(widgets, Title{children = 'Teams'})
-			table.insert(widgets, Cell{name = 'Number of teams', content = {args.team_number}})
+			table.insert(widgets, Cell{name = 'Number of teams', children = {args.team_number}})
 		end
 	end
 	return widgets

--- a/lua/wikis/pubg/Infobox/Map/Custom.lua
+++ b/lua/wikis/pubg/Infobox/Map/Custom.lua
@@ -37,7 +37,7 @@ function CustomInjector:parse(widgetId, widgets)
 	local args = self.caller.args
 
 	if widgetId == 'custom' then
-		table.insert(widgets, Cell{name = 'Versions', content = {args.versions}})
+		table.insert(widgets, Cell{name = 'Versions', children = {args.versions}})
 	end
 
 	return widgets

--- a/lua/wikis/pubg/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/pubg/Infobox/Person/Player/Custom.lua
@@ -41,8 +41,8 @@ function CustomInjector:parse(id, widgets)
 	local args = caller.args
 
 	if id == 'status' then
-		table.insert(widgets, Cell{name = 'Years Active (Player)', content = {args.years_active}})
-		table.insert(widgets, Cell{name = 'Years Active (Talent)', content = {args.years_active_talent}})
+		table.insert(widgets, Cell{name = 'Years Active (Player)', children = {args.years_active}})
+		table.insert(widgets, Cell{name = 'Years Active (Talent)', children = {args.years_active_talent}})
 	elseif id == 'region' then return {}
 	elseif id == 'history' and args.nationalteams then
 		table.insert(widgets, 1, Title{children = 'National Teams'})

--- a/lua/wikis/pubg/Infobox/Weapon/Custom.lua
+++ b/lua/wikis/pubg/Infobox/Weapon/Custom.lua
@@ -41,9 +41,9 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Ammo Type', content = {args.ammotype}},
-			Cell{name = 'Throw Speed', content = {args.throwspeed}},
-			Cell{name = 'Throw Cooldown', content = {args.throwcooldown}}
+			Cell{name = 'Ammo Type', children = {args.ammotype}},
+			Cell{name = 'Throw Speed', children = {args.throwspeed}},
+			Cell{name = 'Throw Cooldown', children = {args.throwcooldown}}
 		)
 
 		if String.isEmpty(args.map1) then

--- a/lua/wikis/pubgmobile/Infobox/League/Custom.lua
+++ b/lua/wikis/pubgmobile/Infobox/League/Custom.lua
@@ -65,22 +65,22 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'sponsors' then
-		table.insert(widgets, Cell{name = 'Official Device', content = {args.device}})
+		table.insert(widgets, Cell{name = 'Official Device', children = {args.device}})
 	elseif id == 'gamesettings' then
 		return {
-			Cell{name = 'Game version', content = {Game.name{game = args.game}}},
-			Cell{name = 'Game mode', content = {CustomLeague._getGameMode(args)}},
+			Cell{name = 'Game version', children = {Game.name{game = args.game}}},
+			Cell{name = 'Game mode', children = {CustomLeague._getGameMode(args)}},
 		}
 	elseif id == 'customcontent' then
 		if args.player_number then
 			table.insert(widgets, Title{children = 'Players'})
-			table.insert(widgets, Cell{name = 'Number of players', content = {args.player_number}})
+			table.insert(widgets, Cell{name = 'Number of players', children = {args.player_number}})
 		end
 
 		--teams section
 		if args.team_number then
 			table.insert(widgets, Title{children = 'Teams'})
-			table.insert(widgets, Cell{name = 'Number of teams', content = {args.team_number}})
+			table.insert(widgets, Cell{name = 'Number of teams', children = {args.team_number}})
 		end
 	end
 	return widgets

--- a/lua/wikis/pubgmobile/Infobox/Map/Custom.lua
+++ b/lua/wikis/pubgmobile/Infobox/Map/Custom.lua
@@ -48,12 +48,12 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Game Version', content = {Game.text{
+			Cell{name = 'Game Version', children = {Game.text{
 				game = args.game,
 				useDefault = true,
 				useAbbreviation = true,
 			}}},
-			Cell{name = 'Game Mode(s)',content = self.caller:getGameModes(args)}
+			Cell{name = 'Game Mode(s)', children = self.caller:getGameModes(args)}
 		)
 	end
 	return widgets

--- a/lua/wikis/pubgmobile/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/pubgmobile/Infobox/Person/Player/Custom.lua
@@ -58,11 +58,11 @@ function CustomInjector:parse(id, widgets)
 		end
 	elseif id == 'status' then
 		return {
-			Cell{name = 'Status', content = CustomPlayer._getStatusContents(args)},
-			Cell{name = 'Years Active (Player)', content = {args.years_active}},
-			Cell{name = 'Years Active (Org)', content = {args.years_active_manage}},
-			Cell{name = 'Years Active (Coach)', content = {args.years_active_coach}},
-			Cell{name = 'Years Active (Talent)', content = {args.years_active_talent}},
+			Cell{name = 'Status', children = CustomPlayer._getStatusContents(args)},
+			Cell{name = 'Years Active (Player)', children = {args.years_active}},
+			Cell{name = 'Years Active (Org)', children = {args.years_active_manage}},
+			Cell{name = 'Years Active (Coach)', children = {args.years_active_coach}},
+			Cell{name = 'Years Active (Talent)', children = {args.years_active_talent}},
 		}
 	elseif id == 'region' then return {}
 	end

--- a/lua/wikis/rainbowsix/Infobox/Character/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Character/Custom.lua
@@ -139,7 +139,7 @@ function CustomInjector:parse(id, widgets)
 		})
 
 		return ageCalculationSuccess and {
-			Cell{name = 'Born', content = {age.birth}},
+			Cell{name = 'Born', children = {age.birth}},
 		} or {}
 	elseif id == 'role' then
 		return WidgetUtil.collect(
@@ -149,7 +149,7 @@ function CustomInjector:parse(id, widgets)
 			},
 			Cell{
 				name = 'Operator Role',
-				content = Array.map(
+				children = Array.map(
 					self.caller:getAllArgsForBase(args, 'function'),
 					function (role)
 						return Link{
@@ -164,12 +164,12 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Team Rainbow',
-				content = self.caller:_getTeamRainbow(args),
+				children = self.caller:_getTeamRainbow(args),
 				options = { separator = ' ' }
 			},
 			Cell{
 				name = 'Affiliation',
-				content = { args.affiliation }
+				children = { args.affiliation }
 			}
 		}
 	elseif id == 'release' then
@@ -181,7 +181,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Released',
-				content = WidgetUtil.collect(
+				children = WidgetUtil.collect(
 					Logic.isNotEmpty(patchData) and Link{
 						link = patchData.pageName,
 						children = patchData.displayName
@@ -202,6 +202,7 @@ function CustomInjector:parse(id, widgets)
 	return widgets
 end
 
+---@param args table
 ---@return Widget[]
 function CustomCharacter:_getTeam(args)
 	local team = (args.team or ''):lower()
@@ -216,6 +217,7 @@ function CustomCharacter:_getTeam(args)
 	end
 end
 
+---@param args table
 ---@return (Widget|string)[]
 function CustomCharacter:_getTeamRainbow(args)
 	local teamRainbow = (args['team rainbow'] or ''):lower()
@@ -254,22 +256,22 @@ function CustomCharacter:_getAdditionalInfo(args)
 	return WidgetUtil.collect(
 		Logic.isNotEmpty(args.height) and Cell{
 			name = 'Height',
-			content = { args.height, 'm' },
+			children = { args.height, 'm' },
 			options = { separator = ' ' }
 		} or nil,
 		Logic.isNotEmpty(args.weight) and Cell{
 			name = 'Weight',
-			content = { args.weight, 'kg' },
+			children = { args.weight, 'kg' },
 			options = { separator = ' ' }
 		} or nil,
 		Logic.isNotEmpty(args.voice) and Cell{
 			name = 'Voiced by',
-			content = { args.voice }
+			children = { args.voice }
 		} or nil,
 		self:_getPriceCells(args.renownprice or args.creditprice),
 		Cell{
 			name = 'Has Elite Skin',
-			content = WidgetUtil.collect(
+			children = WidgetUtil.collect(
 				HtmlWidgets.Fragment{
 					children = Logic.readBool(args.eliteskin) and {
 						IconFa{ iconName = 'yes', color = 'forest-green-text' },
@@ -304,7 +306,7 @@ function CustomCharacter:_getAdditionalInfo(args)
 		},
 		Cell{
 			name = 'Availability',
-			content = { args.availability }
+			children = { args.availability }
 		}
 	)
 end
@@ -318,7 +320,7 @@ function CustomCharacter:_getPriceCells(input)
 		return {
 			Cell{
 				name = 'Renown price',
-				content = WidgetUtil.collect(
+				children = WidgetUtil.collect(
 					'Free',
 					Array.map({ 500, 1000, 1500, 2000 }, function (renownPrice)
 						return HtmlWidgets.Fragment{
@@ -356,7 +358,7 @@ function CustomCharacter:_getPriceCell(currency, price)
 	local lang = mw.getContentLanguage()
 	return Cell{
 		name = currency .. ' price',
-		content = {
+		children = {
 			lang:formatNum(price),
 			HtmlWidgets.Fragment{
 				children = {
@@ -410,7 +412,7 @@ end
 function CustomCharacter._generateStatCell(title, datatype, value, display)
 	return Cell{
 		name = title,
-		content = {
+		children = {
 			Image.display(
 				'R6S operator-rating-' .. datatype .. '-' ..  value .. ' lightmode.png',
 				'R6S operator-rating-' .. datatype .. '-' ..  value .. ' darkmode.png',

--- a/lua/wikis/rainbowsix/Infobox/League/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/League/Custom.lua
@@ -68,10 +68,10 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-		Cell{name = 'Teams', content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
-		Cell{name = 'Game', content = {Game.name{game = args.game}}},
-		Cell{name = 'Platform', content = {caller:_createPlatformCell(args)}},
-		Cell{name = 'Players', content = {args.player_number}}
+		Cell{name = 'Teams', children = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
+		Cell{name = 'Game', children = {Game.name{game = args.game}}},
+		Cell{name = 'Platform', children = {caller:_createPlatformCell(args)}},
+		Cell{name = 'Players', children = {args.player_number}}
 	)
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.map1) then
@@ -91,7 +91,7 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets,
 				Cell{
 					name = 'Ubisoft Tier',
-					content = {'[[' .. UBISOFT_TIERS[caller.data.publishertier] .. ']]'},
+					children = {'[[' .. UBISOFT_TIERS[caller.data.publishertier] .. ']]'},
 					classes = {'valvepremier-highlighted'}
 				}
 			)

--- a/lua/wikis/rainbowsix/Infobox/Map/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Map/Custom.lua
@@ -53,10 +53,10 @@ function CustomInjector:parse(id, widgets)
 		return self.caller:getReleaseCells(args)
 	elseif id == 'custom' then
 		return WidgetUtil.collect(
-			Cell{name = 'Versions', content = {args.versions}},
-			Cell{name = 'Layout', content = {args.layout}},
-			Cell{name = 'Playlists', content = {args.playlists}},
-			Cell{name = 'Day/Night Variant', content = {args['day/night variant']}},
+			Cell{name = 'Versions', children = {args.versions}},
+			Cell{name = 'Layout', children = {args.layout}},
+			Cell{name = 'Playlists', children = {args.playlists}},
+			Cell{name = 'Day/Night Variant', children = {args['day/night variant']}},
 			self.caller:getStatsCells(args)
 		)
 	end
@@ -100,19 +100,19 @@ function CustomMap:getReleaseCells(args)
 	return {
 		Cell{
 			name = 'Released',
-			content = CustomMap._formatPatchInfoCell(releasePatchData, 'Launch')
+			children = CustomMap._formatPatchInfoCell(releasePatchData, 'Launch')
 		},
 		Cell{
 			name = 'Reworked',
-			content = Logic.isNotEmpty(reworkPatchData) and CustomMap._formatPatchInfoCell(reworkPatchData) or nil
+			children = Logic.isNotEmpty(reworkPatchData) and CustomMap._formatPatchInfoCell(reworkPatchData) or nil
 		},
 		Cell{
 			name = 'Map buff',
-			content = Logic.isNotEmpty(mapBuffPatchData) and CustomMap._formatPatchInfoCell(mapBuffPatchData) or nil
+			children = Logic.isNotEmpty(mapBuffPatchData) and CustomMap._formatPatchInfoCell(mapBuffPatchData) or nil
 		},
 		Cell{
 			name = 'Map buff 2',
-			content = Logic.isNotEmpty(mapBuff2PatchData) and CustomMap._formatPatchInfoCell(mapBuff2PatchData) or nil
+			children = Logic.isNotEmpty(mapBuff2PatchData) and CustomMap._formatPatchInfoCell(mapBuff2PatchData) or nil
 		}
 	}
 end
@@ -173,7 +173,7 @@ function CustomMap:getStatsCells(args)
 		Title{children = 'Esports Statistics'},
 		Cell{
 			name = 'Win Rate',
-			content = {
+			children = {
 				HtmlWidgets.Fragment{children = {
 					CustomMap._createTeamDisplayWidget('atk'),
 					': ',

--- a/lua/wikis/rainbowsix/Infobox/Patch/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Patch/Custom.lua
@@ -35,9 +35,9 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'release' then
 		return {
-			Cell{name = 'Release Date', content = {args.release}},
-			Cell{name = 'PC Release Date', content = {args.pcrelease}},
-			Cell{name = 'Console Release Date', content = {args.consolerelease}},
+			Cell{name = 'Release Date', children = {args.release}},
+			Cell{name = 'PC Release Date', children = {args.pcrelease}},
+			Cell{name = 'Console Release Date', children = {args.consolerelease}},
 		}
 	end
 	return widgets

--- a/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
@@ -74,25 +74,25 @@ function CustomInjector:parse(id, widgets)
 		end)
 		table.insert(widgets, Cell{
 			name = #operatorIcons > 1 and 'Signature Operators' or 'Signature Operator',
-			content = {table.concat(operatorIcons, '&nbsp;')},
+			children = {table.concat(operatorIcons, '&nbsp;')},
 		})
 
 		-- Active in Games
 		table.insert(widgets, Cell{
 			name = 'Game Appearances',
-			content = GameAppearances.player{player = caller.pagename}
+			children = GameAppearances.player{player = caller.pagename}
 		})
 	elseif id == 'status' then
 		return {
-			Cell{name = 'Status', content = caller:_getStatusContents()},
-			Cell{name = 'Years Active (Player)', content = {args.years_active}},
-			Cell{name = 'Years Active (Org)', content = {args.years_active_manage}},
-			Cell{name = 'Years Active (Coach)', content = {args.years_active_coach}},
-			Cell{name = 'Years Active (Talent)', content = {args.years_active_talent}},
-			Cell{name = 'Time Banned', content = {args.time_banned}},
+			Cell{name = 'Status', children = caller:_getStatusContents()},
+			Cell{name = 'Years Active (Player)', children = {args.years_active}},
+			Cell{name = 'Years Active (Org)', children = {args.years_active_manage}},
+			Cell{name = 'Years Active (Coach)', children = {args.years_active_coach}},
+			Cell{name = 'Years Active (Talent)', children = {args.years_active_talent}},
+			Cell{name = 'Time Banned', children = {args.time_banned}},
 		}
 	elseif id == 'history' then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	end
 	return widgets
 end

--- a/lua/wikis/rainbowsix/Infobox/Weapon/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Weapon/Custom.lua
@@ -40,7 +40,7 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return {
-			Cell{name = 'Operators', content = {self.caller:_getOperators()}},
+			Cell{name = 'Operators', children = {self.caller:_getOperators()}},
 		}
 	end
 	return widgets

--- a/lua/wikis/rematch/Infobox/League/Custom.lua
+++ b/lua/wikis/rematch/Infobox/League/Custom.lua
@@ -55,18 +55,18 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Platform', content = {caller.data.platform}}
+			Cell{name = 'Platform', children = {caller.data.platform}}
 		)
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.team_number) then
 			Array.appendWith(widgets,
 				Title{children = 'Teams'},
-				Cell{name = 'Number of teams', content = {args.team_number}}
+				Cell{name = 'Number of teams', children = {args.team_number}}
 			)
 		elseif String.isNotEmpty(args.player_number) then
 			Array.appendWith(widgets,
 				Title{children = 'Players'},
-				Cell{name = 'Number of players', content = {args.player_number}}
+				Cell{name = 'Number of players', children = {args.player_number}}
 			)
 		end
 	end

--- a/lua/wikis/rocketleague/Infobox/Company/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Company/Custom.lua
@@ -34,7 +34,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'custom' then
-		table.insert(widgets, Cell{name = 'Epic Creator Code', content = {args.creatorcode}})
+		table.insert(widgets, Cell{name = 'Epic Creator Code', children = {args.creatorcode}})
 	end
 
 	return widgets

--- a/lua/wikis/rocketleague/Infobox/League/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/League/Custom.lua
@@ -54,9 +54,9 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Mode', content = {args.mode}},
-			Cell{name = 'Game', content = {Game.text{game = args.game}}},
-			Cell{name = 'Misc Mode', content = {args.miscmode}}
+			Cell{name = 'Mode', children = {args.mode}},
+			Cell{name = 'Game', children = {Game.text{game = args.game}}},
+			Cell{name = 'Misc Mode', children = {args.miscmode}}
 		)
 	elseif id == 'customcontent' then
 		if not String.isEmpty(args.map1) then
@@ -79,13 +79,13 @@ function CustomInjector:parse(id, widgets)
 			table.insert(widgets, Title{children = 'Teams'})
 			table.insert(widgets, Cell{
 				name = 'Number of teams',
-				content = {args.team_number}
+				children = {args.team_number}
 			})
 		elseif not String.isEmpty(args.player_number) then
 			table.insert(widgets, Title{children = 'Players'})
 			table.insert(widgets, Cell{
 				name = 'Number of players',
-				content = {args.player_number}
+				children = {args.player_number}
 			})
 		end
 	end

--- a/lua/wikis/rocketleague/Infobox/Map/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Map/Custom.lua
@@ -40,10 +40,10 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Layout', content = {args.layout}},
-			Cell{name = 'Versions', content = {args.versions}},
-			Cell{name = 'Playlists', content = {args.playlists}},
-			Cell{name = 'Gamemodes', content = self.caller:getGameModes(args)}
+			Cell{name = 'Layout', children = {args.layout}},
+			Cell{name = 'Versions', children = {args.versions}},
+			Cell{name = 'Playlists', children = {args.playlists}},
+			Cell{name = 'Gamemodes', children = self.caller:getGameModes(args)}
 		)
 	end
 	return widgets

--- a/lua/wikis/rocketleague/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Person/Player/Custom.lua
@@ -90,10 +90,10 @@ function CustomInjector:parse(id, widgets)
 					text = 'Epic Creator Code',
 					title = 'Support-A-Creator Code used when purchasing Rocket League or Epic Games Store products',
 				},
-				content = {args.creatorcode}
+				children = {args.creatorcode}
 			},
-			Cell{name = 'Starting Game', content = {gameDisplay}},
-			Cell{name = 'Solo MMR', content = {mmrDisplay}},
+			Cell{name = 'Starting Game', children = {gameDisplay}},
+			Cell{name = 'Solo MMR', children = {mmrDisplay}},
 		}
 	elseif id == 'status' then
 		local statusContents = CustomPlayer._getStatusContents(args)
@@ -110,10 +110,10 @@ function CustomInjector:parse(id, widgets)
 		)
 
 		return {
-			Cell{name = 'Status', content = statusContents},
-			Cell{name = 'Years Active (Player)', content = {yearsActive}},
-			Cell{name = 'Years Active (Coach)', content = {yearsActiveCoach}},
-			Cell{name = 'Years Active (Talent)', content = {yearsActiveTalent}},
+			Cell{name = 'Status', children = statusContents},
+			Cell{name = 'Years Active (Player)', children = {yearsActive}},
+			Cell{name = 'Years Active (Coach)', children = {yearsActiveCoach}},
+			Cell{name = 'Years Active (Talent)', children = {yearsActiveTalent}},
 		}
 	elseif id == 'history' then
 		local getHistoryCells = function(key, title)
@@ -133,8 +133,8 @@ function CustomInjector:parse(id, widgets)
 		)
 	elseif id == 'nationality' then
 		return {
-			Cell{name = 'Location', content = {args.location}},
-			Cell{name = 'Nationality', content = caller:displayLocations()}
+			Cell{name = 'Location', children = {args.location}},
+			Cell{name = 'Nationality', children = caller:displayLocations()}
 		}
 	end
 	return widgets

--- a/lua/wikis/rocketleague/Infobox/Team/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Team/Custom.lua
@@ -43,14 +43,14 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(widgets,
 			Cell{
 				name = '[[Portal:Rating|LPRating]]',
-				content = {
+				children = {
 					args.rating and args.ratingRank and math.floor(args.rating + 0.5) .. ' (Rank #'.. args.ratingRank ..')'
 						or 'Not enough data'
 				}
 			},
 			Cell{
 				name = '[[RankingTableRLCS|RLCS Points]]',
-				content = {TeamRanking.run{
+				children = {TeamRanking.run{
 					ranking = args.ranking_name,
 					team = self.caller.pagename
 				}}

--- a/lua/wikis/rocketleague/Infobox/Unit/Car/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Unit/Car/Custom.lua
@@ -36,7 +36,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'custom' then
 		return {
-			Cell{name = 'Released', content = {args.released}},
+			Cell{name = 'Released', children = {args.released}},
 		}
 	end
 

--- a/lua/wikis/sideswipe/Infobox/League/Custom.lua
+++ b/lua/wikis/sideswipe/Infobox/League/Custom.lua
@@ -35,7 +35,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'custom' then
-		table.insert(widgets, Cell{name = 'Mode', content = {args.mode}})
+		table.insert(widgets, Cell{name = 'Mode', children = {args.mode}})
 	end
 
 	return widgets

--- a/lua/wikis/sideswipe/Infobox/Map/Custom.lua
+++ b/lua/wikis/sideswipe/Infobox/Map/Custom.lua
@@ -38,10 +38,10 @@ function CustomInjector:parse(widgetId, widgets)
 
 	if widgetId == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Playlists', content = {args.playlists}},
-			Cell{name = 'Gamemodes', content = {args.gamemodes}},
-			Cell{name = 'Versions', content = {args.versions}},
-			Cell{name = 'Layout', content = {args.layout}}
+			Cell{name = 'Playlists', children = {args.playlists}},
+			Cell{name = 'Gamemodes', children = {args.gamemodes}},
+			Cell{name = 'Versions', children = {args.versions}},
+			Cell{name = 'Layout', children = {args.layout}}
 		)
 	end
 	return widgets

--- a/lua/wikis/simracing/Infobox/League/Custom.lua
+++ b/lua/wikis/simracing/Infobox/League/Custom.lua
@@ -52,9 +52,9 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Game', content = {args.game}},
-			Cell{name = 'Number of Players', content = {args.player_number}},
-			Cell{name = 'Number of Teams', content = {args.team_number}}
+			Cell{name = 'Game', children = {args.game}},
+			Cell{name = 'Number of Players', children = {args.player_number}},
+			Cell{name = 'Number of Teams', children = {args.team_number}}
 		)
 	end
 

--- a/lua/wikis/simracing/Infobox/Map/Custom.lua
+++ b/lua/wikis/simracing/Infobox/Map/Custom.lua
@@ -40,10 +40,10 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return Array.appendWith(widgets,
-			Cell{name = 'Architect', content = {args.type}},
-			Cell{name = 'Opened', content = {args.open}},
-			Cell{name = 'Length', content = {args.length}},
-			Cell{name = 'Turns', content = {args.turns}}
+			Cell{name = 'Architect', children = {args.type}},
+			Cell{name = 'Opened', children = {args.open}},
+			Cell{name = 'Length', children = {args.length}},
+			Cell{name = 'Turns', children = {args.turns}}
 		)
 	end
 

--- a/lua/wikis/simracing/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/simracing/Infobox/Person/Player/Custom.lua
@@ -35,7 +35,7 @@ end
 function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		return {
-			Cell{name = 'Game Appearances', content = GameAppearances.player{player = self.caller.pagename}},
+			Cell{name = 'Game Appearances', children = GameAppearances.player{player = self.caller.pagename}},
 		}
 	end
 

--- a/lua/wikis/smash/Infobox/League/Custom.lua
+++ b/lua/wikis/smash/Infobox/League/Custom.lua
@@ -160,9 +160,9 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Number of Players', content = {args.player_number}},
-			Cell{name = 'Doubles Players', content = {args.doubles_number}},
-			Cell{name = 'Number of Teams', content = {args.team_number}}
+			Cell{name = 'Number of Players', children = {args.player_number}},
+			Cell{name = 'Doubles Players', children = {args.doubles_number}},
+			Cell{name = 'Number of Teams', children = {args.team_number}}
 		)
 	elseif id == 'customcontent' then
 		if args.circuit or args.points or args.circuit_next or args.circuit_previous then
@@ -186,13 +186,13 @@ function CustomInjector:parse(id, widgets)
 		end
 	elseif id == 'dates' then
 		return {
-			Cell{name = 'Date', content = {
+			Cell{name = 'Date', children = {
 				args.date and CustomLeague:_formatDate(args.date)
 			}},
-			Cell{name = 'Start Date', content = {
+			Cell{name = 'Start Date', children = {
 				args.sdate and CustomLeague:_formatDate(args.sdate)
 			}},
-			Cell{name = 'End Date', content = {
+			Cell{name = 'End Date', children = {
 				args.edate and CustomLeague:_formatDate(args.edate)
 			}},
 		}
@@ -201,23 +201,23 @@ function CustomInjector:parse(id, widgets)
 
 		-- Normal prize pool
 		if args.prizepool or args.prizepoolusd then
-			table.insert(widgets, Cell{name = 'Prize pool', content = {league.prizepoolDisplay}})
+			table.insert(widgets, Cell{name = 'Prize pool', children = {league.prizepoolDisplay}})
 		end
 
 		-- Doubles prize pool
 		if args.doublesprizepool or args.doublesprizepoolusd then
-			table.insert(widgets,Cell{name = 'Doubles prize pool', content = {league.doublePrizepoolDisplay}})
+			table.insert(widgets,Cell{name = 'Doubles prize pool', children = {league.doublePrizepoolDisplay}})
 		end
 	elseif id == 'gamesettings' then
 		if not args.overview then
 			local version = {args.version, args.endversion}
 			return {
-				Cell{name = 'Game', content = {Game.name{game = args.game}}},
-				Cell{name = 'Version', content = {table.concat(version, '&nbsp;- ')}},
+				Cell{name = 'Game', children = {Game.name{game = args.game}}},
+				Cell{name = 'Version', children = {table.concat(version, '&nbsp;- ')}},
 			}
 		end
 	elseif id == 'format' then
-		table.insert(widgets, Cell{name = 'Doubles Format', content = {args.doubles_format}})
+		table.insert(widgets, Cell{name = 'Doubles Format', children = {args.doubles_format}})
 	end
 
 	return widgets
@@ -402,11 +402,11 @@ function CustomLeague:_createCircuitInformation(widgets, circuitIndex)
 	Array.appendWith(widgets,
 		Cell{
 			name = 'Circuit',
-			content = {self:_createCircuitLink(circuitIndex)}
+			children = {self:_createCircuitLink(circuitIndex)}
 		},
-		Cell{name = 'Circuit Tier', content = {circuitArgs.tier}},
-		Cell{name = 'Tournament Region', content = {circuitArgs.region}},
-		Cell{name = 'Points', content = {circuitArgs.points}},
+		Cell{name = 'Circuit Tier', children = {circuitArgs.tier}},
+		Cell{name = 'Tournament Region', children = {circuitArgs.region}},
+		Cell{name = 'Points', children = {circuitArgs.points}},
 		Chronology{args = circuitArgs, showTitle = false}
 	)
 end

--- a/lua/wikis/smash/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/smash/Infobox/Person/Player/Custom.lua
@@ -72,19 +72,19 @@ function CustomInjector:parse(id, widgets)
 
 			Array.appendWith(widgets,
 				(main or former or alt) and Title{children = gameData.name} or nil,
-				Cell{name = 'Current Mains', content = main or {}},
-				Cell{name = 'Former Mains', content = former or {}},
-				Cell{name = 'Secondaries', content = alt or {}}
+				Cell{name = 'Current Mains', children = main or {}},
+				Cell{name = 'Former Mains', children = former or {}},
+				Cell{name = 'Secondaries', children = alt or {}}
 			)
 		end)
 	elseif id == 'status' then
 		table.insert(widgets,
-			Cell{name = 'Years Active', content = {YearsActive.get{player = mw.title.getCurrentTitle().baseText}}}
+			Cell{name = 'Years Active', children = {YearsActive.get{player = mw.title.getCurrentTitle().baseText}}}
 		)
 	elseif id == 'team' then
-		table.insert(widgets, Cell{name = 'Crew', content = {args.crew}})
+		table.insert(widgets, Cell{name = 'Crew', children = {args.crew}})
 	elseif id == 'nationality' then
-		table.insert(widgets, Cell{name = 'Location', content = {args.residence}})
+		table.insert(widgets, Cell{name = 'Location', children = {args.residence}})
 	elseif id == 'achievements' then
 		local achievements = {}
 		Array.forEach(GAME_ORDER, function(game)
@@ -95,7 +95,7 @@ function CustomInjector:parse(id, widgets)
 		end)
 		if #achievements == 0 then return {} end
 		return Array.extend({Title{children = 'Achievements'}}, Array.map(achievements, function(achievement)
-			return Cell{name = achievement.gameName, content = {achievement.icons}, options = {columns = 3}}
+			return Cell{name = achievement.gameName, children = {achievement.icons}, options = {columns = 3}}
 		end))
 	end
 

--- a/lua/wikis/smash/Infobox/Series/Custom.lua
+++ b/lua/wikis/smash/Infobox/Series/Custom.lua
@@ -43,7 +43,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Type',
-				content = {mw.language.getContentLanguage():ucfirst(self.caller.args.type or '')}
+				children = {mw.language.getContentLanguage():ucfirst(self.caller.args.type or '')}
 		}}
 	end
 

--- a/lua/wikis/smite/Infobox/League/Custom.lua
+++ b/lua/wikis/smite/Infobox/League/Custom.lua
@@ -37,12 +37,12 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Number of teams', content = {args.team_number}},
-			Cell{name = 'Number of players', content = {args.player_number}},
+			Cell{name = 'Number of teams', children = {args.team_number}},
+			Cell{name = 'Number of players', children = {args.player_number}},
 		}
 	elseif id == 'gamesettings' then
 		return {
-			Cell{name = 'Game', content = {Game.name{game = args.game}}},
+			Cell{name = 'Game', children = {Game.name{game = args.game}}},
 		}
 	end
 	return widgets

--- a/lua/wikis/smite/Infobox/Unit/God/Custom.lua
+++ b/lua/wikis/smite/Infobox/Unit/God/Custom.lua
@@ -73,7 +73,7 @@ function CustomInjector:parse(id, widgets)
 			)
 		return {
 			Breakdown{classes = {'infobox-center'}, children = breakDownContents},
-			Cell{name = 'Real Name', content = {args.realname}},
+			Cell{name = 'Real Name', children = {args.realname}},
 		}
 	elseif id == 'cost' then
 		local cost = Array.append({},
@@ -81,7 +81,7 @@ function CustomInjector:parse(id, widgets)
 				String.isNotEmpty(args.costgems ) and (args.costgems .. ' ' .. GEMS_ICON) or nil
 			)
 			return {
-				Cell{name = 'Price', content = {table.concat(cost, '&emsp;&ensp;')}},
+				Cell{name = 'Price', children = {table.concat(cost, '&emsp;&ensp;')}},
 			}
 	elseif id == 'custom' then
 		return self.caller:getCustomCells(widgets)
@@ -96,9 +96,9 @@ function CustomGod:getCustomCells(widgets)
 	local args = self.args
 	Array.appendWith(
 		widgets,
-		Cell{name = 'Attack Type', content = {args.attacktype}},
-		Cell{name = 'Difficulty', content = {args.difficulty}},
-		Cell{name = 'Release Date', content = {args.releasedate}}
+		Cell{name = 'Attack Type', children = {args.attacktype}},
+		Cell{name = 'Difficulty', children = {args.difficulty}},
+		Cell{name = 'Release Date', children = {args.releasedate}}
 	)
 
 	if Array.any({'hp', 'hplvl', 'hp5', 'hp5lvl'}, function(key) return String.isNotEmpty(args[key]) end) then
@@ -111,18 +111,18 @@ function CustomGod:getCustomCells(widgets)
 
 	Array.appendWith(
 		widgets,
-		Cell{name = 'Health', content = {bonusPerLevel(args.hp, args.hplvl)}},
-		Cell{name = 'Health Regen (HP5)', content = {bonusPerLevel(args.hp5, args.hp5lvl)}},
-		Cell{name = 'Mana', content = {bonusPerLevel(args.mana, args.manalvl)}},
-		Cell{name = 'Mana Regen (MP5)', content = {bonusPerLevel(args.mp5, args.mp5lvl)}},
-		Cell{name = 'Movement Speed', content = {bonusPerLevel(args.speed, args.speedlvl)}},
-		Cell{name = 'Attack Range', content = {bonusPerLevel(args.attackrange, args.attackrangelvl)}},
-		Cell{name = 'Attack Speed', content = {bonusPerLevel(args.attackspeed, args.attackspeedlvl)}},
-		Cell{name = 'Attack Damage', content = {bonusPerLevel(args.damage, args.damagelvl), args.damagebonus}},
-		Cell{name = 'Progression', content = {args.progression}},
+		Cell{name = 'Health', children = {bonusPerLevel(args.hp, args.hplvl)}},
+		Cell{name = 'Health Regen (HP5)', children = {bonusPerLevel(args.hp5, args.hp5lvl)}},
+		Cell{name = 'Mana', children = {bonusPerLevel(args.mana, args.manalvl)}},
+		Cell{name = 'Mana Regen (MP5)', children = {bonusPerLevel(args.mp5, args.mp5lvl)}},
+		Cell{name = 'Movement Speed', children = {bonusPerLevel(args.speed, args.speedlvl)}},
+		Cell{name = 'Attack Range', children = {bonusPerLevel(args.attackrange, args.attackrangelvl)}},
+		Cell{name = 'Attack Speed', children = {bonusPerLevel(args.attackspeed, args.attackspeedlvl)}},
+		Cell{name = 'Attack Damage', children = {bonusPerLevel(args.damage, args.damagelvl), args.damagebonus}},
+		Cell{name = 'Progression', children = {args.progression}},
 		Title{children = 'Protections'},
-		Cell{name = 'Physical', content = {bonusPerLevel(args.physical, args.physicallvl)}},
-		Cell{name = 'Magical', content = {bonusPerLevel(args.magical, args.magicallvl)}}
+		Cell{name = 'Physical', children = {bonusPerLevel(args.physical, args.physicallvl)}},
+		Cell{name = 'Magical', children = {bonusPerLevel(args.magical, args.magicallvl)}}
 	)
 
 	local wins, loses = CharacterWinLoss.run()
@@ -132,7 +132,7 @@ function CustomGod:getCustomCells(widgets)
 
 	return Array.append(widgets,
 		Title{children = 'Esports Statistics'},
-		Cell{name = 'Win Rate', content = {wins .. 'W : ' .. loses .. 'L (' .. winPercentage .. '%)'}}
+		Cell{name = 'Win Rate', children = {wins .. 'W : ' .. loses .. 'L (' .. winPercentage .. '%)'}}
 	)
 end
 

--- a/lua/wikis/splatoon/Infobox/League/Custom.lua
+++ b/lua/wikis/splatoon/Infobox/League/Custom.lua
@@ -39,12 +39,12 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Teams', content = {args.team_number}},
-			Cell{name = 'Players', content = {args.player_number}}
+			Cell{name = 'Teams', children = {args.team_number}},
+			Cell{name = 'Players', children = {args.player_number}}
 		)
 	elseif id == 'gamesettings' then
 		return {
-			Cell{name = 'Game version', content = {Game.name{game = args.game}}},
+			Cell{name = 'Game version', children = {Game.name{game = args.game}}},
 		}
 	end
 

--- a/lua/wikis/splatoon/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/splatoon/Infobox/Person/Player/Custom.lua
@@ -62,7 +62,7 @@ function CustomInjector:parse(id, widgets)
 
 		table.insert(widgets, Cell{
 			name = #weaponIcons > 1 and 'Signature Weapons' or 'Signature Weapon',
-			content = {table.concat(weaponIcons, '&nbsp;')}
+			children = {table.concat(weaponIcons, '&nbsp;')}
 		})
 	elseif id == 'region' then return {}
 	end

--- a/lua/wikis/squadrons/Infobox/League/Custom.lua
+++ b/lua/wikis/squadrons/Infobox/League/Custom.lua
@@ -42,8 +42,8 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Teams', content = {args.team_number}},
-			Cell{name = 'Players', content = {args.player_number}}
+			Cell{name = 'Teams', children = {args.team_number}},
+			Cell{name = 'Players', children = {args.player_number}}
 		)
 	elseif id == 'customcontent' and String.isNotEmpty(args.map1) then
 		local maps = {}

--- a/lua/wikis/starcraft/Infobox/Building/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Building/Custom.lua
@@ -46,19 +46,19 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Attributes', content = {args.att}},
-			Cell{name = '[[Distance#Sight Range|Sight]]', content = {args.sight}},
-			Cell{name = '[[Distance#Sight Range|Detection Range]]', content = {args.detection_range}},
-			Cell{name = 'Type', content = {args.type}},
-			Cell{name = 'Size', content = {args.size}},
-			Cell{name = '[[Game Speed#DPS|Energy Maximum]]', content = caller:_contentWithBonus('energy', 8)},
+			Cell{name = 'Attributes', children = {args.att}},
+			Cell{name = '[[Distance#Sight Range|Sight]]', children = {args.sight}},
+			Cell{name = '[[Distance#Sight Range|Detection Range]]', children = {args.detection_range}},
+			Cell{name = 'Type', children = {args.type}},
+			Cell{name = 'Size', children = {args.size}},
+			Cell{name = '[[Game Speed#DPS|Energy Maximum]]', children = caller:_contentWithBonus('energy', 8)},
 			Cell{name = '[[Game Speed#Regeneration Rates|Starting Energy]]',
-				content = caller:_contentWithBonus('energystart', 9)},
-			Cell{name = 'Animated', content = {args.banimation}},
+				children = caller:_contentWithBonus('energystart', 9)},
+			Cell{name = 'Animated', children = {args.banimation}},
 		}
 	elseif id == 'cost' then
 		return {
-			Cell{name = 'Cost', content = {CostDisplay.run{
+			Cell{name = 'Cost', children = {CostDisplay.run{
 				faction = args.race,
 				minerals = args.min,
 				mineralsTotal = args.totalmin,
@@ -72,49 +72,49 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'requirements' then
 		return {
-			Cell{name = 'Requirements', content = {String.convertWikiListToHtmlList(args.requires)}},
+			Cell{name = 'Requirements', children = {String.convertWikiListToHtmlList(args.requires)}},
 		}
 	elseif id == 'hotkey' then
 		return {
-			Cell{name = '[[Shortcuts|Hotkey]]', content = {caller:_getHotkeys()}}
+			Cell{name = '[[Shortcuts|Hotkey]]', children = {caller:_getHotkeys()}}
 		}
 	elseif id == 'builds' then
 		return {
-			Cell{name = 'Built By', content = {args.builtfrom}},
-			Cell{name = 'Builds', content = {String.convertWikiListToHtmlList(args.builds)}},
-			Cell{name = 'Morphs into', content = {String.convertWikiListToHtmlList(args.morphs)}},
-			Cell{name = 'Morphs into', content = {String.convertWikiListToHtmlList(args.morphsf)}},
-			Cell{name = 'Add-Ons', content = {String.convertWikiListToHtmlList(args.addons)}},
+			Cell{name = 'Built By', children = {args.builtfrom}},
+			Cell{name = 'Builds', children = {String.convertWikiListToHtmlList(args.builds)}},
+			Cell{name = 'Morphs into', children = {String.convertWikiListToHtmlList(args.morphs)}},
+			Cell{name = 'Morphs into', children = {String.convertWikiListToHtmlList(args.morphsf)}},
+			Cell{name = 'Add-Ons', children = {String.convertWikiListToHtmlList(args.addons)}},
 		}
 	elseif id == 'unlocks' then
 		return {
-			Cell{name = 'Unlocked Tech', content = {String.convertWikiListToHtmlList(args.unlocks)}},
-			Cell{name = 'Upgrades available', content = {String.convertWikiListToHtmlList(args.upgrades)}},
+			Cell{name = 'Unlocked Tech', children = {String.convertWikiListToHtmlList(args.unlocks)}},
+			Cell{name = 'Upgrades available', children = {String.convertWikiListToHtmlList(args.upgrades)}},
 		}
 	elseif id == 'defense' then
 		return {
-			Cell{name = 'Defense', content = {caller:_defenseDisplay()}}
+			Cell{name = 'Defense', children = {caller:_defenseDisplay()}}
 		}
 	elseif id == 'attack' then
 		return {
-			Cell{name = 'Damage', content = {args.damage}},
-			Cell{name = '[[Distance#Range|Range]]', content = {args.range}},
-			Cell{name = '[[Game Speed#Cooldown|Cooldown]]', content = {args.cooldown}},
-			Cell{name = '[[Game Speed#Cooldown|Cooldown Bonus]]', content = caller:_contentWithBonus('cd2', 2)},
-			Cell{name = '[[Game Speed#DPS|DPS]]', content = {args.dps}},
-			Cell{name = '[[Game Speed#DPS|DPS Bonus]]', content = caller:_contentWithBonus('dps2', 3)},
-			Cell{name = 'Ground Attack', content = {args.ground_attack}},
-			Cell{name = '[[Distance#Range|Ground Range]]', content = {args.grange}},
-			Cell{name = '[[Game Speed#Cooldown|G. Cooldown]]', content = {args.gcd}},
-			Cell{name = '[[Game Speed#Cooldown|G. Cooldown Bonus]]', content = caller:_contentWithBonus('gcd2', 4)},
-			Cell{name = '[[Game Speed#DPS|G. DPS]]', content = {args.gdps}},
-			Cell{name = '[[Game Speed#DPS|G. DPS Bonus]]', content = caller:_contentWithBonus('gdps2', 6)},
-			Cell{name = 'Air Attack', content = {args.air_attack}},
-			Cell{name = '[[Distance#Range|Air Range]]', content = {args.arange}},
-			Cell{name = '[[Game Speed#Cooldown|A. Cooldown]]', content = {args.acd}},
-			Cell{name = '[[Game Speed#Cooldown|A. Cooldown Bonus]]', content = caller:_contentWithBonus('acd2', 5)},
-			Cell{name = '[[Game Speed#DPS|A. DPS]]', content = {args.adps}},
-			Cell{name = '[[Game Speed#DPS|A. DPS Bonus]]', content = caller:_contentWithBonus('adps2', 7)},
+			Cell{name = 'Damage', children = {args.damage}},
+			Cell{name = '[[Distance#Range|Range]]', children = {args.range}},
+			Cell{name = '[[Game Speed#Cooldown|Cooldown]]', children = {args.cooldown}},
+			Cell{name = '[[Game Speed#Cooldown|Cooldown Bonus]]', children = caller:_contentWithBonus('cd2', 2)},
+			Cell{name = '[[Game Speed#DPS|DPS]]', children = {args.dps}},
+			Cell{name = '[[Game Speed#DPS|DPS Bonus]]', children = caller:_contentWithBonus('dps2', 3)},
+			Cell{name = 'Ground Attack', children = {args.ground_attack}},
+			Cell{name = '[[Distance#Range|Ground Range]]', children = {args.grange}},
+			Cell{name = '[[Game Speed#Cooldown|G. Cooldown]]', children = {args.gcd}},
+			Cell{name = '[[Game Speed#Cooldown|G. Cooldown Bonus]]', children = caller:_contentWithBonus('gcd2', 4)},
+			Cell{name = '[[Game Speed#DPS|G. DPS]]', children = {args.gdps}},
+			Cell{name = '[[Game Speed#DPS|G. DPS Bonus]]', children = caller:_contentWithBonus('gdps2', 6)},
+			Cell{name = 'Air Attack', children = {args.air_attack}},
+			Cell{name = '[[Distance#Range|Air Range]]', children = {args.arange}},
+			Cell{name = '[[Game Speed#Cooldown|A. Cooldown]]', children = {args.acd}},
+			Cell{name = '[[Game Speed#Cooldown|A. Cooldown Bonus]]', children = caller:_contentWithBonus('acd2', 5)},
+			Cell{name = '[[Game Speed#DPS|A. DPS]]', children = {args.adps}},
+			Cell{name = '[[Game Speed#DPS|A. DPS Bonus]]', children = caller:_contentWithBonus('adps2', 7)},
 		}
 	end
 	return widgets

--- a/lua/wikis/starcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/League/Custom.lua
@@ -148,13 +148,13 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'gamesettings' then
-		table.insert(widgets, Cell{name = 'Patch', content = {CustomLeague._getPatch(args)}})
+		table.insert(widgets, Cell{name = 'Patch', children = {CustomLeague._getPatch(args)}})
 	elseif id == 'customcontent' then
 		if args.player_number and args.player_number > 0 or args.team_number then
 			Array.appendWith(widgets,
 				Title{children = 'Participants'},
-				Cell{name = 'Number of Players', content = {self.caller.data.raceBreakDown.total}},
-				Cell{name = 'Number of Teams', content = {args.team_number}},
+				Cell{name = 'Number of Players', children = {self.caller.data.raceBreakDown.total}},
+				Cell{name = 'Number of Teams', children = {args.team_number}},
 				Breakdown{children = self.caller.data.raceBreakDown.display or {}, classes = { 'infobox-center' }}
 			)
 		end

--- a/lua/wikis/starcraft/Infobox/Map/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Map/Custom.lua
@@ -42,11 +42,11 @@ function CustomInjector:parse(widgetId, widgets)
 
 	if widgetId == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Tileset', content = {args.tileset or self.caller:_tlpdMap(id, 'tileset')}},
-			Cell{name = 'Size', content = {self.caller:_getSize(id, args)}},
-			Cell{name = 'Spawn Positions', content = {self.caller:_getSpawn(id, args)}},
-			Cell{name = 'Versions', content = {String.convertWikiListToHtmlList(args.versions)}},
-			Cell{name = 'Leagues Featured', content = {args.leagues}}
+			Cell{name = 'Tileset', children = {args.tileset or self.caller:_tlpdMap(id, 'tileset')}},
+			Cell{name = 'Size', children = {self.caller:_getSize(id, args)}},
+			Cell{name = 'Spawn Positions', children = {self.caller:_getSpawn(id, args)}},
+			Cell{name = 'Versions', children = {String.convertWikiListToHtmlList(args.versions)}},
+			Cell{name = 'Leagues Featured', children = {args.leagues}}
 		)
 	end
 

--- a/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
@@ -95,7 +95,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Race',
-				content = {CustomPlayer._getRaceDisplay(args.race)}
+				children = {CustomPlayer._getRaceDisplay(args.race)}
 			}
 		}
 	elseif id == 'role' then return {}
@@ -104,7 +104,7 @@ function CustomInjector:parse(id, widgets)
 		id == 'history' and
 		string.match(args.retired or '', '%d%d%d%d')
 	then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	end
 	return widgets
 end
@@ -114,16 +114,16 @@ end
 function CustomPlayer:_addCustomCells(args)
 	if args.informationType == BOT_INFORMATION_TYPE then
 		return {
-			Cell{name = 'Programmer', content = {args.programmer}},
-			Cell{name = 'Affiliation', content = {args.affiliation}},
-			Cell{name = 'Bot Version', content = {args.botversion}},
-			Cell{name = 'BWAPI Version', content = {args.bwapiversion}},
-			Cell{name = 'Language', content = {args.language}},
-			Cell{name = 'Wrapper', content = {args.wrapper}},
-			Cell{name = 'Terrain Analysis', content = {args.terrain_analysis}},
-			Cell{name = 'AI Techniques', content = {args.aitechniques}},
-			Cell{name = 'Framework', content = {args.framework}},
-			Cell{name = 'Strategies', content = {args.strategies}},
+			Cell{name = 'Programmer', children = {args.programmer}},
+			Cell{name = 'Affiliation', children = {args.affiliation}},
+			Cell{name = 'Bot Version', children = {args.botversion}},
+			Cell{name = 'BWAPI Version', children = {args.bwapiversion}},
+			Cell{name = 'Language', children = {args.language}},
+			Cell{name = 'Wrapper', children = {args.wrapper}},
+			Cell{name = 'Terrain Analysis', children = {args.terrain_analysis}},
+			Cell{name = 'AI Techniques', children = {args.aitechniques}},
+			Cell{name = 'Framework', children = {args.framework}},
+			Cell{name = 'Strategies', children = {args.strategies}},
 		}
 	end
 
@@ -140,9 +140,9 @@ function CustomPlayer:_addCustomCells(args)
 	return {
 		Cell{
 			name = 'Approx. Winnings ' .. CURRENT_YEAR,
-			content = {currentYearEarnings}
+			children = {currentYearEarnings}
 		},
-		Cell{name = 'Years active', content = {yearsActive}}
+		Cell{name = 'Years active', children = {yearsActive}}
 	}
 end
 

--- a/lua/wikis/starcraft/Infobox/Series/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Series/Custom.lua
@@ -52,14 +52,14 @@ function CustomInjector:parse(id, widgets)
 	if id == 'totalprizepool' then
 		if Logic.readBoolOrNil(args.prizepooltot) == false then return {} end
 		return {
-			Cell{name = 'Cumulative Prize Pool', content = {self.caller:_displaySeriesPrizepools()}},
+			Cell{name = 'Cumulative Prize Pool', children = {self.caller:_displaySeriesPrizepools()}},
 		}
 	elseif id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Patch', content = {self.caller:_getPatch()}},
-			Cell{name = 'Server', content = {args.server}},
-			Cell{name = 'Type', content = {args.type}},
-			Cell{name = 'Format', content = {args.format}}
+			Cell{name = 'Patch', children = {self.caller:_getPatch()}},
+			Cell{name = 'Server', children = {args.server}},
+			Cell{name = 'Type', children = {args.type}},
+			Cell{name = 'Format', children = {args.format}}
 		)
 	end
 

--- a/lua/wikis/starcraft/Infobox/Skill/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Skill/Custom.lua
@@ -46,20 +46,20 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Area of Effect', content = {args.area}},
-			Cell{name = 'Move Speed', content = {args.movespeed}},
-			Cell{name = 'Researched from', content = {self.caller:getResearchFrom()}},
-			Cell{name = 'Research Cost', content = {self.caller:getResearchCost()}},
-			Cell{name = 'Research Hotkey', content = {self.caller:getResearchHotkey()}},
+			Cell{name = 'Area of Effect', children = {args.area}},
+			Cell{name = 'Move Speed', children = {args.movespeed}},
+			Cell{name = 'Researched from', children = {self.caller:getResearchFrom()}},
+			Cell{name = 'Research Cost', children = {self.caller:getResearchCost()}},
+			Cell{name = 'Research Hotkey', children = {self.caller:getResearchHotkey()}},
 		}
 	elseif id == 'cost' then
-		return {Cell{name = 'Cost', content = {self.caller:getCostDisplay()}}}
+		return {Cell{name = 'Cost', children = {self.caller:getCostDisplay()}}}
 	elseif id == 'hotkey' then
-		return {Cell{name = '[[Shortcuts|Hotkey]]', content = {self.caller:getHotkeys()}}}
+		return {Cell{name = '[[Shortcuts|Hotkey]]', children = {self.caller:getHotkeys()}}}
 	elseif id == 'cooldown' then
-		return {Cell{name = '[[Cooldown]]', content = {args.cooldown}}}
+		return {Cell{name = '[[Cooldown]]', children = {args.cooldown}}}
 	elseif id == 'duration' then
-		return {Cell{name = '[[Game Speed|Duration]]', content = {args.duration}}}
+		return {Cell{name = '[[Game Speed|Duration]]', children = {args.duration}}}
 	end
 
 	return widgets

--- a/lua/wikis/starcraft/Infobox/Strategy/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Strategy/Custom.lua
@@ -50,12 +50,12 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Matchups', content = {args.matchups or 'All'}},
-			Cell{name = 'Type', content = {args.type or 'Opening'}},
-			Cell{name = 'Popularized by', content = {args.popularized}},
-			Cell{name = 'Converted Form', content = {args.convert}},
-			Cell{name = 'TL-Article', content = {caller:_getTLarticle(args.tlarticle)}},
-			Cell{name = 'Game', content = {args.game or
+			Cell{name = 'Matchups', children = {args.matchups or 'All'}},
+			Cell{name = 'Type', children = {args.type or 'Opening'}},
+			Cell{name = 'Popularized by', children = {args.popularized}},
+			Cell{name = 'Converted Form', children = {args.convert}},
+			Cell{name = 'TL-Article', children = {caller:_getTLarticle(args.tlarticle)}},
+			Cell{name = 'Game', children = {args.game or
 				(args.informationType == COUNTER_INFORMATION_TYPE and DEFAULT_COUNTER_GAME or nil)}},
 		}
 	elseif id == 'header' then

--- a/lua/wikis/starcraft/Infobox/Team/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Team/Custom.lua
@@ -69,25 +69,25 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'custom' then
-		table.insert(widgets, Cell{name = 'Gaming Director', content = {args['gaming director']}})
+		table.insert(widgets, Cell{name = 'Gaming Director', children = {args['gaming director']}})
 	elseif id == 'earnings' then
 		local displayEarnings = function(value)
 			return value > 0 and '$' .. mw.getContentLanguage():formatNum(value) or nil
 		end
 
 		return {
-			Cell{name = 'Approx. Total Winnings', content = {displayEarnings(self.caller.totalEarnings)}},
-			Cell{name = PLAYER_EARNINGS_ABBREVIATION, content = {displayEarnings(self.caller.totalEarningsWhileOnTeam)}},
+			Cell{name = 'Approx. Total Winnings', children = {displayEarnings(self.caller.totalEarnings)}},
+			Cell{name = PLAYER_EARNINGS_ABBREVIATION, children = {displayEarnings(self.caller.totalEarningsWhileOnTeam)}},
 		}
 	elseif id == 'achievements' then
-		table.insert(widgets, Cell{name = 'Solo Achievements', content = {args['solo achievements']}})
+		table.insert(widgets, Cell{name = 'Solo Achievements', children = {args['solo achievements']}})
 		--need this ABOVE the history display and below the
 		--achievements display, hence moved it here
 		local raceBreakdown = RaceBreakdown.run(args)
 		if raceBreakdown then
 			Array.appendWith(widgets,
 				Title{children = 'Player Breakdown'},
-				Cell{name = 'Number of Players', content = {raceBreakdown.total}},
+				Cell{name = 'Number of Players', children = {raceBreakdown.total}},
 				Breakdown{children = raceBreakdown.display, classes = { 'infobox-center' }}
 			)
 		end
@@ -96,7 +96,7 @@ function CustomInjector:parse(id, widgets)
 		while(not String.isEmpty(args['history' .. index .. 'title'])) do
 			table.insert(widgets, Cell{
 				name = args['history' .. index .. 'title'],
-				content = {args['history' .. index]}
+				children = {args['history' .. index]}
 			})
 			index = index + 1
 		end

--- a/lua/wikis/starcraft/Infobox/Unit/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Unit/Custom.lua
@@ -47,7 +47,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'cost' and not String.isEmpty(args.min) then
 		return {
-			Cell{name = 'Cost', content = {CostDisplay.run{
+			Cell{name = 'Cost', children = {CostDisplay.run{
 				faction = args.race,
 				minerals = args.min,
 				mineralsTotal = args.totalmin,
@@ -63,11 +63,11 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'Lua.importments' then
 		return {
-			Cell{name = 'Lua.importments', content = {String.convertWikiListToHtmlList(args.Lua.imports)}},
+			Cell{name = 'Lua.importments', children = {String.convertWikiListToHtmlList(args.Lua.imports)}},
 		}
 	elseif id == 'hotkey' then
 		return {
-			Cell{name = '[[Shortcuts|Hotkey]]', content = {CustomUnit:_getHotkeys(args)}}
+			Cell{name = '[[Shortcuts|Hotkey]]', children = {CustomUnit:_getHotkeys(args)}}
 		}
 	elseif id == 'type' then
 		local display
@@ -76,7 +76,7 @@ function CustomInjector:parse(id, widgets)
 		elseif args.type then
 			display = args.size .. ' ' .. args.type
 		end
-		return {Cell{name = 'Type', content = {display}}}
+		return {Cell{name = 'Type', children = {display}}}
 	elseif id == 'defense' or id == 'attack' then return {}
 	elseif id == 'customcontent' then
 		local aoeArgs = Json.parseIfTable(args.aoe)
@@ -84,9 +84,9 @@ function CustomInjector:parse(id, widgets)
 
 		return {
 			Title{children = aoeArgs.name},
-			Cell{name = 'Inner', content = {aoeArgs.size1}},
-			Cell{name = 'Medium', content = {aoeArgs.size2}},
-			Cell{name = 'Outer', content = {aoeArgs.size3}},
+			Cell{name = 'Inner', children = {aoeArgs.size1}},
+			Cell{name = 'Medium', children = {aoeArgs.size2}},
+			Cell{name = 'Outer', children = {aoeArgs.size3}},
 			Center{children = {aoeArgs.footnotes and ('<small>' .. aoeArgs.footnotes .. '</small>') or nil}}
 		}
 	elseif id == 'custom' then
@@ -106,40 +106,40 @@ function CustomUnit:getCustomCells(widgets)
 
 	return {
 		Title{children = 'Unit stats'},
-		Cell{name = 'Attributes', content = {args.att}},
-		Cell{name = 'Defense', content = {CustomUnit:_defenseDisplay(args)}},
-		Cell{name = 'Damage', content = {args.damage}},
-		Cell{name = 'Ground Damage', content = {args.ground_attack}},
-		Cell{name = 'Air Damage', content = {args.air_attack}},
-		Cell{name = '[[Distance#Range|Range]]', content = {args.range}},
-		Cell{name = '[[Distance#Range|Ground Range]]', content = {args.grange}},
-		Cell{name = '[[Distance#Range|Air Range]]', content = {args.arange}},
-		Cell{name = '[[Distance#Range|Minimum Range]]', content = {args.mrange}},
-		Cell{name = '[[Distance#Range|Minimum A. Range]]', content = {args.marange}},
-		Cell{name = '[[Distance#Range|Minimum G. Range]]', content = {args.mgrange}},
-		Cell{name = '[[Distance#Leash Range|Leash Range]]', content = {args.lrange}},
-		Cell{name = '[[Game Speed#Cooldown|Cooldown]]', content = {args.cooldown}},
-		Cell{name = '[[Game Speed#Cooldown|G. Cooldown]]', content = {args.gcd}},
-		Cell{name = '[[Game Speed#Cooldown|A. Cooldown]]', content = {args.acd}},
-		Cell{name = '[[Game Speed#Cooldown|Cooldown Bonus]]', content = contentWithBonus('cd2', 2)},
-		Cell{name = '[[Game Speed#Cooldown|G. Cooldown Bonus]]', content = contentWithBonus('gcd2', 4)},
-		Cell{name = '[[Game Speed#Cooldown|A. Cooldown Bonus]]', content = contentWithBonus('acd2', 5)},
-		Cell{name = 'Air Attacks', content = {args.aa}},
-		Cell{name = 'Attacks', content = {args.ga}},
-		Cell{name = '[[Game Speed#DPS|DPS]]', content = {args.dps}},
-		Cell{name = '[[Game Speed#DPS|G. DPS]]', content = {args.gdps}},
-		Cell{name = '[[Game Speed#DPS|A. DPS]]', content = {args.adps}},
-		Cell{name = '[[Game Speed#DPS|DPS Bonus]]', content = contentWithBonus('dps2', 3)},
-		Cell{name = '[[Game Speed#DPS|G. DPS Bonus]]', content = contentWithBonus('gdps2', 6)},
-		Cell{name = '[[Game Speed#DPS|A. DPS Bonus]]', content = contentWithBonus('adps2', 7)},
-		Cell{name = '[[Game Speed#Regeneration Rates|Energy Maximum]]', content = contentWithBonus('energy', 8)},
-		Cell{name = '[[Game Speed#Regeneration Rates|Starting Energy]]', content = contentWithBonus('energystart', 9)},
-		Cell{name = '[[Distance#Range|Sight]]', content = {args.sight}},
-		Cell{name = '[[Distance#Range|Detection Range]]', content = {args.detection_range}},
-		Cell{name = '[[Game Speed#Movement Speed|Speed]]', content = {args.speed}},
-		Cell{name = '[[Game Speed#Movement Speed|Speed Bonus]]', content = contentWithBonus('speed2', 1)},
-		Cell{name = 'Morphs into', content = {args.morphs, args.morphs2}},
-		Cell{name = 'Morphs From', content = {args.morphsf}},
+		Cell{name = 'Attributes', children = {args.att}},
+		Cell{name = 'Defense', children = {CustomUnit:_defenseDisplay(args)}},
+		Cell{name = 'Damage', children = {args.damage}},
+		Cell{name = 'Ground Damage', children = {args.ground_attack}},
+		Cell{name = 'Air Damage', children = {args.air_attack}},
+		Cell{name = '[[Distance#Range|Range]]', children = {args.range}},
+		Cell{name = '[[Distance#Range|Ground Range]]', children = {args.grange}},
+		Cell{name = '[[Distance#Range|Air Range]]', children = {args.arange}},
+		Cell{name = '[[Distance#Range|Minimum Range]]', children = {args.mrange}},
+		Cell{name = '[[Distance#Range|Minimum A. Range]]', children = {args.marange}},
+		Cell{name = '[[Distance#Range|Minimum G. Range]]', children = {args.mgrange}},
+		Cell{name = '[[Distance#Leash Range|Leash Range]]', children = {args.lrange}},
+		Cell{name = '[[Game Speed#Cooldown|Cooldown]]', children = {args.cooldown}},
+		Cell{name = '[[Game Speed#Cooldown|G. Cooldown]]', children = {args.gcd}},
+		Cell{name = '[[Game Speed#Cooldown|A. Cooldown]]', children = {args.acd}},
+		Cell{name = '[[Game Speed#Cooldown|Cooldown Bonus]]', children = contentWithBonus('cd2', 2)},
+		Cell{name = '[[Game Speed#Cooldown|G. Cooldown Bonus]]', children = contentWithBonus('gcd2', 4)},
+		Cell{name = '[[Game Speed#Cooldown|A. Cooldown Bonus]]', children = contentWithBonus('acd2', 5)},
+		Cell{name = 'Air Attacks', children = {args.aa}},
+		Cell{name = 'Attacks', children = {args.ga}},
+		Cell{name = '[[Game Speed#DPS|DPS]]', children = {args.dps}},
+		Cell{name = '[[Game Speed#DPS|G. DPS]]', children = {args.gdps}},
+		Cell{name = '[[Game Speed#DPS|A. DPS]]', children = {args.adps}},
+		Cell{name = '[[Game Speed#DPS|DPS Bonus]]', children = contentWithBonus('dps2', 3)},
+		Cell{name = '[[Game Speed#DPS|G. DPS Bonus]]', children = contentWithBonus('gdps2', 6)},
+		Cell{name = '[[Game Speed#DPS|A. DPS Bonus]]', children = contentWithBonus('adps2', 7)},
+		Cell{name = '[[Game Speed#Regeneration Rates|Energy Maximum]]', children = contentWithBonus('energy', 8)},
+		Cell{name = '[[Game Speed#Regeneration Rates|Starting Energy]]', children = contentWithBonus('energystart', 9)},
+		Cell{name = '[[Distance#Range|Sight]]', children = {args.sight}},
+		Cell{name = '[[Distance#Range|Detection Range]]', children = {args.detection_range}},
+		Cell{name = '[[Game Speed#Movement Speed|Speed]]', children = {args.speed}},
+		Cell{name = '[[Game Speed#Movement Speed|Speed Bonus]]', children = contentWithBonus('speed2', 1)},
+		Cell{name = 'Morphs into', children = {args.morphs, args.morphs2}},
+		Cell{name = 'Morphs From', children = {args.morphsf}},
 	}
 end
 

--- a/lua/wikis/starcraft2/Infobox/Building/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Building/Custom.lua
@@ -52,10 +52,10 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Size', content = {args.size}},
-			Cell{name = 'Sight', content = {args.sight}},
-			Cell{name = 'Energy', content = {args.energy}},
-			Cell{name = 'Detection/Attack Range', content = {args.detection_range}}
+			Cell{name = 'Size', children = {args.size}},
+			Cell{name = 'Sight', children = {args.sight}},
+			Cell{name = 'Energy', children = {args.energy}},
+			Cell{name = 'Detection/Attack Range', children = {args.detection_range}}
 		)
 
 		if args.game ~= GAME_LOTV then
@@ -67,7 +67,7 @@ function CustomInjector:parse(id, widgets)
 		end
 	elseif id == 'cost' then
 		return {
-			Cell{name = 'Cost', content = {CostDisplay.run{
+			Cell{name = 'Cost', children = {CostDisplay.run{
 				faction = args.race,
 				minerals = args.min,
 				mineralsTotal = args.totalmin,
@@ -81,37 +81,37 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'requirements' then
 		return {
-			Cell{name = 'Requirements', content = {String.convertWikiListToHtmlList(args.requires)}},
+			Cell{name = 'Requirements', children = {String.convertWikiListToHtmlList(args.requires)}},
 		}
 	elseif id == 'hotkey' then
 		return {
-			Cell{name = '[[Hotkeys per Race|Hotkey]]', content = {self.caller:_getHotkeys()}}
+			Cell{name = '[[Hotkeys per Race|Hotkey]]', children = {self.caller:_getHotkeys()}}
 		}
 	elseif id == 'builds' then
 		return {
-			Cell{name = 'Builds', content = {String.convertWikiListToHtmlList(args.builds)}},
-			Cell{name = 'Morphs into', content = {String.convertWikiListToHtmlList(args.morphs)}},
-			Cell{name = '[[Add-on]]s', content = {String.convertWikiListToHtmlList(args.addons)}},
+			Cell{name = 'Builds', children = {String.convertWikiListToHtmlList(args.builds)}},
+			Cell{name = 'Morphs into', children = {String.convertWikiListToHtmlList(args.morphs)}},
+			Cell{name = '[[Add-on]]s', children = {String.convertWikiListToHtmlList(args.addons)}},
 		}
 	elseif id == 'unlocks' then
 		return {
-			Cell{name = 'Unlocked Tech', content = {String.convertWikiListToHtmlList(args.unlocks)}},
-			Cell{name = 'Upgrades available', content = {String.convertWikiListToHtmlList(args.upgrades)}},
+			Cell{name = 'Unlocked Tech', children = {String.convertWikiListToHtmlList(args.unlocks)}},
+			Cell{name = 'Upgrades available', children = {String.convertWikiListToHtmlList(args.upgrades)}},
 		}
 	elseif id == 'defense' then
 		return {
-			Cell{name = 'Defense', content = {self.caller:_defenseDisplay()}}
+			Cell{name = 'Defense', children = {self.caller:_defenseDisplay()}}
 		}
 	elseif id == 'attack' then
 		return {
-			Cell{name = 'Ground Attack', content = {args.ground_attack}},
-			Cell{name = 'Ground [[Damage Per Second|DPS]]', content = {args.ground_dps}},
-			Cell{name = 'Air Attack', content = {args.air_attack}},
-			Cell{name = 'Air [[Damage Per Second|DPS]]', content = {args.air_dps}},
-			Cell{name = 'Bonus', content = {args.bonus}},
-			Cell{name = 'Bonus [[Damage Per Second|DPS]]', content = {args.bonus_dps}},
-			Cell{name = 'Range', content = {args.range}},
-			Cell{name = 'Cooldown', content = {args.cooldown}},
+			Cell{name = 'Ground Attack', children = {args.ground_attack}},
+			Cell{name = 'Ground [[Damage Per Second|DPS]]', children = {args.ground_dps}},
+			Cell{name = 'Air Attack', children = {args.air_attack}},
+			Cell{name = 'Air [[Damage Per Second|DPS]]', children = {args.air_dps}},
+			Cell{name = 'Bonus', children = {args.bonus}},
+			Cell{name = 'Bonus [[Damage Per Second|DPS]]', children = {args.bonus_dps}},
+			Cell{name = 'Range', children = {args.range}},
+			Cell{name = 'Cooldown', children = {args.cooldown}},
 		}
 	end
 	return widgets

--- a/lua/wikis/starcraft2/Infobox/CampaignMission/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/CampaignMission/Custom.lua
@@ -71,12 +71,12 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'custom' then
 		return {
-			Cell{ name = 'Credits Earned', content = {args.credits}},
-			Cell{ name = 'Research Points', content = {args.research}},
-			Cell{ name = 'Kerrigan Levels', content = {args.Kerrigan}},
-			Cell{ name = 'Evolution Unlock', content = {self.caller:_getEvolution()}},
-			Cell{ name = 'New Units', content = {args.units}},
-			Cell{ name = 'Available Heroes', content = {args.heroes}},
+			Cell{ name = 'Credits Earned', children = {args.credits}},
+			Cell{ name = 'Research Points', children = {args.research}},
+			Cell{ name = 'Kerrigan Levels', children = {args.Kerrigan}},
+			Cell{ name = 'Evolution Unlock', children = {self.caller:_getEvolution()}},
+			Cell{ name = 'New Units', children = {args.units}},
+			Cell{ name = 'Available Heroes', children = {args.heroes}},
 		}
 	end
 	return widgets

--- a/lua/wikis/starcraft2/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/League/Custom.lua
@@ -196,25 +196,25 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'gamesettings' then
 		return {
-			Cell{name = 'Game Version', content = {caller:_getGameVersion(args)}},
-			Cell{name = 'Server', content = {caller:_getServer(args)}}
+			Cell{name = 'Game Version', children = {caller:_getGameVersion(args)}},
+			Cell{name = 'Server', children = {caller:_getServer(args)}}
 		}
 	elseif id == 'dates' and data.startTime.display then
 		local startTime = Countdown._create{date = data.startTime.display, rawdatetime = true}
 
 		if data.startDate == data.endDate then
-			return {Cell{name = 'Start Time', content = {startTime}}}
+			return {Cell{name = 'Start Time', children = {startTime}}}
 		end
 		return {
-			Cell{name = 'Start Time', content = {startTime}},
-			Cell{name = 'End Date', content = {args.edate}},
+			Cell{name = 'Start Time', children = {startTime}},
+			Cell{name = 'End Date', children = {args.edate}},
 		}
 	elseif id == 'customcontent' then
 		if args.player_number and args.player_number > 0 or args.team_number then
 			Array.appendWith(widgets,
 				Title{children = 'Participants'},
-				Cell{name = 'Number of Players', content = {args.raceBreakDown.total}},
-				Cell{name = 'Number of Teams', content = {args.team_number}},
+				Cell{name = 'Number of Players', children = {args.raceBreakDown.total}},
+				Cell{name = 'Number of Teams', children = {args.team_number}},
 				Breakdown{children = args.raceBreakDown.display or {}, classes = { 'infobox-center' }}
 			)
 		end

--- a/lua/wikis/starcraft2/Infobox/Map/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Map/Custom.lua
@@ -45,16 +45,16 @@ function CustomInjector:parse(widgetId, widgets)
 
 	return Array.append(
 		widgets,
-		Cell{name = 'Tileset', content = {args.tileset or self.caller:_tlpdMap(id, 'tileset')}},
-		Cell{name = 'Size', content = {self.caller:_getSize(id)}},
-		Cell{name = 'Spawn Positions', content = {self.caller:_getSpawn(id)}},
-		Cell{name = 'Versions', content = {args.versions}},
-		Cell{name = 'Leagues Featured', content = {args.leagues}},
-		Cell{name = '[[Rush distance]]', content = {self.caller:_getRushDistance()}},
-		Cell{name = '1v1 Ladder', content = {args['1v1history']}},
-		Cell{name = '2v2 Ladder', content = {args['2v2history']}},
-		Cell{name = '3v3 Ladder', content = {args['3v3history']}},
-		Cell{name = '4v4 Ladder', content = {args['4v4history']}}
+		Cell{name = 'Tileset', children = {args.tileset or self.caller:_tlpdMap(id, 'tileset')}},
+		Cell{name = 'Size', children = {self.caller:_getSize(id)}},
+		Cell{name = 'Spawn Positions', children = {self.caller:_getSpawn(id)}},
+		Cell{name = 'Versions', children = {args.versions}},
+		Cell{name = 'Leagues Featured', children = {args.leagues}},
+		Cell{name = '[[Rush distance]]', children = {self.caller:_getRushDistance()}},
+		Cell{name = '1v1 Ladder', children = {args['1v1history']}},
+		Cell{name = '2v2 Ladder', children = {args['2v2history']}},
+		Cell{name = '3v3 Ladder', children = {args['3v3history']}},
+		Cell{name = '4v4 Ladder', children = {args['4v4history']}}
 	)
 	end
 

--- a/lua/wikis/starcraft2/Infobox/Patch/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Patch/Custom.lua
@@ -36,10 +36,10 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'release' then
 		return {
-			Cell{name = 'SEA Release Date', content = {args.searelease}},
-			Cell{name = 'NA Release Date', content = {args.narelease}},
-			Cell{name = 'EU Release Date', content = {args.eurelease}},
-			Cell{name = 'KR Release Date', content = {args.korrelease}},
+			Cell{name = 'SEA Release Date', children = {args.searelease}},
+			Cell{name = 'NA Release Date', children = {args.narelease}},
+			Cell{name = 'EU Release Date', children = {args.eurelease}},
+			Cell{name = 'KR Release Date', children = {args.korrelease}},
 		}
 	end
 	return widgets

--- a/lua/wikis/starcraft2/Infobox/Person/MapMaker/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Person/MapMaker/Custom.lua
@@ -39,13 +39,13 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Military Service', content = {args.military}},
+			Cell{name = 'Military Service', children = {args.military}},
 		}
 	elseif id == 'status' then
 		return {
 			Cell{
 				name = 'Race',
-				content = {self.caller:getRaceData(args.race or 'unknown')}
+				children = {self.caller:getRaceData(args.race or 'unknown')}
 			}
 		}
 	elseif id == 'role' then return {}
@@ -54,8 +54,8 @@ function CustomInjector:parse(id, widgets)
 		if String.isNotEmpty(args.maps_ladder) or String.isNotEmpty(args.maps_special) then
 			return {
 				Title{children = 'Achievements'},
-				Cell{name = 'Ladder maps created', content = {args.maps_ladder}},
-				Cell{name = 'Non-ladder competitive maps created', content = {args.maps_special}}
+				Cell{name = 'Ladder maps created', children = {args.maps_ladder}},
+				Cell{name = 'Non-ladder competitive maps created', children = {args.maps_special}}
 			}
 		end
 		return {}
@@ -65,7 +65,7 @@ function CustomInjector:parse(id, widgets)
 	then
 		table.insert(widgets, Cell{
 				name = 'Retired',
-				content = {args.retired}
+				children = {args.retired}
 			})
 	end
 	return widgets

--- a/lua/wikis/starcraft2/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Person/Player/Custom.lua
@@ -111,25 +111,25 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Approx. Winnings ' .. CURRENT_YEAR,
-				content = {currentYearEarnings > 0 and ('$' .. mw.getContentLanguage():formatNum(currentYearEarnings)) or nil}
+				children = {currentYearEarnings > 0 and ('$' .. mw.getContentLanguage():formatNum(currentYearEarnings)) or nil}
 			},
-			Cell{name = ranks[1].name or 'Rank', content = {ranks[1].rank}},
-			Cell{name = ranks[2].name or 'Rank', content = {ranks[2].rank}},
-			Cell{name = 'Military Service', content = {args.military}},
+			Cell{name = ranks[1].name or 'Rank', children = {ranks[1].rank}},
+			Cell{name = ranks[2].name or 'Rank', children = {ranks[2].rank}},
+			Cell{name = 'Military Service', children = {args.military}},
 			Cell{
 				name = Abbreviation.make{text = 'Years Active', title = 'Years active as a player'},
-				content = {caller.yearsActive}
+				children = {caller.yearsActive}
 			},
 			Cell{
 				name = Abbreviation.make{text = 'Years Active (caster)', title = 'Years active as a caster'},
-				content = {self.caller:_getActiveCasterYears()}
+				children = {self.caller:_getActiveCasterYears()}
 			},
 		}
 	elseif id == 'status' then
 		return {
 			Cell{
 				name = 'Race',
-				content = {caller:getRaceData(args.race or 'unknown', RACE_FIELD_AS_CATEGORY_LINK)}
+				children = {caller:getRaceData(args.race or 'unknown', RACE_FIELD_AS_CATEGORY_LINK)}
 			}
 		}
 	elseif id == 'role' then return {}
@@ -143,11 +143,11 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Title{children = 'Achievements'},
 			Center{children = {Achievements.display(caller.infoboxAchievements)}},
-			Cell{name = 'All-Kills', content = {allkills > 0 and (ALL_KILL_ICON .. allkills) or nil}}
+			Cell{name = 'All-Kills', children = {allkills > 0 and (ALL_KILL_ICON .. allkills) or nil}}
 		}
 	elseif id == 'achievements' then return {}
 	elseif id == 'history' and string.match(args.retired or '', '%d%d%d%d') then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	end
 
 	return widgets

--- a/lua/wikis/starcraft2/Infobox/Series/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Series/Custom.lua
@@ -62,14 +62,14 @@ function CustomInjector:parse(id, widgets)
 	if id == 'totalprizepool' then
 		if Logic.readBoolOrNil(args.prizepooltot) == false then return {} end
 		return {
-			Cell{name = 'Cumulative Prize Pool', content = {self.caller:_displaySeriesPrizepools()}},
+			Cell{name = 'Cumulative Prize Pool', children = {self.caller:_displaySeriesPrizepools()}},
 		}
 	elseif id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Game version', content = {self.caller:_getGameVersion(args.game, args.patch)}},
-			Cell{name = 'Server', content = {args.server}},
-			Cell{name = 'Type', content = {args.type}},
-			Cell{name = 'Format', content = {args.format}}
+			Cell{name = 'Game version', children = {self.caller:_getGameVersion(args.game, args.patch)}},
+			Cell{name = 'Server', children = {args.server}},
+			Cell{name = 'Type', children = {args.type}},
+			Cell{name = 'Format', children = {args.format}}
 		)
 	end
 

--- a/lua/wikis/starcraft2/Infobox/Show/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Show/Custom.lua
@@ -43,8 +43,8 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'No. of episodes', content = {args['num_episodes']}},
-			Cell{name = 'Original Release', content = {self.caller:_getReleasePeriod(args.sdate, args.edate)}}
+			Cell{name = 'No. of episodes', children = {args['num_episodes']}},
+			Cell{name = 'Original Release', children = {self.caller:_getReleasePeriod(args.sdate, args.edate)}}
 		)
 	end
 

--- a/lua/wikis/starcraft2/Infobox/Skill/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Skill/Custom.lua
@@ -54,22 +54,22 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = '[[Game Speed|Duration 2]]', content = {self.caller:getDuration(2)}},
-			Cell{name = 'Researched from', content = {self.caller:getResearchFrom()}},
-			Cell{name = 'Research Cost', content = {self.caller:getResearchCost()}},
-			Cell{name = 'Research Hotkey', content = {self.caller:getResearchHotkey()}},
-			Cell{name = 'Move Speed', content = {args.movespeed}}
+			Cell{name = '[[Game Speed|Duration 2]]', children = {self.caller:getDuration(2)}},
+			Cell{name = 'Researched from', children = {self.caller:getResearchFrom()}},
+			Cell{name = 'Research Cost', children = {self.caller:getResearchCost()}},
+			Cell{name = 'Research Hotkey', children = {self.caller:getResearchHotkey()}},
+			Cell{name = 'Move Speed', children = {args.movespeed}}
 		)
 	elseif id == 'cost' then
-		return {Cell{name = 'Cost', content = {self.caller:getCostDisplay()}}}
+		return {Cell{name = 'Cost', children = {self.caller:getCostDisplay()}}}
 	elseif id == 'hotkey' then
-		return {Cell{name = '[[Hotkeys per Race|Hotkey]]', content = {self.caller:getHotkeys()}}}
+		return {Cell{name = '[[Hotkeys per Race|Hotkey]]', children = {self.caller:getHotkeys()}}}
 	elseif id == 'cooldown' then
 		return {
-			Cell{name = Page.makeInternalLink({onlyIfExists = true},'Cooldown') or 'Cooldown', content = {args.cooldown}}
+			Cell{name = Page.makeInternalLink({onlyIfExists = true},'Cooldown') or 'Cooldown', children = {args.cooldown}}
 		}
 	elseif id == 'duration' then
-		return {Cell{name = '[[Game Speed|Duration]]', content = {self.caller:getDuration()}}}
+		return {Cell{name = '[[Game Speed|Duration]]', children = {self.caller:getDuration()}}}
 	end
 
 	return widgets

--- a/lua/wikis/starcraft2/Infobox/Strategy/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Strategy/Custom.lua
@@ -52,11 +52,11 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Matchups', content = {args.matchups or 'All'}},
-			Cell{name = 'Type', content = {args.type or 'Opening'}},
-			Cell{name = 'Popularized by', content = {args.popularized}, options = {makeLink = true}},
-			Cell{name = 'Converted Form', content = {args.convert}},
-			Cell{name = 'TL-Article', content = {self.caller:_getTLarticle(args.tlarticle)}}
+			Cell{name = 'Matchups', children = {args.matchups or 'All'}},
+			Cell{name = 'Type', children = {args.type or 'Opening'}},
+			Cell{name = 'Popularized by', children = {args.popularized}, options = {makeLink = true}},
+			Cell{name = 'Converted Form', children = {args.convert}},
+			Cell{name = 'TL-Article', children = {self.caller:_getTLarticle(args.tlarticle)}}
 		)
 	end
 	return widgets

--- a/lua/wikis/starcraft2/Infobox/Team/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Team/Custom.lua
@@ -71,8 +71,8 @@ function CustomInjector:parse(id, widgets)
 		end
 
 		return {
-			Cell{name = 'Approx. Total Winnings', content = {displayEarnings(self.caller.teamEarnings)}},
-			Cell{name = PLAYER_EARNINGS_ABBREVIATION, content = {displayEarnings(self.caller.playerEarnings)}},
+			Cell{name = 'Approx. Total Winnings', children = {displayEarnings(self.caller.teamEarnings)}},
+			Cell{name = PLAYER_EARNINGS_ABBREVIATION, children = {displayEarnings(self.caller.playerEarnings)}},
 		}
 	elseif id == 'achievements' then
 		local achievements, soloAchievements = Achievements.teamAndTeamSolo()
@@ -93,7 +93,7 @@ function CustomInjector:parse(id, widgets)
 		if raceBreakdown then
 			Array.appendWith(widgets,
 				Title{children = 'Player Breakdown'},
-				Cell{name = 'Number of Players', content = {raceBreakdown.total}},
+				Cell{name = 'Number of Players', children = {raceBreakdown.total}},
 				Breakdown{children = raceBreakdown.display, classes = {'infobox-center'}}
 			)
 		end
@@ -104,7 +104,7 @@ function CustomInjector:parse(id, widgets)
 		while(not String.isEmpty(args['history' .. index .. 'title'])) do
 			table.insert(widgets, Cell{
 				name = args['history' .. index .. 'title'],
-				content = {args['history' .. index]}
+				children = {args['history' .. index]}
 			})
 			index = index + 1
 		end

--- a/lua/wikis/starcraft2/Infobox/Unit/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Unit/Custom.lua
@@ -53,7 +53,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'cost' and not String.isEmpty(args.min) then
 		return {
-			Cell{name = 'Cost', content = {CostDisplay.run{
+			Cell{name = 'Cost', children = {CostDisplay.run{
 				faction = args.race,
 				minerals = args.min,
 				mineralsTotal = args.totalmin,
@@ -69,11 +69,11 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'requirements' then
 		return {
-			Cell{name = 'Requirements', content = {String.convertWikiListToHtmlList(args.requires)}},
+			Cell{name = 'Requirements', children = {String.convertWikiListToHtmlList(args.requires)}},
 		}
 	elseif id == 'hotkey' then
 		return {
-			Cell{name = '[[Hotkeys per Race|Hotkey]]', content = {self.caller:_getHotkeys()}}
+			Cell{name = '[[Hotkeys per Race|Hotkey]]', children = {self.caller:_getHotkeys()}}
 		}
 	elseif id == 'type' and (not String.isEmpty(args.size) or not String.isEmpty(args.type)) then
 		local display = args.size
@@ -83,7 +83,7 @@ function CustomInjector:parse(id, widgets)
 			display = display .. ' ' .. args.type
 		end
 		return {
-			Cell{name = 'Type', content = {display}}
+			Cell{name = 'Type', children = {display}}
 		}
 	elseif id == 'defense' then return {}
 	elseif id == 'attack' then
@@ -100,20 +100,20 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(
 			widgets,
 			Title{children = 'Unit stats'},
-			Cell{name = 'Defense', content = {self.caller:_defenseDisplay()}},
-			Cell{name = 'Attributes', content = {args.attributes}},
-			Cell{name = 'Energy', content = {args.energy}},
-			Cell{name = 'Sight', content = {args.sight}},
-			Cell{name = 'Detection range', content = {args.detection_range}},
-			Cell{name = 'Speed', content = {args.speed}},
-			Cell{name = 'Speed Multiplier on Creep', content = {args.creepspeedmult}},
-			Cell{name = 'Speed on Creep', content = {args.speedoncreep}},
-			Cell{name = 'Flags', content = {args.flags}},
-			Cell{name = 'Morphs into', content = {args.morphs}},
-			Cell{name = 'Cargo size', content = {args.cargo_size}},
-			Cell{name = 'Cargo capacity', content = {args.cargo_capacity}},
-			Cell{name = 'Strong against', content = {String.convertWikiListToHtmlList(args.strong)}},
-			Cell{name = 'Weak against', content = {String.convertWikiListToHtmlList(args.weak)}}
+			Cell{name = 'Defense', children = {self.caller:_defenseDisplay()}},
+			Cell{name = 'Attributes', children = {args.attributes}},
+			Cell{name = 'Energy', children = {args.energy}},
+			Cell{name = 'Sight', children = {args.sight}},
+			Cell{name = 'Detection range', children = {args.detection_range}},
+			Cell{name = 'Speed', children = {args.speed}},
+			Cell{name = 'Speed Multiplier on Creep', children = {args.creepspeedmult}},
+			Cell{name = 'Speed on Creep', children = {args.speedoncreep}},
+			Cell{name = 'Flags', children = {args.flags}},
+			Cell{name = 'Morphs into', children = {args.morphs}},
+			Cell{name = 'Cargo size', children = {args.cargo_size}},
+			Cell{name = 'Cargo capacity', children = {args.cargo_capacity}},
+			Cell{name = 'Strong against', children = {String.convertWikiListToHtmlList(args.strong)}},
+			Cell{name = 'Weak against', children = {String.convertWikiListToHtmlList(args.weak)}}
 		)
 
 		if args.game ~= GAME_LOTV and args.buildtime then
@@ -218,13 +218,13 @@ function CustomUnit:_getAttack(index)
 
 	return {
 		Title{children = attackHeader},
-		Cell{name = 'Targets', content = {args['attack' .. index .. '_target']}},
-		Cell{name = 'Damage', content = {args['attack' .. index .. '_damage']}},
-		Cell{name = '[[Damage Per Second|DPS]]', content = {args['attack' .. index .. '_dps']}},
-		Cell{name = '[[Cooldown]]', content = {args['attack' .. index .. '_cooldown']}},
-		Cell{name = 'Bonus', content = {args['attack' .. index .. '_bonus']}},
-		Cell{name = 'Bonus DPS', content = {args['attack' .. index .. '_bonus_dps']}},
-		Cell{name = '[[Range]]', content = {
+		Cell{name = 'Targets', children = {args['attack' .. index .. '_target']}},
+		Cell{name = 'Damage', children = {args['attack' .. index .. '_damage']}},
+		Cell{name = '[[Damage Per Second|DPS]]', children = {args['attack' .. index .. '_dps']}},
+		Cell{name = '[[Cooldown]]', children = {args['attack' .. index .. '_cooldown']}},
+		Cell{name = 'Bonus', children = {args['attack' .. index .. '_bonus']}},
+		Cell{name = 'Bonus DPS', children = {args['attack' .. index .. '_bonus_dps']}},
+		Cell{name = '[[Range]]', children = {
 				(args['attack' .. index .. '_range'] or '')..
 				(args['attack' .. index .. '_range_note'] or '')
 			}

--- a/lua/wikis/starcraft2/Infobox/UnofficialWorldChampion/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/UnofficialWorldChampion/Custom.lua
@@ -44,7 +44,7 @@ function CustomInjector:parse(id, widgets)
 		local index = 1
 		local defencesCells = {}
 		while not String.isEmpty(args['most defences against ' .. index]) do
-			table.insert(defencesCells, Breakdown{ content = {
+			table.insert(defencesCells, Breakdown{ children = {
 				args['most defences against ' .. index],
 				args['most defences against ' .. (index + 1)],
 			}})
@@ -78,7 +78,7 @@ function CustomUnofficialWorldChampion:_buildCellsFromBase(base, title)
 
 	local widgets = {Title{children = title}}
 	for key, value in Table.iter.pairsByPrefix(args, base .. ' ') do
-		table.insert(widgets, Cell{name = (args[key .. ' no'] or '?') .. ' champions', content = {value}})
+		table.insert(widgets, Cell{name = (args[key .. ' no'] or '?') .. ' champions', children = {value}})
 	end
 
 	return widgets

--- a/lua/wikis/stormgate/Infobox/Building/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Building/Custom.lua
@@ -78,19 +78,19 @@ function CustomInjector:parse(id, widgets)
 	if id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Size', content = {args.size}},
-			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
-			Cell{name = 'Speed', content = {args.speed}},
-			Cell{name = 'Sight', content = {args.sight}},
-			Cell{name = 'Upgrades To', content = caller:_csvToPageList(args.upgrades_to)},
-			Cell{name = 'Introduced', content = {args.introducedDisplay}}
+			Cell{name = 'Size', children = {args.size}},
+			Cell{name = 'Energy', children = {caller:_energyDisplay()}},
+			Cell{name = 'Speed', children = {args.speed}},
+			Cell{name = 'Sight', children = {args.sight}},
+			Cell{name = 'Upgrades To', children = caller:_csvToPageList(args.upgrades_to)},
+			Cell{name = 'Introduced', children = {args.introducedDisplay}}
 		)
 		for _, attackArgs, attackIndex in Table.iter.pairsByPrefix(args, 'attack') do
 			Array.extendWith(widgets, Attack.run(attackArgs, attackIndex, caller.faction))
 		end
 	elseif id == 'cost' then
 		return {
-			Cell{name = 'Cost', content = {CostDisplay.run{
+			Cell{name = 'Cost', children = {CostDisplay.run{
 				faction = caller.faction,
 				luminite = args.luminite,
 				luminiteTotal = args.totalluminite,
@@ -110,8 +110,8 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'requirements' then
 		return {
-			Cell{name = 'Tech. Requirements', content = caller:_csvToPageList(args.tech_requirement)},
-			Cell{name = 'Building Requirements', content = caller:_csvToPageList(args.building_requirement)},
+			Cell{name = 'Tech. Requirements', children = caller:_csvToPageList(args.tech_requirement)},
+			Cell{name = 'Building Requirements', children = caller:_csvToPageList(args.building_requirement)},
 		}
 	elseif id == 'hotkey' then
 		if not args.hotkey and not args.macro_key then return {} end
@@ -122,21 +122,21 @@ function CustomInjector:parse(id, widgets)
 			args.hotkey and CustomBuilding._hotkeys(args.hotkey, args.hotkey2),
 			args.macro_key and CustomBuilding._hotkeys(args.macro_key, args.macro_key2)
 		), HOTKEY_SEPERATOR)
-		return {Cell{name = hotkeyName, content = {hotkeys}}}
+		return {Cell{name = hotkeyName, children = {hotkeys}}}
 	elseif id == 'builds' then
 		return {
-			Cell{name = 'Builds', content = caller:_getBuildsOrUnlocksDisplay(args.builds)},
+			Cell{name = 'Builds', children = caller:_getBuildsOrUnlocksDisplay(args.builds)},
 		}
 	elseif id == 'unlocks' then
 		return {
-			Cell{name = 'Unlocks', content = caller:_getBuildsOrUnlocksDisplay(args.unlocks)},
-			Cell{name = 'Supply Gained', content = Array.parseCommaSeparatedString(args.supply_gained)},
-			Cell{name = 'Power Gained', content = Array.parseCommaSeparatedString(args.power_gained)},
+			Cell{name = 'Unlocks', children = caller:_getBuildsOrUnlocksDisplay(args.unlocks)},
+			Cell{name = 'Supply Gained', children = Array.parseCommaSeparatedString(args.supply_gained)},
+			Cell{name = 'Power Gained', children = Array.parseCommaSeparatedString(args.power_gained)},
 		}
 	elseif id == 'defense' then
 		return {
-			Cell{name = 'Defense', content = {caller:_getDefenseDisplay()}},
-			Cell{name = 'Attributes', content = {caller:_displayCsvAsPageCsv(args.armor_type)}}
+			Cell{name = 'Defense', children = {caller:_getDefenseDisplay()}},
+			Cell{name = 'Attributes', children = {caller:_displayCsvAsPageCsv(args.armor_type)}}
 		}
 	elseif id == 'attack' then return {}
 	end
@@ -386,12 +386,12 @@ function CustomBuilding:_parseForCreeps(id, widgets)
 	if id ~= 'custom' then return {} end
 
 	return {
-		Cell{name = 'Start Level', content = {startLevel}},
-		Cell{name = 'Defenders', content = {self._displayCreepDefenders(creeps)}},
-		Cell{name = 'Respawn', content = {args.respawn and args.respawn .. 's'}},
+		Cell{name = 'Start Level', children = {startLevel}},
+		Cell{name = 'Defenders', children = {self._displayCreepDefenders(creeps)}},
+		Cell{name = 'Respawn', children = {args.respawn and args.respawn .. 's'}},
 		Title{children = 'Tower Rewards'},
-		Cell{name = 'Capture Point', content = {args.capture_point}},
-		Cell{name = 'Global Buff', content = {args.global_buff}},
+		Cell{name = 'Capture Point', children = {args.capture_point}},
+		Cell{name = 'Global Buff', children = {args.global_buff}},
 	}
 end
 

--- a/lua/wikis/stormgate/Infobox/Extension/Attack.lua
+++ b/lua/wikis/stormgate/Infobox/Extension/Attack.lua
@@ -49,12 +49,12 @@ function Attack.run(argsJson, attackIndex, faction)
 
 	return {
 		Title{children = 'Attack' .. attackIndex .. ': ' .. args.name},
-		Cell{name = 'Target', content = {Attack._displayArray(data.targets)}},
-		Cell{name = 'Damage', content = {Attack._displayDamage(data)}},
-		Cell{name = 'Effect', content = {Attack._displayArray(data.effect)}},
-		Cell{name = 'Attack Speed', content = {data.speed}},
-		Cell{name = 'DPS', content = {Attack._displayDPS(data)}},
-		Cell{name = 'Range', content = {data.range}},
+		Cell{name = 'Target', children = {Attack._displayArray(data.targets)}},
+		Cell{name = 'Damage', children = {Attack._displayDamage(data)}},
+		Cell{name = 'Effect', children = {Attack._displayArray(data.effect)}},
+		Cell{name = 'Attack Speed', children = {data.speed}},
+		Cell{name = 'DPS', children = {Attack._displayDPS(data)}},
+		Cell{name = 'Range', children = {data.range}},
 	}
 end
 

--- a/lua/wikis/stormgate/Infobox/Item/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Item/Custom.lua
@@ -65,14 +65,14 @@ function CustomInjector:parse(id, widgets)
 	if id == 'info' then
 		return {
 			Title{children = args.informationType .. ' Information'},
-			Cell{name = 'Slot', content = {tonumber(args.slot)}},
-			Cell{name = 'Introduced', content = {caller.data.introduced.display}}
+			Cell{name = 'Slot', children = {tonumber(args.slot)}},
+			Cell{name = 'Introduced', children = {caller.data.introduced.display}}
 		}
 	elseif id == 'availability' then
 		return {
 			Title{children = 'Availability'},
-			Cell{name = 'Faction', content = {CustomItem._getFactionsDisplay(args.faction)}},
-			Cell{name = 'Unlocked', content = {CustomItem._getUnlockedDisplay(args.unlocked)}},
+			Cell{name = 'Faction', children = {CustomItem._getFactionsDisplay(args.faction)}},
+			Cell{name = 'Unlocked', children = {CustomItem._getUnlockedDisplay(args.unlocked)}},
 		}
 	elseif id == 'recipe' then
 		return {

--- a/lua/wikis/stormgate/Infobox/League/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/League/Custom.lua
@@ -100,12 +100,12 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'gamesettings' then
-		table.insert(widgets, Cell{name = 'Game Version', content = {self.caller:_getGameVersion()}})
+		table.insert(widgets, Cell{name = 'Game Version', children = {self.caller:_getGameVersion()}})
 	elseif id == 'customcontent' then
 		if args.player_number and args.player_number > 0 then
 			Array.appendWith(widgets,
 				Title{children = 'Player Breakdown'},
-				Cell{name = 'Number of Players', content = {args.raceBreakDown.total}},
+				Cell{name = 'Number of Players', children = {args.raceBreakDown.total}},
 				Breakdown{children = args.raceBreakDown.display, classes = { 'infobox-center' }}
 			)
 		end
@@ -114,7 +114,7 @@ function CustomInjector:parse(id, widgets)
 		if Logic.isNumeric(args.team_number) and tonumber(args.team_number) > 0 then
 			Array.appendWith(widgets,
 				Title{children = 'Teams'},
-				Cell{name = 'Number of Teams', content = {args.team_number}}
+				Cell{name = 'Number of Teams', children = {args.team_number}}
 			)
 		end
 

--- a/lua/wikis/stormgate/Infobox/Map/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Map/Custom.lua
@@ -123,13 +123,13 @@ function CustomInjector:parse(id, widgets)
 		return Array.extend(
 			widgets,
 			{
-				Cell{name = typeName, content = self.caller:_displayTypes(args.types)},
-				Cell{name = 'Tileset', content = {args.tileset}},
-				Cell{name = 'Size', content = {self.caller:_getSizeDisplay(args)}},
-				Cell{name = 'Spawn Positions', content = {self.caller:_getSpawnDisplay(args)}},
-				Cell{name = 'Versions', content = {args.versions}},
-				Cell{name = 'Rush distance', content = {args.rushDistance and (args.rushDistance .. ' seconds') or nil}},
-				Cell{name = 'Available Resources', content = {self.caller:_resourcesDisplay(args)}},
+				Cell{name = typeName, children = self.caller:_displayTypes(args.types)},
+				Cell{name = 'Tileset', children = {args.tileset}},
+				Cell{name = 'Size', children = {self.caller:_getSizeDisplay(args)}},
+				Cell{name = 'Spawn Positions', children = {self.caller:_getSpawnDisplay(args)}},
+				Cell{name = 'Versions', children = {args.versions}},
+				Cell{name = 'Rush distance', children = {args.rushDistance and (args.rushDistance .. ' seconds') or nil}},
+				Cell{name = 'Available Resources', children = {self.caller:_resourcesDisplay(args)}},
 			},
 			self.caller:_addCellsFromDataTable(args, LADDER_HISTORY),
 			{hasCampData and Title{children = 'Camp Information'} or nil},
@@ -145,7 +145,7 @@ end
 ---@return Widget[]
 function CustomMap:_addCellsFromDataTable(args, tbl)
 	return Array.map(tbl, function(data)
-		return Cell{name = data.name, content = {args[data.key]}}
+		return Cell{name = data.name, children = {args[data.key]}}
 	end)
 end
 

--- a/lua/wikis/stormgate/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Person/Player/Custom.lua
@@ -60,21 +60,21 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Approx. Winnings ' .. CURRENT_YEAR,
-				content = {currentYearEarnings > 0 and ('$' .. mw.getContentLanguage():formatNum(currentYearEarnings)) or nil}
+				children = {currentYearEarnings > 0 and ('$' .. mw.getContentLanguage():formatNum(currentYearEarnings)) or nil}
 			},
 			Cell{
 				name = Abbreviation.make{text = 'Years Active', title = 'Years active as a player'},
-				content = {YearsActive.display({player = caller.pagename})
+				children = {YearsActive.display({player = caller.pagename})
 			}
 			},
 			Cell{
 				name = Abbreviation.make{text = 'Years Active (caster)', title = 'Years active as a caster'},
-				content = {caller:_getActiveCasterYears()}
+				children = {caller:_getActiveCasterYears()}
 			},
 		}
 	elseif id == 'status' then
 		return {
-			Cell{name = 'Faction', content = {caller:getFactionData(args.faction or 'unknown')}}
+			Cell{name = 'Faction', children = {caller:getFactionData(args.faction or 'unknown')}}
 		}
 	elseif id == 'role' then return {}
 	elseif id == 'region' then return {}
@@ -92,7 +92,7 @@ function CustomInjector:parse(id, widgets)
 			Center{children = {achievements}},
 		}
 	elseif id == 'history' and string.match(args.retired or '', '%d%d%d%d') then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	end
 
 	return widgets

--- a/lua/wikis/stormgate/Infobox/Skill/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Skill/Custom.lua
@@ -87,21 +87,21 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'caster' then
 		return {
-			Cell{name = 'Caster(s)', content = caller:_castersDisplay()},
+			Cell{name = 'Caster(s)', children = caller:_castersDisplay()},
 		}
 	elseif id == 'cost' then
 		return {
-			Cell{name = 'Cost', content = {caller:_costDisplay()}},
-			Cell{name = 'Recharge Time', content = {args.charge_time and (args.charge_time .. 's') or nil}},
+			Cell{name = 'Cost', children = {caller:_costDisplay()}},
+			Cell{name = 'Recharge Time', children = {args.charge_time and (args.charge_time .. 's') or nil}},
 		}
 	elseif id == 'duration' then
 		return {
-			Cell{name = 'Duration', content = {args.duration and (args.duration .. 's') or nil}},
+			Cell{name = 'Duration', children = {args.duration and (args.duration .. 's') or nil}},
 		}
 	elseif id == 'hotkey' then
 		return {
-			Cell{name = 'Hotkeys', content = {CustomSkill._hotkeys(args.hotkey, args.hotkey2)}},
-			Cell{name = 'Macrokeys', content = {CustomSkill._hotkeys(args.macro_key, args.macro_key2)}},
+			Cell{name = 'Hotkeys', children = {CustomSkill._hotkeys(args.hotkey, args.hotkey2)}},
+			Cell{name = 'Macrokeys', children = {CustomSkill._hotkeys(args.macro_key, args.macro_key2)}},
 		}
 	elseif id == 'custom' then
 		local castingTime = tonumber(args.casting_time)
@@ -120,18 +120,18 @@ function CustomInjector:parse(id, widgets)
 		end
 
 		Array.extendWith(widgets, {
-				Cell{name = 'Researched From', content = {Page.makeInternalLink({}, args.from)}},
-				Cell{name = 'Upgrade Target', content = makeArrayLinks(Array.parseCommaSeparatedString(args.upgrade_target))},
-				Cell{name = 'Tech. Requirements', content = makeArrayLinks(Array.parseCommaSeparatedString(args.tech_requirement))},
+				Cell{name = 'Researched From', children = {Page.makeInternalLink({}, args.from)}},
+				Cell{name = 'Upgrade Target', children = makeArrayLinks(Array.parseCommaSeparatedString(args.upgrade_target))},
+				Cell{name = 'Tech. Requirements', children = makeArrayLinks(Array.parseCommaSeparatedString(args.tech_requirement))},
 				Cell{name = 'Building Requirements',
-					content = makeArrayLinks(Array.parseCommaSeparatedString(args.building_requirement))},
-				Cell{name = 'Unlocks', content = makeArrayLinks(Array.parseCommaSeparatedString(args.unlocks))},
-				Cell{name = 'Target', content = makeArrayLinks(Array.parseCommaSeparatedString(args.target))},
-				Cell{name = 'Casting Time', content = {castingTime and (castingTime .. 's') or nil}},
-				Cell{name = 'Effect', content = makeArrayLinks(Array.parseCommaSeparatedString(args.effect), ' %(effect%)$')},
-				Cell{name = 'Trigger', content = {args.trigger}},
-				Cell{name = 'Invulnerable', content = makeArrayLinks(Array.parseCommaSeparatedString(args.invulnerable))},
-				Cell{name = 'Introduced', content = {args.introducedDisplay}}
+					children = makeArrayLinks(Array.parseCommaSeparatedString(args.building_requirement))},
+				Cell{name = 'Unlocks', children = makeArrayLinks(Array.parseCommaSeparatedString(args.unlocks))},
+				Cell{name = 'Target', children = makeArrayLinks(Array.parseCommaSeparatedString(args.target))},
+				Cell{name = 'Casting Time', children = {castingTime and (castingTime .. 's') or nil}},
+				Cell{name = 'Effect', children = makeArrayLinks(Array.parseCommaSeparatedString(args.effect), ' %(effect%)$')},
+				Cell{name = 'Trigger', children = {args.trigger}},
+				Cell{name = 'Invulnerable', children = makeArrayLinks(Array.parseCommaSeparatedString(args.invulnerable))},
+				Cell{name = 'Introduced', children = {args.introducedDisplay}}
 			},
 			caller:_damageHealDisplay('damage'),
 			caller:_damageHealDisplay('heal')
@@ -228,9 +228,9 @@ function CustomSkill:_damageHealDisplay(prefix)
 
 	local textPrefix = mw.getContentLanguage():ucfirst(prefix)
 	return {
-		Cell{name = textPrefix, content = {valueText}},
-		Cell{name = 'Total ' .. textPrefix, content = {total ~= 0 and total or nil}},
-		Cell{name = textPrefix .. ' per second', content = {dps ~= 0 and dps ~= overTime and dps or nil}},
+		Cell{name = textPrefix, children = {valueText}},
+		Cell{name = 'Total ' .. textPrefix, children = {total ~= 0 and total or nil}},
+		Cell{name = textPrefix .. ' per second', children = {dps ~= 0 and dps ~= overTime and dps or nil}},
 	}
 end
 

--- a/lua/wikis/stormgate/Infobox/Skill/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Skill/Custom.lua
@@ -122,7 +122,10 @@ function CustomInjector:parse(id, widgets)
 		Array.extendWith(widgets, {
 				Cell{name = 'Researched From', children = {Page.makeInternalLink({}, args.from)}},
 				Cell{name = 'Upgrade Target', children = makeArrayLinks(Array.parseCommaSeparatedString(args.upgrade_target))},
-				Cell{name = 'Tech. Requirements', children = makeArrayLinks(Array.parseCommaSeparatedString(args.tech_requirement))},
+				Cell{
+					name = 'Tech. Requirements',
+					children = makeArrayLinks(Array.parseCommaSeparatedString(args.tech_requirement))
+				},
 				Cell{name = 'Building Requirements',
 					children = makeArrayLinks(Array.parseCommaSeparatedString(args.building_requirement))},
 				Cell{name = 'Unlocks', children = makeArrayLinks(Array.parseCommaSeparatedString(args.unlocks))},

--- a/lua/wikis/stormgate/Infobox/Team/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Team/Custom.lua
@@ -59,7 +59,7 @@ function CustomInjector:parse(id, widgets)
 		if raceBreakdown then
 			Array.appendWith(widgets,
 				Title{children = 'Player Breakdown'},
-				Cell{name = 'Number of Players', content = {raceBreakdown.total}},
+				Cell{name = 'Number of Players', children = {raceBreakdown.total}},
 				Breakdown{children = raceBreakdown.display, classes = { 'infobox-center' }}
 			)
 		end

--- a/lua/wikis/stormgate/Infobox/Unit/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Unit/Custom.lua
@@ -74,20 +74,20 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'type' then
 		return {
-			Cell{name = 'Type', content = {caller:_displayCsvAsPageCsv(args.type)}},
+			Cell{name = 'Type', children = {caller:_displayCsvAsPageCsv(args.type)}},
 		}
 	elseif id == 'builtfrom' then
 		return {
-			Cell{name = 'Built From', content = caller:_csvToPageList(args.built)},
+			Cell{name = 'Built From', children = caller:_csvToPageList(args.built)},
 		}
 	elseif id == 'requirements' then
 		return {
-			Cell{name = 'Tech. Requirement', content = {caller:_displayCsvAsPageCsv(args.tech_requirement)}},
-			Cell{name = 'Building Requirement', content = {caller:_displayCsvAsPageCsv(args.building_requirement)}},
+			Cell{name = 'Tech. Requirement', children = {caller:_displayCsvAsPageCsv(args.tech_requirement)}},
+			Cell{name = 'Building Requirement', children = {caller:_displayCsvAsPageCsv(args.building_requirement)}},
 		}
 	elseif id == 'cost' then
 		return {
-			Cell{name = 'Cost', content = {args.informationType ~= 'Hero' and CostDisplay.run{
+			Cell{name = 'Cost', children = {args.informationType ~= 'Hero' and CostDisplay.run{
 				faction = caller.faction,
 				luminite = args.luminite,
 				luminiteTotal = args.totalluminite,
@@ -103,7 +103,7 @@ function CustomInjector:parse(id, widgets)
 				animus = args.animus,
 				animusTotal = args.totalanimus,
 			} or nil}},
-			Cell{name = 'Recharge Time', content = {args.charge_time and (args.charge_time .. 's') or nil}},
+			Cell{name = 'Recharge Time', children = {args.charge_time and (args.charge_time .. 's') or nil}},
 		}
 	elseif id == 'hotkey' then
 		if not args.hotkey and not args.macro_key then return {} end
@@ -114,20 +114,20 @@ function CustomInjector:parse(id, widgets)
 			args.hotkey and CustomUnit._hotkeys(args.hotkey, args.hotkey2),
 			args.macro_key and CustomUnit._hotkeys(args.macro_key, args.macro_key2)
 		), HOTKEY_SEPERATOR)
-		return {Cell{name = hotkeyName, content = {hotkeys}}}
+		return {Cell{name = hotkeyName, children = {hotkeys}}}
 	elseif id == 'attack' then return {}
 	elseif id == 'defense' then
 		return {
-			Cell{name = 'Defense', content = {caller:_getDefenseDisplay()}},
-			Cell{name = 'Attributes', content = {caller:_displayCsvAsPageCsv(args.armor_type)}}
+			Cell{name = 'Defense', children = {caller:_getDefenseDisplay()}},
+			Cell{name = 'Attributes', children = {caller:_displayCsvAsPageCsv(args.armor_type)}}
 		}
 	elseif id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Energy', content = {caller:_energyDisplay()}},
-			Cell{name = 'Speed', content = {args.speed}},
-			Cell{name = 'Sight', content = {args.sight}},
-			Cell{name = 'Upgrades To', content = {caller:_displayCsvAsPageCsv(args.upgrades_to)}},
-			Cell{name = 'Introduced', content = {args.introducedDisplay}}
+			Cell{name = 'Energy', children = {caller:_energyDisplay()}},
+			Cell{name = 'Speed', children = {args.speed}},
+			Cell{name = 'Sight', children = {args.sight}},
+			Cell{name = 'Upgrades To', children = {caller:_displayCsvAsPageCsv(args.upgrades_to)}},
+			Cell{name = 'Introduced', children = {args.introducedDisplay}}
 		)
 		-- moved to the bottom due to having headers that would look ugly if in place where attack is set in commons
 		for _, attackArgs, attackIndex in Table.iter.pairsByPrefix(args, 'attack') do

--- a/lua/wikis/teamfortress/Infobox/Character/Custom.lua
+++ b/lua/wikis/teamfortress/Infobox/Character/Custom.lua
@@ -39,11 +39,11 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'country' then
-		return Cell{name = 'Origin', content = {args.origin}}
+		return Cell{name = 'Origin', children = {args.origin}}
 	elseif id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Voiced by', content = {args.voice}},
-			Cell{name = 'Health', content = {args.hp}}
+			Cell{name = 'Voiced by', children = {args.voice}},
+			Cell{name = 'Health', children = {args.hp}}
 		)
 	end
 

--- a/lua/wikis/teamfortress/Infobox/Company/Custom.lua
+++ b/lua/wikis/teamfortress/Infobox/Company/Custom.lua
@@ -34,9 +34,9 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'parent' then
-		table.insert(widgets, Cell{name = 'Focus', content = {args.focus}})
+		table.insert(widgets, Cell{name = 'Focus', children = {args.focus}})
 	elseif id == 'employees' then
-		table.insert(widgets, Cell{name = 'Key People', content = {args.people}})
+		table.insert(widgets, Cell{name = 'Key People', children = {args.people}})
 	end
 
 	return widgets

--- a/lua/wikis/teamfortress/Infobox/League/Custom.lua
+++ b/lua/wikis/teamfortress/Infobox/League/Custom.lua
@@ -49,7 +49,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'custom' then
-		table.insert(widgets, Cell{name = 'Mode', content = {args.mode}})
+		table.insert(widgets, Cell{name = 'Mode', children = {args.mode}})
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.map1) then
 			local maps = {}

--- a/lua/wikis/teamfortress/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/teamfortress/Infobox/Person/Player/Custom.lua
@@ -37,7 +37,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'role' then
 		if not args.role then return widgets end
 		return {
-			Cell{name = 'Main', content = {Template.safeExpand(mw.getCurrentFrame(), 'Class/'.. args.role)}}
+			Cell{name = 'Main', children = {Template.safeExpand(mw.getCurrentFrame(), 'Class/'.. args.role)}}
 		}
 	end
 	return widgets

--- a/lua/wikis/tetris/Infobox/League/Custom.lua
+++ b/lua/wikis/tetris/Infobox/League/Custom.lua
@@ -51,12 +51,12 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Teams', content = {args.team_number}},
-			Cell{name = 'Players', content = {args.player_number}}
+			Cell{name = 'Teams', children = {args.team_number}},
+			Cell{name = 'Players', children = {args.player_number}}
 		)
 	elseif id == 'gamesettings' then
 		return {
-			Cell{name = 'Game version', content = {Game.name{game = args.game}}},
+			Cell{name = 'Game version', children = {Game.name{game = args.game}}},
 		}
 	end
 	return widgets

--- a/lua/wikis/tft/Infobox/League/Custom.lua
+++ b/lua/wikis/tft/Infobox/League/Custom.lua
@@ -50,14 +50,14 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Teams', content = {args.team_number}},
-			Cell{name = 'Players', content = {args.participants_number}}
+			Cell{name = 'Teams', children = {args.team_number}},
+			Cell{name = 'Players', children = {args.participants_number}}
 		)
 	elseif id == 'gamesettings' then
 		Array.appendWith(widgets,
-			Cell{name = 'Game', content = {Game.name{game = args.game}}},
-			Cell{name = 'Patch', content = {self.caller:_createPatchCell(args)}},
-			Cell{name = 'Game Mode', content = {args.mode}}
+			Cell{name = 'Game', children = {Game.name{game = args.game}}},
+			Cell{name = 'Patch', children = {self.caller:_createPatchCell(args)}},
+			Cell{name = 'Game Mode', children = {args.mode}}
 		)
 	end
 

--- a/lua/wikis/tft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/tft/Infobox/Person/Player/Custom.lua
@@ -38,7 +38,7 @@ function CustomInjector:parse(id, widgets)
 	local args = caller.args
 
 	if id == 'history' then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	end
 	return widgets
 end

--- a/lua/wikis/trackmania/Infobox/League/Custom.lua
+++ b/lua/wikis/trackmania/Infobox/League/Custom.lua
@@ -51,13 +51,13 @@ function CustomInjector:parse(id, widgets)
 		local partners = self.caller:getAllArgsForBase(args, 'partner')
 		table.insert(widgets, Cell{
 			name = 'Partner' .. (#partners > 1 and 's' or ''),
-			content = Array.map(partners, Page.makeInternalLink)
+			children = Array.map(partners, Page.makeInternalLink)
 		})
 	elseif id == 'gamesettings' then
 		local games = self.caller:getAllArgsForBase(args, 'game')
 		table.insert(widgets, Cell{
 			name = 'Game' .. (#games > 1 and 's' or ''),
-			content = Array.map(games,
+			children = Array.map(games,
 					function(game)
 						local info = Game.raw{game = game}
 						if not info then
@@ -70,11 +70,11 @@ function CustomInjector:parse(id, widgets)
 		table.insert(widgets, Title{children = String.isNotEmpty(args.team_number) and 'Teams' or 'Players'})
 		table.insert(widgets, Cell{
 			name = 'Number of Teams',
-			content = {args.team_number}
+			children = {args.team_number}
 		})
 		table.insert(widgets, Cell{
 			name = 'Number of Players',
-			content = {args.player_number}
+			children = {args.player_number}
 		})
 
 		local maps = self.caller:getAllArgsForBase(args, 'map')
@@ -157,10 +157,10 @@ function CustomLeague:_createCircuitInformation(widgets)
 	Array.appendWith(widgets,
 		Cell{
 			name = 'Circuit',
-			content = {self:_createCircuitLink()}
+			children = {self:_createCircuitLink()}
 		},
-		Cell{name = 'Circuit Tier', content = {args.circuittier}},
-		Cell{name = 'Tournament Region', content = {args.region}},
+		Cell{name = 'Circuit Tier', children = {args.circuittier}},
+		Cell{name = 'Tournament Region', children = {args.region}},
 		Chronology{args = {next = args.circuit_next, previous = args.circuit_previous}, showTitle = false}
 	)
 end

--- a/lua/wikis/trackmania/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/trackmania/Infobox/Person/Player/Custom.lua
@@ -36,7 +36,7 @@ end
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
 	if id == 'status' then
-		table.insert(widgets, Cell{name = 'Years Active (Player)', content = {self.caller.args.years_active}})
+		table.insert(widgets, Cell{name = 'Years Active (Player)', children = {self.caller.args.years_active}})
 	end
 
 	return widgets

--- a/lua/wikis/underlords/Infobox/Character/Custom.lua
+++ b/lua/wikis/underlords/Infobox/Character/Custom.lua
@@ -92,7 +92,7 @@ function CustomInjector:parse(id, widgets)
 		end
 
 		Array.appendWith(widgets,
-			Cell{name = 'Tier', content = {args.tier}},
+			Cell{name = 'Tier', children = {args.tier}},
 			Title{children = 'Alliances'},
 			Center{children = Array.interleave(Array.map(self.caller.alliances, allianceIcon), '&nbsp;')},
 			Title{children = 'Level Changes'},
@@ -128,6 +128,7 @@ end
 
 ---@param lpdbData table
 ---@param args table
+---@return table
 function CustomCharacter:addToLpdb(lpdbData, args)
 	local extradata = lpdbData.extradata
 	extradata.name = lpdbData.name

--- a/lua/wikis/valorant/Infobox/Character/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Character/Custom.lua
@@ -46,13 +46,13 @@ function CustomInjector:parse(id, widgets)
 					return {
 						Cell{
 							name = 'Abilities',
-							content = abilities,
+							children = abilities,
 						}
 					}
 				end
 			},
-			Cell{name = 'Signature Ability', content = {args.signature}},
-			Cell{name = 'Ultimate', content = {args.ultimate}}
+			Cell{name = 'Signature Ability', children = {args.signature}},
+			Cell{name = 'Ultimate', children = {args.ultimate}}
 		)
 	end
 

--- a/lua/wikis/valorant/Infobox/League/Custom.lua
+++ b/lua/wikis/valorant/Infobox/League/Custom.lua
@@ -66,8 +66,8 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Teams', content = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
-			Cell{name = 'Players', content = {args.player_number}}
+			Cell{name = 'Teams', children = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
+			Cell{name = 'Players', children = {args.player_number}}
 		)
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.map1) then
@@ -86,7 +86,7 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'gamesettings' then
 		table.insert(widgets, Cell{
 			name = 'Patch',
-			content = {self.caller:_createPatchCell(args)}
+			children = {self.caller:_createPatchCell(args)}
 		})
 	end
 

--- a/lua/wikis/valorant/Infobox/Map/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Map/Custom.lua
@@ -42,7 +42,7 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Location',
-				content = {
+				children = {
 					args.country and (Flags.Icon{flag = args.country, shouldLink = false} .. '&nbsp;' .. args.country)
 					or nil
 				},
@@ -51,9 +51,9 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'custom' then
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Bomb Sites', content = {args.bombsites}},
-			Cell{name = 'Teleporters', content = {args.teleporters}},
-			Cell{name = 'Game Mode', content = self.caller:getGameModes(args)}
+			Cell{name = 'Bomb Sites', children = {args.bombsites}},
+			Cell{name = 'Teleporters', children = {args.teleporters}},
+			Cell{name = 'Game Mode', children = self.caller:getGameModes(args)}
 		)
 	end
 	return widgets

--- a/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
@@ -91,21 +91,21 @@ function CustomInjector:parse(id, widgets)
 			return CharacterIcon.Icon{character = agent, size = SIZE_AGENT}
 		end)
 		return {
-			Cell{name = 'Signature Agent' .. (#icons > 1 and 's' or ''), content = {table.concat(icons, '&nbsp;')}}
+			Cell{name = 'Signature Agent' .. (#icons > 1 and 's' or ''), children = {table.concat(icons, '&nbsp;')}}
 		}
 	elseif id == 'status' then
 		Array.appendWith(widgets,
-			Cell{name = 'Years Active (Player)', content = {args.years_active}},
+			Cell{name = 'Years Active (Player)', children = {args.years_active}},
 			Cell{
 				name = 'Years Active (' .. Abbreviation.make{text = 'Org', title = 'Organisation'} .. ')',
-				content = {args.years_active_org}
+				children = {args.years_active_org}
 			},
-			Cell{name = 'Years Active (Coach)', content = {args.years_active_coach}},
-			Cell{name = 'Years Active (Talent)', content = {args.years_active_talent}}
+			Cell{name = 'Years Active (Coach)', children = {args.years_active_coach}},
+			Cell{name = 'Years Active (Talent)', children = {args.years_active_talent}}
 		)
 
 	elseif id == 'history' then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	elseif id == 'region' then
 		return {}
 	end

--- a/lua/wikis/valorant/Infobox/Series/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Series/Custom.lua
@@ -50,7 +50,7 @@ function CustomInjector:parse(id, widgets)
 			end
 			table.insert(locations, text)
 		end
-		return { Cell{name = 'Location', content = locations} }
+		return { Cell{name = 'Location', children = locations} }
 	elseif id == 'customcontent' then
 		return {
 			Chronology{args = args, showTitle = true}

--- a/lua/wikis/valorant/Infobox/Team/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Team/Custom.lua
@@ -39,11 +39,11 @@ function CustomInjector:parse(id, widgets)
 	if id == 'staff' then
 		table.insert(widgets, Cell{
 			name = 'In-Game Leader',
-			content = {args.igl}
+			children = {args.igl}
 		})
 	elseif id == 'custom' then
 		return {
-			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', content = {
+			Cell{name = '[[Affiliate_Partnerships|Affiliate]]', children = {
 				args.affiliate and OpponentDisplay.InlineTeamContainer{template = args.affiliate, displayType = 'standard'} or nil}}
 		}
 	end

--- a/lua/wikis/valorant/Infobox/Weapon/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Weapon/Custom.lua
@@ -48,14 +48,14 @@ function CustomInjector:parse(id, widgets)
 			args.price and Cell{
 				name = 'Price',
 				options = { separator = ' ' },
-				content = { CREDS_ICON, args.price }
+				children = { CREDS_ICON, args.price }
 			} or nil
 		}
 	elseif id == 'damage' then
 		return {
 			Cell{
 				name = 'Damage',
-				content = self.caller:getAllArgsForBase(args, 'damage'),
+				children = self.caller:getAllArgsForBase(args, 'damage'),
 			}
 		}
 	elseif id == 'killaward' then
@@ -63,7 +63,7 @@ function CustomInjector:parse(id, widgets)
 			args.killaward and Cell{
 				name = 'Kill Award',
 				options = { separator = ' ' },
-				content = { CREDS_ICON, args.killaward }
+				children = { CREDS_ICON, args.killaward }
 			} or nil
 		}
 	elseif id == 'rateoffire' then
@@ -80,12 +80,12 @@ function CustomInjector:parse(id, widgets)
 			Cell{
 				name = 'Firerate',
 				options = { separator = ' ' },
-				content = { rateOfFire, FIRE_RATE_UNIT }
+				children = { rateOfFire, FIRE_RATE_UNIT }
 			},
 			Cell{
 				name = 'Alternate Fire rate',
 				options = { separator = ' ' },
-				content = {
+				children = {
 					args.altrateoffire,
 					args.altrateoffire and FIRE_RATE_UNIT or nil
 				}
@@ -96,11 +96,11 @@ function CustomInjector:parse(id, widgets)
 		return WidgetUtil.collect(
 			Cell{
 				name = 'Wall peneration',
-				content = { args.wallpenetration }
+				children = { args.wallpenetration }
 			},
 			Cell{
 				name = 'Movement speed',
-				content = { args.movementspeed and (args.movementspeed .. ' m/sec') or nil }
+				children = { args.movementspeed and (args.movementspeed .. ' m/sec') or nil }
 			}
 		)
 	end

--- a/lua/wikis/warcraft/Infobox/Building/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Building/Custom.lua
@@ -63,25 +63,25 @@ function CustomBuilding:addCustomCells(widgets)
 	local race = Faction.toName(Faction.read(args.race)) or ADDITIONAL_BUILDING_RACES[string.lower(args.race or '')]
 
 	Array.appendWith(widgets,
-		Cell{name = '[[Food supplied|Food]]', content = {
+		Cell{name = '[[Food supplied|Food]]', children = {
 			args.foodproduced and (ICON_FOOD .. ' ' .. args.foodproduced) or nil,
 		}},
-		Cell{name = '[[Race]]', content = {race and ('[[' .. race .. ']]') or args.race}},
-		Cell{name = '[[Targeting#Target_Classifications|Classification]]', content = {
+		Cell{name = '[[Race]]', children = {race and ('[[' .. race .. ']]') or args.race}},
+		Cell{name = '[[Targeting#Target_Classifications|Classification]]', children = {
 			args.class and String.convertWikiListToHtmlList(args.class) or nil}},
-		Cell{name = 'Sleeps', content = {args.sleeps}},
-		Cell{name = 'Cargo Capacity', content = {args.cargo_capacity}},
-		Cell{name = 'Morphs into', content = {args.morphs}},
-		Cell{name = 'Duration', content = {args.duration}},
-		Cell{name = 'Formation Rank', content = {args.formationrank}},
-		Cell{name = '[[Sight_Range|Sight]]', content = {race and (args.daysight .. ' / ' .. args.nightsight) or nil}},
-		Cell{name = 'Acquisition Range', content = {acquisitionRange > 0 and acquisitionRange or nil}},
-		Cell{name = '[[Experience#Determining_Experience_Gained|Level]]', content = {
+		Cell{name = 'Sleeps', children = {args.sleeps}},
+		Cell{name = 'Cargo Capacity', children = {args.cargo_capacity}},
+		Cell{name = 'Morphs into', children = {args.morphs}},
+		Cell{name = 'Duration', children = {args.duration}},
+		Cell{name = 'Formation Rank', children = {args.formationrank}},
+		Cell{name = '[[Sight_Range|Sight]]', children = {race and (args.daysight .. ' / ' .. args.nightsight) or nil}},
+		Cell{name = 'Acquisition Range', children = {acquisitionRange > 0 and acquisitionRange or nil}},
+		Cell{name = '[[Experience#Determining_Experience_Gained|Level]]', children = {
 			level > 0 and ('[[Experience|'..args.level..']]') or nil}},
-		Cell{name = '[[Mana]]', content = {mana.manaDisplay}},
-		Cell{name = '[[Mana|Initial Mana]]', content = {mana.initialManaDisplay}},
-		Cell{name = '[[Mana#Mana_Gain|Mana Regeneration]]', content = {mana.manaRegenDisplay}},
-		Cell{name = 'Selection Priorty', content = {args.priority}}
+		Cell{name = '[[Mana]]', children = {mana.manaDisplay}},
+		Cell{name = '[[Mana|Initial Mana]]', children = {mana.initialManaDisplay}},
+		Cell{name = '[[Mana#Mana_Gain|Mana Regeneration]]', children = {mana.manaRegenDisplay}},
+		Cell{name = 'Selection Priorty', children = {args.priority}}
 	)
 
 	local movement = Shared.movement(args, 'Uprooted Movement')
@@ -121,7 +121,7 @@ function CustomInjector:parse(id, widgets)
 		return self.caller:addCustomCells(widgets)
 	elseif id == 'cost' then
 		return {
-			Cell{name = 'Cost', content = {CostDisplay.run{
+			Cell{name = 'Cost', children = {CostDisplay.run{
 				faction = args.race,
 				gold = self.caller:_calculateCostValue('gold'),
 				lumber = self.caller:_calculateCostValue('lumber'),
@@ -130,25 +130,25 @@ function CustomInjector:parse(id, widgets)
 			}}},
 		}
 	elseif id == 'requirements' then
-		return {Cell{name = 'Requirements', content = {String.convertWikiListToHtmlList(args.requires)}}}
+		return {Cell{name = 'Requirements', children = {String.convertWikiListToHtmlList(args.requires)}}}
 	elseif id == 'builds' then
 		return {
-			Cell{name = 'Built From', content = {args.builtfrom}},
-			Cell{name = '[[Hotkeys_per_Race|Hotkey]]', content = {self.caller:_getHotkeys()}},
-			Cell{name = 'Builds', content = {String.convertWikiListToHtmlList(args.builds)}},
+			Cell{name = 'Built From', children = {args.builtfrom}},
+			Cell{name = '[[Hotkeys_per_Race|Hotkey]]', children = {self.caller:_getHotkeys()}},
+			Cell{name = 'Builds', children = {String.convertWikiListToHtmlList(args.builds)}},
 		}
 	elseif id == 'unlocks' then
 		return {
-			Cell{name = 'Unlocked Tech', content = {String.convertWikiListToHtmlList(args.unlocks)}},
-			Cell{name = 'Upgrades available', content = {String.convertWikiListToHtmlList(args.upgrades)}},
-			Cell{name = 'Upgrades to', content = {String.convertWikiListToHtmlList(args.upgradesTo)}},
+			Cell{name = 'Unlocked Tech', children = {String.convertWikiListToHtmlList(args.unlocks)}},
+			Cell{name = 'Upgrades available', children = {String.convertWikiListToHtmlList(args.upgrades)}},
+			Cell{name = 'Upgrades to', children = {String.convertWikiListToHtmlList(args.upgradesTo)}},
 		}
 	elseif id == 'defense' then
 		return {
-			Cell{name = '[[Hit Points|Hit Points]]', content = {self.caller:_defenseDisplay()}},
-			Cell{name = '[[Hit Points#Hit Points Gain|HP Regeneration]]', content = {
+			Cell{name = '[[Hit Points|Hit Points]]', children = {self.caller:_defenseDisplay()}},
+			Cell{name = '[[Hit Points#Hit Points Gain|HP Regeneration]]', children = {
 				Shared.hitPointsRegeneration(args, {display = true})}},
-			Cell{name = '[[Armor|Armor]]', content = {self.caller:_armorDisplay()}}
+			Cell{name = '[[Armor|Armor]]', children = {self.caller:_armorDisplay()}}
 		}
 	elseif id == 'attack' then return {}
 	end

--- a/lua/wikis/warcraft/Infobox/Character/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Character/Custom.lua
@@ -73,13 +73,13 @@ function CustomInjector:parse(id, widgets)
 		local levelBreakdown = function(level)
 			level = level - 1
 			return {
-				Cell{name = 'HP', content = {caller:_calculateHitPoints(level)}},
-				Cell{name = 'HP Regen.', content = {caller:_calculateHitPointsRegen(level) .. '/sec'}},
-				Cell{name = 'Mana', content = {caller:_calculateMana(level)}},
-				Cell{name = 'Mana Regen.', content = {caller:_calculateManaRegen(level) .. '/sec'}},
-				Cell{name = 'Armor', content = {Math.round(caller:_calculateArmor(level), 2)}},
-				Cell{name = 'Damage', content = {caller:_calculateDamage(level)}},
-				Cell{name = 'Attack Cooldown', content = {Math.round(caller:_calculateCooldown(level), 2)}}
+				Cell{name = 'HP', children = {caller:_calculateHitPoints(level)}},
+				Cell{name = 'HP Regen.', children = {caller:_calculateHitPointsRegen(level) .. '/sec'}},
+				Cell{name = 'Mana', children = {caller:_calculateMana(level)}},
+				Cell{name = 'Mana Regen.', children = {caller:_calculateManaRegen(level) .. '/sec'}},
+				Cell{name = 'Armor', children = {Math.round(caller:_calculateArmor(level), 2)}},
+				Cell{name = 'Damage', children = {caller:_calculateDamage(level)}},
+				Cell{name = 'Attack Cooldown', children = {Math.round(caller:_calculateCooldown(level), 2)}}
 			}
 		end
 
@@ -134,16 +134,16 @@ function CustomInjector:parse(id, widgets)
 			}, classes = {'infobox-center'}},
 
 			Title{children = 'Base Stats'},
-			Cell{name = '[[Movement Speed]]', content = {args.basespeed}},
-			Cell{name = '[[Sight Range]]', content = {args.sightrange or (
+			Cell{name = '[[Movement Speed]]', children = {args.basespeed}},
+			Cell{name = '[[Sight Range]]', children = {args.sightrange or (
 				tostring(Icon{iconName = 'day'}) .. (args.daysight or 1800) .. ' / ' ..
 				tostring(Icon{iconName = 'night'}) .. (args.nightsight or 800)
 			)}},
-			Cell{name = '[[Attack Range]]', content = {args.attackrange}},
-			Cell{name = 'Missile Speed', content = {args.missilespeed}},
-			Cell{name = 'Attack Duration', content = {args.attackduration}},
-			Cell{name = 'Base Attack Time', content = {args.attacktime}},
-			Cell{name = 'Turn Rate', content = {args.turnrate}},
+			Cell{name = '[[Attack Range]]', children = {args.attackrange}},
+			Cell{name = 'Missile Speed', children = {args.missilespeed}},
+			Cell{name = 'Attack Duration', children = {args.attackduration}},
+			Cell{name = 'Base Attack Time', children = {args.attacktime}},
+			Cell{name = 'Turn Rate', children = {args.turnrate}},
 
 			Title{children = 'Stats per Level'},
 			Slider{min = 1, max = 10, step = 1, defaultValue = 1, id = 'level', class = 'infobox-slider',

--- a/lua/wikis/warcraft/Infobox/Company/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Company/Custom.lua
@@ -35,9 +35,9 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'parent' then
-		table.insert(widgets, Cell{name = 'Focus', content = {args.focus}})
+		table.insert(widgets, Cell{name = 'Focus', children = {args.focus}})
 	elseif id == 'employees' then
-		table.insert(widgets, Cell{name = 'Key People', content = {args.people}})
+		table.insert(widgets, Cell{name = 'Key People', children = {args.people}})
 	end
 
 	return widgets

--- a/lua/wikis/warcraft/Infobox/Extension/BuildingUnitShared.lua
+++ b/lua/wikis/warcraft/Infobox/Extension/BuildingUnitShared.lua
@@ -347,11 +347,11 @@ function CustomBuildingUnit.mercenaryStats(args)
 
 	return {
 		Title{children = 'Mercenary Stats'},
-		Cell{name = 'Stock Maximum', content = {args.stock}},
-		Cell{name = 'Stock Start Delay', content = {Abbreviation.make{
+		Cell{name = 'Stock Maximum', children = {args.stock}},
+		Cell{name = 'Stock Start Delay', children = {Abbreviation.make{
 			text = args.stockstart .. 's', title = 'First available at ' .. GameClock.run(args.stockstart)}}},
-		Cell{name = 'Replenish Interval', content = {args.stockreplenish}},
-		Cell{name = 'Tileset', content = {args.merctileset, args.merctileset2, args.merctileset3}},
+		Cell{name = 'Replenish Interval', children = {args.stockreplenish}},
+		Cell{name = 'Tileset', children = {args.merctileset, args.merctileset2, args.merctileset3}},
 	}
 end
 
@@ -367,11 +367,11 @@ function CustomBuildingUnit.movement(args, title)
 
 	return {
 		Title{children = title},
-		Cell{name = '[[Movement Speed|Speed]]', content = {speed}},
-		Cell{name = 'Turn Rate', content = {args.turnrate}},
-		Cell{name = 'Move Type', content = {args.movetype}},
-		Cell{name = 'Collision Size', content = {args.collision}},
-		Cell{name = 'Cargo Size', content = {args.cargo_size}},
+		Cell{name = '[[Movement Speed|Speed]]', children = {speed}},
+		Cell{name = 'Turn Rate', children = {args.turnrate}},
+		Cell{name = 'Move Type', children = {args.movetype}},
+		Cell{name = 'Collision Size', children = {args.collision}},
+		Cell{name = 'Cargo Size', children = {args.cargo_size}},
 	}
 end
 

--- a/lua/wikis/warcraft/Infobox/Item/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Item/Custom.lua
@@ -102,40 +102,40 @@ function CustomInjector:parse(id, widgets)
 	elseif id == 'info' then
 		return {
 			Title{children = 'Item Information'},
-			Cell{name = 'Level', content = {args.level}},
-			Cell{name = 'Class', content = {CLASSES[(args.class or ''):lower()] or args.class}},
-			Cell{name = 'Charges', content = {args.charges}},
+			Cell{name = 'Level', children = {args.level}},
+			Cell{name = 'Class', children = {CLASSES[(args.class or ''):lower()] or args.class}},
+			Cell{name = 'Charges', children = {args.charges}},
 		}
 	elseif id == 'availability' then
 		return Array.append(widgets,
 			Title{children = 'Availability'},
-			Cell{name = 'Sold From', content = Array.map(args.soldFrom, function(soldFrom)
+			Cell{name = 'Sold From', children = Array.map(args.soldFrom, function(soldFrom)
 				return '[[' .. soldFrom.link .. '|' .. soldFrom.name .. ']]' end)},
-			Cell{name = 'Requirements', content = {args.requires}},
-			Cell{name = 'Cost', content = {CostDisplay.run{gold = args.gold, lumber = args.lumber}}},
-			Cell{name = 'Sell value', content = {CostDisplay.run{
+			Cell{name = 'Requirements', children = {args.requires}},
+			Cell{name = 'Cost', children = {CostDisplay.run{gold = args.gold, lumber = args.lumber}}},
+			Cell{name = 'Sell value', children = {CostDisplay.run{
 				gold = SELL_FACTOR * (tonumber(args.gold) or 0),
 				lumber = SELL_FACTOR * (tonumber(args.lumber) or 0)
 			}}},
-			Cell{name = 'Purchase Hotkey', content = {args.hotkey and Hotkey.hotkey{hotkey = args.hotkey} or nil}},
-			Cell{name = 'Stock Max', content = {args.stock}},
-			Cell{name = 'Stock Start Delay', content = {args.stockstart and (
+			Cell{name = 'Purchase Hotkey', children = {args.hotkey and Hotkey.hotkey{hotkey = args.hotkey} or nil}},
+			Cell{name = 'Stock Max', children = {args.stock}},
+			Cell{name = 'Stock Start Delay', children = {args.stockstart and (
 				Abbreviation.make{text = args.stockstart .. 's', title = 'First available at ' .. GameClock.run(args.stockstart)}
 			) or nil}},
 			Cell{
 				name = Abbreviation.make{text = 'Stock Repl. Interval',title = 'Stock Replenish Interval'},
-				content = {args.stockreplenish}
+				children = {args.stockreplenish}
 			}
 		)
 	elseif id == 'ability' then
 		return Array.append(widgets,
 			Title{children = 'Ability'},
-			Cell{name = 'Cast Time', content = {args.cast}},
-			Cell{name = 'Cooldown', content = {args.cooldown}},
-			Cell{name = 'Cooldown Group', content = {args.cooldown and (args.coolgroup or
+			Cell{name = 'Cast Time', children = {args.cast}},
+			Cell{name = 'Cooldown', children = {args.cooldown}},
+			Cell{name = 'Cooldown Group', children = {args.cooldown and (args.coolgroup or
 				Abbreviation.make{text = 'Custom', title = 'This item has its own cooldown group.'}
 			) or nil}},
-			Cell{name = 'Duration', content = {args.duration}}
+			Cell{name = 'Duration', children = {args.duration}}
 		)
 	end
 

--- a/lua/wikis/warcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/League/Custom.lua
@@ -244,27 +244,27 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'gamesettings' then
 		return {
-			Cell{name = 'Game', content = {Game.text{game = caller.data.game}}},
-			Cell{name = 'Game Version', content = {
+			Cell{name = 'Game', children = {Game.text{game = caller.data.game}}},
+			Cell{name = 'Game Version', children = {
 				caller:_displayGameVersion(),
 				args.patch2 and ('[[' .. args.patch2 .. ']]') or nil
 			}},
-			Cell{name = 'Server', content = caller:_getServers(args)}
+			Cell{name = 'Server', children = caller:_getServers(args)}
 			}
 	elseif id == 'liquipediatier' then
 		table.insert(widgets, Cell{
 			name = ESL_ICON .. 'Pro Tour Tier',
-			content = {ESL_TIERS[caller.data.publishertier]}
+			children = {ESL_TIERS[caller.data.publishertier]}
 		})
 	elseif id == 'dates' then
 		if args.starttime then
 			local dateCells = {}
 			if args.sdate then
-				table.insert(dateCells, Cell{name = 'Start Date', content = {caller:_displayStartDateTime()}})
+				table.insert(dateCells, Cell{name = 'Start Date', children = {caller:_displayStartDateTime()}})
 			elseif args.date then
-				table.insert(dateCells, Cell{name = 'Date', content = {caller:_displayStartDateTime()}})
+				table.insert(dateCells, Cell{name = 'Date', children = {caller:_displayStartDateTime()}})
 			end
-			table.insert(dateCells, Cell{name = 'End Date', content = {args.edate}})
+			table.insert(dateCells, Cell{name = 'End Date', children = {args.edate}})
 			return dateCells
 		end
 	elseif id == 'customcontent' then
@@ -275,14 +275,14 @@ function CustomInjector:parse(id, widgets)
 
 		if playerNumber then
 			Array.appendWith(widgets,
-				Cell{name = 'Number of Players', content = {playerNumber}},
+				Cell{name = 'Number of Players', children = {playerNumber}},
 				Breakdown{children = caller.data.raceBreakDown.display or {}, classes = { 'infobox-center' }}
 			)
 		end
 
 		if args.team_number then
 			table.insert(widgets, Cell{name = 'Number of Teams',
-				content = {CustomLeague._displayParticipantNumber(args.team_number)}})
+				children = {CustomLeague._displayParticipantNumber(args.team_number)}})
 
 			-- clean var of '+' suffix
 			args.team_number = string.gsub(args.team_number, '%+', '')

--- a/lua/wikis/warcraft/Infobox/Map/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Map/Custom.lua
@@ -41,12 +41,12 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Tileset', content = {args.tileset}},
-			Cell{name = 'Size', content = {(args.width or '') .. 'x' .. (args.height or '')}},
-			Cell{name = 'Spawn Positions', content = {(args.players or '') .. ' at ' .. (args.positions or '')}},
-			Cell{name = 'Versions', content = {String.convertWikiListToHtmlList(args.versions)}},
-			Cell{name = 'Leagues Featured', content = {args.leagues}},
-			Cell{name = 'Mercenary Camps', content = {
+			Cell{name = 'Tileset', children = {args.tileset}},
+			Cell{name = 'Size', children = {(args.width or '') .. 'x' .. (args.height or '')}},
+			Cell{name = 'Spawn Positions', children = {(args.players or '') .. ' at ' .. (args.positions or '')}},
+			Cell{name = 'Versions', children = {String.convertWikiListToHtmlList(args.versions)}},
+			Cell{name = 'Leagues Featured', children = {args.leagues}},
+			Cell{name = 'Mercenary Camps', children = {
 				self.caller:_mercenaryCamp(),
 				self.caller:_mercenaryCamp(2),
 				self.caller:_mercenaryCamp(3),

--- a/lua/wikis/warcraft/Infobox/Patch/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Patch/Custom.lua
@@ -46,9 +46,9 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'release' then
 		return {
-			Cell{name = '[[Public Test Realm|PTR]] Release Date', content = {args.release_ptr}},
-			Cell{name = 'Release Date', content = {args.release}},
-			Cell{name = '[[NetEase]] Release Date', content = {CustomPatch._netEaseRelease(args)}},
+			Cell{name = '[[Public Test Realm|PTR]] Release Date', children = {args.release_ptr}},
+			Cell{name = 'Release Date', children = {args.release}},
+			Cell{name = '[[NetEase]] Release Date', children = {CustomPatch._netEaseRelease(args)}},
 		}
 	end
 

--- a/lua/wikis/warcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Person/Player/Custom.lua
@@ -60,12 +60,12 @@ function CustomInjector:parse(id, widgets)
 		if currentYearEarnings == 0 then return widgets end
 		local currentYearEarningsDisplay = '$' .. mw.getContentLanguage():formatNum(Math.round(currentYearEarnings))
 
-		table.insert(widgets, Cell{name = 'Approx. Earnings '.. CURRENT_YEAR, content = {currentYearEarningsDisplay}})
+		table.insert(widgets, Cell{name = 'Approx. Earnings '.. CURRENT_YEAR, children = {currentYearEarningsDisplay}})
 
 	elseif id == 'role' then
 		-- WC doesn't show any roles, but rather shows the Race/Faction instead
 		return {
-			Cell{name = 'Race', content = {Faction.toName(args.race)}}
+			Cell{name = 'Race', children = {Faction.toName(args.race)}}
 		}
 	end
 	return widgets

--- a/lua/wikis/warcraft/Infobox/Skill/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Skill/Custom.lua
@@ -45,19 +45,19 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'cost' then
-		return {Cell{name = 'Cost', content = {self.caller:getCostDisplay()}}}
+		return {Cell{name = 'Cost', children = {self.caller:getCostDisplay()}}}
 	elseif id == 'hotkey' then
-		return {Cell{name = '[[Hotkeys per Race|Hotkey]]', content = {self.caller:getHotkeys()}}}
+		return {Cell{name = '[[Hotkeys per Race|Hotkey]]', children = {self.caller:getHotkeys()}}}
 	elseif id == 'cooldown' then
-		return {Cell{name = '[[Cooldown]]', content = {args.cooldown}}}
+		return {Cell{name = '[[Cooldown]]', children = {args.cooldown}}}
 	elseif id == 'duration' then
-		return {Cell{name = '[[Game Speed|Duration]]', content = {args.duration}}}
+		return {Cell{name = '[[Game Speed|Duration]]', children = {args.duration}}}
 	elseif id == 'custom' then
 		return {
-			Cell{name = 'Move Speed', content = {args.movespeed}},
-			Cell{name = 'Researched from', content = {self.caller:getResearchFrom()}},
-			Cell{name = 'Research Cost', content = {self.caller:getResearchCost()}},
-			Cell{name = 'Research Hotkey', content = {Hotkeys.hotkey{hotkey = args.rhotkey}}},
+			Cell{name = 'Move Speed', children = {args.movespeed}},
+			Cell{name = 'Researched from', children = {self.caller:getResearchFrom()}},
+			Cell{name = 'Research Cost', children = {self.caller:getResearchCost()}},
+			Cell{name = 'Research Hotkey', children = {Hotkeys.hotkey{hotkey = args.rhotkey}}},
 		}
 	end
 

--- a/lua/wikis/warcraft/Infobox/Strategy/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Strategy/Custom.lua
@@ -54,11 +54,11 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'custom' then
 		return {
-			Cell{name = 'Matchups', content = {args.matchups or 'All'}},
-			Cell{name = 'Type', content = {args.type or 'Opening'}},
-			Cell{name = 'Popularized by', content = {args.popularized}, options = {makeLink = true}},
-			Cell{name = 'Converted Form', content = {args.convert}},
-			Cell{name = 'TL-Article', content = {self.caller:_getTLarticle(args.tlarticle)}},
+			Cell{name = 'Matchups', children = {args.matchups or 'All'}},
+			Cell{name = 'Type', children = {args.type or 'Opening'}},
+			Cell{name = 'Popularized by', children = {args.popularized}, options = {makeLink = true}},
+			Cell{name = 'Converted Form', children = {args.convert}},
+			Cell{name = 'TL-Article', children = {self.caller:_getTLarticle(args.tlarticle)}},
 		}
 	end
 	return widgets

--- a/lua/wikis/warcraft/Infobox/Team/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Team/Custom.lua
@@ -69,7 +69,7 @@ function CustomInjector:parse(id, widgets)
 	if id == 'topcustomcontent' then
 		table.insert(widgets, Cell{
 			name = 'Clan tag',
-			content = {self.caller.teamTemplate.shortname}
+			children = {self.caller.teamTemplate.shortname}
 		})
 	elseif id == 'customcontent' then
 		local profiles = Array.extractValues(Table.map(PROFILES, function (param, profileData)

--- a/lua/wikis/warcraft/Infobox/Unit/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Unit/Custom.lua
@@ -62,23 +62,23 @@ function CustomUnit:addCustomCells(widgets)
 	local race = Faction.toName(Faction.read(args.race)) or ADDITIONAL_UNIT_RACES[string.lower(args.race or '')]
 
 	Array.appendWith(widgets,
-		Cell{name = '[[Race]]', content = {race and ('[[' .. race .. ']]') or args.race}},
-		Cell{name = '[[Targeting#Target_Classifications|Classification]]', content = {
+		Cell{name = '[[Race]]', children = {race and ('[[' .. race .. ']]') or args.race}},
+		Cell{name = '[[Targeting#Target_Classifications|Classification]]', children = {
 			args.class and String.convertWikiListToHtmlList(args.class) or nil}},
-		Cell{name = 'Bounty Awarded', content = {CustomUnit._bounty(args)}},
-		Cell{name = 'Sleeps', content = {args.sleeps}},
-		Cell{name = 'Cargo Capacity', content = {args.cargo_capacity}},
-		Cell{name = 'Morphs into', content = {args.morphs}},
-		Cell{name = 'Duration', content = {args.duration}},
-		Cell{name = 'Formation Rank', content = {args.formationrank}},
-		Cell{name = '[[Sight_Range|Sight]]', content = {args.daysight .. ' / ' .. args.nightsight}},
-		Cell{name = 'Acquisition Range', content = {acquisitionRange > 0 and acquisitionRange or nil}},
-		Cell{name = '[[Experience#Determining_Experience_Gained|Level]]', content = {
+		Cell{name = 'Bounty Awarded', children = {CustomUnit._bounty(args)}},
+		Cell{name = 'Sleeps', children = {args.sleeps}},
+		Cell{name = 'Cargo Capacity', children = {args.cargo_capacity}},
+		Cell{name = 'Morphs into', children = {args.morphs}},
+		Cell{name = 'Duration', children = {args.duration}},
+		Cell{name = 'Formation Rank', children = {args.formationrank}},
+		Cell{name = '[[Sight_Range|Sight]]', children = {args.daysight .. ' / ' .. args.nightsight}},
+		Cell{name = 'Acquisition Range', children = {acquisitionRange > 0 and acquisitionRange or nil}},
+		Cell{name = '[[Experience#Determining_Experience_Gained|Level]]', children = {
 			level > 0 and ('[[Experience|'..args.level..']]') or nil}},
-		Cell{name = '[[Mana]]', content = {mana.manaDisplay}},
-		Cell{name = '[[Mana|Initial Mana]]', content = {mana.initialManaDisplay}},
-		Cell{name = '[[Mana#Mana_Gain|Mana Regeneration]]', content = {mana.manaRegenDisplay}},
-		Cell{name = 'Selection Priorty', content = {args.priority}}
+		Cell{name = '[[Mana]]', children = {mana.manaDisplay}},
+		Cell{name = '[[Mana|Initial Mana]]', children = {mana.initialManaDisplay}},
+		Cell{name = '[[Mana#Mana_Gain|Mana Regeneration]]', children = {mana.manaRegenDisplay}},
+		Cell{name = 'Selection Priorty', children = {args.priority}}
 	)
 
 	local movement = Shared.movement(args, 'Movement')
@@ -108,7 +108,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'cost' then
 		return {
-			Cell{name = 'Cost', content = {CostDisplay.run{
+			Cell{name = 'Cost', children = {CostDisplay.run{
 				faction = args.race,
 				gold = args.gold,
 				lumber = args.lumber,
@@ -117,13 +117,13 @@ function CustomInjector:parse(id, widgets)
 			}}},
 		}
 	elseif id == 'requirements' then
-		return {Cell{name = 'Requirements', content = {String.convertWikiListToHtmlList(args.requires)}}}
+		return {Cell{name = 'Requirements', children = {String.convertWikiListToHtmlList(args.requires)}}}
 	elseif id == 'defense' then
 		return {
-			Cell{name = '[[Hit Points|Hit Points]]', content = {self.caller:_defenseDisplay()}},
-			Cell{name = '[[Hit Points#Hit Points Gain|HP Regeneration]]', content = {
+			Cell{name = '[[Hit Points|Hit Points]]', children = {self.caller:_defenseDisplay()}},
+			Cell{name = '[[Hit Points#Hit Points Gain|HP Regeneration]]', children = {
 				Shared.hitPointsRegeneration(args, {display = true})}},
-			Cell{name = '[[Armor|Armor]]', content = {self.caller:_armorDisplay()}}
+			Cell{name = '[[Armor|Armor]]', children = {self.caller:_armorDisplay()}}
 		}
 	elseif id == 'attack' then return {}
 	elseif id == 'custom' then

--- a/lua/wikis/warthunder/Infobox/League/Custom.lua
+++ b/lua/wikis/warthunder/Infobox/League/Custom.lua
@@ -56,8 +56,8 @@ function CustomInjector:parse(id, widgets)
 		local vehicle = VEHICLES[string.lower(args.vehicle or '')] or 'Unknown'
 		Array.appendWith(
 			widgets,
-			Cell{name = 'Mode', content = {mode}},
-			Cell{name = 'Vehicle', content = {vehicle}}
+			Cell{name = 'Mode', children = {mode}},
+			Cell{name = 'Vehicle', children = {vehicle}}
 		)
 	end
 

--- a/lua/wikis/warthunder/Infobox/Map/Custom.lua
+++ b/lua/wikis/warthunder/Infobox/Map/Custom.lua
@@ -51,15 +51,15 @@ function CustomInjector:parse(id, widgets)
 	if id == 'location' and String.isNotEmpty(args.country) then
 		local locationText = String.isNotEmpty(args.city) and args.city or args.country
 		return {
-			Cell{name = 'Location', content = {Flags.Icon{flag = args.country, shouldLink = false} .. '&nbsp;' .. locationText}},
+			Cell{name = 'Location', children = {Flags.Icon{flag = args.country, shouldLink = false} .. '&nbsp;' .. locationText}},
 		}
 	elseif id == 'custom' then
 		return Array.append(
 				widgets,
 				Title{children = 'Other Information'},
-				Cell{name = 'Tank area size', content = {self:_getMapSize(args.tanksize)}},
-				Cell{name = 'Air area size', content = {self:_getMapSize(args.airsize)}},
-				Cell{name = 'Game Modes', content = Logic.nilIfEmpty(self.caller:getGameModes(args))}
+				Cell{name = 'Tank area size', children = {self:_getMapSize(args.tanksize)}},
+				Cell{name = 'Air area size', children = {self:_getMapSize(args.airsize)}},
+				Cell{name = 'Game Modes', children = Logic.nilIfEmpty(self.caller:getGameModes(args))}
 			)
 		end
 		return widgets

--- a/lua/wikis/warthunder/Infobox/Map/Custom.lua
+++ b/lua/wikis/warthunder/Infobox/Map/Custom.lua
@@ -51,7 +51,10 @@ function CustomInjector:parse(id, widgets)
 	if id == 'location' and String.isNotEmpty(args.country) then
 		local locationText = String.isNotEmpty(args.city) and args.city or args.country
 		return {
-			Cell{name = 'Location', children = {Flags.Icon{flag = args.country, shouldLink = false} .. '&nbsp;' .. locationText}},
+			Cell{
+				name = 'Location',
+				children = {Flags.Icon{flag = args.country, shouldLink = false} .. '&nbsp;' .. locationText}
+			},
 		}
 	elseif id == 'custom' then
 		return Array.append(

--- a/lua/wikis/warthunder/Infobox/Unit/Custom.lua
+++ b/lua/wikis/warthunder/Infobox/Unit/Custom.lua
@@ -44,12 +44,12 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return Array.append(widgets,
-			Cell{name = 'Released', content = {args.releasedate}},
-			Cell{name = 'Acquisition', content = {args.acquisition}},
-			Cell{name = 'Vehicle Type', content = {args.vehicletype}},
-			Cell{name = 'Battle Rating', content = {args.br}},
-			Cell{name = 'Nation', content = {caller:buildNationDisplay()}},
-			Cell{name = 'Role', content = {args.role}}
+			Cell{name = 'Released', children = {args.releasedate}},
+			Cell{name = 'Acquisition', children = {args.acquisition}},
+			Cell{name = 'Vehicle Type', children = {args.vehicletype}},
+			Cell{name = 'Battle Rating', children = {args.br}},
+			Cell{name = 'Nation', children = {caller:buildNationDisplay()}},
+			Cell{name = 'Role', children = {args.role}}
 		)
 	end
 	return widgets

--- a/lua/wikis/wildcard/Infobox/Character/Custom.lua
+++ b/lua/wikis/wildcard/Infobox/Character/Custom.lua
@@ -40,16 +40,16 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(
 			widgets,
 			Title{children = 'Basic Attributes'},
-			Cell{name = 'Health', content = {args.health}},
-			Cell{name = 'Damage per second', content = {args.dps}},
-			Cell{name = 'Move Speed', content = {args.movespeed}},
-			Cell{name = 'House', content = {args.house}},
+			Cell{name = 'Health', children = {args.health}},
+			Cell{name = 'Damage per second', children = {args.dps}},
+			Cell{name = 'Move Speed', children = {args.movespeed}},
+			Cell{name = 'House', children = {args.house}},
 			Title{children = 'Basic Stats'},
-			Cell{name = 'Healing', content = {args.healing}},
-			Cell{name = 'Mobility', content = {args.mobility}},
-			Cell{name = 'Offense', content = {args.offense}},
-			Cell{name = 'Defense', content = {args.defense}},
-			Cell{name = 'Utility', content = {args.utility}}
+			Cell{name = 'Healing', children = {args.healing}},
+			Cell{name = 'Mobility', children = {args.mobility}},
+			Cell{name = 'Offense', children = {args.offense}},
+			Cell{name = 'Defense', children = {args.defense}},
+			Cell{name = 'Utility', children = {args.utility}}
 		)
 		return widgets
 	end

--- a/lua/wikis/wildcard/Infobox/Unit/Custom.lua
+++ b/lua/wikis/wildcard/Infobox/Unit/Custom.lua
@@ -38,21 +38,21 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'custom' then
 		return Array.append(widgets,
-			Cell{name = 'Pronouns', content = {args.pronouns}},
-			Cell{name = 'House', content = {args.house}},
-			Cell{name = 'Rarity', content = {args.rarity}},
-			Cell{name = 'Quantity', content = {args.quantity}},
-			Cell{name = 'Mana Cost', content = {args.cost}},
-			Cell{name = 'Health', content = {args.health}},
-			Cell{name = 'Movement Speed', content = {args.movement}},
-			Cell{name = 'Sight Range', content = {args.sightrange}},
-			Cell{name = 'Key Words', content = {args.keywords}},
+			Cell{name = 'Pronouns', children = {args.pronouns}},
+			Cell{name = 'House', children = {args.house}},
+			Cell{name = 'Rarity', children = {args.rarity}},
+			Cell{name = 'Quantity', children = {args.quantity}},
+			Cell{name = 'Mana Cost', children = {args.cost}},
+			Cell{name = 'Health', children = {args.health}},
+			Cell{name = 'Movement Speed', children = {args.movement}},
+			Cell{name = 'Sight Range', children = {args.sightrange}},
+			Cell{name = 'Key Words', children = {args.keywords}},
 			Title{children = 'Basic Stats'},
-			Cell{name = 'Healing', content = {args.healing}},
-			Cell{name = 'Mobility', content = {args.mobility}},
-			Cell{name = 'Offense', content = {args.offense}},
-			Cell{name = 'Defense', content = {args.defense}},
-			Cell{name = 'Utility', content = {args.utility}}
+			Cell{name = 'Healing', children = {args.healing}},
+			Cell{name = 'Mobility', children = {args.mobility}},
+			Cell{name = 'Offense', children = {args.offense}},
+			Cell{name = 'Defense', children = {args.defense}},
+			Cell{name = 'Utility', children = {args.utility}}
 		)
 	end
 	return widgets

--- a/lua/wikis/wildrift/Infobox/Item/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Item/Custom.lua
@@ -87,45 +87,45 @@ function CustomInjector:parse(id, widgets)
 			}})
 		end
 		Array.appendWith(widgets,
-			Cell{name = 'Health', content = {caller:_positiveConcatedArgsForBase('hp')}},
-			Cell{name = 'Max Health', content = {caller:_positiveConcatedArgsForBase('maxhealth')}},
-			Cell{name = 'Health Regen', content = {caller:_positiveConcatedArgsForBase('hpregen')}},
-			Cell{name = 'Health Regen / Lifesteal Amp', content = {caller:_positivePercentDisplay('hpregenamp')}},
-			Cell{name = 'Mana', content = {caller:_positiveConcatedArgsForBase('mana')}},
-			Cell{name = 'Mana Regen', content = {caller:_positiveConcatedArgsForBase('manaregen')}},
-			Cell{name = 'Mana Cost / Mana Loss Reduction', content = {caller:_manaLossDisplay()}},
-			Cell{name = 'Mana Regen Amplification', content = {caller:_positivePercentDisplay('manaregenamp')}},
-			Cell{name = 'Lifesteal', content = {caller:_positiveConcatedArgsForBase('lifesteal')}},
-			Cell{name = 'Spell Lifesteal', content = {caller:_positiveConcatedArgsForBase('spellsteal')}},
-			Cell{name = 'Spell Lifesteal Amplification', content = {caller:_positiveConcatedArgsForBase('spellstealamp')}},
-			Cell{name = 'Armor', content = {caller:_positiveConcatedArgsForBase('armor')}},
-			Cell{name = 'Evasion', content = {caller:_positivePercentDisplay('evasion')}},
-			Cell{name = 'Magic Resistance', content = {caller:_positiveConcatedArgsForBase('magicresist')}},
-			Cell{name = 'Status Resistance', content = {caller:_positivePercentDisplay('statusresist')}},
-			Cell{name = 'Debuff Duration', content = {caller:_positiveConcatedArgsForBase('debuffamp')}},
-			Cell{name = 'Spell Amplification', content = {caller:_positivePercentDisplay('spellamp')}},
-			Cell{name = 'Bonus GPM', content = {caller:_positiveConcatedArgsForBase('bonusgpm')}},
-			Cell{name = 'Turn Rate Speed', content = {caller:_positiveConcatedArgsForBase('turnrate')}},
-			Cell{name = 'Projectile Speed', content = {caller:_positiveConcatedArgsForBase('projectilespeed')}},
-			Cell{name = 'Attack Damage', content = {caller:_negativeConcatedArgsForBase('damagedown')}},
-			Cell{name = 'Armor', content = {caller:_negativeConcatedArgsForBase('armordown')}},
-			Cell{name = 'Attack Speed', content = {caller:_negativeConcatedArgsForBase('attackspeeddown')}},
-			Cell{name = 'Max Mana', content = {caller:_negativeConcatedArgsForBase('maxmanadown')}},
-			Cell{name = 'Base Attack Time', content = {caller:_negativeConcatedArgsForBase('batdown')}},
-			Cell{name = 'Base Damage', content = {caller:_positiveConcatedArgsForBase('basedamage')}},
-			Cell{name = 'Damage', content = {caller:_positiveConcatedArgsForBase('damage')}},
-			Cell{name = 'Attack Speed', content = {caller:_positiveConcatedArgsForBase('attackspeed')}},
-			Cell{name = 'Ability Power', content = {caller:_positiveConcatedArgsForBase('ap')}},
-			Cell{name = 'Attack Damage', content = {caller:_positiveConcatedArgsForBase('ad')}},
-			Cell{name = 'Cooldown Reduction', content = {caller:_positiveConcatedArgsForBase('cdreduction')}},
-			Cell{name = 'Ability Haste', content = {caller:_positiveConcatedArgsForBase('haste')}},
-			Cell{name = 'Critical Chance', content = {caller:_positiveConcatedArgsForBase('critchance')}},
-			Cell{name = 'Attack Range', content = {caller:_positiveConcatedArgsForBase('attackrange')}},
-			Cell{name = 'Cast Range', content = {caller:_positiveConcatedArgsForBase('castrange')}},
-			Cell{name = 'Day Vision', content = {caller:_positiveConcatedArgsForBase('dayvision')}},
-			Cell{name = 'Night Vision', content = {caller:_positiveConcatedArgsForBase('nightvision')}},
-			Cell{name = 'Movement Speed', content = {caller:_movementSpeedDisplay()}},
-			Cell{name = 'Limitations', content = {args.limits}}
+			Cell{name = 'Health', children = {caller:_positiveConcatedArgsForBase('hp')}},
+			Cell{name = 'Max Health', children = {caller:_positiveConcatedArgsForBase('maxhealth')}},
+			Cell{name = 'Health Regen', children = {caller:_positiveConcatedArgsForBase('hpregen')}},
+			Cell{name = 'Health Regen / Lifesteal Amp', children = {caller:_positivePercentDisplay('hpregenamp')}},
+			Cell{name = 'Mana', children = {caller:_positiveConcatedArgsForBase('mana')}},
+			Cell{name = 'Mana Regen', children = {caller:_positiveConcatedArgsForBase('manaregen')}},
+			Cell{name = 'Mana Cost / Mana Loss Reduction', children = {caller:_manaLossDisplay()}},
+			Cell{name = 'Mana Regen Amplification', children = {caller:_positivePercentDisplay('manaregenamp')}},
+			Cell{name = 'Lifesteal', children = {caller:_positiveConcatedArgsForBase('lifesteal')}},
+			Cell{name = 'Spell Lifesteal', children = {caller:_positiveConcatedArgsForBase('spellsteal')}},
+			Cell{name = 'Spell Lifesteal Amplification', children = {caller:_positiveConcatedArgsForBase('spellstealamp')}},
+			Cell{name = 'Armor', children = {caller:_positiveConcatedArgsForBase('armor')}},
+			Cell{name = 'Evasion', children = {caller:_positivePercentDisplay('evasion')}},
+			Cell{name = 'Magic Resistance', children = {caller:_positiveConcatedArgsForBase('magicresist')}},
+			Cell{name = 'Status Resistance', children = {caller:_positivePercentDisplay('statusresist')}},
+			Cell{name = 'Debuff Duration', children = {caller:_positiveConcatedArgsForBase('debuffamp')}},
+			Cell{name = 'Spell Amplification', children = {caller:_positivePercentDisplay('spellamp')}},
+			Cell{name = 'Bonus GPM', children = {caller:_positiveConcatedArgsForBase('bonusgpm')}},
+			Cell{name = 'Turn Rate Speed', children = {caller:_positiveConcatedArgsForBase('turnrate')}},
+			Cell{name = 'Projectile Speed', children = {caller:_positiveConcatedArgsForBase('projectilespeed')}},
+			Cell{name = 'Attack Damage', children = {caller:_negativeConcatedArgsForBase('damagedown')}},
+			Cell{name = 'Armor', children = {caller:_negativeConcatedArgsForBase('armordown')}},
+			Cell{name = 'Attack Speed', children = {caller:_negativeConcatedArgsForBase('attackspeeddown')}},
+			Cell{name = 'Max Mana', children = {caller:_negativeConcatedArgsForBase('maxmanadown')}},
+			Cell{name = 'Base Attack Time', children = {caller:_negativeConcatedArgsForBase('batdown')}},
+			Cell{name = 'Base Damage', children = {caller:_positiveConcatedArgsForBase('basedamage')}},
+			Cell{name = 'Damage', children = {caller:_positiveConcatedArgsForBase('damage')}},
+			Cell{name = 'Attack Speed', children = {caller:_positiveConcatedArgsForBase('attackspeed')}},
+			Cell{name = 'Ability Power', children = {caller:_positiveConcatedArgsForBase('ap')}},
+			Cell{name = 'Attack Damage', children = {caller:_positiveConcatedArgsForBase('ad')}},
+			Cell{name = 'Cooldown Reduction', children = {caller:_positiveConcatedArgsForBase('cdreduction')}},
+			Cell{name = 'Ability Haste', children = {caller:_positiveConcatedArgsForBase('haste')}},
+			Cell{name = 'Critical Chance', children = {caller:_positiveConcatedArgsForBase('critchance')}},
+			Cell{name = 'Attack Range', children = {caller:_positiveConcatedArgsForBase('attackrange')}},
+			Cell{name = 'Cast Range', children = {caller:_positiveConcatedArgsForBase('castrange')}},
+			Cell{name = 'Day Vision', children = {caller:_positiveConcatedArgsForBase('dayvision')}},
+			Cell{name = 'Night Vision', children = {caller:_positiveConcatedArgsForBase('nightvision')}},
+			Cell{name = 'Movement Speed', children = {caller:_movementSpeedDisplay()}},
+			Cell{name = 'Limitations', children = {args.limits}}
 		)
 	elseif id == 'ability' then
 		if String.isEmpty(args.use) and String.isEmpty(args.active) and String.isEmpty(args.passive) then
@@ -133,9 +133,9 @@ function CustomInjector:parse(id, widgets)
 		end
 		Array.appendWith(widgets,
 			Title{children = 'Ability'},
-			Cell{name = 'Use', content = {args.use}},
-			Cell{name = 'Active', content = {args.active}},
-			Cell{name = 'Passive', content = {args.passive, args.passive2}}
+			Cell{name = 'Use', children = {args.use}},
+			Cell{name = 'Active', children = {args.active}},
+			Cell{name = 'Passive', children = {args.passive, args.passive2}}
 		)
 	elseif id == 'availability' then
 		if String.isEmpty(args.category) and String.isEmpty(args.shop) and String.isEmpty(args.drop) then
@@ -143,16 +143,16 @@ function CustomInjector:parse(id, widgets)
 		end
 		return {
 			Title{children = 'Item Tier'},
-			Cell{name = 'Category', content = {caller:_categoryDisplay()}},
-			Cell{name = 'Bought From', content = caller:_shopDisplay()},
-			Cell{name = 'Dropped From', content = {args.drop}},
+			Cell{name = 'Category', children = {caller:_categoryDisplay()}},
+			Cell{name = 'Bought From', children = caller:_shopDisplay()},
+			Cell{name = 'Dropped From', children = {args.drop}},
 		}
 	elseif id == 'maps' then
 		if String.isEmpty(args.wr) and String.isEmpty(args.ha) then return {} end
 		Array.appendWith(widgets,
 			Title{children = 'Maps'},
-			Cell{name = '[[Wild Rift (Map)|Wild Rift]]', content = {args.wr}},
-			Cell{name = '[[Howling Abyss]]', content = {args.ha}}
+			Cell{name = '[[Wild Rift (Map)|Wild Rift]]', children = {args.wr}},
+			Cell{name = '[[Howling Abyss]]', children = {args.ha}}
 		)
 	elseif id == 'recipe' then
 		if String.isEmpty(args.recipe) then return {} end

--- a/lua/wikis/wildrift/Infobox/Item/Rune/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Item/Rune/Custom.lua
@@ -57,13 +57,13 @@ function CustomInjector:parse(id, widgets)
 		)
 	elseif id == 'custom' then
 		return WidgetUtil.collect(
-			Cell{name = 'Path', content = {args.path}},
-			Cell{name = 'Slot', content = {args.slot}},
+			Cell{name = 'Path', children = {args.path}},
+			Cell{name = 'Slot', children = {args.slot}},
 			Array.map(caller:getAllArgsForBase(args, 'description'), function(desc)
 				return Center{children = {desc}}
 			end),
-			Cell{name = 'Cooldown', content = {args.cooldown}},
-			Cell{name = 'Account level', content = {args.level}}
+			Cell{name = 'Cooldown', children = {args.cooldown}},
+			Cell{name = 'Account level', children = {args.level}}
 		)
 	end
 

--- a/lua/wikis/wildrift/Infobox/League/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/League/Custom.lua
@@ -39,20 +39,20 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'sponsors' then
-		table.insert(widgets, Cell{name = 'Official Device', content = {args.device}})
+		table.insert(widgets, Cell{name = 'Official Device', children = {args.device}})
 	elseif id == 'gamesettings' then
-		return {Cell{name = 'Patch', content = {self.caller:_getPatchVersion()}}}
+		return {Cell{name = 'Patch', children = {self.caller:_getPatchVersion()}}}
 	elseif id == 'customcontent' then
 		if args.player_number then
 			table.insert(widgets, Title{children = 'Players'})
-			table.insert(widgets, Cell{name = 'Number of players', content = {args.player_number}})
+			table.insert(widgets, Cell{name = 'Number of players', children = {args.player_number}})
 		end
 
 		--teams section
 		if args.team_number or (not String.isEmpty(args.team1)) then
 			table.insert(widgets, Title{children = 'Teams'})
 		end
-		table.insert(widgets, Cell{name = 'Number of teams', content = {args.team_number}})
+		table.insert(widgets, Cell{name = 'Number of teams', children = {args.team_number}})
 	end
 	return widgets
 end

--- a/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
@@ -89,16 +89,16 @@ function CustomInjector:parse(id, widgets)
 		end)
 		return {Cell{
 			name = #championIcons > 1 and 'Signature Champions' or 'Signature Champions',
-			content = {table.concat(championIcons, '&nbsp;')},
+			children = {table.concat(championIcons, '&nbsp;')},
 		}}
 	elseif id == 'status' then
 		local status = args.status and mw.getContentLanguage():ucfirst(args.status) or nil
 
 		return {
-			Cell{name = 'Status', content = {Page.makeInternalLink({onlyIfExists = true}, status) or status}},
+			Cell{name = 'Status', children = {Page.makeInternalLink({onlyIfExists = true}, status) or status}},
 		}
 	elseif id == 'history' then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	end
 	return widgets
 end

--- a/lua/wikis/wildrift/Infobox/Team/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Team/Custom.lua
@@ -53,7 +53,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
 	if id == 'custom' then
-		table.insert(widgets, Cell{name = 'Abbreviation', content = {args.abbreviation}})
+		table.insert(widgets, Cell{name = 'Abbreviation', children = {args.abbreviation}})
 	end
 
 	return widgets

--- a/lua/wikis/wildrift/Infobox/Unit/Champion/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Unit/Champion/Custom.lua
@@ -71,7 +71,7 @@ function CustomInjector:parse(id, widgets)
 		)
 		return {
 			Breakdown{classes = {'infobox-center'}, children = breakDownContents},
-			Cell{name = 'Real Name', content = {args.realname}},
+			Cell{name = 'Real Name', children = {args.realname}},
 		}
 	elseif id == 'cost' then
 		local cost = Array.append({},
@@ -79,7 +79,7 @@ function CustomInjector:parse(id, widgets)
 			String.isNotEmpty(args.costrp ) and (args.costrp .. ' ' .. WILD_CORES_ICON) or nil
 		)
 		return {
-			Cell{name = 'Price', content = {table.concat(cost, '&emsp;&ensp;')}},
+			Cell{name = 'Price', children = {table.concat(cost, '&emsp;&ensp;')}},
 		}
 	elseif id == 'custom' then
 		return self.caller:getCustomCells(widgets)
@@ -94,10 +94,10 @@ function CustomChampion:getCustomCells(widgets)
 	local args = self.args
 	Array.appendWith(
 		widgets,
-		Cell{name = 'Resource Bar', content = {args.secondarybar}},
-		Cell{name = 'Secondary Bar', content = {args.secondarybar1}},
-		Cell{name = 'Secondary Attributes', content = {args.secondaryattributes1}},
-		Cell{name = 'Release Date', content = {args.releasedate}}
+		Cell{name = 'Resource Bar', children = {args.secondarybar}},
+		Cell{name = 'Secondary Bar', children = {args.secondarybar1}},
+		Cell{name = 'Secondary Attributes', children = {args.secondaryattributes1}},
+		Cell{name = 'Release Date', children = {args.releasedate}}
 	)
 
 	if Array.any({'hp', 'hplvl', 'hpreg', 'hpreglvl'}, function(key) return String.isNotEmpty(args[key]) end) then
@@ -106,27 +106,27 @@ function CustomChampion:getCustomCells(widgets)
 
 	Array.appendWith(
 		widgets,
-		Cell{name = 'Health', content = {args.hp}},
-		Cell{name = 'Health Regen', content = {args.hpreg}},
-		Cell{name = 'Courage', content = {args.courage}},
-		Cell{name = 'Rage', content = {args.rage}},
-		Cell{name = 'Fury', content = {args.fury}},
-		Cell{name = 'Heat', content = {args.heat}},
-		Cell{name = 'Ferocity', content = {args.ferocity}},
-		Cell{name = 'Bloodthirst', content = {args.bloodthirst}},
-		Cell{name = 'Mana', content = {args.mana}},
-		Cell{name = 'Mana Regen', content = {args.manareg}},
-		Cell{name = 'Cooldown Reduction', content = {args.cdr}},
-		Cell{name = 'Energy', content = {args.energy}},
-		Cell{name = 'Energy Regen', content = {args.energyreg}},
-		Cell{name = 'Attack Type', content = {args.attacktype}},
-		Cell{name = 'Attack Damage', content = {args.damage}},
-		Cell{name = 'Attack Speed', content = {args.attackspeed}},
-		Cell{name = 'Attack Range', content = {args.attackrange}},
-		Cell{name = 'Ability Power', content = {args.ap}},
-		Cell{name = 'Armor', content = {args.armor}},
-		Cell{name = 'Magic Resistance', content = {args.magicresistance}},
-		Cell{name = 'Movement Speed', content = {args.movespeed}}
+		Cell{name = 'Health', children = {args.hp}},
+		Cell{name = 'Health Regen', children = {args.hpreg}},
+		Cell{name = 'Courage', children = {args.courage}},
+		Cell{name = 'Rage', children = {args.rage}},
+		Cell{name = 'Fury', children = {args.fury}},
+		Cell{name = 'Heat', children = {args.heat}},
+		Cell{name = 'Ferocity', children = {args.ferocity}},
+		Cell{name = 'Bloodthirst', children = {args.bloodthirst}},
+		Cell{name = 'Mana', children = {args.mana}},
+		Cell{name = 'Mana Regen', children = {args.manareg}},
+		Cell{name = 'Cooldown Reduction', children = {args.cdr}},
+		Cell{name = 'Energy', children = {args.energy}},
+		Cell{name = 'Energy Regen', children = {args.energyreg}},
+		Cell{name = 'Attack Type', children = {args.attacktype}},
+		Cell{name = 'Attack Damage', children = {args.damage}},
+		Cell{name = 'Attack Speed', children = {args.attackspeed}},
+		Cell{name = 'Attack Range', children = {args.attackrange}},
+		Cell{name = 'Ability Power', children = {args.ap}},
+		Cell{name = 'Armor', children = {args.armor}},
+		Cell{name = 'Magic Resistance', children = {args.magicresistance}},
+		Cell{name = 'Movement Speed', children = {args.movespeed}}
 	)
 
 	local wins, loses = CharacterWinLoss.run()
@@ -136,7 +136,7 @@ function CustomChampion:getCustomCells(widgets)
 
 	return Array.append(widgets,
 		Title{children = 'Esports Statistics'},
-		Cell{name = 'Win Rate', content = {wins .. 'W : ' .. loses .. 'L (' .. winPercentage .. '%)'}}
+		Cell{name = 'Win Rate', children = {wins .. 'W : ' .. loses .. 'L (' .. winPercentage .. '%)'}}
 	)
 end
 

--- a/lua/wikis/worldoftanks/Infobox/League/Custom.lua
+++ b/lua/wikis/worldoftanks/Infobox/League/Custom.lua
@@ -45,13 +45,13 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Number of teams', content = {args.team_number}},
-			Cell{name = 'Number of players', content = {args.player_number}},
+			Cell{name = 'Number of teams', children = {args.team_number}},
+			Cell{name = 'Number of players', children = {args.player_number}},
 		}
 	elseif id == 'gamesettings' then
 		Array.appendWith(widgets,
-			Cell{name = 'Patch', content = {caller:_createPatchCell()}},
-			Cell{name = 'Game', content = {Game.name{game = args.game}}}
+			Cell{name = 'Patch', children = {caller:_createPatchCell()}},
+			Cell{name = 'Game', children = {Game.name{game = args.game}}}
 		)
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.map1) then

--- a/lua/wikis/worldoftanks/Infobox/Map/Custom.lua
+++ b/lua/wikis/worldoftanks/Infobox/Map/Custom.lua
@@ -44,19 +44,19 @@ function CustomInjector:parse(id, widgets)
 		return {
 			Cell{
 				name = 'Location',
-				content = {Flags.Icon{flag = args.location, shouldLink = false} .. '&nbsp;' .. args.location}
+				children = {Flags.Icon{flag = args.location, shouldLink = false} .. '&nbsp;' .. args.location}
 			},
 		}
 	elseif id == 'custom' then
 		return Array.append(widgets,
-			Cell{name = 'Map Season', content = {args.season}},
-			Cell{name = 'Size', content = {(args.width or '') .. ' x ' .. (args.height or '')}},
-			Cell{name = 'Battle Tier', content = {String.isNotEmpty(args.btmin) and
+			Cell{name = 'Map Season', children = {args.season}},
+			Cell{name = 'Size', children = {(args.width or '') .. ' x ' .. (args.height or '')}},
+			Cell{name = 'Battle Tier', children = {String.isNotEmpty(args.btmin) and
 				String.isNotEmpty(args.btmax) and (args.btmin .. ' - ' .. args.btmax) or nil}
 			},
 			Cell{
 				name = 'Game Modes',
-				content = Array.map(
+				children = Array.map(
 					self.caller:getGameModes(args),
 					function (gameMode)
 						local modeIcon = MapModes.get{mode = gameMode, date = args.releasedate, size = 15}

--- a/lua/wikis/worldoftanks/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/worldoftanks/Infobox/Person/Player/Custom.lua
@@ -40,11 +40,11 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'status' then
 		return {
-			Cell{name = 'Status', content = caller:_getStatusContents()},
-			Cell{name = 'Years Active', content = {args.years_active}},
+			Cell{name = 'Status', children = caller:_getStatusContents()},
+			Cell{name = 'Years Active', children = {args.years_active}},
 		}
 	elseif id == 'history' then
-		table.insert(widgets, Cell{name = 'Retired', content = {args.retired}})
+		table.insert(widgets, Cell{name = 'Retired', children = {args.retired}})
 	end
 
 	return widgets

--- a/lua/wikis/worldoftanks/Infobox/Unit/Tank/Custom.lua
+++ b/lua/wikis/worldoftanks/Infobox/Unit/Tank/Custom.lua
@@ -41,12 +41,12 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'custom' then
 		return Array.append(widgets,
-			Cell{name = 'Released', content = {args.released}},
-			Cell{name = 'Technical Name', content = {args.techname}},
-			Cell{name = 'Tank Type', content = {CustomUnit._getTankType(args)}},
-			Cell{name = 'Tank Tier', content = {args.tier}},
-			Cell{name = 'Nation', content = {Nation.run(args.nation)}},
-			Cell{name = 'Role', content = {args.role}}
+			Cell{name = 'Released', children = {args.released}},
+			Cell{name = 'Technical Name', children = {args.techname}},
+			Cell{name = 'Tank Type', children = {CustomUnit._getTankType(args)}},
+			Cell{name = 'Tank Tier', children = {args.tier}},
+			Cell{name = 'Nation', children = {Nation.run(args.nation)}},
+			Cell{name = 'Role', children = {args.role}}
 		)
 	end
 	return widgets

--- a/lua/wikis/worldofwarcraft/Infobox/Company/Custom.lua
+++ b/lua/wikis/worldofwarcraft/Infobox/Company/Custom.lua
@@ -34,9 +34,9 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'parent' then
-		table.insert(widgets, Cell{name = 'Focus', content = {args.focus}})
+		table.insert(widgets, Cell{name = 'Focus', children = {args.focus}})
 	elseif id == 'employees' then
-		table.insert(widgets, Cell{name = 'Key People', content = {args.people}})
+		table.insert(widgets, Cell{name = 'Key People', children = {args.people}})
 	end
 
 	return widgets

--- a/lua/wikis/zula/Infobox/League/Custom.lua
+++ b/lua/wikis/zula/Infobox/League/Custom.lua
@@ -37,12 +37,12 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'custom' then
 		return {
-			Cell{name = 'Number of teams', content = {args.team_number}},
-			Cell{name = 'Number of players', content = {args.player_number}},
+			Cell{name = 'Number of teams', children = {args.team_number}},
+			Cell{name = 'Number of players', children = {args.player_number}},
 		}
 	elseif id == 'gamesettings' then
 		return {
-			Cell{name = 'Game', content = {Game.name{game = args.game}}},
+			Cell{name = 'Game', children = {Game.name{game = args.game}}},
 		}
 	end
 	return widgets


### PR DESCRIPTION
## Summary
switch `content` to `children` in all widget calls inside infoboxes on wikis start with P-Z.
This is roughly 50% of the infobox modules that still use(d) content.
The other modules are targeted via #6334

## How did you test this change?
N/A