### PR TITLE
fix: Transfer Navbox adding new quarter with wrong link

### DIFF
--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -128,7 +128,7 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 
 		if quarter then
 			local ordinal = currentQuarter .. Ordinal.suffix(currentQuarter)
-			pageName = pageName:gsub('(%d)%a%a(_[qQ]uarter)', ordinal .. '%1')
+			pageName = pageName:gsub('(%d)%a%a(_[qQ]uarter)', ordinal .. '%2')
 			table.insert(children.child0, 1, Link{
 				link = pageName,
 				children = {'Q' .. currentQuarter},


### PR DESCRIPTION
## Summary
returning the wrong capture group leads to links of the kind `.../2025/4th3` instead of the intended `.../2025/4th_Quarter`

reported on discord: https://discord.com/channels/93055209017729024/1209065403955806270/1424337620162445333

## How did you test this change?
dev