### PR TITLE
fix(ResultsTable): opponents center aligned looking bad in award table

### DIFF
--- a/lua/wikis/commons/ResultsTable/Award.lua
+++ b/lua/wikis/commons/ResultsTable/Award.lua
@@ -33,9 +33,7 @@ function AwardsTable:buildColumnDefinitions()
 		{align = 'left'},
 		{align = 'left'},
 		{align = 'left'},
-		self.config.queryType ~= Opponent.team and {
-			align = 'left',
-		} or self.config.playerResultsOfTeam and {
+		(self.config.queryType ~= Opponent.team or self.config.playerResultsOfTeam) and {
 			align = 'left',
 		} or nil,
 		{


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/1400382174078832670/1477151792235286721
<img width="520" height="290" alt="image" src="https://github.com/user-attachments/assets/7c6c8ab9-36e9-4c74-8401-d8608abee791" />

imo it should be left aligned

and it was et aligned before #7141
![IMG_5247](https://github.com/user-attachments/assets/f60d183e-f9a2-4d77-8e47-c198973d60fe)

## How did you test this change?
untested but trivial