### PR TITLE
refactor(infobox): use standardized match ticker / widget for infobox footer

### DIFF
--- a/lua/wikis/brawlstars/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/brawlstars/Infobox/Person/Player/Custom.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
 local Logic = Lua.import('Module:Logic')
+local MatchTicker = Lua.import('Module:MatchTicker/Custom')
 local Page = Lua.import('Module:Page')
 local PlayerIntroduction = Lua.import('Module:PlayerIntroduction/Custom')
 local String = Lua.import('Module:StringUtils')
@@ -19,7 +20,9 @@ local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
 local Widgets = Lua.import('Module:Widget/All')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Cell = Widgets.Cell
+local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 ---@class BrawlstarsInfoboxPlayer: Person
 local CustomPlayer = Class.new(Player)
@@ -105,18 +108,18 @@ function CustomPlayer:adjustLPDB(lpdbData, args)
 	return lpdbData
 end
 
+---@return Widget?
 function CustomPlayer:createBottomContent()
-	local components = {}
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
 		local teamPage = TeamTemplate.getPageName(self.args.team)
 
-		table.insert(components,
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing matches of', {team = teamPage}))
-		table.insert(components,
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage}))
+		return HtmlWidgets.Fragment{
+			children = {
+				MatchTicker.participant{team = teamPage},
+				UpcomingTournaments{name = teamPage}
+			}
+		}
 	end
-
-	return table.concat(components)
 end
 
 ---@param args table

--- a/lua/wikis/dota2/Infobox/Team/Custom.lua
+++ b/lua/wikis/dota2/Infobox/Team/Custom.lua
@@ -57,12 +57,7 @@ end
 ---@return Widget?
 function CustomTeam:createBottomContent()
 	if not self.args.disbanded then
-		return HtmlWidgets.Fragment{
-			children = {
-				MatchTicker.participant{team = self.pagename},
-				UpcomingTournaments{name = self.pagename}
-			}
-		}
+		return UpcomingTournaments{name = self.pagename}
 	end
 end
 

--- a/lua/wikis/dota2/Infobox/Team/Custom.lua
+++ b/lua/wikis/dota2/Infobox/Team/Custom.lua
@@ -8,7 +8,6 @@
 local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
-local MatchTicker = Lua.import('Module:MatchTicker/Custom')
 local RoleOf = Lua.import('Module:RoleOf')
 
 local Condition = Lua.import('Module:Condition')
@@ -20,7 +19,6 @@ local ConditionUtil = Condition.Util
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Team = Lua.import('Module:Infobox/Team')
 
-local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 local ACHIEVEMENTS_BASE_CONDITIONS = {

--- a/lua/wikis/dota2/Infobox/Team/Custom.lua
+++ b/lua/wikis/dota2/Infobox/Team/Custom.lua
@@ -8,6 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
+local MatchTicker = Lua.import('Module:MatchTicker/Custom')
 local RoleOf = Lua.import('Module:RoleOf')
 
 local Condition = Lua.import('Module:Condition')
@@ -18,6 +19,9 @@ local ConditionUtil = Condition.Util
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Team = Lua.import('Module:Infobox/Team')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 local ACHIEVEMENTS_BASE_CONDITIONS = {
 	ConditionUtil.noneOf(ColumnName('liquipediatiertype'), {'Showmatch', 'Qualifier', 'Charity'}),
@@ -50,25 +54,16 @@ function CustomTeam.run(frame)
 	return team:createInfobox()
 end
 
----@return string?
+---@return Widget?
 function CustomTeam:createBottomContent()
---[[
-	if not _team.args.disbanded then
-		TODO:
-		Leaving this out for now, will be a follow-up PR,
-		as both the templates needs to be removed from team pages plus the templates also requires some div changes
-
-		return Template.expandTemplate(
-			mw.getCurrentFrame(),
-			'Upcoming and ongoing matches of',
-			{team = _team.name or _team.pagename}
-		) .. Template.expandTemplate(
-			mw.getCurrentFrame(),
-			'Upcoming and ongoing tournaments of',
-			{team = _team.name or _team.pagename}
-		)
+	if not self.args.disbanded then
+		return HtmlWidgets.Fragment{
+			children = {
+				MatchTicker.participant{team = self.pagename},
+				UpcomingTournaments{name = self.pagename}
+			}
+		}
 	end
---]]
 end
 
 ---@param lpdbData table

--- a/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
@@ -12,6 +12,7 @@ local CharacterIcon = Lua.import('Module:CharacterIcon')
 local CharacterNames = Lua.import('Module:CharacterNames')
 local Class = Lua.import('Module:Class')
 local GameAppearances = Lua.import('Module:Infobox/Extension/GameAppearances')
+local MatchTicker = Lua.import('Module:MatchTicker/Custom')
 local Page = Lua.import('Module:Page')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
@@ -24,8 +25,10 @@ local Comparator = Condition.Comparator
 local ColumnName = Condition.ColumnName
 local ConditionUtil = Condition.Util
 
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
+local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 
@@ -109,7 +112,7 @@ function CustomPlayer:adjustLPDB(lpdbData, args)
 	lpdbData.region = Template.safeExpand(mw.getCurrentFrame(), 'Player region', {args.country})
 
 	if String.isNotEmpty(args.team2) then
-		lpdbData.extradata.team2 = mw.ext.TeamTemplate.raw(args.team2).page
+		lpdbData.extradata.team2 = TeamTemplate.getPageName(args.team2)
 	end
 
 	return lpdbData
@@ -119,9 +122,12 @@ end
 function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
 		local teamPage = TeamTemplate.getPageName(self.args.team)
-		return
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing matches of', {team = teamPage}) ..
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
+		return HtmlWidgets.Fragment{
+			children = {
+				MatchTicker.participant{team = teamPage},
+				UpcomingTournaments{name = teamPage}
+			}
+		}
 	end
 end
 

--- a/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
@@ -12,6 +12,7 @@ local Class = Lua.import('Module:Class')
 local ChampionNames = Lua.import('Module:ChampionNames', {loadData = true})
 local CharacterIcon = Lua.import('Module:CharacterIcon')
 local Logic = Lua.import('Module:Logic')
+local MatchTicker = Lua.import('Module:MatchTicker/Custom')
 local Page = Lua.import('Module:Page')
 local PlayerIntroduction = Lua.import('Module:PlayerIntroduction/Custom')
 local String = Lua.import('Module:StringUtils')
@@ -22,7 +23,9 @@ local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
 local Widgets = Lua.import('Module:Widget/All')
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Cell = Widgets.Cell
+local UpcomingTournaments = Lua.import('Module:Widget/Infobox/UpcomingTournaments')
 
 local SIZE_CHAMPION = '25x25px'
 
@@ -114,13 +117,16 @@ function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 	return lpdbData
 end
 
----@return string?
+---@return Widget?
 function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
 		local teamPage = TeamTemplate.getPageName(self.args.team)
-		return
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing matches of', {team = teamPage}) ..
-			Template.safeExpand(mw.getCurrentFrame(), 'Upcoming and ongoing tournaments of', {team = teamPage})
+		return HtmlWidgets.Fragment{
+			children = {
+				MatchTicker.participant{team = teamPage},
+				UpcomingTournaments{name = teamPage}
+			}
+		}
 	end
 end
 


### PR DESCRIPTION
## Summary

resolves #6495

after merge: `python pwb.py replace -lang:dota2 -regex -transcludes:"Infobox team" "{{[uU]pcoming[_ ]and[_ ]ongoing[_ ]tournaments[_ ]of}}\n?" "" -summary:"cleanup upcoming tournaments template usage"`

## How did you test this change?

dev