### PR TITLE
refactor: clean up crosstable styles

### DIFF
--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -185,24 +185,24 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 	text-align: center;
 }
 
-.crosstable .crosstable-tr {
-	height: 30px;
-}
-
 .crosstable {
 	text-align: center;
 	margin: 0;
 	line-height: 14px;
-}
 
-.crosstable th,
-.crosstable td {
-	padding: 1px;
-}
+	.crosstable-tr {
+		height: 30px;
+	}
 
-/* fix for i icon in crosstables */
-.crosstable .bracket-game .icon {
-	margin-top: 2px !important;
-	margin-right: -6px !important;
-	opacity: 0.6;
+	th,
+	td {
+		padding: 1px;
+	}
+
+	/* fix for i icon in crosstables */
+	.bracket-game .icon {
+		margin-top: 2px !important;
+		margin-right: -6px !important;
+		opacity: 0.6;
+	}
 }

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -97,22 +97,16 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 }
 
 @mixin crosstable($min, $max) {
-	@include crosstable-outer($min, $max, $min);
-}
-
-@mixin crosstable-outer($min, $max, $current) {
-	@if $current <= $max {
-		@include crosstable-inner($min, $max, $min, $current);
-		@include crosstable-outer($min, $max, $current + 1);
+	@for $current from $min through $max {
+		@include crosstable-inner($min, $max, $current);
 	}
 }
 
-@mixin crosstable-inner($min, $max, $current, $outer) {
-	@if $current <= $max {
+@mixin crosstable-inner($min, $max, $outer) {
+	@for $current from $min through $max {
 		@include crosstable-gray($current, $outer);
 		@include crosstable-green($current, $outer);
 		@include crosstable-red($current, $outer);
-		@include crosstable-inner($min, $max, $current + 1, $outer);
 	}
 }
 

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -25,8 +25,8 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 }
 
 @mixin crosstable-shadows($size) {
-	@include crosstable-col(1, $size);
-	@include crosstable-row(1, $size);
+	@include crosstable-col($size);
+	@include crosstable-row($size);
 }
 
 @mixin crosstable-row-over() {
@@ -50,13 +50,12 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 	box-shadow: unset !important;
 }
 
-@mixin crosstable-col($id, $max) {
-	@for $i from $id through $max {
-		$idp1: $i + 1;
-		.crosstable.crosstable-col-#{$idp1} td:nth-child(#{$i}) {
+@mixin crosstable-col($max) {
+	@for $i from 1 through $max {
+		.crosstable.crosstable-col-#{$i + 1} td:nth-child(#{$i}) {
 			@include crosstable-row-left();
 		}
-		.crosstable.crosstable-col-#{$i} td:nth-child(#{$idp1}) {
+		.crosstable.crosstable-col-#{$i} td:nth-child(#{$i + 1}) {
 			@include crosstable-row-right();
 		}
 		.crosstable.crosstable-col-#{$i} td:nth-child(#{$i}) {
@@ -65,13 +64,12 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 	}
 }
 
-@mixin crosstable-row($id, $max) {
-	@for $i from $id through $max {
-		$idp1: $i + 1;
-		.crosstable.crosstable-row-#{$idp1} tr:nth-child(#{$i}) td {
+@mixin crosstable-row($max) {
+	@for $i from 1 through $max {
+		.crosstable.crosstable-row-#{$i + 1} tr:nth-child(#{$i}) td {
 			@include crosstable-row-over();
 		}
-		.crosstable.crosstable-row-#{$i} tr:nth-child(#{$idp1}) td {
+		.crosstable.crosstable-row-#{$i} tr:nth-child(#{$i + 1}) td {
 			@include crosstable-row-under();
 		}
 		.crosstable.crosstable-row-#{$i} tr:nth-child(#{$i}) td {

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -30,33 +30,23 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 }
 
 @mixin crosstable-row-over() {
-	-moz-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
-	-webkit-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 	box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 }
 
 @mixin crosstable-row-under() {
-	-moz-box-shadow: inset 0 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
-	-webkit-box-shadow: inset 0 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 	box-shadow: inset 0 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 }
 
 @mixin crosstable-row-left() {
-	-moz-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
-	-webkit-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 	box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 }
 
 @mixin crosstable-row-right() {
-	-moz-box-shadow: inset 10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
-	-webkit-box-shadow: inset 10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 	box-shadow: inset 10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 }
 
 @mixin crosstable-row-standard() {
 	opacity: 1 !important;
-	-moz-box-shadow: unset !important;
-	-webkit-box-shadow: unset !important;
 	box-shadow: unset !important;
 }
 
@@ -93,26 +83,18 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 @include crosstable-shadows($crosstable-size);
 
 .crosstable .crosstable-top-left {
-	-moz-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
-	-webkit-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 	box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 }
 
 .crosstable .crosstable-top-right {
-	-moz-box-shadow: inset 10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
-	-webkit-box-shadow: inset 10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 	box-shadow: inset 10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 -10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 }
 
 .crosstable .crosstable-bottom-left {
-	-moz-box-shadow: inset 0 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
-	-webkit-box-shadow: inset 0 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 	box-shadow: inset 0 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset -10px 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 }
 
 .crosstable .crosstable-bottom-right {
-	-moz-box-shadow: inset 10px 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
-	-webkit-box-shadow: inset 10px 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 	box-shadow: inset 10px 10px 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ) !important;
 }
 

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -61,36 +61,32 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 }
 
 @mixin crosstable-col($id, $max) {
-	@if $id <= $max {
-		$idp1: $id + 1;
-		.crosstable.crosstable-col-#{$idp1} td:nth-child(#{$id}) {
+	@for $i from $id through $max {
+		$idp1: $i + 1;
+		.crosstable.crosstable-col-#{$idp1} td:nth-child(#{$i}) {
 			@include crosstable-row-left();
 		}
-		.crosstable.crosstable-col-#{$id} td:nth-child(#{$idp1}) {
+		.crosstable.crosstable-col-#{$i} td:nth-child(#{$idp1}) {
 			@include crosstable-row-right();
 		}
-		.crosstable.crosstable-col-#{$id} td:nth-child(#{$id}) {
+		.crosstable.crosstable-col-#{$i} td:nth-child(#{$i}) {
 			@include crosstable-row-standard();
 		}
-
-		@include crosstable-col($id + 1, $max);
 	}
 }
 
 @mixin crosstable-row($id, $max) {
-	@if $id <= $max {
-		$idp1: $id + 1;
-		.crosstable.crosstable-row-#{$idp1} tr:nth-child(#{$id}) td {
+	@for $i from $id through $max {
+		$idp1: $i + 1;
+		.crosstable.crosstable-row-#{$idp1} tr:nth-child(#{$i}) td {
 			@include crosstable-row-over();
 		}
-		.crosstable.crosstable-row-#{$id} tr:nth-child(#{$idp1}) td {
+		.crosstable.crosstable-row-#{$i} tr:nth-child(#{$idp1}) td {
 			@include crosstable-row-under();
 		}
-		.crosstable.crosstable-row-#{$id} tr:nth-child(#{$id}) td {
+		.crosstable.crosstable-row-#{$i} tr:nth-child(#{$i}) td {
 			@include crosstable-row-standard();
 		}
