### PR TITLE
fix: dialog close button not centered

### DIFF
--- a/stylesheets/commons/Dialog.scss
+++ b/stylesheets/commons/Dialog.scss
@@ -32,6 +32,10 @@ div.general-dialog-container {
 		color-scheme: dark;
 	}
 
+	.ui-dialog-titlebar .ui-icon {
+		margin: unset;
+	}
+
 	@media ( max-width: 435px ) {
 		max-height: 80vh;
 	}


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/1474351702638460968/1480197231691960533

## How did you test this change?

browser dev tools