### PR TITLE
feat: add h3gg link support in matches

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -146,6 +146,7 @@ local PREFIXES = {
 	gol = {match = 'https://gol.gg/game/stats/'},
 	gosugamers = {''},
 	gplus = {'http://plus.google.com/-plus'},
+	h3gg = {match = 'https://www.h3.gg/competitions/v2/match/'},
 	halodatahive = {
 		'https://halodatahive.com/Tournament/Detail/',
 		team = 'https://halodatahive.com/Team/Detail/',
@@ -463,6 +464,10 @@ local MATCH_ICONS = {
 	gol = {
 		icon = 'File:Gol.gg allmode.png',
 		text = 'GolGG Match Report',
+	},
+	h3gg = {
+		icon = 'File:H3gg icon allmode.png',
+		text = 'H3.gg match details',
 	},
 	halodatahive = {
 		icon = 'File:Halo Data Hive allmode.png',


### PR DESCRIPTION
## Summary
As per request on discord: https://discord.com/channels/93055209017729024/268719633366777856/1404192898819424467

As per discussion in last weeks modules sync we allow new links for hub wiki as long as they do not overwrite existing ones.

## How did you test this change?
N/A just data