### PR TITLE
feat(infobox): Add a custom team infobox to marvelrivals

### DIFF
--- a/lua/wikis/marvelrivals/Infobox/Team/Custom.lua
+++ b/lua/wikis/marvelrivals/Infobox/Team/Custom.lua
@@ -1,0 +1,47 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+local String = Lua.import('Module:StringUtils')
+
+local Team = Lua.import('Module:Infobox/Team')
+
+---@class MarvelrivalsInfoboxTeam: InfoboxTeam
+local CustomTeam = Class.new(Team)
+
+---@param frame Frame
+---@return Html
+function CustomTeam.run(frame)
+	local team = CustomTeam(frame)
+
+	return team:createInfobox()
+end
+
+---@param lpdbData table
+---@param args table
+---@return table
+function CustomTeam:addToLpdb(lpdbData, args)
+	lpdbData.extradata.competesin = string.upper(args.league or '')
+
+	return lpdbData
+end
+
+---@param args table
+---@return string[]
+function CustomTeam:getWikiCategories(args)
+	local categories = {}
+
+	if String.isNotEmpty(args.league) then
+		table.insert(categories, string.upper(args.league) .. ' Teams')
+	end
+
+	return categories
+end
+
+return CustomTeam


### PR DESCRIPTION
## Summary

MarvelRivals wants to display Collegiate (school) teams on the Portal:Teams. This custom enables them to set a league=collegiate in the team infobox to save the team into lpdb extradata, the extradata can be queried in Portal:Teams. 

Same behaviour/functionality as in the overwatch wiki, maybe there is a better way to achieve this than what we did there.

[request on discord](https://discord.com/channels/93055209017729024/1209065403955806270/1418678807178514533)

## How did you test this change?
[dev](https://liquipedia.net/marvelrivals/Module:Infobox/Team/Custom/dev/iGeneral)

Input in Portal:Teams with the new extradata
<img width="1034" height="1112" alt="grafik" src="https://github.com/user-attachments/assets/03e35b8b-e80a-4fec-9f47-8abe3f6a7fa9" />
