### PR TITLE
feat: Add custom PlayerIntroduction to chess

### DIFF
--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -40,7 +40,28 @@ function CustomPlayer.run(frame)
 
 	player.args.id = player.args.id or player.args.romanized_name or player.args.name
 
+
 	return player:createInfobox()
+end
+
+---@param lpdbData table
+---@param args table
+---@param personType string
+---@return table
+function CustomPlayer:adjustLPDB(lpdbData, args, personType)
+	local highestTitleName
+	for _, title in ipairs(TITLES) do
+		if Logic.isNotEmpty(args['title_' .. title.code]) then
+			highestTitleName = title.name
+			break
+		end
+	end
+
+	if highestTitleName then
+		lpdbData.extradata.chesstitle = highestTitleName
+	end
+
+	return lpdbData
 end
 
 ---@param id string

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -40,7 +40,6 @@ function CustomPlayer.run(frame)
 
 	player.args.id = player.args.id or player.args.romanized_name or player.args.name
 
-
 	return player:createInfobox()
 end
 

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -48,17 +48,9 @@ end
 ---@param personType string
 ---@return table
 function CustomPlayer:adjustLPDB(lpdbData, args, personType)
-	local highestTitleName
-	for _, title in ipairs(TITLES) do
-		if Logic.isNotEmpty(args['title_' .. title.code]) then
-			highestTitleName = title.name
-			break
-		end
-	end
+	local highestTitle = Array.find(TITLES, function(title) return Logic.isNotEmpty(args['title_' .. title.code]) end)
 
-	if highestTitleName then
-		lpdbData.extradata.chesstitle = highestTitleName
-	end
+	lpdbData.extradata.chesstitle = (highestTitle or {}).name
 
 	return lpdbData
 end

--- a/lua/wikis/chess/PlayerIntroduction/Custom.lua
+++ b/lua/wikis/chess/PlayerIntroduction/Custom.lua
@@ -7,21 +7,39 @@
 
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
+local Class = require('Module:Class')
+local Arguments = require('Module:Arguments')
+
 local PlayerIntroduction = Lua.import('Module:PlayerIntroduction')
+
+---@class CustomPlayerIntroduction: PlayerIntroduction
+local CustomPlayerIntroduction = Class.new(PlayerIntroduction)
+
+--- Module entry point for PlayerIntroduction
+---@param args playerIntroArgsValues?
+---@return string
+function CustomPlayerIntroduction.run(args)
+	return CustomPlayerIntroduction(args):queryPlayerInfo():queryTransferData(true):adjustData():create()
+end
+
+--- Template entry point for PlayerIntroduction
+---@param frame Frame
+---@return string
+function CustomPlayerIntroduction.templatePlayerIntroduction(frame)
+	return CustomPlayerIntroduction.run(Arguments.getArgs(frame))
+end
 
 --- Overrides the name display.
 ---@return string
-function PlayerIntroduction:nameDisplay()
+function CustomPlayerIntroduction:nameDisplay()
 	return '<b>' .. self.playerInfo.id .. '</b>'
 end
-
-local originalParsePlayerInfo = PlayerIntroduction._parsePlayerInfo
 
 --- Extends the original _parsePlayerInfo to include chess-specific data.
 ---@param args table
 ---@param playerInfo table
-function PlayerIntroduction:_parsePlayerInfo(args, playerInfo)
-	originalParsePlayerInfo(self, args, playerInfo)
+function CustomPlayerIntroduction:_parsePlayerInfo(args, playerInfo)
+	PlayerIntroduction._parsePlayerInfo(self, args, playerInfo)
 
 	if playerInfo and playerInfo.extradata then
 		self.playerInfo.chessTitle = playerInfo.extradata.chesstitle
@@ -29,26 +47,22 @@ function PlayerIntroduction:_parsePlayerInfo(args, playerInfo)
 	end
 end
 
-local originalGameDisplay = PlayerIntroduction._gameDisplay
-
 --- Customizes how the game is displayed.
 ---@return string
-function PlayerIntroduction:_gameDisplay()
+function CustomPlayerIntroduction:_gameDisplay()
 	local title = self.playerInfo.chessTitle
 	local game = self.playerInfo.game
 
 	if String.isNotEmpty(title) and String.isNotEmpty(game) then
 		return self._addConcatText(game)
 	else
-		return originalGameDisplay(self)
+		return PlayerIntroduction._gameDisplay(self)
 	end
 end
 
-local originalTypeDisplay = PlayerIntroduction.typeDisplay
-
 --- Customizes the player type display.
 ---@return string
-function PlayerIntroduction:typeDisplay()
+function CustomPlayerIntroduction:typeDisplay()
 	local title = self.playerInfo.chessTitle
 
 	if self.playerInfo.banned then
