### PR TITLE
feat(match2): adjust random faction handling in warcraft games

### DIFF
--- a/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
@@ -30,6 +30,7 @@ local MODE_MIXED = 'mixed'
 local MODE_FFA = 'FFA'
 local ASSUME_FINISHED_AFTER = MatchGroupInputUtil.ASSUME_FINISHED_AFTER
 local NOW = os.time()
+local RANDOM_FACTION = 'r'
 
 ---@class WarcraftParticipant
 ---@field player string
@@ -256,7 +257,9 @@ function MapFunctions.getTeamMapPlayers(mapInput, opponent, opponentIndex)
 		end,
 		function(playerIndex, playerIdData, playerInputData)
 			local prefix = 't' .. opponentIndex .. 'p' .. playerIndex
+			local isRandom = Logic.readBool(mapInput[prefix .. 'random'])
 			local faction = Faction.read(mapInput[prefix .. 'race'])
+				or (isRandom and Faction.read(RANDOM_FACTION))
 				or (playerIdData.extradata or {}).faction or Faction.defaultFaction
 			local link = playerIdData.name or playerInputData.link or playerInputData.name:gsub(' ', '_')
 			return {
@@ -264,7 +267,7 @@ function MapFunctions.getTeamMapPlayers(mapInput, opponent, opponentIndex)
 				player = link,
 				flag = Flags.CountryName{flag = playerIdData.flag},
 				position = playerIndex,
-				random = Logic.readBool(mapInput[prefix .. 'random']),
+				random = isRandom,
 				heroes = MapFunctions.readHeroes(
 					mapInput[prefix .. 'heroes'],
 					faction,


### PR DESCRIPTION
## Summary
reported/requested at https://discord.com/channels/93055209017729024/372075546231832576/1410979433191313612
Although it was reported in bugs channel i do not consider the current behaviour a bug.
It never worked differently nor is it inconsisstent with how we handle factiosn in other places.
Hence i consider the "bug-report" as a feature request.

Before the PR the faction input on game level directly falls back to the faction data on match level.
Independently if the `tXpYrandom` param is set or not.

After this PR the behaviour is changed so that if `tXpYrandom` evaluates as true the input is still read as before but the fallback will be random-faction instead of looking at the match level.

## How did you test this change?
dev