### PR TITLE
fix: stack overflow when fetching tournament with specific page setup

### DIFF
--- a/lua/wikis/commons/Tournament.lua
+++ b/lua/wikis/commons/Tournament.lua
@@ -215,6 +215,7 @@ function Tournament.isFeatured(record)
 		local parentPage = table.concat(Array.sub(mw.text.split(page, '/'), 1, -2), '/')
 		if Logic.isEmpty(parentPage) then
 			return nil
+		-- Avoid infinite loops
 		elseif page == Page.pageifyLink(parentPage) then
 			return nil
 		end


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1443909718786707456

Regression from #6859

see [here](https://discord.com/channels/93055209017729024/372075546231832576/1443915507848974366) for @mbergen's diagnosis

## How did you test this change?

live