### PR TITLE
feat: add Suspended role alias to TH manual

### DIFF
--- a/lua/wikis/commons/Infobox/Extension/TeamHistory/Manual.lua
+++ b/lua/wikis/commons/Infobox/Extension/TeamHistory/Manual.lua
@@ -19,6 +19,8 @@ local ROLE_CLEAN = Lua.requireIfExists('Module:TeamHistoryAuto/cleanRole', {load
 local ROLE_ALIASES = {
 	r = 'Retired',
 	retired = 'Retired',
+	s = 'Suspended',
+	suspended = 'Suspended',
 }
 
 local TeamHistoryManual = {}


### PR DESCRIPTION
## Summary

There are a couple of pages on the HoTS wiki that are currently throwing errors on their TH because `suspended` and `s` aren't recognized role aliases. I don't know if they were recognized in the past. 

https://liquipedia.net/heroes/index.php?title=Relic&action=submit

## How did you test this change?

N/A
