### PR TITLE
feat(prizepool): update weight calculation in league of legends

### DIFF
--- a/lua/wikis/leagueoflegends/PrizePool/Custom.lua
+++ b/lua/wikis/leagueoflegends/PrizePool/Custom.lua
@@ -74,8 +74,11 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, tierType, isHi
 	end
 
 	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier) or ''] or 1
+	local prizeFactor = (1000000 + prizeMoney) / 1000000
+	local tierTypeFactor = TIER_TYPE_MODIFIER[tierType] or 1
+	local highlightedFactor = isHighlighted and 2 or 1
 
-	return (1000000 + prizeMoney) / 1000000 * tierValue * (TIER_TYPE_MODIFIER[tierType] or 1) * (isHighlighted and 2 or 1) / place
+	return prizeFactor * tierValue * tierTypeFactor * highlightedFactor / place
 end
 
 return CustomPrizePool


### PR DESCRIPTION
## Summary

League of Legends prize pools for major tournaments are no longer publicized, which means that tournaments going forward will no longer show up in the highlighted results for players, even if the achievement is more important (ex: [Quid](https://liquipedia.net/leagueoflegends/Quid) getting $200 for an off-season event being valued higher than a 4th place in the LCS). This means that existing tier 1 players will not have newer tournaments in their summarized achievements table, while upcoming players will not have tier 1 results in their results table if they make it to a tier 1 competition (ex: [Sajed](https://liquipedia.net/leagueoflegends/Sajed), who debuted in the LCS but a top 8, B-tier finish is considered more valuable due to $313 prizemoney).

Additionally, player results are often dominated by qualifiers for events instead of said event (ex: [Geiger](https://liquipedia.net/leagueoflegends/Geiger), who has 6 highlighted events which are qualifiers instead of the event itself), by adding weights to the tier types, these are now less valuable.

Changes are discussed and agreed on by the most active contributors: https://discord.com/channels/93055209017729024/276340346831765504/1470697786591674458

## How did you test this change?

Difficult to change properly as many pages must be purged, but tiertype changes are directly taken from Hearthstone. Prizemoney should not return issues as it is removed from the equation altogether. ``TIER_TYPE_MODIFIER`` is introduced to use the same weighting as notability guidelines, this aligns with previous consensus on 'value' of events and this should resolve the qualifier concern.

I'm open to suggestions on how to properly test this.