### PR TITLE
feat(TournamentsList): support querying 'circuit' for trackmania

### DIFF
--- a/lua/wikis/trackmania/TournamentsListing/CardList/Custom.lua
+++ b/lua/wikis/trackmania/TournamentsListing/CardList/Custom.lua
@@ -32,14 +32,14 @@ function CustomTournamentsListing:buildConditions()
 	local conditions = ListingConditions.base(self.args)
 
 	if Logic.isNotEmpty(self.args.circuit) then
-		conditions:add(ConditionTree(BooleanOperator.any):add{
+		conditions:add(
 			ConditionTree(BooleanOperator.all):add{
 				ConditionNode(ColumnName('circuit', 'extradata'), Comparator.eq, self.args.circuit),
 				ConditionUtil.anyOf(
 					ColumnName('circuittier', 'extradata'), Array.parseCommaSeparatedString(self.args.circuittier)
 				)
 			}
-		})
+		)
 	end
 
 	if self.args.additionalConditions then


### PR DESCRIPTION
## Summary
Copy `circuit` and `circuittier` querying from fighters wiki


## How did you test this change?
https://liquipedia.net/trackmania/User:SobakaPirat/TournamentsList