### PR TITLE
feat(infobox): add mode parameter to rainbowsix league infobox

### DIFF
--- a/lua/wikis/rainbowsix/Infobox/League/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/League/Custom.lua
@@ -71,7 +71,8 @@ function CustomInjector:parse(id, widgets)
 		Cell{name = 'Teams', children = {(args.team_number or '') .. (args.team_slots and ('/' .. args.team_slots) or '')}},
 		Cell{name = 'Game', children = {Game.name{game = args.game}}},
 		Cell{name = 'Platform', children = {caller:_createPlatformCell(args)}},
-		Cell{name = 'Players', children = {args.player_number}}
+		Cell{name = 'Players', children = {args.player_number}},
+		Cell{name = 'Mode', children = {args.mode or '5v5'}}
 	)
 	elseif id == 'customcontent' then
 		if String.isNotEmpty(args.map1) then


### PR DESCRIPTION


## Summary

Added a |mode= parameter to the infobox with a default value of "5v5", currently placed at the bottom of the custom cells, if it would be better to move it upwards feel free to do so.

The main reason is to make clear what events are played in the non-standard form of 5v5, like this recent event held at the Six Invitational (World Championships) as a side event: https://liquipedia.net/rainbowsix/1v1_NOW/2026.

I would expect more events to pop-up using the 1v1 or upcoming 2v2/3v3 mode's.

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?

Using |dev=okidokie98

### Base (Current live version)
<img width="333" height="559" alt="image" src="https://github.com/user-attachments/assets/f9167eb4-30db-4ba3-9ccf-9c153cb8b42c" />


### Default (|mode=...)
It will default to display 5v5, once merged I will go through old events and change them to display the correct mode (1v1, 2v2 or 3v3) where needed.

<img width="343" height="583" alt="image" src="https://github.com/user-attachments/assets/6442bb57-a72e-4b7b-8723-84ff62f090cd" />


### Parameter filled in (1v1)
<img width="352" height="589" alt="image" src="https://github.com/user-attachments/assets/70f41c00-905c-49f0-806f-9191ec209a70" />


<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
