### PR TITLE
feat: add set 3 and 4 support to dota2 cosmetics

### DIFF
--- a/lua/wikis/dota2/Infobox/Cosmetic/Custom.lua
+++ b/lua/wikis/dota2/Infobox/Cosmetic/Custom.lua
@@ -213,6 +213,30 @@ function CustomCosmetic:_createIntroText()
 		output:node(CosmeticIcon._main{item, '130px'})
 	end
 
+	local thirdSet = CustomCosmetic._createSet(self.args.setname3)
+
+	if not thirdSet then
+		return output
+	end
+
+	output:newline():wikitext('Also part of the following set:'):newline()
+	output:node(CosmeticIcon._main{args.setname3, '170px'})
+	for _, item in ipairs(thirdSet) do
+		output:node(CosmeticIcon._main{item, '130px'})
+	end
+
+	local fourthSet = CustomCosmetic._createSet(self.args.setname4)
+
+	if not fourthSet then
+		return output
+	end
+
+	output:newline():wikitext('Also part of the following set:'):newline()
+	output:node(CosmeticIcon._main{args.setname4, '170px'})
+	for _, item in ipairs(fourthSet) do
+		output:node(CosmeticIcon._main{item, '130px'})
+	end
+
 	return output
 end
 
@@ -245,6 +269,8 @@ function CustomCosmetic:setLpdbData(args)
 			marketlock = args.marketlock or '',
 			setname = args.setname or '',
 			setname2 = args.setname2 or '',
+			setname3 = args.setname3 or '',
+			setname4 = args.setname4 or '',
 			setitems = self:getAllArgsForBase(args, 'setitem'),
 			releasedate = args.releasedate or '',
 			expiredate = args.expiredate or '',


### PR DESCRIPTION
## Summary

This change adds 2 more setname parameters to support multi-set items from the "Dota 2 x Monster Hunter" collab, specifically https://liquipedia.net/dota2/Palico_Sign and https://liquipedia.net/dota2/Palico_Sticky_Bomb

## How did you test this change?

Tested on my sandbox over at Russian-locale part of Dota 2 Wiki (images may be broken there due to it being a bit outdated in comparison to main wiki):
https://liquipedia.net/dota2gameru/%D0%A3%D1%87%D0%B0%D1%81%D1%82%D0%BD%D0%B8%D0%BA:Le_Mur/%D0%A8%D0%B0%D0%B1%D0%BB%D0%BE%D0%BD:SandboxModule
https://liquipedia.net/dota2gameru/%D0%A3%D1%87%D0%B0%D1%81%D1%82%D0%BD%D0%B8%D0%BA:Le_Mur/%D0%A8%D0%B0%D0%B1%D0%BB%D0%BE%D0%BD:SandboxModule/doc
https://liquipedia.net/dota2gameru/%D0%9C%D0%BE%D0%B4%D1%83%D0%BB%D1%8C:Sandbox/Le_Mur
