### PR TITLE
feat(Infobox): Add version of the patch on Deadlock

### DIFF
--- a/lua/wikis/deadlock/Infobox/League/Custom.lua
+++ b/lua/wikis/deadlock/Infobox/League/Custom.lua
@@ -52,7 +52,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 ---@param args table
----@return string?
+---@return Widget[]?
 function CustomLeague:_createPatchCell(args)
 	if String.isEmpty(args.patch) then
 		return


### PR DESCRIPTION
## Summary

Inspired by LOL wiki. Editors of Deadlock would like to have version included directly in the infobox
Hopefully we get proper version names from valve one day. :)

## How did you test this change?

dev (moved only last patch to correct name structure. Will do same for other pages most likely, but its really not needed as We will not update older tournaments)

<img width="323" height="203" alt="image" src="https://github.com/user-attachments/assets/1ae2f955-3ad4-4a20-9ad4-bb8036f2f65f" />

<img width="306" height="330" alt="image" src="https://github.com/user-attachments/assets/aaa6de9b-7499-4fac-85ab-d23dbce3a8aa" />
