### PR TITLE
fix(match2): game score holder in lol matchpage shows unintended line break in bo1

### DIFF
--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -983,7 +983,7 @@ span.slash {
 			flex-direction: column;
 			justify-content: center;
 			align-items: center;
-			padding: 0 1rem;
+			padding: 0 0.5rem;
 			gap: 4px;
 			text-align: center;
 		}


### PR DESCRIPTION
## Summary

<img width="383" height="103" alt="image" src="https://github.com/user-attachments/assets/47f0e211-ea38-4d9b-aee4-ba57e4a1ccf6" />

This PR fixes the unintended line break in the above screenshot.

## How did you test this change?

browser dev tools