### PR TITLE
feat(Links): add LOLTV link

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -193,6 +193,11 @@ local PREFIXES = {
 	},
 	loco = {'https://loco.gg/streamers/'},
 	lolchess = {'https://lolchess.gg/profile/'},
+	loltv = {
+		team = 'https://loltv.gg/team/',
+		player = 'https://loltv.gg/player/',
+		match = 'https://loltv.gg/match/',
+	},
 	lrthread = {'', match = ''},
 	mapdraft = {match = 'https://aoe2cm.net/draft/'},
 	matcherino = {
@@ -524,6 +529,10 @@ local MATCH_ICONS = {
 	logstfgold = {
 		icon = 'Logstf_gold_icon.png',
 		text = 'logs.tf Match Page (Golden Cap) '
+	},
+	loltv = {
+		icon = 'LOLTV.gg allmode.png',
+		text = 'LOLTV.gg Match Stats'
 	},
 	lpl = {
 		icon = 'LPL_Logo_lightmode.png',

--- a/stylesheets/commons/Icons.scss
+++ b/stylesheets/commons/Icons.scss
@@ -158,6 +158,7 @@ https://liquipedia.net/commons/Infobox_Icons
 	@include icon-make-image( liquipedia, "//liquipedia.net/commons/images/d/de/InfoboxIcon_Liquipedia.png" );
 	@include icon-make-image( loco, "//liquipedia.net/commons/images/0/06/InfoboxIcon_Loco.png" );
 	@include icon-make-image( lolchess, "//liquipedia.net/commons/images/0/0f/InfoboxIcon_LoLCHESS.png" );
+	@include icon-make-image( loltv, "//liquipedia.net/commons/images/8/8c/InfoboxIcon_LOLTVgg.png" );
 	@include icon-make-image( masteroverwatch, "//liquipedia.net/commons/images/6/60/InfoboxIcon_MasterOverwatch.png" );
 	@include icon-make-image( matcherino, "//liquipedia.net/commons/images/8/8c/InfoboxIcon_Matcherino.png" );
 	@include icon-make-image( metafy, "//liquipedia.net/commons/images/0/02/InfoboxIcon_Metafy.png" );


### PR DESCRIPTION
## Summary

I've added the link to LOLTV.gg so we can add it to the LoL match pages to provide more in-depth and complementary stats. LOLTV.gg also has a live feed with real-time match stats. Let me know if I need to make any changes.

Example of a link to a match page: https://loltv.gg/match/2026-01-18-drx-vs-t1

File: https://liquipedia.net/commons/File:LOLTV.gg_allmode.png

## How did you test this change?

I don't really have much idea how I could test this. Let me know if I need to do anything.