### PR TITLE
fix: styling of h2 for entity matchticker

### DIFF
--- a/lua/wikis/commons/MatchTicker/DisplayComponents/Entity.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents/Entity.lua
@@ -69,9 +69,14 @@ function Container:create()
 	return HtmlWidgets.Div{
 		css = {['margin-bottom'] = '1rem'},
 		children = {
-			HtmlWidgets.H2{
-				css = {border = 'unset'},
-				children = I18n.translate('matchticker-upcoming-matches'),
+			HtmlWidgets.Div{
+				classes = {'mw-heading', 'mw-heading2'},
+				children = {
+					HtmlWidgets.H2{
+						css = {border = 'unset'},
+						children = I18n.translate('matchticker-upcoming-matches'),
+					},
+				},
 			},
 			Switch{
 				label = 'Show countdown',


### PR DESCRIPTION
## Summary

The h2 for the entity matchticker has different styling compared to other h2. This is fixed by wrapping it to a div with h2 specific classes.

## How did you test this change?

`|dev=emth`

Before:
<img width="1058" height="388" alt="image" src="https://github.com/user-attachments/assets/84e7f2ed-2f65-4ffe-8690-7db8cb72da31" />

After:
<img width="1066" height="353" alt="image" src="https://github.com/user-attachments/assets/f28acb5f-c94e-4d5b-a69c-dffea6d008fe" />