### PR TITLE
fix: deploy script incorrectly tries to lock newly added commons module from creation

### DIFF
--- a/scripts/protect.py
+++ b/scripts/protect.py
@@ -50,7 +50,7 @@ def main():
             protect_existing_page(page, wiki)
         else:  # commons case
             protect_existing_page(page, wiki)
-            for deploy_wiki in get_wikis():
+            for deploy_wiki in get_wikis() - {"commons"}:
                 protect_if_has_no_local_version(module, deploy_wiki)
         print("::endgroup::")
     handle_protect_errors()


### PR DESCRIPTION
## Summary

caught with https://github.com/Liquipedia/Lua-Modules/actions/runs/22845417399/job/66260502203
regression from #7152

## How did you test this change?

logically trivial