### PR TITLE
fix(infobox): show stats icon for generic stats page links

### DIFF
--- a/stylesheets/commons/Icons.scss
+++ b/stylesheets/commons/Icons.scss
@@ -193,6 +193,7 @@ https://liquipedia.net/commons/Infobox_Icons
 	@include icon-make-image( sostronk, "//liquipedia.net/commons/images/4/4e/InfoboxIcon_SoStronk.png" );
 	@include icon-make-image( spotify, "//liquipedia.net/commons/images/1/14/InfoboxIcon_Spotify.png" );
 	@include icon-make-image( start-gg, "//liquipedia.net/commons/images/9/9d/InfoboxIcon_StartGG.png" );
+	@include icon-make-image( stats, "//liquipedia.net/commons/images/c/ce/Match_Info_Stats.png" );
 	@include icon-make-image( statshark, "//liquipedia.net/commons/images/3/33/InfoboxIcon_StatShark.png" );
 	@include icon-make-image( steam, "//liquipedia.net/commons/images/d/d0/InfoboxIcon_Steam.png" );
 	@include icon-make-image( stratz, "//liquipedia.net/commons/images/3/3e/InfoboxIcon_Stratz.png" );


### PR DESCRIPTION
## Summary
Adds a class for lp-stats to allow for use, with logo matching that used in [Module:Links](https://github.com/Liquipedia/Lua-Modules/blob/main/lua/wikis/commons/Links.lua)
