### PR TITLE
fix: Change head coach abbr for THA to HC

### DIFF
--- a/lua/wikis/commons/StaffRoles.lua
+++ b/lua/wikis/commons/StaffRoles.lua
@@ -13,7 +13,7 @@ local staffRoles = {
 	['caster'] = {category = 'Casters', display = 'Caster'},
 	['assistant coach'] = {category = 'Coaches', display = 'Assistant Coach', abbreviation = 'AC.'},
 	['coach'] = {category = 'Coaches', display = 'Coach', abbreviation = 'C.'},
-	['head coach'] = {category = 'Coaches', display = 'Head Coach', abbreviation = 'C.'},
+	['head coach'] = {category = 'Coaches', display = 'Head Coach', abbreviation = 'HC.'},
 	['positional coach'] = {category = 'Coaches', display = 'Positional Coach'},
 	['strategic coach'] = {category = 'Coaches', display = 'Strategic Coach'},
 	['creator'] = {category = 'Content Creators', display = 'Content Creator', abbreviation = 'CC.'},


### PR DESCRIPTION
## Summary

Currently:
The Display for Assistant Coach in THA is -> AC. (tooltip Assistant Coach)
The Display for Coach in THA is -> C. (tooltip Coach)
The Display for Head Coach in THA is -> C. (tooltip Head Coach)

By changing the abbrevation to HC. it is possible to distinguish between Coaches and Head Coaches in THA without having to use the tooltip. This is especially helpful for mobile view. 


## How did you test this change?

i did not
