### PR TITLE
fix: Correctly display single-transfer lists

### DIFF
--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -190,7 +190,7 @@ function TransferList:fetch()
 			cache.team1_2 = transfer.extradata.fromteamsec
 			cache.team2_2 = transfer.extradata.toteamsec
 
-			if #groupedData == self.config.limit then
+			if #groupedData == self.config.limit - 1 then
 				break
 			end
 			Array.appendWith(groupedData, currentGroup)


### PR DESCRIPTION
## Summary
When trying to fix duplicate entries in #6442, i overlooked yet another thing:
When the display is not limited by the set limit, but by the amount of transfers returned (e.g. when using the transfer query form), the last transfer would be discarded.

This adds back always including the last group;
to still fix the duplicate entries or incorrect limit, the order of checking the limit and adding the next group is adjusted.

Hopefully this is the last issue caused by this :/

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
