### PR TITLE
fix(match2): matchpage footer being displayed even if it has no content

### DIFF
--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -337,28 +337,31 @@ end
 ---@return Widget
 function BaseMatchPage:footer()
 	local vods = self:getVods()
+	local parsedLinks = self:_parseLinks()
+	local patchLink = self:getPatchLink()
+
 	return Footer{
 		comments = self:_getComments(),
 		children = WidgetUtil.collect(
-			AdditionalSection{
+			Logic.isNotEmpty(vods) and AdditionalSection{
 				header = 'VODs',
 				children = vods
-			},
-			AdditionalSection{
+			} or nil,
+			Logic.isNotEmpty(parsedLinks) and AdditionalSection{
 				header = 'Links',
 				bodyClasses = { 'vodlink' },
-				children = Array.map(self:_parseLinks(), function (parsedLink)
-					return IconImage{
+				children = Array.map(parsedLinks, function (parsedLink)
+					return HtmlWidgets.Span{children = IconImage{
 						imageLight = parsedLink.icon:sub(6),
 						imageDark = (parsedLink.iconDark or parsedLink.icon):sub(6),
 						link = parsedLink.link
-					}
+					}}
 				end)
-			},
-			AdditionalSection{
+			} or nil,
+			patchLink and AdditionalSection{
 				header = 'Patch',
-				children = { self:getPatchLink() }
-			}
+				children = patchLink
+			} or nil
 		)
 	}
 end
@@ -397,6 +400,7 @@ function BaseMatchPage:addComments()
 end
 
 ---@protected
+---@return Widget?
 function BaseMatchPage:getPatchLink()
 	if Logic.isEmpty(self.matchData.patch) then return end
 	return Link{ link = 'Patch ' .. self.matchData.patch }


### PR DESCRIPTION
## Summary

This PR:
- hides matchpage footer if there is no information to display  
  currently it displays header regardless of information availability
- wraps external link icons with `Span`  
  there were extra gaps being inserted for every non-`allmode` icon, and wrapping light/darkmode icons with extra `Span` mitigates the issue

## How did you test this change?

dev