### PR TITLE
feat(mainpage): Update Clash Royale portal pill images

### DIFF
--- a/lua/wikis/clashroyale/MainPageLayout/data.lua
+++ b/lua/wikis/clashroyale/MainPageLayout/data.lua
@@ -88,7 +88,7 @@ return {
 	title = 'Clash Royale',
 	navigation = {
 		{
-			file = 'Mohamed_Light_CRL_2024_World_Finals.jpg',
+			file = 'SuperCardCompDraft RunicMountain Banner.png',
 			title = 'Players',
 			link = 'Portal:Players',
 			count = {
@@ -97,7 +97,7 @@ return {
 			},
 		},
 		{
-			file = 'TL_Crl_World_Finals-2019.png',
+			file = 'HolidayFeast CozyClashmas Banner.png',
 			title = 'Teams',
 			link = 'Portal:Teams',
 			count = {
@@ -106,7 +106,7 @@ return {
 			},
 		},
 		{
-			file = 'Mugi_CRL_2023_World_Finals.jpeg ',
+			file = 'Touchdown LumberLove Banner.png',
 			title = 'Tournaments',
 			link = 'Portal:Tournaments',
 			count = {
@@ -165,7 +165,7 @@ return {
 			link = 'Portal:Merge Tactics',
 		},
 		{
-			file = 'Nova_Crl_2018_World_Finals.jpg',
+			file = 'RuneGiant RunicMountain Banner.png',
 			title = 'Statistics',
 			link = 'Portal:Statistics',
 		},


### PR DESCRIPTION
## Summary

Update portal pill images to replace photos that were violating copyright.

## How did you test this change?

live https://liquipedia.net/clashroyale/Main_Page