### PR TITLE
fix: image export bugs

### DIFF
--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -55,12 +55,6 @@ const EXPORT_IMAGE_CONFIG = {
 			TEXT: '#181818'
 		}
 	},
-	SVG_ICONS: {
-		INFO: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" width="12" height="12">' +
-			'<circle fill="#616161" cx="6" cy="6" r="6"/>' +
-			'<polygon fill="#fff" points="4 5 4 6 5 6 5 9 4 9 4 10 8 10 8 9 7 9 7 2 5 2 5 4 7 4 7 5 4 5"/>' +
-			'</svg>'
-	},
 	SELECTORS: [
 		{ selector: '.brkts-bracket-wrapper', targetSelector: '.brkts-bracket', typeName: 'Bracket' },
 		{
@@ -398,20 +392,13 @@ class ExportService {
 
 	// Applies fixes to cloned document for proper rendering in exported images
 	applyCloneFixes( clonedDoc ) {
-		this.fixInfoIcons( clonedDoc );
+		this.hideInfoIcons( clonedDoc );
 	}
 
-	// Fixes info icon used in match lists and brackets rendering
-	// by replacing the icon with a SVG instead of backgroundImage for the exported image
-	fixInfoIcons( clonedDoc ) {
+	hideInfoIcons( clonedDoc ) {
 		const infoIcons = clonedDoc.querySelectorAll( '.brkts-match-info-icon' );
 		infoIcons.forEach( ( icon ) => {
-			icon.style.backgroundImage = 'none';
-			icon.innerHTML = EXPORT_IMAGE_CONFIG.SVG_ICONS.INFO;
-			icon.style.display = 'inline-flex';
-			icon.style.alignItems = 'center';
-			icon.style.justifyContent = 'center';
-			icon.style.verticalAlign = 'middle';
+			icon.style.display = 'none';
 		} );
 	}
 


### PR DESCRIPTION
## Summary

This PR addresses and/or fixes:
- preloading html2canvas when clicking Share for better performance
- include alternative `.grouptable` selector for image exports
- fix image rendering if user is zoomed in/out by resetting the zoom for the image
- fix copy-to-clipboard failing due to the window losing focus mid copying
- fix hide info icon from exported images

## How did you test this change?

dev tools