### PR TITLE
feat(match2): adjust icon sizes on WarCraft 3 for FFA

### DIFF
--- a/lua/wikis/warcraft/MatchSummary.lua
+++ b/lua/wikis/warcraft/MatchSummary.lua
@@ -196,13 +196,9 @@ function CustomMatchSummary.DisplayHeroes(opponent, options)
 		classes = {'brkts-popup-body-element-vertical-centered'},
 		css = {['flex-direction'] = 'column', ['padding-' .. (options.flipped and 'left' or 'right')] = '8px'},
 		children = Array.map(heroesPerPlayer, function(heroes)
-			return HtmlWidgets.Div{
-				classes = {'brkts-popup-body-element-thumbs', 'brkts-champion-icon'},
-				children = MatchSummaryWidgets.Characters{
-					flipped = options.flipped,
-					characters = heroes,
-					bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (options.flipped and 'blue' or 'red'),
-				},
+			return MatchSummaryWidgets.Characters{
+				flipped = options.flipped,
+				characters = heroes,
 			}
 		end)
 	}

--- a/stylesheets/commons/Brackets.less
+++ b/stylesheets/commons/Brackets.less
@@ -601,37 +601,37 @@ div.brkts-popup-body-element-thumbs {
 	padding: 0.5rem;
 	margin: 0 -0.5rem;
 
-	.brkts-champion-icon {
-		gap: 0.125rem;
-		display: flex;
-
-		img {
-			width: 1.5rem;
-			height: 1.5rem;
-			border-radius: 0.25rem;
-
-			@media ( max-width: 768px ) {
-				width: 1.25rem;
-				height: 1.25rem;
-			}
-
-			@media ( hover: hover ) {
-				&:hover {
-					height: unset;
-					box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
-					outline: 0.0625rem solid #ffffff;
-					outline-offset: -0.0625rem;
-					background-color: var( --clr-background );
-				}
-			}
-		}
-	}
-
 	.brkts-popup-winloss-icon {
 		margin: unset;
 
 		& > i {
 			font-size: 0.875rem;
+		}
+	}
+}
+
+.brkts-champion-icon {
+	gap: 0.125rem;
+	display: flex;
+
+	img {
+		width: 1.5rem;
+		height: 1.5rem;
+		border-radius: 0.25rem;
+
+		@media ( max-width: 768px ) {
+			width: 1.25rem;
+			height: 1.25rem;
+		}
+
+		@media ( hover: hover ) {
+			&:hover {
+				height: unset;
+				box-shadow: 0 0.0625rem 0.25rem 0 rgba( 0, 0, 0, 0.12 );
+				outline: 0.0625rem solid #ffffff;
+				outline-offset: -0.0625rem;
+				background-color: var( --clr-background );
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

 Adjust hero icon sizes on FFA tables        
 On WC3 wiki, can remove the colored outline for all use cases, there is no "side" in a game of WarCraft 3

## How did you test this change?

dev & devtools respecitively