### PR TITLE
fix: toc font sizing on pages with entity matchticker

### DIFF
--- a/lua/wikis/commons/MatchTicker/DisplayComponents/Entity.lua
+++ b/lua/wikis/commons/MatchTicker/DisplayComponents/Entity.lua
@@ -88,7 +88,12 @@ function Container:create()
 				css = {margin = '0.75rem 0 1rem'},
 				content = carousel,
 			},
-			TABLE_OF_CONTENTS,
+			HtmlWidgets.Div{
+				css = {['margin-top'] = '1rem'},
+				children = {
+					TABLE_OF_CONTENTS,
+				},
+			},
 		},
 	}
 end


### PR DESCRIPTION
## Summary

Fixes #6957

Mediawiki inserts the inline TOC above the first section heading on page, which causes the font sizing to be large as it gets placed inside the heading wrapper with text styling.

We can go around this by defining to render the TOC outside of the heading wrapper and below the entity match ticker.

## How did you test this change?

`dev=toc-fix` flag to infobox that renders the entity match ticker on page.
