### PR TITLE
feat(mainpage):Fix Transfers edit button to direct to the correct page on F1

### DIFF
--- a/lua/wikis/formula1/MainPageLayout/data.lua
+++ b/lua/wikis/formula1/MainPageLayout/data.lua
@@ -6,7 +6,9 @@
 --
 
 local Lua = require('Module:Lua')
+
 local DateExt = Lua.import('Module:Date/Ext')
+
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div


### PR DESCRIPTION
## Summary

Fix the TransferList so the edit button on the main page points to the correct place. It currently takes you to `Player Transfers/YEAR/MONTH` but the F1 wiki uses `Driver Transfers/YEAR`

## How did you test this change?

Made the same changes in userspace

https://liquipedia.net/formula1/Module:MainPageLayout/data/dev/centaur
https://liquipedia.net/formula1/index.php?title=Module%3AMainPageLayout%2Fdata%2Fdev%2Fcentaur&diff=40813&oldid=37995

https://liquipedia.net/formula1/User:I_am_entry/main_page
