### PR TITLE
feat(match2): add tracking category for unknown player input

### DIFF
--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -957,7 +957,7 @@ function MatchGroupInputUtil.findPlayerId(players, playerInput, playerLink)
 	if playerIndex > 0 then
 		return playerIndex
 	end
-	mw.ext.TeamLiquidIntegration.add_category('Pages with unknown player input')
+	mw.ext.TeamLiquidIntegration.add_category('Pages with unknown player input in matches')
 	mw.log('Player with id ' .. playerInput .. ' not found in opponent data')
 end
 


### PR DESCRIPTION
## Summary

feature request on discord: https://discord.com/channels/93055209017729024/1356577556567953550/1480874082718187550

I'm open to better category name suggestions 😃 

## How did you test this change?

trivial