### PR TITLE
chore: protect `Template:StageWinnings`

### DIFF
--- a/templates/templatesToProtect
+++ b/templates/templatesToProtect
@@ -272,6 +272,7 @@ SingleMatch
 SoloOpponent
 SoloPrizePool
 Stage
+StageWinnings
 Streams
 SwissStandings
 Tabs_dynamic


### PR DESCRIPTION
## Summary
template to #6602
protection run for existing wikis already under way

## How did you test this change?
N/A