### PR TITLE
fix: incorrect width rule for general dialog

### DIFF
--- a/stylesheets/commons/Dialog.scss
+++ b/stylesheets/commons/Dialog.scss
@@ -22,7 +22,7 @@ div.general-dialog-container {
 	background-color: #ffffff;
 	border-radius: 0.5rem;
 	box-shadow: 0 0.0625rem 0.25rem 0 var( --clr-on-surface-dark-primary-12 );
-	width: fit-content !important;
+	width: max-content !important;
 	max-width: 100vw;
 	max-height: 100vh;
 


### PR DESCRIPTION
## Summary

Small oversight from #6962, content of the dialog should be making use of all horizontal space.

## How did you test this change?

browser dev tools