### PR TITLE
feat: change Portal:Ratings to Portal:Rankings

### DIFF
--- a/lua/wikis/commons/Widget/Ratings/List.lua
+++ b/lua/wikis/commons/Widget/Ratings/List.lua
@@ -207,7 +207,7 @@ function RatingsList:render()
 		children = HtmlWidgets.Th {
 			attributes = { colspan = '7' },
 			children = Link {
-				link = 'Portal:Rating',
+				link = 'Portal:Rankings',
 				linktype = 'internal',
 				children = { buttonDiv },
 			},


### PR DESCRIPTION
## Summary
<img width="1108" height="326" alt="image" src="https://github.com/user-attachments/assets/f2dee9bd-4a7d-477a-8eb8-4ca86a3b36f4" />

This changes the link wrapped behind this button
<img width="653" height="117" alt="image" src="https://github.com/user-attachments/assets/9ff41f21-6535-4777-9812-ae239f01f797" />

so it goes to the actual page instead of redirected 
<img width="660" height="89" alt="image" src="https://github.com/user-attachments/assets/8b442149-f017-4ec3-88b5-59622fae29f0" />

## How did you test this change?
[dev](https://liquipedia.net/commons/Module:Widget/Ratings/List/dev/h2)