### PR TITLE
fix(match2): missing nil handling in valorant match pages

### DIFF
--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -64,6 +64,7 @@ function MatchPage:populateGames()
 		game.teams = game.opponents
 		Array.forEach(game.teams, function(team, teamIdx)
 			team.scoreDisplay = game.winner == teamIdx and 'winner' or game.finished and 'loser' or '-'
+			team.postPlant = team.postPlant or {}
 		end)
 	end)
 end


### PR DESCRIPTION
## Summary

Original report: https://discord.com/channels/93055209017729024/372075546231832576/1427684725463711849

Regression from #6645 

Because we now check for round data availability before initializing `postPlant` storage in MGI, setting map manually without API data (i.e., before the map ends) causes `postPlant` to remain uninitialized.
This PR adds a `nil` check for `postPlant` in match page initialization to mitigate the issue.

## How did you test this change?

dev