### PR TITLE
fix: Improve display for participant columns

### DIFF
--- a/lua/wikis/commons/TournamentsListing/CardList.lua
+++ b/lua/wikis/commons/TournamentsListing/CardList.lua
@@ -180,6 +180,7 @@ function BaseTournamentsListing:build()
 	self.cachedData = {rank = 1, prize = 0, skippedRanks = self.config.offset}
 
 	return TableWidgets.Table{
+		classes = 'tournaments-listing',
 		columns = self:buildColumnDefinitions(),
 		children = {
 			TableWidgets.TableHeader{
@@ -202,7 +203,10 @@ function BaseTournamentsListing:buildColumnDefinitions()
 		config.showTier and {align = 'left'} or nil, 		-- Tier
 		config.showGameIcon and {align = 'center'} or nil, 	-- Game
 		{align = 'left'},									-- Icon
-		{align = 'left'},									-- Tournament
+		{													-- Tournament
+			align = 'left',
+			classes = {'column__tournament'},
+		},
 		config.showOrganizer and {align = 'left'} or nil,	-- Organizer
 		{align = 'left'},									-- Date
 		{													-- Prizepool
@@ -212,10 +216,19 @@ function BaseTournamentsListing:buildColumnDefinitions()
 		{align = 'left'},									-- Location
 		{align = 'right'},									-- Participants
 		config.showQualifierColumnOverWinnerRunnerup
-			and {align = 'left'}							-- Qualified
+			and {											-- Qualified
+				align = 'left',
+				classes = {'column__qualified'},
+			}
 			or WidgetUtil.collect(
-				{align = 'left'},							-- Winner
-				{align = 'left'}							-- Runner-up
+				{											-- Winner
+					align = 'left',
+					classes = {'column__placement'},
+				},
+				{											-- Runner-up
+					align = 'left',
+					classes = {'column__placement'},
+				}
 			)
 	)
 end
@@ -347,11 +360,13 @@ end
 
 ---@private
 ---@param opponents table[]
----@return Widget[]
+---@return Widget
 function BaseTournamentsListing:_buildParticipants(opponents)
-	return Array.map(opponents, function (opponent)
-		return OpponentDisplay.BlockOpponent{opponent = opponent}
-	end)
+	return HtmlWidgets.Div{
+		children = Array.map(opponents, function (opponent)
+			return OpponentDisplay.BlockOpponent{opponent = opponent}
+		end)
+	}
 end
 
 ---@private

--- a/stylesheets/commons/Table2.scss
+++ b/stylesheets/commons/Table2.scss
@@ -280,3 +280,30 @@ $table2-cell-padding-x: 0.75rem;
 		}
 	}
 }
+
+// TournamentsListing variant (Module:TournamentsListing/CardList)
+.tournaments-listing {
+	width: 100%;
+
+	.column {
+		&__tournament {
+			width: 100%;
+			min-width: 15rem;
+			max-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		&__placement > div {
+			display: inline-grid;
+			grid-template-columns: repeat( auto-fit, minmax( 150px, 1fr ) );
+			min-width: 12vw;
+		}
+
+		&__qualified > div {
+			display: inline-grid;
+			grid-template-columns: repeat( auto-fit, minmax( 150px, 1fr ) );
+			min-width: 20vw;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Remove the css that enabled positioning multiple participants in the same row, as it introduces scrollbars.
(see https://liquipedia.net/leagueoflegends/Portal:Tournaments#Qualifiers)

This means display is worse for tournaments with larger amounts of qualified participants or otherwise shared placements:
<img width="1837" height="1034" alt="image" src="https://github.com/user-attachments/assets/74461192-028a-4540-9e80-378acaae431b" />

Ideally we'd have this wrapping while also not introducing scroll bars, but i have no idea how to make that happen. 
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
Retested, dev+inspector
Examples:
<img width="1851" height="998" alt="image" src="https://github.com/user-attachments/assets/6fb46603-eab8-46e7-801d-a504e515febc" />
<img width="1878" height="962" alt="image" src="https://github.com/user-attachments/assets/cdf068dd-322c-4bf2-9f9d-ce48f88a64d1" />
<img width="1878" height="962" alt="image" src="https://github.com/user-attachments/assets/6465916b-c994-48de-aee1-e0f677f89bcf" />




<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
