### PR TITLE
fix(MainPage): addition of missing regions

### DIFF
--- a/lua/wikis/rocketleague/FilterButtons/Config.lua
+++ b/lua/wikis/rocketleague/FilterButtons/Config.lua
@@ -21,6 +21,9 @@ local REGION_TO_SUPERREGION = {
 	['Latin America South'] = 'SAM',
 	['Brazil'] = 'SAM',
 	['South America'] = 'SAM',
+	['Middle East'] = 'MENA',
+	['Asia'] = 'APAC',
+	['Africa'] = 'SSA',
 	['Other'] = 'Other',
 }
 
@@ -51,7 +54,7 @@ Config.categories = {
 		name = 'region',
 		property = 'region',
 		expandable = true,
-		items = {'EU', 'NA', 'OCE', 'SAM', 'Other'},
+		items = {'EU', 'NA', 'OCE', 'SAM', 'MENA', 'APAC', 'SSA', 'Other'},
 		defaultItem = 'Other',
 		itemToPropertyValues = function(region)
 			-- Input is a region


### PR DESCRIPTION
## Summary

Addition of following regions to FilterButtons for events and matches:

- MENA - Middle East and North Africa (for events with "Middle East" as region)
- APAC  - Asia Pacific (for events with "Asia" as region)
- SSA - Sub-Saharan Africa (for events with "Africa" as region).

Standard terms used to describe regions for RLCS.
Alternatively, the buttons could be “ME,” “ASIA,” and “AF/AFR,” for greater consistency with the regions listed for the various RL events.

## How did you test this change?

[dev](https://liquipedia.net/rocketleague/Module:FilterButtons/Config/dev/Dyl_m)
+tested here (preview only): [Rocket League - Liquipedia:Matches](https://liquipedia.net/rocketleague/Liquipedia:Matches) 
