### PR TITLE
feat: add js build script to the project

### DIFF
--- a/build-js.js
+++ b/build-js.js
@@ -1,7 +1,3 @@
-/* eslint-env node */
-/* eslint-disable no-console */
-/* eslint-disable security/detect-non-literal-fs-filename */
-
 const fs = require( 'fs' ).promises;
 const path = require( 'path' );
 

--- a/build-js.js
+++ b/build-js.js
@@ -1,0 +1,73 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+/* eslint-disable security/detect-non-literal-fs-filename */
+
+const fs = require( 'fs' ).promises;
+const path = require( 'path' );
+
+const modulesDir = path.join( __dirname, 'javascript' );
+const mainJsPath = path.join( modulesDir, 'Main.js' );
+const commonsDir = path.join( modulesDir, 'commons' );
+const outFile = path.join( __dirname, 'lua', 'output', 'js', 'main.js' );
+
+function extractJsModules( content ) {
+	const modulesMatch = content.match( /const jsModules = (\[[\s\S]*?\]);/ );
+	if ( !modulesMatch ) {
+		throw new Error( 'Could not find jsModules array in Main.js' );
+	}
+	return JSON.parse( modulesMatch[ 1 ].replace( /'/g, '"' ) );
+}
+
+async function concatenateModules( moduleNames ) {
+	const moduleContents = await Promise.all(
+		moduleNames.map( async ( moduleName ) => {
+			const modulePath = path.join( commonsDir, `${ moduleName }.js` );
+			try {
+				return await fs.readFile( modulePath, 'utf8' );
+			} catch ( e ) {
+				console.warn( `Warning: Could not read ${ modulePath }` );
+				return null;
+			}
+		} )
+	);
+
+	const validContents = moduleContents.filter( ( content ) => content !== null );
+	const modulesString = validContents.map( ( content ) => content + '\n;\n' ).join( '' );
+
+	return '// --- INJECTED LOCAL MODULES ---\n\n' +
+        modulesString +
+        '// --- END OF INJECTED MODULES ---\n';
+}
+
+function removeOriginalCode( content ) {
+	const listRegex = /const jsModules = (\[[\s\S]*?\]);/m;
+	const dynamicLoaderRegex = /(\/\/ Dynamically load JavaScript modules[\s\S]*?}\s*\);)/m;
+
+	return content
+		.replace( listRegex, '// --- jsModules list removed by build script ---' )
+		.replace( dynamicLoaderRegex, '// --- Dynamic loader replaced by build script ---' );
+}
+
+async function build() {
+	console.log( 'Building JS by injecting modules into Main.js...' );
+
+	try {
+		const mainJsContent = await fs.readFile( mainJsPath, 'utf8' );
+		const moduleNames = extractJsModules( mainJsContent ).filter( ( name ) => name !== 'Analytics' );
+		const concatenatedModules = await concatenateModules( moduleNames );
+		const processedMainContent = removeOriginalCode( mainJsContent );
+
+		const warningMessage = "console.warn('Browser is using locally compiled JavaScript, and cannot be fully trusted to match the production counterpart.')";
+		const finalContent = warningMessage + processedMainContent + '\n\n' + concatenatedModules;
+
+		await fs.mkdir( path.dirname( outFile ), { recursive: true } );
+		await fs.writeFile( outFile, finalContent );
+		console.log( 'JS build complete! Output to lua/output/js/main.js' );
+	} catch ( error ) {
+		console.error( 'JS Build FAILED:' );
+		console.error( error.message );
+		process.exit( 1 );
+	}
+}
+
+build();

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
 		"test:js": "jest",
 		"compile:scss": "sass stylesheets/Main.scss lua/output/css/main.css",
 		"build:css": "npm run compile:scss",
+		"build:js": "node build-js.js",
+		"build": "npm run build:css && npm run build:js",
 		"lua-test": "npm run build:css && busted -C lua",
 		"update-snapshots": "UPDATE_SNAPSHOTS=true npm run lua-test"
 	}


### PR DESCRIPTION
## Summary

Adds a new build-js.js file that compiles the project javascript into a output file in: `lua/output/js/main.js`.
This allows devs to setup better local dev env for css and js changes by following these instructions:

https://github.com/Liquipedia/Lua-Modules/wiki/Local-Development-Setup-for-CSS-and-JS

## How did you test this change?

setup working locally