### PR TITLE
fix(match2): rocketleague score parser overwrites substitutes input

### DIFF
--- a/lua/wikis/rocketleague/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/rocketleague/MatchGroup/Input/Custom.lua
@@ -37,7 +37,7 @@ end
 ---@param opponent MGIParsedOpponent
 ---@param opponentIndex integer
 function MatchFunctions.adjustOpponent(opponent, opponentIndex)
-	opponent.extradata = Table.merge(opponent.extradata, CustomMatchGroupInput.getOpponentExtradata(opponent))
+	Table.mergeInto(opponent.extradata, CustomMatchGroupInput.getOpponentExtradata(opponent))
 	if opponent.extradata.additionalScores then
 		opponent.score = CustomMatchGroupInput._getSetWins(opponent)
 	end


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/202524980146208768/1433628794106806402

https://github.com/Liquipedia/Lua-Modules/blob/962bfe8e76372c4f8164f3e15425836786ff4522/lua/wikis/commons/MatchGroup/Input/Util.lua#L289

https://github.com/Liquipedia/Lua-Modules/blob/962bfe8e76372c4f8164f3e15425836786ff4522/lua/wikis/rocketleague/MatchGroup/Input/Custom.lua#L40

Substitute information is stored in `match2opponent.extradata`, but it is overwritten by rocketleague's score parsing logic.
This PR adjusts the parsed score to be stored _with_ the substitutes input, instead of overwriting it entirely.

## How did you test this change?

preview with dev
