### PR TITLE
feat(Mainpage): Remove some headings for esports

### DIFF
--- a/lua/wikis/esports/MainPageLayout/data.lua
+++ b/lua/wikis/esports/MainPageLayout/data.lua
@@ -19,12 +19,12 @@ local CONTENT = {
 		boxid = 1504,
 	},
 	specialEvents = {
-		heading = 'Feature Event',
+		noPanel = 'true',
 		body = '{{Liquipedia:Special Event}}',
 		boxid = 1516,
 	},
 	popularEsports = {
-		heading = 'Popular Esports',
+		noPanel = 'true',
 		body = '{{Liquipedia:Popular Esports}}',
 		boxid = 1529,
 	},


### PR DESCRIPTION
## Summary
These two panel were converted into Liquipedia namespace but not as Panel, so I adjust those to be panels so it duplicates with the existing headings from this module.