### PR TITLE
ci: fix external repos failing to update snapshots 

### DIFF
--- a/.github/workflows/update visual snapshots.yml
+++ b/.github/workflows/update visual snapshots.yml
@@ -13,8 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+          # Support runs of this action in forks
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup lua
         # Workaround until https://github.com/leafo/gh-actions-lua/issues/57 is resolved


### PR DESCRIPTION
## Summary

- Dropping workflow dispatch event, don't think it would work well anyway
- Set target repo, so external repos work

## How did you test this change?
https://github.com/Liquipedia/Lua-Modules/actions/runs/17201030498/job/48791515720?pr=6439