### PR TITLE
feat: adjust breakpoints

### DIFF
--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -105,7 +105,7 @@ function MainPageLayout._makeCells(cells)
 			end
 			table.insert(cellContent, GridWidgets.Cell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end
-		table.insert(output, GridWidgets.Cell{cellContent = cellContent, lg = column.size, xs = 'ignore', sm = 'ignore'})
+		table.insert(output, GridWidgets.Cell{cellContent = cellContent, xxl = column.size, xs = 'ignore', sm = 'ignore'})
 	end
 
 	return GridWidgets.Container{ gridCells = output }

--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -12,6 +12,7 @@ local Array = Lua.import('Module:Array')
 local Image = Lua.import('Module:Image')
 local LpdbCounter = Lua.import('Module:LPDB entity count')
 local String = Lua.import('Module:StringUtils')
+local Table = Lua.import('Module:Table')
 
 local WikiData = Lua.import('Module:MainPageLayout/data')
 local GridWidgets = Lua.import('Module:Widget/Grid')
@@ -105,14 +106,10 @@ function MainPageLayout._makeCells(cells)
 			end
 			table.insert(cellContent, GridWidgets.Cell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end
-		local cellProps = {cellContent = cellContent, xs = 'ignore', sm = 'ignore'}
-		if column.sizes then
-			for k, v in pairs(column.sizes) do
-				cellProps[k] = v
-			end
-		else
-			cellProps.xxl = column.size
-		end
+		local cellProps = Table.merge(
+			{cellContent = cellContent, xs = 'ignore', sm = 'ignore'},
+			column.sizes or {xxl = column.size}
+		)
 		table.insert(output, GridWidgets.Cell(cellProps))
 	end
 

--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -82,6 +82,7 @@ end
 ---@return Widget
 function MainPageLayout._makeCells(cells)
 	local output = {}
+	local desktopBreakpoints = {'lg', 'xl', 'xxl', 'xxxl'}
 
 	for _, column in ipairs(cells) do
 		local cellContent = {}
@@ -111,16 +112,13 @@ function MainPageLayout._makeCells(cells)
 			})
 		end
 
-		-- Change line below once all mainpages are properly migrated to new breakpoints
-		-- local columnSizes = column.sizes or {}
-		local columnSizes = column.sizes
-
-		-- 5 lines below can be removed once all mainpages are properly migrated to new breakpoints.
-		local desktopBreakpoints = {'lg', 'xl', 'xxl', 'xxxl'}
-		if not columnSizes and column.size then
+		local columnSizes = {}
+		if column.size then
 			columnSizes = Table.map(desktopBreakpoints, function(_, bp) return bp, column.size end)
 		end
-		columnSizes = columnSizes or {}
+		if column.sizes then
+			columnSizes = Table.merge(columnSizes, column.sizes)
+		end
 
 		local cellProps = Table.merge(
 			{cellContent = cellContent, xs = 'ignore', sm = 'ignore'},

--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -111,8 +111,12 @@ function MainPageLayout._makeCells(cells)
 			})
 		end
 
-		local desktopBreakpoints = {'lg', 'xl', 'xxl', 'xxxl'}
+		-- Change line below once all mainpages are properly migrated to new breakpoints
+		-- local columnSizes = column.sizes or {}
 		local columnSizes = column.sizes
+
+		-- 5 lines below can be removed once all mainpages are properly migrated to new breakpoints.
+		local desktopBreakpoints = {'lg', 'xl', 'xxl', 'xxxl'}
 		if not columnSizes and column.size then
 			columnSizes = Table.map(desktopBreakpoints, function(_, bp) return bp, column.size end)
 		end

--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -105,7 +105,15 @@ function MainPageLayout._makeCells(cells)
 			end
 			table.insert(cellContent, GridWidgets.Cell{cellContent = content, ['order-xs'] = item.mobileOrder})
 		end
