### PR TITLE
fix(Player): Disable syncTeam on WoT

### DIFF
--- a/lua/wikis/worldoftanks/Player/Ext/Custom.lua
+++ b/lua/wikis/worldoftanks/Player/Ext/Custom.lua
@@ -1,0 +1,22 @@
+---
+-- @Liquipedia
+-- page=Module:Player/Ext/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local PlayerExt = Lua.import('Module:Player/Ext')
+local Table = Lua.import('Module:Table')
+
+---@class WorldoftanksPlayerExt: PlayerExt
+local CustomPlayerExt = Table.copy(PlayerExt)
+
+--- Disabled due to common use of multi-team players (7v7/15v15)
+---@return nil
+function CustomPlayerExt.syncTeam()
+    return nil
+end
+
+return CustomPlayerExt


### PR DESCRIPTION
## Summary
WoT commonly has players on multiple teams.
With currently stored data, it can't be checked which team to sync here, so disable that entirely.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
