### PR TITLE
fix(match2): map veto type not readable in light theme

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -875,7 +875,7 @@ div.brkts-popup-body-element-thumbs {
 
 	.brkts-popup-mapveto-vetotype {
 		font-weight: bold;
-		color: var( --clr-on-background, #000000 );
+		color: var( --clr-primary-100 );
 		border: 0;
 		border-radius: 0.875rem;
 		letter-spacing: 0.1em;


### PR DESCRIPTION
## Summary

Regression from #6514

Report on discord: https://discord.com/channels/93055209017729024/372075546231832576/1414976233397293086

## How did you test this change?

browser dev tools