### PR TITLE
feat(table2): update highlight style

### DIFF
--- a/stylesheets/commons/Table2.scss
+++ b/stylesheets/commons/Table2.scss
@@ -118,10 +118,23 @@ $table2-cell-padding-x: 0.75rem;
 		}
 
 		&.table2__row--highlighted {
-			background-color: var( --publisher-premier-highlight-background-color ) !important;
+			position: relative;
 
-			&:hover {
-				background-color: var( --publisher-premier-highlight-background-color ) !important;
+			&::after {
+				content: "";
+				position: absolute;
+				left: 0;
+				top: 0;
+				bottom: 0;
+				width: 6px;
+
+				.theme--light & {
+					background-color: var( --clr-semantic-gold-40 );
+				}
+
+				.theme--dark & {
+					background-color: var( --clr-semantic-gold-30 );
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

We want to try out a new row highlight styling, moving from the old yellow background to a left gold border to highlight rows.

## How did you test this change?

dev tools

Before:
<img width="1079" height="571" alt="image" src="https://github.com/user-attachments/assets/40f2f54b-6dad-4300-8aeb-69d4a0fc9ca2" />

After:
<img width="1079" height="572" alt="image" src="https://github.com/user-attachments/assets/8a3ff9a3-3b74-480f-bb89-aa8839106d73" />