### PR TITLE
refactor(match2): clean up rocketleague parser implementation

### DIFF
--- a/lua/wikis/commons/Opponent.lua
+++ b/lua/wikis/commons/Opponent.lua
@@ -504,9 +504,22 @@ unsuccessful.
 Wikis sometimes provide variants of this function that include wiki specific
 transformations.
 ]]
----@param record match2opponent|MGIParsedOpponent
+---@param record match2opponent
 ---@return standardOpponent
 function Opponent.fromMatch2Record(record)
+	return Opponent._fromMatchRecord(record)
+end
+
+---@param record MGIParsedOpponent
+---@return standardOpponent
+function Opponent.fromMatchParsedOpponent(record)
+	return Opponent._fromMatchRecord(record)
+end
+
+---@private
+---@param record {type: OpponentType, template: string?, match2players: match2player[]|MGIParsedPlayer[], name: string?}
+---@return standardOpponent
+function Opponent._fromMatchRecord(record)
 	if record.type == Opponent.team then
 		return {type = Opponent.team, template = record.template, extradata = {}}
 

--- a/lua/wikis/rocketleague/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/rocketleague/MatchGroup/Input/Custom.lua
@@ -123,8 +123,8 @@ end
 function MatchFunctions.getExtraData(match, games, opponents)
 	return {
 		isfeatured = MatchFunctions.isFeatured(opponents, tonumber(match.liquipediatier)),
-		hasopponent1 = not Opponent.isTbd(Opponent.fromMatch2Record(opponents[1])),
-		hasopponent2 = not Opponent.isTbd(Opponent.fromMatch2Record(opponents[2])),
+		hasopponent1 = not Opponent.isTbd(Opponent.fromMatchParsedOpponent(opponents[1])),
+		hasopponent2 = not Opponent.isTbd(Opponent.fromMatchParsedOpponent(opponents[2])),
 		liquipediatiertype2 = Variables.varDefault('tournament_tiertype2'),
 	}
 end


### PR DESCRIPTION
## Summary

This PR:
- updates rocketleague match2 parser to use `MatchGroupInputUtil.standardProcessMaps`
- cleans up H2H link building logic inside rocketleague match2 parser
- adjusts type annotations

## How did you test this change?

dev