### PR TITLE
feat: support mobile tournament on ea fc in the infobox

### DIFF
--- a/lua/wikis/easportsfc/Infobox/League/Custom.lua
+++ b/lua/wikis/easportsfc/Infobox/League/Custom.lua
@@ -35,6 +35,7 @@ local PLATFORMS = {
 	playstation5 = 'PlayStation 5',
 	xboxplaystation = 'Xbox and PlayStation',
 	xboxandplaystation = 'Xbox and PlayStation',
+	mobile = 'Mobile',
 }
 
 ---@param frame Frame


### PR DESCRIPTION
Making the infobox to display Mobile tournaments

## Summary

EA Sports FC Mobile tournaments have been covered since 2024, yet the Mobile platform is not included in the infobox.

## How did you test this change?

<img width="328" height="756" alt="image" src="https://github.com/user-attachments/assets/f74ad31f-b708-4f1f-baad-e74d221246bf" />

I added "mobile = 'Mobile'," into the original module