### PR TITLE
fix: Set TransferRow color to neutral for dual special role

### DIFF
--- a/lua/wikis/commons/Widget/Transfer/Row.lua
+++ b/lua/wikis/commons/Widget/Transfer/Row.lua
@@ -195,6 +195,8 @@ function TransferRowWidget:_getStatus()
 		return 'from-team'
 	elseif transfer.to.teams[1] then
 		return 'to-team'
+	elseif self:_isSpecialRole(transfer.from.roles[1]) and self:_isSpecialRole(transfer.to.roles[1]) then
+		return 'neutral'
 	elseif self:_isSpecialRole(transfer.from.roles[1]) then
 		return 'to-team'
 	elseif self:_isSpecialRole(transfer.to.roles[1]) then


### PR DESCRIPTION
## Summary
Per title, reported on discord.

Potential alternative: Check to-role first for special role and thus prefer the red color for this case.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev to live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
