### PR TITLE
fix(mainpage): rename photo on tournament pill in heroes

### DIFF
--- a/lua/wikis/heroes/MainPageLayout/data.lua
+++ b/lua/wikis/heroes/MainPageLayout/data.lua
@@ -102,7 +102,7 @@ return {
 			},
 		},
 		{
-			file = 'Hearthstone Trophy at ESL Katowice 2016.jpg',
+			file = 'HotS Trophy at ESL Katowice 2016.jpg',
 			title = 'Tournaments',
 			link = 'Portal:Tournaments',
 			count = {


### PR DESCRIPTION
## Summary

Photo was uploaded with wrong name (trophy is for HotS, not Hearthstone), I moved it with redirect

## How did you test this change?

Not tested (only filename changed)

After merging redirect can be removed: https://liquipedia.net/commons/index.php?title=File:Hearthstone_Trophy_at_ESL_Katowice_2016.jpg&redirect=no