### PR TITLE
ci: Bump mikepenz/action-junit-report from 5 to 6

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -30,7 +30,7 @@ jobs:
           luacheck lua --config lua/.luacheckrc --formatter=JUnit > report.xml
 
       - name: Report lint
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: 'report.xml'
@@ -63,7 +63,7 @@ jobs:
           busted -C lua -v --run=ci --output=junit > busted.xml
 
       - name: Report test
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: 'busted.xml'


### PR DESCRIPTION
## Summary

Bumps [mikepenz/action-junit-report](https://github.com/mikepenz/action-junit-report) from 5 to 6.

## How did you test this change?

<https://github.com/Liquipedia/Lua-Modules/actions/runs/21348286289>