### PR TITLE
fix(infobox): chronology not displayed in fighters game infobox

### DIFF
--- a/lua/wikis/fighters/Infobox/Game/Custom.lua
+++ b/lua/wikis/fighters/Infobox/Game/Custom.lua
@@ -17,7 +17,12 @@ local Widgets = Lua.import('Module:Widget/All')
 local Chronology = Widgets.Chronology
 
 ---@class FightersGameInfobox: GameInfobox
+---@operator call(Frame): FightersGameInfobox
 local CustomGame = Class.new(Game)
+
+---@class FightersGameInfoboxWidgetInjector: WidgetInjector
+---@operator call(FightersGameInfobox): FightersGameInfoboxWidgetInjector
+---@field caller FightersGameInfobox
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame


### PR DESCRIPTION
## Summary

Because cleanup of fighters game infobox was omitted in #6109, chronology is not rendered properly inside it. This PR adjusts params passed into chronology widget to make it work again.

While we are at it, this PR also updates type annotation for the infobox.

## How did you test this change?

preview with dev