### PR TITLE
fix: display buttons correctly on the vod dropdown

### DIFF
--- a/lua/wikis/commons/Widget/Basic/Button.lua
+++ b/lua/wikis/commons/Widget/Basic/Button.lua
@@ -24,7 +24,7 @@ local Div = HtmlWidgets.Div
 ---@field variant 'primary'|'secondary'|'tertiary'|'ghost'|'destructive'|nil
 ---@field size 'xs'|'sm'|'md'|'lg'|nil
 ---@field grow boolean?
----@field aligncontent 'left'|'center'|'right'|nil
+---@field aligncontent 'left'|'right'|nil
 
 ---@class ButtonWidget: Widget
 ---@operator call(ButtonWidgetParameters): ButtonWidget

--- a/lua/wikis/commons/Widget/Basic/Button.lua
+++ b/lua/wikis/commons/Widget/Basic/Button.lua
@@ -23,6 +23,7 @@ local Div = HtmlWidgets.Div
 ---@field variant 'primary'|'secondary'|'tertiary'|'ghost'|'destructive'|nil
 ---@field size 'xs'|'sm'|'md'|'lg'|nil
 ---@field grow boolean?
+---@field aligncontent 'left'|'center'|'right'|nil
 
 ---@class ButtonWidget: Widget
 ---@operator call(ButtonWidgetParameters): ButtonWidget
@@ -33,6 +34,7 @@ Button.defaultProps = {
 	variant = 'primary',
 	size = 'md',
 	grow = false, -- Whether the button should grow to fill the available space
+	aligncontent = 'center',
 }
 
 ---@return Widget
@@ -59,8 +61,19 @@ function Button:render()
 		table.insert(cssClasses, 'btn-large')
 	end
 
