### PR TITLE
fix: Remove disband check for Team Footer

### DIFF
--- a/lua/wikis/honorofkings/Infobox/Team/Custom.lua
+++ b/lua/wikis/honorofkings/Infobox/Team/Custom.lua
@@ -65,12 +65,10 @@ end
 
 ---@return Widget?
 function CustomTeam:createBottomContent()
-	if not self.args.disbanded then
-		return HtmlWidgets.Fragment{children = {
-			UpcomingTournaments.team(self.teamTemplate.templatename),
-			PlacementStats.run{tiers = {'1', '2', '3', '4', '5'}}
-		}}
-	end
+	return HtmlWidgets.Fragment{children = {
+		UpcomingTournaments.team(self.teamTemplate.templatename),
+		PlacementStats.run{tiers = {'1', '2', '3', '4', '5'}}
+	}}
 end
 
 return CustomTeam


### PR DESCRIPTION
## Summary
Given HOK wiki has multiple games, if a team is disbanded in 1 division, it has `args.disbanded`, therefore does not show the Team Footer of Placements/Upcoming Tournaments

## How did you test this change?
/dev
