### PR TITLE
feat(copypaste) move finish param to map for FC

### DIFF
--- a/lua/wikis/easportsfc/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/easportsfc/GetMatchGroupCopyPaste/wiki.lua
@@ -31,7 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match',
-		bestof ~= 0 and (INDENT .. '|bestof=' .. bestof) or nil,
+		bestof ~= 0 and (INDENT .. '|bestof=' .. bestof) or (INDENT .. '|finished='),
 		hasSubmatches and INDENT .. '|hasSubmatches=1' or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|youtube=|twitch='} or {},

--- a/lua/wikis/easportsfc/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/easportsfc/GetMatchGroupCopyPaste/wiki.lua
@@ -30,7 +30,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local hasSubmatches = Logic.readBool(args.hasSubmatches)
 
 	local lines = Array.extend(
-		'{{Match|finished=',
+		'{{Match',
 		bestof ~= 0 and (INDENT .. '|bestof=' .. bestof) or nil,
 		hasSubmatches and INDENT .. '|hasSubmatches=1' or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
@@ -52,7 +52,7 @@ end
 ---@return string
 function WikiCopyPaste._getMap(hasSubmatches)
 	local lines = Array.extend(
-		'{{Map',
+		'{{Map|finished=',
 		INDENT .. INDENT .. '|score1= |score2=',
 		hasSubmatches and {
 			INDENT .. INDENT .. '|penaltyScore1= |penaltyScore2=',


### PR DESCRIPTION
Can't remember why it was setup that way because nowaday it should be able to to just mark finished in the map 

and it will apply the series score & finished status accordingly witthout having to set it manually at match level anymore.

