### PR TITLE
feat(matchticker): change featured tournaments to featured match/tournament

### DIFF
--- a/lua/wikis/commons/MatchTicker.lua
+++ b/lua/wikis/commons/MatchTicker.lua
@@ -99,7 +99,7 @@ end
 ---@field regions string[]?
 ---@field games string[]?
 ---@field newStyle boolean?
----@field featuredTournamentsOnly boolean?
+---@field featuredOnly boolean?
 ---@field displayGameIcons boolean?
 
 ---@class MatchTickerGameData
@@ -155,7 +155,7 @@ function MatchTicker:init(args)
 					return Game.toIdentifier{game=game}
 				end) or nil,
 		newStyle = Logic.readBool(args.newStyle),
-		featuredTournamentsOnly = Logic.readBool(args.featuredTournamentsOnly),
+		featuredOnly = Logic.readBool(args.featuredOnly),
 		displayGameIcons = Logic.readBool(args.displayGameIcons)
 	}
 
@@ -366,7 +366,7 @@ function MatchTicker:parseMatch(match)
 	match.opponents = Array.map(match.match2opponents, function(opponent, opponentIndex)
 		return MatchGroupUtil.opponentFromRecord(match, opponent, opponentIndex)
 	end)
-	if self.config.regions or self.config.featuredTournamentsOnly then
+	if self.config.regions or self.config.featuredOnly then
 		match.tournamentData = MatchTicker.fetchTournament(match.parent)
 	end
 	return match
@@ -387,11 +387,10 @@ function MatchTicker:keepMatch(match)
 		end
 	end
 
-	if self.config.featuredTournamentsOnly then
-		if not match.tournamentData then
-			return false
-		end
-		if not match.tournamentData.featured then
+	if self.config.featuredOnly then
+		local matchIsInFeaturedTournament = match.tournamentData and match.tournamentData.featured
+		local matchIsFeatured = match.extradata and match.extradata.featured
+		if not matchIsInFeaturedTournament and not matchIsFeatured then
 			return false
 		end
 	end

--- a/lua/wikis/commons/MatchTicker/Custom.lua
+++ b/lua/wikis/commons/MatchTicker/Custom.lua
@@ -55,7 +55,7 @@ function CustomMatchTicker.newMainPage(frame)
 	args.tiers = args['filterbuttons-liquipediatier']
 	if args.tiers == 'curated' then
 		args.tiers = nil
-		args.featuredTournamentsOnly = true
+		args.featuredOnly = true
 	end
 
 	args.tiertypes = args['filterbuttons-liquipediatiertype']


### PR DESCRIPTION
## Summary
Changes the (unused) featuredTournamentOnly to cover both featuredMatch and featuredTournaments (with a rename of the variable to match).

The feature will be used on counterstrike

## How did you test this change?

Tested on https://liquipedia.net/counterstrike/User:Rathoz