### PR TITLE
refactor(mainpage): use thisday widgets directly in mainpage

### DIFF
--- a/lua/wikis/commons/Widget/MainPage/ThisDay/Content.lua
+++ b/lua/wikis/commons/Widget/MainPage/ThisDay/Content.lua
@@ -28,7 +28,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local Config = Info.config.thisDay or {}
 
 ---@class ThisDayContent: Widget
----@field props { month: integer?, day: integer?, birthdayListPage: string? }
+---@field props { month: integer?, day: integer?, birthdayListPage: string?, noTwitter: boolean?}
 ---@operator call(table): ThisDayContent
 local ThisDayContent = Class.new(Widget)
 ThisDayContent.defaultProps = {
@@ -53,7 +53,7 @@ function ThisDayContent:render()
 					month = month,
 					day = day,
 					hideIfEmpty = Logic.readBool(Config.hideEmptyBirthdayList),
-					noTwitter = args.noTwitter
+					noTwitter = self.props.noTwitter
 				},
 				ThisDayPatch{
 					month = month,

--- a/lua/wikis/commons/Widget/MainPage/ThisDay/Content.lua
+++ b/lua/wikis/commons/Widget/MainPage/ThisDay/Content.lua
@@ -9,16 +9,23 @@ local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
 local DateExt = Lua.import('Module:Date/Ext')
+local Info = Lua.import('Module:Info', {loadData = true})
+local Logic = Lua.import('Module:Logic')
 local Page = Lua.import('Module:Page')
 local String = Lua.import('Module:StringUtils')
-local Template = Lua.import('Module:Template')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Small = HtmlWidgets.Small
+local ThisDayBirthday = Lua.import('Module:Widget/ThisDay/Birthday')
+local ThisDayPatch = Lua.import('Module:Widget/ThisDay/Patch')
+local ThisDayTournament = Lua.import('Module:Widget/ThisDay/Tournament')
 local WidgetUtil = Lua.import('Module:Widget/Util')
+
+---@type ThisDayConfig
+local Config = Info.config.thisDay or {}
 
 ---@class ThisDayContent: Widget
 ---@field props { month: integer?, day: integer?, birthdayListPage: string? }
@@ -32,14 +39,27 @@ ThisDayContent.defaultProps = {
 function ThisDayContent:render()
 	local month = self.props.month
 	local day = self.props.day
-	local frame = mw.getCurrentFrame()
 	local birthdayListPage = self.props.birthdayListPage
 	local showBirthdayList = String.isNotEmpty(birthdayListPage) and Page.exists(birthdayListPage --[[@as string]])
 	return WidgetUtil.collect(
 		Div{
 			attributes = { id = 'this-day-facts' },
 			children = {
-				Template.safeExpand(frame, 'Liquipedia:This day/' .. month .. '/' .. day)
+				ThisDayTournament{
+					month = month,
+					day = day
+				},
+				ThisDayBirthday{
+					month = month,
+					day = day,
+					hideIfEmpty = Logic.readBool(Config.hideEmptyBirthdayList),
+					noTwitter = args.noTwitter
+				},
+				ThisDayPatch{
+					month = month,
+					day = day,
+					hideIfEmpty = not Logic.readBool(Config.showEmptyPatchList)
+				}
 			}
 		},
 		showBirthdayList and HtmlWidgets.Fragment{


### PR DESCRIPTION
## Summary

_Follow-up for #5551_

This PR updates `Module:Widget/MainPage/ThisDay/Content` to directly call widgets added in #5692.

## How did you test this change?

dev
