### PR TITLE
fix: pagify pagename when fetching tournament

### DIFF
--- a/lua/wikis/commons/Tournament.lua
+++ b/lua/wikis/commons/Tournament.lua
@@ -11,6 +11,7 @@ local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
 local Lpdb = Lua.import('Module:Lpdb')
 local Logic = Lua.import('Module:Logic')
+local Page = Lua.import('Module:Page')
 local Table = Lua.import('Module:Table')
 local Tier = Lua.import('Module:Tier/Utils')
 


### PR DESCRIPTION
## Summary
replrted on discord that in new TC the qualified page input has to be with underscores for it to work
https://discord.com/channels/93055209017729024/1417454383406252103/1443647112674939004

## How did you test this change?
dev