### PR TITLE
fix(MainPage): rocketleague - fix on FilterButtons and TournamentsTicker

### DIFF
--- a/lua/wikis/rocketleague/FilterButtons/Config.lua
+++ b/lua/wikis/rocketleague/FilterButtons/Config.lua
@@ -15,6 +15,7 @@ local Config = {}
 
 local REGION_TO_SUPERREGION = {
 	['Europe'] = 'EU',
+	['Turkey'] = 'EU',
 	['North America'] = 'NA',
 	['Oceania'] = 'OCE',
 	['Latin America North'] = 'SAM',
@@ -22,7 +23,9 @@ local REGION_TO_SUPERREGION = {
 	['Brazil'] = 'SAM',
 	['South America'] = 'SAM',
 	['Middle East'] = 'MENA',
+	['MENA'] = 'MENA',
 	['Asia'] = 'APAC',
+	['Asia-Pacific'] = 'APAC',
 	['Africa'] = 'SSA',
 	['Other'] = 'Other',
 }

--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -83,7 +83,15 @@ local CONTENT = {
 	},
 	tournaments = {
 		heading = 'Tournaments',
-		body = TournamentsTicker{},
+		body = TournamentsTicker{
+			--- 1 week as threshold by default
+			upcomingDays = 7,
+			completedDays = 7,
+			--- Special thresholds for higher tier events
+			modifierTier1 = 28,
+			modifierTier2 = 21,
+			modifierTier3 = 14
+		},
 		padding = true,
 		boxid = 1508,
 	},


### PR DESCRIPTION
## Summary

### Additions of terms to define regions and temporary fix for Turkey

- Terms "MENA" and "Asia-Pacific" associated to SUPERREGION "MENA" and "APAC", respectively.
- SUPERREGION "EU" set for Turkey, because it seems that the country is not correctly included in Europe, as we could see with the [FIFAe World Cup qualifier for the country](https://liquipedia.net/s/W7wdQZvpj4h). I don't know if the [ContryData](https://liquipedia.net/rocketleague/Module:Region/CountryData) module should be called here or if we are inheriting a wrong regional separation from an upstream module (based on previous commits, it looks like the old League of Legends' regional segmentation), but I think it's the easiest workaround to implement.

### Changing days thresholds for tournaments appearance on Main Page
- 1 week set as default value for upcoming and completed events
- New threshold for higher tiers:
  * 4 weeks for S-Tier events
  * 3 weeks for A-Tier
  * 2 weeks for B-Tier

This part can be discussed with the other active editors and reviewers of the LP Rocket League. These are values that I suggest, but before the new layout, these thresholds were different, I believe. Perhaps others can take a critical look at this.

## How did you test this change?

- [dev - FilterButtons](https://liquipedia.net/rocketleague/Module:FilterButtons/Config/dev/Dyl_m)
- [dev - MainPageLayout](https://liquipedia.net/rocketleague/Module:MainPageLayout/data/dev/Dyl_m)
- [User page for test](https://liquipedia.net/rocketleague/User:Dyl_m/Main_Page_Test)