### PR TITLE
feat(infobox): marvelrivals map infobox

### DIFF
--- a/lua/wikis/marvelrivals/Infobox/Map/Custom.lua
+++ b/lua/wikis/marvelrivals/Infobox/Map/Custom.lua
@@ -15,7 +15,7 @@ local String = Lua.import('Module:StringUtils')
 local Injector = Lua.import('Module:Widget/Injector')
 local Map = Lua.import('Module:Infobox/Map')
 
-local Widgets = require('Module:Widget/All')
+local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
 ---@class MarvelRivalsMapInfobox: MapInfobox


### PR DESCRIPTION
## Summary

Marvelrivals' map infobox is _not_ tracked on this repository, though it really should be. Thus, this PR copies over the wiki version with all the necessary cleanup added.

## How did you test this change?

live