### PR TITLE
feat: support subpage/relative tournament links in team cards

### DIFF
--- a/lua/wikis/commons/Page.lua
+++ b/lua/wikis/commons/Page.lua
@@ -88,13 +88,4 @@ function Page.applyUnderScoresIfEnforced(pageName)
 	return pageName
 end
 
----@param link string
----@return string
-function Page.makeSubPage(link)
-	if link:sub(1, 1) ~= '/' then
-		return link
-	end
-	return mw.title.getCurrentTitle().text .. link
-end
-
 return Page

--- a/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
+++ b/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
@@ -12,8 +12,8 @@ local DateExt = Lua.import('Module:Date/Ext')
 local Info = Lua.import('Module:Info', {loadData = true})
 local Logic = Lua.import('Module:Logic')
 local Opponent = Lua.import('Module:Opponent/Custom')
-local Page = Lua.import('Module:Page')
 local RoleUtil = Lua.import('Module:Role/Util')
+local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local TeamTemplate = Lua.import('Module:TeamTemplate')
 local Tournament = Lua.import('Module:Tournament')
@@ -90,10 +90,13 @@ local function parseQualifier(input)
 	}
 
 	if qualificationType == 'tournament' then
-		if not input.page then
+		local tournamentPage = input.page
+		if not tournamentPage then
 			error('Tournament qualifier must have a page')
 		end
-		local tournamentPage = Page.makeSubPage(input.page)
+		if String.startsWith(tournamentPage, '/') then
+			tournamentPage = mw.title.getCurrentTitle().text .. tournamentPage
+		end
 		local tournament = Tournament.getTournament(tournamentPage)
 		if not tournament then
 			qualificationStructure.type = 'other'


### PR DESCRIPTION
## Summary
Support subpage tournament links for tournament pages in the team cards. 

Easier maintaince for editors, espectially if a tournament is moved with its subpages.

## How did you test this change?
dev