### PR TITLE
fix(match2): game win/loss indicator not shown in hearthstone match summary with incomplete input

### DIFF
--- a/lua/wikis/hearthstone/MatchSummary.lua
+++ b/lua/wikis/hearthstone/MatchSummary.lua
@@ -96,7 +96,7 @@ function CustomMatchSummary.Game(options, game, gameIndex)
 	local rowWidget = options.isPartOfSubMatch and HtmlWidgets.Div or MatchSummaryWidgets.Row
 
 	---@param opponentIndex any
-	---@return table[]
+	---@return Widget[]
 	local function createOpponentDisplay(opponentIndex)
 		return WidgetUtil.collect(
 			CustomMatchSummary.DisplayClass(game.opponents[opponentIndex], opponentIndex == 1),


### PR DESCRIPTION
## Summary

fixes #6446

## How did you test this change?

dev