@@ -56,8 +70,8 @@ function PlayerIntroduction:typeDisplay()
 	elseif String.isNotEmpty(title) then
 		return self._addConcatText('chess ' .. title)
 	else
-		return originalTypeDisplay(self)
+		return PlayerIntroduction.typeDisplay(self)
 	end
 end
 
-return PlayerIntroduction
+return CustomPlayerIntroduction

--- a/lua/wikis/chess/PlayerIntroduction/Custom.lua
+++ b/lua/wikis/chess/PlayerIntroduction/Custom.lua
@@ -5,11 +5,12 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local Arguments = require('Module:Arguments')
-local Class = require('Module:Class')
-local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
-local String = require('Module:StringUtils')
+
+local Arguments = Lua.import('Module:Arguments')
+local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
+local String = Lua.import('Module:StringUtils')
 
 local PlayerIntroduction = Lua.import('Module:PlayerIntroduction')
 

--- a/lua/wikis/chess/PlayerIntroduction/Custom.lua
+++ b/lua/wikis/chess/PlayerIntroduction/Custom.lua
@@ -5,10 +5,11 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
+local Arguments = require('Module:Arguments')
+local Class = require('Module:Class')
+local Logic = require('Module:Logic')
 local Lua = require('Module:Lua')
 local String = require('Module:StringUtils')
-local Class = require('Module:Class')
-local Arguments = require('Module:Arguments')
 
 local PlayerIntroduction = Lua.import('Module:PlayerIntroduction')
 
@@ -43,7 +44,7 @@ function CustomPlayerIntroduction:_parsePlayerInfo(args, playerInfo)
 
 	if playerInfo and playerInfo.extradata then
 		self.playerInfo.chessTitle = playerInfo.extradata.chesstitle
-		self.playerInfo.banned = playerInfo.extradata.banned == true
+		self.playerInfo.banned = Logic.readBool(playerInfo.extradata.banned)
 	end
 end
 

--- a/lua/wikis/chess/PlayerIntroduction/Custom.lua
+++ b/lua/wikis/chess/PlayerIntroduction/Custom.lua
@@ -1,0 +1,63 @@
+---
+-- @Liquipedia
+-- page=Module:PlayerIntroduction/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+local String = require('Module:StringUtils')
+local PlayerIntroduction = Lua.import('Module:PlayerIntroduction')
+
+--- Overrides the name display.
+---@return string
+function PlayerIntroduction:nameDisplay()
+	return '<b>' .. self.playerInfo.id .. '</b>'
+end
+
+local originalParsePlayerInfo = PlayerIntroduction._parsePlayerInfo
+
+--- Extends the original _parsePlayerInfo to include chess-specific data.
+---@param args table
+---@param playerInfo table
+function PlayerIntroduction:_parsePlayerInfo(args, playerInfo)
+	originalParsePlayerInfo(self, args, playerInfo)
+
+	if playerInfo and playerInfo.extradata then
+		self.playerInfo.chessTitle = playerInfo.extradata.chesstitle
+		self.playerInfo.banned = playerInfo.extradata.banned == true
+	end
+end
+
+local originalGameDisplay = PlayerIntroduction._gameDisplay
+
+--- Customizes how the game is displayed.
+---@return string
+function PlayerIntroduction:_gameDisplay()
+	local title = self.playerInfo.chessTitle
+	local game = self.playerInfo.game
+
+	if String.isNotEmpty(title) and String.isNotEmpty(game) then
+		return self._addConcatText(game)
+	else
+		return originalGameDisplay(self)
+	end
+end
+
+local originalTypeDisplay = PlayerIntroduction.typeDisplay
+
+--- Customizes the player type display.
+---@return string
+function PlayerIntroduction:typeDisplay()
+	local title = self.playerInfo.chessTitle
+
+	if self.playerInfo.banned then
+		return self._addConcatText('chess player')
+	elseif String.isNotEmpty(title) then
+		return self._addConcatText('chess ' .. title)
+	else
+		return originalTypeDisplay(self)
+	end
+end
+
+return PlayerIntroduction


### PR DESCRIPTION
## Summary

requested on discord.
Start of convo https://discord.com/channels/93055209017729024/1333849898583330947/1406973862096146514

Pretty much chess used their custom stuff in the their infobox and didn't use {{PlayerIntroduction}} template at all.
Now they replaced all text with that template, but they several issue with it.

Duplicate names + They would like instead "player" say "chess + title". 
Also included that for banned users it just say "chess player"

Would love help with coding or maybe better idea how to handle this?

## How did you test this change?
https://liquipedia.net/chess/Hikaru_Nakamura
https://liquipedia.net/chess/Igors_Rausis

dev
