### PR TITLE
feat: Add support for Meta Threads

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -283,6 +283,7 @@ local PREFIXES = {
 		player = 'https://www.teamfortress.tv/user/',
 		match = 'http://tf.gg/',
 	},
+	threads = {'https://threads.com/'},
 	tiktok = {'https://tiktok.com/@'},
 	tlpd = {''},
 	tlpdint = {


### PR DESCRIPTION
## Summary
Add support of Meta threads in the links.
Threads are using "https://www.threads.com/@nickaneme".
I saw that some socials already include @ and some not. Followed structure of the instagram without it.

## How did you test this change?

dev
<img width="342" height="193" alt="image" src="https://github.com/user-attachments/assets/046b3864-d95c-406f-abf2-35d5aa8bc4b5" />