-		table.insert(output, GridWidgets.Cell{cellContent = cellContent, xxl = column.size, xs = 'ignore', sm = 'ignore'})
+		local cellProps = {cellContent = cellContent, xs = 'ignore', sm = 'ignore'}
+		if column.sizes then
+			for k, v in pairs(column.sizes) do
+				cellProps[k] = v
+			end
+		else
+			cellProps.xxl = column.size
+		end
+		table.insert(output, GridWidgets.Cell(cellProps))
 	end
 
 	return GridWidgets.Container{ gridCells = output }

--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -108,7 +108,7 @@ function MainPageLayout._makeCells(cells)
 		end
 		local cellProps = Table.merge(
 			{cellContent = cellContent, xs = 'ignore', sm = 'ignore'},
-			column.sizes or {xxl = column.size}
+			column.sizes or {md = column.size}
 		)
 		table.insert(output, GridWidgets.Cell(cellProps))
 	end

--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -104,11 +104,23 @@ function MainPageLayout._makeCells(cells)
 			if item.children then
 				Array.appendWith(content, MainPageLayout._makeCells(item.children))
 			end
-			table.insert(cellContent, GridWidgets.Cell{cellContent = content, ['order-xs'] = item.mobileOrder})
+			table.insert(cellContent, GridWidgets.Cell{
+				cellContent = content,
+				['order-xs'] = item.mobileOrder,
+				['order-sm'] = item.mobileOrder
+			})
 		end
+
+		local desktopBreakpoints = {'lg', 'xl', 'xxl', 'xxxl'}
+		local columnSizes = column.sizes
+		if not columnSizes and column.size then
+			columnSizes = Table.map(desktopBreakpoints, function(_, bp) return bp, column.size end)
+		end
+		columnSizes = columnSizes or {}
+
 		local cellProps = Table.merge(
 			{cellContent = cellContent, xs = 'ignore', sm = 'ignore'},
-			column.sizes or {md = column.size}
+			columnSizes
 		)
 		table.insert(output, GridWidgets.Cell(cellProps))
 	end

