### PR TITLE
ci: Bump actions/checkout from 5 to 6

### DIFF
--- a/.github/workflows/delete dev env.yml
+++ b/.github/workflows/delete dev env.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy test.yml
+++ b/.github/workflows/deploy test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup lua
         # Workaround until https://github.com/leafo/gh-actions-lua/issues/57 is resolved
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup lua
         # Workaround until https://github.com/leafo/gh-actions-lua/issues/57 is resolved

--- a/.github/workflows/protect new wiki modules.yml
+++ b/.github/workflows/protect new wiki modules.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Lua Protect
         env:

--- a/.github/workflows/protect new wiki templates.yml
+++ b/.github/workflows/protect new wiki templates.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Template Protect
         env:

--- a/.github/workflows/resources.yml
+++ b/.github/workflows/resources.yml
@@ -7,7 +7,7 @@ jobs:
   test-resources:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install modules
         run: npm install
       - name: Run lint check

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/update visual snapshots.yml
+++ b/.github/workflows/update visual snapshots.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           # Support runs of this action in forks


### PR DESCRIPTION
## Summary

Bumps [actions/checkout](https://github.com/actions/checkout) from 5 to 6.

Part of #7258

## How did you test this change?

<https://github.com/Liquipedia/Lua-Modules/actions/runs/21275397112>