### PR TITLE
fix(matchticker): moved padding to the right element

### DIFF
--- a/stylesheets/commons/Match.less
+++ b/stylesheets/commons/Match.less
@@ -90,6 +90,7 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
+			padding: 0 0.25rem;
 
 			&-icon {
 				display: flex;
@@ -111,7 +112,6 @@
 				display: flex;
 				align-items: center;
 				justify-content: center;
-				padding: 0 0.25rem;
 			}
 
 			&-lower {


### PR DESCRIPTION
## Summary

The padding was applied to the wrong element in #6411 . This pr fixes the issue.
