### PR TITLE
fix(match2): display name arg in legacy wrapper not processed correctly

### DIFF
--- a/lua/wikis/commons/MatchGroup/Legacy.lua
+++ b/lua/wikis/commons/MatchGroup/Legacy.lua
@@ -13,6 +13,7 @@ local Class = Lua.import('Module:Class')
 local CopyPaste = Lua.import('Module:GetMatchGroupCopyPaste')
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
+local Opponent = Lua.import('Module:Opponent/Custom')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
@@ -272,6 +273,10 @@ end
 function MatchGroupLegacy:readOpponent(opponentData)
 	local opponent = self:_copyAndReplace(opponentData, self.args)
 	opponent.type = self.bracketType
+	if self.bracketType == Opponent.solo and Logic.isNotEmpty(opponent.displayname) then
+		opponent.link = opponent.name
+		opponent.name = Table.extract(opponent, 'displayname')
+	end
 	return opponent
 end
 


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/bdcb878e3a21f6d8637b26e0f8798af3295e9205/lua/wikis/commons/MatchGroup/Legacy.lua#L223-L233

https://github.com/Liquipedia/Lua-Modules/blob/bdcb878e3a21f6d8637b26e0f8798af3295e9205/lua/wikis/commons/Opponent.lua#L402-L410

Legacy parser stores the display name of a solo opponent under `displayname` and the pagename under `name`. This is problematic as `Opponent.readOpponentArgs` expects the display name to be under `name` and the pagename to be under `link`.
This PR adds an extra check to see if display name arg is supplied from the legacy wrapper template, and if so, adjusts the param names accordingly.

## How did you test this change?

preview with dev