### PR TITLE
feat(infobox): Update Show Infobox with more parameters

### DIFF
--- a/lua/wikis/commons/Infobox/Show.lua
+++ b/lua/wikis/commons/Infobox/Show.lua
@@ -53,7 +53,7 @@ function Show:createInfobox()
 		},
 		Center{children = {args.caption}},
 		Title{children = 'Show Information'},
-		Cell{name = 'Series', children = {Page.makeInternalLink({onlyIfExists = true}, args.series, args.series)}},
+		Cell{name = 'Series', children = {Page.makeInternalLink({onlyIfExists = true}, args.series) or args.series}},
 		Cell{name = 'Host(s)', children = self:getAllArgsForBase(args, 'host', {makeLink = true})},
 		Cell{name = 'Format', children = {args.format}},
 		Cell{name = 'Airs', children = {args.airs}},


### PR DESCRIPTION
## Summary of Changes
- Add ability to show series (for Shows which have multiple Seasons)
- Utilise Standard Location Widget
- Add ability to show Venue
- Add ability to set one-off shows with `date` parameter
- Show chronological data

## How did you test this change?
/dev locally on honorofkings. [Sample Page](https://liquipedia.net/honorofkings/User:Lolliftw/Sandbox/4)