### PR TITLE
fix: missing nil catch in opponent module

### DIFF
--- a/lua/wikis/commons/Opponent.lua
+++ b/lua/wikis/commons/Opponent.lua
@@ -451,7 +451,7 @@ function Opponent.fromMatch2Record(record)
 					displayName = playerRecord.displayname,
 					flag = String.nilIfEmpty(Flags.CountryName{flag = playerRecord.flag}),
 					pageName = String.nilIfEmpty(playerRecord.name),
-					faction = Logic.nilIfEmpty(Faction.read(playerRecord.extradata.faction) or Faction.defaultFaction),
+					faction = Logic.nilIfEmpty(Faction.read((playerRecord.extradata or {}).faction) or Faction.defaultFaction),
 				}
 			end),
 			extradata = {},


### PR DESCRIPTION
## Summary
when accessing extradata that might be nil we currently get an error
this pr fixes that issue

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1410799673333256284

## How did you test this change?
live