### PR TITLE
feat(notability checker): Add Deadlock

### DIFF
--- a/lua/wikis/deadlock/NotabilityChecker/config.lua
+++ b/lua/wikis/deadlock/NotabilityChecker/config.lua
@@ -14,7 +14,7 @@ Config.TIER_TYPE_QUALIFIER = 'qualifier'
 Config.TIER_TYPE_WEEKLY = 'weekly'
 Config.TIER_TYPE_MONTHLY = 'monthly'
 Config.TIER_TYPE_MISC = 'misc'
-Config.TIER_TYPE_SHOW_MATCH = 'show match'
+Config.TIER_TYPE_SHOW_MATCH = 'showmatch'
 Config.MAX_NUMBER_OF_PARTICIPANTS = 10
 Config.MAX_NUMBER_OF_COACHES = 2
 


### PR DESCRIPTION
## Summary
We switched to more standartized module of notability checker as We had issue with our "custom" module
https://liquipedia.net/deadlock/Module:Archive/Notability

https://liquipedia.net/deadlock/Liquipedia:Notability_Guidelines
https://liquipedia.net/deadlock/Special:RunQuery/Notability_Checker

## How did you test this change?

live
