### PR TITLE
feat: add missing major fighting games data

### DIFF
--- a/lua/wikis/fighters/Info.lua
+++ b/lua/wikis/fighters/Info.lua
@@ -6,7 +6,7 @@
 --
 
 return {
-	startYear = 1996,
+	startYear = 1991,
 	wikiName = 'fighters',
 	name = 'Fighting Games',
 	defaultGame = 'fighters',

--- a/lua/wikis/fighters/Info.lua
+++ b/lua/wikis/fighters/Info.lua
@@ -115,7 +115,7 @@ return {
 				lightMode = 'AH3 Xtend Logo.png',
 			},
 		},
-		aquapazza = {
+		aadm = {
 			abbreviation = 'AADM',
 			name = 'Aquapazza: Aquaplus Dream Match',
 			link = 'Aquapazza: Aquaplus Dream Match',

--- a/lua/wikis/fighters/Info.lua
+++ b/lua/wikis/fighters/Info.lua
@@ -63,6 +63,32 @@ return {
 				lightMode = 'ABK Ausf Achse Logo.png',
 			},
 		},
+		ah = {
+			abbreviation = 'AH',
+			name = 'Arcana Heart',
+			link = 'Arcana Heart',
+			logo = {
+				darkMode = 'Arcana Heart allmode.png',
+				lightMode = 'Arcana Heart allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Arcana Heart allmode.png',
+				lightMode = 'Arcana Heart allmode.png',
+			},
+		},
+		ah2 = {
+			abbreviation = 'AH2',
+			name = 'Arcana Heart 2',
+			link = 'Arcana Heart 2',
+			logo = {
+				darkMode = 'Arcana Heart 2 allmode.png',
+				lightMode = 'Arcana Heart 2 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Arcana Heart 2 allmode.png',
+				lightMode = 'Arcana Heart 2 allmode.png',
+			},
+		},
 		ah3 = {
 			abbreviation = 'AH3',
 			name = 'Arcana Heart 3',
@@ -89,6 +115,19 @@ return {
 				lightMode = 'AH3 Xtend Logo.png',
 			},
 		},
+		aquapazza = {
+			abbreviation = 'AADM',
+			name = 'Aquapazza: Aquaplus Dream Match',
+			link = 'Aquapazza: Aquaplus Dream Match',
+			logo = {
+				darkMode = 'Aquapazza Aquaplus Dream Match allmode.png',
+				lightMode = 'Aquapazza Aquaplus Dream Match allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Aquapazza Aquaplus Dream Match allmode.png',
+				lightMode = 'Aquapazza Aquaplus Dream Match allmode.png',
+			},
+		},
 		arms = {
 			abbreviation = 'ARMS',
 			name = 'ARMS',
@@ -100,6 +139,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'ARMS default allmode.png',
 				lightMode = 'ARMS default allmode.png',
+			},
+		},
+		aof3 = {
+			abbreviation = 'AOF3',
+			name = 'Art of Fighting 3',
+			link = 'Art of Fighting 3',
+			logo = {
+				darkMode = 'Art of Fighting 3 allmode.png',
+				lightMode = 'Art of Fighting 3 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Art of Fighting 3 allmode.png',
+				lightMode = 'Art of Fighting 3 allmode.png',
 			},
 		},
 		bbcf = {
@@ -217,6 +269,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'Bloody Roar Extreme logo.png',
 				lightMode = 'Bloody Roar Extreme logo.png',
+			},
+		},
+		cfj = {
+			abbreviation = 'CFJ',
+			name = 'Capcom Fighting Jam',
+			link = 'Capcom Fighting Jam',
+			logo = {
+				darkMode = 'Capcom Fighting Jam allmode.png',
+				lightMode = 'Capcom Fighting Jam allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Capcom Fighting Jam allmode.png',
+				lightMode = 'Capcom Fighting Jam allmode.png',
 			},
 		},
 		cotw = {
@@ -373,6 +438,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'Eternal Fighter Zero Logo.png',
 				lightMode = 'Eternal Fighter Zero Logo.png',
+			},
+		},
+		fateuc = {
+			abbreviation = 'FateUC',
+			name = 'Fate Unlimited Codes',
+			link = 'Fate Unlimited Codes',
+			logo = {
+				darkMode = 'Fate Unlimited Codes allmode.png',
+				lightMode = 'Fate Unlimited Codes allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Fate Unlimited Codes allmode.png',
+				lightMode = 'Fate Unlimited Codes allmode.png',
 			},
 		},
 		fexl = {
@@ -791,6 +869,58 @@ return {
 				lightMode = 'KOF 2002 default allmode.png',
 			},
 		},
