### PR TITLE
refactor(THA): split the display into a sep widget

### DIFF
--- a/lua/wikis/commons/Infobox/Extension/TeamHistoryAuto.lua
+++ b/lua/wikis/commons/Infobox/Extension/TeamHistoryAuto.lua
@@ -12,27 +12,12 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
-local FnUtil = Lua.import('Module:FnUtil')
 local Info = Lua.import('Module:Info', {loadData = true})
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Namespace = Lua.import('Module:Namespace')
-local Roles = Lua.import('Module:Roles')
-local Table = Lua.import('Module:Table')
 local TeamTemplate = Lua.import('Module:TeamTemplate')
 local TransferModel = Lua.import('Module:Transfer/Model')
-local TransferRef = Lua.import('Module:Transfer/References')
-
-local Link = Lua.import('Module:Widget/Basic/Link')
-local HtmlWidgets = Lua.import('Module:Widget/Html/All')
-local Abbr = HtmlWidgets.Abbr
-local Fragment = HtmlWidgets.Fragment
-local Span = HtmlWidgets.Span
-local Tbl = HtmlWidgets.Table
-local Td = HtmlWidgets.Td
-local Th = HtmlWidgets.Th
-local Tr = HtmlWidgets.Tr
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local Condition = require('Module:Condition')
 local ConditionTree = Condition.Tree
@@ -40,6 +25,8 @@ local ConditionNode = Condition.Node
 local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
