### PR TITLE
Updated Halo Wiki Info.lua

### DIFF
--- a/lua/wikis/halo/Info.lua
+++ b/lua/wikis/halo/Info.lua
@@ -105,7 +105,7 @@ return {
 	},
 	config = {
 		squads = {
-			hasPosition = true,
+			hasPosition = false,
 			hasSpecialTeam = false,
 			allowManual = true,
 		},


### PR DESCRIPTION
Included Manual Squad Tables

## Summary
I made it so manual Squad Tables are available on the Halo wiki as i would like to have squads on my user pages

## How did you test this change?
This is the exact same code as on call of duty

