### PR TITLE
ci: disable "mediawiki/no-unlabeled-buttonwidget" eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
 		"es/no-array-from": "off",
 		"mediawiki/class-doc": "off",
 		"mediawiki/no-nodelist-unsupported-methods": "off",
+		"mediawiki/no-unlabeled-buttonwidget": "off",
 		"es-x/no-block-scoped-variables": "off",
 		"es-x/no-string-prototype-startswith": "off",
 		"es-x/no-string-prototype-includes": "off",


### PR DESCRIPTION
Closes https://github.com/Liquipedia/Lua-Modules/issues/6643

## Summary

We did the same ion the LakesideView repo

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
