### PR TITLE
fix(team participant): revert min width change

### DIFF
--- a/stylesheets/commons/TeamParticipantCard.scss
+++ b/stylesheets/commons/TeamParticipantCard.scss
@@ -51,7 +51,7 @@ $compact-selector: '[data-switch-group="team-cards-compact"]';
 .team-participant__grid {
 	display: grid;
 	gap: 0.25rem;
-	grid-template-columns: repeat( auto-fit, minmax( 300px, 1fr ) );
+	grid-template-columns: repeat( auto-fit, minmax( 280px, 1fr ) );
 
 	@media ( min-width: 1024px ) {
 		gap: 0.5rem;


### PR DESCRIPTION
## Summary

Reverting the min width change from #7080

We're looking to implement a smaller tab variant for desktop so we can comfortably fit 4 in the 280px wide card.

## How did you test this change?

Dev tools