### PR TITLE
feat: update Overwatch mainpage logo

### DIFF
--- a/lua/wikis/overwatch/MainPageLayout/data.lua
+++ b/lua/wikis/overwatch/MainPageLayout/data.lua
@@ -74,8 +74,8 @@ local CONTENT = {
 
 return {
 	banner = {
-		lightmode = 'Overwatch 2 wordmark lightmode.png',
-		darkmode = 'Overwatch 2 wordmark darkmode.png',
+		lightmode = 'Overwatch 2026 wordmark lightmode.png',
+		darkmode = 'Overwatch 2026 wordmark darkmode.png',
 	},
 	metadesc = 'Comprehensive Overwatch wiki with articles covering everything from heroes, to tournaments, ' ..
 		'to competitive players and teams.',


### PR DESCRIPTION
## Summary
<img width="700" height="390" alt="image" src="https://github.com/user-attachments/assets/cd8c33f0-9225-4852-a168-8ff7faf5f3d0" />

Blizzard decide to remove the "2" and go back to just Overwatch with the upcoming season lol 
(while keeping the same visual wordmark from OW2)

This change is to update the game logo that is on the header
