### PR TITLE
feat(TeamHistory): adjust maxLength of team display

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory/Display.lua
@@ -300,7 +300,7 @@ end
 ---@param roleLength integer
 ---@return string
 function TeamHistoryDisplay._getTeamDisplayName(teamData, roleLength)
-	local maxLength = 23 - (POSITION_ICON_DATA and 4 or 0) - (HAS_REFS and 4 or 0) - roleLength
+	local maxLength = 22 - (POSITION_ICON_DATA and 4 or 0) - (HAS_REFS and 4 or 0) - roleLength
 	if string.len(teamData.name) <= maxLength then
 		return teamData.name
 	elseif string.len(teamData.bracketname) <= maxLength then


### PR DESCRIPTION
## Summary
as per request on discord: https://discord.com/channels/93055209017729024/1400382174078832670/1440868605754347532

## How did you test this change?
dev