### PR TITLE
fix: Use executeMassQuery in StatsPortal queries

### DIFF
--- a/lua/wikis/commons/PortalStatistics.lua
+++ b/lua/wikis/commons/PortalStatistics.lua
@@ -806,20 +806,31 @@ end
 Section: Query Functions
 ]]--
 
+---Executes a given LPDB query using Lpdb.executeMassQuery
+---@param tableName string Name of the table
+---@param parameters table Query parameters
+---@return table
+function StatisticsPortal._massQuery(tableName, parameters)
+	local data = {}
+
+	Lpdb.executeMassQuery(tableName, parameters, function (item)
+		table.insert(data, item)
+	end)
+
+	return data
+end
 
 ---@param limit number?
 ---@param addConditions string?
 ---@param addOrder string?
 ---@return table
 function StatisticsPortal._getPlayers(limit, addConditions, addOrder)
-	local data = mw.ext.LiquipediaDB.lpdb('player', {
+	return StatisticsPortal._massQuery('player', {
 		query = 'pagename, id, nationality, earnings, birthdate, team, earningsbyyear',
 		conditions = addConditions or '',
 		order = addOrder,
-		limit = limit or MAX_QUERY_LIMIT,
+		limit = limit,
 	})
-
-	return data
 end
 
 
@@ -828,14 +839,12 @@ end
 ---@param addOrder string?
 ---@return table
 function StatisticsPortal._getTeams(limit, addConditions, addOrder)
-	local data = mw.ext.LiquipediaDB.lpdb('team', {
+	return StatisticsPortal._massQuery('team', {
 		query = 'pagename, name, template, earnings, earningsbyyear',
 		conditions = addConditions or '',
 		order = addOrder,
-		limit = limit or MAX_QUERY_LIMIT,
+		limit = limit,
 	})
-
-	return data
 end
 
 


### PR DESCRIPTION
## Summary
With the plain query, it could miss players/teams on wikis with >5000 pages of that type
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
