### PR TITLE
chore: remove unused schedules display styles

### DIFF
--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -2717,15 +2717,6 @@ Author(s): salle
 }
 
 /*******************************************************************************
-"Match Page" font-awesome stacked icon correction
-Author(s): salle
-*******************************************************************************/
-
-span.fa-stack i.fas.fa-info.fa-stack-1x:last-child {
-	padding-top: 0.2em;
-}
-
-/*******************************************************************************
 .scribunto-error when not added via <style> tags
 Author(s): Scribunto developer( s )
 *******************************************************************************/


### PR DESCRIPTION
## Summary

`fa-stack` based matchpage button in schedules display was replaced with `MatchPageButton` widget back in #6030. Hence this PR removes the obsolete styles.

## How did you test this change?

N/A