### PR TITLE
Update StaffRoles.lua

### DIFF
--- a/lua/wikis/commons/StaffRoles.lua
+++ b/lua/wikis/commons/StaffRoles.lua
@@ -37,6 +37,7 @@ local staffRoles = {
 	['organizer'] = {category = 'Tournament Organizer', display = 'Tournament Organizer'},
 	['staff'] = {category = 'Staff', display = 'Staff'},
 	['referee'] = {category = 'Referees', display = 'Referee'},
+	['replayer operator'] = {category = 'Replayer Operators', display = 'Replayer Operator'},
 }
 
 staffRoles['commentator'] = staffRoles['caster']


### PR DESCRIPTION
added replay operator as staff role

## Summary

I've added Replay Operator as a role to StaffRoles as many tournaments have Replay Operators that don't have any other role like observer etc.

## How did you test this change?

I've pasted the text line above and changed names to replay operator
