### PR TITLE
feat: add staff only mode to CountryRepresentation

### DIFF
--- a/lua/wikis/commons/CountryRepresentation.lua
+++ b/lua/wikis/commons/CountryRepresentation.lua
@@ -66,6 +66,8 @@ function CountryRepresentation:init(args)
 		end)), Page.pageifyLink),
 	}
 
+	assert(self.config.player or self.config.staff, 'Invalid config: at least one of |player= or |staff= must be true')
+
 	if Logic.isEmpty(self.config.tournaments) then
 		self.config.tournaments = {Page.pageifyLink(mw.title.getCurrentTitle().text)}
 	end


### PR DESCRIPTION
## Summary

Requested on discord: https://discord.com/channels/93055209017729024/276340346831765504/1446814212067299359

This PR adds "staff only" mode to `Module:CountryRepresentation`.

## How did you test this change?

preview with dev