### PR TITLE
fix: vertical scrolling not working in new table widget

### DIFF
--- a/stylesheets/commons/Table2.scss
+++ b/stylesheets/commons/Table2.scss
@@ -30,7 +30,7 @@ $table2-cell-padding-x: 0.75rem;
 		overflow: auto hidden;
 		max-width: 100%;
 		-webkit-overflow-scrolling: touch;
-		touch-action: pan-x;
+		touch-action: pan-x pan-y;
 		overscroll-behavior-x: contain;
 	}
 


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/1474351702638460968/1474352369017032878

## How did you test this change?

browser dev tools