### PR TITLE
feat(mainpage): add extra links for Hub mainpage

### DIFF
--- a/lua/wikis/hub/MainPageLayout/data.lua
+++ b/lua/wikis/hub/MainPageLayout/data.lua
@@ -28,9 +28,8 @@ local CONTENT = {
 				linktype = 'external',
 			}},
 			Li{children = Link{
-				link = 'https://liquipedia.net/commons/Main_Page',
+				link = 'lpcommons:Main Page',
 				children = 'Liquipedia Commons',
-				linktype = 'external',
 			}},
 			Li{children = Link{
 				link = 'Support',


### PR DESCRIPTION
## Summary
<img width="1117" height="255" alt="image" src="https://github.com/user-attachments/assets/41d9129a-3a0f-4d53-8cd7-10536bf2da5d" />

Only extra clickable link that will take user directly back to commons
<img width="402" height="236" alt="image" src="https://github.com/user-attachments/assets/e784e013-82c0-4de7-866a-066e9f1fc50c" />

