### PR TITLE
feat: engine tiertype for chess wiki

### DIFF
--- a/lua/wikis/chess/Tier/Data.lua
+++ b/lua/wikis/chess/Tier/Data.lua
@@ -97,7 +97,7 @@ return {
 			category = 'Showmatch Tournaments',
 		},
 		engine = {
-			value = 'engine',
+			value = 'Engine',
 			sort = 'B2',
 			name = 'Engine',
 			short = 'Engine',


### PR DESCRIPTION
## Summary
Resolves https://github.com/Liquipedia/Lua-Modules/issues/6749
Add `engine` tiertype for chess wiki
## How did you test this change?
Infobox league (`dev=soba2`):
https://liquipedia.net/chess/Top_Chess_Engine_Championship/fourk_6
Main page filter buttons:
https://liquipedia.net/chess/User:SobakaPirat/Main_Page
