### PR TITLE
fix(TournamentsList): Catch non-numeric placements when fetching dynamic runner up

### DIFF
--- a/lua/wikis/commons/TournamentsListing/Conditions.lua
+++ b/lua/wikis/commons/TournamentsListing/Conditions.lua
@@ -190,21 +190,25 @@ function TournamentsListingConditions.placeConditions(tournamentData, config)
 		table.insert(allowedPlacements, firstPlacement.placement)
 
 		local parts = Array.parseCommaSeparatedString(firstPlacement.placement, '-')
-		local runnerupPlacementStart = tonumber(parts[2] or parts[1]) + 1
-		local placeConditions = ConditionTree(BooleanOperator.all):add(conditions)
-		placeConditions:add(ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('placement'), Comparator.gt, runnerupPlacementStart .. '-'),
-			ConditionNode(ColumnName('placement'), Comparator.eq, runnerupPlacementStart),
-		})
-		queryResult = mw.ext.LiquipediaDB.lpdb('placement', {
-			conditions = placeConditions:toString(),
-			query = 'placement',
-			order = 'placement asc',
-			groupby = 'placement asc',
-			limit = 1,
-		})[1]
-		if queryResult then
-			table.insert(allowedPlacements, queryResult.placement)
+		local upperBound = tonumber(parts[2] or parts[1])
+		-- Avoid non-numeric placements (W/L)
+		if upperBound then
+			local runnerupPlacementStart = upperBound + 1
+			local placeConditions = ConditionTree(BooleanOperator.all):add(conditions)
+			placeConditions:add(ConditionTree(BooleanOperator.any):add{
+				ConditionNode(ColumnName('placement'), Comparator.gt, runnerupPlacementStart .. '-'),
+				ConditionNode(ColumnName('placement'), Comparator.eq, runnerupPlacementStart),
+			})
+			queryResult = mw.ext.LiquipediaDB.lpdb('placement', {
+				conditions = placeConditions:toString(),
+				query = 'placement',
+				order = 'placement asc',
+				groupby = 'placement asc',
+				limit = 1,
+			})[1]
+			if queryResult then
+				table.insert(allowedPlacements, queryResult.placement)
+			end
 		end
 	end
 


### PR DESCRIPTION
## Summary
Would error when dynamicPlacements is enabled and there's a tournament with non-numeric placements (W/L)
(Why can't we just have 1/2 instead😭)
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
