### PR TITLE
fix: Do not duplicate last group in transfer list

### DIFF
--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -198,7 +198,6 @@ function TransferList:fetch()
 		end
 		table.insert(currentGroup, transfer)
 	end
-	Array.appendWith(groupedData, currentGroup)
 
 	self.groupedTransfers = groupedData
 


### PR DESCRIPTION
## Summary
Another mishap from changing how grouping works:
In some situations it was possible that the last transfer group got duplicated, because the last group would always get added past the loop.
This can be removed, as the loop is stopped when the amount of groups hits the configured limit; which already includes the last group.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
Before:
<img width="1067" height="521" alt="image" src="https://github.com/user-attachments/assets/2c01896a-ed29-4c97-8c20-1ea7750156c7" />
After:
<img width="1061" height="479" alt="image" src="https://github.com/user-attachments/assets/caac0ee1-b0d7-42b2-b60e-f79702d54779" />

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
