### PR TITLE
feat(infobox): darkmode EA icon for apex infobox league 

### DIFF
--- a/lua/wikis/apexlegends/Infobox/League/Custom.lua
+++ b/lua/wikis/apexlegends/Infobox/League/Custom.lua
@@ -26,7 +26,8 @@ local Center = Widgets.Center
 
 local GAME_MODE = Lua.import('Module:GameMode', {loadData = true})
 local EA_ICON = '&nbsp;[[File:EA icon.png|x15px|middle|link=Electronic Arts|'
-	.. 'Tournament sponsored by Electronirc Arts & Respawn.]]'
+	.. 'Tournament sponsored by Electronic Arts & Respawn.|class=show-when-light-mode]][[File:EA icon darkmode.png|'
+	.. 'x15px|middle|link=Electronic Arts|Tournament sponsored by Electronic Arts & Respawn.|class=show-when-dark-mode]]'
 
 ---@class ApexlegendsLeagueInfobox: InfoboxLeague
 local CustomLeague = Class.new(League)


### PR DESCRIPTION
## Summary

1) Added darkmode icon because lightmode icon is almost invisible in darkmode (code taken from brawlstars module)
2) Fixed typo in company name (electroniRc)

## How did you test this change?

https://liquipedia.net/apexlegends/User:Nikita_r28/test
https://liquipedia.net/apexlegends/Module:Infobox/League/Custom/dev/r28