### PR TITLE
fix: TH erroring if second date starts with `?`

### DIFF
--- a/lua/wikis/commons/Infobox/Extension/TeamHistory/Manual.lua
+++ b/lua/wikis/commons/Infobox/Extension/TeamHistory/Manual.lua
@@ -79,7 +79,7 @@ function TeamHistoryManual._readDateInput(dateInput)
 	local leaveInput = string.sub(dateInput, 11) -- everything after the first date
 	local leaveDate
 	if not leaveInput:find('Present') then
-		leaveDate = leaveInput:gsub('^[^%d]*', '') -- trim away everything before the (second) date
+		leaveDate = leaveInput:gsub('^[^%d%?]*', '') -- trim away everything before the (second) date
 		TeamHistoryManual._checkDate(leaveDate)
 	end
 


### PR DESCRIPTION
stacked on #6536
## Summary
regression of #6388
missed that the second date coiuld also start with a questionmark instead of a number

## How did you test this change?
live