### PR TITLE
refactor(match2): splatoon map display rework

### DIFF
--- a/lua/wikis/splatoon/MatchSummary.lua
+++ b/lua/wikis/splatoon/MatchSummary.lua
@@ -63,7 +63,13 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		classes = {'brkts-popup-body-game'},
 		children = WidgetUtil.collect(
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
-			MatchSummaryWidgets.GameCenter{children = DisplayHelper.MapAndMode(game)},
+			MatchSummaryWidgets.GameCenter{
+				css = {
+					width = '100px',
+					['text-overflow'] = 'ellipsis',
+				},
+				children = DisplayHelper.MapAndMode(game)
+			},
 			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(2), flipped = true},
 			MatchSummaryWidgets.GameComment{children = game.comment}
 		)

--- a/lua/wikis/splatoon/MatchSummary.lua
+++ b/lua/wikis/splatoon/MatchSummary.lua
@@ -5,23 +5,20 @@
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --
 
-local CustomMatchSummary = {}
-
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
-local MapTypeIcon = Lua.import('Module:MapType')
+local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local Operator = Lua.import('Module:Operator')
-local String = Lua.import('Module:StringUtils')
-local Table = Lua.import('Module:Table')
 local WeaponIcon = Lua.import('Module:WeaponIcon')
 
-local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
-local MatchSummary = Lua.import('Module:MatchSummary/Base')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
-local NON_BREAKING_SPACE = '&nbsp;'
+
+local CustomMatchSummary = {}
 
 ---@param args table
 ---@return Html
@@ -29,25 +26,46 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '500px', teamStyle = 'bracket'})
 end
 
----@param date string
+---@param match MatchGroupUtilMatch
+---@return Widget[]
+function CustomMatchSummary.createBody(match)
+	return WidgetUtil.collect(
+		Array.map(match.games, function(game, gameIndex)
+			return CustomMatchSummary._createGameRow(game, gameIndex, match.game)
+		end)
+	)
+end
+
 ---@param game MatchGroupUtilGame
 ---@param gameIndex integer
+---@param gameTitle string
 ---@return Widget?
-function CustomMatchSummary.createGame(date, game, gameIndex)
-	local weaponsData = Array.map(game.opponents, function(opponent)
-		return Array.map(opponent.players, Operator.property('weapon'))
-	end)
+function CustomMatchSummary._createGameRow(game, gameIndex, gameTitle)
+	if not game.map then
+		return
+	end
 
 	local function makeTeamSection(opponentIndex)
-		local isLeftTeam = opponentIndex == 1
+		local opponent = game.opponents[opponentIndex] or {}
+		local weaponsData = Array.map(opponent.players or {}, Operator.property('weapon'))
+
+		local score = opponent.score
+		if score and game.mode == 'turf war' then
+			score = score .. '%'
+		end
+		local scoreDisplay = DisplayHelper.MapScore({score = score}, game.status)
+
 		return {
-			CustomMatchSummary._opponentWeaponsDisplay{
-				data = weaponsData[opponentIndex],
-				flip = not isLeftTeam,
-				game = game.game
+			CustomMatchSummary._createWeaponsDisplay{
+				data = weaponsData,
+				flip = (opponentIndex == 2),
+				game = gameTitle
 			},
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = opponentIndex},
-			CustomMatchSummary._gameScore(game, opponentIndex)
+			HtmlWidgets.Div{
+				css = {['min-width'] = '24px', ['text-align'] = 'center'},
+				children = scoreDisplay,
+			}
 		}
 	end
 
@@ -62,61 +80,33 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 	}
 end
 
----@param game MatchGroupUtilGame
----@return string
-function CustomMatchSummary._getMapDisplay(game)
-	local mapDisplay = '[[' .. game.map .. ']]'
-
-	if String.isNotEmpty(game.extradata.maptype) then
-		mapDisplay = MapTypeIcon.display(game.extradata.maptype) .. NON_BREAKING_SPACE .. mapDisplay
-	end
-
-	return mapDisplay
-end
-
----@param game MatchGroupUtilGame
----@param opponentIndex integer
----@return Html
-function CustomMatchSummary._gameScore(game, opponentIndex)
-	local opponentCopy = Table.deepCopy(game.opponents[opponentIndex])
-	if opponentCopy.score and game.mode == 'Turf War' then
-		opponentCopy.score = opponentCopy.score .. '%'
-	end
-	local scoreDisplay = DisplayHelper.MapScore(game.opponents[opponentIndex], game.status)
-	return mw.html.create('div')
-		:css('min-width', '24px')
-		:css('text-align', 'center')
-		:wikitext(scoreDisplay)
-end
-
 ---@param props {data: string[], flip: boolean, game: string}