+		kof2003 = {
+			abbreviation = 'KOF03',
+			name = 'The King of Fighters 2003',
+			link = 'The King of Fighters 2003',
+			logo = {
+				darkMode = 'KoF2003 allmode.png',
+				lightMode = 'KoF2003 allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'KoF2003 allmode.png',
+				lightMode = 'KoF2003 allmode.png',
+			},
+		},
+		kofnw = {
+			abbreviation = 'KOF NW',
+			name = 'The King of Fighters Neowave',
+			link = 'The King of Fighters Neowave',
+			logo = {
+				darkMode = 'The King of Fighters Neowave allmode.png',
+				lightMode = 'The King of Fighters Neowave allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'The King of Fighters Neowave allmode.png',
+				lightMode = 'The King of Fighters Neowave allmode.png',
+			},
+		},
+		kofxi = {
+			abbreviation = 'KOF XI',
+			name = 'The King of Fighters XI',
+			link = 'The King of Fighters XI',
+			logo = {
+				darkMode = 'The King of Fighters XI allmode.png',
+				lightMode = 'The King of Fighters XI allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'The King of Fighters XI allmode.png',
+				lightMode = 'The King of Fighters XI allmode.png',
+			},
+		},
+		kofxii = {
+			abbreviation = 'KOF XII',
+			name = 'The King of Fighters XII',
+			link = 'The King of Fighters XII',
+			logo = {
+				darkMode = 'The King of Fighters XII allmode.png',
+				lightMode = 'The King of Fighters XII allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'The King of Fighters XII allmode.png',
+				lightMode = 'The King of Fighters XII allmode.png',
+			},
+		},
 		kofxiii = {
 			abbreviation = 'KOF XIII',
 			name = 'The King of Fighters XIII',
@@ -869,6 +999,19 @@ return {
 				lightMode = 'Million Arthur Arcana Blood Logo.png',
 			},
 		},
+		mbac = {
+			abbreviation = 'MBAC',
+			name = 'Melty Blood: Act Cadenza',
+			link = 'Melty Blood: Act Cadenza',
+			logo = {
+				darkMode = 'Melty Blood Act Cadenza allmode.png',
+				lightMode = 'Melty Blood Act Cadenza allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Melty Blood Act Cadenza allmode.png',
+				lightMode = 'Melty Blood Act Cadenza allmode.png',
+			},
+		},
 		mbaa = {
 			abbreviation = 'MBAA',
 			name = 'Melty Blood: Actress Again',
@@ -906,6 +1049,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'Melty Blood Type Lumina Logo.png',
 				lightMode = 'Melty Blood Type Lumina Logo.png',
+			},
+		},
+		mk3 = {
+			abbreviation = 'MK3',
+			name = 'Mortal Kombat 3',
+			link = 'Mortal Kombat 3',
+			logo = {
+				darkMode = 'Mortal Kombat 3 default allmode.png',
+				lightMode = 'Mortal Kombat 3 default allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Mortal Kombat 3 default allmode.png',
+				lightMode = 'Mortal Kombat 3 default allmode.png',
 			},
 		},
 		mk9 = {
@@ -1010,6 +1166,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'MVCI Logo.png',
 				lightMode = 'MVCI Logo.png',
+			},
+		},
+		ngbc = {
+			abbreviation = 'NGBC',
+			name = 'Neo Geo Battle Coliseum',
+			link = 'Neo Geo Battle Coliseum',
+			logo = {
+				darkMode = 'Neo Geo Battle Coliseum allmode.png',
+				lightMode = 'Neo Geo Battle Coliseum allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Neo Geo Battle Coliseum allmode.png',
+				lightMode = 'Neo Geo Battle Coliseum allmode.png',
 			},
 		},
 		p4a = {
@@ -1129,6 +1298,19 @@ return {
 				lightMode = 'Samurai Shodown II Logo.png',
 			},
 		},
