### PR TITLE
fix: EWC Team arg for fortnite

### DIFF
--- a/lua/wikis/esports/Widget/EwcTeamsOverview.lua
+++ b/lua/wikis/esports/Widget/EwcTeamsOverview.lua
@@ -78,7 +78,7 @@ local GAMES = {
 		{lis = 'tft', wiki = 'tft'},
 		{lis = 'valorant', wiki = 'valorant'},
 		{lis = 't8', wiki = 'fighters'},
-		{lis = 'fornite', wiki = 'fortnite'},
+		{lis = 'fortnite', wiki = 'fortnite'},
 	}
 }
 


### PR DESCRIPTION
## Summary

reported on discord
https://discord.com/channels/93055209017729024/268719633366777856/1469732446865195230

in short. fn reserved for function name

## How did you test this change?

live
