### PR TITLE
feat(TeamParticipant): adjust color for free text insider qualifier information in dark theme

### DIFF
--- a/stylesheets/commons/TeamParticipantCard.scss
+++ b/stylesheets/commons/TeamParticipantCard.scss
@@ -184,14 +184,15 @@ $compact-selector: '[data-switch-group="team-cards-compact"]';
 		padding: 0.25rem 0.5rem;
 		margin: 0.25rem 0.5rem;
 		min-height: 2rem;
-		color: var( --clr-secondary-25 );
 
 		.theme--light & {
 			background-color: var( --clr-on-surface-light-primary-4 );
+			color: var( --clr-secondary-25 );
 		}
 
 		.theme--dark & {
 			background-color: var( --clr-on-surface-dark-primary-4 );
+			color: var( --clr-secondary-90 );
 		}
 
 		a & {


### PR DESCRIPTION
## Summary

This PR adjusts colors for free text inside qualifier information in teamparticipants as it is hard to read in dark theme.

## How did you test this change?

browser dev tools