### PR TITLE
feat: add participants as exportables

### DIFF
--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -72,8 +72,7 @@ const EXPORT_IMAGE_CONFIG = {
 			typeName: 'Participants'
 		},
 		{ selector: '.standings-ffa', targetSelector: 'tbody', typeName: 'BR/FFA Standings Table' },
-		{ selector: '.standings-swiss', targetSelector: 'tbody', typeName: 'Swiss Standings Table' },
-		{ selector: '.brkts-matchlist', targetSelector: '.brkts-matchlist-collapse-area', typeName: 'Match List' }
+		{ selector: '.standings-swiss', targetSelector: 'tbody', typeName: 'Swiss Standings Table' }
 	]
 };
 


### PR DESCRIPTION
## Summary

- [x] Supports new Team Participants
  * [x] Supports expanded/collapsed view
  * [x] Supports rosters shown/hidden
- [x] Supports 2+ Participants sections [like here](https://liquipedia.net/mobilelegends/M7_World_Championship)
- [x] Supports old Team Participants the same way as New
- [x] Supports Player Participants like [ in here](https://liquipedia.net/starcraft2/Rongyi_Cup#Participants)
- [x] Supports these participant cards [ in here ](https://liquipedia.net/starcraft2/World_Team_League/2023/Summer#Participating_Teams)

## How did you test this change?

Dev tools

Examples:

<img width="2196" height="1120" alt="image" src="https://github.com/user-attachments/assets/632f9bf8-2d9e-4b24-b804-1a5698cc52ac" />
<img width="2196" height="3808" alt="image" src="https://github.com/user-attachments/assets/7c26df91-69b2-44b3-8329-5fb53322eda9" />
<img width="1948" height="2368" alt="image" src="https://github.com/user-attachments/assets/cb7331de-c9ba-44d6-adc9-640ab5bdfd71" />
<img width="1980" height="1467" alt="image" src="https://github.com/user-attachments/assets/cffe520e-7c1d-4a50-a5dc-3c79be70a36e" />