### PR TITLE
feat(mainpage): automate 'in memory of' display in mainpages

### DIFF
--- a/lua/wikis/commons/MainPageLayout.lua
+++ b/lua/wikis/commons/MainPageLayout.lua
@@ -112,7 +112,7 @@ function MainPageLayout._makeInMemoryOfDisplay(args)
 		return
 	end
 	return Array.map(passedAwayPlayers, function (player)
-		return InMemoryOf{pageLink = player}
+		return InMemoryOf{pageLink = player.pagename}
 	end)
 end
 


### PR DESCRIPTION
## Summary

_Depends on #6946_

This PR automates use of #5569 in main pages.

## How did you test this change?

https://liquipedia.net/leagueoflegends/User:ElectricalBoy/MainPage (dev uses 4 week offset for testing purposes instead of 2 weeks as specified in this PR)