### PR TITLE
fix(infobox) : icon vs series handling for fighters

### DIFF
--- a/lua/wikis/fighters/Infobox/League/Custom.lua
+++ b/lua/wikis/fighters/Infobox/League/Custom.lua
@@ -46,11 +46,14 @@ function CustomLeague.run(frame)
 	args.circuitabbr = args.circuitabbr or CustomLeague.getAbbrFromSeries(args.circuit)
 
 	-- Auto Icon
-	local seriesIconLight, seriesIconDark = CustomLeague.getIconFromSeries(args.series)
-	args.circuitIconLight, args.circuitIconDark = CustomLeague.getIconFromSeries(args.circuit)
-	args.icon = args.icon or seriesIconLight or args.circuitIconLight
-	args.icondark = args.icondark or seriesIconDark or args.circuitIconDark
-	args.display_series_icon_from_manual_input = MANUAL_SERIES_ICON
+    local seriesIconLight, seriesIconDark = CustomLeague.getIconFromSeries(args.series)
+    args.circuitIconLight, args.circuitIconDark = CustomLeague.getIconFromSeries(args.circuit)
+    local icons = Logic.emptyOr(
+        {args.icon, args.icondark},
+        {seriesIconLight, seriesIconDark},
+        {args.circuitIconLight, args.circuitIconDark}
+    )
+    args.icon, args.icondark = unpack(icons)
 
 	-- Normalize name
 	args.game = Game.toIdentifier{game = args.game}


### PR DESCRIPTION
## Summary
<img width="1138" height="453" alt="image" src="https://github.com/user-attachments/assets/52497d86-ece4-4961-b293-fc9e64ac1c8f" />

This fixes the issue where e.g. on Lightmode series pulls `|icon` while Darkmode pulls `LIS template` probably due to the custom series thingy inside there code

<img width="197" height="37" alt="image" src="https://github.com/user-attachments/assets/e57b3da8-c723-4dce-8163-b211b36de9d2" />
<img width="173" height="30" alt="image" src="https://github.com/user-attachments/assets/1b5f4f10-e7dd-4a47-862e-4f1a24d94572" />

Code fixes are untested revision provided by hjpa, i've picked up into setting up test cases for it. I dont have plans to rework that part because I don't even edit fighters but just picking it up due to it was left unpicked.

## How did you test this change?
https://liquipedia.net/fighters/Street_Fighter_League/World_Championship/2024 
|dev=h2