+	local cssTable = {}
+	if self.props.grow then
+		cssTable.width = '100%'
+	end
+	if self.props.aligncontent == 'left' then
+		cssTable['justify-content'] = 'left'
+	end
+	if self.props.aligcontent == 'right' then
+		cssTable['justify-content'] = 'right'
+	end
+
 	local button = Div{
-		css = self.props.grow and {width = '100%'} or nil,
+		css = next(cssTable) and cssTable or nil,
 		classes = Array.extend(cssClasses, self.props.classes or {}),
 		attributes = Table.merge({
 			title = self.props.title,

--- a/lua/wikis/commons/Widget/Basic/Button.lua
+++ b/lua/wikis/commons/Widget/Basic/Button.lua
@@ -68,7 +68,7 @@ function Button:render()
 	end
 	if self.props.aligncontent == 'left' then
 		cssTable['justify-content'] = 'left'
-	elseif self.props.aligcontent == 'right' then
+	elseif self.props.aligncontent == 'right' then
 		cssTable['justify-content'] = 'right'
 	end
 

--- a/lua/wikis/commons/Widget/Basic/Button.lua
+++ b/lua/wikis/commons/Widget/Basic/Button.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
 local Widget = Lua.import('Module:Widget')
@@ -34,7 +35,7 @@ Button.defaultProps = {
 	variant = 'primary',
 	size = 'md',
 	grow = false, -- Whether the button should grow to fill the available space
-	aligncontent = 'center',
+	aligncontent = nil,
 }
 
 ---@return Widget
@@ -67,13 +68,12 @@ function Button:render()
 	end
 	if self.props.aligncontent == 'left' then
 		cssTable['justify-content'] = 'left'
-	end
-	if self.props.aligcontent == 'right' then
+	elseif self.props.aligcontent == 'right' then
 		cssTable['justify-content'] = 'right'
 	end
 
 	local button = Div{
-		css = next(cssTable) and cssTable or nil,
+		css = Logic.nilIfEmpty(cssTable),
 		classes = Array.extend(cssClasses, self.props.classes or {}),
 		attributes = Table.merge({
 			title = self.props.title,

--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -105,7 +105,7 @@ function MatchButtonBar:render()
 		collapseAreaClasses = {'match-info-vods-area'},
 		classes = {'match-info-links-wrapper'},
 		children = displayVods and Array.map(vods, function(vod)
-			return VodButton{vodLink = vod.vod, gameNumber = vod.number, showText = #vods < 4, variant = 'dropdown'}
+			return VodButton{vodLink = vod.vod, gameNumber = vod.number, showText = #vods < 4, variant = 'dropdown', grow = true}
 		end) or nil,
 	}
 end

--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -111,7 +111,6 @@ function MatchButtonBar:render()
 				showText = #vods < 4,
 				variant = 'dropdown',
 				grow = true,
-				leftAlign = true
 			}
 		end) or nil,
 	}

--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -105,7 +105,14 @@ function MatchButtonBar:render()
 		collapseAreaClasses = {'match-info-vods-area'},
 		classes = {'match-info-links-wrapper'},
 		children = displayVods and Array.map(vods, function(vod)
-			return VodButton{vodLink = vod.vod, gameNumber = vod.number, showText = #vods < 4, variant = 'dropdown', grow = true}
+			return VodButton{
+				vodLink = vod.vod,
+				gameNumber = vod.number,
+				showText = #vods < 4,
+				variant = 'dropdown',
+				grow = true,
+				leftAlign = true
+			}
 		end) or nil,
 	}
 end

--- a/lua/wikis/commons/Widget/Match/VodButton.lua
+++ b/lua/wikis/commons/Widget/Match/VodButton.lua
@@ -15,6 +15,7 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Button = Lua.import('Module:Widget/Basic/Button')
 local ImageIcon = Lua.import('Module:Widget/Image/Icon/Image')
 local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
+local Div = HtmlWidgets.Div
 
 ---@class VodButton: Widget
 ---@operator call(table): VodButton
@@ -32,7 +33,6 @@ function VodButton:render()
 	local showText = self.props.showText
 	local gameNumber = self.props.gameNumber
 	local useGrow = self.props.grow == true
-	local leftAlignContent = self.props.leftAlign == true
 
 	return Button{
 		linktype = 'external',
@@ -41,12 +41,16 @@ function VodButton:render()
 		link = vodLink,
 		size = 'sm',
 		grow = useGrow,
-		classes = leftAlignContent and {'filter-buttons--left'} or nil,
 		children = useDropdownVariant and {
-			Icon{iconName = 'vod_play', size = 'sm'},
-			HtmlWidgets.Span{
-				children = showText and ('Game ' .. gameNumber) or gameNumber,
-			}
+			Div{
+				css = {['justify-content'] = 'left'},
+				children = {
+					Icon{iconName = 'vod_play', size = 'sm'},
+					HtmlWidgets.Span{
+						children = showText and ('Game ' .. gameNumber) or gameNumber,
+					}
+				}
+			},
 		} or {
 			ImageIcon{imageLight = VodLink.getIcon(gameNumber)},
 			HtmlWidgets.Span{

--- a/lua/wikis/commons/Widget/Match/VodButton.lua
+++ b/lua/wikis/commons/Widget/Match/VodButton.lua
@@ -31,6 +31,7 @@ function VodButton:render()
 	local useDropdownVariant = self.props.variant == 'dropdown'
 	local showText = self.props.showText
 	local gameNumber = self.props.gameNumber
+	local useGrow = self.props.grow == true
 
 	return Button{
 		linktype = 'external',
@@ -38,6 +39,7 @@ function VodButton:render()
 		variant = 'tertiary',
 		link = vodLink,
 		size = 'sm',
+		grow = useGrow,
 		children = useDropdownVariant and {
 			Icon{iconName = 'vod_play'},
 			HtmlWidgets.Span{

--- a/lua/wikis/commons/Widget/Match/VodButton.lua
+++ b/lua/wikis/commons/Widget/Match/VodButton.lua
@@ -8,6 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
 local VodLink = Lua.import('Module:VodLink')
 
 local Widget = Lua.import('Module:Widget')
@@ -31,7 +32,7 @@ function VodButton:render()
 	local useDropdownVariant = self.props.variant == 'dropdown'
 	local showText = self.props.showText
 	local gameNumber = self.props.gameNumber
-	local useGrow = self.props.grow == true
+	local useGrow = Logic.readBool(self.props.grow)
 
 	return Button{
 		linktype = 'external',

--- a/lua/wikis/commons/Widget/Match/VodButton.lua
+++ b/lua/wikis/commons/Widget/Match/VodButton.lua
@@ -41,7 +41,6 @@ function VodButton:render()
 		link = vodLink,
 		size = 'sm',
 		grow = useGrow,
-		aligncontent = 'left',
 		children = useDropdownVariant and {
 			Icon{iconName = 'vod_play', size = 'sm'},
 			HtmlWidgets.Span{

--- a/lua/wikis/commons/Widget/Match/VodButton.lua
+++ b/lua/wikis/commons/Widget/Match/VodButton.lua
@@ -32,6 +32,7 @@ function VodButton:render()
 	local showText = self.props.showText
 	local gameNumber = self.props.gameNumber
 	local useGrow = self.props.grow == true
+	local leftAlignContent = self.props.leftAlign == true
 
 	return Button{
 		linktype = 'external',
@@ -40,10 +41,11 @@ function VodButton:render()
 		link = vodLink,
 		size = 'sm',
 		grow = useGrow,
+		classes = leftAlignContent and {'filter-buttons--left'} or nil,
 		children = useDropdownVariant and {
-			Icon{iconName = 'vod_play'},
+			Icon{iconName = 'vod_play', size = 'sm'},
 			HtmlWidgets.Span{
-				children = showText and ('VOD ' .. gameNumber) or gameNumber,
+				children = showText and ('Game ' .. gameNumber) or gameNumber,
 			}
 		} or {
 			ImageIcon{imageLight = VodLink.getIcon(gameNumber)},

--- a/lua/wikis/commons/Widget/Match/VodButton.lua
+++ b/lua/wikis/commons/Widget/Match/VodButton.lua
@@ -15,7 +15,6 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Button = Lua.import('Module:Widget/Basic/Button')
 local ImageIcon = Lua.import('Module:Widget/Image/Icon/Image')
 local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
-local Div = HtmlWidgets.Div
 
 ---@class VodButton: Widget
 ---@operator call(table): VodButton
@@ -41,16 +40,12 @@ function VodButton:render()
 		link = vodLink,
 		size = 'sm',
 		grow = useGrow,
+		aligncontent = 'left',
 		children = useDropdownVariant and {
-			Div{
-				css = {['justify-content'] = 'left'},
-				children = {
-					Icon{iconName = 'vod_play', size = 'sm'},
-					HtmlWidgets.Span{
-						children = showText and ('Game ' .. gameNumber) or gameNumber,
-					}
-				}
-			},
+			Icon{iconName = 'vod_play', size = 'sm'},
+			HtmlWidgets.Span{
+				children = showText and ('Game ' .. gameNumber) or gameNumber,
+			}
 		} or {
 			ImageIcon{imageLight = VodLink.getIcon(gameNumber)},
 			HtmlWidgets.Span{


### PR DESCRIPTION
## Summary

Currently, the vod buttons in the vod dropdowns don't display as intended.

## How did you test this change?

dev: https://liquipedia.net/dota2/User:Eetwalt

Design for reference:
<img width="760" height="2736" alt="image" src="https://github.com/user-attachments/assets/f172fe06-564b-4ecc-aa8b-040b61f28cbc" />
