### PR TITLE
fix: Transparency adjustment for POIDraft

### DIFF
--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -2885,20 +2885,20 @@ Slightly transparent imagelabel on POIDraft
 *******************************************************************************/
 .poi-label-rotation-one {
 	.theme--light & {
-		background-color: rgba( 204, 171, 0, 0.95 );
+		background-color: rgba( 204, 171, 0, 0.75 );
 	}
 
 	.theme--dark & {
-		background-color: rgba( 102, 84, 0, 0.95 );
+		background-color: rgba( 102, 84, 0, 0.75 );
 	}
 }
 
 .poi-label-rotation-two {
 	.theme--light & {
-		background-color: rgba( 204, 225, 255, 0.95 );
+		background-color: rgba( 204, 225, 255, 0.75 );
 	}
 
 	.theme--dark & {
-		background-color: rgba( 0, 25, 51, 0.95 );
+		background-color: rgba( 0, 25, 51, 0.75 );
 	}
 }


### PR DESCRIPTION
## Summary

Regression. Used old values of the transparency.

## How did you test this change?

dev tools
