### PR TITLE
refactor(match2): use StandardTournamentPartial in match page rendering

### DIFF
--- a/lua/wikis/commons/MatchPage/Base.lua
+++ b/lua/wikis/commons/MatchPage/Base.lua
@@ -12,6 +12,7 @@ local CharacterIcon = Lua.import('Module:CharacterIcon')
 local Class = Lua.import('Module:Class')
 local Countdown = Lua.import('Module:Countdown')
 local DateExt = Lua.import('Module:Date/Ext')
+local FnUtil = Lua.import('Module:FnUtil')
 local Logic = Lua.import('Module:Logic')
 local Links = Lua.import('Module:Links')
 local Operator = Lua.import('Module:Operator')
@@ -346,10 +347,11 @@ function BaseMatchPage:renderGame(game)
 end
 
 ---@protected
+---@param self BaseMatchPage
 ---@return StandardTournamentPartial
-function BaseMatchPage:getMatchContext()
+BaseMatchPage.getMatchContext = FnUtil.memoize(function (self)
 	return Tournament.partialTournamentFromMatch(self.matchData)
-end
+end)
 
 ---@protected
 ---@return Widget


### PR DESCRIPTION
## Summary

This PR replaces use of MGI in match page with `StandardTournamentPartial` from `Module:Tournament`.

## How did you test this change?

dev: https://liquipedia.net/valorant/Match:ID_User_ElectricalBoy_L7qBdI40jW_R01-M001