### PR TITLE
fix: filter button hover color

### DIFF
--- a/stylesheets/commons/FilterButtons.scss
+++ b/stylesheets/commons/FilterButtons.scss
@@ -130,7 +130,14 @@ Author(s): Elysienna, Nadox
 
 		&:hover {
 			color: #ffffff;
-			background-color: var( --clr-wiki-theme-30, #0a558f );
+
+			.theme--light & {
+				background-color: var( --clr-wiki-theme-30, #0a558f );
+			}
+
+			.theme--dark & {
+				background-color: var( --clr-wiki-theme-40, #1f73c1 );
+			}
 
 			&::after {
 				opacity: 0.24;


### PR DESCRIPTION
## Summary

We defined the filter buttons in the design system. This definition changed the hover colors on light and dark mode.

We also added the theme color tones to the skin so they are available to use from here.

## How did you test this change?

https://liquipedia.net/leagueoflegends/User:Eetwalt + css changes