### PR TITLE
fix(dynamic tabs): styling issues form inherited styles

### DIFF
--- a/stylesheets/commons/Tabs.scss
+++ b/stylesheets/commons/Tabs.scss
@@ -85,11 +85,13 @@ html.client-nojs .tabs-content > div:not( .active ) {
 	}
 
 	.tabs-nav-wrapper .nav-tabs {
+		display: flex;
 		flex-wrap: nowrap;
 		overflow-x: auto;
 		scrollbar-width: none;
 		border: unset !important;
 		margin: 0 !important;
+		list-style: none;
 
 		&::-webkit-scrollbar {
 			display: none;
@@ -101,6 +103,7 @@ html.client-nojs .tabs-content > div:not( .active ) {
 			border: unset !important;
 			height: auto;
 			min-height: 2.75rem;
+			background-color: unset !important;
 
 			a {
 				display: flex;


### PR DESCRIPTION
## Summary

Some unwanted styles are inherited from the skin by the new dynamic tabs, causing odd looking tabs on elements with background color.

This PR unsets the bg color and also overrides a couple properties originally used from skin so the implementation is more self-contained and not relying on skin

Context:
https://discord.com/channels/93055209017729024/1460560309050671196/1468353510818189332

## How did you test this change?

dev tools

Before: 
<img width="797" height="457" alt="image" src="https://github.com/user-attachments/assets/b3143ea7-7484-45f3-979e-51b41d3a934c" />

After:
<img width="781" height="455" alt="image" src="https://github.com/user-attachments/assets/f3224eb8-4acc-4654-aec6-b9eafa7b6e63" />