### PR TITLE
feat(standings): Improve standings query options

### DIFF
--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -15,12 +15,11 @@ local NS_USER = 2
 local NS_PROJECT = 4 -- "Liquipedia" namespace
 local NS_TEMPLATE = 10
 local NS_HELP = 12
+local NS_MATCH = 130
 local NS_MODULE = 828
 local NS_MODULE_TALK = 829
 
-local Namespace = {
-	NS_MATCH = 130,
-}
+local Namespace = {}
 
 ---Determins whether a given title object is in the given namespaces, and optionally their talk namespaces.
 ---@param title Title
@@ -98,6 +97,12 @@ function Namespace.prefixFromId(id)
 	end
 
 	return name
+end
+
+---can not use Namespace.idFromName because the NS does not exist on all wikis
+---@return integer
+function Namespace.matchNamespaceId()
+	return NS_MATCH
 end
 
 return Namespace

--- a/lua/wikis/commons/Namespace.lua
+++ b/lua/wikis/commons/Namespace.lua
@@ -18,7 +18,9 @@ local NS_HELP = 12
 local NS_MODULE = 828
 local NS_MODULE_TALK = 829
 
-local Namespace = {}
+local Namespace = {
+	NS_MATCH = 130,
+}
 
 ---Determins whether a given title object is in the given namespaces, and optionally their talk namespaces.
 ---@param title Title

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -48,7 +48,7 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	end)
 
 	local conditions = ConditionTree(BooleanOperator.all):add{
-		ConditionNode(ColumnName('namespace'), Comparator.neq, Namespace.NS_MATCH),
+		ConditionNode(ColumnName('namespace'), Comparator.neq, Namespace.matchNamespaceId()),
 		ConditionUtil.anyOf(ColumnName('match2id'), matchIds),
 	}
 

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -10,6 +10,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Lpdb = Lua.import('Module:Lpdb')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util')
+local Namespace = Lua.import('Module:Namespace')
 local Opponent = Lua.import('Module:Opponent/Custom')
 
 local Condition = Lua.import('Module:Condition')
@@ -21,8 +22,6 @@ local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
 local StandingsParseLpdb = {}
-
-local NAMESPACE_MATCH = 130
 
 ---@param rounds {roundNumber: integer, matches: string[]}[]
 ---@param scoreMapper fun(opponent: match2opponent): number|nil
@@ -49,7 +48,7 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	end)
 
 	local conditions = ConditionTree(BooleanOperator.all):add{
-		ConditionNode(ColumnName('namespace'), Comparator.neq, NAMESPACE_MATCH),
+		ConditionNode(ColumnName('namespace'), Comparator.neq, Namespace.NS_MATCH),
 		ConditionUtil.anyOf(ColumnName('match2id'), matchIds),
 	}
 

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -47,10 +47,7 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	end)
 
 	local conditions = ConditionTree(BooleanOperator.all):add{
-		ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('namespace'), Comparator.eq, 0),
-			ConditionNode(ColumnName('namespace'), Comparator.neq, 0),
-		},
+		ConditionNode(ColumnName('namespace'), Comparator.neq, 130),
 		ConditionUtil.anyOf(ColumnName('match2id'), matchIds),
 	}
 

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -22,6 +22,8 @@ local ColumnName = Condition.ColumnName
 
 local StandingsParseLpdb = {}
 
+local NAMESPACE_MATCH = 130
+
 ---@param rounds {roundNumber: integer, matches: string[]}[]
 ---@param scoreMapper fun(opponent: match2opponent): number|nil
 ---@return StandingTableOpponentData[]
@@ -47,7 +49,7 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 	end)
 
 	local conditions = ConditionTree(BooleanOperator.all):add{
-		ConditionNode(ColumnName('namespace'), Comparator.neq, 130),
+		ConditionNode(ColumnName('namespace'), Comparator.neq, NAMESPACE_MATCH),
 		ConditionUtil.anyOf(ColumnName('match2id'), matchIds),
 	}
 

