### PR TITLE
fix(match2): league icon not read properly in valorant matchpage under light theme

### DIFF
--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -295,7 +295,7 @@ function MatchPage:_renderTeamStats(game)
 						Div{
 							classes = {'match-bm-team-stats-list-cell'},
 							children = IconImage{
-								imageLight = self:getMatchContext().iconlight,
+								imageLight = self:getMatchContext().icon,
 								imageDark = self:getMatchContext().icondark,
 								size = 'x25px',
 							}


### PR DESCRIPTION
## Summary

small oversight from #6558

## How did you test this change?

dev