### PR TITLE
feat(match2): adjust stream button sizes in matchpage header

### DIFF
--- a/lua/wikis/commons/Widget/Match/Page/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Page/Header.lua
@@ -106,6 +106,7 @@ function MatchPageHeader:_showStreams()
 		children = StreamsContainer{
 			streams = StreamLinks.filterStreams(self.props.stream),
 			matchIsLive = self.props.phase == 'ongoing',
+			growButtons = true,
 		}
 	}
 end

--- a/lua/wikis/commons/Widget/Match/Stream.lua
+++ b/lua/wikis/commons/Widget/Match/Stream.lua
@@ -64,6 +64,7 @@ function MatchStream:render()
 		}},
 		variant = 'tertiary',
 		size = 'sm',
+		grow = self.props.grow,
 	}
 end
 

--- a/lua/wikis/commons/Widget/Match/StreamsContainer.lua
+++ b/lua/wikis/commons/Widget/Match/StreamsContainer.lua
@@ -46,6 +46,7 @@ function MatchStreamsContainer:render()
 			platform = stream.platform,
 			stream = stream.stream,
 			matchIsLive = self.props.matchIsLive,
+			grow = self.props.growButtons,
 		}
 	end)
 end


### PR DESCRIPTION
## Summary

This PR adjusts sizes of stream buttons in matchpage header so that the entire width is filled in all cases.

## How did you test this change?

dev

- current:  
  <img width="1220" height="363" alt="image" src="https://github.com/user-attachments/assets/8ef41f06-2e1a-413f-843d-be7f06f8da1b" />

- this pr:  
  <img width="1219" height="360" alt="image" src="https://github.com/user-attachments/assets/a13bd25d-5224-407c-aa8f-8e77fe94c685" />

