### PR TITLE
feat(infobox): Add automatic achievements for Apex legends

### DIFF
--- a/lua/wikis/apexlegends/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/apexlegends/Infobox/Person/Player/Custom.lua
@@ -17,11 +17,24 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local UpcomingMatches = Lua.import('Module:Matches Player')
 
+local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
+
+local Condition = Lua.import('Module:Condition')
+local ConditionNode = Condition.Node
+local Comparator = Condition.Comparator
+local ColumnName = Condition.ColumnName
+local ConditionUtil = Condition.Util
+
+local ACHIEVEMENTS_BASE_CONDITIONS = {
+	ConditionUtil.noneOf(ColumnName('liquipediatiertype'), {'Showmatch', 'Qualifier'}),
+	ConditionUtil.anyOf(ColumnName('liquipediatier'), {1, 2}),
+	ConditionNode(ColumnName('placement'), Comparator.eq, 1),
+}
 
 local INPUTS = {
 	controller = 'Controller',
@@ -41,6 +54,12 @@ local CustomInjector = Class.new(Injector)
 function CustomPlayer.run(frame)
 	local player = CustomPlayer(frame)
 	player:setWidgetInjector(CustomInjector(player))
+
+	-- Automatic achievements
+	player.args.achievements = Achievements.player{
+		noTemplate = true,
+		baseConditions = ACHIEVEMENTS_BASE_CONDITIONS
+	}
 
 	return player:createInfobox()
 end

--- a/lua/wikis/apexlegends/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/apexlegends/Infobox/Person/Player/Custom.lua
@@ -7,6 +7,7 @@
 
 local Lua = require('Module:Lua')
 
+local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Array = Lua.import('Module:Array')
 local CharacterIcon = Lua.import('Module:CharacterIcon')
 local CharacterNames = Lua.import('Module:CharacterNames')
@@ -17,7 +18,6 @@ local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local UpcomingMatches = Lua.import('Module:Matches Player')
 
-local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 

--- a/lua/wikis/apexlegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/apexlegends/Infobox/Team/Custom.lua
@@ -7,14 +7,26 @@
 
 local Lua = require('Module:Lua')
 
+local Achievements = Lua.import('Module:Infobox/Extension/Achievements')
 local Class = Lua.import('Module:Class')
-
 local Injector = Lua.import('Module:Widget/Injector')
 local Team = Lua.import('Module:Infobox/Team')
 local UpcomingTournaments = Lua.import('Module:Infobox/Extension/UpcomingTournaments')
 
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
+
+local Condition = Lua.import('Module:Condition')
+local ConditionNode = Condition.Node
+local Comparator = Condition.Comparator
+local ColumnName = Condition.ColumnName
+local ConditionUtil = Condition.Util
+
+local ACHIEVEMENTS_BASE_CONDITIONS = {
+	ConditionUtil.noneOf(ColumnName('liquipediatiertype'), {'Showmatch', 'Qualifier'}),
+	ConditionUtil.anyOf(ColumnName('liquipediatier'), {1, 2}),
+	ConditionNode(ColumnName('placement'), Comparator.eq, 1),
+}
 
 ---@class ApexlegendsInfoboxTeam: InfoboxTeam
 local CustomTeam = Class.new(Team)
@@ -25,6 +37,12 @@ local CustomInjector = Class.new(Injector)
 function CustomTeam.run(frame)
 	local team = CustomTeam(frame)
 	team:setWidgetInjector(CustomInjector(team))
+	
+	-- Automatic achievements
+	team.args.achievements = Achievements.team{
+		noTemplate = true,
+		baseConditions = ACHIEVEMENTS_BASE_CONDITIONS
+	}
 
 	return team:createInfobox()
 end

--- a/lua/wikis/apexlegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/apexlegends/Infobox/Team/Custom.lua
@@ -37,7 +37,7 @@ local CustomInjector = Class.new(Injector)
 function CustomTeam.run(frame)
 	local team = CustomTeam(frame)
 	team:setWidgetInjector(CustomInjector(team))
-	
+
 	-- Automatic achievements
 	team.args.achievements = Achievements.team{
 		noTemplate = true,


### PR DESCRIPTION
## Summary
Rquested on discord: 
https://discord.com/channels/93055209017729024/545651077710872576/1415959687110852705

They would like to include both S/A tier tournaments.

Example of page with most achievements for both tiers.
Most of the players doesn't have that many achievements. Mostly 3-5 with both tiers
<img width="326" height="804" alt="image" src="https://github.com/user-attachments/assets/320c981f-2107-4481-ad15-273383300ce0" />


## How did you test this change?

dev