----@return Html
-function CustomMatchSummary._opponentWeaponsDisplay(props)
-	local flip = props.flip
-
-	local displayElements = Array.map(props.data, function(weapon)
-		return mw.html.create('div')
-			:addClass('brkts-champion-icon')
-			:node(WeaponIcon._getImage{
+---@return Widget
+function CustomMatchSummary._createWeaponsDisplay(props)
+	local weaponIcons = Array.map(props.data, function(weapon)
+		return HtmlWidgets.Div{
+			classes = {'brkts-champion-icon'},
+			children = WeaponIcon._getImage{
 				weapon = weapon,
 				game = props.game,
 				class = 'brkts-champion-icon',
-			})
+			}
+		}
 	end)
 
-	if flip then
-		displayElements = Array.reverse(displayElements)
+	if props.flip then
+		weaponIcons = Array.reverse(weaponIcons)
 	end
 
-	local display = mw.html.create('div')
-		:addClass('brkts-popup-body-element-thumbs')
-		:addClass(flip and 'brkts-popup-body-element-thumbs-right' or nil)
-
-	for _, item in ipairs(displayElements) do
-		display:node(item)
+	local classes = {'brkts-popup-body-element-thumbs'}
+	if props.flip then
+		table.insert(classes, 'brkts-popup-body-element-thumbs-right')
 	end
 
-	return display
+	return HtmlWidgets.Div{
+		classes = classes,
+		children = weaponIcons
+	}
 end
 
 return CustomMatchSummary

--- a/lua/wikis/splatoon/MatchSummary.lua
+++ b/lua/wikis/splatoon/MatchSummary.lua
@@ -30,9 +30,6 @@ end
 ---@param gameIndex integer
 ---@return Widget?
 function CustomMatchSummary.createGame(date, game, gameIndex)
-	local weaponsData = Array.map(game.opponents, function(opponent)
-		return Array.map(opponent.players, Operator.property('weapon'))
-	end)
 	if not game.map then
 		return
 	end

--- a/lua/wikis/splatoon/MatchSummary.lua
+++ b/lua/wikis/splatoon/MatchSummary.lua
@@ -26,6 +26,7 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '500px', teamStyle = 'bracket'})
 end
 
+---@param date string
 ---@param game MatchGroupUtilGame
 ---@param gameIndex integer
 ---@return Widget?

--- a/lua/wikis/splatoon/MatchSummary.lua
+++ b/lua/wikis/splatoon/MatchSummary.lua
@@ -26,21 +26,13 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '500px', teamStyle = 'bracket'})
 end
 
----@param match MatchGroupUtilMatch
----@return Widget[]
-function CustomMatchSummary.createBody(match)
-	return WidgetUtil.collect(
-		Array.map(match.games, function(game, gameIndex)
-			return CustomMatchSummary._createGameRow(game, gameIndex, match.game)
-		end)
-	)
-end
-
 ---@param game MatchGroupUtilGame
 ---@param gameIndex integer
----@param gameTitle string
 ---@return Widget?
-function CustomMatchSummary._createGameRow(game, gameIndex, gameTitle)
+function CustomMatchSummary.createGame(date, game, gameIndex)
+	local weaponsData = Array.map(game.opponents, function(opponent)
+		return Array.map(opponent.players, Operator.property('weapon'))
+	end)
 	if not game.map then
 		return
 	end
