### PR TITLE
fix(match2): empty countdown displayed for upcoming matches with inexact time

### DIFF
--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -122,7 +122,7 @@ function BaseMatchPage:getCountdownBlock()
 		children = Countdown.create{
 			date = DateExt.toCountdownArg(self.matchData.timestamp, self.matchData.timezoneId, self.matchData.dateIsExact),
 			finished = self.matchData.finished,
-			rawdatetime = Logic.readBool(self.matchData.finished),
+			rawdatetime = (not self.matchData.dateIsExact) or self.matchData.finished,
 		}
 	}
 end

--- a/lua/wikis/commons/Widget/Match/Countdown.lua
+++ b/lua/wikis/commons/Widget/Match/Countdown.lua
@@ -36,7 +36,7 @@ function MatchCountdown:render()
 	return HtmlWidgets.Span{
 		classes = {'match-info-countdown'},
 		children = Countdown.create{
-			rawdatetime = match.finished,
+			rawdatetime = (not match.dateIsExact) or match.finished,
 			date = DateExt.toCountdownArg(match.timestamp, match.timezoneId, match.dateIsExact),
 			finished = match.finished,
 		},


### PR DESCRIPTION
## Summary

<img width="179" height="36" alt="image" src="https://github.com/user-attachments/assets/68104ad7-6cb4-4029-934a-f0a98d789b96" />

Upcoming matches without exact start time have an empty countdown container displayed in their match summaries / matchpage headers. This PR adjusts countdown args to suppress creation of these empty containers.

## How did you test this change?

dev