### PR TITLE
fix: change vodgame to vod in Splatoon Copypaste

### DIFF
--- a/lua/wikis/splatoon/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/splatoon/GetMatchGroupCopyPaste/wiki.lua
@@ -51,11 +51,9 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.hasDate) and {
 			INDENT .. '|date=',
 			INDENT .. '|twitch= |youtube=',
-			INDENT .. '|mvp='
+			INDENT .. '|mvp=',
+			INDENT .. '|vod='
 		} or nil,
-		Array.map(Array.range(1, bestof), function (i)
-			return INDENT .. '|vodgame'.. i ..'='
-		end),
 		(mapVeto and VETOES[bestof]) and {
 			INDENT .. '|mapveto={{MapVeto',
 			INDENT .. INDENT .. '|firstpick=',
@@ -73,6 +71,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 				INDENT .. INDENT .. '|t1w1= |t1w2= |t1w3= |t1w4=',
 				INDENT .. INDENT .. '|t2w1= |t2w2= |t2w3= |t2w4=',
 				INDENT .. INDENT .. '|score1=|score2=|winner=',
+				INDENT .. INDENT .. '|vod=',
 				INDENT .. '}}'
 			}
 		end),


### PR DESCRIPTION
## Summary
This might be my oversight, that `vodgame` exists within the generator but this is an unused param (no longer works) by now, so I changed it to be just `vod` now
