### PR TITLE
feat(TeamHistory): Break outside of team names and roles

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
@@ -210,8 +210,8 @@ function TeamHistoryDisplay:_row(transfer)
 			Span{
 				css = {['padding-left'] = '3px', ['font-style'] = 'italic'},
 				children = {
-					'(',
-					role,
+					'&ZeroWidthSpace;(',
+					role:gsub(' ', '&nbsp;'),
 					')',
 				},
 			}
@@ -287,7 +287,7 @@ function TeamHistoryDisplay:_getTeamText(transfer)
 
 	return Link{
 		link = teamData.page,
-		children = {TeamHistoryDisplay._getTeamDisplayName(teamData)}
+		children = {TeamHistoryDisplay._getTeamDisplayName(teamData):gsub(' ', '&nbsp;')}
 	}
 end
 


### PR DESCRIPTION
## Summary
As a stopgap solution to improve display of TH with roles, replace spaces in team names and roles with non-breaking spaces, as well as introducing a zero-width space to be used for breaking inbetween the two.

As team names are at most 17 chars wide (unless a shortname of that length is used, which... shouldn't), this will not lead to a situation where the team name overflows (for reference: "Copenhagen Flames" in the screenshots is of that length and fits, even on wikis with position icons).
It technically would be possible for the role to now overflow if it completely fills the second row, but i'd argue that's the fault of the role.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
Before:
<img width="417" height="637" alt="image" src="https://github.com/user-attachments/assets/2ac4399b-9b44-4c6a-b0c8-f642da14aa5c" />

After:
<img width="370" height="569" alt="image" src="https://github.com/user-attachments/assets/1635d354-17ac-444e-a6fa-00c4c4c0841c" />

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
