### PR TITLE
feat(infobox): show less results in SC2 achievements

### DIFF
--- a/lua/wikis/starcraft2/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Person/Player/Custom.lua
@@ -44,7 +44,7 @@ local ALLOWED_PLACES = {'1', '2', '3', '4', '3-4'}
 local ALL_KILL_ICON = '[[File:AllKillIcon.png|link=All-Kill Format]]&nbsp;×&nbsp;'
 local MAXIMUM_NUMBER_OF_PLAYERS_IN_PLACEMENTS = Info.config.defaultMaxPlayersPerPlacement
 local MINIMUM_NUMBER_OF_ALLOWED_ACHIEVEMENTS = 10
-local MAXIMUM_NUMBER_OF_ACHIEVEMENTS = 30
+local MAXIMUM_NUMBER_OF_ACHIEVEMENTS = 15
 local NUMBER_OF_RECENT_MATCHES = 10
 
 --race stuff
@@ -440,12 +440,12 @@ end
 function CustomPlayer:_isAchievement(placement, tier, place)
 	if not Table.includes(ALLOWED_PLACES, placement.placement) or not place then return false end
 
-	return tier == 1 and place <= 4
-		or tier == 2 and place <= 2
+	return tier == 1 and place <= 2
+		or tier == 2 and place == 1
 		or #self.achievements < MAXIMUM_NUMBER_OF_ACHIEVEMENTS and (
-			tier == 2 and place <= 4 or
-			tier == 3 and place <= 2 or
-			tier == 4 and place <= 1
+			tier == 1 and place <= 4 or
+			tier == 2 and place <= 2 or
+			tier == 3 and place <= 1
 		)
 end
 


### PR DESCRIPTION
## Summary
basically this in prep of the new table stuff so that our player pages do not run into runtime/memory issues as much

proposed among other sc2 admins, their emote reactions were favorable

## How did you test this change?
N/A, just switching some numbers