-
-		@include crosstable-row($id + 1, $max);
 	}
 }
 

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -104,31 +104,21 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 
 @mixin crosstable-inner($min, $max, $outer) {
 	@for $current from $min through $max {
-		@include crosstable-gray($current, $outer);
-		@include crosstable-green($current, $outer);
-		@include crosstable-red($current, $outer);
+		@include crosstable-color($current, $outer);
 	}
 }
 
-@mixin crosstable-gray($s1, $s2) {
-	@if $s1 == $s2 {
-		td.crosstable-bgc-r#{$s1}-r#{$s2} {
+@mixin crosstable-color($s1, $s2) {
+	td.crosstable-bgc-r#{$s1}-r#{$s2} {
+		@if $s1 == $s2 {
 			background-color: $crosstable-yellow;
 		}
-	}
-}
 
-@mixin crosstable-green($s1, $s2) {
-	@if $s1 > $s2 {
-		td.crosstable-bgc-r#{$s1}-r#{$s2} {
+		@else if $s1 > $s2 {
 			background-color: $crosstable-green;
 		}
-	}
-}
 
-@mixin crosstable-red($s1, $s2) {
-	@if $s1 < $s2 {
-		td.crosstable-bgc-r#{$s1}-r#{$s2} {
+		@else if $s1 < $s2 {
 			background-color: $crosstable-red;
 		}
 	}

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -118,7 +118,7 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 			background-color: $crosstable-green;
 		}
 
-		@else if $s1 < $s2 {
+		@else {
 			background-color: $crosstable-red;
 		}
 	}


### PR DESCRIPTION
## Summary

This PR:
- replaces recursive `@include`s with `@for` loop
- removes vendor prefix variants of `box-shadow`  
  `box-shadow` is baseline widely available for over a decade now, so it should be safe to remove all vendor prefix variants
- reduces number of `@mixin`s

## How did you test this change?

difftools + browser dev tools