--- a/lua/wikis/commons/Standings/Parse/Wiki.lua
+++ b/lua/wikis/commons/Standings/Parse/Wiki.lua
@@ -131,7 +131,8 @@ function StandingsParseWiki.getMatchIdsFromStage(rawStage)
 	local matchGroup = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = tostring(ConditionTree(BooleanOperator.all):add(Array.append(
 			{ConditionNode(ColumnName('pagename'), Comparator.eq, basePage)},
-			namespace and ConditionNode(ColumnName('namespace'), Comparator.eq, Namespace.idFromName(namespace)) or nil
+			namespace and ConditionNode(ColumnName('namespace'), Comparator.eq, Namespace.idFromName(namespace)) or nil,
+			stage and ConditionNode(ColumnName('match2bracketdata_sectionheader'), Comparator.eq, stage) or nil
 		))),
 		query = 'match2id',
 		limit = '1000',

--- a/lua/wikis/commons/Standings/Parse/Wiki.lua
+++ b/lua/wikis/commons/Standings/Parse/Wiki.lua
@@ -108,7 +108,7 @@ end
 function StandingsParseWiki.getMatchIdsOfMatchGroup(matchGroupId)
 	local matchGroup = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = tostring(ConditionTree(BooleanOperator.all):add{
-			ConditionNode(ColumnName('namespace'), Comparator.neq, Namespace.NS_MATCH),
+			ConditionNode(ColumnName('namespace'), Comparator.neq, Namespace.matchNamespaceId()),
 			ConditionNode(ColumnName('match2bracketid'), Comparator.eq, matchGroupId),
 		}),
 		query = 'match2id',

--- a/lua/wikis/commons/Standings/Parse/Wiki.lua
+++ b/lua/wikis/commons/Standings/Parse/Wiki.lua
@@ -25,8 +25,6 @@ local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
-local NAMESPACE_MATCH = 130
-
 local StandingsParseWiki = {}
 
 --[[
@@ -110,7 +108,7 @@ end
 function StandingsParseWiki.getMatchIdsOfMatchGroup(matchGroupId)
 	local matchGroup = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = tostring(ConditionTree(BooleanOperator.all):add{
-			ConditionNode(ColumnName('namespace'), Comparator.neq, NAMESPACE_MATCH),
+			ConditionNode(ColumnName('namespace'), Comparator.neq, Namespace.NS_MATCH),
 			ConditionNode(ColumnName('match2bracketid'), Comparator.eq, matchGroupId),
 		}),
 		query = 'match2id',

--- a/lua/wikis/commons/Standings/Parse/Wiki.lua
+++ b/lua/wikis/commons/Standings/Parse/Wiki.lua
@@ -18,14 +18,16 @@ local Table = Lua.import('Module:Table')
 
 local TiebreakerFactory = Lua.import('Module:Standings/Tiebreaker/Factory')
 
-local StandingsParseWiki = {}
-
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree
 local ConditionNode = Condition.Node
 local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
+
+local NAMESPACE_MATCH = 130
+
+local StandingsParseWiki = {}
 
 --[[
 {{FfaStandings|title=League Standings
@@ -108,10 +110,7 @@ end
 function StandingsParseWiki.getMatchIdsOfMatchGroup(matchGroupId)
 	local matchGroup = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = tostring(ConditionTree(BooleanOperator.all):add{
-			ConditionTree(BooleanOperator.any):add{
-				ConditionNode(ColumnName('namespace'), Comparator.eq, 0),
-				ConditionNode(ColumnName('namespace'), Comparator.neq, 0),
-			},
+			ConditionNode(ColumnName('namespace'), Comparator.neq, NAMESPACE_MATCH),
 			ConditionNode(ColumnName('match2bracketid'), Comparator.eq, matchGroupId),
 		}),
 		query = 'match2id',


### PR DESCRIPTION
## Summary
Currently Standings are only abel to query from main space.
As per mentions on discord we likely should allow querying from non main space.
This PR allows querying from any main space when retrieving the match data for standings.

Additional changes:
- use `Module:Condition` to build the conditions in some places in Standings modules
- simplify some code
- slap Array.unique around the matches to make sure we do not have duplicate matches listed
- allow new input `|stages=`
  - comma sep list of pagenames with potentially stages (`nameSpace:pagename#stage`)
  - intended usage: import all matches from a stage/page into a round
  - fetches up to 1k matchIds from a given stage/pagename and extends the matches array with those

**lmk if the stage stuff is not wanted, not maried to it :P**

## How did you test this change?
dev (preview tests)