### PR TITLE
fix(Notability): Do not apply score dropoff for tiertypes on MR

### DIFF
--- a/lua/wikis/marvelrivals/NotabilityChecker/config.lua
+++ b/lua/wikis/marvelrivals/NotabilityChecker/config.lua
@@ -198,6 +198,11 @@ function Config.placementDropOffFunction(tier, tierType)
 				if ((tier == 1 or tier == 2 or tier == 3) and placement == 1) then
 					return score
 				end
+			elseif (tierType == Config.TIER_TYPE_MISC
+					or tierType == Config.TIER_TYPE_WEEKLY
+					or tierType == Config.TIER_TYPE_MONTHLY
+					or tierType == Config.TIER_TYPE_SHOW_MATCH) then
+				return score
 			else
 				if (tier == 1 and placement <= 16) or placement == 1 then
 					return score


### PR DESCRIPTION
## Summary
According to https://liquipedia.net/marvelrivals/Liquipedia:Notability_Guidelines, there is no placement dropoff for placements with tiertypes Showmatch, Weekly, Monthly, and Misc
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
