### PR TITLE
feat(match2): Add multiple missing params to marvelrivals match copy pasta generator

### DIFF
--- a/lua/wikis/marvelrivals/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/marvelrivals/GetMatchGroupCopyPaste/wiki.lua
@@ -40,6 +40,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
+		Logic.readBool(args.mvp) and (INDENT .. '|mvp=') or nil,
 		INDENT .. '}}'
 	)
 


### PR DESCRIPTION
## Summary

The form for the match copy pasta generator for matchlists and brackets on the marvelrivals wiki has several inputs that are currently not doing anything. Rather then removing them from the form they should actually generate the correct output in the generator.

This PR should add MVPs (new), winner (currently in form but not working, bestof=x (currently in form but not working), score (currently in form but not working), finished (currently in form but not working) and caster (1+2) (currently in form but not working) to the output.

## How did you test this change?

[dev](https://liquipedia.net/marvelrivals/Module:GetMatchGroupCopyPaste/wiki/dev)
