### PR TITLE
fix(Tabs): all sub tabs always shown in static tabs

### DIFF
--- a/lua/wikis/commons/Tabs.lua
+++ b/lua/wikis/commons/Tabs.lua
@@ -52,10 +52,8 @@ function Tabs.static(args)
 					end)
 				}
 			},
-			HtmlWidgets.Fragment{children =
-				Array.map(Array.filter(tabArgs, function (tab)
-					return tab.this
-				end), Operator.property('tabs'))
+			HtmlWidgets.Fragment{
+				children = Array.map(Array.filter(tabArgs, Operator.property('this')), Operator.property('tabs'))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
regression of #6693

`tab.this` is a bool and never nil, hence `tab.this ~= nil` always evaluates as true

## How did you test this change?
dev into live, hot fix (on phone)