### PR TITLE
fix: missing nil check in rocketleague ratings

### DIFF
--- a/lua/wikis/rocketleague/Ratings/Display/List.lua
+++ b/lua/wikis/rocketleague/Ratings/Display/List.lua
@@ -33,6 +33,10 @@ function RatingsDisplayList.build(teamRankings)
 		:allDone()
 
 	Array.forEach(teams, function(team, rank)
+		if (team.streak == nil) or (team.rating == nil) then
+			return
+		end
+
 		local chart = mw.ext.Charts.chart({
 			xAxis = {
 				type = 'category',


### PR DESCRIPTION
Add checks for nil values in team streak and rating.

## Summary

There is currently an error on the Liquipedia Rating portal page (https://liquipedia.net/rocketleague/Portal:Rating) that prevents the rating list being created:

`Module:Ratings/Display/List:70: attempt to compare number with nil (stack trace logged)`

The following change allows the rating list to work as usual on the portal page by discarding teams which return nil values in their streak or rating.

## How did you test this change?

Tested the changes using `|dev=umr` on my userspace (https://liquipedia.net/rocketleague/User:Umr_1000/draft). The rating list is generated with the given change without any issues.
