### PR TITLE
feat: add analytic details to table of contents

### DIFF
--- a/javascript/commons/Analytics.js
+++ b/javascript/commons/Analytics.js
@@ -32,7 +32,6 @@ liquipedia.analytics = {
 		/********************************************************************
 		 * A registry of functions to find component-specific properties.
 		 * Each key matches a `data-analytics-name` value.
-		 * Each function receives (element, properties, analyticsElement).
 		 *******************************************************************/
 		Infobox: function( element, analyticsElement ) {
 			const parentDiv = element.parentElement;


### PR DESCRIPTION
## Summary

Adds a `position` and `ToC position` properties to link click events inside table of contents.

## How did you test this change?

dev tools

<img width="614" height="399" alt="image" src="https://github.com/user-attachments/assets/cd2b927f-381d-4703-88a3-85568b395e00" />
<img width="610" height="404" alt="image" src="https://github.com/user-attachments/assets/8114d9ae-d7d5-4540-b3f8-8a657197be61" />
