### PR TITLE
refactor(infobox): use daterange widget in upcoming and ongoing tournaments widget

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
+++ b/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
@@ -11,7 +11,6 @@ local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local Countdown = Lua.import('Module:Countdown')
 local DateExt = Lua.import('Module:Date/Ext')
-local FnUtil = Lua.import('Module:FnUtil')
 local HighlightConditions = Lua.import('Module:HighlightConditions')
 local LeagueIcon = Lua.import('Module:LeagueIcon')
 

--- a/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
+++ b/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
@@ -16,6 +16,7 @@ local HighlightConditions = Lua.import('Module:HighlightConditions')
 local LeagueIcon = Lua.import('Module:LeagueIcon')
 
 local Widget = Lua.import('Module:Widget')
+local DateRange = Lua.import('Module:Widget/Misc/DateRange')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 local Link = Lua.import('Module:Widget/Basic/Link')
@@ -76,7 +77,10 @@ function UpcomingTournamentsRow:render()
 							},
 							children = Div{
 								classes = {'tournament-span'},
-								children = self:_getTournamentSpan()
+								children = DateRange{
+									startDate = data.startdate,
+									endDate = data.endDate
+								}
 							}
 						}
 					}
@@ -104,28 +108,6 @@ function UpcomingTournamentsRow:_getCountdown()
 			classes = {'timer-object-countdown-live'},
 			children = 'ONGOING!'
 		} or Countdown._create{timestamp = startDateTimestamp, rawcountdown = true}
-	}
-end
-
----@private
----@return string|string[]
-function UpcomingTournamentsRow:_getTournamentSpan()
-	local data = self.props.data
-	local startDateTimestamp = DateExt.readTimestamp(data.startdate)
-	assert(startDateTimestamp)
-	local endDateTimestamp = DateExt.readTimestamp(data.date)
-	assert(endDateTimestamp)
-	local getMonth = FnUtil.curry(DateExt.formatTimestamp, 'M')
-	if startDateTimestamp == endDateTimestamp then
-		return DateExt.formatTimestamp('M d', startDateTimestamp)
-	end
-	return {
-		DateExt.formatTimestamp('M d', startDateTimestamp),
-		' - ',
-		DateExt.formatTimestamp(
-			getMonth(startDateTimestamp) == getMonth(endDateTimestamp) and 'd' or 'M d',
-			endDateTimestamp
-		)
 	}
 end
 

--- a/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
+++ b/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
@@ -78,7 +78,7 @@ function UpcomingTournamentsRow:render()
 								classes = {'tournament-span'},
 								children = DateRange{
 									startDate = data.startdate,
-									endDate = data.endDate
+									endDate = data.date
 								}
 							}
 						}

--- a/lua/wikis/commons/Widget/Misc/DateRange.lua
+++ b/lua/wikis/commons/Widget/Misc/DateRange.lua
@@ -15,6 +15,7 @@ local Widget = Lua.import('Module:Widget')
 
 ---@class DateRangeWidget: Widget
 ---@operator call(table): DateRangeWidget
+---@field props {startDate: string|osdateparam?, endDate: string|osdateparam?}
 local DateRange = Class.new(Widget)
 
 ---@param startDate {day?: integer, month?: integer}?
@@ -57,10 +58,10 @@ end
 function DateRange:render()
 	local startDate, endDate = self.props.startDate, self.props.endDate
 	if type(startDate) ~= 'table' then
-		startDate = DateExt.parseIsoDate(startDate)
+		startDate = DateExt.parseIsoDate(startDate --[[ @as string? ]])
 	end
 	if type(endDate) ~= 'table' then
-		endDate = DateExt.parseIsoDate(endDate)
+		endDate = DateExt.parseIsoDate(endDate --[[ @as string? ]])
 	end
 
 	---@type osdateparam?

--- a/lua/wikis/commons/Widget/Misc/DateRange.lua
+++ b/lua/wikis/commons/Widget/Misc/DateRange.lua
@@ -15,7 +15,6 @@ local Widget = Lua.import('Module:Widget')
 
 ---@class DateRangeWidget: Widget
 ---@operator call(table): DateRangeWidget
-
 local DateRange = Class.new(Widget)
 
 ---@param startDate {day?: integer, month?: integer}?


### PR DESCRIPTION
## Summary

This PR removes custom string building logic in the upcoming and ongoing tournaments widget, replacing it with `Module:Widget/Misc/DateRange`.

## How did you test this change?

dev