### PR TITLE
feat(TournamentsListing): clean args.game where reasonable

### DIFF
--- a/lua/wikis/commons/TournamentsListing/Conditions.lua
+++ b/lua/wikis/commons/TournamentsListing/Conditions.lua
@@ -68,7 +68,7 @@ function TournamentsListingConditions.base(args)
 	if Logic.isNotEmpty(args.game) then
 		local game = assert(Game.toIdentifier{game = args.game, useDefault = false},
 			'Invalid game input "' .. args.game .. '"')
-		conditions:add{ConditionNode(ColumnName('game'), Comparator.eq, game)}
+		conditions:add(ConditionNode(ColumnName('game'), Comparator.eq, game))
 	end
 
 	if args.series1 or args.series then


### PR DESCRIPTION
## Summary
mentioned on discord: https://discord.com/channels/93055209017729024/268719633366777856/1431334568060911817

imo cleaning the game input so it automatically matches the value that infobox stores is appropriate

## How did you test this change?
dev