### PR TITLE
feat: new HoK logos

### DIFF
--- a/lua/wikis/honorofkings/Info.lua
+++ b/lua/wikis/honorofkings/Info.lua
@@ -43,12 +43,12 @@ return {
 			name = 'Honor of Kings',
 			link = 'Honor of Kings',
 			logo = {
-				darkMode = 'Honor of Kings Icon.png',
-				lightMode = 'Honor of Kings Icon.png',
+				darkMode = 'Honor of Kings 2026 allmode.png',
+				lightMode = 'Honor of Kings 2026 allmode.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Honor of Kings 2018-12-24 Logo.png',
-				lightMode = 'Honor of Kings 2018-12-24 Logo.png',
+				darkMode = 'Honor of Kings 2026 allmode.png',
+				lightMode = 'Honor of Kings 2026 allmode.png',
 			},
 		},
 		hokic = {


### PR DESCRIPTION
## Summary
<img width="732" height="323" alt="image" src="https://github.com/user-attachments/assets/c961c594-005e-4d88-b45c-4dad1555242d" />

The game recieved a new logo change (the one on right side)

This changes the Info.lua icons
Eventually a Main page update will follow in separate PR

## How did you test this change?
Live

## Side Note 
We do need that change on the wiki font icon as well but that's outside Github, just to note it here
