### PR TITLE
fix(NavBox): fix month abbr handling for current month

### DIFF
--- a/lua/wikis/commons/Widget/NavBox/Transfer.lua
+++ b/lua/wikis/commons/Widget/NavBox/Transfer.lua
@@ -119,7 +119,7 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 	local quarter = tonumber((firstEntry.abbreviation:match('Q(%d)')))
 	local origMonthAbbreviation = firstEntry.abbreviation:gsub('#.*', '')
 	local monthTimeStamp = (not quarter) and DateExt.readTimestamp(origMonthAbbreviation .. ' 1970') or nil
-	local month = monthTimeStamp and tonumber(DateExt.formatTimestamp('n', monthTimeStamp)) or nil
+	local month = monthTimeStamp and DateExt.getMonthOf(monthTimeStamp) or nil
 
 	local addCurrent = function()
 		if not month and not quarter then return children end
@@ -141,7 +141,7 @@ function TransferNavBox._checkForCurrentQuarterOrMonth(children, firstEntry)
 
 		local currentMonthTimeStamp = DateExt.readTimestamp(monthAbbreviation .. ' 1970')
 		--can not be nil since it is a valid timestamp as per above nil check
-		--@cast currentMonthTimeStamp -nil
+		---@cast currentMonthTimeStamp -nil
 		local monthName = DateExt.formatTimestamp('F', currentMonthTimeStamp)
 		pageName = pageName:gsub('/[^/]*/?%d?$', '/' .. monthName)
 


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1456085402388664493

currently transfer navbox errors in january if no transfer is known for the current year on wikis that use monthly transfer pages

this is due to the month abbr building not being able to handle integer input while getting an integer supplied

## How did you test this change?
dev