### PR TITLE
fix(mvpTable): cutafter is off by one

### DIFF
--- a/lua/wikis/commons/MvpTable.lua
+++ b/lua/wikis/commons/MvpTable.lua
@@ -71,7 +71,7 @@ function MvpTable.run(args)
 		tableAttributes = {
 			['data-opentext'] = 'place ' .. (parsedArgs.cutafter + 1) .. ' to ' .. #mvpList,
 			['data-closetext'] = 'place ' .. (parsedArgs.cutafter + 1) .. ' to ' .. #mvpList,
-			['data-cutafter'] = parsedArgs.cutafter + (String.isNotEmpty(args.title) and 1 or 0),
+			['data-cutafter'] = parsedArgs.cutafter,
 			['data-definedcutafter'] = ''
 		},
 		children = WidgetUtil.collect(


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/276340346831765504/1475420563659948093

regression from #7122 - title is no longer inside `<table>` so adding offset for it is redundant

## How did you test this change?

preview with dev