### PR TITLE
feat: upcoming events in infobox

### DIFF
--- a/lua/wikis/rainbowsix/Infobox/Team/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Team/Custom.lua
@@ -49,7 +49,10 @@ end
 ---@return Widget?
 function CustomTeam:createBottomContent()
 	if not self.args.disbanded then
-		return UpcomingTournaments.team{name = self.teamTemplate.templatename}
+		return UpcomingTournaments.team{
+			name = self.args.lpdbname or self.teamTemplate.templatename,
+			additionalConditions = ConditionNode(ColumnName('liquipediatiertype'), Comparator.neq, 'Points')
+		}
 	end
 end
 


### PR DESCRIPTION
## Summary
Adding Upcoming/Ongoing events to the team infobox. Asked around in the Discord channel as well and no one opposed it

## How did you test this change?

https://liquipedia.net/rainbowsix/Module:Infobox/Team/Custom/dev/centaur

https://liquipedia.net/rainbowsix/index.php?title=G2_Esports&diff=prev&oldid=813727
