### PR TITLE
fix(match2): scss broken for dota2 stats header title in matchpage

### DIFF
--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1168,7 +1168,7 @@ span.slash {
 			border-color: var( --clr-secondary-25 );
 		}
 
-		@at-root html h4#{&}-title {
+		&-title {
 			font-weight: bold;
 			text-transform: uppercase;
 			color: var( --clr-on-background ) !important;


### PR DESCRIPTION
## Summary

Related: #6463

https://github.com/Liquipedia/Lua-Modules/blob/93b33c553fef1efaf1c10b6705eaa232d0fb0cd8/stylesheets/commons/BigMatch.scss#L1171-L1177

The above scss compiles to the following css in php-scss 1.x:

```css
html h4self-header-title {
    font-weight: bold;
    text-transform: uppercase;
    color: var(--clr-on-background) !important;
    margin: 0;
    padding: 0
}
```

This PR adjusts the stylesheet to workaround the scss issue.

_Note: May become obsolete with Liquipedia/ResourceLoaderArticles#17_

## How did you test this change?

browser dev tools