### PR TITLE
feat(matchTable): use the same naming style in matchtables as in new match tickers

### DIFF
--- a/lua/wikis/commons/MatchTable.lua
+++ b/lua/wikis/commons/MatchTable.lua
@@ -104,7 +104,6 @@ local SECONDS_ONE_DAY = 3600 * 24
 ---@field config MatchTableConfig
 ---@field matches MatchTableMatch[]
 ---@field stats MatchTableStats
----@field display Html
 local MatchTable = Class.new(function(self, args)
 	self.args = args or {}
 	self.title = mw.title.getCurrentTitle()
@@ -553,7 +552,7 @@ end
 
 ---@return Html
 function MatchTable:build()
-	self.display = mw.html.create('table')
+	local display = mw.html.create('table')
 		:addClass('wikitable wikitable-striped sortable')
 		:css('text-align', 'center')
 		:node(self:_titleRow(self.config.title))
@@ -563,7 +562,7 @@ function MatchTable:build()
 		local text = 'This ' .. (self.config.mode == Opponent.solo and Opponent.solo or Opponent.team)
 			.. ' has not played any matches yet.'
 
-		return self.display:tag('tr')
+		return display:tag('tr')
 			:tag('td')
 				:attr('colspan', '100')
 				:css('font-style', 'italic')
@@ -576,14 +575,14 @@ function MatchTable:build()
 		local year = tonumber(match.date:sub(1, 4))
 		if self.config.showYearHeaders and year ~= currentYear then
 			currentYear = year
-			self.display:node(self:_yearRow(year))
+			display:node(self:_yearRow(year))
 		end
-		self.display:node(self:matchRow(match))
+		display:node(self:matchRow(match))
 	end)
 
 	if self.config.linkSubPage then
 		local pagename = self.title.text .. '/Matches'
-		self.display:tag('tr')
+		display:tag('tr')
 			:tag('th')
 				:attr('colspan', 42)
 				:css('font-style', 'italic')
@@ -593,7 +592,7 @@ function MatchTable:build()
 	local wrappedTableNode = mw.html.create('div')
 		:addClass('match-table-wrapper')
 		:addClass('table-responsive')
-		:node(self.display)
+		:node(display)
 
 	return mw.html.create('div')
 		:node(self:displayStats())


### PR DESCRIPTION
## Summary

requested on discord: https://discord.com/channels/93055209017729024/276340346831765504/1443915982572884129

This PR adjusts display names in match tables to use the same naming logic as in the new match ticker (i.e., tickername + section).

## How did you test this change?

dev in LoL