### PR TITLE
feat(match2): surrendered round handling for valorant match page

### DIFF
--- a/lua/wikis/commons/Icon/Data.lua
+++ b/lua/wikis/commons/Icon/Data.lua
@@ -36,6 +36,7 @@ return {
 	explosion_valorant = 'fas fa-fire-alt',
 	defuse = 'fas fa-wrench',
 	outoftime = 'fas fa-hourglass',
+	surrendered = 'far fa-flag',
 	ace_valorant = 'fas fa-dagger',
 	flawless_valorant = 'fas fa-gem',
 

--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -57,6 +57,10 @@ local WIN_TYPES = {
 	['time'] = {
 		icon = 'outoftime',
 		description = 'Timer expired',
+	},
+	surrendered = {
+		icon = 'surrendered',
+		description = 'Surrendered'
 	}
 }
 


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/684060921898860569/1472663262217769041

[Match:ID 9x4HVQ1OLE R01-M005](https://liquipedia.net/valorant/Match:ID_9x4HVQ1OLE_R01-M005) has a surrendered round and the current impl of matchpage has no handling for it.
Thus, this PR adds surrendered round handling in valorant match pages.

## How did you test this change?

preview with dev