### PR TITLE
style(FfaStandings): center text in a column with placement

### DIFF
--- a/lua/wikis/commons/Widget/Standings/Ffa.lua
+++ b/lua/wikis/commons/Widget/Standings/Ffa.lua
@@ -101,7 +101,7 @@ function StandingsFfaWidget:render()
 						children = WidgetUtil.collect(
 							HtmlWidgets.Td{
 								children = {slot.placement, '.'},
-								css = {['font-weight'] = 'bold'},
+								css = {['font-weight'] = 'bold', ['text-align'] = 'center'},
 								classes = {positionBackground},
 							},
 							HtmlWidgets.Td{


### PR DESCRIPTION
## Summary
Arguable, but I prefer the placement numbers to be centered
<img width="496" height="747" alt="изображение" src="https://github.com/user-attachments/assets/8200bf3b-475d-400e-90cf-c3709649f603" />

## How did you test this change?
https://liquipedia.net/trackmania/User:SobakaPirat/FfaStandings