### PR TITLE
fix(match2): halo h2h custom icons

### DIFF
--- a/lua/wikis/halo/Links/CustomData.lua
+++ b/lua/wikis/halo/Links/CustomData.lua
@@ -16,8 +16,8 @@ return {
 	},
 	matchIcons = {
 		headtohead = {
-			icon = 'File:Match_Info_Halo_H2H.png',
-			iconDark = 'File:Match_Info_Halo_H2H_darkmode.png',
+			icon = 'Match_Info_Halo_H2H.png',
+			iconDark = 'Match_Info_Halo_H2H_darkmode.png',
 			text = 'Head-to-head statistics'
 		},
 	}


### PR DESCRIPTION
## Summary

Currently every matchsummary on halo wiki has broken icons ([example](https://liquipedia.net/halo/WSVG/2006/Louisville))
<img width="543" height="252" alt="image" src="https://github.com/user-attachments/assets/65297469-3efd-4790-a229-0745af6943d9" />


## How did you test this change?

Used dev module on the [page](https://liquipedia.net/halo/Halo_World_Championship/2016/Latin_America/Brazil/Qualifier_1)
