### PR TITLE
feat: set sort order for roles in marvelrivals

### DIFF
--- a/lua/wikis/marvelrivals/InGameRoles.lua
+++ b/lua/wikis/marvelrivals/InGameRoles.lua
@@ -7,10 +7,10 @@
 
 ---@type table<string, RoleBaseData>
 local inGameRoles = {
-	['duelist'] = {category = 'Duelist Players', display = 'Duelist'},
-	['flex'] = {category = 'Flex Players', display = 'Flex'},
-	['strategist'] = {category = 'Strategist Players', display = 'Strategist'},
-	['vanguard'] = {category = 'Vanguard Players', display = 'Vanguard'},
+	['duelist'] = {category = 'Duelist Players', display = 'Duelist', sortOrder = 1},
+	['flex'] = {category = 'Flex Players', display = 'Flex', sortOrder = 4},
+	['strategist'] = {category = 'Strategist Players', display = 'Strategist', sortOrder = 3},
+	['vanguard'] = {category = 'Vanguard Players', display = 'Vanguard', sortOrder = 2},
 }
 
 return inGameRoles


### PR DESCRIPTION
## Summary

Set a sortOrder (Duelist-> Vanguard -> Strategist -> Flex) for correct display.

## How did you test this change?

based on #6860 
