### PR TITLE
Updated logo for Portal:Teams to landscape photo

### DIFF
--- a/lua/wikis/trackmania/MainPageLayout/data.lua
+++ b/lua/wikis/trackmania/MainPageLayout/data.lua
@@ -83,7 +83,7 @@ return {
 	title = 'Trackmania',
 	navigation = {
 		{
-			file = 'Papou and Wosile Efrei Trackmania Cup 2022.jpg',
+			file = 'Papou and Wosile Efrei Trackmania Cup Cropped.jpg',
 			title = 'Teams',
 			link = 'Portal:Teams',
 			count = {


### PR DESCRIPTION
Picture cropped to landscape

## Summary

Changed picture to Landscape as currently the picture is showing the upper legs only on Portal:Teams