@@ -59,7 +51,7 @@ function CustomMatchSummary._createGameRow(game, gameIndex, gameTitle)
 			CustomMatchSummary._createWeaponsDisplay{
 				data = weaponsData,
 				flip = (opponentIndex == 2),
-				game = gameTitle
+				game = game.game
 			},
 			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = opponentIndex},
 			HtmlWidgets.Div{
@@ -86,7 +78,7 @@ function CustomMatchSummary._createWeaponsDisplay(props)
 	local weaponIcons = Array.map(props.data, function(weapon)
 		return HtmlWidgets.Div{
 			classes = {'brkts-champion-icon'},
-			children = WeaponIcon._getImage{
+			children = WeaponIcon.Icon{
 				weapon = weapon,
 				game = props.game,
 				class = 'brkts-champion-icon',

--- a/lua/wikis/splatoon/MatchSummary.lua
+++ b/lua/wikis/splatoon/MatchSummary.lua
@@ -26,7 +26,7 @@ local NON_BREAKING_SPACE = '&nbsp;'
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '490px', teamStyle = 'bracket'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '500px', teamStyle = 'bracket'})
 end
 
 ---@param date string
@@ -38,24 +38,25 @@ function CustomMatchSummary.createGame(date, game, gameIndex)
 		return Array.map(opponent.players, Operator.property('weapon'))
 	end)
 
+	local function makeTeamSection(opponentIndex)
+		local isLeftTeam = opponentIndex == 1
+		return {
+			CustomMatchSummary._opponentWeaponsDisplay{
+				data = weaponsData[opponentIndex],
+				flip = not isLeftTeam,
+				game = game.game
+			},
+			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = opponentIndex},
+			CustomMatchSummary._gameScore(game, opponentIndex)
+		}
+	end
+
 	return MatchSummaryWidgets.Row{
 		classes = {'brkts-popup-body-game'},
 		children = WidgetUtil.collect(
-			CustomMatchSummary._opponentWeaponsDisplay{
-				data = weaponsData[1],
-				flip = false,
-				game = game.game
-			},
-			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
-			CustomMatchSummary._gameScore(game, 1),
-			MatchSummaryWidgets.GameCenter{children = CustomMatchSummary._getMapDisplay(game), css = {['flex-grow'] = 1}},
-			CustomMatchSummary._gameScore(game, 2),
-			MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},
-			CustomMatchSummary._opponentWeaponsDisplay{
-				data = weaponsData[2],
-				flip = true,
-				game = game.game
-			},
+			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(1)},
+			MatchSummaryWidgets.GameCenter{children = DisplayHelper.MapAndMode(game)},
+			MatchSummaryWidgets.GameTeamWrapper{children = makeTeamSection(2), flipped = true},
 			MatchSummaryWidgets.GameComment{children = game.comment}
 		)
 	}
@@ -83,12 +84,9 @@ function CustomMatchSummary._gameScore(game, opponentIndex)
 	end
 	local scoreDisplay = DisplayHelper.MapScore(game.opponents[opponentIndex], game.status)
 	return mw.html.create('div')
-		:addClass('brkts-popup-body-element-vertical-centered')
 		:css('min-width', '24px')
-		:node(mw.html.create('div')
-			:css('margin', 'auto')
-			:wikitext(scoreDisplay)
-		)
+		:css('text-align', 'center')
+		:wikitext(scoreDisplay)
 end
 
 ---@param props {data: string[], flip: boolean, game: string}


### PR DESCRIPTION
## Summary
Changes for these were done by slothyman

Splatoon match2 has an issue where if map template exist, but at least one of it does not have a map name added , the match summary will throw an error. 

<img width="1209" height="304" alt="image" src="https://github.com/user-attachments/assets/e78ffa2a-e0a1-460d-a213-76360cd7a751" />

The fix originally is to use the DisplayHelper to do that, however that creates another issue where the score and checkmark is not consistent
<img width="501" height="414" alt="image" src="https://github.com/user-attachments/assets/e8d3e345-8aea-43a6-a6f5-5396cf53019e" />

slothy rework a lot of it to use html widgets to fix it while also keeping it visually the same
<img width="542" height="437" alt="image" src="https://github.com/user-attachments/assets/7c85dce6-f2d4-4d67-8859-b45fb27a1b31" />

Additionally this also removes the usage for the local version of **Module:MapType** as well, it will now just use **Module:MapModes** properly for the mode icons

## How did you test this change?
https://liquipedia.net/splatoon/Splatoon_2_World_Championship/2018

## Note
I'm not sure which is Slothy's github name, otherwise I would added him to the assignees