### PR TITLE
chore: mark `Template:BasePrizePoolTable` as protected

### DIFF
--- a/templates/templatesToProtect
+++ b/templates/templatesToProtect
@@ -223,6 +223,7 @@ Abbr/WITA
 Abbr/YEKT
 Abbr/ZAR
 ApiMap
+BasePrizePoolTable
 Box
 Bracket
 BroadcasterCard


### PR DESCRIPTION
## Summary
as title says
the new template corresponds to the modules added with #7165

protection run already under way: https://github.com/hjpalpha/test/actions/runs/22900383945/job/66445155062

## How did you test this change?
N/A