### PR TITLE
feat(TournamentsTicker): improve error message for missing endDates

### DIFF
--- a/lua/wikis/commons/Widget/Tournaments/Ticker.lua
+++ b/lua/wikis/commons/Widget/Tournaments/Ticker.lua
@@ -66,6 +66,7 @@ function TournamentsTickerWidget:render()
 		elseif tournament.phase == 'UPCOMING' then
 			return tournament.startDate.timestamp < startDateThreshold
 		elseif tournament.phase == 'FINISHED' then
+			assert(tournament.endDate, 'Tournament without end date: ' .. tournament.pageName)
 			return tournament.endDate.timestamp > endDateThreshold
 		end
 		return false


### PR DESCRIPTION
## Summary
instead of letting it error because it tries to access nil use assert to get a cleaner more informative error message which also states the pagename of the problematic tournament

## How did you test this change?
dev