### PR TITLE
feat(mainpage): Add game filters for Crossfire

### DIFF
--- a/lua/wikis/crossfire/FilterButtons/Config.lua
+++ b/lua/wikis/crossfire/FilterButtons/Config.lua
@@ -1,0 +1,43 @@
+---
+-- @Liquipedia
+-- page=Module:FilterButtons/Config
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Game = Lua.import('Module:Game')
+local Tier = Lua.import('Module:Tier/Utils')
+
+local Config = {}
+
+---@type FilterButtonCategory[]
+Config.categories = {
+	{
+		name = 'liquipediatier',
+		property = 'liquipediaTier',
+		load = function(category)
+			category.items = {}
+			for _, tier in Tier.iterate('tiers') do
+				table.insert(category.items, tier.value)
+			end
+		end,
+		defaultItems = {'1', '2', '3'},
+		transform = function(tier)
+			return Tier.toName(tier)
+		end,
+		expandKey = "game",
+	},
+	{
+		name = 'game',
+		property = 'game',
+		expandable = true,
+		items = {'cf', 'cfm', 'cfhd'},
+		transform = function(game)
+			return Game.abbreviation({game = game, noSpan = true, noLink = true})
+		end
+	}
+}
+
+return Config

--- a/lua/wikis/crossfire/FilterButtons/Config.lua
+++ b/lua/wikis/crossfire/FilterButtons/Config.lua
@@ -35,7 +35,7 @@ Config.categories = {
 		expandable = true,
 		items = {'cf', 'cfm', 'cfhd'},
 		transform = function(game)
-			return Game.abbreviation({game = game, noSpan = true, noLink = true})
+			return Game.abbreviation{game = game, noSpan = true, noLink = true}
 		end
 	}
 }

--- a/lua/wikis/crossfire/Info.lua
+++ b/lua/wikis/crossfire/Info.lua
@@ -12,7 +12,7 @@ return {
 	defaultGame = 'cf',
 	games = {
 		cf = {
-			abbreviation = 'CF',
+			abbreviation = 'Classic',
 			name = 'CrossFire',
 			link = 'CrossFire',
 			logo = {
@@ -25,7 +25,7 @@ return {
 			},
 		},
 		cfm = {
-			abbreviation = 'CFM',
+			abbreviation = 'Mobile',
 			name = 'CrossFire Mobile',
 			link = 'CrossFire Mobile',
 			logo = {
@@ -38,7 +38,7 @@ return {
 			},
 		},
 		cfhd = {
-			abbreviation = 'CFHD',
+			abbreviation = 'HD',
 			name = 'CrossFire HD',
 			link = 'CrossFire HD',
 			logo = {


### PR DESCRIPTION
## Summary
<img width="1000" height="515" alt="image" src="https://github.com/user-attachments/assets/7cd023ea-aa5b-46f5-8f69-b4363fc62a71" />

CrossFire houses coverage of 3 different game versions, however on this one I decide to use the **Abbreviation** from Module:Info instead of icons. This is because even with finding the exact logo of these three, they are actually all using the same logo so icons would not work in this case. 

## How did you test this change?
dev

<img width="562" height="101" alt="image" src="https://github.com/user-attachments/assets/8c59c0a5-a1bf-4171-a9a9-0142b82d73bb" />

## Notes
I am completely not sure on the Game.abbreviation returns if that code line needs adjustment, I just copied over from other filters that uses game icons and I replace it to abbreviation
