### PR TITLE
feat: set role order for overwatch

### DIFF
--- a/lua/wikis/overwatch/InGameRoles.lua
+++ b/lua/wikis/overwatch/InGameRoles.lua
@@ -7,10 +7,10 @@
 
 ---@type table<string, RoleBaseData>
 local inGameRoles = {
-	['dps'] = {category = 'DPS Players', display = 'DPS'},
-	['flex'] = {category = 'Flex Players', display = 'Flex'},
-	['support'] = {category = 'Support Players', display = 'Support'},
-	['tank'] = {category = 'Tank Players', display = 'Tank'},
+	['dps'] = {category = 'DPS Players', display = 'DPS', sortOrder = 1},
+	['flex'] = {category = 'Flex Players', display = 'Flex', sortOrder = 4},
+	['support'] = {category = 'Support Players', display = 'Support', sortOrder = 3},
+	['tank'] = {category = 'Tank Players', display = 'Tank', sortOrder =2},
 }
 
 inGameRoles.sup = inGameRoles.support


### PR DESCRIPTION
## Summary

IGL/In-Game Leader is not utlizied in overwatch at all and should be removed. "sup" as alias for "support" is in almost all cases (>99%) used so far and should also be an option with the new TeamCards.

Also set a sortOrder (dps -> tank -> sup -> flex) for correct display.

## How did you test this change?

dev
