### PR TITLE
feat(mainpage): Add Game filters for EA FC

### DIFF
--- a/lua/wikis/easportsfc/FilterButtons/config.lua
+++ b/lua/wikis/easportsfc/FilterButtons/config.lua
@@ -34,6 +34,7 @@ Config.categories = {
 		name = 'game',
 		property = 'game',
 		items = {'fc 26', 'fc mobile', 'fc online'},
+		expandable = true,
 		transform = function(game)
 			return HtmlWidgets.Fragment{
 				children = {


### PR DESCRIPTION
## Summary
<img width="926" height="96" alt="image" src="https://github.com/user-attachments/assets/b3dd7bcb-9906-44b0-b186-85276bddec0f" />


<img width="599" height="100" alt="image" src="https://github.com/user-attachments/assets/92666062-b5bd-405e-9377-748232e42b3b" />

Adds a secondary filter for game-based, this will be similar to COD where one of the three games changes annually

## How did you test this change?
LIVE