### PR TITLE
feat(Mainpage): Add Pokemon

### DIFF
--- a/lua/wikis/pokemon/MainPageLayout/data.lua
+++ b/lua/wikis/pokemon/MainPageLayout/data.lua
@@ -1,0 +1,209 @@
+---
+-- @Liquipedia
+-- page=Module:MainPageLayout/data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local DateExt = Lua.import('Module:Date/Ext')
+
+local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
+local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Div = HtmlWidgets.Div
+local MatchTicker = Lua.import('Module:Widget/MainPage/MatchTicker')
+local ThisDayWidgets = Lua.import('Module:Widget/MainPage/ThisDay')
+local TransfersList = Lua.import('Module:Widget/MainPage/TransfersList')
+local WantToHelp = Lua.import('Module:Widget/MainPage/WantToHelp')
+
+local CONTENT = {
+	usefulArticles = {
+		heading = 'Useful Articles',
+		body = '{{Liquipedia:Useful Articles}}',
+		padding = true,
+		boxid = 1503,
+	},
+	wantToHelp = {
+		heading = 'Want To Help?',
+		body = WantToHelp{},
+		padding = true,
+		boxid = 1504,
+	},
+	transfers = {
+		heading = 'Transfers',
+		body = TransfersList{
+			rumours = true,
+			limits = 10,
+			transferPage = 'Player Transfers/' .. os.date('%Y') .. '/' ..
+				DateExt.quarterOf{ ordinalSuffix = true } .. ' Quarter'
+		},
+		boxid = 1509,
+	},
+	thisDay = {
+		heading = ThisDayWidgets.Title(),
+		body = ThisDayWidgets.Content{
+			birthdayListPage = 'Birthday list'
+		},
+		padding = true,
+		boxid = 1510,
+	},
+	specialEvents = {
+		noPanel = true,
+		body = '{{Liquipedia:Special Event}}',
+		boxid = 1516,
+	},
+	filterButtons = {
+		noPanel = true,
+		body = Div{
+			css = { width = '100%', ['margin-bottom'] = '8px' },
+			children = { FilterButtonsWidget() }
+		}
+	},
+	matches = {
+		heading = 'Matches',
+		body = MatchTicker{},
+		padding = true,
+		boxid = 1507,
+	},
+	tournaments = {
+		heading = 'Tournaments',
+		body = TournamentsTicker{
+			upcomingDays = 45,
+			completedDays = 45,
+			displayGameIcons = true
+		},
+		padding = true,
+		boxid = 1508,
+	},
+}
+
+return {
+	banner = {
+		lightmode = 'Pokemon default allmode.svg',
+		darkmode = 'Pokemon default allmode.svg',
+	},
+	metadesc = 'The Pokémon esports wiki covering everything from players, teams and transfers, ' ..
+		'to tournaments, results and games.',
+	title = 'Pokémon',
+	navigation = {
+		{
+			file = 'Main_Venue_at_Oceania_IC_2023.jpg',
+			title = 'Teams',
+			link = 'Portal:Teams',
+			count = {
+				method = 'LPDB',
+				table = 'team',
+			},
+		},
+		{
+			file = 'Wolfey_Vegas_Open_2023.jpg',
+			title = 'Players',
+			link = 'Portal:Players',
+			count = {
+				method = 'LPDB',
+				table = 'player',
+			},
+		},
+		{
+			file = 'Wyndon_Stadium_in Pokemon Sword and Shield.png',
+			title = 'Tournaments',
+			link = 'Portal:Tournaments',
+			count = {
+				method = 'LPDB',
+				table = 'tournament',
+			},
+		},
+		{
+			file = 'TCG Cards at Brisbane Regionals 2025.jpg',
+			title = 'Transfers',
+			link = 'Portal:Transfers',
+			count = {
+				method = 'LPDB',
+				table = 'transfer',
+			},
+		},
+		{
+			file = 'Nintendo Switch at Perth Regionals 2024.jpg',
+			title = 'Games',
+			link = 'Portal:Games',
+			count = {
+				method = 'LPDB',
+				table = 'datapoint',
+				conditions = '[[type::game]]',
+			},
+		},		
+		{
+			file = 'TCG Cards at Melbourne Regionals 2025.jpg',
+			title = 'Statistics',
+			link = 'Portal:Statistics',
+		},
+	},
+	layouts = {
+		main = {
+			{ -- Left
+				size = 5,
+				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
+						mobileOrder = 3,
+						content = CONTENT.transfers,
+					},
+					{
+						mobileOrder = 6,
+						content = CONTENT.wantToHelp,
+					},
+				}
+			},
+			{ -- Right
+				size = 7,
+				children = {
+					{
+						mobileOrder = 2,
+						children = {
+							{
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.filterButtons,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.matches,
+									},
+								},
+							},
+							{
+								size = 6,
+								children = {
+									{
+										noPanel = true,
+										content = CONTENT.tournaments,
+									},
+								},
+							},
+						},
+					},
+					{
+						mobileOrder = 5,
+						content = CONTENT.thisDay,
+					},
+					{
+						mobileOrder = 4,
+						content = CONTENT.usefulArticles,
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
## Summary
New Main Page for Pokemon

also includes adjusted Filter Buttons to be able to filter by game, because of this Module:Info also needs to be updated with the actual game logos in it as well but since only these 4 are active the Info will see changes only on these 4 games, I planned to do it all at a later point

https://liquipedia.net/pokemon/User:Hesketh2/Test

## Notes
Finding the usable picture for Pokemon pills has been really hard because, well Pokemon.




