### PR TITLE
fix(prizepool): broken style of prize pool collapse button

### DIFF
--- a/stylesheets/commons/Prizepooltable.scss
+++ b/stylesheets/commons/Prizepooltable.scss
@@ -286,8 +286,8 @@ Author: Rathoz
 	grid-column: 1 / -1;
 
 	> * {
-		color: unset;
-		text-decoration: none;
+		color: unset !important;
+		text-decoration: none !important;
 	}
 }
 


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1468230243163836548

Regression from #7023

https://github.com/Liquipedia/Lua-Modules/blob/29424232c3f57e331726ab4672ce1c2627fe3168/stylesheets/commons/Prizepooltable.scss#L313-L316

The original style had quadruple(!) `.ppt-toggle-expand` selectors to increase specificity, which got cleaned up as part of nesting. This caused an unintended side effect: lower specificity. Link rules from lakeside got higher specificity than the cleaned up rule and caused expand/collapse toggle to be styled like any other link.

This PR restores the previous behavior by slapping `!important`s to the rules.

## How did you test this change?

browser dev tools