### PR TITLE
feat: Pokemon banner for mainpage

### DIFF
--- a/stylesheets/commons/Banner.less
+++ b/stylesheets/commons/Banner.less
@@ -180,6 +180,12 @@
 		}
 	}
 
+	.wiki-pokemon & {
+		@media ( min-width: 768px ) {
+			background: url( https://liquipedia.net/commons/images/d/d6/Pokemon_wiki_banner.webp ) no-repeat center / cover;
+		}
+	}
+
 	.wiki-rainbowsix & {
 		@media ( min-width: 768px ) {
 			background: url( https://liquipedia.net/commons/images/c/c0/R6_bg.png ) no-repeat center / cover;


### PR DESCRIPTION
## Summary
I forgot the stylesheet that supposed to be part of  #6384 

https://liquipedia.net/commons/images/d/d6/Pokemon_wiki_banner.webp