### PR TITLE
fix(Links): steam links not working

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -269,7 +269,7 @@ local PREFIXES = {
 		player = 'https://start.gg/user/',
 	},
 	steam = {'https://steamcommunity.com/id/'}, -- to be removed after conversion
-	steamID64 = {'https://steamcommunity.com/profiles/'},
+	steam64ID = {'https://steamcommunity.com/profiles/'},
 	steamtv = {'https://steam.tv/'},
 	strikr = {'https://strikr.pro/pilot/'},
 	privsteam = {'https://steamcommunity.com/groups/'},
@@ -382,7 +382,7 @@ local ALIASES = {
 	yandexefir = {'yandex'},
 	zhanqitv = {'zhanqi'},
 	-- temporarily for conversion
-	steamID64 = {'steamalternative'},
+	steam64ID = {'steamalternative'},
 }
 
 local ICON_KEYS_TO_RENAME = {
@@ -399,7 +399,7 @@ local ICON_KEYS_TO_RENAME = {
 	playlist = 'music',
 	privsteam = 'steam',
 	pubsteam = 'steam',
-	steamID64 = 'steam',
+	steam64ID = 'steam',
 	tlpdint = 'tlpd',
 	tlpdkr = 'tlpd-wol-korea',
 	tlpdsospa = 'tlpd-sospa',

--- a/lua/wikis/commons/Links/PriorityGroups.lua
+++ b/lua/wikis/commons/Links/PriorityGroups.lua
@@ -78,7 +78,7 @@ return {
 		'pubsteam',
 		'reddit',
 		'snapchat',
-		'steamID64',
+		'steam64ID',
 		'telegram',
 		'threads',
 		'tiktok',


### PR DESCRIPTION
## Summary
appended numbers are treated as index hence causing `steamID64` to be treated as the fourth `steamID6`
to fix this rename it to `steam64ID`

## How did you test this change?
live