### PR TITLE
fix(Brackets): Do not error on empty bracketID on template pages

### DIFF
--- a/lua/wikis/commons/Match.lua
+++ b/lua/wikis/commons/Match.lua
@@ -119,7 +119,7 @@ function Match.storeMatchGroup(matchRecords, options)
 		end
 		Array.forEach(matchRecordsCopy, Logic.wrapTryOrLog(storeMatch2))
 		-- Used in MatchGroupBase.isBracketIdAvailable duplicate check
-		Variables.varDefine('matchid_duplicate_check_' .. options.bracketId, 'used')
+		Variables.varDefine('matchid_duplicate_check_' .. (options.bracketId or ''), 'used')
 	end
 
 	if not LegacyMatch then


### PR DESCRIPTION
## Summary
On bracket template pages, the bracket is stored without an ID, so this would error.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
