### PR TITLE
feat: add categories to match pages

### DIFF
--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -67,6 +67,7 @@ local BaseMatchPage = Class.new(
 		self.matchData = match
 		self.games = match.games
 		self.opponents = match.opponents
+		self:addCategories()
 	end
 )
 
@@ -77,7 +78,6 @@ BaseMatchPage.NO_CHARACTER = 'default'
 ---@return Widget
 function BaseMatchPage.getByMatchId(props)
 	local matchPage = BaseMatchPage(props.match)
-	matchPage:addCategories()
 	return matchPage:render()
 end
 


### PR DESCRIPTION
## Summary
Add 2 categories to Match Pages, one that they are "Matches" (similiar to Players or Tournaments) and additionally also add a category for upcoming/ongoing/finished. 

## How did you test this change?
dev
<img width="389" height="62" alt="image" src="https://github.com/user-attachments/assets/a16aa648-ddaa-4471-90c1-b8dc50cdec3d" />
