### PR TITLE
fix: on HoK, mvp form parameter to determine whether to show the mvp param

### DIFF
--- a/lua/wikis/honorofkings/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/honorofkings/GetMatchGroupCopyPaste/wiki.lua
@@ -39,7 +39,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.hasDate) and {
 			INDENT .. '|date=',
 			INDENT .. '|twitch= |youtube= |bilibili= |douyu= |huya=',
-			args.mvp and INDENT .. '|mvp=' or nil,
+			Logic.readBool(args.mvp) and INDENT .. '|mvp=' or nil,
 			args.vod == 'series' and (INDENT .. '|vod=') or nil,
 		} or nil,
 		Array.map(Array.range(1, bestof), function(mapIndex)


### PR DESCRIPTION
Random fix to Honor of Kings Wiki GetMatchGroupCopyPaste to tie it to MVP field in existing forms