### PR TITLE
fix: logo rendering on exported images when user is zoomed in

### DIFF
--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -437,7 +437,7 @@ class ExportService {
 			element.style.background = backgroundColor;
 
 			const capturedCanvas = await html2canvas( element, {
-				scale: 1,
+				scale: window.devicePixelRatio || 1,
 				windowWidth: document.documentElement.scrollWidth,
 				windowHeight: document.documentElement.scrollHeight,
 				scrollX: 0,


### PR DESCRIPTION
## Summary

Fix logo rendering for exported images when user is zoomed in browser

## How did you test this change?

Dev tools

Credit to Slothyman for this fix:
https://discord.com/channels/93055209017729024/372075546231832576/1465710634804183155

Before: 
<img width="548" height="437" alt="image" src="https://github.com/user-attachments/assets/9d207aa2-e866-45ca-a7e4-8f4d4f4e0bde" />

After:
<img width="722" height="541" alt="image" src="https://github.com/user-attachments/assets/6fd4a92d-a1f0-4bc8-80e5-298cd847cb11" />
