### PR TITLE
fix(infobox): broken import in r6 character infobox

### DIFF
--- a/lua/wikis/rainbowsix/Infobox/Character/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Character/Custom.lua
@@ -17,7 +17,7 @@ local Operator = Lua.import('Module:Operator')
 local AgeCalculation = Lua.import('Module:AgeCalculation')
 local AutoInlineIcon = Lua.import('Module:AutoInlineIcon')
 local CharacterIcon = Lua.import('Module:CharacterIcon')
-local NameAliases = Lua.Lua.importIfExists('Module:CharacterNames', {loadData = true})
+local NameAliases = Lua.requireIfExists('Module:CharacterNames', {loadData = true})
 local Patch = Lua.import('Module:Patch')
 
 local Injector = Lua.import('Module:Widget/Injector')


### PR DESCRIPTION
## Summary

Report on discord: https://discord.com/channels/93055209017729024/372075546231832576/1403089913552965712

Regression from #6322

## How did you test this change?

[hotfix](https://liquipedia.net/rainbowsix/index.php?title=Module:Infobox/Character/Custom&diff=801103&oldid=801041) in live (by @hjpalpha)
