### PR TITLE
fix(match2): Bracket conversion wrapper not handling missing first opponent

### DIFF
--- a/lua/wikis/commons/MatchGroup/Legacy.lua
+++ b/lua/wikis/commons/MatchGroup/Legacy.lua
@@ -481,7 +481,7 @@ end
 function MatchGroupLegacy._generateMatch(match)
 	local opponents = Array.mapIndexes(function(opponentIndex)
 		local opp = Table.extract(match, 'opponent' .. opponentIndex)
-		if Logic.isEmpty(opp) then return end
+		if opponentIndex > 2 and Logic.isEmpty(opp) then return end
 		return '|opponent' .. opponentIndex .. '=' .. MatchGroupLegacy._generateOpponent(opp)
 	end)
 
@@ -506,6 +506,7 @@ end
 ---@param opp table
 ---@return string
 function MatchGroupLegacy._generateOpponent(opp)
+	if Logic.isEmpty(opp) then return '' end
 	local opponentType = Table.extract(opp, 'type')
 	local opponentTemplate = String.upperCaseFirst(opponentType) .. 'Opponent'
 


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/161454541009715200/1416361449814622239

## How did you test this change?
untested, as atm tl.net seems to be down and i hence can not log in ...