### PR TITLE
fix(matchticker): align tournament name and image

### DIFF
--- a/stylesheets/commons/Match.scss
+++ b/stylesheets/commons/Match.scss
@@ -179,6 +179,7 @@
 		border-radius: 0.5rem;
 		font-size: 0.75rem;
 		line-height: 1.125rem;
+		align-items: center;
 
 		.theme--light & {
 			background-color: #0000000a;


### PR DESCRIPTION
## Summary

The tournament image and text are not vertically aligned.

## How did you test this change?

devtools

Current:
<img width="447" height="350" alt="image" src="https://github.com/user-attachments/assets/b8ec2b36-f129-494c-bea5-58b411f06ff3" />

New:
<img width="448" height="347" alt="image" src="https://github.com/user-attachments/assets/7c063bcd-30a2-41a8-be8e-5fa5a1c50bb6" />