### PR TITLE
fix: table2 wrapper does not respect parent container width

### DIFF
--- a/stylesheets/commons/Table2.scss
+++ b/stylesheets/commons/Table2.scss
@@ -20,13 +20,18 @@ $table2-cell-padding-x: 0.75rem;
 
 .table2 {
 	display: block;
-	width: stretch;
+	width: fit-content;
+	max-width: stretch;
 	border: 1px solid;
 	border-radius: $table2-radius;
 	overflow: hidden;
 
-	@supports not ( width: stretch ) {
-		width: -webkit-fill-available;
+	@supports not ( max-width: stretch ) {
+		max-width: -webkit-fill-available;
+
+		@supports not ( max-width: -webkit-fill-available ) {
+			max-width: 100%;
+		}
 	}
 
 	@include table2-surface-colors();


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/1474351702638460968/1476543095163195432

## How did you test this change?

browser dev tools