### PR TITLE
feat: change toggle btn to show/hide all matchlists to small

### DIFF
--- a/javascript/commons/Collapse.js
+++ b/javascript/commons/Collapse.js
@@ -120,7 +120,7 @@ liquipedia.collapse = {
 				hideAllText = 'Hide all';
 			}
 			const button = document.createElement( 'button' );
-			button.classList.add( 'btn', 'btn-secondary' );
+			button.classList.add( 'btn', 'btn-secondary', 'btn-small' );
 			if ( toggleGroup.classList.contains( 'toggle-state-hide' ) ) {
 				button.innerHTML = this.makeIcon( false ) + ' ' + hideAllText;
 			} else {


### PR DESCRIPTION
## Summary
We felt it was a bit too big with medium based on its placement

## How did you test this change?
devtools