### PR TITLE
fix(infobox): startdate not displayed in warcraft league infobox

### DIFF
--- a/lua/wikis/warcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/League/Custom.lua
@@ -95,7 +95,7 @@ function CustomLeague.run(frame)
 		args.prizepool = nil
 	end
 
-	return league:createInfobox(frame)
+	return league:createInfobox()
 end
 
 ---@param args table


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1470505942721236993

regression from #7035

## How did you test this change?

live