### PR TITLE
fix(match2): missing nil catch in lol matchpage

### DIFF
--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -118,7 +118,7 @@ function MatchPage:populateGames()
 						items = Array.map(Array.range(1, ITEMS_TO_SHOW), function(idx)
 							return player.items[idx] or DEFAULT_ITEM
 						end),
-						runeKeystone = Array.filter(player.runes.primary.runes, function(rune)
+						runeKeystone = Array.filter(player.runes.primary.runes or {}, function(rune)
 							return KEYSTONES[rune]
 						end)[1]
 					})


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/6cc5c96719492f15e2fc321a2b5494b4db18b6f8/lua/wikis/leagueoflegends/MatchPage.lua#L121

`player.runes.primary` could be an empty table if the upstream data is (partially) bad. This PR mitigates such absence of data points from upstream, handling the error gracefully instead of yelling out errors.

## How did you test this change?

dev