### PR TITLE
rename forestgreen theme to forest

### DIFF
--- a/stylesheets/commons/Bracket.scss
+++ b/stylesheets/commons/Bracket.scss
@@ -1632,7 +1632,7 @@ Author(s): spazer
 .bg-up,
 .bg-proceed,
 .bg-win {
-	background-color: var( --clr-forestgreen-background-color, #ddf4dd ) !important;
+	background-color: var( --clr-forest-background-color, #ddf4dd ) !important;
 }
 
 .bg-su,

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -942,12 +942,12 @@ div.brkts-popup-body-element-thumbs {
 
 .brkts-popup-body-gradient-left {
 	padding: 4px 0;
-	background: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 35%, var( --table-background-color, #ffffff ) 35%, var( --table-background-color, #ffffff ) 65%, var( --clr-forestgreen-background-color, #ddf4dd ) 65% ) !important;
+	background: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 35%, var( --table-background-color, #ffffff ) 35%, var( --table-background-color, #ffffff ) 65%, var( --clr-forest-background-color, #ddf4dd ) 65% ) !important;
 }
 
 .brkts-popup-body-gradient-right {
 	padding: 4px 0;
-	background: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 35%, var( --table-background-color, #ffffff ) 35%, var( --table-background-color, #ffffff ) 65%, var( --clr-forestgreen-background-color, #ddf4dd ) 65% ) !important;
+	background: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 35%, var( --table-background-color, #ffffff ) 35%, var( --table-background-color, #ffffff ) 65%, var( --clr-forest-background-color, #ddf4dd ) 65% ) !important;
 }
 
 .brkts-popup-body-gradient-draw {

--- a/stylesheets/commons/Colours.scss
+++ b/stylesheets/commons/Colours.scss
@@ -379,11 +379,11 @@ ul.nav-tabs li.game-brawl,
 /* FOREST GREEN */
 .forest-green-text,
 .forest-theme-dark-text {
-	color: var( --clr-forestgreen-20, #1e7a1d );
+	color: var( --clr-forest-20, #1e7a1d );
 }
 
 .forest-green-faction-text {
-	color: var( --clr-forestgreen-20, #1f821f );
+	color: var( --clr-forest-20, #1f821f );
 }
 
 .forest-green-non-text {
@@ -391,7 +391,7 @@ ul.nav-tabs li.game-brawl,
 }
 
 .bg-seedup {
-	background-color: var( --clr-forestgreen-90, #dbeded );
+	background-color: var( --clr-forest-90, #dbeded );
 }
 
 .forest-green-bg,
@@ -408,15 +408,15 @@ ul.nav-tabs li.game-brawl,
 ul.nav-tabs li.game-melee,
 .overview.game-melee,
 .ambox-green {
-	background-color: var( --clr-forestgreen-background-color, #ddf4dd );
+	background-color: var( --clr-forest-background-color, #ddf4dd );
 }
 
 .bg-win-important {
-	background-color: var( --clr-forestgreen-background-color, #ddf4dd ) !important;
+	background-color: var( --clr-forest-background-color, #ddf4dd ) !important;
 }
 
 .forest-theme-dark-bg {
-	background-color: var( --clr-forestgreen-20, #1e7a1d );
+	background-color: var( --clr-forest-20, #1e7a1d );
 }
 
 .forest-green-dark-alt-bg,
@@ -425,15 +425,15 @@ ul.nav-tabs li.game-melee,
 }
 
 .forest-theme-light-text {
-	color: var( --clr-forestgreen-90, #ddf4dd );
+	color: var( --clr-forest-90, #ddf4dd );
 }
 
 .forest-theme-light-alt-text {
-	color: var( --clr-forestgreen-80, #c4ecc4 );
+	color: var( --clr-forest-80, #c4ecc4 );
 }
 
 .forest-theme-light-alt-bg {
-	background-color: var( --clr-forestgreen-80, #c4ecc4 );
+	background-color: var( --clr-forest-80, #c4ecc4 );
 }
 
 .forest-green-theme-dark-alt-bg-striped {
@@ -704,7 +704,7 @@ ul.nav-tabs li.game-wiiu,
 }
 
 .ambox-green {
-	border-color: var( --clr-forestgreen-40, #5ecb5e );
+	border-color: var( --clr-forest-40, #5ecb5e );
 }
 
 .ambox-red {

--- a/stylesheets/commons/Faction.scss
+++ b/stylesheets/commons/Faction.scss
@@ -9,7 +9,7 @@ Author(s): hjpalpha
 .Protoss th,
 .warcraft-nightelf td,
 .Protoss td {
-	background: var( --clr-forestgreen-90, #d1ffcc ) !important;
+	background: var( --clr-forest-90, #d1ffcc ) !important;
 }
 
 .Zerg,
@@ -138,6 +138,6 @@ Author(s): hjpalpha
 	.warcraft-nightelf th,
 	.Protoss td,
 	.warcraft-nightelf td {
-		background: var( --clr-forestgreen-20, #d1ffcc ) !important;
+		background: var( --clr-forest-20, #d1ffcc ) !important;
 	}
 }

--- a/stylesheets/commons/Fountain.scss
+++ b/stylesheets/commons/Fountain.scss
@@ -89,7 +89,7 @@ html.theme--dark .componentsinvert {
 		}
 
 		&2 {
-			background-color: var( --clr-forestgreen-40 ); // #0dbf0d;
+			background-color: var( --clr-forest-40 ); // #0dbf0d;
 			font-weight: bold;
 			color: #e2e2e6;
 		}
@@ -114,7 +114,7 @@ html.theme--dark .componentsinvert {
 	}
 
 	&_accessories {
-		background-color: var( --clr-forestgreen-base ); // #2cba2c
+		background-color: var( --clr-forest-base ); // #2cba2c
 		font-weight: bold;
 		color: #e2e2e6;
 	}

--- a/stylesheets/commons/Infobox.scss
+++ b/stylesheets/commons/Infobox.scss
@@ -268,11 +268,11 @@ Author(s): FO-nTTaX
 
 /* Starcraft II - Legacy of the Void */
 .theme--light .fo-nttax-infobox-wrapper.infobox-lotv .infobox-header {
-	background-color: var( --clr-forestgreen-90 );
+	background-color: var( --clr-forest-90 );
 }
 
 .theme--dark .fo-nttax-infobox-wrapper.infobox-lotv .infobox-header {
-	background-color: var( --clr-forestgreen-20 );
+	background-color: var( --clr-forest-20 );
 }
 
 /* Starcraft II - Custom mods */
@@ -290,7 +290,7 @@ Author(s): FO-nTTaX
 }
 
 .fo-nttax-infobox-wrapper.infobox-melee .infobox-header {
-	background-color: var( --clr-forestgreen-background-color, #b6e5c6 );
+	background-color: var( --clr-forest-background-color, #b6e5c6 );
 }
 
 .fo-nttax-infobox-wrapper.infobox-brawl .infobox-header {

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -2080,11 +2080,11 @@ Template/Module: Recent games // Recent matches ( for new Bracket/Match System )
 Author(s): hjpalpha
 *******************************************************************************/
 .recent-matches-left {
-	background-image: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 45%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 55%, var( --clr-forestgreen-background-color, #ddf4dd ) 75% ) !important;
+	background-image: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 45%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 55%, var( --clr-forest-background-color, #ddf4dd ) 75% ) !important;
 }
 
 .recent-matches-right {
-	background-image: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 45%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 55%, var( --clr-forestgreen-background-color, #ddf4dd ) 75% ) !important;
+	background-image: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 45%, var( --table-background-color, var( --clr-surface-1, #ffffff ) ) 55%, var( --clr-forest-background-color, #ddf4dd ) 75% ) !important;
 }
 
 .recent-matches-draw {
@@ -2092,11 +2092,11 @@ Author(s): hjpalpha
 }
 
 .recent-matches-left-publishertier {
-	background-image: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --publisher-premier-highlight-background-color, #ffffcc ) 45%, var( --publisher-premier-highlight-background-color, #ffffcc ) 55%, var( --clr-forestgreen-background-color, #ddf4dd ) 75% ) !important;
+	background-image: linear-gradient( to left, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --publisher-premier-highlight-background-color, #ffffcc ) 45%, var( --publisher-premier-highlight-background-color, #ffffcc ) 55%, var( --clr-forest-background-color, #ddf4dd ) 75% ) !important;
 }
 
 .recent-matches-right-publishertier {
-	background-image: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --publisher-premier-highlight-background-color, #ffffcc ) 45%, var( --publisher-premier-highlight-background-color, #ffffcc ) 55%, var( --clr-forestgreen-background-color, #ddf4dd ) 75% ) !important;
+	background-image: linear-gradient( to right, var( --clr-cinnabar-background-color, #fbdfdf ) 25%, var( --publisher-premier-highlight-background-color, #ffffcc ) 45%, var( --publisher-premier-highlight-background-color, #ffffcc ) 55%, var( --clr-forest-background-color, #ddf4dd ) 75% ) !important;
 }
 
 .recent-matches-draw-publishertier {

--- a/stylesheets/commons/Prizepooltable.scss
+++ b/stylesheets/commons/Prizepooltable.scss
@@ -232,11 +232,11 @@ div.prizepooltable > div.csstable-widget-row.bg-win {
 }
 
 div.csstable-widget-row.bg-win > .csstable-widget-cell {
-	border-bottom: 0.125rem solid var( --clr-forestgreen-background-color, transparent );
+	border-bottom: 0.125rem solid var( --clr-forest-background-color, transparent );
 }
 
 div.bg-win > *.prizepooltable-place {
-	background-color: var( --clr-forestgreen-background-color, inherit );
+	background-color: var( --clr-forest-background-color, inherit );
 }
 
 div.csstable-widget-row.bg-lose {


### PR DESCRIPTION
## Summary
forestgreen is a named color, which leads to odd edgecases in the skin scss. To avoid these we're renaming the forestgreen theme to just forest

## How did you test this change?

Dev wiki
