### PR TITLE
feat(match2): always show streams in match popups (when variant is primary)

### DIFF
--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -334,7 +334,7 @@ function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 	match:footer(createFooter(matchData, MatchSummary.Footer()))
 
 	--- Vods are currently part of the footer, so we don't need them here
-	match:button(MatchButtonBar{match = matchData, showVods = false, buttonType = 'primary'})
+	match:button(MatchButtonBar{match = matchData, showVods = false, variant = 'primary'})
 
 	return match
 end

--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -23,7 +23,7 @@ local SHOW_STREAMS_WHEN_LESS_THAN_TO_LIVE = 2 * 60 * 60 -- 2 hours in seconds
 ---@class MatchButtonBarProps
 ---@field match MatchGroupUtilMatch
 ---@field showVods boolean?
----@field buttonType? 'primary' | 'secondary'
+---@field variant? 'primary' | 'secondary'
 
 ---@class MatchButtonBar: Widget
 ---@operator call(MatchButtonBarProps): MatchButtonBar
@@ -31,7 +31,7 @@ local SHOW_STREAMS_WHEN_LESS_THAN_TO_LIVE = 2 * 60 * 60 -- 2 hours in seconds
 local MatchButtonBar = Class.new(Widget)
 MatchButtonBar.defaultProps = {
 	showVods = true,
-	buttonType = 'secondary',
+	variant = 'secondary',
 }
 
 ---@return Widget?
@@ -50,6 +50,8 @@ function MatchButtonBar:render()
 		os.difftime(match.timestamp, DateExt.getCurrentTimestamp()) < SHOW_STREAMS_WHEN_LESS_THAN_TO_LIVE then
 
 		displayStreams = true
+	elseif match.phase == 'upcoming' and self.props.variant == 'primary' then
+		displayStreams = true
 	end
 
 	return HtmlWidgets.Div{
@@ -57,7 +59,7 @@ function MatchButtonBar:render()
 		children = WidgetUtil.collect(
 			MatchPageButton{
 				match = match,
-				buttonType = self.props.buttonType,
+				buttonType = self.props.variant,
 			},
 			displayStreams and StreamsContainer{
 				streams = StreamLinks.filterStreams(match.stream),


### PR DESCRIPTION
## Summary

        
      
 Remove the t-2h logic and always show stream links in match summary popups, but keep the t-2h logic on other places

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
