### PR TITLE
feat(matchticker): hide details button text when more than two streams

### DIFF
--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -59,8 +59,9 @@ function MatchButtonBar:render()
 		displayStreams = true
 	end
 
+	local filteredStreams = StreamLinks.filterStreams(match.stream)
 	local processedStreams = Array.flatMap(StreamLinks.countdownPlatformNames, function(platform)
-		return Array.map(match.stream[platform] or {}, function(stream)
+		return Array.map(filteredStreams[platform] or {}, function(stream)
 			return {platform = platform, stream = stream}
 		end)
 	end)
@@ -96,7 +97,7 @@ function MatchButtonBar:render()
 				hideText = displayStreams and numberOfStreams >= 3
 			},
 			displayStreams and StreamsContainer{
-				streams = StreamLinks.filterStreams(match.stream),
+				streams = filteredStreams,
 				matchIsLive = match.phase == 'ongoing',
 			} or nil,
 			makeDropdownForVods and VodsDropdownButton{count = #vods} or nil,

--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -59,6 +59,14 @@ function MatchButtonBar:render()
 		displayStreams = true
 	end
 
+	local processedStreams = Array.flatMap(StreamLinks.countdownPlatformNames, function(platform)
+		return Array.map(match.stream[platform] or {}, function(stream)
+			return {platform = platform, stream = stream}
+		end)
+	end)
+
+	local numberOfStreams = #processedStreams
+
 	local makeVodDTO = function(type, gameOrMatch, number)
 		if Logic.isEmpty(gameOrMatch.vod) then
 			return
@@ -85,7 +93,7 @@ function MatchButtonBar:render()
 			MatchPageButton{
 				match = match,
 				buttonType = self.props.variant,
-				hideText = displayStreams and #StreamLinks.filterStreams(match.stream) >= 3
+				hideText = displayStreams and numberOfStreams >= 3
 			},
 			displayStreams and StreamsContainer{
 				streams = StreamLinks.filterStreams(match.stream),

--- a/lua/wikis/commons/Widget/Match/ButtonBar.lua
+++ b/lua/wikis/commons/Widget/Match/ButtonBar.lua
@@ -85,6 +85,7 @@ function MatchButtonBar:render()
 			MatchPageButton{
 				match = match,
 				buttonType = self.props.variant,
+				hideText = displayStreams and #StreamLinks.filterStreams(match.stream) >= 3
 			},
 			displayStreams and StreamsContainer{
 				streams = StreamLinks.filterStreams(match.stream),

--- a/lua/wikis/commons/Widget/Match/PageButton.lua
+++ b/lua/wikis/commons/Widget/Match/PageButton.lua
@@ -58,12 +58,12 @@ function MatchPageButton:render()
 			size = 'sm',
 			link = link,
 			grow = true,
-			children = {
+			children = self.props.hideText and {
 				Icon{iconName = 'matchpagelink'},
-				(not self.props.hideText){
-					' ',
-					'View match details',
-				}
+			} or {
+				Icon{iconName = 'matchpagelink'},
+				' ',
+				'View match details',
 			}
 		}
 	end
@@ -75,11 +75,10 @@ function MatchPageButton:render()
 		size = 'sm',
 		link = link,
 		grow = true,
-		children = {
+		children = self.props.hideText and {
 			'+ ',
-			(not self.props.hideText){
-				'Add details',
-			}
+		} or {
+			'+ Add details'
 		}
 	}
 end

--- a/lua/wikis/commons/Widget/Match/PageButton.lua
+++ b/lua/wikis/commons/Widget/Match/PageButton.lua
@@ -76,7 +76,7 @@ function MatchPageButton:render()
 		link = link,
 		grow = true,
 		children = self.props.hideText and {
-			'+ ',
+			'+ Add',
 		} or {
 			'+ Add details'
 		}

--- a/lua/wikis/commons/Widget/Match/PageButton.lua
+++ b/lua/wikis/commons/Widget/Match/PageButton.lua
@@ -23,6 +23,7 @@ local SHOW_STREAMS_WHEN_LESS_THAN_TO_LIVE = 2 * 60 * 60 -- 2 hours in seconds
 local MatchPageButton = Class.new(Widget)
 MatchPageButton.defaultProps = {
 	buttonType = 'secondary',
+	hideText = false,
 }
 
 ---@return Widget?
@@ -59,8 +60,10 @@ function MatchPageButton:render()
 			grow = true,
 			children = {
 				Icon{iconName = 'matchpagelink'},
-				' ',
-				'View match details',
+				(not self.props.hideText){
+					' ',
+					'View match details',
+				}
 			}
 		}
 	end
@@ -73,7 +76,10 @@ function MatchPageButton:render()
 		link = link,
 		grow = true,
 		children = {
-			'+ Add details',
+			'+ ',
+			(not self.props.hideText){
+				'Add details',
+			}
 		}
 	}
 end


### PR DESCRIPTION
## Summary

Currently, when there's more than 2 streams for a match, the Match details button causes the button bar to overflow the container. This is a temporary fix for that. When we implement the new breakpoints for the project, we will make more fine-tuned exceptions for the button text content behavior.

## How did you test this change?

dev: https://liquipedia.net/leagueoflegends/User:Eetwalt
