### PR TITLE
refactor(infobox): clean up wildrift player infobox

### DIFF
--- a/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
@@ -96,7 +96,7 @@ function CustomInjector:parse(id, widgets)
 			children = {table.concat(championIcons, '&nbsp;')},
 		}}
 	elseif id == 'status' then
-		local status = args.status and mw.getContentLanguage():ucfirst(args.status) or nil
+		local status = args.status and String.upperCaseFirst(args.status) or nil
 
 		return {
 			Cell{name = 'Status', children = {Page.makeInternalLink({onlyIfExists = true}, status) or status}},


### PR DESCRIPTION
## Summary

This PR:
- replaces `mw.getContentLanguage():ucfirst` with `String.upperCaseFirst`
- fixes return type for template entrypoint
- adds missing class type annotations in wildrift player infobox

## How did you test this change?

logically trivial