### PR TITLE
fix(mvp tables): right align points

### DIFF
--- a/lua/wikis/commons/MvpTable.lua
+++ b/lua/wikis/commons/MvpTable.lua
@@ -62,7 +62,7 @@ function MvpTable.run(args)
 		title = String.nilIfEmpty(args.title),
 		columns = {
 			{align = 'left'},
-			{align = 'center'},
+			{align = 'right'},
 			parsedArgs.points and {align = 'right'} or nil,
 		},
 		css = {


### PR DESCRIPTION
## Summary

By convention, we want to right align numbers with the new table design

## How did you test this change?

`|dev=mna` on MVP Tables