### PR TITLE
fix(Standings): Do not include unfinished matches in "Buchholz"

### DIFF
--- a/lua/wikis/commons/Standings/Tiebreaker/Buchholz.lua
+++ b/lua/wikis/commons/Standings/Tiebreaker/Buchholz.lua
@@ -22,6 +22,9 @@ local TiebreakerBuchholz = Class.new(TiebreakerInterface)
 ---@return integer
 function TiebreakerBuchholz:valueOf(state, opponent)
 	local enemies = Array.flatMap(opponent.matches, function(match)
+		if not match.finished then
+			return {}
+		end
 		return Array.filter(match.opponents, function (opp)
 			return not Opponent.same(opp, opponent.opponent)
 		end)


### PR DESCRIPTION
## Summary
As per title: The "buchholz" calculation did include the scores of opponents from matches that weren't played yet. This is not usually how it's done, so exclude these matches.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
