### PR TITLE
fix(match2): raw datetime not displayed in matchlist dateheader

### DIFF
--- a/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
@@ -190,6 +190,7 @@ function MatchlistDisplay.DateHeader(match)
 			children = Countdown.create(Table.merge(match.stream, {
 				date = DateExt.toCountdownArg(match.timestamp, match.timezoneId, match.dateIsExact),
 				finished = match.finished,
+				rawdatetime = (not match.dateIsExact) or match.finished,
 			}))
 		}
 	}


### PR DESCRIPTION
## Summary

yet another regression from #7035...
See #7067 for issue description, this PR fixes broken dateheaders in matchlists.

## How did you test this change?

dev