### PR TITLE
feat: Add different fields on HoK for different game links

### DIFF
--- a/lua/wikis/honorofkings/Infobox/Character/Custom.lua
+++ b/lua/wikis/honorofkings/Infobox/Character/Custom.lua
@@ -91,7 +91,9 @@ end
 function CustomCharacter:_getCustomCells()
 	local args = self.args
 	local widgets = {
-		Center{children = {Page.makeExternalLink('Official Hero Page', args.page)}},
+		Center{children = {Page.makeExternalLink('Official HoK Global Hero Page', args.page_global)}},
+		Center{children = {Page.makeExternalLink('Official HoK CN Hero Page', args.page_cn)}},
+		Center{children = {Page.makeExternalLink('Official AoV Hero Page', args.page_aov)}},
 	}
 
 	local wins, loses = CharacterWinLoss.run(args.name)


### PR DESCRIPTION
## Summary
Allow for different display text in links to account for 1 hero (character) being used in different game versions.

As requested by @Riieee22 

## How did you test this change?
[/dev/freg](https://liquipedia.net/honorofkings/Module:Infobox/Character/Custom/dev/freg)