### PR TITLE
fix(TeamHistory): displaying empty section with header sometimes

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -19,6 +19,7 @@ local Br = HtmlWidgets.Br
 local Div = HtmlWidgets.Div
 local Small = HtmlWidgets.Small
 local TeamHistoryAuto = Lua.import('Module:Widget/Infobox/TeamHistory/Auto')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local DEFAULT_MODE = 'manual'
 

--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -19,7 +19,6 @@ local Br = HtmlWidgets.Br
 local Div = HtmlWidgets.Div
 local Small = HtmlWidgets.Small
 local TeamHistoryAuto = Lua.import('Module:Widget/Infobox/TeamHistory/Auto')
-local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local DEFAULT_MODE = 'manual'
 
@@ -60,13 +59,13 @@ function TeamHistory:_getHistory()
 		return manualInput
 	end
 
-	local automatedHistory = WidgetUtil.nilIfRendersEmpty(TeamHistoryAuto{player = self.props.player, store = true})
+	local automatedHistory = tostring(TeamHistoryAuto{player = self.props.player, store = true})
 
 	if Logic.isEmpty(manualInput) or (mode ~= 'cleanup' and mode ~= 'merge') then
 		return automatedHistory
 	end
 
-	if not automatedHistory then
+	if Logic.isEmpty(automatedHistory) then
 		return manualInput
 	end
 

--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -59,10 +59,14 @@ function TeamHistory:_getHistory()
 		return manualInput
 	end
 
-	local automatedHistory = TeamHistoryAuto{player = self.props.player, store = true}
+	local automatedHistory = WidgetUtil.nilIfRendersEmpty(TeamHistoryAuto{player = self.props.player, store = true})
 
 	if Logic.isEmpty(manualInput) or (mode ~= 'cleanup' and mode ~= 'merge') then
 		return automatedHistory
+	end
+
+	if not automatedHistory then
+		return manualInput
 	end
 
 	if mode == 'merge' then

--- a/lua/wikis/commons/Widget/Util.lua
+++ b/lua/wikis/commons/Widget/Util.lua
@@ -8,6 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
+local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
 local Util = {}
@@ -26,6 +27,24 @@ function Util.collect(...)
 		end
 	end
 	return array
+end
+
+---@param widget Widget?
+---@return widget?
+function Util.nilIfRendersEmpty(widget)
+	return Util.rendersNonEmpty(widget) and widget or nil
+end
+
+---@param widget Widget?
+---@return boolean
+function Util.rendersNonEmpty(widget)
+	return not Util.rendersEmpty(widget)
+end
+
+---@param widget Widget?
+---@return boolean
+function Util.rendersEmpty(widget)
+	return widget and Logic.isEmpty(tostring(widget))
 end
 
 return Util

--- a/lua/wikis/commons/Widget/Util.lua
+++ b/lua/wikis/commons/Widget/Util.lua
@@ -8,7 +8,6 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
-local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
 local Util = {}
@@ -27,24 +26,6 @@ function Util.collect(...)
 		end
 	end
 	return array
-end
-
----@param widget Widget?
----@return widget?
-function Util.nilIfRendersEmpty(widget)
-	return Util.rendersNonEmpty(widget) and widget or nil
-end
-
----@param widget Widget?
----@return boolean
-function Util.rendersNonEmpty(widget)
-	return not Util.rendersEmpty(widget)
-end
-
----@param widget Widget?
----@return boolean
-function Util.rendersEmpty(widget)
-	return widget and Logic.isEmpty(tostring(widget))
 end
 
 return Util


### PR DESCRIPTION
## Summary
Currently if THA renders empty the TH section header is still shown.
example: https://liquipedia.net/starcraft2/Lindsey_Sporrer

To avoid that we need to fix the check if TH renders empty or not.
(Sry, don't see a better solution...)

if someone has a better idea lmk ...

## How did you test this change?
dev