### PR TITLE
feat: Add transparent theme color for POIDraft

### DIFF
--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -2885,20 +2885,20 @@ Slightly transparent imagelabel on POIDraft
 *******************************************************************************/
 .poi-label-rotation-one {
 	.theme--light & {
-		background-color: rgba(204, 171, 0, 0.95);
+		background-color: rgba( 204, 171, 0, 0.95 );
 	}
 
 	.theme--dark & {
-		background-color: rgba(102, 84, 0, 0.95);
+		background-color: rgba( 102, 84, 0, 0.95 );
 	}
 }
 
 .poi-label-rotation-two {
 	.theme--light & {
-		background-color: rgba(204, 225, 255, 0.95);
+		background-color: rgba( 204, 225, 255, 0.95 );
 	}
 
 	.theme--dark & {
-		background-color: rgba(0, 25, 51, 0.95);
+		background-color: rgba( 0, 25, 51, 0.95 );
 	}
 }


### PR DESCRIPTION
## Summary
I got some suggestions and wanna slowly apply them. First of the suggestion was to have POI Label to have transparent color
If merged need to replace **placement-1** and **bg-dq** for these custom css.
Personally not sure if there are any rules when to use RGBA/HEX/etc... I wouldn't be suprise if my implementation is not even good. CSS is a big unknown for me.

Related templates and modules:
I know that modules are not likely up to standard. I shared them just so you have idea where this css gonna be used
https://liquipedia.net/apexlegends/Module:Widget/POIDraft/POIMap
https://liquipedia.net/apexlegends/Module:Widget/POIDraft/POIMap/Data
https://liquipedia.net/apexlegends/Module:Widget/POIDraft/Table
https://liquipedia.net/apexlegends/Module:Widget/POIDraft/POILabel

Page where such POIDraft template is used:
https://liquipedia.net/apexlegends/Apex_Legends_Global_Series/2025/Split_2/Pro_League/EMEA/POI_Drafts

## How did you test this change?

dev tools

Before             |  After
:-------------------------:|:-------------------------:
<img width="665" height="689" alt="image" src="https://github.com/user-attachments/assets/942ac447-f7af-4133-8f79-aafc99e8411a" />  | <img width="722" height="735" alt="image" src="https://github.com/user-attachments/assets/411a7a4a-371b-41ce-9b03-4192be700337" />

Before             |  After
:-------------------------:|:-------------------------:
<img width="654" height="677" alt="image" src="https://github.com/user-attachments/assets/26573916-907d-4617-8aeb-705b518d9301" />  | <img width="709" height="735" alt="image" src="https://github.com/user-attachments/assets/63ed345c-8721-4ae5-857b-2e3e69ab958e" />

