### PR TITLE
feat: add Uruguayan Peso (UYU) currency

### DIFF
--- a/lua/wikis/commons/Currency/Data.lua
+++ b/lua/wikis/commons/Currency/Data.lua
@@ -855,7 +855,7 @@ return {
 	uyu = {
 		code = 'UYU',
 		name = 'Uruguayan Peso',
-		synbol = {
+		symbol = {
 			hasSpace = false,
 			isAfter = false,
 			text = '$',


### PR DESCRIPTION
Added missing Uruguayan Peso currency data in Data.lua

## Summary

I created a tournament pagewhere the prizepool local currency was uruguayan and didn't work.
Checked further and noticed that it wasn't added to the currency list.

Just 9 lines, same format as the rest of the code

## How did you test this change?

TBH I don't know how to. But I would be surprize to mess up in 9 lines
