### PR TITLE
feat(match2): make match2 behavior customizable for each project in lab

### DIFF
--- a/lua/wikis/lab/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/lab/MatchGroup/Input/Custom.lua
@@ -36,6 +36,11 @@ local FfaMapFunctions = {}
 ---@param options table?
 ---@return table
 function CustomMatchGroupInput.processMatch(match, options)
+	local projectName = mw.title.getCurrentTitle().rootText
+	local ProjectCustomMatchGroupInput = Lua.requireIfExists('Module:MatchGroup/Input/Custom/' .. projectName)
+	if ProjectCustomMatchGroupInput then
+		return ProjectCustomMatchGroupInput.processMatch(match, options)
+	end
 	return MatchGroupInputUtil.standardProcessMatch(match, MatchFunctions, FfaMatchFunctions)
 end
 

--- a/lua/wikis/lab/MatchSummary.lua
+++ b/lua/wikis/lab/MatchSummary.lua
@@ -17,6 +17,11 @@ local CustomMatchSummary = {}
 ---@param args table
 ---@return Html
 function CustomMatchSummary.getByMatchId(args)
+	local projectName = mw.title.getCurrentTitle().rootText
+	local ProjectCustomMatchSummary = Lua.requireIfExists('Module:MatchSummary/' .. projectName)
+	if ProjectCustomMatchSummary then
+		return ProjectCustomMatchSummary.getByMatchId(args)
+	end
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 

--- a/lua/wikis/lab/MatchSummary/Ffa.lua
+++ b/lua/wikis/lab/MatchSummary/Ffa.lua
@@ -19,6 +19,11 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@param props {bracketId: string, matchId: string}
 ---@return Widget
 function CustomMatchSummary.getByMatchId(props)
+	local projectName = mw.title.getCurrentTitle().rootText
+	local ProjectCustomMatchSummary = Lua.requireIfExists('Module:MatchSummary/Ffa/' .. projectName)
+	if ProjectCustomMatchSummary then
+		return ProjectCustomMatchSummary.getByMatchId(props)
+	end
 	---@class FFAMatchGroupUtilMatch
 	local match = MatchGroupUtil.fetchMatchForBracketDisplay(props.bracketId, props.matchId)
 	SummaryHelper.updateMatchOpponents(match)


### PR DESCRIPTION
## Summary

Each project in the lab wiki has one root page and all content pages for a project are (grand)children of the root page.
This PR takes advantage of this structure and adds per-project entrypoints in lab match2, with the current lab match2 setup as a fallback.

## How did you test this change?

preview with dev