### PR TITLE
feat: add analytics for (static) tabs link clicks

### DIFF
--- a/lua/wikis/commons/Tabs.lua
+++ b/lua/wikis/commons/Tabs.lua
@@ -34,7 +34,7 @@ function Tabs.static(args)
 
 	return AnalyticsWidgets{
 		analyticsName = 'Navigation tab',
-		children = HtmlWidgets.Fragment{children = {
+		children = {
 			HtmlWidgets.Div{
 				classes = {'tabs-static'},
 				attributes = {['data-nosnippet'] = ''},
@@ -57,7 +57,7 @@ function Tabs.static(args)
 					return tab.this ~= nil
 				end), Operator.property('tabs'))
 			}
-		}}
+		}
 	}
 end
 

--- a/lua/wikis/commons/Widget/Analytics.lua
+++ b/lua/wikis/commons/Widget/Analytics.lua
@@ -26,9 +26,9 @@ function AnalyticsWidget:render()
 			attributes = {['data-analytics-name'] = analyticsName},
 			children = self.props.children
 		}
-	else
-		return self.props.children
 	end
+
+	return HtmlWidgets.Fragment{children = self.props.children}
 end
 
 return AnalyticsWidget


### PR DESCRIPTION
## Summary
Add analytics datapoint for the static (actual links) tab clicks.

Also refactor the code to the WidgetTree style instead of mw.html

## How did you test this change?
dev