### PR TITLE
feat: add rankings to dota2 mainpage

### DIFF
--- a/lua/wikis/dota2/MainPageLayout/data.lua
+++ b/lua/wikis/dota2/MainPageLayout/data.lua
@@ -13,7 +13,7 @@ local Template = Lua.import('Module:Template')
 
 local FilterButtonsWidget = Lua.import('Module:Widget/FilterButtons')
 local TournamentsTicker = Lua.import('Module:Widget/Tournaments/Ticker')
--- local Rankings = Lua.import('Module:Widget/Ratings')
+local Rankings = Lua.import('Module:Widget/Ratings')
 
 local Button = Lua.import('Module:Widget/Basic/Button')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
@@ -166,7 +166,6 @@ local CONTENT = {
 		padding = true,
 		boxid = MainPageLayoutUtil.BoxId.TOURNAMENTS_TICKER,
 	},
---[[
 	rankings = {
 		heading = 'Liquipedia Rankings (Beta)',
 		body = Rankings{
@@ -178,7 +177,6 @@ local CONTENT = {
 		padding = false,
 		boxid = 1520,
 	},
-]]
 }
 
 local LAYOUT_MAIN = {
@@ -187,11 +185,14 @@ local LAYOUT_MAIN = {
 		children = {
 			{
 				mobileOrder = 1,
-				content = CONTENT.specialEvents
+				content = CONTENT.specialEvents,
 			},
-
 			{
 				mobileOrder = 3,
+				content = CONTENT.rankings,
+			},
+			{
+				mobileOrder = 4,
 				content = CONTENT.transfers,
 			},
 		},
@@ -236,7 +237,7 @@ local LAYOUT_MAIN = {
 		sizes = {xxl = 12},
 		children = {
 			{
-				mobileOrder = 4,
+				mobileOrder = 5,
 				content = CONTENT.heroes,
 			},
 		}
@@ -245,11 +246,11 @@ local LAYOUT_MAIN = {
 		sizes = {xxl = 6},
 		children = {
 			{
-				mobileOrder = 5,
+				mobileOrder = 6,
 				content = CONTENT.wantToHelp,
 			},
 			{
-				mobileOrder = 6,
+				mobileOrder = 7,
 				content = CONTENT.updates,
 			},
 
@@ -259,7 +260,7 @@ local LAYOUT_MAIN = {
 		sizes = {xxl = 6},
 		children = {
 			{
-				mobileOrder = 7,
+				mobileOrder = 8,
 				content = CONTENT.thisDay,
 			},
 		}
@@ -268,12 +269,12 @@ local LAYOUT_MAIN = {
 		sizes = {xxl = 12},
 		children = {
 			{
-				mobileOrder = 8,
+				mobileOrder = 9,
 				content = CONTENT.usefulArticles,
 			},
 			{
-				mobileOrder = 9,
-				content = CONTENT.partnerWikis
+				mobileOrder = 10,
+				content = CONTENT.partnerWikis,
 			},
 		}
 	}
@@ -293,6 +294,10 @@ local LAYOUT_ESPORTS = {
 			},
 			{
 				mobileOrder = 5,
+				content = CONTENT.rankings,
+			},
+			{
+				mobileOrder = 6,
 				content = CONTENT.transfers,
 			},
 			{
@@ -339,12 +344,6 @@ local LAYOUT_ESPORTS = {
 					},
 				},
 			},
---[[
-			{
-				mobileOrder = 6,
-				content = CONTENT.rankings
-			},
-]]
 			{
 				mobileOrder = 7,
 				content = CONTENT.updates,


### PR DESCRIPTION
## Summary
We have the dota2 rankings in beta again, and as such should be added to the mainpage

## How did you test this change?

dev