### PR TITLE
feat: Add 'Page searched' analytics event

### DIFF
--- a/javascript/commons/Analytics.js
+++ b/javascript/commons/Analytics.js
@@ -8,6 +8,8 @@ liquipedia.analytics = {
 	init: function() {
 		liquipedia.analytics.setupWikiMenuLinkClickAnalytics();
 		liquipedia.analytics.setupLinkClickAnalytics();
+		liquipedia.analytics.setupSearchAnalytics();
+		liquipedia.analytics.setupSearchFormSubmitAnalytics();
 
 		document.body.addEventListener( 'click', ( event ) => {
 			for ( const tracker of liquipedia.analytics.clickTrackers ) {
@@ -15,10 +17,17 @@ liquipedia.analytics = {
 
 				if ( element ) {
 					const eventProperties = tracker.propertiesBuilder( element );
-					window.amplitude.track( tracker.trackerName, eventProperties );
+					liquipedia.analytics.track( tracker.trackerName, eventProperties );
 				}
 			}
 		}, true );
+	},
+
+	track: function( eventName, properties ) {
+		window.amplitude.track( eventName, {
+			'page url': window.location.href,
+			...properties
+		} );
 	},
 
 	findLinkPosition: function( element ) {
@@ -26,35 +35,20 @@ liquipedia.analytics = {
 		if ( analyticsElement ) {
 			return analyticsElement.dataset.analyticsName;
 		}
-
 		const walker = document.createTreeWalker(
 			document.body,
 			NodeFilter.SHOW_ELEMENT,
-			{
-				acceptNode: function( node ) {
-					if ( node.tagName === 'H1' || node.tagName === 'H2' ) {
-						return NodeFilter.FILTER_ACCEPT;
-					}
-					return NodeFilter.FILTER_SKIP;
-				}
-			}
+			( node ) => (
+				[ 'H1', 'H2', 'H3', 'H4' ].includes( node.tagName ) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+			)
 		);
-
 		walker.currentNode = element;
-
 		const headingNode = walker.previousNode();
-
 		if ( !headingNode ) {
 			return null;
 		}
-
 		const clone = headingNode.cloneNode( true );
-		const editSection = clone.querySelector( '.mw-editsection' );
-
-		if ( editSection ) {
-			editSection.remove();
-		}
-
+		clone.querySelector( '.mw-editsection' )?.remove();
 		return clone.textContent.trim();
 	},
 
@@ -64,7 +58,6 @@ liquipedia.analytics = {
 			trackerName: 'Wiki switched',
 			propertiesBuilder: ( wikiMenuLink ) => ( {
 				wiki: wikiMenuLink.closest( '[data-wiki-id]' ).dataset.wikiId,
-				'page url': window.location.href,
 				position: 'wiki menu',
 				destination: wikiMenuLink.href,
 				'trending page': false,
@@ -80,9 +73,55 @@ liquipedia.analytics = {
 			propertiesBuilder: ( link ) => ( {
 				title: link.innerText,
 				position: liquipedia.analytics.findLinkPosition( link ),
-				'page url': window.location.href,
-				'destination url': link.href
+				destination: link.href
 			} )
+		} );
+	},
+
+	setupSearchAnalytics: function() {
+		const searchInput = document.querySelector( '#searchInput' );
+
+		if ( searchInput ) {
+			searchInput.addEventListener( 'input', () => {
+				searchInput.dataset.lastSearchTerm = searchInput.value;
+			} );
+		}
+
+		liquipedia.analytics.clickTrackers.push( {
+			selector: '.mw-searchSuggest-link',
+			trackerName: 'Page searched',
+			propertiesBuilder: ( link ) => {
+				const searchTerm = searchInput?.dataset.lastSearchTerm ?? searchInput?.value ?? '';
+				const getResultPosition = () => {
+					if ( link.querySelector( '.suggestions-special' ) ) {
+						return 'more';
+					}
+
+					return parseInt( link.querySelector( '.suggestions-result' ).getAttribute( 'rel' ), 10 ) + 1;
+				};
+
+				return {
+					'search input': searchTerm,
+					title: link.innerText,
+					destination: link.href,
+					'result position': getResultPosition()
+				};
+			}
+		} );
+	},
+
+	setupSearchFormSubmitAnalytics: function() {
+		document.body.addEventListener( 'submit', ( event ) => {
+			if ( event.target.matches( '#searchform' ) ) {
+				const searchTerm = event.target.querySelector( 'input' ).value;
+
+				liquipedia.analytics.track( 'Page searched', {
+					'search input': searchTerm,
+					title: null,
+					destination: `index.php?search=${ encodeURIComponent( searchTerm ) }`,
+					'result position': 'enter'
+				} );
+			}
 		} );
 	}
 };


### PR DESCRIPTION
## Summary

Adding wiki menu bar search analytics. One for when user submits the search form and another for clicking the search results. Both send the same event.

Also some slight refactoring for making the code more maintainable for future.

## How did you test this change?

chrome dev tools local overrides by pasting the new js from this branch  in place of the current production script.