### PR TITLE
fix(infobox_extension): Missing team display for THA rows with role

### DIFF
--- a/lua/wikis/commons/Infobox/Extension/TeamHistoryAuto.lua
+++ b/lua/wikis/commons/Infobox/Extension/TeamHistoryAuto.lua
@@ -244,6 +244,8 @@ function TeamHistoryAuto:_row(transfer)
 		teamDisplay = Span{
 			css = {['padding-left'] = '3px', ['font-style'] = 'italic'},
 			children = {
+				teamText,
+				' ',
 				'(',
 				role,
 				')',


### PR DESCRIPTION
## Summary
reported on discord

## How did you test this change?
dev into live