### PR TITLE
feat: add analytic details to info banner

### DIFF
--- a/javascript/commons/Analytics.js
+++ b/javascript/commons/Analytics.js
@@ -37,7 +37,7 @@ liquipedia.analytics = {
 		 *******************************************************************/
 		InfoBanner: function( element ) {
 			return {
-				'info banner id': element.dataset.id;
+				'info banner id': element.dataset.id
 			};
 		},
 


### PR DESCRIPTION
## Summary

Adds a `position` and `info banner id` properties to link click events inside table of contents.
Add a new even `Info banner closed` with property of `info banner id`.

## How did you test this change?

dev tools on user pages

<img width="2407" height="719" alt="image" src="https://github.com/user-attachments/assets/a8c56dbb-c0b0-487f-96c5-4f4d69a7920a" />
