### PR TITLE
fix: Convert 8-char hex values to RGBA in less

### DIFF
--- a/stylesheets/commons/Fountain.less
+++ b/stylesheets/commons/Fountain.less
@@ -453,7 +453,7 @@ a.cf {
 .spelllore {
 	display: inline-block;
 	text-align: center;
-	background-color: #282828c4;
+	background-color: rgba( 40, 40, 40, 0.77 );
 	padding: 0.125rem;
 	font-size: 85%; // convert to rem
 	font-style: italic;
@@ -467,7 +467,7 @@ a.cf {
 	cursor: default;
 	padding: 0.1875rem;
 	font-size: 80%; // convert to rem
-	border: 0.0625rem solid #7681968c;
+	border: 0.0625rem solid rgba( 118, 129, 150, 0.55 );
 
 	&:hover {
 		border: 0.0625rem solid #768196;
@@ -558,7 +558,7 @@ a.cf {
 // This is mainly for the mini-infobox within the Spellcard.
 .craft {
 	&_base {
-		background-color: #93000d2e;
+		background-color: rgba( 147, 0, 13, 0.18 );
 		font-size: 15px;
 		padding: 5px;
 	}

--- a/stylesheets/commons/Match.less
+++ b/stylesheets/commons/Match.less
@@ -54,11 +54,11 @@
 				color: var( --clr-on-background );
 
 				.theme--light & {
-					background-color: #00000014;
+					background-color: rgba( 0, 0, 0, 0.08 );
 				}
 
 				.theme--dark & {
-					background-color: #ffffff14;
+					background-color: rgba( 255, 255, 255, 0.08 );
 				}
 			}
 		}
@@ -151,11 +151,11 @@
 		line-height: 1.125rem;
 
 		.theme--light & {
-			background-color: #0000000a;
+			background-color: rgba( 0, 0, 0, 0.04 );
 		}
 
 		.theme--dark & {
-			background-color: #ffffff0a;
+			background-color: rgba( 255, 255, 255, 0.04 );
 		}
 
 		/**


### PR DESCRIPTION
## Summary
This would be a fix for the broken background colors in match(tickers).
Probably superseeded by the SCSS, but in case that takes more time this can be used.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Checked whether lessc (from less.php) correctly handles this
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
