### PR TITLE
feat: add static faceit link support

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -140,7 +140,7 @@ local PREFIXES = {
 	faceitdb = {
 		'',
 		player = 'https://faceitdb.com/profile/faceit/',
-	},	
+	},
 	fanclub = {''},
 	fide = {
 		'https://ratings.fide.com/tournament_information.phtml?event=',


### PR DESCRIPTION
## Summary

Adding static faceitdb links to player pages https://faceitdb.com/profile/ to replace Faceit links as they aren't static and players often change their aliases breaking the link.

Ideally these would replace and eventually deprecate regular faceit links for the same reason we are replacing Steam links with a static version.

## How did you test this change?

Not sure how I would test, but it's a very simple change so it should work. 
