### PR TITLE
feat(table2): new highlight style

### DIFF
--- a/stylesheets/commons/Table2.scss
+++ b/stylesheets/commons/Table2.scss
@@ -146,16 +146,6 @@ $table2-cell-padding-x: 0.75rem;
 					background-color: var( --clr-semantic-gold-30 );
 				}
 			}
-
-			&:hover {
-				.theme--light & {
-					background-color: var( --clr-semantic-gold-90 );
-				}
-
-				.theme--dark & {
-					background-color: var( --clr-semantic-gold-18 );
-				}
-			}
 		}
 
 		&:hover {
@@ -165,6 +155,16 @@ $table2-cell-padding-x: 0.75rem;
 
 			.theme--dark & {
 				background-color: var( --clr-on-surface-dark-primary-8 );
+			}
+		}
+
+		&.table2__row--highlighted:hover {
+			.theme--light & {
+				background-color: var( --clr-semantic-gold-90 );
+			}
+
+			.theme--dark & {
+				background-color: var( --clr-semantic-gold-18 );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

New highlight style for table2 rows:
- 6px gold bar on the left
- background color with a more suitable color
- new hover colors

Needs new variables live on skin before merge

## How did you test this change?

dev tools

Light mode:
<img width="771" height="650" alt="image" src="https://github.com/user-attachments/assets/7c2b9055-63aa-4aed-8d31-1378d2ced449" />

Dark mode:
<img width="772" height="648" alt="image" src="https://github.com/user-attachments/assets/89447b70-5fee-48e7-b240-d03785053ebd" />