### PR TITLE
feat: hide empty countdown cell for finished countdowns

### DIFF
--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -37,7 +37,7 @@ Author(s): FO-nTTaX
 	font-weight: bold;
 }
 
-.timer-object:has(.timer-object-countdown-time:empty),
+.timer-object:has( .timer-object-countdown-time:empty ),
 .timer-object-countdown-only .timer-object-date,
 .timer-object-countdown-only .timer-object-separator,
 .timer-object-datetime-only .timer-object-countdown,


### PR DESCRIPTION
## Summary
before:
<img width="396" height="570" alt="image" src="https://github.com/user-attachments/assets/09cd070c-5b7f-45fa-a666-ec98d9676a9d" />

after:
<img width="398" height="580" alt="image" src="https://github.com/user-attachments/assets/ed36a54f-f092-4396-980f-b353d22da45d" />

## How did you test this change?
browser dev tools