### PR TITLE
fix(dynamic tabs): static tabs as children wrong active styling

### DIFF
--- a/stylesheets/commons/Tabs.scss
+++ b/stylesheets/commons/Tabs.scss
@@ -365,7 +365,11 @@ html.client-nojs .tabs-content > div:not( .active ) {
 				background-color: var( --clr-background );
 
 				.selflink {
-					background-color: var( --clr-background ) !important;
+					background-color: unset !important;
+				}
+
+				a {
+					background-color: unset !important;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Context:
https://discord.com/channels/93055209017729024/372075546231832576/1468230838503215195
https://discord.com/channels/93055209017729024/372075546231832576/1468236320173330503

This PR:
- Tightens dynamic tab selectors so they only target the dynamic tabs’ own nav inside .tabs-nav-wrapper, preventing active styles from leaking into nested static tabs.
- Fixes static tab logos having white background and also forces team names background to be the correct bg color

<img width="957" height="282" alt="image" src="https://github.com/user-attachments/assets/009b9a52-b1ae-4b6e-a6f4-d44f9e80d627" />
<img width="604" height="258" alt="image" src="https://github.com/user-attachments/assets/6feb32f4-b284-4d6d-837e-a2fae20672b4" />

## How did you test this change?

dev tools