### PR TITLE
feat(tier): tiertype for awards show 

### DIFF
--- a/lua/wikis/esports/Tier/Data.lua
+++ b/lua/wikis/esports/Tier/Data.lua
@@ -96,7 +96,7 @@ return {
 			link = 'Showmatches',
 			category = 'Showmatch Tournaments',
 		},
-    	awards = {
+		awards = {
 			value = 'Awards',
 			sort = 'B4',
 			name = 'Awards',

--- a/lua/wikis/esports/Tier/Data.lua
+++ b/lua/wikis/esports/Tier/Data.lua
@@ -96,7 +96,7 @@ return {
 			link = 'Showmatches',
 			category = 'Showmatch Tournaments',
 		},
-    awards = {
+    	awards = {
 			value = 'Awards',
 			sort = 'B4',
 			name = 'Awards',

--- a/lua/wikis/esports/Tier/Data.lua
+++ b/lua/wikis/esports/Tier/Data.lua
@@ -1,0 +1,108 @@
+---
+-- @Liquipedia
+-- page=Module:Tier/Data
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	tiers = {
+		{
+			value = '1',
+			sort = 'A1',
+			name = 'S-Tier',
+			short = 'S',
+			link = 'S-Tier Tournaments',
+			category = 'S-Tier Tournaments',
+		},
+		{
+			value = '2',
+			sort = 'A2',
+			name = 'A-Tier',
+			short = 'A',
+			link = 'A-Tier Tournaments',
+			category = 'A-Tier Tournaments',
+		},
+		{
+			value = '3',
+			sort = 'A3',
+			name = 'B-Tier',
+			short = 'B',
+			link = 'B-Tier Tournaments',
+			category = 'B-Tier Tournaments',
+		},
+		{
+			value = '4',
+			sort = 'A4',
+			name = 'C-Tier',
+			short = 'C',
+			link = 'C-Tier Tournaments',
+			category = 'C-Tier Tournaments',
+		},
+		{
+			value = '5',
+			sort = 'A5',
+			name = 'D-Tier',
+			short = 'D',
+			link = 'D-Tier Tournaments',
+			category = 'D-Tier Tournaments',
+		},
+		[''] = {
+			value = nil,
+			sort = 'B2',
+			name = 'Undefined',
+			short = '?',
+		},
+	},
+
+	tierTypes = {
+		monthly = {
+			value = 'Monthly',
+			sort = 'A6',
+			name = 'Monthly',
+			short = 'Mon.',
+			link = 'Monthly Tournaments',
+			category = 'Monthly Tournaments',
+		},
+		weekly = {
+			value = 'Weekly',
+			sort = 'A7',
+			name = 'Weekly',
+			short = 'Week.',
+			link = 'Weekly Tournaments',
+			category = 'Weekly Tournaments',
+		},
+		qualifier = {
+			value = 'Qualifier',
+			sort = 'A8',
+			name = 'Qualifier',
+			short = 'Qual.',
+			link = 'Qualifier Tournaments',
+			category = 'Qualifier Tournaments',
+		},
+		misc = {
+			value = 'Misc',
+			sort = 'A9',
+			name = 'Misc',
+			short = 'Misc',
+			link = 'Miscellaneous Tournaments',
+			category = 'Miscellaneous Tournaments',
+		},
+		showmatch = {
+			value = 'Showmatch',
+			sort = 'B1',
+			name = 'Showmatch',
+			short = 'Showm.',
+			link = 'Showmatches',
+			category = 'Showmatch Tournaments',
+		},
+    awards = {
+			value = 'Awards',
+			sort = 'B4',
+			name = 'Awards',
+			short = 'Awards',
+			link = 'Award Shows',
+			category = 'Award Shows',
+		},
+	},
+}


### PR DESCRIPTION
## Summary

Preparation to cover Esports Awards and other awards show on esports wiki
Link to discord conversation: https://discord.com/channels/93055209017729024/824979065307136010/1465711192134909952

## How did you test this change?

dev module and userspace page: https://liquipedia.net/esports/User:Nikita_r28/Esports_Awards/Decade
(code is Tier/Data from commons + last entry from rainbowsix Tier/Data)