### PR TITLE
fix(infobox): roles on marvel rivals

### DIFF
--- a/lua/wikis/marvelrivals/Infobox/Character/Custom.lua
+++ b/lua/wikis/marvelrivals/Infobox/Character/Custom.lua
@@ -103,7 +103,7 @@ function CustomHero:_getRole(roleInput)
 		return ROLE_LOOKUP[role:lower()]
 	end)
 
-	return Logic.nilIfEmpty(Array.interleave(roles, HtmlWidgets.Br{}))
+	return Logic.nilIfEmpty(roles)
 end
 
 ---@param args table


### PR DESCRIPTION
## Summary
Fixed a bug where roles defaulted to "NPC" because the `args` table was being passed to `_getRole` instead of `args.role`.
Updated `_getRole` to handle comma-separated strings.

## How did you test this change?
dev


<img width="178" height="32" alt="image" src="https://github.com/user-attachments/assets/528d3eb0-b2aa-476d-88fc-fbdf0651196b" />

<img width="198" height="81" alt="image" src="https://github.com/user-attachments/assets/03f53128-1a85-46d0-8426-23ed16a53dd6" />
