### PR TITLE
refactor(transfer): clean up transfer row widget implementation

### DIFF
--- a/lua/wikis/commons/Widget/Transfer/Row.lua
+++ b/lua/wikis/commons/Widget/Transfer/Row.lua
@@ -227,9 +227,9 @@ function TransferRowWidget:rumourCells()
 			children = IconFa(RUMOUR_STATUS_TO_ICON_ARGS[transfer.confirmed])
 		},
 		createDivCell{
-		classes = {'Confidence', CONFIDENCE_TO_COLOR[confidence]},
-		css = {['font-weight'] = 'bold'},
-		children = confidence and String.upperCaseFirst(confidence) or nil
+			classes = {'Confidence', CONFIDENCE_TO_COLOR[confidence]},
+			css = {['font-weight'] = 'bold'},
+			children = confidence and String.upperCaseFirst(confidence) or nil
 		}
 	}
 end

--- a/lua/wikis/commons/Widget/Transfer/Row.lua
+++ b/lua/wikis/commons/Widget/Transfer/Row.lua
@@ -76,7 +76,7 @@ function TransferRowWidget:render()
 	return HtmlWidgets.Div{
 		classes = self:_getClasses(),
 		children = WidgetUtil.collect(
-			self:status(),
+			self:rumourCells(),
 			self:date(),
 			self:platform(),
 			self:players(),
@@ -214,7 +214,7 @@ function TransferRowWidget:_isSpecialRole(role)
 end
 
 ---@return Widget[]?
-function TransferRowWidget:status()
+function TransferRowWidget:rumourCells()
 	local transfer = self.transfer
 
 	if not transfer.isRumour then return end

--- a/lua/wikis/commons/Widget/Transfer/Row.lua
+++ b/lua/wikis/commons/Widget/Transfer/Row.lua
@@ -353,6 +353,23 @@ TransferRowWidget._getTransferArrow = FnUtil.memoize(function (status)
 	return IconFa{iconName = TRANSFER_STATUS_TO_ICON_NAME[status]}
 end)
 
+---@param iconInput string?
+---@return string|Widget
+TransferRowWidget.getIcon = FnUtil.memoize(function (iconInput)
+	if Logic.isEmpty(iconInput) then
+		return EMPTY_POSITION_ICON
+	end
+	---@cast iconInput -nil
+	local icon = IconModule[iconInput:lower()]
+	if not icon then
+		mw.log( 'No entry found in Module:PositionIcon/data: ' .. iconInput)
+		mw.ext.TeamLiquidIntegration.add_category('Pages with transfer errors')
+		return EMPTY_POSITION_ICON
+	end
+
+	return icon
+end)
+
 ---@return Widget
 function TransferRowWidget:icon()
 	if not IconModule then
@@ -363,23 +380,6 @@ function TransferRowWidget:icon()
 		}
 	end
 
-	---@param iconInput string?
-	---@return string|Widget
-	local getIcon = function(iconInput)
-		if Logic.isEmpty(iconInput) then
-			return EMPTY_POSITION_ICON
-		end
-		---@cast iconInput -nil
-		local icon = IconModule[iconInput:lower()]
-		if not icon then
-			mw.log( 'No entry found in Module:PositionIcon/data: ' .. iconInput)
-			mw.ext.TeamLiquidIntegration.add_category('Pages with transfer errors')
-			return EMPTY_POSITION_ICON
-		end
-
-		return icon
-	end
-
 	local targetRoleIsSpecialRole = self:_isSpecialRole(self.transfer.to.roles[1])
 
 	return createDivCell{
@@ -388,11 +388,11 @@ function TransferRowWidget:icon()
 		children = WidgetUtil.collect(Array.interleave(
 			Array.map(self.transfer.players, function (player)
 				return HtmlWidgets.Fragment{children = {
-					getIcon(player.icons[1]),
+					TransferRowWidget.getIcon(player.icons[1]),
 					'&nbsp;',
 					TransferRowWidget._getTransferArrow(self:_getStatus()),
 					'&nbsp;',
-					getIcon(player.icons[2] or targetRoleIsSpecialRole and player.icons[1] or nil)
+					TransferRowWidget.getIcon(player.icons[2] or targetRoleIsSpecialRole and player.icons[1] or nil)
 				}}
 			end),
 			HtmlWidgets.Br{}

--- a/lua/wikis/commons/Widget/Transfer/Row.lua
+++ b/lua/wikis/commons/Widget/Transfer/Row.lua
@@ -10,6 +10,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local DateExt = Lua.import('Module:Date/Ext')
+local FnUtil = Lua.import('Module:FnUtil')
 local Logic = Lua.import('Module:Logic')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
@@ -352,10 +353,11 @@ function TransferRowWidget:_createRole(props)
 end
 
 ---@private
----@return Widget
-function TransferRowWidget:_getTransferArrow()
-	return IconFa{iconName = TRANSFER_STATUS_TO_ICON_NAME[self:_getStatus()]}
-end
+---@param status string?
+---@return Widget?
+TransferRowWidget._getTransferArrow = FnUtil.memoize(function (status)
+	return IconFa{iconName = TRANSFER_STATUS_TO_ICON_NAME[status]}
+end)
 
 ---@return Widget
 function TransferRowWidget:icon()
@@ -363,7 +365,7 @@ function TransferRowWidget:icon()
 		return createDivCell{
 			classes = {'Icon'},
 			css = {width = '70px', ['font-size'] = 'larger'},
-			children = self:_getTransferArrow()
+			children = TransferRowWidget._getTransferArrow(self:_getStatus())
 		}
 	end
 
@@ -394,7 +396,7 @@ function TransferRowWidget:icon()
 				return HtmlWidgets.Fragment{children = {
 					getIcon(player.icons[1]),
 					'&nbsp;',
-					self:_getTransferArrow(),
+					TransferRowWidget._getTransferArrow(self:_getStatus()),
 					'&nbsp;',
 					getIcon(player.icons[2] or targetRoleIsSpecialRole and player.icons[1] or nil)
 				}}

--- a/lua/wikis/commons/Widget/Transfer/Row.lua
+++ b/lua/wikis/commons/Widget/Transfer/Row.lua
@@ -353,9 +353,10 @@ TransferRowWidget._getTransferArrow = FnUtil.memoize(function (status)
 	return IconFa{iconName = TRANSFER_STATUS_TO_ICON_NAME[status]}
 end)
 
+---@private
 ---@param iconInput string?
 ---@return string|Widget
-TransferRowWidget.getIcon = FnUtil.memoize(function (iconInput)
+TransferRowWidget._getIcon = FnUtil.memoize(function (iconInput)
 	if Logic.isEmpty(iconInput) then
 		return EMPTY_POSITION_ICON
 	end
@@ -388,11 +389,11 @@ function TransferRowWidget:icon()
 		children = WidgetUtil.collect(Array.interleave(
 			Array.map(self.transfer.players, function (player)
 				return HtmlWidgets.Fragment{children = {
-					TransferRowWidget.getIcon(player.icons[1]),
+					TransferRowWidget._getIcon(player.icons[1]),
 					'&nbsp;',
 					TransferRowWidget._getTransferArrow(self:_getStatus()),
 					'&nbsp;',
-					TransferRowWidget.getIcon(player.icons[2] or targetRoleIsSpecialRole and player.icons[1] or nil)
+					TransferRowWidget._getIcon(player.icons[2] or targetRoleIsSpecialRole and player.icons[1] or nil)
 				}}
 			end),
 			HtmlWidgets.Br{}

--- a/lua/wikis/commons/Widget/Transfer/Row.lua
+++ b/lua/wikis/commons/Widget/Transfer/Row.lua
@@ -77,7 +77,6 @@ function TransferRowWidget:render()
 		classes = self:_getClasses(),
 		children = WidgetUtil.collect(
 			self:status(),
-			self:confidence(),
 			self:date(),
 			self:platform(),
 			self:players(),
@@ -214,29 +213,24 @@ function TransferRowWidget:_isSpecialRole(role)
 	return Table.includes(SPECIAL_ROLES, role)
 end
 
----@return Widget?
+---@return Widget[]?
 function TransferRowWidget:status()
 	local transfer = self.transfer
 
 	if not transfer.isRumour then return end
 
-	return createDivCell{
-		classes = {'Status'},
-		children = IconFa(RUMOUR_STATUS_TO_ICON_ARGS[transfer.confirmed])
-	}
-end
-
----@return Widget?
-function TransferRowWidget:confidence()
-	local transfer = self.transfer
-	if not transfer.isRumour then return end
-
 	local confidence = transfer.confidence
 
-	return createDivCell{
+	return {
+		createDivCell{
+			classes = {'Status'},
+			children = IconFa(RUMOUR_STATUS_TO_ICON_ARGS[transfer.confirmed])
+		},
+		createDivCell{
 		classes = {'Confidence', CONFIDENCE_TO_COLOR[confidence]},
 		css = {['font-weight'] = 'bold'},
 		children = confidence and String.upperCaseFirst(confidence) or nil
+		}
 	}
 end
 


### PR DESCRIPTION
## Summary

This PR:
- replaces two helper functions that are specific to rumor display with one function
- memoizes icon getters instead of creating one for every function call

## How did you test this change?

smoke