### PR TITLE
fix(team participants): names overlap labels

### DIFF
--- a/stylesheets/commons/TeamParticipantCard.scss
+++ b/stylesheets/commons/TeamParticipantCard.scss
@@ -150,10 +150,12 @@ $compact-selector: '[data-switch-group="team-cards-compact"]';
 
 	&__opponent-compact {
 		display: none;
+		width: 100%;
 	}
 
 	&__opponent-full {
 		display: flex;
+		width: 100%;
 	}
 
 	&__label {


### PR DESCRIPTION
## Summary

Reported on Discord:
https://discord.com/channels/93055209017729024/372075546231832576/1475825630665904212

This was introduced with the recent changes of using bracket names for compact and full names for non-compact mode. Forcing the opponent display to take parent width seems to fix the issue.

## How did you test this change?

dev tools

<img width="1486" height="199" alt="image" src="https://github.com/user-attachments/assets/aa8678fd-d5c5-4762-8557-21404c7fb03c" />