### PR TITLE
feat(roles): Add Identity V Roles

### DIFF
--- a/lua/wikis/identityv/InGameRoles.lua
+++ b/lua/wikis/identityv/InGameRoles.lua
@@ -1,0 +1,14 @@
+---
+-- @Liquipedia
+-- page=Module:InGameRoles
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+---@type table<string, RoleBaseData>
+local inGameRoles = {
+	['hunter'] = {category = 'Hunters', display = 'Hunter'},
+	['survivor'] = {category = 'Survivors', display = 'Survivor'},
+}
+
+return inGameRoles


### PR DESCRIPTION
## Summary
Almost all players in the wiki is filled with this (but I recall the error wasnt there when wiki was first exported, recent role changes?)

<img width="995" height="258" alt="image" src="https://github.com/user-attachments/assets/fab03496-f1e9-469d-9da4-8ae19c4ba216" />

The module is adding the two player class roles for this game: `hunter` and `survivor`

