### PR TITLE
fix(tabs): width undefined in dynamic tab content container

### DIFF
--- a/lua/wikis/commons/Tabs.lua
+++ b/lua/wikis/commons/Tabs.lua
@@ -202,6 +202,7 @@ function Tabs.dynamic(args)
 
 	return AnalyticsWidgets{
 		analyticsName = 'Dynamic Navigation tab',
+		css = {width = '-webkit-fill-available'},
 		children = HtmlWidgets.Div{
 			classes = {'tabs-dynamic', 'navigation-not-searchable', variantClass, wrapsClass},
 			attributes = {['data-nosnippet'] = ''},


### PR DESCRIPTION
## Summary

reported via https://github.com/Liquipedia/Lua-Modules/pull/7113#issuecomment-3932679290

ideally this would be using [`stretch`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/width#stretch) but some platforms only have non-standard alias of it available ☹️ 

## How did you test this change?

browser dev tools