### PR TITLE
fix(infobox): Fix fpschallenge icon link

### DIFF
--- a/stylesheets/commons/Icons.scss
+++ b/stylesheets/commons/Icons.scss
@@ -132,7 +132,7 @@ https://liquipedia.net/commons/Infobox_Icons
 	@include icon-make-image( fanclub, "//liquipedia.net/commons/images/f/fe/InfoboxIcon_TLFanPage.png" );
 	@include icon-make-image( fide, "//liquipedia.net/commons/images/8/8f/InfoboxIcon_FIDE.png" );
 	@include icon-make-image( flickr, "//liquipedia.net/commons/images/d/d2/InfoboxIcon_Flickr.png" );
-	@include icon-make-image( fpschallenge, "//liquipedia.net/commons/images/a/a0/InfoboxIcon_Fpschallenge.png");
+	@include icon-make-image( fpschallenge, "//liquipedia.net/commons/images/5/59/InfoboxIcon_Fpschallenge.png" );
 	@include icon-make-image( gamersclub, "//liquipedia.net/commons/images/a/a5/InfoboxIcon_Gamers_Club.png" );
 	@include icon-make-image( garena, "//liquipedia.net/commons/images/6/6b/InfoboxIcon_Garena.png" );
 	@include icon-make-image( geoguessr, "//liquipedia.net/commons/images/a/a7/InfoboxIcon_GeoGuessr.png" );


### PR DESCRIPTION
## Summary

fix url to infobox icon in Stylesheets, must have changed after changing a latter to uppercase in the filename.
Currently only displays an empty icon on infoboxes