### PR TITLE
feat(match2): Add conversion generatzors for matchlists

### DIFF
--- a/lua/wikis/commons/MatchGroup/Legacy.lua
+++ b/lua/wikis/commons/MatchGroup/Legacy.lua
@@ -441,10 +441,12 @@ function MatchGroupLegacy:generate()
 	self:_populateNewArgs(match2mapping)
 	self:handleOtherBracketParams()
 
-	return MatchGroupLegacy._generateWikiCode(self.newArgs)
+	return MatchGroupLegacy._generateWikiCodeForBracket(self.newArgs)
 end
 
-function MatchGroupLegacy._generateWikiCode(args)
+---@param args table
+---@return string
+function MatchGroupLegacy._generateWikiCodeForBracket(args)
 	local bracketType = Table.extract(args, 1)
 	local bracketTypeWithoutPrefix = bracketType:gsub('^[bB]racket/', '')
 	local bracketDataList = CopyPaste._getBracketData(bracketTypeWithoutPrefix)
@@ -468,6 +470,26 @@ function MatchGroupLegacy._generateWikiCode(args)
 
 	local lines = Array.extend(
 		{'{{Bracket|' .. bracketType .. '|id=' .. Table.extract(args, 'id')},
+		MatchGroupLegacy._argsToString(args),
+		matches,
+		'}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+---@param args table
+---@return string
+function MatchGroupLegacy.generateWikiCodeForMatchList(args)
+	local matches = Array.mapIndex(function(matchIndex)
+		local matchKey = 'M' .. matchIndex
+		local match = Table.extract(args, matchKey)
+		if Logic.isEmpty(match) then return end
+		return '|' .. matchKey .. '=' .. MatchGroupLegacy._generateMatch(match)
+	end)
+
+	local lines = Array.extend(
+		{'{{Matchlist|id=' .. Table.extract(args, 'id')},
 		MatchGroupLegacy._argsToString(args),
 		matches,
 		'}}'

--- a/lua/wikis/warcraft/LegacyMatchMaps.lua
+++ b/lua/wikis/warcraft/LegacyMatchMaps.lua
@@ -15,6 +15,7 @@ local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Match = Lua.import('Module:Match')
 local MatchGroup = Lua.import('Module:MatchGroup')
+local MatchGroupLegacy = Lua.import('Module:MatchGroup/Legacy')
 local Opponent = Lua.import('Module:Opponent/Custom')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
 local Table = Lua.import('Module:Table')
@@ -29,6 +30,67 @@ local TBD = 'TBD'
 local BYE = 'BYE'
 
 local LegacyMatchMaps = {}
+
+--- for bot conversion to proper match2 matchlists
+---@param frame Frame
+---@return string
+function LegacyMatchMaps.generateSolo(frame)
+	local args = Arguments.getArgs(frame)
+
+	local store = Logic.readBoolOrNil(args.store)
+
+	local parsedArgs = {
+		id = args.id,
+		title = args.title,
+		width = args.width,
+		collapsed = Logic.nilOr(Logic.readBoolOrNil(args.hide), true),
+		attached = Logic.nilOr(Logic.readBoolOrNil(args.hide), true),
+		store = store,
+		noDuplicateCheck = store == false or nil,
+	}
+
+	for _, matchInput, matchIndex in Table.iter.pairsByPrefix(args, 'match') do
+		parsedArgs['M' .. matchIndex] = LegacyMatchMaps._readSoloMatch(matchInput)
+	end
+
+	return MatchGroupLegacy.generateWikiCodeForMatchList(parsedArgs)
+end
+
+--- for bot conversion to proper match2 matchlists
+---@param frame Frame
+---@return string
+function LegacyMatchMaps.generateTeam(frame)
+	local args = Arguments.getArgs(frame)
+
+	local store = Logic.readBoolOrNil(args.store)
+
+	local offset = 0
+	local title = args.title
+	if not title and not Json.parseIfTable(args[1]) then
+		title = args[1]
+		offset = 1
+	end
+
+	local parsedArgs = {
+		id = args.id,
+		title = title,
+		width = args.width or '350px',
+		collapsed = Logic.nilOr(Logic.readBoolOrNil(args.hide), true),
+		attached = Logic.nilOr(Logic.readBoolOrNil(args.hide), true),
+		store = store,
+		noDuplicateCheck = store == false or nil,
+	}
+
+	local matches = Array.mapIndexes(function(index)
+		return args[index + offset]
+	end)
+
+	Array.forEach(matches, function(match, matchIndex)
+		args['M' .. matchIndex] = Match.makeEncodedJson(match)
+	end)
+
+	return MatchGroupLegacy.generateWikiCodeForMatchList(parsedArgs)
+end
 
 -- invoked by Template:MatchList
 ---@param frame Frame
@@ -171,8 +233,11 @@ end
 
 -- invoked by Template:MatchMapsTeams
 ---@param frame Frame
+---@return string?
 function LegacyMatchMaps.teamMatch(frame)
 	local args = Arguments.getArgs(frame)
+
+	local generate = Logic.readBool(Table.extract(args, 'generate'))
 
 	args = Table.merge(Json.parseIfString(args.details) or {}, args)
 	args.details = nil
@@ -180,6 +245,10 @@ function LegacyMatchMaps.teamMatch(frame)
 	LegacyMatchMaps._readTeamOpponents(args)
 	--map data gets preprocessed already due to using the same template as in brackets
 	LegacyMatchMaps._readMaps(args)
+
+	if generate then
+		return Json.stringify(args)
+	end
 
 	Template.stashReturnValue(args, 'LegacyMatchlist')
 end


### PR DESCRIPTION
## Summary
the goal is to allow bot converting matchlists along side brackets from legacy wrapper to proper match2 input.

- [x] warcraft
- [ ] starcraft (`MatchMaps/Legacy`)
- [ ] starcraft2 (`MatchMaps/Legacy`, `MatchMapsTeam/Legacy`)
- [ ] aoe (`MatchMaps/Legacy`)
- [ ] arenafps (`MatchMaps/Legacy`)
- [ ] battalion (``MatchGroup/Legacy/MatchList) 
- [ ] brawlstars (`MatchMaps/Legacy`)
- [ ] cod (`MatchMaps/Legacy`)
- [ ] cr (`MatchGroup/Legacy/MatchList`)
- [ ] dota2 (`MatchMaps/Legacy`)
- [ ] hs (`MatchMaps/Legacy`)
- [ ] heroes (`MatchMaps/Legacy`)
- [ ] hok (`MatchMaps/Legacy`)
- [ ] wow (`MatchGroup/Legacy/MatchList`)
- [ ] wildrift (`MatchMaps/Legacy`)
- [ ] val (`MatchMaps/Legacy`)
- [ ] trackmania (`MatchGroup/Legacy/MatchList`)
- [ ] squadrons(`MatchGroup/Legacy/MatchList`)
- [ ] rl (`LegacyMatchList`)
- [ ] r6 (`MatchMaps/Legacy/Store`, `MatchMaps/Legacy`)
- [ ] lol (`MatchMaps/Legacy`)
- [ ] ow (`MatchMaps/Legacy`)

## How did you test this change?
to be done (atm tl.net is down so can not even log in ...)