### PR TITLE
fix(match2): header not set for Third-Place matches

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input.lua
+++ b/lua/wikis/commons/MatchGroup/Input.lua
@@ -204,7 +204,7 @@ function MatchGroupInput.readBracket(bracketId, args, options)
 		match.bracketdata = Table.mergeInto(bracketData, match.bracketdata or {})
 
 		bracketData.type = 'bracket'
-		bracketData.header = args[matchKey .. 'header'] or bracketData.header
+		bracketData.header = args[matchKey .. 'header'] or bracketData.header or (matchKey == 'RxMTP' and '!tp') or nil
 		bracketData.qualifiedheader = MatchGroupInput._readQualifiedHeader(bracketData, args, matchKey)
 		bracketData.inheritedheader = MatchGroupInput._inheritedHeader(bracketData.header)
 


### PR DESCRIPTION
## Summary
[reported on discord](https://discord.com/channels/93055209017729024/372075546231832576/1448799401601536162) 
 
currently Match Tickers show "Grand Final" for Third-Place matches.
The root cause of this is that no header is stored for Third-Place matches unless manually entered.
This PR adjusts input parsing so that i will add a default Third-Place header for Third-Place matches.

## How did you test this change?
dev

## After merge
Touch/Purge jobs across all wikis for all pages with Third-Place matches.

## Alternative solutions

### Alterantive solution 1:
1. bot adjust all bracket templates on commons like [here](https://liquipedia.net/commons/index.php?title=Template%3ABracket%2F32&diff=949664&oldid=685835)
2. adjust bracket designer JS accordingly (closed source so employees have to do it)
3. Touch/Purge jobs across all wikis for all pages with Third-Place matches.

### Alterantive solution 2:
adjust all display components that use inheritedHeader (this would likely be quite a few ...)