### PR TITLE
chore(infobox): use new arg name in marvelrivals map infobox

### DIFF
--- a/lua/wikis/marvelrivals/Infobox/Map/Custom.lua
+++ b/lua/wikis/marvelrivals/Infobox/Map/Custom.lua
@@ -45,8 +45,8 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(
 			widgets,
 			Cell{name = #gameModes == 1 and 'Game Mode' or 'Game Modes', children = gameModes},
-			Cell{name = 'Lighting', children = args.lighting},
-			Cell{name = 'Checkpoints', children = args.checkpoints}
+			Cell{name = 'Lighting', children = {args.lighting}},
+			Cell{name = 'Checkpoints', children = {args.checkpoints}}
 		)
 	end
 	return widgets


### PR DESCRIPTION
## Summary

`content` was renamed to `children` some time ago and it wasn't caught in #6848 :/
well, technically both work but let's drop content in favor of children in this "new" infobox

## How did you test this change?

trivial