### PR TITLE
feat: make `componentsinvert` class available on all wikis

### DIFF
--- a/stylesheets/commons/Fountain.scss
+++ b/stylesheets/commons/Fountain.scss
@@ -3,11 +3,6 @@
 	display: none;
 }
 
-/* Invert colors for dark theme */
-html.theme--dark .componentsinvert {
-	filter: invert( 1 );
-}
-
 // Default text-shadow
 .txtshd {
 	text-shadow: 0.0625em 0.0625em 0.125em var( --clr-moon-base ); // #000000

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -2148,6 +2148,14 @@ Author(s): hjpalpha
 }
 
 /*******************************************************************************
+Invert colors for dark theme - moved here from Fountain.scss
+*******************************************************************************/
+
+html.theme--dark .componentsinvert {
+	filter: invert( 1 );
+}
+
+/*******************************************************************************
 Template: GroupTableLeague
 Use case: up/down arrows to indicate a ranking change between rounds
 Author(s): hjpalpha


### PR DESCRIPTION
## Summary
Move the exisitng class from `Fountain.scss` to `Miscellaneous.scss` so it becomes available on all wikis.

Based on a conversation on discord starting at https://discord.com/channels/93055209017729024/235015279711748096/1473622429661270129

## How did you test this change?
N/A