### PR TITLE
ci: roll back eslint vue plugin update

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
 		]
 	},
 	"scripts": {
-		"lint": "npm run lint:js & npm run lint:scss",
-		"lint:ci": "npm run lint:js & npm run lint:scss:ci",
+		"lint": "npm run lint:js && npm run lint:scss",
+		"lint:ci": "npm run lint:js && npm run lint:scss:ci",
 		"lint:js": "eslint --fix",
 		"lint:scss": "stylelint \"stylesheets/**/*.scss\"",
 		"lint:scss:ci": "stylelint \"stylesheets/**/*.scss\" --custom-formatter @csstools/stylelint-formatter-github",


### PR DESCRIPTION
## Summary

Regression from #7173

eslint config from mediawiki is not compatible with `eslint-plugin-vue >= 10.7.0` 🤷 

## How did you test this change?

<https://github.com/Liquipedia/Lua-Modules/actions/runs/22482843148>