### PR TITLE
feat(Mainpage): Remove rumours transfers on Deadlock

### DIFF
--- a/lua/wikis/deadlock/MainPageLayout/data.lua
+++ b/lua/wikis/deadlock/MainPageLayout/data.lua
@@ -48,7 +48,6 @@ local CONTENT = {
 	transfers = {
 		heading = 'Transfers',
 		body = TransfersList{
-			rumours = true,
 			transferPage = 'Player Transfers/' .. DateExt.getYearOf()
 		},
 		boxid = 1509,


### PR DESCRIPTION
## Summary

After small discussion with Deadlock editors We decided to not use Rumours transfers at this current stage of Deadlock. So far there was non of the transfers on that page. Moved Rumours to Archive and updated Transfer page to reflect it

## How did you test this change?

dev
