### PR TITLE
fix(match2): empty link container in chess match summary when there are no links

### DIFF
--- a/lua/wikis/chess/MatchSummary.lua
+++ b/lua/wikis/chess/MatchSummary.lua
@@ -166,6 +166,10 @@ function CustomMatchSummary._linksTable(match)
 		}}
 	end)
 
+	if Logic.isEmpty(rows) then
+		return
+	end
+
 	return Collapsible{
 		tableClasses = {'wikitable-striped'},
 		header = Tr{children = {


### PR DESCRIPTION
## Summary

fixes #6684

## How did you test this change?

dev