### PR TITLE
docs: type annotation for MatchGroupsSpec

### DIFF
--- a/lua/wikis/commons/MvpTable.lua
+++ b/lua/wikis/commons/MvpTable.lua
@@ -28,7 +28,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field margin number
 ---@field points boolean
 ---@field title string?
----@field matchGroupSpec {matchGroupIds: string[], pageNames: string[][]}
+---@field matchGroupSpec MatchGroupsSpec
 
 local MvpTable = {}
 

--- a/lua/wikis/commons/ParticipantTable/Base.lua
+++ b/lua/wikis/commons/ParticipantTable/Base.lua
@@ -34,7 +34,7 @@ local prizePoolVars = PageVariableNamespace('PrizePool')
 ---@class ParticipantTableConfig
 ---@field lpdbPrefix string?
 ---@field noStorage boolean
----@field matchGroupSpec table?
+---@field matchGroupSpec MatchGroupsSpec?
 ---@field syncPlayers boolean
 ---@field showCountBySection boolean
 ---@field onlyNotable boolean

--- a/lua/wikis/commons/PrizePool/Import.lua
+++ b/lua/wikis/commons/PrizePool/Import.lua
@@ -45,7 +45,7 @@ local Import = Class.new(function(self, ...) self:init(...) end)
 ---@field ignoreNonScoreEliminations boolean
 ---@field importLimit integer
 ---@field placementsToSkip integer
----@field matchGroupsSpec table
+---@field matchGroupsSpec MatchGroupsSpec
 ---@field groupElimStatuses string[]
 ---@field groupScoreDelimiter string
 ---@field allGroupsUseWdl boolean

--- a/lua/wikis/commons/TournamentStructure.lua
+++ b/lua/wikis/commons/TournamentStructure.lua
@@ -21,6 +21,7 @@ local FULL_PAGENAME = mw.title.getCurrentTitle().prefixedText
 
 local TournamentStructure = {types = {}}
 
+---@alias MatchGroupsSpec {matchGroupIds: string[], pageNames: string[][]}
 TournamentStructure.types.MatchGroupsSpec = TypeUtil.struct{
 	matchGroupIds = TypeUtil.array('string'),
 	pageNames = TypeUtil.array(TypeUtil.array('string')),
@@ -47,7 +48,7 @@ end
 --- |matchGroupId1=Z1lDMZPiGA
 --- |matchGroupId2=Liquipedia_wnbxUh4Vm1
 ---@param args table
----@return table?
+---@return MatchGroupsSpec?
 function TournamentStructure.readMatchGroupsSpec(args)
 	local matchGroupIds = {args.id}
 	table.insert(matchGroupIds, args.matchGroupId)
@@ -89,7 +90,7 @@ function TournamentStructure.readMatchGroupsSpec(args)
 	end
 end
 
----@return {matchGroupIds: {}, pageNames: {[1]: {[1]: string}}}
+---@return MatchGroupsSpec
 function TournamentStructure.currentPageSpec()
 	return {
 		matchGroupIds = {},
@@ -113,7 +114,7 @@ end)
 --- the tournamentX arg determines the ordering of pages, hence stage order.
 ---@param groupTables table
 ---@param brackets table
----@param spec {matchGroupIds: table, pageNames: string[][]}
+---@param spec MatchGroupsSpec
 ---@return table
 function TournamentStructure.groupByStage(groupTables, brackets, spec)
 	local function getStageKey(recordGroup)
@@ -259,7 +260,7 @@ function TournamentStructure.fetchGroupsFromFilter(filter)
 end
 
 --- Fetch group table results from standings table.
----@param spec {matchGroupIds: table, pageNames: string[][]}
+---@param spec MatchGroupsSpec
 ---@return table
 function TournamentStructure.fetchGroupTables(spec)
 	local pageData = Array.flatten(Array.map(spec.pageNames, function(pageName, groupIndex)
@@ -370,7 +371,7 @@ function TournamentStructure._groupPlacement(finished, slotIndex, placement)
 end
 
 --- Converts a match group spec to a standing record filter. Returns a filter string for use in LPDB queries.
----@param spec {matchGroupIds: table, pageNames: string[][]}
+---@param spec MatchGroupsSpec
 ---@return string
 function TournamentStructure.getGroupTableFilter(spec)
 	local whereClauses = Array.map(spec.pageNames, function(pageName)
@@ -381,7 +382,7 @@ function TournamentStructure.getGroupTableFilter(spec)
 end
 
 --- Fetches bracket data (matches) for a given match group spec.
----@param spec {matchGroupIds: table, pageNames: string[][]}
+---@param spec MatchGroupsSpec
 ---@return table
 function TournamentStructure.fetchBrackets(spec)
 	local idData = Array.map(spec.matchGroupIds, function(matchGroupId)
@@ -402,7 +403,7 @@ function TournamentStructure.fetchBrackets(spec)
 end
 
 --- Converts a match group spec to a match2 record filter. Returns a filter string for use in LPDB queries.
----@param spec {matchGroupIds: table, pageNames: string[][]}
+---@param spec MatchGroupsSpec
 ---@return string
 function TournamentStructure.getMatch2Filter(spec)
 	local whereClauses = Array.extend(
@@ -415,7 +416,7 @@ function TournamentStructure.getMatch2Filter(spec)
 end
 
 --- Queries and returns a list of matches using the provided match group spec.
----@param spec {matchGroupIds: table, pageNames: string[][]}
+---@param spec MatchGroupsSpec
 ---@return MatchGroupUtilMatch[]
 function TournamentStructure.fetchMatches(spec)
 	return Array.map(


### PR DESCRIPTION
## Summary

This PR adds type alias for `MatchGroupsSpec` in `Module:TournamentStructure` and updates its consumers accordingly.

## How did you test this change?

N/A