### PR TITLE
feat: Add slash to the end of the BLAST.tv parameter on Dota 2 matches

### DIFF
--- a/lua/wikis/dota2/Links/CustomData.lua
+++ b/lua/wikis/dota2/Links/CustomData.lua
@@ -15,7 +15,7 @@ return {
 		},
 		blasttv = {
 			'https://blast.tv/dota/',
-			match = 'https://blast.tv/dota/match'
+			match = 'https://blast.tv/dota/match/'
 		}
 	}
 }


### PR DESCRIPTION
feat: Add slash to the end of the BLAST.tv parameter on Dota 2 matches (`blasttv=`) so that editors do not need to add this slash manually

## Summary

In `Match`/`MatchPage`, we have a `blasttv` parameter that allows us to set a match ID and point it to BLAST.tv's platform where it is supported (such as Dota 2 and CS2) and there is a tournament page.  However, the base URL does not end in a slash, meaning we always have to add one to the parameter.  For example:
* `blasttv=8546927307` produces `https://blast.tv/dota/match8546927307` (invalid URL)
* `blasttv=/8546927307` produces `https://blast.tv/dota/match/8546927307` (valid URL)

This is a quality-of-life change that adds a slash to the end, so we don't need to add one to the parameter value by default.

This only affects Dota 2.  Counter-Strike doesn't support the BLAST.tv parameter.

There are a handful (literally, one hand) of places where it is set on the wiki, so these would need to be changed after this is applied.  This can be done manually (I'll handle it).

[Discussion on Discord](https://discord.com/channels/93055209017729024/372075546231832576/1436350022273859705)

## How did you test this change?

* [Dev module](https://liquipedia.net/dota2/Module:Links/CustomData/dev/x42bn6)
* [Sample `MatchPage` diff](https://liquipedia.net/dota2/index.php?title=Match:ID_jl1JY2OnQa_R01-M001&diff=prev&oldid=2315594)