### PR TITLE
feat: add analytics for match popup clicking

### DIFF
--- a/javascript/commons/Analytics.js
+++ b/javascript/commons/Analytics.js
@@ -193,7 +193,7 @@ liquipedia.analytics = {
 
 				return {
 					position: liquipedia.analytics.findLinkPosition( match ),
-					participants: participants,
+					participants,
 					type: containerType
 				};
 			}


### PR DESCRIPTION
## Summary
Gather analytics for the opening (or technically for now all clicks) that toggles a match popup.

## How did you test this change?
<img width="878" height="364" alt="image" src="https://github.com/user-attachments/assets/c7ca22ec-377a-4273-94b9-db788d39e57c" />
