### PR TITLE
feat(Infobox): standardize seriesnumber across craft wikis

### DIFF
--- a/lua/wikis/starcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/League/Custom.lua
@@ -246,6 +246,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them
 	lpdbData.series = args.series
+	lpdbData.extradata.seriesnumber = self.data.number and string.format('%05i', self.data.number) or nil
 
 	lpdbData.extradata.female = Logic.readBool(args.female) or nil
 

--- a/lua/wikis/starcraft2/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/League/Custom.lua
@@ -386,7 +386,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.tickername = lpdbData.tickername or lpdbData.name
 	lpdbData.maps = Json.stringify(args.maps)
 
-	lpdbData.extradata.seriesnumber = args.number and string.format('%05i', args.number) or nil
+	lpdbData.extradata.seriesnumber = self.data.number and string.format('%05i', self.data.number) or nil
 	lpdbData.extradata.starttime = self.data.startTime.storage
 	lpdbData.extradata.mod = self.data.mod
 

--- a/lua/wikis/warcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/League/Custom.lua
@@ -153,7 +153,7 @@ function CustomLeague:defineCustomPageVariables(args)
 	Variables.varDefine('firstmatch', self.data.firstMatch)
 	Variables.varDefine('tournament_finished', tostring(self.data.isFinished or false))
 	Variables.varDefine('tournament_maps', Json.stringify(self.data.maps))
-	Variables.varDefine('tournament_series_number', self.data.number)
+	Variables.varDefine('tournament_series_number', self.data.number and string.format('%05i', self.data.number) or nil)
 end
 
 ---@param prefix string
@@ -402,7 +402,7 @@ function CustomLeague:addToLpdb(lpdbData, args)
 	end
 	lpdbData.participantsnumber = participantsNumber
 	lpdbData.mode = self:_getMode()
-	lpdbData.extradata.seriesnumber = self.data.number
+	lpdbData.extradata.seriesnumber = self.data.number and string.format('%05i', self.data.number) or nil
 
 	lpdbData.extradata.server2 = args.server2
 	lpdbData.extradata.patch2 = args.patch2


### PR DESCRIPTION
## Summary
needed so we can convert `Cups list` usage to `TournamentsList` usage
(needs purge/touch runs on broodwar and warcraft after merge)

## How did you test this change?
untested, but trivial