### PR TITLE
fix(Locale): Use unresolvedCountry for fetching region from mapping

### DIFF
--- a/lua/wikis/commons/Locale.lua
+++ b/lua/wikis/commons/Locale.lua
@@ -84,7 +84,7 @@ function Locale.formatLocations(args)
 
 			-- Get the Region from the country if still unknown
 			if not location.region then
-				location.region = String.nilIfEmpty(Region.name{country = location.country})
+				location.region = String.nilIfEmpty(Region.name{country = unresolvedCountry})
 			end
 		elseif location.region then
 			location.region = String.nilIfEmpty(Region.name{region = location.region})


### PR DESCRIPTION
## Summary
When one of the special entries of Flags/MasterData is being used that does not have an alpha2-code and at the same time does not have it's own entry in Region/Data, but instead is only mapped to a different region in Region/CountryData, the processing would fail, as `location.country` is already set to nil earlier.

Initially reported to be broken with `country=EMEA`, which displayed "fine" (using EU flag) but didn't store a region despite being mapped in Region/CountryData. Whether that entry should exist as it does in Flags/MasterData to begin with is a different discussion.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