+		ssv = {
+			abbreviation = 'SSV',
+			name = 'Samurai Shodown V',
+			link = 'Samurai Shodown V',
+			logo = {
+				darkMode = 'Samurai Shodown V allmode.png',
+				lightMode = 'Samurai Shodown V allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Samurai Shodown V allmode.png',
+				lightMode = 'Samurai Shodown V allmode.png',
+			},
+		},
 		ssvs = {
 			abbreviation = 'SSVS',
 			name = 'Samurai Shodown V Special',
@@ -1140,6 +1322,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'Samurai Shodown V Special Logo.png',
 				lightMode = 'Samurai Shodown V Special Logo.png',
+			},
+		},
+		ssvi = {
+			abbreviation = 'SSVI',
+			name = 'Samurai Shodown VI',
+			link = 'Samurai Shodown VI',
+			logo = {
+				darkMode = 'Samurai Shodown VI allmode.png',
+				lightMode = 'Samurai Shodown VI allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Samurai Shodown VI allmode.png',
+				lightMode = 'Samurai Shodown VI allmode.png',
 			},
 		},
 		ss2019 = {
@@ -1155,6 +1350,19 @@ return {
 				lightMode = 'Samurai Shodown 2019 default allmode.png',
 			},
 		},
+		sbx = {
+			abbreviation = 'SBX',
+			name = 'Sengoku Basara X',
+			link = 'Sengoku Basara X',
+			logo = {
+				darkMode = 'Sengoku Basara X allmode.png',
+				lightMode = 'Sengoku Basara X allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Sengoku Basara X allmode.png',
+				lightMode = 'Sengoku Basara X allmode.png',
+			},
+		},
 		scii = {
 			abbreviation = 'SCII',
 			name = 'Soulcalibur II',
@@ -1166,6 +1374,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'SCII Logo.png',
 				lightMode = 'SCII Logo.png',
+			},
+		},
+		sciii = {
+			abbreviation = 'SCIII',
+			name = 'Soulcalibur III',
+			link = 'Soulcalibur III',
+			logo = {
+				darkMode = 'SoulCalibur III allmode.png',
+				lightMode = 'SoulCalibur III allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'SoulCalibur III allmode.png',
+				lightMode = 'SoulCalibur III allmode.png',
 			},
 		},
 		sciv = {
@@ -1686,6 +1907,19 @@ return {
 			defaultTeamLogo = {
 				darkMode = 'Under Night In-Birth II allmode.png',
 				lightMode = 'Under Night In-Birth II allmode.png',
+			},
+		},
+		xvsf = {
+			abbreviation = 'XVSF',
+			name = 'X-Men vs. Street Fighter',
+			link = 'X-Men vs. Street Fighter',
+			logo = {
+				darkMode = 'X-Men vs. Street Fighter allmode.png',
+				lightMode = 'X-Men vs. Street Fighter allmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'X-Men vs. Street Fighter allmode.png',
+				lightMode = 'X-Men vs. Street Fighter allmode.png',
 			},
 		},
 		['project l'] = {


### PR DESCRIPTION
Adding major fighting game releases that are currently missing from this module/Fighters coverage.

Ref on discord: https://discordapp.com/channels/93055209017729024/202549269134180352/1413938982076551178

Full list:

Aquapazza: Aquaplus Dream Match (2011)
Arcana Heart (2007)
Arcana Heart 2 (2008)
Art of Fighting 3 (1996)
Capcom Fighting Jam (2004)
Fate/unlimited codes (2008)
Melty Blood Act Cadenza (2005)
Mortal Kombat 3 (1995)
Neo Geo Battle Coliseum (2005)
Samurai Shodown V (2003)
Samurai Shodown VI (2005)
Sengoku Basara X (2008)
Soulcalibur III (2005)
The King of Fighters 2003 (2003)
The King of Fighters Neowave (2005)
The King of Fighters XI (2005)
The King of Fighters XII (2009)
X-Men vs. Street Fighter (1996)

## Summary

All games on this list were releases by major fighting game developers like Capcom, Arcsys, Bandai Namco, etc. and played a significant role in fighting game history as they were hosted by many of the biggest tournaments between 2000 and 2012.

## How did you test this change?

No change other than adding these titles to the current game list on the fighters wiki.