### PR TITLE
fix(match2): Improve chess matchsummary links collapsing

### DIFF
--- a/lua/wikis/chess/MatchSummary.lua
+++ b/lua/wikis/chess/MatchSummary.lua
@@ -144,7 +144,7 @@ end
 ---@param match any
 ---@return Widget?
 function CustomMatchSummary._linksTable(match)
-	if Logic.isDeepEmpty(match.links) then
+	if Logic.isDeepEmpty(match.links) or Logic.isEmpty(map) then
 		return
 	end
 


### PR DESCRIPTION
## Summary

Currently having even 1 link (like recap or interview) results in appearing useless "Additional Links" row 
Before: <img width="351" height="132" alt="before" src="https://github.com/user-attachments/assets/ae2fe32c-8c4a-46ee-8368-58424727832e" />
After: 
<img width="342" height="105" alt="after" src="https://github.com/user-attachments/assets/2c9dde62-fd04-4e4f-97a5-5b392993de5a" />

Probably better solution would be to exclude match links since collapsible row is for map links (only check those inside maps), but that's beyond my coding skills xD

## How did you test this change?

https://liquipedia.net/chess/Womens_Speed_Chess_Championship/2025#Results