### PR TITLE
feat(navbox): Add option to suppres the html list building in navbox lists

### DIFF
--- a/lua/wikis/commons/Widget/NavBox/Child.lua
+++ b/lua/wikis/commons/Widget/NavBox/Child.lua
@@ -40,6 +40,7 @@ local EMPTY_CHILD_ERROR = 'Empty child found'
 ---@field collapsed boolean? # from wiki input string?
 ---@field center boolean? # from wiki input string?
 ---@field allowEmpty boolean? # from wiki input string?
+---@field supressHtmlList boolean? # from wiki input string?
 ---@field image string?
 ---@field imageleft string?
 ---@field imagedark string?
@@ -78,7 +79,7 @@ function NavBoxChild:render()
 	local listCss = {['text-align'] = Logic.readBool(props.center) and 'center' or nil}
 
 	if not props.child1 then
-		return NavBoxList{children = listElements, css = listCss}
+		return NavBoxList{children = listElements, css = listCss, supressHtmlList = Logic.readBool(props.supressHtmlList)}
 	end
 
 	local children = Array.mapIndexes(function(rowIndex)

--- a/lua/wikis/commons/Widget/NavBox/List.lua
+++ b/lua/wikis/commons/Widget/NavBox/List.lua
@@ -19,25 +19,32 @@ local Li = HtmlWidgets.Li
 
 ---@class NavBoxList: Widget
 ---@operator call(table): NavBoxList
+---@field props {children: (string|number|Html|Widget)[], css: string[], supressHtmlList: boolean?}
 local NavBoxList = Class.new(Widget)
-
---text-align:center
 
 ---@return Widget
 function NavBoxList:render()
-	local elements = Array.map(self.props.children, function(child)
-		return Li{
-			children = child
-		}
-	end)
+	local elements = self.props.children
+
+	if not self.props.supressHtmlList then
+		elements = Array.map(self.props.children, function(child)
+			return Li{
+				children = child
+			}
+		end)
+	end
+
+	-- interleaving with new lines is needed for better break points on certain widths
+	elements = Array.interleave(elements, '\n')
+
+	if not self.props.supressHtmlList then
+		elements = {Ul{children = elements}}
+	end
 
 	return Div{
 		classes = {'hlist'},
 		css = Table.merge({padding = '0 0.25em'}, self.props.css),
-		children = {
-			-- interleaving with new lines is needed for better break points on certain widths
-			Ul{children = Array.interleave(elements, '\n')}
-		}
+		children = elements
 	}
 end
 


### PR DESCRIPTION
## Summary
Dota needs navbox list to not render as html list in some instances
To allow this introduce an optiona parameter `|supressHtmlList=` (expects a bool representation or nil).

## How did you test this change?
dev
https://liquipedia.net/dota2/User:Buny154/sandbox_3