### PR TITLE
refactor(match2): move matchpage css override for pill containers to inline css

### DIFF
--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -303,6 +303,10 @@ function BaseMatchPage:renderGames()
 	local overallStats = self:renderOverallStats()
 
 	return ContentSwitch{
+		css = {
+			['margin-top'] = '0.5rem',
+			['margin-bottom'] = '0.5rem',
+		},
 		tabs = WidgetUtil.collect(
 			overallStats and {
 				label = {

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1569,8 +1569,3 @@ $valorant-def: #01654c;
 		}
 	}
 }
-
-.match-bm .switch-pill-container {
-	margin-top: 0.5rem;
-	margin-bottom: 0.5rem;
-}


### PR DESCRIPTION
## Summary

See https://github.com/Liquipedia/Lua-Modules/pull/6753#discussion_r2498812119 for context.

This PR moves css override for switch pill containers in matchpages to inline css.

## How did you test this change?

dev