### PR TITLE
fix(NotabilityChecker): Adjust showmatch constant on Rocket League

### DIFF
--- a/lua/wikis/rocketleague/NotabilityChecker/config.lua
+++ b/lua/wikis/rocketleague/NotabilityChecker/config.lua
@@ -17,7 +17,7 @@ Config.TIER_TYPE_GENERAL = 'general'
 Config.TIER_TYPE_QUALIFIER = 'qualifier'
 Config.TIER_TYPE_WEEKLY = 'weekly'
 Config.TIER_TYPE_MONTHLY = 'monthly'
-Config.TIER_TYPE_SHOW_MATCH = 'show match'
+Config.TIER_TYPE_SHOW_MATCH = 'showmatch'
 Config.TIER_TYPE_SCHOOL = 'school'
 
 -- How many placements should we retrieve from LPDB for a team/player?


### PR DESCRIPTION
Updating show match to be showmatch so points are given when ran in the notability checker for rocket league

