### PR TITLE
feat(prizepool): apply tierType modifiers in weight calculation on hs

### DIFF
--- a/lua/wikis/hearthstone/PrizePool/Custom.lua
+++ b/lua/wikis/hearthstone/PrizePool/Custom.lua
@@ -13,7 +13,6 @@ local Logic = Lua.import('Module:Logic')
 local Variables = Lua.import('Module:Variables')
 
 local PrizePool = Lua.import('Module:PrizePool')
-local Opponent = Lua.import('Module:Opponent/Custom')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 local CustomLpdbInjector = Class.new(LpdbInjector)
@@ -54,7 +53,7 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize', lpdbData.extradata.prizepoints)
 	Variables.varDefine('ranking' .. lpdbPrefix .. '_' .. (team:lower()) .. '_pointprize2',
 		lpdbData.extradata.prizepoints2)
-	
+
 	return lpdbData
 end
 


### PR DESCRIPTION
## Summary
**Changes**: lowed weight of Showmatches, Daily and Weekly tiertypes (based on Overwatch module)

**Reasons**:
1) Hearthstone has showmatches with huge prize pool (up to $300k, which is more than many S-tier tournaments) and they are shown on players pages instead of more important events (example - 5 showmatches of 10 entries here - https://liquipedia.net/hearthstone/DogDog)
2) 1st places of Daily/Weekly events are shown instead of 3-4 places in "normal" C-tier events despite having less prize.

## How did you test this change?

https://liquipedia.net/hearthstone/Death_Knight_Showmatch (after applying `|dev=r28` is isn't shown on https://liquipedia.net/hearthstone/DogDog)
https://liquipedia.net/hearthstone/VK_Play_Battlegrounds_Cup/2024/146

Please check if the values of `TIER_VALUE` and `TIER_TYPE_MODIFIER` are okay