### PR TITLE
feat(transfer): update transfer arrow icons

### DIFF
--- a/lua/wikis/commons/Icon/Data.lua
+++ b/lua/wikis/commons/Icon/Data.lua
@@ -76,9 +76,9 @@ return {
 	helparticles = 'far fa-life-ring',
 
 	-- Usage: To indicate different transfer type with icon difference not just background colour
-	transferbetween = 'fas fa-arrow-alt-right',
-	transfertofreeagent = 'fas fa-arrow-alt-from-left',
-	transferfromfreeagent = 'fas fa-arrow-alt-to-right',
+	transferbetween = 'far fa-arrow-alt-right',
+	transfertofreeagent = 'far fa-arrow-alt-to-right',
+	transferfromfreeagent = 'far fa-arrow-alt-from-left',
 
 	-- Usage: Reference links in tables (ie transfers)
 	reference = 'fad fa-external-link-alt',


### PR DESCRIPTION
## Summary

context: https://discord.com/channels/93055209017729024/1400382174078832670/1414634994659233823

This PR updates arrow icons used in transfer rows. Specifically:
- solid icons are replaced with regular icons
- switches from-team and to-team icons

### Preview
- Current  
  <img width="779" height="132" alt="image" src="https://github.com/user-attachments/assets/8d57695f-d45b-482f-b39b-af7dc03aff9d" />
- This PR  
  <img width="779" height="133" alt="image" src="https://github.com/user-attachments/assets/9cd05154-2343-42e8-8ef7-43ff31decfc8" />

## How did you test this change?

dev