### PR TITLE
feat(match2): map veto styling improvements

### DIFF
--- a/lua/wikis/commons/Widget/Match/Summary/MapVeto.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVeto.lua
@@ -32,7 +32,7 @@ function MatchSummaryMapVeto:render()
 		children = HtmlWidgets.Table{
 			classes = {'wikitable-striped', 'collapsible', 'collapsed'},
 			children = WidgetUtil.collect(
-				HtmlWidgets.Tr{children = {
+				HtmlWidgets.Tr{css = {padding = '0.25rem 0.25rem'}, children = {
 					HtmlWidgets.Th{css = {width = '33%'}},
 					HtmlWidgets.Th{css = {width = '34%', ['text-align'] = 'center'}, children = 'Map Veto'},
 					HtmlWidgets.Th{css = {width = '33%'}},

--- a/lua/wikis/commons/Widget/Match/Summary/MapVeto.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVeto.lua
@@ -31,11 +31,10 @@ function MatchSummaryMapVeto:render()
 		classes = {'brkts-popup-mapveto'},
 		children = HtmlWidgets.Table{
 			classes = {'wikitable-striped', 'collapsible', 'collapsed'},
-			css = {['text-align'] = 'center'},
 			children = WidgetUtil.collect(
 				HtmlWidgets.Tr{children = {
 					HtmlWidgets.Th{css = {width = '33%'}},
-					HtmlWidgets.Th{css = {width = '34%'}, children = 'Map Veto'},
+					HtmlWidgets.Th{css = {width = '34%', ['text-align'] = 'center'}, children = 'Map Veto'},
 					HtmlWidgets.Th{css = {width = '33%'}},
 				}},
 				MapVetoStart{firstVeto = self.props.firstVeto, vetoFormat = self.props.vetoFormat},

--- a/lua/wikis/commons/Widget/Match/Summary/MapVeto.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVeto.lua
@@ -32,7 +32,7 @@ function MatchSummaryMapVeto:render()
 		children = HtmlWidgets.Table{
 			classes = {'wikitable-striped', 'collapsible', 'collapsed'},
 			children = WidgetUtil.collect(
-				HtmlWidgets.Tr{css = {padding = '0.25rem 0.25rem'}, children = {
+				HtmlWidgets.Tr{children = {
 					HtmlWidgets.Th{css = {width = '33%'}},
 					HtmlWidgets.Th{css = {width = '34%', ['text-align'] = 'center'}, children = 'Map Veto'},
 					HtmlWidgets.Th{css = {width = '33%'}},

--- a/lua/wikis/commons/Widget/Match/Summary/MapVetoRound.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVetoRound.lua
@@ -57,30 +57,30 @@ function MatchSummaryMapVetoRound:render()
 	if vetoType == VETO_DECIDER then
 		children = {
 			HtmlWidgets.Td{
-				css = {['text-align'] = 'left'},
+				css = {padding = '0.25rem 0.5rem',['text-align'] = 'left'},
 				children = createVetoTypeElement()
 			},
 			HtmlWidgets.Td{
-				css = {['text-align'] = 'center'},
+				css = {padding = '0.25rem 0.5rem',['text-align'] = 'center'},
 				children = displayMap(self.props.map1)
 			},
 			HtmlWidgets.Td{
-				css = {['text-align'] = 'right'},
+				css = {padding = '0.25rem 0.5rem',['text-align'] = 'right'},
 				children = createVetoTypeElement()
 			},
 		}
 	else
 		children = {
 			HtmlWidgets.Td{
-				css = {['text-align'] = 'left'},
+				css = {padding = '0.25rem 0.5rem',['text-align'] = 'left'},
 				children = displayMap(self.props.map1)
 			},
 			HtmlWidgets.Td{
-				css = {['text-align'] = 'center'},
+				css = {padding = '0.25rem 0.5rem',['text-align'] = 'center'},
 				children = createVetoTypeElement()
 			},
 			HtmlWidgets.Td{
-				css = {['text-align'] = 'right'},
+				css = {padding = '0.25rem 0.5rem',['text-align'] = 'right'},
 				children = displayMap(self.props.map2)
 			},
 		}

--- a/lua/wikis/commons/Widget/Match/Summary/MapVetoRound.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVetoRound.lua
@@ -56,15 +56,33 @@ function MatchSummaryMapVetoRound:render()
 	local children
 	if vetoType == VETO_DECIDER then
 		children = {
-			HtmlWidgets.Td{children = createVetoTypeElement()},
-			HtmlWidgets.Td{children = displayMap(self.props.map1)},
-			HtmlWidgets.Td{children = createVetoTypeElement()},
+			HtmlWidgets.Td{
+				css = {['text-align'] = 'left'},
+				children = createVetoTypeElement()
+			},
+			HtmlWidgets.Td{
+				css = {['text-align'] = 'center'},
+				children = displayMap(self.props.map1)
+			},
+			HtmlWidgets.Td{
+				css = {['text-align'] = 'right'},
+				children = createVetoTypeElement()
+			},
 		}
 	else
 		children = {
-			HtmlWidgets.Td{children = displayMap(self.props.map1)},
-			HtmlWidgets.Td{children = createVetoTypeElement()},
-			HtmlWidgets.Td{children = displayMap(self.props.map2)},
+			HtmlWidgets.Td{
+				css = {['text-align'] = 'left'},
+				children = displayMap(self.props.map1)
+			},
+			HtmlWidgets.Td{
+				css = {['text-align'] = 'center'},
+				children = createVetoTypeElement()
+			},
+			HtmlWidgets.Td{
+				css = {['text-align'] = 'right'},
+				children = displayMap(self.props.map2)
+			},
 		}
 	end
 

--- a/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
@@ -50,7 +50,7 @@ function MatchSummaryMapVetoStart:render()
 		classes = {'brkts-popup-mapveto-vetostart'},
 		children = Array.map(children, function(child, i)
 			return HtmlWidgets.Th{
-				css = {['text-align'] = alignments[i] or nil},
+				css = {padding = '0.25rem 0.5rem', ['text-align'] = alignments[i] or nil},
 				children = child
 			}
 		end)

--- a/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/MapVetoStart.lua
@@ -45,10 +45,14 @@ function MatchSummaryMapVetoStart:render()
 		}
 	end
 
+	local alignments = {'left', 'center', 'right'}
 	return HtmlWidgets.Tr{
 		classes = {'brkts-popup-mapveto-vetostart'},
-		children = Array.map(children, function(child)
-			return HtmlWidgets.Th{children = child}
+		children = Array.map(children, function(child, i)
+			return HtmlWidgets.Th{
+				css = {['text-align'] = alignments[i] or nil},
+				children = child
+			}
 		end)
 	}
 end

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -859,10 +859,12 @@ div.brkts-popup-body-element-thumbs {
 
 	.brkts-popup-mapveto-vetostart {
 		background-color: var( --table-striped-background-color, #f5f5f5 );
+		padding: 0.25rem 0.25rem;
 	}
 
 	.brkts-popup-mapveto-vetoround {
 		background-color: var( --table-background-color, #ffffff );
+		padding: 0.25rem 0.25rem;
 	}
 
 	.brkts-popup-mapveto-vetotype {

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -859,29 +859,28 @@ div.brkts-popup-body-element-thumbs {
 
 	.brkts-popup-mapveto-vetostart {
 		background-color: var( --table-striped-background-color, #f5f5f5 );
-		padding: 0.25rem 0.25rem;
 	}
 
 	.brkts-popup-mapveto-vetoround {
 		background-color: var( --table-background-color, #ffffff );
-		padding: 0.25rem 0.25rem;
 	}
 
 	.brkts-popup-mapveto-vetotype {
 		font-weight: bold;
 		color: var( --clr-on-background, #000000 );
 		border: 0;
-		border-radius: 0;
+		border-radius: 0.875rem;
 		letter-spacing: 0.1em;
 		font-family: "Source Code Pro", monospace;
+		padding: 0 0.5rem;
 	}
 
 	.brkts-popup-mapveto-pick {
-		background-color: var( --clr-forestgreen-background-color, #ddf4dd ) !important;
+		background-color: var( --clr-semantic-positive-40, #27a527 ) !important;
 	}
 
 	.brkts-popup-mapveto-ban {
-		background-color: var( --clr-cinnabar-background-color, #fbdfdf ) !important;
+		background-color: var( --clr-semantic-negative-40, #b81414 ) !important;
 	}
 
 	.brkts-popup-mapveto-defaultban {


### PR DESCRIPTION
## Summary

Map Veto table looks dated. This PR aims to make it a bit cleaner with better alignment  and better readability for `BAN`, `PICK` and `DECIDER` labels
 
#6203 

## How did you test this change?

dev: https://liquipedia.net/rainbowsix/User:Eetwalt (css changes don't show)
