### PR TITLE
refactor(infobox): use super in smash league infobox

### DIFF
--- a/lua/wikis/commons/Infobox/Basic.lua
+++ b/lua/wikis/commons/Infobox/Basic.lua
@@ -16,7 +16,7 @@ local Table = Lua.import('Module:Table')
 local Info = Lua.import('Module:Info')
 local Infobox = Lua.import('Module:Widget/Infobox/Core')
 
----@class BasicInfobox
+---@class BasicInfobox: BaseClass
 ---@operator call(Frame): BasicInfobox
 ---@field args table
 ---@field pagename string

--- a/lua/wikis/smash/Infobox/League/Custom.lua
+++ b/lua/wikis/smash/Infobox/League/Custom.lua
@@ -33,13 +33,18 @@ local DEFAULT_TYPE = 'offline'
 local MANUAL_SERIES_ICON = 1
 local UNKNOWN_DATE_PART = '??'
 
---- @class SmashLeagueInfobox: InfoboxLeague
---- @field super fun(self: SmashLeagueInfobox): InfoboxLeague
+---@class SmashLeagueInfobox: InfoboxLeague
+---@operator call(Frame): SmashLeagueInfobox
+---@field super fun(self: SmashLeagueInfobox): InfoboxLeague
 local CustomLeague = Class.new(League)
+
+---@class SmashLeagueInfoboxWidgetInjector: WidgetInjector
+---@operator call(SmashLeagueInfobox): SmashLeagueInfoboxWidgetInjector
+---@field caller SmashLeagueInfobox
 local CustomInjector = Class.new(Injector)
 
 --- @param frame Frame
---- @return Html
+--- @return Widget
 function CustomLeague.run(frame)
 	local league = CustomLeague(frame)
 	league:setWidgetInjector(CustomInjector(league))


### PR DESCRIPTION
## Summary

_Depends on #6990_

This PR adjusts smash league infobox to use `super()`

## How did you test this change?

untested