### PR TITLE
fix: export image increase resolution of the screenshot

### DIFF
--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -481,7 +481,7 @@ class ExportService {
 		const originalBackground = element.style.background;
 		const isDarkTheme = document.documentElement.classList.contains( 'theme--dark' );
 		const backgroundColor = this.getBackgroundColor();
-		// This ensures the scale is at least 2, but never higher than 2
+		// This ensures the scale is at least 2, but never higher than 3
 		const scale = Math.min( Math.max( window.devicePixelRatio || 1, 2 ), 3 );
 
 		try {


### PR DESCRIPTION
## Summary
Reported on discord:
https://discord.com/channels/93055209017729024/372075546231832576/1466115912334704762

Zoom still affects image quality. I tried make this change and it seems to be reliable enough.
It seems that if you zoom out then calcullation is not always perfect, but errors are not that visible. Only problem I found is that vertical/horizontal lines are thicker if zooming out. Tested only on few pages

## How did you test this change?

Dev tools

50%
<img width="696" height="484" alt="50% zoom" src="https://github.com/user-attachments/assets/41563d0e-6a80-48c4-a9ee-196ec9528a6f" />
150%
<img width="696" height="480" alt="150% zoom" src="https://github.com/user-attachments/assets/ae77b34e-8ef5-4ad9-8c3e-ec18036003af" />

50%
<img width="840" height="718" alt="50% zoom 2" src="https://github.com/user-attachments/assets/2f7d6b75-3d08-4e67-a77d-2724aa9b8439" />
150%
<img width="846" height="700" alt="150% zoom 2" src="https://github.com/user-attachments/assets/093c07f0-694e-4ee7-92cd-e129743c5ca0" />

50%
<img width="1616" height="1218" alt="50% zoom 3" src="https://github.com/user-attachments/assets/cbd57962-dc6a-4d3a-b725-b23a37acf54a" />
150%
<img width="1616" height="1182" alt="150% zoom 3" src="https://github.com/user-attachments/assets/89080d52-285a-4e1a-8377-88c63ec626ea" />

50%
<img width="2816" height="1856" alt="50% zoom 4" src="https://github.com/user-attachments/assets/e2a25d70-125e-44c8-b671-b12d46a44fad" />
150%
<img width="2816" height="1798" alt="150% zoom 4" src="https://github.com/user-attachments/assets/0e45275d-4618-4881-81d0-83599535cfcc" />

