### PR TITLE
feat(TournamentList): Display up to three teams per row in qual cells

### DIFF
--- a/stylesheets/commons/DivTable.scss
+++ b/stylesheets/commons/DivTable.scss
@@ -252,7 +252,7 @@ Author(s): iMarbot
 
 .gridTable.tournamentCard .gridCell.Placement.Qualified > .Participants {
 	display: inline-grid;
-	grid-template-columns: repeat(auto-fit,minmax(150px,1fr));
+	grid-template-columns: repeat( auto-fit, minmax( 150px, 1fr ) );
 	min-width: 15vw;
 }
 


### PR DESCRIPTION
## Summary
For a bit better space usage, reduce the flex basis of entries in the qualifier slot to allow up to two entries per row.
As seen on the mobile screenshot, this can look weird for longer names, but my CSS skills aren't sufficient enough to create a good version for that.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev tools
Before:
<img width="342" height="568" alt="image" src="https://github.com/user-attachments/assets/320168a2-cae2-459d-817e-62b3de0eda46" />
<img width="1836" height="672" alt="image" src="https://github.com/user-attachments/assets/17b625ed-9020-4559-a33c-a0e6312f2bfa" />


After:
<img width="377" height="660" alt="image" src="https://github.com/user-attachments/assets/4f5bbf64-c1ef-4c12-a4a6-b81c353fd04b" />
<img width="1865" height="465" alt="image" src="https://github.com/user-attachments/assets/68a29f3a-cd3f-4441-91fe-90e89d68e980" />
for solo opponents
<img width="658" height="773" alt="image" src="https://github.com/user-attachments/assets/5874d4db-5527-4ebd-a5f0-22ea9c2bcb28" />

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
