### PR TITLE
docs(match2): fix incorrect order of arguments in FfaMatchParserInterface.calculateMatchScore documentation

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -1338,7 +1338,7 @@ end
 ---@class FfaMatchParserInterface
 ---@field extractMaps fun(match: table, opponents: MGIParsedOpponent[], mapProps: any?): table[]
 ---@field parseSettings? fun(match: table, opponentCount: integer): table
----@field calculateMatchScore? fun(maps: table[], opponents: MGIParsedOpponent[]): fun(opponentIndex: integer): integer?
+---@field calculateMatchScore? fun(opponents: MGIParsedOpponent[], maps: table[]): fun(opponentIndex: integer): integer?
 ---@field getExtraData? fun(match: table, games: table[], opponents: MGIParsedOpponent[], settings: table): table?
 ---@field getMode? fun(opponents: MGIParsedOpponent[]): string
 ---@field readDate? readDateFunction
@@ -1357,7 +1357,7 @@ end
 ---
 --- It may optionally have the following functions:
 --- - parseSettings(match, opponentCount): table
---- - calculateMatchScore(maps, opponents): fun(opponentIndex): integer?
+--- - calculateMatchScore(opponents, maps): fun(opponentIndex): integer?
 --- - getExtraData(match, games, opponents, settings): table?
 --- - getMode(opponents): string?
 --- - readDate(match): table


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/962bfe8e76372c4f8164f3e15425836786ff4522/lua/wikis/commons/MatchGroup/Input/Util.lua#L1397

## How did you test this change?

N/A