### PR TITLE
fix(eml): unstrip nowiki tags in title input

### DIFF
--- a/lua/wikis/commons/ExternalMediaLink.lua
+++ b/lua/wikis/commons/ExternalMediaLink.lua
@@ -73,7 +73,7 @@ function ExternalMediaLink._readArgs(args)
 	local lpdbData = {
 		date = args.date,
 		language = args.language or DEFAULT_LANGUAGE,
-		title = args.title,
+		title = mw.text.unstripNoWiki(args.title),
 		translatedtitle = args.trans_title,
 		link = args.link,
 		publisher = args.of,


### PR DESCRIPTION
## Summary

Reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1441745023648534611

Regression from #6761

https://github.com/Liquipedia/Lua-Modules/blob/827c545dada26ebc722c8dc461731543e9038e7d/lua/wikis/commons/Widget/ExternalMedia/Link.lua#L62

Titles of EML entries are wrapped with `mw.text.nowiki` to avoid it interfering with MW parser, especially to avoid square brackets in titles breaking the external link syntax. This messes with manual `<nowiki>` tag from wikicode input, putting MW strip markers in the rendered title instead.

This PR sanitizes the title input from wikicode by wrapping it with `mw.text.unstripNoWiki`.

## How did you test this change?

live