### PR TITLE
fix: OPLeague updated their url

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -204,7 +204,7 @@ local PREFIXES = {
 	},
 	openrec = {'https://www.openrec.tv/live/'},
 	opl = {
-		match = 'https://www.opleague.eu/match/'
+		match = 'https://www.opleague.pro/match/'
 	},
 	osu = {
 		'https://osu.ppy.sh/',


### PR DESCRIPTION
## Summary

opleague updated their links from .eu to .pro

Old urls:
https://www.opleague.eu/
https://www.opleague.eu/match/65167

New urls
https://www.opleague.pro/
https://www.opleague.pro/match/65167

## How did you test this change?

