### PR TITLE
fix: custom player introduction for chess

### DIFF
--- a/lua/wikis/chess/PlayerIntroduction/Custom.lua
+++ b/lua/wikis/chess/PlayerIntroduction/Custom.lua
@@ -72,7 +72,7 @@ function CustomPlayerIntroduction:typeDisplay()
 	elseif String.isNotEmpty(title) then
 		return self._addConcatText('chess ' .. title)
 	else
-		return PlayerIntroduction.typeDisplay(self)
+		return self._addConcatText('chess player')
 	end
 end
 


### PR DESCRIPTION
## Summary

Custom PlayerIntroduction for chess (from #6452) shows "player" instead of "chess player" for players who don't have FIDE titles or not banned. It affects player pages who passed away before titles apperance in 1950. 

## How did you test this change?

https://liquipedia.net/chess/Max_Judd

Before/after screenshot: 
<img width="608" height="192" alt="image" src="https://github.com/user-attachments/assets/ada336ff-075d-4c0d-a95f-88d01183f4f8" />