### PR TITLE
feat(infobox): standardize dota2 version infobox

### DIFF
--- a/lua/wikis/dota2/Infobox/Patch/Custom.lua
+++ b/lua/wikis/dota2/Infobox/Patch/Custom.lua
@@ -40,6 +40,7 @@ end
 function CustomPatch.runVersion(frame)
 	local patch = CustomPatch(frame)
 	local args = patch.args
+	args.name = 'Version ' .. args.version
 	args.release = args.dota2
 	args.informationType = 'Version'
 	patch:setWidgetInjector(CustomInjector(patch))


### PR DESCRIPTION
## Summary

This PR replaces wikicode-based fandom version of [Template:Version infobox](https://liquipedia.net/dota2/Template:Version_infobox) with standardized patch infobox.

## How did you test this change?

https://liquipedia.net/dota2/User:ElectricalBoy/Sandbox2