### PR TITLE
fix: analytic events for mainpage matchticker not registering

### DIFF
--- a/javascript/commons/Analytics.js
+++ b/javascript/commons/Analytics.js
@@ -18,7 +18,7 @@ liquipedia.analytics = {
 					window.amplitude.track( tracker.trackerName, eventProperties );
 				}
 			}
-		} );
+		}, true );
 	},
 
 	findLinkPosition: function( element ) {


### PR DESCRIPTION
## Summary

Noticed matchticker panel doesn't send analytic events as the links are dynamically rendered after initial page load.

This can be fixed by changing the clickhandler to register clicks from the body instead of the individual link elements, which might not exist on page load.

## How did you test this change?

chrome devtools with local overrides to change the js.