### PR TITLE
fix(mainpage): incorrect map in pubgm main page

### DIFF
--- a/lua/wikis/pubgmobile/MainPageLayout/data.lua
+++ b/lua/wikis/pubgmobile/MainPageLayout/data.lua
@@ -125,7 +125,7 @@ return {
 			},
 		},
 		{
-			file = 'PUBG Erangel Remaster Map.jpg',
+			file = 'PUBG Mobile Erangel 2023.png',
 			title = 'Maps',
 			link = 'Portal:Maps',
 			count = {


### PR DESCRIPTION
## Summary

main page was using the PC version of the map, pr switches to mobile version instead

## How did you test this change?

browser dev tool
