### PR TITLE
fix(match2): win/loss indicator in matchpage header overflows at certain width

### DIFF
--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -196,7 +196,7 @@ span.slash {
 	white-space: nowrap;
 	font-size: 2rem;
 
-	@media ( min-width: 767px ) {
+	@media ( min-width: 768px ) {
 		font-size: 2.5rem;
 		margin: 0 5rem;
 	}

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -198,7 +198,7 @@ span.slash {
 
 	@media ( min-width: 768px ) {
 		font-size: 2.5rem;
-		margin: 0 5rem;
+		min-width: 10rem;
 	}
 
 	&-text {


### PR DESCRIPTION
## Summary

fixes #6559

## How did you test this change?

browser dev tools