--- a/lua/wikis/commons/Widget/Grid/Cell.lua
+++ b/lua/wikis/commons/Widget/Grid/Cell.lua
@@ -21,7 +21,8 @@ local GRID_WIDTHS = {
 	'md',
 	'lg',
 	'xl',
-	'xxl'
+	'xxl',
+	'xxxl'
 }
 
 local GRID_DIRECTIONS = {

--- a/lua/wikis/dota2/MainPageLayout/data.lua
+++ b/lua/wikis/dota2/MainPageLayout/data.lua
@@ -176,7 +176,7 @@ local CONTENT = {
 
 local LAYOUT_MAIN = {
 	{ -- Top Left
-		size = 5,
+		sizes = {xxl = 5, xxxl = 6},
 		children = {
 			{
 				mobileOrder = 1,
@@ -190,7 +190,7 @@ local LAYOUT_MAIN = {
 		},
 	},
 	{ -- Top Right
-		size = 7,
+		size = {xxl = 7, xxxl = 6},
 		children = {
 			{
 				mobileOrder = 2,

--- a/lua/wikis/dota2/MainPageLayout/data.lua
+++ b/lua/wikis/dota2/MainPageLayout/data.lua
@@ -176,7 +176,7 @@ local CONTENT = {
 
 local LAYOUT_MAIN = {
 	{ -- Top Left
-		sizes = {md = 12, lg = 12, xl = 12, xxl = 5, xxxl = 6},
+		sizes = {xxl = 5, xxxl = 6},
 		children = {
 			{
 				mobileOrder = 1,
@@ -190,7 +190,7 @@ local LAYOUT_MAIN = {
 		},
 	},
 	{ -- Top Right
-		sizes = {md = 12, lg = 12, xl = 12, xxl = 7, xxxl = 6},
+		sizes = {xxl = 7, xxxl = 6},
 		children = {
 			{
 				mobileOrder = 2,
@@ -226,7 +226,7 @@ local LAYOUT_MAIN = {
 		},
 	},
 	{ -- Heroes
-		size = 12,
+		sizes = {xxl = 12},
 		children = {
 			{
 				mobileOrder = 4,
@@ -235,7 +235,7 @@ local LAYOUT_MAIN = {
 		}
 	},
 	{ -- Bottom Left
-		size = 6,
+		sizes = {xxl = 6},
 		children = {
 			{
 				mobileOrder = 5,
@@ -249,7 +249,7 @@ local LAYOUT_MAIN = {
 		}
 	},
 	{ -- Bottom Right
-		size = 6,
+		sizes = {xxl = 6},
 		children = {
 			{
 				mobileOrder = 7,
@@ -258,7 +258,7 @@ local LAYOUT_MAIN = {
 		}
 	},
 	{ -- Useful articles
-		size = 12,
+		sizes = {xxl = 12},
 		children = {
 			{
 				mobileOrder = 8,

--- a/lua/wikis/dota2/MainPageLayout/data.lua
+++ b/lua/wikis/dota2/MainPageLayout/data.lua
@@ -190,7 +190,7 @@ local LAYOUT_MAIN = {
 		},
 	},
 	{ -- Top Right
-		size = {xxl = 7, xxxl = 6},
+		sizes = {xxl = 7, xxxl = 6},
 		children = {
 			{
 				mobileOrder = 2,

--- a/lua/wikis/dota2/MainPageLayout/data.lua
+++ b/lua/wikis/dota2/MainPageLayout/data.lua
@@ -176,7 +176,7 @@ local CONTENT = {
 
 local LAYOUT_MAIN = {
 	{ -- Top Left
-		sizes = {xxl = 5, xxxl = 6},
+		sizes = {md = 12, lg = 12, xl = 12, xxl = 5, xxxl = 6},
 		children = {
 			{
 				mobileOrder = 1,
@@ -190,7 +190,7 @@ local LAYOUT_MAIN = {
 		},
 	},
 	{ -- Top Right
-		sizes = {xxl = 7, xxxl = 6},
+		sizes = {md = 12, lg = 12, xl = 12, xxl = 7, xxxl = 6},
 		children = {
 			{
 				mobileOrder = 2,

--- a/lua/wikis/hearthstone/MainPageLayout/data.lua
+++ b/lua/wikis/hearthstone/MainPageLayout/data.lua
@@ -145,12 +145,8 @@ return {
 				size = 6,
 				children = {
 					{
-						mobileOrder = 1,
-						content = CONTENT.specialEvents,
-					},
-					{
-						mobileOrder = 3,
-						content = CONTENT.transfers,
+						mobileOrder = 4,
+						content = CONTENT.usefulArticles,
 					},
 					{
 						mobileOrder = 6,
@@ -161,6 +157,10 @@ return {
 			{ -- Right
 				size = 6,
 				children = {
+					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
 					{
 						mobileOrder = 2,
 						children = {
@@ -193,12 +193,12 @@ return {
 						},
 					},
 					{
-						mobileOrder = 5,
-						content = CONTENT.thisDay,
+						mobileOrder = 3,
+						content = CONTENT.transfers,
 					},
 					{
-						mobileOrder = 4,
-						content = CONTENT.usefulArticles,
+						mobileOrder = 5,
+						content = CONTENT.thisDay,
 					},
 				},
 			},

--- a/lua/wikis/hearthstone/MainPageLayout/data.lua
+++ b/lua/wikis/hearthstone/MainPageLayout/data.lua
@@ -173,7 +173,7 @@ return {
 								},
 							},
 							{
-								size = 6,
+								sizes = { xxl = nil, xxxl = 6},
 								children = {
 									{
 										noPanel = true,
@@ -182,7 +182,7 @@ return {
 								},
 							},
 							{
-								size = 6,
+								sizes = { xxl = nil, xxxl = 6},
 								children = {
 									{
 										noPanel = true,

--- a/lua/wikis/hearthstone/MainPageLayout/data.lua
+++ b/lua/wikis/hearthstone/MainPageLayout/data.lua
@@ -173,7 +173,7 @@ return {
 								},
 							},
 							{
-								sizes = { xxl = nil, xxxl = 6},
+								sizes = {xxxl = 6},
 								children = {
 									{
 										noPanel = true,
@@ -182,7 +182,7 @@ return {
 								},
 							},
 							{
-								sizes = { xxl = nil, xxxl = 6},
+								sizes = {xxxl = 6},
 								children = {
 									{
 										noPanel = true,

--- a/lua/wikis/hearthstone/MainPageLayout/data.lua
+++ b/lua/wikis/hearthstone/MainPageLayout/data.lua
@@ -145,6 +145,10 @@ return {
 				size = 6,
 				children = {
 					{
+						mobileOrder = 1,
+						content = CONTENT.specialEvents,
+					},
+					{
 						mobileOrder = 4,
 						content = CONTENT.usefulArticles,
 					},
@@ -157,10 +161,6 @@ return {
 			{ -- Right
 				size = 6,
 				children = {
-					{
-						mobileOrder = 1,
-						content = CONTENT.specialEvents,
-					},
 					{
 						mobileOrder = 2,
 						children = {

--- a/lua/wikis/wildrift/MainPageLayout/data.lua
+++ b/lua/wikis/wildrift/MainPageLayout/data.lua
@@ -137,7 +137,7 @@ return {
 	layouts = {
 		main = {
 			{ -- Left
-				sizes = {xxl = nil, xxxl = 6},
+				sizes = {xxxl = 6},
 				children = {
 					{
 						mobileOrder = 1,
@@ -158,7 +158,7 @@ return {
 				}
 			},
 			{ -- Right
-				sizes = {xxl = nil, xxxl = 6},
+				sizes = {xxxl = 6},
 				children = {
 					{
 						mobileOrder = 2,

--- a/lua/wikis/wildrift/MainPageLayout/data.lua
+++ b/lua/wikis/wildrift/MainPageLayout/data.lua
@@ -137,7 +137,7 @@ return {
 	layouts = {
 		main = {
 			{ -- Left
-				size = 6,
+				sizes = {xxl = nil, xxxl = 6},
 				children = {
 					{
 						mobileOrder = 1,
@@ -158,7 +158,7 @@ return {
 				}
 			},
 			{ -- Right
-				size = 6,
+				sizes = {xxl = nil, xxxl = 6},
 				children = {
 					{
 						mobileOrder = 2,

--- a/stylesheets/commons/BattleRoyale/NavigationTabs.scss
+++ b/stylesheets/commons/BattleRoyale/NavigationTabs.scss
@@ -10,7 +10,7 @@ Author(s): Elysienna
 	margin-bottom: 1.5rem;
 	overflow-x: auto;
 
-	@media ( min-width: 1320px ) {
+	@media ( min-width: 1440px ) {
 		padding: 0.75rem 0;
 	}
 

--- a/stylesheets/commons/BootstrapVisibility.scss
+++ b/stylesheets/commons/BootstrapVisibility.scss
@@ -61,7 +61,7 @@ Author(s): Bootstrap 3
 	}
 }
 
-@media ( min-width: 768px ) and ( max-width: 991px ) {
+@media ( min-width: 768px ) and ( max-width: 1023px ) {
 	.visible-sm {
 		display: block !important;
 	}
@@ -80,25 +80,25 @@ Author(s): Bootstrap 3
 	}
 }
 
-@media ( min-width: 768px ) and ( max-width: 991px ) {
+@media ( min-width: 768px ) and ( max-width: 1023px ) {
 	.visible-sm-block {
 		display: block !important;
 	}
 }
 
-@media ( min-width: 768px ) and ( max-width: 991px ) {
+@media ( min-width: 768px ) and ( max-width: 1023px ) {
 	.visible-sm-inline {
 		display: inline !important;
 	}
 }
 
-@media ( min-width: 768px ) and ( max-width: 991px ) {
+@media ( min-width: 768px ) and ( max-width: 1023px ) {
 	.visible-sm-inline-block {
 		display: inline-block !important;
 	}
 }
 
-@media ( min-width: 992px ) and ( max-width: 1319px ) {
+@media ( min-width: 1024px ) and ( max-width: 1439px ) {
 	.visible-md {
 		display: block !important;
 	}
@@ -117,25 +117,25 @@ Author(s): Bootstrap 3
 	}
 }
 
-@media ( min-width: 992px ) and ( max-width: 1319px ) {
+@media ( min-width: 1024px ) and ( max-width: 1439px ) {
 	.visible-md-block {
 		display: block !important;
 	}
 }
 
-@media ( min-width: 992px ) and ( max-width: 1319px ) {
+@media ( min-width: 1024px ) and ( max-width: 1439px ) {
 	.visible-md-inline {
 		display: inline !important;
 	}
 }
 
-@media ( min-width: 992px ) and ( max-width: 1319px ) {
+@media ( min-width: 1024px ) and ( max-width: 1439px ) {
 	.visible-md-inline-block {
 		display: inline-block !important;
 	}
 }
 
-@media ( min-width: 1320px ) {
+@media ( min-width: 1440px ) {
 	.visible-lg {
 		display: block !important;
 	}
@@ -154,19 +154,19 @@ Author(s): Bootstrap 3
 	}
 }
 
-@media ( min-width: 1320px ) {
+@media ( min-width: 1440px ) {
 	.visible-lg-block {
 		display: block !important;
 	}
 }
 
-@media ( min-width: 1320px ) {
+@media ( min-width: 1440px ) {
 	.visible-lg-inline {
 		display: inline !important;
 	}
 }
 
-@media ( min-width: 1320px ) {
+@media ( min-width: 1440px ) {
 	.visible-lg-inline-block {
 		display: inline-block !important;
 	}
@@ -178,19 +178,19 @@ Author(s): Bootstrap 3
 	}
 }
 
-@media ( min-width: 768px ) and ( max-width: 991px ) {
+@media ( min-width: 768px ) and ( max-width: 1023px ) {
 	.hidden-sm {
 		display: none !important;
 	}
 }
 
-@media ( min-width: 992px ) and ( max-width: 1319px ) {
+@media ( min-width: 1024px ) and ( max-width: 1439px ) {
 	.hidden-md {
 		display: none !important;
 	}
 }
 
-@media ( min-width: 1320px ) {
+@media ( min-width: 1440px ) {
 	.hidden-lg {
 		display: none !important;
 	}

--- a/stylesheets/commons/Grid.scss
+++ b/stylesheets/commons/Grid.scss
@@ -87,7 +87,7 @@ License: MIT
 		}
 	}
 
-	@media ( min-width: 992px ) {
+	@media ( min-width: 1024px ) {
 		.lp-d-lg-block {
 			display: block !important;
 		}
@@ -112,7 +112,7 @@ License: MIT
 		}
 	}
 
-	@media ( min-width: 1320px ) {
+	@media ( min-width: 1440px ) {
 		.lp-d-xl-block {
 			display: block !important;
 		}
@@ -137,7 +137,7 @@ License: MIT
 		}
 	}
 
-	@media ( min-width: 1620px ) {
+	@media ( min-width: 1560px ) {
 		.lp-d-xxl-block {
 			display: block !important;
 		}

--- a/stylesheets/commons/Grid.scss
+++ b/stylesheets/commons/Grid.scss
@@ -161,6 +161,31 @@ License: MIT
 			padding-left: 5px;
 		}
 	}
+
+	@media ( min-width: 1920px ) {
+		.lp-d-xxxl-block {
+			display: block !important;
+		}
+
+		.lp-d-xxxl-contents {
+			display: contents !important;
+		}
+
+		.lp-d-xxxl-flex {
+			display: flex !important;
+		}
+
+		.lp-d-xxxl-block > .lp-col,
+		.lp-d-xxxl-flex > .lp-col {
+			padding-right: 0;
+			padding-left: 0;
+		}
+
+		.lp-d-xxxl-contents > .lp-col {
+			padding-right: 5px;
+			padding-left: 5px;
+		}
+	}
 }
 
 @supports not ( display: contents ) {
@@ -227,6 +252,20 @@ License: MIT
 .lp-col-xxl-3,
 .lp-col-xxl-2,
 .lp-col-xxl-1,
+.lp-col-xxxl,
+.lp-col-xxxl-auto,
+.lp-col-xxxl-12,
+.lp-col-xxxl-11,
+.lp-col-xxxl-10,
+.lp-col-xxxl-9,
+.lp-col-xxxl-8,
+.lp-col-xxxl-7,
+.lp-col-xxxl-6,
+.lp-col-xxxl-5,
+.lp-col-xxxl-4,
+.lp-col-xxxl-3,
+.lp-col-xxxl-2,
+.lp-col-xxxl-1,
 .lp-col-xl,
 .lp-col-xl-auto,
 .lp-col-xl-12,
@@ -1565,6 +1604,218 @@ License: MIT
 	}
 
 	.lp-offset-xxl-11 {
+		margin-left: 91.6666666667%;
+	}
+}
+
+@media ( min-width: 1920px ) {
+	.lp-col-xxxl {
+		flex-basis: 0;
+		flex-grow: 1;
+		max-width: 100%;
+	}
+
+	.lp-row-cols-xxxl-1 > * {
+		flex: 0 0 100%;
+		max-width: 100%;
+	}
+
+	.lp-row-cols-xxxl-2 > * {
+		flex: 0 0 50%;
+		max-width: 50%;
+	}
+
+	.lp-row-cols-xxxl-3 > * {
+		flex: 0 0 33.3333333333%;
+		max-width: 33.3333333333%;
+	}
+
+	.lp-row-cols-xxxl-4 > * {
+		flex: 0 0 25%;
+		max-width: 25%;
+	}
+
+	.lp-row-cols-xxxl-5 > * {
+		flex: 0 0 20%;
+		max-width: 20%;
+	}
+
+	.lp-row-cols-xxxl-6 > * {
+		flex: 0 0 16.6666666667%;
+		max-width: 16.6666666667%;
+	}
+
+	.lp-col-xxxl-auto {
+		flex: 0 0 auto;
+		width: auto;
+		max-width: 100%;
+	}
+
+	.lp-col-xxxl-1 {
+		flex: 0 0 8.3333333333%;
+		max-width: 8.3333333333%;
+	}
+
+	.lp-col-xxxl-2 {
+		flex: 0 0 16.6666666667%;
+		max-width: 16.6666666667%;
+	}
+
+	.lp-col-xxxl-3 {
+		flex: 0 0 25%;
+		max-width: 25%;
+	}
+
+	.lp-col-xxxl-4 {
+		flex: 0 0 33.3333333333%;
+		max-width: 33.3333333333%;
+	}
+
+	.lp-col-xxxl-5 {
+		flex: 0 0 41.6666666667%;
+		max-width: 41.6666666667%;
+	}
+
+	.lp-col-xxxl-6 {
+		flex: 0 0 50%;
+		max-width: 50%;
+	}
+
+	.lp-col-xxxl-7 {
+		flex: 0 0 58.3333333333%;
+		max-width: 58.3333333333%;
+	}
+
+	.lp-col-xxxl-8 {
+		flex: 0 0 66.6666666667%;
+		max-width: 66.6666666667%;
+	}
+
+	.lp-col-xxxl-9 {
+		flex: 0 0 75%;
+		max-width: 75%;
+	}
+
+	.lp-col-xxxl-10 {
+		flex: 0 0 83.3333333333%;
+		max-width: 83.3333333333%;
+	}
+
+	.lp-col-xxxl-11 {
+		flex: 0 0 91.6666666667%;
+		max-width: 91.6666666667%;
+	}
+
+	.lp-col-xxxl-12 {
+		flex: 0 0 100%;
+		max-width: 100%;
+	}
+
+	.lp-order-xxxl-first {
+		order: -1;
+	}
+
+	.lp-order-xxxl-last {
+		order: 13;
+	}
+
+	.lp-order-xxxl-0 {
+		order: 0;
+	}
+
+	.lp-order-xxxl-1 {
+		order: 1;
+	}
+
+	.lp-order-xxxl-2 {
+		order: 2;
+	}
+
+	.lp-order-xxxl-3 {
+		order: 3;
+	}
+
+	.lp-order-xxxl-4 {
+		order: 4;
+	}
+
+	.lp-order-xxxl-5 {
+		order: 5;
+	}
+
+	.lp-order-xxxl-6 {
+		order: 6;
+	}
+
+	.lp-order-xxxl-7 {
+		order: 7;
+	}
+
+	.lp-order-xxxl-8 {
+		order: 8;
+	}
+
+	.lp-order-xxxl-9 {
+		order: 9;
+	}
+
+	.lp-order-xxxl-10 {
+		order: 10;
+	}
+
+	.lp-order-xxxl-11 {
+		order: 11;
+	}
+
+	.lp-order-xxxl-12 {
+		order: 12;
+	}
+
+	.lp-offset-xxxl-0 {
+		margin-left: 0;
+	}
+
+	.lp-offset-xxxl-1 {
+		margin-left: 8.3333333333%;
+	}
+
+	.lp-offset-xxxl-2 {
+		margin-left: 16.6666666667%;
+	}
+
+	.lp-offset-xxxl-3 {
+		margin-left: 25%;
+	}
+
+	.lp-offset-xxxl-4 {
+		margin-left: 33.3333333333%;
+	}
+
+	.lp-offset-xxxl-5 {
+		margin-left: 41.6666666667%;
+	}
+
+	.lp-offset-xxxl-6 {
+		margin-left: 50%;
+	}
+
+	.lp-offset-xxxl-7 {
+		margin-left: 58.3333333333%;
+	}
+
+	.lp-offset-xxxl-8 {
+		margin-left: 66.6666666667%;
+	}
+
+	.lp-offset-xxxl-9 {
+		margin-left: 75%;
+	}
+
+	.lp-offset-xxxl-10 {
+		margin-left: 83.3333333333%;
+	}
+
+	.lp-offset-xxxl-11 {
 		margin-left: 91.6666666667%;
 	}
 }

--- a/stylesheets/commons/Grid.scss
+++ b/stylesheets/commons/Grid.scss
@@ -171,7 +171,7 @@ License: MIT
 		max-width: 100%;
 	}
 
-	@media ( min-width: 1620px ) {
+	@media ( min-width: 1560px ) {
 		.lp-col-lg-5 {
 			flex: 0 0 50% !important;
 			max-width: 50% !important;
@@ -933,7 +933,7 @@ License: MIT
 	}
 }
 
-@media ( min-width: 992px ) {
+@media ( min-width: 1024px ) {
 	.lp-col-lg {
 		flex-basis: 0;
 		flex-grow: 1;
@@ -1145,7 +1145,7 @@ License: MIT
 	}
 }
 
-@media ( min-width: 1320px ) {
+@media ( min-width: 1440px ) {
 	.lp-col-xl {
 		flex-basis: 0;
 		flex-grow: 1;
@@ -1357,7 +1357,7 @@ License: MIT
 	}
 }
 
-@media ( min-width: 1620px ) {
+@media ( min-width: 1560px ) {
 	.lp-col-xxl {
 		flex-basis: 0;
 		flex-grow: 1;

--- a/stylesheets/commons/Grid.scss
+++ b/stylesheets/commons/Grid.scss
@@ -202,6 +202,13 @@ License: MIT
 			max-width: 50% !important;
 		}
 	}
+
+	@media ( min-width: 1920px ) {
+		.lp-col-lg-6 {
+			flex: 0 0 50% !important;
+			max-width: 50% !important;
+		}
+	}
 }
 
 .lp-container-fluid {

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -1592,13 +1592,13 @@ tr.stats-row:nth-child( 2n+1 ) {
 	}
 }
 
-@media ( max-width: 989px ) {
+@media ( max-width: 1023px ) {
 	.matchpage-team2col {
 		order: 2;
 	}
 }
 
-@media ( min-width: 990px ) {
+@media ( min-width: 1024px ) {
 	.matchpage-team2col {
 		order: 4;
 	}
@@ -1832,19 +1832,19 @@ Author(s): FO-nTTaX
 	}
 }
 
-@media ( min-width: 992px ) {
+@media ( min-width: 1024px ) {
 	.pull-right-md {
 		float: right;
 	}
 }
 
-@media ( min-width: 1320px ) {
+@media ( min-width: 1440px ) {
 	.pull-right-lg {
 		float: right;
 	}
 }
 
-@media ( min-width: 1620px ) {
+@media ( min-width: 1560px ) {
 	.pull-right-xl {
 		float: right;
 	}
@@ -2588,7 +2588,7 @@ Author(s): hjpalpha
 	display: none;
 }
 
-@media screen and ( max-width: 1620px ) {
+@media screen and ( max-width: 1560px ) {
 	.sc2-stream-page-oppponent-info,
 	.sc2-stream-page-oppponent-info2 {
 		width: 25%;
@@ -2611,7 +2611,7 @@ Author(s): hjpalpha
 	}
 }
 
-@media screen and ( max-width: 992px ) {
+@media screen and ( max-width: 1024px ) {
 	.sc2-stream-page-oppponent-info,
 	.sc2-stream-page-oppponent-info2 {
 		width: 50%;

--- a/stylesheets/commons/NavigationCard.scss
+++ b/stylesheets/commons/NavigationCard.scss
@@ -6,11 +6,11 @@
 	position: relative;
 
 	@media ( min-width: 576px ) {
-		grid-template-columns: repeat( 4, 1fr );
+		grid-template-columns: repeat( 5, 1fr );
 	}
 
 	@media ( min-width: 768px ) {
-		grid-template-columns: repeat( 5, 1fr );
+		grid-template-columns: repeat( 4, 1fr );
 	}
 
 	@media ( min-width: 1024px ) {

--- a/stylesheets/commons/NavigationCard.scss
+++ b/stylesheets/commons/NavigationCard.scss
@@ -6,11 +6,11 @@
 	position: relative;
 
 	@media ( min-width: 576px ) {
-		grid-template-columns: repeat( 5, 1fr );
+		grid-template-columns: repeat( 4, 1fr );
 	}
 
 	@media ( min-width: 768px ) {
-		grid-template-columns: repeat( 4, 1fr );
+		grid-template-columns: repeat( 5, 1fr );
 	}
 
 	@media ( min-width: 1024px ) {


### PR DESCRIPTION
## Summary

New viewports, so our pages look good on all types of devices. Currently, especially on smaller viewport sizes, content get's squished and unreadable on certain pages. Also, content on really large screen gets stretched and hard to read. We aim to improve this by tweaking the responsivity on smaller breakpoints, and introducing content centering on larger breakpoints.

Note that these Module changes don't reflect reality in isolation, as there are changes needed to the wiki skin layout together with the module changes.

## Additional info

This PR needs to be merged in sync with skin and extension changes.

## Design reference
New viewports:
<img width="2474" height="1196" alt="image" src="https://github.com/user-attachments/assets/e78ccf66-c6c0-4588-a611-d27a23b63444" />

Large viewport variants we are looking to A/B test on different wikis:
<img width="2177" height="1270" alt="image" src="https://github.com/user-attachments/assets/e361582a-363b-414f-a991-687c4fb5354f" />

Large viewport variants are applied to the following wikis:
Option A: See [Overwatch](https://liquipedia.net/overwatch/Main_Page) (no changes needed as this is the layout currently)
Option B: See [Hearthstone](https://liquipedia.net/hearthstone/User:Eetwalt)
Option C: See [Dota 2 ](https://liquipedia.net/dota2/User:Eetwalt)
Option D: See [Wildrift](https://liquipedia.net/wildrift/User:Eetwalt)