### PR TITLE
docs(match2): add missing type annotation for MatchGroupUtilGame

### DIFF
--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -204,6 +204,7 @@ MatchGroupUtil.types.Status = TypeUtil.optional(TypeUtil.literalUnion('notplayed
 ---@class MatchGroupUtilGame
 ---@field comment string?
 ---@field date string?
+---@field dateIsExact boolean
 ---@field game string?
 ---@field header string?
 ---@field length number?


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/7553db4ed4f67a36be99adf50240d25e01fd4185/lua/wikis/commons/MatchGroup/Util.lua#L725-L731

## How did you test this change?

N/A