### PR TITLE
feat(match2): rework games display in fighters matchsummary

### DIFF
--- a/lua/wikis/fighters/MatchSummary.lua
+++ b/lua/wikis/fighters/MatchSummary.lua
@@ -42,10 +42,7 @@ end
 ---@return boolean
 function CustomMatchSummary._isSolo(match)
 	return Array.all(match.opponents, function (opponent)
-		if not Opponent.isOpponent(opponent) then
-			return false
-		end
-		return opponent.type == Opponent.solo
+		return Opponent.isOpponent(opponent) and opponent.type == Opponent.solo
 	end)
 end
 


### PR DESCRIPTION
## Summary

feature request from discord: https://discord.com/channels/93055209017729024/202549269134180352/1460437314583920870

This PR:
- cleans up 'solo mode' detection logic
- adjusts character display for solo mode
- throws away uses of `mw.html` in fighters match summary

## How did you test this change?

https://liquipedia.net/fighters/User:ElectricalBoy/Sandbox5