### PR TITLE
feat(mainpage): New HoK Header

### DIFF
--- a/lua/wikis/honorofkings/MainPageLayout/data.lua
+++ b/lua/wikis/honorofkings/MainPageLayout/data.lua
@@ -81,8 +81,8 @@ local CONTENT = {
 
 return {
 	banner = {
-		lightmode = 'HoK_AoV_allmode.png',
-		darkmode = 'HoK_AoV_allmode.png',
+		lightmode = 'HoK_AoV_Header 2026 lightmode.png',
+		darkmode = 'HoK_AoV_Header 2026 darkmode.png',
 	},
 	metadesc = 'Comprehensive Honor of Kings & Arena of Valor wiki with articles covering everything from heroes, '..
 		'to strategies, to tournaments, to competitive players and teams.',


### PR DESCRIPTION
## Summary
<img width="392" height="180" alt="image" src="https://github.com/user-attachments/assets/2702833c-d809-4ee1-8ecd-4cb84e56798f" />


Following #7118 this one is for the mainpage, which also has some rework on it to be the full wordmark for both games and will have modes accordingly (for Mobile versions)

## How did you test this change?
LIVE