### PR TITLE
feat: add matcherino support for players

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -195,7 +195,10 @@ local PREFIXES = {
 	lolchess = {'https://lolchess.gg/profile/'},
 	lrthread = {'', match = ''},
 	mapdraft = {match = 'https://aoe2cm.net/draft/'},
-	matcherino = {'https://matcherino.com/tournaments/'},
+	matcherino = {
+		'https://matcherino.com/tournaments/',
+		player = 'https://matcherino.com/',
+	},
 	matcherinolink = {'https://matcherino.com/t/'},
 	mildom = {'https://www.mildom.com/'},
 	mplink = {match = 'https://osu.ppy.sh/community/matches/'}, -- Should this key be renamed?


### PR DESCRIPTION
## Summary
requested on discord: https://discord.com/channels/93055209017729024/1400382174078832670/1442588566747090977

matcherino player links are of the form
`https://matcherino.com/gameOrPublisherIdentifier/u/displayName/numericalId`
due to the game/publisher identifier varying between wikis we can only use the base url of the website as prefix

## How did you test this change?
dev