### PR TITLE
Fix Tetris Infobox extradata.gamegroup determination to use game identifier instead of game name

### DIFF
--- a/lua/wikis/tetris/Infobox/League/Custom.lua
+++ b/lua/wikis/tetris/Infobox/League/Custom.lua
@@ -24,14 +24,14 @@ local CustomLeague = Class.new(League)
 local CustomInjector = Class.new(Injector)
 
 local GAME_GROUPS = {
-	classic = {'Tetris', 'NES (1989)', 'NES (1989) NTSC', 'NES (1989) PAL', 'NES (1989) DAS', 'Super Tetris',
-		'Plus', 'Plus 2'},
-	modern = {'Tetris Effect', 'Tetris Effect: Connected', 'Jstris', 'Worldwide Combos', 'TETR.IO', 'Nuketris',
-		'Tetris 2', 'Puyo Puyo Tetris', 'Puyo Puyo Tetris 2', 'Tetris 99', 'Tetris DS', 'Tetris Friends',
-		'Tetris Online Japan', 'Tetris Online Poland'},
-	other = {'Attack', '64 (1998)', 'The New Tetris', 'Tetris & Dr.Mario', 'NullpoMino', 'Blockbox', 'Cultris 2',
-		'TetriNET 2'},
-	tgm = {'The Grand Master', 'The Grand Master 2', 'The Grand Master 3'},
+	classic = {'tetris', 'classic', 'classic ntsc', 'classic pal', 'classic das', 'super',
+		'plus', 'plus 2'},
+	modern = {'te', 'tec', 'jstris', 'wwc', 'tetrio', 'nuketris',
+		'tetris 2', 'ppt1', 'ppt2', 't99', 'td', 'tetris friends',
+		'tetris online japan', 'tetris online poland'},
+	other = {'attack', '64', 'tnt', 'tetris & dr.mario', 'nullpomino', 'blockbox', 'cultris 2',
+		'tetrinet 2'},
+	tgm = {'tgm', 'tgm2', 'tgm3', 'tgm4'},
 }
 
 ---@param frame Frame


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

In https://liquipedia.net/tetris/S-Tier_Tournaments/Classic and https://liquipedia.net/tetris/S-Tier_Tournaments/Modern we want to list tournaments by game category, and there are too many individual games to list them all out, so we use the following:

```
{{TournamentsList|tier=1|tiertype=!Qualifier|additionalConditions=AND [[extradata_gamegroup::modern]]|showGameIcon=1|year=2024}}
```

Previously in https://github.com/Liquipedia/Lua-Modules/pull/3122, Infobox/League/Custom was modified to set the gamegroup in extradata. However, it seems like this no longer works. The tournament listing for both seem to be completely blank.

hjpalpha pointed out that the issue is that Infobox League is checking against game names, not the game identifiers (i.e. keys used in Module:Info). Changing it to compare against the game identifiers seems to work.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->

Test module: https://liquipedia.net/tetris/Module:Infobox/League/Custom/dev/mitsu_at

Example page modified to use the dev infobox module: https://liquipedia.net/tetris/TETR.IO_Cup/15

After purging https://liquipedia.net/tetris/S-Tier_Tournaments/Modern the tournament now shows up (it didn't show up before).
