### PR TITLE
fix(mainpage): dark mode styling in nested HR elements

### DIFF
--- a/stylesheets/commons/Panels.scss
+++ b/stylesheets/commons/Panels.scss
@@ -103,7 +103,7 @@ html .panel-box-heading {
 		.theme--dark & {
 			background-color: #26292d;
 
-			> hr {
+			hr {
 				background-color: var( --clr-secondary-25 );
 			}
 		}


### PR DESCRIPTION
## Summary
Reported on Discord. https://discord.com/channels/93055209017729024/960883616769007676/1471126776825774266

Someone might correct me, but I don't think we need ">" selector in this case?

Tested on few wikis and doesn't seems to broke anything.

**Example where it doesn't currently work:**
- https://liquipedia.net/formula1/Main_Page
- https://liquipedia.net/formula1/Liquipedia:Season_Calendar (just link to the template)
- https://liquipedia.net/ageofempires/Main_Page
- https://liquipedia.net/ageofempires/Liquipedia:Special_Event (just link to the template)

| Before | After |
| :---: | :---: |
| <img width="400" alt="AOE Before" src="https://github.com/user-attachments/assets/7af2fac4-a6c7-4e89-873d-d512c2acf5db" /> | <img width="400" alt="AOE After" src="https://github.com/user-attachments/assets/2a95bbef-6aa8-4246-a0c4-08cace940411" /> |
| <img width="400" alt="F1 Before" src="https://github.com/user-attachments/assets/8e88105f-71da-44df-8713-eac6d100d7d8" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/c946dad5-c3d7-43e3-a4b8-4907ceb2ab63" /> |
## How did you test this change?

dev tools