### PR TITLE
feat(mainpage): Display Game Icons for Simracing

### DIFF
--- a/lua/wikis/simracing/MainPageLayout/data.lua
+++ b/lua/wikis/simracing/MainPageLayout/data.lua
@@ -80,6 +80,7 @@ local CONTENT = {
 		body = TournamentsTicker{
 			upcomingDays = 60,
 			completedDays = 60,
+			displayGameIcons = true,
 		},
 		padding = true,
 		boxid = 1508,
@@ -149,7 +150,7 @@ return {
 	layouts = {
 		main = {
 			{ -- Left
-				size = 6,
+				size = 5,
 				children = {
 					{
 						mobileOrder = 2,
@@ -166,7 +167,7 @@ return {
 				}
 			},
 			{ -- Right
-				size = 6,
+				size = 7,
 				children = {
 					{
 						mobileOrder = 1,
@@ -180,7 +181,7 @@ return {
 								},
 							},
 							{
-								size = 6,
+								size = 5,
 								children = {
 									{
 										noPanel = true,
@@ -189,7 +190,7 @@ return {
 								},
 							},
 							{
-								size = 6,
+								size = 7,
 								children = {
 									{
 										noPanel = true,


### PR DESCRIPTION
## Summary
Since the wiki is multi-game, adding icons to the tournament listings is a good addition, although this comes at yet another 5:7 page ratio again, Simracing often had long event names even with short tickernames it's still quite long so 5:7 is to make up space for that

I did not add the button filter because the number of games would make it too big. Probably this sentence holds the same when Fighters gets one in future

## How did you test this change?
dev  https://liquipedia.net/simracing/Module:MainPageLayout/data/dev/h2
<img width="544" height="642" alt="Screenshot 2025-08-27 021553" src="https://github.com/user-attachments/assets/0db0fb18-0327-4523-91fc-c4fd6490d5fc" />
