### PR TITLE
fix(infobox_extensions): typo in GameAppearances

### DIFF
--- a/lua/wikis/commons/Infobox/Extension/GameAppearances.lua
+++ b/lua/wikis/commons/Infobox/Extension/GameAppearances.lua
@@ -1,6 +1,6 @@
 ---
 -- @Liquipedia
--- page=Module:Infobox/Extension/GameApperances
+-- page=Module:Infobox/Extension/GameAppearances
 --
 -- Please see https://github.com/Liquipedia/Lua-Modules to contribute
 --


### PR DESCRIPTION
## Summary

Noticed when someone reported problem with the GameAppearances in the discord
https://discord.com/channels/93055209017729024/372075546231832576/1481332966826446901

Therefore it was linking to outdated module on commons.

After that protect page and delete typo module.

## How did you test this change?

Just checked usage and all modules use "GameAppearances" so should be fine.
