### PR TITLE
fix(match2): dota2 matchpage incorrectly uses team pagename for display

### DIFF
--- a/lua/wikis/dota2/MatchPage.lua
+++ b/lua/wikis/dota2/MatchPage.lua
@@ -164,7 +164,7 @@ function MatchPage:_renderTeamStats(game)
 						HtmlWidgets.H4{
 							classes = {'match-bm-team-stats-header-title'},
 							children = game.finished
-								and self.opponents[game.winner].name .. ' Victory'
+								and self.opponents[game.winner].teamTemplateData.name .. ' Victory'
 								or 'No winner determined yet'
 						},
 						game.length and Div{children = game.length} or nil


### PR DESCRIPTION
## Summary

report on discord: https://discord.com/channels/93055209017729024/372075546231832576/1467169526780002396

## How did you test this change?

preview with dev