### PR TITLE
add NfS Shift 2 to Simracing Info

### DIFF
--- a/lua/wikis/simracing/Info.lua
+++ b/lua/wikis/simracing/Info.lua
@@ -882,6 +882,19 @@ return {
 				lightMode = 'NFS default lightmode.png',
 			},
 		},
+		shift2 = {
+			abbreviation = 'Shift 2',
+			name = 'Need for Speed: Shift 2 – Unleashed',
+			link = 'Need for Speed: Shift 2 – Unleashed',
+			logo = {
+				darkMode = 'NFS default darkmode.png',
+				lightMode = 'NFS default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'NFS default darkmode.png',
+				lightMode = 'NFS default lightmode.png',
+			},
+		},
 	},
 	config = {
 		squads = {


### PR DESCRIPTION
## Summary

Another game for simracing wiki (already has Shift, but not Shift 2) to document old events

## How did you test this change?

Not tested, shouldn't break anytihng
