### PR TITLE
feat(infobox): let infobox team throw on missing team template

### DIFF
--- a/lua/wikis/commons/Infobox/Team.lua
+++ b/lua/wikis/commons/Infobox/Team.lua
@@ -21,6 +21,7 @@ local Namespace = Lua.import('Module:Namespace')
 local MatchTicker = Lua.import('Module:MatchTicker')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
+local TeamTemplate = Lua.import('Module:TeamTemplate')
 local Variables = Lua.import('Module:Variables')
 
 local BasicInfobox = Lua.import('Module:Infobox/Basic')
@@ -75,7 +76,7 @@ function Team:createInfobox()
 
 	-- Team Information
 	local team = args.teamtemplate or self.pagename
-	self.teamTemplate = mw.ext.TeamTemplate.raw(team) or {}
+	self.teamTemplate = TeamTemplate.getRaw(team)
 
 	args.imagedark = args.imagedark or args.imagedarkmode or args.image or self.teamTemplate.imagedark
 	args.image = args.image or self.teamTemplate.image
@@ -207,7 +208,7 @@ function Team:processCreateDates()
 	local earliestGameTimestamp = Team._parseDate(ReferenceCleaner.clean{input = self.args.created}) or Date.maxTimestamp
 
 	local created = Array.map(self:getAllArgsForBase(self.args, 'created'), function (creation)
-		local splitInput = Array.map(mw.text.split(creation, ':'), String.trim)
+		local splitInput = Array.parseCommaSeparatedString(creation, ':')
 		if #splitInput ~= 2 then
 			-- Legacy Input
 			return creation
@@ -239,17 +240,12 @@ end
 ---@return string?
 ---@return string?
 function Team:_getTeamIcon(date)
-	if not self.teamTemplate then
-		return
-	end
+	local historicalTeamTemplateData = self.teamTemplate.historicaltemplate
+		and TeamTemplate.getRawOrNil(self.teamTemplate.historicaltemplate, date)
+		or {}
 
-	local icon = self.teamTemplate.historicaltemplate
-		and mw.ext.TeamTemplate.raw(self.teamTemplate.historicaltemplate, date).image
-		or self.teamTemplate.image
-
-	local iconDark = self.teamTemplate.historicaltemplate
-		and mw.ext.TeamTemplate.raw(self.teamTemplate.historicaltemplate, date).imagedark
-		or self.teamTemplate.imagedark
+	local icon = historicalTeamTemplateData.image or self.teamTemplate.image
+	local iconDark = historicalTeamTemplateData.imagedark or self.teamTemplate.imagedark
 
 	return icon, iconDark
 end


### PR DESCRIPTION
## Summary
as per discussion in #6995

additionally replaces usage of `mw.ext.TeamTemplate.raw` with `Module:TeamTemplate` and cleaned up a single `mw.text.split` to use `Array.parseCommaSeparatedString`

## How did you test this change?
dev