+
+local TeamHistoryDisplay = Lua.import('Module:Widget/Infobox/TeamHistory/Display')
 
 local SPECIAL_ROLES = {
 	'Retired',
@@ -54,26 +41,6 @@ local SPECIAL_ROLES = {
 	'Talent',
 	'League Operator',
 	'Inactive'
-}
-local LOAN = 'Loan'
-
-local POSITION_ICON_DATA = Lua.requireIfExists('Module:PositionIcon/data', {loadData = true})
-
--- todo at a later date: move into standardized role data where reasonable or kick
-local NOT_YET_IN_ROLES_DATA = {
-	['coach/analyst'] = {display = 'Coach/Analyst', abbreviation = 'C./A.'},
-	['coach and analyst'] = {display = 'Coach/Analyst', abbreviation = 'C./A.'},
-	['overall coach'] = {display = 'Overall Coach', abbreviation = 'OC.'},
-	['manager and analyst'] = {display = 'Manager/Analyst', abbreviation = 'M./A.'},
-	['manager/analyst'] = {display = 'Manager/Analyst', abbreviation = 'M./A.'},
-	['general manager'] = {display = 'General Manager', abbreviation = 'GM.'},
-	['assistant general manager'] = {display = 'Assistant General Manager', abbreviation = 'AGM.'},
-	['team manager'] = {display = 'Team Manager', abbreviation = 'TM.'},
-	['assistant team manager'] = {display = 'Assistant Team Manager', abbreviation = 'ATM.'},
-	substitute = {display = 'Substitute', abbreviation = 'Sub.'},
-	inactive = {display = 'Inactive', abbreviation = 'Ia.'},
-	['training advisor'] = {display = 'Training Advisor', abbreviation = 'TA.'},
-	['founder & training director'] = {display = 'Founder & Training Director', abbreviation = 'F. & TD.'},
 }
 
 ---@class TeamHistoryAuto
@@ -95,7 +62,7 @@ function TeamHistoryAuto:store()
 	if not Namespace.isMain() then return self end
 	Array.forEach(self.transferList, function(transfer, transferIndex)
 		TeamHistoryAuto._checkForMissingLeaveDate(transfer, transferIndex, #self.transferList)
-		local teamLink = self:_getTeamLinkAndText(transfer)
+		local teamLink = self:_getTeamLink(transfer)
 		if not teamLink and not transfer.role then return end
 
 		mw.ext.LiquipediaDB.lpdb_datapoint('Team_'..transferIndex, Json.stringifySubTables{
@@ -125,32 +92,14 @@ end
 
 ---@param transfer table
 ---@return string?
----@return Widget
-function TeamHistoryAuto:_getTeamLinkAndText(transfer)
-	if Logic.isEmpty(transfer.team) and Table.includes(SPECIAL_ROLES, transfer.role) then
-		return nil, HtmlWidgets.B{children = {transfer.role}}
-	elseif not TeamTemplate.exists(transfer.team) then
-		return transfer.team, Link{link = transfer.team}
+function TeamHistoryAuto:_getTeamLink(transfer)
+	if Logic.isEmpty(transfer.team) or not TeamTemplate.exists(transfer.team) then
+		return Logic.nilIfEmpty(transfer.team)
 	end
 	local leaveDateCleaned = TeamHistoryAuto._adjustDate(transfer.leaveDate)
 	local teamData = TeamTemplate.getRawOrNil(transfer.team, leaveDateCleaned) or {}
 
-	return teamData.page, Link{
-		link = teamData.page,
-		children = {TeamHistoryAuto._getTeamDisplayName(teamData)}
-	}
-end
-
----@param teamData {name: string, bracketname: string, shortname: string}
----@return string
-function TeamHistoryAuto._getTeamDisplayName(teamData)
-	if string.len(teamData.name) <= 17 then
-		return teamData.name
-	elseif string.len(teamData.bracketname) <= 17 then
-		return teamData.bracketname
-	else
-		return teamData.shortname or teamData.name
-	end
+	return teamData.page
 end
 
 -- earlier date for fromteam to account for rebrands
@@ -169,176 +118,11 @@ end
 
 ---@return Widget?
 function TeamHistoryAuto:build()
-	if Logic.isEmpty(self.transferList) then return end
-
-	return Tbl{
-		css = {width = '100%', ['text-align'] = 'left'},
-		children = WidgetUtil.collect(
-			self.config.hasHeaderAndRefs and self:_header() or nil,
-			Array.map(self.transferList, FnUtil.curry(self._row, self))
-		)
+	return TeamHistoryDisplay{
+		transferList = self.transferList,
+		hasHeaderAndRefs = self.config.hasHeaderAndRefs,
+		player = self.config.player,
 	}
-end
-
----@return Widget
-function TeamHistoryAuto:_header()
-	local makeQueryFormLink = function()
-		return Link{
-			link = tostring(mw.uri.fullUrl('Special:RunQuery/Transfer history', {
-				pfRunQueryFormName = 'Transfer history',
-				['Transfer query[players]'] = self.config.player,
-				wpRunQuery ='Run query'
-			})),
-			linktype = 'external',
-			children = {'q'},
-		}
-	end
-
-	return Tr{children = {
-		Th{children = {'Join'}},
-		Th{
-			css = {['padding-left'] = '5px'},
-			children = {'Leave'},
-		},
-		Th{
-			css = {['padding-left'] = '5px'},
-			children = {
-				'Team',
-				Span{
-					css = {float = 'right', ['font-size'] = '90%', ['font-weight'] = '500'},
-					children = {
-						mw.text.nowiki('['),
-						makeQueryFormLink(),
-						mw.text.nowiki(']'),
-					},
-				},
-			},
-		},
-	}}
-end
-
----@param transfer table
----@return Widget
-function TeamHistoryAuto:_row(transfer)
-	local _, teamText = self:_getTeamLinkAndText(transfer)
-
-	---@type Widget|string?
-	local role = Logic.nilIfEmpty(transfer.role)
-	if role then
-		local splitRole = Array.parseCommaSeparatedString(role --[[@as string]], ' ')
-		local lastSplitRole = splitRole[#splitRole]:lower()
-		local roleData = Roles.All[transfer.role:lower()] or Roles.All[lastSplitRole]
-			or NOT_YET_IN_ROLES_DATA[transfer.role:lower()] or NOT_YET_IN_ROLES_DATA[lastSplitRole] or {}
-		if roleData.doNotShowInHistory then
-			role = nil
-		elseif roleData.abbreviation then
-			role = roleData and Abbr{title = roleData.display, children = {roleData.abbreviation}}
-		end
-	end
-	if role == LOAN then
-		teamText = '&#8250;&nbsp;' .. teamText
-	end
-	---@type (string|Widget)[]
-	local teamDisplay = {teamText}
-	if role then
-		table.insert(teamDisplay,
-			Span{
-				css = {['padding-left'] = '3px', ['font-style'] = 'italic'},
-				children = {
-					'(',
-					role,
-					')',
-				},
-			}
-		)
-	end
-
-	local positionIcon
-	if POSITION_ICON_DATA then
-		local position = (transfer.position or ''):lower()
-		positionIcon = (POSITION_ICON_DATA[position] or POSITION_ICON_DATA['']) .. '&nbsp;'
-	end
-
-	local leaveateDisplay = self:_buildLeaveDateDisplay(transfer)
-
-	if not self.config.hasHeaderAndRefs then
-		return Tr{children = {
-			Td{
-				classes = {'th-mono'},
-				css = {float = 'left', width = '50%', ['font-style'] = 'italic'},
-				children = {
-					transfer.joinDateDisplay,
-					leaveateDisplay and ' &#8212; ' or nil,
-					leaveateDisplay,
-				},
-			},
-			Td{
-				css = {float = 'right', width = '50%'},
-				children = WidgetUtil.collect(
-					positionIcon,
-					teamDisplay
-				),
-			},
-		}}
-	end
-
-	return Tr{children = {
-		Td{
-			classes = {'th-mono'},
-			css = {['white-space'] = 'nowrap', ['vertical-align'] = 'top'},
-			children = {
-				transfer.joinDateDisplay,
-				TeamHistoryAuto._displayRef(transfer.reference.join, transfer.joinDateDisplay)
-			},
-		},
-		Td{
-			classes = {'th-mono'},
-			css = {['white-space'] = 'nowrap', ['vertical-align'] = 'top', ['padding-left'] = '5px'},
-			children = {
-				leaveateDisplay,
-				TeamHistoryAuto._displayRef(transfer.reference.leave, transfer.leaveDateDisplay)
-			},
-		},
-		Td{
-			css = {['padding-left'] = '5px'},
-			children = WidgetUtil.collect(
-				positionIcon and (positionIcon .. '&nbsp;') or nil,
-				teamDisplay
-			),
-		},
-	}}
-end
-
----@param references table[]
----@param date string
----@return Widget?
-function TeamHistoryAuto._displayRef(references, date)
-	local refs = Array.map(TransferRef.fromStorageData(references), function(reference)
-		return reference.link and TransferRef.useReference(reference, date) or nil
-	end)
-
-	if Logic.isEmpty(refs) then return end
-
-	return Fragment{children = WidgetUtil.collect(
-		Span{
-			css = {['font-size'] = '50%'},
-			children = {'&thinsp;'},
-		},
-		refs
-	)}
-end
-
----@param transfer table
----@return string|Widget?
-function TeamHistoryAuto:_buildLeaveDateDisplay(transfer)
-	if transfer.leaveDateDisplay then return transfer.leaveDateDisplay end
-
-	if not Table.includes(SPECIAL_ROLES, transfer.role) then
-		return Span{
-			css = {['font-weight'] = 'bold'},
-			children = {'Present'}
-		}
-	end
 end
 
 ---@return transfer[]

--- a/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
@@ -1,0 +1,296 @@
+---
+-- @Liquipedia
+-- page=Module:Widget/Infobox/TeamHistory/Display
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local DateExt = Lua.import('Module:Date/Ext')
+local FnUtil = Lua.import('Module:FnUtil')
+local Info = Lua.import('Module:Info', {loadData = true})
+local Logic = Lua.import('Module:Logic')
+local Roles = Lua.import('Module:Roles')
+local String = Lua.import('Module:StringUtils')
+local Table = Lua.import('Module:Table')
+local TeamTemplate = Lua.import('Module:TeamTemplate')
+local TransferRef = Lua.import('Module:Transfer/References')
+local Widget = Lua.import('Module:Widget')
+
+local Link = Lua.import('Module:Widget/Basic/Link')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Abbr = HtmlWidgets.Abbr
+local Fragment = HtmlWidgets.Fragment
+local Span = HtmlWidgets.Span
+local Tbl = HtmlWidgets.Table
+local Td = HtmlWidgets.Td
+local Th = HtmlWidgets.Th
+local Tr = HtmlWidgets.Tr
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local SPECIAL_ROLES = {
+	'Retired',
+	'Retirement',
+	'Military',
+	'Banned',
+	'Producer',
+	'Caster',
+	'Admin',
+	'Observer',
+	'Host',
+	'Talent',
+	'League Operator',
+	'Inactive'
+}
+local LOAN = 'Loan'
+local POSITION_ICON_DATA = Lua.requireIfExists('Module:PositionIcon/data', {loadData = true})
+
+-- todo at a later date: move into standardized role data where reasonable or kick
+local NOT_YET_IN_ROLES_DATA = {
+	['coach/analyst'] = {display = 'Coach/Analyst', abbreviation = 'C./A.'},
+	['coach and analyst'] = {display = 'Coach/Analyst', abbreviation = 'C./A.'},
+	['overall coach'] = {display = 'Overall Coach', abbreviation = 'OC.'},
+	['manager and analyst'] = {display = 'Manager/Analyst', abbreviation = 'M./A.'},
+	['manager/analyst'] = {display = 'Manager/Analyst', abbreviation = 'M./A.'},
+	['general manager'] = {display = 'General Manager', abbreviation = 'GM.'},
+	['assistant general manager'] = {display = 'Assistant General Manager', abbreviation = 'AGM.'},
+	['team manager'] = {display = 'Team Manager', abbreviation = 'TM.'},
+	['assistant team manager'] = {display = 'Assistant Team Manager', abbreviation = 'ATM.'},
+	substitute = {display = 'Substitute', abbreviation = 'Sub.'},
+	inactive = {display = 'Inactive', abbreviation = 'Ia.'},
+	['training advisor'] = {display = 'Training Advisor', abbreviation = 'TA.'},
+	['founder & training director'] = {display = 'Founder & Training Director', abbreviation = 'F. & TD.'},
+}
+
+---@class TeamHistoryDisplayWidget: Widget
+---@operator call(table): TeamHistoryDisplayWidget
+---@field props {transferList: table[], hasHeaderAndRefs: boolean?, player: string}
+local TeamHistoryDisplay = Class.new(Widget)
+TeamHistoryDisplay.defaultProps = {
+	hasHeaderAndRefs = ((Info.config.infoboxPlayer or {}).automatedHistory or {}).hasHeaderAndRefs,
+	transferList = {},
+	player = String.upperCaseFirst(mw.title.getCurrentTitle().subpageText),
+}
+
+---@return Widget?
+function TeamHistoryDisplay:render()
+	if Logic.isEmpty(self.props.transferList) then return end
+
+	return Tbl{
+		css = {width = '100%', ['text-align'] = 'left'},
+		children = WidgetUtil.collect(
+			self.props.hasHeaderAndRefs and self:_header() or nil,
+			Array.map(self.props.transferList, FnUtil.curry(self._row, self))
+		)
+	}
+end
+
+---@return Widget
+function TeamHistoryDisplay:_header()
+	local makeQueryFormLink = function()
+		return Link{
+			link = tostring(mw.uri.fullUrl('Special:RunQuery/Transfer history', {
+				pfRunQueryFormName = 'Transfer history',
+				['Transfer query[players]'] = self.props.player,
+				wpRunQuery ='Run query'
+			})),
+			linktype = 'external',
+			children = {'q'},
+		}
+	end
+
+	return Tr{children = {
+		Th{children = {'Join'}},
+		Th{
+			css = {['padding-left'] = '5px'},
+			children = {'Leave'},
+		},
+		Th{
+			css = {['padding-left'] = '5px'},
+			children = {
+				'Team',
+				Span{
+					css = {float = 'right', ['font-size'] = '90%', ['font-weight'] = '500'},
+					children = {
+						mw.text.nowiki('['),
+						makeQueryFormLink(),
+						mw.text.nowiki(']'),
+					},
+				},
+			},
+		},
+	}}
+end
+
+---@param transfer table
+---@return Widget
+function TeamHistoryDisplay:_row(transfer)
+	local teamText = self:_getTeamText(transfer)
+
+	---@type Widget|string?
+	local role = Logic.nilIfEmpty(transfer.role)
+	if role then
+		local splitRole = Array.parseCommaSeparatedString(role --[[@as string]], ' ')
+		local lastSplitRole = splitRole[#splitRole]:lower()
+		local roleData = Roles.All[transfer.role:lower()] or Roles.All[lastSplitRole]
+			or NOT_YET_IN_ROLES_DATA[transfer.role:lower()] or NOT_YET_IN_ROLES_DATA[lastSplitRole] or {}
+		if roleData.doNotShowInHistory then
+			role = nil
+		elseif roleData.abbreviation then
+			role = roleData and Abbr{title = roleData.display, children = {roleData.abbreviation}}
+		end
+	end
+	if role == LOAN then
+		teamText = '&#8250;&nbsp;' .. teamText
+	end
+	---@type (string|Widget)[]
+	local teamDisplay = {teamText}
+	if role then
+		table.insert(teamDisplay,
+			Span{
+				css = {['padding-left'] = '3px', ['font-style'] = 'italic'},
+				children = {
+					'(',
+					role,
+					')',
+				},
+			}
+		)
+	end
+
+	local positionIcon
+	if POSITION_ICON_DATA then
+		local position = (transfer.position or ''):lower()
+		positionIcon = (POSITION_ICON_DATA[position] or POSITION_ICON_DATA['']) .. '&nbsp;'
+	end
+
+	local leaveateDisplay = self:_buildLeaveDateDisplay(transfer)
+
+	if not self.props.hasHeaderAndRefs then
+		return Tr{children = {
+			Td{
+				classes = {'th-mono'},
+				css = {float = 'left', width = '50%', ['font-style'] = 'italic'},
+				children = {
+					transfer.joinDateDisplay,
+					leaveateDisplay and ' &#8212; ' or nil,
+					leaveateDisplay,
+				},
+			},
+			Td{
+				css = {float = 'right', width = '50%'},
+				children = WidgetUtil.collect(
+					positionIcon,
+					teamDisplay
+				),
+			},
+		}}
+	end
+
+	return Tr{children = {
+		Td{
+			classes = {'th-mono'},
+			css = {['white-space'] = 'nowrap', ['vertical-align'] = 'top'},
+			children = {
+				transfer.joinDateDisplay,
+				TeamHistoryDisplay._displayRef(transfer.reference.join, transfer.joinDateDisplay)
+			},
+		},
+		Td{
+			classes = {'th-mono'},
+			css = {['white-space'] = 'nowrap', ['vertical-align'] = 'top', ['padding-left'] = '5px'},
+			children = {
+				leaveateDisplay,
+				TeamHistoryDisplay._displayRef(transfer.reference.leave, transfer.leaveDateDisplay)
+			},
+		},
+		Td{
+			css = {['padding-left'] = '5px'},
+			children = WidgetUtil.collect(
+				positionIcon and (positionIcon .. '&nbsp;') or nil,
+				teamDisplay
+			),
+		},
+	}}
+end
+
+---@param transfer table
+---@return string?
+---@return Widget
+function TeamHistoryDisplay:_getTeamText(transfer)
+	if Logic.isEmpty(transfer.team) and Table.includes(SPECIAL_ROLES, transfer.role) then
+		return HtmlWidgets.B{children = {transfer.role}}
+	elseif not TeamTemplate.exists(transfer.team) then
+		return Link{link = transfer.team}
+	end
+	local leaveDateCleaned = TeamHistoryDisplay._adjustDate(transfer.leaveDate)
+	local teamData = TeamTemplate.getRawOrNil(transfer.team, leaveDateCleaned) or {}
+
+	return Link{
+		link = teamData.page,
+		children = {TeamHistoryDisplay._getTeamDisplayName(teamData)}
+	}
+end
+
+---@param teamData {name: string, bracketname: string, shortname: string}
+---@return string
+function TeamHistoryDisplay._getTeamDisplayName(teamData)
+	if string.len(teamData.name) <= 17 then
+		return teamData.name
+	elseif string.len(teamData.bracketname) <= 17 then
+		return teamData.bracketname
+	else
+		return teamData.shortname or teamData.name
+	end
+end
+
+-- earlier date for fromteam to account for rebrands
+---@param date string?
+---@return string?
+function TeamHistoryDisplay._adjustDate(date)
+	if Logic.isEmpty(date) then
+		return date
+	end
+	---@cast date -nil
+
+	local dateStruct = DateExt.parseIsoDate(date)
+	dateStruct.day = dateStruct.day - 1
+	return os.date('%Y-%m-%d', os.time(dateStruct)) --[[@as string]]
+end
+
+---@param transfer table
+---@return string|Widget?
+function TeamHistoryDisplay:_buildLeaveDateDisplay(transfer)
+	if transfer.leaveDateDisplay then return transfer.leaveDateDisplay end
+
+	if not Table.includes(SPECIAL_ROLES, transfer.role) then
+		return Span{
+			css = {['font-weight'] = 'bold'},
+			children = {'Present'}
+		}
+	end
+end
+
+---@param references table[]
+---@param date string
+---@return Widget?
+function TeamHistoryDisplay._displayRef(references, date)
+	local refs = Array.map(TransferRef.fromStorageData(references), function(reference)
+		return reference.link and TransferRef.useReference(reference, date) or nil
+	end)
+
+	if Logic.isEmpty(refs) then return end
+
+	return Fragment{children = WidgetUtil.collect(
+		Span{
+			css = {['font-size'] = '50%'},
+			children = {'&thinsp;'},
+		},
+		refs
+	)}
+end
+
+return TeamHistoryDisplay


### PR DESCRIPTION
## Summary
Split the display parts from THA Extension into a widget.
Planned followup is to add a module to process the manual TH inputs and parse them to a format that `Module:Widget/Infobox/TeamHistory/Display` can use.

## How did you test this change?
to be done