### PR TITLE
fix(ParticipantTable): placement fetching faulty

### DIFF
--- a/lua/wikis/commons/ParticipantTable/Base.lua
+++ b/lua/wikis/commons/ParticipantTable/Base.lua
@@ -302,9 +302,7 @@ function ParticipantTable:store()
 		if shouldNotStoreOpponent(section, entry.opponent) then return end
 
 		local lpdbData = Opponent.toLpdbStruct(entry.opponent)
-		local pageNameWithUnderscores = (lpdbData.opponentname or ''):gsub(' ', '_')
-		local pageNameWithSpaces = (lpdbData.opponentname or ''):gsub('_', ' ')
-		local placement = placements[pageNameWithUnderscores] or placements[pageNameWithSpaces]
+		local placement = placements[lpdbData.opponentname]
 
 		if placement then
 			lpdbData = Table.deepMerge(


### PR DESCRIPTION
## Summary
placement fetching currently is faulty for duo/trio/quad opponents with players that have spaces/underscores

example:
opponentname `HerO_(Kim_Joon_Ho) / Maru`
what the parttable checks for: `HerO (Kim Joon Ho) / Maru` or `HerO_(Kim_Joon_Ho)_/_Maru`

in the past (before we added `Page.applyUnderScoresIfEnforced` with #5854) on sc and sc2 we did a `:gsub(' ', '_')` in matches and prize pools to determine the opponentname
with `Page.applyUnderScoresIfEnforced` we now do the gsub on the playernames before concatting them
apparently i forgot to adjust the participant tale when intorducing `Page.applyUnderScoresIfEnforced`

report on discord:
https://discord.com/channels/93055209017729024/213614988647071744/1470085617395171389
(points not getting stored for a duo opponent due to above mentioned issue))

## How did you test this change?
dev

---
reminder for myself (for after merge):
- remove dev on https://liquipedia.net/starcraft2/UThermal_2v2_Circuit/2026/2
- purge run for pages which use duo/trio/quad opponent or duo/trio/quad prize pool