### PR TITLE
feat(mainpage): New Brawl Stars Logo

### DIFF
--- a/lua/wikis/brawlstars/MainPageLayout/data.lua
+++ b/lua/wikis/brawlstars/MainPageLayout/data.lua
@@ -80,8 +80,8 @@ local CONTENT = {
 
 return {
 	banner = {
-		lightmode = 'Brawl_Stars_2025_allmode.png',
-		darkmode = 'Brawl_Stars_2025_allmode.png',
+		lightmode = 'Brawl Stars 2025 allmode.png',
+		darkmode = 'Brawl Stars 2025 allmode.png',
 	},
 	metadesc = 'The Brawl Stars esports wiki covering everything from players, teams and transfers, ' ..
 		'to tournaments and results, maps, and Brawlers.',


### PR DESCRIPTION
## Summary
Two months ago Brawl Stars changed their logo, but it wasnt until few weeks ago that they uploaded the logo onto their asset kit

<img width="527" height="561" alt="image" src="https://github.com/user-attachments/assets/b9e99d9d-72cc-4980-bc73-b98a892356cb" />

<img width="526" height="171" alt="image" src="https://github.com/user-attachments/assets/58952b4e-765e-43b4-9fe1-4e9993c14229" />

## Note 
oos, idk if they'll need new wiki icon or not,its still the same skull ish shape
