### PR TITLE
refactor(match2): use GeneralCollapsible for draft order in LoL matchpage

### DIFF
--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -265,6 +265,7 @@ function MatchPage:_renderDraft(game)
 				},
 				GeneralCollapsible{
 					title = 'Draft Order',
+					attributes = {style = 'width:100%'},
 					titleClasses = {'match-bm-lol-game-veto-order-toggle'},
 					shouldCollapse = true,
 					collapseAreaClasses = {'match-bm-lol-game-veto-order-list'},


### PR DESCRIPTION
## Summary

LoL matchpage used custom stuff for draft order toggle. This PR replaces the custom stuff with the `GeneralCollapsible` widget.

## How did you test this change?

dev