### PR TITLE
fix(match2): broken alignment for party opponents in matchpage header

### DIFF
--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -38,7 +38,7 @@ span.slash {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	padding: 16px;
+	padding: 16px 0;
 }
 
 .match-bm-match-header-opponent {
@@ -156,6 +156,10 @@ span.slash {
 .match-bm-match-header-party {
 	align-items: flex-start;
 	font-size: 1.25rem;
+
+	&:first-child {
+		align-items: flex-end;
+	}
 }
 
 .match-bm-match-header-round {


### PR DESCRIPTION
## Summary

Reported via https://github.com/Liquipedia/Lua-Modules/pull/7113#issuecomment-3925726374

## How did you test this change?

browser dev tools