### PR TITLE
chore: wrap Countdown with Class.export

### DIFF
--- a/lua/wikis/commons/Countdown.lua
+++ b/lua/wikis/commons/Countdown.lua
@@ -83,4 +83,7 @@ function Countdown.create(args)
 	)
 end
 
+--- temporary to not break non-Git uses
+Countdown._create = Countdown.create
+
 return Class.export(Countdown, {exports = {'create'}})

--- a/lua/wikis/commons/Countdown.lua
+++ b/lua/wikis/commons/Countdown.lua
@@ -14,9 +14,19 @@ local Table = Lua.import('Module:Table')
 
 local StreamLinks = Lua.import('Module:Links/Stream')
 
+---@class CountdownArgs
+---@field date string?
+---@field timestamp integer?
+---@field rawcountdown boolean?
+---@field rawdatetime boolean?
+---@field finished boolean?
+---@field nostreams boolean?
+---@field text string?
+---@field separator string?
+
 local Countdown = {}
 
----@param args table
+---@param args CountdownArgs
 ---@return string
 function Countdown.create(args)
 	args = args or {}

--- a/lua/wikis/commons/Countdown.lua
+++ b/lua/wikis/commons/Countdown.lua
@@ -7,7 +7,7 @@
 
 local Lua = require('Module:Lua')
 
-local Arguments = Lua.import('Module:Arguments')
+local Class = Lua.import('Module:Class')
 local DateExt = Lua.import('Module:Date/Ext')
 local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
@@ -16,15 +16,9 @@ local StreamLinks = Lua.import('Module:Links/Stream')
 
 local Countdown = {}
 
----@param frame Frame
----@return string
-function Countdown.create(frame)
-	return Countdown._create(Arguments.getArgs(frame))
-end
-
 ---@param args table
 ---@return string
-function Countdown._create(args)
+function Countdown.create(args)
 	args = args or {}
 	if Logic.isEmpty(args.date) and not args.timestamp then
 		return ''
@@ -79,4 +73,4 @@ function Countdown._create(args)
 	)
 end
 
-return Countdown
+return Class.export(Countdown, {exports = {'create'}})

--- a/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
@@ -187,7 +187,7 @@ function MatchlistDisplay.DateHeader(match)
 		},
 		children = HtmlWidgets.Div{
 			css = {padding = '2px 10px'},
-			children = Countdown._create(Table.merge(match.stream, {
+			children = Countdown.create(Table.merge(match.stream, {
 				date = DateExt.toCountdownArg(match.timestamp, match.timezoneId, match.dateIsExact),
 				finished = match.finished,
 			}))

--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -95,7 +95,7 @@ function BaseMatchPage:getCountdownBlock()
 			display = 'block',
 			['text-align'] = 'center'
 		},
-		children = Countdown._create{
+		children = Countdown.create{
 			date = DateExt.toCountdownArg(self.matchData.timestamp, self.matchData.timezoneId, self.matchData.dateIsExact),
 			finished = self.matchData.finished,
 			rawdatetime = Logic.readBool(self.matchData.finished),

--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -662,7 +662,7 @@ function MatchTable:_displayDate(match)
 		return cell
 	end
 
-	return cell:node(Countdown._create{
+	return cell:node(Countdown.create{
 		finished = match.finished,
 		date = DateExt.toCountdownArg(match.timestamp, match.timezoneId, match.dateIsExact),
 		rawdatetime = true,

--- a/lua/wikis/commons/MatchTicker/DisplayComponents.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents.lua
@@ -322,7 +322,7 @@ function Details:countdown(matchPageIcon)
 
 	local countdownDisplay = mw.html.create('span')
 		:addClass('match-countdown')
-		:node(Countdown._create(countdownArgs))
+		:node(Countdown.create(countdownArgs))
 
 	if Logic.readBool(match.finished) then
 		local function makeVod(vod, num)

--- a/lua/wikis/commons/MatchesScheduleDisplay.lua
+++ b/lua/wikis/commons/MatchesScheduleDisplay.lua
@@ -202,7 +202,7 @@ function MatchesTable:dateDisplay(match)
 		end
 		countdownArgs.timestamp = match.timestamp
 		countdownArgs.date = DateExt.toCountdownArg(match.timestamp, match.timezoneId)
-		return createDateCell{children = Countdown._create(countdownArgs)}
+		return createDateCell{children = Countdown.create(countdownArgs)}
 	elseif self.config.onlyShowExactDates then
 		return createDateCell{
 			css = {

--- a/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
+++ b/lua/wikis/commons/Widget/Infobox/UpcomingTournaments/Row.lua
@@ -106,7 +106,7 @@ function UpcomingTournamentsRow:_getCountdown()
 		children = ongoing and Span{
 			classes = {'timer-object-countdown-live'},
 			children = 'ONGOING!'
-		} or Countdown._create{timestamp = startDateTimestamp, rawcountdown = true}
+		} or Countdown.create{timestamp = startDateTimestamp, rawcountdown = true}
 	}
 end
 

--- a/lua/wikis/commons/Widget/Match/Countdown.lua
+++ b/lua/wikis/commons/Widget/Match/Countdown.lua
@@ -35,7 +35,7 @@ function MatchCountdown:render()
 
 	return HtmlWidgets.Span{
 		classes = {'match-info-countdown'},
-		children = Countdown._create{
+		children = Countdown.create{
 			rawdatetime = match.finished,
 			date = DateExt.toCountdownArg(match.timestamp, match.timezoneId, match.dateIsExact),
 			finished = match.finished,

--- a/lua/wikis/commons/Widget/Match/Summary/Ffa/GameCountdown.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Ffa/GameCountdown.lua
@@ -42,7 +42,7 @@ function MatchSummaryFfaGameCountdown:render()
 	return HtmlWidgets.Div{
 		classes = {'match-countdown-block'},
 		children = {
-			Countdown._create(streamParameters),
+			Countdown.create(streamParameters),
 			game.vod and VodLink.display{vod = game.vod} or nil,
 		},
 	}

--- a/lua/wikis/lab/Widget/ProjectOverview.lua
+++ b/lua/wikis/lab/Widget/ProjectOverview.lua
@@ -130,7 +130,7 @@ function ProjectOverview:_generateOverview()
 			{
 				IconFa{iconName = 'lastupdated', screenReaderHidden = true},
 				' Last Update: ',
-				timestamp and Countdown._create{
+				timestamp and Countdown.create{
 					timestamp = timestamp,
 					date = DateExt.toCountdownArg(timestamp),
 					rawdatetime = true

--- a/lua/wikis/starcraft2/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/League/Custom.lua
@@ -200,7 +200,7 @@ function CustomInjector:parse(id, widgets)
 			Cell{name = 'Server', children = {caller:_getServer(args)}}
 		}
 	elseif id == 'dates' and data.startTime.display then
-		local startTime = Countdown._create{date = data.startTime.display, rawdatetime = true}
+		local startTime = Countdown.create{date = data.startTime.display, rawdatetime = true}
 
 		if data.startDate == data.endDate then
 			return {Cell{name = 'Start Time', children = {startTime}}}

--- a/lua/wikis/warcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/League/Custom.lua
@@ -327,7 +327,7 @@ end
 
 ---@return string
 function CustomLeague:_displayStartDateTime()
-	return Countdown._create{
+	return Countdown.create{
 		date = self.data.startTime.raw,
 		finished = self.data.isFinished,
 	}


### PR DESCRIPTION
## Summary

This PR wraps `Module:Countdown` with `Class.export`, and updates existing uses accordingly.

### Note

Non-git uses of `Countdown._create` have to be updated after merge

## How did you test this change?

trivial