### PR TITLE
feat(mainpage): make rocketleague ratings panel foldable

### DIFF
--- a/lua/wikis/rocketleague/MainPageLayout/data.lua
+++ b/lua/wikis/rocketleague/MainPageLayout/data.lua
@@ -58,7 +58,7 @@ local CONTENT = {
 	},
 	rating = {
 		heading = 'Liquipedia Rating',
-		boxid=1520
+		boxid = 1520,
 		body = HtmlWidgets.Fragment{
 			children = {
 				RatingsDisplay.graph{id = 'rating'},


### PR DESCRIPTION
Adding the ability to hide the  LP ratings table on the main page. 

Tested :  https://liquipedia.net/rocketleague/User:Reidthesloth/Main_Page/New

Module: https://liquipedia.net/rocketleague/Module:MainPageLayout/data/dev/Reidthesloth

