### PR TITLE
fix(dynamic tab): horizontal scroll on unwanted elements

### DIFF
--- a/stylesheets/commons/Tabs.scss
+++ b/stylesheets/commons/Tabs.scss
@@ -42,7 +42,7 @@ $tabs-bg-hover-dark: var( --clr-on-surface-dark-primary-8 );
 		display: none;
 	}
 
-	div {
+	& > div {
 		overflow: auto hidden;
 	}
 


### PR DESCRIPTION
## Summary

https://discord.com/channels/93055209017729024/372075546231832576/1468223292107259958

- Fixes horizontal scroll on nested elements
- This fix narrows the overflow rule to only direct tab panes instead of every nested div, so only the active tab content container can scroll horizontally.

## How did you test this change?

dev tools