### PR TITLE
feat(mainpage): remove Portal:Rumours in MLBB wiki

### DIFF
--- a/lua/wikis/mobilelegends/MainPageLayout/data.lua
+++ b/lua/wikis/mobilelegends/MainPageLayout/data.lua
@@ -41,7 +41,7 @@ local CONTENT = {
 	},
 	transfers = {
 		heading = 'Transfers',
-		body = TransfersList{rumours = true},
+		body = TransfersList{},
 		boxid = MainPageLayoutUtil.BoxId.TRANSFERS,
 	},
 	thisDay = {
@@ -123,11 +123,6 @@ return {
 				method = 'LPDB',
 				table = 'transfer',
 			},
-		},
-		{
-			file = 'BG Shadow at M5.jpg',
-			title = 'Rumours',
-			link = 'Portal:Rumours',
 		},
 		{
 			file = 'NPFL Zarate at M6 Knockout Stage.jpg',


### PR DESCRIPTION
## Summary
[As per discussed by MLBB editor/reviewers](https://discord.com/channels/93055209017729024/901877147638054932/1469348292612718743), in reaction to recent spate of vandalism & wiki misuse.

## How did you test this change?
Basically left like that on live (as a stopgap)
