### PR TITLE
feat(match2): new design for matchpage footers

### DIFF
--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1087,12 +1087,11 @@ span.slash {
 		flex-direction: column;
 		padding: 4px;
 		gap: 4px;
-		border: 1px solid #bbbbbb;
-		background: #f5f5f5;
+		border-radius: 0.5rem;
+		background: #00000014;
 
 		.theme--dark & {
-			background-color: var( --clr-secondary-16 );
-			border-color: var( --clr-secondary-25 );
+			background-color: #ffffff14;
 		}
 
 		> div {

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1122,9 +1122,8 @@ span.slash {
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			padding: 0.25rem;
+			padding-bottom: 0.5rem;
 			font-weight: bold;
-			height: 2.375rem;
 			flex-grow: 0;
 		}
 

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1124,6 +1124,7 @@ span.slash {
 			align-items: center;
 			padding-bottom: 0.5rem;
 			font-weight: bold;
+			height: 2.375rem;
 			flex-grow: 0;
 		}
 

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1062,6 +1062,18 @@ span.slash {
 	display: flex;
 	gap: 1rem;
 	flex-wrap: wrap;
+	border: 1px solid #bbbbbb;
+	border-radius: 0.5rem;
+	padding: 0.5rem;
+
+	.theme--light & {
+		background-color: #ffffff;
+	}
+
+	.theme--dark & {
+		background-color: var( --clr-secondary-16 );
+		border-color: rgba( 255, 255, 255, 0.08 );
+	}
 
 	@media ( max-width: 767px ) {
 		flex-direction: column;

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1085,7 +1085,7 @@ span.slash {
 		align-items: center;
 		flex: 3 0 100%;
 		flex-direction: column;
-		padding: 4px;
+		padding: 0.5rem;
 		gap: 4px;
 		border-radius: 0.5rem;
 		background: #00000014;

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1104,7 +1104,15 @@ span.slash {
 
 	&-section {
 		flex: 1 0 20%;
-		border: 0.0625rem solid #bbbbbb;
+		border-radius: 0.5rem;
+		background: #00000014;
+		display: flex;
+		flex-flow: column;
+		padding: 0.5rem;
+
+		.theme--dark & {
+			background-color: #ffffff14;
+		}
 
 		.theme--dark & {
 			border-color: var( --clr-secondary-25 );
@@ -1115,15 +1123,9 @@ span.slash {
 			justify-content: center;
 			align-items: center;
 			padding: 0.25rem;
-			border-bottom: 0.0625rem solid #bbbbbb;
-			background: #f5f5f5;
 			font-weight: bold;
 			height: 2.375rem;
-
-			.theme--dark & {
-				background-color: var( --clr-secondary-16 );
-				border-color: var( --clr-secondary-25 );
-			}
+			flex-grow: 0;
 		}
 
 		&-body {
@@ -1131,6 +1133,15 @@ span.slash {
 			gap: 0.5rem;
 			padding: 1rem 0.5rem;
 			justify-content: center;
+			align-items: center;
+			flex-grow: 1;
+			border-radius: 0.5rem;
+			background: var( --clr-background );
+
+			.theme--dark & {
+				background-color: var( --clr-secondary-16 );
+				border-color: rgba( 255, 255, 255, 0.08 );
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR applies the new match summary design from #6187 to match page footers.

## How did you test this change?

browser dev tools

### PC

<img width="1221" height="222" alt="image" src="https://github.com/user-attachments/assets/1efae61c-4695-4083-85fe-9c74a21e5e3e" />
<img width="1222" height="223" alt="image" src="https://github.com/user-attachments/assets/507f185e-d6d1-435e-a78a-d878d24bec5e" />

### Mobile

<img width="401" height="472" alt="image" src="https://github.com/user-attachments/assets/7f7acaff-2398-4872-85ec-94149dd0b818" /><img width="402" height="473" alt="image" src="https://github.com/user-attachments/assets/8564dead-3051-4ff9-927a-5e639d0e16d6" />
