### PR TITLE
feat(statistics): add nationality filter for player stats portal

### DIFF
--- a/lua/wikis/commons/PortalStatistics.lua
+++ b/lua/wikis/commons/PortalStatistics.lua
@@ -781,6 +781,13 @@ function StatisticsPortal.playerAgeTable(args)
 		conditions:add{typeConditions}
 	end
 
+	conditions:add(ConditionUtil.anyOf(
+		ColumnName('nationality'),
+		Array.map(Array.parseCommaSeparatedString(args.nationality), function (nationality)
+			return Flags.CountryName{flag = nationality}
+		end)
+	))
+
 	local playerData = StatisticsPortal._getPlayers(args.limit, conditions:toString(), args.order)
 
 	local tbl = mw.html.create('table')


### PR DESCRIPTION
## Summary

Requested on discord: https://discord.com/channels/93055209017729024/268719633366777856/1440361078969339924

This PR adds support for filtering queried players by nationality in statistics portal.

## How did you test this change?

dev