### PR TITLE
feat(stylesheets): Adjust size of the icon to match text size better

### DIFF
--- a/stylesheets/commons/TeamTemplates.scss
+++ b/stylesheets/commons/TeamTemplates.scss
@@ -25,33 +25,33 @@ Author(s): FO-nTTaX
 
 .team-template-image img {
 	width: 60px;
-	height: 25px;
+	height: 20px;
 	image-rendering: -webkit-optimize-contrast;
 }
 
 .team-template-image-icon {
 	width: 60px;
-	height: 25px;
+	height: 20px;
 	display: inline-block;
 	text-align: center;
 }
 
 .team-template-image-icon img {
 	max-width: 50px;
-	max-height: 25px;
+	max-height: 20px;
 	width: auto;
 	height: auto;
 }
 
 .team-template-image-icon i {
-	font-size: 25px;
+	font-size: 20px;
 	vertical-align: middle;
 	color: var( --clr-secondary-70 );
 }
 
 .team-template-image-legacy img {
 	width: 60px;
-	height: 25px;
+	height: 20px;
 }
 
 .tabs .team-template-image img {


### PR DESCRIPTION
## Summary
While making some changes to the POIdrop template in Apex I notice that teamicons have size of 25px which I would say is too big. Would be possible to change it to 20px instead to match font size of the text better?

before:
<img width="175" height="72" alt="image" src="https://github.com/user-attachments/assets/8b080e47-9222-40b1-818a-d069e523fc25" />

after:
<img width="182" height="60" alt="image" src="https://github.com/user-attachments/assets/21267a02-a15c-46b6-a209-1094d469ff5a" />

## How did you test this change?
https://liquipedia.net/apexlegends/User:Sl0thyMan/Sandbox (example usage of TeamShort template)
dev tools
(Only on this POIdrop template)