### PR TITLE
fix(match2): new result label not aligned properly

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -1457,6 +1457,7 @@ div.brkts-opponent-hover {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	align-self: center;
 
 	&.result--win {
 		.theme--light & {


### PR DESCRIPTION
## Summary

The new result labels from #7237 aren't aligned properly in some wikis because their matchsummary rows are thicker (e.g., counterstrike)

<img width="363" height="269" alt="image" src="https://github.com/user-attachments/assets/e62f2629-a9d1-436e-a0b6-ace8a50fa72e" />

This PR adjusts styles to have the result labels aligned properly

## How did you test this change?

browser dev tools