### PR TITLE
fix(match2): countdown not displayed for finished ffa games

### DIFF
--- a/lua/wikis/commons/Widget/Match/Summary/Ffa/GameCountdown.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Ffa/GameCountdown.lua
@@ -37,6 +37,7 @@ function MatchSummaryFfaGameCountdown:render()
 		-- TODO: Use game-TZ
 		date = Date.toCountdownArg(timestamp, nil, game.dateIsExact),
 		finished = game.winner ~= nil and 'true' or nil,
+		rawdatetime = (not game.dateIsExact) or game.winner ~= nil
 	})
 
 	return HtmlWidgets.Div{


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/1209065403955806270/1470925096012218499

regression from #7035

## How did you test this change?

live