### PR TITLE
feat(Infobox):Add Custom Team Infobox module for osu!

### DIFF
--- a/lua/wikis/osu/Infobox/Team/Custom.lua
+++ b/lua/wikis/osu/Infobox/Team/Custom.lua
@@ -12,8 +12,6 @@ local PlacementStats = Lua.import('Module:InfoboxPlacementStats')
 
 local Team = Lua.import('Module:Infobox/Team')
 
-local HtmlWidgets = Lua.import('Module:Widget/Html/All')
-
 ---@class OsuInfoboxTeam: InfoboxTeam
 ---@operator call(Frame): OsuInfoboxTeam
 local CustomTeam = Class.new(Team)


### PR DESCRIPTION
## Summary

Add results table widget to team infobox on osu after request from contributors

## How did you test this change?

Dev module:
https://liquipedia.net/osu/Module:Infobox/Team/Custom/dev/centaur

Trying the output of dev module on a less popular team page:
https://liquipedia.net/osu/Team_Guatemala
