### PR TITLE
feat(TH): improve length determination for team display

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
@@ -300,7 +300,7 @@ end
 ---@param roleLength integer
 ---@return string
 function TeamHistoryDisplay._getTeamDisplayName(teamData, roleLength)
-	local maxLength = 19 - (POSITION_ICON_DATA and 2 or 0) - (HAS_REFS and 2 or 0) - roleLength
+	local maxLength = 23 - (POSITION_ICON_DATA and 4 or 0) - (HAS_REFS and 4 or 0) - roleLength
 	if string.len(teamData.name) <= maxLength then
 		return teamData.name
 	elseif string.len(teamData.bracketname) <= maxLength then


### PR DESCRIPTION
## Summary
tweak the length dtermination in team display in TeamHistory display
it now considers the role length to determine the max length before switching to a shorter variant of the team name (name -> bracketname -> shortname)

## How did you test this change?
to be done